### PR TITLE
changes captain sabre to use get_desc instead of overriding examine

### DIFF
--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -847,7 +847,7 @@
 /obj/item/katana/captain
 	icon_state = "cap_sword"
 	name = "Commander's Sabre"
-	desc = null
+	desc = ""
 
 	inhand_image_icon = 'icons/mob/inhand/hand_weapons.dmi'
 	force = 16 //not awful but not amazing
@@ -855,12 +855,11 @@
 	delimb_prob = 1
 	contraband = 4
 
-	examine()
-		set src in usr
-		if (usr.mind && usr.mind.assigned_role == "Captain")
-			boutput(usr, "An ornate and finely crafted blade designed only for the most competent and highly respected of NT's chain of command. Like you!")
+	get_desc(var/dist, var/mob/user)
+		if (user.mind && user.mind.assigned_role == "Captain")
+			. = "An ornate and finely crafted blade designed only for the most competent and highly respected of NT's chain of command. Like you!"
 		else
-			boutput(usr, "Looks like some sort of cheap historical recreation sword. You'd have to be a total dork to own this thing.")
+			. = "Looks like some sort of cheap historical recreation sword. You'd have to be a total dork to own this thing."
 
 	New()
 		..()
@@ -1008,12 +1007,11 @@
 			return
 		..()
 
-	examine()
-		set src in usr
-		if (usr.mind && usr.mind.assigned_role == "Captain")
-			boutput(usr, "A stylish container for your sabre. Made from the finest metals NT can afford, or so you've heard.")
+	get_desc(var/dist, var/mob/user)
+		if (user.mind && user.mind.assigned_role == "Captain")
+			. = "A stylish container for your sabre. Made from the finest metals NT can afford, or so you've heard."
 		else
-			boutput(usr, "A tacky container for a sword. Hey! This thing's actually just plastic painted to look like metal! What a ripoff!")
+			. = "A tacky container for a sword. Hey! This thing's actually just plastic painted to look like metal! What a ripoff!"
 
 	blue //for NTSO medal reward
 		icon_state = "blue_cap_sword_scabbard"


### PR DESCRIPTION

<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
this changes captains sabres to use get_desc instead of overriding examine, which was making tooltips not display at all for the sabre. this change makes it so that that tooltip displays properly.
related to 
Fixes #116 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
for consistency's sake, every item should have a tooltip if it can.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use * for major changes and + for minor changes. For example: -->

```
adharainspace:
- gives captains sabre a tooltip by making it use get_desc instead of examine
```

