### PR TITLE
doors have small chance to open when taking damage at low hp

### DIFF
--- a/code/obj/machinery/door/door_parent.dm
+++ b/code/obj/machinery/door/door_parent.dm
@@ -426,9 +426,12 @@
 			s.set_up(2, 1, src)
 			s.start()
 
-		if (user && src.health <= health_max / 2 && istype(src, /obj/machinery/door/airlock) )
+		if (user && src.health <= health_max * 0.55 && istype(src, /obj/machinery/door/airlock) )
 			var/obj/machinery/door/airlock/A = src
 			A.shock(user, 3)
+
+		if (prob(2) && src.health <= health_max * 0.35 && istype(src, /obj/machinery/door/airlock) )
+			src.open()
 
 
 /obj/machinery/door/bullet_act(var/obj/projectile/P)


### PR DESCRIPTION
cool alternative to destroying the door permanently


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)mbc:
(+)Doors have a small chance to open when taking damage at very low health.
```
