### PR TITLE
mining tool changes

### DIFF
--- a/code/WorkInProgress/ItemSpecials.dm
+++ b/code/WorkInProgress/ItemSpecials.dm
@@ -621,7 +621,7 @@
 			if (istype(master,/obj/item/mining_tool))
 				var/obj/item/mining_tool/M = master
 				if (M.status)
-					M.process_charges(3)
+					M.process_charges(30)
 
 		pixelaction(atom/target, params, mob/user, reach)
 			if(!isturf(target.loc) && !isturf(target)) return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Mining tools (power pick, hammer, shovel) changed to use small energy cells (default 100u) for internal charge, and makes attacking non-rocks with them significantly more expensive


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
power hammers (and power picks, to an extent) are very strong melee weapons, and while theoretically limited by charges, you rarely feel them when bashing skulls, and when actually mining with one, charging it takes forever. This makes them charge much faster, but also drain much faster when attacking pods/people, unless you take the time to make a custom power cell for them


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Tarmunora:
(*)Power picks, hammers, shovels now use standard small power cells for their internal charge. This makes them charge more quickly, as an aside. Additionally, attacking things that aren't asteroids with them will drain their cell much more quickly - if using one as a weapon, keep an eye on your charge!
```
