### PR TITLE
MAKE CANBOMBS GREAT AGAIN

### DIFF
--- a/code/obj/item/assembly/detonator.dm
+++ b/code/obj/item/assembly/detonator.dm
@@ -287,7 +287,7 @@
 	message_admins("A canister bomb detonates at [epicenter.loc.name] ([showCoords(epicenter.x, epicenter.y, epicenter.z)])")
 	src.attachedTo.visible_message("<b><span style=\"color:red\">The ruptured canister shatters from the pressure, and the hot gas ignites.</span></b>")
 
-	var/power = min(850 * (attachedTo.air_contents.return_pressure() + attachedTo.air_contents.temperature - 107000) / 233196469.0 + 200, 7000) //the second arg is the max explosion power
+	var/power = min(850 * (attachedTo.air_contents.return_pressure() + attachedTo.air_contents.temperature - 107000) / 233196469.0 + 200, 50000) //the second arg is the max explosion power
 	//if (power == 150000) //they reached the cap SOMEHOW? well dang they deserve a medal
 		//src.builtBy.unlock_medal("", 1) //WIRE TODO: make new medal for this
 	explosion_new(attachedTo, epicenter, power)


### PR DESCRIPTION
Raises the canister bomb maxcap from 7000 power to 50,000 power. Not quite the billions that made the server shit itself all those times, but close enough.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Because some~~dumbass~~one made the magically powerful canbombs have a pretty restrictive max cap. Now it takes >10 canbombs to completely trash the station instead of just one or two.


