### PR TITLE
grenade tweaks

### DIFF
--- a/code/modules/chemistry/tools/grenades.dm
+++ b/code/modules/chemistry/tools/grenades.dm
@@ -427,12 +427,12 @@
 		..()
 		var/obj/item/reagent_containers/glass/B1 = new(src)
 		var/obj/item/reagent_containers/glass/B2 = new(src)
+		B1.reagents.maximum_volume=75 //dumb hack, but it works
+		B1.reagents.add_reagent("capsaicin", 50)
+		B1.reagents.add_reagent("sugar",25)
 
-		B1.reagents.add_reagent("capsaicin", 25)
-		B1.reagents.add_reagent("water",25)
-
-		B2.reagents.add_reagent("fluorosurfactant", 25)
-
+		B2.reagents.add_reagent("phosphorus", 25)
+		B2.reagents.add_reagent("potassium", 25)
 		beakers += B1
 		beakers += B2
 
@@ -448,8 +448,8 @@
 		..()
 		var/obj/item/reagent_containers/glass/B1 = new(src)
 		var/obj/item/reagent_containers/glass/B2 = new(src)
-
-		B1.reagents.add_reagent("sarin", 25)
+		B1.reagents.maximum_volume=100 //dumb hack, but it works
+		B1.reagents.add_reagent("sarin", 75)
 		B1.reagents.add_reagent("sugar",25)
 
 		B2.reagents.add_reagent("phosphorus", 25)


### PR DESCRIPTION


<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Triples the sarin concentration in sarin grenades (25u -> 75u), so that they have about 1u/tile if detonated in an open room,
Also changes capsaicin grenades to use newsmoke instead of foam, and bumps them up to 50u from 25

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Sarin grenades were a little toothless when they only had 25u that was split evenly over the whole cloud, when they were originally balanced for the 25u being applied individually to everyone inside

The capsaicin nade change just kinda made sense to do at the time.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Tarmunora:
(+)Made sarin grenades more concentrated and changed the delivery mechanism of capsaicin grenades
```
