### PR TITLE
Remove some dead code and reformat adjacent code

### DIFF
--- a/_stdlib/_setup.dm
+++ b/_stdlib/_setup.dm
@@ -1035,8 +1035,7 @@ var/ZLOG_START_TIME
 #endif
 
 #define CRITTER_REACTION_LIMIT 50
-#define fucking_critter_bullshit_fuckcrap_limiter(x) if (x > CRITTER_REACTION_LIMIT) return; else x += 1
-#define get_fucked_clarks if (istype(my_atom, "/obj/critter/domestic_bee")) return my_atom.visible_message("<span style=\"color:red\">[my_atom] burps.</span>"); if (istype(my_atom, "/obj/item/reagent_containers/food/snacks/ingredient/honey")) return
+#define CRITTER_REACTION_CHECK(x) if (x++ > CRITTER_REACTION_LIMIT) return
 
 //Activates the viscontents warps
 #define NON_EUCLIDEAN 1

--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -256,7 +256,6 @@ datum
 			mix_sound = 'sound/impact_sounds/Metal_Hit_Heavy_1.ogg'
 			on_reaction(var/datum/reagents/holder, var/created_volume)
 				var/atom/my_atom = holder.my_atom
-				get_fucked_clarks
 
 				var/turf/location = 0
 				if (my_atom)
@@ -280,7 +279,6 @@ datum
 			mix_sound = 'sound/impact_sounds/Metal_Hit_Heavy_1.ogg'
 			on_reaction(var/datum/reagents/holder, var/created_volume)
 				var/atom/my_atom = holder.my_atom
-				get_fucked_clarks
 
 				var/turf/location = 0
 				if (my_atom)
@@ -304,7 +302,6 @@ datum
 			mix_sound = 'sound/impact_sounds/Metal_Hit_Heavy_1.ogg'
 			on_reaction(var/datum/reagents/holder, var/created_volume)
 				var/atom/my_atom = holder.my_atom
-				get_fucked_clarks
 
 				var/turf/location = 0
 				if (my_atom)
@@ -329,7 +326,6 @@ datum
 			mix_sound = 'sound/impact_sounds/Metal_Hit_Heavy_1.ogg'
 			on_reaction(var/datum/reagents/holder, var/created_volume)
 				var/atom/my_atom = holder.my_atom
-				get_fucked_clarks
 
 				var/turf/location = 0
 				if (my_atom)
@@ -353,7 +349,6 @@ datum
 			mix_sound = 'sound/impact_sounds/Metal_Hit_Heavy_1.ogg'
 			on_reaction(var/datum/reagents/holder, var/created_volume)
 				var/atom/my_atom = holder.my_atom
-				get_fucked_clarks
 
 				var/turf/location = 0
 				if (my_atom)
@@ -1631,7 +1626,6 @@ datum
 					return
 				holder.last_basic_explosion = ticker.round_elapsed_ticks
 				var/atom/my_atom = holder.my_atom
-				get_fucked_clarks
 
 				var/turf/location = 0
 				if (my_atom)
@@ -1658,7 +1652,6 @@ datum
 					return
 				holder.last_basic_explosion = ticker.round_elapsed_ticks
 				var/atom/my_atom = holder.my_atom
-				get_fucked_clarks
 
 				var/turf/location = 0
 				if (my_atom)
@@ -1685,7 +1678,6 @@ datum
 					return
 				holder.last_basic_explosion = ticker.round_elapsed_ticks
 				var/atom/my_atom = holder.my_atom
-				get_fucked_clarks
 
 				var/turf/location = 0
 				if (my_atom)
@@ -2463,7 +2455,6 @@ datum
 			mix_sound = 'sound/impact_sounds/Metal_Hit_Heavy_1.ogg'
 			on_reaction(var/datum/reagents/holder, var/created_volume)
 				var/atom/my_atom = holder.my_atom
-				get_fucked_clarks
 
 				var/turf/location = 0
 				if (my_atom)
@@ -2487,7 +2478,6 @@ datum
 			mix_sound = 'sound/impact_sounds/Metal_Hit_Heavy_1.ogg'
 			on_reaction(var/datum/reagents/holder, var/created_volume)
 				var/atom/my_atom = holder.my_atom
-				get_fucked_clarks
 
 				var/turf/location = 0
 				if (my_atom)
@@ -3211,7 +3201,6 @@ datum
 			mix_sound = 'sound/impact_sounds/Crystal_Shatter_1.ogg'
 			on_reaction(var/datum/reagents/holder, var/created_volume)
 				var/atom/my_atom = holder.my_atom // if you heat this stuff in your hand, you'll die! heh!
-				get_fucked_clarks
 
 				var/turf/location = 0
 				if (my_atom)
@@ -3467,7 +3456,7 @@ datum
 			var/static/reaction_count = 0
 
 			on_reaction(var/datum/reagents/holder, var/created_volume)
-				fucking_critter_bullshit_fuckcrap_limiter(reaction_count)
+				CRITTER_REACTION_CHECK(reaction_count)
 				if (holder.my_atom)
 					new /obj/critter/fermid(get_turf(holder.my_atom))
 				else
@@ -3485,7 +3474,7 @@ datum
 			var/static/reaction_count = 0
 
 			on_reaction(var/datum/reagents/holder, var/created_volume)
-				fucking_critter_bullshit_fuckcrap_limiter(reaction_count)
+				CRITTER_REACTION_CHECK(reaction_count)
 				var/result = 0
 				var/roll = rand(1,100)
 				if(roll + created_volume > 100) result = rand(95,100)
@@ -3658,7 +3647,7 @@ datum
 			var/static/reaction_count = 0
 
 			on_reaction(var/datum/reagents/holder, var/created_volume)
-				fucking_critter_bullshit_fuckcrap_limiter(reaction_count)
+				CRITTER_REACTION_CHECK(reaction_count)
 				var/turf/T = holder.my_atom ? get_turf(holder.my_atom) : pick(holder.covered_cache.len)
 				if (prob(1) && !already_a_dominic)
 					new /obj/critter/parrot/eclectus/dominic(T)
@@ -4012,5 +4001,3 @@ datum
 			mix_phrase = "The mixture comes together slowly. It doesn't seem like it wants to be here."
 			required_reagents = list("poor_cement" = 1, "silicon_dioxide" = 5, "water" = 1)
 			result_amount = 7
-
-#undef get_fucked_clarks

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -1579,7 +1579,7 @@ datum
 				return
 
 			reaction_turf(var/turf/T, var/volume)
-				fucking_critter_bullshit_fuckcrap_limiter(reaction_count)
+				CRITTER_REACTION_CHECK(reaction_count)
 				var/turf/simulated/target = T
 				if (istype(target) && volume >= 5)
 					if (!locate(/obj/reagent_dispensers/spiders) in target)
@@ -2526,7 +2526,7 @@ datum
 				createSomeBirds(T, volume)
 
 			proc/createSomeBirds(var/turf/T as turf, var/volume)
-				fucking_critter_bullshit_fuckcrap_limiter(reaction_count)
+				CRITTER_REACTION_CHECK(reaction_count)
 				if (!T)
 					return
 				if (volume < 5)
@@ -3964,5 +3964,3 @@ datum
 			else
 				walk_towards(src, src.deathtarget, deathspeed)
 				sleep(0.1 SECONDS)
-
-


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This removes the `get_fucked_clarks` macro which has never done anything, `istype(thing, "string")` always returns 0. 

It also renames the ambiguous `fucking_critter_bullshit_fuckcrap_limiter(x)` macro to `CRITTER_REACTION_CHECK(x)` in order to make it more obvious that it is a macro that quite possibly can `return` out of current context, as opposed to a proc call which would be unable to do so. 