### PR TITLE
Clarify admins.txt instructions

### DIFF
--- a/config/admins.txt
+++ b/config/admins.txt
@@ -1,5 +1,5 @@
 #This is the file you modify if you want to make yourself an admin.
 #The available ranks can be found in /proc/rank_to_level().
-#Most of the time, you'll want to make yourself a Coder.
-#To do so, type your BYOND key with no spaces or capitals, a dash with spaces on both side, then the rank you want.
-#For example, the key "ZeWaka" would be given Coder rank like this: zewaka - Coder
+#Most of the time, you'll want to make yourself a Host.
+#To do so, type your BYOND key with no spaces, capitals or other punctuation (including underscores!), a dash with spaces on both side, then the rank you want.
+#For example, the key "ZeWaka" would be given Host rank like this: zewaka - Host


### PR DESCRIPTION
## About the PR

Changes instructions in admins.txt to indicate that punctuation and underscores should be scrubbed from ckeys, and to suggest changing your rank to "Host" instead of "Coder".

## Why's this needed?

Failing to remove punctuation or underscores is a common error, resolved hitherto by entering the Discord and asking manually; this change provides in-codebase instructions to avoid it. In addition, I'm not aware of any reason why the "Host" role would not be preferable, even if it does have very few advantages.
