### PR TITLE
adds admin-spawnable howitzer gun. crime

### DIFF
--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -1060,6 +1060,12 @@
 	cycle = 0
 	recharge_rate = 10.0
 
+/obj/item/ammo/power_cell/self_charging/howitzer
+	name = "Miniaturized SMES"
+	desc = "This thing is huge! How did you even lift it put it into the gun?"
+	charge = 2500.0
+	max_charge = 2500.0
+
 /obj/item/ammo/bullets/flintlock //Flintlock cant be reloaded so this is only for the initial bullet.
 	sname = ".58 Flintlock"
 	name = ".58 Flintlock"

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1475,3 +1475,21 @@
 		current_projectile = new/datum/projectile/special/spreader/quadwasp
 		projectiles = list(current_projectile)
 		..()
+
+// HOWIZTER GUN
+// dumb meme admin item. not remotely fair, will probably kill person firing it.
+
+/obj/item/gun/energy/howitzer
+	name = "man-portable plasma howitzer"
+	desc = "How can you even lift this?"
+	icon_state = "bfg"
+	uses_multiple_icon_states = 0
+	force = 25
+	two_handed = 1
+	can_dual_wield = 0
+
+	New()
+		..()
+		cell = new/obj/item/ammo/power_cell/self_charging/howitzer
+		current_projectile = new/datum/projectile/special/howitzer
+		projectiles = list(new/datum/projectile/special/howitzer )


### PR DESCRIPTION
## About the PR 

Adds a howitzer gun to the game. it fires howitzers. mega grief. will almost certainly gib you on firing it, sometimes you end up merely in crit. 

it has one shot. (technically its cell is self charging but it will take an eternity to recharge)

(also adds a gun powercell capable of firing the howitzer gun)

(currently using bfg sprites)




## Why's this needed? 

the admins can't share the joy of gibbing people with howitzers with the players. how will their hearts ever know joy



