### PR TITLE
Fix bioholders not properly copying blood DNA, fingerprints, and genetic effects

### DIFF
--- a/code/mob/dead/observer.dm
+++ b/code/mob/dead/observer.dm
@@ -350,17 +350,8 @@
 
 
 		var/datum/bioHolder/newbio = new/datum/bioHolder(O)
-		newbio.CopyOther(src.bioHolder)
+		newbio.CopyOther(src.bioHolder, copyActiveEffects = 0)
 		O.bioHolder = newbio
-		// cirr fix for mutations carrying over to ghosts leading to awful side-effects like ghostly irradiating
-		// for now keep glow because it amuses me very much, but we'll take that out if people abuse it
-		var/datum/bioEffect/glowy/G = null
-		if(O.bioHolder.HasEffect("glowy"))
-			G = O.bioHolder.GetEffect("glowy")
-		O.bioHolder.RemoveAllEffects()
-		// add the glow back if it exists
-		if(istype(G))
-			O.bioHolder.AddEffect(G)
 
 	return O
 

--- a/code/modules/chemistry/Chemistry-Holder.dm
+++ b/code/modules/chemistry/Chemistry-Holder.dm
@@ -735,6 +735,7 @@ datum
 					added_new = 1
 				else
 					return 0
+			// Else, if the reagent datum already exists, we'll just be adding to that and won't update with our new reagent datum data
 
 			var/new_amount = (current_reagent.volume + amount)
 			current_reagent.volume = new_amount

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -1575,24 +1575,16 @@ datum
 			on_mob_life(var/mob/M, var/mult = 1)
 				if (!M) M = holder.my_atom
 				//M.changeStatus("radiation", 30, 1)
-				var/datum/bioHolder/data_as_holder = null
-				if (!src.data) //Do we have some BLOOODDD to use?
+				if (!src.data) // Pull bioholder data from blood that's in the same reagentholder
 					var/datum/reagent/blood/cheating = holder.reagent_list["blood"]
 					if (cheating && istype(cheating.data, /datum/bioHolder))
 						src.data = cheating.data
-						data_as_holder = src.data
 
 				if (src.data && M.bioHolder && progress_timer <= 10)
 
 					M.bioHolder.StaggeredCopyOther(data, progress_timer+=(1 * mult))
 					if (progress_timer > 10)
-						if (data_as_holder && data_as_holder.ownerName)
-							M.real_name = data_as_holder.ownerName
-							M.bioHolder.ownerName = M.real_name
-							M.bioHolder.CopyOther(data)
-						else if (data && data:ownerName)
-							M.real_name = data:ownerName
-							M.bioHolder.ownerName = M.real_name
+						M.real_name = M.bioHolder.ownerName
 
 				..()
 				return

--- a/code/modules/medical/blood_system.dm
+++ b/code/modules/medical/blood_system.dm
@@ -516,9 +516,10 @@ this is already used where it needs to be used, you can probably ignore it.
 		if (!isvampire(some_human_idiot) && (some_human_idiot.blood_volume < blood_to_transfer))
 			blood_to_transfer = some_human_idiot.blood_volume
 
-		bloodHolder = new/datum/bioHolder(null)
-		bloodHolder.CopyOther(some_idiot.bioHolder)
-		bloodHolder.ownerName = some_idiot.real_name
+		if (!A.reagents.get_reagent("bloodc") && !A.reagents.get_reagent("blood")) // if it doesn't have blood with blood bioholder data already, only then create this
+			bloodHolder = new/datum/bioHolder(null)
+			bloodHolder.CopyOther(some_idiot.bioHolder)
+			bloodHolder.ownerName = some_idiot.real_name
 
 	var/datum/reagent/R = null
 

--- a/code/modules/medical/genetics/bioHolder.dm
+++ b/code/modules/medical/genetics/bioHolder.dm
@@ -259,7 +259,7 @@ var/list/datum/bioEffect/mutini_effects = list()
 		// changed this to transfer the instance across rather than add a copy
 		// since some bioeffects have unique stuff
 		effects[E.id] = E
-		effectPool -= E.id
+		effectPool.Remove(E.id)
 		E.owner = owner
 		E.holder = src
 		E.activated_from_pool = 1
@@ -427,10 +427,19 @@ var/list/datum/bioEffect/mutini_effects = list()
 			mobAppearance.CopyOther(toCopy.mobAppearance)
 			mobAppearance.UpdateMob()
 
+			age = toCopy.age
 			bloodType = toCopy.bloodType
 			bloodColor = toCopy.bloodColor
-			age = toCopy.age
 			clone_generation = toCopy.clone_generation
+			genetic_stability = toCopy.genetic_stability
+			ownerName = toCopy.ownerName
+			Uid = toCopy.Uid
+
+		if (copyPool)
+			src.RemoveAllPoolEffects()
+			for (var/id in toCopy.effectPool)
+				AddNewPoolEffect(id)
+
 		if(copyActiveEffects)
 			src.RemoveAllEffects()
 			var/datum/bioEffect/BE
@@ -456,7 +465,7 @@ var/list/datum/bioEffect/mutini_effects = list()
 		return
 
 	proc/StaggeredCopyOther(var/datum/bioHolder/toCopy, progress = 1)
-		if (progress >= 10)
+		if (progress > 10)
 			return CopyOther(toCopy)
 
 		if (mobAppearance)
@@ -569,7 +578,7 @@ var/list/datum/bioEffect/mutini_effects = list()
 		for(var/D in effectPool)
 			var/datum/bioEffect/BE = effectPool[D]
 			if(BE && (isnull(type) || BE.effectType == type))
-				effectPool -= BE
+				effectPool.Remove(D)
 				//qdel(BE)
 		return 1
 

--- a/code/modules/medical/genetics/bioHolder.dm
+++ b/code/modules/medical/genetics/bioHolder.dm
@@ -479,7 +479,6 @@ var/list/datum/bioEffect/mutini_effects = list()
 
 	proc/AddEffect(var/idToAdd, var/variant = 0, var/timeleft = 0, var/do_stability = 1, var/magical = 0)
 		//Adds an effect to this holder. Returns the newly created effect if succesful else 0.
-		if(!owner) return
 
 		if(HasEffect(idToAdd))
 			return 0
@@ -512,7 +511,7 @@ var/list/datum/bioEffect/mutini_effects = list()
 			if (do_stability)
 				src.genetic_stability -= newEffect.stability_loss
 				src.genetic_stability = max(0,src.genetic_stability)
-			if(lentext(newEffect.msgGain) > 0)
+			if(owner && lentext(newEffect.msgGain) > 0)
 				if (newEffect.isBad)
 					boutput(owner, "<span style=\"color:red\">[newEffect.msgGain]</span>")
 				else

--- a/code/obj/machinery/clonepod.dm
+++ b/code/obj/machinery/clonepod.dm
@@ -174,7 +174,7 @@
 
 	if (istype(oldholder))
 		oldholder.clone_generation++
-		src.occupant.bioHolder.CopyOther( oldholder )
+		src.occupant.bioHolder.CopyOther(oldholder, copyActiveEffects = gen_analysis)
 	else
 		logTheThing("debug", null, null, "<b>Cloning:</b> growclone([english_list(args)]) with invalid holder.")
 
@@ -200,7 +200,6 @@
 	src.occupant.take_oxygen_deprivation(40)
 	src.occupant.take_brain_damage(90)
 	src.occupant.changeStatus("paralysis", 60)
-	src.occupant.bioHolder.AddEffect("premature_clone")
 	if(src.occupant.bioHolder.clone_generation > 1)
 		src.occupant.setStatus("maxhealth-", null, -((src.occupant.bioHolder.clone_generation - 1) * 15))
 		//src.occupant.max_health -= (src.occupant.bioHolder.clone_generation - 1) * 15 //Genetic degradation! Oh no!!
@@ -552,11 +551,8 @@ var/list/clonepod_accepted_reagents = list("blood"=0.5,"synthflesh"=1,"beff"=0.7
 	for (var/obj/O in src)
 		O.set_loc(get_turf(src))
 
-	if ((src.occupant.health >= heal_level - 50) && src.occupant.bioHolder) // this seems to often not work right, changing 20 to 50
-		src.occupant.bioHolder.RemoveEffect("premature_clone")
-		src.occupant.update_face()
-		src.occupant.update_body()
-		src.occupant.update_clothing()
+	if ((src.occupant.health < heal_level - 50) && src.occupant.bioHolder) // this seems to often not work right, changing 20 to 50
+		src.occupant.bioHolder.AddEffect("premature_clone")
 	if (src.occupant.get_oxygen_deprivation())
 		src.occupant.take_oxygen_deprivation(-INFINITY)
 		src.occupant.updatehealth()

--- a/code/obj/machinery/computer/cloning.dm
+++ b/code/obj/machinery/computer/cloning.dm
@@ -251,8 +251,8 @@
 		if(5) //Advanced genetics analysis
 			dat += {"<h4>Advanced Genetic Analysis</h4>
 					<a href='byond://?src=\ref[src];menu=1'>Back</a><br>
-					<B>Notice:</B> Enabling this feature will prompt the attached clone pod to analyze the genetic makeup of the subject during cloning.
-					Data will then be sent to any nearby GeneTek scanners and be used to improve their efficiency. The cloning process will be slightly slower as a result.<BR><BR>"}
+					<B>Notice:</B> Enabling this feature will prompt the attached clone pod to transfer active genetic mutations from the genetic record to the subject during cloning.
+					The cloning process will be slightly slower as a result.<BR><BR>"}
 
 			if(pod1 && !pod1.operating)
 				if(pod1.gen_analysis)


### PR DESCRIPTION
[FIX] [ENHANCEMENT]

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR fixes #334; bioholders not properly copying fingerprints or genetic effects. It also cleans up stable mutagen code and makes transfer_blood slightly better (reduces bioholder creation + copying). Fixing these bugs restores functionality that was previously not ingame - mainly copying latent + active genetic effects.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes a bug.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Flourish:
(*)Cloning and stable mutagen now properly copy blood DNA, fingerprints, and genetic effects. The advanced genetic analysis option on the cloning computer toggles copying active genetic effects (yes, that includes mutantraces).
```
