### PR TITLE
bleed + adjacent fluid fixes

### DIFF
--- a/code/datums/controllers/process/fluid.dm
+++ b/code/datums/controllers/process/fluid.dm
@@ -134,7 +134,7 @@ datum/controller/process/fluid_group
 								if (!F) continue
 								var/obj/decal/cleanable/blood/dynamic/B = make_cleanable(/obj/decal/cleanable/blood/dynamic,F.loc)
 								B.sample_reagent = "blood"
-								B.add_volume(F.color, 1, null, null, null, 0)
+								B.add_volume(F.color, do_fluid_react = 0)
 								B.handle_reagent_list(FG.reagents.reagent_list)
 								B.blood_DNA = F.blood_DNA
 								B.blood_type = F.blood_type

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -1657,8 +1657,7 @@
 
 			var/turf/T = get_turf(mob)
 			bleed(mob, 10, 3, T)
-
-
+			T.react_all_cleanables()
 
 
 #undef OVERRIDE_ARM_L

--- a/code/modules/fluids/fluid_procs.dm
+++ b/code/modules/fluids/fluid_procs.dm
@@ -13,7 +13,6 @@
 		var/atom/thing = A
 		if (!A) continue
 		if(IS_SOLID_TO_FLUID(thing) && thing.density) return 0 // && !istype(thing,/obj/grille) && !istype(thing,/obj/table) && !istype(thing,/obj/structure/girder)) return 0
-		LAGCHECK(LAG_LOW)
 	return 1
 
 turf/simulated/floor/plating/airless/ocean_canpass()
@@ -52,18 +51,15 @@ turf/simulated/floor/plating/airless/ocean_canpass()
 
 
 /turf/proc/fluid_react(var/datum/reagents/R, var/react_volume, var/airborne = 0) //this should happen whenever a liquid reagent hits a simulated tile
-	LAGCHECK(LAG_MED)
 	if (react_volume <= 0) return
 	if (!IS_VALID_FLUIDREACT_TURF(src)) return
 
 	if (airborne)
 		for(var/reagent_id in R.reagent_list)
 			if (ban_from_airborne_fluid.Find(reagent_id)) return
-			LAGCHECK(LAG_MED)
 	else
 		for(var/reagent_id in R.reagent_list)
 			if (ban_from_fluid.Find(reagent_id)) return
-			LAGCHECK(LAG_MED)
 
 	var/datum/fluid_group/FG
 	var/obj/fluid/F
@@ -115,12 +111,11 @@ turf/simulated/floor/plating/airless/ocean_canpass()
 			for (var/obj/decal/cleanable/C in T)
 				if (istype(T) && !T.cleanable_fluid_react(C, 1)) // Some cleanables need special treatment
 					found_cleanable = 1 //there exists a cleanable without a special case
-				LAGCHECK(LAG_LOW)
+					break
 			if (found_cleanable)
 				T.cleanable_fluid_react(0,1)
 
 /turf/proc/fluid_react_single(var/reagent_name, var/react_volume, var/airborne = 0) //same as the above, but using a reagent_id instead of a datum
-	LAGCHECK(LAG_MED)
 	if (react_volume <= 0) return
 	if (!IS_VALID_FLUIDREACT_TURF(src)) return
 
@@ -128,7 +123,6 @@ turf/simulated/floor/plating/airless/ocean_canpass()
 		if (ban_from_airborne_fluid.Find(reagent_name)) return
 	else
 		if (ban_from_fluid.Find(reagent_name)) return
-	LAGCHECK(LAG_LOW)
 
 	var/datum/fluid_group/FG
 	var/obj/fluid/F
@@ -184,7 +178,7 @@ turf/simulated/floor/plating/airless/ocean_canpass()
 			for (var/obj/decal/cleanable/C in T)
 				if (istype(T) && !T.cleanable_fluid_react(C, 1))
 					found_cleanable = 1
-				LAGCHECK(LAG_LOW)
+					break
 			if (found_cleanable)
 				T.cleanable_fluid_react(0,1)
 
@@ -197,14 +191,12 @@ turf/simulated/floor/plating/airless/ocean_canpass()
 	for (var/obj/decal/cleanable/C in src)
 		if (!src.cleanable_fluid_react(C, 1)) // Some cleanables need special treatment
 			found_cleanable = 1 //there exists a cleanable without a special case
-		LAGCHECK(LAG_LOW)
 	if (found_cleanable)
 		src.cleanable_fluid_react(0,1)
 
 //called whenever a cleanable is spawned. Returns 1 on success
 //grab_any_amount will be True when a fluid spreads onto a tile that may have cleanables on it
 /turf/simulated/proc/cleanable_fluid_react(var/obj/decal/cleanable/possible_cleanable = 0, var/grab_any_amount = 0)
-	LAGCHECK(LAG_MED)
 	if (!IS_VALID_FLUIDREACT_TURF(src)) return
 	//if possible_cleanable has a value, handle exclusively this decal. don't search thru the turf.
 	if (possible_cleanable)
@@ -214,16 +206,16 @@ turf/simulated/floor/plating/airless/ocean_canpass()
 			var/blood_dna = blood.blood_DNA
 			var/blood_type = blood.blood_type
 			var/is_tracks = istype(possible_cleanable,/obj/decal/cleanable/blood/dynamic/tracks)
-			if (blood.blood_volume >= 13 || src.active_liquid || grab_any_amount)
+			if (blood.reagents && blood.reagents.total_volume >= 13 || src.active_liquid || grab_any_amount)
 				if (blood.reagents)
 					var/datum/reagents/R = new(blood.reagents.maximum_volume) //Store reagents, delete cleanable, and then fluid react. prevents recursion
 					blood.reagents.copy_to(R)
-					var/blood_volume = blood.blood_volume
+					var/blood_volume = blood.reagents.total_volume
 					blood.clean_forensic()
 					src.fluid_react(R,is_tracks ? 0 : blood_volume)
 				else
 					var/reagent = blood.sample_reagent
-					var/amt = blood.blood_volume
+					var/amt = blood.reagents.total_volume
 					blood.clean_forensic()
 					src.fluid_react_single(reagent,is_tracks ? 0 : amt)
 
@@ -246,7 +238,6 @@ turf/simulated/floor/plating/airless/ocean_canpass()
 		return 0	//If the tile has an active liquid already, there is no requirement
 
 	for (var/obj/decal/cleanable/C in cleanables)
-		LAGCHECK(LAG_LOW)
 		if (C && C.reagents)
 			for(var/reagent_id in C.reagents.reagent_list)
 				if (ban_stacking_into_fluid.Find(reagent_id)) return

--- a/code/modules/forensics/atom_forensic.dm
+++ b/code/modules/forensics/atom_forensic.dm
@@ -294,7 +294,8 @@
 			B = make_cleanable( /obj/decal/cleanable/blood/dynamic/tracks/reliquary,get_turf(src))
 		else
 			B = make_cleanable( /obj/decal/cleanable/blood/dynamic/tracks,get_turf(src))
-	B.set_sample_reagent_custom(src.tracked_blood["sample_reagent"],0)
+		B.set_sample_reagent_custom(src.tracked_blood["sample_reagent"],0)
+
 	B.add_volume(blood_color_to_pass, src.tracked_blood["sample_reagent"], 1, 0, src.tracked_blood, "footprints[rand(1,2)]", src.last_move, 0)
 
 	if (src.tracked_blood && isnum(src.tracked_blood["count"])) // mirror from below
@@ -332,7 +333,6 @@
 			return //must have been consumed by a fluid? this might be unnecessary...
 
 	if (src.limbs)
-		B.set_sample_reagent_custom(src.tracked_blood["sample_reagent"],0)
 		var/Lstate = istype(src.limbs.l_leg) ? src.limbs.l_leg.step_image_state : null
 		var/Rstate = istype(src.limbs.r_leg) ? src.limbs.r_leg.step_image_state : null
 		if (Lstate || Rstate)

--- a/code/modules/forensics/atom_forensic.dm
+++ b/code/modules/forensics/atom_forensic.dm
@@ -281,7 +281,10 @@
 	if (!islist(src.tracked_blood))
 		return
 	var/turf/T = get_turf(src)
-	var/obj/decal/cleanable/blood/dynamic/tracks/B = T.messy ? (locate(/obj/decal/cleanable/blood/dynamic/tracks) in T) : 0
+	var/obj/decal/cleanable/blood/dynamic/tracks/B = null
+	if (T.messy > 0)
+		B = locate(/obj/decal/cleanable/blood/dynamic) in T
+
 	var/blood_color_to_pass = src.tracked_blood["color"] ? src.tracked_blood["color"] : DEFAULT_BLOOD_COLOR
 
 	if (!B)
@@ -291,7 +294,8 @@
 			B = make_cleanable( /obj/decal/cleanable/blood/dynamic/tracks/reliquary,get_turf(src))
 		else
 			B = make_cleanable( /obj/decal/cleanable/blood/dynamic/tracks,get_turf(src))
-	B.add_volume(blood_color_to_pass, 1, src.tracked_blood, "footprints[rand(1,2)]", src.last_move, 0)
+	B.set_sample_reagent_custom(src.tracked_blood["sample_reagent"],0)
+	B.add_volume(blood_color_to_pass, src.tracked_blood["sample_reagent"], 1, 0, src.tracked_blood, "footprints[rand(1,2)]", src.last_move, 0)
 
 	if (src.tracked_blood && isnum(src.tracked_blood["count"])) // mirror from below
 		src.tracked_blood["count"] --
@@ -309,7 +313,10 @@
 		return
 
 	var/turf/T = get_turf(src)
-	var/obj/decal/cleanable/blood/dynamic/tracks/B = T.messy ? (locate(/obj/decal/cleanable/blood/dynamic/tracks) in T) : 0
+	var/obj/decal/cleanable/blood/dynamic/tracks/B = null
+	if (T.messy > 0)
+		B = locate(/obj/decal/cleanable/blood/dynamic) in T
+
 	var/blood_color_to_pass = src.tracked_blood["color"] ? src.tracked_blood["color"] : DEFAULT_BLOOD_COLOR
 
 	if (!B)
@@ -319,17 +326,22 @@
 			B = make_cleanable( /obj/decal/cleanable/blood/dynamic/tracks/reliquary,get_turf(src))
 		else
 			B = make_cleanable( /obj/decal/cleanable/blood/dynamic/tracks,get_turf(src))
-	if (!B)
-		return //must have been consumed by a fluid? this might be unnecessary...
+		if (B)
+			B.set_sample_reagent_custom(src.tracked_blood["sample_reagent"],0)
+		else
+			return //must have been consumed by a fluid? this might be unnecessary...
 
 	if (src.limbs)
+		B.set_sample_reagent_custom(src.tracked_blood["sample_reagent"],0)
 		var/Lstate = istype(src.limbs.l_leg) ? src.limbs.l_leg.step_image_state : null
 		var/Rstate = istype(src.limbs.r_leg) ? src.limbs.r_leg.step_image_state : null
 		if (Lstate || Rstate)
-			if (Lstate) B.add_volume(blood_color_to_pass, 0.5, src.tracked_blood, Lstate, src.last_move, 0)
-			if (Rstate) B.add_volume(blood_color_to_pass, 0.5, src.tracked_blood, Rstate, src.last_move, 0)
+			if (Lstate)
+				B.add_volume(blood_color_to_pass, src.tracked_blood["sample_reagent"], 0.5, 0.5, src.tracked_blood, Lstate, src.last_move, 0)
+			if (Rstate)
+				B.add_volume(blood_color_to_pass, src.tracked_blood["sample_reagent"], 0.5, 0.5, src.tracked_blood, Rstate, src.last_move, 0)
 		else
-			B.add_volume(blood_color_to_pass, 1, src.tracked_blood, "smear2", src.last_move, 0)
+			B.add_volume(blood_color_to_pass, src.tracked_blood["sample_reagent"], 1, 1, src.tracked_blood, "smear2", src.last_move, 0)
 
 	if (src.tracked_blood && isnum(src.tracked_blood["count"])) // maybe this will fix the bad index runtime PART
 		src.tracked_blood["count"] --
@@ -357,14 +369,21 @@
 			B = make_cleanable( /obj/decal/cleanable/blood/dynamic/tracks/reliquary,get_turf(src))
 		else
 			B = make_cleanable( /obj/decal/cleanable/blood/dynamic/tracks,get_turf(src))
+		if (B)
+			B.set_sample_reagent_custom(src.tracked_blood["sample_reagent"],0)
+		else
+			return
 
 	var/Lstate = istype(src.part_leg_l) ? src.part_leg_l.step_image_state : null
 	var/Rstate = istype(src.part_leg_r) ? src.part_leg_r.step_image_state : null
+
 	if (Lstate || Rstate)
-		if (Lstate) B.add_volume(blood_color_to_pass, 0.5, src.tracked_blood, Lstate, src.last_move, 0)
-		if (Rstate) B.add_volume(blood_color_to_pass, 0.5, src.tracked_blood, Rstate, src.last_move, 0)
+		if (Lstate)
+			B.add_volume(blood_color_to_pass, src.tracked_blood["sample_reagent"], 0.5, 0.5, src.tracked_blood, Lstate, src.last_move, 0)
+		if (Rstate)
+			B.add_volume(blood_color_to_pass, src.tracked_blood["sample_reagent"], 0.5, 0.5, src.tracked_blood, Rstate, src.last_move, 0)
 	else
-		B.add_volume(blood_color_to_pass, 1, src.tracked_blood, "smear2", src.last_move, 0)
+		B.add_volume(blood_color_to_pass, src.tracked_blood["sample_reagent"], 1, 1, src.tracked_blood, "smear2", src.last_move, 0)
 
 	if (src.tracked_blood && isnum(src.tracked_blood["count"])) //mirror from above
 		src.tracked_blood["count"] --

--- a/code/modules/medical/blood_system.dm
+++ b/code/modules/medical/blood_system.dm
@@ -400,7 +400,9 @@ this is already used where it needs to be used, you can probably ignore it.
 	if (!blood_system) // we're here because we want to create a decal, so create it anyway
 
 
-		var/obj/decal/cleanable/blood/dynamic/B = locate(/obj/decal/cleanable/blood/dynamic) in T
+		var/obj/decal/cleanable/blood/dynamic/B = null
+		if (T.messy > 0)
+			B = locate(/obj/decal/cleanable/blood/dynamic) in T
 		var/blood_color_to_pass = DEFAULT_BLOOD_COLOR
 
 		if (some_idiot.blood_id && (some_idiot.blood_id != "blood" && some_idiot.blood_id != "bloodc"))
@@ -426,10 +428,7 @@ this is already used where it needs to be used, you can probably ignore it.
 			B.blood_DNA = "--unidentified substance--"
 			B.blood_type = "--unidentified substance--"
 
-		B.add_volume(blood_color_to_pass, vis_amount)
-		if (some_idiot.blood_id)
-			B.reagents.add_reagent(some_idiot.blood_id, num_amount)
-
+		B.add_volume(blood_color_to_pass, some_idiot.blood_id, num_amount, vis_amount)
 		return
 
 	BLOOD_DEBUG("[some_idiot] begins bleed")
@@ -451,12 +450,14 @@ this is already used where it needs to be used, you can probably ignore it.
 
 	if ((!isvampire(H) && H.blood_volume > 0) || (isvampire(H) && H.get_vampire_blood() > 0)) // you shouldn't bleed unless you have blood okay
 		//BLOOD_DEBUG("[H] blood level [H.blood_volume]")
-		var/obj/decal/cleanable/blood/dynamic/B = locate(/obj/decal/cleanable/blood/dynamic) in T
+		var/obj/decal/cleanable/blood/dynamic/B = null
+		if (T.messy > 0)
+			B = locate(/obj/decal/cleanable/blood/dynamic) in T
 
 		if (!B) // look for an existing dynamic blood decal and add to it if you find one
 			B = make_cleanable( /obj/decal/cleanable/blood/dynamic,T)
 			if (H.blood_id)
-				B.set_sample_reagent_custom(H.blood_id)
+				B.set_sample_reagent_custom(H.blood_id,0)
 			if (H.blood_color)
 				B.color = H.blood_color
 
@@ -477,14 +478,12 @@ this is already used where it needs to be used, you can probably ignore it.
 				H.blood_volume = 0
 				//BLOOD_DEBUG("[H]'s blood volume dropped below 0 and was reset to 0")
 
-		B.add_volume(H.blood_color, vis_amount)
+		B.add_volume(H.blood_color, H.blood_id, num_amount, vis_amount)
 		//BLOOD_DEBUG("[H] adds volume to existing blood decal")
 
-		if (H.bleeding > 4 && B && B.reagents && B.reagents.total_volume < 90 && H.reagents && H.reagents.total_volume)
+		if (B && B.reagents && H.reagents && H.reagents.total_volume)
 			//BLOOD_DEBUG("[H] transfers reagents to blood decal [log_reagents(H)]")
 			H.reagents.trans_to(B, min(round(H.bleeding / 2, 1), 5))
-
-
 	else
 		return
 

--- a/code/obj/decal/cleanable.dm
+++ b/code/obj/decal/cleanable.dm
@@ -585,7 +585,7 @@ var/list/blood_decal_violent_icon_states = list("floor1", "floor2", "floor3", "f
 	desc = "Someone walked through some blood and got it everywhere, jeez!"
 	can_track = 0
 
-	add_volume(var/add_color, var/reagent_id = "blood", var/amount = 1, var/vis_amount = 1, var/list/bdata = null, var/i_state = null, var/direction = null, var/e_tracking = 1)
+	add_volume(var/add_color, var/reagent_id = "blood", var/amount = 1, var/vis_amount = 1, var/list/bdata = null, var/i_state = null, var/direction = null, var/e_tracking = 1, var/do_fluid_react = 1)
 		// e_tracking will be set to 0 by the track_blood() proc atoms run when moving, so anything that doesn't set it to 0 is a regular sort of bleed and should re-enable tracking
 		if (e_tracking)
 			src.can_track = 1

--- a/code/obj/decal/cleanable.dm
+++ b/code/obj/decal/cleanable.dm
@@ -62,7 +62,7 @@ proc/make_cleanable(var/type,var/loc,var/list/viral_list)
 			if (src.stain)
 				src.Stain()
 
-			if(istype(src.loc, /turf))
+			if(isturf(src.loc))
 				var/turf/T = src.loc
 				T.messy++
 				last_turf = T
@@ -111,8 +111,8 @@ proc/make_cleanable(var/type,var/loc,var/list/viral_list)
 			last_turf.messy = max(last_turf.messy-1, 0)
 		last_turf = src.loc
 
-		if (istype(src.loc, /turf/simulated/floor))
-			var/turf/simulated/floor/F = src.loc
+		if (isturf(src.loc))
+			var/turf/F = src.loc
 			F.messy++
 
 	HasEntered(AM as mob|obj)
@@ -123,10 +123,8 @@ proc/make_cleanable(var/type,var/loc,var/list/viral_list)
 			src.Stain(AM)
 		if (!src.slippery || src.dry)
 			return
-		if (istype(src, /obj/decal/cleanable/blood/dynamic))
-			var/obj/decal/cleanable/blood/dynamic/D = src
-			if (D.blood_volume <= 2)
-				return
+		if (src.reagents && src.reagents.total_volume < 5)
+			return
 		if (istype(src.loc, /turf/space))
 			return
 		if (iscarbon(AM))
@@ -240,7 +238,6 @@ proc/make_cleanable(var/type,var/loc,var/list/viral_list)
 	random_icon_states = list("floor1", "floor2", "floor3", "floor4", "floor5", "floor6", "floor7")
 	var/ling_blood = 0
 	var/reliquary_blood = 0
-	var/blood_volume = 0
 	color = DEFAULT_BLOOD_COLOR
 	slippery = 10
 	slipped_in_blood = 1
@@ -249,9 +246,10 @@ proc/make_cleanable(var/type,var/loc,var/list/viral_list)
 	can_dry = 1
 	stain = "blood-stained"
 	var/can_track = 1
+	var/reagents_max = 10
 
 	New()
-		var/datum/reagents/R = new/datum/reagents(10) // 9u is the max since we wanna leave at least 1u of blood in the blood puddle
+		var/datum/reagents/R = new/datum/reagents(reagents_max) // 9u is the max since we wanna leave at least 1u of blood in the blood puddle
 		reagents = R
 		R.my_atom = src
 		if (ling_blood)
@@ -272,11 +270,10 @@ proc/make_cleanable(var/type,var/loc,var/list/viral_list)
 
 	unpooled()
 		..()
-		blood_volume = 0
 
 	setup()
 		if (!src.reagents)
-			var/datum/reagents/R = new/datum/reagents(10)
+			var/datum/reagents/R = new/datum/reagents(reagents_max)
 			reagents = R
 			R.my_atom = src
 		else
@@ -296,12 +293,12 @@ proc/make_cleanable(var/type,var/loc,var/list/viral_list)
 			if (!src.pooled)
 				for (var/obj/O in src.loc)
 					LAGCHECK(LAG_LOW)
-					if (O && prob(max(src.blood_volume*10, 10)))
+					if (O && prob(max(src.reagents.total_volume*5, 10)))
 						O.add_blood(src)
 
-	proc/set_sample_reagent_custom(var/reagent_id)
+	proc/set_sample_reagent_custom(var/reagent_id, var/amt = 10)
 		if (!src.reagents)
-			var/datum/reagents/R = new/datum/reagents(10)
+			var/datum/reagents/R = new/datum/reagents(reagents_max)
 			reagents = R
 			R.my_atom = src
 		else
@@ -310,14 +307,14 @@ proc/make_cleanable(var/type,var/loc,var/list/viral_list)
 		if (ling_blood)
 			src.reagents.add_reagent("bloodc", 0.1)
 		src.sample_reagent = reagent_id
-		src.reagents.add_reagent(reagent_id, 10)
+		src.reagents.add_reagent(reagent_id, amt)
 
 
 	HasEntered(atom/movable/AM as mob|obj)
 		..()
 		if (!istype(AM))
 			return
-		if (src.dry == FRESH_BLOOD && src.blood_volume >= 3 && src.can_track)
+		if (src.dry == FRESH_BLOOD && src.reagents.total_volume >= 5 && src.can_track)
 			if (ishuman(AM))
 				var/mob/living/carbon/human/H = AM
 				if (H.lying)
@@ -370,9 +367,9 @@ proc/make_cleanable(var/type,var/loc,var/list/viral_list)
 
 	proc/add_tracked_blood(atom/movable/AM as mob|obj, var/reliquary = 0)
 		if (reliquary)
-			AM.tracked_blood = list("bDNA" = src.blood_DNA, "btype" = src.blood_type, "color" = src.get_blood_color(), "count" = rand(2,6), "reliquary" = 1)
+			AM.tracked_blood = list("bDNA" = src.blood_DNA, "btype" = src.blood_type, "color" = src.get_blood_color(), "count" = rand(2,6), "reliquary" = 1, "sample_reagent" = sample_reagent)
 		else
-			AM.tracked_blood = list("bDNA" = src.blood_DNA, "btype" = src.blood_type, "color" = src.get_blood_color(), "count" = rand(2,6))
+			AM.tracked_blood = list("bDNA" = src.blood_DNA, "btype" = src.blood_type, "color" = src.get_blood_color(), "count" = rand(2,6), "sample_reagent" = sample_reagent)
 		if (ismob(AM))
 			var/mob/M = AM
 			M.set_clothing_icon_dirty()
@@ -440,11 +437,11 @@ var/list/blood_decal_violent_icon_states = list("floor1", "floor2", "floor3", "f
 	desc = "It's blood."
 	icon_state = "blank" // if you make any more giant white cumblobs all over my nice blood decals
 	random_icon_states = null // I swear to god I will fucking end you
-	blood_volume = 0
 	slippery = 0 // increases as blood volume does
 	color = null
 	var/last_color = null
 	var/last_volume = 1
+	reagents_max = 100
 
 	disposing()
 		diseases = list()
@@ -456,7 +453,6 @@ var/list/blood_decal_violent_icon_states = list("floor1", "floor2", "floor3", "f
 			B.icon = src.icon
 			B.icon_state = src.icon_state
 		var/image/working_image
-		//for (var/i = src.blood_volume, i > 0, i--)
 		for (var/i in src.overlay_refs)
 			working_image = GetOverlayImage(i)
 			if (!working_image)
@@ -499,22 +495,19 @@ var/list/blood_decal_violent_icon_states = list("floor1", "floor2", "floor3", "f
 			processing_items.Remove(src)
 			return
 
-	proc/add_volume(var/add_color, var/amount = 1, var/list/bdata = null, var/i_state = null, var/direction = null, var/do_fluid_react = 1)
+	proc/add_volume(var/add_color, var/reagent_id = "blood", var/amount = 1, var/vis_amount = 1, var/list/bdata = null, var/i_state = null, var/direction = null, var/do_fluid_react = 1)
 	// add_color passes the blood's color to the overlays
-	// amount should only be 1-5 if you want anything to happen
+	// vis_amount should only be 1-5 if you want anything to happen
 		if (istype(bdata))
 			src.blood_DNA = bdata["bDNA"]
 			src.blood_type = bdata["btype"]
 
-		src.blood_volume += amount
+		src.reagents.add_reagent(reagent_id, amount)
 
 		var/turf/simulated/floor/T = src.loc
 		if (istype(T) && do_fluid_react)
 			if (T.cleanable_fluid_react(src))
 				return
-
-		if (src.blood_volume - amount >= 13)
-			return
 
 		/*if (istext(amount))
 			create_overlay(amount, add_color, direction)
@@ -523,8 +516,8 @@ var/list/blood_decal_violent_icon_states = list("floor1", "floor2", "floor3", "f
 
 		if (i_state)
 			create_overlay(i_state, add_color, direction)
-		else if (isnum(amount))
-			switch (amount)
+		else if (isnum(vis_amount))
+			switch (vis_amount)
 				if (1)
 					if (!list_and_len(blood_decal_low_icon_states))
 						return
@@ -551,13 +544,11 @@ var/list/blood_decal_violent_icon_states = list("floor1", "floor2", "floor3", "f
 					create_overlay(blood_decal_violent_icon_states, add_color, direction) // for when you wanna create a BIG MESS
 					src.slippery = 10
 
-		src.Dry(rand(amount*80,amount*120))
-		if (src.reagents && src.reagents.maximum_volume < 100)
-			src.reagents.maximum_volume += 10
+		src.Dry(rand(vis_amount*80,vis_amount*120))
 
 		for (var/obj/item/I in get_turf(src))
 			LAGCHECK(LAG_LOW)
-			if (prob(amount*10))
+			if (prob(vis_amount*10))
 				I.add_blood(src)
 
 	proc/create_overlay(var/list/icons_to_choose, var/add_color, var/direction)
@@ -587,14 +578,14 @@ var/list/blood_decal_violent_icon_states = list("floor1", "floor2", "floor3", "f
 				if (src.overlays.len >= 1) //stop adding more overlays you're lagging client FPS!!!!
 					src.UpdateOverlays(blood_overlay, "bloodfinal")
 				else
-					src.UpdateOverlays(blood_overlay, "blood[src.blood_volume]")
+					src.UpdateOverlays(blood_overlay, "blood[src.reagents.total_volume]")
 
 /obj/decal/cleanable/blood/dynamic/tracks
 	//name = "bloody footprints"
 	desc = "Someone walked through some blood and got it everywhere, jeez!"
 	can_track = 0
 
-	add_volume(var/add_color, var/amount = 1, var/list/bdata = null, var/i_state = null, var/direction = null, var/e_tracking = 1)
+	add_volume(var/add_color, var/reagent_id = "blood", var/amount = 1, var/vis_amount = 1, var/list/bdata = null, var/i_state = null, var/direction = null, var/e_tracking = 1)
 		// e_tracking will be set to 0 by the track_blood() proc atoms run when moving, so anything that doesn't set it to 0 is a regular sort of bleed and should re-enable tracking
 		if (e_tracking)
 			src.can_track = 1


### PR DESCRIPTION
- remove blood_volume var, it was a silly magic number and it served no useful purpose that reagents couldnt handle

-fixed stacky blood cleanables from footprints

- fix bloody footprints custom blood reagent handling

- fixed bleed>puddle/footprint reagent unit amounts being whack as fuc

- remove lagchecks from fluid_procs.dm, as they likely caused problems in blood code (and elsewhere lol)

-fix blootletting

-cows bleed puddles, not splashes

## Changelog
```
mbc:
+ Fixed a number of assorted bugs where blood cleanables would get wrong unit amounts and bloody footprints were handling things improperly
* Fixed bloodletting not working if you were under the max bleed level (that means when you bleed,  some reagents in bloodstream should properly come out with the blood regardless of the bleed type)
```


