### PR TITLE
Last two fixes

### DIFF
--- a/code/WorkInProgress/AbilityItem.dm
+++ b/code/WorkInProgress/AbilityItem.dm
@@ -464,9 +464,9 @@
 
 		the_mob:rush()
 		icon_state = "rushoff"
-		return 1
 
 		..()
+		return 1
 
 	on_cooldown()
 		..()

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1202,7 +1202,8 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 	. = ..()
 	if(src && src.loc && (!istype(src.loc, /turf) || !istype(oldloc, /turf)))
 		if(src.chat_text.vis_locs.len)
-			src.chat_text.vis_locs[1].vis_contents -= src.chat_text
+			var/atom/movable/AM = src.chat_text.vis_locs[1]
+			AM.vis_contents -= src.chat_text
 		if(istype(src.loc, /turf))
 			src.vis_contents += src.chat_text
 		else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Last two outstanding dreamchecker diags, theres no non-awful solution to the vis_locs type hinting that wouldn't potentially cause bigger issues and this is the only code in all of byond that does `vis_locs[1].vis_contents`
<!-- Describe your Pull Request here. What does it change? What other things could this affect? -->
