### PR TITLE
Clean up portable reclaimer code

### DIFF
--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -707,15 +707,13 @@
 	anchored = 0
 	density = 1
 	var/active = 0
+	var/reject = 0
+	var/insufficient = 0
 	var/smelt_interval = 5
 	var/sound/sound_load = sound('sound/items/Deconstruct.ogg')
 	var/sound/sound_process = sound('sound/effects/pop.ogg')
 	var/sound/sound_grump = sound('sound/machines/buzz-two.ogg')
 	var/atom/output_location = null
-
-	/*onMaterialChanged()
-		..()
-		if (istype(src.material))*/
 
 	attack_hand(var/mob/user as mob)
 		if (active)
@@ -729,69 +727,35 @@
 		anchored = 1
 		icon_state = "reclaimer-on"
 
-		var/reject_counter = 0
 		for (var/obj/item/M in src.contents)
-			if (istype(M,/obj/item/cable_coil))
-				// haaaaaaaaaaaaaaack
-				continue
-			if (!istype(M.material))
-				M.set_loc(get_output_location())
-				reject_counter++
-				continue
-			if (!(M.material.material_flags & MATERIAL_CRYSTAL) && !(M.material.material_flags & MATERIAL_METAL))
-				M.set_loc(get_output_location())
-				reject_counter++
+			if (!istype(M.material) || !(M.material.material_flags & MATERIAL_CRYSTAL) && !(M.material.material_flags & MATERIAL_METAL) && !(M.material.material_flags & MATERIAL_RUBBER))
+				M.set_loc(src.loc)
+				src.reject = 1
 				continue
 
-		if (reject_counter > 0)
-			src.visible_message("<b>[src]</b> emits an angry buzz and rejects some unsuitable materials!")
-			playsound(src.loc, sound_grump, 40, 1)
+			else if (istype(M, /obj/item/raw_material))
+				output_bar_from_item(M)
+				pool(M)
 
-		for (var/obj/item/raw_material/M in src.contents)
-			output_bar_from_item(M)
-			pool(M)
+			else if (istype(M, /obj/item/sheet))
+				output_bar_from_item(M, 10)
+
+			else if (istype(M, /obj/item/rods))
+				output_bar_from_item(M, 20)
+
+			else if (istype(M, /obj/item/tile))
+				output_bar_from_item(M, 40)
+
+			else if (istype(M, /obj/item/cable_coil))
+				output_bar_from_item(M, 30)
+
+			/*else if (istype(M, /obj/item/wizard_crystal))
+				W.create_bar(src)
+				qdel(W)*/
+
 			sleep(smelt_interval)
 
-		var/insufficient_counter = 0
-		for (var/obj/item/sheet/S in src.contents)
-			while(S.amount >= 10)
-				output_bar_from_item(S)
-				S.amount -= 10
-				sleep(smelt_interval)
-			if (!S.amount)
-				qdel(S)
-			else
-				insufficient_counter += S.amount
-				S.set_loc(get_output_location())
-
-		for (var/obj/item/rods/R in src.contents)
-			while(R.amount >= 20)
-				output_bar_from_item(R)
-				R.amount -= 20
-				sleep(smelt_interval)
-			if (!R.amount)
-				qdel(R)
-			else
-				insufficient_counter += R.amount
-				R.set_loc(get_output_location())
-
-		for (var/obj/item/tile/T in src.contents)
-			while(T.amount >= 40)
-				output_bar_from_item(T)
-				T.amount -= 40
-				sleep(smelt_interval)
-			if (!T.amount)
-				qdel(T)
-			else
-				insufficient_counter += T.amount
-				T.set_loc(get_output_location())
-
-		for (var/obj/item/wizard_crystal/W in src.contents)
-			W.create_bar(src)
-			qdel(W)
-			sleep(smelt_interval)
-
-		var/list/cable_materials = list()
+		/*var/list/cable_materials = list()
 		var/list/quality_sum = list()
 		for (var/obj/item/cable_coil/C in src.contents)
 			if (!(C.conductor.mat_id in cable_materials))
@@ -821,10 +785,15 @@
 					bad_flag = 1
 
 		if (bad_flag)
-			src.visible_message("<b>[src]</b> emits a grumpy buzz.")
+			src.visible_message("<b>[src]</b> emits a grumpy buzz.")*/
+
+		if (reject)
+			src.reject = 0
+			src.visible_message("<b>[src]</b> emits an angry buzz and rejects some unsuitable materials!")
 			playsound(src.loc, sound_grump, 40, 1)
 
-		if (insufficient_counter > 0)
+		if (insufficient)
+			src.insufficient = 0
 			src.visible_message("<b>[src]</b> emits a grumpy buzz and ejects some leftovers.")
 			playsound(src.loc, sound_grump, 40, 1)
 
@@ -833,50 +802,40 @@
 		icon_state = "reclaimer"
 		src.visible_message("<b>[src]</b> finishes working and shuts down.")
 
-	proc/output_bar_with_quality(var/quality,var/default_material)
-		var/datum/material/MAT = null
-		if (istext(default_material))
-			MAT = getMaterial(default_material)
-			if (!MAT)
-				return null
-		else
-			return null
-
-		var/bar_type = getProcessedMaterialForm(MAT)
-		var/obj/item/material_piece/BAR = unpool(bar_type)
-		BAR.set_loc(get_output_location())
-
-		BAR.quality = quality
-		BAR.name += getQualityName(quality)
-		BAR.setMaterial(MAT)
-		playsound(src.loc, sound_process, 40, 1)
-
-		return BAR
-
-	proc/output_bar_from_item(var/obj/O,var/default_material)
-		if (!O)
-			return null
+	proc/output_bar_from_item(obj/item/O, var/amount_modifier)
+		if (!O || !O.material)
+			return
 
 		var/datum/material/MAT = O.material
-		if (!O.material)
-			if (istext(default_material))
-				MAT = getMaterial(default_material)
-				SPAWN_DBG(0)
-					if (!O.material)
-						return null
+
+		var/stack_amount = O.amount
+		if (amount_modifier)
+			var/divide = O.amount / amount_modifier
+			stack_amount = round(divide)
+
+			if (stack_amount != divide)
+				src.insufficient = 1
+				O.amount -= (stack_amount * amount_modifier)
+				O.set_loc(src.loc)
 			else
-				return null
+				qdel(O)
+
+		var/output_location = src.get_output_location()
 
 		var/bar_type = getProcessedMaterialForm(MAT)
 		var/obj/item/material_piece/BAR = unpool(bar_type)
-		BAR.set_loc(get_output_location())
-
+		BAR.setMaterial(MAT)
+		BAR.change_stack_amount(stack_amount - 1)
 		BAR.quality = O.quality
 		BAR.name += getQualityName(O.quality)
-		BAR.setMaterial(MAT)
-		playsound(src.loc, sound_process, 40, 1)
 
-		return BAR
+		if (istype(output_location, /obj/machinery/manufacturer))
+			var/obj/machinery/manufacturer/M = output_location
+			M.load_item(BAR)
+		else
+			BAR.set_loc(output_location)
+
+		playsound(src.loc, sound_process, 40, 1)
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (istype(W,/obj/item/raw_material/) || istype(W,/obj/item/sheet/) || istype(W,/obj/item/rods/) || istype(W,/obj/item/tile/) || istype(W,/obj/item/cable_coil))
@@ -923,13 +882,13 @@
 				src.output_location = over_object
 				boutput(usr, "<span style=\"color:blue\">You set the reclaimer to output to [over_object]!</span>")
 
-		/*else if (istype(over_object,/obj/machinery/manufacturer/))
+		else if (istype(over_object,/obj/machinery/manufacturer/))
 			var/obj/machinery/manufacturer/M = over_object
 			if (M.status & BROKEN || M.status & NOPOWER || M.dismantle_stage > 0)
 				boutput(usr, "<span style=\"color:red\">You can't use a non-functioning manufacturer as an output target.</span>")
 			else
 				src.output_location = M
-				boutput(usr, "<span style=\"color:blue\">You set the reclaimer to output to [over_object]!</span>")*/
+				boutput(usr, "<span style=\"color:blue\">You set the reclaimer to output to [over_object]!</span>")
 
 		else if (istype(over_object,/obj/table/) && istype(over_object,/obj/rack/))
 			var/obj/O = over_object
@@ -941,7 +900,6 @@
 			boutput(usr, "<span style=\"color:blue\">You set the reclaimer to output to [over_object]!</span>")
 
 		else
-
 			boutput(usr, "<span style=\"color:red\">You can't use that as an output target.</span>")
 		return
 
@@ -953,11 +911,11 @@
 			boutput(user, "<span style=\"color:red\">Only living mobs are able to use the reclaimer's quick-load feature.</span>")
 			return
 
-		if (!istype(O,/obj/))
+		if (!isobj(O))
 			boutput(user, "<span style=\"color:red\">You can't quick-load that.</span>")
 			return
 
-		if(get_dist(O,user) > 1)
+		if(!DIST_CHECK(O, user, 1))
 			boutput(user, "<span style=\"color:red\">You are too far away!</span>")
 			return
 
@@ -999,10 +957,10 @@
 		return
 
 	proc/get_output_location()
-		if (isnull(output_location))
+		if (!output_location)
 			return src.loc
 
-		if (get_dist(src.output_location,src) > 1)
+		if (!DIST_CHECK(src.output_location, src, 1))
 			output_location = null
 			return src.loc
 
@@ -1012,15 +970,10 @@
 				return M.loc
 			return M
 
-		else if (istype(output_location,/obj/storage/crate))
-			var/obj/storage/crate/C = output_location
-			if (C.locked || C.welded || C.open)
-				return C.loc
-			return C
+		if (istype(output_location,/obj/storage))
+			var/obj/storage/S = output_location
+			if (S.locked || S.welded || S.open)
+				return S.loc
+			return S
 
-		else if (istype(output_location,/obj/storage/cart))
-			var/obj/storage/cart/C = output_location
-			if (C.locked || C.welded || C.open)
-				return C.loc
-			return C
 		return output_location


### PR DESCRIPTION
[CHORE] [BUG]

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR cleans up some portable reclaimer code and fixes a bug where it'd output fewer processed materials than inputted. I also commented out some complicated cable coil code rather than removing it because someone may want to work on it in the future.

Note: portable reclaimers have a similar functionality to material processors. However, the differences are significant enough such that I want to keep them separate for now. I might refactor them in the future so we have less duplicate code, but for now, I think this is okay.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes a bug.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Flourish:
(+)Fixed a bug with portable reclaimers outputting fewer processed materials than inputted.
```
