### PR TITLE
fix benign kudzu not adding to the kudzu flag on turfs when moved, 

### DIFF
--- a/code/datums/abilities/kudzumen.dm
+++ b/code/datums/abilities/kudzumen.dm
@@ -208,6 +208,19 @@
 		var/turf/T = get_turf(location)
 		T.temp_flags |= HAS_KUDZU
 
+	set_loc(var/newloc as turf|mob|obj in world)
+		//remove kudzu flag from current turf
+		var/turf/T1 = get_turf(loc)
+		if (T1)
+			T1.temp_flags &= ~HAS_KUDZU
+
+		..()
+		//Add kudzu flag to new turf.
+		var/turf/T2 = get_turf(newloc)
+		if (T2)
+			T2.temp_flags |= HAS_KUDZU
+
+
 	disposing()
 		var/turf/T = get_turf(src)
 		T.temp_flags &= ~HAS_KUDZU

--- a/code/modules/events/gimmick/kudzu.dm
+++ b/code/modules/events/gimmick/kudzu.dm
@@ -140,6 +140,10 @@
 			qdel(src)
 			return 1
 		..()
+		//Add kudzu flag to new turf.
+		var/turf/T2 = get_turf(newloc)
+		if (T2)
+			T2.temp_flags |= HAS_KUDZU
 
 	Move()
 		var/turf/T = get_turf(src)


### PR DESCRIPTION

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
https://github.com/goonstation/goonstation/issues/533
When benign kudzu objects tiles are moved (Like they are when the escape shuttle moves), they don't set the kudzu flag on the tile. Now they do.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug

