### PR TITLE
A handful of guncode tweaks

### DIFF
--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -660,9 +660,8 @@
 		shot = 1
 
 		if (affecting && assailant && isitem(src.loc))
-			if (get_dist(src.affecting,src.assailant) <= 1)
-				var/obj/item/gun/G = src.loc
-				G.shoot_point_blank(src.affecting,src.assailant)
+			var/obj/item/gun/G = src.loc
+			G.shoot_point_blank(src.affecting,src.assailant,1) //don't shoot an offhand gun
 
 		qdel(src)
 

--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -82,6 +82,33 @@
 	attackby(obj/b as obj, mob/user as mob)
 		if(istype(b, /obj/item/gun/kinetic) && b:allowReverseReload)
 			b.attackby(src, user)
+		else if(b.type == src.type)
+			var/obj/item/ammo/bullets/A = b
+			if(A.amount_left<1)
+				user.show_text("There's no ammo left in [A.name].", "red")
+				return
+			if(src.amount_left>=src.max_amount)
+				user.show_text("[src] is full!", "red")
+				return
+
+			while ((A.amount_left > 0) && (src.amount_left < src.max_amount))
+				A.amount_left--
+				src.amount_left++
+			if ((A.amount_left < 1) && (src.amount_left < src.max_amount))
+				A.update_icon()
+				src.update_icon()
+				if (A.delete_on_reload)
+					qdel(A) // No duplicating empty magazines, please (Convair880).
+				user.visible_message("<span style=\"color:red\">[user] refills [src].</span>", "<span style=\"color:red\">There wasn't enough ammo left in [A.name] to fully refill [src]. It only has [src.amount_left] rounds remaining.</span>")
+				return // Couldn't fully reload the gun.
+			if ((A.amount_left >= 0) && (src.amount_left == src.max_amount))
+				A.update_icon()
+				src.update_icon()
+				if (A.amount_left == 0)
+					if (A.delete_on_reload)
+						qdel(A) // No duplicating empty magazines, please (Convair880).
+				user.visible_message("<span style=\"color:red\">[user] refills [src].</span>", "<span style=\"color:red\">You fully refill [src] with ammo from [A.name]. There are [A.amount_left] rounds left in [A.name].</span>")
+				return // Full reload or ammo left over.
 		else return ..()
 
 	swap(var/obj/item/ammo/bullets/A, var/obj/item/gun/kinetic/K)

--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -343,7 +343,21 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 				sleep(slowdown_time)
 				M.movement_delay_modifier -= slowdown
 
-	var/obj/projectile/P = shoot_projectile_ST_pixel_spread(user, current_projectile, target, POX, POY, spread_angle)
+	var/spread = spread_angle
+	if (ismob(user) && user.reagents)
+		var/mob/living/carbon/human/M = user
+		var/how_drunk = 0
+		var/amt = M.reagents.get_reagent_amount("ethanol")
+		if (amt >= 110)
+			how_drunk = 2
+		else if (amt < 110)
+			how_drunk = 1
+		else if (amt <= 0)
+			how_drunk = 0
+		how_drunk = max(0, how_drunk - isalcoholresistant(M) ? 1 : 0)
+		spread += 5 * how_drunk
+
+	var/obj/projectile/P = shoot_projectile_ST_pixel_spread(user, current_projectile, target, POX, POY, spread)
 	if (P)
 		alter_projectile(P)
 		P.forensic_ID = src.forensic_ID

--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -318,9 +318,9 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 
 		alter_projectile(P)
 		P.forensic_ID = src.forensic_ID // Was missing (Convair880).
-		P.was_pointblank = 1
 		if(get_dist(user,M) <= 1)
 			hit_with_existing_projectile(P, M) // Includes log entry.
+			P.was_pointblank = 1
 		else
 			P.launch()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes a few tweaks to guns that I felt were cool/needed/missing:
Burstfire guns not burstfiring on pointblank was weird and dumb, so fixed
click a magazine with another one (of the same type) to transfer ammo
adds some projectile spread to guns while drunk - enough to be noticeable , not enough to be really devastating hopefully
adds support for giving guns different rates of fire - doesn't actually change any, that can be considered for future changes... except on assday, when it defaults to 0 ticks of delay. heh.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
A bit of bugfixing, a bit of QoL changes, and the image of the drunken det shooting a *little* more wildly than normal is really funny, and rate of fire stuff gives another knob to tweak for gun balance


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use * for major changes and + for minor changes. For example: -->

```
Tarmunora:
* Guns can now have a custom click delay (rate of fire). Delay is currently kept at 4 for all guns (no change), except on ass day, where you can shoot as fast as you can click.
* Guns have a little bit of extra spread when drunk. Alcohol immunity mitigates this, to an extent
* Added the ability to refill/combine ammo boxes by hitting them with a box of the same type
* Changed pointblanking to hit with all the projectiles in a burst, not just one
* Fixes up gunpoint grabs a little bit (should shoot more consistently)
```

