### PR TITLE
targeted item abilities

### DIFF
--- a/code/WorkInProgress/AbilityItem.dm
+++ b/code/WorkInProgress/AbilityItem.dm
@@ -804,27 +804,3 @@
 			src.last_use_time = world.time
 			sleep(src.cooldown)
 			src.on_cooldown()
-
-/obj/item/space_thing/ability_thing //testing, debug, please remove
-	name = "ability_thing"
-	abilities = list(/obj/ability_button/testing)
-	ability_buttons = list()
-
-	New()
-		..()
-
-	attack_self(mob/user as mob)
-		if (src.ability_buttons.len)
-			var/obj/ability_button/AB = ability_buttons[1]
-			AB.the_mob = user
-
-/obj/ability_button/testing
-	name = "testing"
-	icon_state = "jeton"
-	targeted = 1
-
-	execute_ability(var/atom/target)
-		if (target == src)
-			return
-		boutput(src.the_mob, "[target] fuck")
-		..()

--- a/code/WorkInProgress/AbilityItem.dm
+++ b/code/WorkInProgress/AbilityItem.dm
@@ -1,7 +1,10 @@
 #define ITEM_ABILITIES_WRAP_AT 15
 
-//There is no stunned etc. check when clicking the buttons.
-//If you want one, code it. (the_mob var on the buttons).
+//i did a bit of work to make these more versatile?
+//im not like, a code goddess or anything tho, so its not really that great
+//you can now make targeted item abilities
+//item abilities also now check for statuses like stunned, and do a restrained check on the mob too
+//also hopefully optimised it a tiny bit?
 
 //oh my god what the fuck is going on in this file jesus wow
 //save me from this freak horror show aaaaaa
@@ -99,6 +102,7 @@
 						spraybits -= SP
 						qdel(SP)
 				sleep(5)
+		..()
 
 	OnDrop()
 		if (the_mob) the_mob.transforming = 0
@@ -136,6 +140,7 @@
 			icon_state = "welddown"
 
 			W.flip_up()
+		..()
 
 ////////////////////////////////////////////////////////////
 
@@ -151,6 +156,7 @@
 		var/obj/item/tank/T = the_item
 		if (!T) return
 		T.toggle_valve() // the tank valve toggle handles the icon updates since its also used by tank/Topic
+		..()
 
 ////////////////////////////////////////////////////////////
 ///////////Sonic + Rocket Shoe Abilities & Smoke////////////
@@ -231,6 +237,7 @@
 					sleep(1)
 
 			the_mob.throw_at(curr, 16, 3)
+			..()
 
 
 /obj/ability_button/sonic
@@ -258,6 +265,7 @@
 						pool(A)
 				if (!step(the_mob, the_mob.dir) && R.sonicbreak) break
 				sleep(10 - R.soniclevel)
+			..()
 
 /obj/effect/smoketemp
 	name = "smoke"
@@ -287,6 +295,7 @@
 	execute_ability()
 		var/obj/item/storage/belt/utility/ceshielded/C = the_item
 		C.toggle()
+		..()
 		//if(C.active) icon_state = "shieldceoff"
 		//else icon_state = "shieldceon"
 
@@ -303,6 +312,7 @@
 		J.attack_self(the_mob)
 		if(J.on) icon_state = "off"
 		else  icon_state = "on"
+		..()
 
 ////////////////////////////////////////////////////////////
 
@@ -317,6 +327,7 @@
 		J.flashlight_toggle(the_mob)
 		if (J.on) src.icon_state = "off"
 		else  src.icon_state = "on"
+		..()
 
 ////////////////////////////////////////////////////////////
 
@@ -331,6 +342,7 @@
 		J.flashlight_toggle(the_mob)
 		if (J.on) src.icon_state = "off"
 		else  src.icon_state = "on"
+		..()
 
 ////////////////////////////////////////////////////////////
 
@@ -343,6 +355,7 @@
 		J.attack_self(the_mob)
 		if(J.on) icon_state = "off"
 		else  icon_state = "on"
+		..()
 
 ////////////////////////////////////////////////////////////
 
@@ -355,6 +368,7 @@
 		J.attack_self(the_mob)
 		if(J.on) icon_state = "meson1"
 		else  icon_state = "meson0"
+		..()
 
 ////////////////////////////////////////////////////////////
 
@@ -367,6 +381,7 @@
 		J.toggle()
 		if(J.on) icon_state = "jet2off"
 		else  icon_state = "jet2on"
+		..()
 
 /obj/ability_button/jetpack_toggle
 	name = "Toggle jetpack"
@@ -377,6 +392,7 @@
 		J.toggle()
 		if(J.on) icon_state = "jetoff"
 		else  icon_state = "jeton"
+		..()
 
 ////////////////////////////////////////////////////////////
 
@@ -388,6 +404,7 @@
 		var/obj/item/clothing/shoes/jetpack/J = the_item
 		J.toggle()
 		icon_state = "jet[J.on ? "off" : "on"]"
+		..()
 
 ////////////////////////////////////////////////////////////
 
@@ -400,6 +417,7 @@
 		if (!istype(M)) return
 		M.toggleHighPower()
 		icon_state = "magtractor[M.highpower]"
+		..()
 
 /obj/ability_button/magtractor_drop
 	name = "Release Item"
@@ -412,6 +430,7 @@
 			return
 		if (M.releaseItem() && !M.holding)
 			icon_state = "mag_drop0"
+		..()
 
 ////////////////////////////////////////////////////////////
 
@@ -446,6 +465,8 @@
 		the_mob:rush()
 		icon_state = "rushoff"
 		return 1
+
+		..()
 
 	on_cooldown()
 		..()
@@ -489,47 +510,49 @@
 			else
 				usr.client.view = "15x15"
 				icon_state = "airoff"
+		..()
 
 ////////////////////////////////////////////////////////////
 
 /* this version moves the center of your view */
 
 /obj/ability_button/scope_toggle
-    name = "Toggle Scope"
-    var/off_icon = "northoff"
-    var/on_icon = "northon"
-    var/distance = 200
-    var/x_mult = 0
-    var/y_mult = 0
-    var/zoomed = 0
+	name = "Toggle Scope"
+	var/off_icon = "northoff"
+	var/on_icon = "northon"
+	var/distance = 200
+	var/x_mult = 0
+	var/y_mult = 0
+	var/zoomed = 0
 
-    New()
-        icon_state = off_icon
-        ..()
+	New()
+		icon_state = off_icon
+		..()
 
-    OnDrop()
-        set_zoom(0)
-        ..()
+	OnDrop()
+		set_zoom(0)
+		..()
 
-    execute_ability()
-        set_zoom(!zoomed)
+	execute_ability()
+		set_zoom(!zoomed)
+		..()
 
 /obj/ability_button/scope_toggle/proc/set_zoom(var/new_zoomed)
-    if(new_zoomed == zoomed)
-        return
-    if(new_zoomed) // we unzoom all the other buttons
-        for(var/obj/ability_button/scope_toggle/S in the_item.ability_buttons)
-            S.set_zoom(0)
-    zoomed = new_zoomed
-    if(zoomed)
-        usr.client.pixel_x += distance * x_mult
-        usr.client.pixel_y += distance * y_mult
-        icon_state = on_icon
-		//todo playsound here
-    else
-        usr.client.pixel_x -= distance * x_mult
-        usr.client.pixel_y -= distance * y_mult
-        icon_state = off_icon
+	if(new_zoomed == zoomed)
+		return
+	if(new_zoomed) // we unzoom all the other buttons
+		for(var/obj/ability_button/scope_toggle/S in the_item.ability_buttons)
+			S.set_zoom(0)
+			zoomed = new_zoomed
+			if(zoomed)
+				usr.client.pixel_x += distance * x_mult
+				usr.client.pixel_y += distance * y_mult
+				icon_state = on_icon
+			//todo playsound here
+			else
+				usr.client.pixel_x -= distance * x_mult
+				usr.client.pixel_y -= distance * y_mult
+				icon_state = off_icon
 
 /obj/ability_button/scope_toggle/north
 	name = "Zoom North"
@@ -566,6 +589,7 @@
 		//var/mob/M = holder.owner
 		usr.set_eye(null)
 		usr.client.view = world.view
+		..()
 
 //////////////////////////////////////////////////////////////////////////////
 /mob/var/list/item_abilities = new/list()
@@ -690,6 +714,7 @@
 		if(!the_mob) return
 		the_mob.item_abilities = list()
 
+//HEY this should be moved over to use /obj/screen/ability_button but it breaks a few paths and needs different procs and its outta my depth tbh
 /obj/ability_button
 	name = "baseButton"
 	desc = ""
@@ -703,17 +728,23 @@
 	var/cooldown = 0
 	var/last_use_time = 0
 
+	var/targeted = 0 //does clicking this let you click on something to target it?
+	var/target_anything = 0 //can you target any atom, not just people
+
 	var/obj/item/the_item = null
 	var/mob/the_mob = null
 
-	Click()
-		if(ability_allowed())
-			if(execute_ability())
-				last_use_time = world.time
-
-				//I'm hideous, don't look at meeeeeee!
-				SPAWN_DBG(cooldown)
-					on_cooldown()
+	RawClick()
+		if(src.ability_allowed())
+			if (src.targeted)
+				if (src.the_mob.targeting_ability)
+					src.the_mob.targeting_ability = null
+					src.the_mob.update_cursor()
+					return
+				src.the_mob.targeting_ability = src
+				src.the_mob.update_cursor()
+			else
+				src.execute_ability()
 
 	attackby()
 		return
@@ -734,13 +765,26 @@
 		if (usr.client.tooltipHolder)
 			usr.client.tooltipHolder.hideHover()
 
+	disposing() //probably best to do this?
+		if (src.the_item)
+			src.the_item = null
+		if (src.the_mob)
+			src.the_mob = null
+		..()
+
 	proc/ability_allowed()
-		if (!the_item)
+		if (!src.the_item)
 			return 0
-		if (!the_mob || !the_mob.canmove)
+		if (!src.the_mob || !src.the_mob.canmove)
 			return 0
-		if (cooldown > 0 && ( last_use_time + cooldown ) > world.time)
-			boutput(the_mob, "<span style=\"color:red\">This ability is recharging. ([round((cooldown/10)-((world.time - last_use_time)/10))] seconds left)</span>")
+		if (src.the_mob.hasStatus("paralysis") || src.the_mob.hasStatus("stunned") || src.the_mob.hasStatus("weakened")) //stun check
+			return 0
+		if (src.the_mob && ishuman(src.the_mob)) //cuff, straightjacket, nolimb check
+			var/mob/living/carbon/human/H = the_mob
+			if (H.restrained())
+				return 0
+		if (src.cooldown > 0 && ( src.last_use_time + cooldown ) > world.time)
+			boutput(src.the_mob, "<span style=\"color:red\">This ability is recharging. ([round((src.cooldown/10)-((world.time - src.last_use_time)/10))] seconds left)</span>")
 			return 0
 		return 1
 
@@ -748,8 +792,39 @@
 	proc/on_cooldown()
 		return
 
+	//please call back to parent to trigger handle cooldown
 	proc/execute_ability()
 		return
 
 	proc/OnDrop()
 		return
+
+	proc/handle_cooldown() //copy and pasted from Click() - which is dead now
+		if (src.cooldown)
+			src.last_use_time = world.time
+			sleep(src.cooldown)
+			src.on_cooldown()
+
+/obj/item/space_thing/ability_thing //testing, debug, please remove
+	name = "ability_thing"
+	abilities = list(/obj/ability_button/testing)
+	ability_buttons = list()
+
+	New()
+		..()
+
+	attack_self(mob/user as mob)
+		if (src.ability_buttons.len)
+			var/obj/ability_button/AB = ability_buttons[1]
+			AB.the_mob = user
+
+/obj/ability_button/testing
+	name = "testing"
+	icon_state = "jeton"
+	targeted = 1
+
+	execute_ability(var/atom/target)
+		if (target == src)
+			return
+		boutput(src.the_mob, "[target] fuck")
+		..()

--- a/code/WorkInProgress/DaerenReligionOverhaul.dm
+++ b/code/WorkInProgress/DaerenReligionOverhaul.dm
@@ -10,7 +10,7 @@
 		if (spell.targeted)
 			if (world.time < spell.last_cast)
 				return
-			usr:targeting_spell = owner
+			usr.targeting_ability = owner
 			usr.update_cursor()
 		else
 			SPAWN_DBG(0)

--- a/code/WorkInProgress/GerhazoStuff.dm
+++ b/code/WorkInProgress/GerhazoStuff.dm
@@ -50,7 +50,7 @@
 			deflecting_sword = src.r_hand
 		else if(istype(src.l_hand, /obj/item/sword))
 			deflecting_sword = src.l_hand
-			
+
 		if(deflecting_sword)
 			if(deflecting_sword.active == 0)  // turn the sword on if it's off
 				deflecting_sword.attack_self(src)
@@ -114,14 +114,14 @@
 		if (!isturf(owner.holder.owner.loc))
 			boutput(owner.holder.owner, "<span style=\"color:red\">You can't use this spell here.</span>")
 			return
-		if (spell.targeted && usr:targeting_spell == owner)
-			usr:targeting_spell = null
+		if (spell.targeted && usr.targeting_ability == owner)
+			usr.targeting_ability = null
 			usr.update_cursor()
 			return
 		if (spell.targeted)
 			if (world.time < spell.last_cast)
 				return
-			owner.holder.owner.targeting_spell = owner
+			owner.holder.owner.targeting_ability = owner
 			owner.holder.owner.update_cursor()
 		else
 			SPAWN_DBG(0)
@@ -181,7 +181,7 @@
 		if (..())
 			return 1
 
-		
+
 		if(!istype(holder.owner, /mob/living/carbon/human/cyalume_knight))
 			boutput(holder.owner, "<span style=\"color:red\">You aren't a true cyalume knight to be able to recall your sword!</span>")
 			return 1
@@ -331,7 +331,7 @@
 		M.visible_message("<span style=\"color:red\"><b>[M] starts to release a storm of lightning from his hands!</b></span>")
 
 		actions.start(new/datum/action/bar/icon/force_lightning_action(M,holder,target_turf,src,lightning_targets), M)
-		
+
 /datum/action/bar/icon/force_lightning_action // UNLIMITED POWER
 	duration = 5
 	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
@@ -343,7 +343,7 @@
 	var/turf/HH
 	var/datum/targetable/cyalume_knight/force_lightning/lightningability
 	var/list/lightning_targets
-	
+
 
 	New(user,knightabilityholder,targetturf,lightningabil,potentiallightningtargets)
 		M = user
@@ -425,7 +425,7 @@
 			return 1
 
 		var/mob/living/M = holder.owner
-		
+
 		var/mob/living/mob_target = target
 
 		var/original_pixel_y = mob_target.pixel_y
@@ -445,7 +445,7 @@
 		mob_target.losebreath += 10
 
 		actions.start(new/datum/action/bar/icon/force_choke_action(M,holder,mob_target,src,original_pixel_y), M)
-		
+
 
 /datum/action/bar/icon/force_choke_action
 	duration = 50
@@ -458,7 +458,7 @@
 	var/mob/living/HH
 	var/datum/targetable/cyalume_knight/force_choke/chokeability
 	var/original_pixel_y
-	
+
 
 	New(user,knightabilityholder,targetmob,chokeabil,potentiallightningtargets,origpixely)
 		M = user
@@ -487,7 +487,7 @@
 		if(M == null || chokeability == null)
 			interrupt(INTERRUPT_ALWAYS)
 			return
-		
+
 		if(HH.losebreath < 8)
 			HH.losebreath += 5
 			HH.visible_message("<span style=\"color:red\"><b>[HH] is grasping their neck desperately trying to breathe in!</b></span>", "<span style=\"color:red\"><b>Something is constricting your throat, you cannot breathe!</b></span>")
@@ -527,7 +527,7 @@
 		M.visible_message("<span style=\"color:red\"><b>[M] stands still, focused in meditation!</b></span>", "<span style=\"color:red\"><b>You begin meditation.</b></span>")
 
 		actions.start(new/datum/action/bar/icon/force_heal_action(M,holder,src), M)
-		
+
 /datum/action/bar/icon/force_heal_action
 	duration = 50
 	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
@@ -537,7 +537,7 @@
 	var/mob/living/carbon/human/M
 	var/datum/abilityHolder/cyalume_knight/H
 	var/datum/targetable/cyalume_knight/force_choke/healability
-	
+
 	New(user,knightabilityholder,healabil)
 		M = user
 		H = knightabilityholder
@@ -563,7 +563,7 @@
 		if(M == null || healability == null)
 			interrupt(INTERRUPT_ALWAYS)
 			return
-		
+
 		if (M.get_burn_damage() > 0 || M.get_toxin_damage() > 0 || M.get_brute_damage() > 0 || M.get_oxygen_deprivation() > 0 || M.losebreath > 0)
 			M.HealDamage("All", 15, 15)
 			M.take_toxin_damage(-15)

--- a/code/WorkInProgress/actuallyKeelinsStuff.dm
+++ b/code/WorkInProgress/actuallyKeelinsStuff.dm
@@ -794,7 +794,7 @@ var/list/electiles = list()
 
 	var/mob/M = usr
 	var/datum/targetable/cincam/R = new()
-	M.targeting_spell = R
+	M.targeting_ability = R
 	M.update_cursor()
 
 /datum/targetable/cincam
@@ -1642,14 +1642,14 @@ var/list/electiles = list()
 		dothepixelthing(selected)
 		var/mob/M = usr
 		var/datum/targetable/pixelpicker/R = new()
-		M.targeting_spell = R
+		M.targeting_ability = R
 		M.update_cursor()
 		return 1
 
 /proc/pixelmagic()
 	var/mob/M = usr
 	var/datum/targetable/pixelpicker/R = new()
-	M.targeting_spell = R
+	M.targeting_ability = R
 	M.update_cursor()
 
 /proc/dothepixelthing(var/atom/A)
@@ -2992,7 +2992,7 @@ var/list/electiles = list()
 			var/mob/M = usr
 			if (istype(M))
 				var/datum/targetable/portalpickerOrigin/R = new()
-				M.targeting_spell = R
+				M.targeting_ability = R
 				M.update_cursor()
 				R.target = selected
 				return
@@ -3016,13 +3016,13 @@ var/list/electiles = list()
 			if (alert == "Yes")
 				var/datum/targetable/portalpickerOrigin/R = new()
 				alert("Click on where you want your portal to be placed",,"Ok")
-				M.targeting_spell = R
+				M.targeting_ability = R
 				M.update_cursor()
 				R.target = selected
 				return
 			else if (alert == "No")
 				var/datum/targetable/portalpickerTarget/R = new()
-				M.targeting_spell = R
+				M.targeting_ability = R
 				M.update_cursor()
 			else
 				return
@@ -3036,7 +3036,7 @@ var/list/electiles = list()
 	if (istype(M))
 		alert("Click on where you want your portal to end up at",,"Ok")
 		var/datum/targetable/portalpickerTarget/R = new()
-		M.targeting_spell = R
+		M.targeting_ability = R
 		M.update_cursor()
 		return
 
@@ -3319,7 +3319,7 @@ var/list/electiles = list()
 			if(range == 1) boutput(user, "<span style=\"color:red\">You slip...</span>")
 			user.layer = MOB_LAYER
 			user.buckled = null
-			if (user.targeting_spell == user.chair_flip_ability) //we havent chair flipped, just do normal jump
+			if (user.targeting_ability == user.chair_flip_ability) //we havent chair flipped, just do normal jump
 				user.throw_at(target, 5, 1)
 				user:changeStatus("weakened", 2 SECONDS)
 			user.end_chair_flip_targeting()

--- a/code/datums/abilities/ability_parent.dm
+++ b/code/datums/abilities/ability_parent.dm
@@ -322,10 +322,10 @@
 						T.handleCast()
 						return
 					else
-						if(usr.targeting_spell == T)
-							usr.targeting_spell = null
+						if(usr.targeting_ability == T)
+							usr.targeting_ability = null
 						else
-							usr.targeting_spell = T
+							usr.targeting_ability = T
 						usr.update_cursor()
 					T.holder.updateButtons()
 					return 1
@@ -624,8 +624,8 @@
 		var/mob/user = holder.owner
 
 		if(parameters["left"])
-			if (owner.targeted && user.targeting_spell == owner)
-				user.targeting_spell = null
+			if (owner.targeted && user.targeting_ability == owner)
+				user.targeting_ability = null
 				user.update_cursor()
 				return
 
@@ -685,7 +685,7 @@
 						owner.handleCast()
 						return
 					else
-						user.targeting_spell = owner
+						user.targeting_ability = owner
 						user.update_cursor()
 		else if(parameters["middle"])
 			if(owner.waiting_for_hotkey)
@@ -1038,7 +1038,7 @@
 				x_occupied = H.x_occupied
 				y_occupied = H.y_occupied
 				any_abilities_displayed = any_abilities_displayed || H.any_abilities_displayed
-	
+
 	click(atom/target, params)
 		// ok, this is not ideal since each ability holder has its own keybinds. That sucks and should be reworked
 		. = 0

--- a/code/datums/abilities/brassgauntlet.dm
+++ b/code/datums/abilities/brassgauntlet.dm
@@ -42,6 +42,7 @@
 				L.friends = list(usr)
 				L.original_object = I
 				animate_float(L, -1, 30)
+		..()
 		return 1
 
 //Power Stone
@@ -53,6 +54,7 @@
 	execute_ability()
 		//Presumably explode a dude
 		boutput(the_mob, "<span style='color:red'>You totally would've exploded a dude. If it was implemented. This power stone is kinda chumpy, huh?</span>")
+		..()
 		return 1
 
 //Time Stone
@@ -67,6 +69,7 @@
 		SPAWN_DBG(0)
 			usr.full_heal()
 			timeywimey(100)
+		..()
 		return 1
 
 //Reality Stone
@@ -107,7 +110,7 @@
 
 			for(var/turf/T in affected)
 				animate(T)
-
+		..()
 		return 1
 
 ///////////////////////////////////////
@@ -185,7 +188,7 @@
 					if(prob(30))
 						boutput(usr,"<span style=\"color:red\"><B>The stone rejects you and backfires.</B></span>")
 						usr.owlgib()
-
+		..()
 		return 1
 
 
@@ -235,7 +238,7 @@
 							make_cleanable( /obj/decal/cleanable/blood/gibs,T)
 						else
 							make_cleanable( /obj/decal/cleanable/vomit,T) //Oh geez the janitor will not be happy
-
+		..()
 		return 1
 
 

--- a/code/datums/abilities/critter.dm
+++ b/code/datums/abilities/critter.dm
@@ -7,18 +7,19 @@
 			return
 		if (!isturf(usr.loc))
 			return
-		if (spell.targeted && usr:targeting_spell == owner)
-			usr:targeting_spell = null
+		if (spell.targeted && usr.targeting_ability == owner)
+			usr.targeting_ability = null
 			usr.update_cursor()
 			return
 		if (spell.targeted)
 			if (world.time < spell.last_cast)
 				return
-			usr:targeting_spell = owner
+			usr.targeting_ability = owner
 			usr.update_cursor()
 		else
 			SPAWN_DBG(0)
 				spell.handleCast()
+		return
 
 /datum/abilityHolder/critter
 	usesPoints = 0

--- a/code/datums/abilities/cruiser.dm
+++ b/code/datums/abilities/cruiser.dm
@@ -15,19 +15,19 @@
 				return
 			if (!spell.holder)
 				return
-			if (spell.targeted && usr:targeting_spell == owner)
-				usr:targeting_spell = null
+			if (spell.targeted && usr.targeting_ability == owner)
+				usr.targeting_ability = null
 				usr.update_cursor()
 				return
 			if (spell.targeted)
 				if (world.time < spell.last_cast)
 					return
-				usr:targeting_spell = owner
+				usr.targeting_ability = owner
 				usr.update_cursor()
-				return
 			else
 				SPAWN_DBG(0)
 					spell.handleCast()
+			return
 
 		owner.holder.updateButtons()
 

--- a/code/datums/abilities/diabolical.dm
+++ b/code/datums/abilities/diabolical.dm
@@ -26,14 +26,14 @@
 		if (!isturf(owner.holder.owner.loc))
 			boutput(owner.holder.owner, "<span style=\"color:red\">You can't use this ability here.</span>")
 			return
-		if (spell.targeted && usr:targeting_spell == owner)
-			usr:targeting_spell = null
+		if (spell.targeted && usr.targeting_ability == owner)
+			usr.targeting_ability = null
 			usr.update_cursor()
 			return
 		if (spell.targeted)
 			if (world.time < spell.last_cast)
 				return
-			owner.holder.owner.targeting_spell = owner
+			owner.holder.owner.targeting_ability = owner
 			owner.holder.owner.update_cursor()
 		else
 			SPAWN_DBG(0)

--- a/code/datums/abilities/generic.dm
+++ b/code/datums/abilities/generic.dm
@@ -10,13 +10,13 @@
 			chair_flip_ability = src.abilityHolder.addAbility(/datum/targetable/chairflip)
 
 		chair_flip_ability.extrarange = extrarange
-		src.targeting_spell = chair_flip_ability
+		src.targeting_ability = chair_flip_ability
 		src.update_cursor()
 
 		playsound(src.loc, "sound/effects/chair_step.ogg", 50, 1)
 
 /mob/proc/end_chair_flip_targeting()
-	src.targeting_spell = null
+	src.targeting_ability = null
 	src.update_cursor()
 	if (src.chair_flip_ability)
 		src.chair_flip_ability.extrarange = 0
@@ -81,7 +81,7 @@
 		M.buckled = null
 		M.anchored = 0
 
-		M.targeting_spell = null
+		M.targeting_ability = null
 		M.update_cursor()
 
 		if (ishuman(M))

--- a/code/datums/abilities/hunter.dm
+++ b/code/datums/abilities/hunter.dm
@@ -234,14 +234,14 @@
 		if (!isturf(owner.holder.owner.loc))
 			boutput(owner.holder.owner, "<span style=\"color:red\">You can't use this ability here.</span>")
 			return
-		if (spell.targeted && usr:targeting_spell == owner)
-			usr:targeting_spell = null
+		if (spell.targeted && usr.targeting_ability == owner)
+			usr.targeting_ability = null
 			usr.update_cursor()
 			return
 		if (spell.targeted)
 			if (world.time < spell.last_cast)
 				return
-			owner.holder.owner.targeting_spell = owner
+			owner.holder.owner.targeting_ability = owner
 			owner.holder.owner.update_cursor()
 		else
 			SPAWN_DBG(0)

--- a/code/datums/abilities/kudzumen.dm
+++ b/code/datums/abilities/kudzumen.dm
@@ -22,14 +22,14 @@
 		if (!isturf(owner.holder.owner.loc))
 			boutput(owner.holder.owner, "<span style=\"color:red\">You can't use this spell here.</span>")
 			return
-		if (spell.targeted && usr:targeting_spell == owner)
-			usr:targeting_spell = null
+		if (spell.targeted && usr.targeting_ability == owner)
+			usr.targeting_ability = null
 			usr.update_cursor()
 			return
 		if (spell.targeted)
 			if (world.time < spell.last_cast)
 				return
-			owner.holder.owner.targeting_spell = owner
+			owner.holder.owner.targeting_ability = owner
 			owner.holder.owner.update_cursor()
 		else
 			SPAWN_DBG(0)

--- a/code/datums/abilities/vampire.dm
+++ b/code/datums/abilities/vampire.dm
@@ -175,14 +175,14 @@
 		if (!isturf(owner.holder.owner.loc))
 			boutput(owner.holder.owner, "<span style=\"color:red\">You can't use this spell here.</span>")
 			return
-		if (spell.targeted && usr:targeting_spell == owner)
-			usr:targeting_spell = null
+		if (spell.targeted && usr.targeting_ability == owner)
+			usr.targeting_ability = null
 			usr.update_cursor()
 			return
 		if (spell.targeted)
 			if (world.time < spell.last_cast)
 				return
-			owner.holder.owner.targeting_spell = owner
+			owner.holder.owner.targeting_ability = owner
 			owner.holder.owner.update_cursor()
 		else
 			SPAWN_DBG(0)

--- a/code/datums/abilities/vampiric_zombie.dm
+++ b/code/datums/abilities/vampiric_zombie.dm
@@ -48,15 +48,15 @@
 		if (!isturf(owner.holder.owner.loc))
 			boutput(owner.holder.owner, "<span style=\"color:red\">You can't use this spell here.</span>")
 			return
-		if (spell.targeted && usr:targeting_spell == owner)
-			usr:targeting_spell = null
+		if (spell.targeted && usr.targeting_ability == owner)
+			usr.targeting_ability = null
 			usr.update_cursor()
 			return
 		if (spell.targeted)
 			if (world.time < spell.last_cast)
 				return
-			owner.holder.owner.targeting_spell = owner
-			owner.holder.owner.update_cursor()
+			usr.targeting_ability = owner
+			usr.update_cursor()
 		else
 			SPAWN_DBG(0)
 				spell.handleCast()

--- a/code/datums/abilities/werewolf.dm
+++ b/code/datums/abilities/werewolf.dm
@@ -332,15 +332,15 @@
 		if (!isturf(owner.holder.owner.loc))
 			boutput(owner.holder.owner, "<span style=\"color:red\">You can't use this ability here.</span>")
 			return
-		if (spell.targeted && usr:targeting_spell == owner)
-			usr:targeting_spell = null
+		if (spell.targeted && usr.targeting_ability == owner)
+			usr.targeting_ability = null
 			usr.update_cursor()
 			return
 		if (spell.targeted)
 			if (world.time < spell.last_cast)
 				return
-			owner.holder.owner.targeting_spell = owner
-			owner.holder.owner.update_cursor()
+			usr.targeting_ability = owner
+			usr.update_cursor()
 		else
 			SPAWN_DBG(0)
 				spell.handleCast()

--- a/code/datums/abilities/wizard.dm
+++ b/code/datums/abilities/wizard.dm
@@ -166,15 +166,15 @@
 			return
 		if (world.time < spell.last_cast)
 			return
-		if (spell.targeted && usr:targeting_spell == owner)
-			usr:targeting_spell = null
+		if (spell.targeted && usr.targeting_ability == owner)
+			usr.targeting_ability = null
 			usr.update_cursor()
 			return
 		var/mob/user = spell.holder.owner
 		if (!istype(spell, /datum/targetable/spell/prismatic_spray/admin) && !user.wizard_castcheck(spell.offensive))
 			return
 		if (spell.targeted)
-			usr:targeting_spell = owner
+			usr.targeting_ability = owner
 			usr.update_cursor()
 		else
 			SPAWN_DBG(0)

--- a/code/datums/abilities/wrestler.dm
+++ b/code/datums/abilities/wrestler.dm
@@ -91,8 +91,8 @@
 			if (!isturf(owner.holder.owner.loc))
 				boutput(owner.holder.owner, "<span style=\"color:red\">You can't use this ability here.</span>")
 				return
-		if (spell.targeted && usr:targeting_spell == owner)
-			usr:targeting_spell = null
+		if (spell.targeted && usr.targeting_ability == owner)
+			usr.targeting_ability = null
 			usr.update_cursor()
 			return
 
@@ -102,7 +102,7 @@
 		if (spell.targeted || use_targeted == 1)
 			if (world.time < spell.last_cast)
 				return
-			owner.holder.owner.targeting_spell = owner
+			owner.holder.owner.targeting_ability = owner
 			owner.holder.owner.update_cursor()
 		else
 			SPAWN_DBG(0)

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -815,7 +815,7 @@
 					R = new()
 				R.target = D
 				R.varname = variable
-				M.targeting_spell = R
+				M.targeting_ability = R
 				M.update_cursor()
 				return
 

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -2900,5 +2900,3 @@
 		src.mind.damned = 1
 
 	return 1
-
-// /mob/proc/set_targeting_ability(var/path)

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -12,7 +12,8 @@
 
 	var/datum/abilityHolder/abilityHolder = null
 	var/datum/bioHolder/bioHolder = null
-	var/datum/targetable/targeting_spell = null
+
+	var/targeting_ability = null
 
 	var/last_move_trigger = 0
 
@@ -307,6 +308,9 @@
 
 	if (src.abilityHolder)
 		src.abilityHolder.disposing()
+
+	if (src.targeting_ability)
+		src.targeting_ability = null
 
 	if (zone_sel)
 		if (zone_sel.master == src)
@@ -713,7 +717,7 @@
 		src.client.mouse_pointer_icon = cursor
 
 /mob/proc/update_cursor()
-	if (src.targeting_spell)
+	if (src.targeting_ability)
 		if(client)
 			src.set_cursor(cursors_selection[client.preferences.target_cursor])
 			return
@@ -1065,54 +1069,79 @@
 /mob/proc/click(atom/target, params)
 	actions.interrupt(src, INTERRUPT_ACT) //Definitely not the best place for this.
 
-	if (src.targeting_spell)
-		var/datum/targetable/S = src.targeting_spell
+	if (src.targeting_ability)
+		if (istype(src.targeting_ability, /datum/targetable))
+			var/datum/targetable/S = src.targeting_ability
+			src.targeting_ability = null
+			update_cursor()
 
-		src.targeting_spell = null
-		update_cursor()
+			if (!S.target_anything && !ismob(target))
+				src.show_text("You have to target a person.", "red")
+				if(S.sticky)
+					src.targeting_ability = S
+					update_cursor()
+				return 100
+			if (!S.target_in_inventory && !isturf(target.loc) && !isturf(target))
+				if(S.sticky)
+					src.targeting_ability = S
+					update_cursor()
+				return 100
+			if (S.target_in_inventory && ( get_dist(src, target) > 1 && !isturf(target) && !isturf(target.loc)))
+				if(S.sticky)
+					src.targeting_ability = S
+					update_cursor()
+				return 100
+			if (S.check_range && (get_dist(src, target) > S.max_range))
+				src.show_text("You are too far away from the target.", "red") // At least tell them why it failed.
+				if(S.sticky)
+					src.targeting_ability = S
+					update_cursor()
+				return 100
+			if (!S.can_target_ghosts && ismob(target) && (!isliving(target) || iswraith(target) || isintangible(target)))
+				src.show_text("It would have no effect on this target.", "red")
+				if(S.sticky)
+					src.targeting_ability = S
+					update_cursor()
+				return 100
+			if (!S.castcheck(src))
+				if(S.sticky)
+					src.targeting_ability = S
+					update_cursor()
+				return 100
+			actions.interrupt(src, INTERRUPT_ACTION)
+			SPAWN_DBG(0)
+				S.handleCast(target)
+				if(S)
+					if((S.ignore_sticky_cooldown && !S.cooldowncheck()) || (S.sticky && S.cooldowncheck()))
+						if(src)
+							src.targeting_ability = S
+							src.update_cursor()
+			return 100
 
-		if (!S.target_anything && !ismob(target))
-			src.show_text("You have to target a person.", "red")
-			if(S.sticky)
-				src.targeting_spell = S
-				update_cursor()
+		else if (istype(src.targeting_ability, /obj/ability_button))
+			var/obj/ability_button/B = src.targeting_ability
+
+			if (!B.target_anything && !ismob(target) && !istype(target, B))
+				src.show_text("You have to target a person.", "red")
+				src.targeting_ability = null
+				src.update_cursor()
+				return 100
+			if (!isturf(target.loc) && !isturf(target) && !istype(target, B))
+				src.targeting_ability = null
+				src.update_cursor()
+				return 100
+			if (!B.ability_allowed())
+				src.targeting_ability = null
+				src.update_cursor()
+				return 100
+			if (istype(target, B))
+				return 100
+			actions.interrupt(src, INTERRUPT_ACTION)
+			SPAWN_DBG(0)
+				B.execute_ability(target)
+				src.targeting_ability = null
+				src.update_cursor()
 			return 100
-		if (!S.target_in_inventory && !isturf(target.loc) && !isturf(target))
-			if(S.sticky)
-				src.targeting_spell = S
-				update_cursor()
-			return 100
-		if (S.target_in_inventory && ( get_dist(src, target) > 1 && !isturf(target) && !isturf(target.loc)))
-			if(S.sticky)
-				src.targeting_spell = S
-				update_cursor()
-			return 100
-		if (S.check_range && (get_dist(src, target) > S.max_range))
-			src.show_text("You are too far away from the target.", "red") // At least tell them why it failed.
-			if(S.sticky)
-				src.targeting_spell = S
-				update_cursor()
-			return 100
-		if (!S.can_target_ghosts && ismob(target) && (!isliving(target) || iswraith(target) || isintangible(target)))
-			src.show_text("It would have no effect on this target.", "red")
-			if(S.sticky)
-				src.targeting_spell = S
-				update_cursor()
-			return 100
-		if (!S.castcheck(src))
-			if(S.sticky)
-				src.targeting_spell = S
-				update_cursor()
-			return 100
-		actions.interrupt(src, INTERRUPT_ACTION)
-		SPAWN_DBG(0)
-			S.handleCast(target)
-			if(S)
-				if((S.ignore_sticky_cooldown && !S.cooldowncheck()) || (S.sticky && S.cooldowncheck()))
-					if(src)
-						src.targeting_spell = S
-						src.update_cursor()
-		return 100
 
 	if (abilityHolder)
 		if (abilityHolder.topBarRendered)
@@ -2871,3 +2900,5 @@
 		src.mind.damned = 1
 
 	return 1
+
+// /mob/proc/set_targeting_ability(var/path)

--- a/code/mob/dead.dm
+++ b/code/mob/dead.dm
@@ -19,7 +19,7 @@
 
 
 /mob/dead/click(atom/target, params)
-	if (targeting_spell)
+	if (targeting_ability)
 		..()
 	else
 		if (get_dist(src, target) > 0)

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -100,7 +100,7 @@
 	ai_target = null
 	ai_target_old.len = 0
 	move_laying = null
-	
+
 	qdel(chat_text)
 	chat_text = null
 
@@ -1189,8 +1189,8 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 			if (src.buckled)
 				src.buckled.attack_hand(src)
 				src.force_laydown_standup() //safety because buckle code is a mess
-				if (src.targeting_spell == src.chair_flip_ability) //fuCKKK
-					src.targeting_spell = null
+				if (src.targeting_ability == src.chair_flip_ability) //fuCKKK
+					src.targeting_ability = null
 					src.update_cursor()
 			else
 				if (!src.getStatusDuration("burning"))

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -1120,8 +1120,9 @@
 							goto showmessage
 
 
-					if (src.targeting_spell)
-						src.targeting_spell.flip_callback()
+					if (src.targeting_ability && istype(src.targeting_ability, /datum/targetable))
+						var/datum/targetable/D = src.targeting_ability
+						D.flip_callback()
 
 					if ((!istype(src.loc, /turf/space)) && (!src.on_chair))
 						if (!src.lying)

--- a/code/mob/living/carbon/human/virtual.dm
+++ b/code/mob/living/carbon/human/virtual.dm
@@ -148,14 +148,14 @@
 		if (!spell.holder)
 			return
 
-		if (spell.targeted && usr:targeting_spell == owner)
-			usr:targeting_spell = null
+		if (spell.targeted && usr.targeting_ability == owner)
+			usr.targeting_ability = null
 			usr.update_cursor()
 			return
 		if (spell.targeted)
 			if (world.time < spell.last_cast)
 				return
-			owner.holder.owner.targeting_spell = owner
+			owner.holder.owner.targeting_ability = owner
 			owner.holder.owner.update_cursor()
 		else
 			SPAWN_DBG(0)

--- a/code/mob/living/intangible/flockmob_parent.dm
+++ b/code/mob/living/intangible/flockmob_parent.dm
@@ -138,7 +138,7 @@ var/list/fuckedUpFlockVisionColorMatrix = list(\
 
 // C&P'd from dead.dm until I think of something better to do
 /mob/living/intangible/flock/click(atom/target, params)
-	if (targeting_spell)
+	if (targeting_ability)
 		..()
 	else
 		if (get_dist(src, target) > 0)

--- a/code/modules/admin/modifyvariables.dm
+++ b/code/modules/admin/modifyvariables.dm
@@ -100,7 +100,7 @@
 				var/datum/targetable/listrefpicker/R = new()
 				R.target = L
 				R.varname = index
-				M.targeting_spell = R
+				M.targeting_ability = R
 				M.update_cursor()
 			return
 
@@ -175,7 +175,7 @@
 			if (istype(M))
 				var/datum/targetable/addtolistrefpicker/R = new()
 				R.target = L
-				M.targeting_spell = R
+				M.targeting_ability = R
 				M.update_cursor()
 			return
 
@@ -369,7 +369,7 @@
 				var/datum/targetable/listrefpicker/R = new()
 				R.target = L
 				R.varname = variable_index
-				M.targeting_spell = R
+				M.targeting_ability = R
 				M.update_cursor()
 				return
 
@@ -629,7 +629,7 @@
 				var/datum/targetable/refpicker/R = new()
 				R.target = O
 				R.varname = variable
-				M.targeting_spell = R
+				M.targeting_ability = R
 				M.update_cursor()
 				return
 

--- a/code/modules/antagonists/changeling/abilities/changeling.dm
+++ b/code/modules/antagonists/changeling/abilities/changeling.dm
@@ -60,18 +60,19 @@
 		if (!isturf(owner.holder.owner.loc) && !spell.can_use_in_container)
 			boutput(owner.holder.owner, "<span style=\"color:red\">Using that in here will do just about no good for you.</span>")
 			return
-		if (spell.targeted && usr:targeting_spell == owner)
-			usr:targeting_spell = null
+		if (spell.targeted && usr.targeting_ability == owner)
+			usr.targeting_ability = null
 			usr.update_cursor()
 			return
 		if (spell.targeted)
 			if (world.time < spell.last_cast)
 				return
-			owner.holder.owner.targeting_spell = owner
+			owner.holder.owner.targeting_ability = owner
 			owner.holder.owner.update_cursor()
 		else
 			SPAWN_DBG(0)
 				spell.handleCast()
+		return
 
 /datum/abilityHolder/changeling
 	usesPoints = 1

--- a/code/modules/antagonists/grinch/abilities/grinch.dm
+++ b/code/modules/antagonists/grinch/abilities/grinch.dm
@@ -49,14 +49,14 @@
 		if (!isturf(owner.holder.owner.loc))
 			boutput(owner.holder.owner, "<span style=\"color:red\">You can't use this ability here.</span>")
 			return
-		if (spell.targeted && usr:targeting_spell == owner)
-			usr:targeting_spell = null
+		if (spell.targeted && usr.targeting_ability == owner)
+			usr.targeting_ability = null
 			usr.update_cursor()
 			return
 		if (spell.targeted)
 			if (world.time < spell.last_cast)
 				return
-			owner.holder.owner.targeting_spell = owner
+			owner.holder.owner.targeting_ability = owner
 			owner.holder.owner.update_cursor()
 		else
 			SPAWN_DBG(0)

--- a/code/modules/medical/genetics/baseBioeffect.dm
+++ b/code/modules/medical/genetics/baseBioeffect.dm
@@ -271,7 +271,7 @@ var/const/effectTypeFood = 4
 			owner.handleCast()
 			return
 		else
-			user.targeting_spell = owner
+			user.targeting_ability = owner
 			user.update_cursor()
 
 	get_controlling_mob()

--- a/code/modules/transport/cruisers/cruisers.dm
+++ b/code/modules/transport/cruisers/cruisers.dm
@@ -834,7 +834,7 @@
 	New()
 		. = ..()
 		START_TRACKING
-	
+
 	disposing()
 		. = ..()
 		STOP_TRACKING
@@ -1338,7 +1338,7 @@
 		//using.set_eye(null)
 		//using.client.view = world.view
 		if(ishuman(using) && istype(using.abilityHolder, /datum/abilityHolder/composite))
-			using.targeting_spell = null
+			using.targeting_ability = null
 			using.update_cursor()
 			var/datum/abilityHolder/composite/H = using.abilityHolder
 			AbHolder.suspendAllAbilities()

--- a/code/obj/item/deployable_turret.dm
+++ b/code/obj/item/deployable_turret.dm
@@ -232,7 +232,7 @@
 
 				user.show_message("<span style=\"color:blue\">Click where you want to aim the turret!</span>")
 				var/datum/targetable/deployable_turret_aim/A = new()
-				user.targeting_spell = A
+				user.targeting_ability = A
 				user.update_cursor()
 				A.my_turret = src
 				A.user_turf = get_turf(user)

--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -178,7 +178,7 @@
 				if (src.affecting.buckled)
 					src.affecting.buckled.attack_hand(src.assailant)
 					src.affecting.force_laydown_standup() //safety because buckle code is a mess
-					if (src.affecting.targeting_spell == src.affecting.chair_flip_ability) //fuCKKK
+					if (src.affecting.targeting_ability == src.affecting.chair_flip_ability) //fuCKKK
 						src.affecting.end_chair_flip_targeting()
 					src.affecting.buckled = null
 

--- a/code/obj/item/organ_holder.dm
+++ b/code/obj/item/organ_holder.dm
@@ -1221,14 +1221,14 @@
 			return
 		if (!isturf(usr.loc))
 			return
-		if (spell.targeted && usr:targeting_spell == owner)
-			usr:targeting_spell = null
+		if (spell.targeted && usr.targeting_ability == owner)
+			usr:targeting_ability = null
 			usr.update_cursor()
 			return
 		if (spell.targeted)
 			if (world.time < spell.last_cast)
 				return
-			usr:targeting_spell = owner
+			usr.targeting_ability = owner
 			usr.update_cursor()
 		else
 			SPAWN_DBG(0)


### PR DESCRIPTION
## About the PR

this is mostly behind the scenes work, so not anything hugely gameplay changing. this is partially a code cleanup in WorkInProgress/AbilityItem.dm, i didn't do a whole lot to it, but i think i made it a bit tidier. the big main thing is that i added the functionality to make targeted item abilities. so that whole system is a lot more robust (and i plan on using it for some upcoming content later). i also cleaned up a lot of usr:targeting_spell because targeting_spell is a variable on /mob so in pretty much every case, mob has that variable.

## Why's this needed?

this adds some pretty cool functionality to item abilities for the future potentially, and also cleans up a bit of code
