### PR TITLE
Added the net_id to APC's Access Panel

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -576,7 +576,8 @@ var/zapLimiter = 0
 			return
 	if(wiresexposed && (!isAI(user)))
 		user.machine = src
-		var/t1 = text("<B>Access Panel</B><br><br>")
+		var/t1 = text("<B>Access Panel</B><br>")
+		t1 += text("An identifier is engraved above the APC's wires: <i>[net_id]</i><br><br>")
 		var/list/apcwires = list(
 			"Orange" = 1,
 			"Dark red" = 2,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Similar to airlocks, APCs will now show their powernet ID when unscrewed. Nothing else changed.
[MINOR]

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Airlocks already have this feature and make setting up packet-nerd systems easier. Seems reasonable that a station that labels every door should also label every APC.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)MarkNstein:
(+)Similar to airlocks, APCs will now show their powernet address when unscrewed.
```
