### PR TITLE
item limb bugfix + balance

### DIFF
--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -373,6 +373,10 @@
 		msgs.played_sound = 'sound/impact_sounds/Generic_Shove_1.ogg'
 		msgs.base_attack_message = "<span style=\"color:red\"><B>[src] rolls [target] backwards[DISARM_WITH_ITEM_TEXT]!</B></span>"
 		msgs.disarm_RNG_result = "shoved"
+		var/obj/item/I = target.equipped()
+		if (I && I.temp_flags & IS_LIMB_ITEM)
+			msgs.disarm_RNG_result = "attack_self_with_item_shoved"
+
 		return msgs
 
 	var/damage = rand(base_damage_low, base_damage_high) * extra_damage
@@ -918,7 +922,7 @@
 						target.deliver_move_trigger("bump")
 						target.drop_item_throw()
 
-					if ("attack_self_with_item", "attack_self_with_item_shoved_down")
+					if ("attack_self_with_item", "attack_self_with_item_shoved_down", "attack_self_with_item_shoved")
 						var/obj/item/I = target.equipped()
 						if (I)
 							var/old_zone_sel = 0
@@ -938,9 +942,12 @@
 							if (prob(20))
 								I.attack_self(target)
 
+							//SORRY
 							if (src.disarm_RNG_result == "attack_self_with_item_shoved_down")
 								target.changeStatus("weakened", 1 SECONDS)
 								target.force_laydown_standup()
+							if (src.disarm_RNG_result == "attack_self_with_item_shoved")
+								step_away(target, owner, 1)
 
 					if ("shoved_down")
 						target.deliver_move_trigger("pushdown")

--- a/code/obj/item/mob_parts/human_parts.dm
+++ b/code/obj/item/mob_parts/human_parts.dm
@@ -383,6 +383,7 @@
 				//H.update_clothing()
 				H.update_body()
 				H.update_inhands()
+				H.hud.add_other_object(H.l_hand,H.hud.layouts[H.hud.layout_style]["lhand"])
 
 
 	proc/remove_from_mob(delete = 0)
@@ -512,6 +513,7 @@
 				H.update_body()
 				H.set_body_icon_dirty()
 				H.update_inhands()
+				H.hud.add_other_object(H.r_hand,H.hud.layouts[H.hud.layout_style]["rhand"])
 
 	proc/remove_from_mob(delete = 0)
 		if (isitem(remove_object))


### PR DESCRIPTION
fix #182 
also some balance to fix a scenario where someone could lie down to prevent the main downside of item limbs

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)mbc:
(*)Shoving a person who is downed and using item limbs will cause them to attack themselves just like they would if they were standing upright.
(+)Fixed bug where item limbs wouldn't show icons on your hud.
```
