### PR TITLE
fix gun spread from drunkenness

### DIFF
--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -295,18 +295,18 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 			sleep(slowdown_time)
 			user.movement_delay_modifier -= slowdown
 
-	var/spread = spread_angle
+	var/spread = 0
 	if (user.reagents)
 		var/how_drunk = 0
 		var/amt = user.reagents.get_reagent_amount("ethanol")
-		if (amt >= 110)
-			how_drunk = 2
-		else if (amt < 110)
-			how_drunk = 1
-		else if (amt <= 0)
-			how_drunk = 0
+		switch(amt)
+			if (110 to INFINITY)
+				how_drunk = 2
+			if (1 to 110)
+				how_drunk = 1
 		how_drunk = max(0, how_drunk - isalcoholresistant(user) ? 1 : 0)
 		spread += 5 * how_drunk
+	spread = max(spread, spread_angle)
 
 	for (var/i = 0; i < current_projectile.shot_number; i++)
 		var/obj/projectile/P = initialize_projectile_pixel_spread(user, current_projectile, M, 0, 0, spread)
@@ -368,18 +368,18 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 				sleep(slowdown_time)
 				M.movement_delay_modifier -= slowdown
 
-	var/spread = spread_angle
+	var/spread = 0
 	if (user.reagents)
 		var/how_drunk = 0
 		var/amt = user.reagents.get_reagent_amount("ethanol")
-		if (amt >= 110)
-			how_drunk = 2
-		else if (amt < 110)
-			how_drunk = 1
-		else if (amt <= 0)
-			how_drunk = 0
+		switch(amt)
+			if (110 to INFINITY)
+				how_drunk = 2
+			if (1 to 110)
+				how_drunk = 1
 		how_drunk = max(0, how_drunk - isalcoholresistant(user) ? 1 : 0)
 		spread += 5 * how_drunk
+	spread = max(spread, spread_angle)
 
 	var/obj/projectile/P = shoot_projectile_ST_pixel_spread(user, current_projectile, target, POX, POY, spread)
 	if (P)

--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -1,4 +1,3 @@
-
 var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder uID stuff
 
 /obj/item/gun


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Split off fix for drunken shooting from #262 that was causing all guns to be fired as if you were slightly drunk. Also changes drunkenness spread to use the higher of the drunkspread or the gun's spread, as so not to cripple guns that already have some (e.g.: clock 188)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Random spread on all guns all the time is probably not good?


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Tarmunora:
(+)Fixed issue where guns treated you as if you were always slightly drunk for the purposes of aiming.
```
