### PR TITLE
Fixes being able to RCD shuttle walls.

### DIFF
--- a/code/obj/item/rcd.dm
+++ b/code/obj/item/rcd.dm
@@ -206,7 +206,7 @@ Broken RCD + Effects
 						return
 
 				if (istype(A, /turf/simulated/wall))
-					if (istype(A, /turf/simulated/wall/r_wall) || istype(A, /turf/simulated/wall/auto/reinforced))
+					if (istype(A, /turf/simulated/wall/r_wall) || istype(A, /turf/simulated/wall/auto/reinforced) || istype(A, /turf/simulated/wall/auto/shuttle))
 						return	// You can't go reinforcing stuff that's already reinforced you dope.
 					if (do_thing(user, A, "reinforcing the wall", matter_create_wall, 5 SECONDS))
 						var/datum/material/M = A:material

--- a/code/obj/item/rcd.dm
+++ b/code/obj/item/rcd.dm
@@ -250,6 +250,8 @@ Broken RCD + Effects
 						return
 
 				if (istype(A, /turf/simulated/wall))
+					if (istype(A, /turf/simulated/wall/auto/shuttle))
+						return
 					if (do_thing(user, A, "deconstructing \the [A]", matter_remove_wall, 5 SECONDS))
 						var/datum/material/M = A:material
 						var/turf/simulated/floor/T = A:ReplaceWithFloor()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When using an RCD, checks for shuttle walls to avoid being able to reinforce shuttle walls thus turning them into regular destructible walls. Same for deconstructing them.

That said (input needed):
With shuttle floors being unsimulated, is there a point to the shuttle walls being simulated?
The former is also a recent-ish change, it used to be that the shuttle would depressurize after some damages to the windows.
Perhaps that aspect should be considered in terms of whether this should be changed in any way: whether the shuttle's elements should be unsimulated(and by extension indestructible) or simulated along with being indestructible.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Prevents people from RCD-ing the shuttle walls.

Fixes #324