### PR TITLE
Implement signal changing for delay component

### DIFF
--- a/code/WorkInProgress/MechanicMadness.dm
+++ b/code/WorkInProgress/MechanicMadness.dm
@@ -858,6 +858,7 @@ var/list/mechanics_telepads = new/list()
 	icon_state = "comp_wait"
 	var/active = 0
 	var/delay = 10
+	var/changesig = 0
 
 	get_desc()
 		. += "<br><span style=\"color:blue\">Current Delay: [delay]</span>"
@@ -866,6 +867,7 @@ var/list/mechanics_telepads = new/list()
 		..()
 		mechanics.addInput("delay", "delayproc")
 		configs.Add("Set Delay")
+		configs.Add("Toggle Signal Changing")
 		src.append_default_configs()
 
 	attackby(obj/item/W as obj, mob/user as mob)
@@ -880,6 +882,9 @@ var/list/mechanics_telepads = new/list()
 					if(inp)
 						delay = inp
 						boutput(user, "Set delay to [inp]")
+				if("Toggle Signal Changing")
+					changesig = !changesig
+					boutput(user, "Signal changing now [changesig ? "on":"off"]")
 
 	proc/delayproc(var/datum/mechanicsMessage/input)
 		if(level == 2) return
@@ -891,6 +896,8 @@ var/list/mechanics_telepads = new/list()
 					active = 1
 				sleep(delay)
 				if(src)
+					if(changesig)
+						input.signal = mechanics.outputSignal
 					mechanics.fireOutgoing(input)
 					icon_state = "[under_floor ? "u":""]comp_wait"
 					active = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MINOR]


## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The delay component has a "Set Send Signal" config that doesn't actually do anything. This adds a "Toggle Signal Changing" config that allows the delay component to use the send signal setting as the output signal.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Without this fix, in order to get the same effect, you'd need both a delay component and a relay component. This makes things simpler and also makes the Set Send Signal config on the delay component not useless.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)glassofmilk:
(+)Added signal changing toggle to Delay Component
```
