### PR TITLE
Jobxp clown

### DIFF
--- a/code/WorkInProgress/JobXPRewards.dm
+++ b/code/WorkInProgress/JobXPRewards.dm
@@ -351,19 +351,23 @@ mob/verb/checkrewards()
 
 /////////////CLOWN////////////////
 /datum/jobXpReward/clown1
-	name = "Nothing"
-	desc = "Nothing!"
+	name = "Special Crayon"
+	desc = "Spin it and watch it work its \"Magic\"!"
 	required_levels = list("Clown"=1)
 	icon_state = "?"
 	claimable = 1
 	claimPerRound = 1
 
 	activate(var/client/C)
-		boutput(C, "Nothing seems to happen!")
+		boutput(C, "You pull your special crayon out from your special place!")
+		var/obj/item/I = new/obj/item/pen/crayon/random/choose()
+		I.set_loc(get_turf(C.mob))
+		C.mob.put_in_hand(I)
 		return
+
 /datum/jobXpReward/clown5
-	name = "Nothing Again!"
-	desc = "Nothing!"
+	name = "Nothing!"
+	desc = "Nothing Again!"
 	required_levels = list("Clown"=5)
 	icon_state = "?"
 	claimable = 1
@@ -374,8 +378,8 @@ mob/verb/checkrewards()
 		return
 
 /datum/jobXpReward/clown10
-	name = "Nothing Again Again!!"
-	desc = "Nothing!"
+	name = "Nothing!!"
+	desc = "Nothing Again Again!!"
 	required_levels = list("Clown"=10)
 	icon_state = "?"
 	claimable = 1
@@ -385,8 +389,8 @@ mob/verb/checkrewards()
 		boutput(C, "Nothing seems to happen!")
 		return
 /datum/jobXpReward/clown15
-	name = "Nothing Again Again Again!!!"
-	desc = "Nothing!"
+	name = "Nothing!!!"
+	desc = "Nothing Again Again Again!!!"
 	required_levels = list("Clown"=15)
 	icon_state = "?"
 	claimable = 1
@@ -406,12 +410,11 @@ mob/verb/checkrewards()
 
 	activate(var/client/C)
 		boutput(C, "You get a \"banana\"!")
-		var/obj/banana 
-		if (prob(1)
-			banana = new/obj/item/old_grenade/banana
+		var/obj/item/banana = null 
+		if (prob(1))
+			banana = new/obj/item/old_grenade/banana()
 		else
-
-			banana = new/obj/item/reagent_containers/food/snacks/plant/banana
+			banana = new/obj/item/reagent_containers/food/snacks/plant/banana()
 		banana.set_loc(get_turf(C.mob))
 		C.mob.put_in_hand(banana)
 		return

--- a/code/WorkInProgress/JobXPRewards.dm
+++ b/code/WorkInProgress/JobXPRewards.dm
@@ -348,3 +348,70 @@ mob/verb/checkrewards()
 	desc = ""
 	required_levels = list("Security Officer"=999)
 	icon_state = "?"
+
+/////////////CLOWN////////////////
+/datum/jobXpReward/clown1
+	name = "Nothing"
+	desc = "Nothing!"
+	required_levels = list("Clown"=1)
+	icon_state = "?"
+	claimable = 1
+	claimPerRound = 1
+
+	activate(var/client/C)
+		boutput(C, "Nothing seems to happen!")
+		return
+/datum/jobXpReward/clown5
+	name = "Nothing Again!"
+	desc = "Nothing!"
+	required_levels = list("Clown"=5)
+	icon_state = "?"
+	claimable = 1
+	claimPerRound = 1
+
+	activate(var/client/C)
+		boutput(C, "Nothing seems to happen!")
+		return
+
+/datum/jobXpReward/clown10
+	name = "Nothing Again Again!!"
+	desc = "Nothing!"
+	required_levels = list("Clown"=10)
+	icon_state = "?"
+	claimable = 1
+	claimPerRound = 1
+
+	activate(var/client/C)
+		boutput(C, "Nothing seems to happen!")
+		return
+/datum/jobXpReward/clown15
+	name = "Nothing Again Again Again!!!"
+	desc = "Nothing!"
+	required_levels = list("Clown"=15)
+	icon_state = "?"
+	claimable = 1
+	claimPerRound = 1
+
+	activate(var/client/C)
+		boutput(C, "Nothing seems to happen!")
+		return
+
+/datum/jobXpReward/clown20
+	name = "Bananna"
+	desc = "Banana, but misspelled!"
+	required_levels = list("Clown"=20)
+	icon_state = "?"
+	claimable = 1
+	claimPerRound = 1
+
+	activate(var/client/C)
+		boutput(C, "You get a \"banana\"!")
+		var/obj/banana 
+		if (prob(1)
+			banana = new/obj/item/old_grenade/banana
+		else
+
+			banana = new/obj/item/reagent_containers/food/snacks/plant/banana
+		banana.set_loc(get_turf(C.mob))
+		C.mob.put_in_hand(banana)
+		return

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1154,6 +1154,7 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 			if (src.bioHolder && src.bioHolder.HasEffect("clumsy") && prob(50))
 				message = "<B>[src]</B> tries to hand [thing] to [M], but [src] drops it!"
 				thing.set_loc(src.loc)
+				JOB_XP(src, "Clown", 2)
 			else if (M.bioHolder && M.bioHolder.HasEffect("clumsy") && prob(50))
 				message = "<B>[src]</B> tries to hand [thing] to [M], but [M] drops it!"
 				thing.set_loc(M.loc)

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -695,6 +695,7 @@
 
 		if (src.getStatusDuration("burning") > 400)
 			src.unlock_medal("Black and Blue", 1)
+		JOB_XP(src, "Clown", 10)
 
 	ticker.mode.check_win()
 

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -238,6 +238,7 @@
 									message = "<B>[src]</B> [pick("spins", "twirls")] [thing] around in [his_or_her(src)] hand, and drops it right on the ground.[prob(10) ? " What an oaf." : null]"
 									src.u_equip(thing)
 									thing.set_loc(src.loc)
+									JOB_XP(user, "Clown", 1)
 								else
 									message = "<B>[src]</B> [pick("spins", "twirls")] [thing] around in [his_or_her(src)] hand."
 									thing.on_spin_emote(src)
@@ -1133,6 +1134,8 @@
 								message = pick("<B>[src]</B> tries to flip, but stumbles!", "<B>[src]</B> slips!")
 								src.changeStatus("weakened", 4 SECONDS)
 								src.TakeDamage("head", 8, 0, 0, DAMAGE_BLUNT)
+								JOB_XP(src, "Clown", 1)
+
 							if (src.bioHolder.HasEffect("fat"))
 								message = pick("<B>[src]</B> tries to flip, but stumbles!", "<B>[src]</B> collapses under [his_or_her(src)] own weight!")
 								src.changeStatus("weakened", 2 SECONDS)

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -238,7 +238,7 @@
 									message = "<B>[src]</B> [pick("spins", "twirls")] [thing] around in [his_or_her(src)] hand, and drops it right on the ground.[prob(10) ? " What an oaf." : null]"
 									src.u_equip(thing)
 									thing.set_loc(src.loc)
-									JOB_XP(user, "Clown", 1)
+									JOB_XP(src, "Clown", 1)
 								else
 									message = "<B>[src]</B> [pick("spins", "twirls")] [thing] around in [his_or_her(src)] hand."
 									thing.on_spin_emote(src)

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -1039,6 +1039,7 @@
 					"You add [W] to [src].<br><span class='alert'>[src] is too full and spills!</span>")
 					src.reagents.reaction(get_turf(user), TOUCH, src.reagents.total_volume / 2)
 					src.reagents.add_reagent("ice", 5, null, (T0C - 1))
+					JOB_XP(user, "Clown", 1)
 					pool(W)
 					return
 				else

--- a/code/modules/food_and_drink/bread.dm
+++ b/code/modules/food_and_drink/bread.dm
@@ -29,6 +29,7 @@
 				user.visible_message("<span class='alert'><b>[user]</b> fumbles and jabs \himself in the eye with [W].</span>")
 				user.change_eye_blurry(5)
 				user.changeStatus("weakened", 3 SECONDS)
+				JOB_XP(user, "Clown", 2)
 				return
 
 			var/turf/T = get_turf(src)

--- a/code/modules/food_and_drink/plants.dm
+++ b/code/modules/food_and_drink/plants.dm
@@ -833,6 +833,8 @@
 				user.visible_message("<span class='alert'><b>[user]</b> fumbles and pokes \himself in the eye with [src].</span>")
 				user.change_eye_blurry(5)
 				user.changeStatus("weakened", 3 SECONDS)
+				JOB_XP(user, "Clown", 2)
+
 				return
 			boutput(user, "<span class='notice'>You peel [src].</span>")
 			src.name = copytext(src.name, 10)	// "unpeeled "

--- a/code/modules/holiday/spacemas.dm
+++ b/code/modules/holiday/spacemas.dm
@@ -538,6 +538,7 @@ var/list/seal_names = list("Fluffles","Ronan","Selena","Selkie","Ukog","Ategev",
 			user.visible_message("<span class='alert'>[user] plasters the snowball over [his_or_her(user)] face.</span>",\
 			"<span class='alert'>You plaster the snowball over your face.</span>")
 			src.hit(user, 0)
+			JOB_XP(user, "Clown", 4)
 			return
 
 		src.add_fingerprint(user)

--- a/code/modules/medical/surgery_procs.dm
+++ b/code/modules/medical/surgery_procs.dm
@@ -300,6 +300,7 @@ limbs are their own thing not included here.
 		"<span class='alert'>You fumble and stab yourself in the eye with [src]!</span>")
 		surgeon.bioHolder.AddEffect("blind")
 		surgeon.changeStatus("weakened", 4 SECONDS)
+		JOB_XP(surgeon, "Clown", 1)
 		var/damage = rand(5, 15)
 		random_brute_damage(surgeon, damage)
 		take_bleeding_damage(surgeon, null, damage)
@@ -911,6 +912,7 @@ limbs are their own thing not included here.
 		surgeon.visible_message("<span class='alert'><b>[surgeon]</b> mishandles [src] and cuts [him_or_her(surgeon)]self!</span>",\
 		"<span class='alert'>You mishandle [src] and cut yourself!</span>")
 		surgeon.changeStatus("weakened", 1 SECOND)
+		JOB_XP(surgeon, "Clown", 1)
 		var/damage = rand(10, 20)
 		random_brute_damage(surgeon, damage)
 		take_bleeding_damage(surgeon, damage)
@@ -1256,6 +1258,7 @@ limbs are their own thing not included here.
 		// I'm not deleting it I'm just commenting it out so my shame will be eternal and perhaps future generations of coders can learn from my mistake
 		// - Haine
 		surgeon.changeStatus("weakened", 4 SECONDS)
+		JOB_XP(surgeon, "Clown", 1)
 		var/damage = rand(1, 10)
 		random_brute_damage(surgeon, damage)
 		take_bleeding_damage(surgeon, damage)
@@ -1429,6 +1432,7 @@ limbs are their own thing not included here.
 		surgeon.visible_message("<span class='alert'><b>[surgeon]</b> burns [him_or_her(surgeon)]self with [src]!</span>",\
 		"<span class='alert'>You burn yourself with [src]</span>")
 
+		JOB_XP(surgeon, "Clown", 1)
 		surgeon.changeStatus("weakened", 4 SECONDS)
 		random_burn_damage(surgeon, damage)
 		return 1
@@ -1693,6 +1697,7 @@ limbs are their own thing not included here.
 		surgeon.bioHolder.AddEffect("blind")
 		patient.changeStatus("weakened", 4)
 
+		JOB_XP(surgeon, "Clown", 1)
 		var/damage = rand(5, 15)
 		random_brute_damage(surgeon, damage)
 		take_bleeding_damage(surgeon, null, damage)

--- a/code/modules/medical/surgery_tools.dm
+++ b/code/modules/medical/surgery_tools.dm
@@ -1225,7 +1225,7 @@ CONTAINS:
 
 		if (user.bioHolder && user.bioHolder.HasEffect("clumsy") && prob(33))
 			M = user // hold the pen the right way, dingus!
-			JOB_XP(surgeon, "Clown", 1)
+			JOB_XP(user, "Clown", 1)
 
 		if (!src.on || def_zone != "head")
 			M.tri_message("[user] wiggles [src] at [M == user ? "[his_or_her(user)] own" : "[M]'s"] [zone_sel2name[def_zone]].[!src.on ? " \The [src] isn't on, so it doesn't do much." : null]",\

--- a/code/modules/medical/surgery_tools.dm
+++ b/code/modules/medical/surgery_tools.dm
@@ -1225,6 +1225,7 @@ CONTAINS:
 
 		if (user.bioHolder && user.bioHolder.HasEffect("clumsy") && prob(33))
 			M = user // hold the pen the right way, dingus!
+			JOB_XP(surgeon, "Clown", 1)
 
 		if (!src.on || def_zone != "head")
 			M.tri_message("[user] wiggles [src] at [M == user ? "[his_or_her(user)] own" : "[M]'s"] [zone_sel2name[def_zone]].[!src.on ? " \The [src] isn't on, so it doesn't do much." : null]",\

--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -1207,6 +1207,7 @@ toxic - poisons
 				SPAWN_DBG(0)
 					H.throw_at(get_offset_target_turf(H, rand(5)-rand(5), rand(5)-rand(5)), rand(2,4), 2, throw_type = THROW_GUNIMPACT)
 				H.emote("twitch_v")
+				JOB_XP(H, "Clown", 1)
 		return
 
 /datum/projectile/bullet/mininuke //Assday only.

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -1276,6 +1276,7 @@
 	if ((user.bioHolder && user.bioHolder.HasEffect("clumsy") && prob(50)) || (user.reagents && prob(user.reagents.get_reagent_amount("ethanol") / 2)) || prob(5))
 		user.visible_message("<span class='alert'><b>[user] fumbles [src]!</b></span>")
 		src.throw_impact(user)
+		JOB_XP(user, "Clown", 1)
 	return
 
 /obj/item/proc/HY_set_species()

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -1276,7 +1276,6 @@
 	if ((user.bioHolder && user.bioHolder.HasEffect("clumsy") && prob(50)) || (user.reagents && prob(user.reagents.get_reagent_amount("ethanol") / 2)) || prob(5))
 		user.visible_message("<span class='alert'><b>[user] fumbles [src]!</b></span>")
 		src.throw_impact(user)
-		JOB_XP(user, "Clown", 1)
 	return
 
 /obj/item/proc/HY_set_species()

--- a/code/obj/item/basketball.dm
+++ b/code/obj/item/basketball.dm
@@ -41,7 +41,7 @@
 				if((prob(50) && M.bioHolder.HasEffect("clumsy")) || M.equipped() || get_dir(M, src) == M.dir)
 					src.visible_message("<span class='combat'>[M] gets beaned with the [src.name].</span>")
 					M.changeStatus("stunned", 2 SECONDS)
-					JOB_XP(surgeon, "Clown", 1)
+					JOB_XP(M, "Clown", 1)
 					return
 				// catch the ball!
 				src.attack_hand(M)

--- a/code/obj/item/basketball.dm
+++ b/code/obj/item/basketball.dm
@@ -41,6 +41,7 @@
 				if((prob(50) && M.bioHolder.HasEffect("clumsy")) || M.equipped() || get_dir(M, src) == M.dir)
 					src.visible_message("<span class='combat'>[M] gets beaned with the [src.name].</span>")
 					M.changeStatus("stunned", 2 SECONDS)
+					JOB_XP(surgeon, "Clown", 1)
 					return
 				// catch the ball!
 				src.attack_hand(M)
@@ -116,6 +117,8 @@
 			if (user.bioHolder.HasEffect("clumsy") && prob(50)) // clowns are not good at basketball I guess
 				user.visible_message("<span class='combat'><b>[user] knocks their head into the rim of [src]!</b></span>")
 				user.changeStatus("weakened", 5 SECONDS)
+				JOB_XP(user, "Clown", 1)
+
 			if (!src.shoot(W, user))
 				SPAWN_DBG(1 SECOND)
 					src.visible_message("<span class='alert'>[user] whiffs the dunk.</span>")

--- a/code/obj/item/clothing/gimmick.dm
+++ b/code/obj/item/clothing/gimmick.dm
@@ -1045,6 +1045,7 @@
 			user.visible_message("<span class='alert'><b>[user] fumbles and drops [src]!</b></span>",\
 			"<span class='alert'><b>You fumble and drop [src]!</b></span>")
 			user.u_equip(src)
+			JOB_XP(user, "Clown", 2)
 			src.set_loc(get_turf(user))
 			src.oh_no_the_ring()
 			return

--- a/code/obj/item/clown_items.dm
+++ b/code/obj/item/clown_items.dm
@@ -50,8 +50,11 @@ VUVUZELA
 		if(M.bioHolder.HasEffect("clumsy"))
 			M.changeStatus("stunned", 80)
 			M.changeStatus("weakened", 5 SECONDS)
+			JOB_XP(user, "Clown", 2)
 		else
 			M.changeStatus("weakened", 2 SECONDS)
+			if (prob(20))
+				JOB_XP(last_touched, "Clown", 1)
 		M.force_laydown_standup()
 
 /obj/item/canned_laughter

--- a/code/obj/item/clown_items.dm
+++ b/code/obj/item/clown_items.dm
@@ -50,7 +50,7 @@ VUVUZELA
 		if(M.bioHolder.HasEffect("clumsy"))
 			M.changeStatus("stunned", 80)
 			M.changeStatus("weakened", 5 SECONDS)
-			JOB_XP(user, "Clown", 2)
+			JOB_XP(M, "Clown", 2)
 		else
 			M.changeStatus("weakened", 2 SECONDS)
 			if (prob(20))

--- a/code/obj/item/device/flash.dm
+++ b/code/obj/item/device/flash.dm
@@ -191,6 +191,7 @@
 	if (user && user.bioHolder && user.bioHolder.HasEffect("clumsy") && prob(50))
 		user.visible_message("<span class='alert'><b>[user]</b> tries to use [src], but slips and drops it!</span>")
 		user.drop_item()
+		JOB_XP(user, "Clown", 1)
 		return
 	if (status == 0)
 		boutput(user, "<span class='alert'>The bulb has been burnt out!</span>")

--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -159,6 +159,7 @@
 				if (M.bioHolder.HasEffect("clumsy"))
 					M.changeStatus("stunned", 80)
 					M.changeStatus("weakened", 5 SECONDS)
+					JOB_XP(M, "Clown", 1)
 				else
 					M.changeStatus("weakened", 2 SECONDS)
 				M.force_laydown_standup()

--- a/code/obj/item/device/scanners.dm
+++ b/code/obj/item/device/scanners.dm
@@ -281,6 +281,7 @@ that cannot be itched
 			user.show_message("&emsp; Damage Specifics: <font color='#1F75D1'>[0]</font> - <font color='#138015'>[0]</font> - <font color='#CC7A1D'>[0]</font> - <font color='red'>[0]</font>", 1)
 			user.show_message("&emsp; Key: <font color='#1F75D1'>Suffocation</font>/<font color='#138015'>Toxin</font>/<font color='#CC7A1D'>Burns</font>/<font color='red'>Brute</font>", 1)
 			user.show_message("<span class='notice'>Body Temperature: ???</span>", 1)
+			JOB_XP(user, "Clown", 1)
 			return
 
 		user.visible_message("<span class='alert'><b>[user]</b> has analyzed [M]'s vitals.</span>",\

--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -459,3 +459,4 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 	if ((user.bioHolder && user.bioHolder.HasEffect("clumsy") && prob(50)) || (user.reagents && prob(user.reagents.get_reagent_amount("ethanol") / 2)) || prob(5))
 		user.visible_message("<span class='alert'><b>[user] accidentally shoots [him_or_her(user)]self with [src]!</b></span>")
 		src.shoot_point_blank(user, user)
+		JOB_XP(user, "Clown", 3)

--- a/code/obj/item/handcuffs.dm
+++ b/code/obj/item/handcuffs.dm
@@ -82,7 +82,7 @@
 			if (!H.limbs || !H.limbs.l_arm || !H.limbs.r_arm)
 				return
 			M = user
-
+			JOB_XP(user, "Clown", 1)
 	if (ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if (isabomination(H))

--- a/code/obj/item/hydroponics.dm
+++ b/code/obj/item/hydroponics.dm
@@ -153,6 +153,7 @@
 		if (user.bioHolder.HasEffect("clumsy") && prob(50))
 			user.visible_message("<span class='alert'><b>[user]</b> accidentally grabs the blade of [src].</span>")
 			user.TakeDamage(user.hand == 1 ? "l_arm" : "r_arm", 5, 5)
+			JOB_XP(user, "Clown", 1)
 		src.active = !( src.active )
 		if (src.active)
 			boutput(user, "<span class='notice'>[src] is now active.</span>")

--- a/code/obj/item/instruments.dm
+++ b/code/obj/item/instruments.dm
@@ -219,9 +219,6 @@
 				if (H.hasStatus("weakened"))
 					JOB_XP(user, "Clown", 2)
 					break
-				else (prob(50))
-					break
-
 
 	is_detonator_attachment()
 		return 1

--- a/code/obj/item/instruments.dm
+++ b/code/obj/item/instruments.dm
@@ -211,6 +211,18 @@
 			qdel(W)
 			qdel(src)
 
+	attack_self(mob/user as mob)
+		..()
+		//bad, but eh clowns...
+		if (prob(30))
+			for (var/mob/living/carbon/human/H in view(2, user))
+				if (H.hasStatus("weakened"))
+					JOB_XP(user, "Clown", 2)
+					break
+				else (prob(50))
+					break
+
+
 	is_detonator_attachment()
 		return 1
 

--- a/code/obj/item/kitchen.dm
+++ b/code/obj/item/kitchen.dm
@@ -81,6 +81,7 @@ TRAYS
 		if(user && user.bioHolder.HasEffect("clumsy") && prob(50))
 			user.visible_message("<span class='alert'><b>[user]</b> fumbles [src] and stabs \himself.</span>")
 			random_brute_damage(user, 10)
+			JOB_XP(user, "Clown", 1)
 		if(!saw_surgery(M,user)) // it doesn't make sense, no. but hey, it's something.
 			return ..()
 
@@ -106,6 +107,7 @@ TRAYS
 		if(user && user.bioHolder.HasEffect("clumsy") && prob(50))
 			user.visible_message("<span class='alert'><b>[user]</b> fumbles [src] and stabs \himself.</span>")
 			random_brute_damage(user, 5)
+			JOB_XP(user, "Clown", 1)
 		if(prob(20))
 			src.break_fork(user)
 			return
@@ -150,6 +152,7 @@ TRAYS
 		if(user && user.bioHolder.HasEffect("clumsy") && prob(50))
 			user.visible_message("<span class='alert'><b>[user]</b> fumbles [src] and cuts \himself.</span>")
 			random_brute_damage(user, 20)
+			JOB_XP(user, "Clown", 1)
 		if(!scalpel_surgery(M,user))
 			return ..()
 
@@ -174,6 +177,7 @@ TRAYS
 		if(user && user.bioHolder.HasEffect("clumsy") && prob(50))
 			user.visible_message("<span class='alert'><b>[user]</b> fumbles [src] and cuts \himself.</span>")
 			random_brute_damage(user, 5)
+			JOB_XP(user, "Clown", 1)
 		if(prob(20))
 			src.break_knife(user)
 			return
@@ -210,6 +214,7 @@ TRAYS
 		if(user && user.bioHolder.HasEffect("clumsy") && prob(50))
 			user.visible_message("<span class='alert'><b>[user]</b> fumbles [src] and cuts \himself.</span>")
 			random_brute_damage(user, 20)
+			JOB_XP(user, "Clown", 1)
 		if(prob(5))
 			user.changeStatus("weakened", 4 SECONDS)
 			user.visible_message("<span class='alert'><b>[user]</b>'s hand slips from the [src] and accidentally cuts [himself_or_herself(user)]. </span>")
@@ -257,6 +262,7 @@ TRAYS
 		if(user && user.bioHolder.HasEffect("clumsy") && prob(50))
 			user.visible_message("<span class='alert'><b>[user]</b> fumbles [src] and pinches [his_or_her(user)] fingers against the blade guard.</span>")
 			random_brute_damage(user, 5)
+			JOB_XP(user, "Clown", 1)
 		if(!saw_surgery(M,user))
 			return ..()
 
@@ -277,6 +283,7 @@ TRAYS
 		if(user && user.bioHolder.HasEffect("clumsy") && prob(50))
 			user.visible_message("<span class='alert'><b>[user]</b> fumbles [src] and jabs [his_or_her(user)]self.</span>")
 			random_brute_damage(user, 5)
+			JOB_XP(user, "Clown", 1)
 		if(!spoon_surgery(M,user))
 			return ..()
 
@@ -303,6 +310,7 @@ TRAYS
 		if(user && user.bioHolder.HasEffect("clumsy") && prob(50))
 			user.visible_message("<span class='alert'><b>[user]</b> fumbles [src] and jabs \himself.</span>")
 			random_brute_damage(user, 5)
+			JOB_XP(user, "Clown", 1)
 		if(prob(20))
 			src.break_spoon(user)
 			return
@@ -797,6 +805,7 @@ TRAYS
 	if(user && user.bioHolder.HasEffect("clumsy") && prob(50))
 		user.visible_message("<span class='alert'><b>[user]</b> swings [src] and hits \himself in the face!.</span>")
 		user.changeStatus("weakened", 20 * src.force)
+		JOB_XP(user, "Clown", 1)
 		return
 	else
 		playsound(src.loc, pick('sound/impact_sounds/Slimy_Hit_1.ogg', 'sound/impact_sounds/Slimy_Hit_2.ogg'), 50, 1, -1)

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -191,6 +191,7 @@
 		user.visible_message("<span class='alert'><b>[user]</b> fumbles [src] and cuts \himself.</span>")
 		user.TakeDamage(user.hand == 1 ? "l_arm" : "r_arm", 5, 5)
 		take_bleeding_damage(user, user, 5)
+		JOB_XP(user, "Clown", 1)
 	src.active = !( src.active )
 	if (src.active)
 		var/datum/component/holdertargeting/simple_light/light_c = src.GetComponent(/datum/component/holdertargeting/simple_light)

--- a/code/obj/item/mousetrap.dm
+++ b/code/obj/item/mousetrap.dm
@@ -54,6 +54,7 @@
 				if (!user.hand)
 					which_hand = "r_arm"
 				src.triggered(user, which_hand)
+				JOB_XP(user, "Clown", 1)
 				user.visible_message("<span class='alert'><B>[user] accidentally sets off the mousetrap, breaking their fingers.</B></span>",\
 				"<span class='alert'><B>You accidentally trigger the mousetrap!</B></span>")
 				return
@@ -70,6 +71,7 @@
 				if (!user.hand)
 					which_hand = "r_arm"
 				src.triggered(user, which_hand)
+				JOB_XP(user, "Clown", 1)
 				user.visible_message("<span class='alert'><B>[user] accidentally sets off the mousetrap, breaking their fingers.</B></span>",\
 				"<span class='alert'><B>You accidentally trigger the mousetrap!</B></span>")
 				return

--- a/code/obj/item/pens_writing_etc.dm
+++ b/code/obj/item/pens_writing_etc.dm
@@ -277,6 +277,23 @@
 			src.color_name = hex2color_name(src.color)
 			src.name = "[src.color_name] crayon"
 
+		choose
+			desc = "Don't shove it up your nose, no matter how good of an idea that may seem to you.  You might not get it back. Spin it, go ahead, you know you want to."
+
+			on_spin_emote(var/mob/living/carbon/human/user as mob)
+				src.color = random_color()
+				src.font_color = src.color
+				src.color_name = hex2color_name(src.color)
+				src.name = "[src.color_name] crayon"
+
+				if ((user.bioHolder && user.bioHolder.HasEffect("clumsy") && prob(40)))
+					user.visible_message("<span class='alert'><b>[user] fumbles [src]!</b></span>")
+					src.throw_impact(user)
+					JOB_XP(user, "Clown", 3)
+
+
+
+
 	rainbow
 		name = "strange crayon"
 		color = "#FFFFFF"

--- a/code/obj/item/storage/bible.dm
+++ b/code/obj/item/storage/bible.dm
@@ -62,6 +62,7 @@ var/list/bible_contents = list()
 			user.visible_message("<span class='alert'><b>[user]</b> fumbles and drops [src] on \his foot.</span>")
 			random_brute_damage(user, 10)
 			user.changeStatus("stunned", 3 SECONDS)
+			JOB_XP(user, "Clown", 1)
 			return
 
 	//	if(..() == BLOCKED)

--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -240,7 +240,7 @@
 			if ("stun", "stun_classic")
 				user.visible_message("<span class='alert'><B>[victim] has been stunned with the [src.name] by [user]!</B></span>")
 				logTheThing("combat", user, victim, "stuns %target% with the [src.name] at [log_loc(victim)].")
-
+				JOB_XP(victim, "Clown", 3)
 				if (type == "stun_classic")
 					playsound(get_turf(src), "sound/impact_sounds/Generic_Stab_1.ogg", 50, 1, -1)
 				else

--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -313,6 +313,7 @@
 
 		if (src.can_stun() == 1 && user.bioHolder && user.bioHolder.HasEffect("clumsy") && prob(50))
 			src.do_stun(user, user, "failed", 1)
+			JOB_XP(user, "Clown", 2)
 			return
 
 		if (src.status)
@@ -339,6 +340,7 @@
 
 		if (src.can_stun() == 1 && user.bioHolder && user.bioHolder.HasEffect("clumsy") && prob(50))
 			src.do_stun(user, M, "failed", 1)
+			JOB_XP(user, "Clown", 1)
 			return
 
 		switch (user.a_intent)
@@ -478,6 +480,7 @@
 		//make it harder for them clowns...
 		if (src.can_stun() == 1 && user.bioHolder && user.bioHolder.HasEffect("clumsy") && prob(50))
 			src.do_stun(user, user, "failed", 1)
+			JOB_XP(user, "Clown", 2)
 			return
 
 		//move to next state

--- a/code/obj/mopbucket.dm
+++ b/code/obj/mopbucket.dm
@@ -91,6 +91,7 @@
 				playsound(user.loc, 'sound/impact_sounds/Generic_Hit_2.ogg', 15, 1, -3)
 				user.set_loc(src.loc)
 				user.changeStatus("weakened", 1 SECOND)
+				JOB_XP(user, "Clown", 1)
 				return
 			else
 				user.show_text("You scoot around [src].")

--- a/code/obj/storage/large_storage_parent.dm
+++ b/code/obj/storage/large_storage_parent.dm
@@ -321,6 +321,7 @@
 					user.set_loc(src.loc)
 					if (!user.hasStatus("weakened"))
 						user.changeStatus("weakened", 10 SECONDS)
+					JOB_XP(user, "Clown", 3)
 					return
 				else
 					user.show_text("You scoot around [src].")

--- a/code/obj/vehicle.dm
+++ b/code/obj/vehicle.dm
@@ -191,6 +191,7 @@ Contains:
 				continue
 			C.show_message("<span class='alert'><B>[rider] crashes into the wall with \the [src]!</B></span>", 1)
 		eject_rider(2)
+		JOB_XP(rider, "Clown", 1)
 		in_bump = 0
 		return
 	if(ismob(AM))


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds clown exp for doing clown things. A lot of "clumsy" interactions grant exp. Honking the bike horn near people who are downed, tripping people with bananas. Getting stun batoned. Dying.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's not.


## Changelog

```
(u)Kyle:
(*)Added Clown Job XP and Rewards. Get it from doing Clown things. 
```
