### PR TITLE
checks that a player has the wizard special_role (which is only assig…

### DIFF
--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -653,7 +653,7 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 				bank_earnings.badguy = 1
 				player_dead = 0
 			//some might not actually have a wage
-			if (isnukeop(player) || iswizard(player) || isblob(player) || iswraith(player) || iswizard(player))
+			if (isnukeop(player) ||  (isblob(player) && (player.mind && player.mind.special_role == "blob")) || iswraith(player) || (iswizard(player) && (player.mind && player.mind.special_role == "wizard")) )
 				earnings = 800
 
 			if (player.mind.completed_objs > 0)


### PR DESCRIPTION

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes an exploit in https://github.com/goonstation/goonstation/issues/531 where players get the spacebux for real wizards if they are VR wizards on round end. Also preemptively fixes this bug for when I eventually add a blob tutorial for ghosts, if I ever get around to it.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Without it, the spacebux economy is kaput.