### PR TITLE
Move some verbs down to PA in player options

### DIFF
--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -326,7 +326,7 @@
 		//dat += "</div>"
 
 	//Coder options
-	if( src.level >= LEVEL_SHITGUY )
+	if( src.level >= LEVEL_PA )
 		dat += {"
 			<div class='optionGroup' style='border-color: #FFB347;'>
 				<h2 style='background-color: #FFB347;'>High Level Problems</h2>

--- a/strings/admin_changelog.txt
+++ b/strings/admin_changelog.txt
@@ -1,4 +1,7 @@
 
+(t)sat apr 25 20
+(u)kyle
+(*)Move the view variables, posess, and Modify icon down to PA in the player options panel.
 (t)wed apr 22 20
 (u)mbc
 (*)Moved all admin-specific right click verbs into a new menu. Press Tilde to turn on 'Admin Interact' mode, and then left click on an item to view options for that item (or right click a tile to select from a list of items on that tile).


### PR DESCRIPTION
## About the PR 
move the view variables, posess, and Modify icon down to PA in the player options panel. I think they already have access to these verbs so they might as well see them here too.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
We removed some of these verbs from the right click menu, namely view variables. But the player options screen has enough general utility to warrant keeping that one verb on the right click. And since PA's have access to the view vars verb anyway, it should be shown to them in this menu.
