### PR TITLE
tweak limb-loss bleeding

### DIFF
--- a/code/mob/living/carbon/human/procs/Life.dm
+++ b/code/mob/living/carbon/human/procs/Life.dm
@@ -1534,7 +1534,7 @@
 			if (src.bleeding < 0) //INVERSE BLOOD LOSS was a fun but ultimately easily fixed bug
 				src.bleeding = 0
 
-		else if (!src.bleeding && src.get_surgery_status())
+		else if (src.bleeding && src.get_surgery_status())
 			src.bleeding += 1 * mult
 
 		if (src.bleeding && src.blood_volume)

--- a/code/modules/medical/blood_system.dm
+++ b/code/modules/medical/blood_system.dm
@@ -358,7 +358,7 @@ this is already used where it needs to be used, you can probably ignore it.
 		if (H.bleeding < 0)
 			H.bleeding = 0
 			//BLOOD_DEBUG("[H]'s bleeding dropped below 0 and was reset to 0")
-		if (!H.bleeding && H.get_surgery_status())
+		if (H.bleeding && H.get_surgery_status())
 			H.bleeding ++
 		switch (H.bleeding)
 			if (-INFINITY to 0)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FIX] [BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
limbloss bleeding changed to only happen if you're already bleeding. this also means that your bleeding will steadily get worse over time with a lost limb if you don't reduce your bleeding to 0


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
MBC told me to


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Tarmunora:
(+)Tweaked bleeding from lost limbs
```
