### PR TITLE
Fixes special cuff types not breaking on removal as well as silver handcuffs bricking a slot.

### DIFF
--- a/code/obj/item/handcuffs.dm
+++ b/code/obj/item/handcuffs.dm
@@ -126,16 +126,14 @@
 	user.delStatus("handcuffed")
 	user.drop_item(src)
 	user.update_clothing()
-	if(src.strength == 1)
+	if (src.strength == 1) // weak cuffs break
 		if (src.material && src.material.mat_id == "silver")
 			src.visible_message("<span style='color:red'>[src] disintegrate.</span>")
-			qdel(src)
-		else if((istype(src, /obj/item/handcuffs/guardbot)))
+		else if ((istype(src, /obj/item/handcuffs/guardbot)))
 			src.visible_message("<span style='color:red'>[src] biodegrade instantly. [prob (10) ? "DO NOT QUESTION THIS" : null]</span>")
-			qdel(src)
 		else
 			src.visible_message("<span style='color:red'>[src] break apart.</span>")
-			qdel(src)
+		qdel(src)
 
 /obj/item/handcuffs/proc/destroy_handcuffs(mob/user)
 	user.handcuffs = null

--- a/code/obj/item/handcuffs.dm
+++ b/code/obj/item/handcuffs.dm
@@ -117,9 +117,6 @@
 
 /obj/item/handcuffs/unequipped(var/mob/user)
 	..()
-	if (src.material && src.material.mat_id == "silver")
-		boutput(user, "<span style='color:red'>[src] disintegrate.</span>")
-		qdel(src)
 
 /obj/item/handcuffs/proc/werewolf_cant_rip()
 	.= src.material && src.material.mat_id == "silver"
@@ -130,6 +127,16 @@
 	user.delStatus("handcuffed")
 	user.drop_item(src)
 	user.update_clothing()
+	if(src.strength == 1)
+		if (src.material && src.material.mat_id == "silver")
+			src.visible_message("<span style='color:red'>[src] disintegrate.</span>")
+			qdel(src)
+		else if((istype(src, /obj/item/handcuffs/guardbot)))
+			src.visible_message("<span style='color:red'>[src] biodegrade instantly. [prob (10) ? "DO NOT QUESTION THIS" : null]</span>")
+			qdel(src)
+		else
+			src.visible_message("<span style='color:red'>[src] break apart.</span>")
+			qdel(src)
 
 /obj/item/handcuffs/proc/destroy_handcuffs(mob/user)
 	user.handcuffs = null
@@ -159,5 +166,3 @@
 
 /obj/item/handcuffs/guardbot/unequipped(var/mob/user)
 	..()
-	boutput(user, "<span style='color:red'>[src] biodegrade instantly. [prob (10) ? "DO NOT QUESTION THIS" : null]</span>")
-	qdel(src)

--- a/code/obj/item/handcuffs.dm
+++ b/code/obj/item/handcuffs.dm
@@ -115,9 +115,6 @@
 		H.set_clothing_icon_dirty()
 	..()
 
-/obj/item/handcuffs/unequipped(var/mob/user)
-	..()
-
 /obj/item/handcuffs/proc/werewolf_cant_rip()
 	.= src.material && src.material.mat_id == "silver"
 
@@ -160,6 +157,3 @@
 	icon_state = "buddycuff"
 	m_amt = 0
 	strength = 1
-
-/obj/item/handcuffs/guardbot/unequipped(var/mob/user)
-	..()

--- a/code/obj/item/handcuffs.dm
+++ b/code/obj/item/handcuffs.dm
@@ -121,7 +121,6 @@
 /obj/item/handcuffs/proc/werewolf_cant_rip()
 	.= src.material && src.material.mat_id == "silver"
 
-
 /obj/item/handcuffs/proc/drop_handcuffs(mob/user)
 	user.handcuffs = null
 	user.delStatus("handcuffed")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Some cuffs, like guardbuddy's ziptie cuffs are supposed to get deleted upon removal. However, the code responsible for such is located in unequipped code, which doesn't get called in the place responsible for removing cuffs. Moreso, it causes significant issues when inside that proc, even an infinite loop and completely breaking an equipment slot detailed here #266 which this PR also fixes.

Within the handcuffs code, there is a var/strength declared. It doesn't seem to have had any point, as it appears to only be declared and set within the handcuffs code, but never used for anything, perhaps a remnant of some very ancient code, maybe relating to uncuff time, however it doesn't seem to have been used since at least 2016. That said, the values the cuffs were set seemed to match the kinds that would get destroyed on removal, so within the PR the value is now being used to determine whether removed cuffs should break or not.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes a bug that could lead to breaking an inventory slot as well as attempting to run code on loop. Makes special cuff types break apart on removal as intended again.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Gerhazo:
(+)Fixed certain cuff types not breaking apart on removal as well as trying to remove silver handcuffs from your belt breaking that slot.
```
