### PR TITLE
APCs will now include their area name when they post their status

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1448,7 +1448,7 @@ var/zapLimiter = 0
 
 			switch(lowertext(data["command"]))
 				if ("status")
-					src.post_status(src.host_id,"command","term_message","data","command=status&charge=[cell ? round(cell.percent()) : "00"]&equip=[equipment]&light=[lighting]&environ=[environ]&cover=[coverlocked]")
+					src.post_status(src.host_id,"command","term_message","data","command=status&area=[ckey("[src.area]")]&charge=[cell ? round(cell.percent()) : "00"]&equip=[equipment]&light=[lighting]&environ=[environ]&cover=[coverlocked]")
 					return
 				if ("setmode")
 					var/newEquip = text2num(data["equip"])


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[ENHANCEMENT]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes APCs status response packet to include the area the APC is in


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Sometimes you want to do something to one specific APC - now you can actually figure out which is which!

