### PR TITLE
Deflukying the MPRT-7

### DIFF
--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -714,6 +714,7 @@
 	contraband = 8
 	caliber = 1.58
 	max_ammo_capacity = 1
+	can_dual_wield = 0
 
 	New()
 		ammo = new /obj/item/ammo/bullets/rpg


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes dual-wielding MPRT-7 launchers. you can still dual-wield MPRT zipguns if you're brave (or stupid) enough


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This just kills so many inexperienced nukeops, or rather, causes them to kill allies with accidental rockets while trying to use a revolver.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Tarmunora:
(+)MPRT-7 launcher no longer supports dual-wielding
```
