### PR TITLE
Adds functionality for multiple nuke op name lists

### DIFF
--- a/code/datums/gamemodes/nuclear.dm
+++ b/code/datums/gamemodes/nuclear.dm
@@ -131,9 +131,13 @@
 	var/obj/landmark/closet_spawn = locate("landmark*Nuclear-Closet")
 
 	var/leader_title = pick("Czar", "Boss", "Commander", "Chief", "Kingpin", "Director", "Overlord", "General", "Warlord", "Commissar")
-	//var/agent_callsigns = list("Alpha", "Bravo", "Charlie", "Delta", "Echo", "Foxtrot", "Golf", "Hotel", "India", "Juliett", "Kilo", "Lima", "Mike", "November", "Oscar", "Papa", "Quebec", "Romeo", "Sierra", "Tango", "Uniform", "Victor", "Whiskey", "X-ray", "Yankee", "Zulu")
-	var/agent_callsigns = list("Axe", "Baselard", "Cutlass", "Dagger", "Estoc", "Falchion", "Gladius", "Hatchet", "Ice-pick", "Javelin", "Katana", "Longsword", "Machete", "Nodachi", "Odachi", "Partisan", "Quarterstaff", "Rapier", "Scimitar", "Tomahawk", "Uchigatana", "Voulge", "Warhammer", "Xiphos", "Yumi", "Zweihander")
 	var/leader_selected = 0
+
+	//Alphabetical agent callsign lists are delcared here, seperated in to catagories.
+	var/list/nato_callsigns = pick_string("agent_callsigns.txt", "nato")
+	var/list/melee_callsigns = pick_string("agent_callsigns.txt", "melee_weapons")
+	//Add new lists to the master callsign list.
+	var/list/callsign_list = pick(nato_callsigns, melee_callsigns)
 
 	for(var/datum/mind/synd_mind in syndicates)
 		synd_spawn = pick(syndicatestart) // So they don't all spawn on the same tile.
@@ -161,9 +165,9 @@
 				new /obj/item/pinpointer/disk(synd_mind.current.loc)
 			leader_selected = 1
 		else
-			var/callsign = pick(agent_callsigns)
+			var/callsign = pick(callsign_list)
 			synd_mind.current.real_name = "[syndicate_name()] Operative [callsign]" //new naming scheme
-			agent_callsigns -= callsign
+			callsign_list -= callsign
 			equip_syndicate(synd_mind.current, 0)
 		boutput(synd_mind.current, "<span style=\"color:red\">Your headset allows you to communicate on the syndicate radio channel by prefacing messages with :h, as (say \":h Agent reporting in!\").</span>")
 

--- a/code/datums/gamemodes/nuclear.dm
+++ b/code/datums/gamemodes/nuclear.dm
@@ -134,10 +134,7 @@
 	var/leader_selected = 0
 
 	//Alphabetical agent callsign lists are delcared here, seperated in to catagories.
-	var/list/nato_callsigns = pick_string("agent_callsigns.txt", "nato")
-	var/list/melee_callsigns = pick_string("agent_callsigns.txt", "melee_weapons")
-	//Add new lists to the master callsign list.
-	var/list/callsign_list = pick(nato_callsigns, melee_callsigns)
+	var/list/callsign_list = strings("agent_callsigns.txt", "nato") + strings("agent_callsigns.txt", "melee_weapons") + strings("agent_callsigns.txt", "colors")
 
 	for(var/datum/mind/synd_mind in syndicates)
 		synd_spawn = pick(syndicatestart) // So they don't all spawn on the same tile.

--- a/strings/agent_callsigns.txt
+++ b/strings/agent_callsigns.txt
@@ -1,0 +1,2 @@
+nato@=Alpha@,Bravo@,Charlie@,Delta@,Echo@,Foxtrot@,Golf@,Hotel,India@,Juliett@,Kilo@,Lima@,Mike@,November@,Oscar@,Papa@,Quebec@,Romeo@,Sierra@,Tango@,Uniform@,Victor@,Whiskey@,X-ray@,Yankee@,Zulu
+melee_weapons@=Axe@,Baselard@,Cutlass@,Dagger@,Estoc@,Falchion@,Gladius@,Hatchet@,Ice-pick@,Javelin@,Katana@,Longsword@,Machete@,Nodachi@,Odachi@,Partisan@,Quarterstaff@,Rapier@,Scimitar@,Tomahawk@,Uchigatana@,Voulge@,Warhammer@,Xiphos@,Yumi@,Zweihander

--- a/strings/agent_callsigns.txt
+++ b/strings/agent_callsigns.txt
@@ -1,2 +1,3 @@
 nato@=Alpha@,Bravo@,Charlie@,Delta@,Echo@,Foxtrot@,Golf@,Hotel,India@,Juliett@,Kilo@,Lima@,Mike@,November@,Oscar@,Papa@,Quebec@,Romeo@,Sierra@,Tango@,Uniform@,Victor@,Whiskey@,X-ray@,Yankee@,Zulu
 melee_weapons@=Axe@,Baselard@,Cutlass@,Dagger@,Estoc@,Falchion@,Gladius@,Hatchet@,Ice-pick@,Javelin@,Katana@,Longsword@,Machete@,Nodachi@,Odachi@,Partisan@,Quarterstaff@,Rapier@,Scimitar@,Tomahawk@,Uchigatana@,Voulge@,Warhammer@,Xiphos@,Yumi@,Zweihander
+colors@=Red@,Orange@,Yellow@,Green@,Blue@,Indigo@,Violet@,Black@,White


### PR DESCRIPTION
## About the PR
Note: Unable to test locally, compiled and doesn't throw runtimes but I'd appreciate someone checking for idiocy.

Adds multiple lists to a strings file, allowing nuclear operatives to spawn with randomly picked, themed agent callsigns, as opposed to the static list that they currently use. This should also make it easier to add new lists in future.

Current lists include the existing melee weapons list and the nato alphabet.

## Why's this needed?

For fun nuke op team theming and easy identification.
