### PR TITLE
bugfix - Forklifts override attack cooldown

### DIFF
--- a/code/obj/vehicle.dm
+++ b/code/obj/vehicle.dm
@@ -2262,11 +2262,9 @@ obj/vehicle/forklift/attackby(var/obj/item/I, var/mob/user)
 			broken = 0
 			if (helditems_maximum < 4)
 				helditems_maximum = 4
+			return
 
-	//attacking rider on forklift
-	if(rider && rider_visible && I.force)
-		..()
-	return
+	return ..() // attacking rider on forklift
 
 /obj/vehicle/forklift/proc/break_forklift()
 	broken = 1

--- a/code/obj/vehicle.dm
+++ b/code/obj/vehicle.dm
@@ -40,10 +40,10 @@ Contains:
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		if(rider && rider_visible && W.force)
-			eject_rider()
 			W.attack(rider, user)
 			user.lastattacked = src
-			return
+			eject_rider()
+			W.visible_message("<span style=\"color:red\">[user] swings at [rider] with [W]!</span>")
 		return
 
 	proc/eject_rider(var/crashed, var/selfdismount)
@@ -2266,7 +2266,6 @@ obj/vehicle/forklift/attackby(var/obj/item/I, var/mob/user)
 	//attacking rider on forklift
 	if(rider && rider_visible && I.force)
 		..()
-		I.visible_message("<span style=\"color:red\">[user] swings at [rider] with [I]!</span>")
 	return
 
 /obj/vehicle/forklift/proc/break_forklift()

--- a/code/obj/vehicle.dm
+++ b/code/obj/vehicle.dm
@@ -42,6 +42,7 @@ Contains:
 		if(rider && rider_visible && W.force)
 			eject_rider()
 			W.attack(rider, user)
+			user.lastattacked = src
 			return
 		return
 
@@ -1256,6 +1257,7 @@ obj/vehicle/clowncar/proc/log_me(var/mob/rider, var/mob/pax, var/action = "", va
 /obj/vehicle/clowncar/cluwne/attackby(var/obj/item/W, var/mob/user)
 	eject_rider()
 	W.attack(rider, user)
+	user.lastattacked = src
 
 /obj/vehicle/clowncar/cluwne/eject_rider(var/crashed, var/selfdismount)
 	..(crashed, selfdismount)
@@ -2263,7 +2265,7 @@ obj/vehicle/forklift/attackby(var/obj/item/I, var/mob/user)
 
 	//attacking rider on forklift
 	if(rider && rider_visible && I.force)
-		I.attack(rider, user)
+		..()
 		I.visible_message("<span style=\"color:red\">[user] swings at [rider] with [I]!</span>")
 	return
 


### PR DESCRIPTION
[FIX]

## About the PR

Fixes #253 - Forklifts override attack cooldown

The root cause was that vehicles were not setting user.lastattacked properly, so combat click delays were not kicking in.
Other vehicles tended to eject their user on attack as well, but forklifts did not.
Cluwne cars also had the lastattacked bug, but ejected the user so had the issue mitigated.

I've updated both, so delays are properly set for both vehicles and forklifts eject then user when attacked.

## Why's this needed?

Forklifts bypass restrictions on attack frequency, making them deadly to the user.

## Changelog
```
(u)Uta
(+)Forklifts now eject rider when attacked to prevent an attack spam bug.
```