### PR TITLE
Monkeys and humans can be blindfolded by targeting their head.

### DIFF
--- a/code/mob/living/carbon/human/monkeys.dm
+++ b/code/mob/living/carbon/human/monkeys.dm
@@ -124,19 +124,6 @@
 		npcmonkeypals -= src
 		..()
 
-	attackby(obj/item/W as obj, mob/user as mob) //Monkies can be blindfolded by targetting head with help intent
-		if (istype(W, /obj/item/clothing/glasses/blindfold) && user.zone_sel.selecting == "head" && user.a_intent == "help")
-			if(src.glasses)
-				boutput(user, "<span style=\"color:red\">[src] is already wearing something on their eyes!</span>")
-				return
-			src.glasses = W
-			user.drop_item()
-			W.set_loc(src)
-			src.update_clothing()
-			user.visible_message("<span style=\"color:blue\"><b>[user]</b> puts a blindfold on [src]!</span>")
-			return
-		..()
-
 	ai_action()
 		if(ai_aggressive)
 			return ..()

--- a/code/mob/living/carbon/human/monkeys.dm
+++ b/code/mob/living/carbon/human/monkeys.dm
@@ -133,7 +133,7 @@
 			user.drop_item()
 			W.set_loc(src)
 			src.update_clothing()
-			boutput(user, "<span style=\"color:blue\">You blindfold [src].</span>")
+			user.visible_message("<span style=\"color:blue\"><b>[user]</b> puts a blindfold on [src]!</span>")
 			return
 		..()
 

--- a/code/mob/living/carbon/human/monkeys.dm
+++ b/code/mob/living/carbon/human/monkeys.dm
@@ -124,6 +124,19 @@
 		npcmonkeypals -= src
 		..()
 
+	attackby(obj/item/W as obj, mob/user as mob) //Monkies can be blindfolded by targetting head with help intent
+		if (istype(W, /obj/item/clothing/glasses/blindfold) && user.zone_sel.selecting == "head" && user.a_intent == "help")
+			if(src.glasses)
+				boutput(user, "<span style=\"color:red\">[src] is already wearing something on their eyes!</span>")
+				return
+			src.glasses = W
+			user.drop_item()
+			W.set_loc(src)
+			src.update_clothing()
+			boutput(user, "<span style=\"color:blue\">You blindfold [src].</span>")
+			return
+		..()
+
 	ai_action()
 		if(ai_aggressive)
 			return ..()

--- a/code/obj/item/clothing/glasses.dm
+++ b/code/obj/item/clothing/glasses.dm
@@ -37,6 +37,19 @@
 	desc = "A strip of cloth painstakingly designed to wear around your eyes so you cannot see."
 	block_vision = 1
 
+	attack(mob/M as mob, mob/user as mob, def_zone) //this is for equipping blindfolds on head attack.
+		if (user.zone_sel.selecting == "head" && ishuman(M)) //ishuman() works on monkeys too apparently.
+			if(user == M) //Accidentally blindfolding yourself might be annoying so I'm leaving that out.
+				boutput(user, "<span style=\"color:red\">Put it on your eyes, dingus!</span>")
+				return
+			var/mob/living/carbon/human/target = M //can't equip to mobs unless they are human
+			if(target.glasses)
+				boutput(user, "<span style=\"color:red\">[target] is already wearing something on their eyes!</span>")
+				return
+			actions.start(new/datum/action/bar/icon/otherItem(user, target, user.equipped() , target.slot_glasses, 1.3 SECONDS) , user) //Uses extended timer to make up for previously having to manually equip to someone's eyes.
+			return
+		..() //if not selecting the head of a human or monkey, just do normal attack.
+
 /obj/item/clothing/glasses/meson
 	name = "Meson Goggles"
 	icon_state = "meson"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Made it so that when a user has a blindfold in hand and target area set to head, attacking a human or monkey blindfolds them. You cannot do this by attacking yourself, but you can still equip by putting it in your glasses slot. The timer has a 1.3 second extension to make up for the previous method of dragging the target and selecting their glasses slot.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

As a geneticist I found blindfolding monkeys annoying. Also, by extension of that, it doesn't really make sense to have to go through a menu to use the blindfold when it only has one purpose.

However, since it's been almost 7 years since I was active I may be lost as to what's fun, or if there's any compelling reasons to keep it the way it is, so I'm open for criticism.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Fautz0:
(+)You can now blindfold monkeys and humans by attacking their head with a blindfold.
```
