### PR TITLE
Ghostdrone construction worker tools!

### DIFF
--- a/code/mob/living/silicon/ghostdrone.dm
+++ b/code/mob/living/silicon/ghostdrone.dm
@@ -40,6 +40,7 @@
 		ghost_drones += src
 		hud = new(src)
 		src.attach_hud(hud)
+		src.see_invisible = 8
 		//src.sight |= SEE_TURFS //Uncomment for meson-like vision. I'm not a fan of it though. -Wire
 
 		//Set the drone name
@@ -77,6 +78,7 @@
 			new /obj/item/magtractor(src),
 			new /obj/item/tool/omnitool(src),
 			new /obj/item/rcd/safe(src),
+			new /obj/item/room_planner(src),
 			new /obj/item/device/analyzer/atmospheric(src),
 			new /obj/item/device/t_scanner(src),
 			new /obj/item/electronics/soldering(src),

--- a/code/mob/living/silicon/ghostdrone.dm
+++ b/code/mob/living/silicon/ghostdrone.dm
@@ -40,7 +40,7 @@
 		ghost_drones += src
 		hud = new(src)
 		src.attach_hud(hud)
-		src.see_invisible = 8
+		src.see_invisible = 8 //Gives them the ability to see the Floor and Wall planner blueprints, identical to Construction Visualizer glasses
 		//src.sight |= SEE_TURFS //Uncomment for meson-like vision. I'm not a fan of it though. -Wire
 
 		//Set the drone name


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR 

Adds Floor and Wall Planner to ghostdrone's list of available tools and gives ghostdrones construction visualizer vision

## Why's this needed?

Ghostdrones are tasked to maintain, repair and improve the station. Giving them Floor and Wall Planner enhances their ability to do so. It offers them more ways to improve the station to their silicon liking and also makes this role more attractive to bored ghost players.


## Changelog

```
(u)TTerc:
(+)Adds Floor and Wall Planner to ghostdrone's list of available tools
(+)Gives ghostdrone the ability to see the blueprints made with Floor and Wall Planner
```
