### PR TITLE
Podseeker nerf (against non-pods)

### DIFF
--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -674,9 +674,22 @@ toxic - poisons
 
 	seeker
 		name = "drone-seeking grenade"
+		power = 50 //even if they don't explode, you FEEL this one
 		var/max_turn_rate = 20
 		var/type_to_seek = /obj/critter/gunbot/drone //what are we going to seek
 		precalculated = 0
+		on_hit(atom/hit, angle, var/obj/projectile/P)
+			if (P.data || prob(10)) //maybe
+				..()
+			else
+				new /obj/effects/rendersparks(hit.loc)
+				if(ishuman(hit))//copypasted shamelessly from singbuster rockets
+					var/mob/living/carbon/human/M = hit
+					boutput(M, "<span style=\"color:red\">You are struck by an autocannon round! Thankfully it was not armed.</span>")
+					M.do_disorient(stunned = 40)
+					if (!M.stat)
+						M.emote("scream")
+				
 
 		on_launch(var/obj/projectile/P)
 			var/D = locate(type_to_seek) in range(15, P)

--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -648,6 +648,16 @@ toxic - poisons
 	on_hit(atom/hit)
 		explosion_new(null, get_turf(hit), 12)
 
+	knocker
+		name = "breaching round"
+		power = 10
+		on_hit(atom/hit)
+			if(istype(hit , /obj/machinery/door))
+				var/obj/machinery/door/D = hit
+				if(!D.cant_emag)
+					D.take_damage(D.health/2) //fuck up doors without needing ex_act(1)
+			explosion_new(null, get_turf(hit), 4, 1.75)
+
 	plasma_orb
 		name = "fusion orb"
 		damage_type = D_BURNING

--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -626,6 +626,11 @@
 		name = "40mm HE pod-seeking shells"
 		ammo_type = new/datum/projectile/bullet/autocannon/seeker/pod_seeking
 
+	knocker
+		sname = "40mm HE Knocker"
+		name = "40mm HE airlock-breaching shells"
+		ammo_type = new/datum/projectile/bullet/autocannon/knocker
+
 /obj/item/ammo/bullets/grenade_round
 	sname = "40mm HEDP"
 	name = "40mm HEDP shells"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes podseekers to only explode if they are seeking a target. otherwise, they just do (hefty) blunt damage and disorient


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Podseekers see more use as a 'fuck this guy in particular' ammo rather than as anti-pod ammo, which is rather silly.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Tarmunora:
(*)Changed pod(etc)seeking 40mmHE shells to have a high chance of not detonating on impact unless they have found a target to seek. Additionally boosted their direct-impact stats to compensate somewhat.
```
