### PR TITLE
Experimental changes to gang

### DIFF
--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -29,12 +29,19 @@
 
 	var/list/potential_hot_zones = null
 	var/area/hot_zone = null
-	var/hot_zone_timer = 3000
+	var/hot_zone_timer = 5 MINUTES
 	var/hot_zone_score = 1000
+	
+	var/const/kidnapping_timer = 8 MINUTES 	//Time to find and kidnap the victim.
+	var/const/delay_between_kidnappings = 5 MINUTES
+	var/kidnapping_score = 20000
+	var/kidnapp_success = 0			//true if the gang successfully kidnapps.
+
 	var/obj/item/device/radio/headset/gang/announcer_radio = new /obj/item/device/radio/headset/gang()
 	var/datum/generic_radio_source/announcer_source = new /datum/generic_radio_source()
 	var/slow_process = 0			//number of ticks to skip the extra gang process loops
 	var/janktank_price = 300		//should start the same as /datum/gang_item/misc/janktank.
+	var/mob/kidnapping_target
 
 /datum/game_mode/gang/announce()
 	boutput(world, "<B>The current game mode is - Gang War!</B>")
@@ -99,13 +106,16 @@
 
 	find_potential_hot_zones()
 
-	SPAWN_DBG (6000)
+	SPAWN_DBG (10 MINUTES)
 		process_hot_zones()
+
+	SPAWN_DBG (15 MINUTES)
+		process_kidnapping_event()
 
 	SPAWN_DBG (rand(waittime_l, waittime_h))
 		send_intercept()
 
-	SPAWN_DBG (30000)
+	SPAWN_DBG (50 MINUTES)
 		force_shuttle()
 
 	return 1
@@ -428,6 +438,63 @@
 				broadcast_to_all_gangs("[G.gang_name] has been rewarded for their control of the [hot_zone.name].")
 				sleep(10 SECONDS)
 			process_hot_zones()
+
+/datum/game_mode/gang/proc/process_kidnapping_event()
+	kidnapp_success = 0
+	var/datum/gang/top_gang = null
+	for (var/datum/gang/G in gangs)
+		if (!top_gang)
+			top_gang = G
+			continue
+		if (G.gang_score() > top_gang.gang_score())
+			top_gang = G
+
+	if (!top_gang)
+		logTheThing("debug", null, null, "No winning gang chosen for kidnapping event. Something's broken.")
+		message_admins("No winning gang chosen for kidnapping event. Something's broken.")
+		return 0
+
+	//get possible targets. Looks for ckey, if they are not dead, and if they are not in the top gang.
+	var/list/potential_targets = list()
+	for (var/mob/living/carbon/human/H in mobs)
+		if (H.ckey && H.stat != 2 && H.mind.gang != top_gang)
+			potential_targets += H
+
+	if (!potential_targets.len)
+		logTheThing("debug", null, null, "No players found to be kidnapping targets.")
+		message_admins("No kidnapping target has been chosen for kidnapping event. This should be pretty unlikely, unless there's only like 1 person on.")
+		return 0
+
+	kidnapping_target = pick(potential_targets)
+	if (ismob(kidnapping_target))
+	var/target_name = kidnapping_target.real_name
+	broadcast_to_all_gangs("The [hot_zone.name] is a high priority area. Ensure that your gang has control of it five minutes from now!")
+
+	//alert gangs, alert target which gang to be wary of. 
+	for (var/datum/gang/G in gangs)
+		if (G == top_gang)
+			broadcast_to_gang("A bounty has been placed on the capture of <b>[target_name]<b>. Shove them into your gang locker <ALIVE>, within 8 minutes for a massive reward!", G)
+		else
+			broadcast_to_gang("<b>[target_name]<b> is the target of a kidnapping by [G.gang_name]. Ensure that [target_name] is alive and well for the next 8 minutes for a reward!", G)
+
+
+	SPAWN_DBG(kidnapping_timer - 1 MINUTE)
+		if(kidnapping_target != null) broadcast_to_all_gangs("[target_name] has still not been captured by [top_gang.gang_name] and they have 1 minute left!")
+		SPAWN_DBG(1 MINUTE)
+			//if they didn't kidnapp em, then give points to other gangs depending on whether they are alive or not.
+			if(!kidnapp_success)
+				//if the kidnapping target is null or dead, nobody gets points. (the target will be "gibbed" if successfully "kidnapped" and points awarded there)
+				if (kidnapping_target && kidnapping_target.stat != 2)
+					for (var/datum/gang/G in gangs)
+						if (G != top_gang)
+							G.score_event += kidnapping_score/gangs.len 	//This is less than the total points the top_gang would get, so it behooves security to help the non-top gangs keep the target safe.
+					var/datum/gang/G = hot_zone.gang_owners
+					broadcast_to_all_gangs("[top_gang.gang_name] has failed to kidnapp [target_name] and the other gangs have been rewarded for thwarting the kidnapping attempt!")
+				else
+					broadcast_to_all_gangs("[target_name] has died in one way or another. No gangs have been rewarded for this futile exercise.")
+				sleep(delay_between_kidnappings)
+			process_kidnapping_event()
+
 
 //bleh
 /datum/game_mode/gang/proc/broadcast_to_all_gangs(var/message)
@@ -1004,6 +1071,32 @@
 
 		if (W.cant_drop)
 			return
+
+
+		//kidnapping event here
+		//if they're the target
+		if (istype(W, /obj/item/grab))
+			if (user.gang != src.gang)
+				bouput(user, "<span class='alert'>You can't kidnapp someone for a different gang!</span>")
+				return
+			var/obj/item/grab/G = W
+			if (G.affecting == kidnapping_target)
+				if (G.affecting.stat == 2)
+					bouput(user, "<span class='alert'>[G.affecting] is dead, you can't kidnapp a dead person!</span>")
+				else if (G.stat < 3)
+					bouput(user, "<span class='alert'>You'll need a stronger grip to successfully kinapp this person!")
+				else
+					user.visible_message("<span class='notice'>[user] shoves [G.affecting] into [src]!</span></span>")
+					G.affecting.set_loc(src)
+					//assign poitns, gangs
+					user.gang.score_event += kidnapping_score
+					broadcast_to_all_gangs("[user.gang] has successfully kidnapped [kidnapping_target] and has been rewarded for their efforts.")
+
+					kidnapping_target == null
+					kidnapp_success = 1
+					qdel(G.affecting)
+					qdel(G)
+
 
 		if(istype(W,/obj/item/plant/herb/cannabis) || istype(W,/obj/item/gun) || istype(W,/obj/item/spacecash) || (W.reagents != null && W.reagents.total_volume > 0))
 			if (insert_item(W,user))

--- a/code/modules/status_system/statusSystem.dm
+++ b/code/modules/status_system/statusSystem.dm
@@ -1088,7 +1088,10 @@ var/list/statusGroupLimits = list("Food"=4)
 		var/const/max_health = 30
 		var/const/max_stam = 60
 		var/const/regen_stam = 5
+		var/const/max_dist = 50
 		var/mob/living/carbon/human/H
+		var/datum/gang/gang
+		var/on_turf = 0
 
 		onAdd(var/optional=null)
 			if (ishuman(owner))
@@ -1098,14 +1101,46 @@ var/list/statusGroupLimits = list("Food"=4)
 			H.max_health += max_health
 			H.add_stam_mod_max("ganger_max", max_stam)
 			H.add_stam_mod_regen("ganger_regen", regen_stam)
+			if (ismob(owner))
+				var/mob/M = owner
+				if (M.mind)
+					gang = M.mind.gang
 
 		onRemove()
 			H.max_health -= max_health
 			H.remove_stam_mod_max("ganger_max")
 			H.remove_stam_mod_regen("ganger_regen")
+			gang = null
+
+		onUpdate(var/timedPassed)
+			var/area/cur_area = get_area(H)
+			if (cur_area?.gang_owners == gang && prob(50))
+				on_turf = 1
+
+				//get distance divided by max distance and invert it. Result will be between 0 and 1
+				var/buff_mult = round(1-(min(get_dist(owner,gang.locker), max_dist) / max_dist), 0.1)
+				if (buff_mult <=0)
+					buff_mult = 0.1
+
+				var/mob/living/carbon/human/H
+				if(ishuman(owner))
+					H = owner
+					H.HealDamage("All", 10*buff_mult, 0, 0)
+					if (H.bleeding && prob(100*buff_mult))
+						repair_bleeding_damage(H, 5, 1)
+
+					if(H.hasStatus("paralysis")) H.changeStatus("paralysis", -3*buff_mult)
+					if(H.hasStatus("stunned")) H.changeStatus("stunned", -3*buff_mult)
+					if(H.hasStatus("weakened")) H.changeStatus("weakened", -3*buff_mult)
+
+					H.updatehealth()
+			else
+				on_turf = 0
+
+			return
 
 		getTooltip()
-			return "Your max health, max stamina, and stamina regen have been increased because of the pride you feel while wearing your uniform."
+			return "Your max health, max stamina, and stamina regen have been increased because of the pride you feel while wearing your uniform. [on_turf?"You are on home turf and receiving healing and stun reduction buffs when nearer your locker.":""]"
 
 	janktank
 		id = "janktank"
@@ -1139,19 +1174,19 @@ var/list/statusGroupLimits = list("Food"=4)
 			var/mob/living/carbon/human/H
 			if(ishuman(owner))
 				H = owner
-			H.take_oxygen_deprivation(-1)
-			H.HealDamage("All", 2, 0, 0)
-			if (prob(60))
-				H.HealDamage("All", 1, 1, 1)
-				if (H.bleeding)
-					repair_bleeding_damage(H, 10, 1)
-			if (prob(10))
-				H.make_jittery(2)
+				H.take_oxygen_deprivation(-1)
+				H.HealDamage("All", 2, 0, 0)
+				if (prob(60))
+					H.HealDamage("All", 1, 1, 1)
+					if (H.bleeding)
+						repair_bleeding_damage(H, 10, 1)
+				if (prob(10))
+					H.make_jittery(2)
 
-			if (H.misstep_chance)
-				H.change_misstep_chance(-5)
+				if (H.misstep_chance)
+					H.change_misstep_chance(-5)
 
-			H.updatehealth()
+				H.updatehealth()
 			return
 
 	gang_drug_withdrawl


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Testing out some gang changes, might revert if they don't go as planned:
- new gang event that


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Adding some more spice to gangs to make it a bit more gang vs gang and territory control oriented as opposed to gang vs crew/security.
- New gang event in addition to the "turf capture


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Kyle:
(*)New gang mode event: Kidnapping. A target is selected from the crew that is not a member of the currently winning gang that . The rest of the gangs have to stop the target from being kidnapped or killed.
(*)Gang members wearing their gang clothes get slight passive heal and stun reduction if they are on turf that they own corresponding to the inverse of the distance between them and their gang locker.
```
