### PR TITLE
Minor changes to Syndicate Buylist

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -325,6 +325,13 @@ proc/build_syndi_buylist_cache()
 	cost = 3
 	desc = "A casette player that breaks all lights near you. It also temporarily deafens and staggers all nearby people. Comes with four charges and has a distinctive sound."
 
+/datum/syndicate_buylist/traitor/sonicgrenades
+	name = "Sonic Grenades"
+	item = /obj/item/storage/box/sonic_grenade_kit
+	cost = 2
+	desc = "Each one packs enough power to shatter reinforced windows and pop eardrums. No more being cornered by an angry mob! Comes with earplugs."
+	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
+
 /datum/syndicate_buylist/traitor/surplus
 	name = "Surplus Crate"
 	item = /obj/storage/crate/syndicate_surplus
@@ -620,7 +627,7 @@ This is basically useless for anyone but miners.
 	item = /obj/item/gun/energy/pickpocket
 	cost = 3
 	desc = "A stealthy claw gun capable of stealing and planting items, and severely messing with people."
-	job = list("Engineer", "Chief Engineer", "Mechanic")
+	job = list("Engineer", "Chief Engineer", "Mechanic", "Clown", "Staff Assistant")
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 
 /datum/syndicate_buylist/traitor/poisonbottle
@@ -628,7 +635,7 @@ This is basically useless for anyone but miners.
 	item = /obj/item/reagent_containers/glass/bottle/poison
 	cost = 1
 	desc = "A bottle of poison. Which poison? Who knows."
-	job = list("Medical Doctor", "Medical Director", "Research Director", "Barman")
+	job = list("Medical Doctor", "Medical Director", "Research Director", "Scientist", "Barman")
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 
 /datum/syndicate_buylist/traitor/chemicompiler
@@ -673,7 +680,7 @@ This is basically useless for anyone but miners.
 	item = /obj/item/reagent_containers/food/snacks/condiment/syndisauce
 	cost = 1
 	desc = "Our patented secret blend of herbs and spices! Guaranteed to knock even the harshest food critic right off their feet! And into the grave. Because this is poison."
-	job = list("Chef")
+	job = list("Chef", "Barman")
 	blockedmode = list(/datum/game_mode/revolution)
 
 /datum/syndicate_buylist/traitor/donkpockets
@@ -714,7 +721,7 @@ This is basically useless for anyone but miners.
 	item = /obj/item/gun/energy/vuvuzela_gun
 	cost = 3
 	desc = "<b>BZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ</b>"
-	job = list("Assistant","Technical Assistant","Medical Assistant","Staff Assistant")
+	job = list("Assistant","Technical Assistant","Medical Assistant","Staff Assistant", "Clown")
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 
 /datum/syndicate_buylist/traitor/moustache_grenade
@@ -722,7 +729,7 @@ This is basically useless for anyone but miners.
 	item = /obj/item/old_grenade/moustache
 	cost = 1
 	desc = "A disturbingly hairy grenade."
-	job = list("Assistant","Technical Assistant","Medical Assistant","Staff Assistant")
+	job = list("Assistant","Technical Assistant","Medical Assistant","Staff Assistant", "Clown")
 	blockedmode = list(/datum/game_mode/revolution)
 
 /datum/syndicate_buylist/traitor/hotdog_bomb
@@ -730,16 +737,8 @@ This is basically useless for anyone but miners.
 	item = /obj/item/gimmickbomb/hotdog
 	cost = 1
 	desc = "Turn your worst enemies into hotdogs."
-	job = list("Chef", "Sous-Chef", "Waiter")
+	job = list("Chef", "Sous-Chef", "Waiter", "Clown")
 	blockedmode = list(/datum/game_mode/revolution)
-
-/datum/syndicate_buylist/traitor/sonicgrenades
-	name = "Sonic Grenades"
-	item = /obj/item/storage/box/sonic_grenade_kit
-	cost = 2
-	desc = "Each one packs enough power to shatter reinforced windows and pop eardrums. No more being cornered by an angry mob! Comes with earplugs."
-	job = list("Scientist")
-	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 
 /datum/syndicate_buylist/traitor/chemgrenades
 	name = "Chem Grenade Starter Kit"


### PR DESCRIPTION
[ENHANCEMENT] [INPUT WANTED]

## About the PR 
Added and moved a couple of Syndicate items to be a bit more fitting for different jobs. Exact changes are as such

*Sonic Grenades are no longer job specific. I believe they're pretty general and are a utility item. Making them specific to Scientists is an odd choice IMO.

*Pickpocket gun is now available to Clowns and Staff Assistants.

*Hotdog grenade, Amped Vuvuzela and Moustache Grenade are all available to the clown as well due to being appropriately wacky items.

*Scientists can get poison bottles now.

*Bartenders can buy Syndicate sauce now.

## Why's this needed?

To allow more player creativity with said items. Also, some items are almost on spot EG the clown, with the pickpocket gun and hotdog grenade.

## Changelog
```
(u)Carbadox:
(+)Loosened the job restrictions for Syndicate items like sonic grenade, amplified vuvuzela, pickpocket gun, hotdog grenade, moustache grenade, poison bottles and syndicate sauce.
```
