### PR TITLE
Fixed a runtime error and made a quality of life improvement to plates

### DIFF
--- a/code/obj/item/kitchen.dm
+++ b/code/obj/item/kitchen.dm
@@ -511,6 +511,25 @@ TRAYS
 		return "[food_desc]"
 
 	attackby(obj/item/W as obj, mob/user as mob)
+		if (istype(W, /obj/item/plate) && !istype(W, /obj/item/plate/tray))
+			qdel(W)
+			src.set_loc(user)
+			user.put_in_hand_or_drop(new /obj/item/platestack)
+			user.visible_message("<b>[user]</b> adds a plate to the stack.","You add a plate to the stack.")
+			qdel(src)
+			return
+		else if (istype(W, /obj/item/platestack))
+			var/obj/item/platestack/stack = W
+			if(stack.platenum >= 7)
+				boutput(user,"<span style=\"color:red\"><b>The plates are piled too high!</b></span>")
+				return
+			src.set_loc(user)
+			stack.platenum++
+			stack.icon_state = "platestack[stack.platenum]"
+			stack.item_state = "platestack[stack.platenum]"
+			user.visible_message("<b>[user]</b> adds a plate to the stack.","You add a plate to the stack.")
+			qdel(src)
+			return
 		if (!W.edible)
 			if (istype(W, /obj/item/kitchen/utensil/fork) || istype(W, /obj/item/kitchen/utensil/spoon))
 				var/obj/item/reagent_containers/food/sel_food = input(user, "Which food do you want to eat?", "[src] Contents") as null|anything in ordered_contents
@@ -1017,6 +1036,8 @@ TRAYS
 	throw_impact(var/turf/T)
 		..()
 		var/list/throw_targets = list()
+		if(platenum == 0)
+			return
 		for(var/i=1,i<=platenum,i++)
 			throw_targets += get_offset_target_turf(src.loc, rand(3)-rand(3), rand(3)-rand(3))
 		platenum++

--- a/code/obj/item/kitchen.dm
+++ b/code/obj/item/kitchen.dm
@@ -49,14 +49,14 @@ TRAYS
 	var/rotatable = 1 //just in case future utensils are added that dont wanna be rotated
 
 	New()
-		if (prob(60))
+		if(prob(60))
 			src.pixel_y = rand(0, 4)
 		return
 
 	verb/rotate()
 		set name = "Rotate"
 		set category = "Local"
-		if (rotatable)
+		if(rotatable)
 			set src in oview(1)
 
 			src.dir = turn(src.dir, 90)
@@ -72,15 +72,15 @@ TRAYS
 	dir = NORTH
 
 	attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-		if (user && user.bioHolder.HasEffect("clumsy") && prob(50))
+		if(user && user.bioHolder.HasEffect("clumsy") && prob(50))
 			user.visible_message("<span style='color:red'><b>[user]</b> fumbles [src] and stabs \himself.</span>")
 			random_brute_damage(user, 10)
-		if (!saw_surgery(M,user)) // it doesn't make sense, no. but hey, it's something.
+		if(!saw_surgery(M,user)) // it doesn't make sense, no. but hey, it's something.
 			return ..()
 
 	custom_suicide = 1
 	suicide(var/mob/user as mob)
-		if (!src.user_can_suicide(user))
+		if(!src.user_can_suicide(user))
 			return 0
 		user.visible_message("<span style='color:red'><b>[user] stabs [src] right into [his_or_her(user)] heart!</b></span>")
 		blood_slash(user, 25)
@@ -97,13 +97,13 @@ TRAYS
 	throwforce = 1.0
 
 	attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-		if (user && user.bioHolder.HasEffect("clumsy") && prob(50))
+		if(user && user.bioHolder.HasEffect("clumsy") && prob(50))
 			user.visible_message("<span style=\"color:red\"><b>[user]</b> fumbles [src] and stabs \himself.</span>")
 			random_brute_damage(user, 5)
-		if (prob(20))
+		if(prob(20))
 			src.break_fork(user)
 			return
-		if (!saw_surgery(M,user))
+		if(!saw_surgery(M,user))
 			return ..()
 
 	proc/break_fork(mob/living/carbon/user as mob)
@@ -117,7 +117,7 @@ TRAYS
 		user.visible_message("<span style=\"color:red\"><b>[user] tries to stab [src] right into \his heart!</b></span>")
 		src.break_fork(user)
 		SPAWN_DBG(10 SECONDS)
-			if (user)
+			if(user)
 				user.suiciding = 0
 		return 1
 
@@ -141,15 +141,15 @@ TRAYS
 		src.setItemSpecial(/datum/item_special/double)
 
 	attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-		if (user && user.bioHolder.HasEffect("clumsy") && prob(50))
+		if(user && user.bioHolder.HasEffect("clumsy") && prob(50))
 			user.visible_message("<span style='color:red'><b>[user]</b> fumbles [src] and cuts \himself.</span>")
 			random_brute_damage(user, 20)
-		if (!scalpel_surgery(M,user))
+		if(!scalpel_surgery(M,user))
 			return ..()
 
 	custom_suicide = 1
 	suicide(var/mob/user as mob)
-		if (!src.user_can_suicide(user))
+		if(!src.user_can_suicide(user))
 			return 0
 		user.visible_message("<span style='color:red'><b>[user] slashes [his_or_her(user)] own throat with [src]!</b></span>")
 		blood_slash(user, 25)
@@ -165,20 +165,20 @@ TRAYS
 	desc = "A long bit plastic that is serated on one side, prone to breaking. It is used for cutting foods. Also useful for butchering dead animals, somehow."
 
 	attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-		if (user && user.bioHolder.HasEffect("clumsy") && prob(50))
+		if(user && user.bioHolder.HasEffect("clumsy") && prob(50))
 			user.visible_message("<span style=\"color:red\"><b>[user]</b> fumbles [src] and cuts \himself.</span>")
 			random_brute_damage(user, 5)
-		if (prob(20))
+		if(prob(20))
 			src.break_knife(user)
 			return
-		if (!scalpel_surgery(M,user))
+		if(!scalpel_surgery(M,user))
 			return ..()
 
 	suicide(var/mob/user as mob)
 		user.visible_message("<span style=\"color:red\"><b>[user] tries to slash  \his own throat with [src]!</b></span>")
 		src.break_knife(user)
 		SPAWN_DBG(10 SECONDS)
-			if (user)
+			if(user)
 				user.suiciding = 0
 		return 1
 
@@ -201,10 +201,10 @@ TRAYS
 	hitsound = 'sound/impact_sounds/Blade_Small_Bloody.ogg'
 
 	attack(mob/living/carbon/human/target as mob, mob/user as mob)
-		if (user && user.bioHolder.HasEffect("clumsy") && prob(50))
+		if(user && user.bioHolder.HasEffect("clumsy") && prob(50))
 			user.visible_message("<span style='color:red'><b>[user]</b> fumbles [src] and cuts \himself.</span>")
 			random_brute_damage(user, 20)
-		if (prob(20))
+		if(prob(20))
 			user.changeStatus("weakened", 4 SECONDS)
 			user.visible_message("<span style='color:red'><b>[user]</b>'s hand slips from the [src] and accidentally cuts [himself_or_herself(user)]. </span>")
 			random_brute_damage(user, 20)
@@ -217,7 +217,7 @@ TRAYS
 	throw_impact(atom/A)
 		if(iscarbon(A))
 			var/mob/living/carbon/C = A
-			if (ismob(usr))
+			if(ismob(usr))
 				A:lastattacker = usr
 				A:lastattackertime = world.time
 			C.changeStatus("weakened", 2 SECONDS)
@@ -250,10 +250,10 @@ TRAYS
 	tool_flags = TOOL_SAWING
 
 	attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-		if (user && user.bioHolder.HasEffect("clumsy") && prob(50))
+		if(user && user.bioHolder.HasEffect("clumsy") && prob(50))
 			user.visible_message("<span style=\"color:red\"><b>[user]</b> fumbles [src] and pinches [his_or_her(user)] fingers against the blade guard.</span>")
 			random_brute_damage(user, 5)
-		if (!saw_surgery(M,user))
+		if(!saw_surgery(M,user))
 			return ..()
 
 	suicide(var/mob/user as mob)
@@ -270,15 +270,15 @@ TRAYS
 	dir = NORTH
 
 	attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-		if (user && user.bioHolder.HasEffect("clumsy") && prob(50))
+		if(user && user.bioHolder.HasEffect("clumsy") && prob(50))
 			user.visible_message("<span style='color:red'><b>[user]</b> fumbles [src] and jabs [his_or_her(user)]self.</span>")
 			random_brute_damage(user, 5)
-		if (!spoon_surgery(M,user))
+		if(!spoon_surgery(M,user))
 			return ..()
 
 	custom_suicide = 1
 	suicide(var/mob/user as mob)
-		if (!src.user_can_suicide(user))
+		if(!src.user_can_suicide(user))
 			return 0
 		var/hisher = his_or_her(user)
 		user.visible_message("<span style='color:red'><b>[user] jabs [src] straight through [hisher] eye and into [hisher] brain!</b></span>")
@@ -296,13 +296,13 @@ TRAYS
 	throwforce = 1.0
 
 	attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-		if (user && user.bioHolder.HasEffect("clumsy") && prob(50))
+		if(user && user.bioHolder.HasEffect("clumsy") && prob(50))
 			user.visible_message("<span style=\"color:red\"><b>[user]</b> fumbles [src] and jabs \himself.</span>")
 			random_brute_damage(user, 5)
-		if (prob(20))
+		if(prob(20))
 			src.break_spoon(user)
 			return
-		if (!spoon_surgery(M,user))
+		if(!spoon_surgery(M,user))
 			return ..()
 
 	proc/break_spoon(mob/living/carbon/user as mob)
@@ -316,7 +316,7 @@ TRAYS
 		user.visible_message("<span style=\"color:red\"><b>[user] tries to jab [src] straight through \his eye and into \his brain!</b></span>")
 		src.break_spoon(user)
 		SPAWN_DBG(10 SECONDS)
-			if (user)
+			if(user)
 				user.suiciding = 0
 		return 1
 
@@ -360,21 +360,21 @@ TRAYS
 	New()
 		..()
 		SPAWN_DBG(1 SECOND)
-			if (!ispath(src.contained_food))
+			if(!ispath(src.contained_food))
 				logTheThing("debug", src, null, "has a non-path contained_food, \"[src.contained_food]\", and is being disposed of to prevent errors")
 				qdel(src)
 				return
 
 	get_desc(dist)
-		if (dist <= 1)
+		if(dist <= 1)
 			. += "There's [(src.amount > 0) ? src.amount : "no" ] [src.contained_food_name][s_es(src.amount)] in [src]."
 
 	attackby(obj/item/W as obj, mob/user as mob)
-		if (src.amount >= src.max_amount)
+		if(src.amount >= src.max_amount)
 			boutput(user, "You can't fit anything else in this box!")
 			return
 		else
-			if (istype(W, src.contained_food))
+			if(istype(W, src.contained_food))
 				user.drop_item()
 				W.set_loc(src)
 				src.amount ++
@@ -384,20 +384,20 @@ TRAYS
 
 	MouseDrop(mob/user as mob) // no I ain't even touchin this mess it can keep doin whatever it's doin
 		// I finally came back and touched that mess because it was broke - Haine
-		if (user == usr && !usr.restrained() && !usr.stat && (usr.contents.Find(src) || in_range(src, usr)))
-			if (!user.put_in_hand(src))
+		if(user == usr && !usr.restrained() && !usr.stat && (usr.contents.Find(src) || in_range(src, usr)))
+			if(!user.put_in_hand(src))
 				return ..()
 
 	attack_hand(mob/user as mob)
 		src.add_fingerprint(user)
 		var/obj/item/reagent_containers/food/snacks/myFood = locate(src.contained_food) in src
-		if (myFood)
-			if (src.amount >= 1)
+		if(myFood)
+			if(src.amount >= 1)
 				src.amount--
 			user.put_in_hand_or_drop(myFood)
 			boutput(user, "You take [myFood] out of [src].")
 		else
-			if (src.amount >= 1)
+			if(src.amount >= 1)
 				src.amount--
 				var/obj/item/reagent_containers/food/snacks/newFood = new src.contained_food(src.loc)
 				user.put_in_hand_or_drop(newFood)
@@ -439,11 +439,11 @@ TRAYS
 		for (var/i = 1, i <= ordered_contents.len, i++)
 			var/obj/item/F = ordered_contents[i]
 			var/image/I = SafeGetOverlayImage("food_[i]", F.icon, F.icon_state)
-			if (ordered_contents.len == 1)
+			if(ordered_contents.len == 1)
 				I.transform *= 0.75
 			else
 				I.transform *= 0.5
-				if (i % 2)
+				if(i % 2)
 					I.pixel_x = -4
 				else
 					I.pixel_x = 4
@@ -475,7 +475,7 @@ TRAYS
 		playsound(src, "shatter", 70, 1)
 		var/obj/O = unpool(/obj/item/raw_material/shard/glass)
 		O.set_loc(get_turf(M))
-		if (src.material)
+		if(src.material)
 			O.setMaterial(copyMaterial(src.material))
 		if(src.cant_drop == 1)
 			var/mob/living/carbon/human/H = user
@@ -491,34 +491,34 @@ TRAYS
 		src.shit_goes_everywhere()
 
 	get_desc(dist)
-		if (dist > 5)
+		if(dist > 5)
 			return
-		if (ordered_contents.len == 0)
+		if(ordered_contents.len == 0)
 			food_desc = "\The [src] has no food on it!"
 		else
 			food_desc = "\The [src] has "
 			for (var/i = 1, i <= ordered_contents.len, i++)
 				var/obj/item/F = ordered_contents[i]
-				if (i == ordered_contents.len && i == 1)
+				if(i == ordered_contents.len && i == 1)
 					food_desc += "\an [F] on it."
 					return "[food_desc]"
-				if (i == ordered_contents.len)
+				if(i == ordered_contents.len)
 					food_desc += "and \an [F] on it."
 				else
 					food_desc += "\an [F], "
-		if (length("[food_desc]") > MAX_MESSAGE_LEN)
+		if(length("[food_desc]") > MAX_MESSAGE_LEN)
 			return "<span style=\"color:orange\">There's a positively <i>indescribable</i> amount of food on \the [src]!</span>"
 		return "[food_desc]"
 
 	attackby(obj/item/W as obj, mob/user as mob)
-		if (istype(W, /obj/item/plate) && !istype(W, /obj/item/plate/tray))
+		if(istype(W, /obj/item/plate) && !istype(W, /obj/item/plate/tray))
 			qdel(W)
 			src.set_loc(user)
 			user.put_in_hand_or_drop(new /obj/item/platestack)
 			user.visible_message("<b>[user]</b> adds a plate to the stack.","You add a plate to the stack.")
 			qdel(src)
 			return
-		else if (istype(W, /obj/item/platestack))
+		else if(istype(W, /obj/item/platestack))
 			var/obj/item/platestack/stack = W
 			if(stack.platenum >= 7)
 				boutput(user,"<span style=\"color:red\"><b>The plates are piled too high!</b></span>")
@@ -530,8 +530,8 @@ TRAYS
 			user.visible_message("<b>[user]</b> adds a plate to the stack.","You add a plate to the stack.")
 			qdel(src)
 			return
-		if (!W.edible)
-			if (istype(W, /obj/item/kitchen/utensil/fork) || istype(W, /obj/item/kitchen/utensil/spoon))
+		if(!W.edible)
+			if(istype(W, /obj/item/kitchen/utensil/fork) || istype(W, /obj/item/kitchen/utensil/spoon))
 				var/obj/item/reagent_containers/food/sel_food = input(user, "Which food do you want to eat?", "[src] Contents") as null|anything in ordered_contents
 				if(!sel_food)
 					return
@@ -544,7 +544,7 @@ TRAYS
 				return
 			boutput(user, "[W] isn't food, That doesn't belong on \the [src]!")
 			return
-		if (ordered_contents.len == max_food)
+		if(ordered_contents.len == max_food)
 			boutput(user, "That won't fit, \the [src] is too full!")
 			return
 		user.drop_item()
@@ -555,13 +555,13 @@ TRAYS
 		boutput(user, "You put [W] on \the [src]")
 
 	MouseDrop(atom/over_object, src_location, over_location)
-		if (over_object == usr && get_dist(src, usr) <=1 && isliving(usr) && !usr.stat && !usr.restrained())
+		if(over_object == usr && get_dist(src, usr) <=1 && isliving(usr) && !usr.stat && !usr.restrained())
 			var/mob/M = over_object
-			if (ordered_contents.len == 0)
+			if(ordered_contents.len == 0)
 				boutput(M, "There's no food to take off of \the [src]!")
 				return
 			var/food_sel = input(M, "Which food do you want to take off of \the [src]?", "[src]'s contents") as null|anything in ordered_contents
-			if (!food_sel)
+			if(!food_sel)
 				return
 
 			M.put_in_hand_or_drop(food_sel)
@@ -572,11 +572,11 @@ TRAYS
 			..()
 
 	attack_self(mob/user as mob)
-		if (ordered_contents.len == 0)
+		if(ordered_contents.len == 0)
 			boutput(user, "There's no food to take off of \the [src]!")
 			return
 		var/food_sel = input(user, "Which food do you want to take off of \the [src]?", "[src]'s contents") as null|anything in ordered_contents
-		if (!food_sel)
+		if(!food_sel)
 			return
 		user.put_in_hand_or_drop(food_sel)
 		src.remove_contents(food_sel)
@@ -584,13 +584,13 @@ TRAYS
 		boutput(user, "You take \the [food_sel] off of \the [src].")
 
 	attack(mob/M as mob, mob/user as mob)
-		if (user.a_intent == INTENT_HARM)
-			if (M == user)
+		if(user.a_intent == INTENT_HARM)
+			if(M == user)
 				boutput(user, "<span style=\"color:red\"><B>You smash [src] over your own head!</b></span>")
 			else
 				M.visible_message("<span style=\"color:red\"><B>[user] smashes [src] over [M]'s head!</B></span>")
 				logTheThing("combat", user, M, "smashes [src] over %target%'s head! ")
-			if (ordered_contents.len != 0)
+			if(ordered_contents.len != 0)
 				src.shit_goes_everywhere()
 			unique_attack_garbage_fuck(M, user)
 		else
@@ -604,19 +604,19 @@ TRAYS
 
 	dropped(mob/user as mob) //shit_goes_everwhere doesnt work
 		..()
-		if (user.lying)
+		if(user.lying)
 			user.visible_message("<span style=\"color:red\">[user] drops \the [src]!</span>")
-			if (ordered_contents.len == 0)
+			if(ordered_contents.len == 0)
 				return
 			src.shit_goes_everywhere()
-		if (user && user.bioHolder.HasEffect("clumsy") && prob(25))
+		if(user && user.bioHolder.HasEffect("clumsy") && prob(25))
 			user.visible_message("<span style=\"color:red\">[user] clumsily drops \the [src]!</span>")
-			if (ordered_contents.len == 0)
+			if(ordered_contents.len == 0)
 				return
 			src.shit_goes_everywhere()
 
 	MouseDrop_T(atom/movable/a as mob|obj, mob/user as mob)
-		if (istype(a, /obj/item/plate) && (!istype(a, /obj/item/plate/tray)))
+		if(istype(a, /obj/item/plate) && (!istype(a, /obj/item/plate/tray)))
 			var/obj/item/platestack/p = new /obj/item/platestack
 			var/gate = 0
 			for (var/obj/item/plate/P in range(1, user))
@@ -658,23 +658,23 @@ TRAYS
 
 	proc/update_inhand_icon()
 		var/weighted_num = round(ordered_contents.len / 5) //6 inhand sprites, 30 possible foods on the tray
-		if (ordered_contents.len == 0)
+		if(ordered_contents.len == 0)
 			src.item_state = "tray"
 			return
 
 		switch (weighted_num)
-			if (1)
+			if(1)
 				src.item_state = "tray_2"
-			if (2)
+			if(2)
 				src.item_state = "tray_3"
-			if (3)
+			if(3)
 				src.item_state = "tray_4"
-			if (4)
+			if(4)
 				src.item_state = "tray_5"
-			if (5)
+			if(5)
 				src.item_state = "tray_6"
 			else  //overflow from 25 to 30, underflow from 0 to 5
-				if (ordered_contents.len < 5)
+				if(ordered_contents.len < 5)
 					src.item_state = "tray_1"
 					return
 				src.item_state = "tray_6"
@@ -684,12 +684,12 @@ TRAYS
 			var/obj/item/F = ordered_contents[i]
 			var/image/I = SafeGetOverlayImage("food_[i]", F.icon, F.icon_state)
 			I.transform *= 0.75
-			if (i % 2) //i feel clever for this haha
+			if(i % 2) //i feel clever for this haha
 				I.pixel_x = -8
 			else
 				I.pixel_x = 8
 			y_counter++
-			if (y_counter == 3)
+			if(y_counter == 3)
 				y_mod++
 				y_counter = 1
 			I.pixel_y = y_mod * 3 //food layers are 3px above eachother
@@ -703,28 +703,28 @@ TRAYS
 		return
 
 	get_desc(dist)
-		if (dist > 5)
+		if(dist > 5)
 			return
-		if ((5 >= tray_health) && (tray_health > 3)) //im using hardcoded values im so garbage
+		if((5 >= tray_health) && (tray_health > 3)) //im using hardcoded values im so garbage
 			health_desc = "\The [src] seems nice and sturdy!"
-		else if ((3 >= tray_health) && (tray_health > 1)) //im a trash human
+		else if((3 >= tray_health) && (tray_health > 1)) //im a trash human
 			health_desc = "\The [src] is getting pretty warped and flimsy."
-		else if ((1 >= tray_health) && (tray_health >=0))  //im a bad coder
+		else if((1 >= tray_health) && (tray_health >=0))  //im a bad coder
 			health_desc = "\The [src] is about to break, be careful!"
-		if (ordered_contents.len == 0)
+		if(ordered_contents.len == 0)
 			food_desc = "\The [src] has no food on it!"
 		else
 			food_desc = "\The [src] has "
 			for (var/i = 1, i <= ordered_contents.len, i++)
 				var/obj/item/F = ordered_contents[i]
-				if (i == ordered_contents.len && i == 1)
+				if(i == ordered_contents.len && i == 1)
 					food_desc += "\an [F] on it."
 					return "[health_desc] [food_desc]"
-				if (i == ordered_contents.len)
+				if(i == ordered_contents.len)
 					food_desc += "and \an [F] on it."
 				else //just a normal food then ok
 					food_desc += "\an [F], "
-		if (length("[health_desc] [food_desc]") > MAX_MESSAGE_LEN)
+		if(length("[health_desc] [food_desc]") > MAX_MESSAGE_LEN)
 			return "<span style=\"color:orange\">There's a positively <i>indescribable</i> amount of food on \the [src]!</span>"
 		return "[health_desc] [food_desc]" //heres yr desc you *bastard*
 
@@ -736,7 +736,7 @@ TRAYS
 		src.visible_message("\The [src] falls out of [user]'s hands due to the impact!")
 		user.drop_item(src)
 
-		if (tray_health == 0) //breakable trays because you flew too close to the sun, you tried to have unlimited damage AND stuns you fool, your hubris is too fat, too wide
+		if(tray_health == 0) //breakable trays because you flew too close to the sun, you tried to have unlimited damage AND stuns you fool, your hubris is too fat, too wide
 			src.visible_message("<b>\The [src] shatters!</b>")
 			playsound(src, "sound/impact_sounds/Metal_Hit_Light_1.ogg", 70, 1)
 			new /obj/item/scrap(src.loc)
@@ -783,7 +783,7 @@ TRAYS
 		icon_state = "red_herring"
 
 /obj/item/fish/attack(mob/M as mob, mob/user as mob)
-	if (user && user.bioHolder.HasEffect("clumsy") && prob(50))
+	if(user && user.bioHolder.HasEffect("clumsy") && prob(50))
 		user.visible_message("<span style=\"color:red\"><b>[user]</b> swings [src] and hits \himself in the face!.</span>")
 		user.changeStatus("weakened", 20 * src.force)
 		return
@@ -792,8 +792,8 @@ TRAYS
 		user.visible_message("<span style=\"color:red\"><b>[user] slaps [M] with [src]!</b>.</span>")
 
 /obj/item/fish/attackby(var/obj/item/W as obj, var/mob/user as mob)
-	if (istype(W, /obj/item/kitchen/utensil/knife))
-		if (fillet_type)
+	if(istype(W, /obj/item/kitchen/utensil/knife))
+		if(fillet_type)
 			var/obj/fillet = new fillet_type(src.loc)
 			user.put_in_hand_or_drop(fillet)
 			boutput(user, "<span style=\"color:blue\">You skin and gut [src] using your knife.</span>")
@@ -1064,7 +1064,7 @@ TRAYS
 			qdel(src)
 
 	MouseDrop_T(atom/movable/a as mob|obj, mob/user as mob)
-		if (istype(a, /obj/item/plate))
+		if(istype(a, /obj/item/plate))
 			if(src.platenum >= 7)
 				boutput(user,"<span style=\"color:red\"><b>The plates are piled too high!</b></span>")
 				return


### PR DESCRIPTION
## About the PR
//throwing plate stacks into objects previously caused a runtime error and players werent able to stack plates without click-dragging

- Fixed plate stack throw_impact runtime error
- Players can now stack plates by clicking a plate with another plate in addition to click-dragging.

## Why's this needed?

- Quality of life changes and code maiding yay :D

## Changelog

Awkward Dryad:
* Fixed a plate stack runtime error.
+ Plates can now be stacked one by one instead of click-drag only.

