### PR TITLE
Allow change in guardbuddy and navbeacon freqs + navbeacon packet control

### DIFF
--- a/code/obj/machinery/navbeacon.dm
+++ b/code/obj/machinery/navbeacon.dm
@@ -19,7 +19,7 @@
 	var/codes_txt = ""	// codes as set on map: "tag1;tag2" or "tag1=value;tag2=value"
 	var/net_id = ""
 
-	req_access = list(access_engineering)
+	req_access = list(access_engineering,access_engineering_mechanic,access_research_director)
 	object_flags = CAN_REPROGRAM_ACCESS
 
 	New()
@@ -79,19 +79,37 @@
 	// or one of the set transponder keys
 	// if found, return a signal
 	receive_signal(datum/signal/signal)
+		if (!signal || signal.encryption) return
 
-//		if(status & NOPOWER)
-//			return
-
-		var/request = signal.data["findbeacon"]
-		if(request && ((request in codes) || request == "any" || request == location))
+		var/beaconrequest = signal.data["findbeacon"]
+		if(beaconrequest && ((beaconrequest in codes) || beaconrequest == "any" || beaconrequest == location))
 			SPAWN_DBG(1 DECI SECOND)
-				post_signal()
+				post_status()
+			return
+
+		if (!signal.data["address_1"] || signal.data["address_1"] != src.net_id || !signal.data["sender"])
+			// Not for us, ignore
+			return
+
+		switch (signal.data["command"])
+			if ("status")
+				post_status(signal.data["sender"])
+			if ("set_location")
+				if (!signal.data["location"]) return
+				var/newloq = adminscrub(signal.data["location"])
+				src.location = newloq
+				post_status(signal.data["sender"])
+			if ("set_code")
+				if (!signal.data["code_key"] || !signal.data["code_value"]) return
+				var/code_key = adminscrub(signal.data["code_key"])
+				var/code_value = adminscrub(signal.data["code_value"])
+				codes.Remove(code_key)
+				codes[code_key] = code_value
+				post_status(signal.data["sender"])
 
 
 	// return a signal giving location and transponder codes
-
-	proc/post_signal()
+	proc/post_status(var/target)
 
 		var/datum/radio_frequency/frequency = radio_controller.return_frequency("[freq]")
 
@@ -102,6 +120,8 @@
 		signal.transmission_method = 1
 		signal.data["beacon"] = location
 		signal.data["netid"] = net_id
+		if (target)
+			signal.data["address_1"] = target
 
 		for(var/key in codes)
 			signal.data[key] = codes[key]
@@ -201,6 +221,7 @@ Transponder Codes:<UL>"}
 
 				if (href_list["freq"])
 					freq = sanitize_frequency(freq + text2num(href_list["freq"]))
+					set_frequency(freq)
 					updateDialog()
 
 				else if(href_list["locedit"])
@@ -220,7 +241,7 @@ Transponder Codes:<UL>"}
 
 					var/codeval = codes[codekey]
 					var/newval = input("Enter Transponder Code Value", "Navigation Beacon", codeval) as text|null
-					newval = copytext(adminscrub(newval), 1, 64)
+					newval = copytext(adminscrub(newval), 1, 256)
 					if(!newval)
 						newval = codekey
 						return
@@ -254,6 +275,11 @@ Transponder Codes:<UL>"}
 					codes[newkey] = newval
 
 					updateDialog()
+
+	proc/set_frequency(var/new_freq)
+		radio_controller.remove_object(src, "[freq]")
+		freq = new_freq
+		radio_controller.add_object(src, "[freq]")
 
 //Wired nav device
 /obj/machinery/wirenav


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[ENHANCEMENT]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
A few enhancements and fixes for guardbuddies and navbeacons.

1. Fixes changing navbeacon frequencies - wasn't actually working before
2. Allows changing a guardbuddy's beacon and control frequencies. Option for changing beacon frequency should be added to prman at some point (when I figure out how that works)
3. Increases the limit on navbeacon code values from 64 to 256. A lot of the default descriptions were much longer than 64 characters, so if you hit edit, it'd get truncated even if you tried to keep it the same. This should eliminate that for most cases
4. Allow mechanics and the RD to unlock and reconfigure navbeacons as well as engineers
5. Add more options for controlling navbeacon settings using wireless packets


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I think the guardbuddies are neat, and having more flexibility in determining where they go and how they're controlled will allow for them to do fun stuff! For example, making the buddies go on strike and march up and down the hallways demanding weekends off. I want to continue adding more stuff for buddies to do, and this seemed like a good first step.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)glassofmilk:
(+)Changed to allow more configuration for guardbuddy and navbeacon settings
```
