### PR TITLE
changes cuffs in sectechs to buddy cuffs

### DIFF
--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -394,7 +394,7 @@
 
 	create_products()
 		..()
-		product_list += new/datum/data/vending_product(/obj/item/handcuffs, 8)
+		product_list += new/datum/data/vending_product(/obj/item/handcuffs/guardbot, 8)
 		product_list += new/datum/data/vending_product(/obj/item/chem_grenade/flashbang, 5)
 		product_list += new/datum/data/vending_product(/obj/item/chem_grenade/fog, 5)
 		product_list += new/datum/data/vending_product(/obj/item/device/flash, 4)
@@ -407,7 +407,7 @@
 #endif
 		product_list += new/datum/data/vending_product(/obj/item/device/flash/turbo, rand(1, 6), hidden=1)
 		product_list += new/datum/data/vending_product(/obj/item/ammo/bullets/a38, rand(1, 2), hidden=1) // Obtaining a backpack full of lethal ammo required no effort whatsoever, hence why nobody ordered AP speedloaders from the Syndicate (Convair880).
-
+		product_list += new/datum/data/vending_product(/obj/item/handcuffs, rand(1, 4))
 /obj/machinery/vending/security_ammo
 	name = "AmmoTech"
 	desc = "A restricted ammunition vendor."

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -407,7 +407,7 @@
 #endif
 		product_list += new/datum/data/vending_product(/obj/item/device/flash/turbo, rand(1, 6), hidden=1)
 		product_list += new/datum/data/vending_product(/obj/item/ammo/bullets/a38, rand(1, 2), hidden=1) // Obtaining a backpack full of lethal ammo required no effort whatsoever, hence why nobody ordered AP speedloaders from the Syndicate (Convair880).
-		product_list += new/datum/data/vending_product(/obj/item/handcuffs, rand(1, 4))
+		product_list += new/datum/data/vending_product(/obj/item/handcuffs, rand(1, 4), hidden=1)
 /obj/machinery/vending/security_ammo
 	name = "AmmoTech"
 	desc = "A restricted ammunition vendor."

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -407,7 +407,7 @@
 #endif
 		product_list += new/datum/data/vending_product(/obj/item/device/flash/turbo, rand(1, 6), hidden=1)
 		product_list += new/datum/data/vending_product(/obj/item/ammo/bullets/a38, rand(1, 2), hidden=1) // Obtaining a backpack full of lethal ammo required no effort whatsoever, hence why nobody ordered AP speedloaders from the Syndicate (Convair880).
-		product_list += new/datum/data/vending_product(/obj/item/handcuffs, rand(1, 4), hidden=1)
+		product_list += new/datum/data/vending_product(/obj/item/handcuffs, 8, hidden=1)
 /obj/machinery/vending/security_ammo
 	name = "AmmoTech"
 	desc = "A restricted ammunition vendor."

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -394,7 +394,8 @@
 
 	create_products()
 		..()
-		product_list += new/datum/data/vending_product(/obj/item/handcuffs/guardbot, 8)
+		product_list += new/datum/data/vending_product(/obj/item/handcuffs/guardbot, 16)
+		product_list += new/datum/data/vending_product(/obj/item/handcuffs, 8)
 		product_list += new/datum/data/vending_product(/obj/item/chem_grenade/flashbang, 5)
 		product_list += new/datum/data/vending_product(/obj/item/chem_grenade/fog, 5)
 		product_list += new/datum/data/vending_product(/obj/item/device/flash, 4)
@@ -407,7 +408,6 @@
 #endif
 		product_list += new/datum/data/vending_product(/obj/item/device/flash/turbo, rand(1, 6), hidden=1)
 		product_list += new/datum/data/vending_product(/obj/item/ammo/bullets/a38, rand(1, 2), hidden=1) // Obtaining a backpack full of lethal ammo required no effort whatsoever, hence why nobody ordered AP speedloaders from the Syndicate (Convair880).
-		product_list += new/datum/data/vending_product(/obj/item/handcuffs, 8, hidden=1)
 /obj/machinery/vending/security_ammo
 	name = "AmmoTech"
 	desc = "A restricted ammunition vendor."


### PR DESCRIPTION
[FEATURE]
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
changes handcuffs in sectechs to buddy cuffs (faster to escape, disintegrate when resisted out of)
Adds a few regular cuffs to hacked sectechs to compensate

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Ziptie cuffs gives sec a way to 'lightly' handcuff people, and just gives security another option in how they deal with (lesser) crime
Sec already gets a lot of standard cuffs, and you can hack the sectech vendors to get a few more


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Tarmunora:
(+)Added plastic cuffs, which take a shorter amount of time to break out of, to security vendors.
```
