### PR TITLE
More movement modifier stuff

### DIFF
--- a/code/WorkInProgress/SpyGuyStuff.dm
+++ b/code/WorkInProgress/SpyGuyStuff.dm
@@ -905,7 +905,13 @@ proc/Create_Tommyname()
 		//Slow us down slightly when we have the thing readied to encourage late-readying
 		src.setProperty("movespeed", 1 * wire_readied)
 
-
+	var/mob/M = src.loc // inc terminally stupid code
+	if (!ismob(M) && src.chokehold && ismob(src.chokehold.assailant))
+		M = src.chokehold.assailant
+	else if (ismob(usr)) // we've tried nothing and we're all out of ideas
+		M = usr
+	message_admins("garrote user is [M]")
+	M.update_equipped_modifiers() // Call the bruteforce movement modifier proc because we changed movespeed while (maybe!) equipped
 
 /obj/item/garrote/proc/is_behind_target(var/mob/living/assailant, var/mob/living/target)
 	var/assailant_dir = get_dir(target, assailant)
@@ -952,7 +958,7 @@ proc/Create_Tommyname()
 	update_state()
 
 // It will crumple when dropped
-/obj/item/garrote/dropped()
+/obj/item/garrote/dropped(mob/user)
 	..()
 	set_readiness(0)
 
@@ -968,7 +974,7 @@ proc/Create_Tommyname()
 		set_readiness(0)
 
 // Change the size of the garrote or the posture
-/obj/item/garrote/attack_self()
+/obj/item/garrote/attack_self(mob/user)
 	if(!chokehold)
 		..()
 		toggle_wire_readiness()

--- a/code/WorkInProgress/SpyGuyStuff.dm
+++ b/code/WorkInProgress/SpyGuyStuff.dm
@@ -853,6 +853,7 @@ proc/Create_Tommyname()
 	name = "fibre wire"
 	desc = "A sturdy wire between two handles. Could be used with both hands to really ruin someone's day."
 	w_class = 1
+	c_flags = EQUIPPED_WHILE_HELD
 
 	icon = 'icons/obj/items/items.dmi'
 	icon_state = "garrote0"
@@ -905,12 +906,13 @@ proc/Create_Tommyname()
 		//Slow us down slightly when we have the thing readied to encourage late-readying
 		src.setProperty("movespeed", 1 * wire_readied)
 
-	var/mob/M = src.loc // inc terminally stupid code
+	var/mob/M = the_mob // inc terminally stupid code
 	if (!ismob(M) && src.chokehold && ismob(src.chokehold.assailant))
 		M = src.chokehold.assailant
+	else if (ismob(src.loc))
+		M = src.loc
 	else if (ismob(usr)) // we've tried nothing and we're all out of ideas
 		M = usr
-	message_admins("garrote user is [M]")
 	M.update_equipped_modifiers() // Call the bruteforce movement modifier proc because we changed movespeed while (maybe!) equipped
 
 /obj/item/garrote/proc/is_behind_target(var/mob/living/assailant, var/mob/living/target)

--- a/code/datums/abilities/generic.dm
+++ b/code/datums/abilities/generic.dm
@@ -74,6 +74,7 @@
 
 
 		if (istype(M.buckled,/obj/stool/chair))
+			M.buckled.unbuckle()
 			var/obj/stool/chair/C = M.buckled
 			C.buckledIn = 0
 			C.buckled_guy = 0

--- a/code/datums/movement_modifier/movement_modifiers.dm
+++ b/code/datums/movement_modifier/movement_modifiers.dm
@@ -111,13 +111,17 @@
 	ask_proc = 1
 
 /datum/movement_modifier/wheelchair/modifiers(mob/living/carbon/human/user, move_target, running)
-	var/missing_arms
-	var/missing_legs
+	var/missing_arms = 0
+	var/missing_legs = 0
 	if (user.limbs)
-		if (!user.limbs.l_leg) missing_legs++
-		if (!user.limbs.r_leg) missing_legs++
-		if (!user.limbs.l_arm) missing_arms++
-		if (!user.limbs.r_arm) missing_arms++
+		if (!user.limbs.l_leg)
+			missing_legs++
+		if (!user.limbs.r_leg)
+			missing_legs++
+		if (!user.limbs.l_arm)
+			missing_arms++
+		if (!user.limbs.r_arm)
+			missing_arms++
 
 	if (user.lying)
 		missing_legs = 2
@@ -127,7 +131,11 @@
 	if (missing_arms == 2)
 		return list(100,0) // this was snowflaked in as 300 in previous movement delay code
 	else
-		var/applied_modifier = max((missing_legs * 7.5) - (missing_arms * 4), 0)
+		var/applied_modifier = max((missing_legs * 7.5) - ((2-missing_arms) * 4), 0)
+		if (missing_arms == 0)
+
+
+		message_admins("applied modifier is [applied_modifier], correction is [0-(applied_modifier*((2-missing_arms)*0.5))]")
 		// apply a negative modifier to balance out what movement_delay would set, times half times the number of arms
 		// (2 arms get full negation, 1 negates half, 0 would get nothing except hardcoded to be 100 earlier)
-		return list(0-(applied_modifier*(missing_arms*0.5)),0)
+		return list(0-(applied_modifier*((2-missing_arms)*0.5)),0)

--- a/code/datums/movement_modifier/movement_modifiers.dm
+++ b/code/datums/movement_modifier/movement_modifiers.dm
@@ -137,8 +137,6 @@
 		else
 			applied_modifier = 7.5*missing_legs
 
-
-		message_admins("applied modifier is [applied_modifier], correction is [0-(applied_modifier*((2-missing_arms)*0.5))]")
 		// apply a negative modifier to balance out what movement_delay would set, times half times the number of arms
 		// (2 arms get full negation, 1 negates half, 0 would get nothing except hardcoded to be 100 earlier)
 		return list(0-(applied_modifier*((2-missing_arms)*0.5)),0)

--- a/code/datums/movement_modifier/movement_modifiers.dm
+++ b/code/datums/movement_modifier/movement_modifiers.dm
@@ -131,8 +131,11 @@
 	if (missing_arms == 2)
 		return list(100,0) // this was snowflaked in as 300 in previous movement delay code
 	else
-		var/applied_modifier = max((missing_legs * 7.5) - ((2-missing_arms) * 4), 0)
-		if (missing_arms == 0)
+		var/applied_modifier = 0
+		if (missing_legs == 2)
+			applied_modifier = 15 - ((2-missing_arms) * 2) // each missing leg adds 7.5 of movement delay. Each functional arm reduces this by 2.
+		else
+			applied_modifier = 7.5*missing_legs
 
 
 		message_admins("applied modifier is [applied_modifier], correction is [0-(applied_modifier*((2-missing_arms)*0.5))]")

--- a/code/datums/movement_modifier/movement_modifiers.dm
+++ b/code/datums/movement_modifier/movement_modifiers.dm
@@ -139,4 +139,4 @@
 
 		// apply a negative modifier to balance out what movement_delay would set, times half times the number of arms
 		// (2 arms get full negation, 1 negates half, 0 would get nothing except hardcoded to be 100 earlier)
-		return list(0-(applied_modifier*((2-missing_arms)*0.5)),0)
+		return list(0-(applied_modifier*((2-missing_arms)*0.5)),1)

--- a/code/datums/movement_modifier/movement_modifiers.dm
+++ b/code/datums/movement_modifier/movement_modifiers.dm
@@ -10,10 +10,18 @@
 	var/multiplicative_slowdown = 0 // multiplicative slowdown, applied just before running. Stacks multiplicatively with other multiplicative modifiers, ie.
 	var/health_deficiency_adjustment = 0 // additive adjustment to health deficiency, mostly used by reagents which reduce the effect of damage on movement
 	var/maximum_slowdown = 100 // maximum slowdown, applied before pulling (and before multiplier)
+	var/pushpull_multiplier = 1 // multiplier for pushing/pulling speed
+	var/space_movement = 0
+	var/aquatic_movement = 0
 	var/ask_proc = 0
 
 /datum/movement_modifier/proc/modifiers(mob/user, turf/move_target, running)
 	return list(0,0) // list(additive_slowdown, multiplicative_slowdown)
+
+/datum/movement_modifier/equipment // per-mob instanced thing proxying an equip/unequip updated tally from equipment
+
+/datum/movement_modifier/hulkstrong
+	pushpull_multiplier = 0
 
 /datum/movement_modifier/status_slowed // these are instantiated by the status effect and the slowdown adjusted there
 	additive_slowdown = 10
@@ -98,3 +106,28 @@
 				.[1] = 2
 			if (51 to 101)
 				.[1] = 3
+
+/datum/movement_modifier/wheelchair
+	ask_proc = 1
+
+/datum/movement_modifier/wheelchair/modifiers(mob/living/carbon/human/user, move_target, running)
+	var/missing_arms
+	var/missing_legs
+	if (user.limbs)
+		if (!user.limbs.l_leg) missing_legs++
+		if (!user.limbs.r_leg) missing_legs++
+		if (!user.limbs.l_arm) missing_arms++
+		if (!user.limbs.r_arm) missing_arms++
+
+	if (user.lying)
+		missing_legs = 2
+	else if (user.shoes && user.shoes.chained)
+		missing_legs = 2
+
+	if (missing_arms == 2)
+		return list(100,0) // this was snowflaked in as 300 in previous movement delay code
+	else
+		var/applied_modifier = max((missing_legs * 7.5) - (missing_arms * 4), 0)
+		// apply a negative modifier to balance out what movement_delay would set, times half times the number of arms
+		// (2 arms get full negation, 1 negates half, 0 would get nothing except hardcoded to be 100 earlier)
+		return list(0-(applied_modifier*(missing_arms*0.5)),0)

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -1259,7 +1259,6 @@
 				W.set_loc(get_turf(src.loc))
 			else
 				W.set_loc(src.loc)
-			W.dropped(src)
 			if (W)
 				W.layer = initial(W.layer)
 		var/turf/T = get_turf(src.loc)
@@ -1351,7 +1350,7 @@
 /mob/proc/swap_hand()
 	return
 
-/mob/proc/u_equip(W as obj)
+/mob/proc/u_equip(obj/item/W)
 
 // I think this bit is handled by each method of dropping it, and it prevents dropping items in your hands and other procs using u_equip so I'll get rid of it for now.
 //	if (hasvar(W,"cant_self_remove"))
@@ -1373,6 +1372,8 @@
 		src.client.screen -= W
 
 	set_clothing_icon_dirty()
+
+	W.dropped(src)
 
 /*
 /mob/verb/dump_source()

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -254,11 +254,6 @@
 		src.buckled.Move(a, b, flag)
 		src.buckled.glide_size = glide_size // dumb hack
 	else
-		if (mob_flags & AT_GUNPOINT)
-			for(var/obj/item/grab/gunpoint/G in grabbed_by)
-				//if (usr == G.assailant)
-				continue
-				G.shoot()
 		. = ..()
 
 	src.closeContextActions()
@@ -2348,7 +2343,7 @@
 	src.take_ear_damage(-INFINITY, 1)
 	src.take_brain_damage(-INFINITY)
 	src.health = src.max_health
-	src.buckled = initial(src.buckled)
+	src.buckled = null
 	if (src.hasStatus("handcuffed"))
 		src.handcuffs.destroy_handcuffs(src)
 	src.bodytemperature = src.base_body_temp
@@ -2736,13 +2731,7 @@
 		return 1
 	return 0
 
-/mob/living/carbon/human/is_hulk()
-	if (src.bioHolder && src.bioHolder.HasEffect("hulk"))
-		return 1
-	else if (istype(src.gloves, /obj/item/clothing/gloves/ring/titanium))
-		return 1
-	return 0
-
+/mob/proc/update_equipped_modifiers()
 
 // alright this is copy pasted a million times across the code, time for SOME unification - cirr
 // no text description though, because it's all different everywhere
@@ -2929,12 +2918,6 @@
 	if(istype(src.equipped(), /obj/item/device/pda2))
 		var/obj/item/device/pda2/pda = src.equipped()
 		return pda.ID_card
-
-
-
-
-
-
 
 // http://www.byond.com/forum/post/1326139&page=2
 //MOB VERBS ARE FASTER THAN OBJ VERBS, ELIMINATE ALL OBJ VERBS WHERE U CAN

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1169,7 +1169,7 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 
 /mob/living/proc/pull_speed_modifier(var/atom/move_target = 0)
 	. = 1
-	if (src.pulling && istype(src.pulling, /atom/movable) && !(src.is_hulk() || (src.bioHolder && src.bioHolder.HasEffect("strong"))))
+	if (istype(src.pulling, /atom/movable) && !(src.is_hulk() || (src.bioHolder && src.bioHolder.HasEffect("strong"))))
 		var/atom/movable/A = src.pulling
 		// hi grayshift sorry grayshift
 		if (get_dist(src,A) > 0 && get_dist(move_target,A) > 0) //i think this is mbc dist stuff for if we're actually stepping away and pulling the thing or not?
@@ -1178,21 +1178,6 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 			else
 				if(istype(A,/obj/machinery/nuclearbomb)) //can't speed off super fast with the nuke, it's heavy
 					. *= max(A.p_class, 1)
-				// else, ignore p_class*/
-				else if (ishuman(src))
-					if(ismob(A))
-						var/mob/M = A
-						//if they're lying, pull em slower, unless you have a gang and they are in your gang.
-						if(M.lying)
-							if (src.mind?.gang && (src.mind.gang == M.mind?.gang))
-								. *= 1		//do nothing
-							else
-								. *= max(A.p_class, 1)
-					else if(istype(A, /obj/storage))
-						// if the storage object contains mobs, use its p_class (updated within storage to reflect containing mobs or not)
-						if (locate(/mob) in A.contents)
-							. *= max(A.p_class,1)
-	return .
 
 //Phyvo: Resist generalization. For when humans can break or remove shackles/cuffs, see daughter proc in humans.dm
 /mob/living/proc/resist()

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -884,7 +884,7 @@
 	var/turf/T = get_turf(src)
 
 	if (T)
-		if (T.turf_flags & CAN_BE_SPACE_SAMPLE)
+		if (!(T.turf_flags & CAN_BE_SPACE_SAMPLE))
 			. -= space_movement
 
 		if (!(src.mutantrace && src.mutantrace.aquatic))

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -887,14 +887,15 @@
 		if (T.turf_flags & CAN_BE_SPACE_SAMPLE)
 			. -= space_movement
 
-		if (aquatic_movement > 0)
-			if (T.active_liquid || T.turf_flags & FLUID_MOVE)
-				. -= aquatic_movement
-		else
-			if (T.active_liquid)
-				. += T.active_liquid.movement_speed_mod
-			else if (istype(T,/turf/space/fluid))
-				. += 4
+		if (!(src.mutantrace && src.mutantrace.aquatic))
+			if (aquatic_movement > 0)
+				if (T.active_liquid || T.turf_flags & FLUID_MOVE)
+					. -= aquatic_movement
+			else
+				if (T.active_liquid)
+					. += T.active_liquid.movement_speed_mod
+				else if (istype(T,/turf/space/fluid))
+					. += 4
 
 	. = min(., maximum_slowdown)
 

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -873,8 +873,10 @@
 	else if (src.shoes && src.shoes.chained)
 		missing_legs = 2
 
-	if (missing_legs)
-		. += max((missing_legs * 7.5) - ((2-missing_arms) * 4), 0) // each missing leg adds 7.5 of movement delay. Each functional arm reduces this by 4.
+	if (missing_legs == 2)
+		. += 15 - ((2-missing_arms) * 2) // each missing leg adds 7.5 of movement delay. Each functional arm reduces this by 2.
+	else
+		. += 7.5*missing_legs
 
 	if (src.bodytemperature < src.base_body_temp - (src.temp_tolerance * 2) && !src.is_cold_resistant())
 		. += min( ((((src.base_body_temp - (src.temp_tolerance * 2)) - src.bodytemperature) / 10)), 3)
@@ -1098,11 +1100,6 @@
 	u_equip(I)
 
 	I.set_loc(src.loc)
-
-	// u_equip() already calls I.dropped()
-	// no it doesn't
-	if (isitem(I))
-		I.dropped(src) // let it know it's been dropped
 
 	if (get_dist(src, target) > 0)
 		src.dir = get_dir(src, target)
@@ -2024,7 +2021,7 @@
 		W.dropped(src)
 		src.update_inhands()
 
-/mob/living/carbon/human/update_equipped_modifiers() // A bruteforce approach
+/mob/living/carbon/human/update_equipped_modifiers() // A bruteforce approach, for things like the garrote that like to change their modifier while equipped
 	var/datum/movement_modifier/equipment/equipment_proxy = locate() in src.movement_modifiers
 	if (!equipment_proxy)
 		equipment_proxy = new
@@ -2045,7 +2042,6 @@
 		if (spacemove)
 			equipment_proxy.additive_slowdown += spacemove // compatibility hack for old code treating space & fluid movement capability as a slowdown
 			equipment_proxy.space_movement += spacemove
-	message_admins("additive slowdown is [equipment_proxy.additive_slowdown], fluidmove is [equipment_proxy.aquatic_movement], spacemove is [equipment_proxy.space_movement]")
 
 
 /mob/living/carbon/human/updateTwoHanded(var/obj/item/I, var/twoHanded = 1)

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -884,7 +884,7 @@
 	var/turf/T = get_turf(src)
 
 	if (T)
-		if (!(T.turf_flags & CAN_BE_SPACE_SAMPLE))
+		if (T.turf_flags & CAN_BE_SPACE_SAMPLE)
 			. -= space_movement
 
 		if (!(src.mutantrace && src.mutantrace.aquatic))

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -820,6 +820,9 @@
 	var/multiplier = 1 // applied before running multiplier
 	var/health_deficiency_adjustment = 0
 	var/maximum_slowdown = 100 // applied before pulling checks
+	var/pushpull_multiplier = 1
+	var/aquatic_movement = 0
+	var/space_movement = 0
 
 	var/datum/movement_modifier/modifier
 	for(var/type_or_instance in src.movement_modifiers)
@@ -827,13 +830,20 @@
 			modifier = movement_modifier_instances[type_or_instance]
 		else
 			modifier = type_or_instance
-		if (modifier.ask_proc)
+
+		if (modifier.ask_proc) // if we have to call a proc
 			var/list/r = modifier.modifiers(src, move_target, running)
 			. += r[1]
 			multiplier *= r[2]
+
+		// collect modifiers from the datum
 		. += modifier.additive_slowdown
 		multiplier += modifier.multiplicative_slowdown
 		health_deficiency_adjustment += modifier.health_deficiency_adjustment
+		pushpull_multiplier *= modifier.pushpull_multiplier
+		aquatic_movement += modifier.aquatic_movement
+		space_movement += modifier.space_movement
+
 		if (modifier.maximum_slowdown < maximum_slowdown)
 			maximum_slowdown = modifier.maximum_slowdown
 
@@ -851,15 +861,6 @@
 	if (health_deficiency >= 30)
 		. += (health_deficiency / 25)
 
-	var/in_wheelchair = 0
-	if (src.buckled)
-		if (istype(src.buckled, /obj/stool/chair/comfy/wheelchair))
-			if (!src.l_hand)
-				in_wheelchair++
-				. *= 0.66
-			if (!src.r_hand)
-				in_wheelchair++
-				. *= 0.66
 	var/missing_legs = 0
 	var/missing_arms = 0
 	if (src.limbs)
@@ -869,56 +870,24 @@
 		if (!src.limbs.r_arm) missing_arms++
 	if (src.lying)
 		missing_legs = 2
+	else if (src.shoes && src.shoes.chained)
+		missing_legs = 2
 
-	switch(missing_legs)
-		if (0)
-			if (!in_wheelchair && src.shoes)
-				if (src.shoes.chained)
-					. += 15
-				else if (src.shoes.speedy) // miner boots, split off from the suit
-					. *= 0.5
-		if (1)
-			if (!in_wheelchair || (in_wheelchair && missing_arms))
-				. += 7
-			else if (in_wheelchair < 2)
-				. += 3
-			if (src.shoes && src.shoes.speedy) // miner boots, split off from the suit
-				. *= 0.75 //less effect if there's only one i guess
-		if (2)
-			if (!in_wheelchair)
-				. += 15
-			else if (in_wheelchair < 2)
-				. += 7
-			switch(missing_arms)
-				if (1)
-					. += 15 //can't pull yourself along too well
-				if (2)
-					. += 300 //haha good luck
+	. += max((missing_legs * 7.5) - (missing_arms * 4), 0) // each missing leg adds 7.5 of movement delay. Each functional arm reduces this by 4.
 
 	if (src.bodytemperature < src.base_body_temp - (src.temp_tolerance * 2) && !src.is_cold_resistant())
 		. += min( ((((src.base_body_temp - (src.temp_tolerance * 2)) - src.bodytemperature) / 10)), 3)
 
-	var/has_fluid_move_gear = 0
-	var/has_space_move_gear = 0
+	var/turf/T = get_turf(src)
 
-	for(var/atom in src.get_equipped_items()) // maybe replace this with items adding movement modifiers as well?
-		var/obj/item/I = atom
-		. += I.getProperty("movespeed")
-		has_fluid_move_gear += I.getProperty("negate_fluid_speed_penalty")
-		has_space_move_gear += I.getProperty("space_movespeed")
+	if (T)
+		if (T.turf_flags & CAN_BE_SPACE_SAMPLE)
+			. -= space_movement
 
-
-	if (has_space_move_gear)
-		var/turf/T = get_turf(src)
-		if (!(T.turf_flags & CAN_BE_SPACE_SAMPLE))
-			. += has_space_move_gear
-
-	if (!(src.mutantrace && src.mutantrace.aquatic)) //aquatic race suffers no penalty on dry land OR in fluid
-		var/turf/T = get_turf(src)
-		if (T && has_fluid_move_gear)		//add tally : we are on dry land and have gear on
-			if (!T.active_liquid && !(T.turf_flags & FLUID_MOVE))
-				. += has_fluid_move_gear
-		else if (T && !has_fluid_move_gear) 	//add tally : we are in fluid but have no gear
+		if (aquatic_movement > 0)
+			if (T.active_liquid || T.turf_flags & FLUID_MOVE)
+				. -= aquatic_movement
+		else
 			if (T.active_liquid)
 				. += T.active_liquid.movement_speed_mod
 			else if (istype(T,/turf/space/fluid))
@@ -926,21 +895,24 @@
 
 	. = min(., maximum_slowdown)
 
-	. *= pull_speed_modifier(move_target)
+	if (pushpull_multiplier != 0) // if we're not completely ignoring pushing/pulling
+		if (src.pulling)
+			. *= (pull_speed_modifier(move_target) * pushpull_multiplier)
 
-	if (!(src.is_hulk() || (src.bioHolder && src.bioHolder.HasEffect("strong"))))
 		if (src.pushing && (src.pulling != src.pushing))
-			. *= max (src.pushing.p_class, 1)
+			. *= (max(src.pushing.p_class, 1) * pushpull_multiplier)
 
-		for (var/obj/item/grab/G in src.equipped_list(check_for_magtractor=0))
+		for (var/obj/item/grab/G in list(src.r_hand, src.l_hand))
 			var/mob/M = G.affecting
-			if (isnull(M)) continue //ZeWaka: If we have a null affecting, ex. someone jumped in lava when we were grabbing them
+			if (isnull(M))
+				continue //ZeWaka: If we have a null affecting, ex. someone jumped in lava when we were grabbing them
+
 			if (G.state == 0)
 				if (get_dist(src,M) > 0 && get_dist(move_target,M) > 0) //pasted into living.dm pull slow as well (consider merge somehow)
 					if(ismob(M) && M.lying)
-						. *= max(M.p_class, 1)
+						. *= (max(M.p_class, 1) * pushpull_multiplier)
 			else
-				. *= max(M.p_class, 1)
+				. *= (max(M.p_class, 1) * pushpull_multiplier)
 
 	. *= multiplier
 
@@ -951,6 +923,31 @@
 
 #undef BASE_SPEED
 #undef RUN_SCALING
+
+/mob/living/carbon/human/pull_speed_modifier(var/atom/move_target = 0)
+	. = 1
+	if (istype(src.pulling, /atom/movable) && !(src.is_hulk() || (src.bioHolder && src.bioHolder.HasEffect("strong"))))
+		var/atom/movable/A = src.pulling
+		// hi grayshift sorry grayshift
+		if (get_dist(src,A) > 0 && get_dist(move_target,A) > 0) //i think this is mbc dist stuff for if we're actually stepping away and pulling the thing or not?
+			if(pull_slowing)
+				. *= max(A.p_class, 1)
+			else
+				if(istype(A,/obj/machinery/nuclearbomb)) //can't speed off super fast with the nuke, it's heavy
+					. *= max(A.p_class, 1)
+				// else, ignore p_class*/
+				if(ismob(A))
+					var/mob/M = A
+					//if they're lying, pull em slower, unless you have a gang and they are in your gang.
+					if(M.lying)
+						if (src.mind?.gang && (src.mind.gang == M.mind?.gang))
+							. *= 1		//do nothing
+						else
+							. *= max(A.p_class, 1)
+				else if(istype(A, /obj/storage))
+					// if the storage object contains mobs, use its p_class (updated within storage to reflect containing mobs or not)
+					if (locate(/mob) in A.contents)
+						. *= max(A.p_class,1)
 
 /mob/living/carbon/human/Stat()
 	..()
@@ -2026,6 +2023,29 @@
 		W.dropped(src)
 		src.update_inhands()
 
+/mob/living/carbon/human/update_equipped_modifiers() // A bruteforce approach
+	var/datum/movement_modifier/equipment/equipment_proxy = locate() in src.movement_modifiers
+	if (!equipment_proxy)
+		equipment_proxy = new
+		APPLY_MOVEMENT_MODIFIER(src, equipment_proxy, /obj/item)
+
+	// reset the modifiers to defaults
+	equipment_proxy.additive_slowdown = 0
+	equipment_proxy.aquatic_movement = 0
+	equipment_proxy.space_movement = 0
+
+	for (var/obj/item/I in src.get_equipped_items(check_for_magtractor = 0))
+		equipment_proxy.additive_slowdown += I.getProperty("movespeed")
+		var/fluidmove = I.getProperty("negate_fluid_speed_penalty")
+		if (fluidmove)
+			equipment_proxy.additive_slowdown += fluidmove // compatibility hack for old code treating space & fluid movement capability as a slowdown
+			equipment_proxy.aquatic_movement += fluidmove
+		var/spacemove = I.getProperty("space_movespeed")
+		if (spacemove)
+			equipment_proxy.additive_slowdown += spacemove // compatibility hack for old code treating space & fluid movement capability as a slowdown
+			equipment_proxy.space_movement += spacemove
+
+
 /mob/living/carbon/human/updateTwoHanded(var/obj/item/I, var/twoHanded = 1)
 	if(!(I in src) || (src.l_hand != I && src.r_hand != I)) return 0
 	I.two_handed = twoHanded
@@ -2280,6 +2300,7 @@
 			if (slot != slot_in_backpack && slot != slot_in_belt)
 				I.show_buttons()
 		src.update_clothing()
+
 
 /mob/living/carbon/human/proc/update_equipment_screen_loc()
 	hud.inventory_items.len = 0
@@ -3509,3 +3530,10 @@
 	if(istype(src.wear_id, /obj/item/device/pda2))
 		var/obj/item/device/pda2/pda = src.wear_id
 		return pda.ID_card
+
+/mob/living/carbon/human/is_hulk()
+	if (src.bioHolder && src.bioHolder.HasEffect("hulk"))
+		return 1
+	else if (istype(src.gloves, /obj/item/clothing/gloves/ring/titanium))
+		return 1
+	return 0

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -873,7 +873,8 @@
 	else if (src.shoes && src.shoes.chained)
 		missing_legs = 2
 
-	. += max((missing_legs * 7.5) - (missing_arms * 4), 0) // each missing leg adds 7.5 of movement delay. Each functional arm reduces this by 4.
+	if (missing_legs)
+		. += max((missing_legs * 7.5) - ((2-missing_arms) * 4), 0) // each missing leg adds 7.5 of movement delay. Each functional arm reduces this by 4.
 
 	if (src.bodytemperature < src.base_body_temp - (src.temp_tolerance * 2) && !src.is_cold_resistant())
 		. += min( ((((src.base_body_temp - (src.temp_tolerance * 2)) - src.bodytemperature) / 10)), 3)
@@ -2034,7 +2035,7 @@
 	equipment_proxy.aquatic_movement = 0
 	equipment_proxy.space_movement = 0
 
-	for (var/obj/item/I in src.get_equipped_items(check_for_magtractor = 0))
+	for (var/obj/item/I in src.get_equipped_items())
 		equipment_proxy.additive_slowdown += I.getProperty("movespeed")
 		var/fluidmove = I.getProperty("negate_fluid_speed_penalty")
 		if (fluidmove)
@@ -2044,6 +2045,7 @@
 		if (spacemove)
 			equipment_proxy.additive_slowdown += spacemove // compatibility hack for old code treating space & fluid movement capability as a slowdown
 			equipment_proxy.space_movement += spacemove
+	message_admins("additive slowdown is [equipment_proxy.additive_slowdown], fluidmove is [equipment_proxy.aquatic_movement], spacemove is [equipment_proxy.space_movement]")
 
 
 /mob/living/carbon/human/updateTwoHanded(var/obj/item/I, var/twoHanded = 1)

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -1610,40 +1610,47 @@
 		return ..()
 
 	movement_delay(var/atom/move_target = 0)
-		var/tally = 2
 
-		tally += movement_delay_modifier
+		. = 2 + movement_delay_modifier
 
-		if (src.oil) tally -= 0.5
+		if (src.oil)
+			. -= 0.5
 
 		if (!src.part_leg_l)
-			tally += 3.5
-			if (src.part_arm_l) tally -= 1
+			. += 3.5
+			if (src.part_arm_l)
+				. -= 1
 		if (!src.part_leg_r)
-			tally += 3.5
-			if (src.part_arm_r) tally -= 1
+			. += 3.5
+			if (src.part_arm_r)
+				. -= 1
 
 		var/add_weight = 0
 		for (var/obj/item/parts/robot_parts/P in src.contents)
-			if (P.weight > 0) add_weight += P.weight
-			if (P.speedbonus) tally -= P.speedbonus
+			if (P.weight > 0)
+				add_weight += P.weight
+			if (P.speedbonus)
+				. -= P.speedbonus
 
 		if (add_weight > 0)
-			if (istype(src.part_leg_l,/obj/item/parts/robot_parts/leg/treads) || istype(src.part_leg_r,/obj/item/parts/robot_parts/leg/treads)) tally += add_weight / 3
-			else tally += add_weight
+			if (istype(src.part_leg_l,/obj/item/parts/robot_parts/leg/treads) || istype(src.part_leg_r,/obj/item/parts/robot_parts/leg/treads))
+				. += add_weight / 3
+			else
+				. += add_weight
 
 		for (var/obj/item/roboupgrade/R in src.upgrades)
 			if (istype(R, /obj/item/roboupgrade/speed) && R.activated)
-				if (src.part_leg_r) tally *= 0.75
-				if (src.part_leg_l) tally *= 0.75
+				if (src.part_leg_r)
+					. *= 0.75
+				if (src.part_leg_l)
+					. *= 0.75
 
 		//This is how it's done in humans, but since borg max health is a bunch of nonsense, I'm not going to add it.
 		// var/health_deficiency = (src.max_health - src.health)
 		// if (health_deficiency >= 90) tally += (health_deficiency / 25)
 
-		tally *= pull_speed_modifier(move_target)
-
-		return tally
+		if (src.pulling)
+			. *= pull_speed_modifier(move_target)
 
 	hotkey(name)
 		switch (name)

--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -3218,7 +3218,8 @@ datum
 			bladder_value = -2
 
 			on_add(var/mob/M)
-				APPLY_MOVEMENT_MODIFIER(M, /datum/movement_modifier/reagent/cocktail_triple, src.type)
+				if (ismob(M))
+					APPLY_MOVEMENT_MODIFIER(M, /datum/movement_modifier/reagent/cocktail_triple, src.type)
 
 			reaction_mob(var/mob/M, var/method=INGEST, var/volume)
 				if(method == INGEST)
@@ -3244,8 +3245,6 @@ datum
 			on_mob_life(var/mob/M, var/mult = 1)
 				if(!M)
 					M = holder.my_atom
-
-				REMOVE_MOVEMENT_MODIFIER(M, /datum/movement_modifier/reagent/cocktail_triple, src.type)
 
 				if(istype(holder) && istype(holder.my_atom) && hascall(holder.my_atom,"add_stam_mod_regen"))
 					holder.my_atom:add_stam_mod_regen("tripletriple", 3333)

--- a/code/modules/medical/genetics/bioEffects/beneficial.dm
+++ b/code/modules/medical/genetics/bioEffects/beneficial.dm
@@ -322,6 +322,18 @@
 	msgLose = "You feel wimpy and weak."
 	icon_state  = "strong"
 
+	OnAdd()
+		..()
+		if (ishuman(owner))
+			var/mob/living/carbon/human/H = owner
+			APPLY_MOVEMENT_MODIFIER(H, /datum/movement_modifier/hulkstrong, src.type)
+
+	OnRemove()
+		..()
+		if (ishuman(owner))
+			var/mob/living/carbon/human/H = owner
+			REMOVE_MOVEMENT_MODIFIER(H, /datum/movement_modifier/hulkstrong, src.type)
+
 /datum/bioEffect/radio_brain
 	name = "Meta-Neural Antenna"
 	desc = "Enables the subject's brain to pick up radio signals."
@@ -373,7 +385,9 @@ var/list/radio_brains = list()
 	OnAdd()
 		owner.unlock_medal("It's not easy being green", 1)
 		if (ishuman(owner))
-			owner:set_body_icon_dirty()
+			var/mob/living/carbon/human/H = owner
+			H.set_body_icon_dirty()
+			APPLY_MOVEMENT_MODIFIER(H, /datum/movement_modifier/hulkstrong, src.type)
 		..()
 
 	OnMobDraw()
@@ -385,7 +399,9 @@ var/list/radio_brains = list()
 
 	OnRemove()
 		if (ishuman(owner))
-			owner:set_body_icon_dirty()
+			var/mob/living/carbon/human/H = owner
+			H.set_body_icon_dirty()
+			REMOVE_MOVEMENT_MODIFIER(H, /datum/movement_modifier/hulkstrong, src.type)
 
 	OnLife()
 		if(..()) return

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -764,11 +764,38 @@
 	#ifdef COMSIG_ITEM_EQUIPPED
 	SEND_SIGNAL(src, COMSIG_ITEM_EQUIPPED, user, slot)
 	#endif
+	var/datum/movement_modifier/equipment/equipment_proxy = locate() in user.movement_modifiers
+	if (!equipment_proxy)
+		equipment_proxy = new
+		APPLY_MOVEMENT_MODIFIER(user, equipment_proxy, /obj/item)
+	equipment_proxy.additive_slowdown += src.getProperty("movespeed")
+	var/fluidmove = src.getProperty("negate_fluid_speed_penalty")
+	if (fluidmove)
+		equipment_proxy.additive_slowdown += fluidmove // compatibility hack for old code treating space & fluid movement capability as a slowdown
+		equipment_proxy.aquatic_movement += fluidmove
+	var/spacemove = src.getProperty("space_movespeed")
+	if (spacemove)
+		equipment_proxy.additive_slowdown += spacemove // compatibility hack for old code treating space & fluid movement capability as a slowdown
+		equipment_proxy.space_movement += spacemove
+
 
 /obj/item/proc/unequipped(var/mob/user)
 	#ifdef COMSIG_ITEM_UNEQUIPPED
 	SEND_SIGNAL(src, COMSIG_ITEM_UNEQUIPPED, user)
 	#endif
+	var/datum/movement_modifier/equipment/equipment_proxy = locate() in user.movement_modifiers
+	if (!equipment_proxy)
+		equipment_proxy = new
+		APPLY_MOVEMENT_MODIFIER(user, equipment_proxy, /obj/item)
+	equipment_proxy.additive_slowdown -= src.getProperty("movespeed")
+	var/fluidmove = src.getProperty("negate_fluid_speed_penalty")
+	if (fluidmove)
+		equipment_proxy.additive_slowdown -= fluidmove
+		equipment_proxy.aquatic_movement -= fluidmove
+	var/spacemove = src.getProperty("space_movespeed")
+	if (spacemove)
+		equipment_proxy.additive_slowdown -= spacemove
+		equipment_proxy.space_movement -= spacemove
 
 /obj/item/proc/afterattack(atom/target, mob/user, reach, params)
 	return
@@ -1328,4 +1355,3 @@
 	set_mob(user)
 	show_buttons()
 	return
-

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -86,6 +86,7 @@
 
 	var/obj/item/grab/chokehold = null
 	var/obj/item/grab/special_grab = null
+	var/debug_pickedup = 0
 
 
 	proc/setTwoHanded(var/twohanded = 1) //This is the safe way of changing 2-handed-ness at runtime. Use this please.
@@ -1333,6 +1334,8 @@
 				possible_mob_holder.hand = !possible_mob_holder.hand
 
 /obj/item/proc/dropped(mob/user)
+	if (src.c_flags & EQUIPPED_WHILE_HELD)
+		src.unequipped(user)
 	#ifdef COMSIG_ITEM_DROPPED
 	SEND_SIGNAL(src, COMSIG_ITEM_DROPPED, user)
 	#endif
@@ -1351,7 +1354,9 @@
 	#ifdef COMSIG_ITEM_PICKUP
 	SEND_SIGNAL(src, COMSIG_ITEM_PICKUP, user)
 	#endif
-	if(src.material) src.material.triggerPickup(user, src)
+	if(src.material)
+		src.material.triggerPickup(user, src)
 	set_mob(user)
 	show_buttons()
-	return
+	if (src.c_flags & EQUIPPED_WHILE_HELD)
+		src.equipped(user, user.get_slot_from_item(src))

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -86,7 +86,6 @@
 
 	var/obj/item/grab/chokehold = null
 	var/obj/item/grab/special_grab = null
-	var/debug_pickedup = 0
 
 
 	proc/setTwoHanded(var/twohanded = 1) //This is the safe way of changing 2-handed-ness at runtime. Use this please.

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -1332,7 +1332,7 @@
 				possible_mob_holder.drop_item()
 				possible_mob_holder.hand = !possible_mob_holder.hand
 
-/obj/item/proc/dropped(mob/user as mob)
+/obj/item/proc/dropped(mob/user)
 	#ifdef COMSIG_ITEM_DROPPED
 	SEND_SIGNAL(src, COMSIG_ITEM_DROPPED, user)
 	#endif

--- a/code/obj/item/clothing/gimmick.dm
+++ b/code/obj/item/clothing/gimmick.dm
@@ -1172,11 +1172,14 @@
 	material_prints = "deep scratches"
 
 	equipped(var/mob/user, var/slot)
-		if (slot == "gloves" && (!user.bioHolder || !user.bioHolder.HasEffect("hulk")))
-			boutput(user, "You feel your muscles swell to an immense size.")
+		if (slot == "gloves")
+			if (!user.bioHolder || !user.bioHolder.HasEffect("hulk"))
+				boutput(user, "You feel your muscles swell to an immense size.")
+			APPLY_MOVEMENT_MODIFIER(user, /datum/movement_modifier/hulkstrong, src.type)
 		return ..()
 
 	unequipped(var/mob/user)
+		REMOVE_MOVEMENT_MODIFIER(user, /datum/movement_modifier/hulkstrong, src.type)
 		if (!user.bioHolder || !user.bioHolder.HasEffect("hulk"))
 			boutput(user, "Your muscles shrink back down.")
 		return ..()

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -468,7 +468,7 @@
 /obj/item/dagger/throwing_knife/tele
 	name = "portable knife"
 	icon_state = "teleport_knife"
-		
+
 	throw_impact(atom/A)
 		..()
 		usr.set_loc(get_turf(src))
@@ -573,6 +573,8 @@
 				setProperty("movespeed", 0)
 				force = one_handed_force
 				src.setItemSpecial(/datum/item_special/simple)
+
+			user.update_equipped_modifiers() // Call the bruteforce movement modifier proc because we changed movespeed while equipped
 
 			can_disarm = src.status
 			item_state = status ? "quarterstaff2" : "quarterstaff1"

--- a/code/obj/item/storage/small_storage_parent.dm
+++ b/code/obj/item/storage/small_storage_parent.dm
@@ -95,7 +95,7 @@
 			SPAWN_DBG(1 DECI SECOND)
 				O.attack_hand(user)
 
-	attackby(obj/item/W as obj, mob/user as mob, params, obj/item/storage/T as obj) // T for transfer - transferring items from one storage obj to another
+	attackby(obj/item/W, mob/user, params, obj/item/storage/T) // T for transfer - transferring items from one storage obj to another
 		if (W.cant_drop)
 			return
 		if (islist(src.can_hold) && src.can_hold.len)

--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -623,6 +623,8 @@
 
 				src.setItemSpecial(/datum/item_special/simple)
 
+			user.update_equipped_modifiers() // Call the bruteforce movement modifier proc because we changed movespeed while equipped
+
 			destroy_deployed_barrier(user)
 
 			can_disarm = src.status

--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -971,7 +971,7 @@
 	arm_icon_state = "arm-wheelchair"
 	anchored = 0
 	comfort_value = 3
-	buckle_move_delay = 0
+	buckle_move_delay = 1
 	p_class = 2
 	scoot_sounds = list("sound/misc/chair/office/scoot1.ogg", "sound/misc/chair/office/scoot2.ogg", "sound/misc/chair/office/scoot3.ogg", "sound/misc/chair/office/scoot4.ogg", "sound/misc/chair/office/scoot5.ogg")
 	var/lying = 0 // didja get knocked over? fall down some stairs?

--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -971,7 +971,7 @@
 	arm_icon_state = "arm-wheelchair"
 	anchored = 0
 	comfort_value = 3
-	buckle_move_delay = 1
+	buckle_move_delay = 0
 	p_class = 2
 	scoot_sounds = list("sound/misc/chair/office/scoot1.ogg", "sound/misc/chair/office/scoot2.ogg", "sound/misc/chair/office/scoot3.ogg", "sound/misc/chair/office/scoot4.ogg", "sound/misc/chair/office/scoot5.ogg")
 	var/lying = 0 // didja get knocked over? fall down some stairs?
@@ -1028,6 +1028,12 @@
 		if (src.lying)
 			return
 		..()
+		if (src.buckled_guy == to_buckle)
+			APPLY_MOVEMENT_MODIFIER(to_buckle, /datum/movement_modifier/wheelchair, src.type)
+
+	unbuckle()
+		REMOVE_MOVEMENT_MODIFIER(src.buckled_guy, /datum/movement_modifier/wheelchair, src.type)
+		return ..()
 
 /* ======================================================= */
 /* -------------------- Wooden Chairs -------------------- */


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This continued on the work started in the previous PR by removing equipment loops, hulk/strength checks, and space/aquatic movement enablers from movement delay calculation. It also ensures `dropped` is called but only once on an item, and that picking up and dropping counts as equipping and unequipping for things that count as equipped while in hand. 

Stuff can now partially help with pushing, you could for example have cargomitts that give a 10% reduction to increased pushing/pulling delay.

There's a slight balance change to how missing limbs work wrt movement delay, this is mostly to get rid of the giant `switch` block. A wheelchair shouldn't enable faster-than-normal movement anymore.

The garrote slowdowns actually work now, previously the garrote was missing the EQUIPPED_WHILE_HELD flag and didn't get counted for movement_delay despite having the movespeed property.

I'm leaving this as a draft until I can test it more tomorrow, but it *might* be good.
