### PR TITLE
Enable motives on Goon2

### DIFF
--- a/code/datums/sims.dm
+++ b/code/datums/sims.dm
@@ -451,7 +451,7 @@
 					return 0
 				if (holder.owner.lying)
 					return 0
-				if (holder.owner.sleeping) 
+				if (holder.owner.sleeping)
 					return 0
 				if (holder.owner.resting)
 					return 0
@@ -522,10 +522,10 @@
 		SPAWN_DBG(1 SECOND) //Give it some time to finish creating the simsController because fak
 			for (var/M in childrentypesof(/datum/simsMotive))
 				motives[M] = new M(1)
-#ifdef RP_MODE
+//#ifdef RP_MODE
 			SPAWN_DBG(0)
 				set_multiplier(1)
-#endif
+//#endif
 
 	Topic(href, href_list)
 		usr_admin_only
@@ -664,9 +664,9 @@ var/global/datum/simsControl/simsController = new()
 		simsController.register_simsHolder(src)
 		make_motives()
 		add_hud()
-	
+
 	proc/make_motives()
-	
+
 	proc/add_hud()
 		if (owner && ishuman(owner))
 			var/SY = src.start_y


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR

<!-- Describe your Pull Request here. What does it change? What other things could this affect? -->
Might be controversial, but this PR adds motives like hunger to Goon2

## Why's this needed?

<!-- Describe why you think this should be added to the game. -->
Currently there's really not much point in the kitchen or bartender, meaning they mostly just serve to provide reskinned floorpills for the station; enabling motives (or at the very least hunger, like other L/MRP servers) would give people more of a reason to interact with eachother (ie getting food or phoning the kitchen to demand food deliveries to their department)

## Changelog

<!-- If necessary, put your changelog entry here. Use * for major changes and + for minor changes. For example:
CodeDude:
* Added soft soft pizza to the game - a tasty drink found in soda machines!
+ Made some sprite changes to the base pizza sprite.
-->
