### PR TITLE
Adds the botanical mister as a valid transfer target for High capacity watering tanks

### DIFF
--- a/code/modules/chemistry/tools/dispensers.dm
+++ b/code/modules/chemistry/tools/dispensers.dm
@@ -65,7 +65,7 @@
 				reagents.temperature_reagents(exposed_temperature, exposed_volume)
 
 	MouseDrop(atom/over_object as obj)
-		if (!istype(over_object, /obj/item/reagent_containers/glass) && !istype(over_object, /obj/item/reagent_containers/food/drinks) && !istype(over_object, /obj/item/spraybottle) && !istype(over_object, /obj/machinery/plantpot) && !istype(over_object, /obj/mopbucket))
+		if (!istype(over_object, /obj/item/reagent_containers/glass) && !istype(over_object, /obj/item/reagent_containers/food/drinks) && !istype(over_object, /obj/item/spraybottle) && !istype(over_object, /obj/machinery/plantpot) && !istype(over_object, /obj/mopbucket) && !istype(over_object, /obj/machinery/hydro_mister))
 			return ..()
 
 		if (get_dist(usr, src) > 1 || get_dist(usr, over_object) > 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Describe the Pull Request here. What does it change? What other things could this impact? -->



## Added a QoL change to the tank to allow for easier botanical mister filling <!-- Describe why you think this should be added to the game -->

```
CodeDude: Literally just added the mister to the valid transfer target list...

