### PR TITLE
Surplus crate additions/balancing

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -537,7 +537,7 @@ This is basically useless for anyone but miners.
 	item = /obj/item/saw/syndie
 	cost = 7
 	desc = "This old earth beauty is made by hand with strict attention to detail. Unlike today's competing botanical chainsaw, it actually cuts things!"
-	//not_in_crates = 1
+	not_in_crates = 1
 	job = list("Botanist")
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 
@@ -940,13 +940,6 @@ This is basically useless for anyone but miners.
 	cost = 1
 	desc = "A device capable of disguising your identity temporarily. Beware of flashes and projectiles!"
 	blockedmode = list(/datum/game_mode/revolution)
-
-/datum/syndicate_buylist/surplus/bighat
-	name = "Syndicate Hat"
-	item = /obj/item/clothing/head/bighat/syndicate
-	cost = 1 //to prevent it from using 12 tc in a crate
-	desc = "Think you're tough shit buddy?"
-	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 
 /datum/syndicate_buylist/surplus/emaghypo
 	name = "Hacked Hypospray"

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -215,6 +215,7 @@ proc/build_syndi_buylist_cache()
 	item = /obj/item/clothing/head/bighat/syndicate
 	cost = 12
 	desc = "Think you're tough shit buddy?"
+	not_in_crates = 1 //see /datum/syndicate_buylist/surplus/bighat
 
 
 //////////////////////////////////////////////////// Standard items (traitor uplink) ///////////////////////////////////
@@ -536,7 +537,7 @@ This is basically useless for anyone but miners.
 	item = /obj/item/saw/syndie
 	cost = 7
 	desc = "This old earth beauty is made by hand with strict attention to detail. Unlike today's competing botanical chainsaw, it actually cuts things!"
-	not_in_crates = 1
+	//not_in_crates = 1
 	job = list("Botanist")
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 
@@ -895,11 +896,11 @@ This is basically useless for anyone but miners.
 	desc = "Honk."
 	blockedmode = list(/datum/game_mode/spy)
 
-/datum/syndicate_buylist/surplus/turboflash
-	name = "Flash/cell assembly"
-	item = /obj/item/device/flash/turbo
+/datum/syndicate_buylist/surplus/turboflash_box
+	name = "Flash/cell assembly box"
+	item = /obj/item/storage/box/turbo_flash_kit
 	cost = 1
-	desc = "A common stun weapon with a power cell hastily wired into it. Looks dangerous."
+	desc = "A box full of common stun weapons with power cells hastily wired into them. Looks dangerous."
 	blockedmode = list(/datum/game_mode/spy)
 
 /datum/syndicate_buylist/surplus/syndicate_armor
@@ -932,6 +933,34 @@ This is basically useless for anyone but miners.
 	cost = 1
 	desc = "A pair of surplus cybereyes that can access the Security HUD system. Operating table not included."
 	blockedmode = list(/datum/game_mode/revolution)
+
+/datum/syndicate_buylist/surplus/holographic_disguiser
+	name = "Holographic Disguiser"
+	item = /obj/item/device/disguiser
+	cost = 1
+	desc = "A device capable of disguising your identity temporarily. Beware of flashes and projectiles!"
+	blockedmode = list(/datum/game_mode/revolution)
+
+/datum/syndicate_buylist/surplus/bighat
+	name = "Syndicate Hat"
+	item = /obj/item/clothing/head/bighat/syndicate
+	cost = 1 //to prevent it from using 12 tc in a crate
+	desc = "Think you're tough shit buddy?"
+	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
+
+/datum/syndicate_buylist/surplus/emaghypo
+	name = "Hacked Hypospray"
+	item = /obj/item/reagent_containers/hypospray/emagged
+	cost = 1
+	desc = "A special hacked hypospray, capable of holding any chemical!"
+	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
+
+/datum/syndicate_buylist/surplus/sarin_grenade
+	name = "Sarin Grenade"
+	item = /obj/item/chem_grenade/sarin
+	cost = 1
+	desc = "A terrifying grenade containing a potent nerve gas. Try not to get caught in the smoke."
+	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 
 /////////////////////////////////////////////// Disabled items /////////////////////////////////////////////////////
 

--- a/code/obj/item/device/flash.dm
+++ b/code/obj/item/device/flash.dm
@@ -392,6 +392,12 @@
 			secure = !secure
 		return
 
+/obj/item/storage/box/turbo_flash_kit
+	name = "\improper Box of flash/cell assemblies."
+	desc = "A box filled with five dangerous looking flash/cell assemblies."
+	icon_state = "flashbang"
+	spawn_contents = list(/obj/item/device/flash/turbo = 5)
+
 /obj/item/device/flash/revolution
 	name = "revolutionary flash"
 	desc = "A device that emits an extremely bright light when used. Something about this device forces people to revolt, when flashed by a revolution leader."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR 

Adds a few items to the surplus crate, and changes the balance of the syndicate hat and flash/cell assemblies in crates. Changes are as follows:

Adds a special surplus crate version of the syndicate hat that costs 1 TC that you **only** get in crates. This functionally means that a syndicate hat won't take up 12 TC of your gear in a crate, but it'll still show up. (This usually meant that if you rolled the hat, you'd only get one or two other items.)

Changes the flash/cell assembly into a flash/cell assembly box. So you get five instead of one. Still worth 1 TC, I see people talking about how this thing is kinda useless so I figure that getting More Of Them would help.

Additions to the crate:
Red chainsaw (Worth the regular 7 TC)
Holographic Disguiser (Worth 1 TC, it's kinda like a cloak that disguises your identity with a random one, it's pretty neat)
A pre-emagged hypospray (Worth 1 TC)
A sarin grenade (Worth 1 TC)

## Why's this needed? 

I think the surplus crate sorta thrives on weird variety items, and I think having a wider selection of cheap stuff that it can pick is good. This specifically doesn't add anything completely new for crates, it's just a few miscellaneous preexisting items that I've thought would fit well in the crate.

The syndicate hat change is cuz I think it's sorta lame how it could basically sap your crate of items. It's a cool and fun item but it sucks to lose 12 TC to it in a crate, especially if you're not the type to wear it. The cell/flash change is in response to a lot of feedback I've seen about it being very very useless due to being a one-use item.

## Changelog
```
Flaborized:
* Added a few small items to the surplus crate!
```