### PR TITLE
Chair rotate verb replacements

### DIFF
--- a/code/mob/input.dm
+++ b/code/mob/input.dm
@@ -105,6 +105,8 @@ mob
 					if (src.buckled && istype(src.buckled, /obj/stool/chair))
 						var/obj/stool/chair/C = src.buckled
 						delay += C.buckle_move_delay //GriiiiIIIND
+						if (C.rotatable)
+							C.rotate(src.move_dir)
 
 					for (var/obj/item/grab/G in src.equipped_list(check_for_magtractor = 0))
 						if (get_dist(src, G.affecting) > 1)

--- a/code/mob/living/carbon/human/procs/Life.dm
+++ b/code/mob/living/carbon/human/procs/Life.dm
@@ -820,8 +820,14 @@
 			return
 
 		if (buckled && buckled.anchored)
-			canmove = 0
-			return
+			if (istype(src.buckled, /obj/stool/chair)) //this check so we can still rotate the chairs on their slower delay even if we are anchored
+				var/obj/stool/chair/chair = src.buckled
+				if (!chair.rotatable)
+					canmove = 0
+					return
+			else
+				canmove = 0
+				return
 
 		if (throwing & (THROW_CHAIRFLIP | THROW_GUNIMPACT))
 			canmove = 0

--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -637,7 +637,7 @@
 		return
 
 	MouseDrop(atom/over_object as mob|obj)
-		if(get_dist(over_object,usr) <= 1)
+		if(get_dist(src,usr) <= 1)
 			src.rotate(get_dir(get_turf(src),get_turf(over_object)))
 		..()
 

--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -637,7 +637,8 @@
 		return
 
 	MouseDrop(atom/over_object as mob|obj)
-		src.rotate(get_dir(get_turf(src),get_turf(over_object)))
+		if(get_dist(over_object,usr) <= 1)
+			src.rotate(get_dir(get_turf(src),get_turf(over_object)))
 		..()
 
 	can_buckle(var/mob/M, var/mob/user)

--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -636,6 +636,10 @@
 					user.unlock_medal("Leave no man behind!", 1)
 		return
 
+	MouseDrop(atom/over_object as mob|obj)
+		src.rotate(get_dir(get_turf(src),get_turf(over_object)))
+		..()
+
 	can_buckle(var/mob/M, var/mob/user)
 		if (!ticker)
 			boutput(user, "You can't buckle anyone in before the game starts.")
@@ -760,9 +764,13 @@
 #endif
 		else return ..()
 
-	proc/rotate()
+	proc/rotate(var/face_dir = 0)
 		if (rotatable)
-			src.dir = turn(src.dir, 90)
+			if (!face_dir)
+				src.dir = turn(src.dir, 90)
+			else
+				src.dir = face_dir
+
 			if (src.dir == NORTH)
 				src.layer = FLY_LAYER+1
 			else


### PR DESCRIPTION

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)mbc:
(+)Click+Drag chairs in order to rotate them. They also rotate when you are buckled in and trying to move.
```
