### PR TITLE
Add "cls" or "clear" to DWAINE

### DIFF
--- a/code/modules/networks/computer3/mainframe2/shell.dm
+++ b/code/modules/networks/computer3/mainframe2/shell.dm
@@ -326,8 +326,9 @@
 								return 1
 
 						continue
-
-
+					if ("cls", "clear")
+						message_user("Screen cleared.", "clear")
+						continue
 					//SCRIPTING COMMANDS FOLLOW:
 					//If - Evaluate an expression.  If true, set SCRIPT_IF_TRUE in scriptstat and continue piping
 					//if false, unset SCRIPT_IF_TRUE and continue to the next line


### PR DESCRIPTION

## About the PR 
Clears your screen while logged into DWAINE. Yet another QoL thing for packet nerds.
This time I integrated the command directly into the shell so that I dont have to mess with tapes or filesystem stuff.

## Why's this needed?
Letting large amounts of text build up in computers/terminals causes lag, at least on the client-side. Currently, the only ways to clear text currently are to logout of DWAINE and log back in or to outright restart your terminal/computer. Basically, convenience ~~and replacing essential programs with troll scripts that clear your screen repeatedly~~.

