### PR TITLE
[Bugfix/Modification] Fixed sushi roller error and changed fish fillet food_color

### DIFF
--- a/code/modules/food_and_drink/ingredients.dm
+++ b/code/modules/food_and_drink/ingredients.dm
@@ -48,22 +48,22 @@
 	desc = "A slab of meat from a fish."
 	icon_state = "fillet_pink"
 	amount = 1
-	food_color = "#FF6699"
+	food_color = "#F4B4BC"
 	real_name = "fish"
 	salmon
 		name = "salmon fillet"
 		icon_state = "fillet_orange"
-		food_color = "#FF9900"
+		food_color = "#F29866"
 		real_name = "salmon"
 	white
 		name = "white fish fillet"
 		icon_state = "fillet_white"
-		food_color = "#FFFFFF"
+		food_color = "#FFECB7"
 		real_name = "white fish"
 	small
 		name = "small fish fillet"
 		icon_state = "fillet_small"
-		food_color = "#FFFFFF"
+		food_color = "#FFECB7"
 		real_name = "small fish"
 
 /obj/item/reagent_containers/food/snacks/ingredient/meat/synthmeat

--- a/code/obj/item/kitchen.dm
+++ b/code/obj/item/kitchen.dm
@@ -887,11 +887,14 @@ TRAYS
 						var/image/rolltopping = new /image('icons/obj/kitchen.dmi',"roll_topping-[i]")
 						switch(i)
 							if(1)
-								rolltopping.color = topping1.food_color
+								if(topping1)
+									rolltopping.color = topping1.food_color
 							if(2)
-								rolltopping.color = topping2.food_color
+								if(topping2)
+									rolltopping.color = topping2.food_color
 							if(3)
-								rolltopping.color = topping3.food_color
+								if(topping3)
+									rolltopping.color = topping3.food_color
 						src.UpdateOverlays(rolltopping,"roll_topping-[i]")
 					src.rolling = 0
 			else if(src.rolling == 0) //and out pops a sushi roll!


### PR DESCRIPTION
## About the PR
//Sushi rollers would behave strangely sometimes and spit out a null.food_color error occasionally. I still don't exactly know what causes the issue because it seems to be linked to byond memory management. I'll still look into it, but for now, I added some null checks to the topping food color check so it'll just sometimes spit out a blank sushi roll instead which is comparatively better. Also, I changed the food_color of the fish fillets to look more natural :)

- Fixed recurring error with sushi roller
- Updated fish fillet food_color

## Why's this needed?
- Runtime errors are evil.
