### PR TITLE
Removed Porta-Brig from Sec Equipment Crate, Created Sec Containment Crate, Added gear to Sec Equipment Crat + more 

### DIFF
--- a/code/datums/supply_packs.dm
+++ b/code/datums/supply_packs.dm
@@ -390,7 +390,7 @@
 	category = "Security Department"
 	contains = list(/obj/item/storage/belt/security,
 					/obj/item/clothing/suit/armor/vest,
-					/obj/item/clothing/head/helmet
+					/obj/item/clothing/head/helmet,
 					/obj/item/gun/energy/taser_gun,
 					/obj/item/baton,
 					/obj/item/storage/box/QM_grenadekit_security,

--- a/code/datums/supply_packs.dm
+++ b/code/datums/supply_packs.dm
@@ -390,7 +390,7 @@
 	category = "Security Department"
 	contains = list(/obj/item/storage/belt/security,
 					/obj/item/clothing/suit/armor/vest,
-					/obj/item/clothing/head/helmet,
+					/obj/item/clothing/head/helmet/hardhat/security,
 					/obj/item/gun/energy/taser_gun,
 					/obj/item/baton,
 					/obj/item/storage/box/QM_grenadekit_security,

--- a/code/datums/supply_packs.dm
+++ b/code/datums/supply_packs.dm
@@ -400,7 +400,7 @@
 	containername = "Weapons Crate - Security Equipment (Cardlocked \[Security])"
 	access = access_security
 
-/datum/supply_packs/security_resupply
+/datum/supply_packs/security_brig_resupply
 	name = "Security Containment Crate - Security Equipment (Cardlocked \[Security])"
 	desc = "x1 Port-a-Brig and Remote"
 	category = "Security Department"

--- a/code/datums/supply_packs.dm
+++ b/code/datums/supply_packs.dm
@@ -386,10 +386,11 @@
 // Added security resupply crate (Convair880).
 /datum/supply_packs/security_resupply
 	name = "Weapons Crate - Security Equipment (Cardlocked \[Security])"
-	desc = "x1 Port-a-Brig and remote, x1 Taser, x1 Stun Baton, x1 Security-Issue Grenade Box, x1 Handcuff Kit"
+	desc = "x1 Security Belt, 1x Armoured Vest, 1x Helmet, x1 Taser, x1 Stun Baton, x1 Security-Issue Grenade Box, x1 Handcuff Kit"
 	category = "Security Department"
-	contains = list(/obj/machinery/port_a_brig,
-					/obj/item/remote/porter/port_a_brig,
+	contains = list(/obj/item/storage/belt/security,
+					/obj/item/clothing/suit/armor/vest,
+					/obj/item/clothing/head/helmet
 					/obj/item/gun/energy/taser_gun,
 					/obj/item/baton,
 					/obj/item/storage/box/QM_grenadekit_security,
@@ -397,6 +398,17 @@
 	cost = 5000
 	containertype = /obj/storage/secure/crate/weapon
 	containername = "Weapons Crate - Security Equipment (Cardlocked \[Security])"
+	access = access_security
+
+/datum/supply_packs/security_resupply
+	name = "Security Containment Crate - Security Equipment (Cardlocked \[Security])"
+	desc = "x1 Port-a-Brig and Remote"
+	category = "Security Department"
+	contains = list(/obj/machinery/port_a_brig,
+					/obj/item/remote/porter/port_a_brig)
+	cost = 1000
+	containertype = /obj/storage/secure/crate/weapon
+	containername = "Security Containment Crate - Security Equipment (Cardlocked \[Security])"
 	access = access_security
 
 /datum/supply_packs/security_upgrade //Azungar's upgrade pack for security.
@@ -911,6 +923,7 @@
 	category = "Civilian Department"
 	contains = list(/obj/item/chem_grenade/cleaner = 4,
 					/obj/item/spraybottle/cleaner = 2,
+					/obj/item/reagent_containers/glass/bottle/cleaner = 2,
 					/obj/item/storage/box/trash_bags,
 					/obj/item/storage/box/biohazard_bags)
 	cost = 500


### PR DESCRIPTION
 [ENHANCEMENT]

Removed the porta-brig from the Sec crate, made it it's own unique purchase, added sec belt, helmet and vest to said crate. Also added 2 bottle of space cleaner to Janitor Resupply while I was at it.


I think having the porta brig be lumped in with the other equipment is a bit much and makes everything very clunky due to its size and all. Not to mention it's nothing something that gets lost behind the couch or something. The added gear is to stand in place of missing brig. I don't believe this would affect anything gameplay wise since wearing armour as a non head/sec is pretty suspicious, not to mention if you've got a taser you're more of a threat than if you're wearing a helmet or a vest.

## Changelog
```
(u)Carbadox:
(+)Removed Port-a-brig from Security Equipment Crate and moved it to it's own seperate purchase
(+)Added general Security gear like belt, helmet and vest in place of the Brig
```
