### PR TITLE
#defines num2hex and hex2num, cleans up adjacent stuff

### DIFF
--- a/_stdlib/code/_macros.dm
+++ b/_stdlib/code/_macros.dm
@@ -182,3 +182,9 @@ var/list/global_spawn_dbg = list()
 
 //used for pods
 #define BOARD_DIST_ALLOWED(M,V) ( ((V.bound_width > world.icon_size || V.bound_height > world.icon_size) && (M.x > V.x || M.y > V.y) && (get_dist(M, V) <= 2) ) || (get_dist(M, V) <= 1) )
+
+
+// num2hex, hex2num
+#define num2hex(X, len) num2text(X, len, 16)
+
+#define hex2num(X) text2num(X, 16)

--- a/_stdlib/math.dm
+++ b/_stdlib/math.dm
@@ -1,10 +1,3 @@
-//#define CLAMP(V, MN, MX) max(MN, min(MX, V))
-#define CLAMP(V, MN, MX) ((V<MN) ? MN : (V>MX) ? MX : V)
-
-/proc/atan2(x, y)
-	if(!x && !y) return 0
-	.= y >= 0 ? arccos(x / sqrt(x * x + y * y)) : -arccos(x / sqrt(x * x + y * y))
-
 /proc/angledifference(a1,a2) //difference in degrees between two angles in degrees
 	.= ( a2 - a1 + 180 ) % 360 - 180
 	if (. < -180)
@@ -12,17 +5,7 @@
 
 /proc/sign(x) //Should get bonus points for being the most compact code in the world!
 	return x!=0?x/abs(x):0
-#if DM_BUILD < 1490
-/proc/clamp(var/number, var/min, var/max)
-	return max(min(number, max), min)
-//moved out of Railgun.dm into a slightly more applicable math.dm
-/proc/arctan(x)
-  var/y=arcsin(x/sqrt(1+x*x))
-  return y
-//This returns the tangent of x, for use with North and South straights.
-/proc/tan(x)
-	return (sin(x)/cos(x))
-#endif
+
 //This returns the tangent reciprocal of x, for use with East and West straights.
 /proc/tanR(x)
 	return (cos(x)/sin(x))

--- a/code/WorkInProgress/ItemSpecials.dm
+++ b/code/WorkInProgress/ItemSpecials.dm
@@ -49,7 +49,7 @@
 	if(params["icon-y"])
 		dy += (text2num(params["icon-y"]) - 16)
 
-	var/angle = atan2(dy,dx)
+	var/angle = arctan(dy,dx)
 	//boutput(world, "[dx] : [dy] ::: makes for [angle]")
 
 	//oh no ! i'm bad!!!!!!!!!!!

--- a/code/WorkInProgress/MechanicMadness.dm
+++ b/code/WorkInProgress/MechanicMadness.dm
@@ -698,7 +698,7 @@ var/list/mechanics_telepads = new/list()
 					return
 				if("Set Range")
 					var/rng = input("Range is limited between 1-5.", "Enter a new range", range) as num
-					range = CLAMP(rng, 1, 5)
+					range = clamp(rng, 1, 5)
 					boutput(user, "<span class='notice'>Range set to [range]!</span>")
 					if(level == 1)
 						rebeam()

--- a/code/datums/controllers/action_controls.dm
+++ b/code/datums/controllers/action_controls.dm
@@ -1135,7 +1135,7 @@ var/datum/action_controller/actions
 
 			M.dir = turn(M.dir,up ? -90 : 90)
 			pixely += up ? 1 : -1
-			if (pixely != CLAMP(pixely, -5,5))
+			if (pixely != clamp(pixely, -5,5))
 				up = !up
 			M.pixel_y = pixely
 

--- a/code/datums/controllers/sea_hotspot_controls.dm
+++ b/code/datums/controllers/sea_hotspot_controls.dm
@@ -544,8 +544,8 @@
 					if (H.can_drift)
 						var/turf/dir_step = get_step(center, H.drift_dir)
 
-						var/angle = atan2(src.loc.y - center.y, src.loc.x - center.x)
-						var/angle2 = atan2(dir_step.y - center.y, dir_step.x - center.x) //todo : atan2 not necessary here. Make some dir2angle function for speed.
+						var/angle = arctan(src.loc.y - center.y, src.loc.x - center.x)
+						var/angle2 = arctan(dir_step.y - center.y, dir_step.x - center.x) //todo : atan2 not necessary here. Make some dir2angle function for speed.
 
 						var/diff = abs(angledifference(angle,angle2))
 						diff -= 90

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -29,7 +29,7 @@
 		if (namecheck.len >= 2)
 			namecheck.Insert(2, H.client.preferences.name_middle)
 			G.fields["full_name"] = jointext(namecheck, " ")
-	G.fields["id"] = "[add_zero(num2hex(rand(1, 1.6777215E7)), 6)]"
+	G.fields["id"] = "[add_zero(num2hex(rand(1, 1.6777215E7), 0), 6)]"
 	M.fields["name"] = G.fields["name"]
 	M.fields["id"] = G.fields["id"]
 	S.fields["name"] = G.fields["name"]

--- a/code/datums/movement_controller/colosseum_putt.dm
+++ b/code/datums/movement_controller/colosseum_putt.dm
@@ -69,7 +69,7 @@
 		else
 			move_dir = 0
 
-		var/delay = CLAMP(10 - master.speed, 1, 10)
+		var/delay = clamp(10 - master.speed, 1, 10)
 
 		if ((owner in master) && (owner == master.piloting))
 			master.facing = move_dir

--- a/code/datums/movement_controller/pod.dm
+++ b/code/datums/movement_controller/pod.dm
@@ -69,7 +69,7 @@
 			if (input_magnitude)
 				if (input_dir & (input_dir-1))
 					owner.dir = NORTH
-					owner.transform = turn(M,atan2(input_y,input_x))
+					owner.transform = turn(M,arctan(input_y,input_x))
 				else
 					owner.transform = null
 			last_dir = owner.dir

--- a/code/datums/preferences.dm
+++ b/code/datums/preferences.dm
@@ -1818,11 +1818,11 @@ datum/preferences
 	if (copytext(hcolor, 1, 2) == "#")
 		adj = 1
 	//DEBUG_MESSAGE("HAIR initial: [hcolor]")
-	var/hR_adj = num2hex(hex2num(copytext(hcolor, 1 + adj, 3 + adj)) + rand(-25,25))
+	var/hR_adj = num2hex(hex2num(copytext(hcolor, 1 + adj, 3 + adj)) + rand(-25,25), 2)
 	//DEBUG_MESSAGE("HAIR R: [hR_adj]")
-	var/hG_adj = num2hex(hex2num(copytext(hcolor, 3 + adj, 5 + adj)) + rand(-5,5))
+	var/hG_adj = num2hex(hex2num(copytext(hcolor, 3 + adj, 5 + adj)) + rand(-5,5), 2)
 	//DEBUG_MESSAGE("HAIR G: [hG_adj]")
-	var/hB_adj = num2hex(hex2num(copytext(hcolor, 5 + adj, 7 + adj)) + rand(-10,10))
+	var/hB_adj = num2hex(hex2num(copytext(hcolor, 5 + adj, 7 + adj)) + rand(-10,10), 2)
 	//DEBUG_MESSAGE("HAIR B: [hB_adj]")
 	var/return_color = "#" + hR_adj + hG_adj + hB_adj
 	//DEBUG_MESSAGE("HAIR final: [return_color]")
@@ -1835,11 +1835,11 @@ datum/preferences
 	if (copytext(ecolor, 1, 2) == "#")
 		adj = 1
 	//DEBUG_MESSAGE("EYE initial: [ecolor]")
-	var/eR_adj = num2hex(hex2num(copytext(ecolor, 1 + adj, 3 + adj)) + rand(-10,10))
+	var/eR_adj = num2hex(hex2num(copytext(ecolor, 1 + adj, 3 + adj)) + rand(-10,10), 2)
 	//DEBUG_MESSAGE("EYE R: [eR_adj]")
-	var/eG_adj = num2hex(hex2num(copytext(ecolor, 3 + adj, 5 + adj)) + rand(-10,10))
+	var/eG_adj = num2hex(hex2num(copytext(ecolor, 3 + adj, 5 + adj)) + rand(-10,10), 2)
 	//DEBUG_MESSAGE("EYE G: [eG_adj]")
-	var/eB_adj = num2hex(hex2num(copytext(ecolor, 5 + adj, 7 + adj)) + rand(-10,10))
+	var/eB_adj = num2hex(hex2num(copytext(ecolor, 5 + adj, 7 + adj)) + rand(-10,10), 2)
 	//DEBUG_MESSAGE("EYE B: [eB_adj]")
 	var/return_color = "#" + eR_adj + eG_adj + eB_adj
 	//DEBUG_MESSAGE("EYE final: [return_color]")

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -1960,7 +1960,7 @@
 /mob/proc/cluwnegib(var/duration = 30, var/anticheat = 0)
 	if(isobserver(src)) return
 	SPAWN_DBG(0) //multicluwne
-		duration = CLAMP(duration, 10, 100)
+		duration = clamp(duration, 10, 100)
 
 	#ifdef DATALOGGER
 		game_stats.Increment("violence")

--- a/code/mob/input.dm
+++ b/code/mob/input.dm
@@ -29,7 +29,7 @@ mob
 			if (keys & KEY_LEFT)
 				move_x -= 1
 			if (move_x || move_y)
-				src.move_dir = angle2dir(atan2(move_y, move_x))
+				src.move_dir = angle2dir(arctan(move_y, move_x))
 				src.attempt_move()
 			else
 				src.move_dir = 0

--- a/code/mob/living/carbon/human/procs/Life.dm
+++ b/code/mob/living/carbon/human/procs/Life.dm
@@ -1143,7 +1143,7 @@
 		if(src.getStatusDuration("food_disease_resist"))
 			resist_prob += 80
 
-		resist_prob = CLAMP(resist_prob,0,100)
+		resist_prob = clamp(resist_prob,0,100)
 		return resist_prob
 
 	proc/get_rad_protection()
@@ -1547,12 +1547,12 @@
 
 		if (src.bleeding && src.blood_volume)
 
-			var/final_bleed = CLAMP(src.bleeding, 0, 5) // trying this at 5 being the max
-			//var/final_bleed = CLAMP(src.bleeding, 0, 10) // still don't want this above 10
+			var/final_bleed = clamp(src.bleeding, 0, 5) // trying this at 5 being the max
+			//var/final_bleed = clamp(src.bleeding, 0, 10) // still don't want this above 10
 
 			if (src.reagents)
 				var/anticoag_amt = src.reagents.has_reagent("heparin") // anticoagulant
-				final_bleed += round(CLAMP((anticoag_amt / 10), 0, 2), 1)
+				final_bleed += round(clamp((anticoag_amt / 10), 0, 2), 1)
 
 			if (prob(max(0, min(final_bleed, 10)) * 5)) // up to 50% chance to make a big bloodsplatter
 				bleed(src, final_bleed, 5)

--- a/code/mob/living/critter/bee.dm
+++ b/code/mob/living/critter/bee.dm
@@ -721,7 +721,7 @@
 				src.visible_message("<span class='alert'><b>[src]</b> dies!</span>",\
 				"<span class='alert'><b>You die!</b></span>")
 				src.set_density(0)
-			src.playing_dead = CLAMP((src.playing_dead + addtime), 0, 100)
+			src.playing_dead = clamp((src.playing_dead + addtime), 0, 100)
 		if (src.playing_dead <= 0)
 			return
 		if (src.playing_dead == 1)

--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -599,7 +599,7 @@ todo: add more small animals!
 				src.visible_message("<span class='alert'><b>[src]</b> [pick("tires","tuckers out","gets pooped")] and lies down!!</span>",\
 				"<span class='alert'><b>You get [pick("tired","tuckered out","pooped")] and lie down!!</b></span>")
 				src.set_density(0)
-			src.playing_dead = CLAMP((src.playing_dead + addtime), 0, 100)
+			src.playing_dead = clamp((src.playing_dead + addtime), 0, 100)
 		if (src.playing_dead <= 0)
 			return
 		if (src.playing_dead == 1)
@@ -1538,7 +1538,7 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 				src.visible_message("<span class='alert'><b>[src]</b> dies!</span>",\
 				"<span class='alert'><b>You play dead!</b></span>")
 				src.set_density(0)
-			src.playing_dead = CLAMP((src.playing_dead + addtime), 0, 100)
+			src.playing_dead = clamp((src.playing_dead + addtime), 0, 100)
 		if (src.playing_dead <= 0)
 			return
 		if (src.playing_dead == 1)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1781,7 +1781,7 @@ var/global/noir = 0
 						return
 
 					var/list/offset = splittext(href_list["offset"],",")
-					var/number = CLAMP(text2num(href_list["object_count"]), 1, 100)
+					var/number = clamp(text2num(href_list["object_count"]), 1, 100)
 					var/X = offset.len > 0 ? text2num(offset[1]) : 0
 					var/Y = offset.len > 1 ? text2num(offset[2]) : 0
 					var/Z = offset.len > 2 ? text2num(offset[3]) : 0

--- a/code/modules/admin/buildmodes/spawn_gift.dm
+++ b/code/modules/admin/buildmodes/spawn_gift.dm
@@ -46,7 +46,7 @@ change the direction of created objects.<br>
 				random_style = rand(1,8)
 			else
 				random_style = pick("r", "rs", "g", "gs")
-			G.icon_state = "gift[CLAMP(G.size, 1, 3)]-[random_style]"
+			G.icon_state = "gift[clamp(G.size, 1, 3)]-[random_style]"
 		else if(ismob(A) || istype(A, /obj/critter))
 			G.size = 3
 			G.w_class = G.size + 1

--- a/code/modules/atmospherics/FEA_airgroup.dm
+++ b/code/modules/atmospherics/FEA_airgroup.dm
@@ -363,7 +363,7 @@
 			var/datum/gas_mixture/member_air = member.air
 			// Todo - retain nearest space tile border and apply force proportional to amount
 			// of air leaving through it
-			member_air.mimic(sample, CLAMP(length_space_border / (2 * max(1, minDist)), 0.1, 1))
+			member_air.mimic(sample, clamp(length_space_border / (2 * max(1, minDist)), 0.1, 1))
 			SPACEFASTPRESSURE(member_air, totalPressure) // Build your own atmos disaster
 
 		LAGCHECK(LAG_REALTIME)

--- a/code/modules/atmospherics/machinery/binary/pump_ui.dm
+++ b/code/modules/atmospherics/machinery/binary/pump_ui.dm
@@ -28,11 +28,11 @@ datum/pump_ui/Topic(href, href_list)
 		if(href_list["ui_action"] == "set_value")
 			var/value_to_set = input(usr, "[value_name] ([min_value] - [max_value] [value_units]):", "Enter new value", get_value()) as num
 			if(isnum(value_to_set))
-				set_value(CLAMP(value_to_set, min_value, max_value))
+				set_value(clamp(value_to_set, min_value, max_value))
 		else if(href_list["ui_action"] == "toggle_power")
 			toggle_power()
 		else if(href_list["ui_action"] == "bump_value")
-			set_value(CLAMP(get_value() + text2num(href_list["bump_value"]), min_value, max_value))
+			set_value(clamp(get_value() + text2num(href_list["bump_value"]), min_value, max_value))
 	show_ui(usr)
  // Displays the UI
 datum/pump_ui/proc/show_ui(mob/user)

--- a/code/modules/chemistry/Chemistry-Dispenser.dm
+++ b/code/modules/chemistry/Chemistry-Dispenser.dm
@@ -223,7 +223,7 @@
 			var/amount = input("How much of it do you want? (1 to [amtlimit])", "[dispenser_name] Dispenser", null, null) as null|num
 			if (isnull(amount) || amount <= 0)
 				return
-			amount = CLAMP(amount, 0, amtlimit)
+			amount = clamp(amount, 0, amtlimit)
 			if (get_dist(src,user) > 1)
 				boutput(user, "You need to move closer to get the chemicals!")
 				return
@@ -317,7 +317,7 @@
 					if (istext(reagentlist[reagent])) //Set a dispense amount
 						var/num = text2num(reagentlist[reagent])
 						if(!num) num = 10
-						G.reagents[lowertext(reagent)] = CLAMP(round(num), 1, 100)
+						G.reagents[lowertext(reagent)] = clamp(round(num), 1, 100)
 					else //Default to 10 if no specific amount given
 						G.reagents[lowertext(reagent)] = 10
 
@@ -357,7 +357,7 @@
 			if (isnull(nadd) || get_dist(src,usr) > 1)
 				doing_a_thing = 0
 				return
-			src.user_dispense_amt = CLAMP(round(nadd), 1, 100)
+			src.user_dispense_amt = clamp(round(nadd), 1, 100)
 			src.updateUsrDialog()
 			doing_a_thing = 0
 			return
@@ -368,7 +368,7 @@
 			if (isnull(nremove) || get_dist(src,usr) > 1)
 				doing_a_thing = 0
 				return
-			src.user_remove_amt = CLAMP(round(nremove), 1, 100)
+			src.user_remove_amt = clamp(round(nremove), 1, 100)
 			src.updateUsrDialog()
 			doing_a_thing = 0
 			return

--- a/code/modules/chemistry/Chemistry-Machinery.dm
+++ b/code/modules/chemistry/Chemistry-Machinery.dm
@@ -423,7 +423,7 @@
 			var/pillvol = input(usr, "Volume of chemical per pill: (Min/Max 5/100):", "Volume", 5) as null|num
 			if (!pillvol || !src.beaker || !R)
 				return
-			pillvol = CLAMP(pillvol, 5, 100)
+			pillvol = clamp(pillvol, 5, 100)
 			// maths
 			var/pillcount = round(R.total_volume / pillvol) // round with a single parameter is actually floor because byond
 			logTheThing("combat",usr,null,"created [pillcount] [pillname] pills from [log_reagents(R)].")
@@ -515,7 +515,7 @@
 			var/patchvol = input(usr, "Volume of chemical per patch: (Min/Max 5/40)", "Volume", 5) as null|num
 			if (!patchvol || !src.beaker || !R)
 				return
-			patchvol = CLAMP(patchvol, 5, 40)
+			patchvol = clamp(patchvol, 5, 40)
 			// maths
 			var/patchcount = round(R.total_volume / patchvol) // round with a single parameter is actually floor because byond
 			logTheThing("combat",usr,null,"created [patchcount] [patchname] patches from [log_reagents(R)].")

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -1725,7 +1725,7 @@ datum
 			reaction_mob(var/mob/M, var/method = TOUCH, var/volume)
 				if (method == INGEST)
 					if (ishuman(M))
-						M:blood_color = "#[num2hex(rand(0, 255))][num2hex(rand(0, 255))][num2hex(rand(0, 255))]"
+						M:blood_color = "#[num2hex(rand(0, 255),2)][num2hex(rand(0, 255), 2)][num2hex(rand(0, 255), 2)]"
 				return
 
 			reaction_obj(var/obj/O, var/volume)
@@ -3659,12 +3659,12 @@ datum
 				if(M && our_amt > 20)
 					if(M.bioHolder && !M.bioHolder.HasEffect("fat"))
 						M.bioHolder.AddEffect("fat")
-				for (var/obj/V in orange(CLAMP(our_amt / 5, 2,10),M))
+				for (var/obj/V in orange(clamp(our_amt / 5, 2,10),M))
 					if (V.anchored)
 						continue
 					step_towards(V,M)
 
-				for (var/mob/living/N in orange(CLAMP(our_amt / 5, 2,10),M))
+				for (var/mob/living/N in orange(clamp(our_amt / 5, 2,10),M))
 					step_towards(N,M)
 					if(ishuman(N) && prob(1))
 						N.say("[M.name] is an ocean of muscle.")

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -1878,7 +1878,7 @@ datum
 							H.emote("scream") //It REALLY hurts
 							H.TakeDamage(zone="All", brute=rand(2,5) * mult)
 
-					if(prob(CLAMP(data/1.5, 100, 30))) //At least 30% risk of oxy damage
+					if(prob(clamp(data/1.5, 100, 30))) //At least 30% risk of oxy damage
 						if(prob(50))H.emote(pick("gasp", "choke", "cough"))
 						H.losebreath += rand(1,3) * mult
 

--- a/code/modules/events/battle_storm.dm
+++ b/code/modules/events/battle_storm.dm
@@ -17,7 +17,7 @@
 		activations++
 		safe_area_names = list()
 		safe_areas = list()
-		var/num_safe_areas = CLAMP(6 - activations, 1, 5)
+		var/num_safe_areas = clamp(6 - activations, 1, 5)
 		var/area/temp = null
 		var/list/locations_copy = list()
 		for(var/A in safe_locations)

--- a/code/modules/fluids/fluid_pipes.dm
+++ b/code/modules/fluids/fluid_pipes.dm
@@ -284,7 +284,7 @@ proc/flow_through(var/list/obj/fluid_pipe/path, max_allowed_flow)
 	for(var/obj/fluid_pipe/pipe in path)
 		if(pipe.capacity - pipe.used_capacity < min_capacity)
 			min_capacity = pipe.capacity - pipe.used_capacity
-	min_capacity = CLAMP(min_capacity,0,max_allowed_flow)
+	min_capacity = clamp(min_capacity,0,max_allowed_flow)
 	DEBUG_MESSAGE("Pushing [min_capacity] through this path.")
 	for(var/obj/fluid_pipe/pipe in path)
 		pipe.used_capacity += min_capacity

--- a/code/modules/holiday/spacemas.dm
+++ b/code/modules/holiday/spacemas.dm
@@ -630,7 +630,7 @@ var/list/seal_names = list("Fluffles","Ronan","Selena","Selkie","Ukog","Ategev",
 		var/pattern = input(usr, "Type number from 0 to 4", "Enter Number", 1) as null|num
 		if (isnull(pattern))
 			return
-		pattern = CLAMP(pattern, 0, 4)
+		pattern = clamp(pattern, 0, 4)
 		src.light_pattern(pattern)
 
 // Grinch Stuff

--- a/code/modules/medical/blood_system.dm
+++ b/code/modules/medical/blood_system.dm
@@ -228,14 +228,14 @@ this is already used where it needs to be used, you can probably ignore it.
 	if (H.reagents)
 		var/anticoag_amt = H.reagents.get_reagent_amount("heparin")
 		if (anticoag_amt)
-			increase_chance += CLAMP(anticoag_amt, 0, 50)
-			increase_amount += rand(1, round(CLAMP((anticoag_amt / 10), 0, 3), 1))
+			increase_chance += clamp(anticoag_amt, 0, 50)
+			increase_amount += rand(1, round(clamp((anticoag_amt / 10), 0, 3), 1))
 			//BLOOD_DEBUG("[H] processes heparin: increase_chance now [increase_chance], increase_amount now [increase_amount]")
 
 		var/coag_amt = H.reagents.get_reagent_amount("proconvertin")
 		if (coag_amt)
-			increase_chance -= CLAMP(coag_amt, 0, 50)
-			increase_amount -= rand(1, round(CLAMP((coag_amt / 10), 0, 3), 1))
+			increase_chance -= clamp(coag_amt, 0, 50)
+			increase_amount -= rand(1, round(clamp((coag_amt / 10), 0, 3), 1))
 			//BLOOD_DEBUG("[H] processes proconvertin: increase_chance now [increase_chance], increase_amount now [increase_amount]")
 
 	if (ischangeling(H))
@@ -247,16 +247,16 @@ this is already used where it needs to be used, you can probably ignore it.
 		increase_chance *= 3
 		increase_amount += rand(0,1)
 
-	var/final_increase_chance = round(CLAMP(increase_chance, 0, 100), 1)
-	var/final_increase_amount = round(CLAMP(increase_amount, 0, 5), 1)
-	//var/final_increase_amount = round(CLAMP(increase_amount, 0, 10), 1)
+	var/final_increase_chance = round(clamp(increase_chance, 0, 100), 1)
+	var/final_increase_amount = round(clamp(increase_amount, 0, 5), 1)
+	//var/final_increase_amount = round(clamp(increase_amount, 0, 10), 1)
 	//BLOOD_DEBUG("[H]'s final_increase_chance: [final_increase_chance], final_increase_amount: [final_increase_amount]")
 
 	if (final_increase_amount > 0 && prob(final_increase_chance))
 		var/old_bleeding = H.bleeding
 		H.bleeding += final_increase_amount
-		H.bleeding = CLAMP(H.bleeding, 0, 5)
-		//H.bleeding = CLAMP(H.bleeding, 0, 10)
+		H.bleeding = clamp(H.bleeding, 0, 5)
+		//H.bleeding = clamp(H.bleeding, 0, 10)
 		if (H.bleeding > old_bleeding) // I'm not sure how it wouldn't be, but, uh, yeah
 			if (old_bleeding <= 0)
 				H.visible_message("<span class='alert'>[H] starts bleeding!</span>",\
@@ -316,11 +316,11 @@ this is already used where it needs to be used, you can probably ignore it.
 		if (H.reagents)
 			var/anticoag_amt = H.reagents.get_reagent_amount("heparin")
 			if (anticoag_amt)
-				repair_chance -= CLAMP(anticoag_amt, 0, 10)
+				repair_chance -= clamp(anticoag_amt, 0, 10)
 
 			var/coag_amt = H.reagents.get_reagent_amount("proconvertin")
 			if (coag_amt)
-				repair_chance += CLAMP(coag_amt, 0, 10)
+				repair_chance += clamp(coag_amt, 0, 10)
 
 		switch (H.bleeding)
 			if (-INFINITY to 0)
@@ -799,7 +799,7 @@ this is already used where it needs to be used, you can probably ignore it.
 		if (haine_blood_debug) logTheThing("debug", H, null, "<b>HAINE BLOOD DEBUG: [H] rolls internal bleeding increase, internal bleeding is now [H.bleeding_internal]</b>")
 	else
 		if (haine_blood_debug) logTheThing("debug", H, null, "<b>HAINE BLOOD DEBUG: [H]'s internal bleeding does not increase</b>")
-	H.bleeding_internal = CLAMP(H.bleeding_internal, 0, 5)
+	H.bleeding_internal = clamp(H.bleeding_internal, 0, 5)
 	if (haine_blood_debug) logTheThing("debug", H, null, "<b>HAINE BLOOD DEBUG: [H]'s internal bleeding is [H.bleeding_internal] after clamp</b>")
 
 /* ._.-'~'-._.-'~'-._.-'~'-._.-'~'-._.-'~'-._.-'~'-._.-'~'-._. */

--- a/code/modules/medical/genetics/bioHolder.dm
+++ b/code/modules/medical/genetics/bioHolder.dm
@@ -152,7 +152,7 @@ var/list/datum/bioEffect/mutini_effects = list()
 			targetColor = hex2num(targetColor)
 
 			//Do the math and add to the output
-			. += num2hex(color + ((targetColor - color) / adjust_denominator))
+			. += num2hex(color + ((targetColor - color) / adjust_denominator), 0)
 
 	proc/UpdateMob() //Rebuild the appearance of the mob from the settings in this holder.
 		if (ishuman(owner))

--- a/code/modules/medical/pathology/pathogen.dm
+++ b/code/modules/medical/pathology/pathogen.dm
@@ -1278,7 +1278,7 @@ datum/pathogen
 					suppressed = result
 			if (advance_speed > 0)
 				if (prob(min(advance_speed, 4)))
-					if (suppressed < 1)	
+					if (suppressed < 1)
 						advance()
 					else if (stage > 3)
 						reduce()
@@ -1537,7 +1537,7 @@ proc/num2hexoc(num, pad)
 					logTheThing("pathology", null, null, "Num2hexoc error: overflow on [num].")
 				if (neg)
 					digit += 8
-				return "[dig2hex(digit)][ret]"
+				return "[num2hex(digit,0)][ret]"
 		while (digs <= pad)
 			if (neg)
 				ret = "F[ret]"

--- a/code/modules/medical/pathology/pathogen_machines.dm
+++ b/code/modules/medical/pathology/pathogen_machines.dm
@@ -719,7 +719,7 @@
 					src.manip.icon_state = "manipulator"
 				gui.sendToSubscribers({"{"exposed":[src.manip.exposed]}"}, "setUIState")
 		if (href_list["splice"])
-			var/slotid = CLAMP(text2num(href_list["splice"]), 1, src.manip.slots.len)
+			var/slotid = clamp(text2num(href_list["splice"]), 1, src.manip.slots.len)
 			src.manip.splicesource = slotid
 			gui.sendToSubscribers({"{"splice":{"selected":[src.manip.splicesource]}}"}, "setUIState")
 
@@ -812,14 +812,14 @@
 			var/rptr_index = text2num(href_list["rptr_index"])
 			var/t = text2num(href_list["target"])
 			if(t)
-				lptr_index = CLAMP(lptr_index+1, 1, src.manip.cache_target.len)
-				rptr_index = CLAMP(rptr_index+1, 1, src.manip.cache_target.len)
+				lptr_index = clamp(lptr_index+1, 1, src.manip.cache_target.len)
+				rptr_index = clamp(rptr_index+1, 1, src.manip.cache_target.len)
 				src.manip.sel_target_lptr = lptr_index
 				src.manip.sel_target_rptr = rptr_index
 				gui.sendToSubscribers({"{"splice":{"selTarget":{"lptr_index":[lptr_index], "rptr_index":[rptr_index]}}}"}, "setUIState")
 			else
-				lptr_index = CLAMP(lptr_index+1, 1, src.manip.cache_source.len)
-				rptr_index = CLAMP(rptr_index+1, 1, src.manip.cache_source.len)
+				lptr_index = clamp(lptr_index+1, 1, src.manip.cache_source.len)
+				rptr_index = clamp(rptr_index+1, 1, src.manip.cache_source.len)
 				src.manip.sel_source_lptr = lptr_index
 				src.manip.sel_source_rptr = rptr_index
 				gui.sendToSubscribers({"{"splice":{"selSource":{"lptr_index":[lptr_index], "rptr_index":[rptr_index]}}}"}, "setUIState")
@@ -834,10 +834,10 @@
 			if(direction == null || t_index == null || (direction != 0 && (s_index == null || s_len == null)) || (direction == 0 && t_len == null))
 				return
 
-			direction = CLAMP(direction, -1, 1)
+			direction = clamp(direction, -1, 1)
 			//Increase the positions by one since they are 0-indexed JS.
-			s_index = CLAMP(s_index+1, 1, src.manip.cache_source.len)
-			t_index = CLAMP(t_index+1, 1, src.manip.cache_target.len)
+			s_index = clamp(s_index+1, 1, src.manip.cache_source.len)
+			t_index = clamp(t_index+1, 1, src.manip.cache_target.len)
 
 			if(direction == 0) //Remove
 				if(src.manip.cache_target.len)
@@ -848,7 +848,7 @@
 			else	//Insert
 				direction = max(direction,0) //In case we're inserting before we don't want to subtract from the target index
 				if(src.manip.cache_source.len)
-					var/newpos = CLAMP(t_index + direction, 1, src.manip.cache_target.len+1) 	//Set the position to insert at
+					var/newpos = clamp(t_index + direction, 1, src.manip.cache_target.len+1) 	//Set the position to insert at
 					var/newseq = src.manip.cache_source.Copy(s_index, s_index + s_len) //Copy the elements from source we want to insert
 					src.manip.cache_target.Insert(newpos, newseq)	//Do the insertion
 					src.manip.cache_source.Cut(s_index, s_index + s_len) //Remove the DNA sequence from the source

--- a/code/modules/medical/surgery_tools.dm
+++ b/code/modules/medical/surgery_tools.dm
@@ -727,9 +727,9 @@ CONTAINS:
 		repair_amount = Repair
 		vrb = Vrb
 		if (zone && surgery_status)
-			duration = CLAMP((duration * surgery_status), 5, 50)
+			duration = clamp((duration * surgery_status), 5, 50)
 		else if (ishuman(target))
-			duration = CLAMP((duration * target.bleeding), 5, 50)
+			duration = clamp((duration * target.bleeding), 5, 50)
 		if (tool)
 			icon = tool.icon
 			icon_state = tool.icon_state
@@ -1096,7 +1096,7 @@ CONTAINS:
 		user, "<span class='alert'>You begin clamping the bleeders in [user == H ? "your" : "[H]'s"] incision with [src].</span>",\
 		H, "<span class='alert'>[H == user ? "You begin" : "<b>[user]</b> begins"] clamping the bleeders in your incision with [src].</span>")
 
-		if (!do_mob(user, H, CLAMP(surgery_status * 4, 0, 100)))
+		if (!do_mob(user, H, clamp(surgery_status * 4, 0, 100)))
 			user.visible_message("<span class='alert'><b>[user]</b> was interrupted!</span>",\
 			"<span class='alert'>You were interrupted!</span>")
 			return

--- a/code/modules/networks/computer3/sec_rec.dm
+++ b/code/modules/networks/computer3/sec_rec.dm
@@ -223,7 +223,7 @@
 					var/datum/data/record/G = new /datum/data/record(  )
 					G.fields["name"] = "New Record"
 					G.fields["full_name"] = "New Record"
-					G.fields["id"] = "[add_zero(num2hex(rand(1, 1.6777215E7)), 6)]"
+					G.fields["id"] = "[num2hex(rand(1, 1.6777215E7), 6)]"
 					G.fields["rank"] = "Unassigned"
 					G.fields["sex"] = "Other"
 					G.fields["age"] = "Unknown"

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -177,7 +177,7 @@
 	if(adir != ndir)
 		SPAWN_DBG(10+rand(0,15))
 			var/old_adir = adir
-			adir = (360+adir+CLAMP(ndir-adir,-10,10))%360
+			adir = (360+adir+clamp(ndir-adir,-10,10))%360
 			if (round((old_adir+22.5)%360) != round((old_adir+22.5)%360)) // it's basically angle2dir except it returns wrong values, but it changes when angle2dir changes and stays the same when angle2dir stays the same
 				updateicon()
 			update_solar_exposure()
@@ -380,12 +380,12 @@
 
 	if(href_list["rate control"])
 		if(href_list["cdir"])
-			src.cdir = CLAMP((360+src.cdir+text2num(href_list["cdir"]))%360, 0, 359)
+			src.cdir = clamp((360+src.cdir+text2num(href_list["cdir"]))%360, 0, 359)
 			SPAWN_DBG(1 DECI SECOND)
 				set_panels(cdir)
 				updateicon()
 		if(href_list["tdir"])
-			src.trackrate = CLAMP(src.trackrate+text2num(href_list["tdir"]), -7200,7200)
+			src.trackrate = clamp(src.trackrate+text2num(href_list["tdir"]), -7200,7200)
 			if(src.trackrate) nexttime = world.timeofday + 3600/abs(trackrate)
 
 	if(href_list["track"])
@@ -468,6 +468,6 @@
 
 		if(adir != ndir)
 			SPAWN_DBG(10+rand(0,15))
-				adir = (360+adir+CLAMP(ndir-adir,-10,10))%360
+				adir = (360+adir+clamp(ndir-adir,-10,10))%360
 				updateicon()
 				update_solar_exposure()

--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -69,7 +69,7 @@
 		yo = y
 		if (do_turn)
 			//src.transform = null
-			src.transform = turn(matrix(),(angle_override ? angle_override : atan2(y,x)))
+			src.transform = turn(matrix(),(angle_override ? angle_override : arctan(y,x)))
 		else if (angle_override)
 			src.transform = null
 			facing_dir = angle2dir(angle_override)

--- a/code/modules/projectiles/special.dm
+++ b/code/modules/projectiles/special.dm
@@ -519,7 +519,7 @@
 
 				var/setangle = 0
 				if (face_desired_dir)
-					setangle = atan2(desired_y,desired_x)
+					setangle = arctan(desired_y,desired_x)
 
 				P.setDirection(xchanged,ychanged, do_turn = rotate_proj, angle_override = setangle)
 				P.internal_speed = ( max(min_speed, min(max_speed, magnitude)) )

--- a/code/modules/sound/djpanel_chui.dm
+++ b/code/modules/sound/djpanel_chui.dm
@@ -50,11 +50,11 @@ chui/window/dj_panel //global panel
 		switch(id)
 			if("changevol")
 				var/volnum = (input(who, "Please enter a volume:", "Please enter a volume. Default: 50.", "") as num) //have to do this otherwise multiple input boxes
-				SetVar("set_volume", CLAMP(volnum, 0, 100))
+				SetVar("set_volume", clamp(volnum, 0, 100))
 				return
 			if("changefreq")
 				var/freqnum = (input(who, "Please enter a frequency. Default : 1. Use negatives to play in reverse.", "Pitch?", "") as num) //ditto
-				SetVar("set_freq", CLAMP(freqnum, -99, 99))
+				SetVar("set_freq", clamp(freqnum, -99, 99))
 				return
 			if("changefile")
 				loaded_song = (input(who, "Upload a file:", "File Uploader - No 50MB songs!", "") as sound|null)

--- a/code/modules/sound/~sound2.dm
+++ b/code/modules/sound/~sound2.dm
@@ -46,7 +46,7 @@ var/sound/mutecache
 			//world << "Their dist: [dist] vs [maxdist]"
 			if( dist < maxdist )
 				status &= ~SOUND_UPDATE
-				pan = CLAMP((AT.x - CT.x)/maxdist*100,-100,100)
+				pan = clamp((AT.x - CT.x)/maxdist*100,-100,100)
 				volume = 100-(dist/maxdist*100)
 				c << src
 				status |= SOUND_UPDATE

--- a/code/obj/item/device/scanners.dm
+++ b/code/obj/item/device/scanners.dm
@@ -553,7 +553,7 @@ that cannot be itched
 
 		if(found == 0)
 			src.active1 = new /datum/data/record()
-			src.active1.fields["id"] = text("[]", add_zero(num2hex(rand(1, 1.6777215E7)), 6))
+			src.active1.fields["id"] = num2hex(rand(1, 1.6777215E7),6)
 			src.active1.fields["rank"] = "Unassigned"
 			//Update Information
 			src.active1.fields["name"] = M.name

--- a/code/obj/item/device/transfer_valve.dm
+++ b/code/obj/item/device/transfer_valve.dm
@@ -427,10 +427,10 @@
 	desc = "A pressure crystal. We're not really sure how it works, but it does. Place this near where the epicenter of a bomb would be, then detonate the bomb. Afterwards, place the crystal in a tester to determine the strength."
 	name = "Pressure Crystal"
 	ex_act(var/ex, var/inf, var/factor)
-		pressure = factor || (4-CLAMP(ex, 1, 3))*2
+		pressure = factor || (4-clamp(ex, 1, 3))*2
 		total_pressure += pressure
 		pressure += (rand()-0.5) * (pressure/1000)//its not extremely accurate.
-		icon_state = "pressure_[CLAMP(ex, 1, 3)]"
+		icon_state = "pressure_[clamp(ex, 1, 3)]"
 /obj/item/device/pressure_sensor
 	name = "Pressure Sensor"
 	icon = 'icons/obj/items/assemblies.dmi'

--- a/code/obj/item/gift.dm
+++ b/code/obj/item/gift.dm
@@ -40,7 +40,7 @@
 				var/obj/item/gift/G = new /obj/item/gift(src.loc)
 				G.size = W.w_class
 				G.w_class = G.size + 1
-				G.icon_state = "gift[CLAMP(G.size, 1, 3)]-[src.style]"
+				G.icon_state = "gift[clamp(G.size, 1, 3)]-[src.style]"
 				G.gift = W
 				W.set_loc(G)
 				G.add_fingerprint(user)

--- a/code/obj/item/pens_writing_etc.dm
+++ b/code/obj/item/pens_writing_etc.dm
@@ -378,7 +378,7 @@
 	random
 		New()
 			..()
-			src.color = "#[num2hex(rand(0, 255))][num2hex(rand(0, 255))][num2hex(rand(0, 255))]"
+			src.color = "#[num2hex(rand(0, 255),2)][num2hex(rand(0, 255),2)][num2hex(rand(0, 255),2)]"
 			src.font_color = src.color
 			src.color_name = hex2color_name(src.color)
 			src.name = "[src.color_name] chalk"

--- a/code/obj/item/stickers.dm
+++ b/code/obj/item/stickers.dm
@@ -49,8 +49,8 @@
 			sticker.icon_state = src.icon_state
 			sticker.appearance_flags = RESET_COLOR
 
-			//pox = CLAMP(-round(A.bound_width/2), pox, round(A.bound_width/2))
-			//poy = CLAMP(-round(A.bound_height/2), pox, round(A.bound_height/2))
+			//pox = clamp(-round(A.bound_width/2), pox, round(A.bound_width/2))
+			//poy = clamp(-round(A.bound_height/2), pox, round(A.bound_height/2))
 			sticker.pixel_x = pox
 			sticker.pixel_y = poy
 			overlay_key = "sticker[world.timeofday]"

--- a/code/obj/machinery/computer/secure_data.dm
+++ b/code/obj/machinery/computer/secure_data.dm
@@ -367,7 +367,7 @@
 																if (href_list["new_r"])
 																	var/datum/data/record/G = new /datum/data/record(  )
 																	G.fields["name"] = "New Record"
-																	G.fields["id"] = text("[]", add_zero(num2hex(rand(1, 1.6777215E7)), 6))
+																	G.fields["id"] = num2hex(rand(1, 1.6777215E7), 6)
 																	G.fields["rank"] = "Unassigned"
 																	G.fields["sex"] = "Male"
 																	G.fields["age"] = "Unknown"

--- a/code/obj/machinery/sleeper.dm
+++ b/code/obj/machinery/sleeper.dm
@@ -241,7 +241,7 @@
 					// People do use sleepers for grief from time to time.
 					logTheThing("station", usr, src.our_sleeper.occupant, "increases a sleeper's timer ([src.our_sleeper.emagged ? "<b>EMAGGED</b>, " : ""]occupied by %target%) by [t] seconds at [log_loc(src.our_sleeper)].")
 				//src.time = min(180, max(0, src.time + t))
-				src.time = CLAMP(src.time + (t*10), 0, 1800)
+				src.time = clamp(src.time + (t*10), 0, 1800)
 
 		if (href_list["rejuv"])
 			if (src.our_sleeper && src.our_sleeper.occupant)

--- a/code/obj/machinery/spaceheater.dm
+++ b/code/obj/machinery/spaceheater.dm
@@ -166,7 +166,7 @@
 					var/max = src.emagged ? 400 : 90
 					var/min = src.emagged ? -120 : 90
 
-					set_temperature = CLAMP(set_temperature + value, -min, max)
+					set_temperature = clamp(set_temperature + value, -min, max)
 
 				if("temp")
 					var/value = text2num(href_list["val"])
@@ -174,7 +174,7 @@
 					var/min = src.emagged ? -120 : 90
 
 					// limit to 20-90 degC
-					set_temperature = CLAMP(set_temperature + value, -min, max)
+					set_temperature = clamp(set_temperature + value, -min, max)
 
 				if("cellremove")
 					if(open && cell && !usr.equipped())
@@ -380,7 +380,7 @@
 					var/value = text2num(href_list["val"])
 
 					// limit to 20-90 degC
-					set_temperature = CLAMP(set_temperature + value, 0, 200)
+					set_temperature = clamp(set_temperature + value, 0, 200)
 
 				if("cellremove")
 					if(open && cell && !usr.equipped())

--- a/code/obj/posters.dm
+++ b/code/obj/posters.dm
@@ -529,7 +529,7 @@ var/global/icon/wanted_poster_unknown = icon('icons/obj/decals.dmi', "wanted-unk
 			if (isnull(pnum) || get_dist(usr,src) > 1)
 				return
 			logTheThing("speech", usr, null, "printed out [pnum] wanted poster(s) [log_loc(src)] contents: name [src.plist["name"]], subtitle [src.plist["subtitle"]], wanted [src.plist["wanted"]], for [src.plist["for"]], notes [src.plist["notes"]]")
-			for (var/i = CLAMP(pnum, 1, src.papers), i>0, i--)
+			for (var/i = clamp(pnum, 1, src.papers), i>0, i--)
 				if (src.papers <= 0)
 					break
 				src.print_poster(usr)

--- a/code/obj/submachine/cooking.dm
+++ b/code/obj/submachine/cooking.dm
@@ -671,7 +671,7 @@ table#cooktime a#start {
 			if (src.working)
 				boutput(usr, "<span class='alert'>It's already working.</span>")
 				return
-			src.time = CLAMP(text2num(href_list["time"]), 1, 10)
+			src.time = clamp(text2num(href_list["time"]), 1, 10)
 			src.updateUsrDialog()
 			return
 

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -137,7 +137,7 @@ proc/castRay(var/atom/A, var/Angle, var/Distance) //Adapted from some forum stuf
 	return crossed
 
 proc/get_angle(atom/a, atom/b)
-    .= atan2(b.y - a.y, b.x - a.x)
+    .= arctan(b.y - a.y, b.x - a.x)
 
 //list2params without the dumb encoding
 /proc/list2params_noencode(var/list/L)
@@ -243,62 +243,6 @@ proc/get_angle(atom/a, atom/b)
 			. = locate(1, world.maxy, A.z)
 
 
-//Returns an integer given a hex input, supports negative values "-ff"
-//skips preceding invalid characters
-//breaks when hittin invalid characters thereafter
-/proc/hex2num(hex)
-	. = 0
-	var/place = 1
-	for(var/i in length(hex) to 1 step -1)
-		var/num = text2ascii(hex, i)
-		switch(num)
-			if(48 to 57)
-				num -= 48	//0-9
-			if(97 to 102)
-				num -= 87	//a-f
-			if(65 to 70)
-				num -= 55	//A-F
-			if(45)
-				return . * -1 // -
-			else
-				CRASH("Malformed hex number")
-
-		. += num * place
-		place *= 16
-
-
-//Returns the hex value of a decimal number
-//len == length of returned string
-//if len < 0 then the returned string will be as long as it needs to be to contain the data
-//Only supports positive numbers
-//if an invalid number is provided, it assumes num==0
-//Note, unlike previous versions, this one works from low to high <-- that way
-/proc/num2hex(num, len=2)
-	if(!isnum(num))
-		num = 0
-	num = round(abs(num))
-	. = ""
-	var/i=0
-	while(1)
-		if(len<=0)
-			if(!num)
-				break
-		else
-			if(i>=len)
-				break
-		var/remainder = num/16
-		num = round(remainder)
-		remainder = (remainder - num) * 16
-		switch(remainder)
-			if(9,8,7,6,5,4,3,2,1)
-				. = "[remainder]" + .
-			if(10,11,12,13,14,15)
-				. = ascii2text(remainder+87) + .
-			else
-				. = "0" + .
-		i++
-	return .
-
 /proc/invertHTML(HTMLstring)
 
 	if (!( istext(HTMLstring) ))
@@ -312,9 +256,9 @@ proc/get_angle(atom/a, atom/b)
 	var/r = hex2num(textr)
 	var/g = hex2num(textg)
 	var/b = hex2num(textb)
-	textr = num2hex(255 - r)
-	textg = num2hex(255 - g)
-	textb = num2hex(255 - b)
+	textr = num2hex(255 - r, 2)
+	textg = num2hex(255 - g, 2)
+	textb = num2hex(255 - b, 2)
 	if (length(textr) < 2)
 		textr = text("0[]", textr)
 	if (length(textg) < 2)
@@ -2371,7 +2315,7 @@ proc/vector_magnitude(x,y)
   * Transforms a supplied vector x & y to a direction
   */
 proc/vector_to_dir(x,y)
-	.= angle_to_dir(atan2(y,x))
+	.= angle_to_dir(arctan(y,x))
 
 /**
   * Transforms a given angle to a cardinal/ordinal direction

--- a/code/procs/scorestats.dm
+++ b/code/procs/scorestats.dm
@@ -66,8 +66,8 @@ var/datum/score_tracker/score_tracker
 
 		score_crew_survival_rate = get_percentage_of_fraction_and_whole(fatalities,crew_count)
 
-		score_crew_survival_rate = CLAMP(score_crew_survival_rate,0,100)
-		score_enemy_failure_rate = CLAMP(score_enemy_failure_rate,0,100)
+		score_crew_survival_rate = clamp(score_crew_survival_rate,0,100)
+		score_enemy_failure_rate = clamp(score_enemy_failure_rate,0,100)
 
 		final_score_sec = (score_crew_survival_rate + score_enemy_failure_rate) * 0.5
 
@@ -104,8 +104,8 @@ var/datum/score_tracker/score_tracker
 		score_power_outages = get_percentage_of_fraction_and_whole(apcs_powered,apc_count)
 		score_structural_damage = get_percentage_of_fraction_and_whole(undamaged_areas,station_areas)
 
-		score_power_outages = CLAMP(score_power_outages,0,100)
-		score_structural_damage = CLAMP(score_structural_damage,0,100)
+		score_power_outages = clamp(score_power_outages,0,100)
+		score_structural_damage = clamp(score_structural_damage,0,100)
 
 		final_score_eng = (score_power_outages + score_structural_damage) * 0.5
 
@@ -128,8 +128,8 @@ var/datum/score_tracker/score_tracker
 
 		score_cleanliness = get_percentage_of_fraction_and_whole(clean_areas,station_areas)
 
-		score_expenses = CLAMP(score_expenses,0,100)
-		score_cleanliness = CLAMP(score_cleanliness,0,100)
+		score_expenses = clamp(score_expenses,0,100)
+		score_cleanliness = clamp(score_cleanliness,0,100)
 		final_score_civ = (score_expenses + score_cleanliness) * 0.5
 
 		var/xp_winner = null

--- a/code/z_adventurezones/meatland.dm
+++ b/code/z_adventurezones/meatland.dm
@@ -947,7 +947,7 @@ var/global/list/default_meat_head_dialog = list("hello hello", "... it's not vir
 		..()
 
 		src.code = ""
-		. = "[num2hex(rand(4096, 65535))]"
+		. = "[num2hex(rand(4096, 65535), 0)]"
 		for (var/i = 1, i < 5, i++)
 			switch (copytext(., i, i+1))
 				if ("c","C")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
#defines num2hex and hex2num as macros to built-in num2text/text2num, replaces proc/atan2 and proc/arctan with built-in `arctan()`, removes proc/tan() so that it doesn't run over built-in `tan()`, replaces references to the `CLAMP()` macro with built-in `clamp()`, also removes some unneeded usage of add_zero (almost all add_zero usage is unneeded, something to take care of later)

__This will probably break secret content.__

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's free performance. Also cleaner.