### PR TITLE
Emergency suits/tanks for QM emergency crate

### DIFF
--- a/code/datums/supply_packs.dm
+++ b/code/datums/supply_packs.dm
@@ -433,10 +433,12 @@
 
 /datum/supply_packs/evacuation
 	name = "Emergency Equipment"
-	desc = "x4 Floor Bot, x5 Air Tank, x5 Gas Mask"
+	desc = "x4 Floor Bot, x4 Emergency O2 Tank, x4 Gas Mask, x4 Emergency Space Suit Set"
 	contains = list(/obj/machinery/bot/floorbot = 4,
-	/obj/item/tank/air = 5,
-	/obj/item/clothing/mask/gas = 5)
+	/obj/item/clothing/mask/gas = 4,
+	/obj/item/tank/emergency_oxygen = 4,
+	/obj/item/clothing/head/emerg = 4,
+	/obj/item/clothing/suit/space/emerg = 4)
 	cost = 1500
 	containertype = /obj/storage/crate/internals
 	containername = "Emergency Equipment"

--- a/code/datums/supply_packs.dm
+++ b/code/datums/supply_packs.dm
@@ -433,10 +433,11 @@
 
 /datum/supply_packs/evacuation
 	name = "Emergency Equipment"
-	desc = "x4 Floor Bot, x4 Emergency O2 Tank, x4 Gas Mask, x4 Emergency Space Suit Set"
+	desc = "x4 Floor Bot, x4 Gas Tanks, x4 Gas Mask, x4 Emergency Space Suit Set"
 	contains = list(/obj/machinery/bot/floorbot = 4,
 	/obj/item/clothing/mask/gas = 4,
-	/obj/item/tank/emergency_oxygen = 4,
+	/obj/item/tank/emergency_oxygen = 2,
+	/obj/item/tank/air = 2,
 	/obj/item/clothing/head/emerg = 4,
 	/obj/item/clothing/suit/space/emerg = 4)
 	cost = 1500


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[REWORK] [INPUT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Alters the complement of the Emergency Equipment crate QM can order, replacing half of the air tanks with emergency O2 tanks and adding emergency space suit sets of the sort that can be found in lockers or starting boxes. The complement of these sets also decreases to four, to compensate for their improved completeness and usability.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Means of attaining additional emergency gear of this sort are currently limited, if not nonexistent - upgrading the emergency crate significantly improves their availability without making it completely trivial, and makes it a more generally appealing pick outside of emag shenanigans.

**Important note: If you believe this would too heavily lessen the impact of hull breaches, please do not hesitate to reject it.** This is a concern that I believe merits consideration, and I've tagged this as input wanted for that reason.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Kubius:
(+)QM's emergency crate now contains emergency-grade spacesuits and tanks.
```
