### PR TITLE
Lets janitors parry csabers and katanas with mops

### DIFF
--- a/code/datums/controllers/process/items.dm
+++ b/code/datums/controllers/process/items.dm
@@ -74,8 +74,9 @@ datum/controller/process/items
 				U.remove_stamina(15)
 
 			return 1
-	return 0
 	..()
+	return 0
+
 
 
 /obj/item/proc/handle_katanaparry(mob/target, mob/user)
@@ -99,8 +100,8 @@ datum/controller/process/items
 				U.remove_stamina(20)
 
 			return 1
-	return 0
 	..()
+	return 0
 
 /obj/item/katana/handle_katanaparry(mob/target,mob/user)
 	..()

--- a/code/datums/controllers/process/items.dm
+++ b/code/datums/controllers/process/items.dm
@@ -45,3 +45,57 @@ datum/controller/process/items
 				if (count > 4)
 					stats += "[thing] used [count] ticks.<br>"
 			boutput(usr, "<br>[stats]")
+
+/obj/item/proc/handle_parry(mob/target, mob/user)
+	if (target != user && ishuman(target))
+		var/mob/living/carbon/human/H = target
+		var/obj/item/sword/S = H.find_type_in_hand(/obj/item/sword, "right")
+		if (!S)
+			S = H.find_type_in_hand(/obj/item/sword, "left")
+		var/obj/item/mop/mop = (H.find_type_in_hand(/obj/item/mop, "right")&& H.mind && H.job == "Janitor")
+		if (!mop)
+			mop = (H.find_type_in_hand(/obj/item/mop, "left")&& H.mind && H.job == "Janitor")
+		if (((S && S.active) || (mop)) && !(H.lying || isdead(H) || H.hasStatus("stunned") || H.hasStatus("weakened") || H.hasStatus("paralysis")))
+			var/obj/itemspecialeffect/clash/C = unpool(/obj/itemspecialeffect/clash)
+			if(target.gender == MALE) playsound(get_turf(target), pick('sound/weapons/male_cswordattack1.ogg','sound/weapons/male_cswordattack2.ogg'), 70, 0, 0, max(0.7, min(1.2, 1.0 + (30 - H.bioHolder.age)/60)))
+			else playsound(get_turf(target), pick('sound/weapons/female_cswordattack1.ogg','sound/weapons/female_cswordattack2.ogg'), 70, 0, 0, max(0.7, min(1.4, 1.0 + (30 - H.bioHolder.age)/50)))
+			C.setup(H.loc)
+			var/matrix/m = matrix()
+			m.Turn(rand(0,360))
+			C.transform = m
+			var/matrix/m1 = C.transform
+			m1.Scale(2,2)
+			C.pixel_x = 32*(user.x - target.x)*0.5
+			C.pixel_y = 32*(user.y - target.y)*0.5
+			animate(C,transform=m1,time=8)
+			H.remove_stamina(40)
+			if (ishuman(user))
+				var/mob/living/carbon/human/U = user
+				U.remove_stamina(15)
+
+			return 1
+	return 0
+
+
+/obj/item/proc/handle_katanaparry(mob/target, mob/user)
+	if (target != user && ishuman(target))
+		var/mob/living/carbon/human/H = target
+		if ((H.find_type_in_hand(/obj/item/katana, "right") || H.find_type_in_hand(/obj/item/katana, "left"))||(((H.find_type_in_hand(/obj/item/mop,"right")||H.find_type_in_hand(/obj/item/mop,"left"))&& H.mind && H.job == "Janitor")))
+			var/obj/itemspecialeffect/clash/C = unpool(/obj/itemspecialeffect/clash)
+			playsound(get_turf(target), pick("sound/effects/sword_clash1.ogg","sound/effects/sword_clash2.ogg","sound/effects/sword_clash3.ogg"), 70, 0, 0)
+			C.setup(H.loc)
+			var/matrix/m = matrix()
+			m.Turn(rand(0,360))
+			C.transform = m
+			var/matrix/m1 = C.transform
+			m1.Scale(2,2)
+			C.pixel_x = 32*(user.x - target.x)*0.5
+			C.pixel_y = 32*(user.y - target.y)*0.5
+			animate(C,transform=m1,time=8)
+			H.remove_stamina(60)
+			if (ishuman(user))
+				var/mob/living/carbon/human/U = user
+				U.remove_stamina(20)
+
+			return 1
+	return 0

--- a/code/datums/controllers/process/items.dm
+++ b/code/datums/controllers/process/items.dm
@@ -75,6 +75,7 @@ datum/controller/process/items
 
 			return 1
 	return 0
+	..()
 
 
 /obj/item/proc/handle_katanaparry(mob/target, mob/user)
@@ -99,3 +100,37 @@ datum/controller/process/items
 
 			return 1
 	return 0
+	..()
+
+/obj/item/katana/handle_katanaparry(mob/target,mob/user)
+	..()
+	var/mob/living/carbon/human/H = target
+	if(handle_katanaparry(H,user))
+		if (H.job == "Janitor" && (H.find_type_in_hand(/obj/item/mop,"left")||H.find_type_in_hand(/obj/item/mop,"right")))
+			if (H.find_type_in_hand(/obj/item/mop,"left"))
+				var/obj/item/mop/mop = H.l_hand
+				if(prob(33))
+					H.u_equip(mop)
+					qdel(mop)
+			else if (H.find_type_in_hand(/obj/item/mop,"right"))
+				var/obj/item/mop/mop = H.r_hand
+				if(prob(33))
+					H.u_equip(mop)
+					qdel(mop)
+
+/obj/item/sword/handle_parry(mob/target,mob/user)
+	..()
+	var/mob/living/carbon/human/H = target
+	if(handle_parry(H,user))
+		if (H.job == "Janitor" && (H.find_type_in_hand(/obj/item/mop,"left")||H.find_type_in_hand(/obj/item/mop,"right")))
+			if (H.find_type_in_hand(/obj/item/mop,"left"))
+				var/obj/item/mop/mop = H.l_hand
+				if(prob(69))//haha funny sex number
+					H.u_equip(mop)
+					qdel(mop)
+			else if (H.find_type_in_hand(/obj/item/mop,"right"))
+				var/obj/item/mop/mop = H.r_hand
+				if(prob(69))
+					H.u_equip(mop)
+					qdel(mop)
+

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -93,37 +93,6 @@
 			else
 				..()
 
-/obj/item/sword/proc/handle_parry(mob/target, mob/user)
-    if (target != user && ishuman(target))
-        var/mob/living/carbon/human/H = target
-        var/obj/item/sword/S = H.find_type_in_hand(/obj/item/sword, "right")
-        if (!S)
-            S = H.find_type_in_hand(/obj/item/sword, "left")
-        var/obj/item/mop/mop = H.find_type_in_hand(/obj/item/mop, "right")
-        if (!mop)
-            mop = H.find_type_in_hand(/obj/item/mop, "left")
-        if (((S && S.active) || (mop)) && !(H.lying || isdead(H) || H.hasStatus("stunned") || H.hasStatus("weakened") || H.hasStatus("paralysis")))
-			var/obj/itemspecialeffect/clash/C = unpool(/obj/itemspecialeffect/clash)
-			if(target.gender == MALE) playsound(get_turf(target), pick('sound/weapons/male_cswordattack1.ogg','sound/weapons/male_cswordattack2.ogg'), 70, 0, 0, max(0.7, min(1.2, 1.0 + (30 - H.bioHolder.age)/60)))
-			else playsound(get_turf(target), pick('sound/weapons/female_cswordattack1.ogg','sound/weapons/female_cswordattack2.ogg'), 70, 0, 0, max(0.7, min(1.4, 1.0 + (30 - H.bioHolder.age)/50)))
-			C.setup(H.loc)
-			var/matrix/m = matrix()
-			m.Turn(rand(0,360))
-			C.transform = m
-			var/matrix/m1 = C.transform
-			m1.Scale(2,2)
-			C.pixel_x = 32*(user.x - target.x)*0.5
-			C.pixel_y = 32*(user.y - target.y)*0.5
-			animate(C,transform=m1,time=8)
-			H.remove_stamina(40)
-			if (ishuman(user))
-				var/mob/living/carbon/human/U = user
-				U.remove_stamina(15)
-
-			return 1
-	return 0
-
-
 /obj/item/sword/attack_self(mob/user as mob)
 	if (user.bioHolder.HasEffect("clumsy") && prob(50))
 		user.visible_message("<span style=\"color:red\"><b>[user]</b> fumbles [src] and cuts \himself.</span>")
@@ -759,7 +728,7 @@
 		return ..()
 	var/zoney = user.zone_sel.selecting
 	var/mob/living/carbon/human/H = target
-	if (handle_parry(H, user))
+	if (handle_katanaparry(H, user))
 		return
 	switch(zoney)
 		if("head")
@@ -785,29 +754,6 @@
 				H.sever_limb(zoney)
 			return ..()
 	..()
-
-/obj/item/katana/proc/handle_parry(mob/target, mob/user)
-	if (target != user && ishuman(target))
-		var/mob/living/carbon/human/H = target
-		if (H.find_type_in_hand(/obj/item/katana, "right") || H.find_type_in_hand(/obj/item/katana, "left"))
-			var/obj/itemspecialeffect/clash/C = unpool(/obj/itemspecialeffect/clash)
-			playsound(get_turf(target), pick("sound/effects/sword_clash1.ogg","sound/effects/sword_clash2.ogg","sound/effects/sword_clash3.ogg"), 70, 0, 0)
-			C.setup(H.loc)
-			var/matrix/m = matrix()
-			m.Turn(rand(0,360))
-			C.transform = m
-			var/matrix/m1 = C.transform
-			m1.Scale(2,2)
-			C.pixel_x = 32*(user.x - target.x)*0.5
-			C.pixel_y = 32*(user.y - target.y)*0.5
-			animate(C,transform=m1,time=8)
-			H.remove_stamina(60)
-			if (ishuman(user))
-				var/mob/living/carbon/human/U = user
-				U.remove_stamina(20)
-
-			return 1
-	return 0
 
 /obj/item/katana/suicide(var/mob/user as mob)
 	user.visible_message("<span style=\"color:red\"><b>[user] thrusts [src] through their stomach!</b></span>")

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -94,12 +94,15 @@
 				..()
 
 /obj/item/sword/proc/handle_parry(mob/target, mob/user)
-	if (target != user && ishuman(target))
-		var/mob/living/carbon/human/H = target
-		var/obj/item/sword/S = H.find_type_in_hand(/obj/item/sword, "right")
-		if (!S)
-			S = H.find_type_in_hand(/obj/item/sword, "left")
-		if (S && S.active && !(H.lying || isdead(H) || H.hasStatus("stunned") || H.hasStatus("weakened") || H.hasStatus("paralysis")))
+    if (target != user && ishuman(target))
+        var/mob/living/carbon/human/H = target
+        var/obj/item/sword/S = H.find_type_in_hand(/obj/item/sword, "right")
+        if (!S)
+            S = H.find_type_in_hand(/obj/item/sword, "left")
+        var/obj/item/mop/mop = H.find_type_in_hand(/obj/item/mop, "right")
+        if (!mop)
+            mop = H.find_type_in_hand(/obj/item/mop, "left")
+        if (((S && S.active) || (mop)) && !(H.lying || isdead(H) || H.hasStatus("stunned") || H.hasStatus("weakened") || H.hasStatus("paralysis")))
 			var/obj/itemspecialeffect/clash/C = unpool(/obj/itemspecialeffect/clash)
 			if(target.gender == MALE) playsound(get_turf(target), pick('sound/weapons/male_cswordattack1.ogg','sound/weapons/male_cswordattack2.ogg'), 70, 0, 0, max(0.7, min(1.2, 1.0 + (30 - H.bioHolder.age)/60)))
 			else playsound(get_turf(target), pick('sound/weapons/female_cswordattack1.ogg','sound/weapons/female_cswordattack2.ogg'), 70, 0, 0, max(0.7, min(1.4, 1.0 + (30 - H.bioHolder.age)/50)))

--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -251,8 +251,10 @@ WET FLOOR SIGN
 
 /obj/item/mop/attack(mob/target, mob/user, def_zone, is_special = 0)
 	if (ishuman(user))
-			if (handle_parry(target, user))
-					return 1
+		if ((handle_katanaparry(target, user))||handle_parry(target, user))
+			return 1
+
+		..()
 
 /obj/item/mop/New()
 	..()

--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -251,9 +251,8 @@ WET FLOOR SIGN
 
 /obj/item/mop/attack(mob/target, mob/user, def_zone, is_special = 0)
 	if (ishuman(user))
-		if ((handle_katanaparry(target, user))||handle_parry(target, user))
+		if (handle_katanaparry(target, user)||handle_parry(target,user))
 			return 1
-
 		..()
 
 /obj/item/mop/New()

--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -249,6 +249,11 @@ WET FLOOR SIGN
 	stamina_cost = 15
 	stamina_crit_chance = 10
 
+/obj/item/mop/attack(mob/target, mob/user, def_zone, is_special = 0)
+	if (ishuman(user))
+			if (handle_parry(target, user))
+					return 1
+
 /obj/item/mop/New()
 	..()
 	var/datum/reagents/R = new/datum/reagents(20)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Puts parry code into items.dm, so its an item level proc, and makes janitors able to parry anything under /obj/item/sword and /obj/item/katana with a mop. Depending on feedback, might make it necessary for the mop to be in their active hand.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
People get salty as fuck over csaber and katana rampages,  and I thought this would be a fun dumb thing to add. Also I love watching janitors clean up after rampagers.
