### PR TITLE
Removes the stunbaton self-hitting when using it on harm intent

### DIFF
--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -232,10 +232,10 @@
 						user.show_text("The [src.name] is out of charge!", "red")
 				return
 
-			if ("failed_harm")
-				user.visible_message("<span class='alert'><B>[user] has attempted to beat [victim] with the [src.name] but held it wrong!</B></span>")
-				playsound(get_turf(src), "sound/impact_sounds/Generic_Stab_1.ogg", 50, 1, -1)
-				logTheThing("combat", user, victim, "unsuccessfully tries to beat %target% with the [src.name] at [log_loc(victim)].")
+//			if ("failed_harm")
+//				user.visible_message("<span class='alert'><B>[user] has attempted to beat [victim] with the [src.name] but held it wrong!</B></span>")
+//				playsound(get_turf(src), "sound/impact_sounds/Generic_Stab_1.ogg", 50, 1, -1)
+//				logTheThing("combat", user, victim, "unsuccessfully tries to beat %target% with the [src.name] at [log_loc(victim)].")
 
 			if ("stun", "stun_classic")
 				user.visible_message("<span class='alert'><B>[victim] has been stunned with the [src.name] by [user]!</B></span>")
@@ -357,7 +357,7 @@
 							playsound(get_turf(src), "swing_hit", 50, 1, -1)
 							..()
 					else
-						src.do_stun(user, M, "failed_harm", 1)
+						src.do_stun(user, M, "stun", 2)
 
 			else
 				if (src.uses_electricity == 0)


### PR DESCRIPTION


## About the PR 

Removes the self-hitting "harmbaton" behavior from the stun baton. It is replaced with a normal stun proc like when using any other intent. (It does not beat them)

(it does not remove hitting yourself with the baton while clumsy)

The harmbaton behavior is commented out in case someone needs the legacy code for some reason.



## Why's this needed? 

To put it simply, the harmbaton self-stun is a newbie trap. This was originally added in the donut 1 days to screw over people who picked security just to grief. Long story short, our security is very different nowadays and few people play it. I do not think having an entirely arbitrary self-stunning trap is a good way to encourage people to play this job. 



Some arguments that have been made in its favor and why I think they are wrong:
- it discourages beating people to death

Given that you can still do lethal damage beatings with the baton just by turning it off, I do not think this is the case. If the person wants to beat someone to death with a baton, this will prevent them from doing so exactly once before they figure out they can just turn it off and commence the beating.

On top of that, the message does not make it entirely clear why they are stunning themselves, so a new player might just think they somehow misclicked, or just think our code is shit, instead of connecting in their heads that harm-intent + baton = bad thing.

- You shouldn't have harm intent on anyway

There is about a billion reasons someone could have harm intent on, including legit reasons like point blank tasers, and "i tried to turn harm intent off but the highly resposive byond ui did not register it before i tried to stun them".

- It protects security from newbie assistant griefers making them drop it and then picking it up and beating them, as they are more likely to have/need harm intent on.

Technically true! But guess what, that still makes it a newbie trap, as its still trivally avoidable to anyone in the know, and also we don't give out batons to assistants, so its more likely to effect the players who actually have batons at roundstart, who will stun themselves and drop their batons for the assistants to loot anyway.



## Changelog

```
(u)Lyra (Lison):
(+)Removed stunning yourself with an active baton on harm intent. 
```
