### PR TITLE
clean up tooltip info icon on tg ui

### DIFF
--- a/code/datums/hud/human.dm
+++ b/code/datums/hud/human.dm
@@ -315,11 +315,15 @@
 						src.add_screen(S)
 					for (var/obj/O in inventory_items)
 						src.add_object(O, HUD_LAYER+2)
+					if (layout_style == "tg")
+						src.add_screen(legend)
 				else
 					for (var/obj/screen/hud/S in inventory_bg)
 						src.remove_screen(S)
 					for (var/obj/O in inventory_items)
 						src.remove_object(O)
+					if (layout_style == "tg")
+						src.remove_screen(legend)
 
 			if ("lhand")
 				master.swap_hand(1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Tooltip info icon (little [?] box) will now hide when hiding inventory on TG ui

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
looked kinda dumb before