### PR TITLE
Your Lawgiver And You instruction pamphlet

### DIFF
--- a/code/WorkInProgress/JobXPRewards.dm
+++ b/code/WorkInProgress/JobXPRewards.dm
@@ -189,6 +189,7 @@ mob/verb/checkrewards()
 			return
 
 		var/obj/item/gun/energy/lawgiver/LG = new reward_path()
+		var/obj/item/paper/lawgiver_pamphlet/LGP = new/obj/item/paper/lawgiver_pamphlet()
 		if (!istype(LG))
 			boutput(C.mob, "Something terribly went wrong. The reward path got screwed up somehow. call 1-800-CODER. But you're an HoS! You don't need no stinkin' guns anyway!")
 			src.claimedNumbers[usr.key] --
@@ -200,6 +201,8 @@ mob/verb/checkrewards()
 		LG.set_loc(get_turf(C.mob))
 		C.mob.put_in_hand(LG)
 		boutput(C.mob, "Your E-Gun vanishes and is replaced with [LG]!")
+		C.mob.put_in_hand_or_drop(LGP)
+		boutput(C.mob, "<span style='color:#605b59'>A pamphlet flutters out.</span>")
 		return
 
 /datum/jobXpReward/head_of_security_LG/old

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1170,7 +1170,7 @@
 			boutput(user, "<span style=\"color:red\">[src] has accepted your fingerprint ID. You are its owner!</span>")
 			asign_name(user)
 		else
-			boutput(user, "<span style=\"color:blue\">There don't see to be any buttons on [src] to press.</span>")
+			boutput(user, "<span style=\"color:blue\">There don't seem to be any buttons on [src] to press.</span>")
 
 	proc/asign_name(var/mob/M)
 		if (ishuman(M))
@@ -1377,7 +1377,7 @@
 			gun_setting_name = "execute"
 		else if (current_projectile.type == /datum/projectile/bullet/smoke)
 			gun_setting_name = "smokeshot"
-		else if (current_projectile.type == /datum/projectile/bullet/tranq_dart)
+		else if (current_projectile.type == /datum/projectile/bullet/tranq_dart/law_giver)
 			gun_setting_name = "knockout"
 		else if (current_projectile.type == /datum/projectile/bullet/flare)
 			gun_setting_name = "hotshot"
@@ -1391,13 +1391,13 @@
 		src.desc = "It is set to [gun_setting_name]."
 		if(src.cell)
 				//[src.projectiles ? "It will use the projectile: [src.current_projectile.sname]. " : ""]
-			src.desc += "There are [src.cell.charge]/[src.cell.max_charge] PUs left!"
+			src.desc += " There are [src.cell.charge]/[src.cell.max_charge] PUs left!"
 		else
-			src.desc += "There is no cell loaded!"
+			src.desc += " There is no cell loaded!"
 		if(current_projectile)
 			src.desc += " Each shot will currently use [src.current_projectile.cost] PUs!"
 		else
-			src.desc += "<span style=\"color:red\">*ERROR* No output selected!</span>"
+			src.desc += " <span style=\"color:red\">*ERROR* No output selected!</span>"
 		return
 
 

--- a/code/obj/item/paper.dm
+++ b/code/obj/item/paper.dm
@@ -1300,3 +1300,80 @@ WHO DID THIS */
     <b>SPECIAL INSTRUCTIONS</b> WILL PAY DOUBLE IF SUB-BASEMENT 3 IS CLEARED OF ALL RESEARCH SPECIMENS AND SUBJECTS, ALL SPECIMENS AND SUBJECTS ARE EFFECTIVELY BRAINDEAD, SUPPLY OWN MEANS OF EXECUTION OF SUBJECTS.<br>
     <b>STATUS:</b> BEING CLEANED"}
 
+/obj/item/paper/lawgiver_pamphlet
+	name = "Your Lawgiver And You"
+	icon_state = "paper"
+	info = {"
+<h2>Your Lawgiver And You</h2>
+<i>A Nanotrasen Arms Division Instructional Publication</i>
+<hr>
+<p>Welcome, noble lawperson, to the greatest technological development in policing since the helmet: Your new <b>Lawgiver™</b>!<br>
+The Lawgiver™ is a multi-purpose self-recharging personal armament for our loyal Heads of Security.<br>
+Please take a moment to acquaint yourself with your new colleague's features, and to scan your fingerprints into the provided identity lock system.</p>
+
+<p>The Lawgiver™ is equipped with eight different Crime Pacification Projectile Synthesization Methods, or "Modes,"
+all of which draw from the central Self-Renewing Energy Capacitance Device, or "Cell."<br> The Cell has a capacity of
+300 Power Units ("PU"), and recharges at a rate of approximately 10 PU per 6 seconds;
+however, due to the exacting measurements used in the Lawgiver™'s foolproof* design, the Cell
+cannot be removed from the unit or externally recharged.<br>
+<small><i><b>*</b>The Lawgiver™ should not be exposed to fools. If this occurs, wash thoroughly under cold water.</i></small></p>
+
+<p>The greatest feature of the Lawgiver™ is its unique voice control system: To choose your desired Mode, simply speak its name!
+So long as your fingerprints† match those assigned to the identity lock (configured during device setup) the Lawgiver™ will
+automatically adopt your criminal control strategy of choice.<br>
+<small><i><b>†</b>The user is considered responsible for the protection of their own fingerprints and arms.</i></small></p>
+<hr>
+<h3>Provided: A table of all Modes, their power drains, and their purposes.</h3>
+
+<table border = "1" cellpadding = "3" cellspacing = "3">
+<tr>
+<td><b>"Detain"</b></td>
+<td>50 PU</td>
+<td>The perfect crowd control option, this Mode stuns all your enemies within a close radius, but leaves you untouched!</td>
+</tr>
+<tr>
+<td><b>"Execute"</b></td>
+<td>30 PU</td>
+<td>Turn your Lawgiver™ into your favourite sidearm with these .38 Full Metal Jacket rounds!</td>
+</tr>
+<tr>
+<td><b>"Hotshot"</b></td>
+<td>60 PU</td>
+<td>This handy flare gun/flamethrower option is sure to heat things up! The Lawgiver™ is not certified fireproof. Do not set on fire.</td>
+</tr>
+<tr>
+<td><b>"Smokeshot"</b></td>
+<td>50 PU</td>
+<td>Never use a riot launcher again! These smoke grenades will let you manage line of sight with ease.</td>
+</tr>
+<tr>
+<td><b>"Knockout"</b></td>
+<td>60 PU</td>
+<td>When you just can't get things to slow down, <i>make 'em</i> slow down with these handy haloperidol tranquilizer darts!</td>
+</tr>
+<tr>
+<td><b>"Bigshot"*</b></td>
+<td>170 PU</td>
+<td>You'll be the talk of the station when you bust down a wall with one of these explosive rounds! May cause loss of limbs or life.</td>
+</tr>
+<tr>
+<td><b>"Clownshot"</b></td>
+<td>15 PU</td>
+<td>Lawgiver™ warranty is voided if exposed to clowns. Keep them at bay.</td>
+</tr>
+<tr>
+<td><b>"Pulse"</b></td>
+<td>35 PU</td>
+<td>Just like our patented Pulse Rifle™s, this Mode sends your enemies flying! Keep crime at arm's length!</td>
+</tr>
+</table>
+<i><b>*</b>Also accepted for this Mode: "High Explosive," "HE."</i>
+<hr>
+<p><b>Disclaimer:</b> Nanotrasen Arms Division cannot be held liable in the case of inconvenience, failure or death,
+as per your Nanotrasen Employment Agreement. If any of the Modes are found to be ineffective, underpowered,
+minimally successful at their purpose, or otherwise useless; and in the event that the user survives to do so;
+Nanotrasen Arms Division requests that they submit a formal Suggestion to our company forums,
+so that the Lawgiver™ can be the best it can be. Do not place fingers in path of moving parts, as the Lawgiver™ device
+is solid-state and should not feature moving parts. Note that the Cell may experience spontaneous explosive overload when
+exposed to overconfident outbursts on the part of individuals unqualifed to embody the law; in event of such explosion, run.
+"}


### PR DESCRIPTION
## About the PR
* Redeeming the Lawgiver now grants you the pamphlet Your Lawgiver And You, which explains all the Lawgiver's functions. You can see what it looks like in-game [in this screenshot.](https://i.imgur.com/DWa56fX.png)
* Also fixes a couple of typos around the Lawgiver, and a bug where Knockout mode was listed as Detain in examine text

Credit to Flaborized for the pamphlet idea and name. Thank you to the folks who proofread and advised me.
## Why's this needed?
Currently, there's no in-game guide to the Lawgiver, so if you want to know how it works you need to check the wiki. This PR changes that.

## Changelog
```
Enfaeutchie:
*The Lawgiver now comes with an instructional pamphlet! Let me know if you see any mistakes or have any suggestions.
+Fixed a couple of Lawgiver typos, and a bug where knockout was listed as detain in examine text.
```

