### PR TITLE
contextAction underlay stacking

### DIFF
--- a/code/WorkInProgress/multiContext.dm
+++ b/code/WorkInProgress/multiContext.dm
@@ -270,6 +270,10 @@ var/list/globalContextActions = null
 			var/mob/dead/observer/GO = usr
 			if(istype(GO)) GO.hud.remove_screen(C)
 			contextButtons.Remove(C)
+			if(C.overlays)
+				C.overlays = list()
+			if(C.underlays)
+				C.underlays = list()
 
 			pool(C)
 		return


### PR DESCRIPTION
[BUG][PERFORMANCE]
//while its not exactly infinite stacking, it causes a lot of strange data allocation issues, so this clears the overlay and underlay buffers for buttons before they're pooled

## About the PR 
- Fixes contextAction underlay stacking (and overlays too for when I push the overlay support in it's completed form)



## Why's this needed?
- This clears up some lag surrounding contextAction menus
