### PR TITLE
Custom sound source argument for projectile code, largepods use it for their weapons

### DIFF
--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -536,7 +536,7 @@ datum/projectile
 		cost = 1                 // How much ammo this costs
 		max_range = 500          // How many ticks can this projectile go for if not stopped, if it doesn't die from falloff
 		dissipation_rate = 2     // How fast the power goes away
-		dissipation_delay = 10   // How many tiles till it starts to lose power - not exactly tiles, because falloff works on ticks, and doesn't seem to quite match 1-1 to tiles. 
+		dissipation_delay = 10   // How many tiles till it starts to lose power - not exactly tiles, because falloff works on ticks, and doesn't seem to quite match 1-1 to tiles.
 		                         // When firing in a straight line, I was getting doubled falloff values on the fourth tile from the shooter, as well as others further along. -Tarm
 		dissipation_ticker = 0   // Tracks how many tiles we moved
 		ks_ratio = 1.0           /* Kill/Stun ratio, when it hits a mob the damage/stun is based upon this and the power
@@ -778,18 +778,18 @@ datum/projectile/snowball
 			P.proj_data.on_pointblank(P, T)
 	P.collide(T) // The other immunity check is in there (Convair880).
 
-/proc/shoot_projectile_ST(var/atom/movable/S, var/datum/projectile/DATA, var/T)
+/proc/shoot_projectile_ST(var/atom/movable/S, var/datum/projectile/DATA, var/T, var/atom/movable/remote_sound_source)
 	if (!S)
 		return
 	if (!isturf(S) && !isturf(S.loc))
 		return null
 	var/turf/target = get_turf(T)
-	var/obj/projectile/Q = shoot_projectile_relay(S, DATA, target)
+	var/obj/projectile/Q = shoot_projectile_relay(S, DATA, target, remote_sound_source)
 	if (DATA.shot_number > 1)
 		SPAWN_DBG(-1)
 			for (var/i = 2, i < DATA.shot_number, i++)
 				sleep(DATA.shot_delay)
-				shoot_projectile_relay(S, DATA, target)
+				shoot_projectile_relay(S, DATA, target, remote_sound_source)
 	return Q
 
 /proc/shoot_projectile_ST_pixel(var/atom/movable/S, var/datum/projectile/DATA, var/T, var/pox, var/poy)
@@ -820,22 +820,22 @@ datum/projectile/snowball
 				shoot_projectile_relay_pixel_spread(S, DATA, target, pox, poy, spread_angle)
 	return Q
 
-/proc/shoot_projectile_DIR(var/atom/movable/S, var/datum/projectile/DATA, var/dir)
+/proc/shoot_projectile_DIR(var/atom/movable/S, var/datum/projectile/DATA, var/dir, var/atom/movable/remote_sound_source)
 	if (!S)
 		return
 	if (!isturf(S) && !isturf(S.loc))
 		return null
 	var/turf/T = get_step(get_turf(S), dir)
 	if (T)
-		return shoot_projectile_ST(S, DATA, T)
+		return shoot_projectile_ST(S, DATA, T, remote_sound_source)
 	return null
 
-/proc/shoot_projectile_relay(var/atom/movable/S, var/datum/projectile/DATA, var/T)
+/proc/shoot_projectile_relay(var/atom/movable/S, var/datum/projectile/DATA, var/T, var/atom/movable/remote_sound_source)
 	if (!S)
 		return
 	if (!isturf(S) && !isturf(S.loc))
 		return
-	var/obj/projectile/P = initialize_projectile_ST(S, DATA, T)
+	var/obj/projectile/P = initialize_projectile_ST(S, DATA, T, remote_sound_source)
 	if (P)
 		P.launch()
 	return P
@@ -883,14 +883,14 @@ datum/projectile/snowball
 		P.launch()
 	return P
 
-/proc/initialize_projectile_ST(var/atom/movable/S, var/datum/projectile/DATA, var/T)
+/proc/initialize_projectile_ST(var/atom/movable/S, var/datum/projectile/DATA, var/T, var/atom/movable/remote_sound_source)
 	if (!S)
 		return
 	if (!isturf(S) && !isturf(S.loc))
 		return
 	var/turf/Q1 = get_turf(S)
 	var/turf/Q2 = get_turf(T)
-	return initialize_projectile(Q1, DATA, Q2.x - Q1.x, Q2.y - Q1.y, S)
+	return initialize_projectile(Q1, DATA, Q2.x - Q1.x, Q2.y - Q1.y, S, remote_sound_source)
 
 /proc/initialize_projectile_pixel(var/atom/movable/S, var/datum/projectile/DATA, var/T, var/pox, var/poy)
 	if (!S)
@@ -910,7 +910,7 @@ datum/projectile/snowball
 		P.rotateDirection(prob(50) ? spread : -spread)
 	return P
 
-/proc/initialize_projectile(var/turf/S, var/datum/projectile/DATA, var/xo, var/yo, var/shooter = null)
+/proc/initialize_projectile(var/turf/S, var/datum/projectile/DATA, var/xo, var/yo, var/shooter = null, var/turf/remote_sound_source)
 	if (!S)
 		return
 	var/obj/projectile/P = unpool(/obj/projectile)
@@ -927,6 +927,9 @@ datum/projectile/snowball
 
 	if (DATA.implanted)
 		P.implanted = DATA.implanted
+
+	if(remote_sound_source)
+		shooter = remote_sound_source
 
 	if (narrator_mode)
 		playsound(S, 'sound/vox/shoot.ogg', 50, 1)

--- a/code/modules/transport/pods/ships.dm
+++ b/code/modules/transport/pods/ships.dm
@@ -878,37 +878,37 @@
 		//fucK ME
 		if (shoot_dir & (shoot_dir-1))
 			if (shoot_dir == SOUTHEAST)
-				var/obj/projectile/P = shoot_projectile_DIR(get_step(get_turf(src), SOUTHEAST), PROJ, shoot_dir)
+				var/obj/projectile/P = shoot_projectile_DIR(get_step(get_turf(src), SOUTHEAST), PROJ, shoot_dir, src)
 				if (P)
 					P.mob_shooter = user
 				var/turf/E = get_step(get_turf(src), EAST)
-				P = shoot_projectile_DIR(get_step(E, EAST), PROJ, shoot_dir)
+				P = shoot_projectile_DIR(get_step(E, EAST), PROJ, shoot_dir, src)
 				if (P)
 					P.mob_shooter = user
 			if (shoot_dir == SOUTHWEST)
-				var/obj/projectile/P = shoot_projectile_DIR(get_step(get_turf(src), WEST), PROJ, shoot_dir)
+				var/obj/projectile/P = shoot_projectile_DIR(get_step(get_turf(src), WEST), PROJ, shoot_dir, src)
 				if (P)
 					P.mob_shooter = user
-				P = shoot_projectile_DIR(get_step(get_turf(src), SOUTH), PROJ, shoot_dir)
+				P = shoot_projectile_DIR(get_step(get_turf(src), SOUTH), PROJ, shoot_dir, src)
 				if (P)
 					P.mob_shooter = user
 
 			if (shoot_dir == NORTHEAST)
 				var/turf/NE = get_step(get_turf(src), NORTHEAST)
 
-				var/obj/projectile/P = shoot_projectile_DIR(get_step(NE, NORTH), PROJ, shoot_dir)
+				var/obj/projectile/P = shoot_projectile_DIR(get_step(NE, NORTH), PROJ, shoot_dir, src)
 				if (P)
 					P.mob_shooter = user
-				P = shoot_projectile_DIR(get_step(NE, EAST), PROJ, shoot_dir)
+				P = shoot_projectile_DIR(get_step(NE, EAST), PROJ, shoot_dir, src)
 				if (P)
 					P.mob_shooter = user
 
 			if (shoot_dir == NORTHWEST)
 				var/turf/N = get_step(get_turf(src), NORTH)
-				var/obj/projectile/P = shoot_projectile_DIR(get_step(N, WEST), PROJ, shoot_dir)
+				var/obj/projectile/P = shoot_projectile_DIR(get_step(N, WEST), PROJ, shoot_dir, src)
 				if (P)
 					P.mob_shooter = user
-				P = shoot_projectile_DIR(get_step(N, NORTH), PROJ, shoot_dir)
+				P = shoot_projectile_DIR(get_step(N, NORTH), PROJ, shoot_dir, src)
 				if (P)
 					P.mob_shooter = user
 		else
@@ -919,21 +919,21 @@
 					P.pixel_x = H * -5
 					P.pixel_y = V * -5
 			if (shoot_dir == SOUTH || shoot_dir == EAST)
-				var/obj/projectile/P = shoot_projectile_DIR(get_step(get_turf(src), EAST), PROJ, shoot_dir)
+				var/obj/projectile/P = shoot_projectile_DIR(get_step(get_turf(src), EAST), PROJ, shoot_dir, src)
 				if (P)
 					P.shooter = src
 					P.mob_shooter = user
 					P.pixel_x = H * 5
 					P.pixel_y = V * -5
 			if (shoot_dir == NORTH || shoot_dir == WEST)
-				var/obj/projectile/P = shoot_projectile_DIR(get_step(get_turf(src), NORTH), PROJ, shoot_dir)
+				var/obj/projectile/P = shoot_projectile_DIR(get_step(get_turf(src), NORTH), PROJ, shoot_dir, src)
 				if (P)
 					P.shooter = src
 					P.mob_shooter = user
 					P.pixel_x = H * -5
 					P.pixel_y = V * 5
 			if (shoot_dir == NORTH || shoot_dir == EAST)
-				var/obj/projectile/P = shoot_projectile_DIR(get_step(get_turf(src), NORTHEAST), PROJ, shoot_dir)
+				var/obj/projectile/P = shoot_projectile_DIR(get_step(get_turf(src), NORTHEAST), PROJ, shoot_dir, src)
 				if (P)
 					P.shooter = src
 					P.mob_shooter = user


### PR DESCRIPTION
## About the PR 
    
Before the PR, large pods did not make any noise in space when fired north or east. It's reasonable for at least the pod driver and occupants to be able to hear such, which this PR allows.

This PR adds a new argument to some projectile-code functions. This won't affect anything that hasn't been changed to utilize it. What it does is allow there to be a second "shooter" which can more accurately reflect the source of the shots.

In particular, the previous code would see that projectiles came from the other three tiles of a large pod, and thus not play the firing noise to the pod's occupants. Now the largepod projectile firing code specifically passes the tile which the occupants count as being in, so that while it shoots from a different tile, the playsound() function plays it to the occupants of the pod.

## Why's this needed?
It allows consistent noise behavior for all directions firing from a large pod.



## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use * for major changes and + for minor changes. For example: -->

```
saccharineChampion:
+ Additional argument in projectile code allows sounds to correctly play to drivers of large vehicles.
+ Large pod code changed to utilize this additional argument.
```

