### PR TITLE
Fix Control Unit getting stuck in pockets/bags

### DIFF
--- a/code/WorkInProgress/MechanicMC14500.dm
+++ b/code/WorkInProgress/MechanicMC14500.dm
@@ -117,9 +117,9 @@ var/list/hex_digit_values = list("0" = 0, "1" = 1, "2" = 2, "3" = 3, "4" = 4, "5
 				sleep(0.1 SECONDS)
 
 	attack_hand(mob/user as mob)
+		if (src.level != 1)
+			return ..(user)
 		if (!istype(src.loc, /turf/)) return
-		if (!src.level)
-			return ..()
 
 		if (user.machine == src)
 			user << output("[src.running]&[RR ? 1 : 0]&[IEN]&[OEN]", "mcu14500b.browser:update_indicators")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #596 where Control Units would get stuck in backpacks/pockets. Need to check that it's not wrenched down first, then return a super call.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I can't get this thing out of my pocket - it's stuck in there with glue or something

