### PR TITLE
chopping tool fix

### DIFF
--- a/code/obj/machinery/door/door_parent.dm
+++ b/code/obj/machinery/door/door_parent.dm
@@ -287,6 +287,12 @@
 			attack_particle(user,src)
 			playsound(src.loc, src.hitsound , 50, 1, pitch = 1.6)
 			src.take_damage(I.force, user)
+			if (I.tool_flags & TOOL_CHOPPING)
+				user.lastattacked = src
+				attack_particle(user,src)
+				playsound(src.loc, src.hitsound , 50, 1, pitch = 1.6)
+				src.take_damage(I.force*4, user)
+
 		return
 	if (src.operating)
 		return


### PR DESCRIPTION

<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
chopping tools do their bonus to bolted doors. if someone wants to do a verson of this that doesn't suck go ahead


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Airlock breaching weapons not working on bolted doors kinda kills the point of them


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use * for major changes and + for minor changes. For example: -->

```
Tarmunora:
* Chopping weapons work properly on bolted doors
```

