### PR TITLE
Change pathogen manipulator cooldown to be dynamic

### DIFF
--- a/code/modules/medical/pathology/pathogen_machines.dm
+++ b/code/modules/medical/pathology/pathogen_machines.dm
@@ -410,7 +410,6 @@
 	var/datum/pathobank/db = new
 	var/predictive_data = ""
 	var/datum/spyGUI/gui = null
-	var/manip_cooldown = 4 DECI SECONDS // was 20
 	var/manipulating = false //are we currently irradiating the pathogen?
 	New()
 		..()
@@ -757,6 +756,7 @@
 			var/dir = text2num(href_list["dir"])
 			if(mut_type && dir && (src.manip.machine_state == PATHOGEN_MANIPULATOR_STATE_MANIPULATE) && !(manipulating))
 				manipulating = true
+				var/manip_cooldown = src.manip.loaded.reference.maliciousness<65? 1 DECI SECONDS : 20 DECI SECONDS
 				SPAWN_DBG(manip_cooldown)
 					var/act = src.manip.loaded.manipulate(mut_type, dir)
 					var/out

--- a/code/modules/medical/pathology/pathogen_machines.dm
+++ b/code/modules/medical/pathology/pathogen_machines.dm
@@ -756,7 +756,8 @@
 			var/dir = text2num(href_list["dir"])
 			if(mut_type && dir && (src.manip.machine_state == PATHOGEN_MANIPULATOR_STATE_MANIPULATE) && !(manipulating))
 				manipulating = true
-				var/manip_cooldown = src.manip.loaded.reference.maliciousness<65? 1 DECI SECONDS : 20 DECI SECONDS
+				var/mal = src.manip.loaded.reference.maliciousness
+				var/manip_cooldown = mal < 15 ? 1 : mal < 65 ? 10 : 20
 				SPAWN_DBG(manip_cooldown)
 					var/act = src.manip.loaded.manipulate(mut_type, dir)
 					var/out


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This changes it so if your maliciousness is above 65 (which is where you really start to be able to gain strong symptoms from mutations) the cooldown for adjusting pathogen stats is upped to 20 deciseconds (what it used to be before the buff).
Seeing as the delay is only really in place to stop spamming it for mutations, I have also reduced the delay on manipulating under 65 maliciousness to 1 deciseconds from 4 deciseconds (which is probably not very noticeable, but I figured I might as well try to make it more responsive).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This should hopefully stop people from gathering symptoms via spamming stat adjustments in the pathogen manipulator and make them instead use the dna analyzer to find them, as marq intended!

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)zjdtmkhzt:
(+)Readded the old delay to the pathogen manipulator when adjusting pathogens with >65 maliciousness.
```
