### PR TITLE
reagent transfer in lost blood will reflect the amount of blood lost instead of the current 'bleeding' level

### DIFF
--- a/code/modules/medical/blood_system.dm
+++ b/code/modules/medical/blood_system.dm
@@ -483,7 +483,7 @@ this is already used where it needs to be used, you can probably ignore it.
 
 		if (B && B.reagents && H.reagents && H.reagents.total_volume)
 			//BLOOD_DEBUG("[H] transfers reagents to blood decal [log_reagents(H)]")
-			H.reagents.trans_to(B, min(round(H.bleeding / 2, 1), 5))
+			H.reagents.trans_to(B, min(round(num_amount / 2, 1), 5))
 	else
 		return
 


### PR DESCRIPTION
this just makes more sense, you'd expect to lose reagents based on how much blood fell out of you and not your total amount of open wounds.
