### PR TITLE
Makes missing/broken kidney/liver decrease chem depletion rates

### DIFF
--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -209,6 +209,12 @@ datum
 				var/mob/living/carbon/human/H = M
 				if (H.traitHolder.hasTrait("slowmetabolism"))
 					deplRate /= 2
+				if (H.organHolder)
+					if (!H.organHolder.liver || H.organHolder.liver.broken)	//if no liver or liver is dead, deplete slower
+						deplRate /= 2
+					if (H.organHolder.get_working_kidney_amt() == 0)	//same with kidneys
+						deplRate /= 2
+
 				if (H.sims)
 					if (src.thirst_value)
 						H.sims.affectMotive("Thirst", thirst_value)


### PR DESCRIPTION
[MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
per title, makes missing/broken kidneys/liver decrease chem depletion rates. I think that this was intended behavior, but I can't be certain. Requesting clarification from @Kyle2143 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes a bug? Or maybe doesn't? it is a mystery.
