### PR TITLE
Fixes doublehit and magically piercing bullets. I hope

### DIFF
--- a/code/modules/fluids/fluid_groups.dm
+++ b/code/modules/fluids/fluid_groups.dm
@@ -200,7 +200,6 @@
 		//	contained_amt = src.reagents.total_volume
 		//	amt_per_tile = contained_amt
 
-		LAGCHECK(LAG_HIGH)
 		if (!guarantee_is_member)
 			if (!members.len || !(F in members))
 				members += F

--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -52,7 +52,8 @@ toxic - poisons
 //Any special things when it hits shit?
 	on_hit(atom/hit, direction, obj/projectile/P)
 		if (ishuman(hit) && src.hit_type)
-			take_bleeding_damage(hit, null, round(src.power / 3), src.hit_type) // oh god no why was the first var set to src what was I thinking
+			SPAWN_DBG(0) //otherwise bullets pierce mobs at high lag
+				take_bleeding_damage(hit, null, round(src.power / 3), src.hit_type) // oh god no why was the first var set to src what was I thinking
 			hit.changeStatus("staggered", clamp(P.power/8, 5, 1) SECONDS)
 		..()//uh, what the fuck, call your parent
 		//return // BULLETS CANNOT BLEED, HAINE

--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -52,8 +52,7 @@ toxic - poisons
 //Any special things when it hits shit?
 	on_hit(atom/hit, direction, obj/projectile/P)
 		if (ishuman(hit) && src.hit_type)
-			SPAWN_DBG(0) //otherwise bullets pierce mobs at high lag
-				take_bleeding_damage(hit, null, round(src.power / 3), src.hit_type) // oh god no why was the first var set to src what was I thinking
+			take_bleeding_damage(hit, null, round(src.power / 3), src.hit_type) // oh god no why was the first var set to src what was I thinking
 			hit.changeStatus("staggered", clamp(P.power/8, 5, 1) SECONDS)
 		..()//uh, what the fuck, call your parent
 		//return // BULLETS CANNOT BLEED, HAINE

--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -164,6 +164,7 @@
 						if (src.proj_data) //ZeWaka: Fix for null.ticks_between_mob_hits
 							if (proj_data.hit_mob_sound)
 								playsound(X.loc, proj_data.hit_mob_sound, 60, 0.5)
+							proj_data.on_hit(X, angle_to_dir(src.angle), src)
 						for (var/obj/item/cloaking_device/S in X.contents)
 							if (S.active)
 								S.deactivate(X)
@@ -595,7 +596,7 @@ datum/projectile
 	var/goes_through_walls = 0
 	var/goes_through_mobs = 0
 	var/pierces = 0
-	var/ticks_between_mob_hits = 0
+	var/ticks_between_mob_hits = 1
 	// var/type = "K"					//3 types, K = Kinetic, E = Energy, T = Taser
 
 

--- a/code/obj/decal/cleanable.dm
+++ b/code/obj/decal/cleanable.dm
@@ -545,11 +545,11 @@ var/list/blood_decal_violent_icon_states = list("floor1", "floor2", "floor3", "f
 					src.slippery = 10
 
 		src.Dry(rand(vis_amount*80,vis_amount*120))
-
+		var/counter = 0
 		for (var/obj/item/I in get_turf(src))
-			LAGCHECK(LAG_LOW)
 			if (prob(vis_amount*10))
 				I.add_blood(src)
+			if(counter++>25)break
 
 	proc/create_overlay(var/list/icons_to_choose, var/add_color, var/direction)
 		var/blood_addition


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Hopefully finally fixes the doublehit bug for bullets, because I forgot to put in the active ingredient in my last attempted fix
Also fixes the issue where bullets would pierce mobs during periods of high lag
This had better be the last time this bug comes up or I'll scream
Also fixes transverse wave projectiles not stunning additional people on the tile as they were supposed to, whoops.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bullets doublehitting and magically piercing during laggy periods is... bad?

