### PR TITLE
add player's job back to player options 

### DIFF
--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -99,7 +99,7 @@
 </div>
 
 <div style="margin-top: 2em;">
-	Mob: <b>[M.name]</b> (<tt>[M.key ? M.key : "<em>no key</em>"]</tt>)
+	Mob: <b>[M.name]</b> [M.mind && M.mind.assigned_role ? "{M.mind.assigned_role}": ""] (<tt>[M.key ? M.key : "<em>no key</em>"]</tt>)
 	[M.client ? "" : "<em>(no client)</em>"]
 	[isdead(M) ? "<span class='antag'>(dead)</span>" : ""]
 	<br>Mob Type: <b>[M.type]</b> ([antag])

--- a/strings/admin_changelog.txt
+++ b/strings/admin_changelog.txt
@@ -1,4 +1,7 @@
 
+(t)mon apr 27 20
+(u)kyle
+(*)Add back player original job to player options next to mob name. This was removed a while ago for no reason afaik, so I'm adding it back. It was helpful to me when I added it originally.
 (t)sat apr 25 20
 (u)kyle
 (*)Move the view variables, posess, and Modify icon down to PA in the player options panel.


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
In the player options menu, adds the job of the player to the top of the menu, right next to the mob name and ckey if the mob in question has a Mind with a job attached.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This was removed months ago when the player options screen was updated. Now it's back.
