### PR TITLE
Lock fix

### DIFF
--- a/code/obj/item/storage/secure_safe.dm
+++ b/code/obj/item/storage/secure_safe.dm
@@ -264,7 +264,7 @@
 				playsound(src.loc, "sound/items/Deconstruct.ogg", 65, 1)
 
 			else
-				usr << output("ERR!&0", "ship_lock.browser:updateReadout")
+				usr << output("ERR!&0", "caselock.browser:updateReadout")
 				var/code_attempt = uppertext(ckey(href_list["enter"]))
 				/*
 				Mastermind game in which the solution is "code" and the guess is "code_attempt"
@@ -306,11 +306,11 @@
 					var/desctext = ""
 					switch(rightplace)
 						if (1)
-							desctext += "a short beep"
+							desctext += "a grumpy beep"
 						if (2)
-							desctext += "a pair of short beeps"
+							desctext += "a pair of grumpy beeps"
 						if (3)
-							desctext += "a trio of short beeps"
+							desctext += "a trio of grumpy beeps"
 
 					if (desctext && (wrongplace) > 0)
 						desctext += " and "
@@ -319,14 +319,14 @@
 						if (1)
 							desctext += "a short boop"
 						if (2)
-							desctext += "two warbly boops"
+							desctext += "two harsh boops"
 						if (3)
 							desctext += "a quick three boops"
 						if (4)
-							desctext += "a rather long boop"
+							desctext += "a long, sad, warbly boop"
 
 					if (desctext)
-						boutput(usr, "<span style=\"color:red\">The lock panel emits [desctext].</span>")
+						src.visible_message("<span style=\"color:red\">[src]'s lock panel emits [desctext].</span>")
 						playsound(src.loc, "sound/machines/twobeep.ogg", 55, 1) // set this to play proper beeps later
 
 	else if (href_list["lock"])

--- a/code/obj/item/storage/secure_safe.dm
+++ b/code/obj/item/storage/secure_safe.dm
@@ -264,54 +264,69 @@
 				playsound(src.loc, "sound/items/Deconstruct.ogg", 65, 1)
 
 			else
-				usr << output("ERR!&0", "caselock.browser:updateReadout")
+				usr << output("ERR!&0", "ship_lock.browser:updateReadout")
 				var/code_attempt = uppertext(ckey(href_list["enter"]))
+				/*
+				Mastermind game in which the solution is "code" and the guess is "code_attempt"
+				First go through the guess and find any with the exact same position as in the solution
+				Increment rightplace when such occurs.
+				Then go through the guess and, with each letter, go through all the letters of the solution code
+				Increment wrongplace when such occurs.
+
+				In both cases, add a power of two corresponding to the locations of the relevant letters
+				This forms a set of flags which is checked whenever same-letters are found
+
+				Once all of the guess has been iterated through for both rightplace and wrongplace, construct
+				a beep/boop message dependant on what was gotten right.
+				*/
 				if (length(code_attempt) == 4)
-					var/i = 0
-					var/j = 0
-					var/incode = 0
+					var/guessplace = 0
+					var/codeplace = 0
+					var/guessflags = 0
+					var/codeflags = 0
+
+					var/wrongplace = 0
 					var/rightplace = 0
-					var/offset = 0
-					while (++i < 5)
-						if (copytext(code_attempt, i,i+1) == copytext(code, i, i + 1))
-							offset += 2 ** (i-1)
+					while (++guessplace < 5)
+						if ((((guessflags - guessflags % (2 ** (guessplace - 1))) / (2 ** (guessplace - 1))) % 2 == 0) && (copytext(code_attempt, guessplace , guessplace + 1) == copytext(code, guessplace, guessplace + 1)))
+							guessflags += 2 ** (guessplace-1)
+							codeflags += 2 ** (guessplace-1)
 							rightplace++
-							incode++
-							continue
-					
-					i = 0
-					while (++i < 5)
-						j = 0
-						while(++j < 5)
-							if(i != j && (((offset - offset % (2 ** (j - 1))) / (2 ** (j - 1))) % 2 == 0) && (copytext(code_attempt, i,i+1) == copytext(code, j, j+1)))
-								offset += 2 ** (j-1)
-								incode++
-								j = 5
+
+					guessplace = 0
+					while (++guessplace < 5)
+						codeplace = 0
+						while(++codeplace < 5)
+							if(guessplace != codeplace && (((guessflags - guessflags % (2 ** (guessplace - 1))) / (2 ** (guessplace - 1))) % 2 == 0) && (((codeflags - codeflags % (2 ** (codeplace - 1))) / (2 ** (codeplace - 1))) % 2 == 0) && (copytext(code_attempt, guessplace , guessplace + 1) == copytext(code, codeplace , codeplace + 1)))
+								guessflags += 2 ** (guessplace-1)
+								codeflags += 2 ** (codeplace-1)
+								wrongplace++
+								codeplace = 5
 
 					var/desctext = ""
 					switch(rightplace)
 						if (1)
-							desctext += "a grumpy beep"
+							desctext += "a short beep"
 						if (2)
-							desctext += "a pair of grumpy beeps"
+							desctext += "a pair of short beeps"
 						if (3)
-							desctext += "a trio of grumpy beeps"
+							desctext += "a trio of short beeps"
 
-					if (desctext && (incode - rightplace) > 0)
+					if (desctext && (wrongplace) > 0)
 						desctext += " and "
 
-					switch(incode - rightplace)
+					switch(wrongplace)
 						if (1)
 							desctext += "a short boop"
 						if (2)
-							desctext += "two harsh boops"
+							desctext += "two warbly boops"
 						if (3)
 							desctext += "a quick three boops"
 						if (4)
-							desctext += "a long, sad, warbly boop"
+							desctext += "a rather long boop"
 
 					if (desctext)
-						src.visible_message("<span style=\"color:red\">[src]'s lock panel emits [desctext].</span>")
+						boutput(usr, "<span style=\"color:red\">The lock panel emits [desctext].</span>")
 						playsound(src.loc, "sound/machines/twobeep.ogg", 55, 1) // set this to play proper beeps later
 
 	else if (href_list["lock"])
@@ -654,7 +669,7 @@
 				S.setup(src)
 				S = unpool(/obj/item/spacecash/thousand)
 				S.setup(src)
-	
+
 	disposing()
 		. = ..()
 		STOP_TRACKING


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
The minigame for unlocking pod locks and secure crate locks is further improved.



## Why's this needed?
Current behavior is erroneous, such as a guess of 1000 for a code of 1231 resulting in both a beep and a boop; ideally it should just be a beep. This leads to incorrect feedback on the code guessing. 



## Changelog

```
saccharineChampion:
+ Corrected improper feedback on incorrect pod and secure safe lock guesses.
```

