### PR TITLE
Makes ass day nukie target locations unrestricted

### DIFF
--- a/code/datums/gamemodes/nuclear.dm
+++ b/code/datums/gamemodes/nuclear.dm
@@ -90,7 +90,7 @@
 		message_admins("<span style ='color:red'><b>CRITICAL BUG:</b> nuke mode setup encountered an error while trying to choose a target location for the bomb and the target has defaulted to anywhere on the station! The round will be able to be played like this but it will be unbalanced! Please inform a coder!")
 		logTheThing("debug", null, null, "<b>CRITICAL BUG:</b> nuke mode setup encountered an error while trying to choose a target location for the bomb and the target has defaulted to anywhere on the station.")
 
-#ifdef ASS_JAM
+#if ASS_JAM
 	var/station_only = prob(40)
 	target_locations = list()
 	for(var/area/A in world)

--- a/code/datums/gamemodes/nuclear.dm
+++ b/code/datums/gamemodes/nuclear.dm
@@ -90,6 +90,18 @@
 		message_admins("<span style ='color:red'><b>CRITICAL BUG:</b> nuke mode setup encountered an error while trying to choose a target location for the bomb and the target has defaulted to anywhere on the station! The round will be able to be played like this but it will be unbalanced! Please inform a coder!")
 		logTheThing("debug", null, null, "<b>CRITICAL BUG:</b> nuke mode setup encountered an error while trying to choose a target location for the bomb and the target has defaulted to anywhere on the station.")
 
+#ifdef ASS_JAM
+	var/station_only = prob(40)
+	target_locations = list()
+	for(var/area/A in world)
+		if(station_only && !istype(A, /area/station))
+			continue
+		if(!(A.name in target_locations))
+			target_locations[A.name] = list(A)
+		else
+			target_locations[A.name].Add(A)
+#endif
+
 	target_location_name = pick(target_locations)
 	if (!target_location_name)
 		boutput(world, "<span style='color:red'><b>ERROR: couldn't assign target location for bomb, aborting nuke round pre-setup.</b></span>")

--- a/code/datums/gamemodes/nuclear.dm
+++ b/code/datums/gamemodes/nuclear.dm
@@ -43,7 +43,7 @@
 		return 0
 
 	// I wandered in and made things hopefully a bit easier to work with since we have multiple maps now - Haine
-	var/list/target_locations = null
+	var/list/list/target_locations = null
 
 	if (map_settings && islist(map_settings.valid_nuke_targets) && map_settings.valid_nuke_targets.len)
 		target_locations = map_settings.valid_nuke_targets


### PR DESCRIPTION
## About the PR
During ass day (13th each month) nukies' target location will be chosen from a much wider pool. With 40% probability the pool is all station areas, with 60% probability the pool is *all* areas. There's no guarantee that the area is actually reachable by player means. 

## Why's this needed?
The future of ass day is hopefully along the lines of less griefing, more wacky experimental gameplay. Nukies trying to get to Biodome to explode the nuke there is the pinnacle of wacky experimental gameplay.

## Changelog
```
(u)pali
(*)Nukies on ass day can now get much wilder target locations. 
```
