### PR TITLE
Check for distance from QT console on interaction

### DIFF
--- a/code/WorkInProgress/telescope/quantumTelescope.dm
+++ b/code/WorkInProgress/telescope/quantumTelescope.dm
@@ -79,6 +79,7 @@ TODO: Enforce ping rate limit here as well in case someone futzes with the javas
 		return
 
 	Topic(href, href_list)
+		if (get_dist(src, usr) > 1) return
 		if(href_list["close"])
 			using = null
 

--- a/code/WorkInProgress/telescope/quantumTelescope.dm
+++ b/code/WorkInProgress/telescope/quantumTelescope.dm
@@ -79,7 +79,9 @@ TODO: Enforce ping rate limit here as well in case someone futzes with the javas
 		return
 
 	Topic(href, href_list)
-		if (get_dist(src, usr) > 1) return
+		if (get_dist(src, usr) > 1)
+			bootUser()
+			return
 		if(href_list["close"])
 			using = null
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FIX]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes #228 - Quantum telescope can be used from any distance
The ping animation on the map will still play, since there's not an easy way to check for distance from the javascript, but actual interaction will be prevented.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bugfix



