### PR TITLE
Adds (+) to changelog syntax for minor changes which are collapsed by default.

### DIFF
--- a/browserassets/html/changelog.html
+++ b/browserassets/html/changelog.html
@@ -12,9 +12,43 @@
 	.log li.date {background: #f1f1f1; font-size: 1.1em; font-weight: bold; padding: 8px 5px; border-bottom: 2px solid #bbb;}
 	.log li.admin {font-size: 1.2em; padding: 5px 5px 5px 10px;}
 	.log li.admin span {color: #2A76E7;}
+	.log li.collapse-button { background: rgb(243, 243, 243); padding-left: 5px; cursor: pointer;}
+	.log .collapsible { max-height: 0; overflow: hidden; transition: max-height 0.2s ease-out;}
 
 	h3 {padding: 0 10px; margin: 0; color: #115FD5;}
 	.team, .lic {padding: 10px; margin: 0; line-height: 1.4;}
 	.lic {font-size: 0.9em;}
+
+	.collapse-button:before {
+		content: '\02795'; /* Unicode character for "plus" sign (+) */
+		font-size: 13px;
+		margin-right: 5px;
+	}
+
+	.active:before {
+		content: "\2796"; /* Unicode character for "minus" sign (-) */
+	}
+
+	li.collapse-button.active, li.collapse-button:hover {
+		background: rgb(225, 225, 225);
+	}
 </style>
+
+<script>
+window.onload = function(e) {
+	var coll = document.getElementsByClassName("collapse-button");
+	var i;
+	for (i = 0; i < coll.length; i++) {
+		coll[i].addEventListener("click", function() {
+			this.classList.toggle("active");
+			var content = this.nextElementSibling;
+			if (content.style.maxHeight){
+				content.style.maxHeight = null;
+			} else {
+				content.style.maxHeight = content.scrollHeight + "px";
+			}
+		});
+	}
+}
+</script>
 <!-- HTML GOES HERE -->


### PR DESCRIPTION
## About the PR
Similarly to `(*)` this PR adds `(+)` as a marker for minor changes to changelog.txt syntax. Those changes are automatically grouped up (along with their author names) at the end of the day and collapsed by default. Clicking on the "Minor Changes" button opens up this section.

## Why's this needed?
With the codebase being public we might get far more changes in the changelog and seeing the very minor tweaks and bugfixes only drives attention from the features and bigger changes.
