### PR TITLE
UM-001 - Soup Pot Adjustments, Plastic Utensil Fixes, Two helpers

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -2630,6 +2630,9 @@
 /mob/proc/find_in_equipment(var/eqtype)
 	return null
 
+/mob/proc/get_slot_from_item(var/obj/item/I)
+	return null
+
 /mob/proc/is_in_hands(var/obj/O)
 	return 0
 

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -1375,6 +1375,44 @@
 		return r_store
 	return null
 
+/mob/living/carbon/human/get_slot_from_item(var/thing)
+	if (!(thing in src.contents))
+		return null
+
+	//wanted the following to be a switch case but those expect constant expressions
+
+	if (src.w_uniform == thing)
+		return slot_w_uniform
+	if (src.wear_id == thing)
+		return slot_wear_id
+	if (src.gloves == thing)
+		return slot_gloves
+	if (src.shoes == thing)
+		return slot_shoes
+	if (src.wear_suit == thing)
+		return slot_wear_suit
+	if (src.back == thing)
+		return slot_back
+	if (src.glasses == thing)
+		return slot_glasses
+	if (src.ears == thing)
+		return ears
+	if (src.wear_mask == thing)
+		return slot_wear_mask
+	if (src.head == thing)
+		return slot_head
+	if (src.belt == thing)
+		return slot_belt
+	if (src.l_store == thing)
+		return slot_l_store
+	if (src.r_store == thing)
+		return slot_r_store
+	if(src.l_hand == thing)
+		return slot_l_hand
+	if(src.r_hand == thing)
+		return slot_r_hand
+	return null
+
 /mob/living/carbon/human/is_in_hands(var/obj/O)
 	if (l_hand == O || r_hand == O)
 		return 1

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -1375,41 +1375,41 @@
 		return r_store
 	return null
 
-/mob/living/carbon/human/get_slot_from_item(var/thing)
-	if (!(thing in src.contents))
+/mob/living/carbon/human/get_slot_from_item(var/obj/item/I)
+	if (!(I in src.contents))
 		return null
 
 	//wanted the following to be a switch case but those expect constant expressions
 
-	if (src.w_uniform == thing)
+	if (src.w_uniform == I)
 		return slot_w_uniform
-	if (src.wear_id == thing)
+	if (src.wear_id == I)
 		return slot_wear_id
-	if (src.gloves == thing)
+	if (src.gloves == I)
 		return slot_gloves
-	if (src.shoes == thing)
+	if (src.shoes == I)
 		return slot_shoes
-	if (src.wear_suit == thing)
+	if (src.wear_suit == I)
 		return slot_wear_suit
-	if (src.back == thing)
+	if (src.back == I)
 		return slot_back
-	if (src.glasses == thing)
+	if (src.glasses == I)
 		return slot_glasses
-	if (src.ears == thing)
+	if (src.ears == I)
 		return ears
-	if (src.wear_mask == thing)
+	if (src.wear_mask == I)
 		return slot_wear_mask
-	if (src.head == thing)
+	if (src.head == I)
 		return slot_head
-	if (src.belt == thing)
+	if (src.belt == I)
 		return slot_belt
-	if (src.l_store == thing)
+	if (src.l_store == I)
 		return slot_l_store
-	if (src.r_store == thing)
+	if (src.r_store == I)
 		return slot_r_store
-	if(src.l_hand == thing)
+	if(src.l_hand == I)
 		return slot_l_hand
-	if(src.r_hand == thing)
+	if(src.r_hand == I)
 		return slot_r_hand
 	return null
 

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -102,6 +102,8 @@
 	var/list/food_effects = list()
 	var/create_time = 0
 
+	var/dropped_item = null
+
 	New()
 		..()
 		start_amount = amount
@@ -146,7 +148,11 @@
 		if (istype(W,/obj/item/kitchen/utensil/fork) || istype(W,/obj/item/kitchen/utensil/spoon))
 			if (prob(20) && (istype(W,/obj/item/kitchen/utensil/fork/plastic) || istype(W,/obj/item/kitchen/utensil/spoon/plastic)))
 				var/obj/item/kitchen/utensil/spoon/plastic/S = W
-				S.break_spoon(user)
+				if(istype(S))
+					S.break_spoon(user)
+				var/obj/item/kitchen/utensil/fork/plastic/F = W
+				if(istype(F))
+					F.break_fork(user)
 				user.visible_message("<span style=\"color:red\">[user] stares glumly at [src].</span>")
 				return
 
@@ -263,6 +269,8 @@
 									S.planttype = hybrid
 								user.visible_message("<span style='color:blue'><b>[user]</b> spits out a seed.</span>",\
 								"<span style='color:blue'>You spit out a seed.</span>")
+					if(src.dropped_item)
+						drop_item(dropped_item)
 					user.u_equip(src)
 					on_finish(M, user)
 					qdel(src)
@@ -306,6 +314,8 @@
 				if (!src.amount)
 					M.visible_message("<span style='color:red'>[M] finishes eating [src].</span>",\
 					"<span style='color:red'>You finish eating [src].</span>")
+					if(src.dropped_item)
+						drop_item(dropped_item)
 					user.u_equip(src)
 					on_finish(M, user)
 					qdel(src)
@@ -350,6 +360,26 @@
 		eat_twitch(eater)
 
 	proc/on_finish(mob/eater)
+		return
+
+	proc/drop_item(var/path)
+		var/obj/drop = new path
+		if(istype(drop))
+			drop.pixel_x = src.pixel_x
+			drop.pixel_y = src.pixel_y
+			var/obj/item/I = drop
+			if(istype(I))
+				var/mob/M = src.loc
+				if(istype(M))
+					var/item_slot = M.get_slot_from_item(src)
+					if(item_slot)
+						M.u_equip(src)
+						src.loc = null
+						var/mob/living/carbon/human/H = M
+						if(istype(H))
+							H.force_equip(I,item_slot) // mobs don't have force_equip
+							return
+			drop.loc = src.loc
 		return
 
 /obj/item/reagent_containers/food/snacks/bite

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -375,8 +375,8 @@
 					if(item_slot)
 						M.u_equip(src)
 						src.loc = null
-						var/mob/living/carbon/human/H = M
-						if(istype(H))
+						if(ishuman(M))
+							var/mob/living/carbon/human/H = M
 							H.force_equip(I,item_slot) // mobs don't have force_equip
 							return
 			drop.loc = get_turf(src.loc)

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -380,7 +380,6 @@
 							H.force_equip(I,item_slot) // mobs don't have force_equip
 							return
 			drop.loc = get_turf(src.loc)
-		return
 
 /obj/item/reagent_containers/food/snacks/bite
 	name = "half-digested food chunk"

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -379,7 +379,7 @@
 						if(istype(H))
 							H.force_equip(I,item_slot) // mobs don't have force_equip
 							return
-			drop.loc = src.loc
+			drop.loc = get_turf(src.loc)
 		return
 
 /obj/item/reagent_containers/food/snacks/bite

--- a/code/modules/food_and_drink/popsicles.dm
+++ b/code/modules/food_and_drink/popsicles.dm
@@ -49,6 +49,7 @@
 	food_color = null
 	initial_volume = 40
 	var/flavor = ""
+	dropped_item = /obj/item/stick
 
 	New()
 		..()
@@ -114,11 +115,6 @@
 		..()
 		M.bodytemperature = min(M.base_body_temp, M.bodytemperature-20)
 		return
-
-	on_finish(mob/eater, var/mob/user)
-		var/obj/item/stick/S = new
-		user.put_in_hand_or_drop(S)
-		..()
 
 	proc/melt(var/mob/user)
 		boutput(user,"<span style=\"color:blue\"><b>[src] has already melted! Damn!</b></span>")

--- a/code/modules/food_and_drink/snacks.dm
+++ b/code/modules/food_and_drink/snacks.dm
@@ -374,6 +374,7 @@
 	w_class = 2
 	initial_volume = 100
 	food_effects = list("food_warm")
+	dropped_item = /obj/item/reagent_containers/food/drinks/bowl
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (istype(W, /obj/item/reagent_containers/food/snacks/tortilla_chip))

--- a/code/obj/item/kitchen.dm
+++ b/code/obj/item/kitchen.dm
@@ -114,7 +114,7 @@ TRAYS
 
 	proc/break_fork(mob/living/carbon/user as mob)
 		user.visible_message("<span style=\"color:red\">[src] breaks!</span>")
-		playsound(user.loc, "sound/effects/snap.ogg", 30, 1)
+		playsound(user.loc, "sound/impact_sounds/Generic_Snap_1.ogg", 30, 1)
 		user.u_equip(src)
 		qdel(src)
 		return
@@ -190,7 +190,7 @@ TRAYS
 
 	proc/break_knife(mob/living/carbon/user as mob)
 		user.visible_message("<span style=\"color:red\">[src] breaks!</span>")
-		playsound(user.loc, "sound/effects/snap.ogg", 30, 1)
+		playsound(user.loc, "sound/impact_sounds/Generic_Snap_1.ogg", 30, 1)
 		user.u_equip(src)
 		qdel(src)
 		return
@@ -311,7 +311,7 @@ TRAYS
 
 	proc/break_spoon(mob/living/carbon/user as mob)
 		user.visible_message("<span style=\"color:red\">[src] breaks!</span>")
-		playsound(user.loc, "sound/effects/snap.ogg", 30, 1)
+		playsound(user.loc, "sound/impact_sounds/Generic_Snap_1.ogg", 30, 1)
 		user.u_equip(src)
 		qdel(src)
 		return

--- a/code/obj/soup_pot.dm
+++ b/code/obj/soup_pot.dm
@@ -53,7 +53,7 @@
 
 /obj/stove
 	name = "stove"
-	desc = "A perfectly ordinary kitchen stove; not that you'll be doing anything ordinary with it."
+	desc = "A perfectly ordinary kitchen stove; not that you'll be doing anything ordinary with it.<br>It seems this model doesn't have a built in igniter, so you'll have to light it manually."
 	icon = 'icons/obj/soup_pot.dmi'
 	icon_state = "stove0"
 	anchored = 1
@@ -66,10 +66,13 @@
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (istype(W,/obj/item/soup_pot))
-			src.icon_state = "stove1"
-			src.pot = W
-			user.u_equip(W)
-			W.loc = src
+			if(src.pot)
+				boutput(user,"<span style=\"color:red\"><b>There's already a pot on the stove, dummy!</span>")
+			else
+				src.icon_state = "stove1"
+				src.pot = W
+				user.u_equip(W)
+				W.loc = src
 
 		if (!src.on && src.pot)
 
@@ -371,7 +374,13 @@
 					boutput(user,"<span style=\"color:red\"><b>There's nothing in there to serve!</span>")
 
 			else if (L.my_soup)
-				boutput(user,"<span style=\"color:red\"><b>There's still soup in the ladle. Serve that first!</span>")
+				if(L.my_soup == src.my_soup)
+					src.total_wclass++
+					L.my_soup = null
+					L.overlays = null
+					user.visible_message("[user] empties [L] into [src].", "You empty [L] into [src]")
+				else
+					boutput(user,"<span style=\"color:red\"><b>You can't mix soups! That'd be ridiculous!</span>")
 			else
 				src.total_wclass--
 				L.my_soup = src.my_soup


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

1) Adds a helper proc for mobs/humans that lets you get the equipped item's slot value based on the item's instance.

2) Added generalized functionality for dropping items from food/snacks and converted soups and popsicles to using that functionality. Soups now drop bowls, popsicles drop popsicle sticks.

3) Added some checks for soup pots that (1) Allow you to ladle soup back into the pot and (2) stops you from putting on two pots at once

4) Fixed two runtimes with plastic utensils, one where the sound it plays couldn't be found, and one where there was some embarrassingly bad type checking that I had written in their breaking logic during eating

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

1) Needed to make (2) work properly with foods that can be eaten while being worn in pocket or hand slots with forks/spoons.

2) Allows for general dropping of items from food/snacks. In this instance, people were a bit bummed that eating a soup destroyed the bowl, which made soup serving gimmicks pretty annoying. Popsicles would teleport their sticks into the user's hand if you ate them with a fork, which was a bit unintuitive. I found myself repeating code a lot so I made it a general behavior that you can utilize in your code by giving your food/snack a path in its dropped_item var

3) Not having these checks caused people to get frustrated with either soup pots being lost inside the stove + getting stuck with a ladle full of soup they couldn't put back in the pot.

4) Saw these while I was testing my code and decided to fix them. Runtimes bad.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)UrsulaMajor:
(+)You can now ladle soup back into the soup pot, if you want. Soups also now drop their bowls when eaten. 
```
