### PR TITLE
Prevent click+dragging from overfilling crates

### DIFF
--- a/code/obj/storage/large_storage_parent.dm
+++ b/code/obj/storage/large_storage_parent.dm
@@ -295,6 +295,7 @@
 			. = 1
 
 	MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
+		var/turf/T = get_turf(src)
 		if (!in_range(user, src) || !in_range(user, O) || user.restrained() || user.getStatusDuration("paralysis") || user.sleeping || user.stat || user.lying || isAI(user))
 			return
 
@@ -341,6 +342,10 @@
 		if (!src.open)
 			src.open()
 
+		if (T.contents.len >= src.max_capacity)
+			user.show_text("[src] is too full!", "red")
+			return
+
 		if (O.loc == user)
 			user.u_equip(O)
 			O.set_loc(get_turf(user))
@@ -361,6 +366,8 @@
 						break
 					if (user.loc != staystill)
 						break
+					if (T.contents.len >= src.max_capacity)
+						break
 				for (var/obj/item/material_piece/M in view(1,user))
 					if (M.material && M.material.getProperty("radioactive") > 0)
 						user.changeStatus("radiation", (round(min(M.material.getProperty("radioactive") / 2, 20)))*10, 2)
@@ -371,6 +378,8 @@
 					if (!src.open)
 						break
 					if (user.loc != staystill)
+						break
+					if (T.contents.len >= src.max_capacity)
 						break
 				user.show_text("You finish stuffing materials into [src]!", "blue")
 				SPAWN_DBG(0.5 SECONDS)
@@ -392,6 +401,8 @@
 						break
 					if (user.loc != staystill)
 						break
+					if (T.contents.len >= src.max_capacity)
+						break
 				for (var/obj/item/reagent_containers/food/snacks/F in view(1,user))
 					if (F in user)
 						continue
@@ -402,6 +413,8 @@
 					if (!src.open)
 						break
 					if (user.loc != staystill)
+						break
+					if (T.contents.len >= src.max_capacity)
 						break
 				user.show_text("You finish stuffing produce into [src]!", "blue")
 				SPAWN_DBG(0.5 SECONDS)


### PR DESCRIPTION
## About the PR
Click+dragging produce items onto a crate currently shoves all nearby items of produce into it. With this PR, it only shoves enough produce to fill the crate up to its maximum capacity, and click+dragging items to crates in general won't work if the crate is full.


## Why's this needed?
Since crates now have a maximum capacity, and produce is handled in large quantities, click+dragging can often overfill crates so they can't be closed. While it's already possible to divvy up your produce with satchels, this PR means you can simply click+drag your stuff and get perfect, neat crates without needing to mess around with other equipment.


## Changelog
```
(u)Enfaeutchie:
(+)Click+dragging produce into crates won't overfill them, so you can ship and sell it more easily.
```
