### PR TITLE
Removes ability to attach 2-handed nuke-op guns as arms.

### DIFF
--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -850,6 +850,7 @@
 	caliber = 0.223
 	max_ammo_capacity = 30
 	auto_eject = 1
+	object_flags = NO_ARM_ATTACH
 
 	two_handed = 1
 	can_dual_wield = 0
@@ -903,6 +904,7 @@
 	auto_eject = 0
 
 	flags =  FPRINT | TABLEPASS | CONDUCT | USEDELAY | EXTRADELAY | ONBACK
+	object_flags = NO_ARM_ATTACH
 
 	spread_angle = 8
 	can_dual_wield = 0
@@ -964,6 +966,8 @@
 	caliber = 0.308
 	max_ammo_capacity = 4
 	auto_eject = 1
+	flags =  FPRINT | TABLEPASS | CONDUCT | USEDELAY | EXTRADELAY | ONBACK
+	object_flags = NO_ARM_ATTACH
 
 	slowdown = 7
 	slowdown_time = 5
@@ -971,7 +975,6 @@
 	can_dual_wield = 0
 	two_handed = 1
 	w_class = 4
-	flags =  FPRINT | TABLEPASS | CONDUCT | USEDELAY | EXTRADELAY | ONBACK
 
 	var/datum/movement_controller/snipermove = null
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds a flag to the nuclear operative assault rifle, marksman's rifle and light machine gun that removes them as options for item-arm surgery, possibly with the scope to extend this to all two-handed firearms in future.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Nuclear operative specialist gear was not balanced to account for undroppable two-handed guns. While I like seeing creative use of the Cairngorm medbay, this has felt too powerful in rounds i've observed.
Please comment if you have feelings about this change!


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use * for major changes and + for minor changes. For example: -->

```
Gannets:
* Removed Nuclear Operative assault rifle, marksman's rifle and light machine gun as options for item-arm surgery.
```

