### PR TITLE
Examine-code refactor

### DIFF
--- a/_stdlib/code/_controls.dm
+++ b/_stdlib/code/_controls.dm
@@ -382,20 +382,26 @@ var/list/key_names = list(
 				if (src.preferences.use_azerty)
 					return new /datum/keymap(list(
 							"B" = KEY_POINT,
+							"ALT" = KEY_EXAMINE,
+							"CTRL" = KEY_PULL,
 							"C" = "attackself",
-							"A" = "unequip"
+							"A" = "unequip",
 						))
 				else if (src.tg_controls)
 					return new /datum/keymap(list(
 							"B" = KEY_POINT,
+							"SHIFT" = KEY_EXAMINE,
+							"CTRL" = KEY_PULL,
 							"Z" = "attackself",
-							"Q" = "unequip"
+							"Q" = "unequip",
 						))
 				else
 					return new /datum/keymap(list(
 							"B" = KEY_POINT,
+							"ALT" = KEY_EXAMINE,
+							"CTRL" = KEY_PULL,
 							"C" = "attackself",
-							"Q" = "unequip"
+							"Q" = "unequip",
 						))
 			if ("pod")
 				return new /datum/keymap(list(

--- a/code/WorkInProgress/Hydrothings.dm
+++ b/code/WorkInProgress/Hydrothings.dm
@@ -23,7 +23,7 @@ obj/decal/floor/displays/owlsign
 		info = "<html><body style='margin:2px'><img src='[resource("images/arts/postcard_Owlery.png")]'></body></html>"
 
 	examine()
-		..()
+		return ..()
 
 	attackby()
 		return
@@ -1552,7 +1552,3 @@ var/list/owlery_sounds = list('sound/voice/animal/hoot.ogg','sound/ambience/owlz
 		if(prob(10))
 			usr.visible_message("<span class='game say'><span class='name'>[src]</span> says, \"Woah [real_name] thats [pick("radical", "awesome", "sweet", "delicious", "100% spectacular", "better then sliced bread", "hootacular", "horrible", "hootastic", "dab worthy")]!\"")
 			return
-
-
-
-

--- a/code/WorkInProgress/KingInYellow.dm
+++ b/code/WorkInProgress/KingInYellow.dm
@@ -106,24 +106,22 @@
 		SPAWN_DBG(3 SECONDS) work()
 		return
 
-	examine()
-		set src in view()
-		if (!issilicon(usr))
-			var/mob/living/carbon/reader = usr
-			if(!istype(reader)) return
+	examine(mob/user)
+		. = list()
+		if (!issilicon(user))
+			var/mob/living/carbon/reader = user
+			if(!istype(reader))
+				return
 
-			if(usr in readers)
-				var/message = "This appears to be an ancient Book containing a Play.<br><br>"
-				message += "You frantically read the play again ...<br>"
-				message += "You feel as if you're about to faint."
-				boutput(usr, message)
+			. = "This appears to be an ancient Book containing a Play.<br>"
 
+			if(user in readers)
+				. += "You frantically read the play again ..."
+				. += "You feel as if you're about to faint."
 				reader.drowsyness += 3
 			else
-				var/message = "This appears to be an ancient Book containing a Play.<br><br>"
-				message += "The first act tells of a city named Carcosa, and a mysterious \"King in Yellow\"<br>"
-				message += "The second act seems incomplete but ... It is horrifying.<br>"
-				boutput(usr, message)
+				. += "The first act tells of a city named Carcosa, and a mysterious \"King in Yellow\""
+				. += "The second act seems incomplete but ... It is horrifying."
 
 				for(var/mob/M in readers)
 					boutput(M, "<span style=\"color:red\">You feel the irresistible urge to read the \"The King In Yellow\" again.</span>")
@@ -132,7 +130,7 @@
 				readers += reader
 			return
 		else
-			boutput(usr, "This ancient data storage medium appears to contain data used for entertainment purposes.")
+			. += "This ancient data storage medium appears to contain data used for entertainment purposes."
 
 	custom_suicide = 1
 	suicide_distance = 0

--- a/code/WorkInProgress/MarqStuff.dm
+++ b/code/WorkInProgress/MarqStuff.dm
@@ -123,8 +123,8 @@
 	anchored = 1
 
 	examine()
-		..()
-		boutput(usr, "Your keen skills of observation tell you that [expected.len - unlocked.len] out of the [expected.len] locks are locked.")
+		. = ..()
+		. += "Your keen skills of observation tell you that [expected.len - unlocked.len] out of the [expected.len] locks are locked."
 
 	attackby(var/obj/item/I, var/mob/user)
 		if (istype(I, /obj/item/device/key))
@@ -370,11 +370,11 @@
 		return 1
 
 	examine()
-		..()
+		. = ..()
 		if (amount > 1)
-			boutput(usr, "<span style='color:blue'>This is a stack of [amount] arrows.")
+			. += "<span style='color:blue'>This is a stack of [amount] arrows."
 		if (reagents.total_volume)
-			boutput(usr, "<span style='color:blue'>The tip of the arrow is coated with reagents.</span>")
+			. += "<span style='color:blue'>The tip of the arrow is coated with reagents.</span>"
 
 	clone(var/newloc = null)
 		var/obj/item/arrow/O = new(loc)
@@ -495,8 +495,8 @@
 	icon_state = "arrowhead"
 
 	examine()
-		..()
-		boutput(usr, "There [amount == 1 ? "is" : "are"] [amount] arrowhead[amount != 1 ? "s" : null] in the stack.")
+		. = ..()
+		. += "There [amount == 1 ? "is" : "are"] [amount] arrowhead[amount != 1 ? "s" : null] in the stack."
 
 /obj/item/implant/projectile/arrow
 	name = "arrow"

--- a/code/WorkInProgress/MportsStuff.dm
+++ b/code/WorkInProgress/MportsStuff.dm
@@ -7,12 +7,11 @@
 	anchored = 1
 	invisibility = 1
 
-/obj/infared_icon/examine()
-	set src in view()
-	if(usr.see_infrared)
-		usr << browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", src.name, src.info), text("window=[]", src.name))
-		onclose(usr, "[src.name]")
-	return
+/obj/infared_icon/examine(mob/user)
+	if(user.see_infrared)
+		user << browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", src.name, src.info), text("window=[]", src.name))
+		onclose(user, "[src.name]")
+	return list()
 
 /obj/infared_icon/attack_ai(var/mob/living/silicon/user as mob)
 //I still need a way for the AI to actually make these
@@ -87,5 +86,3 @@
 			if("Remove")
 				SPAWN_DBG(0.5 SECONDS)
 				qdel(src)
-
-

--- a/code/WorkInProgress/antimatter/fuel.dm
+++ b/code/WorkInProgress/antimatter/fuel.dm
@@ -66,10 +66,9 @@
 	return
 
 
-/obj/item/fuel/examine()
-	set src in view(1)
-	if(usr && !usr.stat)
-		boutput(usr, "A magnetic storage ring, it contains [fuel]kg of [content ? content : "nothing"].")
+/obj/item/fuel/examine(mob/user)
+	if(user && !user.stat)
+		return list("A magnetic storage ring, it contains [fuel]kg of [content ? content : "nothing"].")
 
 /obj/item/fuel/proc/injest(mob/M as mob)
 	switch(content)

--- a/code/WorkInProgress/construction/supply_controller.dm
+++ b/code/WorkInProgress/construction/supply_controller.dm
@@ -523,12 +523,12 @@
 				sleep(0.1 SECONDS)
 
 	examine()
-		..()
-		boutput(usr, "<span style=\"color:blue\">The pad is currently at [charge]% charge.</span>")
+		. = ..()
+		. += "<span style=\"color:blue\">The pad is currently at [charge]% charge.</span>"
 		if (has_crystal)
-			boutput(usr, "<span style=\"color:blue\">The pad is complete with a telecrystal.</span>")
+			. += "<span style=\"color:blue\">The pad is complete with a telecrystal.</span>"
 		else
-			boutput(usr, "<span style=\"color:red\">The pad's telecrystal socket is empty!</span>")
+			. += "<span style=\"color:red\">The pad's telecrystal socket is empty!</span>"
 
 	attackby(var/obj/item/I as obj, user as mob)
 		if (istype(I, /obj/item/raw_material/telecrystal))

--- a/code/WorkInProgress/construction/tools.dm
+++ b/code/WorkInProgress/construction/tools.dm
@@ -324,16 +324,16 @@
 		boutput(usr, "<span style=\"color:blue\">The shaper has [metal_count] units of metal and [glass_count] units of glass left.</span>")
 
 	examine()
-		..()
+		. = ..()
 		if (metal)
-			boutput(usr, "<span style=\"color:blue\">Metal: [metal_count] units of [metal.name].</span>")
+			. += "<span style=\"color:blue\">Metal: [metal_count] units of [metal.name].</span>"
 		else
-			boutput(usr, "<span style=\"color:red\">Metal: 0 units.</span>")
+			. += "<span style=\"color:red\">Metal: 0 units.</span>"
 
 		if (glass)
-			boutput(usr, "<span style=\"color:blue\">Glass: [glass_count] units of [glass.name].</span>")
+			. += "<span style=\"color:blue\">Glass: [glass_count] units of [glass.name].</span>"
 		else
-			boutput(usr, "<span style=\"color:red\">Glass: 0 units</span>")
+			. += "<span style=\"color:red\">Glass: 0 units</span>"
 
 	attack_self(mob/user as mob)
 		mode = !mode

--- a/code/WorkInProgress/griffening/griffening_controller.dm
+++ b/code/WorkInProgress/griffening/griffening_controller.dm
@@ -759,11 +759,12 @@ td, th {
 		src.controller = ctrl
 
 	examine()
+		. = ..()
 		if (!controller || !card)
-			return ..()
+			return
 		else
-			boutput(usr, "Area card in effect: <i>[card.card_name]</i>")
-			boutput(usr, card.card_desc)
+			. += "Area card in effect: <i>[card.card_name]</i>"
+			. += card.card_desc
 
 /obj/griffening_hologram
 	name = "hologram"

--- a/code/WorkInProgress/infernal_contracts.dm
+++ b/code/WorkInProgress/infernal_contracts.dm
@@ -335,12 +335,12 @@
 
 	New()
 		src.color = random_color()
-	examine()
-		if ((ishuman(usr) && istype(usr:w_uniform, /obj/item/clothing/under/misc/lawyer/red/demonic)) || isobserver(usr))
-			..()
+
+	examine(mob/user)
+		if ((ishuman(user) && istype(user:w_uniform, /obj/item/clothing/under/misc/lawyer/red/demonic)) || isobserver(user))
+			return ..()
 		else
-			boutput(usr, "A strange piece of old crinkled paper, covered in mysterious gibberish legalese.")
-			return
+			return list("A strange piece of old crinkled paper, covered in mysterious gibberish legalese.")
 
 	get_desc(dist)
 		if (src.limiteduse == 0)

--- a/code/WorkInProgress/ud5/urs_dungeon.dm
+++ b/code/WorkInProgress/ud5/urs_dungeon.dm
@@ -586,11 +586,10 @@
 	return
 
 
-/obj/item/ursium/examine()
-	set src in view(1)
-	if(usr && !usr.stat)
-		boutput(usr, "A magnetic storage ring, it contains [ursium]kg of [content ? content : "nothing"].")
-	..()
+/obj/item/ursium/examine(mob/user)
+	. = ..()
+	if(user && !user.stat)
+		. += "A magnetic storage ring, it contains [ursium]kg of [content ? content : "nothing"]."
 
 /obj/item/ursium/proc/injest(mob/M as mob)
 	M.gib(1)

--- a/code/WorkInProgress/warcrimes.dm
+++ b/code/WorkInProgress/warcrimes.dm
@@ -42,9 +42,9 @@ var/fartcount = 0
 	examine()
 		. = ..()
 		if(stapled)
-			return "Two thongs stapled together, to make a MEGA VELOCITY boomarang."
+			. += "Two thongs stapled together, to make a MEGA VELOCITY boomarang."
 		else
-			return "These cheap [pick(possible_names)] don't even look legal."
+			. += "These cheap [pick(possible_names)] don't even look legal."
 
 	attackby(obj/item/W, mob/user)
 		if (istype(W, /obj/item/staple_gun) && !stapled)
@@ -833,5 +833,3 @@ Urs' Hauntdog critter
 			"You screams!")
 			var/hogg = pick("sound/voice/hagg_vorbis.ogg","sound/voice/hogg_vorbis.ogg","sound/voice/hogg_vorbis_the.ogg","sound/voice/hogg_vorbis_screams.ogg","sound/voice/hogg_with_scream.ogg","sound/voice/hoooagh2.ogg","sound/voice/hoooagh.ogg",)
 			playsound(T, hogg, 60, 1)
-
-

--- a/code/WorkInProgress/wizardset.dm
+++ b/code/WorkInProgress/wizardset.dm
@@ -796,12 +796,12 @@ var/global/datum/wizard_zone_controller/wizard_zone_controller
 	desc = "A book laid out neatly on a pedestal."
 	var/written = null
 
-	examine()
-		..()
+	examine(mob/user)
+		. = ..()
 		if (!written)
-			boutput(usr, "<span style=\"color:red\">You cannot decipher the runes written in the book.</span>")
+			. += "<span style=\"color:red\">You cannot decipher the runes written in the book.</span>"
 		else
-			usr.Browse(written, "window=tome;size=200x400")
+			user.Browse(written, "window=tome;size=200x400")
 
 /obj/bookcase
 	name = "bookcase"

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -640,45 +640,38 @@
 /atom/proc/special_desc(dist, mob/user)
 	return null
 
-/atom/proc/examine()
-	set name = "Examine"
-	set category = "Local"
-	set src in view(12)	//make it work from farther away
-
-	if(src.hiddenFrom && hiddenFrom.Find(usr.client)) //invislist
+/atom/proc/examine(mob/user)
+	if(src.hiddenFrom && hiddenFrom.Find(user.client)) //invislist
 		return
 
-	var/dist = get_dist(src, usr)
-	if (istype(usr, /mob/dead/target_observer))
-		dist = get_dist(src, usr:target)
+	var/dist = get_dist(src, user)
+	if (istype(user, /mob/dead/target_observer))
+		var/mob/dead/target_observer/target_observer_user = user
+		dist = get_dist(src, target_observer_user.target)
 
 	// added for custom examine behaviour override - cirr
-	var/special_description = src.special_desc(dist, usr)
+	var/special_description = src.special_desc(dist, user)
 
 	if(special_description)
-		boutput(usr, special_description)
-		return
+		return list(special_description)
 	//////////////////////////////
 
-	var/output = "This is \an [src.name]."
+	. = list("This is \an [src.name].")
 
 	// Added for forensics (Convair880).
 	if (isitem(src) && src.blood_DNA)
-		output = "<span style='color:red'>This is a bloody [src.name].</span>"
+		. = list("<span style='color:red'>This is a bloody [src.name].</span>")
 		if (src.desc)
 			if (src.desc && src.blood_DNA == "--conductive_substance--")
-				output += "<br>[src.desc] <span style='color:red'>It seems to be covered in an odd azure liquid!</span>"
+				. += "<br>[src.desc] <span style='color:red'>It seems to be covered in an odd azure liquid!</span>"
 			else
-				output += "<br>[src.desc] <span style='color:red'>It seems to be covered in blood!</span>"
+				. += "<br>[src.desc] <span style='color:red'>It seems to be covered in blood!</span>"
 	else if (src.desc)
-		output += "<br>[src.desc]"
+		. += "<br>[src.desc]"
 
 	var/extra = src.get_desc(dist, usr)
 	if (extra)
-		output += " [extra]"
-
-	if (output)
-		boutput(usr, output)
+		. += " [extra]"
 
 /atom/proc/MouseDrop_T()
 	return
@@ -1046,4 +1039,3 @@
 
 	if (user.client)
 		user.client.Click(src,get_turf(src))
-

--- a/code/datums/controllers/sea_hotspot_controls.dm
+++ b/code/datums/controllers/sea_hotspot_controls.dm
@@ -1121,9 +1121,9 @@
 	health = 100
 	var/can_put_up = 1
 
-	examine()
-		if (usr.client && hotspot_controller)
-			hotspot_controller.show_map(usr.client)
+	examine(mob/user)
+		if (user.client && hotspot_controller)
+			hotspot_controller.show_map(user.client)
 		else
 			return ..()
 

--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -746,25 +746,25 @@
 			new/datum/gang_item/space/stims)
 
 	examine()
-		..()
+		. = ..()
 
 		if(health == 0)
-			boutput(usr, "It is completely destroyed!")
+			. += "It is completely destroyed!"
 			return
 
 		switch(round(100*health/max_health))
 			if(1 to 25)
-				boutput(usr, "It is almost destroyed!")
+				. += "It is almost destroyed!"
 			if(26 to 50)
-				boutput(usr, "It is badly damaged!")
+				. += "It is badly damaged!"
 			if(51 to 75)
-				boutput(usr, "It is somewhat damaged.")
+				. += "It is somewhat damaged."
 			if(76 to 99)
-				boutput(usr, "It is slightly damaged.")
+				. += "It is slightly damaged."
 			if(100)
-				boutput(usr, "It is undamaged.")
+				. += "It is undamaged."
 
-		boutput(usr, "The screen displays \"Total Score: [gang.gang_score()] and Spendable Points: [gang.spendable_points]\"")
+		. += "The screen displays \"Total Score: [gang.gang_score()] and Spendable Points: [gang.spendable_points]\""
 
 	attack_hand(var/mob/living/carbon/human/user as mob)
 		if(!isalive(user))

--- a/code/input.dm
+++ b/code/input.dm
@@ -172,7 +172,7 @@ var/list/dirty_keystates = list()
 					return
 				else
 					if (parameters["right"])
-						object.examine()
+						src.mob.examine_verb(object)
 
 
 		if (parameters["drag"] == "middle") //fixes exploit that basically gave everyone access to an aimbot

--- a/code/mapSwitching.dm
+++ b/code/mapSwitching.dm
@@ -528,6 +528,6 @@ var/global/datum/mapSwitchHandler/mapSwitcher
 			boutput(user, "Map vote successful???")*/
 
 	examine()
-		return
+		return list()
 
 var/global/mapVoteLinkStat = new /obj/mapVoteLink

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -2953,7 +2953,9 @@
 /mob/verb/examine_verb(atom/A as mob|obj|turf in view())
 	set name = "Examine"
 	set category = "Local"
-	A.examine()
+	var/list/result = A.examine(src)
+	to_chat(src, result.Join("\n"))
+
 
 /mob/verb/interact_verb(obj/A as obj in view(1))
 	set name = "Pick Up / Interact"

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -2954,7 +2954,7 @@
 	set name = "Examine"
 	set category = "Local"
 	var/list/result = A.examine(src)
-	to_chat(src, result.Join("\n"))
+	boutput(src, result.Join("\n"))
 
 
 /mob/verb/interact_verb(obj/A as obj in view(1))

--- a/code/mob/dead.dm
+++ b/code/mob/dead.dm
@@ -24,7 +24,7 @@
 	else
 		if (get_dist(src, target) > 0)
 			dir = get_dir(src, target)
-		target.examine()
+		src.examine_verb(target)
 
 /mob/dead/process_move(keys)
 	if (!istype(src.loc,/turf)) //Pop observers and Follow-Thingers out!!

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -319,7 +319,7 @@
 //#endif
 
 		if (src.client && src.client.check_key(KEY_EXAMINE))
-			target.examine() // in theory, usr should be us, this is shit though
+			src.examine_verb(target)
 			return
 
 		if (src.in_point_mode || (src.client && src.client.check_key(KEY_POINT)))

--- a/code/mob/living/carbon/cube.dm
+++ b/code/mob/living/carbon/cube.dm
@@ -16,15 +16,15 @@
 	var/life_timer = 10
 	sound_scream = 'sound/voice/screams/male_scream.ogg'
 
-	examine()
-		boutput(usr, "<span style=\"color:blue\">*---------*</span>")
-		boutput(usr, "<span style=\"color:blue\">This is a [bicon(src)] <B>[src.name]</B>!</span>")
-		if(prob(50) && ishuman(usr) && usr.bioHolder.HasEffect("clumsy"))
-			boutput(usr, "<span style=\"color:red\">You can't help but laugh at it.</span>")
-			usr.emote("laugh")
+	examine(mob/user)
+		. = list("<span style=\"color:blue\">*---------*</span>")
+		. += "<span style=\"color:blue\">This is a [bicon(src)] <B>[src.name]</B>!</span>")
+		if(prob(50) && ishuman(user) && user.bioHolder.HasEffect("clumsy"))
+			. += "<span style=\"color:red\">You can't help but laugh at it.</span>")
+			user.emote("laugh")
 		else
-			boutput(usr, "<span style=\"color:red\">It looks [pick("kinda", "really", "sorta", "a bit", "slightly")] [desc].</span>")
-		boutput(usr, "<span style=\"color:blue\">*---------*</span>") // the fact this was missing bugged me - cirr
+			. += "<span style=\"color:red\">It looks [pick("kinda", "really", "sorta", "a bit", "slightly")] [desc].</span>")
+		. += "<span style=\"color:blue\">*---------*</span>") // the fact this was missing bugged me - cirr
 
 	say_understands(var/other)
 		if (ishuman(other) || isrobot(other) || isAI(other))

--- a/code/mob/living/carbon/cube.dm
+++ b/code/mob/living/carbon/cube.dm
@@ -18,13 +18,13 @@
 
 	examine(mob/user)
 		. = list("<span style=\"color:blue\">*---------*</span>")
-		. += "<span style=\"color:blue\">This is a [bicon(src)] <B>[src.name]</B>!</span>")
+		. += "<span style=\"color:blue\">This is a [bicon(src)] <B>[src.name]</B>!</span>"
 		if(prob(50) && ishuman(user) && user.bioHolder.HasEffect("clumsy"))
-			. += "<span style=\"color:red\">You can't help but laugh at it.</span>")
+			. += "<span style=\"color:red\">You can't help but laugh at it.</span>"
 			user.emote("laugh")
 		else
-			. += "<span style=\"color:red\">It looks [pick("kinda", "really", "sorta", "a bit", "slightly")] [desc].</span>")
-		. += "<span style=\"color:blue\">*---------*</span>") // the fact this was missing bugged me - cirr
+			. += "<span style=\"color:red\">It looks [pick("kinda", "really", "sorta", "a bit", "slightly")] [desc].</span>"
+		. += "<span style=\"color:blue\">*---------*</span>" // the fact this was missing bugged me - cirr
 
 	say_understands(var/other)
 		if (ishuman(other) || isrobot(other) || isAI(other))

--- a/code/mob/living/carbon/wall.dm
+++ b/code/mob/living/carbon/wall.dm
@@ -16,14 +16,14 @@
 		//..(parent)
 		//return
 
-	examine()
-		boutput(usr, "<span style=\"color:blue\">*---------*</span>")
-		boutput(usr, "<span style=\"color:blue\">This is a [bicon(src)] <B>[src.name]</B>!</span>")
-		if(prob(50) && ishuman(usr) && usr.bioHolder.HasEffect("clumsy"))
-			boutput(usr, "<span style=\"color:red\">You can't help but laugh at it.</span>")
-			usr.emote("laugh")
+	examine(mob/user)
+		. = list("<span style=\"color:blue\">*---------*</span>"
+		. += "<span style=\"color:blue\">This is a [bicon(src)] <B>[src.name]</B>!</span>"
+		if(prob(50) && ishuman(user) && user.bioHolder.HasEffect("clumsy"))
+			. += "<span style=\"color:red\">You can't help but laugh at it.</span>"
+			user.emote("laugh")
 		else
-			boutput(usr, "<span style=\"color:red\">It looks pretty disturbing.</span>")
+			. += "<span style=\"color:red\">It looks pretty disturbing.</span>"
 
 	say_understands(var/other)
 		if (ishuman(other) || isrobot(other) || isAI(other))

--- a/code/mob/living/carbon/wall.dm
+++ b/code/mob/living/carbon/wall.dm
@@ -17,7 +17,7 @@
 		//return
 
 	examine(mob/user)
-		. = list("<span style=\"color:blue\">*---------*</span>"
+		. = list("<span style=\"color:blue\">*---------*</span>")
 		. += "<span style=\"color:blue\">This is a [bicon(src)] <B>[src.name]</B>!</span>"
 		if(prob(50) && ishuman(user) && user.bioHolder.HasEffect("clumsy"))
 			. += "<span style=\"color:red\">You can't help but laugh at it.</span>"

--- a/code/mob/living/critter/drone.dm
+++ b/code/mob/living/critter/drone.dm
@@ -98,20 +98,18 @@
 			return 1
 		inertia_dir = 0
 
-	examine()
-		..()
-		if(src.hiddenFrom && hiddenFrom.Find(usr.client)) //invislist
-			return
+	examine(mob/user)
+		. = ..()
 		var/perc = get_health_percentage()
 		switch(perc)
 			if(75 to 100)
 				return
 			if(50 to 74)
-				boutput(usr, "[src] looks lightly [pick("dented", "burned", "scorched", "scratched")].")
+				. += "[src] looks lightly [pick("dented", "burned", "scorched", "scratched")]."
 			if(25 to 49)
-				boutput(usr, "[src] looks [pick("quite", "pretty", "rather")] [pick("dented", "busted", "messed up", "burned", "scorched", "haggard")].")
+				. += "[src] looks [pick("quite", "pretty", "rather")] [pick("dented", "busted", "messed up", "burned", "scorched", "haggard")]."
 			if(0 to 24)
-				boutput(usr, "[src] looks [pick("really", "totally", "very", "all sorts of", "super")] [pick("mangled", "busted", "messed up", "burned", "broken", "haggard", "smashed up", "trashed")].")
+				. += "[src] looks [pick("really", "totally", "very", "all sorts of", "super")] [pick("mangled", "busted", "messed up", "burned", "broken", "haggard", "smashed up", "trashed")]."
 
 	setup_equipment_slots()
 		equipment += new /datum/equipmentHolder/ears/intercom(src)

--- a/code/mob/living/intangible/flockmob_parent.dm
+++ b/code/mob/living/intangible/flockmob_parent.dm
@@ -143,7 +143,7 @@ var/list/fuckedUpFlockVisionColorMatrix = list(\
 	else
 		if (get_dist(src, target) > 0)
 			dir = get_dir(src, target)
-		target.examine()
+		src.examine_verb(target)
 
 /mob/living/intangible/flock/say_quote(var/text)
 	var/speechverb = pick("sings", "clicks", "whistles", "intones", "transmits", "submits", "uploads")

--- a/code/mob/living/object.dm
+++ b/code/mob/living/object.dm
@@ -108,10 +108,10 @@
 			return src.dummy
 
 	examine()
-		..()
-		boutput(usr, "<span style=\"color:red\">It seems to be alive.</span>")
+		. = ..()
+		. += "<span style=\"color:red\">It seems to be alive.</span>"
 		if (health < 25)
-			boutput(usr, "<span style=\"color:blue\">The ethereal grip on this object appears to be weak.</span>")
+			. += "<span style=\"color:blue\">The ethereal grip on this object appears to be weak.</span>"
 
 	meteorhit(var/obj/O as obj)
 		src.death(1)

--- a/code/mob/living/seanceghost.dm
+++ b/code/mob/living/seanceghost.dm
@@ -48,7 +48,7 @@
 		..()*/
 
 	click(atom/target)
-		target.examine()
+		src.examine_verb(target)
 
 	CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 		return 1

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -751,33 +751,27 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 #endif
 	return ..(gibbed)
 
-/mob/living/silicon/ai/examine()
-	set src in oview()
-	set category = "Local"
+/mob/living/silicon/ai/examine(mob/user)
+	if (isghostdrone(user))
+		return list()
 
-	if(src.hiddenFrom && hiddenFrom.Find(usr.client)) //invislist
-		return
-
-	if (isghostdrone(usr))
-		return
-	boutput(usr, "<span style=\"color:blue\">This is [bicon(src)] <B>[src.name]</B>!</span>")
+	. = list("<span style=\"color:blue\">This is [bicon(src)] <B>[src.name]</B>!</span>")
 
 	if (isdead(src))
-		boutput(usr, text("<span style=\"color:red\">[] is nonfunctional...</span>", src.name))
+		. += "<span style=\"color:red\">[src.name] is nonfunctional...</span>"
 	else if (isunconscious(src))
-		boutput(usr, text("<span style=\"color:red\">[] doesn't seem to be responding.</span>", src.name))
+		. += "<span style=\"color:red\">[src.name] doesn't seem to be responding.</span>"
 
 	if (src.bruteloss)
 		if (src.bruteloss < 30)
-			boutput(usr, text("<span style=\"color:red\">[] looks slightly dented.</span>", src.name))
+			. += "<span style=\"color:red\">[src.name] looks slightly dented.</span>"
 		else
-			boutput(usr, text("<span style=\"color:red\"><B>[] looks severely dented!</B></span>", src.name))
+			. += "<span style=\"color:red\"><B>[src.name] looks severely dented!</B></span>"
 	if (src.fireloss)
 		if (src.fireloss < 30)
-			boutput(usr, text("<span style=\"color:red\">[] looks slightly burnt!</span>", src.name))
+			. += "<span style=\"color:red\">[src.name] looks slightly burnt!</span>"
 		else
-			boutput(usr, text("<span style=\"color:red\"><B>[] looks severely burnt!</B></span>", src.name))
-	return
+			. += "<span style=\"color:red\"><B>[src.name] looks severely burnt!</B></span>"
 
 /mob/living/silicon/ai/emote(var/act, var/voluntary = 0)
 	var/param = null

--- a/code/mob/living/silicon/drone.dm
+++ b/code/mob/living/silicon/drone.dm
@@ -90,19 +90,16 @@
 					src.updateOverlaysClient(x.client)
 
 	examine()
-		..()
-		if(src.hiddenFrom && hiddenFrom.Find(usr.client)) //invislist
-			return
-
+		. = ..()
 		if (src.controller)
-			boutput(usr, "It is currently active and being controlled by someone.")
+			. += "It is currently active and being controlled by someone."
 		else
-			boutput(usr, "It is currently shut down and not being used.")
+			. += "It is currently shut down and not being used."
 		if (src.health < 100)
 			if (src.health < 50)
-				boutput(usr, "<span style=\"color:red\">It's rather badly damaged. It probably needs some wiring replaced inside.</span>")
+				. += "<span style=\"color:red\">It's rather badly damaged. It probably needs some wiring replaced inside.</span>"
 			else
-				boutput(usr, "<span style=\"color:red\">It's a bit damaged. It looks like it needs some welding done.</span>")
+				. += "<span style=\"color:red\">It's a bit damaged. It looks like it needs some welding done.</span>"
 
 	movement_delay()
 		var/tally = 0
@@ -371,23 +368,22 @@
 			overlays += part_propulsion.drone_overlay
 
 	examine()
-		..()
+		. = ..()
 		switch(construct_stage)
 			if(0)
-				boutput(usr, "It's nothing but a pile of scrap right now. Wrench the parts together to build it up or weld it back down to metal sheets.")
+				. += "It's nothing but a pile of scrap right now. Wrench the parts together to build it up or weld it back down to metal sheets."
 			if(1)
-				boutput(usr, "It's still a bit rickety. Weld it to make it more secure or wrench it to take it apart.")
+				. += "It's still a bit rickety. Weld it to make it more secure or wrench it to take it apart."
 			if(2)
-				boutput(usr, "It needs cabling. Add some to build it up or take the circuit board out to deconstruct it.")
+				. += "It needs cabling. Add some to build it up or take the circuit board out to deconstruct it."
 			if(3)
-				boutput(usr, "A radio needs to be added, or you could take the cabling out to deconstruct it.")
+				. += "A radio needs to be added, or you could take the cabling out to deconstruct it."
 			if(4)
-				boutput(usr, "A power cell needs to be added, or you could remove the radio to deconstruct it.")
+				. += "A power cell needs to be added, or you could remove the radio to deconstruct it."
 			if(5)
-				boutput(usr, "It needs a propulsion system, or you could remove the power cell to deconstruct it.")
+				. += "It needs a propulsion system, or you could remove the power cell to deconstruct it."
 			if(6)
-				boutput(usr, "It looks almost finished, all that's left to add is extra optional components.")
-				boutput(usr, "Wrench it together to activate it, or remove all parts and the power cell to deconstruct it.")
+				. += "It looks almost finished, all that's left to add is extra optional components.\nWrench it together to activate it, or remove all parts and the power cell to deconstruct it."
 
 	attack_hand(var/mob/user as mob)
 		switch(construct_stage)

--- a/code/mob/living/silicon/ghostdrone.dm
+++ b/code/mob/living/silicon/ghostdrone.dm
@@ -387,8 +387,8 @@
 		..()
 
 	click(atom/target, params)
-		if (params["alt"])
-			target.examine() // in theory, usr should be us, this is shit though
+		if (src.client && src.client.check_key(KEY_EXAMINE))
+			src.examine_verb(target) // in theory, usr should be us, this is shit though
 			return
 
 		if (src.in_point_mode)
@@ -409,7 +409,7 @@
 			item.attack_self(src)
 			return
 
-		if (params["ctrl"])
+		if (src.client && src.client.check_key(KEY_PULL))
 			var/atom/movable/movable = target
 			if (istype(movable))
 				movable.pull()

--- a/code/mob/living/silicon/ghostdrone.dm
+++ b/code/mob/living/silicon/ghostdrone.dm
@@ -250,7 +250,7 @@
 			return
 
 
-		var/msg = list("<span style='color: blue;'>")
+		var/list/msg = list("<span style='color: blue;'>")
 		if (src.active_tool)
 			msg += "[src] is holding a little [bicon(src.active_tool)] [src.active_tool.name]"
 			if (istype(src.active_tool, /obj/item/magtractor) && src.active_tool:holding)

--- a/code/mob/living/silicon/ghostdrone.dm
+++ b/code/mob/living/silicon/ghostdrone.dm
@@ -241,35 +241,32 @@
 		return
 
 	examine()
-		..()
+		. = ..()
 
-		if(src.hiddenFrom && hiddenFrom.Find(usr.client)) //invislist
-			return
-
-		var/msg = "*---------*<br>"
+		. += "*---------*"
 
 		if (isdead(src))
-			msg += "<span style'color:red'>It looks dead and lifeless.</span><br>"
-			msg += "*---------*"
-			return out(usr, msg)
+			. += "<span style'color:red'>It looks dead and lifeless.</span>\n*---------*"
+			return
 
-		msg += "<span style='color: blue;'>"
+
+		var/msg = list("<span style='color: blue;'>")
 		if (src.active_tool)
 			msg += "[src] is holding a little [bicon(src.active_tool)] [src.active_tool.name]"
 			if (istype(src.active_tool, /obj/item/magtractor) && src.active_tool:holding)
 				msg += ", containing \an [src.active_tool:holding]"
 			msg += "<br>"
-		msg += "[src] has a power charge of [bicon(src.cell)] [src.cell.charge]/[src.cell.maxcharge]<br>"
-		msg += "</span>"
+		msg += "[src] has a power charge of [bicon(src.cell)] [src.cell.charge]/[src.cell.maxcharge]</span>"
+
+		. += msg.Join("")
 
 		if (src.health < src.max_health)
 			if (src.health < (src.max_health / 2))
-				msg += "<span style='color:red'>It's rather badly damaged. It probably needs some wiring replaced inside.</span><br>"
+				. += "<span style='color:red'>It's rather badly damaged. It probably needs some wiring replaced inside.</span>"
 			else
-				msg += "<span style='color:red'>It's a bit damaged. It looks like it needs some welding done.</span><br>"
+				. += "<span style='color:red'>It's a bit damaged. It looks like it needs some welding done.</span>"
 
-		msg += "*---------*"
-		out(usr, msg)
+		. += "*---------*"
 
 	Login()
 		..()

--- a/code/mob/living/silicon/hivebot.dm
+++ b/code/mob/living/silicon/hivebot.dm
@@ -395,29 +395,25 @@
 				O.show_message("<span style='color:#605b59'>[message]</span>", m_type)
 	return
 
-/mob/living/silicon/hivebot/examine()
-	set src in oview()
-	set category = "Local"
-
-	if (isghostdrone(usr))
-		return
-	boutput(usr, "<span style=\"color:blue\">*---------*</span>")
-	boutput(usr, text("<span style=\"color:blue\">This is [bicon(src)] <B>[src.name]</B>!</span>"))
+/mob/living/silicon/hivebot/examine(mob/user)
+	if (isghostdrone(user))
+		return list()
+	. = list({"<span style=\"color:blue\">*---------*</span>
+							<span style=\"color:blue\">This is [bicon(src)] <B>[src.name]</B>!</span>"}
 	if (isdead(src))
-		boutput(usr, text("<span style=\"color:red\">[src.name] is powered-down.</span>"))
+		. += "<span style=\"color:red\">[src.name] is powered-down.</span>"
 	if (src.bruteloss)
 		if (src.bruteloss < 75)
-			boutput(usr, text("<span style=\"color:red\">[src.name] looks slightly dented</span>"))
+			. += "<span style=\"color:red\">[src.name] looks slightly dented</span>"
 		else
-			boutput(usr, text("<span style=\"color:red\"><B>[src.name] looks severely dented!</B></span>"))
+			. += "<span style=\"color:red\"><B>[src.name] looks severely dented!</B></span>"
 	if (src.fireloss)
 		if (src.fireloss < 75)
-			boutput(usr, text("<span style=\"color:red\">[src.name] looks slightly burnt!</span>"))
+			. += "<span style=\"color:red\">[src.name] looks slightly burnt!</span>"
 		else
-			boutput(usr, text("<span style=\"color:red\"><B>[src.name] looks severely burnt!</B></span>"))
+			. += "<span style=\"color:red\"><B>[src.name] looks severely burnt!</B></span>"
 	if (isunconscious(src))
-		boutput(usr, text("<span style=\"color:red\">[src.name] doesn't seem to be responding.</span>"))
-	return
+		. += "<span style=\"color:red\">[src.name] doesn't seem to be responding.</span>"
 
 /mob/living/silicon/hivebot/blob_act(var/power)
 	if (!isdead(src))

--- a/code/mob/living/silicon/hivebot.dm
+++ b/code/mob/living/silicon/hivebot.dm
@@ -398,8 +398,9 @@
 /mob/living/silicon/hivebot/examine(mob/user)
 	if (isghostdrone(user))
 		return list()
-	. = list({"<span style=\"color:blue\">*---------*</span>
-							<span style=\"color:blue\">This is [bicon(src)] <B>[src.name]</B>!</span>"}
+
+	. = list("<span style=\"color:blue\">*---------*</span>\n<span style=\"color:blue\">This is [bicon(src)] <B>[src.name]</B>!</span>")
+
 	if (isdead(src))
 		. += "<span style=\"color:red\">[src.name] is powered-down.</span>"
 	if (src.bruteloss)

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -618,7 +618,7 @@
 		if (src.health <= 50)
 			. += "<span style=\"color:red\">[src.name] is twitching and sparking!</span>"
 		if (isunconscious(src))
-	 		. += "<span style=\"color:red\">[src.name] doesn't seem to be responding.</span>"
+			. += "<span style=\"color:red\">[src.name] doesn't seem to be responding.</span>"
 
 		. += "The cover is [opened ? "open" : "closed"]."
 		. += "The power cell display reads: [ cell ? "[round(cell.percent())]%" : "WARNING: No cell installed."]"

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -592,38 +592,43 @@
 		return
 
 	examine()
-		set src in oview()
-
 		if(src.hiddenFrom && hiddenFrom.Find(usr.client)) //invislist
-			return
+			return list()
 
 		if (isghostdrone(usr))
-			return
-		var/rendered = "<span style=\"color:blue\">*---------*</span><br>"
-		rendered += "<span style=\"color:blue\">This is [bicon(src)] <B>[src.name]</B>!</span><br>"
-		if (isdead(src)) rendered += "<span style=\"color:red\">[src.name] is powered-down.</span><br>"
+			return list()
+		. += "<span style=\"color:blue\">*---------*</span>"
+		. += "<span style=\"color:blue\">This is [bicon(src)] <B>[src.name]</B>!</span>"
+
+		if (isdead(src))
+			. += "<span style=\"color:red\">[src.name] is powered-down.</span>"
+
 		var/brute = get_brute_damage()
 		var/burn = get_burn_damage()
 		if (brute)
-			if (brute < 75) rendered += "<span style=\"color:red\">[src.name] looks slightly dented</span><br>"
-			else rendered += "<span style=\"color:red\"><B>[src.name] looks severely dented!</B></span><br>"
+			if (brute < 75)
+				. += "<span style=\"color:red\">[src.name] looks slightly dented</span>"
+			else
+				. += "<span style=\"color:red\"><B>[src.name] looks severely dented!</B></span>"
 		if (burn)
-			if (burn < 75) rendered += "<span style=\"color:red\">[src.name] has slightly burnt wiring!</span><br>"
-			else rendered += "<span style=\"color:red\"><B>[src.name] has severely burnt wiring!</B></span><br>"
-		if (src.health <= 50) rendered += "<span style=\"color:red\">[src.name] is twitching and sparking!</span><br>"
-		if (isunconscious(src)) rendered += "<span style=\"color:red\">[src.name] doesn't seem to be responding.</span><br>"
+			if (burn < 75)
+				. += "<span style=\"color:red\">[src.name] has slightly burnt wiring!</span>"
+			else
+				. += "<span style=\"color:red\"><B>[src.name] has severely burnt wiring!</B></span>"
+		if (src.health <= 50)
+			. += "<span style=\"color:red\">[src.name] is twitching and sparking!</span>"
+		if (isunconscious(src))
+	 		. += "<span style=\"color:red\">[src.name] doesn't seem to be responding.</span>"
 
-		rendered += "The cover is [opened ? "open" : "closed"].<br>"
-		rendered += "The power cell display reads: [ cell ? "[round(cell.percent())]%" : "WARNING: No cell installed."]<br>"
+		. += "The cover is [opened ? "open" : "closed"]."
+		. += "The power cell display reads: [ cell ? "[round(cell.percent())]%" : "WARNING: No cell installed."]"
 
 		if (src.module)
-			rendered += "[src.name] has a [src.module.name] installed.<br>"
+			. += "[src.name] has a [src.module.name] installed."
 		else
-			rendered += "[src.name] does not appear to have a module installed.<br>"
+			. += "[src.name] does not appear to have a module installed."
 
-		rendered += "<span style=\"color:blue\">*---------*</span>"
-		out(usr, rendered)
-		return
+		. += "<span style=\"color:blue\">*---------*</span>"
 
 	choose_name(var/retries = 3)
 		var/newname

--- a/code/mob/wraith.dm
+++ b/code/mob/wraith.dm
@@ -357,7 +357,7 @@
 		if (. == 100)
 			return 100
 		if (!density)
-			target.examine()
+			src.examine_verb(target)
 
 	say(var/message)
 		message = trim(copytext(sanitize(message), 1, MAX_MESSAGE_LEN))

--- a/code/mob/zoldorfmob.dm
+++ b/code/mob/zoldorfmob.dm
@@ -158,7 +158,7 @@
 			src.invisibility = 0
 			qdel(target)
 		else
-			target.examine()
+			src.examine_verb(target)
 
 	CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 		return 1

--- a/code/modules/chemistry/tools/iv_drips.dm
+++ b/code/modules/chemistry/tools/iv_drips.dm
@@ -230,7 +230,8 @@
 
 	get_desc()
 		if (src.IV)
-			return src.IV.examine()
+			var/list/examine_list = src.IV.examine()
+			return examine_list.Join("\n")
 
 	proc/update_icon()
 		src.overlays = null

--- a/code/modules/chemistry/tools/patches.dm
+++ b/code/modules/chemistry/tools/patches.dm
@@ -390,13 +390,13 @@
 			name = initial(src.name)
 
 	examine()
-		..()
+		. = ..()
 		if (patches.len)
 			var/obj/item/reagent_containers/patch/P = patches[patches.len]
 			if (P)
-				boutput(usr, "The topmost patch is a [P.name]; [patches.len] patch(es) on the stack.")
+				. += "The topmost patch is a [P.name]; [patches.len] patch(es) on the stack."
 		else
-			boutput(usr, "0 patches on the stack.")
+			. += "0 patches on the stack."
 
 	attackby(var/obj/item/W, var/mob/user)
 		if (patches.len)

--- a/code/modules/food_and_drink/snacks.dm
+++ b/code/modules/food_and_drink/snacks.dm
@@ -2237,12 +2237,12 @@ var/list/valid_jellybean_reagents = childrentypesof(/datum/reagent)
 	. = ..()
 	var/n = round(src.amount)
 	if (n <= 0)
-		. = "There are no beans left in the bag.")
+		. += "There are no beans left in the bag."
 	else
 		if (n == 1)
-			. = list("There is one bean left in the bag.")
+			. += "There is one bean left in the bag."
 		else
-			. = list("There are [n] beans in the bag.")
+			. += "There are [n] beans in the bag."
 
 //#endif
 

--- a/code/modules/food_and_drink/snacks.dm
+++ b/code/modules/food_and_drink/snacks.dm
@@ -904,20 +904,19 @@
 		..()
 
 
-	examine()
-		..()
-		if (usr.bioHolder.HasEffect("accent_swedish"))
+	examine(mob/user)
+		. = ..()
+		if (user.bioHolder.HasEffect("accent_swedish"))
 			if (src.icon_state == "surs_closed")
-				boutput(usr, "Oooh, a can of surströmming! It's been a while since you've seen one of these. It looks like it's ready to eat.")
+				. += "Oooh, a can of surströmming! It's been a while since you've seen one of these. It looks like it's ready to eat."
 			else
-				boutput(usr, "Oooh, a can of surströmming! It's been a while since you've seen one of these. It smells heavenly!")
+				. += "Oooh, a can of surströmming! It's been a while since you've seen one of these. It smells heavenly!"
 			return
 		else
 			if (src.icon_state == "surs_closed")
-				boutput(usr, "The fuck is this? The label's written in some sort of gibberish, and you're pretty sure cans aren't supposed to bulge like that.")
+				. += "The fuck is this? The label's written in some sort of gibberish, and you're pretty sure cans aren't supposed to bulge like that."
 			else
-				boutput(usr, "<b>AAAAAAAAAAAAAAAAUGH AAAAAAAAAAAUGH IT SMELLS LIKE FERMENTED SKUNK EGG BUTTS MAKE IT STOP</b>")
-			return
+				. += "<b>AAAAAAAAAAAAAAAAUGH AAAAAAAAAAAUGH IT SMELLS LIKE FERMENTED SKUNK EGG BUTTS MAKE IT STOP</b>"
 
 	attack_self(var/mob/user as mob)
 		if (src.icon_state == "surs_closed")
@@ -2235,22 +2234,15 @@ var/list/valid_jellybean_reagents = childrentypesof(/datum/reagent)
 	return
 
 /obj/item/kitchen/everyflavor_box/examine()
-	set src in oview(1)
-	set category = "Local"
-
-	src.amount = round(src.amount)
-	var/n = src.amount
-	for(var/obj/item/reagent_containers/food/snacks/donut/P in src)
-		n++
+	. = ..()
+	var/n = round(src.amount)
 	if (n <= 0)
-		n = 0
-		boutput(usr, "There are no beans left in the bag.")
+		. = "There are no beans left in the bag.")
 	else
 		if (n == 1)
-			boutput(usr, "There is one bean left in the bag.")
+			. = list("There is one bean left in the bag.")
 		else
-			boutput(usr, "There are [n] beans in the bag.")
-	return
+			. = list("There are [n] beans in the bag.")
 
 //#endif
 
@@ -2365,15 +2357,16 @@ var/list/valid_jellybean_reagents = childrentypesof(/datum/reagent)
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (istype(W, /obj/item/reagent_containers/food/snacks/condiment/)) src.amount += 1
 
-	examine()
-		boutput(usr, "This is a [src.name].")
+	examine(mob/user)
+		. = list("This is a [src.name].")
+
 		if(isbutt)
-			boutput(usr, "A dire misunderstanding of how haggis works.")
+			. += "A dire misunderstanding of how haggis works."
 		else
-			if (usr.bioHolder.HasEffect("accent_scots"))
-				boutput(usr, "Fair fa' your honest, sonsie face, great chieftain o the puddin'-race!")
+			if (user.bioHolder.HasEffect("accent_scots"))
+				. += "Fair fa' your honest, sonsie face, great chieftain o the puddin'-race!"
 			else
-				boutput(usr, "A big ol' meat pudding, wrapped up in a synthetic stomach stuffed nearly to bursting. Gusty!")
+				. += "A big ol' meat pudding, wrapped up in a synthetic stomach stuffed nearly to bursting. Gusty!"
 
 	heal(var/mob/M)
 		if (M.bioHolder.HasEffect("accent_scots"))
@@ -2706,7 +2699,3 @@ var/list/valid_jellybean_reagents = childrentypesof(/datum/reagent)
 
 	get_desc(dist)
 		. = "<br><span style='color: blue'>It says: [phrase]</span>"
-
-
-
-

--- a/code/modules/holiday/halloween.dm
+++ b/code/modules/holiday/halloween.dm
@@ -45,10 +45,8 @@
 /obj/joeq/spooky
 	name = "Memorial Plaque"
 
-	examine()
-		set src in view()
-		boutput(usr, "Here lies [usr:real_name]. Loved by all. R.I.P.")
-		return
+	examine(mob/user)
+		boutput(usr, "Here lies [user.real_name]. Loved by all. R.I.P.")
 
 /*
  *	Spooky TOMBSTONE.  It is a tombstone.
@@ -483,10 +481,10 @@
 	attack_hand(mob/user as mob)
 		boutput(user, "<span class='combat'>The knobs are fixed in place.  Might as well sit back and watch, I guess?</span>")
 
-	examine()
-		set src in oview()
-		if (ishuman(usr) && !usr.stat)
-			var/mob/living/carbon/human/M = usr
+	examine(mob/user)
+		. = list()
+		if (ishuman(user) && !user.stat)
+			var/mob/living/carbon/human/M = user
 
 			M.visible_message("<span class='combat'>[M] stares blankly into [src], \his eyes growing duller and duller...</span>","<span class='combat'>You stare deeply into [src].  You...can't look away.  It's mesmerizing.  Sights, sounds, colors, shapes.  They blur together into a phantasm of beauty and wonder.</span>")
 			var/mob/living/carbon/wall/halloween/holder = new
@@ -522,8 +520,7 @@
 			stoneman.dir = get_dir(stoneman, src)
 
 		else
-			boutput(usr, desc)
-			return
+			. += desc
 
 /obj/item/toy/halloween2014spellbook
 	name = "Book of Spells"

--- a/code/modules/medical/genetics/geneticsScanner.dm
+++ b/code/modules/medical/genetics/geneticsScanner.dm
@@ -42,19 +42,17 @@ var/list/genescanner_addresses = list()
 		return 0
 
 	examine()
-		set src in oview(7)
-
-		..()
+		. = ..()
 		if (src.occupant)
-			boutput(usr, "[src.occupant.name] is inside the scanner.")
+			. += "[src.occupant.name] is inside the scanner."
 		else
-			boutput(usr, "There is nobody currently inside the scanner.")
+			. += "There is nobody currently inside the scanner."
 		if (src.locked)
-			boutput(usr, "The scanner is currently locked.")
+			. += "The scanner is currently locked."
 		else
-			boutput(usr, "The scanner is not currently locked.")
+			. += "The scanner is not currently locked."
 
-	mob_flip_inside(var/mob/user)
+	mob_flip_inside(mob/user)
 		..(user)
 		if (prob(33))
 			user.show_text("<span style=\"color:red\">[src] [pick("cracks","bends","shakes","groans")].</span>")

--- a/code/modules/medical/pathology/pathogen_tools.dm
+++ b/code/modules/medical/pathology/pathogen_tools.dm
@@ -59,26 +59,27 @@
 
 	examine()
 		if (src.dirty || src.dirty_reason)
-			..()
-			boutput(usr, "<span style=\"color:red\">The petri dish appears to be incapable of growing any pathogen, and must be cleaned.</span>")
+			. = ..()
+			. += "<span style=\"color:red\">The petri dish appears to be incapable of growing any pathogen, and must be cleaned.</span>"
 			return
-		boutput(usr, "This is [src]")
+			
+		. = list("This is [src]")
 		if (src.reagents.reagent_list["pathogen"])
 			var/datum/reagent/blood/pathogen/P = src.reagents.reagent_list["pathogen"]
-			boutput(usr, "<span style=\"color:blue\">It contains [P.volume] units of harvestable pathogen.</span>")
+			. += "<span style=\"color:blue\">It contains [P.volume] units of harvestable pathogen.</span>"
 		if (src.medium)
-			boutput(usr, "<span style=\"color:blue\">The petri dish is coated with [src.medium.name].</span>")
-		boutput(usr, "Nutrients in the dish:")
+			. += "<span style=\"color:blue\">The petri dish is coated with [src.medium.name].</span>"
+		. += "Nutrients in the dish:"
 		var/count = 0
 		for (var/N in nutrition)
 			if (nutrition[N])
 				if (nutrition[N] != 1)
-					boutput(usr, "<span style=\"color:blue\">[nutrition[N]] units of [N]</span>")
+					. += "<span style=\"color:blue\">[nutrition[N]] units of [N]</span>"
 				else
-					boutput(usr, "<span style=\"color:blue\">[nutrition[N]] unit of [N]</span>")
+					. += "<span style=\"color:blue\">[nutrition[N]] unit of [N]</span>"
 				count++
 		if (!count)
-			boutput(usr, "<span style=\"color:blue\">None.</span>")
+			. += "<span style=\"color:blue\">None.</span>"
 
 	afterattack(obj/target, mob/user , flag)
 		if (istype(target, /obj/machinery/microscope))

--- a/code/modules/medical/surgery_tools.dm
+++ b/code/modules/medical/surgery_tools.dm
@@ -233,9 +233,8 @@ CONTAINS:
 
 	// Every bit of usability helps (Convair880).
 	examine()
-		src.desc = "A medical staple gun for securely reattaching limbs. There are [src.ammo] staples left."
-		..()
-		return
+		. = ..()
+		. += "There are [src.ammo] staples left."
 
 	attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 		if (!ismob(M))

--- a/code/modules/networks/computer3/disks.dm
+++ b/code/modules/networks/computer3/disks.dm
@@ -77,10 +77,8 @@
 	boutput(user, "You flip the write-protect tab to [src.read_only ? "protected" : "unprotected"].")
 
 /obj/item/disk/data/floppy/examine()
-	set src in oview(5)
-	..()
-	boutput(usr, text("The write-protect tab is set to [src.read_only ? "protected" : "unprotected"]."))
-	return
+	. = ..()
+	. += "The write-protect tab is set to [src.read_only ? "protected" : "unprotected"]."
 
 /obj/item/disk/data/floppy/demo
 	name = "data disk - 'Farmer Jeff'"

--- a/code/modules/networks/computer3/mainframe2/telesci.dm
+++ b/code/modules/networks/computer3/mainframe2/telesci.dm
@@ -91,10 +91,9 @@ proc/is_teleportation_allowed(var/turf/T)
 		return
 
 	examine()
-		set src in view()
-		..()
+		. = ..()
 		if (!src.host_id)
-			boutput(usr, "<span style=\"color:red\">The [src.name]'s \"disconnected from host\" light is flashing.</span>")
+			. += "<span style=\"color:red\">The [src.name]'s \"disconnected from host\" light is flashing.</span>"
 
 	attack_hand(mob/user as mob)
 		if(..())

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -206,18 +206,18 @@ var/zapLimiter = 0
 	terminal = null
 	..()
 
-/obj/machinery/power/apc/examine()
-	set src in oview(1)
-	set category = "Local"
+/obj/machinery/power/apc/examine(mob/user)
+	. = ..()
 
-	if(status & BROKEN) return
+	if(status & BROKEN)
+		return
 
-	if(usr && !usr.stat)
-		boutput(usr, "A control terminal for the area electrical systems.")
+	if(user && !user.stat)
+		. += "A control terminal for the area electrical systems."
 		if(opened)
-			boutput(usr, "The cover is open and the power cell is [ cell ? "installed" : "missing"].")
+			. += "The cover is open and the power cell is [ cell ? "installed" : "missing"]."
 		else
-			boutput(usr, "The cover is closed.")
+			. += "The cover is closed."
 
 
 /obj/machinery/power/apc/proc/getMaxExcess()

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -165,17 +165,17 @@
 	if (genrate > 0) give(genrate)
 	if (!genrate) ..()
 
-/obj/item/cell/examine()
-	set src in view(1)
-	set category = "Local"
+/obj/item/cell/examine(mob/user)
+	. = ..()
+
 	if (src.artifact || src.unusualCell)
-		..()
 		return
-	if(usr && !usr.stat)
+
+	if(user && !user.stat)
 		if(maxcharge <= 2500)
-			boutput(usr, "[desc]<br>The manufacturer's label states this cell has a power rating of [maxcharge], and that you should not swallow it.<br>The charge meter reads [round(src.percent() )]%.")
+			. += "The manufacturer's label states this cell has a power rating of [maxcharge], and that you should not swallow it.<br>The charge meter reads [round(src.percent() )]%."
 		else
-			boutput(usr, "This power cell has an exciting chrome finish, as it is an uber-capacity cell type! It has a power rating of [maxcharge]!!!<br>The charge meter reads [round(src.percent() )]%.")
+			. += "This power cell has an exciting chrome finish, as it is an uber-capacity cell type! It has a power rating of [maxcharge]!!!<br>The charge meter reads [round(src.percent() )]%."
 
 /obj/item/cell/attackby(obj/item/W, mob/user) // Moved the stungloves stuff to gloves.dm (Convair880).
 	if (istype(W, /obj/item/reagent_containers/syringe))

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -512,19 +512,21 @@
 	update()
 
 // examine verb
-/obj/machinery/light/examine()
-	set src in oview(1)
-	set category = "Local"
-	if(usr && !usr.stat)
-		switch(light_status)
-			if(LIGHT_OK)
-				boutput(usr, "[desc] It is turned [on? "on" : "off"].")
-			if(LIGHT_EMPTY)
-				boutput(usr, "[desc] The [fitting] has been removed.")
-			if(LIGHT_BURNED)
-				boutput(usr, "[desc] The [fitting] is burnt out.")
-			if(LIGHT_BROKEN)
-				boutput(usr, "[desc] The [fitting] has been smashed.")
+/obj/machinery/light/examine(mob/user)
+	. = ..()
+
+	if(!user || user.stat)
+		return
+
+	switch(light_status)
+		if(LIGHT_OK)
+			. += "[desc] It is turned [on? "on" : "off"]."
+		if(LIGHT_EMPTY)
+			. += "[desc] The [fitting] has been removed."
+		if(LIGHT_BURNED)
+			. += "[desc] The [fitting] is burnt out."
+		if(LIGHT_BROKEN)
+			. += "[desc] The [fitting] has been smashed."
 
 
 

--- a/code/modules/robotics/bot/bot_parent.dm
+++ b/code/modules/robotics/bot/bot_parent.dm
@@ -90,3 +90,11 @@
 					return 1
 				else
 					return 0
+
+/obj/machinery/bot/examine()
+	. = ..()
+	if (src.health < 20)
+		if (src.health > 15)
+			. += "<span style='color:red'>[src]'s parts look loose.</span>"
+		else
+			. += "<span style='color:red'><B>[src]'s parts look very loose!</B></span>"

--- a/code/modules/robotics/bot/cambot.dm
+++ b/code/modules/robotics/bot/cambot.dm
@@ -40,18 +40,6 @@
 			src.botcard.access = get_access(src.access_lookup)
 			src.camera = new /obj/item/camera_test(src)
 			src.icon_state = "cambot[src.on]"
-	return
-
-/obj/machinery/bot/cambot/examine()
-	set src in view()
-	set category = "Local"
-	..()
-	if (src.health < 20)
-		if (src.health > 15)
-			boutput(usr, text("<span style='color:red'>[src]'s parts look loose.</span>"))
-		else
-			boutput(usr, text("<span style='color:red'><B>[src]'s parts look very loose!</B></span>"))
-	return
 
 /obj/machinery/bot/cambot/emag_act(var/mob/user, var/obj/item/card/emag/E)
 	if (!src.emagged)

--- a/code/modules/robotics/bot/cleanbot.dm
+++ b/code/modules/robotics/bot/cleanbot.dm
@@ -89,17 +89,6 @@
 				src.toggle_power(1)
 		return
 
-	examine()
-		set src in view()
-		..()
-
-		if (src.health < initial(health))
-			if (src.health > (initial(src.health) / 2))
-				boutput(usr, text("<span style=\"color:red\">[src]'s parts look loose.</span>"))
-			else
-				boutput(usr, text("<span style=\"color:red\"><B>[src]'s parts look very loose!</B></span>"))
-		return
-
 	emag_act(var/mob/user, var/obj/item/card/emag/E)
 		if (!src.emagged)
 			if (user && ismob(user))

--- a/code/modules/robotics/bot/firebot.dm
+++ b/code/modules/robotics/bot/firebot.dm
@@ -53,22 +53,10 @@
 			src.botcard = new /obj/item/card/id(src)
 			src.botcard.access = get_access(src.access_lookup)
 			src.icon_state = "firebot[src.on]"
-	return
 
 //		if(radio_connection)
 //			radio_controller.add_object(src, "[beacon_freq]")
 
-/obj/machinery/bot/firebot/examine()
-	set src in view()
-	set category = "Local"
-	..()
-
-	if (src.health < 20)
-		if (src.health > 15)
-			boutput(usr, text("<span style=\"color:red\">[src]'s parts look loose.</span>"))
-		else
-			boutput(usr, text("<span style=\"color:red\"><B>[src]'s parts look very loose!</B></span>"))
-	return
 
 /obj/machinery/bot/firebot/attack_ai(mob/user as mob, params)
 	var/dat
@@ -85,8 +73,6 @@
 			"title" = "Firebot v1.0 controls",
 			"content" = dat,
 		))
-
-	return
 
 /obj/machinery/bot/firebot/attack_hand(mob/user as mob, params)
 	var/dat

--- a/code/modules/robotics/bot/medbot.dm
+++ b/code/modules/robotics/bot/medbot.dm
@@ -142,18 +142,6 @@
 			src.update_icon()
 	return
 
-/obj/machinery/bot/medbot/examine()
-	set src in view()
-	set category = "Local"
-	..()
-
-	if (src.health < 20)
-		if (src.health > 15)
-			boutput(usr, text("<span style=\"color:red\">[src]'s parts look loose.</span>"))
-		else
-			boutput(usr, text("<span style=\"color:red\"><B>[src]'s parts look very loose!</B></span>"))
-	return
-
 /obj/machinery/bot/medbot/attack_ai(mob/user as mob)
 	return toggle_power()
 

--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -157,17 +157,6 @@
 			if(src.hat)
 				src.overlays += image('icons/obj/aibots.dmi', "hat-[src.hat]")
 
-	examine()
-		set src in view()
-		..()
-
-		if (src.health < initial(health))
-			if (src.health > 15)
-				boutput(usr, text("<span style=\"color:red\">[src]'s parts look loose.</span>"))
-			else
-				boutput(usr, text("<span style=\"color:red\"><B>[src]'s parts look very loose!</B></span>"))
-		return
-
 	attack_hand(mob/user as mob, params)
 		var/dat
 

--- a/code/modules/telescience/teleport_jammer.dm
+++ b/code/modules/telescience/teleport_jammer.dm
@@ -44,17 +44,17 @@
 		teleport_jammers -= src
 		..()
 
-	examine()
-		..()
-		if(usr.client)
+	examine(mob/user)
+		. = ..()
+		if(user.client)
 			var/charge_percentage = 0
 			if (PCEL && PCEL.charge > 0 && PCEL.maxcharge > 0)
 				charge_percentage = round((PCEL.charge/PCEL.maxcharge)*100)
-				boutput(usr, "It has [PCEL.charge]/[PCEL.maxcharge] ([charge_percentage]%) battery power left.")
-				boutput(usr, "The jammer's range is [src.range] units of distance.")
-				boutput(usr, "The unit will consume [5 * src.range] power a second.")
+				. += "It has [PCEL.charge]/[PCEL.maxcharge] ([charge_percentage]%) battery power left."
+				. += "The jammer's range is [src.range] units of distance."
+				. += "The unit will consume [5 * src.range] power a second."
 			else
-				boutput(usr, "It seems to be missing a usable battery.")
+				. += "It seems to be missing a usable battery."
 
 	process()
 		if (src.active)

--- a/code/modules/transport/shuttle/shuttle_misc.dm
+++ b/code/modules/transport/shuttle/shuttle_misc.dm
@@ -91,9 +91,9 @@
 
 /obj/machinery/shuttle/engine/propulsion/examine()
 	if (src.stat1 == 1 && src.stat2 == 1)
-		boutput(usr, "<span style=\"color:blue\">The propulsion engine is working properly!</span>")
+		return list("<span style=\"color:blue\">The propulsion engine is working properly!</span>")
 	else
-		boutput(usr, "<span style=\"color:red\">The propulsion engine is not functioning.</span>")
+		return list("<span style=\"color:red\">The propulsion engine is not functioning.</span>")
 
 /obj/machinery/shuttle/engine/propulsion/ex_act()
 	if(src.stat1 == 0 && src.stat2 == 0) // don't break twice, that'd be silly

--- a/code/modules/transport/shuttle/shuttle_turfobjs.dm
+++ b/code/modules/transport/shuttle/shuttle_turfobjs.dm
@@ -111,14 +111,14 @@
 	mouse_opacity = 0
 
 	examine()
-		return
+		return list()
 
 
 /obj/indestructible/invisible_block/opaque
 	opacity = 1
 
 	examine()
-		return
+		return list()
 
 
 /turf/simulated/shuttle/wall/cockpit

--- a/code/obj/alien/facehugger.dm
+++ b/code/obj/alien/facehugger.dm
@@ -49,17 +49,15 @@
 		src.process()
 
 	examine()
-		set src in view()
-		..()
+		. = ..()
 		if(src.hiddenFrom && hiddenFrom.Find(usr.client)) //invislist
 			return
 		if(!alive)
-			boutput(usr, text("<span style=\"color:red\"><B>the alien is not moving</B></span>"))
+			. += "<span style=\"color:red\"><B>the alien is not moving</B></span>"
 		else if (src.health > 15)
-			boutput(usr, text("<span style=\"color:red\"><B>the alien looks fresh, just out of the egg</B></span>"))
+			. += "<span style=\"color:red\"><B>the alien looks fresh, just out of the egg</B></span>"
 		else
-			boutput(usr, text("<span style=\"color:red\"><B>the alien looks pretty beat up</B></span>"))
-		return
+			. += "<span style=\"color:red\"><B>the alien looks pretty beat up</B></span>"
 
 
 	attack_hand(user as mob)
@@ -384,4 +382,3 @@
 	proc/healthcheck()
 		if (src.health <= 0)
 			src.death()
-

--- a/code/obj/artifacts/artifact_items/energy_gun.dm
+++ b/code/obj/artifacts/artifact_items/energy_gun.dm
@@ -31,13 +31,12 @@
 		src.setItemSpecial(null)
 
 	examine()
-		set src in oview()
-		boutput(usr, "You have no idea what this thing is!")
+		. = list("You have no idea what this thing is!")
 		if (!src.ArtifactSanityCheck())
 			return
 		var/datum/artifact/A = src.artifact
 		if (istext(A.examine_hint))
-			boutput(usr, "[A.examine_hint]")
+			. += A.examine_hint
 
 	UpdateName()
 		src.name = "[name_prefix(null, 1)][src.real_name][name_suffix(null, 1)]"

--- a/code/obj/artifacts/artifact_items/gun_cell.dm
+++ b/code/obj/artifacts/artifact_items/gun_cell.dm
@@ -25,13 +25,12 @@
 		..()
 
 	examine()
-		set src in oview()
-		boutput(usr, "You have no idea what this thing is!")
+		. = list("You have no idea what this thing is!")
 		if (!src.ArtifactSanityCheck())
 			return
 		var/datum/artifact/A = src.artifact
 		if (istext(A.examine_hint))
-			boutput(usr, "[A.examine_hint]")
+			. += A.examine_hint
 
 	UpdateName()
 		src.name = "[name_prefix(null, 1)][src.real_name][name_suffix(null, 1)]"

--- a/code/obj/artifacts/artifact_items/mining_tool.dm
+++ b/code/obj/artifacts/artifact_items/mining_tool.dm
@@ -16,13 +16,12 @@
 		src.dig_sound = pick('sound/effects/exlow.ogg','sound/effects/mag_magmisimpact.ogg','sound/impact_sounds/Energy_Hit_1.ogg')
 
 	examine()
-		set src in oview()
-		boutput(usr, "You have no idea what this thing is!")
+		. = list("You have no idea what this thing is!")
 		if (!src.ArtifactSanityCheck())
 			return
 		var/datum/artifact/A = src.artifact
 		if (istext(A.examine_hint))
-			boutput(usr, "[A.examine_hint]")
+			. += A.examine_hint
 
 /datum/artifact/mining
 	associated_object = /obj/item/artifact/mining_tool

--- a/code/obj/artifacts/artifact_items/power_cell.dm
+++ b/code/obj/artifacts/artifact_items/power_cell.dm
@@ -24,13 +24,12 @@
 			..()
 
 	examine()
-		set src in oview()
-		boutput(usr, "You have no idea what this thing is!")
+		. = list("You have no idea what this thing is!")
 		if (!src.ArtifactSanityCheck())
 			return
 		var/datum/artifact/A = src.artifact
 		if (istext(A.examine_hint))
-			boutput(usr, "[A.examine_hint]")
+			. += A.examine_hint
 
 	UpdateName()
 		src.name = "[name_prefix(null, 1)][src.real_name][name_suffix(null, 1)]"

--- a/code/obj/artifacts/artifact_items/watering_can.dm
+++ b/code/obj/artifacts/artifact_items/watering_can.dm
@@ -156,8 +156,7 @@
 			..()
 
 	examine()
-		boutput(usr, "[desc]")
-		return
+		return list(desc)
 
 	UpdateName()
 		src.name = "[name_prefix(null, 1)][src.real_name][name_suffix(null, 1)]"

--- a/code/obj/artifacts/artifacts.dm
+++ b/code/obj/artifacts/artifacts.dm
@@ -44,13 +44,12 @@
 		..()
 
 	examine()
-		set src in oview()
-		boutput(usr, "You have no idea what this thing is!")
+		. = list("You have no idea what this thing is!")
 		if (!src.ArtifactSanityCheck())
 			return
 		var/datum/artifact/A = src.artifact
 		if (istext(A.examine_hint))
-			boutput(usr, "[A.examine_hint]")
+			. += A.examine_hint
 
 	ex_act(severity)
 		switch(severity)
@@ -168,13 +167,12 @@
 		..()
 
 	examine()
-		set src in oview()
-		boutput(usr, "You have no idea what this thing is!")
+		. = list("You have no idea what this thing is!")
 		if (!src.ArtifactSanityCheck())
 			return
 		var/datum/artifact/A = src.artifact
 		if (istext(A.examine_hint))
-			boutput(usr, "[A.examine_hint]")
+			. += A.examine_hint
 
 	UpdateName()
 		src.name = "[name_prefix(null, 1)][src.real_name][name_suffix(null, 1)]"
@@ -312,13 +310,12 @@
 		..()
 
 	examine()
-		set src in oview()
-		boutput(usr, "You have no idea what this thing is!")
+		. = list("You have no idea what this thing is!")
 		if (!src.ArtifactSanityCheck())
 			return
 		var/datum/artifact/A = src.artifact
 		if (istext(A.examine_hint))
-			boutput(usr, "[A.examine_hint]")
+			. += A.examine_hint
 
 	UpdateName()
 		src.name = "[name_prefix(null, 1)][src.real_name][name_suffix(null, 1)]"

--- a/code/obj/blob.dm
+++ b/code/obj/blob.dm
@@ -72,7 +72,7 @@ var/image/blob_icon_cache
 				actions.start(new /datum/action/bar/blob_absorb(H, overmind), src)
 
 	proc/right_click_action()
-		examine()
+		examine_verb()
 
 	Click(location, control, params)
 		if (usr != overmind)
@@ -659,17 +659,17 @@ var/image/blob_icon_cache
 		if (!overlay_image)
 			overlay_image = image('icons/mob/new_blob.dmi', "deposit-material")
 
-	examine()
+	examine(mob/user)
 		if (disposed)
-			return
-		..()
-		if (usr == overmind)
+			return list()
+		. = ..()
+		if (user == overmind)
 			if (movable)
-				boutput(usr, "<span style=\"color:blue\">Clickdrag this onto any standard (not special) blob tile to move the reagent deposit there.</span>")
-			boutput(usr, "<span style=\"color:blue\">It contains:</span>")
+				. += "<span style=\"color:blue\">Clickdrag this onto any standard (not special) blob tile to move the reagent deposit there.</span>"
+			+= "<span style=\"color:blue\">It contains:</span>"
 			for (var/id in src.reagents.reagent_list)
 				var/datum/reagent/R = src.reagents.reagent_list[id]
-				boutput(usr, "<span style=\"color:blue\">- [R.volume] unit[R.volume != 1 ? "s" : null] of [R.name]</span>")
+				+= "<span style=\"color:blue\">- [R.volume] unit[R.volume != 1 ? "s" : null] of [R.name]</span>"
 
 	proc/update_reagent_overlay()
 		if (disposed)

--- a/code/obj/blob.dm
+++ b/code/obj/blob.dm
@@ -72,7 +72,7 @@ var/image/blob_icon_cache
 				actions.start(new /datum/action/bar/blob_absorb(H, overmind), src)
 
 	proc/right_click_action()
-		examine_verb()
+		usr.examine_verb()
 
 	Click(location, control, params)
 		if (usr != overmind)
@@ -666,10 +666,10 @@ var/image/blob_icon_cache
 		if (user == overmind)
 			if (movable)
 				. += "<span style=\"color:blue\">Clickdrag this onto any standard (not special) blob tile to move the reagent deposit there.</span>"
-			+= "<span style=\"color:blue\">It contains:</span>"
+			. += "<span style=\"color:blue\">It contains:</span>"
 			for (var/id in src.reagents.reagent_list)
 				var/datum/reagent/R = src.reagents.reagent_list[id]
-				+= "<span style=\"color:blue\">- [R.volume] unit[R.volume != 1 ? "s" : null] of [R.name]</span>"
+				. += "<span style=\"color:blue\">- [R.volume] unit[R.volume != 1 ? "s" : null] of [R.name]</span>"
 
 	proc/update_reagent_overlay()
 		if (disposed)

--- a/code/obj/critter/headspider.dm
+++ b/code/obj/critter/headspider.dm
@@ -18,11 +18,11 @@
 		if(src.hiddenFrom && hiddenFrom.Find(usr.client)) //invislist
 			return
 		if(!alive)
-			+= "<span style=\"color:red\"><B>the disgusting creature is not moving</B></span>"
+			. += "<span style=\"color:red\"><B>the disgusting creature is not moving</B></span>"
 		else if (src.health > 40)
-			+= "<span style=\"color:red\"><B>the spindly-legged head looks healthy and strong</B></span>"
+			. += "<span style=\"color:red\"><B>the spindly-legged head looks healthy and strong</B></span>"
 		else
-			+= "<span style=\"color:red\"><B>the ugly thing is missing several limbs</B></span>"
+			. += "<span style=\"color:red\"><B>the ugly thing is missing several limbs</B></span>"
 		return
 
 	filter_target(var/mob/living/C)

--- a/code/obj/critter/headspider.dm
+++ b/code/obj/critter/headspider.dm
@@ -14,16 +14,15 @@
 	var/datum/mind/owner = null
 
 	examine()
-		set src in view()
-		..()
+		. = ..()
 		if(src.hiddenFrom && hiddenFrom.Find(usr.client)) //invislist
 			return
 		if(!alive)
-			boutput(usr, text("<span style=\"color:red\"><B>the disgusting creature is not moving</B></span>"))
+			+= "<span style=\"color:red\"><B>the disgusting creature is not moving</B></span>"
 		else if (src.health > 40)
-			boutput(usr, text("<span style=\"color:red\"><B>the spindly-legged head looks healthy and strong</B></span>"))
+			+= "<span style=\"color:red\"><B>the spindly-legged head looks healthy and strong</B></span>"
 		else
-			boutput(usr, text("<span style=\"color:red\"><B>the ugly thing is missing several limbs</B></span>"))
+			+= "<span style=\"color:red\"><B>the ugly thing is missing several limbs</B></span>"
 		return
 
 	filter_target(var/mob/living/C)

--- a/code/obj/decal/poster.dm
+++ b/code/obj/decal/poster.dm
@@ -15,6 +15,7 @@
 	examine()
 		if (usr.client && src.popup_win)
 			src.show_popup_win(usr)
+			return list()
 		else
 			return ..()
 

--- a/code/obj/decorations.dm
+++ b/code/obj/decorations.dm
@@ -976,7 +976,7 @@ obj/decoration/ceilingfan
 	mouse_opacity = 0
 
 	examine()
-		return
+		return list()
 
 /obj/decoration/plasmabullethole
 	anchored = 2
@@ -985,4 +985,4 @@ obj/decoration/ceilingfan
 	mouse_opacity = 0
 
 	examine()
-		return
+		return list()

--- a/code/obj/displaycase.dm
+++ b/code/obj/displaycase.dm
@@ -131,30 +131,29 @@
 		..()
 		return
 
-	examine()
-		set src in usr
-		if (usr.mind && usr.mind.assigned_role == "Captain")
-			boutput(usr, "It's your laser gun! It's really just for show and made of plastic but man it looks cool. Everybody thinks you're awesome, and you know it.")
+	examine(mob/user)
+		. = ..()
+		if (user.mind && user.mind.assigned_role == "Captain")
+			. += "It's your laser gun! It's really just for show and made of plastic but man it looks cool. Everybody thinks you're awesome, and you know it."
 		else
-			boutput(usr, "On closer inspection, it looks like it's just a display model...? What a cheapskate. Fuck our captain.")
+			. += "On closer inspection, it looks like it's just a display model...? What a cheapskate. Fuck our captain."
 
 		if (src.repair_stage > 0)
 			switch (src.repair_stage)
 				if (1)
-					boutput(usr, "<br><span style=\"color:blue\">The maintenance panel is open, revealing a largely empty circuit board.</span>")
+					. += "<span style=\"color:blue\">The maintenance panel is open, revealing a largely empty circuit board.</span>"
 				if (2)
-					boutput(usr, "<br><span style=\"color:blue\">The wiring has been replaced, but there's still an empty spot in the circuit board.</span>")
+					. += "<span style=\"color:blue\">The wiring has been replaced, but there's still an empty spot in the circuit board.</span>"
 				if (3)
-					boutput(usr, "<br><span style=\"color:blue\">A new coil has been inserted, but not secured yet.</span>")
+					. += "<span style=\"color:blue\">A new coil has been inserted, but not secured yet.</span>"
 				if (4)
-					boutput(usr, "<br><span style=\"color:blue\">The coil has been soldered into place, but there's nothing to focus the laser beam.</span>")
+					. += "<span style=\"color:blue\">The coil has been soldered into place, but there's nothing to focus the laser beam.</span>"
 				if (5)
-					boutput(usr, "<br><span style=\"color:blue\">A lens has been installed, but the control circuits aren't set up yet.</span>")
+					. += "<span style=\"color:blue\">A lens has been installed, but the control circuits aren't set up yet.</span>"
 				if (6)
-					boutput(usr, "<br><span style=\"color:blue\">The gun appears to be missing a power cell.</span>")
+					. += "<span style=\"color:blue\">The gun appears to be missing a power cell.</span>"
 				if (7)
-					boutput(usr, "<br><span style=\"color:blue\">Power cell installed. The maintenance panel is open.</span>")
-		return
+					. += "<span style=\"color:blue\">Power cell installed. The maintenance panel is open.</span>"
 
 	attack()
 		..()

--- a/code/obj/health_scanner.dm
+++ b/code/obj/health_scanner.dm
@@ -55,11 +55,11 @@
 			else
 				. += "<br>It says:<br><font color='red'>ERROR: NO SUBJECT(S) DETECTED</font>"
 
-	attack_hand(mob/user as mob)
-		return src.examine()
+	attack_hand(mob/user)
+		return user.examine_verb(src)
 
-	attack_ai(mob/user as mob)
-		return src.examine()
+	attack_ai(mob/user)
+		return user.examine_verb(src)
 
 	find_partners(var/in_range = 0)
 		if (in_range)

--- a/code/obj/item/assembly/single_tank_bomb.dm
+++ b/code/obj/item/assembly/single_tank_bomb.dm
@@ -60,8 +60,8 @@
 	return
 
 /obj/item/assembly/proximity_bomb/examine()
-	..()
-	src.part3.examine()
+	. = ..()
+	. += src.part3.examine()
 
 /obj/item/assembly/proximity_bomb/disposing()
 	qdel(part1)
@@ -189,8 +189,8 @@
 	return
 
 /obj/item/assembly/time_bomb/examine()
-	..()
-	src.part3.examine()
+	. = ..()
+	. += src.part3.examine()
 
 /obj/item/assembly/time_bomb/disposing()
 	qdel(part1)
@@ -273,8 +273,8 @@
 	flags = FPRINT | TABLEPASS| CONDUCT
 
 /obj/item/assembly/radio_bomb/examine()
-	..()
-	src.part3.examine()
+	. = ..()
+	. += src.part3.examine()
 
 /obj/item/assembly/radio_bomb/disposing()
 

--- a/code/obj/item/book.dm
+++ b/code/obj/item/book.dm
@@ -16,10 +16,10 @@
 	stamina_cost = 2
 	stamina_crit_chance = 0
 
-	attack_self(mob/user as mob)
-		return src.examine()
+	attack_self(mob/user)
+		return user.examine_verb(src)
 
-	attackby(obj/item/P as obj, mob/user as mob)
+	attackby(obj/item/P, mob/user)
 		src.add_fingerprint(user)
 		return
 

--- a/code/obj/item/book.dm
+++ b/code/obj/item/book.dm
@@ -977,10 +977,9 @@
 		..()
 		BLOCK_BOOK
 
-	examine()
-		set src in view()
-		if (!issilicon(usr))
-			boutput(usr, "What...what is this? It's written entirely in barcodes or something, cripes. You can't make out ANY of this.")
+	examine(mob/user)
+		if (!issilicon(user))
+			. = list("What...what is this? It's written entirely in barcodes or something, cripes. You can't make out ANY of this.")
 			var/mob/living/carbon/jerk = usr
 			if (!istype(jerk))
 				return
@@ -991,11 +990,8 @@
 						if (S.fields["id"] == R.fields["id"])
 							S.fields["criminal"] = "*Arrest*"
 							S.fields["mi_crim"] = "Reading highly-confidential private information."
-
-			return
-
 		else
-			boutput(usr, "It appears to be heavily encrypted information.")
+			return list("It appears to be heavily encrypted information.")
 
 /obj/item/storage/photo_album/beepsky
 	name = "Beepsky's photo album"

--- a/code/obj/item/brain.dm
+++ b/code/obj/item/brain.dm
@@ -24,16 +24,16 @@
 		if (icon_state == "brain2")
 			desc = "A human brain. It looks [pick("small", "big", "normal", "rotten", "healthy", "tasty", "like it should be flushed down disposals", "bloody")]."
 
-/obj/item/brain/examine()
-	..()
-	if (usr.job == "Roboticist" || usr.job == "Medical Doctor" || usr.job == "Geneticist" || usr.job == "Medical Director")
+/obj/item/brain/examine(mob/user)
+	. = ..()
+	if (user.job == "Roboticist" || user.job == "Medical Doctor" || user.job == "Geneticist" || user.job == "Medical Director")
 		if (src.owner)
 			if (src.owner.current)
-				boutput(usr, "<span style=\"color:blue\">This brain is still warm.</span>")
+				. += "<span style=\"color:blue\">This brain is still warm.</span>"
 			else
-				boutput(usr, "<span style=\"color:red\">This brain has gone cold.</span>")
+				. += "<span style=\"color:red\">This brain has gone cold.</span>"
 		else
-			boutput(usr, "<span style=\"color:red\">This brain has gone cold.</span>")
+			. += "<span style=\"color:red\">This brain has gone cold.</span>"
 
 /obj/item/brain/throw_impact(var/turf/T)
 	playsound(src.loc, "sound/impact_sounds/Slimy_Splat_1.ogg", 100, 1)

--- a/code/obj/item/bruisepack_ointment.dm
+++ b/code/obj/item/bruisepack_ointment.dm
@@ -13,17 +13,8 @@
 	stamina_crit_chance = 3
 
 	examine()
-		set src in view(1)
-		set category = "Local"
-
-		if (src.amount <= 0)
-			qdel(src)
-			return
-
-		..()
-
-		boutput(usr, "[bicon(src)] <span style=\"color:blue\">There [src.amount == 1 ? "is" : "are"] [src.amount] [src.name]\s left on the stack!</span>")
-		return
+		. = ..()
+		. += "[bicon(src)] <span style=\"color:blue\">There [src.amount == 1 ? "is" : "are"] [src.amount] [src.name]\s left on the stack!</span>"
 
 	attack_hand(mob/user as mob)
 		if (user.r_hand == src || user.l_hand == src)

--- a/code/obj/item/building_materials.dm
+++ b/code/obj/item/building_materials.dm
@@ -227,11 +227,8 @@ MATERIAL
 		return 1
 
 	examine()
-		set src in view(1)
-
-		..()
-		boutput(usr, text("There are [] sheet\s on the stack.", src.amount))
-		return
+		. = ..()
+		. += "There are [src.amount] sheet\s on the stack."
 
 	attack_self(mob/user as mob)
 		var/t1 = text("<HTML><HEAD></HEAD><TT>Amount Left: [] <BR>", src.amount)
@@ -622,11 +619,8 @@ MATERIAL
 		boutput(user, "<span style=\"color:blue\">You finish gathering rods.</span>")
 
 	examine()
-		set src in view(1)
-
-		..()
-		boutput(usr, text("There are [amount] rods in this stack."))
-		return
+		. = ..()
+		. += "There are [src.amount] rod\s on this stack."
 
 	attack_hand(mob/user as mob)
 		if((user.r_hand == src || user.l_hand == src) && src.amount > 1)

--- a/code/obj/item/cable_coil.dm
+++ b/code/obj/item/cable_coil.dm
@@ -221,20 +221,15 @@
 		return
 
 /obj/item/cable_coil/examine()
-	set src in view(1)
-	set category = "Local"
-
 	if (amount == 1)
-		boutput(usr, "A short piece of [base_name].")
-	else if (amount == 1)
-		boutput(usr, "A piece of [base_name].")
+		. = list("A short piece of [base_name].")
 	else
-		boutput(usr, "A coil of [base_name]. There's [amount] length[s_es(amount)] of cable in the coil.")
+		. = list("A coil of [base_name]. There's [amount] length[s_es(amount)] of cable in the coil.")
 
 	if (insulator)
-		boutput(usr, "It is insulated with [insulator].")
+		. += "It is insulated with [insulator]."
 	if (conductor)
-		boutput(usr, "Its conductive layer is made out of [conductor].")
+		. += "Its conductive layer is made out of [conductor]."
 
 /obj/item/cable_coil/attackby(obj/item/W, mob/user)
 	if (issnippingtool(W) && src.amount > 1)

--- a/code/obj/item/cameras.dm
+++ b/code/obj/item/cameras.dm
@@ -39,9 +39,8 @@
 
 
 	examine()
-		..()
-		boutput(usr, "There are [src.pictures_left < 0 ? "a whole lot of" : src.pictures_left] pictures left!")
-		return
+		. = ..()
+		. += "There are [src.pictures_left < 0 ? "a whole lot of" : src.pictures_left] pictures left!"
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (istype(W, /obj/item/camera_film))
@@ -98,9 +97,8 @@
 		mats = 15
 
 	examine()
-		..()
-		boutput(usr, "It is good for [src.pictures] pictures.")
-		return
+		. = ..()
+		. += "It is good for [src.pictures] pictures."
 
 
 /obj/item/photo

--- a/code/obj/item/card.dm
+++ b/code/obj/item/card.dm
@@ -259,10 +259,10 @@ GAUNTLET CARDS
 			if(access == starting_access) //don't delete access if it's modified with an ID computer
 				access = list()
 
-/obj/item/card/id/temporary/examine()
-	..()
-	if(usr.client && src.timer)
-		boutput(usr, "A small display in the corner reads: \"Time remaining: [max(0,round((end_time-ticker.round_elapsed_ticks)/10))] seconds.\"")
+/obj/item/card/id/temporary/examine(mob/user)
+	. = ..()
+	if(user.client && src.timer)
+		. += "A small display in the corner reads: \"Time remaining: [max(0,round((end_time-ticker.round_elapsed_ticks)/10))] seconds.\""
 
 /obj/item/card/id/gauntlet
 	icon = 'icons/effects/VR.dmi'
@@ -349,4 +349,3 @@ GAUNTLET CARDS
 				message_admins("[key_name(user)] dropped their license to kill")
 			owner = user
 		..()
-

--- a/code/obj/item/clothing/armor.dm
+++ b/code/obj/item/clothing/armor.dm
@@ -100,13 +100,11 @@
 		return
 
 	examine()
-		set src in oview(2)
-		..()
+		. = ..()
 		if (src.payload)
-			boutput(usr, "<span style=\"color:red\">Looks like the payload is a [src.payload].</span>")
+			. += "<span style=\"color:red\">Looks like the payload is a [src.payload].</span>"
 		else
-			boutput(usr, "<span style=\"color:red\">There doesn't appear to be a payload attached.</span>")
-		return
+			. += "<span style=\"color:red\">There doesn't appear to be a payload attached.</span>"
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		src.add_fingerprint(user)

--- a/code/obj/item/clothing/gloves.dm
+++ b/code/obj/item/clothing/gloves.dm
@@ -44,10 +44,9 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 		return
 
 	examine()
-		..()
+		. = ..()
 		if (src.stunready)
-			boutput(usr, "It seems to have some wires attached to it.[src.max_uses > 0 ? " There are [src.uses]/[src.max_uses] charges left!" : ""]")
-		return
+			. += "It seems to have some wires attached to it.[src.max_uses > 0 ? " There are [src.uses]/[src.max_uses] charges left!" : ""]"
 
 	// reworked this proc a bit so it can't run more than 5 times, just in case
 	proc/CreateID()

--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -263,34 +263,28 @@
 
 	New()
 		..()
-		items = list("bodybag" = /obj/item/body_bag, \
-									"scanner" = /obj/item/device/detective_scanner, \
-									"lighter" = /obj/item/device/light/zippo/, \
-									"spray" = /obj/item/spraybottle, \
-									"monitor" = /obj/item/device/camera_viewer, \
-									"camera" = /obj/item/camera_test, \
-									"audiolog" = /obj/item/device/audio_log , \
-									"flashlight" = /obj/item/device/light/flashlight, \
+		items = list("bodybag" = /obj/item/body_bag,
+									"scanner" = /obj/item/device/detective_scanner,
+									"lighter" = /obj/item/device/light/zippo/,
+									"spray" = /obj/item/spraybottle,
+									"monitor" = /obj/item/device/camera_viewer,
+									"camera" = /obj/item/camera_test,
+									"audiolog" = /obj/item/device/audio_log ,
+									"flashlight" = /obj/item/device/light/flashlight,
 									"glasses" = /obj/item/clothing/glasses)
 		cigs = list()
 	examine()
-		set src in view()
-		set category = "Local"
-
-		..()
-		var/str = "<span style=\"color:blue\">Current activation phrase is <b>\"[phrase]\"</b>.</span>"
+		. = ..()
+		. += "<span style=\"color:blue\">Current activation phrase is <b>\"[phrase]\"</b>.</span>"
 		for (var/name in items)
 			var/type = items[name]
 			var/obj/item/I = locate(type) in contents
 			if(I)
-				str += "<br><span style=\"color:blue\">[bicon(I)][I] is ready and bound to the word \"[name]\"!</span>"
+				. += "<br><span style=\"color:blue\">[bicon(I)][I] is ready and bound to the word \"[name]\"!</span>"
 			else
-				str += "<br>There is no [name]!"
+				. += "<br>There is no [name]!"
 		if (cigs.len)
-			str += "<br><span style=\"color:blue\">It contains <b>[cigs.len]</b> cigarettes!</span>"
-
-		usr.show_message(str)
-		return
+			. += "<br><span style=\"color:blue\">It contains <b>[cigs.len]</b> cigarettes!</span>"
 
 	hear_talk(mob/M as mob, msg, real_name, lang_id)
 		var/turf/T = get_turf(src)
@@ -1014,10 +1008,9 @@
 		item_state = "sunhatg"
 
 	examine()
-		..()
+		. = ..()
 		if (src.stunready)
-			boutput(usr, "It appears to be been modified into a... stunhat? [src.max_uses > 0 ? " There are [src.uses]/[src.max_uses] charges left!" : ""]")
-		return
+			. += "It appears to be been modified into a... stunhat? [src.max_uses > 0 ? " There are [src.uses]/[src.max_uses] charges left!" : ""]"
 
 	attackby(obj/item/W, mob/user)
 		if (istype(W, /obj/item/cable_coil))

--- a/code/obj/item/device/igniter.dm
+++ b/code/obj/item/device/igniter.dm
@@ -152,14 +152,10 @@
 
 	return
 
-/obj/item/device/igniter/examine()
-	set src in view()
-	set category = "Local"
-
-	..()
-	if ((in_range(src, usr) || src.loc == usr))
+/obj/item/device/igniter/examine(mob/user)
+	. = ..()
+	if ((in_range(src, user) || src.loc == user))
 		if (src.status)
-			usr.show_message("The igniter is ready!")
+			. += "The igniter is ready!"
 		else
-			usr.show_message("The igniter can be attached!")
-	return
+			. += "The igniter can be attached!"

--- a/code/obj/item/device/lightbreaker.dm
+++ b/code/obj/item/device/lightbreaker.dm
@@ -1,5 +1,6 @@
 /obj/item/lightbreaker
 	name = "compact tape"
+	desc = "A casette player loaded with a casette of a vampire's screech."
 	icon = 'icons/obj/items/device.dmi'
 	icon_state = "recorder"
 	var/active = 0.0
@@ -16,12 +17,11 @@
 	var/ammo = 4
 
 	examine()
+		. = ..()
 		if(src.ammo > 0)
-			src.desc = "A casette player loaded with a casette of a vampire's screech. It has [src.ammo] uses left out of 4."
+			. += "It has [src.ammo] uses left out of [initial(src.ammo)]."
 		else
-			src.desc = "A casette player loaded with a casette of a vampire's screech. The tape has worn out!"
-		..()
-		return
+			. += "The tape has worn out!"
 
 	attack_self(mob/user as mob)
 		src.add_fingerprint(user)

--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -481,11 +481,10 @@
 				boutput(user, "<span style=\"color:blue\">You insert [ID] into [src].</span>")
 
 /obj/item/device/pda2/examine()
-	..()
-	boutput(usr, "The back cover is [src.closed ? "closed" : "open"].")
+	. = ..()
+	. += "The back cover is [src.closed ? "closed" : "open"]."
 	if (src.ID_card)
-		boutput(usr, "[ID_card] has been inserted into it.")
-	return
+		. += "[ID_card] has been inserted into it."
 
 /obj/item/device/pda2/receive_signal(datum/signal/signal, rx_method, rx_freq)
 	if(!signal || signal.encryption || !src.owner) return

--- a/code/obj/item/device/radio.dm
+++ b/code/obj/item/device/radio.dm
@@ -334,7 +334,7 @@ Green Wire: <a href='?src=\ref[src];wires=[WIRE_TRANSMIT]'>[src.wires & WIRE_TRA
 	if (src.protected_radio != 1 && isnull(src.traitorradio))
 		for (var/mob/living/L in radio_brains)
 			receive += L
-			
+
 		for(var/mob/zoldorf/z in the_zoldorf)
 			if(z.client)
 				receive += z
@@ -531,22 +531,17 @@ Green Wire: <a href='?src=\ref[src];wires=[WIRE_TRANSMIT]'>[src.wires & WIRE_TRA
 			SPAWN_DBG(1.5 SECONDS)
 				UpdateOverlays(null, "speech_bubble")
 
-/obj/item/device/radio/examine()
-	set src in view()
-	set category = "Local"
-
-	..()
-	if ((in_range(src, usr) || src.loc == usr))
+/obj/item/device/radio/examine(mob/user)
+	. = ..()
+	if ((in_range(src, user) || src.loc == user))
 		if (src.b_stat)
-			usr.show_message("<span style=\"color:blue\">\the [src] can be attached and modified!</span>")
+			. += "<span style=\"color:blue\">\the [src] can be attached and modified!</span>"
 		else
-			usr.show_message("<span style=\"color:blue\">\the [src] can not be modified or attached!</span>")
+			. += "<span style=\"color:blue\">\the [src] can not be modified or attached!</span>"
 	if (istype(src.secure_frequencies) && src.secure_frequencies.len)
-		var/o = "Supplementary Channels:"
+		. += "Supplementary Channels:"
 		for (var/sayToken in src.secure_frequencies) //Most convoluted string of the year award 2013
-			o += "<br>[ headset_channel_lookup["[src.secure_frequencies["[sayToken]"]]"] ? headset_channel_lookup["[src.secure_frequencies["[sayToken]"]]"] : "???" ]: \[[format_frequency(src.secure_frequencies["[sayToken]"])]] (Activator: <b>[sayToken]</b>)"
-		boutput(usr, o)
-	return
+			. += "[ headset_channel_lookup["[src.secure_frequencies["[sayToken]"]]"] ? headset_channel_lookup["[src.secure_frequencies["[sayToken]"]]"] : "???" ]: \[[format_frequency(src.secure_frequencies["[sayToken]"])]] (Activator: <b>[sayToken]</b>)"
 
 /obj/item/device/radio/attackby(obj/item/W as obj, mob/user as mob)
 	user.machine = src
@@ -1008,14 +1003,8 @@ obj/item/device/radio/signaler/attackby(obj/item/W as obj, mob/user as mob)
 			talk_into(M, msgs, null, real_name, lang_id)
 
 /obj/item/device/radio/intercom/loudspeaker/examine()
-	set src in view()
-	set category = "Local"
-
-	..()
-	boutput(usr, "[src] is[src.broadcasting ? " " : " not "]active!")
-	boutput(usr, "It is tuned to [format_frequency(src.frequency)]Hz.")
-
-	return
+	. = ..()
+	. += "[src] is[src.broadcasting ? " " : " not "]active!\nIt is tuned to [format_frequency(src.frequency)]Hz."
 
 /obj/item/device/radio/intercom/loudspeaker/attack_self(mob/user as mob)
 	if (!broadcasting)

--- a/code/obj/item/fingerprint.dm
+++ b/code/obj/item/fingerprint.dm
@@ -118,14 +118,9 @@
 
 
 /obj/item/f_card/examine()
-	set src in view(2)
-	set category = "Local"
-
-	..()
-	boutput(usr, text("<span style=\"color:blue\">There are [] on the stack!</span>", src.amount))
-	usr << browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", src.name, display()), text("window=[]", src.name))
-	onclose(usr, "[src.name]")
-	return
+	. = ..()
+	. += "<span style=\"color:blue\">There are [src.amount] on the stack!</span>"
+	. += src.display()
 
 /obj/item/f_card/proc/display()
 

--- a/code/obj/item/glass.dm
+++ b/code/obj/item/glass.dm
@@ -93,11 +93,8 @@ SHARDS
 				return
 
 	examine()
-		set src in view(1)
-
-		..()
-		boutput(usr, text("There are [] glass sheet\s on the stack.", src.amount))
-		return
+		. = ..()
+		. += "There are [src.amount] glass sheet\s on the stack."
 
 	attack_self(mob/user as mob)
 

--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -852,12 +852,11 @@
 
 	examine()
 		if (src.artifact)
-			boutput(usr, text("You have no idea what this thing is!"))
+			return list("You have no idea what this thing is!")
+		. = ..()
+		if (src.unusualCell)
 			return
-		..()
-		if (src.unusualCell) return
-		boutput(usr, "There are [src.charge]/[src.max_charge] PU left!")
-		return
+		. += "There are [src.charge]/[src.max_charge] PU left!"
 
 	use(var/amt = 0)
 		if (src.charge <= 0)

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -27,17 +27,15 @@
 
 
 	examine()
-		set src in usr
+		. = ..()
 		if(src.cell)
-			src.desc = "[src.projectiles ? "It is set to [src.current_projectile.sname]. " : ""]There are [src.cell.charge]/[src.cell.max_charge] PUs left!"
+			. += "[src.projectiles ? "It is set to [src.current_projectile.sname]. " : ""]There are [src.cell.charge]/[src.cell.max_charge] PUs left!"
 		else
-			src.desc = "There is no cell loaded!"
+			. += "There is no cell loaded!"
 		if(current_projectile)
-			src.desc += " Each shot will currently use [src.current_projectile.cost] PUs!"
+			. += "Each shot will currently use [src.current_projectile.cost] PUs!"
 		else
-			src.desc += "<span style=\"color:red\">*ERROR* No output selected!</span>"
-		..()
-		return
+			. += "<span style=\"color:red\">*ERROR* No output selected!</span>"
 
 	update_icon()
 		return 0

--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -408,15 +408,9 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 	return 0
 
 /obj/item/gun/examine()
-	set src in usr
-	set category = "Local"
-
 	if (src.artifact)
-		boutput(usr, "You have no idea what the hell this thing is!")
-		return
-
-	..()
-	return
+		return list("You have no idea what the hell this thing is!")
+	return ..()
 
 /obj/item/gun/proc/update_icon()
 	return 0

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -26,17 +26,16 @@
 	// 1.58 - RPG-7 (Tube is 40mm too, though warheads are usually larger in diameter.)
 
 	examine()
-		set src in usr
+		. = ..()
 		if (src.ammo && (src.ammo.amount_left > 0))
 			var/datum/projectile/ammo_type = src.ammo
-			src.desc = "There are [src.ammo.amount_left][(ammo_type.material && istype(ammo_type, /datum/material/metal/silver)) ? " silver " : " "]bullets of [src.ammo.sname] left!"
+			. += "There are [src.ammo.amount_left][(ammo_type.material && istype(ammo_type, /datum/material/metal/silver)) ? " silver " : " "]bullets of [src.ammo.sname] left!"
 		else
-			src.desc = "There are 0 bullets left!"
+			. += "There are 0 bullets left!"
 		if (current_projectile)
-			src.desc += "<br>Each shot will currently use [src.current_projectile.cost] bullets!"
+			. += "Each shot will currently use [src.current_projectile.cost] bullets!"
 		else
-			src.desc += "<br><span style=\"color:red\">*ERROR* No output selected!</span>"
-		..()
+			. += "<span style=\"color:red\">*ERROR* No output selected!</span>"
 
 	update_icon()
 		return 0

--- a/code/obj/item/handcuffs.dm
+++ b/code/obj/item/handcuffs.dm
@@ -22,10 +22,9 @@
 		strength = 1
 
 /obj/item/handcuffs/examine()
-	..()
+	. = ..()
 	if (src.delete_on_last_use)
-		boutput(usr, "There are [src.amount] lengths of [istype(src, /obj/item/handcuffs/tape_roll) ? "tape" : "ziptie"] left!")
-	return
+		. += "There are [src.amount] lengths of [istype(src, /obj/item/handcuffs/tape_roll) ? "tape" : "ziptie"] left!"
 
 /obj/item/handcuffs/suicide(var/mob/living/carbon/human/user as mob) //brutal
 	if (!istype(user) || !user.organHolder || !src.user_can_suicide(user))

--- a/code/obj/item/magtractor.dm
+++ b/code/obj/item/magtractor.dm
@@ -127,13 +127,11 @@
 			actions.stopId("magpickerhold", usr)
 
 	examine()
-		..()
-		var/msg = "<span style='color: blue;'>"
+		. = ..()
 		if (src.highpower)
-			msg += "The [src] has HPM enabled!<br>"
+			. += "<span style='color: blue;'>The [src] has HPM enabled!</span>"
 		if (src.holding)
-			msg += "\The [src.holding] is enveloped in the magnetic field.<br>"
-		out(usr, "[msg]</span>")
+			. += "<span style='color: blue;'>\The [src.holding] is enveloped in the magnetic field.</span>"
 
 	proc/releaseItem()
 		set src in usr

--- a/code/obj/item/metal.dm
+++ b/code/obj/item/metal.dm
@@ -33,11 +33,8 @@ MATERIAL
 		boutput(user, "<span style=\"color:blue\">You finish gathering rods.</span>")
 
 	examine()
-		set src in view(1)
-
-		..()
-		boutput(usr, text("There are [amount] rods in this stack."))
-		return
+		. = ..()
+		. += "There are [amount] rod\s in this stack."
 
 	attack_hand(mob/user as mob)
 		if((user.r_hand == src || user.l_hand == src) && src.amount > 1)

--- a/code/obj/item/metal.dm
+++ b/code/obj/item/metal.dm
@@ -175,12 +175,8 @@ MATERIAL
 		boutput(user, "<span style=\"color:blue\">You finish stacking metal.</span>")
 
 	metal/examine()
-		set src in view(1)
-		set category = "Local"
-
-		..()
-		boutput(usr, text("There are [] metal sheet\s on the stack.", src.amount))
-		return
+		. = ..()
+		. += "There are [src.amount] metal sheet\s on the stack."
 
 	attack_hand(mob/user as mob)
 		if((user.r_hand == src || user.l_hand == src) && src.amount > 1)

--- a/code/obj/item/mine.dm
+++ b/code/obj/item/mine.dm
@@ -28,10 +28,9 @@
 		return
 
 	examine()
-		..()
+		. = ..()
 		if (src.suppress_flavourtext != 1)
-			boutput(usr, "It appears to be [src.armed == 1 ? "armed" : "disarmed"].")
-		return
+			. += "It appears to be [src.armed == 1 ? "armed" : "disarmed"]."
 
 	attack_hand(mob/user as mob)
 		src.add_fingerprint(user)

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -340,10 +340,8 @@
 	hit_type = DAMAGE_BLUNT
 
 	examine()
-		set src in usr
-		src.desc = "It is set to [src.active ? "on" : "off"]."
 		..()
-		return
+		. += "It is set to [src.active ? "on" : "off"]."
 
 /obj/item/sword/discount/attack(mob/target, mob/user, def_zone, is_special = 0)
 	//hhaaaaxxxxxxxx. overriding the disorient for my own effect

--- a/code/obj/item/mob_parts/robot_parts.dm
+++ b/code/obj/item/mob_parts/robot_parts.dm
@@ -27,17 +27,22 @@
 	stamina_crit_chance = 5
 
 	examine()
-		set src in oview()
-		..()
+		. = ..()
 		switch(ropart_get_damage_percentage(1))
-			if(15 to 29) boutput(usr, "<span style=\"color:red\">It looks a bit dented and worse for wear.</span>")
-			if(29 to 59) boutput(usr, "<span style=\"color:red\">It looks somewhat bashed up.</span>")
-			if(60 to INFINITY) boutput(usr, "<span style=\"color:red\">It looks badly mangled.</span>")
+			if(15 to 29)
+				. += "<span style=\"color:red\">It looks a bit dented and worse for wear.</span>"
+			if(29 to 59)
+				. += "<span style=\"color:red\">It looks somewhat bashed up.</span>"
+			if(60 to INFINITY)
+				. += "<span style=\"color:red\">It looks badly mangled.</span>"
 
 		switch(ropart_get_damage_percentage(2))
-			if(15 to 29) boutput(usr, "<span style=\"color:red\">It has some light scorch marks.</span>")
-			if(29 to 59) boutput(usr, "<span style=\"color:red\">Parts of it are kind of melted.</span>")
-			if(60 to INFINITY) boutput(usr, "<span style=\"color:red\">It looks terribly burnt up.</span>")
+			if(15 to 29)
+				. += "<span style=\"color:red\">It has some light scorch marks.</span>"
+			if(29 to 59)
+				. += "<span style=\"color:red\">Parts of it are kind of melted.</span>"
+			if(60 to INFINITY)
+				. += "<span style=\"color:red\">It looks terribly burnt up.</span>"
 
 	getMobIcon(var/lying)
 		if (src.standImage)
@@ -161,14 +166,13 @@
 		icon_state = "head-" + src.appearanceString
 
 	examine()
-		set src in oview()
-		..()
+		. = ..()
 		if (src.brain)
-			boutput(usr, "<span style=\"color:blue\">This head unit has [src.brain] inside. Use a wrench if you want to remove it.</span>")
+			. += "<span style=\"color:blue\">This head unit has [src.brain] inside. Use a wrench if you want to remove it.</span>"
 		else if (src.ai_interface)
-			boutput(usr, "<span style=\"color:blue\">This head unit has [src.ai_interface] inside. Use a wrench if you want to remove it.</span>")
+			. += "<span style=\"color:blue\">This head unit has [src.ai_interface] inside. Use a wrench if you want to remove it.</span>"
 		else
-			boutput(usr, "<span style=\"color:red\">This head unit is empty.</span>")
+			. += "<span style=\"color:red\">This head unit is empty.</span>"
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (!W)
@@ -390,12 +394,17 @@
 	var/obj/item/cell/cell = null
 
 	examine()
-		set src in oview()
-		..()
-		if (src.cell) boutput(usr, "<span style=\"color:blue\">This chest unit has a [src.cell] installed. Use a wrench if you want to remove it.</span>")
-		else boutput(usr, "<span style=\"color:red\">This chest unit has no power cell.</span>")
-		if (src.wires) boutput(usr, "<span style=\"color:blue\">This chest unit has had wiring installed.</span>")
-		else boutput(usr, "<span style=\"color:red\">This chest unit has not yet been wired up.</span>")
+		. = ..()
+
+		if (src.cell)
+			. += "<span style=\"color:blue\">This chest unit has a [src.cell] installed. Use a wrench if you want to remove it.</span>"
+		else
+			. += "<span style=\"color:red\">This chest unit has no power cell.</span>"
+
+		if (src.wires)
+			. += "<span style=\"color:blue\">This chest unit has had wiring installed.</span>"
+		else
+			. += "<span style=\"color:red\">This chest unit has not yet been wired up.</span>"
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		if(istype(W, /obj/item/cell))

--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -36,7 +36,7 @@ WET FLOOR SIGN
 
 	examine()
 		. = ..()
-		. += "[bicon(src)] [src.reagents.total_volume] units of luminol left!")
+		. += "[bicon(src)] [src.reagents.total_volume] units of luminol left!"
 
 /obj/item/spraybottle/cleaner/
 	name = "cleaner bottle"

--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -263,11 +263,9 @@ WET FLOOR SIGN
 	STOP_TRACKING
 
 /obj/item/mop/examine()
-	set src in view()
-	set category = "Local"
-	..()
+	. = ..()
 	if(reagents && reagents.total_volume)
-		boutput(usr, "<span style=\"color:blue\">[src] is wet!</span>")
+		. += "<span style=\"color:blue\">[src] is wet!</span>"
 
 /obj/item/mop/afterattack(atom/A, mob/user as mob)
 	if ((src.reagents.total_volume < 1 || mopcount >= 9) && !istype(A, /obj/fluid))
@@ -433,11 +431,9 @@ WET FLOOR SIGN
 	..()
 
 /obj/item/sponge/examine()
-	set src in view()
-	set category = "Local"
-	..()
+	. = ..()
 	if(reagents && reagents.total_volume)
-		boutput(usr, "<span style=\"color:blue\">The sponge is wet!</span>")
+		. += "<span style=\"color:blue\">[src] is wet!</span>"
 
 /obj/item/sponge/attack_self(mob/user as mob)
 	if(spam_flag)

--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -33,11 +33,10 @@ WET FLOOR SIGN
 		reagents = R
 		R.my_atom = src
 		R.add_reagent("luminol", 100)
+
 	examine()
-		set src in usr
-		boutput(usr, "[bicon(src)] [src.reagents.total_volume] units of luminol left!")
-		..()
-		return
+		. = ..()
+		. += "[bicon(src)] [src.reagents.total_volume] units of luminol left!")
 
 /obj/item/spraybottle/cleaner/
 	name = "cleaner bottle"

--- a/code/obj/item/mousetrap.dm
+++ b/code/obj/item/mousetrap.dm
@@ -39,12 +39,9 @@
 				return
 
 	examine()
-		set src in oview(12)
-		set category = "Local"
-		..()
+		. = ..()
 		if (src.armed)
-			boutput(usr, "<span style=\"color:red\">It looks like it's armed.</span>")
-		return
+			. += "<span style=\"color:red\">It looks like it's armed.</span>"
 
 	attack_self(mob/user as mob)
 		if (!src.armed)

--- a/code/obj/item/organs/skull.dm
+++ b/code/obj/item/organs/skull.dm
@@ -41,13 +41,9 @@
 		key = null
 
 	examine() // For the hunter-specific objective (Convair880).
-		set src in usr
+		. = ..()
 		if (ishunter(usr))
-			var/trophy = "This is [src.name]<br>[src.preddesc]<br>This trophy has a value of [src.value]."
-			boutput(usr, trophy)
-		else
-			..()
-		return
+			. += "[src.preddesc]\nThis trophy has a value of [src.value]."
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (istype(W, /obj/item/parts/robot_parts/leg))

--- a/code/obj/item/paper.dm
+++ b/code/obj/item/paper.dm
@@ -97,41 +97,34 @@
 
 	return
 
-/obj/item/paper/examine()
-	set src in view()
-	set category = "Local"
-
-	..()
-	if(ismob(usr) && !usr.literate)
-		. = html_encode(illiterateGarbleText(src.info)) // deny them ANY useful information
+/obj/item/paper/examine(mob/user)
+	. = ..()
+	var/windowtext
+	if(!user.literate)
+		windowtext = html_encode(illiterateGarbleText(src.info)) // deny them ANY useful information
 	else
-		. = src.info
+		windowtext = src.info
 		if (src.form_startpoints && src.form_endpoints)
 			for (var/x = src.form_startpoints.len, x > 0, x--)
-				. = copytext(., 1, src.form_startpoints[src.form_startpoints[x]]) + "<a href='byond://?src=\ref[src];form=[src.form_startpoints[x]]'>" + copytext(., src.form_startpoints[src.form_startpoints[x]], src.form_endpoints[src.form_endpoints[x]]) + "</a>" + copytext(., src.form_endpoints[src.form_endpoints[x]])
+				windowtext = copytext(., 1, src.form_startpoints[src.form_startpoints[x]]) + "<a href='byond://?src=\ref[src];form=[src.form_startpoints[x]]'>" + copytext(., src.form_startpoints[src.form_startpoints[x]], src.form_endpoints[src.form_endpoints[x]]) + "</a>" + copytext(., src.form_endpoints[src.form_endpoints[x]])
 
 	var/font_junk = ""
 	for (var/i in src.fonts)
 		font_junk += "<link href='http://fonts.googleapis.com/css?family=[i]' rel='stylesheet' type='text/css'>"
 
-	usr.Browse("<HTML><HEAD><TITLE>[src.name]</TITLE>[font_junk]</HEAD><BODY><TT>[.]</TT></BODY></HTML>", "window=[src.name][(sizex || sizey) ? {";size=[sizex]x[sizey]"} : ""]")
+	usr.Browse("<HTML><HEAD><TITLE>[src.name]</TITLE>[font_junk]</HEAD><BODY><TT>[windowtext]</TT></BODY></HTML>", "window=[src.name][(sizex || sizey) ? {";size=[sizex]x[sizey]"} : ""]")
 	onclose(usr, "[src.name]")
-	return null
 
 //[(sizex || sizey) ? {";size=[sizex]x[sizey]"} : ""]
-/obj/item/paper/Map/examine()
-	set src in view()
-	set category = "Local"
+/obj/item/paper/Map/examine(mob/user)
+	. = ..()
 
-	..()
-
-	if (!( ishuman(usr) || isobserver(usr) || issilicon(usr) ))
-		usr.Browse("<HTML><HEAD><TITLE>[src.name]</TITLE></HEAD><BODY><TT>[stars(src.info)]</TT></BODY></HTML>", "window=[src.name]")
-		onclose(usr, "[src.name]")
+	if (!( ishuman(user) || isobserver(user) || issilicon(user) ))
+		user.Browse("<HTML><HEAD><TITLE>[src.name]</TITLE></HEAD><BODY><TT>[stars(src.info)]</TT></BODY></HTML>", "window=[src.name]")
+		onclose(user, "[src.name]")
 	else
-		usr.Browse("<HTML><HEAD><TITLE>[src.name]</TITLE></HEAD><BODY><TT>[src.info]</TT></BODY></HTML>", "window=[src.name]")
-		onclose(usr, "[src.name]")
-	return
+		user.Browse("<HTML><HEAD><TITLE>[src.name]</TITLE></HEAD><BODY><TT>[src.info]</TT></BODY></HTML>", "window=[src.name]")
+		onclose(user, "[src.name]")
 
 /obj/item/paper/custom_suicide = 1
 /obj/item/paper/suicide(var/mob/user as mob)
@@ -1137,8 +1130,8 @@ Only trained personnel should operate station systems. Follow all procedures car
 	return
 
 /obj/item/stamp/examine()
-	..()
-	boutput(usr, "It is set to '[current_mode]' mode.")
+	. = ..()
+	. += "It is set to '[current_mode]' mode."
 
 /obj/item/stamp/reagent_act(reagent_id, volume)
 	if (..())
@@ -1253,9 +1246,9 @@ WHO DID THIS */
 
 /obj/item/paper/folded/examine()
 	if (src.sealed)
-		boutput(usr, desc)
+		return list(desc)
 	else
-		..()
+		return ..()
 
 /obj/item/paper/folded/plane
 	name = "paper plane"

--- a/code/obj/item/paper.dm
+++ b/code/obj/item/paper.dm
@@ -196,7 +196,7 @@
 				t = sign_name(t, usr)
 				src.info = copytext(src.info, 1, form_startpoints[.]) + "" + t + "" + copytext(src.info, form_startpoints[.] + length(t))
 				build_formpoints()
-				src.examine()
+				usr.examine_verb(src)
 
 		if (istype(usr.equipped(), /obj/item/stamp))
 			var/obj/item/stamp/S = usr.equipped()
@@ -215,7 +215,7 @@
 						src.info = copytext(src.info, 1, form_startpoints[.]) + "" + T + "" + copytext(src.info, form_endpoints[.])
 						src.icon_state = "paper_stamped"
 						build_formpoints()
-						src.examine()
+						usr.examine_verb(src)
 
 	src.add_fingerprint(usr)
 

--- a/code/obj/item/paper.dm
+++ b/code/obj/item/paper.dm
@@ -915,9 +915,7 @@ Only trained personnel should operate station systems. Follow all procedures car
 
 	examine()
 		usr << browse_rsc(icon(print_icon,print_icon_state), "sstv_cachedimage.png")
-		..()
-		return
-
+		. = ..()
 
 	satellite
 		print_icon_state = "sstv_2"

--- a/code/obj/item/pens_writing_etc.dm
+++ b/code/obj/item/pens_writing_etc.dm
@@ -860,9 +860,9 @@
 		..()
 		src.display_booklet_contents(user,1)
 
-	examine()
-		..()
-		src.display_booklet_contents(usr, 1)
+	examine(mob/user)
+		. = ..()
+		src.display_booklet_contents(user, 1)
 
 	Topic(href, href_list)
 		..()

--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -272,9 +272,8 @@
 		return ..()
 
 	examine()
-		..()
-		boutput(usr, "There are [src.charge]/[src.maxCharge] PU left.")
-		return
+		. = ..()
+		. += "There are [src.charge]/[src.maxCharge] PU left."
 
 	buildTooltipContent()
 		var/content = ..()

--- a/code/obj/item/storage/toolbox.dm
+++ b/code/obj/item/storage/toolbox.dm
@@ -115,20 +115,16 @@
 	var/original_owner = null
 	cant_other_remove = 1
 
-	examine()
-		set src in view()
-		var/mob/living/carbon/human/H = usr
+	examine(mob/user)
+		. = ..()
+		var/mob/living/carbon/human/H = user
 		if(!istype(H))
-			boutput(H, "It almost hurts to look at that, it's all out of focus.")
+			. += "It almost hurts to look at that, it's all out of focus."
 			return
-		if (H.find_ailment_by_type(/datum/ailment/disability/memetic_madness))
-			..()
-			return
-		else
+		if (!H.find_ailment_by_type(/datum/ailment/disability/memetic_madness))
 			H.contract_memetic_madness(src)
 			if (!original_owner)
 				original_owner = H
-		return
 
 	MouseDrop(over_object, src_location, over_location)
 		if(!ishuman(usr) || !usr:find_ailment_by_type(/datum/ailment/disability/memetic_madness))

--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -67,13 +67,12 @@
 		return
 
 	examine()
-		..()
+		. = ..()
 		if (src.uses_charges != 0 && src.uses_electricity != 0)
 			if (!src.cell || !istype(src.cell))
-				boutput(usr, "<span style=\"color:red\">No power cell installed.</span>")
+				. += "<span style=\"color:red\">No power cell installed.</span>"
 			else
-				boutput(usr, "The baton is turned [src.status ? "on" : "off"]. There are [src.cell.charge]/[src.cell.max_charge] PUs left! Each stun will use [src.cost_normal] PUs.")
-		return
+				. += "The baton is turned [src.status ? "on" : "off"]. There are [src.cell.charge]/[src.cell.max_charge] PUs left! Each stun will use [src.cost_normal] PUs."
 
 	emp_act()
 		if (src.uses_charges != 0 && src.uses_electricity != 0)
@@ -586,7 +585,7 @@
 			B.setProperty("rangedprot", 0.5)
 			B.setProperty("exploprot", 1)
 			. = ..()
-			
+
 	proc/update_icon()
 		icon_state = status ? "barrier_1" : "barrier_0"
 		item_state = status ? "barrier1" : "barrier0"

--- a/code/obj/item/tank.dm
+++ b/code/obj/item/tank.dm
@@ -237,13 +237,13 @@ Contains:
 			integrity++
 
 	examine()
-		set category = "Local"
-		var/obj/item/icon = src
 		if (istype(src.loc, /obj/item/assembly))
+			var/obj/item/icon = src
+			. = list()
 			icon = src.loc
 			if (!in_range(src, usr))
 				if (icon == src)
-					boutput(usr, "<span style=\"color:blue\">It's a [bicon(icon)]! If you want any more information you'll need to get closer.</span>")
+					. += "<span style=\"color:blue\">It's a [bicon(icon)]! If you want any more information you'll need to get closer.</span>"
 				return
 
 			var/celsius_temperature = src.air_contents.temperature-T0C
@@ -262,12 +262,9 @@ Contains:
 			else
 				descriptive = "furiously hot"
 
-			boutput(usr, "<span style=\"color:blue\">The [bicon(icon)] feels [descriptive]</span>")
-
+			. += "<span style=\"color:blue\">The [bicon(icon)] feels [descriptive]</span>"
 		else
-			..()
-
-		return
+			return ..()
 
 
 	attackby(obj/item/W as obj, mob/user as mob)

--- a/code/obj/item/tiles_wires.dm
+++ b/code/obj/item/tiles_wires.dm
@@ -31,11 +31,8 @@ TILES
 		return
 
 	examine()
-		set src in view(1)
-
-		..()
-		boutput(usr, text("There are [] tile\s left on the stack.", src.amount))
-		return
+		. = ..()
+		. += "There are [src.amount] tile\s left on the stack."
 
 	attack_hand(mob/user as mob)
 

--- a/code/obj/item/tool/weldingtool.dm
+++ b/code/obj/item/tool/weldingtool.dm
@@ -38,7 +38,7 @@
 
 	examine()
 		. = ..()
-		. += "It has [get_fuel()] units of fuel left!")
+		. += "It has [get_fuel()] units of fuel left!"
 
 	attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 		if (!src.welding)

--- a/code/obj/item/tool/weldingtool.dm
+++ b/code/obj/item/tool/weldingtool.dm
@@ -37,10 +37,8 @@
 		return
 
 	examine()
-		set src in usr
-		set category = "Local"
-		boutput(usr, "[bicon(src)] [src.name] contains [get_fuel()] units of fuel left!")
-		return
+		. = ..()
+		. += "It has [get_fuel()] units of fuel left!")
 
 	attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 		if (!src.welding)

--- a/code/obj/item/zoldorfmisc.dm
+++ b/code/obj/item/zoldorfmisc.dm
@@ -37,9 +37,7 @@
 	var/referencedorf
 
 	examine()
-		set src in oview()
-
-		..()
+		. = ..()
 
 		if((src.branded)&&(src.referencedorf))
 			if(istype(src.referencedorf,/obj/machinery/playerzoldorf) && (istype(usr,/mob/living/carbon/human)))
@@ -49,13 +47,13 @@
 					pz.brandlist.Add(user)
 					src.icon_state = ("fortunepaper")
 					user.visible_message("<span style=\"color:green\"><b>[user.name]'s skin seems to glow faintly.</b></span>","<span style=\"color:green\"><b>You feel an otherworldly presence coursing through you!</b></span>")
-					boutput(user,"<span style=\"color:green\"><b>Tip:</b> This will allow the zoldorf player to observe you like a ghost, if you wish to remain unseen, splashing yourself with holy water will clear the brand.</span>")
+					. += "<span style=\"color:green\"><b>Tip:</b> This will allow the zoldorf player to observe you like a ghost, if you wish to remain unseen, splashing yourself with holy water will clear the brand.</span>"
 					if(the_zoldorf.len)
 						boutput(the_zoldorf[1],"<span style=\"color:blue\"><b>[user.name] has been branded!</b> You may now observe them via Astral Projection.</span>")
 					src.branded = 0
 
 			else if (istype(src.referencedorf,/obj/machinery/playerzoldorf) && (istype(usr,/mob/zoldorf)))
-				boutput(usr,"<span style=\"color:green\"><b>This fortune is branded!</b></span>")
+				. += "<span style=\"color:green\"><b>This fortune is branded!</b></span>"
 
 //Totally Normal Deck of Cards (TM)
 /obj/item/zoldorfdeck //deck of many things code is a bit messy, but the deck stores the card information and player interaction, the card item stores the effects passed to them by the deck

--- a/code/obj/machinery/door/door_timer.dm
+++ b/code/obj/machinery/door/door_timer.dm
@@ -157,14 +157,14 @@
 				pixel_x = -22
 
 /obj/machinery/door_timer/examine()
-	set src in oview()
-	set category = "Local"
-	boutput(usr, "A remote control switch for a door.")
+	. = list("A remote control switch for a door.")
+	
 	if(src.timing)
 		var/second = src.time % 60
 		var/minute = (src.time - second) / 60
-		boutput(usr, "<span style=\"color:red\">Time Remaining: <b>[(minute ? text("[minute]:") : null)][second]</b></span>")
-	else boutput(usr, "<span style=\"color:red\">There is no time set.</span>")
+		. += "<span style=\"color:red\">Time Remaining: <b>[(minute ? text("[minute]:") : null)][second]</b></span>"
+	else
+		. += "<span style=\"color:red\">There is no time set.</span>"
 
 /obj/machinery/door_timer/process()
 	..()

--- a/code/obj/machinery/drone_recharger.dm
+++ b/code/obj/machinery/drone_recharger.dm
@@ -56,11 +56,9 @@
 			src.turnOff()
 
 	examine()
-		..()
-		var/msg = "<span style='color: blue;'>"
+		. = ..()
 		if (src.occupant)
-			msg += "[src.occupant] is currently using it."
-		out(usr, "[msg]</span>")
+			. += "<span style='color: blue;'>[src.occupant] is currently using it.</span>"
 
 	proc/turnOn(mob/living/silicon/ghostdrone/G)
 		if (!G || G.getStatusDuration("stunned")) return 0

--- a/code/obj/machinery/lightswitch.dm
+++ b/code/obj/machinery/lightswitch.dm
@@ -63,11 +63,9 @@
 			icon_state = "light0"
 			light.set_color(1, 0.50, 0.50)
 
-/obj/machinery/light_switch/examine()
-	set src in oview(1)
-	set category = "Local"
-	if(usr && !usr.stat)
-		boutput(usr, "A light switch. It is [on? "on" : "off"].")
+/obj/machinery/light_switch/examine(mob/user)
+	if(user && !user.stat)
+		return list("A light switch. It is [on? "on" : "off"].")
 
 /obj/machinery/light_switch/attack_hand(mob/user)
 

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -122,23 +122,25 @@
 		..()
 
 	examine()
-		..()
+		. = ..()
 		if (src.health < 100)
 			if (src.health < 50)
-				boutput(usr, "<span style=\"color:red\">It's rather badly damaged. It probably needs some wiring replaced inside.</span>")
+				. += "<span style=\"color:red\">It's rather badly damaged. It probably needs some wiring replaced inside.</span>"
 			else
-				boutput(usr, "<span style=\"color:red\">It's a bit damaged. It looks like it needs some welding done.</span>")
+				. += "<span style=\"color:red\">It's a bit damaged. It looks like it needs some welding done.</span>"
+
 		if	(status & BROKEN)
-			boutput(usr, "<span style=\"color:red\">It seems to be damaged beyond the point of operability.</span>")
+			. += "<span style=\"color:red\">It seems to be damaged beyond the point of operability.</span>"
 		if	(status & NOPOWER)
-			boutput(usr, "<span style=\"color:red\">It seems to be offline.</span>")
+			. += "<span style=\"color:red\">It seems to be offline.</span>"
+
 		switch(src.dismantle_stage)
 			if(1)
-				boutput(usr, "<span style=\"color:red\">It's partially dismantled. To deconstruct it, use a crowbar. To repair it, use a wrench.</span>")
+				. += "<span style=\"color:red\">It's partially dismantled. To deconstruct it, use a crowbar. To repair it, use a wrench.</span>"
 			if(2)
-				boutput(usr, "<span style=\"color:red\">It's partially dismantled. To deconstruct it, use wirecutters. To repair it, add reinforced metal.</span>")
+				. += "<span style=\"color:red\">It's partially dismantled. To deconstruct it, use wirecutters. To repair it, add reinforced metal.</span>"
 			if(3)
-				boutput(usr, "<span style=\"color:red\">It's partially dismantled. To deconstruct it, use a wrench. To repair it, add some cable.</span>")
+				. += "<span style=\"color:red\">It's partially dismantled. To deconstruct it, use a wrench. To repair it, add some cable.</span>"
 
 	process()
 		if (status & NOPOWER)

--- a/code/obj/machinery/meter.dm
+++ b/code/obj/machinery/meter.dm
@@ -73,21 +73,15 @@
 		radio_connection.post_signal(src, signal)
 
 /obj/machinery/meter/examine()
-	set src in oview(1)
-	set category = "Local"
-
-	var/t = "A gas flow meter. "
+	. = list("A gas flow meter. ")
 	if (src.target)
 		var/datum/gas_mixture/environment = target.return_air()
 		if(environment)
-			t += text("The pressure gauge reads [] kPa", round(environment.return_pressure(), 0.1))
+			. += text("The pressure gauge reads [] kPa", round(environment.return_pressure(), 0.1))
 		else
-			t += "The sensor error light is blinking."
+			. += "The sensor error light is blinking."
 	else
-		t += "The connect error light is blinking."
-
-	boutput(usr, t)
-
+		. += "The connect error light is blinking."
 
 
 /obj/machinery/meter/Click()

--- a/code/obj/machinery/nuclearbomb.dm
+++ b/code/obj/machinery/nuclearbomb.dm
@@ -66,30 +66,29 @@
 			src.maptext = "<span style=\"color: red; font-family: Fixedsys, monospace; text-align: center; vertical-align: top; -dm-text-outline: 1 black;\">[get_countdown_timer()]</span>"
 		return
 
-	examine()
-		..()
-		if(usr.client)
+	examine(mob/user)
+		. = ..()
+		if(user.client)
 			if (src.armed)
-				boutput(usr, "It is currently counting down to detonation. Ohhhh shit.")
-				boutput(usr, "The timer reads [get_countdown_timer()].[src.disk && istype(src.disk) ? " The authenticaion disk has been inserted." : ""]")
+				. += "It is currently counting down to detonation. Ohhhh shit."
+				. += "The timer reads [get_countdown_timer()].[src.disk && istype(src.disk) ? " The authenticaion disk has been inserted." : ""]"
 			else
-				boutput(usr, "It is not armed. That's a relief.")
+				. += "It is not armed. That's a relief."
 				if (src.disk && istype(src.disk))
-					boutput(usr, "The authenticaion disk has been inserted.")
+					. += "The authenticaion disk has been inserted."
 
 			if (!src.anchored)
-				boutput(usr, "<br>The floor bolts have been unsecured. The bomb can be moved around.")
+				. += "The floor bolts have been unsecured. The bomb can be moved around."
 			else
-				boutput(usr, "<br>It is firmly anchored to the floor by its floor bolts. A screwdriver could undo them.")
+				. += "It is firmly anchored to the floor by its floor bolts. A screwdriver could undo them."
 
 			switch(src.health)
 				if(80 to 125)
-					boutput(usr, "<span style=\"color:red\">It is a little bit damaged.</span>")
+					. += "<span style=\"color:red\">It is a little bit damaged.</span>"
 				if(40 to 79)
-					boutput(usr, "<span style=\"color:red\">It looks pretty beaten up.</span>")
+					. += "<span style=\"color:red\">It looks pretty beaten up.</span>"
 				if(1 to 39)
-					boutput(usr, "<span style=\"color:red\"><b>It seems to be on the verge of falling apart!</b></span>")
-		return
+					. += "<span style=\"color:red\"><b>It seems to be on the verge of falling apart!</b></span>"
 
 	// Nuke round development was abandoned for 4 whole months, so I went out of my way to implement some user feedback from that 11 pages long forum thread (Convair880).
 	attack_hand(mob/user as mob)

--- a/code/obj/machinery/pipe/pipe.dm
+++ b/code/obj/machinery/pipe/pipe.dm
@@ -1354,10 +1354,7 @@ var/linenums = 0
 	icon_state = "valve[open]"
 
 /obj/machinery/valve/mvalve/examine()
-	set src in oview(1)
-	set category = "Local"
-
-	boutput(usr, "[desc] It is [ open? "open" : "closed"].")
+	return list("[desc] It is [ open? "open" : "closed"].")
 
 
 
@@ -1489,13 +1486,9 @@ var/linenums = 0
 	icon_state = "dvalve[open]"
 
 /obj/machinery/valve/dvalve/examine()
-	set src in oview(1)
-	set category = "Local"
 	if(NOPOWER)
-		boutput(usr, "[desc] It is unpowered! It is [ open? "open" : "closed"].")
-		return
-	boutput(usr, "[desc] It is [ open? "open" : "closed"].")
-
+		return list("[desc] It is unpowered! It is [ open? "open" : "closed"].")
+	return list("[desc] It is [ open? "open" : "closed"].")
 
 
 /obj/machinery/valve/dvalve/buildnodes()

--- a/code/obj/machinery/porters.dm
+++ b/code/obj/machinery/porters.dm
@@ -307,9 +307,8 @@ var/global/list/portable_machinery = list() // stop looping through world for th
 		..()
 
 	examine()
-		..()
-		boutput(usr, "Home turf: [get_area(src.homeloc)]. The interface is [src.locked ? "locked" : "unlocked"].")
-		return
+		. = ..()
+		. += "Home turf: [get_area(src.homeloc)]. The interface is [src.locked ? "locked" : "unlocked"]."
 
 	SubscribeToProcess()
 		..()
@@ -672,9 +671,8 @@ var/global/list/portable_machinery = list() // stop looping through world for th
 		..()
 
 	examine()
-		..()
-		boutput(usr, "Home turf: [get_area(src.homeloc)].")
-		return
+		. = ..()
+		. += "Home turf: [get_area(src.homeloc)]."
 
 	// This thing isn't z-level-restricted except for the homeloc.
 	// Somebody WILL find an exploit otherwise (Convair880).
@@ -864,9 +862,8 @@ var/global/list/portable_machinery = list() // stop looping through world for th
 		..()
 
 	examine()
-		..()
-		boutput(usr, "Home turf: [get_area(src.homeloc)].")
-		return
+		. = ..()
+		. += "Home turf: [get_area(src.homeloc)]."
 
 	// Could be useful (Convair880).
 	MouseDrop(over_object, src_location, over_location)

--- a/code/obj/machinery/shield_generators/energy_shield.dm
+++ b/code/obj/machinery/shield_generators/energy_shield.dm
@@ -19,16 +19,15 @@
 		src.power_usage = 5
 
 	examine()
-		if(usr.client)
-			var/charge_percentage = 0
-			if (PCEL && PCEL.charge > 0 && PCEL.maxcharge > 0)
-				charge_percentage = round((PCEL.charge/PCEL.maxcharge)*100)
-				boutput(usr, "It has [PCEL.charge]/[PCEL.maxcharge] ([charge_percentage]%) battery power left.")
-			else
-				boutput(usr, "It seems to be missing a usable battery.")
-			boutput(usr, "The unit will consume [30 * src.range * (src.power_level * src.power_level)] power a second.")
-			boutput(usr, "The range setting is set to [src.range].")
-			boutput(usr, "The power setting is set to [src.power_level].")
+		var/charge_percentage = 0
+		if (PCEL && PCEL.charge > 0 && PCEL.maxcharge > 0)
+			charge_percentage = round((PCEL.charge/PCEL.maxcharge)*100)
+			. += "It has [PCEL.charge]/[PCEL.maxcharge] ([charge_percentage]%) battery power left."
+		else
+			. += "It seems to be missing a usable battery."
+		. += "The unit will consume [30 * src.range * (src.power_level * src.power_level)] power a second."
+		. += "The range setting is set to [src.range]."
+		. += "The power setting is set to [src.power_level]."
 
 	shield_on()
 		if (!PCEL)
@@ -128,4 +127,3 @@
 		src.deployed_shields += S
 
 		return S
-

--- a/code/obj/machinery/shield_generators/portable_shield_generator.dm
+++ b/code/obj/machinery/shield_generators/portable_shield_generator.dm
@@ -175,16 +175,15 @@
 		set_range(user)
 
 	examine()
-		..()
-		if(usr.client)
-			var/charge_percentage = 0
-			if(PCEL && PCEL.charge > 0 && PCEL.maxcharge > 0)
-				charge_percentage = round((PCEL.charge/PCEL.maxcharge)*100)
-				boutput(usr, "It has [PCEL.charge]/[PCEL.maxcharge] ([charge_percentage]%) battery power left.")
-				boutput(usr, "The range setting is set to [src.range].")
-				boutput(usr, "The unit will consume [30 * src.range] power a second, and [60 * src.range] per meteor strike against the projected shield.")
-			else
-				boutput(usr, "It seems to be missing a usable battery.")
+		. = ..()
+		var/charge_percentage = 0
+		if(PCEL && PCEL.charge > 0 && PCEL.maxcharge > 0)
+			charge_percentage = round((PCEL.charge/PCEL.maxcharge)*100)
+			. += "It has [PCEL.charge]/[PCEL.maxcharge] ([charge_percentage]%) battery power left."
+			. += "The range setting is set to [src.range]."
+			. += "The unit will consume [30 * src.range] power a second, and [60 * src.range] per meteor strike against the projected shield."
+		else
+			. += "It seems to be missing a usable battery."
 
 	attack_hand(mob/user as mob)
 		if(src.coveropen && src.PCEL)

--- a/code/obj/machinery/sleeper.dm
+++ b/code/obj/machinery/sleeper.dm
@@ -713,9 +713,8 @@
 			interact_particle(user,src)
 
 	examine()
-		..()
-		boutput(usr, "Home turf: [get_area(src.homeloc)].")
-		return
+		. = ..()
+		. += "Home turf: [get_area(src.homeloc)]."
 
 	// Could be useful (Convair880).
 	MouseDrop(over_object, src_location, over_location)

--- a/code/obj/machinery/spaceheater.dm
+++ b/code/obj/machinery/spaceheater.dm
@@ -66,18 +66,12 @@
 
 
 	examine()
-		set src in oview(12)
-		if (!( usr ))
-			return
-		boutput(usr, "This is [bicon(src)] \an [src.name].")
-		boutput(usr, src.desc)
-
-		boutput(usr, "The HVAC is [on ? "on" : "off"], [heating ? "heating" : "cooling"] and the hatch is [open ? "open" : "closed"].")
+		. = ..()
+		. += "The HVAC is [on ? "on" : "off"], [heating ? "heating" : "cooling"] and the hatch is [open ? "open" : "closed"]."
 		if(open)
-			boutput(usr, "The power cell is [cell ? "installed" : "missing"].")
+			. += "The power cell is [cell ? "installed" : "missing"]."
 		else
-			boutput(usr, "The charge meter reads [cell ? round(cell.percent(),1) : 0]%")
-		return
+			. += "The charge meter reads [cell ? round(cell.percent(),1) : 0]%"
 
 
 	attackby(obj/item/I, mob/user)
@@ -296,18 +290,13 @@
 		return
 
 	examine()
-		set src in oview(12)
-		if (!( usr ))
-			return
-		boutput(usr, "This is [bicon(src)] \an [src.name].")
-		boutput(usr, src.desc)
+		. = ..()
 
-		boutput(usr, "The stove is [on ? "on" : "off"], [heating ? "heating" : "cooling"] and the hatch is [open ? "open" : "closed"].")
+		. += "The stove is [on ? "on" : "off"], [heating ? "heating" : "cooling"] and the hatch is [open ? "open" : "closed"]."
 		if(open)
-			boutput(usr, "The power cell is [cell ? "installed" : "missing"].")
+			. += "The power cell is [cell ? "installed" : "missing"]."
 		else
-			boutput(usr, "The charge meter reads [cell ? round(cell.percent(),1) : 0]%")
-		return
+			. += "The charge meter reads [cell ? round(cell.percent(),1) : 0]%"
 
 
 	attackby(obj/item/I, mob/user)

--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -208,13 +208,13 @@
 	var/obj/machinery/mining_magnet/construction/magnet = null
 
 	examine()
-		..()
+		. = ..()
 		if (loaded)
-			boutput(usr, "<span style=\"color:blue\">The magnetizer is loaded with a plasmastone. Designate the mineral magnet to attach, then designate the lower left tile of the area to magnetize.</span>")
-			boutput(usr, "<span style=\"color:blue\">The magnetized area must be a clean shot of space, surrounded by bordering tiles on all sides.</span>")
-			boutput(usr, "<span style=\"color:blue\">A small mineral magnet requires an 7x7 area of space, a large one requires a 15x15 area of space.</span>")
+			. += "<span style=\"color:blue\">The magnetizer is loaded with a plasmastone. Designate the mineral magnet to attach, then designate the lower left tile of the area to magnetize.</span>"
+			. += "<span style=\"color:blue\">The magnetized area must be a clean shot of space, surrounded by bordering tiles on all sides.</span>"
+			. += "<span style=\"color:blue\">A small mineral magnet requires an 7x7 area of space, a large one requires a 15x15 area of space.</span>"
 		else
-			boutput(usr, "<span style=\"color:red\">The magnetizer must be loaded with a chunk of plasmastone to use.</span>")
+			. += "<span style=\"color:red\">The magnetizer must be loaded with a chunk of plasmastone to use.</span>"
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (istype(W, /obj/item/raw_material/plasmastone) && !loaded)
@@ -438,12 +438,12 @@
 		..()
 
 	examine()
-		..()
+		. = ..()
 		if (src.health < 100)
 			if (src.health < 50)
-				boutput(usr, "<span style=\"color:red\">It's rather badly damaged. It probably needs some wiring replaced inside.</span>")
+				. += "<span style=\"color:red\">It's rather badly damaged. It probably needs some wiring replaced inside.</span>"
 			else
-				boutput(usr, "<span style=\"color:red\">It's a bit damaged. It looks like it needs some welding done.</span>")
+				. += "<span style=\"color:red\">It's a bit damaged. It looks like it needs some welding done.</span>"
 
 	ex_act(severity)
 		switch(severity)
@@ -1458,12 +1458,13 @@
 		BLOCK_ROD
 
 	// Seems like a basic bit of user feedback to me (Convair880).
-	examine()
-		..()
-		if (!src.cell) return
-		if (isrobot(usr)) return // Drains battery instead.
-		boutput(usr, "The [src.name] is turned [src.status ? "on" : "off"]. There are [src.cell.charge]/[src.cell.max_charge] PUs left!")
-		return
+	examine(mob/user)
+		. = ..()
+		if (!src.cell)
+			return
+		if (isrobot(user))
+			return // Drains battery instead.
+		. += "The [src.name] is turned [src.status ? "on" : "off"]. There are [src.cell.charge]/[src.cell.max_charge] PUs left!"
 
 	proc/process_charges(var/use)
 		if (!isnum(use) || use < 0)
@@ -1866,11 +1867,11 @@ obj/item/clothing/gloves/concussive
 	flags = ONBELT
 	mats = 4
 
-	examine()
-		..()
-		if (isrobot(usr)) return // Drains battery instead.
-		boutput(usr, "There are [src.charges]/[src.maximum_charges] charges left!")
-		return
+	examine(mob/user)
+		. = ..()
+		if (isrobot(user))
+			return // Drains battery instead.
+		. += "There are [src.charges]/[src.maximum_charges] charges left!"
 
 	attack_self() // Fixed --melon
 		if (src.charges < 1)

--- a/code/obj/posters.dm
+++ b/code/obj/posters.dm
@@ -253,9 +253,10 @@ var/global/icon/wanted_poster_unknown = icon('icons/obj/decals.dmi', "wanted-unk
 			src.pixel_y = rand(-9,9)
 			src.pixel_x = rand(-8,8)
 
-	examine()
-		if (usr.client && src.popup_win)
+	examine(mob/user)
+		if (src.popup_win)
 			src.show_popup_win(usr)
+			return list()
 		else
 			return ..()
 

--- a/code/obj/vehicle.dm
+++ b/code/obj/vehicle.dm
@@ -2016,7 +2016,7 @@ obj/vehicle/clowncar/proc/log_me(var/mob/rider, var/mob/pax, var/action = "", va
 
 /obj/vehicle/forklift/examine()
 	. = ..()
-	var/examine_text = list()	//Shows who is driving it and also the items being carried
+	var/list/examine_text = list()	//Shows who is driving it and also the items being carried
 	var/obj/HI
 	if(src.rider)
 		examine_text += "[src.rider] is using it. "

--- a/code/obj/vehicle.dm
+++ b/code/obj/vehicle.dm
@@ -2015,8 +2015,8 @@ obj/vehicle/clowncar/proc/log_me(var/mob/rider, var/mob/pax, var/action = "", va
 	actual_light.attach(src)
 
 /obj/vehicle/forklift/examine()
-	..()
-	var/examine_text	//Shows who is driving it and also the items being carried
+	. = ..()
+	var/examine_text = list()	//Shows who is driving it and also the items being carried
 	var/obj/HI
 	if(src.rider)
 		examine_text += "[src.rider] is using it. "
@@ -2033,8 +2033,7 @@ obj/vehicle/clowncar/proc/log_me(var/mob/rider, var/mob/pax, var/action = "", va
 				HI = helditems[helditems.len]
 			examine_text += " and \a [HI.name]"
 		examine_text += "."
-	boutput(usr, "[examine_text]")
-	return
+	. += examine_text.Join("")
 
 /obj/vehicle/forklift/verb/enter_forklift()
 	set src in oview(1)

--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -914,10 +914,6 @@
 	New()
 		return
 
-	examine()
-		set src in oview()
-		boutput(usr, desc)
-
 	smash()
 		if(health <= 0)
 			qdel(src)

--- a/code/z_adventurezones/jonescity.dm
+++ b/code/z_adventurezones/jonescity.dm
@@ -83,7 +83,7 @@ JONES CITY TURFS
 		info = "<html><body style='margin:0px'><img src='[resource("images/jones_note.png")]'></body></html>"
 
 	examine()
-		..()
+		return ..()
 
 	attackby()
 		return

--- a/code/z_adventurezones/numbersstation.dm
+++ b/code/z_adventurezones/numbersstation.dm
@@ -63,7 +63,7 @@ Thanks to our agents inside the organization, we were able to identify two infil
 		info = "<html><body style='margin:0px'><img src='[resource("images/bloody_numbers_note.png")]'></body></html>"
 
 	examine()
-		..()
+		return ..()
 
 	attackby()
 		return

--- a/code/z_adventurezones/vault.dm
+++ b/code/z_adventurezones/vault.dm
@@ -54,7 +54,7 @@
 				info = "<html><body style='margin:0px'><img src='[resource("images/charts/AtlasSurvey_PlasmaGiant.png")]'></body></html>"
 
 			examine()
-				..()
+				return ..()
 
 			attackby()
 				return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This refactors the `examine()` proc to return a list instead of using boutput itself. 

Also includes minor touchups to some examine procs.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
1. Increased performance from reduced amount of boutput operations just to create newlines
2. Increased performance from reduced string concatenation (list.Join is faster than creating ephemeral strings)
3. Increased customizability by allowing overrides to affect parent proc messages


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Naksu:
(+)Refactored examine-code to pass and eventually join a list instead of sending separate browser output for every line of text.
```
