### PR TITLE
Updates surgery to allow borg to remove eyes through surgery

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -3021,28 +3021,28 @@
 
 	if (this_hand)
 		if (this_hand == "right" || this_hand == 3)
-			if (src.module_states[3] && istype(I, src.module_states[3]))
+			if (src.module_states[3] && istype(src.module_states[3], I))
 				return 1
 			else
 				return 0
 		else if (this_hand == "middle" || this_hand == 2)
-			if (src.module_states[2] && istype(I, src.module_states[2]))
+			if (src.module_states[2] && istype(src.module_states[2], I))
 				return 1
 			else
 				return 0
 		else if (this_hand == "left" || this_hand == 1)
-			if (src.module_states[1] && istype(I, src.module_states[1]))
+			if (src.module_states[1] && istype(src.module_states[1], I))
 				return 1
 			else
 				return 0
 		else
 			return 0
 
-	if (src.module_states[3] && istype(I, src.module_states[3]))
+	if (src.module_states[3] && istype(src.module_states[3], I))
 		return src.module_states[3]
-	else if (src.module_states[2] && istype(I, src.module_states[2]))
+	else if (src.module_states[2] && istype(src.module_states[2], I))
 		return src.module_states[2]
-	else if (src.module_states[1] && istype(I, src.module_states[1]))
+	else if (src.module_states[1] && istype(src.module_states[1], I))
 		return src.module_states[1]
 	else
 		return 0

--- a/code/modules/medical/surgery_procs.dm
+++ b/code/modules/medical/surgery_procs.dm
@@ -342,7 +342,7 @@
 				patient.organHolder.head.op_stage = 3.0
 				return 1
 
-		else if (patient.organHolder.right_eye && patient.organHolder.right_eye.op_stage == 1.0 && surgeon.find_in_hand(src) == surgeon.r_hand)
+		else if (patient.organHolder.right_eye && patient.organHolder.right_eye.op_stage == 1.0 && surgeon.find_in_hand(src, "right"))
 			playsound(get_turf(patient), "sound/impact_sounds/Slimy_Cut_1.ogg", 50, 1)
 
 			if (prob(screw_up_prob))
@@ -364,7 +364,7 @@
 			patient.organHolder.right_eye.op_stage = 2.0
 			return 1
 
-		else if (patient.organHolder.left_eye && patient.organHolder.left_eye.op_stage == 1.0 && surgeon.find_in_hand(src) == surgeon.l_hand)
+		else if (patient.organHolder.left_eye && patient.organHolder.left_eye.op_stage == 1.0 && surgeon.find_in_hand(src, "left"))
 			playsound(get_turf(patient), "sound/impact_sounds/Slimy_Cut_1.ogg", 50, 1)
 
 			if (prob(screw_up_prob))
@@ -1627,110 +1627,69 @@
 			surgeon.show_text("You're going to need to remove that mask/helmet/glasses first.", "blue")
 			return 1
 
-/* ---------- SPOON - RIGHT EYE ---------- */
+		var/obj/item/organ/eye/target_eye = null
+		var/target_side = null
 
-		if (surgeon.find_in_hand(src) == surgeon.r_hand && patient.organHolder.right_eye)
-			if (patient.organHolder.right_eye.op_stage == 0.0)
-				playsound(get_turf(patient), "sound/impact_sounds/Slimy_Cut_1.ogg", 50, 1)
-
-				if (prob(screw_up_prob))
-					surgeon.visible_message("<span style='color:red'><b>[surgeon][fluff]!</b></span>")
-					patient.TakeDamage("head", damage_low, 0)
-					take_bleeding_damage(patient, surgeon, damage_low)
-					return 1
-
-				patient.tri_message("<span style='color:red'><b>[surgeon]</b> inserts [src] into [patient == surgeon ? "[his_or_her(patient)]" : "[patient]'s"] right eye socket!</span>",\
-				surgeon, "<span style='color:red'>You insert [src] into [surgeon == patient ? "your" : "[patient]'s"] right eye socket!</span>", \
-				patient, "<span style='color:red'>[patient == surgeon ? "You insert" : "<b>[surgeon]</b> inserts"] [src] into your right eye socket!</span>")
-
-				patient.TakeDamage("head", damage_low, 0)
-				if (!surgeon.find_type_in_hand(/obj/item/hemostat))
-					take_bleeding_damage(patient, surgeon, damage_low)
-				else
-					surgeon.show_text("You clamp the bleeders with the hemostat.", "blue")
-				patient.updatehealth()
-				patient.organHolder.right_eye.op_stage = 1.0
-				return 1
-
-			else if (patient.organHolder.right_eye.op_stage == 2.0)
-				playsound(get_turf(patient), "sound/impact_sounds/Slimy_Cut_1.ogg", 50, 1)
-
-				if (prob(screw_up_prob))
-					surgeon.visible_message("<span style='color:red'><b>[surgeon][fluff2]!</b></span>")
-					patient.TakeDamage("head", damage_high, 0)
-					take_bleeding_damage(patient, surgeon, damage_high)
-					return 1
-
-				patient.tri_message("<span style='color:red'><b>[surgeon]</b> removes [patient == surgeon ? "[his_or_her(patient)]" : "[patient]'s"] right eye with [src]!</span>",\
-				surgeon, "<span style='color:red'>You remove [surgeon == patient ? "your" : "[patient]'s"] right eye with [src]!</span>",\
-				patient, "<span style='color:red'>[patient == surgeon ? "You remove" : "<b>[surgeon]</b> removes"] your right eye with [src]!</span>")
-
-				patient.TakeDamage("head", damage_low, 0)
-				if (!surgeon.find_type_in_hand(/obj/item/hemostat))
-					take_bleeding_damage(patient, surgeon, damage_low)
-				else
-					surgeon.show_text("You clamp the bleeders with the hemostat.", "blue")
-				logTheThing("combat", surgeon, patient, "removed %target%'s right eye with [src].")
-				patient.organHolder.drop_organ("right_eye")
-				return 1
-
-			else
-				src.surgeryConfusion(patient, surgeon, damage_high)
-				return 1
-
-/* ---------- SPOON - LEFT EYE ---------- */
-
-		else if (surgeon.find_in_hand(src) == surgeon.l_hand && patient.organHolder.left_eye)
-			if (patient.organHolder.left_eye.op_stage == 0.0)
-				playsound(get_turf(patient), "sound/impact_sounds/Slimy_Cut_1.ogg", 50, 1)
-
-				if (prob(screw_up_prob))
-					surgeon.visible_message("<span style='color:red'><b>[surgeon][fluff]!</b></span>")
-					patient.TakeDamage("head", damage_low, 0)
-					take_bleeding_damage(patient, surgeon, damage_low)
-					return 1
-
-				patient.tri_message("<span style='color:red'><b>[surgeon]</b> inserts [src] into [patient == surgeon ? "[his_or_her(patient)]" : "[patient]'s"] left eye socket!</span>",\
-				surgeon, "<span style='color:red'>You insert [src] into [surgeon == patient ? "your" : "[patient]'s"] left eye socket!</span>", \
-				patient, "<span style='color:red'>[patient == surgeon ? "You insert" : "<b>[surgeon]</b> inserts"] [src] into your left eye socket!</span>")
-
-				patient.TakeDamage("head", damage_low, 0)
-				if (!surgeon.find_type_in_hand(/obj/item/hemostat))
-					take_bleeding_damage(patient, surgeon, damage_low)
-				else
-					surgeon.show_text("You clamp the bleeders with the hemostat.", "blue")
-				patient.updatehealth()
-				patient.organHolder.left_eye.op_stage = 1.0
-				return 1
-
-			else if (patient.organHolder.left_eye.op_stage == 2.0)
-				playsound(get_turf(patient), "sound/impact_sounds/Slimy_Cut_1.ogg", 50, 1)
-
-				if (prob(screw_up_prob))
-					surgeon.visible_message("<span style='color:red'><b>[surgeon][fluff2]!</b></span>")
-					patient.TakeDamage("head", damage_high, 0)
-					take_bleeding_damage(patient, surgeon, damage_high)
-					return 1
-
-				patient.tri_message("<span style='color:red'><b>[surgeon]</b> removes [patient == surgeon ? "[his_or_her(patient)]" : "[patient]'s"] left eye with [src]!</span>",\
-				surgeon, "<span style='color:red'>You remove [surgeon == patient ? "your" : "[patient]'s"] left eye with [src]!</span>",\
-				patient, "<span style='color:red'>[patient == surgeon ? "You remove" : "<b>[surgeon]</b> removes"] your left eye with [src]!</span>")
-
-				patient.TakeDamage("head", damage_low, 0)
-				if (!surgeon.find_type_in_hand(/obj/item/hemostat))
-					take_bleeding_damage(patient, surgeon, damage_low)
-				else
-					surgeon.show_text("You clamp the bleeders with the hemostat.", "blue")
-				logTheThing("combat", surgeon, patient, "removed %target%'s left eye with [src].")
-				patient.organHolder.drop_organ("left_eye")
-				return 1
-
-			else
-				src.surgeryConfusion(patient, surgeon, damage_high)
-				return 1
-
+		if (surgeon.find_in_hand(src, "right") && patient.organHolder.right_eye)
+			target_eye = patient.organHolder.right_eye
+			target_side = "right"
+		else if (surgeon.find_in_hand(src, "left") && patient.organHolder.left_eye)
+			target_eye = patient.organHolder.left_eye
+			target_side = "left"
 		else
 			return 0
+
+		if (target_eye.op_stage == 0.0)
+			playsound(get_turf(patient), "sound/impact_sounds/Slimy_Cut_1.ogg", 50, 1)
+
+			if (prob(screw_up_prob))
+				surgeon.visible_message("<span style='color:red'><b>[surgeon][fluff]!</b></span>")
+				patient.TakeDamage("head", damage_low, 0)
+				take_bleeding_damage(patient, surgeon, damage_low)
+				return 1
+
+			patient.tri_message("<span style='color:red'><b>[surgeon]</b> inserts [src] into [patient == surgeon ? "[his_or_her(patient)]" : "[patient]'s"] [target_side] eye socket!</span>",\
+			surgeon, "<span style='color:red'>You insert [src] into [surgeon == patient ? "your" : "[patient]'s"] [target_side] eye socket!</span>", \
+			patient, "<span style='color:red'>[patient == surgeon ? "You insert" : "<b>[surgeon]</b> inserts"] [src] into your [target_side] eye socket!</span>")
+
+			patient.TakeDamage("head", damage_low, 0)
+			if (!surgeon.find_type_in_hand(/obj/item/hemostat))
+				take_bleeding_damage(patient, surgeon, damage_low)
+			else
+				surgeon.show_text("You clamp the bleeders with the hemostat.", "blue")
+			patient.updatehealth()
+			target_eye.op_stage = 1.0
+			return 1
+
+		else if (target_eye.op_stage == 2.0)
+			playsound(get_turf(patient), "sound/impact_sounds/Slimy_Cut_1.ogg", 50, 1)
+
+			if (prob(screw_up_prob))
+				surgeon.visible_message("<span style='color:red'><b>[surgeon][fluff2]!</b></span>")
+				patient.TakeDamage("head", damage_high, 0)
+				take_bleeding_damage(patient, surgeon, damage_high)
+				return 1
+
+			patient.tri_message("<span style='color:red'><b>[surgeon]</b> removes [patient == surgeon ? "[his_or_her(patient)]" : "[patient]'s"] [target_side] eye with [src]!</span>",\
+			surgeon, "<span style='color:red'>You remove [surgeon == patient ? "your" : "[patient]'s"] [target_side] eye with [src]!</span>",\
+			patient, "<span style='color:red'>[patient == surgeon ? "You remove" : "<b>[surgeon]</b> removes"] your [target_side] eye with [src]!</span>")
+
+			patient.TakeDamage("head", damage_low, 0)
+			if (!surgeon.find_type_in_hand(/obj/item/hemostat))
+				take_bleeding_damage(patient, surgeon, damage_low)
+			else
+				surgeon.show_text("You clamp the bleeders with the hemostat.", "blue")
+			logTheThing("combat", surgeon, patient, "removed %target%'s [target_side] eye with [src].")
+
+			if (target_eye == patient.organHolder.right_eye)
+				patient.organHolder.drop_organ("right_eye")
+			else if (target_eye == patient.organHolder.left_eye)
+				patient.organHolder.drop_organ("left_eye")
+			return 1
+
+		else
+			src.surgeryConfusion(patient, surgeon, damage_high)
+			return 1
 
 ////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
[FIX]

## About the PR

Fixes #122 - Mediborg eye surgery not progressing
Updates surgery procs to allow mediborg to perform eye surgery.

For changes to /mob/living/silicon/robot/find_type_in_hand() the param order in istype(obj, type_ref) is important, and i believe this function has been bugged. I needed to update it to get hemostats to work. But i'm unsure of all use cases for the borg version of this function.

The changes to spoon_surgery() pull out two variables then combine the two nearly identical code blocks (one for each eye) into a single block of code. This is why the diff is a mess. Main changes are newline 1630-1640, 1684-1687 and using [target_side] in text output

## Why's this needed?

Mediborg come with an enucleation spoon in their equipment and should be able to at least remove eyes.

## Changelog

+ Mediborg can now perform eye surgery. Use tool slot 1 for the left eye and slot 3 for the right eye. 