### PR TITLE
improve damage + stamina damage of basic itemspecials

### DIFF
--- a/code/WorkInProgress/ItemSpecials.dm
+++ b/code/WorkInProgress/ItemSpecials.dm
@@ -414,7 +414,7 @@
 		staminaCost = 0
 		moveDelay = 0//5
 		moveDelayDuration = 0//4
-		damageMult = 0.9
+		damageMult = 1
 
 		image = "simple"
 		name = "Attack"
@@ -422,7 +422,7 @@
 
 		onAdd()
 			if(master)
-				overrideStaminaDamage = master.stamina_damage * 0.8
+				overrideStaminaDamage = master.stamina_damage * 1
 			return
 
 		pixelaction(atom/target, params, mob/user, reach)
@@ -462,7 +462,7 @@
 		onAdd()
 			if(master)
 				//cooldown = master.click_delay
-				overrideStaminaDamage = master.stamina_damage * 0.8
+				overrideStaminaDamage = master.stamina_damage * 1
 			return
 
 		pixelaction(atom/target, params, mob/user, reach)
@@ -498,7 +498,7 @@
 		moveDelay = 5
 		moveDelayDuration = 5
 
-		damageMult = 0.8
+		damageMult = 1
 
 		image = "swipe"
 		name = "Swipe"
@@ -507,7 +507,7 @@
 
 		onAdd()
 			if(master)
-				overrideStaminaDamage = master.stamina_damage * 0.6 //maybe too low? thinking about stuff like baseball bat or rolling pin tho
+				overrideStaminaDamage = master.stamina_damage * 0.8
 				var/obj/item/toy/sword/saber = master
 				if (istype(saber))
 					swipe_color = get_hex_color_from_blade(saber.bladecolor)


### PR DESCRIPTION
Simple, Ranged Stab, and Swipe special attacks have had their base damage increased to match normal attacks and their stamina damage brought more in line too.
These specials already can't crit, which is enough of a debuff IMO