### PR TITLE
Limb bleeding fix

### DIFF
--- a/code/modules/medical/blood_system.dm
+++ b/code/modules/medical/blood_system.dm
@@ -354,6 +354,10 @@ this is already used where it needs to be used, you can probably ignore it.
 
 	if (prob(final_repair_chance))
 		H.bleeding -= repair_amount
+		//BLOOD_DEBUG("[H]'s bleeding repaired by [repair_amount], now [H.bleeding]")
+		if (H.bleeding < 0)
+			H.bleeding = 0
+			//BLOOD_DEBUG("[H]'s bleeding dropped below 0 and was reset to 0")
 		if (!H.bleeding && H.get_surgery_status())
 			H.bleeding ++
 		switch (H.bleeding)
@@ -378,10 +382,6 @@ this is already used where it needs to be used, you can probably ignore it.
 			if (9 to INFINITY)
 				H.show_text("<b>You can't go on very long with blood pouring out of you like this!</b>", "red")
 */
-		//BLOOD_DEBUG("[H]'s bleeding repaired by [repair_amount], now [H.bleeding]")
-		if (H.bleeding < 0)
-			H.bleeding = 0
-			//BLOOD_DEBUG("[H]'s bleeding dropped below 0 and was reset to 0")
 
 	//else
 		//BLOOD_DEBUG("[H] rolled no repair")

--- a/code/obj/item/mob_parts.dm
+++ b/code/obj/item/mob_parts.dm
@@ -231,6 +231,7 @@
 				boutput(attacher, "<span style=\"color:red\">You attach a [src] to [attachee]'s stump[both_legs? "s" : ""]. It fuses instantly with the muscle and tendons!</span>")
 			else
 				boutput(attacher, "<span style=\"color:red\">You attach a [src] to your own stump[both_legs? "s" : ""]. It fuses instantly with the muscle and tendons!</span>")
+			src.remove_stage = 0
 		else
 			if(attachee != attacher)
 				boutput(attachee, "<span style=\"color:red\">[attacher] attaches a [src] to your stump[both_legs? "s" : ""]. It doesn't look very secure!</span>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
 Attaching a synthlimb will fully attach it, instead of leaving it on the last surgery stage

Also reorders a thing in repair_bleeding_damage() to fix misleading messaging when repairing bleeding with open surgical wounds (such as a missing limb) - it will no longer say your bleeding stops and then have bleeding start again the next tick

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #143 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use * for major changes and + for minor changes. For example: -->

```
Tarmunora:
* Attaching a synthlimb will now fully attach it instead of leaving it at the last surgical stage
* Fix messaging when repairing bleeding while having open surgical wounds
```

