### PR TITLE
Added a "Report a Bug" verb to open GitHub issues in the browser.

### DIFF
--- a/code/interface.dm
+++ b/code/interface.dm
@@ -14,11 +14,17 @@
 				src.Browse(changelogHtml, "window=changes;size=500x650;title=Changelog;", 1)
 				src.changes = 1
 
-		bug_report()
+		bugreport()
 			set category = "Commands"
-			set name = "Report a Bug"
-			set desc = "Report a bug on GitHub in your browser (you'll need a GitHub account)"
-			src << link("https://github.com/goonstation/goonstation/issues")
+			set name = "bugreport"
+			set desc = "Report a bug."
+			set hidden = 1
+			if(alert(src, "Do you have a GitHub account?",,"Yes","No") == "Yes")
+				src << link("https://github.com/goonstation/goonstation/issues")
+			else
+				var/details_body = {"**Describe+the+bug**%0AA+clear+and+concise+description+of+what+the+bug+is.%0A%0A**To+Reproduce**%0ASteps+to+reproduce+the+behavior:%0A1.+Buy+a+Pizza+from+a+vending+machine%0A2.+Eat+the+pizza%0A3.+The+pizza+has+not+disappeared%0A4.+See+error%0A%0A**Expected+behavior**%0AA+clear+and+concise+description+of+what+you+expected+to+happen.%0A%0A**Screenshots**%0AIf+applicable,+add+screenshots+to+help+explain+your+problem.%0A%0A**Additional+context**%0AAdd+any+other+context+about+the+problem+here.%0A%0A"}
+				var/url = {"https://gitreports.com/issue/goonstation/goonstation?email_public=0&name=[src.ckey]&details=[details_body]%0AReported on: [config.server_name]+[time2text(world.realtime, "YYYY-MM-DD")]+[time2text(world.timeofday, "hh:mm:ss")]"}
+				src << link(url)
 
 		wiki()
 			set category = "Commands"

--- a/code/interface.dm
+++ b/code/interface.dm
@@ -14,6 +14,12 @@
 				src.Browse(changelogHtml, "window=changes;size=500x650;title=Changelog;", 1)
 				src.changes = 1
 
+		bug_report()
+			set category = "Commands"
+			set name = "Report a Bug"
+			set desc = "Report a bug on GitHub in your browser (you'll need a GitHub account)"
+			src << link("https://github.com/goonstation/goonstation/issues")
+
 		wiki()
 			set category = "Commands"
 			set name = "Wiki"

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1439,6 +1439,16 @@ window "rpane"
 		command = ".winset \"rpanewindow.left=infowindow\""
 		group = "rpanemode"
 		button-type = pushbox
+	elem "bugreportb"
+		type = BUTTON
+		pos = 380,5
+		size = 60x20
+		anchor1 = none
+		anchor2 = 100,0
+		saved-params = "is-checked"
+		text = "Bug Report"
+		command = "bugreport"
+		group = "rpaneutil"
 	elem "wikib"
 		type = BUTTON
 		pos = 445,5


### PR DESCRIPTION
## About the PR
Adds a verb to report bugs here on this very website! If you have a better idea on how to streamline the bug reporting process more please let me know / code it. Possibly a github bot that posts issues from in-game?

## Why's this needed?
We should streamline the process of reporting bugs as much as possible. Adding a verb to open github issues is not ideal because people might still feel intimidated by GitHub or annoyed that they need to make yet another account.