### PR TITLE
Fix mob diagonal glides - we were missing LONG_GLIDE flag

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -6,7 +6,7 @@
 
 	flags = FPRINT | FLUID_SUBMERGE
 	event_handler_flags = USE_CANPASS
-	appearance_flags = KEEP_TOGETHER | PIXEL_SCALE | TILE_BOUND
+	appearance_flags = KEEP_TOGETHER | PIXEL_SCALE | TILE_BOUND | LONG_GLIDE
 
 	var/datum/mind/mind
 


### PR DESCRIPTION
this looks better
```
(u)mbc:
(+)Fixed diagonal tile-glide animation's improper timing.
```
