### PR TITLE
Fixes booklet runtimes by wrapping their HTML stuff into a proc.

### DIFF
--- a/code/obj/item/pens_writing_etc.dm
+++ b/code/obj/item/pens_writing_etc.dm
@@ -823,14 +823,13 @@
 		src.add_fingerprint(user)
 		return
 
-	attack_self(var/mob/user as mob, var/page = 1 )
+	proc/display_booklet_contents(var/mob/user as mob, var/page = 1)
 		var/obj/item/paper/cur_page = pages[page]
 		var/next_page = ""
 		var/prev_page = "     "
 		set src in view()
 		set category = "Local"
 
-		..()
 		if(!user.literate)
 			. = html_encode(illiterateGarbleText(cur_page.info)) // deny them ANY useful information
 		else
@@ -849,14 +848,18 @@
 		if (page < pages.len)
 			next_page = "<a href='byond://?src=\ref[src];action=next_page;page=[page]'>Next</a>"
 
-		user.Browse("<HTML><HEAD><TITLE>[src.name] - [cur_page.name]</TITLE>[font_junk]</HEAD><BODY>Page [page] of [pages.len]<BR><a href='byond://?src=/ref[src];action=first_page'>First Page</a> <a href='byond://?src=\ref[src];action=title_book'>Title Book</a> <a href='byond://?src=\ref[src];action=last_page'>Last Page</a><BR>[prev_page]<a href='byond://?src=\ref[src];action=write;page=[page]'>Write</a> <a href='byond://?src=\ref[src];action=title_page;page=[page]'>Title</a> [next_page]<HR><TT>[.]</TT></BODY></HTML>", "window=[src.name]")
+		user.Browse("<HTML><HEAD><TITLE>[src.name] - [cur_page.name]</TITLE>[font_junk]</HEAD><BODY>Page [page] of [pages.len]<BR><a href='byond://?src=\ref[src];action=first_page'>First Page</a> <a href='byond://?src=\ref[src];action=title_book'>Title Book</a> <a href='byond://?src=\ref[src];action=last_page'>Last Page</a><BR>[prev_page]<a href='byond://?src=\ref[src];action=write;page=[page]'>Write</a> <a href='byond://?src=\ref[src];action=title_page;page=[page]'>Title</a> [next_page]<HR><TT>[.]</TT></BODY></HTML>", "window=[src.name]")
 
 		onclose(usr, "[src.name]")
 		return null
 
+	attack_self(var/mob/user)
+		..()
+		src.display_booklet_contents(user,1)
+
 	examine()
 		..()
-		attack_self(usr, 1)
+		src.display_booklet_contents(usr, 1)
 
 	Topic(href, href_list)
 		..()
@@ -869,22 +872,22 @@
 
 		switch (href_list["action"])
 			if ("next_page")
-				src.attack_self(usr,page_num + 1)
+				src.display_booklet_contents(usr,page_num + 1)
 			if ("prev_page")
-				src.attack_self(usr,page_num - 1)
+				src.display_booklet_contents(usr,page_num - 1)
 			if ("write")
 				if (istype(usr.equipped(), /obj/item/pen))
 					cur_page.attackby(usr.equipped(),usr)
-					src.attack_self(usr,page_num)
+					src.display_booklet_contents(usr,page_num)
 			if ("title_page")
 				if (cur_page.loc.loc == usr)
 					cur_page.attack_self(usr)
 			if ("title_book")
 				src.give_title(usr)
 			if ("first_page")
-				src.attack_self(usr,1)
+				src.display_booklet_contents(usr,1)
 			if ("last_page")
-				src.attack_self(usr,pages.len)
+				src.display_booklet_contents(usr,pages.len)
 
 	attackby(var/obj/item/P as obj, mob/user as mob)
 		if (istype(P, /obj/item/paper))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG_MINOR]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Currently, booklet tries to override attack_self but the way it does so seems to end up causing conflicts and runtimes. Trying to click on the booklet in hand causes a runtime while examining it works, even though they both try to use the attack_self function. Wraps the magic HTML portion of the booklet functionality into a proc and calls that instead to fix this.
Also corrected a mistake in one of the dashes \ / that was causing one of the href links to not work properly, the first page button to be specific.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes buggy portions of already a very uncommon but neat little feature, more specifically fixes one of the buttons and lets people interact with it by clicking it in hand as well as examining it as intended rather than just the latter.