### PR TITLE
Makes UpdateOverlays faster by like 15% or so

### DIFF
--- a/code/atom/UpdateOverlays.dm
+++ b/code/atom/UpdateOverlays.dm
@@ -111,6 +111,7 @@ ClearSpecificOverlays(1, "key0", "key1", "key2") 	//Same as above but retains ca
 #define P_INDEX 1
 #define P_IMAGE 2
 #define P_ISTATE 3
+#define P_ILEN P_ISTATE // maximum index
 
 /atom/var/list/overlay_refs = null
 
@@ -124,24 +125,19 @@ ClearSpecificOverlays(1, "key0", "key1", "key2") 	//Same as above but retains ca
 	//List to store info about the last state of the icon
 	prev_data = overlay_refs[key]
 	if(!prev_data && I) //Ok, we don't have previous data, but we will add an overlay
-		prev_data = list()
-		prev_data.len = 3
+		prev_data = new /list(P_ILEN)
 	else if(!prev_data) //We don't have data and we won't add an overlay
 		return 0
 
-	//Wire: Temp debugging to narrow down on a runtime
-	if (!I && key == 1 && force == 0 && retain_cache == 0)
-		world.log << "\[[time2text(world.timeofday,"hh:mm:ss")]] (Temp Overlay Debug) prev_data is: [json_encode(prev_data)]"
-
-	var/hash = hash_image(I)
+	var/hash = I ? "\ref[I.appearance]" : null
 	var/image/prev_overlay = prev_data[P_IMAGE] //overlay_refs[key]
-	if(!force && (prev_overlay == I) && hash == prev_data[P_ISTATE] ) //If it's the same image as the other one and the hashes match then do not update
+	if(!force && (prev_overlay == I) && hash == prev_data[P_ISTATE] ) //If it's the same image as the other one and the appearances match then do not update
 		return 0
 
 	var/index = prev_data[P_INDEX]
 	if(index > 0) //There is an existing overlay in place in this slot, remove it
 		src.overlays.Cut(index, index+1) //Fuck yoooou byond (this gotta be by index or it'll fail if the same thing's in overlays several times)
-	
+
 		prev_data[P_INDEX] = 0
 		for(var/ikey in overlay_refs) //Because we're storing the position of each overlay in the list we need to shift our indices down to stay synched
 			var/list/L = overlay_refs[ikey]
@@ -153,13 +149,13 @@ ClearSpecificOverlays(1, "key0", "key1", "key2") 	//Same as above but retains ca
 		prev_data[P_INDEX] = index
 
 		prev_data[P_IMAGE] = I
-		prev_data[P_ISTATE] = hash//I.icon_state
+		prev_data[P_ISTATE] = "\ref[I.appearance]"
 
 		overlay_refs[key] = prev_data
 	else
 		if(retain_cache) //Keep the cached image available?
 			prev_data[P_INDEX] = 0	//Clear the index
-			prev_data[P_ISTATE] = 0	//Clear the hash
+			prev_data[P_ISTATE] = 0	//Clear the ref
 
 			//overlay_refs[key] = prev_data //Update our list <- Pointers, dumbass /Spy
 		else
@@ -217,16 +213,8 @@ ClearSpecificOverlays(1, "key0", "key1", "key2") 	//Same as above but retains ca
 			I.layer = layer
 	return I
 
-/////////////////////////////////////////////
-//helper procs
-/////////////////////////////////////////////
-/proc/hash_image(var/image/I)
-	if(I)
-		. = md5("\ref[I][I.icon_state][I.overlays ? I.overlays.len : 0][I.color][I.alpha]")
-	else
-		. = null
-
 
 #undef P_INDEX
 #undef P_IMAGE
 #undef P_ISTATE
+#undef P_ILEN

--- a/code/atom/UpdateOverlays.dm
+++ b/code/atom/UpdateOverlays.dm
@@ -156,8 +156,6 @@ ClearSpecificOverlays(1, "key0", "key1", "key2") 	//Same as above but retains ca
 		if(retain_cache) //Keep the cached image available?
 			prev_data[P_INDEX] = 0	//Clear the index
 			prev_data[P_ISTATE] = 0	//Clear the ref
-
-			//overlay_refs[key] = prev_data //Update our list <- Pointers, dumbass /Spy
 		else
 			overlay_refs -= key
 	return 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
We can piggyback on BYOND's native appearance deduplication to avoid `hash_image()`. I also removed some 3 year old debug code that supposedly does not show up on logs.

This is fairly impossible to profile properly since every way i tried the new and old procs would get uneven/different calls, and I needed the "same thing" to always hit the same code or it wouldn't hit the early return. I guesstimated 15% based on hash_image being roughly 1/6 of the total call time of UpdateOverlays.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More speed = more better.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Naksu:
(+)UpdateOverlays should be a touch faster.
```
