### PR TITLE
NAS-T bullet_act fix

### DIFF
--- a/code/obj/item/deployable_turret.dm
+++ b/code/obj/item/deployable_turret.dm
@@ -318,11 +318,12 @@
 
 
 	bullet_act(var/obj/projectile/P)
-		if(istype(P.proj_data,/datum/projectile/energy_bolt)) // fuck tasers
+		var/damage = 0
+		damage = round((P.power*P.proj_data.ks_ratio), 1.0)
+		if (damage < 1)
 			return
-		else
-			src.health = src.health - max(P.power/2,0) // staples have a power of 5, .22 bullets have a power of 35
-			src.check_health()
+		src.health = src.health - max(P.power/2,0) // staples have a power of 5, .22 bullets have a power of 35
+		src.check_health()
 
 
 	proc/check_health()


### PR DESCRIPTION


<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
 nukie turrets no longer get killed by waveguns and other non-taser-non-lethal weapons, and instead allow ks_ratio of the projectile to modify the damage done to the turret




## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bugfix


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Tarmunora:
(+)NAS-T turrets properly do not take damage from waveguns etc now
```
