### PR TITLE
Block adjust

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1236,9 +1236,8 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 					src.update_cursor()
 			else
 				if (!src.getStatusDuration("burning"))
-
-					if (src.next_click <= world.time && src.grab_block())
-						src.last_resist = world.time + 4
+					if (src.grab_block())
+						src.last_resist = world.time + (COMBAT_CLICK_DELAY/2)
 					else
 						for (var/mob/O in AIviewers(src, null))
 							O.show_message(text("<span class='alert'><B>[] resists!</B></span>", src), 1, group = "resist")

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -386,7 +386,8 @@
 				return
 		else
 			var/reach = can_reach(src, target)
-
+			if (src.pre_attack_modify())
+				equipped = src.equipped() //might have changed from successful modify
 			if (reach || (equipped && equipped.special) || (equipped && (equipped.flags & EXTRADELAY))) //Fuck you, magic number prickjerk //MBC : added bit to get weapon_attack->pixelaction to work for itemspecial
 				if (use_delay)
 					src.next_click = world.time + (equipped ? equipped.click_delay : src.click_delay)
@@ -430,6 +431,14 @@
 
 		if (src.next_click >= world.time) // since some of these attack functions go wild with modifying next_click, we implement the clicking grace window with a penalty instead of changing how next_click is set
 			src.next_click += grace_penalty
+
+/mob/living/proc/pre_attack_modify()
+	.=0
+	var/obj/item/grab/block/G = src.check_block()
+	if (G)
+		qdel(G)
+		.= 1
+
 
 /mob/living/update_cursor()
 	..()
@@ -1228,8 +1237,8 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 			else
 				if (!src.getStatusDuration("burning"))
 
-					if (src.grab_block())
-						src.last_resist = world.time + 5
+					if (src.next_click <= world.time && src.grab_block())
+						src.last_resist = world.time + 4
 					else
 						for (var/mob/O in AIviewers(src, null))
 							O.show_message(text("<span class='alert'><B>[] resists!</B></span>", src), 1, group = "resist")

--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -242,7 +242,7 @@
 		SEND_SIGNAL(I, COMSIG_ITEM_BLOCK_BEGIN, G)
 		src.setStatus("blocking", duration = INFINITE_STATUS)
 		block_begin(src)
-		src.next_click = world.time + (COMBAT_CLICK_DELAY/2)
+		src.next_click = world.time + (COMBAT_CLICK_DELAY)
 
 
 /mob/living/proc/grab_other(var/mob/living/target, var/suppress_final_message = 0, var/obj/item/grab_item = null)

--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -211,7 +211,7 @@
 		SEND_SIGNAL(src, COMSIG_UNARMED_BLOCK_BEGIN, G)
 		src.setStatus("blocking", duration = INFINITE_STATUS)
 		block_begin(src)
-		src.next_click = world.time + (COMBAT_CLICK_DELAY/2)
+		src.next_click = world.time + (COMBAT_CLICK_DELAY)
 		/*
 		RIP
 		else

--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -211,6 +211,7 @@
 		SEND_SIGNAL(src, COMSIG_UNARMED_BLOCK_BEGIN, G)
 		src.setStatus("blocking", duration = INFINITE_STATUS)
 		block_begin(src)
+		src.next_click = world.time + (COMBAT_CLICK_DELAY/2)
 		/*
 		RIP
 		else
@@ -241,6 +242,7 @@
 		SEND_SIGNAL(I, COMSIG_ITEM_BLOCK_BEGIN, G)
 		src.setStatus("blocking", duration = INFINITE_STATUS)
 		block_begin(src)
+		src.next_click = world.time + (COMBAT_CLICK_DELAY/2)
 
 
 /mob/living/proc/grab_other(var/mob/living/target, var/suppress_final_message = 0, var/obj/item/grab_item = null)

--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -717,11 +717,14 @@
 			I.c_flags &= ~HAS_GRAB_EQUIP
 			SEND_SIGNAL(I, COMSIG_ITEM_BLOCK_END, src)
 		else
-			SEND_SIGNAL(src.assailant, COMSIG_UNARMED_BLOCK_END, src)
+			if (assailant)
+				SEND_SIGNAL(src.assailant, COMSIG_UNARMED_BLOCK_END, src)
+
+
 		if (assailant)
 			assailant.visible_message("<span class='alert'>[assailant] lowers their defenses!</span>")
 			assailant.delStatus("blocking")
-			assailant.last_resist = max(assailant.last_resist, world.time + 4)
+			assailant.last_resist = world.time + (COMBAT_CLICK_DELAY/2)
 		..()
 
 	attack(atom/target, mob/user)

--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -16,7 +16,7 @@
 	var/resist_count = 0
 	var/item_grab_overlay_state = "grab_small"
 	var/can_pin = 1
-
+	var/dropped = 0
 
 	New(atom/loc)
 		..()
@@ -44,7 +44,7 @@
 			I.chokehold = null
 
 		if(assailant)	//drop that grab to avoid the sticky behavior
-			if (src in assailant.equipped_list())
+			if (src in assailant.equipped_list() && !dropped)
 				if (assailant.equipped() == src)
 					assailant.drop_item()
 				else
@@ -82,6 +82,7 @@
 		..()
 
 	dropped()
+		dropped += 1
 		qdel(src)
 
 	process(var/mult = 1)
@@ -702,6 +703,7 @@
 	can_pin = 0
 	hide_attack = 1
 
+
 	New()
 		..()
 		if (isitem(src.loc))
@@ -717,17 +719,15 @@
 		else
 			SEND_SIGNAL(src.assailant, COMSIG_UNARMED_BLOCK_END, src)
 		if (assailant)
+			assailant.visible_message("<span class='alert'>[assailant] lowers their defenses!</span>")
 			assailant.delStatus("blocking")
+			assailant.last_resist = max(assailant.last_resist, world.time + 4)
 		..()
 
 	attack(atom/target, mob/user)
-		if (assailant)
-			assailant.visible_message("<span class='alert'>[assailant] lowers their defenses!</span>")
 		qdel(src)
 
-	attack_self()
-		if (assailant)
-			assailant.visible_message("<span class='alert'>[assailant] lowers their defenses!</span>")
+	attack_self(mob/user)
 		qdel(src)
 
 	update_icon()
@@ -736,9 +736,7 @@
 	do_resist()
 		.= 0
 		if (assailant)
-			assailant.last_resist = world.time + 5
 			playsound(assailant.loc, 'sound/impact_sounds/Generic_Shove_1.ogg', 50, 1, 0, 1.5)
-			assailant.visible_message("<span class='alert'>[assailant] lowers their defenses!</span>")
 		qdel(src)
 
 


### PR DESCRIPTION

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)mbc:
(*)You can chain a block into an attack directly now (instead of needing to swap hands / drop the block). To balance this utility, beginning a block now applies combat click delay just like a punch or a throw would.
```
