### PR TITLE
fix petri dish formatting

### DIFF
--- a/code/modules/medical/pathology/pathogen_tools.dm
+++ b/code/modules/medical/pathology/pathogen_tools.dm
@@ -60,26 +60,26 @@
 	examine()
 		if (src.dirty || src.dirty_reason)
 			. = ..()
-			. += "<span style=\"color:red\">The petri dish appears to be incapable of growing any pathogen, and must be cleaned.</span>"
+			. += "<span style=\"color:red\">The petri dish appears to be incapable of growing any pathogen, and must be cleaned.</span><br/>"
 			return
-			
-		. = list("This is [src]")
+
+		. = list("This is [src]<br/>")
 		if (src.reagents.reagent_list["pathogen"])
 			var/datum/reagent/blood/pathogen/P = src.reagents.reagent_list["pathogen"]
-			. += "<span style=\"color:blue\">It contains [P.volume] units of harvestable pathogen.</span>"
+			. += "<span style=\"color:blue\">It contains [P.volume] units of harvestable pathogen.</span><br/>"
 		if (src.medium)
-			. += "<span style=\"color:blue\">The petri dish is coated with [src.medium.name].</span>"
-		. += "Nutrients in the dish:"
+			. += "<span style=\"color:blue\">The petri dish is coated with [src.medium.name].</span><br/>"
+		. += "Nutrients in the dish:<br/>"
 		var/count = 0
 		for (var/N in nutrition)
 			if (nutrition[N])
 				if (nutrition[N] != 1)
-					. += "<span style=\"color:blue\">[nutrition[N]] units of [N]</span>"
+					. += "<span style=\"color:blue\">[nutrition[N]] units of [N]</span><br/>"
 				else
-					. += "<span style=\"color:blue\">[nutrition[N]] unit of [N]</span>"
+					. += "<span style=\"color:blue\">[nutrition[N]] unit of [N]</span><br/>"
 				count++
 		if (!count)
-			. += "<span style=\"color:blue\">None.</span>"
+			. += "<span style=\"color:blue\">None.</span><br/>"
 
 	afterattack(obj/target, mob/user , flag)
 		if (istype(target, /obj/machinery/microscope))

--- a/code/modules/medical/pathology/pathogen_tools.dm
+++ b/code/modules/medical/pathology/pathogen_tools.dm
@@ -66,17 +66,14 @@
 		. = list("This is [src]<br/>")
 		if (src.reagents.reagent_list["pathogen"])
 			var/datum/reagent/blood/pathogen/P = src.reagents.reagent_list["pathogen"]
-			. += "<span style=\"color:blue\">It contains [P.volume] units of harvestable pathogen.</span><br/>"
+			. += "<span style=\"color:blue\">It contains [P.volume] unit\s of harvestable pathogen.</span><br/>"
 		if (src.medium)
 			. += "<span style=\"color:blue\">The petri dish is coated with [src.medium.name].</span><br/>"
 		. += "Nutrients in the dish:<br/>"
 		var/count = 0
 		for (var/N in nutrition)
 			if (nutrition[N])
-				if (nutrition[N] != 1)
-					. += "<span style=\"color:blue\">[nutrition[N]] units of [N]</span><br/>"
-				else
-					. += "<span style=\"color:blue\">[nutrition[N]] unit of [N]</span><br/>"
+				. += "<span style=\"color:blue\">[nutrition[N]] unit\s of [N]</span><br/>"
 				count++
 		if (!count)
 			. += "<span style=\"color:blue\">None.</span><br/>"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[TRIVIAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes petri dish formatting that was broken in examine patch.
After examine patch:
![petri2](https://user-images.githubusercontent.com/35579460/80799538-62b43d00-8ba7-11ea-94b1-7b6f0801c71e.PNG)
How it's supposed to be:
![petri1](https://user-images.githubusercontent.com/35579460/80799542-65169700-8ba7-11ea-9157-86cd318c5943.PNG)
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Because it used to look better.

