### PR TITLE
Change the weighting that brute/burn damage has on the 'instant death' floor

### DIFF
--- a/code/mob/living/carbon/human/procs/Life.dm
+++ b/code/mob/living/carbon/human/procs/Life.dm
@@ -1634,7 +1634,7 @@
 	proc/handle_regular_status_updates(datum/controller/process/mobs/parent,var/mult = 1)
 
 		health = max_health - (get_oxygen_deprivation() + get_toxin_damage() + get_burn_damage() + get_brute_damage())
-
+		var/death_health = src.health + (src.get_oxygen_deprivation() * 0.5) - (get_burn_damage() * 0.67) - (get_brute_damage() * 0.67) //lower weight of oxy, increase weight of brute/burn here
 		// I don't think the revenant needs any of this crap - Marq
 		if (src.bioHolder && src.bioHolder.HasEffect("revenant") || isdead(src)) //You also don't need to do a whole lot of this if the dude's dead.
 			return
@@ -1674,7 +1674,7 @@
 		var/is_chg = is_changeling()
 		//if (src.brain_op_stage == 4.0) // handled above in handle_organs() now
 			//death()
-		if (src.get_brain_damage() >= 120 || (src.health + (src.get_oxygen_deprivation() / 2)) <= -500) //-200) a shitty test here // let's lower the weight of oxy
+		if (src.get_brain_damage() >= 120 || death_health <= -500) //-200) a shitty test here // let's lower the weight of oxy
 			if (!is_chg)
 				death()
 			else if (src.suiciding)


### PR DESCRIPTION
Oxy damage has 50% effect in reaching instant death threshold (-500).
I have increased the weight that brute/burn damage have in this calculation to 166.7%. This means you only need to take 400 brute damage (in ideal test environment) to reach instant death instead of 600 brute damage.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
idea came from a discord discussion where people were saying humans can take way too much punishment


## Changelog
```
mbc:
* High amounts of Brute and Burn damage will be weighted more heavily in deciding whether you die or not. In practice this means that you previously could take 600 brute/burn damage before dropping dead, and now you can take 400.
```

