### PR TITLE
Add hats as an AI spacebux reward

### DIFF
--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -298,7 +298,8 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 
 				if (player.mind && player.mind.assigned_role == "AI")
 					player.close_spawn_windows()
-					player.AIize()
+					var/mob/living/silicon/ai/A = player.AIize()
+					A.Equip_Bank_Purchase(A.mind.purchased_bank_item)
 
 				else if (player.mind && player.mind.special_role == "wraith")
 					player.close_spawn_windows()

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -96,7 +96,7 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 
 	var/deployed_to_eyecam = 0
 
-	proc/set_hat( var/obj/item/clothing/head/hat, mob/user as mob)
+	proc/set_hat(obj/item/clothing/head/hat, var/mob/user as mob)
 		if( src.hat )
 			src.hat.wear_image.pixel_y = 0
 			src.UpdateOverlays(null, "hat")

--- a/code/mob/transform_procs.dm
+++ b/code/mob/transform_procs.dm
@@ -83,8 +83,7 @@
 
 /mob/new_player/AIize(var/mobile=0)
 	src.spawning = 1
-	..()
-	return
+	return ..()
 
 /mob/living/carbon/AIize(var/mobile=0)
 	if (src.transforming)

--- a/code/modules/economy/persistent_bank_purchases.dm
+++ b/code/modules/economy/persistent_bank_purchases.dm
@@ -46,7 +46,9 @@ var/global/list/persistent_bank_purchaseables =	list(\
 	new /datum/bank_purchaseable/gold_that,\
 	new /datum/bank_purchaseable/dancin_shoes,\
 
-	new /datum/bank_purchaseable/alohamaton)
+	new /datum/bank_purchaseable/alohamaton,\
+	new /datum/bank_purchaseable/ai_hat,\
+	new /datum/bank_purchaseable/ai_legs)
 
 
 /datum/bank_purchaseable
@@ -579,3 +581,27 @@ var/global/list/persistent_bank_purchaseables =	list(\
 				A.set_color("#EE0000")
 				return 1
 			return 0
+
+	ai_hat
+		name = "AI hat"
+		cost = 1000
+
+		Create(var/mob/living/M)
+			if (isAI(M))
+				var/mob/living/silicon/ai/A = M
+				var/picked = pick(childrentypesof(/obj/item/clothing/head))
+				A.set_hat(new picked())
+				return 1
+			return 0
+
+	ai_legs
+		name = "AI legs"
+		cost = 10000
+
+		Create(var/mob/living/M)
+			if (isAI(M))
+				var/mob/living/silicon/ai/A = M
+				A.give_feet()
+				return 1
+			return 0
+

--- a/code/modules/economy/persistent_bank_purchases.dm
+++ b/code/modules/economy/persistent_bank_purchases.dm
@@ -47,8 +47,7 @@ var/global/list/persistent_bank_purchaseables =	list(\
 	new /datum/bank_purchaseable/dancin_shoes,\
 
 	new /datum/bank_purchaseable/alohamaton,\
-	new /datum/bank_purchaseable/ai_hat,\
-	new /datum/bank_purchaseable/ai_legs)
+	new /datum/bank_purchaseable/ai_hat)
 
 
 /datum/bank_purchaseable
@@ -594,14 +593,4 @@ var/global/list/persistent_bank_purchaseables =	list(\
 				return 1
 			return 0
 
-	ai_legs
-		name = "AI legs"
-		cost = 10000
-
-		Create(var/mob/living/M)
-			if (isAI(M))
-				var/mob/living/silicon/ai/A = M
-				A.give_feet()
-				return 1
-			return 0
 

--- a/code/obj/item/clothing/gimmick.dm
+++ b/code/obj/item/clothing/gimmick.dm
@@ -680,6 +680,11 @@
 
 //power armor
 
+/obj/item/clothing/head/power // placeholder icons until someone sprites an unpainted helmet
+	name = "plastic power helmet"
+	desc = "Wow this really looks like a noise marine helmet. But it's not!"
+	icon_state = "nm_helm"
+
 /obj/item/clothing/suit/power
 	name = "unpainted cardboard space marine armor"
 	desc = "Wow, what kind of dork fields an unpainted army? Gauche."

--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -572,6 +572,13 @@
 	item_state = "cowboy"
 	c_flags = SPACEWEAR
 
+/obj/item/clothing/head/fancy // placeholder icons until someone sprites an actual fancy hat
+	name = "fancy hat"
+	wear_image_icon = 'icons/mob/fruithat.dmi'
+	icon_state = "tophat"
+	item_state = "that"
+	desc = "What do you mean this is hat isn't fancy?"
+
 /obj/item/clothing/head/fancy/captain
 	name = "captain's hat"
 	icon_state = "captain-fancy"

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -515,7 +515,7 @@
 	else if (src.traitHolder && src.traitHolder.hasTrait("loyalist"))
 		trinket = new/obj/item/clothing/head/NTberet(src)
 	else if (src.traitHolder && src.traitHolder.hasTrait("petasusaphilic"))
-		var/picked = pick(childrentypesof(/obj/item/clothing/head) - (list(/obj/item/clothing/head/power, /obj/item/clothing/head/fancy) + typesof(/obj/item/clothing/head/bighat))) //IM A MONSTER DONT LOOK AT ME. NOOOOOOOOOOO
+		var/picked = pick(childrentypesof(/obj/item/clothing/head) - (typesof(/obj/item/clothing/head/bighat))) //IM A MONSTER DONT LOOK AT ME. NOOOOOOOOOOO
 		trinket = new picked(src)
 	else if (src.traitHolder && src.traitHolder.hasTrait("conspiracytheorist"))
 		trinket = new/obj/item/clothing/head/tinfoil_hat


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR adds two spacebux rewards for the AI - random hats (1k spacebux) and legs (10k spacebux). It also adds placeholders for base power helmets and fancy hats so the code for picking random hats is slightly less bad.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Spacebux rewards are fun and AI players should be able to participate in that fun.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Flourish:
(*)Added hats as an AI spacebux reward.
```