### PR TITLE
MechComp networking component changes

### DIFF
--- a/code/WorkInProgress/MechanicsNetworkCon.dm
+++ b/code/WorkInProgress/MechanicsNetworkCon.dm
@@ -66,7 +66,7 @@
 	proc/spacket(var/datum/mechanicsMessage/input)
 		if(!ready) return
 		ready = 0
-		SPAWN_DBG(2 SECONDS) ready = 1
+		SPAWN_DBG(0.4 SECONDS) ready = 1
 		post_raw(input.signal)
 		return
 

--- a/code/WorkInProgress/MechanicsNetworkCon.dm
+++ b/code/WorkInProgress/MechanicsNetworkCon.dm
@@ -19,6 +19,8 @@
 
 	var/self_only = 1
 
+	var/register = 1 // Whether or not to automagically send command=register&data=MECHNET to connecting devices
+
 	var/ready = 1
 
 	New()
@@ -43,7 +45,24 @@
 		self_only = !self_only
 		boutput(usr, "[self_only ? "Now only processing messages adressed at us.":"Now processing all messages recieved."]")
 		return
+		
+	verb/toggleregister() //shameless copy from above verb
+		set src in view(1)
+		set name = "\[Toggle Mainframe registration\]"
+		set desc = "Toggles whether or not the component registers with the Mainframe when connected to by it."
 
+		if (!isliving(usr))
+			return
+		if (usr.stat)
+			return
+		if (!mechanics.allowChange(usr))
+			boutput(usr, "<span style=\"color:red\">[MECHFAILSTRING]</span>")
+			return
+
+		register = !register
+		boutput(usr, "[register ? "Now registering with mainframes.":"Now no longer registering with mainframes."]")
+		return
+		
 	proc/spacket(var/datum/mechanicsMessage/input)
 		if(!ready) return
 		ready = 0
@@ -193,8 +212,9 @@
 					if(signal.data["data"] != "noreply")
 						src.post_status(target, "command","term_connect","data","noreply","device",src.device_tag)
 					src.updateUsrDialog()
-					SPAWN_DBG(0.2 SECONDS) //Sign up with the driver (if a mainframe contacted us)
-						src.post_status(target,"command","term_message","data","command=register&data=MECHNET")
+					if(src.register)
+						SPAWN_DBG(0.2 SECONDS) //Sign up with the driver (if a mainframe contacted us)
+							src.post_status(target,"command","term_message","data","command=register&data=MECHNET")
 					return
 
 				if("term_ping")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This reduces the sending cooldown on the "Powernet-networking component" from 2 seconds to 0.4 seconds and makes the automatic "register" packet optional (adds a mechanics verb to toggle it). 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Because the relatively long cooldown makes it hard to interface with DWAINE and other packety stuff, and the automatic mainframe driver registration packet gets in the way of fancier packet nerdery e.g. pretending to be an artlab test device so you can remotely control your massive contraption from "gptio".