### PR TITLE
Dummy tweaks

### DIFF
--- a/.github/CODE_GUIDELINES.md
+++ b/.github/CODE_GUIDELINES.md
@@ -59,4 +59,4 @@ Remember: although this trade-off makes sense in many cases, it doesn't cover th
 ### Profiler
 
 ### Target Dummy
-* You can spawn in a target dummy (`/mob/living/carbon/human/dummy`) to more easily test things that do damage - they have the assday health percent and damage popups visible even if your build isn't set to assday.
+* You can spawn in a target dummy (`/mob/living/carbon/human/tdummy`) to more easily test things that do damage - they have the assday health percent and damage popups visible even if your build isn't set to assday.

--- a/code/WorkInProgress/dialogue/dialogue_NTrep.dm
+++ b/code/WorkInProgress/dialogue/dialogue_NTrep.dm
@@ -2,7 +2,7 @@
 This file serves as an example for various things that could be done with dialogues.
 */
 
-/mob/living/carbon/human/dummy/dialogueDummy
+/mob/living/carbon/human/dialogueDummy
 	name = "Admiral Wardson"
 	desc = "That *thing* is not a real person."
 	density = 1

--- a/code/mob/living/carbon/human/procs/update_icon.dm
+++ b/code/mob/living/carbon/human/procs/update_icon.dm
@@ -1229,7 +1229,7 @@ var/list/update_body_limbs = list("r_arm" = "stump_arm_right", "l_arm" = "stump_
 	else
 		src.maptext = ""
 #else
-/mob/living/carbon/human/dummy/UpdateDamage()
+/mob/living/carbon/human/tdummy/UpdateDamage()
 	..()
 	var/prev = health
 	src.updatehealth()
@@ -1249,7 +1249,7 @@ var/list/update_body_limbs = list("r_arm" = "stump_arm_right", "l_arm" = "stump_
 	else
 		src.maptext = ""
 
-/mob/living/carbon/human/dummy/Life(datum/controller/process/mobs/parent)
+/mob/living/carbon/human/tdummy/Life(datum/controller/process/mobs/parent)
 	if (..(parent))
 		return 1
 	src.UpdateDamage()

--- a/code/mob/living/carbon/human/test.dm
+++ b/code/mob/living/carbon/human/test.dm
@@ -1,12 +1,6 @@
-/mob/living/carbon/human/dummy
+/mob/living/carbon/human/tdummy
 	real_name = "Target Dummy"
 //	nodamage = 1
 	New()
 		. = ..()
 		src.maptext_y = 32
-
-	verb/heal_dummy() //this cannot possibly go wrong
-		set src in oview(1)
-		set category = "Local"
-		logTheThing("combat", usr, src, "[usr] did a target dummy fullheal on %target% at [log_loc(usr)]") //maybe worth being logged?
-		src.full_heal()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Remove verb from target dummy because those slow things down oops
change path to `.../human/tdummy` so you can spawn them more easily ("spawn tdu")

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Make them a bit easier to use and not slow down rightclicks for everyone oopsies