### PR TITLE
bullets stagger people on hit

### DIFF
--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -53,7 +53,7 @@ toxic - poisons
 	on_hit(atom/hit, direction, obj/projectile/P)
 		if (ishuman(hit) && src.hit_type)
 			take_bleeding_damage(hit, null, round(src.power / 3), src.hit_type) // oh god no why was the first var set to src what was I thinking
-			hit.changeStatus("staggered", clamp(P.power, 5, 1) SECONDS)
+			hit.changeStatus("staggered", clamp(P.power/8, 5, 1) SECONDS)
 		..()//uh, what the fuck, call your parent
 		//return // BULLETS CANNOT BLEED, HAINE
 

--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -50,9 +50,10 @@ toxic - poisons
 	hit_mob_sound = 'sound/impact_sounds/Flesh_Stab_2.ogg'
 
 //Any special things when it hits shit?
-	on_hit(atom/hit, direction, projectile)
+	on_hit(atom/hit, direction, obj/projectile/P)
 		if (ishuman(hit) && src.hit_type)
 			take_bleeding_damage(hit, null, round(src.power / 3), src.hit_type) // oh god no why was the first var set to src what was I thinking
+			hit.changeStatus("staggered", clamp(P.power, 5, 1) SECONDS)
 		..()//uh, what the fuck, call your parent
 		//return // BULLETS CANNOT BLEED, HAINE
 
@@ -188,9 +189,7 @@ toxic - poisons
 				var/turf/target = get_edge_target_turf(M, dirflag)
 				SPAWN_DBG(0)
 					M.throw_at(target, 2, 2, throw_type = THROW_GUNIMPACT)
-			if (src.hit_type)
-				take_bleeding_damage(hit, null, round(src.power / 3), src.hit_type)
-		impact_image_effect("K", hit)
+		..()
 
 /datum/projectile/bullet/rifle_762_NATO //like .308 but military
 	name = "bullet"
@@ -219,9 +218,7 @@ toxic - poisons
 				var/turf/target = get_edge_target_turf(M, dirflag)
 				SPAWN_DBG(0)
 					M.throw_at(target, 3, 3, throw_type = THROW_GUNIMPACT)
-			if (src.hit_type)
-				take_bleeding_damage(hit, null, round(src.power / 3), src.hit_type)
-
+		..()
 /datum/projectile/bullet/tranq_dart
 	name = "dart"
 	power = 10
@@ -297,11 +294,7 @@ toxic - poisons
 	on_hit(atom/hit)
 		if(ismob(hit) && hasvar(hit, "stunned"))
 			hit:stunned += 5
-		if (ishuman(hit))
-			if (src.hit_type)
-				take_bleeding_damage(hit, null, round(src.power / 3), src.hit_type)
-				impact_image_effect("K", hit)
-		return
+		..()
 
 /datum/projectile/bullet/a12
 	name = "buckshot"
@@ -332,8 +325,7 @@ toxic - poisons
 				SPAWN_DBG(0)
 					if(!M.stat) M.emote("scream")
 					M.throw_at(target, 6, 2, throw_type = THROW_GUNIMPACT)
-			if (src.hit_type)
-				take_bleeding_damage(hit, null, round(src.power / 3), src.hit_type)
+			..()
 
 	weak
 		power = 30
@@ -441,6 +433,7 @@ toxic - poisons
 					if(!M.stat) M.emote("scream")
 					M.throw_at(target, throw_range, 1, throw_type = THROW_GUNIMPACT)
 					M.update_canmove()
+			hit.changeStatus("staggered", clamp(proj.power/8, 5, 1) SECONDS)
 			//if (src.hit_type)
 			// impact_image_effect("K", hit)
 				//take_bleeding_damage(hit, null, round(src.power / 3), src.hit_type)
@@ -472,6 +465,7 @@ toxic - poisons
 					M.changeStatus("weakened", 2 SECONDS)
 					M.throw_at(target, throw_range, 1, throw_type = THROW_GUNIMPACT)
 					M.update_canmove()
+			hit.changeStatus("staggered", clamp(proj.power/8, 5, 1) SECONDS)
 
 /datum/projectile/bullet/minigun
 	name = "bullet"
@@ -510,10 +504,11 @@ toxic - poisons
 	casing = /obj/item/casing/rifle
 	var/slow = 1
 
-	on_hit(atom/hit, dirflag)
+	on_hit(atom/hit, direction, obj/projectile/P)
 		if(slow && ishuman(hit))
 			var/mob/living/carbon/human/M = hit
 			M.changeStatus("slowed", 1.5 SECONDS, optional = 8)
+			hit.changeStatus("staggered", clamp(P.power/8, 5, 1) SECONDS)
 
 /datum/projectile/bullet/lmg/weak
 	power = 1
@@ -605,9 +600,10 @@ toxic - poisons
 	icon_turf_hit = "bhole"
 	casing = /obj/item/casing/shotgun_orange
 
-	on_hit(atom/hit)
+	on_hit(atom/hit, direction, obj/projectile/P)
 		if (isliving(hit))
 			fireflash(get_turf(hit), 0)
+			hit.changeStatus("staggered", clamp(P.power/8, 5, 1) SECONDS)
 		else if (isturf(hit))
 			fireflash(hit, 0)
 		else
@@ -1142,8 +1138,7 @@ toxic - poisons
 				var/turf/target = get_edge_target_turf(M, dirflag)
 				SPAWN_DBG(0)
 					M.throw_at(target, 2, 2, throw_type = THROW_GUNIMPACT)
-			if (src.hit_type)
-				take_bleeding_damage(hit, null, round(src.power / 3), src.hit_type)
+		..()
 
 /datum/projectile/bullet/antisingularity
 	name = "Singularity buster rocket"
@@ -1207,7 +1202,6 @@ toxic - poisons
 				SPAWN_DBG(0)
 					H.throw_at(get_offset_target_turf(H, rand(5)-rand(5), rand(5)-rand(5)), rand(2,4), 2, throw_type = THROW_GUNIMPACT)
 				H.emote("twitch_v")
-
 		return
 
 /datum/projectile/bullet/mininuke //Assday only.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes kinetic projectiles (children of projectile/bullet) to cause the staggered status effect, proportional to the power of the projectile


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes it a little easier to land followup shots with non-stun weapons, which *apparently* are too weak right now


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Tarmunora:
(+)Kinetic projectiles stagger on hit
```
