### PR TITLE
Creates new planes for walls and windows, to allow cleanables to have no shadow

### DIFF
--- a/_stdlib/code/_plane.dm
+++ b/_stdlib/code/_plane.dm
@@ -1,4 +1,6 @@
 #define PLANE_FLOOR -10
+#define PLANE_WALL -5
+#define PLANE_WINDOW -4
 #define PLANE_NOSHADOW_BELOW -1
 #define PLANE_DEFAULT 0
 #define PLANE_NOSHADOW_ABOVE 1
@@ -34,6 +36,8 @@ client
 
 	New()
 		plane_parents += new /obj/screen/plane_parent(PLANE_FLOOR, name = "floor_plane")
+		plane_parents += new /obj/screen/plane_parent(PLANE_WALL, name = "wall_plane")
+		plane_parents += new /obj/screen/plane_parent(PLANE_WINDOW, name = "window_plane")
 		plane_parents += new /obj/screen/plane_parent(PLANE_DEFAULT, name = "game_plane")
 		plane_parents += new /obj/screen/plane_parent(PLANE_LIGHTING, appearance_flags = NO_CLIENT_COLOR, blend_mode = BLEND_MULTIPLY, mouse_opacity = 0, name = "lighting_plane")
 		plane_parents += new /obj/screen/plane_parent(PLANE_SELFILLUM, appearance_flags = NO_CLIENT_COLOR, blend_mode = BLEND_ADD, mouse_opacity = 0, name = "selfillum_plane")

--- a/code/obj/decal/cleanable.dm
+++ b/code/obj/decal/cleanable.dm
@@ -38,7 +38,7 @@ proc/make_cleanable(var/type,var/loc,var/list/viral_list)
 	layer = DECAL_LAYER
 	event_handler_flags = USE_HASENTERED | USE_FLUID_ENTER
 
-	//plane = PLANE_NOSHADOW_BELOW - BAD IDEA, STUFF GOES BELOW WALLS
+	plane = PLANE_NOSHADOW_BELOW //- BAD IDEA, STUFF GOES BELOW WALLS
 
 	New(var/loc,var/list/viral_list)
 		if (!pooled)

--- a/code/obj/decal/cleanable.dm
+++ b/code/obj/decal/cleanable.dm
@@ -38,7 +38,7 @@ proc/make_cleanable(var/type,var/loc,var/list/viral_list)
 	layer = DECAL_LAYER
 	event_handler_flags = USE_HASENTERED | USE_FLUID_ENTER
 
-	plane = PLANE_NOSHADOW_BELOW //- BAD IDEA, STUFF GOES BELOW WALLS
+	plane = PLANE_NOSHADOW_BELOW
 
 	New(var/loc,var/list/viral_list)
 		if (!pooled)

--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -8,6 +8,7 @@
 	dir = 5 //full tile
 	flags = FPRINT | USEDELAY | ON_BORDER | ALWAYS_SOLID_FLUID
 	event_handler_flags = USE_FLUID_ENTER | USE_CHECKEXIT | USE_CANPASS
+	plane = PLANE_WINDOW
 	var/health = 30
 	var/health_max = 30
 	var/health_multiplier = 1

--- a/code/turf/turf.dm
+++ b/code/turf/turf.dm
@@ -805,6 +805,7 @@ var/global/client/ff_debugger = null
 	name = "floor"
 	icon = 'icons/turf/floors.dmi'
 	icon_state = "plating"
+	plane = PLANE_FLOOR
 
 /turf/unsimulated/wall
 	name = "wall"
@@ -814,6 +815,7 @@ var/global/client/ff_debugger = null
 	density = 1
 	pathable = 0
 	turf_flags = ALWAYS_SOLID_FLUID
+	plane = PLANE_WALL
 
 /turf/unsimulated/wall/solidcolor
 	name = "invisible solid turf"

--- a/code/turf/walls.dm
+++ b/code/turf/walls.dm
@@ -2,7 +2,7 @@
 	name = "wall"
 	desc = "Looks like a regular wall."
 	icon = 'icons/turf/walls.dmi'
-	plane = PLANE_DEFAULT
+	plane = PLANE_WALL
 	opacity = 1
 	density = 1
 	blocks_air = 1


### PR DESCRIPTION
[MINOR]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This sets windows and walls to be on their own planes.
This lets us put cleanables on the noshadow_below plane.



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
ugly
