### PR TITLE
Genetic Template Symptom

### DIFF
--- a/code/modules/medical/pathology/pathogen.dm
+++ b/code/modules/medical/pathology/pathogen.dm
@@ -119,6 +119,7 @@ datum/controller/pathogen
 			return
 		if (H in CDC.infections)
 			CDC.infections -= H
+		P.oncured()
 
 	proc/patient_zero(var/datum/pathogen_cdc/CDC, var/topic_holder)
 		if (CDC.patient_zero)
@@ -1431,6 +1432,13 @@ datum/pathogen
 		for (var/effect in src.effects)
 			effect:ondeath(infected, src)
 		suppressant.ondeath(src)
+		return
+
+	// Act when pathogen is cured. Returns nothing.
+	proc/oncured()
+		for (var/effect in src.effects)
+			effect:oncured(infected, src)
+		suppressant.oncured(src)
 		return
 
 	proc/add_new_symptom(var/list/allowed, var/allow_duplicates = 0)

--- a/code/modules/medical/pathology/pathogen_benevolent.dm
+++ b/code/modules/medical/pathology/pathogen_benevolent.dm
@@ -361,31 +361,59 @@ datum/pathogeneffects/benevolent/genetictemplate
 	desc = "Spreads a mutation from patient zero to other afflicted."
 	rarity = RARITY_VERY_RARE
 	infect_type = INFECT_NONE
-	var/list/mutationMap = list()
+	var/list/mutationMap = list() // stores the kind of mutation with the index being the pathogen's name (which is something like "L41D9")
 
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic || !M.bioHolder)
 			return
-		var/datum/bioEffect/BE = mutationMap[origin.name]
-		if(BE == null) // if no mutation has been picked yet, go for a random one from this person
+		if(mutationMap[origin.name_base] == null) // if no mutation has been picked yet, go for a random one from this person
 			var/list/filtered = new/list()
 			for(var/T in M.bioHolder.effects)
 				var/datum/bioEffect/instance = M.bioHolder.effects[T]
 				if(!instance || istype(instance, /datum/bioEffect/hidden)) continue // hopefully this catches all non-mutation bioeffects?
 				filtered.Add(instance)
 			if(!filtered.len) return // wow, this nerd has no mutations, screw this
-			BE = pick(filtered)
-			mutationMap[origin.name] = BE
+			mutationMap[origin.name_base] = pick(filtered)
+			boutput(M, "You somehow feel more attuned to your [mutationMap[origin.name_base]].") // So patient zero will know when the mutation has been chosen
 
-		M.bioHolder.AddEffectInstance(BE)
+		if(origin.symptom_data["genetictemplate"] == origin.stage) // early return if we would just put the same mutation anyway
+			return
 
+		var/datum/bioEffect/BEE = mutationMap[origin.name_base] // remove old version of mutation
+		M.bioHolder.RemoveEffect(BEE.id)
+
+		var/datum/bioEffect/BE = new BEE.type
+		var/datum/dna_chromosome/chromo = new /datum/dna_chromosome/anti_mutadone() // reinforce always
+		chromo.apply(BE)
+		if (origin.stage >= 2)
+			BE.altered = 0 // this lets us apply another chromosome. yay!
+			chromo = new /datum/dna_chromosome() // stabilize after stage 2
+			chromo.apply(BE)
+		if (origin.stage >= 3)
+			BE.altered = 0
+			chromo = new /datum/dna_chromosome/safety() // synchronize starting at stage 3
+			chromo.apply(BE)
+		if (origin.stage >= 4)
+			BE.altered = 0
+			chromo = new /datum/dna_chromosome/power_enhancer() // empower starting at stage 4
+			chromo.apply(BE)
+		if (origin.stage >= 5)
+			BE.altered = 0
+			chromo = new /datum/dna_chromosome/cooldown_reducer() // reduce cooldown starting at stage 5
+			chromo.apply(BE)
+		M.bioHolder.AddEffectInstance(BE) // add updated version of mutation!
+		origin.symptom_data["genetictemplate"] = origin.stage // save the last stage that we added the mutation with
+
+	oncured(mob/M as mob, var/datum/pathogen/origin)
+		if (!origin.symptomatic)
+			return
+		var/datum/bioEffect/BE = mutationMap[origin.name_base] // cure the mutation when the pathogen is cured
+		M.bioHolder.RemoveEffect(BE.id)
 
 	react_to(var/R, var/zoom)
 		if (R == "mutadone")
 			if (zoom)
-				return "Approximately 82.7% of the individual microbodies appear to have returned to genetic normalcy."
-			else
-				return "The pathogen appears to have settled down significantly in the presence of the mutadone."
+				return "Approximately 0% of the individual microbodies appear to have returned to genetic normalcy." // it always reinforces
 
 	may_react_to()
-		return "The pathogen cells appear to be mimicking one another."
+		return "The pathogen cells all look exactly alike."

--- a/code/modules/medical/pathology/pathogen_benevolent.dm
+++ b/code/modules/medical/pathology/pathogen_benevolent.dm
@@ -354,3 +354,38 @@ datum/pathogeneffects/benevolent/neuronrestoration
 
 	may_react_to()
 		return "The pathogen appears to have a gland that may affect neural functions."
+
+
+datum/pathogeneffects/benevolent/genetictemplate
+	name = "Genetic Template"
+	desc = "Spreads a mutation from patient zero to other afflicted."
+	rarity = RARITY_VERY_RARE
+	infect_type = INFECT_NONE
+	var/list/mutationMap = list()
+
+	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
+		if (!origin.symptomatic || !M.bioHolder)
+			return
+		var/datum/bioEffect/BE = mutationMap[origin.name]
+		if(BE == null) // if no mutation has been picked yet, go for a random one from this person
+			var/list/filtered = new/list()
+			for(var/T in M.bioHolder.effects)
+				var/datum/bioEffect/instance = M.bioHolder.effects[T]
+				if(!instance || istype(instance, /datum/bioEffect/hidden)) continue // hopefully this catches all non-mutation bioeffects?
+				filtered.Add(instance)
+			if(!filtered.len) return // wow, this nerd has no mutations, screw this
+			BE = pick(filtered)
+			mutationMap[origin.name] = BE
+
+		M.bioHolder.AddEffectInstance(BE)
+
+
+	react_to(var/R, var/zoom)
+		if (R == "mutadone")
+			if (zoom)
+				return "Approximately 82.7% of the individual microbodies appear to have returned to genetic normalcy."
+			else
+				return "The pathogen appears to have settled down significantly in the presence of the mutadone."
+
+	may_react_to()
+		return "The pathogen cells appear to be mimicking one another."

--- a/code/modules/medical/pathology/pathogen_suppressants.dm
+++ b/code/modules/medical/pathology/pathogen_suppressants.dm
@@ -36,6 +36,7 @@
 	proc/onadd(var/datum/pathogen/P)
 	proc/onemote(var/mob/target, message, var/datum/pathogen/P)
 	proc/ondeath(var/datum/pathogen/P)
+	proc/oncured(var/datum/pathogen/P)
 
 	// While doing pathogen research, the suppression method may define how the pathogen reacts to certain reagents.
 	// Returns null if the pathogen does not react to the reagent.

--- a/code/modules/medical/pathology/pathogen_symptoms.dm
+++ b/code/modules/medical/pathology/pathogen_symptoms.dm
@@ -124,6 +124,11 @@ datum/pathogeneffects
 	proc/ondeath(var/mob/M as mob, var/datum/pathogen/origin)
 		return
 
+	// oncured(mob, datum/pathogen) : void
+	// OVERRIDE: Overriding this is situational.
+	proc/oncured(var/mob/M as mob, var/datum/pathogen/origin)
+		return
+
 
 	// End of events: please do not add any event definitions outside this block.
 	// ====


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[ENHANCEMENT] [INPUT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a new pathology symptom, "Genetic Template", that can spread a mutation among the afflicted. The way it works is that it will pick a random mutation that patient zero has and also give this mutation to anyone else afflicted with the disease. As the pathogen goes through the stages it will also apply chromosomes to this mutation.
The stage progression is:
 1: Reinforced (If removed via genetics, mutation will be reapplied later.)
 2: Stabilized
 3: Synchronized
 4: Empowered
 5: Energized

I also add a new event onCured for pathogen symptoms that is triggered when the pathogen is cured on the afflicted. This is used to remove the mutation from the afflicted if they are cured of the pathogen.

Everything seemed to work fine for my testing and did not cause any runtimes, but there are some things that I am not sure if I implemented them in a good way, so I am quite open to corrections. :)
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This should give pathologists a lot of options for making a beneficial pathogen, like giving everyone thermal resistance or strongly empowered laser eyes.
A traitor pathologist can also hopefully use it to create lots of potentially funny situations, like everyone being a lizard/cow, everyone having a speech mutation or everyone being clumsy.
If a traitor chooses to use a seriously harmful mutation to spread it should hopefully still be less lethal than most other harmful T5 symptoms.
Ideally, it will also lead to some cooperation between the two medical science departments, pathology and genetics.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)zjdtmkhzt:
(+)Added a new mutation-based pathology symptom that can be used for benevolent or nefarious purposes.
```
