### PR TITLE
Flipfix

### DIFF
--- a/_stdlib/_setup.dm
+++ b/_stdlib/_setup.dm
@@ -782,6 +782,8 @@
 #define BLOCK_BOOK		BLOCK_SETUP; src.c_flags |= (BLOCK_CUT | BLOCK_STAB)
 #define BLOCK_ROPE		BLOCK_BOOK
 
+#define DEFAULT_BLOCK_PROTECTION_BONUS 2 //blocking to match damage type correctly gives you a -2 bonus on protection (unless this item grants Even More protection, that overrides this)
+
 // Process Scheduler defines
 // Process status defines
 #define PROCESS_STATUS_IDLE 1

--- a/code/datums/components/itemblock/backpackblock.dm
+++ b/code/datums/components/itemblock/backpackblock.dm
@@ -1,5 +1,5 @@
 /datum/component/itemblock/backpackblock
-	signals = list(COMSIG_MOB_ATTACKED_PRE) 
+	signals = list(COMSIG_MOB_ATTACKED_PRE)
 	mobtype = /mob/living
 	proctype = .proc/loseitem
 
@@ -26,7 +26,7 @@
 
 /datum/component/itemblock/backpackblock/getTooltipDesc()
 	.= ..()
-	if(showTooltip) 
+	if(showTooltip)
 		var/obj/item/storage/I = parent
 		. += itemblock_tooltip_entry("special.png", "Blocks more damage when filled (+[round(I.get_contents().len/3)])")
 		. += itemblock_tooltip_entry("minus.png", "Contents ejected when attacked")
@@ -35,7 +35,7 @@
 	var/obj/item/storage/I = parent
 	if(!istype(I)||!(I.c_flags && I.c_flags & HAS_GRAB_EQUIP))
 		return
-	var/blockplus = 1 + round(I.get_contents().len/3) //a bit of bonus protection. 1 point bonus per 3 items in the bag
+	var/blockplus = DEFAULT_BLOCK_PROTECTION_BONUS + round(I.get_contents().len/3) //a bit of bonus protection. 1 point bonus per 3 items in the bag
 	for (var/obj/item/grab/block/B in I.contents)
 		if(I.c_flags & BLOCK_CUT) //only increase the types we're actually blocking
 			B.setProperty("I_block_cut", blockplus)

--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -197,7 +197,7 @@
 		return
 
 	var/obj/stool/S = (locate(/obj/stool) in src.loc)
-	if (S)
+	if (S && !src.lying && !src.getStatusDuration("weakened") && !src.getStatusDuration("paralysis"))
 		S.buckle_in(src,src,1)
 	else
 		var/obj/item/grab/block/G = new /obj/item/grab/block(src)

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -235,13 +235,13 @@
 	if(!src.c_flags)
 		return
 	if(src.c_flags & BLOCK_CUT)
-		B.setProperty("I_block_cut", max(1, B.getProperty("I_block_cut")))
+		B.setProperty("I_block_cut", max(DEFAULT_BLOCK_PROTECTION_BONUS, B.getProperty("I_block_cut")))
 	if(src.c_flags & BLOCK_STAB)
-		B.setProperty("I_block_stab", max(1, B.getProperty("I_block_stab")))
+		B.setProperty("I_block_stab", max(DEFAULT_BLOCK_PROTECTION_BONUS, B.getProperty("I_block_stab")))
 	if(src.c_flags & BLOCK_BURN)
-		B.setProperty("I_block_burn", max(1, B.getProperty("I_block_burn")))
+		B.setProperty("I_block_burn", max(DEFAULT_BLOCK_PROTECTION_BONUS, B.getProperty("I_block_burn")))
 	if(src.c_flags & BLOCK_BLUNT)
-		B.setProperty("I_block_blunt", max(1, B.getProperty("I_block_blunt")))
+		B.setProperty("I_block_blunt", max(DEFAULT_BLOCK_PROTECTION_BONUS, B.getProperty("I_block_blunt")))
 
 /obj/item/proc/onMouseDrag(src_object,over_object,src_location,over_location,src_control,over_control,params)
 	if(special && !special.manualTriggerOnly)


### PR DESCRIPTION
fix chair flipping while lying down
a bit more block bonus

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)mbc:
(*)Bonus protection when blocking incoming damage with a proper weapon raised to give +2 protection instead of +1.
(+)Fixed bug where chair flips could be executed while lying/stunned
```
