### PR TITLE
Added Janitors spawning with galoshes already equipped.

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -805,7 +805,7 @@
 	wages = 100
 	slot_belt = /obj/item/device/pda2/janitor
 	slot_jump = /obj/item/clothing/under/rank/janitor
-	slot_foot = /obj/item/clothing/shoes/black
+	slot_foot = /obj/item/clothing/shoes/galoshes
 	slot_ears = /obj/item/device/radio/headset/civilian
 
 	New()


### PR DESCRIPTION
[QOL]

## About the PR 
Replaces Janitors regular shoes with galoshes

## Why's this needed? 
Some maps have only 1 pair of galoshes while some have 2, even though the general job slot limit for Janitors is 2. This is supposed to eliminate issues with "galoshes deficiency" without messing too much with balance.

I decided it's better to give it to Janitors without removing them from the lockers since having non slip shoes doesn't exactly make you a huge threat to the station. It's also useful to have a spare available, whether it be because someone transfered to janitor or because someone lost a pair
