### PR TITLE
Can't use scanned/printed eguns to make captain's sabre

### DIFF
--- a/code/WorkInProgress/JobXPRewards.dm
+++ b/code/WorkInProgress/JobXPRewards.dm
@@ -232,7 +232,7 @@ mob/verb/checkrewards()
 				boutput(C.mob, "This [sacrifice_name] has forever been ruined by a device analyzer's magnets. It can't turn into a sword ever again!!")
 				src.claimedNumbers[usr.key] --
 				return
-			if (K.deconstruct_flags == DECON_BUILT) //Checks to see if it was built from a frame
+			if (K.deconstruct_flags & DECON_BUILT) //Checks to see if it was built from a frame
 				boutput(C.mob, "This [sacrifice_name] is a replica and cannot be turned into a sword legally! Only an original, unscanned energy gun will work for this!")
 				src.claimedNumbers[usr.key] --
 				return

--- a/code/WorkInProgress/JobXPRewards.dm
+++ b/code/WorkInProgress/JobXPRewards.dm
@@ -225,10 +225,17 @@ mob/verb/checkrewards()
 
 	activate(var/client/C)
 		var/found = 0
-
 		var/O = locate(sacrifice_path) in C.mob.contents
 		if (istype(O, sacrifice_path))
 			var/obj/item/gun/energy/egun/K = O
+			if (K.nojobreward) // Checks to see if it was scanned by a device analyzer
+				boutput(C.mob, "This [sacrifice_name] has forever been ruined by a device analyzer's magnets. It can't turn into a sword ever again!!")
+				src.claimedNumbers[usr.key] --
+				return
+			if (K.deconstruct_flags == 128) //Checks to see if it was built from a frame
+				boutput(C.mob, "This [sacrifice_name] is a replica and cannot be turned into a sword legally! Only an original, unscanned energy gun will work for this!")
+				src.claimedNumbers[usr.key] --
+				return
 			C.mob.remove_item(K)
 			found = 1
 			qdel(K)

--- a/code/WorkInProgress/JobXPRewards.dm
+++ b/code/WorkInProgress/JobXPRewards.dm
@@ -232,7 +232,7 @@ mob/verb/checkrewards()
 				boutput(C.mob, "This [sacrifice_name] has forever been ruined by a device analyzer's magnets. It can't turn into a sword ever again!!")
 				src.claimedNumbers[usr.key] --
 				return
-			if (K.deconstruct_flags == 128) //Checks to see if it was built from a frame
+			if (K.deconstruct_flags == DECON_BUILT) //Checks to see if it was built from a frame
 				boutput(C.mob, "This [sacrifice_name] is a replica and cannot be turned into a sword legally! Only an original, unscanned energy gun will work for this!")
 				src.claimedNumbers[usr.key] --
 				return

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -322,6 +322,7 @@
 	force = 5.0
 	mats = 50
 	module_research = list("weapons" = 5, "energy" = 4, "miniaturization" = 5)
+	var/nojobreward = 0 //used to stop people from scanning it and then getting both a lawgiver/sabre AND an egun.
 
 	New()
 		cell = new/obj/item/ammo/power_cell/med_power
@@ -345,6 +346,10 @@
 		..()
 		update_icon()
 		M.update_inhands()
+
+	attackby(obj/item/W as obj, mob/user as mob)
+		if (istype(W, /obj/item/electronics/scanner))
+			nojobreward = 1
 
 //////////////////////// nanotrasen gun
 //Azungar's Nanotrasen inspired Laser Assault Rifle for RP gimmicks
@@ -472,7 +477,7 @@
 	update_icon()
 		if (src.cell)
 			var/ratio = min(1, src.cell.charge / src.cell.max_charge)
-			ratio = round(ratio, 0.25) * 100	
+			ratio = round(ratio, 0.25) * 100
 			if(current_projectile.type == /datum/projectile/wavegun)
 				src.icon_state = "wavegun[ratio]"
 				item_state = "wave"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR 

This makes it so that you can't turn a scanned or printed out egun into a captain's sabre. Could also be applied to the lawgiver but I chose not to in this PR. Could reasonably be changed to accommodate the lawgiver too if it's wanted probably

## Why's this needed? 

I want the sabre to be a "I don't need an egun, I have a sword!" sorta thing, being able to get both by scanning the gun and printing it out defeats this purpose. You shouldn't be able to have your cake and eat it too! 