### PR TITLE
Fixes handcuffs not being visible on a mob after they are cuffed.

### DIFF
--- a/code/datums/controllers/action_controls.dm
+++ b/code/datums/controllers/action_controls.dm
@@ -700,8 +700,8 @@ var/datum/action_controller/actions
 			target.drop_from_slot(target.r_hand)
 			target.drop_from_slot(target.l_hand)
 			target.drop_juggle()
-			target.update_clothing()
 			target.setStatus("handcuffed", duration = INFINITE_STATUS)
+			target.update_clothing()
 
 			for(var/mob/O in AIviewers(ownerMob))
 				O.show_message("<span style=\"color:red\"><B>[owner] handcuffs [target]!</B></span>", 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG_MINOR]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Within the code that handles handcuffing someone, swaps the proc applying the cuffed status effect and one that updates the mob's clothing appearance around, as the latter requires the former to know a person is handcuffed and the current layout meant it didn't work as expected.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes a visual bug affecting a fairly common part of the game.