### PR TITLE
Change egun to be unscannable by normal mechscanners

### DIFF
--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -323,6 +323,7 @@
 	item_state = "egun"
 	force = 5.0
 	mats = 50
+	is_syndicate = 1 //haha NO
 	module_research = list("weapons" = 5, "energy" = 4, "miniaturization" = 5)
 	var/nojobreward = 0 //used to stop people from scanning it and then getting both a lawgiver/sabre AND an egun.
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE] [INPUT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the egun syndie-scanner only


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Eguns are very strong, and a common complaint with them seems to be people (antag caps in particular) printing off extras and running around with dual-eguns


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Tarmunora:
(*)Changed eguns to only be scannable with a syndicate device analyzer
```
