### PR TITLE
fixes some things related to cooldowns for item abilities

### DIFF
--- a/code/WorkInProgress/AbilityItem.dm
+++ b/code/WorkInProgress/AbilityItem.dm
@@ -728,8 +728,8 @@
 	var/cooldown = 0
 	var/last_use_time = 0
 
-	var/targeted = 0 //does clicking this let you click on something to target it?
-	var/target_anything = 0 //can you target any atom, not just people
+	var/targeted = 0 //does activating this ability let you click on something to target it?
+	var/target_anything = 0 //can you target any atom, not just people?
 
 	var/obj/item/the_item = null
 	var/mob/the_mob = null
@@ -783,8 +783,8 @@
 			var/mob/living/carbon/human/H = the_mob
 			if (H.restrained())
 				return 0
-		if (src.cooldown > 0 && ( src.last_use_time + cooldown ) > world.time)
-			boutput(src.the_mob, "<span style=\"color:red\">This ability is recharging. ([round((src.cooldown/10)-((world.time - src.last_use_time)/10))] seconds left)</span>")
+		if (src.last_use_time && src.cooldown && ( src.last_use_time + cooldown ) > TIME)
+			boutput(src.the_mob, "<span style=\"color:red\">This ability is recharging. ([round((src.cooldown/10)-((TIME - src.last_use_time)/10))] seconds left)</span>")
 			return 0
 		return 1
 
@@ -794,6 +794,7 @@
 
 	//please call back to parent to trigger handle cooldown
 	proc/execute_ability()
+		src.handle_cooldown()
 		return
 
 	proc/OnDrop()
@@ -801,6 +802,6 @@
 
 	proc/handle_cooldown() //copy and pasted from Click() - which is dead now
 		if (src.cooldown)
-			src.last_use_time = world.time
+			src.last_use_time = TIME
 			sleep(src.cooldown)
 			src.on_cooldown()


### PR DESCRIPTION
[BUG] [CLEANLINESS]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
calls the handle cooldown proc in execute_ability for item abilities, which is good when you want things to actually have a cooldown when calling back to the parent
also converts instances of world.time to TIME in the AbilityItem.dm file. also adds a check to the ability_allowed proc to make sure that last_use_time exists before adding a cooldown.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
converting world.time to the TIME macro is good, and also all the things i fixed were unintended and therefore bugs


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->
