### PR TITLE
Fix bug with powernets not being properly assigned when cables are joined (fixes #366)

### DIFF
--- a/code/modules/power/power_parent.dm
+++ b/code/modules/power/power_parent.dm
@@ -250,7 +250,7 @@ var/makingpowernetssince = 0
         else if( istype(O, /obj/machinery/power) )
 
             var/obj/machinery/power/M = O
-            if(M.netnum > 0) 
+            if(M.netnum > 0)
                 if(!more || !more.len) return
                 O = more[more.len]
                 more -= O
@@ -299,7 +299,7 @@ var/makingpowernetssince = 0
 		cables -= C
 		if(Debug) world.log << "Was end of cable"
 		return
-	
+
 	if(makingpowernets)
 		return // TODO queue instead
 
@@ -375,18 +375,17 @@ var/makingpowernetssince = 0
 
 	return
 
-/datum/powernet/proc/join_to(var/datum/powernet/PN)
+/datum/powernet/proc/join_to(var/datum/powernet/PN) // maybe pool powernets someday
 	for(var/obj/cable/C in src.cables)
 		C.netnum = PN.number
 		PN.cables += C
 
 	for(var/obj/machinery/power/M in src.nodes)
 		M.netnum = PN.number
+		M.powernet = PN
 		PN.nodes += M
-	
-	for(var/obj/machinery/power/M in src.data_nodes)
-		M.netnum = PN.number
-		PN.data_nodes += M
+		if (M.use_datanet)
+			PN.data_nodes += M
 
 /datum/powernet/proc/reset()
 	load = newload


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[MINOR]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR fixes a bug with powernets not properly being assigned after cables are joined (#366).

**Rundown of the bug:**

Powernets are not properly being assigned to data terminals when cables are joined. Data terminals can receive signals because they've been added back to the "main" powernet, but they can't send them because their assigned powernet is still the old one.
As seen in the bug report, emoving and replacing a connected cable has the potential to fix this. Depending on the directions of the cable that was cut (lol), the "main" powernet will be recreated (see /datum/powernet/proc/cut_cable(var/obj/cable/C) of power_parent.dm) and properly assigned to their data terminals. Obviously this isn't reliable, and so fixing the actual bug would be good (which I did, probably).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I'm making a PR because this seems suspiciously straightforward and I'm concerned that I'm missing something. 
