### PR TITLE
Necrotic Detonation and Resurrection Message Fix

### DIFF
--- a/code/modules/medical/pathology/pathogen_benevolent.dm
+++ b/code/modules/medical/pathology/pathogen_benevolent.dm
@@ -263,7 +263,7 @@ datum/pathogeneffects/benevolent/resurrection
 				H.visible_message("<span style=\"color:red\">[H] suddenly starts moving again!</span>","<span style=\"color:red\">You feel the pathogen weakening as you rise from the dead.</span>")
 
 	react_to(var/R, var/zoom)
-		if (R == "Synthflesh")
+		if (R == "synthflesh")
 			return "Dead parts of the synthflesh seem to still be transferring blood."
 
 

--- a/code/modules/medical/pathology/pathogen_symptoms.dm
+++ b/code/modules/medical/pathology/pathogen_symptoms.dm
@@ -2321,6 +2321,6 @@ datum/pathogeneffects/malevolent/detonation
 		explosion_new(M, get_turf(M), origin.stage*5, origin.stage/2.5)
 
 	react_to(var/R, var/zoom)
-		if (R == "Synthflesh")
+		if (R == "synthflesh")
 			return "There are stray synthflesh pieces all over the dish."
 


### PR DESCRIPTION
[BUG]

## About the PR
These two symptoms were incapable of showing the message seen in their react_to() procs, because both were assuming that the synthflesh reagent's id is "Synthflesh" instead of "synthflesh" in their checks. Fixes #338.

## Why's this needed?
As mentioned in the issue, these messages are useful for finding out which of the two symptoms the pathogen might have.

## Changelog

```
(u)Somethings:
(+)You now see the expected messages for the Necrotic Detonation and Necrotic Resurrection symptoms on a pathogen when you look at the pathogen holding petri dish under a microscope after applying some synthflesh on it with a mechanical dropper.
```