### PR TITLE
only allows 1 crusher to be made per turf

### DIFF
--- a/code/WorkInProgress/recycling/crusher.dm
+++ b/code/WorkInProgress/recycling/crusher.dm
@@ -130,15 +130,13 @@
 
 /obj/machinery/crusher/New()
 	..()
-	var/counter = 0
 	var/turf/T = get_turf(src)
-	for(var/obj/thing in T)
-		if (counter > 100) //how many times will we loop thru stuff in the turf before we give up? (if someone deploys a crusher on a huge pile of produce, it might lag?)
-			src.visible_message("<span style='color:red'>\The [src] fails to deploy because of how much stuff there is on the ground! Clean it up!</span>")
-			qdel(src)
-			return
-		if (istype(thing, /obj/machinery/crusher) && thing != src)
-			src.visible_message("<span style='color:red'>\The [src] fails to deploy because there's already a crusher there! Find someplace else!")
-			qdel(src)
-			return
-		counter++
+	if (T.contents.len > 100) //if it has to check too much stuff, it might lag?
+		src.visible_message("<span style='color:red'>\The [src] fails to deploy because of how much stuff there is on the ground! Clean it up!</span>")
+		qdel(src)
+		return
+	var/obj/machinery/crusher/C = locate(/obj/machinery/crusher) in T
+	if(C != src)
+		src.visible_message("<span style='color:red'>\The [src] fails to deploy because there's already a crusher there! Find someplace else!")
+		qdel(src)
+		return

--- a/code/WorkInProgress/recycling/crusher.dm
+++ b/code/WorkInProgress/recycling/crusher.dm
@@ -127,3 +127,18 @@
 	..()
 	if(status & (NOPOWER|BROKEN))	return
 	use_power(500)
+
+/obj/machinery/crusher/New()
+	..()
+	var/counter = 0
+	var/turf/T = get_turf(src)
+	for(var/obj/thing in T)
+		if (counter > 100) //how many times will we loop thru stuff in the turf before we give up? (if someone deploys a crusher on a huge pile of produce, it might lag?)
+			src.visible_message("<span style='color:red'>\The [src] fails to deploy because of how much stuff there is on the ground! Clean it up!</span>")
+			qdel(src)
+			return
+		if (istype(thing, /obj/machinery/crusher) && thing != src)
+			src.visible_message("<span style='color:red'>\The [src] fails to deploy because there's already a crusher there! Find someplace else!")
+			qdel(src)
+			return
+		counter++

--- a/code/obj/machinery.dm
+++ b/code/obj/machinery.dm
@@ -41,7 +41,8 @@
 		SPAWN_DBG(5 DECI SECONDS)
 			src.power_change()
 			var/area/A = get_area(src)
-			A.machines += src
+			if (A && src) //fixes a weird runtime wrt qdeling crushers in crusher/New()
+				A.machines += src
 
 /obj/machinery/initialize()
 	..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
this fixes a bug where stacked crushers would cause a lot of lag when crushing stuff by making it so that only 1 crusher can be deployed per turf. i also put a safety measure in, since this loops through everything on the turf to make sure there isnt a crusher there, for it only to loop thru a certain amt of times before giving up. also i tested this
Fixes #486 
[BUG]

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
no real reason to stack crushers and it was causing lag so this is a good change imo
