### PR TITLE
Add pwd and -h option for grep in DWAINE

### DIFF
--- a/code/modules/networks/computer3/mainframe2/tapes.dm
+++ b/code/modules/networks/computer3/mainframe2/tapes.dm
@@ -10,7 +10,7 @@
 /*
  *	Mainframe 2 starting memory
  */
-/obj/item/disk/data/diskpack/main2
+/obj/item/disk/data/memcard/main2
 	file_amount = 4096
 
 	New()

--- a/code/modules/networks/computer3/mainframe2/tapes.dm
+++ b/code/modules/networks/computer3/mainframe2/tapes.dm
@@ -10,7 +10,7 @@
 /*
  *	Mainframe 2 starting memory
  */
-/obj/item/disk/data/memcard/main2
+/obj/item/disk/data/diskpack/main2
 	file_amount = 4096
 
 	New()
@@ -66,6 +66,7 @@
 		newfolder.add_file( new /datum/computer/file/mainframe_program/utility/mv(src) )
 		newfolder.add_file( new /datum/computer/file/mainframe_program/utility/mount(src) )
 		newfolder.add_file( new /datum/computer/file/mainframe_program/utility/grep(src) )
+		newfolder.add_file( new /datum/computer/file/mainframe_program/utility/pwd(src) )
 		newfolder.add_file( new /datum/computer/file/mainframe_program/utility/scnt(src) )
 		newfolder.add_file( new /datum/computer/file/mainframe_program/utility/getopt(src) )
 		newfolder.add_file( new /datum/computer/file/mainframe_program/utility/date(src) )
@@ -100,7 +101,7 @@
 		subfolder.add_file( groupRec )
 
 		var/list/randomMails = get_random_email_list()
-		var/typeCount = 5
+		var/typeCount = rand(6,12)
 		while (typeCount-- > 0 && randomMails && randomMails.len)
 			var/mailName = pick(randomMails)
 			var/datum/computer/file/record/mailfile = new /datum/computer/file/record/random_email(mailName)
@@ -128,7 +129,7 @@
 		var/datum/computer/file/record/testR = new
 		testR.name = "motd"
 		testR.fields += "Welcome to DWAINE System VI!"
-		testR.fields += pick("Better than System V ever was.","GLUEEEE GLUEEEE GLUEEEEE","Only YOU can prevent lp0 fires!","Please try not to kill yourselves today.", "Please don't set the lab facilities on fire.")
+		testR.fields += pick("Better than System V ever was.","GLUEEEE GLUEEEE GLUEEEEE","Only YOU can prevent lp0 fires!","Please try not to kill yourselves today.", "Please don't set the lab facilities on fire.","system was here")
 		newfolder.add_file( testR )
 
 		newfolder.add_file( new /datum/computer/file/record/dwaine_help(src) )
@@ -204,6 +205,7 @@
 		src.root.add_file( new /datum/computer/file/mainframe_program/utility/mv(src) )
 		src.root.add_file( new /datum/computer/file/mainframe_program/utility/mount(src) )
 		src.root.add_file( new /datum/computer/file/mainframe_program/utility/grep(src) )
+		src.root.add_file( new /datum/computer/file/mainframe_program/utility/pwd(src) )
 		src.root.add_file( new /datum/computer/file/mainframe_program/utility/scnt(src) )
 		src.root.add_file( new /datum/computer/file/mainframe_program/utility/getopt(src) )
 		src.root.add_file( new /datum/computer/file/mainframe_program/utility/date(src) )

--- a/code/modules/networks/computer3/mainframe2/tapes.dm
+++ b/code/modules/networks/computer3/mainframe2/tapes.dm
@@ -101,7 +101,7 @@
 		subfolder.add_file( groupRec )
 
 		var/list/randomMails = get_random_email_list()
-		var/typeCount = rand(6,12)
+		var/typeCount = rand(4,6)
 		while (typeCount-- > 0 && randomMails && randomMails.len)
 			var/mailName = pick(randomMails)
 			var/datum/computer/file/record/mailfile = new /datum/computer/file/record/random_email(mailName)
@@ -129,7 +129,7 @@
 		var/datum/computer/file/record/testR = new
 		testR.name = "motd"
 		testR.fields += "Welcome to DWAINE System VI!"
-		testR.fields += pick("Better than System V ever was.","GLUEEEE GLUEEEE GLUEEEEE","Only YOU can prevent lp0 fires!","Please try not to kill yourselves today.", "Please don't set the lab facilities on fire.","system was here")
+		testR.fields += pick("Better than System V ever was.","GLUEEEE GLUEEEE GLUEEEEE","Only YOU can prevent lp0 fires!","Please try not to kill yourselves today.", "Please don't set the lab facilities on fire.")
 		newfolder.add_file( testR )
 
 		newfolder.add_file( new /datum/computer/file/record/dwaine_help(src) )

--- a/code/modules/networks/computer3/mainframe2/utilities.dm
+++ b/code/modules/networks/computer3/mainframe2/utilities.dm
@@ -1414,4 +1414,4 @@
 	initialize(var/initparams)
 		message_user(read_user_field("curpath"))
 		mainframe_prog_exit
-	return
+	

--- a/code/modules/networks/computer3/mainframe2/utilities.dm
+++ b/code/modules/networks/computer3/mainframe2/utilities.dm
@@ -816,7 +816,7 @@
 					recursive = 1
 				if (findtext(options, "s"))
 					no_messages = 0
-				if (findtext(options, "p"))
+				if (findtext(options, "h"))
 					plain = 1
 				initlist.Cut(1,2)
 				if (initlist.len < 2)

--- a/code/modules/networks/computer3/mainframe2/utilities.dm
+++ b/code/modules/networks/computer3/mainframe2/utilities.dm
@@ -17,6 +17,8 @@
 //date   Time manipulation utility.
 //tar    Archiving utility
 
+//pwd    Print current directory
+
 //List directory
 /datum/computer/file/mainframe_program/utility/ls
 	name = "ls"
@@ -392,6 +394,8 @@
 
 		mainframe_prog_exit
 		return
+
+
 
 //Concatenate...stuff
 /datum/computer/file/mainframe_program/utility/cat
@@ -798,7 +802,7 @@
 			var/print_only_match = 0
 			var/recursive = 0
 			var/no_messages = 1
-
+			var/plain = 0
 			. = ""
 
 			if (copytext(initlist[1], 1, 2) == "-")
@@ -812,7 +816,8 @@
 					recursive = 1
 				if (findtext(options, "s"))
 					no_messages = 0
-
+				if (findtext(options, "p"))
+					plain = 1
 				initlist.Cut(1,2)
 				if (initlist.len < 2)
 					. += "No pattern or target file. Try 'help grep'"
@@ -860,7 +865,8 @@
 						if (R.Find(case_sensitive ? "[textLine][to_check:fields[textLine]]" : lowertext("[textLine][to_check:fields[textLine]]")))
 							if (print_only_match)
 								. += "[R.match]|n"
-
+							else if (plain)
+								. += "[textLine][to_check:fields[textLine]]|n"
 							else
 								. += "[to_check.name]:[j]:" + "[textLine][to_check:fields[textLine]]|n"
 						R = null
@@ -1402,3 +1408,10 @@
 
 		mainframe_prog_exit
 		return
+/datum/computer/file/mainframe_program/utility/pwd
+	name = "pwd"
+	size = 1
+	initialize(var/initparams)
+		message_user(read_user_field("curpath"))
+		mainframe_prog_exit
+	return


### PR DESCRIPTION
## About the PR
Adds pwd, a utility for **p**rinting your current **w**orking **d**irectory
Adds -h option to grep, which omits the "filename:linenumber:" prefix on matched lines
also apparently slightly randomizes the number of spam emails you get, to reward the 2 people that even read the damn things less or more depending on how RNGesus is feeling at the time

## Why's this needed?
for pwd: to allow checking/logging a user's current working directory
for grep -h: to allow even nerdier nerd shit, namely processing (making readable) large amounts of captured PDA messages, almost like you have access to a multi-million-credit state-of-the-art computer system or something. having filenames and stuff forcefully appended to everything makes grep not very useful
