### PR TITLE
fix rng click_delay on failed Agrabs

### DIFF
--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -198,7 +198,7 @@
 				else
 					for(var/mob/O in AIviewers(src.assailant, null))
 						O.show_message("<span class='alert'>[src.assailant] has failed to grab [src.affecting] aggressively!</span>", 1)
-					user.next_click = world.time + rand(6,11)
+					user.next_click = world.time + user.combat_click_delay
 			if (GRAB_AGGRESSIVE)
 				if (ishuman(src.affecting))
 					var/mob/living/carbon/human/H = src.affecting


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE] [FIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes rng click delay on failed agrabs to combat click delay


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Consistency, and doublestacked RNG is kinda sucky


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Tarmunora:
(+)Changed failed aggressive grabs to always have the same delay before you can try again.
```
