### PR TITLE
Fixes extinguisher runtimes.

### DIFF
--- a/code/modules/chemistry/tools/extinguisher.dm
+++ b/code/modules/chemistry/tools/extinguisher.dm
@@ -106,6 +106,7 @@
 				boutput(M, "<span style=\"color:red\">You are struck by shrapnel!</span>")
 				M.emote("scream")
 			qdel(src)
+			return
 
 		else if (src.reagents.has_reagent("infernite") || src.reagents.has_reagent("foof"))
 			user.visible_message("<span style=\"color:red\">[src] ruptures!</span>")
@@ -114,6 +115,7 @@
 			fireflash(src.loc, 0)
 			new/obj/item/scrap(get_turf(user))
 			qdel(src)
+			return
 
 		for (var/reagent in src.banned_reagents)
 			if (src.reagents.has_reagent(reagent))
@@ -126,6 +128,7 @@
 				user.drop_item()
 				make_cleanable(/obj/decal/cleanable/molten_item,get_turf(user))
 				qdel(src)
+				return
 
 		playsound(get_turf(src), "sound/effects/spray.ogg", 75, 1, -3)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes extinguisher.dm line 124 runtime:
Cannot execute null.has reagent().
Where in the loop that checks for reagents that should melt the extinguisher if used, the loop can continue executing after a qdel(src) call and with the reagents being deleted due to disposing being called, runtimes would occur when it tries to check the reagents for a melting chemical on subsequent loops.
Also adds safety returns to the few other places where qdel(src) is called.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes runtimes, returns make sure the code doesn't continue after the object is deleted.
