### PR TITLE
fixes the pump ui clicktips

### DIFF
--- a/code/modules/atmospherics/machinery/binary/passive_gate.dm
+++ b/code/modules/atmospherics/machinery/binary/passive_gate.dm
@@ -59,9 +59,9 @@ obj/machinery/atmospherics/binary/passive_gate
 			if(network2)
 				network2.update = 1
 
-obj/machinery/atmospherics/binary/passive_gate/attack_hand(mob/user as mob)
-	..()
-	ui.show_ui(user)
+obj/machinery/atmospherics/binary/passive_gate/attackby(obj/item/W as obj, mob/user as mob)
+	if(ispulsingtool(W))
+		ui.show_ui(user)
 
 datum/pump_ui/passive_gate_ui
 	value_name = "Release Pressure"

--- a/code/modules/atmospherics/machinery/binary/passive_gate.dm
+++ b/code/modules/atmospherics/machinery/binary/passive_gate.dm
@@ -59,10 +59,9 @@ obj/machinery/atmospherics/binary/passive_gate
 			if(network2)
 				network2.update = 1
 
-obj/machinery/atmospherics/binary/passive_gate/attackby(obj/weapon as obj, mob/user as mob)
+obj/machinery/atmospherics/binary/passive_gate/attack_hand(mob/user as mob)
 	..()
-	if(istype(weapon, /obj/item/device/multitool))
-		ui.show_ui(user)
+	ui.show_ui(user)
 
 datum/pump_ui/passive_gate_ui
 	value_name = "Release Pressure"

--- a/code/modules/atmospherics/machinery/binary/pump.dm
+++ b/code/modules/atmospherics/machinery/binary/pump.dm
@@ -140,10 +140,9 @@ obj/machinery/atmospherics/binary/pump
 
 		update_icon()
 
-obj/machinery/atmospherics/binary/pump/attackby(var/obj/W as obj, var/mob/user as mob)
+obj/machinery/atmospherics/binary/pump/attack_hand(var/mob/user as mob)
 	..()
-	if(istype(W, /obj/item/device/multitool))
-		ui.show_ui(user)
+	ui.show_ui(user)
 
 datum/pump_ui/basic_pump_ui
 	value_name = "Target Pressure"

--- a/code/modules/atmospherics/machinery/binary/pump.dm
+++ b/code/modules/atmospherics/machinery/binary/pump.dm
@@ -140,9 +140,9 @@ obj/machinery/atmospherics/binary/pump
 
 		update_icon()
 
-obj/machinery/atmospherics/binary/pump/attack_hand(var/mob/user as mob)
-	..()
-	ui.show_ui(user)
+obj/machinery/atmospherics/binary/pump/attackby(obj/item/W as obj, mob/user as mob)
+	if(ispulsingtool(W))
+		ui.show_ui(user)
 
 datum/pump_ui/basic_pump_ui
 	value_name = "Target Pressure"

--- a/code/modules/atmospherics/machinery/binary/pump_ui.dm
+++ b/code/modules/atmospherics/machinery/binary/pump_ui.dm
@@ -8,17 +8,14 @@ datum/pump_ui
  	// Increments for the + and - buttons
 	var/incr_sm
 	var/incr_lg
+
  // These need to be overridden in the children
 datum/pump_ui/proc/set_value(value_to_set)
-	CRASH("Non-overridden proc in datum/pump_ui")
 datum/pump_ui/proc/toggle_power()
-	CRASH("Non-overridden proc in datum/pump_ui")
 datum/pump_ui/proc/is_on()
-	CRASH("Non-overridden proc in datum/pump_ui")
 datum/pump_ui/proc/get_value()
-	CRASH("Non-overridden proc in datum/pump_ui")
 datum/pump_ui/proc/get_atom()
-	CRASH("Non-overridden proc in datum/pump_ui")
+
  // Checks user validity
 datum/pump_ui/proc/validate_user(mob/user as mob)
 	return !(user.stat || user.restrained())
@@ -40,7 +37,8 @@ datum/pump_ui/Topic(href, href_list)
  // Displays the UI
 datum/pump_ui/proc/show_ui(mob/user)
 	if (user.client.tooltipHolder)
-		user.client.tooltipHolder.showClickTip(get_atom(), user, list("title" = src.pump_name, "content" = render()))
+		user.client.tooltipHolder.showClickTip(get_atom(), list("title" = src.pump_name, "content" = render()))
+
  // Generates the HTML
 datum/pump_ui/proc/render()
 	return {"

--- a/code/modules/atmospherics/machinery/binary/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/binary/volume_pump.dm
@@ -118,9 +118,9 @@ obj/machinery/atmospherics/binary/volume_pump
 			SPAWN_DBG(0.5 SECONDS) broadcast_status()
 		update_icon()
 
-obj/machinery/atmospherics/binary/volume_pump/attack_hand(mob/user as mob)
-	..()
-	ui.show_ui(user)
+obj/machinery/atmospherics/binary/volume_pump/attackby(obj/item/W as obj, mob/user as mob)
+	if(ispulsingtool(W))
+		ui.show_ui(user)
 
 datum/pump_ui/volume_pump_ui
 	value_name = "Flow Rate"

--- a/code/modules/atmospherics/machinery/binary/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/binary/volume_pump.dm
@@ -118,10 +118,9 @@ obj/machinery/atmospherics/binary/volume_pump
 			SPAWN_DBG(0.5 SECONDS) broadcast_status()
 		update_icon()
 
-obj/machinery/atmospherics/binary/volume_pump/attackby(obj/weapon as obj, mob/user as mob)
+obj/machinery/atmospherics/binary/volume_pump/attack_hand(mob/user as mob)
 	..()
-	if(istype(weapon, /obj/item/device/multitool))
-		ui.show_ui(user)
+	ui.show_ui(user)
 
 datum/pump_ui/volume_pump_ui
 	value_name = "Flow Rate"

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -3,3 +3,5 @@
 #Most of the time, you'll want to make yourself a Coder.
 #To do so, type your BYOND key with no spaces or capitals, a dash with spaces on both side, then the rank you want.
 #For example, the key "ZeWaka" would be given Coder rank like this: zewaka - Coder
+
+elanoots - Coder

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -3,5 +3,3 @@
 #Most of the time, you'll want to make yourself a Coder.
 #To do so, type your BYOND key with no spaces or capitals, a dash with spaces on both side, then the rank you want.
 #For example, the key "ZeWaka" would be given Coder rank like this: zewaka - Coder
-
-elanoots - Coder


### PR DESCRIPTION
## About the PR
This PR fixes the previously merged but perpetually broken patch I made in 2018 that lets you click on a pump and adjust it. 

## Why's this needed?
This would allow marginally more tinkering with engine/toxins stuff and is a first step towards some more customizable atmospheric machinery stuff I want to make eventually.
