### PR TITLE
Smoke

### DIFF
--- a/code/modules/chemistry/Chemistry-Holder.dm
+++ b/code/modules/chemistry/Chemistry-Holder.dm
@@ -1048,8 +1048,11 @@ datum
 			if (classic)
 				classic_smoke_reaction(src, 4, location = my_atom ? get_turf(my_atom) : 0)
 			else
+#if ASS_JAM
+				smoke_reaction(src, 0, location = my_atom ? get_turf(my_atom) : 0)
+#else
 				smoke_reaction(src, 5, location = my_atom ? get_turf(my_atom) : 0)
-
+#endif
 ///////////////////////////////////////////////////////////////////////////////////
 
 

--- a/code/modules/fluids/air.dm
+++ b/code/modules/fluids/air.dm
@@ -10,10 +10,13 @@ var/list/ban_from_airborne_fluid = list()
 
 	//max_alpha = 200
 
-	required_to_spread = 15
+	required_to_spread = 5
 
 	drains_floor = 0
-
+#if ASS_JAM
+	update_required_to_spread()
+		required_to_spread = min(15, max(0.1, (src.contained_amt**0.8)/30)+0.1) //wowowow magic numbers
+#endif
 //What follows is not for the faint of heart.
 // I have done a shitton of copy paste from the base obj/fluid type.
 // This is messy as fuck, but its the fastest solution i could think of CPU wise

--- a/code/modules/fluids/air.dm
+++ b/code/modules/fluids/air.dm
@@ -9,9 +9,11 @@ var/list/ban_from_airborne_fluid = list()
 	bonus_evaporation_time = 30 SECONDS
 
 	//max_alpha = 200
-
+#if ASS_JAM
 	required_to_spread = 5
-
+#else
+	required_to_spread = 15
+#endif
 	drains_floor = 0
 #if ASS_JAM
 	update_required_to_spread()

--- a/code/modules/fluids/air.dm
+++ b/code/modules/fluids/air.dm
@@ -104,7 +104,7 @@ var/list/ban_from_airborne_fluid = list()
 		if (!M) return
 		if (!src.group || !src.group.reagents || !src.group.reagents.reagent_list) return
 
-		var/react_volume = min(1,src.amt)
+		var/react_volume = src.amt > 10 ? (src.amt-10) / 3 + 10 : (src.amt)
 		react_volume = min(react_volume,20)
 		if (M.reagents)
 			react_volume = min(react_volume, abs(M.reagents.maximum_volume - M.reagents.total_volume)) //don't push out other reagents if we are full
@@ -126,7 +126,7 @@ var/list/ban_from_airborne_fluid = list()
 		if (!M) return
 		if (!src.group || !src.group.reagents || !src.group.reagents.reagent_list) return
 
-		var/react_volume = src.amt > 10 ? max(6,src.amt / 3) : (src.amt)
+		var/react_volume = src.amt > 10 ? (src.amt-10) / 3 + 10 : (src.amt)
 		react_volume = min(react_volume,20)
 		if (M.reagents)
 			react_volume = min(react_volume, abs(M.reagents.maximum_volume - M.reagents.total_volume)) //don't push out other reagents if we are full

--- a/code/modules/fluids/fluid_groups.dm
+++ b/code/modules/fluids/fluid_groups.dm
@@ -415,6 +415,9 @@
 		if (!(src in processing_fluid_spreads))
 			processing_fluid_spreads.Add(src)
 
+	proc/update_required_to_spread()
+		return
+
 	proc/update_once(force = 0) //this would be called every time the fluid.dm process procs.
 		if (src.qdeled || !can_update) return 1
 		if (!members || !members.len)
@@ -424,7 +427,7 @@
 		var/fluids_to_create = 0 //try to create X amount of new tiles (based on how much fluid and tiles we currently hold)
 
 		src.update_viscosity()
-
+		src.update_required_to_spread()
 		if (SPREAD_CHECK(src) || force)
 			LAGCHECK(LAG_HIGH)
 			if (src.qdeled) return 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[EXPERIMENTAL] [ASS-JAM]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Experimental change to newsmoke spread (ass jam), changing smoke powder from an automatic radius-5 smoke cloud to only generating smoke on the starting tile and letting natural spread do the rest, (with a new smoke/tile function so smaller volumes can still spread) 

Additionally fixes smoke inhalation to not have a dip in reaction volume b/w concentrations of 10 and 30 units/tile

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently chems spread through smokepowder will almost never undergo natural fluid spread, since it takes >15u/tile to spread, and the reaction will cover ~60 tiles if unimpeded.
This change allows the smoke to actually spread


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Tarmunora:
(+)ASS_JAM: experimental change to newsmoke spreading
```
