### PR TITLE
Makes hand tele usable as a chest implant

### DIFF
--- a/code/obj/item/teleportation.dm
+++ b/code/obj/item/teleportation.dm
@@ -138,6 +138,18 @@ Frequency:
 	attack_self(mob/user as mob)
 		src.add_fingerprint(user)
 
+		// Make sure you're holding the hand tele, or it's implanted, before you can use it.
+		var/obj/item/I = user.equipped()
+		var/obj/item/C = null
+		if (istype(user, /mob/living/carbon/human))
+			var/mob/living/carbon/human/humanuser = user
+			C = humanuser.chest_item
+		if (I != src && C != src)
+			if (istype(I, /obj/item/magtractor))
+				var/obj/item/magtractor/mag = I
+				if (mag.holding != src)
+					return
+
 		if (src.portals.len > 2)
 			user.show_text("The hand teleporter is recharging!", "red")
 			return
@@ -192,14 +204,6 @@ Frequency:
 		var/t1 = input(user, "Please select a teleporter to lock in on.", "Target Selection") in L
 		if (user.stat || user.restrained())
 			return
-		var/obj/item/I = user.equipped()
-		if (I != src)
-			if (istype(I, /obj/item/magtractor))
-				var/obj/item/magtractor/mag = I
-				if (mag.holding != src)
-					return
-			else
-				return
 
 		if (t1 == "Cancel")
 			return

--- a/code/obj/item/teleportation.dm
+++ b/code/obj/item/teleportation.dm
@@ -138,6 +138,20 @@ Frequency:
 	attack_self(mob/user as mob)
 		src.add_fingerprint(user)
 
+		// Make sure you're holding the hand tele, or it's implanted, before you can use it.
+		var/obj/item/I = user.equipped()
+		var/obj/item/C = null
+		if (istype(user, /mob/living/carbon/human))
+			var/mob/living/carbon/human/humanuser = user
+			C = humanuser.chest_item
+		if (I != src)
+			if (istype(I, /obj/item/magtractor))
+				var/obj/item/magtractor/mag = I
+				if (mag.holding != src)
+					return
+		else if (C != src)
+			return
+
 		if (src.portals.len > 2)
 			user.show_text("The hand teleporter is recharging!", "red")
 			return
@@ -192,14 +206,6 @@ Frequency:
 		var/t1 = input(user, "Please select a teleporter to lock in on.", "Target Selection") in L
 		if (user.stat || user.restrained())
 			return
-		var/obj/item/I = user.equipped()
-		if (I != src)
-			if (istype(I, /obj/item/magtractor))
-				var/obj/item/magtractor/mag = I
-				if (mag.holding != src)
-					return
-			else
-				return
 
 		if (t1 == "Cancel")
 			return
@@ -240,7 +246,7 @@ Frequency:
 			return
 
 		var/obj/portal/P = unpool(/obj/portal)
-		P.set_loc(get_turf(src))
+		P.set_loc(our_loc)
 		portals += P
 		if (!src.our_target)
 			P.target = src.our_random_target

--- a/code/obj/item/teleportation.dm
+++ b/code/obj/item/teleportation.dm
@@ -138,20 +138,6 @@ Frequency:
 	attack_self(mob/user as mob)
 		src.add_fingerprint(user)
 
-		// Make sure you're holding the hand tele, or it's implanted, before you can use it.
-		var/obj/item/I = user.equipped()
-		var/obj/item/C = null
-		if (istype(user, /mob/living/carbon/human))
-			var/mob/living/carbon/human/humanuser = user
-			C = humanuser.chest_item
-		if (I != src)
-			if (istype(I, /obj/item/magtractor))
-				var/obj/item/magtractor/mag = I
-				if (mag.holding != src)
-					return
-		else if (C != src)
-			return
-
 		if (src.portals.len > 2)
 			user.show_text("The hand teleporter is recharging!", "red")
 			return
@@ -206,6 +192,14 @@ Frequency:
 		var/t1 = input(user, "Please select a teleporter to lock in on.", "Target Selection") in L
 		if (user.stat || user.restrained())
 			return
+		var/obj/item/I = user.equipped()
+		if (I != src)
+			if (istype(I, /obj/item/magtractor))
+				var/obj/item/magtractor/mag = I
+				if (mag.holding != src)
+					return
+			else
+				return
 
 		if (t1 == "Cancel")
 			return
@@ -246,7 +240,7 @@ Frequency:
 			return
 
 		var/obj/portal/P = unpool(/obj/portal)
-		P.set_loc(our_loc)
+		P.set_loc(get_turf(src))
 		portals += P
 		if (!src.our_target)
 			P.target = src.our_random_target

--- a/code/obj/item/teleportation.dm
+++ b/code/obj/item/teleportation.dm
@@ -240,7 +240,7 @@ Frequency:
 			return
 
 		var/obj/portal/P = unpool(/obj/portal)
-		P.set_loc(get_turf(src))
+		P.set_loc(our_loc)
 		portals += P
 		if (!src.our_target)
 			P.target = src.our_random_target

--- a/code/obj/item/teleportation.dm
+++ b/code/obj/item/teleportation.dm
@@ -149,6 +149,8 @@ Frequency:
 				var/obj/item/magtractor/mag = I
 				if (mag.holding != src)
 					return
+			else
+				return
 
 		if (src.portals.len > 2)
 			user.show_text("The hand teleporter is recharging!", "red")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes hand teleporters usable when implanted into your chest.

Previously, hand teleporters would get all the way to the point of asking you which teleporter to link to before they realised you're not supposed to be able to use them unless they're in your hand. I've moved that check much earlier in the attack_self() proc and added a check for the item being implanted.

I also removed a redundant second instance of the hand tele getting its location turf by reusing the variable the first instance was stored in.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Implanting a portal generator into yourself so you can fart an escape portal out is cool and funny.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Dabir
(+)Hand teleporters now work when implanted as a chest item.
```
