### PR TITLE
Remove lagchecks from message admins procs

### DIFF
--- a/code/datums/controllers/sea_hotspot_controls.dm
+++ b/code/datums/controllers/sea_hotspot_controls.dm
@@ -383,10 +383,10 @@
 		else if (found)
 			playsound(phenomena_point, 'sound/misc/ground_rumble.ogg', 70, 1, 0.1, 1)
 
-
 		//hey recurse at this arbitrary heat value, thanks
 		if (heat > 8000 + (8000 * recursion))
-			if (recursion <= 0 && get_area_name(phenomena_point) != "Ocean")
+			var/areaname = get_area_name(phenomena_point)
+			if (recursion <= 0 && areaname && areaname != "Ocean")
 				var/logmsg = "BIG hotspot phenomena (Heat : [heat])  at [log_loc(phenomena_point)]."
 				message_admins(logmsg)
 				logTheThing("bombing", null, null, logmsg)
@@ -396,7 +396,8 @@
 				LAGCHECK(LAG_HIGH)
 				src.do_phenomena( recursion++, heat - (9000 + (9000 * recursion)) )
 		else
-			if (phenomena_flags > PH_QUAKE && recursion <= 0 && get_area_name(phenomena_point) != "Ocean")
+			var/areaname = get_area_name(phenomena_point)
+			if (phenomena_flags > PH_QUAKE && recursion <= 0 && areaname && areaname != "Ocean")
 				var/logmsg = "Hotspot phenomena (Heat : [heat])  at [log_loc(phenomena_point)]."
 				message_admins(logmsg)
 				logTheThing("bombing", null, null, logmsg)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -23,14 +23,12 @@ var/global/noir = 0
 				continue
 		else
 			boutput(C, replacetext(rendered, "%admin_ref%", "\ref[C.holder]")) //this doesnt fail if the placeholder doesnt exist ok dont worry
-		LAGCHECK(LAG_LOW)
 
 /proc/message_coders(var/text) //Shamelessly adapted from message_admins
 	var/rendered = "<span class=\"admin\"><span class=\"prefix\">CODER LOG:</span> <span class=\"message\">[text]</span></span>"
 	for (var/mob/M in mobs)
 		if (M && M.client && M.client.holder && rank_to_level(M.client.holder.rank) >= LEVEL_CODER) //This is for edge cases where a coder needs a goddamn notification when it happens
 			boutput(M, replacetext(rendered, "%admin_ref%", "\ref[M.client.holder]"))
-		LAGCHECK(LAG_LOW)
 
 /proc/message_coders_vardbg(var/text, var/datum/d)
 	var/rendered
@@ -39,14 +37,12 @@ var/global/noir = 0
 			var/dbg_html = M.client.debug_variable("", d, 0)
 			rendered = "<span class=\"admin\"><span class=\"prefix\">CODER LOG:</span> <span class=\"message\">[text]</span>[dbg_html]</span>"
 			boutput(M, replacetext(rendered, "%admin_ref%", "\ref[M.client.holder]"))
-		LAGCHECK(LAG_LOW)
 
 /proc/message_attack(var/text) //Sends a message to folks when an attack goes down
 	var/rendered = "<span class=\"admin\"><span class=\"prefix\">ATTACK LOG:</span> <span class=\"message\">[text]</span></span>"
 	for (var/mob/M in mobs)
 		if (M && M.client && M.client.holder && rank_to_level(M.client.holder.rank) >= LEVEL_MOD && M.client.holder.attacktoggle && !M.client.player_mode)
 			boutput(M, replacetext(rendered, "%admin_ref%", "\ref[M.client.holder]"))
-		LAGCHECK(LAG_LOW)
 
 /proc/rank_to_level(var/rank)
 	var/level = 0


### PR DESCRIPTION
These loops arent insanely costly (some string building but eh), but they have big potential to cause problems from lagchecking in all the places they are used!!

i also threw in a hotspots logging fix