### PR TITLE
Spreader pointblank refactor

### DIFF
--- a/code/mob/living/carbon/human/procs/damage.dm
+++ b/code/mob/living/carbon/human/procs/damage.dm
@@ -121,7 +121,8 @@
 
 				//bleed
 				if (armor_value_bullet > 1)
-					show_message("<span style=\"color:red\">[P] pierces through your armor!</span>", 4)
+					if (!P.proj_data.nomsg)
+						show_message("<span style=\"color:red\">[P] pierces through your armor!</span>", 4)
 					src.TakeDamage("chest", damage/max((armor_value_bullet/3), 1), 0, 0, DAMAGE_STAB)
 					if (src.organHolder && prob(50))
 						src.organHolder.damage_organ(damage/max(armor_value_bullet/3), 0, 0, target_organ)
@@ -166,7 +167,8 @@
 					src.stamina_stun()
 				//bleed
 				if (armor_value_bullet > 1)
-					show_message("<span style=\"color:red\">Your armor softens the hit!</span>", 4)
+					if (!P.proj_data.nomsg)
+						show_message("<span style=\"color:red\">Your armor softens the hit!</span>", 4)
 					src.TakeDamage("chest", (damage/armor_value_bullet), 0, 0, DAMAGE_BLUNT)
 					if (src.organHolder && prob(50))
 						src.organHolder.damage_organ(damage/armor_value_bullet, 0, 0, target_organ)
@@ -187,7 +189,8 @@
 					src.stuttering = stun
 
 				if (armor_value_bullet > 1)
-					show_message("<span style=\"color:red\">Your armor softens the hit!</span>", 4)
+					if (!P.proj_data.nomsg)
+						show_message("<span style=\"color:red\">Your armor softens the hit!</span>", 4)
 					src.TakeDamage("chest", 0, (damage/armor_value_bullet), 0, DAMAGE_BURN)
 					if (src.organHolder && prob(50))
 						src.organHolder.damage_organ(0, damage/armor_value_bullet, 0, target_organ)
@@ -208,7 +211,8 @@
 					return
 
 				if (armor_value_bullet > 1)
-					show_message("<span style=\"color:red\">Your armor softens the hit!</span>", 4)
+					if (!P.proj_data.nomsg)
+						show_message("<span style=\"color:red\">Your armor softens the hit!</span>", 4)
 					src.TakeDamage("chest", 0, (damage/armor_value_bullet), 0, DAMAGE_BURN)
 					src.update_burning(damage/armor_value_bullet)
 					if (src.organHolder && prob(50))
@@ -236,7 +240,8 @@
 
 				if (P.proj_data.reagent_payload)
 					if (armor_value_bullet > 1)
-						show_message("<span style=\"color:red\">Your armor softens the hit!</span>", 4)
+						if (!P.proj_data.nomsg)
+							show_message("<span style=\"color:red\">Your armor softens the hit!</span>", 4)
 						src.TakeDamage("chest", (damage/armor_value_bullet), 0, 0, DAMAGE_STAB)
 					else
 						src.TakeDamage("chest", damage, 0, 0, DAMAGE_STAB)

--- a/code/modules/projectiles/special.dm
+++ b/code/modules/projectiles/special.dm
@@ -131,6 +131,7 @@
 	var/pellets_to_fire = 15
 	var/spread_projectile_type = /datum/projectile/bullet/flak_chunk
 	var/split_type = 0
+	nomsg = 1
 	// 0 = on spawn
 	// 1 = on impact
 

--- a/code/modules/projectiles/special.dm
+++ b/code/modules/projectiles/special.dm
@@ -142,6 +142,18 @@
 		if(split_type == 1)
 			split(P)
 
+	on_pointblank(obj/projectile/O, mob/target)
+		if(split_type) //don't multihit on pointblank unless we'd be splitting on launch
+			return
+		var/datum/projectile/F = new spread_projectile_type()
+		var/turf/PT = get_turf(O)
+		var/pellets = pellets_to_fire
+		while (pellets > 0)
+			pellets--
+			var/obj/projectile/FC = initialize_projectile(PT, F, O.xo, O.yo, O.shooter)
+			hit_with_existing_projectile(FC, target)
+
+
 	proc/new_pellet(var/obj/projectile/P, var/turf/PT, var/datum/projectile/F)
 		return
 
@@ -199,8 +211,8 @@
 	spread_projectile_type = /datum/projectile/bullet/nails
 	casing = /obj/item/casing/shotgun_gray
 	spread_angle_variance = 10
-	damage_type = D_SLASHING
-	power = 40
+	damage_type = D_SPECIAL
+	power = 32
 
 /datum/projectile/special/spreader/uniform_burst/circle
 	name = "circular spread"
@@ -721,11 +733,10 @@
 /datum/projectile/special/spreader/tasershotgunspread //Used in Azungar's taser shotgun.
 	name = "energy bolt"
 	sname = "shotgun spread"
-	shot_number = 0
 	cost = 37.5
 	power = 45 //a chunky pointblank
 	ks_ratio = 0
-	damage_type = D_ENERGY
+	damage_type = D_SPECIAL
 	pellets_to_fire = 3
 	spread_projectile_type = /datum/projectile/energy_bolt/tasershotgun
 	split_type = 0
@@ -740,10 +751,6 @@
 		angle_adjust_per_pellet = ((spread_angle *3) / pellets_to_fire)
 		current_angle = (0 - spread_angle) + (angle_adjust_per_pellet * initial_angle_offset_mult)
 		..()
-
-	on_hit(atom/A, angle, obj/projectile/P)
-		if(isliving(A))
-			stun_bullet_hit(P,A)
 
 	new_pellet(var/obj/projectile/P, var/turf/PT, var/datum/projectile/F)
 		var/obj/projectile/FC = initialize_projectile(PT, F, P.xo, P.yo, P.shooter)
@@ -790,14 +797,3 @@
 		FC.rotateDirection(current_angle)
 		FC.launch()
 		current_angle += angle_adjust_per_pellet
-
-	on_pointblank(var/obj/projectile/O, var/mob/target)
-		if (!O)
-			return
-		if (!target)
-			return
-		var/turf/T = get_turf(target)
-		if(T)
-			for(var/i=0, i < 4, i++)
-				throw_egg(T)
-		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[CLEANLINESS] [BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Spreader pointblanks make and hit with the projectiles it would have split into
Reduces listed power on nailshot to match actual power, which is reduced from 40 -> 32 as a result of this refactor
Fix taser shotgun pointblanks



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes pointblanking with spreader projectiles work identically to shooting someone with one, instead of needing special-cased interactions. Consistency.
