### PR TITLE
Pod HuD draws properly if a player reconnects to the game

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -438,6 +438,10 @@
 
 		src.addOverlaysClient(src.client)  //ov1
 
+		var/obj/machinery/vehicle/V = src.loc
+		if (istype(V))
+			V.myhud.add_client(src.client)
+
 	src.emote_allowed = 1
 
 	if (!src.mind)

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -438,10 +438,6 @@
 
 		src.addOverlaysClient(src.client)  //ov1
 
-		var/obj/machinery/vehicle/V = src.loc
-		if (istype(V))
-			V.myhud.add_client(src.client)
-
 	src.emote_allowed = 1
 
 	if (!src.mind)

--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -866,7 +866,7 @@
 		return
 
 	if (ejectee.client)
-		myhud.remove_client(ejectee.client)
+		ejectee.detach_hud(myhud)
 		if (ejectee.client.tooltipHolder)
 			ejectee.client.tooltipHolder.inPod = 0
 
@@ -969,7 +969,7 @@
 		src.ion_trail.start()
 	src.find_pilot()
 	if (M.client)
-		myhud.add_client(M.client)
+		M.attach_hud(myhud)
 		if (M.client.tooltipHolder)
 			M.client.tooltipHolder.inPod = 1
 


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
https://github.com/goonstation/goonstation/issues/496
If a mob is in a pod when they login, it now properly draws the hud. The problem was that the pod hud was not stored in the mob's huds list, but in the pod's myhud var. And this var was not checked in mob New, when the rest of the huds are attached. Now it is.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix. It would often trap players in the pod unable to escape without using the verb exit-ship to leave the pod. Which usually had to be relayed to the player via mentor/admin help.

