### PR TITLE
Unused medal acquiring methods

### DIFF
--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -3955,6 +3955,7 @@ datum
 				deathtarget.emote("scream")
 				deathtarget.setStatus("stunned", max(deathtarget.getStatusDuration("stunned"), 50))
 				deathtarget.setStatus("weakened", max(deathtarget.getStatusDuration("weakened"), 50))
+				deathtarget.unlock_medal("OW! MY BALLS!", 1)
 				var/deathturf = get_turf(src)
 				animate_slide(deathturf, 0, -24, 25)
 				sleep(20)

--- a/code/modules/medical/genetics/bioEffects/powers.dm
+++ b/code/modules/medical/genetics/bioEffects/powers.dm
@@ -904,6 +904,7 @@
 			if (!linked_power.safety)
 				gib_user = 1
 				fart_string = "'s body is torn apart like a wet paper bag by [his_or_her(owner)] unbelievably powerful farting!"
+				owner.unlock_medal("Shit Fest", 1)
 
 		sleep(30)
 		if (can_act(owner))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds acquiring methods to two medals that currently don't have a method to do so.
Proposed methods in this PR are 'Shit Fest' - trigger on empowered non-safe superfart mutation, and 'OW! MY BALLS!' for King Readsterium ball-kick.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Getting medals for such things encourage exploration, and uses content that is currently unused.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use * for major changes and + for minor changes. For example: -->

```
2027:
* Adds acquiring methods to 'Shit Fest' & 'OW! MY BALLS!'
```

