### PR TITLE
revert spamshooting on ass day

### DIFF
--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -44,11 +44,7 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 	var/add_residue = 0 // Does this gun add gunshot residue when fired (Convair880)?
 
 	var/charge_up = 0 //Does this gun have a charge up time and how long is it? 0 = normal instant shots.
-#if ASS_JAM
-	var/shoot_delay = 0
-#else
 	var/shoot_delay = 4
-#endif
 
 	buildTooltipContent()
 		var/Tcontent = ..()


### PR DESCRIPTION
It was funny. Once.

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[ASS-JAM]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Reverts ass jam feature allowing guns to be fired as fast as you can click


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It was funny once, but imo one assday is a long enough lifespan for it
