### PR TITLE
fixes bug with trays only stunning the attacker

### DIFF
--- a/code/obj/item/kitchen.dm
+++ b/code/obj/item/kitchen.dm
@@ -740,8 +740,8 @@ TRAYS
 		return "[health_desc] [food_desc]" //heres yr desc you *bastard*
 
 	unique_attack_garbage_fuck(mob/M as mob, mob/user as mob)
-		M.TakeDamageAccountArmor("head", force, 0, 0, DAMAGE_BLUNT)
-		user.changeStatus("weakened", rand(1,2) SECONDS)
+		M.TakeDamageAccountArmor("head", src.force, 0, 0, DAMAGE_BLUNT)
+		M.changeStatus("weakened", 2 SECONDS)
 		M.updatehealth()
 		playsound(get_turf(src), "sound/weapons/trayhit.ogg", 50, 1)
 		src.visible_message("\The [src] falls out of [user]'s hands due to the impact!")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
so trays stunned the user because i accidentally changed users status instead of M's status, this has been rectified. this also removes the rng element (either a 1 or 2 second) from the tray status change, now it can reliably down people.
Fixes #518 
[BUG]

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bugs are bad and that was mega unintended behaviour. also removing rng from the trays attack stuff to make them not totally useless

