### PR TITLE
Occupation Duping in Preferences Fix

### DIFF
--- a/code/datums/preferences.dm
+++ b/code/datums/preferences.dm
@@ -213,7 +213,7 @@ datum/preferences
 
 		if(!user)
 			return
-			
+
 		if (!AH)
 			boutput(usr, "Your settings are missing an AppearanceHolder. This is a good time to tell a coder.")
 
@@ -970,7 +970,7 @@ datum/preferences
 				<div>
 					<a href="byond://?src=\ref[src];preferences=1;occ=[level];job=[JD.name];level=[level - 1]" class="arrow" style="left: 0;">&lt;</a>
 					[level < (4 - (JD.cant_allocate_unwanted ? 1 : 0)) ? {"<a href="byond://?src=\ref[src];preferences=1;occ=[level];job=[JD.name];level=[level + 1]" class="arrow" style="right: 0;">&gt;</a>"} : ""]
-					<a href="byond://?src=\ref[src];preferences=1;occ=2;job=[JD.name];level=0" class="job" style="color: [JD.linkcolor];">
+					<a href="byond://?src=\ref[src];preferences=1;occ=[level];job=[JD.name];level=0" class="job" style="color: [JD.linkcolor];">
 					[JD.name]</a>
 				</div>
 				"}


### PR DESCRIPTION
[BUG]

## About the PR
You could accidentally duplicate an occupation in the job preferences window when you clicked a job that happened to be on low priority or was unwanted and tried to move it from either level, because the links used for them assumed that they are on medium priority. Fixes #232 (unless the described thing is still happening, but it did seem to only be an issue related to the link I changed).

Characters from line 216 were also removed when I made the commit, which I assume is due to it only containing tabs. The main change here is just making the occ variable in the link be the current level of the job instead of it always being 2 for this link.

## Why's this needed?
This should stop you from duplicating your low priority and unwanted jobs by just clicking on the job and trying to move it around.