### PR TITLE
changes pulse to pullse on ass day

### DIFF
--- a/code/modules/projectiles/energy_bolt.dm
+++ b/code/modules/projectiles/energy_bolt.dm
@@ -304,7 +304,24 @@ toxic - poisons
 	disruption = 8
 
 	hit_mob_sound = 'sound/effects/sparks6.ogg'
+#if ASS_JAM
 
+	on_pointblank(var/obj/projectile/P, var/mob/living/M)
+		// var/dir = angle2dir(angle)
+		M.throw_at(get_edge_target_turf(M, get_dir(M, P)),7,1, throw_type = THROW_GUNIMPACT)
+		//When it hits a mob or such should anything special happen
+	on_hit(atom/hit, angle, var/obj/projectile/O)
+		// var/dir = angle2dir(angle)
+		var/dir = get_dir(hit, O.shooter)
+		var/pow = O.power
+		O.die()
+		if (ishuman(hit))
+			var/mob/living/carbon/human/H = hit
+			H.do_disorient(stamina_damage = pow*3, weakened = 0, stunned = 0, disorient = pow*4, remove_stamina_below_zero = 0)
+			H.throw_at(get_edge_target_turf(hit, dir),(pow-7)/2,1, throw_type = THROW_GUNIMPACT)
+			H.emote("twitch_v")
+			H.changeStatus("slowed", 3 SECONDS)
+#else
 	on_pointblank(var/obj/projectile/P, var/mob/living/M)
 		// var/dir = angle2dir(angle)
 		M.throw_at(get_edge_target_turf(M, get_dir(P, M)),7,1, throw_type = THROW_GUNIMPACT)
@@ -322,6 +339,7 @@ toxic - poisons
 			H.emote("twitch_v")
 			H.changeStatus("slowed", 3 SECONDS)
 
+#endif
 	impact_image_effect(var/type, atom/hit, angle, var/obj/projectile/O)
 		return
 

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1248,8 +1248,12 @@
 				if ("pulse")
 					current_projectile = projectiles["pulse"]
 					item_state = "lawg-pulse"
+#if ASS_JAM
+					playsound(M, "sound/vox/pull.ogg", 50)
+#else
 					playsound(M, "sound/vox/push.ogg", 50)
 
+#endif
 					/datum/projectile/energy_bolt/pulse
 		else		//if you're not the owner and try to change it, then fuck you
 			switch(text)
@@ -1429,7 +1433,11 @@
 // An energy gun that uses the lawbringer's Pulse setting, to beef up the current armory.
 
 /obj/item/gun/energy/pulse_rifle
+#if ASS_JAM
+	name = "pullse rifle"
+#else
 	name = "pulse rifle"
+#endif
 	desc = "todo"
 	icon_state = "pulse_rifle"
 	uses_multiple_icon_states = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[ASS-JAM]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes pulse to pullse on ass day (pulse shots make the target fly *towards* the shooter instead of away)
Tweaks name of pulse rifles and makes vox say `pull` instead of `push` for the lawbringer on assday as well


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Pullse rifle is a funny joke


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Tarmunora:
(+)ASS JAM: Changed pulse to pullse
```
