### PR TITLE
Adds config file for the DM Language Client extension in VSCode

### DIFF
--- a/SpacemanDMM.toml
+++ b/SpacemanDMM.toml
@@ -1,0 +1,2 @@
+[langserver]
+dreamchecker = true

--- a/SpacemanDMM.toml
+++ b/SpacemanDMM.toml
@@ -1,2 +1,7 @@
 [langserver]
 dreamchecker = true
+
+[diagnostics]
+no_typehint_implicit_new = "off"
+field_access_static_type = "off"
+proc_call_static_type = "off"

--- a/SpacemanDMM.toml
+++ b/SpacemanDMM.toml
@@ -1,7 +1,2 @@
 [langserver]
 dreamchecker = true
-
-[diagnostics]
-no_typehint_implicit_new = "off"
-field_access_static_type = "off"
-proc_call_static_type = "off"


### PR DESCRIPTION
## About the PR

Look upon your sins and weep, mortal. Adds a config file for the langserver, and tells it to run DreamChecker by default for additional linting.

## Why's this needed?

![image](https://user-images.githubusercontent.com/5714543/78108978-f5519880-73bd-11ea-9af8-4677a9dc3ff6.png)

