### PR TITLE
Blob Bridge ability casts automatically on spread if present

### DIFF
--- a/code/modules/antagonists/blob/blob_abilities.dm
+++ b/code/modules/antagonists/blob/blob_abilities.dm
@@ -318,6 +318,18 @@
 		if (!T)
 			T = get_turf(owner)
 
+		if (istype(T, /turf/space))
+			var/datum/blob_ability/bridge/B = owner.get_ability(/datum/blob_ability/bridge)
+			
+			if (B)
+				var/success = !B.onUse(T)		//Abilities return 1 on failure and 0 on success. fml
+				if (success)
+					boutput(owner, "<span style=\"color:blue\">You create a bridge on [T].</span>")
+				else
+					boutput(owner, "<span style=\"color:red\">You were unable to place a bridge on [T].</span>")
+
+				return 1
+
 		var/obj/blob/B1 = T.can_blob_spread_here(owner, null, isadmin(owner))
 		if (!istype(B1))
 			return 1
@@ -745,8 +757,8 @@
 	name = "Build Bridge"
 	icon_state = "blob-bridge"
 	desc = "Creates a floor that you can cross through in space. The floor can be destroyed by fire or weldingtools, and does not act as a blob tile."
-	bio_point_cost = 15
-	cooldown_time = 200
+	bio_point_cost = 5
+	cooldown_time = 5 SECONDS
 
 	onUse(var/turf/T)
 		if (..())
@@ -1320,7 +1332,7 @@
 	name = "Structure: Bridge"
 	icon_state = "blob-bridge"
 	desc = "Unlocks the Bridge blob bit, which can be placed on space tiles. Bridges are floor tiles, you still need to spread onto them, and cannot spread from them."
-	evo_point_cost = 3
+	evo_point_cost = 2
 	initially_disabled = 0
 	upgradename = "bridge"
 

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -1062,7 +1062,8 @@
 	icon = 'icons/mob/blob.dmi'
 	icon_state = "bridge"
 	default_melt_cap = 80
-
+	allows_vehicles = 1
+	
 	New()
 		..()
 		setMaterial(getMaterial("blob"))


### PR DESCRIPTION
[ENHANCEMENT] 

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I meant to do this like months ago, but I forgot because I was too cool to write things down. I'm less cool now. 
This patch mainly does two things: 
1. See title. If you purchase the Space Bridge ability as a blob, now you can create bridges simply by using the Spread ability on a space tile (providing it's next to a blob tile like normal spreading). 
2. Lowers Cooldown, BP, and EP costs for the blob space bridge ability. They were much to high for space bridge to see any real use. 

Demo: https://streamable.com/k5nrt0
#### Balance changes:
* evo_point_cost = ~3~ -> 2
* bio_point_cost = ~15~ -> 5
* cooldown_time = ~20s~ -> 5
* allows pods to fly over bridge tiles.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This is a bit like my old blob absorb buff that lets you automatically absorb valid corpses when spreading to a tile. It seeks to remove some of the micro strategy stuff you need to worry about as a blob. 



## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Kyle:
(+)Blob Bridge ability now much more useful and usable.
```
