### PR TITLE
Fixes medical records not updating with health implant info

### DIFF
--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -208,13 +208,14 @@ THROWING DARTS
 		var/mob/living/carbon/human/H = src.owner
 		if (!H.mini_health_hud)
 			H.mini_health_hud = 1
-			var/datum/data/record/probably_my_record = null
-			for (var/datum/data/record/R in data_core.medical)
-				if (R.fields["name"] == H.real_name)
-					probably_my_record = R
-					break
-			if (probably_my_record)
-				probably_my_record.fields["h_imp"] = "[src.sensehealth()]"
+
+		var/datum/data/record/probably_my_record = null
+		for (var/datum/data/record/R in data_core.medical)
+			if (R.fields["name"] == H.real_name)
+				probably_my_record = R
+				break
+		if (probably_my_record)
+			probably_my_record.fields["h_imp"] = "[src.sensehealth()]"
 		..()
 
 	on_crit()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Health records have a field that updates with a patient's health implant every life tick. Due to improper indentation, this never actually happened.
This fix just moves everything that's supposed to do that outside of the if statement in `do_life`


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix for longstanding bug