### PR TITLE
Fixes incorrect soundname for jetpack mk2.

### DIFF
--- a/code/obj/item/tank.dm
+++ b/code/obj/item/tank.dm
@@ -640,7 +640,7 @@ Contains:
 		src.icon_state = text("jetpack_mk2_[]", src.on)
 		if(src.on)
 			boutput(usr, "<span style=\"color:blue\">The jetpack is now on</span>")
-			playsound(src.loc, "sound/misc/JetPackMK2on.ogg", 50, 1)
+			playsound(src.loc, "sound/misc/JetpackMK2on.ogg", 50, 1)
 		else
 			boutput(usr, "<span style=\"color:blue\">The jetpack is now off</span>")
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MINOR]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes the jetpack's incorrect sound name (more specifically it having an unnecessary capital letter) that was causing it not to play and runtime.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes jetpack mk2 not playing a sound and causing runtime errors.
