### PR TITLE
Check if a door requires ID before knocking

### DIFF
--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -1222,7 +1222,7 @@ About the new airlock wires panel:
 
 		interact_particle(user,src)
 	//clicking with no access, door closed, and help intent, and panel closed to knock
-	else if (!src.allowed(user) && (user.a_intent == INTENT_HELP) && src.density)
+	else if (!src.allowed(user) && (user.a_intent == INTENT_HELP) && src.density && src.requiresID())
 		knockOnDoor(user)
 		return //Opening the door just because knocks are on cooldown is rude!
 	else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When airlock ID scanner is disabled clicking the door with help intent will open it instead of knocking


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #647 