### PR TITLE
Adds DNA to zoomed-in Microscope

### DIFF
--- a/code/modules/medical/pathology/pathogen_machines.dm
+++ b/code/modules/medical/pathology/pathogen_machines.dm
@@ -259,12 +259,14 @@
 								P = path_list[uid]
 							user.show_message("<span style=\"color:blue\">Apparent features of the pathogen:</span>")
 							var/lines = 1
+							var/DNA = ""
 							user.show_message(P.suppressant.may_react_to())
 							for (var/datum/pathogeneffects/E in P.effects)
 								var/res = E.may_react_to()
 								if (res)
 									lines++
-									user.show_message("[res]")
+									DNA = pathogen_controller.symptom_to_UID[E.type]
+									user.show_message("([DNA]) [res]")
 							if (!lines)
 								user.show_message("You cannot see anything out of the ordinary.")
 							if (src.symptom_action_in.len)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[ENHANCEMENT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Viewing a pathogen with a zoomed-in microscope will show each symptom's DNA string.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes patho easier for benevolent virologists, and does very little for malevolent virologists, as they'll likely include every symptom anyways.

It's not a very thematic or realistic method, but it's an easy code-change that helps a department that suffers a lot of public vitriol.