### PR TITLE
More Nuke-op name lists

### DIFF
--- a/code/datums/gamemodes/nuclear.dm
+++ b/code/datums/gamemodes/nuclear.dm
@@ -145,7 +145,7 @@
 	var/leader_title = pick("Czar", "Boss", "Commander", "Chief", "Kingpin", "Director", "Overlord", "General", "Warlord", "Commissar")
 	var/leader_selected = 0
 
-	var/list/callsign_pool_keys = list("nato", "melee_weapons", "colors")
+	var/list/callsign_pool_keys = list("nato", "melee_weapons", "colors", "birds", "mammals")
 	//Alphabetical agent callsign lists are delcared here, seperated in to catagories.
 	var/list/callsign_list = strings("agent_callsigns.txt", pick(callsign_pool_keys))
 

--- a/code/datums/gamemodes/nuclear.dm
+++ b/code/datums/gamemodes/nuclear.dm
@@ -145,7 +145,7 @@
 	var/leader_title = pick("Czar", "Boss", "Commander", "Chief", "Kingpin", "Director", "Overlord", "General", "Warlord", "Commissar")
 	var/leader_selected = 0
 
-	var/list/callsign_pool_keys = list("nato", "melee_weapons", "colors", "birds", "mammals")
+	var/list/callsign_pool_keys = list("nato", "melee_weapons", "colors", "birds", "mammals", "moons")
 	//Alphabetical agent callsign lists are delcared here, seperated in to catagories.
 	var/list/callsign_list = strings("agent_callsigns.txt", pick(callsign_pool_keys))
 

--- a/strings/agent_callsigns.txt
+++ b/strings/agent_callsigns.txt
@@ -1,3 +1,5 @@
 nato@=Alpha@,Bravo@,Charlie@,Delta@,Echo@,Foxtrot@,Golf@,Hotel@,India@,Juliett@,Kilo@,Lima@,Mike@,November@,Oscar@,Papa@,Quebec@,Romeo@,Sierra@,Tango@,Uniform@,Victor@,Whiskey@,X-ray@,Yankee@,Zulu
 melee_weapons@=Axe@,Baselard@,Cutlass@,Dagger@,Estoc@,Falchion@,Gladius@,Hatchet@,Ice-pick@,Javelin@,Katana@,Longsword@,Machete@,Nodachi@,Odachi@,Partisan@,Quarterstaff@,Rapier@,Scimitar@,Tomahawk@,Uchigatana@,Voulge@,Warhammer@,Xiphos@,Yumi@,Zweihander
-colors@=Red@,Orange@,Yellow@,Green@,Blue@,Indigo@,Violet@,Black@,White
+colors@=Azure@,Black@,Crimson@,Emerald@,Fuchsia@,Gold@,Indigo@,Jade@,Khaki@,Lavender@,Magenta@,Olive@,Platinum@,Quartz@,Ruby@,Silver@,Titanium@,Ultramarine@,White@,Yellow
+birds@=Albatross@,Budgerigar@,Crane@,Duck@,Eagle@,Falcon@,Goose@,Heron@,Ibis@,Kingfisher@,Magpie@,Nightingale@,Ostrich@,Pelican@,Quetzal@,Robin@,Sparrow@,Toucan@,Vulture@,Woodpecker
+mammals@=Armadillo@,Bear@,Coyote@,Dingo@,Elephant@,Fox@,Gorilla@,Hyena@,Impala@,Jackal@,Kangaroo@,Lion@,Monkey@,Ocelot@,Panther@,Rat@,Squirrel@,Tiger@,Wolverine@,Zebra

--- a/strings/agent_callsigns.txt
+++ b/strings/agent_callsigns.txt
@@ -3,3 +3,4 @@ melee_weapons@=Axe@,Baselard@,Cutlass@,Dagger@,Estoc@,Falchion@,Gladius@,Hatchet
 colors@=Azure@,Black@,Crimson@,Emerald@,Fuchsia@,Gold@,Indigo@,Jade@,Khaki@,Lavender@,Magenta@,Olive@,Platinum@,Quartz@,Ruby@,Silver@,Titanium@,Ultramarine@,White@,Yellow
 birds@=Albatross@,Budgerigar@,Crane@,Duck@,Eagle@,Falcon@,Goose@,Heron@,Ibis@,Kingfisher@,Magpie@,Nightingale@,Ostrich@,Pelican@,Quetzal@,Robin@,Sparrow@,Toucan@,Vulture@,Woodpecker
 mammals@=Armadillo@,Bear@,Coyote@,Dingo@,Elephant@,Fox@,Gorilla@,Hyena@,Impala@,Jackal@,Kangaroo@,Lion@,Monkey@,Ocelot@,Panther@,Rat@,Squirrel@,Tiger@,Wolverine@,Zebra
+moons@=Deimos@,Phobos@,Amalthea@,Callisto@,Europa@,Ganymede@,Io@,Dione@,Enceladus@,Hyperion@,Iapetus@,Mimas@,Phoebe@,Rhea@,Tethys@,Titan@,Ariel@,Miranda@,Oberon@,Titania@,Umbriel@,Nereid@,Triton@,Charon


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds three new name lists for nuclear operatives to randomly pull from. 

- Birds
- Mammals
- Moons

Also, edited the previous color list to be more interesting.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

My last PR was mostly me trying to get to grips with github, this is just a lil more fun random content for my adopted game-mode.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use * for major changes and + for minor changes. For example: -->

```
Gannets:
+ Nuclear operatives now pull their names from 6 callsign pools, nato alphabet, melee weapons, colors, birds, mammals and moons.
```

