### PR TITLE
changeling clears stuns when entering abomination

### DIFF
--- a/code/modules/antagonists/changeling/abilities/abomination.dm
+++ b/code/modules/antagonists/changeling/abilities/abomination.dm
@@ -36,6 +36,13 @@
 			H.update_body()
 			H.update_clothing()
 			H.abilityHolder.transferOwnership(H)
+
+			H.delStatus("paralysis")
+			H.delStatus("stunned")
+			H.delStatus("weakened")
+			H.delStatus("disorient")
+			H.force_laydown_standup()
+
 			logTheThing("combat", H, null, "enters horror form as a changeling, [log_loc(H)].")
 			return 0
 


### PR DESCRIPTION
since abom form only resists stuns being applied instead of clearing them every life tick like it used to, we need to clear stuns as we enter