### PR TITLE
Rework machine dialogs refresh

### DIFF
--- a/code/WorkInProgress/Azungarstuff.dm
+++ b/code/WorkInProgress/Azungarstuff.dm
@@ -1154,7 +1154,7 @@
 	Bumped(mob/user as mob)
 		if(busy) return
 		if(get_dist(usr, src) > 1 || usr.z != src.z) return
-		user.machine = src
+		src.add_dialog(user)
 		busy = 1
 		showswirl(user.loc)
 		playsound(src, 'sound/effects/teleport.ogg', 60, 1)

--- a/code/WorkInProgress/DiscountDans.dm
+++ b/code/WorkInProgress/DiscountDans.dm
@@ -163,7 +163,7 @@
 		if(..())
 			return
 
-		user.machine = src
+		src.add_dialog(user)
 		var/dat = "<span style=\"inline-flex\">"
 		dat += "<BR>Current balance: [src.current_tickets] tickets"
 
@@ -179,7 +179,7 @@
 	Topic(href, href_list)
 		if(..())
 			return
-		usr.machine = src
+		src.add_dialog(usr)
 
 		if(href_list["redeem"])
 			src.temp = "<BR><B>Please select the rewards that you would like to redeem your tickets for:</B><BR><BR>"

--- a/code/WorkInProgress/Electronics.dm
+++ b/code/WorkInProgress/Electronics.dm
@@ -218,7 +218,7 @@
 			for(var/obj/item/electronics/P in src.contents)
 				dat += "[P.name]: <A href='?src=\ref[src];op=\ref[P];tp=move'>Remove</A><BR>"
 
-				user.machine = src
+				src.add_dialog(user)
 				user.Browse("<HEAD><TITLE>Frame</TITLE></HEAD><TT>[dat]</TT>", "window=fkit")
 				onclose(user, "fkit")
 
@@ -254,7 +254,7 @@
 	if (usr.stat)
 		return
 	if ((usr.contents.Find(src) || usr.contents.Find(src.master) || in_range(src, usr) && istype(src.loc, /turf)))
-		usr.machine = src
+		src.add_dialog(usr)
 
 		switch(href_list["tp"])
 			if("move")
@@ -270,7 +270,7 @@
 		updateDialog()
 	else
 		usr.Browse(null, "window=fkit")
-		usr.machine = null
+		src.remove_dialog(usr)
 	return
 
 /obj/item/electronics/frame/proc/deploy()
@@ -622,7 +622,7 @@
 
 	dat += "<HR>"
 
-	user.machine = src
+	src.add_dialog(user)
 	user.Browse("<HEAD><TITLE>Ruckingenur Kit Control Panel</TITLE></HEAD><TT>[dat]</TT>", "window=rkit")
 	onclose(user, "rkit")
 
@@ -630,7 +630,7 @@
 	if (usr.stat)
 		return
 	if ((in_range(src, usr) && istype(src.loc, /turf)) || (issilicon(usr)))
-		usr.machine = src
+		src.add_dialog(usr)
 
 		switch(href_list["tp"])
 
@@ -661,7 +661,7 @@
 		updateDialog()
 	else
 		usr.Browse(null, "window=rkit")
-		usr.machine = null
+		src.remove_dialog(usr)
 	return
 
 /obj/item/deconstructor

--- a/code/WorkInProgress/MechanicMC14500.dm
+++ b/code/WorkInProgress/MechanicMC14500.dm
@@ -121,7 +121,7 @@ var/list/hex_digit_values = list("0" = 0, "1" = 1, "2" = 2, "3" = 3, "4" = 4, "5
 		if (!src.level)
 			return ..()
 
-		if (user.machine == src)
+		if (user.using_dialog_of(src))
 			user << output("[src.running]&[RR ? 1 : 0]&[IEN]&[OEN]", "mcu14500b.browser:update_indicators")
 			user << output("[ioPins]", "mcu14500b.browser:update_mem_lights")
 			return
@@ -135,7 +135,7 @@ var/list/hex_digit_values = list("0" = 0, "1" = 1, "2" = 2, "3" = 3, "4" = 4, "5
 		if (!user || user.stat ||(iscarbon(user) && get_dist(user, src) > 1))
 			return
 
-		user.machine = src
+		src.add_dialog(user)
 
 		. = {"<html><head><title>Industrial Control Unit</title></head><body>
 		<center><table border='1'><tr><td id='active_indicator'><font color=white style='background-color:[running ? "#33FF00" : "#F80000"]'>[running ? "&nbsp;ACTIVE&nbsp;" : "INACTIVE"]</font></td></tr></table><br>

--- a/code/WorkInProgress/Phaser.dm
+++ b/code/WorkInProgress/Phaser.dm
@@ -531,7 +531,7 @@ var/const/PHASER_SNIPER = 256
 		if(overloading) return
 		if(usr.stat || usr.restrained()) return
 		if(!in_range(src, usr)) return
-		usr.machine = src
+		src.add_dialog(usr)
 		if (href_list["power"])
 			var/change = href_list["power"]
 			prop_power += text2num(change)
@@ -565,7 +565,7 @@ var/const/PHASER_SNIPER = 256
 
 	attack_self(mob/user as mob)
 		if(overloading) return
-		usr.machine = src
+		src.add_dialog(usr)
 		var/dat = "Phaser settings:<BR><BR>"
 		dat += "Power:<BR>"
 		dat += "<A href='?src=\ref[src];power=-5'>(--)</A><A href='?src=\ref[src];power=-1'>(-)</A> [prop_power] <A href='?src=\ref[src];power=1'>(+)</A><A href='?src=\ref[src];power=5'>(++)</A><BR><BR>"

--- a/code/WorkInProgress/TempEngine.dm
+++ b/code/WorkInProgress/TempEngine.dm
@@ -446,7 +446,7 @@
 
 		if( href_list["close"] )
 			usr.Browse(null, "window=teg")
-			usr.machine = null
+			src.remove_dialog(usr)
 			return 0
 
 		return 1
@@ -582,7 +582,7 @@
 		if(status & (BROKEN | NOPOWER))
 			return
 		user << browse(return_text(),"window=computer;can_close=1")
-		user.machine = src
+		src.add_dialog(user)
 		onclose(user, "computer")
 
 	process()

--- a/code/WorkInProgress/actuallyKeelinsStuff.dm
+++ b/code/WorkInProgress/actuallyKeelinsStuff.dm
@@ -3879,7 +3879,7 @@ var/list/lag_list = new/list()
 	Topic(href, href_list)
 		if(usr.stat || usr.restrained()) return
 		if(!in_range(src, usr)) return
-		usr.machine = src
+		src.add_dialog(usr)
 		if (href_list["set_mode"])
 			active_mode = locate(href_list["set_mode"]) in modes
 

--- a/code/WorkInProgress/antimatter/computer.dm
+++ b/code/WorkInProgress/antimatter/computer.dm
@@ -27,7 +27,7 @@
 /obj/machinery/computer/am_engine/Topic(href, href_list)
 	if(..())
 		return
-	usr.machine = src
+	src.add_dialog(usr)
 
 	if(!href_list["operation"])
 		return
@@ -60,7 +60,7 @@
 /obj/machinery/computer/am_engine/attack_hand(var/mob/user as mob)
 	if(..())
 		return
-	user.machine = src
+	src.add_dialog(user)
 	var/dat = "<head><title>Engine Computer</title></head><body>"
 	switch(src.state)
 		if(STATE_DEFAULT)

--- a/code/WorkInProgress/computerx/base_program.dm
+++ b/code/WorkInProgress/computerx/base_program.dm
@@ -63,7 +63,7 @@
 		if(!(holder in src.master.contents) && !(holder.loc in src.master.contents))
 			return 1
 
-		usr.machine = src.master
+		src.add_dialog(usr).master
 
 		return 0
 

--- a/code/WorkInProgress/computerx/computerx.dm
+++ b/code/WorkInProgress/computerx/computerx.dm
@@ -93,7 +93,7 @@ var/compx_gridx_max = 5
 		if(..())
 			return
 
-		user.machine = src
+		src.add_dialog(user)
 		src.current_user = user
 
 		var/wincheck = winexists(user, "compx_\ref[src]")
@@ -157,7 +157,7 @@ var/compx_gridx_max = 5
 		if(..())
 			return
 
-		usr.machine = src
+		src.add_dialog(usr)
 
 		if((href_list["conin"]) && src.host_program)
 			src.host_program.input_text(href_list["conin"])

--- a/code/WorkInProgress/computerx/peripherals.dm
+++ b/code/WorkInProgress/computerx/peripherals.dm
@@ -758,7 +758,7 @@
 			return
 
 		if(src.host)
-			usr.machine = src.host
+			src.add_dialog(usr).host
 
 		if(href_list["card"])
 			if(!isnull(src.authid))
@@ -873,7 +873,7 @@
 			return
 
 		if(src.host)
-			usr.machine = src.host
+			src.add_dialog(usr).host
 
 		if(href_list["disk"])
 			if(!isnull(src.disk))
@@ -972,7 +972,7 @@
 			return
 
 		if(src.host)
-			usr.machine = src.host
+			src.add_dialog(usr).host
 
 		if(href_list["scanner"])
 			if(!isnull(src.scanner))

--- a/code/WorkInProgress/construction/tools.dm
+++ b/code/WorkInProgress/construction/tools.dm
@@ -115,11 +115,11 @@
 		if ( (get_dist(src, user) > 1 ))
 			if (!issilicon(user))
 				boutput(user, text("Too far away."))
-				user.machine = null
+				src.remove_dialog(user)
 				user.Browse(null, "window=turretid")
 				return
 
-		user.machine = src
+		src.add_dialog(user)
 		var/t = "<TT><B>Turret Control Panel</B><BR><B>Controlled turrets:</B> [turrets.len] (<A href='?src=\ref[src];rescan=1'>Rescan</a>)<HR>"
 
 		if(src.locked && (!issilicon(user)))

--- a/code/WorkInProgress/fission/computer.dm
+++ b/code/WorkInProgress/fission/computer.dm
@@ -32,7 +32,7 @@
 	attack_hand(var/mob/user as mob)
 		if(..())
 			return
-		user.machine = src
+		src.add_dialog(user)
 
 		var/dat = "<head><title>Fission Console</title></head><body>"
 
@@ -106,7 +106,7 @@
 	Topic(href, href_list)
 		if(..())
 			return
-		usr.machine = src
+		src.add_dialog(usr)
 
 		if(href_list["reactor"])
 			var/obj/machinery/fission/reactor/R = locate(href_list["reactor"]) in theEngine.reactors

--- a/code/WorkInProgress/mantaObjects.dm
+++ b/code/WorkInProgress/mantaObjects.dm
@@ -702,7 +702,7 @@ var/obj/manta_speed_lever/mantaLever = null
 	attack_hand(mob/user as mob)
 		if(busy) return
 		if(get_dist(usr, src) > 1 || usr.z != src.z) return
-		user.machine = src
+		src.add_dialog(user)
 		add_fingerprint(user)
 		busy = 1
 		flick("englrt1", src)

--- a/code/WorkInProgress/module_research.dm
+++ b/code/WorkInProgress/module_research.dm
@@ -863,7 +863,7 @@ var/global/datum/module_research_controller/module_control = new
 		show_interface(user)
 
 	proc/add_viewer(var/mob/user)
-		user.machine = src
+		src.add_dialog(user)
 		if (!(user in users))
 			users += user
 

--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -243,7 +243,7 @@
 	proc/interacted(mob/user, var/ai=0)
 		src.add_fingerprint(user)
 		if(status & BROKEN)
-			user.machine = null
+			src.remove_dialog(user)
 			return
 
 		var/dat = "<head><title>Waste Disposal Unit</title></head><body><TT><B>Waste Disposal Unit</B><HR>"
@@ -271,7 +271,7 @@
 		dat += "Pressure: [round(per, 1)]%<BR></body>"
 
 
-		user.machine = src
+		src.add_dialog(user)
 		user.Browse(dat, "window=disposal;size=360x235")
 		onclose(user, "disposal")
 
@@ -290,11 +290,11 @@
 
 		if (in_range(src, usr) && isturf(src.loc))
 			DEBUG_MESSAGE("in range of [src] and it is on a turf")
-			usr.machine = src
+			src.add_dialog(usr)
 
 			if(href_list["close"])
 				DEBUG_MESSAGE("closed [src]")
-				usr.machine = null
+				src.remove_dialog(usr)
 				usr.Browse(null, "window=disposal")
 				return
 
@@ -329,7 +329,7 @@
 				DEBUG_MESSAGE("[src] and [usr] are too far apart: [src] [log_loc(src)], [usr] [log_loc(usr)]")
 
 			usr.Browse(null, "window=disposal")
-			usr.machine = null
+			src.remove_dialog(usr)
 			return
 
 		src.updateDialog()

--- a/code/WorkInProgress/recycling/mail_chute.dm
+++ b/code/WorkInProgress/recycling/mail_chute.dm
@@ -45,7 +45,7 @@
 	interacted(mob/user, var/ai=0)
 		src.add_fingerprint(user)
 		if(status & BROKEN)
-			user.machine = null
+			src.remove_dialog(user)
 			return
 
 		var/dat = "<head><title>Mail Transport Unit</title></head><body><TT><B>Mail Transport Unit: [src.mail_tag ? (capitalize(src.mail_tag)) : "GENERIC"]</B><HR>"
@@ -72,7 +72,7 @@
 		dat += "Pressure: [round(per, 1)]%<BR></body>"
 
 
-		user.machine = src
+		src.add_dialog(user)
 		user.Browse(dat, "window=mailchute;size=360x270")
 		onclose(user, "mailchute")
 
@@ -86,10 +86,10 @@
 			return
 
 		if (in_range(src, usr) && istype(src.loc, /turf))
-			usr.machine = src
+			src.add_dialog(usr)
 
 			if(href_list["close"])
-				usr.machine = null
+				src.remove_dialog(usr)
 				usr.Browse(null, "window=mailchute")
 				return
 
@@ -127,7 +127,7 @@
 				eject()
 		else
 			usr.Browse(null, "window=mailchute")
-			usr.machine = null
+			src.remove_dialog(usr)
 			return
 		return
 

--- a/code/WorkInProgress/simroom.dm
+++ b/code/WorkInProgress/simroom.dm
@@ -70,7 +70,7 @@
 			user.Browse(null, "window=mm")
 			return
 
-	user.machine = src
+	src.add_dialog(user)
 	var/dat = "<HEAD><TITLE>V-space Computer</TITLE><META HTTP-EQUIV='Refresh' CONTENT='10'></HEAD><BODY><br>"
 	dat += "<A HREF='?action=mach_close&window=mm'>Close</A><br><br>"
 
@@ -111,7 +111,7 @@
 	if(..())
 		return
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (issilicon(usr)))
-		usr.machine = src
+		src.add_dialog(usr)
 		if (href_list["setup"])
 			if(active)
 				boutput(usr, "System already set up.")
@@ -217,7 +217,7 @@
 		if(..())
 			return
 		var/dat = "<HTML><BODY><TT><B>VR pod timer</B>"
-		user.machine = src
+		src.add_dialog(user)
 		var/d2
 		if (src.timing)
 			d2 = text("<A href='?src=\ref[];time=0'>Stop Timed</A><br>", src)
@@ -314,7 +314,7 @@
 	if(..())
 		return
 	var/dat = "<HTML><BODY><TT><B>VR pod timer</B>"
-	user.machine = src
+	src.add_dialog(user)
 	var/d2
 	if (src.timing)
 		d2 = text("<A href='?src=\ref[];time=0'>Stop Timed</A><br>", src)
@@ -377,7 +377,7 @@
 	if(..())
 		return
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (issilicon(usr)))
-		usr.machine = src
+		src.add_dialog(usr)
 		if (href_list["time"])
 			if(src.allowed(usr))
 				src.timing = text2num(href_list["time"])
@@ -412,11 +412,11 @@
 /obj/machinery/sim/programcomp/proc/interacted(mob/user)
 	if ( (get_dist(src, user) > 1 ) || (status & (BROKEN|NOPOWER)) )
 		if (!issilicon(user))
-			user.machine = null
+			src.remove_dialog(user)
 			user.Browse(null, "window=mm")
 			return
 
-	user.machine = src
+	src.add_dialog(user)
 	var/dat = "<HEAD><TITLE>V-space Computer</TITLE><META HTTP-EQUIV='Refresh' CONTENT='10'></HEAD><BODY><br>"
 	dat += "<A HREF='?action=mach_close&window=mm'>Close</A><br><br>"
 
@@ -446,7 +446,7 @@
 	if(..())
 		return
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (issilicon(usr)))
-		usr.machine = src
+		src.add_dialog(usr)
 		switch(href_list["set"])
 			if("grass")
 				Setup_Vspace("grass",network)

--- a/code/WorkInProgress/telescope/quantumTelescope.dm
+++ b/code/WorkInProgress/telescope/quantumTelescope.dm
@@ -40,7 +40,7 @@ TODO: Enforce ping rate limit here as well in case someone futzes with the javas
 			return
 
 		using = user
-		user.machine = src
+		src.add_dialog(user)
 		add_fingerprint(user)
 
 		//Other resources are loaded in the files like <link rel="stylesheet" type="text/css" href="{{resource("css/telescope.css")}}">

--- a/code/WorkInProgress/telescope/telescopeMisc.dm
+++ b/code/WorkInProgress/telescope/telescopeMisc.dm
@@ -44,7 +44,7 @@ var/list/magnet_locations = list()
 			</body>
 			"}
 
-		user.machine = src
+		src.add_dialog(user)
 		add_fingerprint(user)
 		user.Browse(html, "window=lrporter;size=250x380;can_resize=0;can_minimize=0;can_close=1;override_setting=1")
 		onclose(user, "lrporter", src)

--- a/code/WorkInProgress/warcrimes.dm
+++ b/code/WorkInProgress/warcrimes.dm
@@ -549,7 +549,7 @@ var/bombini_saved = 0
 	if(..())
 		return
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (issilicon(usr)))
-		usr.machine = src
+		src.add_dialog(usr)
 
 		if (href_list["send"])
 			if(!johnbus_active)
@@ -616,7 +616,7 @@ var/bombini_saved = 0
 
 
 		else if (href_list["close"])
-			usr.machine = null
+			src.remove_dialog(usr)
 			usr.Browse(null, "window=shuttle")
 
 	src.add_fingerprint(usr)

--- a/code/chui/window.dm
+++ b/code/chui/window.dm
@@ -320,9 +320,8 @@ chui/window
 		src << browse( null, "window=[window]" )//Might not be a standard chui window but we'll play along.
 		if(src && src.mob)
 			//boutput(world, "[src] was [src.mob.machine], setting to null")
-			if(src.mob.machine && istype(src.mob.machine, /obj/machinery))
-				src.mob.machine.current_user = null
-			src.mob.machine = null
+			if (win.theAtom && isobj(win.theAtom))
+				win.theAtom:remove_dialog(src.mob)
 
 //A chui substitute for usr << browse()
 //Mostly the same syntax.

--- a/code/chui/window.dm
+++ b/code/chui/window.dm
@@ -320,8 +320,10 @@ chui/window
 		src << browse( null, "window=[window]" )//Might not be a standard chui window but we'll play along.
 		if(src && src.mob)
 			//boutput(world, "[src] was [src.mob.machine], setting to null")
-			if (win.theAtom && isobj(win.theAtom))
+			if (win && win.theAtom && isobj(win.theAtom))
 				win.theAtom:remove_dialog(src.mob)
+			else
+				src.mob.remove_dialogs()
 
 //A chui substitute for usr << browse()
 //Mostly the same syntax.

--- a/code/client.dm
+++ b/code/client.dm
@@ -893,7 +893,7 @@ var/global/curr_day = null
 		if ("mach_close")
 			var/window = href_list["window"]
 			var/t1 = text("window=[window]")
-			usr.machine = null
+			usr.remove_dialogs()
 			usr.Browse(null, t1)
 			//Special cases
 			switch (window)

--- a/code/client.dm
+++ b/code/client.dm
@@ -120,6 +120,9 @@
 
 	src.images.Cut() //Probably not needed but eh.
 
+	if (src.mob)
+		src.mob.remove_dialogs()
+
 	clients -= src
 	if(src.holder)
 		onlineAdmins.Remove(src)

--- a/code/datums/banking.dm
+++ b/code/datums/banking.dm
@@ -272,7 +272,7 @@
 		if(..())
 			return
 
-		user.machine = src
+		src.add_dialog(user)
 		var/dat = "<span style=\"inline-flex\">"
 
 		switch(src.state)
@@ -329,7 +329,7 @@
 	Topic(href, href_list)
 		if(..())
 			return
-		usr.machine = src
+		src.add_dialog(usr)
 
 		if (href_list["type"])
 			if (href_list["type"] == "E")
@@ -478,7 +478,7 @@
 		if (!( data_core.bank.Find(src.active1) ))
 			src.active1 = null
 		if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (usr_is_robot))
-			usr.machine = src
+			src.add_dialog(usr)
 			if (href_list["temp"])
 				src.temp = null
 			if (href_list["scan"])
@@ -702,7 +702,7 @@
 		if(..())
 			return
 
-		user.machine = src
+		src.add_dialog(user)
 		var/dat = "<span style=\"inline-flex\">"
 
 		switch(src.state)
@@ -770,7 +770,7 @@
 	Topic(href, href_list)
 		if(..())
 			return
-		usr.machine = src
+		src.add_dialog(usr)
 
 		switch(href_list["operation"])
 

--- a/code/datums/embedded_controller.dm
+++ b/code/datums/embedded_controller.dm
@@ -404,7 +404,7 @@ obj/machinery/embedded_controller
 
 	attack_hand(mob/user)
 		user.Browse(return_text(), "window=computer")
-		user.machine = src
+		src.add_dialog(user)
 		onclose(user, "computer")
 
 	disposing()
@@ -435,7 +435,7 @@ obj/machinery/embedded_controller
 		if(program)
 			program.receive_user_command(href_list["command"])
 
-		usr.machine = src
+		src.add_dialog(usr)
 
 	process()
 		if(program)
@@ -659,7 +659,7 @@ obj/machinery/embedded_controller/radio/department_controller
 		if(program)
 			program.receive_user_command(href_list["command"])
 
-		usr.machine = src
+		src.add_dialog(usr)
 
 	process()
 		if(status & NOPOWER)
@@ -692,7 +692,7 @@ obj/machinery/embedded_controller/radio/department_controller
 		if (src.status & NOPOWER)
 			return
 
-		user.machine = src
+		src.add_dialog(user)
 
 		var/state_options = null
 

--- a/code/datums/tooltip.dm
+++ b/code/datums/tooltip.dm
@@ -167,7 +167,8 @@ var/global/list/atomTooltips = new()
 
 		//Some stuff relies on currently-viewed-machine being set
 		if (src.owner.mob)
-			src.owner.mob.machine = thing
+			if (isobj(thing))
+				thing:add_dialog(src.owner.mob)
 
 		if (clickTip.visible)
 			//Clicktip is currently showing, just update it
@@ -423,11 +424,8 @@ var/global/list/atomTooltips = new()
 
 	proc/detachMachine()
 		if (src.owner && src.owner.mob)
-			if (src.owner.mob.machine && istype(src.owner.mob.machine, /obj/machinery))
-				src.owner.mob.machine.current_user = null
-
-			src.owner.mob.machine = null
-
+			if (src.A && isobj(src.A))
+				src.A:remove_dialog(src.owner.mob)
 
 	proc/closeHandler()
 		if (!src.hasCloseHandler) return 0

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -43,7 +43,6 @@
 	var/lastattacker = null
 	var/lastattacked = null //tell us whether or not to use Combat or Default click delays depending on whether this var was set.
 	var/lastattackertime = 0
-	var/obj/machinery/machine = null // todo : look into rewriting the way this works. its a lingering ref to the last machine the mob touched, and machines have to search thru all clients to check this var when they update their screens
 	var/other_mobs = null
 	var/memory = ""
 	var/atom/movable/pulling = null
@@ -289,9 +288,6 @@
 	if (ghost && ghost.corpse == src)
 		ghost.corpse = null
 
-	if (src.machine)
-		src.machine.current_user = null
-
 	if (traitHolder)
 		traitHolder.removeAll()
 		traitHolder.owner = null
@@ -469,7 +465,6 @@
 /mob/Logout()
 
 	//logTheThing("diary", src, null, "logged out", "access") <- sometimes shits itself and has been known to out traitors. Disabling for now.
-	src.machine = null
 
 	if (src.last_client && !src.key) // lets see if not removing the HUD from disconnecting players helps with the crashes
 		for (var/datum/hud/hud in src.huds)
@@ -1516,7 +1511,7 @@
 /mob/verb/cancel_camera()
 	set name = "Cancel Camera View"
 	src.set_eye(null)
-	src.machine = null
+	src.remove_dialogs()
 	if (!isliving(src))
 		src.sight = SEE_TURFS | SEE_MOBS | SEE_OBJS | SEE_SELF
 

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -163,6 +163,7 @@
 	var/special_sprint = SPRINT_NORMAL
 
 	var/last_show_inv = 0 //used to speedup update_clothing check. its hacky, im sorry
+	var/list/showing_inv
 
 	var/icon/flat_icon = null
 
@@ -500,6 +501,8 @@
 	if (organHolder)
 		organHolder.dispose()
 		organHolder = null
+
+	showing_inv = null
 	..()
 
 	//blah, this might not be effective for ref clearing but ghost observers inside me NEED this list to be populated in base mob/disposing

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -1505,7 +1505,7 @@
 
 
 /mob/living/carbon/human/proc/show_inv(mob/user as mob)
-	user.machine = src
+	src.add_dialog(user)
 	var/dat = {"
 	<B><HR><FONT size=3>[src.name]</FONT></B>
 	<BR><HR>

--- a/code/mob/living/carbon/human/procs/update_icon.dm
+++ b/code/mob/living/carbon/human/procs/update_icon.dm
@@ -655,12 +655,17 @@
 			UpdateOverlays(I.implant_overlay, "implant--\ref[I]")
 			implant_images += I
 
-	if (world.time - src.last_show_inv <= 600) //icky mbc workaround doing viewers()... only try to update our inventory for nearby viewers if we were interacted with in the last 60sec
-		for (var/mob/M in viewers(1, src))
-			if ((M.client && M.machine == src))
-				SPAWN_DBG (0)
-					src.show_inv(M)
-					return
+	if (world.time - src.last_show_inv <= 30 SECONDS)
+		for (var/client/C in src.showing_inv)
+			if (C.mob)
+				if (get_dist(src,C.mob) <= 1)
+					SPAWN_DBG (0)
+						src.show_inv(C.mob)
+				else
+					src.remove_dialog(C.mob)
+			else
+				src.showing_inv -= C
+
 
 	src.last_b_state = src.stat
 

--- a/code/mob/living/carbon/human/procs/update_icon.dm
+++ b/code/mob/living/carbon/human/procs/update_icon.dm
@@ -1253,7 +1253,7 @@ var/list/update_body_limbs = list("r_arm" = "stump_arm_right", "l_arm" = "stump_
 	if (..(parent))
 		return 1
 	src.UpdateDamage()
-	
+
 #endif
 
 /mob/living/carbon/human/UpdateDamageIcon()

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -1089,7 +1089,6 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 		//src:cameraFollow = null
 		tracker.cease_track()
 		src:current = null
-		src:machine = null
 
 		if (src.health >= 0)
 			// sure keep trying to use power i guess.
@@ -1490,7 +1489,6 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 	set name = "Cancel Camera View"
 
 	//src.set_eye(null)
-	src.machine = null
 	//src:cameraFollow = null
 	src.tracker.cease_track()
 	src.current = null
@@ -1499,7 +1497,7 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 	set category = "AI Commands"
 	set name = "Change Camera Network"
 	src.set_eye(null)
-	src.machine = null
+	src.remove_dialogs()
 	//src:cameraFollow = null
 	tracker.cease_track()
 	if (src.network == "SS13")
@@ -1765,7 +1763,6 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 
 /mob/living/silicon/ai/proc/switchCamera(var/obj/machinery/camera/C)
 	if (!C)
-		src.machine = null
 		src.set_eye(null)
 		return 0
 	if (isdead(src) || C.network != src.network) return 0
@@ -1779,7 +1776,6 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 			if (t.isStuck)
 				t.hide()
 
-	src.machine = src
 	if (!src.deployed_to_eyecam)
 		src.eye_view()
 	src.eyecam.set_loc(get_turf(C))

--- a/code/mob/living/silicon/ai/camera_handling.dm
+++ b/code/mob/living/silicon/ai/camera_handling.dm
@@ -169,8 +169,6 @@
 	if (isdead(src) || !src.classic_move)
 		return
 
-	user.machine = src
-
 	var/list/L = list()
 	for (var/obj/machinery/camera/C in cameras)
 		L.Add(C)
@@ -228,8 +226,6 @@
 			return
 
 		tracking = target
-		if(!owner.machine)
-			owner.machine = owner
 
 		if (!owner.deployed_to_eyecam)
 			if (!owner.deployed_to_eyecam)

--- a/code/mob/living/silicon/ai/mobile.dm
+++ b/code/mob/living/silicon/ai/mobile.dm
@@ -97,7 +97,6 @@
 			//src:cameraFollow = null
 			src.tracker.cease_track()
 			src:current = null
-			src:machine = null
 
 		src.updatehealth()
 

--- a/code/modules/atmospherics/machinery/retrofilter.dm
+++ b/code/modules/atmospherics/machinery/retrofilter.dm
@@ -138,11 +138,11 @@ obj/machinery/atmospherics/retrofilter
 	attack_hand(mob/user as mob)
 		if(..())
 			user.Browse(null, "window=pipefilter")
-			user.machine = null
+			src.remove_dialog(user)
 			return
 
 		var/list/gases = list("O2", "N2", "CO2", "Plasma", "OTHER")
-		user.machine = src
+		src.add_dialog(user)
 		var/dat = "<head><title>Gas Filtration Unit Mk VII</title></head><body><hr>"// "Filter Release Rate:<BR><br><A href='?src=\ref[src];fp=-[num2text(src.maxrate, 9)]'>M</A> <A href='?src=\ref[src];fp=-100000'>-</A> <A href='?src=\ref[src];fp=-10000'>-</A> <A href='?src=\ref[src];fp=-1000'>-</A> <A href='?src=\ref[src];fp=-100'>-</A> <A href='?src=\ref[src];fp=-1'>-</A> [src.f_per] <A href='?src=\ref[src];fp=1'>+</A> <A href='?src=\ref[src];fp=100'>+</A> <A href='?src=\ref[src];fp=1000'>+</A> <A href='?src=\ref[src];fp=10000'>+</A> <A href='?src=\ref[src];fp=100000'>+</A> <A href='?src=\ref[src];fp=[num2text(src.maxrate, 9)]'>M</A><BR><br>"
 		for (var/i = 1; i <= gases.len; i++)
 			if (!issilicon(user) && src.locked)
@@ -185,7 +185,7 @@ obj/machinery/atmospherics/retrofilter
 		if(..() || (status & NOPOWER))
 			return
 
-		usr.machine = src
+		src.add_dialog(usr)
 
 		src.add_fingerprint(usr)
 		if (href_list["toggle_gas"] && (!src.locked || issilicon(usr)))
@@ -203,7 +203,7 @@ obj/machinery/atmospherics/retrofilter
 
 		else if (href_list["close"])
 			usr.Browse(null, "window=pipefilter")
-			usr.machine = null
+			src.remove_dialog(usr)
 			return
 		return
 

--- a/code/modules/atmospherics/machinery/unary/cryo_cell.dm
+++ b/code/modules/atmospherics/machinery/unary/cryo_cell.dm
@@ -136,7 +136,7 @@
 		return
 
 	attack_hand(mob/user as mob)
-		user.machine = src
+		src.add_dialog(user)
 		var/temp_text = ""
 		if(air_contents.temperature > T0C)
 			temp_text = "<FONT color=red>[air_contents.temperature]</FONT>"
@@ -187,7 +187,7 @@
 			return "<B>Reagent Scan : </B>[ reagent_scan_active ? "<A href='?src=\ref[src];reagent_scan_active=1'>Off</A> <B>On</B>" : "<B>Off</B> <A href='?src=\ref[src];reagent_scan_active=1'>On</A>"]"
 
 	Topic(href, href_list)
-		if (( usr.machine==src && ((get_dist(src, usr) <= 1) && istype(src.loc, /turf))) || (isAI(usr)))
+		if (( usr.using_dialog_of(src) && ((get_dist(src, usr) <= 1) && istype(src.loc, /turf))) || (isAI(usr)))
 			if(href_list["start"])
 				src.on = !src.on
 				build_icon()

--- a/code/modules/atmospherics/machinery/unary/freezer.dm
+++ b/code/modules/atmospherics/machinery/unary/freezer.dm
@@ -76,7 +76,7 @@
 		return src.attack_hand(user)
 
 	attack_hand(mob/user as mob)
-		user.machine = src
+		src.add_dialog(user)
 		var/temp_text = ""
 		if(air_contents.temperature > (T0C - 20))
 			temp_text = "<FONT color=red>[air_contents.temperature]</FONT>"
@@ -97,7 +97,7 @@
 
 	Topic(href, href_list)
 		if ((usr.contents.Find(src) || ((get_dist(src, usr) <= 1) && istype(src.loc, /turf))) || (isAI(usr)))
-			usr.machine = src
+			src.add_dialog(usr)
 			if (href_list["start"])
 				src.on = !src.on
 				update_icon()

--- a/code/modules/atmospherics/portable/canister.dm
+++ b/code/modules/atmospherics/portable/canister.dm
@@ -377,7 +377,7 @@
 	if (src.destroyed)
 		return
 
-	user.machine = src
+	src.add_dialog(user)
 	var/holding_text
 	var/safety_text
 	var/det_text
@@ -541,7 +541,7 @@
 	if (usr.stat || usr.restrained())
 		return
 	if (((get_dist(src, usr) <= 1) && istype(src.loc, /turf)))
-		usr.machine = src
+		src.add_dialog(usr)
 
 		if(href_list["toggle"])
 			valve_open = !valve_open

--- a/code/modules/atmospherics/portable/pump.dm
+++ b/code/modules/atmospherics/portable/pump.dm
@@ -96,7 +96,7 @@
 
 /obj/machinery/portable_atmospherics/pump/attack_hand(var/mob/user as mob)
 
-	user.machine = src
+	src.add_dialog(user)
 	var/holding_text
 
 	if(holding)
@@ -127,7 +127,7 @@ Target Pressure: <A href='?src=\ref[src];pressure_adj=-100'>-</A> <A href='?src=
 		return
 
 	if (((get_dist(src, usr) <= 1) && istype(src.loc, /turf)))
-		usr.machine = src
+		src.add_dialog(usr)
 
 		if(href_list["power"])
 			on = !on

--- a/code/modules/atmospherics/portable/scrubber.dm
+++ b/code/modules/atmospherics/portable/scrubber.dm
@@ -123,7 +123,7 @@
 
 /obj/machinery/portable_atmospherics/scrubber/attack_hand(var/mob/user as mob)
 
-	user.machine = src
+	src.add_dialog(user)
 	var/holding_text
 
 	if(holding)
@@ -152,7 +152,7 @@ Target Pressure: <A href='?src=\ref[src];volume_adj=-100'>-</A> <A href='?src=\r
 		return
 
 	if (((get_dist(src, usr) <= 1) && istype(src.loc, /turf)))
-		usr.machine = src
+		src.add_dialog(usr)
 
 		if(href_list["power"])
 			on = !on

--- a/code/modules/chemistry/Chemistry-Dispenser.dm
+++ b/code/modules/chemistry/Chemistry-Dispenser.dm
@@ -274,7 +274,7 @@
 		if (isghostcritter(usr)) return
 		if (doing_a_thing) return
 
-		usr.machine = src
+		src.add_dialog(usr)
 		src.add_fingerprint(usr)
 
 		if (href_list["card"])
@@ -473,7 +473,7 @@
 	attack_hand(mob/user as mob)
 		if(status & (NOPOWER|BROKEN))
 			return
-		user.machine = src
+		src.add_dialog(user)
 		/*
 		src.update_html()
 		user.Browse("<TITLE>[dispenser_name] Dispenser</TITLE>[dispenser_name] dispenser:<BR>[src.HTML]", "window=chem_dispenser;size=500x800;title=Chemistry Dispenser")

--- a/code/modules/chemistry/Chemistry-Machinery.dm
+++ b/code/modules/chemistry/Chemistry-Machinery.dm
@@ -91,7 +91,7 @@
 		if(usr.stat || usr.restrained()) return
 		if(!in_range(src, usr)) return
 
-		usr.machine = src
+		src.add_dialog(usr)
 		if (!beaker)
 			// This should only happen when the UI is out of date - refresh it
 			src.updateUsrDialog()
@@ -156,7 +156,7 @@
 	attack_hand(mob/user as mob)
 		if(status & (NOPOWER|BROKEN))
 			return
-		user.machine = src
+		src.add_dialog(user)
 		var/list/dat = list()
 
 		if(!beaker)
@@ -354,7 +354,7 @@
 
 		src.add_fingerprint(usr)
 
-		usr.machine = src
+		src.add_dialog(usr)
 
 		if (href_list["close"])
 			usr.Browse(null, "window=chem_master;title=Chemmaster 3000")
@@ -570,7 +570,7 @@
 	attack_hand(mob/user as mob)
 		if (status & BROKEN)
 			return
-		user.machine = src
+		src.add_dialog(user)
 		var/dat = ""
 		if (!beaker)
 			dat = "Please insert beaker.<BR>"
@@ -698,7 +698,7 @@ datum/chemicompiler_core/stationaryCore
 		if (status & BROKEN || !powered())
 			boutput( user, "<span class='alert'>You can't seem to power it on!</span>" )
 			return
-		user.machine = src
+		src.add_dialog(user)
 		executor.panel()
 		onclose(usr, "chemicompiler")
 		return

--- a/code/modules/chemistry/tools/hyposprays.dm
+++ b/code/modules/chemistry/tools/hyposprays.dm
@@ -61,7 +61,7 @@ var/global/list/chem_whitelist = list("antihol", "charcoal", "epinephrine", "ins
 
 	attack_self(mob/user as mob)
 		update_icon()
-		user.machine = src
+		src.add_dialog(user)
 		var/dat = ""
 		dat += "Injection amount: <A href='?src=\ref[src];change_amt=1'>[inj_amount == -1 ? "ALL" : inj_amount]</A><BR><BR>"
 

--- a/code/modules/economy/shady_robot.dm
+++ b/code/modules/economy/shady_robot.dm
@@ -166,7 +166,7 @@
 		if(angry)
 			boutput(user, "<span class='alert'>[src] is angry and won't trade with anyone right now.</span>")
 			return
-		user.machine = src
+		src.add_dialog(user)
 		var/dat = updatemenu()
 		if(!temp)
 			dat += {"[src.greeting]<HR>
@@ -190,7 +190,7 @@
 			return
 
 		if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (issilicon(usr)))
-			usr.machine = src
+			src.add_dialog(usr)
 		///////////////////////////////
 		///////Generate Purchase List//
 		///////////////////////////////

--- a/code/modules/economy/trader.dm
+++ b/code/modules/economy/trader.dm
@@ -69,7 +69,7 @@
 		if(angry)
 			boutput(user, "<span class='alert'>[src] is angry and won't trade with anyone right now.</span>")
 			return
-		user.machine = src
+		src.add_dialog(user)
 		lastWindowName = windowName
 
 		var/dat = updatemenu()
@@ -102,7 +102,7 @@
 
 	updateUsrDialog()
 		for(var/client/C)
-			if (C.mob?.machine == src)
+			if (C.mob && C.mob.using_dialog_of(src))
 				if (get_dist(C.mob,src) <= 1)
 					src.openTrade(C.mob)
 
@@ -112,7 +112,7 @@
 			return
 
 		if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (issilicon(usr)))
-			usr.machine = src
+			src.add_dialog(usr)
 		///////////////////////////////
 		///////Generate Purchase List//
 		///////////////////////////////

--- a/code/modules/economy/trader.dm
+++ b/code/modules/economy/trader.dm
@@ -100,12 +100,6 @@
 		shopping_cart = null
 		..()
 
-	updateUsrDialog()
-		for(var/client/C)
-			if (C.mob && C.mob.using_dialog_of(src))
-				if (get_dist(C.mob,src) <= 1)
-					src.openTrade(C.mob)
-
 
 	Topic(href, href_list)
 		if(..())

--- a/code/modules/fluids/fluid_objects.dm
+++ b/code/modules/fluids/fluid_objects.dm
@@ -304,7 +304,7 @@
 		if (usr.stat || usr.restrained())
 			return
 		if (get_dist(src, usr) <= 1)
-			usr.machine = src
+			src.add_dialog(usr)
 
 			if (href_list["slurp"])
 				slurping = 1
@@ -329,7 +329,7 @@
 		return
 
 	attack_hand(var/mob/user as mob)
-		user.machine = src
+		src.add_dialog(user)
 		var/offtext
 		var/intext
 		var/outtext

--- a/code/modules/fluids/fluid_turf.dm
+++ b/code/modules/fluids/fluid_turf.dm
@@ -433,7 +433,7 @@
 	if(..())
 		return
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (issilicon(usr)))
-		usr.machine = src
+		src.add_dialog(usr)
 
 		if (href_list["send"])
 			if(!active)
@@ -444,7 +444,7 @@
 					call_shuttle()
 
 		if (href_list["close"])
-			usr.machine = null
+			src.remove_dialog(usr)
 			usr.Browse(null, "window=sea_elevator")
 
 	src.add_fingerprint(usr)

--- a/code/modules/medical/genetics/geneticsMachines.dm
+++ b/code/modules/medical/genetics/geneticsMachines.dm
@@ -162,7 +162,7 @@ var/list/genetics_computers = list()
 				<span></span></body></html>
 				"}
 
-	user.machine = src
+	src.add_dialog(user)
 	add_fingerprint(user)
 
 	if(print == 1) //Hilariously hacky temporary print thing.
@@ -1322,7 +1322,7 @@ var/list/genetics_computers = list()
 
 							new/datum/genetics_appearancemenu(usr.client, subject)
 							usr << browse(null, "window=genetics")
-							usr.machine = null
+							src.remove_dialog(usr)
 				else
 					topbotbutton_html = ""
 					html_list += "<p>Can not change appearance of non-humans.</p>"

--- a/code/modules/networks/computer3/communication.dm
+++ b/code/modules/networks/computer3/communication.dm
@@ -297,15 +297,15 @@
 
 					if("shutl_e_sen")
 						src.print_text("<b>Alert:</b> The Emergency Shuttle has been called.")
-						if(master && master.current_user)
-							message_admins("<span class='notice'>[key_name(master.current_user)] called the Emergency Shuttle to the station</span>")
-							logTheThing("station", null, null, "[key_name(master.current_user)] called the Emergency Shuttle to the station")
+						if(usr)
+							message_admins("<span class='notice'>[key_name(usr)] called the Emergency Shuttle to the station</span>")
+							logTheThing("station", null, null, "[key_name(usr)] called the Emergency Shuttle to the station")
 
 					if("shutl_e_ret")
 						src.print_text("<b>Alert:</b> The Emergency Shuttle has been recalled.")
-						if(master && master.current_user)
-							message_admins("<span class='notice'>[key_name(master.current_user)] recalled the Emergency Shuttle</span>")
-							logTheThing("station", null, null, "[key_name(master.current_user)] recalled the Emergency Shuttle")
+						if(usr)
+							message_admins("<span class='notice'>[key_name(usr)] recalled the Emergency Shuttle</span>")
+							logTheThing("station", null, null, "[key_name(usr)] recalled the Emergency Shuttle")
 
 					if("transmit_e_success")
 						src.print_text("Message transmitted successfuly.")

--- a/code/modules/networks/computer3/computer3.dm
+++ b/code/modules/networks/computer3/computer3.dm
@@ -331,7 +331,7 @@
 		boutput(user, "<span class='alert'>You don't know how to read or write, operating a computer isn't going to work!</span>")
 		return
 
-	if ((user.machine == src) && (src.current_user == user))
+	if (user.using_dialog_of(src) && (src.current_user == user))
 		if (!src.temp)
 			user << output(null, "comp3.browser:con_clear")
 
@@ -347,7 +347,7 @@
 
 	else
 
-		user.machine = src
+		src.add_dialog(user)
 		src.current_user = user
 
 		if (src.temp_add)
@@ -567,7 +567,7 @@ function lineEnter (ev)
 	if(..())
 		return
 
-	usr.machine = src
+	src.add_dialog(usr)
 
 	if((href_list["command"]) && src.active_program)
 		usr << output(null, "comp3.browser:input_clear")
@@ -650,7 +650,7 @@ function lineEnter (ev)
 /obj/machinery/computer3/attackby(obj/item/W as obj, mob/user as mob)
 	if (istype(W, /obj/item/disk/data/floppy)) //INSERT SOME DISKETTES
 		if ((!src.diskette) && src.setup_has_internal_disk)
-			user.machine = src
+			src.add_dialog(user)
 			user.drop_item()
 			W.set_loc(src)
 			src.diskette = W
@@ -1066,7 +1066,7 @@ function lineEnter (ev)
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (istype(W, /obj/item/disk/data/floppy)) //INSERT SOME DISKETTES
 			if ((!src.diskette) && src.setup_has_internal_disk)
-				user.machine = src
+				src.add_dialog(user)
 				user.drop_item()
 				W.set_loc(src)
 				src.diskette = W

--- a/code/modules/networks/computer3/computer3.dm
+++ b/code/modules/networks/computer3/computer3.dm
@@ -331,7 +331,7 @@
 		boutput(user, "<span class='alert'>You don't know how to read or write, operating a computer isn't going to work!</span>")
 		return
 
-	if (user.using_dialog_of(src) && (src.current_user == user))
+	if (user.using_dialog_of(src))
 		if (!src.temp)
 			user << output(null, "comp3.browser:con_clear")
 
@@ -343,12 +343,8 @@
 				src.temp_add = null
 */
 		update_peripheral_menu(user)
-		src.current_user = user
-
 	else
-
 		src.add_dialog(user)
-		src.current_user = user
 
 		if (src.temp_add)
 			src.temp += temp_add

--- a/code/modules/networks/computer3/mainframe2/artifact_res.dm
+++ b/code/modules/networks/computer3/mainframe2/artifact_res.dm
@@ -1334,7 +1334,7 @@
 </html>
 "}
 
-		user.machine = src
+		src.add_dialog(user)
 		user.Browse(dat, "window=art_computer;size=580x360;can_resize=0")
 		onclose(user, "art_computer")
 		return
@@ -1357,7 +1357,7 @@
 		if(..())
 			return
 
-		usr.machine = src
+		src.add_dialog(usr)
 
 		if (href_list["button"])
 			. = round(text2num(href_list["button"]))
@@ -1409,7 +1409,7 @@
 		var/list/nearby = viewers(1, src)
 		for(var/mob/M in nearby)
 			DEBUG_OUT("[M]")
-			if ((M.client && M.machine == src))
+			if (M.using_dialog_of(src))
 				DEBUG_OUT("[M]!!!")
 				if (forceUpdate || entryUpdateFlags)
 					DEBUG_OUT("[M] ! !  !")
@@ -1420,7 +1420,7 @@
 
 		if (issilicon(usr))
 			if (!(usr in nearby))
-				if (usr.client && usr.machine==src)
+				if (usr.using_dialog_of(src))
 					if (forceUpdate || entryUpdateFlags)
 						src.dynamicUpdate(usr, forceUpdate|entryUpdateFlags)
 						entryUpdateFlags = REASON_NONE

--- a/code/modules/networks/computer3/mainframe2/logreader.dm
+++ b/code/modules/networks/computer3/mainframe2/logreader.dm
@@ -49,7 +49,7 @@
 		if(..() || (status & (NOPOWER|BROKEN)))
 			return
 
-		user.machine = src
+		src.add_dialog(user)
 
 		var/dat = {"<html><head><title>Access Log Reader</title><style>
 .conn-box {
@@ -150,7 +150,7 @@
 		if (!(usr in range(1)))
 			return
 
-		usr.machine = src
+		src.add_dialog(usr)
 		src.add_fingerprint(usr)
 
 		if (href_list["reset"])
@@ -375,7 +375,7 @@
 
 				src.post_status(target,"command","term_message","data","command=status&status=success")
 				for (var/mob/M in range(1))
-					if (M.machine == src)
+					if (M.using_dialog_of(src))
 						attack_hand(M)
 				return
 

--- a/code/modules/networks/computer3/mainframe2/mainframe2.dm
+++ b/code/modules/networks/computer3/mainframe2/mainframe2.dm
@@ -165,7 +165,7 @@
 			if (usr.stat || usr.restrained())
 				return
 
-			usr.machine = src
+			src.add_dialog(usr)
 
 			if(href_list["core"])
 

--- a/code/modules/networks/computer3/mainframe2/misc_terms.dm
+++ b/code/modules/networks/computer3/mainframe2/misc_terms.dm
@@ -218,7 +218,7 @@
 		if(..() && !(status & NOPOWER)) //Allow them to remove tapes even if the power's out.
 			return
 
-		user.machine = src
+		src.add_dialog(user)
 
 		var/dat = "<html><head><title>Databank - \[[bank_id]]</title></head><body>"
 
@@ -260,7 +260,7 @@
 		if(..() && !(href_list["tape"] && (status & NOPOWER)))
 			return
 
-		usr.machine = src
+		src.add_dialog(usr)
 
 		if(href_list["tape"])
 			if(src.locked)
@@ -744,7 +744,7 @@
 		if ((get_dist(src, user) > 1 || !istype(src.loc, /turf)) && !issilicon(user))
 			return 1
 
-		user.machine = src
+		src.add_dialog(user)
 
 		var/dat = "<html><head><title>SimUnit - \[[bank_id]]</title></head><body>"
 
@@ -778,7 +778,7 @@
 		if(..())
 			return
 
-		usr.machine = src
+		src.add_dialog(usr)
 
 		if (href_list["tank"])
 
@@ -1089,7 +1089,7 @@
 		if(..() || status & NOPOWER)
 			return
 
-		user.machine = src
+		src.add_dialog(user)
 
 		var/dat = "<html><head><title>Nuclear Charge</title></head><body>"
 
@@ -1120,7 +1120,7 @@
 		if(..())
 			return
 
-		usr.machine = src
+		src.add_dialog(usr)
 
 		if (href_list["reset"])
 			if(last_reset && (last_reset + NETWORK_MACHINE_RESET_DELAY >= world.time))
@@ -1425,7 +1425,7 @@
 		if(..() || (status & (NOPOWER|BROKEN)))
 			return
 
-		user.machine = src
+		src.add_dialog(user)
 
 		var/dat = "<html><head><title>Network Radio</title></head><body>"
 
@@ -1477,7 +1477,7 @@
 		if(..())
 			return
 
-		usr.machine = src
+		src.add_dialog(usr)
 
 		if (href_list["reset"])
 			if(last_reset && (last_reset + NETWORK_MACHINE_RESET_DELAY >= world.time))
@@ -1811,7 +1811,7 @@
 		if(..() || (status & (NOPOWER|BROKEN)))
 			return
 
-		user.machine = src
+		src.add_dialog(user)
 
 		var/dat = "<html><head><title>Printer - \[[print_id]]</title></head><body>"
 
@@ -1847,7 +1847,7 @@
 		if(..())
 			return
 
-		usr.machine = src
+		src.add_dialog(usr)
 
 		if (href_list["unjam"])
 			if(src.jam)
@@ -2210,7 +2210,7 @@
 		if ((get_dist(src, user) > 1 || !istype(src.loc, /turf)) && !issilicon(user))
 			return 1
 
-		user.machine = src
+		src.add_dialog(user)
 
 		var/dat = "<html><head><title>Scanner - \[[copytext(bank_id,4)]]</title></head><body>"
 
@@ -2258,7 +2258,7 @@
 		if(..())
 			return
 
-		usr.machine = src
+		src.add_dialog(usr)
 
 		if (href_list["document"])
 			if(issilicon(usr) && get_dist(src, usr) > 1)
@@ -2472,7 +2472,7 @@
 		if(..() || (status & (NOPOWER|BROKEN)))
 			return
 
-		user.machine = src
+		src.add_dialog(user)
 
 		var/dat = "<html><head><title>IR Detector - \[[detector_id]]</title></head><body>"
 
@@ -2514,7 +2514,7 @@
 		if(..())
 			return
 
-		usr.machine = src
+		src.add_dialog(usr)
 
 		if (href_list["reset"])
 			if(last_reset && (last_reset + NETWORK_MACHINE_RESET_DELAY >= world.time))
@@ -2942,7 +2942,7 @@
 		if(..() || (status & (NOPOWER|BROKEN)))
 			return
 
-		user.machine = src
+		src.add_dialog(user)
 
 		var/dat = "<html><head><title>HEPT Emitter</title></head><body><hr><center>Emission Crystals<br>"
 
@@ -2992,7 +2992,7 @@
 		if(..())
 			return
 
-		usr.machine = src
+		src.add_dialog(usr)
 		src.add_fingerprint(usr)
 
 		if (href_list["insert"])
@@ -3456,7 +3456,7 @@
 		if(..() || (status & (NOPOWER|BROKEN)))
 			return
 
-		user.machine = src
+		src.add_dialog(user)
 
 		var/dat = "<html><head><title>[setup_device_name]</title></head><body>"
 
@@ -3512,7 +3512,7 @@
 		if(..())
 			return
 
-		usr.machine = src
+		src.add_dialog(usr)
 		src.add_fingerprint(usr)
 
 		interface_topic(href_list)

--- a/code/modules/networks/computer3/mainframe2/os_drivers.dm
+++ b/code/modules/networks/computer3/mainframe2/os_drivers.dm
@@ -1219,8 +1219,8 @@
 						if(istype(callobj.loc, /obj/machinery/computer3))
 							calling_term = callobj.loc
 						if(istype(calling_term))
-							if(calling_term.current_user)
-								logUser = calling_term.current_user
+							if(usr)
+								logUser = usr
 							else
 								logUser = "Terminal \[[src.useracc.user_id]]"
 

--- a/code/modules/networks/computer3/mainframe2/telesci.dm
+++ b/code/modules/networks/computer3/mainframe2/telesci.dm
@@ -99,7 +99,7 @@ proc/is_teleportation_allowed(var/turf/T)
 		if(..())
 			return
 
-		user.machine = src
+		src.add_dialog(user)
 
 		var/dat = "<html><head><title>Telepad</title></head><body>"
 
@@ -128,7 +128,7 @@ proc/is_teleportation_allowed(var/turf/T)
 		if(..())
 			return
 
-		usr.machine = src
+		src.add_dialog(usr)
 		if (href_list["reset"])
 			if(last_reset && (last_reset + NETWORK_MACHINE_RESET_DELAY >= world.time))
 				return
@@ -1013,7 +1013,7 @@ proc/is_teleportation_allowed(var/turf/T)
 			dat += "<br>Linked Pad Number: <a href='?src=\ref[src];setpad=1'>[src.padNum]</a><br>"
 			dat += net_switch_html()
 
-		user.machine = src
+		src.add_dialog(user)
 		user.Browse(dat, "window=t_computer;size=400x600")
 		onclose(user, "t_computer")
 		return
@@ -1033,7 +1033,7 @@ proc/is_teleportation_allowed(var/turf/T)
 	updateUsrDialog(var/updateReadout)
 		var/list/nearby = viewers(1, src)
 		for(var/mob/M in nearby)
-			if ((M.client && M.machine == src))
+			if (M.using_dialog_of(src))
 				if (updateReadout)
 					M << output(url_encode(src.readout), "t_computer.browser:updateReadout")
 				else
@@ -1041,7 +1041,7 @@ proc/is_teleportation_allowed(var/turf/T)
 
 		if (issilicon(usr))
 			if (!(usr in nearby))
-				if (usr.client && usr.machine==src)
+				if (usr.using_dialog_of(src))
 					if (updateReadout)
 						usr << output(url_encode(src.readout), "t_computer.browser:updateReadout")
 					else
@@ -1051,7 +1051,7 @@ proc/is_teleportation_allowed(var/turf/T)
 		if (..(href, href_list))
 			return
 
-		usr.machine = src
+		src.add_dialog(usr)
 		playsound(src.loc, 'sound/machines/keypress.ogg', 50, 1, 5)
 
 		if (href_list["scan"])

--- a/code/modules/networks/computer3/peripherals.dm
+++ b/code/modules/networks/computer3/peripherals.dm
@@ -1147,7 +1147,7 @@
 			return
 
 		if(src.host)
-			src.add_dialog(usr).host
+			src.host.add_dialog(usr)
 
 		if(href_list["card"])
 			if(!isnull(src.authid))
@@ -1267,7 +1267,7 @@
 			return
 
 		if(src.host)
-			src.add_dialog(usr).host
+			src.host.add_dialog(usr)
 
 		if(href_list["disk"])
 			if(!isnull(src.disk))

--- a/code/modules/networks/computer3/peripherals.dm
+++ b/code/modules/networks/computer3/peripherals.dm
@@ -1147,7 +1147,7 @@
 			return
 
 		if(src.host)
-			usr.machine = src.host
+			src.add_dialog(usr).host
 
 		if(href_list["card"])
 			if(!isnull(src.authid))
@@ -1267,7 +1267,7 @@
 			return
 
 		if(src.host)
-			usr.machine = src.host
+			src.add_dialog(usr).host
 
 		if(href_list["disk"])
 			if(!isnull(src.disk))

--- a/code/modules/networks/computer3/sniffer.dm
+++ b/code/modules/networks/computer3/sniffer.dm
@@ -91,7 +91,7 @@
 				return
 
 			src.add_fingerprint(usr)
-			usr.machine = src
+			src.add_dialog(usr)
 
 			if(href_list["filtid"])
 				var/t = input(usr, "Please enter new filter net id", src.name, src.filter_id) as text

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -136,23 +136,7 @@ var/zapLimiter = 0
 		flagIndex+=1
 	return apcwires
 
-/obj/machinery/power/apc/updateUsrDialog()
-	var/list/nearby = viewers(1, src)
-	if (!(status & BROKEN)) // unbroken
-		for(var/mob/M in nearby)
-			if ((M.client && M.machine == src))
-				src.interacted(M)
-	if (issilicon(usr) || isAI(usr))
-		if (!(usr in nearby))
-			if (usr.client && usr.machine==src) // && M.machine == src is omitted because if we triggered this by using the dialog, it doesn't matter if our machine changed in between triggering it and this - the dialog is probably still supposed to refresh.
-				src.interacted(usr)
 
-/obj/machinery/power/apc/updateDialog()
-	if(!(status & BROKEN)) // unbroken
-		for(var/client/C)
-			if (C.mob?.machine == src && get_dist(C.mob,src) <= 1)
-				src.interacted(C.mob)
-	AutoUpdateAI(src)
 
 /obj/machinery/power/apc/New()
 	..()
@@ -566,7 +550,7 @@ var/zapLimiter = 0
 
 	if ( (get_dist(src, user) > 1 ))
 		if (!issilicon(user) && !isAI(user))
-			user.machine = null
+			src.remove_dialog(user)
 			user.Browse(null, "window=apc")
 			return
 		else if ((issilicon(user) || isAI(user)) && src.aidisabled)
@@ -574,7 +558,7 @@ var/zapLimiter = 0
 			user.Browse(null, "window=apc")
 			return
 	if(wiresexposed && (!isAI(user)))
-		user.machine = src
+		src.add_dialog(user)
 		var/t1 = text("<B>Access Panel</B><br>")
 		t1 += text("An identifier is engraved above the APC's wires: <i>[net_id]</i><br><br>")
 		var/list/apcwires = list(
@@ -598,7 +582,7 @@ var/zapLimiter = 0
 		user.Browse(t1, "window=apcwires")
 		onclose(user, "apcwires")
 
-	user.machine = src
+	src.add_dialog(user)
 	var/t = "<TT><B>Area Power Controller</B> ([area.name])<HR>"
 
 	if((locked || (setup_networkapc > 1)) && (!issilicon(user) && !isAI(user)))
@@ -947,7 +931,7 @@ var/zapLimiter = 0
 	if (usr.getStatusDuration("stunned") || usr.getStatusDuration("weakened") || usr.stat)
 		return
 	if ((in_range(src, usr) && istype(src.loc, /turf))||(issilicon(usr) || isAI(usr)))
-		usr.machine = src
+		src.add_dialog(usr)
 		if (href_list["apcwires"] && wiresexposed)
 			var/t1 = text2num(href_list["apcwires"])
 			if (!usr.find_tool_in_hand(TOOL_SNIPPING))
@@ -1068,11 +1052,11 @@ var/zapLimiter = 0
 			update()
 		else if( href_list["close"] )
 			usr.Browse(null, "window=apc")
-			usr.machine = null
+			src.remove_dialog(usr)
 			return
 		else if (href_list["close2"])
 			usr.Browse(null, "window=apcwires")
-			usr.machine = null
+			src.remove_dialog(usr)
 			return
 
 		else if (href_list["overload"])
@@ -1093,7 +1077,7 @@ var/zapLimiter = 0
 
 	else
 		usr.Browse(null, "window=apc")
-		usr.machine = null
+		src.remove_dialog(usr)
 
 	return
 

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -100,7 +100,7 @@
 		user << browse(null, "window=teg")
 		return
 
-	user.machine = src
+	src.add_dialog(user)
 
 	var/t = "<PRE><B>Thermo-Electric Generator</B><HR>"
 

--- a/code/modules/power/generator_type2.dm
+++ b/code/modules/power/generator_type2.dm
@@ -106,7 +106,7 @@
 		user << browse(null, "window=teg")
 		return
 
-	user.machine = src
+	src.add_dialog(user)
 
 	var/t = "<PRE><B>Thermo-Electric Generator</B><HR>"
 

--- a/code/modules/power/lgenerator.dm
+++ b/code/modules/power/lgenerator.dm
@@ -56,7 +56,7 @@
 		else
 			..()
 
-		if (user.machine == src) src.updateUsrDialog()
+		src.updateUsrDialog()
 		return
 
 	proc/update_icon()
@@ -214,7 +214,7 @@
 	attack_hand(var/mob/user as mob)
 		src.add_fingerprint(user)
 
-		user.machine = src
+		src.add_dialog(user)
 		var/dat = "<h4>[src]</h4>"
 
 		if (src.P)
@@ -250,7 +250,7 @@
 		if (!issilicon(usr) && !in_range(src, usr)) return
 
 		src.add_fingerprint(usr)
-		usr.machine = src
+		src.add_dialog(usr)
 
 		if (href_list["eject"])
 			if (src.active)

--- a/code/modules/power/monitor.dm
+++ b/code/modules/power/monitor.dm
@@ -28,11 +28,11 @@
 
 	if ( (get_dist(src, user) > 1 ) || (status & (BROKEN|NOPOWER)) )
 		if (!issilicon(user))
-			user.machine = null
+			src.remove_dialog(user)
 			user.Browse(null, "window=[window_tag]")
 			return
 
-	user.machine = src
+	src.add_dialog(user)
 	var/t = "<TT><B>Power Monitoring</B><HR>"
 
 	if(!powernet)
@@ -74,7 +74,7 @@
 	..()
 	if( href_list["close"] )
 		usr.Browse(null, "window=[window_tag]")
-		usr.machine = null
+		src.remove_dialog(usr)
 		return
 
 /obj/machinery/power/monitor/process()
@@ -144,12 +144,12 @@
 
 	if ( (get_dist(src, user) > 1 ) || (status & (BROKEN|NOPOWER)) )
 		if (!issilicon(user))
-			user.machine = null
+			src.remove_dialog(user)
 			user.Browse(null, "window=[window_tag]")
 			return
 
 
-	user.machine = src
+	src.add_dialog(user)
 	var/t = "<TT><B>Engine and SMES Monitoring</B><HR>"
 
 

--- a/code/modules/power/nuke/nuke.dm
+++ b/code/modules/power/nuke/nuke.dm
@@ -148,7 +148,7 @@
 		return html
 
 	Topic(href, href_list)
-		usr.machine = src
+		src.add_dialog(usr)
 
 		if(href_list["cell"])
 			var/i = text2num(href_list["r"])

--- a/code/modules/power/pt_laser.dm
+++ b/code/modules/power/pt_laser.dm
@@ -164,10 +164,7 @@
 		updateicon()
 
 	if(autorefresh)
-		for(var/mob/M in viewers(1, src))
-			if (M.using_dialog_of(src))
-				src.interacted(M)
-		AutoUpdateAI(src)
+		src.updateDialog()
 
 /obj/machinery/power/pt_laser/proc/power_sold()
 	if (round(output) == 0)

--- a/code/modules/power/pt_laser.dm
+++ b/code/modules/power/pt_laser.dm
@@ -165,7 +165,7 @@
 
 	if(autorefresh)
 		for(var/mob/M in viewers(1, src))
-			if ((M.client && M.machine == src))
+			if (M.using_dialog_of(src))
 				src.interacted(M)
 		AutoUpdateAI(src)
 
@@ -354,11 +354,11 @@
 
 	if ( (get_dist(src, user) > 1 ))
 		if (!isAI(user))
-			user.machine = null
+			src.remove_dialog(user)
 			user.Browse(null, "window=Power Transmission Laser")
 			return
 
-	user.machine = src
+	src.add_dialog(user)
 
 	var/t = "<TT><B>Power Transmission Laser</B><HR><PRE>"
 
@@ -405,10 +405,10 @@
 	if (usr.stat || usr.restrained() )
 		return
 
-	if (( usr.machine==src && ((get_dist(src, usr) <= 1) && istype(src.loc, /turf))) || (isAI(usr)))
+	if (( usr.using_dialog_of(src) && ((get_dist(src, usr) <= 1) && istype(src.loc, /turf))) || (isAI(usr)))
 		if( href_list["close"] )
 			usr.Browse(null, "window=Power Transmission Laser")
-			usr.machine = null
+			src.remove_dialog(usr)
 			return
 
 		else if( href_list["cmode"] )
@@ -483,7 +483,7 @@
 
 	else
 		usr.Browse(null, "window=Power Transmission Laser")
-		usr.machine = null
+		src.remove_dialog(usr)
 
 	return
 

--- a/code/modules/power/reactor_stats.dm
+++ b/code/modules/power/reactor_stats.dm
@@ -1609,7 +1609,7 @@
 	"})
 	html.addToHead(kstyle)
 
-	user.machine = src
+	src.add_dialog(user)
 	if(user.client)
 		luser = user.client
 

--- a/code/modules/power/rtg.dm
+++ b/code/modules/power/rtg.dm
@@ -15,10 +15,7 @@
 			updateicon()
 
 		// shamelessly stolen from the SMES code, this is kinda stupid
-		for(var/mob/M in range(1, src))
-			if (M.using_dialog_of(src))
-				src.interacted(M)
-		AutoUpdateAI(src)
+		src.updateDialog()
 
 	attack_ai(mob/user)
 		add_fingerprint(user)

--- a/code/modules/power/rtg.dm
+++ b/code/modules/power/rtg.dm
@@ -16,7 +16,7 @@
 
 		// shamelessly stolen from the SMES code, this is kinda stupid
 		for(var/mob/M in range(1, src))
-			if (M.client && M.machine == src)
+			if (M.using_dialog_of(src))
 				src.interacted(M)
 		AutoUpdateAI(src)
 
@@ -49,7 +49,7 @@
 			return
 		if (href_list["close"])
 			usr.Browse(null, "window=rtg")
-			usr.machine = null
+			src.remove_dialog(usr)
 		else if (href_list["eject"] && in_range(src, usr))
 			fuel_pellet.loc = src.loc
 			usr.put_in_hand_or_eject(src.fuel_pellet) // try to eject it into the users hand, if we can
@@ -59,11 +59,11 @@
 
 	proc/interacted(mob/user)
 		if (get_dist(src, user) > 1 && !isAI(user))
-			user.machine = null
+			src.remove_dialog(user)
 			user.Browse(null, "window=rtg")
 			return
 
-		user.machine = src
+		src.add_dialog(user)
 
 		var/t = "<B>Radioisotope Thermoelectric Generator</B><br>"
 		t += "Output: [src.lastgen]W<br>"

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -167,7 +167,7 @@
 		updateicon()
 
 	for(var/mob/M in viewers(1, src))
-		if ((M.client && M.machine == src))
+		if (M.using_dialog_of(src))
 			src.interacted(M)
 	AutoUpdateAI(src)
 
@@ -231,11 +231,11 @@
 
 	if ( (get_dist(src, user) > 1 ))
 		if (!isAI(user) && !issilicon(user))
-			user.machine = null
+			src.remove_dialog(user)
 			user.Browse(null, "window=smes")
 			return
 
-	user.machine = src
+	src.add_dialog(user)
 
 	// @todo fix this later
 	var/t = {"
@@ -310,10 +310,10 @@
 	if (usr.stat || usr.restrained() )
 		return
 
-	if (( usr.machine==src && ((get_dist(src, usr) <= 1) && istype(src.loc, /turf))) || (isAI(usr) || issilicon(usr)))
+	if (( usr.using_dialog_of(src) && ((get_dist(src, usr) <= 1) && istype(src.loc, /turf))) || (isAI(usr) || issilicon(usr)))
 		if (href_list["close"])
 			usr.Browse(null, "window=smes")
-			usr.machine = null
+			src.remove_dialog(usr)
 			return
 
 		else if ( href_list["cmode"] )
@@ -356,7 +356,7 @@
 
 	else
 		usr.Browse(null, "window=smes")
-		usr.machine = null
+		src.remove_dialog(usr)
 
 	return
 

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -166,10 +166,7 @@
 	if (last_disp != chargedisplay() || last_chrg != charging || last_onln != online)
 		updateicon()
 
-	for(var/mob/M in viewers(1, src))
-		if (M.using_dialog_of(src))
-			src.interacted(M)
-	AutoUpdateAI(src)
+	src.updateDialog()
 
 // called after all power processes are finished
 // restores charge level to smes if there was excess this ptick

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -333,12 +333,12 @@
 	if(status & (BROKEN | NOPOWER)) return
 	if ( (get_dist(src, user) > 1 ))
 		if (!isAI(user))
-			user.machine = null
+			src.remove_dialog(user)
 			user.Browse(null, "window=solcon")
 			return
 
 	add_fingerprint(user)
-	user.machine = src
+	src.add_dialog(user)
 
 	var/t = "<TT><B>Solar Generator Control</B><HR><PRE>"
 	t += "Generated power : [round(lastgen)] W<BR><BR>"
@@ -365,11 +365,11 @@
 /obj/machinery/power/solar_control/Topic(href, href_list)
 	if(..())
 		usr.Browse(null, "window=solcon")
-		usr.machine = null
+		src.remove_dialog(usr)
 		return
 	if(href_list["close"] )
 		usr.Browse(null, "window=solcon")
-		usr.machine = null
+		src.remove_dialog(usr)
 		return
 
 	if(href_list["dir"])

--- a/code/modules/power/switchgear.dm
+++ b/code/modules/power/switchgear.dm
@@ -64,12 +64,12 @@
 
 	if ( (get_dist(src, user) > 1 ) || (status & (BROKEN|NOPOWER)) )
 		if (!issilicon(user))
-			user.machine = null
+			src.remove_dialog(user)
 			user.Browse(null, "window=switchgear")
 			return
 
 
-	user.machine = src
+	src.add_dialog(user)
 	var/t = "<TT><B>Switchgear Control</B><BR><A href='?src=\ref[src];close=1'>Close Panel</A><HR>"
 
 	if(!powernet)
@@ -125,14 +125,14 @@
 				boutput(usr, "<span class='alert'>You'd close the panel, if only you had hands.</span>")
 				return
 			usr.Browse(null, "window=switchgear")
-			usr.machine = null
+			src.remove_dialog(usr)
 			src.open = 0
 			icon_state = "c_unpowered"
 			// update icon to closed state
 			return
 	else
 		usr.Browse(null, "window=switchgear")
-		usr.machine = null
+		src.remove_dialog(usr)
 
 /obj/machinery/power/switchgear/process()
 	if(!(status & (NOPOWER|BROKEN)) )

--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -138,10 +138,7 @@
 		overlays += image('icons/obj/atmospherics/pipes.dmi', "turb-o", FLY_LAYER)
 
 
-	for(var/mob/M in viewers(1, src))
-		if (M.using_dialog_of(src))
-			src.interacted(M)
-	AutoUpdateAI(src)
+	src.updateDialog()
 
 
 /obj/machinery/power/turbine/attack_ai(mob/user)

--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -139,7 +139,7 @@
 
 
 	for(var/mob/M in viewers(1, src))
-		if ((M.client && M.machine == src))
+		if (M.using_dialog_of(src))
 			src.interacted(M)
 	AutoUpdateAI(src)
 
@@ -163,11 +163,11 @@
 /obj/machinery/power/turbine/proc/interacted(mob/user)
 
 	if ( (get_dist(src, user) > 1 ) || (status & (NOPOWER|BROKEN)) && (!isAI(user)) )
-		user.machine = null
+		src.remove_dialog(user)
 		user.Browse(null, "window=turbine")
 		return
 
-	user.machine = src
+	src.add_dialog(user)
 
 	var/t = "<TT><B>Gas Turbine Generator</B><HR><PRE>"
 
@@ -192,10 +192,10 @@
 	if (usr.stat || usr.restrained() )
 		return
 
-	if (( usr.machine==src && ((get_dist(src, usr) <= 1) && istype(src.loc, /turf))) || (isAI(usr)))
+	if (( usr.using_dialog_of(src) && ((get_dist(src, usr) <= 1) && istype(src.loc, /turf))) || (isAI(usr)))
 		if( href_list["close"] )
 			usr.Browse(null, "window=turbine")
-			usr.machine = null
+			src.remove_dialog(usr)
 			return
 
 		else if( href_list["str"] )
@@ -203,12 +203,12 @@
 
 		SPAWN_DBG(0)
 			for(var/mob/M in viewers(1, src))
-				if ((M.client && M.machine == src))
+				if (M.using_dialog_of(src))
 					src.interacted(M)
 
 	else
 		usr.Browse(null, "window=turbine")
-		usr.machine = null
+		src.remove_dialog(usr)
 
 	return
 
@@ -269,7 +269,7 @@
 	return
 
 /obj/machinery/computer/turbine_computer/attack_hand(var/mob/user as mob)
-	user.machine = src
+	src.add_dialog(user)
 	var/dat
 	if(src.compressor)
 		dat += {"<BR><B>Gas turbine remote control system</B><HR>
@@ -296,7 +296,7 @@
 	if(..())
 		return
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (issilicon(usr)))
-		usr.machine = src
+		src.add_dialog(usr)
 
 		if( href_list["view"] )
 			usr.client.eye = src.compressor
@@ -314,7 +314,7 @@
 						door_status = 0
 		else if( href_list["close"] )
 			usr.Browse(null, "window=computer")
-			usr.machine = null
+			src.remove_dialog(usr)
 			return
 
 		src.add_fingerprint(usr)

--- a/code/modules/robotics/bot/cleanbot.dm
+++ b/code/modules/robotics/bot/cleanbot.dm
@@ -181,7 +181,7 @@
 		if (!issilicon(usr) && !in_range(src, usr)) return
 
 		src.add_fingerprint(usr)
-		usr.machine = src
+		src.add_dialog(usr)
 
 		if (href_list["start"])
 			src.toggle_power(0)

--- a/code/modules/robotics/bot/firebot.dm
+++ b/code/modules/robotics/bot/firebot.dm
@@ -95,7 +95,7 @@
 /obj/machinery/bot/firebot/Topic(href, href_list)
 	if(..())
 		return
-	usr.machine = src
+	src.add_dialog(usr)
 	src.add_fingerprint(usr)
 	if ((href_list["power"]) && (src.allowed(usr)))
 		src.toggle_power()

--- a/code/modules/robotics/bot/floorbot.dm
+++ b/code/modules/robotics/bot/floorbot.dm
@@ -165,7 +165,7 @@ text("<A href='?src=\ref[src];operation=make'>[src.maketiles ? "Yes" : "No"]</A>
 /obj/machinery/bot/floorbot/Topic(href, href_list)
 	if (..())
 		return
-	usr.machine = src
+	src.add_dialog(usr)
 	src.add_fingerprint(usr)
 	switch(href_list["operation"])
 		if ("start")

--- a/code/modules/robotics/bot/guardbot.dm
+++ b/code/modules/robotics/bot/guardbot.dm
@@ -483,7 +483,7 @@
 	attack_hand(mob/user as mob)
 		if(..())
 			return
-		if(user.a_intent == "help" && user.machine != src && (get_dist(user,src) <= 1))
+		if(user.a_intent == "help" && !user.using_dialog_of(src) && (get_dist(user,src) <= 1))
 			var/affection = pick("hug","cuddle","snuggle")
 			user.visible_message("<span class='notice'>[user] [affection]s [src]!</span>","<span class='notice'>You [affection] [src]!</span>")
 			if(src.task)
@@ -498,7 +498,7 @@
 	Topic(href, href_list)
 		if(..())
 			return
-		usr.machine = src
+		src.add_dialog(usr)
 		src.add_fingerprint(usr)
 		if ((href_list["power"]) && (!src.locked || (src.allowed(usr) && (issilicon(usr) || get_dist(usr, src) < 2))))
 			if(src.on)
@@ -3227,7 +3227,7 @@
 		if(..() || status & NOPOWER)
 			return
 
-		user.machine = src
+		src.add_dialog(user)
 
 		var/dat = "<html><head><title>PR-6S Docking Station</title></head><body>"
 
@@ -3261,7 +3261,7 @@
 		if(..())
 			return
 
-		usr.machine = src
+		src.add_dialog(usr)
 
 		if (href_list["reset"])
 			if(last_reset && (last_reset + GUARDBOT_DOCK_RESET_DELAY >= world.time))
@@ -3700,7 +3700,7 @@
 		if (..() || (status & (NOPOWER|BROKEN)))
 			return
 
-		user.machine = src
+		src.add_dialog(user)
 		add_fingerprint(user)
 
 		var/dat = "<center><h4>Tour Monitor</h4></center>"
@@ -3724,7 +3724,7 @@
 	Topic(href, href_list)
 		if(..())
 			return
-		usr.machine = src
+		src.add_dialog(usr)
 		src.add_fingerprint(usr)
 
 		if (href_list["start_tour"] && linked_bot && (linked_bot in orange(1, src)) && linked_bot.charge_dock)

--- a/code/modules/robotics/bot/medbot.dm
+++ b/code/modules/robotics/bot/medbot.dm
@@ -189,7 +189,7 @@
 /obj/machinery/bot/medbot/Topic(href, href_list)
 	if(..())
 		return
-	usr.machine = src
+	src.add_dialog(usr)
 	src.add_fingerprint(usr)
 	if ((href_list["power"]) && (src.allowed(usr)))
 		src.toggle_power()

--- a/code/modules/robotics/bot/mulebot.dm
+++ b/code/modules/robotics/bot/mulebot.dm
@@ -279,7 +279,7 @@
 		if (usr.stat)
 			return
 		if ((in_range(src, usr) && istype(src.loc, /turf)) || (issilicon(usr)))
-			usr.machine = src
+			src.add_dialog(usr)
 
 			switch(href_list["op"])
 				if("lock", "unlock")
@@ -365,7 +365,7 @@
 					auto_pickup = !auto_pickup
 
 				if("close")
-					usr.machine = null
+					src.remove_dialog(usr)
 					usr.Browse(null,"window=mulebot")
 
 				if("wirecut")
@@ -406,7 +406,7 @@
 			updateDialog()
 		else
 			usr.Browse(null, "window=mulebot")
-			usr.machine = null
+			src.remove_dialog(usr)
 		return
 
 	// returns true if the bot has power

--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -185,7 +185,7 @@ Report Arrests: <A href='?src=\ref[src];operation=report'>[report_arrests ? "On"
 	Topic(href, href_list)
 		if(..())
 			return
-		usr.machine = src
+		src.add_dialog(usr)
 		src.add_fingerprint(usr)
 		if ((href_list["power"]) && (!src.locked || src.allowed(usr)))
 			src.on = !src.on

--- a/code/modules/telescience/radiostation.dm
+++ b/code/modules/telescience/radiostation.dm
@@ -138,7 +138,7 @@
 /obj/submachine/mixing_desk/attack_hand(mob/user as mob)
 	if(..())
 		return
-	user.machine = src
+	src.add_dialog(user)
 	var/dat = "<a href='byond://?src=\ref[src];state=1'>[src.state_name]</a>"
 	if(state)
 		dat += "<center><h4>Mixing Desk</h4></center>"

--- a/code/modules/telescience/radiotelescope.dm
+++ b/code/modules/telescience/radiotelescope.dm
@@ -28,7 +28,7 @@
 
 		using = user
 
-		user.machine = src
+		src.add_dialog(user)
 		add_fingerprint(user)
 		user.Browse(grabResource("html/quantumTelescope.html"), "window=telescope;size=800x435;can_resize=0;can_minimize=0;can_close=1;override_setting=1")
 

--- a/code/modules/transport/pods/MainWeapon.dm
+++ b/code/modules/transport/pods/MainWeapon.dm
@@ -20,7 +20,7 @@
 	opencomputer(mob/user as mob)
 		if(user.loc != src.ship)
 			return
-		user.machine = src
+		src.add_dialog(user)
 
 		var/dat = "<TT><B>[src] Console</B><BR><HR><BR>"
 		if(src.active)
@@ -41,7 +41,7 @@
 			return
 
 		if (usr.loc == ship)
-			usr.machine = src
+			src.add_dialog(usr)
 
 			if (href_list["gunner"])
 				MakeGunner(usr)
@@ -49,7 +49,7 @@
 
 			src.add_fingerprint(usr)
 			for(var/mob/M in ship)
-				if ((M.client && M.machine == src))
+				if (M.using_dialog_of(src))
 					src.opencomputer(M)
 		else
 			usr.Browse(null, "window=ship_main_weapon")
@@ -222,7 +222,7 @@
 	opencomputer(mob/user as mob)
 		if(user.loc != src.ship)
 			return
-		user.machine = src
+		src.add_dialog(user)
 
 		var/dat = "<TT><B>Weapon Console</B><BR><HR>"
 		if(src.active)
@@ -245,7 +245,7 @@
 			return
 
 		if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (issilicon(usr)))
-			usr.machine = src
+			src.add_dialog(usr)
 
 		if (href_list["heat"])
 			current_projectile = ufo
@@ -310,7 +310,7 @@
 	opencomputer(mob/user as mob)
 		if(user.loc != src.ship)
 			return
-		user.machine = src
+		src.add_dialog(user)
 
 		var/dat = "<TT><B>Weapon Console</B><BR><HR>"
 		if(src.active)
@@ -333,7 +333,7 @@
 			return
 
 		if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (issilicon(usr)))
-			usr.machine = src
+			src.add_dialog(usr)
 
 		if (href_list["foam"])
 			mode = 0

--- a/code/modules/transport/pods/engine.dm
+++ b/code/modules/transport/pods/engine.dm
@@ -34,7 +34,7 @@
 	opencomputer(mob/user as mob)
 		if(user.loc != src.ship)
 			return
-		user.machine = src
+		src.add_dialog(user)
 
 		var/dat = "<TT><B>[src] Console</B><BR><HR><BR>"
 		if(src.active)

--- a/code/modules/transport/pods/secondary_system.dm
+++ b/code/modules/transport/pods/secondary_system.dm
@@ -50,7 +50,7 @@
 	opencomputer(mob/user as mob)
 		if(user.loc != src.ship)
 			return
-		user.machine = src
+		src.add_dialog(user)
 
 		var/dat = "<TT><B>[src] Console</B><BR><HR><BR>"
 		if(src.active)
@@ -82,7 +82,7 @@
 	opencomputer(mob/user as mob)
 		if(user.loc != src.ship)
 			return
-		user.machine = src
+		src.add_dialog(user)
 
 		var/dat = "<TT><B>[src] Console</B><BR><HR><BR>"
 		dat += {"<BR><B>Capacity: [src.contents.len]/[src.capacity]</B><HR>"}
@@ -175,7 +175,7 @@
 /obj/item/shipcomponent/secondary_system/cargo/opencomputer(mob/user as mob)
 	if(user.loc != src.ship)
 		return
-	user.machine = src
+	src.add_dialog(user)
 
 	var/dat = {"<TT><B>[src] Console</B><BR><HR><BR>
 				<BR><B>Current Contents:</B><HR>"}
@@ -355,7 +355,7 @@
 	opencomputer(mob/user as mob)
 		if(user.loc != src.ship)
 			return
-		user.machine = src
+		src.add_dialog(user)
 
 		var/dat = "<TT><B>[src] Console</B><BR><HR><BR>"
 		if(src.active)
@@ -440,7 +440,7 @@
 	opencomputer(mob/user as mob)
 		if(user.loc != src.ship)
 			return
-		user.machine = src
+		src.add_dialog(user)
 
 		var/dat = "<TT><B>[src] Console</B><BR><HR><BR>"
 		if(src.active)
@@ -461,7 +461,7 @@
 		opencomputer(user)
 		return
 	opencomputer(mob/user as mob)
-		user.machine = src
+		src.add_dialog(user)
 
 		var/dat = "<TT><B>[src] Console</B><BR><HR><BR>"
 		dat+=  {"<BR><B>Located at:</B><HR>
@@ -497,7 +497,7 @@
 			return
 
 		if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (issilicon(usr)))
-			usr.machine = src
+			src.add_dialog(usr)
 		if (href_list["release"])
 			for(var/mob/M in ship)
 				if(cmptext(href_list["release"], M.name))
@@ -651,7 +651,7 @@
 			return
 
 		if ((usr.contents.Find(src) || (in_range(ship, usr) && istype(src.loc, /turf))) || (issilicon(usr)))
-			usr.machine = src
+			src.add_dialog(usr)
 
 		if (href_list["enter"])
 			if (configure_mode)

--- a/code/modules/transport/pods/sensors.dm
+++ b/code/modules/transport/pods/sensors.dm
@@ -40,7 +40,7 @@
 	opencomputer(mob/user as mob)
 		if(user.loc != src.ship)
 			return
-		user.machine = src
+		src.add_dialog(user)
 
 		var/dat = "<B>[src] Console</B><BR><HR><BR>"
 		if(src.active)
@@ -65,7 +65,7 @@
 			return
 
 		if (usr.loc == ship)
-			usr.machine = src
+			src.add_dialog(usr)
 
 			if (href_list["scan"] && !scanning)
 				scan(usr)
@@ -83,7 +83,7 @@
 
 			src.add_fingerprint(usr)
 			for(var/mob/M in ship)
-				if ((M.client && M.machine == src))
+				if (M.using_dialog_of(src))
 					src.opencomputer(M)
 		else
 			usr.Browse(null, "window=ship_sensor")
@@ -211,7 +211,7 @@
 		SPAWN_DBG(0)
 			begin_tracking(0)
 		for(var/mob/M in ship)
-			if ((M.client && M.machine == src))
+			if (M.using_dialog_of(src))
 				src.opencomputer(M)
 
 //Doing nothing with the Z-level value right now.

--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -178,7 +178,7 @@
 
 	updateDialog()
 		for(var/client/C)
-			if (C.mob.machine == src && get_dist(C.mob,src) <= 1)
+			if (C.mob.using_dialog_of(src) && get_dist(C.mob,src) <= 1)
 				src.open_parts_panel(C.mob)
 
 	Topic(href, href_list)
@@ -188,7 +188,7 @@
 		//////Main Computer Code		//////
 		//////////////////////////////////////
 		if (usr.loc == src)
-			usr.machine = src
+			src.add_dialog(usr)
 			if (href_list["dengine"])
 				if (usr != pilot)
 					boutput(usr, "[ship_message("Only the pilot may do this!")]")
@@ -262,7 +262,7 @@
 
 			src.add_fingerprint(usr)
 			for (var/mob/M in src)
-				if ((M.client && M.machine == src))
+				if (M.using_dialog_of(src))
 					src.access_computer(M)
 			myhud.update_states()
 		///////////////////////////////////////
@@ -278,7 +278,7 @@
 				lock.show_lock_panel(usr, 0)
 				return
 
-			usr.machine = src
+			src.add_dialog(usr)
 			if (href_list["unengine"])
 				if (src.engine)
 					engine.deactivate()
@@ -1156,7 +1156,7 @@
 		lock.show_lock_panel(usr, 0)
 		return
 
-	user.machine = src
+	src.add_dialog(user)
 
 	var/dat = "<TT><B>[src] Maintenance Panel</B><BR><HR><BR>"
 	//Air and Fuel tanks
@@ -1231,7 +1231,7 @@
 /obj/machinery/vehicle/proc/access_computer(mob/user as mob)
 	if(user.loc != src)
 		return
-	user.machine = src
+	src.add_dialog(user)
 
 	var/dat = "<TT><B>[src] Control Console</B><BR><HR><BR>"
 	dat += "<B>Hull Integrity:</B> [src.health/src.maxhealth * 100]%<BR>"

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -818,7 +818,7 @@
 			return
 
 		if (usr.contents.Find(src) || in_range(src, usr) && istype(src.loc, /turf))
-			usr.machine = src
+			src.add_dialog(usr)
 			if (href_list["cook"])
 				if(!pizcooking)
 					if((credit < 50)&&(!emagged))
@@ -1588,7 +1588,7 @@
 /obj/machinery/vending/attack_hand(mob/user as mob)
 	if (status & (BROKEN|NOPOWER))
 		return
-	user.machine = src
+	src.add_dialog(user)
 
 	if (src.seconds_electrified != 0)
 		if (src.shock(user, 100))
@@ -1623,7 +1623,7 @@
 		return
 
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))))
-		usr.machine = src
+		src.add_dialog(usr)
 		src.add_fingerprint(usr)
 		if ((href_list["vend"]) && (src.vend_ready))
 

--- a/code/obj.dm
+++ b/code/obj.dm
@@ -116,6 +116,7 @@
 		mats = null
 		if (artifact && !isnum(artifact))
 			artifact:holder = null
+		remove_dialogs()
 		..()
 
 	proc/client_login(var/mob/user)

--- a/code/obj.dm
+++ b/code/obj.dm
@@ -244,47 +244,6 @@
 /obj/proc/get_movement_controller(mob/user)
 	return
 
-/obj/proc/updateUsrDialog()
-	for(var/client/C)
-		if (C.mob?.machine == src)
-			if (get_dist(C.mob,src) <= 1)
-				src.attack_hand(C.mob)
-			else
-				if (issilicon(C.mob))
-					src.attack_ai(usr)
-				else if (isAIeye(C.mob))
-					var/mob/dead/aieye/E = C.mob
-					src.attack_ai(E)
-
-/obj/proc/updateDialog()
-	for(var/client/C)
-		if (C.mob?.machine == src && get_dist(C.mob,src) <= 1)
-			src.attack_hand(C.mob)
-	AutoUpdateAI(src)
-
-/obj/item/proc/updateSelfDialogFromTurf()	//It's weird, yes. only used for spy stickers as of now
-
-	for(var/client/C)
-		if (C.mob?.machine == src && get_dist(C.mob,src) <= 1)
-			src.attack_self(C.mob)
-
-	for(var/mob/living/silicon/ai/M in AIs)
-		var/mob/AI = M
-		if (M.deployed_to_eyecam)
-			AI = M.eyecam
-		if ((AI.client && AI.machine == src))
-			src.attack_self(AI)
-
-/obj/item/proc/updateSelfDialog()
-	var/mob/M = src.loc
-	if(istype(M))
-		if (isAI(M)) //Eyecam handling
-			var/mob/living/silicon/ai/AI = M
-			if (AI.deployed_to_eyecam)
-				M = AI.eyecam
-		if(M.client && M.machine == src)
-			src.attack_self(M)
-
 /obj/bedsheetbin
 	name = "linen bin"
 	desc = "A bin for containing bedsheets."

--- a/code/obj/ToSplit/barber_shop.dm
+++ b/code/obj/ToSplit/barber_shop.dm
@@ -365,7 +365,7 @@
 	attack_hand(mob/user as mob)
 		if(status & BROKEN)
 			return
-		user.machine = src
+		src.add_dialog(user)
 
 		var/dat = "<TT><B>Dye Bottle Dispenser Unit</B><BR><HR><BR>"
 
@@ -408,7 +408,7 @@
 			return
 
 		if ((usr.contents.Find(src) || ((get_dist(src, usr) <= 1) && istype(src.loc, /turf))))
-			usr.machine = src
+			src.add_dialog(usr)
 
 			if (href_list["eject"])
 				if(src.bottle)
@@ -432,7 +432,7 @@
 
 			src.add_fingerprint(usr)
 			for(var/mob/M in viewers(1, src))
-				if ((M.client && M.machine == src))
+				if (M.using_dialog_of(src))
 					src.attack_hand(M)
 		else
 			usr.Browse(null, "window=dye_dispenser")

--- a/code/obj/item/clothing/injector_mask_belt.dm
+++ b/code/obj/item/clothing/injector_mask_belt.dm
@@ -48,7 +48,7 @@ There's A LOT of duplicate code here, which isn't ideal to say the least. Should
 		return
 
 	attack_self(mob/user as mob)
-		user.machine = src
+		src.add_dialog(user)
 		var/dat = ""
 		dat += container ? "Container: <A href='?src=\ref[src];remove_cont=1'>[container.name]</A> - [container.reagents.total_volume] / [container.reagents.maximum_volume] Units<BR><BR>" : "Please attach a beaker<BR><BR>"
 		dat += condition ? "[condition.name] - [condition.desc] <A href='?src=\ref[src];remove_cond=1'>(Remove)</A><BR><BR>" : "<A href='?src=\ref[src];sel_cond=1'>(Select Condition)</A><BR><BR>"
@@ -194,7 +194,7 @@ There's A LOT of duplicate code here, which isn't ideal to say the least. Should
 		return
 
 	attack_self(mob/user as mob)
-		user.machine = src
+		src.add_dialog(user)
 		var/dat = ""
 		dat += container ? "Container: <A href='?src=\ref[src];remove_cont=1'>[container.name]</A> - [container.reagents.total_volume] / [container.reagents.maximum_volume] Units<BR><BR>" : "Please attach a beaker<BR><BR>"
 		dat += condition ? "[condition.name] - [condition.desc] <A href='?src=\ref[src];remove_cond=1'>(Remove)</A><BR><BR>" : "<A href='?src=\ref[src];sel_cond=1'>(Select Condition)</A><BR><BR>"

--- a/code/obj/item/device/audio_log.dm
+++ b/code/obj/item/device/audio_log.dm
@@ -171,7 +171,7 @@
 		if (user.stat || user.restrained() || user.lying)
 			return
 		if ((user.contents.Find(src) || user.contents.Find(src.master) || get_dist(src, user) <= 1 && istype(src.loc, /turf)))
-			user.machine = src
+			src.add_dialog(user)
 
 			var/dat = "<TT><b>Audio Logger</b><br>"
 			if (src.tape)
@@ -190,7 +190,7 @@
 			onclose(user, "audiolog")
 		else
 			user.Browse(null, "window=audiolog")
-			user.machine = null
+			src.remove_dialog(user)
 
 		return
 
@@ -229,7 +229,7 @@
 		if (usr.stat || usr.restrained() || usr.lying)
 			return
 		if ((usr.contents.Find(src) || usr.contents.Find(src.master) || in_range(src, usr) && istype(src.loc, /turf)))
-			usr.machine = src
+			src.add_dialog(usr)
 			switch(href_list["command"])
 				if("rec")
 					src.mode = 1

--- a/code/obj/item/device/camera_viewer.dm
+++ b/code/obj/item/device/camera_viewer.dm
@@ -9,7 +9,7 @@
 	mats = 6
 
 	attack_self(mob/user as mob)
-		user.machine = src
+		src.add_dialog(user)
 		user.unlock_medal("Peeping Tom", 1)
 
 		var/list/L = list()

--- a/code/obj/item/device/gps.dm
+++ b/code/obj/item/device/gps.dm
@@ -47,7 +47,7 @@ var/global/list/all_GPSs = list()
 	proc/show_HTML(var/mob/user)
 		if (!user)
 			return
-		user.machine = src
+		src.add_dialog(user)
 		var/HTML = {"<style type="text/css">
 		.desc {
 			background: #21272C;
@@ -137,7 +137,7 @@ var/global/list/all_GPSs = list()
 			src.show_HTML(user)
 		else
 			user.Browse(null, "window=gps_[src]")
-			user.machine = null
+			src.remove_dialog(user)
 		return
 
 	Topic(href, href_list)
@@ -145,7 +145,7 @@ var/global/list/all_GPSs = list()
 		if (usr.stat || usr.restrained() || usr.lying)
 			return
 		if ((usr.contents.Find(src) || usr.contents.Find(src.master) || in_range(src, usr)))
-			usr.machine = src
+			src.add_dialog(usr)
 			var/turf/T = get_turf(usr)
 			if(href_list["getcords"])
 				boutput(usr, "<span class='notice'>Located at: <b>X</b>: [T.x], <b>Y</b>: [T.y]</span>")
@@ -189,19 +189,10 @@ var/global/list/all_GPSs = list()
 
 
 			if (!src.master)
-				if (ismob(src.loc))
-					attack_self(src.loc)
-				else
-					for(var/mob/M in viewers(1, src))
-						if (M.client && (M.machine == src.master || M.machine == src))
-							src.attack_self(M)
+				src.updateSelfDialog()
 			else
-				if (ismob(src.master.loc))
-					src.attack_self(src.master.loc)
-				else
-					for(var/mob/M in viewers(1, src.master))
-						if (M.client && (M.machine == src.master || M.machine == src))
-							src.attack_self(M)
+				src.master.updateSelfDialog()
+
 			src.add_fingerprint(usr)
 		else
 			usr.Browse(null, "window=gps_[src]")

--- a/code/obj/item/device/infrared_stuff.dm
+++ b/code/obj/item/device/infrared_stuff.dm
@@ -62,7 +62,7 @@ Contains:
 	return
 
 /obj/item/device/infra_sensor/attack_self(mob/user as mob)
-	user.machine = src
+	src.add_dialog(user)
 	var/dat = text("<TT><B>Infrared Sensor</B><BR><br><B>Passive Emitter</B>: []<BR><br><B>Active Emitter</B>: <A href='?src=\ref[];active=0'>Burst Fire</A><br></TT>", (src.passive ? text("<A href='?src=\ref[];passive=0'>On</A>", src) : text("<A href='?src=\ref[];passive=1'>Off</A>", src)), src)
 	user.Browse(dat, "window=infra_sensor")
 	onclose(user, "infra_sensor")
@@ -73,7 +73,7 @@ Contains:
 	if (usr.stat || usr.restrained())
 		return
 	if ((usr.contents.Find(src) || (usr.contents.Find(src.master) || ((get_dist(src, usr) <= 1) && istype(src.loc, /turf)))))
-		usr.machine = src
+		src.add_dialog(usr)
 		if (href_list["passive"])
 			src.passive = !( src.passive )
 			if(passive && !(src in processing_items))
@@ -166,7 +166,7 @@ Contains:
 	return
 
 /obj/item/device/infra/attack_self(mob/user as mob)
-	user.machine = src
+	src.add_dialog(user)
 	var/dat = text("<TT><B>Infrared Laser</B><br><B>Status</B>: []<BR><br><B>Visibility</B>: []<BR><br></TT>", (src.state ? text("<A href='?src=\ref[];state=0'>On</A>", src) : text("<A href='?src=\ref[];state=1'>Off</A>", src)), (src.visible ? text("<A href='?src=\ref[];visible=0'>Visible</A>", src) : text("<A href='?src=\ref[];visible=1'>Invisible</A>", src)))
 	user.Browse(dat, "window=infra")
 	onclose(user, "infra")
@@ -177,7 +177,7 @@ Contains:
 	if (usr.stat || usr.restrained())
 		return
 	if ((usr.contents.Find(src) || usr.contents.Find(src.master) || in_range(src, usr) && istype(src.loc, /turf)))
-		usr.machine = src
+		src.add_dialog(usr)
 		if (href_list["state"])
 			src.state = !( src.state )
 			src.icon_state = text("infrared[]", src.state)

--- a/code/obj/item/device/pda2/base_program.dm
+++ b/code/obj/item/device/pda2/base_program.dm
@@ -163,10 +163,10 @@
 			if(master.active_program == src)
 				master.active_program = null
 			return 1
-		usr.machine = src.master
+		src.master.add_dialog(usr)
 
 		if (href_list["close"])
-			usr.machine = null
+			src.master.remove_dialog(usr)
 			usr.Browse(null, "window=pda2_\ref[src]")
 			return 0
 		if (href_list["quit"])

--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -297,7 +297,7 @@
 		boutput(user, "<span class='alert'>You don't know how to read, the screen is meaningless to you.</span>")
 		return
 
-	user.machine = src
+	src.add_dialog(user)
 
 	var/wincheck = winexists(user, "pda2_\ref[src]")
 	//boutput(world, wincheck)
@@ -386,7 +386,7 @@
 			return
 
 		src.add_fingerprint(usr)
-		usr.machine = src
+		src.add_dialog(usr)
 
 		if (href_list["return_to_host"])
 			if (src.host_program)
@@ -407,7 +407,7 @@
 
 		else if (href_list["close"])
 			usr.Browse(null, "window=pda2_\ref[src]")
-			usr.machine = null
+			src.remove_dialog(usr)
 
 		src.updateSelfDialog()
 		return

--- a/code/obj/item/device/prox_sensor.dm
+++ b/code/obj/item/device/prox_sensor.dm
@@ -56,24 +56,13 @@
 			src.time = 0
 			src.timing = 0
 			src.update_icon()
+
+
 		if (!src.master)
-			if (ismob(src.loc))
-				attack_self(src.loc)
-			else
-				for(var/mob/M in viewers(1, src))
-					if (isintangible(M) || isdead(M))
-						continue
-					if (M.client && (M.machine == src.master || M.machine == src))
-						src.attack_self(M)
+			src.updateDialog()
 		else
-			if (ismob(src.master.loc))
-				src.attack_self(src.master.loc)
-			else
-				for(var/mob/M in viewers(1, src.master))
-					if (isintangible(M) || isdead(M))
-						continue
-					if (M.client && (M.machine == src.master || M.machine == src))
-						src.attack_self(M)
+			src.master.updateDialog()
+
 	else
 		processing_items.Remove(src)
 		return
@@ -109,7 +98,7 @@
 	if (user.stat || user.restrained() || user.lying)
 		return
 	if ((src in user) || (src.master && (src.master in user)) || get_dist(src, user) <= 1 && istype(src.loc, /turf))
-		user.machine = src
+		src.add_dialog(user)
 		var/second = src.time % 60
 		var/minute = (src.time - second) / 60
 		var/dat = text("<TT><B>Proximity Sensor</B><br>[] []:[]<br><A href='?src=\ref[];tp=-30'>-</A> <A href='?src=\ref[];tp=-1'>-</A> <A href='?src=\ref[];tp=1'>+</A> <A href='?src=\ref[];tp=30'>+</A><br></TT>", (src.timing ? text("<A href='?src=\ref[];time=0'>Timing</A>", src) : text("<A href='?src=\ref[];time=1'>Not Timing</A>", src)), minute, second, src, src, src, src)
@@ -119,7 +108,7 @@
 		onclose(user, "prox")
 	else
 		user.Browse(null, "window=prox")
-		user.machine = null
+		src.remove_dialog(user)
 		return
 
 /obj/item/device/prox_sensor/Topic(href, href_list)
@@ -127,7 +116,7 @@
 	if (usr.stat || usr.restrained() || usr.lying)
 		return
 	if ((src in usr) || (src.master && (src.master in usr)) || ((get_dist(src, usr) <= 1) && istype(src.loc, /turf)))
-		usr.machine = src
+		src.add_dialog(usr)
 		if (href_list["arm"])
 			src.armed = !src.armed
 			src.update_icon()
@@ -171,23 +160,14 @@
 
 		if (href_list["close"])
 			usr.Browse(null, "window=prox")
-			usr.machine = null
+			src.remove_dialog(usr)
 			return
 
 		if (!src.master)
-			if (ismob(src.loc))
-				attack_self(src.loc)
-			else
-				for(var/mob/M in viewers(1, src))
-					if (M.client && (M.machine == src.master || M.machine == src))
-						src.attack_self(M)
+			src.updateSelfDialog()
 		else
-			if (ismob(src.master.loc))
-				src.attack_self(src.master.loc)
-			else
-				for(var/mob/M in viewers(1, src.master))
-					if (M.client && (M.machine == src.master || M.machine == src))
-						src.attack_self(M)
+			src.master.updateSelfDialog()
+
 	else
 		usr.Browse(null, "window=prox")
 		return

--- a/code/obj/item/device/radio.dm
+++ b/code/obj/item/device/radio.dm
@@ -105,7 +105,7 @@ var/list/headset_channel_lookup
 	return
 
 /obj/item/device/radio/attack_self(mob/user as mob)
-	user.machine = src
+	src.add_dialog(user)
 
 	var/dat = {"
 Microphone: [src.broadcasting ? "<a href='?src=\ref[src];talk=0'>Engaged</a>" : "<a href='?src=\ref[src];talk=1'>Disengaged</a>"]
@@ -142,7 +142,7 @@ Green Wire: <a href='?src=\ref[src];wires=[WIRE_TRANSMIT]'>[src.wires & WIRE_TRA
 	// Band-aid fix for intercoms, RE 'bounds_dist' check in the 'in_range' proc. Feel free to improve the implementation (Convair880).
 	var/special_cases =((istype(src, /obj/item/device/radio/intercom) && (get_dist(src, usr) <= 1) && (istype(src.loc, /turf))) || (istype(src, /obj/item/device/radio/spy) && (get_dist(src, usr) <= 1)))
 	if ((issilicon(usr) || isAI(usr)) || (src in usr) || (special_cases) || (usr.loc == src.loc))
-		usr.machine = src
+		src.add_dialog(usr)
 
 		if (href_list["track"])
 			// wait is tracking here? really? what? ???? ????????????
@@ -165,7 +165,7 @@ Green Wire: <a href='?src=\ref[src];wires=[WIRE_TRANSMIT]'>[src.wires & WIRE_TRA
 			set_frequency(sanitize_frequency(new_frequency))
 
 			if (!isnull(src.traitorradio) && src.traitor_frequency && src.frequency == src.traitor_frequency)
-				usr.machine = null
+				src.remove_dialog(usr)
 				usr.Browse(null, WINDOW_OPTIONS)
 				onclose(usr, "radio")
 				// now transform the regular radio, into a (disguised)syndicate uplink!
@@ -549,7 +549,7 @@ Green Wire: <a href='?src=\ref[src];wires=[WIRE_TRANSMIT]'>[src.wires & WIRE_TRA
 			. += "[ headset_channel_lookup["[src.secure_frequencies["[sayToken]"]]"] ? headset_channel_lookup["[src.secure_frequencies["[sayToken]"]]"] : "???" ]: \[[format_frequency(src.secure_frequencies["[sayToken]"])]] (Activator: <b>[sayToken]</b>)"
 
 /obj/item/device/radio/attackby(obj/item/W as obj, mob/user as mob)
-	user.machine = src
+	src.add_dialog(user)
 	if (!isscrewingtool(W))
 		return
 	src.b_stat = !( src.b_stat )
@@ -675,7 +675,7 @@ var/global/list/tracking_beacons = list() // things were looping through world t
 	if (usr.stat || usr.restrained())
 		return
 	if (src in usr || (src.master && (src.master in usr)) || (in_range(src, usr) && istype(src.loc, /turf)))
-		usr.machine = src
+		src.add_dialog(usr)
 		if (href_list["freq"])
 			var/new_frequency = sanitize_frequency(frequency + text2num(href_list["freq"]))
 			set_frequency(new_frequency)
@@ -744,7 +744,7 @@ var/global/list/tracking_beacons = list() // things were looping through world t
 
 	if (!( ishuman(user) ))
 		return
-	user.machine = src
+	src.add_dialog(user)
 	var/dat = {"<TT>
 <a href='?src=\ref[src];power=1'>Turn [src.on ? "Off" : "On"]</a><br>
 <B>Frequency/Code</B> for electropack:<br>
@@ -796,7 +796,7 @@ Code:
 */
 
 /obj/item/device/radio/signaler/attack_self(mob/user as mob, flag1)
-	user.machine = src
+	src.add_dialog(user)
 	var/t1
 	if ((src.b_stat && !( flag1 )))
 		t1 = text("-------<br><br>Green Wire: []<br><br>Red Wire:   []<br><br>Blue Wire:  []<br><br>", (src.wires & WIRE_TRANSMIT ? text("<a href='?src=\ref[];wires=[WIRE_TRANSMIT]'>Cut Wire</a>", src) : text("<a href='?src=\ref[];wires=[WIRE_TRANSMIT]'>Mend Wire</a>", src)), (src.wires & WIRE_RECEIVE ? text("<a href='?src=\ref[];wires=[WIRE_RECEIVE]'>Cut Wire</a>", src) : text("<a href='?src=\ref[];wires=[WIRE_RECEIVE]'>Mend Wire</a>", src)), (src.wires & WIRE_SIGNAL ? text("<a href='?src=\ref[];wires=[WIRE_SIGNAL]'>Cut Wire</a>", src) : text("<a href='?src=\ref[];wires=[WIRE_SIGNAL]'>Mend Wire</a>", src)))
@@ -916,7 +916,7 @@ obj/item/device/radio/signaler/attackby(obj/item/W as obj, mob/user as mob)
 			if (istype(src.master.master, /obj/machinery/portable_atmospherics/canister/) && in_range(src.master.master, usr))
 				is_detonator_trigger = 1
 	if (is_detonator_trigger || (src in usr) || (src.master && (src.master in usr)) || (in_range(src, usr) && istype(src.loc, /turf)))
-		usr.machine = src
+		src.add_dialog(usr)
 		if (href_list["freq"])
 			var/new_frequency = sanitize_frequency(frequency + text2num(href_list["freq"]))
 			set_frequency(new_frequency)

--- a/code/obj/item/device/radios/headsets.dm
+++ b/code/obj/item/device/radios/headsets.dm
@@ -277,7 +277,7 @@
 	secure_colors = list(RADIOC_OTHER)
 
 /obj/item/device/radio/headset/multifreq/attack_self(mob/user as mob)
-	user.machine = src
+	src.add_dialog(user)
 	var/t1
 	if (src.b_stat)
 		t1 = {"
@@ -313,7 +313,7 @@ Secure Frequency:
 	if (usr.stat)
 		return
 	if ((usr.contents.Find(src) || in_range(src, usr) && istype(src.loc, /turf)) || (usr.loc == src.loc) || (issilicon(usr)))
-		usr.machine = src
+		src.add_dialog(usr)
 		if (href_list["sfreq"])
 			var/new_frequency = sanitize_frequency(text2num("[secure_frequencies["h"]]") + text2num(href_list["sfreq"]))
 			set_secure_frequency("h", new_frequency)

--- a/code/obj/item/device/timer.dm
+++ b/code/obj/item/device/timer.dm
@@ -62,19 +62,10 @@
 		last_tick = world.time
 
 		if (!src.master)
-			if (ismob(src.loc))
-				attack_self(src.loc)
-			else
-				for(var/mob/M in viewers(1, src))
-					if (M.client && (M.machine == src.master || M.machine == src))
-						src.attack_self(M)
+			src.updateDialog()
 		else
-			if (ismob(src.master.loc))
-				src.attack_self(src.master.loc)
-			else
-				for(var/mob/M in viewers(1, src.master))
-					if (M.client && (M.machine == src.master || M.machine == src))
-						src.attack_self(M)
+			src.master.updateDialog()
+
 	else
 		// If it's not timing, reset the icon so it doesn't look like it's still about to go off.
 		src.c_state(0)
@@ -111,7 +102,7 @@
 		return
 
 	if ((src in user) || (src.master && (src.master in user)) || (get_dist(src, user) <= 1 && istype(src.loc, /turf)) || src.is_detonator_trigger())
-		user.machine = src
+		src.add_dialog(user)
 		var/second = src.time % 60
 		var/minute = (src.time - second) / 60
 		var/detonator_trigger = src.is_detonator_trigger()
@@ -123,7 +114,7 @@
 		onclose(user, "timer")
 	else
 		user.Browse(null, "window=timer")
-		user.machine = null
+		src.remove_dialog(user)
 
 	return
 
@@ -140,7 +131,7 @@
 		return
 	var/can_use_detonator = src.is_detonator_trigger() && !src.timing
 	if (can_use_detonator || (src in usr) || (src.master && (src.master in usr)) || in_range(src, usr) && istype(src.loc, /turf))
-		usr.machine = src
+		src.add_dialog(usr)
 		if (href_list["time"])
 			src.timing = text2num(href_list["time"])
 			if(timing)
@@ -171,25 +162,14 @@
 
 		if (href_list["close"])
 			usr.Browse(null, "window=timer")
-			usr.machine = null
+			src.remove_dialog(usr)
 			return
 
 		if (!src.master)
-			if (ismob(src.loc))
-				attack_self(src.loc)
-			else
-				for(var/mob/M in viewers(1, src))
-					if (M.client && (M.machine == src.master || M.machine == src))
-						src.attack_self(M)
+			src.updateDialog()
 		else
-			if (can_use_detonator)
-				src.attack_self(usr)
-			if (ismob(src.master.loc))
-				src.attack_self(src.master.loc)
-			else
-				for(var/mob/M in viewers(1, src.master))
-					if (M.client && (M.machine == src.master || M.machine == src))
-						src.attack_self(M)
+			src.master.updateDialog()
+
 		src.add_fingerprint(usr)
 	else
 		usr.Browse(null, "window=timer")

--- a/code/obj/item/device/transfer_valve.dm
+++ b/code/obj/item/device/transfer_valve.dm
@@ -98,7 +98,7 @@
 			return
 		if (user.mind && user.mind.gang)
 			boutput(user, "<span class='alert'>You think working with explosives would bring a lot of much heat onto your gang to mess with this. But you do it anyway.</span>")
-		user.machine = src
+		src.add_dialog(user)
 		var/dat = {"<B> Valve properties: </B>
 		<BR> <B> Attachment one:</B> [tank_one] [tank_one ? "<A href='?src=\ref[src];tankone=1'>Remove</A>" : ""]
 		<BR> <B> Attachment two:</B> [tank_two] [tank_two ? "<A href='?src=\ref[src];tanktwo=1'>Remove</A>" : ""]

--- a/code/obj/item/fingerprint.dm
+++ b/code/obj/item/fingerprint.dm
@@ -25,7 +25,7 @@
 	if ((usr.stat || usr.restrained()))
 		return
 	if (usr.contents.Find(src))
-		usr.machine = src
+		src.add_dialog(usr)
 		if (href_list["remove"])
 			var/obj/item/P = locate(href_list["remove"])
 			if (P && P.loc == src)

--- a/code/obj/item/flamethrower.dm
+++ b/code/obj/item/flamethrower.dm
@@ -320,12 +320,12 @@ GETLINEEEEEEEEEEEEEEEEEEEEE
 
 /obj/item/flamethrower/Topic(href,href_list[])
 	if (href_list["close"])
-		usr.machine = null
+		src.remove_dialog(usr)
 		usr.Browse(null, "window=flamethrower")
 		return
 	if(usr.stat || usr.restrained() || usr.lying || src.loc != usr)
 		return
-	usr.machine = src
+	src.add_dialog(usr)
 	if (href_list["light"])
 		if(!src.part4 || !src.part5)	return
 		lit = !(lit)
@@ -354,7 +354,7 @@ GETLINEEEEEEEEEEEEEEEEEEEEE
 			fuel = "_fuel"
 		icon_state = "flamethrower_no_oxy[fuel]"
 		item_state = "flamethrower0"
-		usr.machine = null
+		src.remove_dialog(usr)
 		usr.Browse(null, "window=flamethrower")
 	if (href_list["removefuel"])
 		if(!src.part5)	return
@@ -370,20 +370,19 @@ GETLINEEEEEEEEEEEEEEEEEEEEE
 			oxy = "_oxy"
 		icon_state = "flamethrower[oxy]_no_fuel"
 		item_state = "flamethrower0"
-		usr.machine = null
+		src.remove_dialog(usr)
 		usr.Browse(null, "window=flamethrower")
 	if (href_list["mode"])
 		mode = text2num(href_list["mode"])
-	for(var/mob/M in viewers(1, src.loc))
-		if ((M.client && M.machine == src))
-			src.attack_self(M)
+
+	src.updateDialog()
 	return
 
 
 /obj/item/flamethrower/attack_self(mob/user as mob)
 	if(user.stat || user.restrained() || user.lying)
 		return
-	user.machine = src
+	src.add_dialog(user)
 	var/dat = text("<TT><B>Flamethrower")
 	if(src.part4 && src.part5)
 		dat += text("(<A HREF='?src=\ref[src];light=1'>[lit ? "<font color='red'>Lit</font>" : "Unlit"]</a>)</B><BR>")
@@ -526,9 +525,7 @@ GETLINEEEEEEEEEEEEEEEEEEEEE
 		sleep(0.1 SECONDS)
 
 	operating = 0
-	for(var/mob/M in viewers(1, src.loc))
-		if ((M.client && M.machine == src))
-			src.attack_self(M)
+	src.updateSelfDialog()
 	return 1
 
 /obj/item/flamethrower/proc/spray_turf(turf/target,var/transferamt)

--- a/code/obj/item/game_kit.dm
+++ b/code/obj/item/game_kit.dm
@@ -61,7 +61,7 @@ THAT STUPID GAME KIT
 	src.data = jointext(dat, "")
 
 /obj/item/game_kit/attack_hand(mob/user as mob)
-	user.machine = src
+	src.add_dialog(user)
 
 	if (!( src.data ))
 		update()
@@ -135,6 +135,4 @@ THAT STUPID GAME KIT
 										src.board_stat = text("[][][]", copytext(src.board_stat, 1, place), src.selected, copytext(src.board_stat, place + 2, 129))
 		src.add_fingerprint(usr)
 		update()
-		for(var/mob/M in viewers(1, src))
-			if ((M.client && M.machine == src))
-				src.attack_hand(M)
+		src.updateDialog()

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -1312,7 +1312,7 @@ var/global/list/tracking_implants = list() // things were looping through world 
 
 /obj/item/implantpad/attack_self(mob/user as mob)
 
-	user.machine = src
+	src.add_dialog(user)
 	var/dat = "<B>Implant Mini-Computer:</B><HR>"
 	if (src.case)
 		if (src.case.imp)
@@ -1434,7 +1434,7 @@ circuitry. As a result neurotoxins can cause massive damage.<BR>
 	if (usr.stat)
 		return
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))))
-		usr.machine = src
+		src.add_dialog(usr)
 		if (href_list["freq"])
 			if ((istype(src.case, /obj/item/implantcase) && istype(src.case.imp, /obj/item/implant/tracking)))
 				var/obj/item/implant/tracking/T = src.case.imp

--- a/code/obj/item/misc_wizard_stuff.dm
+++ b/code/obj/item/misc_wizard_stuff.dm
@@ -19,15 +19,15 @@
 	desc = "This isn't that old, you just spilled mugwort tea on it the other day."
 
 /obj/item/teleportation_scroll/attack_self(mob/user as mob)
-	user.machine = src
+	src.add_dialog(user)
 	var/dat = ""
 	if (!iswizard(user))
-		user.machine = null
+		src.remove_dialog(user)
 		boutput(user, "<span class='alert'><b>The text is illegible!</b></span>")
 		return
 	if (!src.uses)
 		boutput(user, "<span class='notice'><b>The depleted scroll vanishes in a puff of smoke!</b></span>")
-		user.machine = null
+		src.remove_dialog(user)
 		user.Browse(null,"window=scroll")
 		qdel(src)
 		return
@@ -46,7 +46,7 @@
 	if (!( ishuman(H)))
 		return 1
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))))
-		usr.machine = src
+		src.add_dialog(usr)
 		if (href_list["spell_teleport"])
 			if (src.uses >= 1 && usr.teleportscroll(0, 1, src) == 1)
 				src.uses -= 1

--- a/code/obj/item/pens_writing_etc.dm
+++ b/code/obj/item/pens_writing_etc.dm
@@ -649,7 +649,7 @@
 		if ((usr.stat || usr.restrained()))
 			return
 		if (usr.contents.Find(src))
-			usr.machine = src
+			src.add_dialog(usr)
 			if (href_list["pen"])
 				if (src.pen)
 					usr.put_in_hand_or_drop(src.pen)
@@ -690,12 +690,7 @@
 
 				src.add_fingerprint(usr)
 
-			if (ismob(src.loc))
-				var/mob/M = src.loc
-				if (M.machine == src)
-					SPAWN_DBG( 0 )
-						src.attack_self(M)
-						return
+			src.updateSelfDialog()
 		return
 
 	attack_hand(mob/user as mob)

--- a/code/obj/item/stickers.dm
+++ b/code/obj/item/stickers.dm
@@ -473,7 +473,7 @@
 	proc/set_internal_camera()
 		if (!ishuman(usr) || !src.camera)
 			return
-		src.add_dialog(usr).camera
+		src.camera.add_dialog(usr)
 		if (!src.HTML)
 			src.generate_html()
 		usr.Browse(src.HTML, "window=sticker_internal_camera;title=Sticker Internal Camera")

--- a/code/obj/item/stickers.dm
+++ b/code/obj/item/stickers.dm
@@ -473,7 +473,7 @@
 	proc/set_internal_camera()
 		if (!ishuman(usr) || !src.camera)
 			return
-		usr.machine = src.camera
+		src.add_dialog(usr).camera
 		if (!src.HTML)
 			src.generate_html()
 		usr.Browse(src.HTML, "window=sticker_internal_camera;title=Sticker Internal Camera")
@@ -484,7 +484,7 @@
 			return
 
 		if ((get_dist(src, usr) <= 1) || (usr.loc == src.loc))
-			usr.machine = src
+			src.add_dialog(usr)
 			switch (href_list["change_setting"])
 				if ("spynetwork")
 					if (src.camera)

--- a/code/obj/item/storage/secure_safe.dm
+++ b/code/obj/item/storage/secure_safe.dm
@@ -95,7 +95,7 @@
 	return ..()
 
 /obj/item/storage/secure/attack_self(mob/user as mob)
-	user.machine = src
+	src.add_dialog(user)
 	add_fingerprint(user)
 	return show_lock_panel(user)
 

--- a/code/obj/item/tank.dm
+++ b/code/obj/item/tank.dm
@@ -66,7 +66,7 @@ Contains:
 				.= 1
 
 	attack_self(mob/user as mob)
-		user.machine = src
+		src.add_dialog(user)
 		if (!(src.air_contents))
 			return
 
@@ -95,7 +95,7 @@ Contains:
 		if (usr.stat|| usr.restrained())
 			return
 		if (src.loc == usr)
-			usr.machine = src
+			src.add_dialog(usr)
 			if (href_list["dist_p"])
 				var/cp = text2num(href_list["dist_p"])
 				src.distribute_pressure += cp
@@ -112,9 +112,7 @@ Contains:
 				return
 
 			src.add_fingerprint(usr)
-			for(var/mob/M in viewers(1, src.loc))
-				if ((M.client && M.machine == src))
-					src.attack_self(M)
+			src.updateSelfDialog()
 		else
 			usr.Browse(null, "window=tank")
 			return

--- a/code/obj/item/teleportation.dm
+++ b/code/obj/item/teleportation.dm
@@ -20,7 +20,7 @@ HAND_TELE
 	m_amt = 400
 
 /obj/item/locator/attack_self(mob/user as mob)
-	user.machine = src
+	src.add_dialog(user)
 	var/dat
 	if (src.temp)
 		dat = "[src.temp]<BR><BR><A href='byond://?src=\ref[src];temp=1'>Clear</A>"
@@ -43,7 +43,7 @@ Frequency:
 	if (usr.stat || usr.restrained())
 		return
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))))
-		usr.machine = src
+		src.add_dialog(usr)
 		if (href_list["refresh"])
 			src.temp = "<B>Persistent Signal Locator</B><HR>"
 			var/turf/sr = get_turf(src)

--- a/code/obj/item/toys.dm
+++ b/code/obj/item/toys.dm
@@ -24,7 +24,7 @@
 	var/list/prizes_ultra_rare = list(/obj/item/toy/plush/small/orca)
 
 /obj/submachine/claw_machine/attack_hand(var/mob/user as mob)
-	user.machine = src
+	src.add_dialog(user)
 	if(src.busy)
 		boutput(user, "<span class='alert'>Someone else is currently playing [src]. Be patient!</span>")
 	else

--- a/code/obj/item/uplinks.dm
+++ b/code/obj/item/uplinks.dm
@@ -194,7 +194,7 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 		if (src.vr_check(user) != 1)
 			user.show_text("This uplink only works in virtual reality.", "red")
 		else if (src.use_default_GUI == 1)
-			user.machine = src
+			src.add_dialog(user)
 			src.generate_menu()
 		return
 
@@ -299,7 +299,7 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 			usr.show_text("This uplink only works in virtual reality.", "red")
 			return
 
-		usr.machine = src
+		src.add_dialog(usr)
 
 		if (href_list["unlock"] && src.locked && !isnull(src.lock_code))
 			var/the_code = adminscrub(input(usr, "Please enter the password.", "Unlock Uplink", null))
@@ -316,7 +316,7 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 			if (istype(src, /obj/item/uplink/integrated/radio))
 				var/obj/item/uplink/integrated/radio/RU = src
 				if (!isnull(RU.origradio) && istype(RU.origradio, /obj/item/device/radio))
-					usr.machine = null
+					src.remove_dialog(usr)
 					usr.Browse(null, "window=radio")
 					var/obj/item/device/radio/T = RU.origradio
 					RU.set_loc(T)
@@ -476,10 +476,7 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 		if (!istype(src.hostpda.host_program, /datum/computer/file/pda_program/os/main_os))
 			return
 		src.hostpda.host_program:note = text
-
-		for (var/mob/M in viewers(1, src.hostpda.loc))
-			if (M.client && M.machine == src.hostpda)
-				src.hostpda.attack_self(M)
+		src.hostpda.updateSelfDialog()
 
 		return
 
@@ -1084,7 +1081,7 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 	if(!user.mind || (user.mind && user.mind.key != src.wizard_key))
 		boutput(user, "<span class='alert'><b>The spellbook is magically attuned to someone else!</b></span>")
 		return
-	user.machine = src
+	src.add_dialog(user)
 	var/html = {"
 [(user.client && !user.client.use_chui) ? "<!doctype html>\n<html><head><meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge,chrome=1\"><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><meta http-equiv=\"pragma\" content=\"no-cache\"><style type='text/css'>body { font-family: Tahoma, sans-serif; font-size: 10pt; }</style><title>Wizard Spellbook</title></head><body>" : ""]
 
@@ -1188,7 +1185,7 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 	if (!( ishuman(H)))
 		return 1
 	if ((usr.contents.Find(src) || (in_range(src,usr) && istype(src.loc, /turf))))
-		usr.machine = src
+		src.add_dialog(usr)
 
 		if (href_list["buyspell"])
 			var/datum/SWFuplinkspell/SP = locate(href_list["buyspell"])
@@ -1208,7 +1205,7 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 
 		else if (href_list["lock"] && src.origradio)
 			// presto chango, a regular radio again! (reset the freq too...)
-			usr.machine = null
+			src.remove_dialog(usr)
 			usr.Browse(null, "window=radio")
 			var/obj/item/device/radio/T = src.origradio
 			var/obj/item/SWF_uplink/R = src

--- a/code/obj/machinery.dm
+++ b/code/obj/machinery.dm
@@ -14,7 +14,7 @@
 	flags = FPRINT | FLUID_SUBMERGE
 
 	var/status = 0
-	var/mob/current_user = null //GC WOES (airlocks seem to capture current_user a lot and prevent mob gc)
+	//var/mob/current_user = null //GC WOES (airlocks seem to capture current_user a lot and prevent mob gc)
 	var/power_usage = 0
 	var/power_channel = EQUIP
 	var/power_credit = 0
@@ -53,7 +53,7 @@
 	if (!isnull(initial(machine_registry_idx)))
 		machine_registry[initial(machine_registry_idx)] -= src
 	UnsubscribeProcess()
-	current_user = null
+
 	var/area/A = get_area(src)
 	if(A) A.machines -= src
 	..()

--- a/code/obj/machinery.dm
+++ b/code/obj/machinery.dm
@@ -14,7 +14,6 @@
 	flags = FPRINT | FLUID_SUBMERGE
 
 	var/status = 0
-	//var/mob/current_user = null //GC WOES (airlocks seem to capture current_user a lot and prevent mob gc)
 	var/power_usage = 0
 	var/power_channel = EQUIP
 	var/power_credit = 0

--- a/code/obj/machinery/air_vendor.dm
+++ b/code/obj/machinery/air_vendor.dm
@@ -106,7 +106,7 @@ obj/machinery/air_vendor
 		src.updateUsrDialog()
 
 	attack_hand(var/mob/user as mob)
-		user.machine = src
+		src.add_dialog(user)
 		var/html = ""
 		html += "<TT><b>Welcome!</b><br>"
 		html += "<b>Current balance: [src.credits] credits</b><br>"
@@ -135,7 +135,7 @@ obj/machinery/air_vendor
 		if (usr.stat || usr.restrained())
 			return
 		if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))))
-			usr.machine = src
+			src.add_dialog(usr)
 			src.add_fingerprint(usr)
 
 			if(href_list["eject"])

--- a/code/obj/machinery/alarm.dm
+++ b/code/obj/machinery/alarm.dm
@@ -166,13 +166,13 @@
 	if(status & (NOPOWER|BROKEN))
 		return
 	user.Browse(return_text(user),"window=atmos")
-	user.machine = src
+	src.add_dialog(user)
 	onclose(user, "atmos")
 
 /obj/machinery/alarm/proc/return_text(mob/user)
 	if ( (get_dist(src, user) > 1 ))
 		if (!issilicon(user))
-			user.machine = null
+			src.remove_dialog(user)
 			user.Browse(null, "window=atmos")
 		return
 

--- a/code/obj/machinery/autolathe.dm
+++ b/code/obj/machinery/autolathe.dm
@@ -112,7 +112,7 @@
 /obj/machinery/autolathe/Topic(href, href_list)
 	if(..() || !(usr in range(1)))
 		return
-	usr.machine = src
+	src.add_dialog(usr)
 	src.add_fingerprint(usr)
 	if(href_list["make"])
 		var/list/makeable = list()

--- a/code/obj/machinery/camera.dm
+++ b/code/obj/machinery/camera.dm
@@ -259,10 +259,10 @@
 				else
 					boutput(OAI, "Your connection to the camera has been lost.")
 		*/
-		if (istype(O.machine, /obj/machinery/computer/security))
-			var/obj/machinery/computer/security/S = O.machine
+		var/obj/machinery/computer/security/S = O.using_dialog_of_type(/obj/machinery/computer/security)
+		if (S)
 			if (S.current == src)
-				O.machine = null
+				S.remove_dialog(O)
 				S.current = null
 				O.set_eye(null)
 				boutput(O, "The screen bursts into static.")
@@ -307,12 +307,13 @@
 				boutput(O, "[user] holds a paper up to one of your cameras ...")
 				O.Browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", X.name, X.info), text("window=[]", X.name))
 				logTheThing("station", user, O, "holds up a paper to a camera at [log_loc(src)], forcing %target% to read it. <b>Title:</b> [X.name]. <b>Text:</b> [adminscrub(X.info)]")
-			else if (istype(O.machine, /obj/machinery/computer/security))
-				var/obj/machinery/computer/security/S = O.machine
-				if (S.current == src)
-					boutput(O, "[user] holds a paper up to one of the cameras ...")
-					O.Browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", X.name, X.info), text("window=[]", X.name))
-					logTheThing("station", user, O, "holds up a paper to a camera at [log_loc(src)], forcing %target% to read it. <b>Title:</b> [X.name]. <b>Text:</b> [adminscrub(X.info)]")
+			else
+				var/obj/machinery/computer/security/S = O.using_dialog_of_type(/obj/machinery/computer/security)
+				if (S)
+					if (S.current == src)
+						boutput(O, "[user] holds a paper up to one of the cameras ...")
+						O.Browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", X.name, X.info), text("window=[]", X.name))
+						logTheThing("station", user, O, "holds up a paper to a camera at [log_loc(src)], forcing %target% to read it. <b>Title:</b> [X.name]. <b>Text:</b> [adminscrub(X.info)]")
 
 //Return a working camera that can see a given mob
 //or null if none

--- a/code/obj/machinery/computer/QM_order.dm
+++ b/code/obj/machinery/computer/QM_order.dm
@@ -40,7 +40,7 @@
 	if (!global.QM_CategoryList)
 		message_coders("ZeWaka/QMCategories: QMcategoryList was not found!")
 
-	user.machine = src
+	src.add_dialog(user)
 	var/dat
 	if (src.temp)
 		dat = src.temp
@@ -94,7 +94,7 @@
 		return
 
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (issilicon(usr)))
-		usr.machine = src
+		src.add_dialog(usr)
 
 	if (href_list["order"])
 		var/datum/data/record/account = null

--- a/code/obj/machinery/computer/QM_supply.dm
+++ b/code/obj/machinery/computer/QM_supply.dm
@@ -166,7 +166,7 @@ var/global/datum/cdc_contact_controller/QM_CDC = new()
 		return
 
 	var/timer = shippingmarket.get_market_timeleft()
-	user.machine = src
+	src.add_dialog(user)
 	post_signal("supply")
 	var/HTML
 
@@ -602,7 +602,7 @@ var/global/datum/cdc_contact_controller/QM_CDC = new()
 		return
 
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (issilicon(usr)))
-		usr.machine = src
+		src.add_dialog(usr)
 
 	var/subaction = (href_list["subaction"] ? href_list["subaction"] : null)
 

--- a/code/obj/machinery/computer/announcement.dm
+++ b/code/obj/machinery/computer/announcement.dm
@@ -36,7 +36,7 @@
 
 	attack_hand(mob/user)
 		if(..()) return
-		user.machine = src
+		src.add_dialog(user)
 		var/dat = {"
 			<body>
 				<h1>Announcement Computer</h1>

--- a/code/obj/machinery/computer/arcade.dm
+++ b/code/obj/machinery/computer/arcade.dm
@@ -81,7 +81,7 @@
 	return
 
 /obj/machinery/computer/arcade/proc/show_ui(var/mob/user)
-	user.machine = src
+	src.add_dialog(user)
 	var/dat = "<a href='byond://?src=\ref[src];close=1'>Close</a>"
 	dat += "<center><h4>[src.enemy_name]</h4></center>"
 
@@ -143,7 +143,7 @@
 			src.arcade_action()
 
 	if (href_list["close"])
-		usr.machine = null
+		src.remove_dialog(usr)
 		usr.Browse(null, "window=arcade")
 
 	else if (href_list["newgame"]) //Reset everything

--- a/code/obj/machinery/computer/atmosphere.dm
+++ b/code/obj/machinery/computer/atmosphere.dm
@@ -82,7 +82,7 @@ Atmos alert computer
 
 
 /obj/machinery/computer/atmosphere/alerts/proc/interacted(mob/user)
-	usr.machine = src
+	src.add_dialog(usr)
 	var/dat = "<HEAD><TITLE>Current Station Alerts</TITLE><META HTTP-EQUIV='Refresh' CONTENT='10'></HEAD><BODY><br>"
 	dat += "<A HREF='?action=mach_close&window=alerts'>Close</A><br><br>"
 	for (var/cat in src.alarms)

--- a/code/obj/machinery/computer/card.dm
+++ b/code/obj/machinery/computer/card.dm
@@ -31,7 +31,7 @@
 	if(..())
 		return
 
-	user.machine = src
+	src.add_dialog(user)
 	var/dat
 	if (!( ticker ))
 		return
@@ -181,7 +181,7 @@
 /obj/machinery/computer/card/Topic(href, href_list)
 	if(..())
 		return
-	usr.machine = src
+	src.add_dialog(usr)
 	if (href_list["modify"])
 		if (src.modify)
 			src.modify.update_name()

--- a/code/obj/machinery/computer/cloning.dm
+++ b/code/obj/machinery/computer/cloning.dm
@@ -168,7 +168,7 @@
 	return attack_hand(user)
 
 /obj/machinery/computer/cloning/attack_hand(mob/user as mob)
-	user.machine = src
+	src.add_dialog(user)
 	add_fingerprint(user)
 
 	if(status & (BROKEN|NOPOWER))

--- a/code/obj/machinery/computer/communications.dm
+++ b/code/obj/machinery/computer/communications.dm
@@ -44,7 +44,7 @@
 /obj/machinery/computer/communications/Topic(href, href_list)
 	if(..())
 		return
-	usr.machine = src
+	src.add_dialog(usr)
 
 	if(!href_list["operation"] || (dd_hasprefix(href_list["operation"], "ai-") && !issilicon(usr) && !isAI(usr)))
 		return
@@ -225,7 +225,7 @@
 	if(..())
 		return
 
-	user.machine = src
+	src.add_dialog(user)
 	var/dat = "<head><title>Communications Console</title></head><body>"
 	if (emergency_shuttle.online && emergency_shuttle.location == SHUTTLE_LOC_CENTCOM)
 		var/timeleft = emergency_shuttle.timeleft()

--- a/code/obj/machinery/computer/door_control.dm
+++ b/code/obj/machinery/computer/door_control.dm
@@ -26,7 +26,7 @@
 	if(..())
 		return
 	var/dat = "<HTML><BODY><TT><B>Brig Computer</B><br><br>"
-	user.machine = src
+	src.add_dialog(user)
 	for(var/obj/machinery/door/window/brigdoor/M in doors)  //DOORS OH MY GOD (was previously looping through WORLD)
 		if(M.id == 1)
 			dat += text("<A href='?src=\ref[src];setid=1'>Door 1: [(M.density ? "Closed" : "Opened")]</A><br>")
@@ -51,7 +51,7 @@
 	if(..())
 		return
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (issilicon(usr)))
-		usr.machine = src
+		src.add_dialog(usr)
 		if (href_list["setid"])
 			if(src.allowed(usr))
 				src.id = text2num(href_list["setid"])

--- a/code/obj/machinery/computer/general_air_control.dm
+++ b/code/obj/machinery/computer/general_air_control.dm
@@ -20,7 +20,7 @@ obj/machinery/computer/general_air_control
 
 	attack_hand(mob/user)
 		user.Browse(return_text(),"window=computer")
-		user.machine = src
+		src.add_dialog(user)
 		onclose(user, "computer")
 
 	process()
@@ -492,7 +492,7 @@ Rate: <A href='?src=\ref[src];change_vol=-10'>--</A> <A href='?src=\ref[src];cha
 
 	attack_hand(mob/user)
 		user.Browse(return_text(),"window=computer")
-		user.machine = src
+		src.add_dialog(user)
 		onclose(user, "computer")
 
 	process()
@@ -570,7 +570,7 @@ Rate: <A href='?src=\ref[src];change_vol=-10'>--</A> <A href='?src=\ref[src];cha
 		if(status & (BROKEN | NOPOWER))
 			return
 		user.Browse(return_text(),"window=computer")
-		user.machine = src
+		src.add_dialog(user)
 		onclose(user, "computer")
 
 	process()

--- a/code/obj/machinery/computer/hologram_comp.dm
+++ b/code/obj/machinery/computer/hologram_comp.dm
@@ -35,7 +35,7 @@
 
 /obj/machinery/computer/hologram_comp/proc/show_console(var/mob/user as mob)
 	var/dat
-	user.machine = src
+	src.add_dialog(user)
 	if (src.temp)
 		dat = text("[]<BR><BR><A href='?src=\ref[];temp=1'>Clear</A>", src.temp, src)
 	else
@@ -93,6 +93,6 @@
 								if (href_list["temp"])
 									src.temp = null
 		for(var/mob/M in viewers(1, src))
-			if ((M.client && M.machine == src))
+			if (M.using_dialog_of(src))
 				src.show_console(M)
 	return

--- a/code/obj/machinery/computer/operating.dm
+++ b/code/obj/machinery/computer/operating.dm
@@ -66,11 +66,11 @@
 /obj/machinery/computer/operating/proc/interacted(mob/user)
 	if ( (get_dist(src, user) > 1 ) || (status & (BROKEN|NOPOWER)) )
 		if (!issilicon(user) && !isAI(user))
-			user.machine = null
+			src.remove_dialog(user)
 			user.Browse(null, "window=op")
 			return
 
-	user.machine = src
+	src.add_dialog(user)
 	var/dat = "<HEAD><TITLE>Operating Computer</TITLE><META HTTP-EQUIV='Refresh' CONTENT='10'></HEAD><BODY><br>"
 	dat += "<A HREF='?action=mach_close&window=op'>Close</A><br><br>" //| <A HREF='?src=\ref[user];update=1'>Update</A>"
 	if(src.table && (src.table.check_victim()))
@@ -103,7 +103,7 @@
 	if(..())
 		return
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (issilicon(usr)))
-		usr.machine = src
+		src.add_dialog(usr)
 //		if (href_list["update"])
 //			src.interacted(usr)
 	return

--- a/code/obj/machinery/computer/pod.dm
+++ b/code/obj/machinery/computer/pod.dm
@@ -133,7 +133,7 @@
 		return
 
 	var/dat = "<HTML><BODY><TT><B>Mass Driver Controls</B>"
-	user.machine = src
+	src.add_dialog(user)
 	var/d2
 	if (src.timing)
 		d2 = text("<A href='?src=\ref[];time=0'>Stop Time Launch</A>", src)
@@ -185,14 +185,14 @@
 	if(..())
 		return
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (issilicon(usr)))
-		usr.machine = src
+		src.add_dialog(usr)
 		if (href_list["spell_teleport"])
 			//src.TPR = 1
 			//SPAWN_DBG(1 MINUTE)
 			//	if(src)
 			//		src.TPR = 0
 			//		src.updateDialog()
-			usr.machine = null
+			src.remove_dialog(usr)
 			usr.Browse(null, "window=computer")
 			usr.teleportscroll(1, 2, src)
 			return

--- a/code/obj/machinery/computer/research_disease.dm
+++ b/code/obj/machinery/computer/research_disease.dm
@@ -26,7 +26,7 @@
 	if(..())
 		return
 
-	user.machine = src
+	src.add_dialog(user)
 
 	var/dat
 	if (src.temp)
@@ -105,7 +105,7 @@ Confirm Identity: <A href='?src=\ref[src];scan=1'>[src.scan ? src.scan.name : "-
 	if (!( data_core.medical.Find(src.active2) ))
 		src.active2 = null
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (issilicon(usr)))
-		usr.machine = src
+		src.add_dialog(usr)
 		if (href_list["temp"])
 			src.temp = null
 		if (href_list["scan"])

--- a/code/obj/machinery/computer/robotics.dm
+++ b/code/obj/machinery/computer/robotics.dm
@@ -70,7 +70,7 @@
 /obj/machinery/computer/robotics/attack_hand(var/mob/user as mob)
 	if(..())
 		return
-	user.machine = src
+	src.add_dialog(user)
 	var/dat = "Located AI Units<BR><BR>"
 	for(var/mob/living/silicon/ai/A in AIs)
 		dat += "[A.name] |"
@@ -135,7 +135,7 @@
 	if(..())
 		return
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (issilicon(usr)))
-		usr.machine = src
+		src.add_dialog(usr)
 
 	var/mob/living/silicon/robot/R = locate(href_list["bot"])
 	var/mob/living/silicon/ai/A = locate(href_list["ai"])

--- a/code/obj/machinery/computer/secure_data.dm
+++ b/code/obj/machinery/computer/secure_data.dm
@@ -114,7 +114,7 @@
 	if (!( data_core.security.Find(src.active2) ))
 		src.active2 = null
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (issilicon(usr) || isAI(usr)))
-		usr.machine = src
+		src.add_dialog(usr)
 		if (href_list["temp"])
 			src.temp = null
 		if (href_list["scan"])

--- a/code/obj/machinery/computer/security.dm
+++ b/code/obj/machinery/computer/security.dm
@@ -23,7 +23,7 @@
 	//This might not be needed. I thought that the proc should be on the computer instead of the mob switching, but maybe not
 	proc/switchCamera(var/mob/living/user, var/obj/machinery/camera/C)
 		if (!C)
-			user.machine = null
+			src.remove_dialog(user)
 			user.set_eye(null)
 			return 0
 
@@ -132,7 +132,7 @@
 		if (!istype(C, /obj/machinery/camera))
 			return
 
-		if ((!isAI(usr)) && (get_dist(usr, src) > 1 || usr.machine != src || !usr.sight_check(1) || !( usr.canmove ) || !( C.camera_status )))
+		if ((!isAI(usr)) && (get_dist(usr, src) > 1 || (!usr.using_dialog_of(src)) || !usr.sight_check(1) || !( usr.canmove ) || !( C.camera_status )))
 			usr.set_eye(null)
 			winshow(usr, "camera_console", 0)
 			return

--- a/code/obj/machinery/computer/shuttle.dm
+++ b/code/obj/machinery/computer/shuttle.dm
@@ -229,13 +229,13 @@
 	if(..())
 		return
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (issilicon(usr)))
-		usr.machine = src
+		src.add_dialog(usr)
 
 		if (href_list["send"])
 			src.send()
 
 		if (href_list["close"])
-			usr.machine = null
+			src.remove_dialog(usr)
 			usr.Browse(null, "window=shuttle")
 
 	src.add_fingerprint(usr)
@@ -298,7 +298,7 @@
 	if(..())
 		return
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (issilicon(usr)))
-		usr.machine = src
+		src.add_dialog(usr)
 
 		if (href_list["send"])
 			if(!active)
@@ -310,7 +310,7 @@
 					call_shuttle()
 
 		else if (href_list["close"])
-			usr.machine = null
+			src.remove_dialog(usr)
 			usr.Browse(null, "window=shuttle")
 
 	src.add_fingerprint(usr)
@@ -390,7 +390,7 @@
 	if(..())
 		return
 	if ((usr.contents.Find(src) || (isturf(src.loc) && in_range(src, usr))) || (issilicon(usr)))
-		usr.machine = src
+		src.add_dialog(usr)
 		if (href_list["send"])
 			for(var/obj/machinery/shuttle/engine/propulsion/eng in machine_registry[MACHINES_SHUTTLEPROPULSION]) // ehh
 				if(eng.stat1 == 0 && eng.stat2 == 0 && eng.id == "zeta")
@@ -412,7 +412,7 @@
 					call_shuttle()
 
 		else if (href_list["close"])
-			usr.machine = null
+			src.remove_dialog(usr)
 			usr.Browse(null, "window=shuttle")
 
 	src.add_fingerprint(usr)
@@ -467,7 +467,7 @@
 	if(..())
 		return
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (issilicon(usr)))
-		usr.machine = src
+		src.add_dialog(usr)
 
 		if (href_list["send"])
 			if(!active)
@@ -478,7 +478,7 @@
 					call_shuttle()
 
 		if (href_list["close"])
-			usr.machine = null
+			src.remove_dialog(usr)
 			usr.Browse(null, "window=ice_elevator")
 
 	src.add_fingerprint(usr)
@@ -531,7 +531,7 @@
 	if(..())
 		return
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (issilicon(usr)))
-		usr.machine = src
+		src.add_dialog(usr)
 
 		if (href_list["send"])
 			if(!active)
@@ -542,7 +542,7 @@
 					call_shuttle()
 
 		if (href_list["close"])
-			usr.machine = null
+			src.remove_dialog(usr)
 			usr.Browse(null, "window=biodome_elevator")
 
 	src.add_fingerprint(usr)

--- a/code/obj/machinery/computer/stock_market.dm
+++ b/code/obj/machinery/computer/stock_market.dm
@@ -20,7 +20,7 @@
 /obj/machinery/computer/stockexchange/attack_hand(var/mob/user)
 	if(..())
 		return
-	user.machine = src
+	src.add_dialog(user)
 
 	var/css={"<style>
 .company {
@@ -252,7 +252,7 @@ a.updated {
 		return 1
 
 	if (usr in range(1, src))
-		usr.machine = src
+		src.add_dialog(usr)
 
 	if (href_list["viewhistory"])
 		var/datum/stock/S = locate(href_list["viewhistory"])

--- a/code/obj/machinery/computer/tetris/tetris.dm
+++ b/code/obj/machinery/computer/tetris/tetris.dm
@@ -89,7 +89,7 @@
 /obj/machinery/computer/tetris/attack_hand(mob/user as mob)
 	if(..())
 		return
-	user.machine = src
+	src.add_dialog(user)
 	var/dat = replacetext(tetriscode, "{{HIGHSCORE}}", num2text(highscore))
 	dat = replacetext(dat, "{{TOPICURL}}", "'?src=\ref[src];highscore='+this.ScoreCur;")
 

--- a/code/obj/machinery/dispenser.dm
+++ b/code/obj/machinery/dispenser.dm
@@ -68,7 +68,7 @@
 /obj/machinery/dispenser/attack_hand(mob/user as mob)
 	if(status & BROKEN)
 		return
-	user.machine = src
+	src.add_dialog(user)
 	var/dat = text("<TT><B>Loaded Tank Dispensing Unit</B><BR><br><FONT color = 'blue'><B>Oxygen</B>: []</FONT> []<BR><br><FONT color = 'orange'><B>Plasma</B>: []</FONT> []<BR><br></TT>", src.o2tanks, (src.o2tanks ? text("<A href='?src=\ref[];oxygen=1'>Dispense</A>", src) : "empty"), src.pltanks, (src.pltanks ? text("<A href='?src=\ref[];plasma=1'>Dispense</A>", src) : "empty"))
 	user.Browse(dat, "window=dispenser")
 	onclose(user, "dispenser")
@@ -84,7 +84,7 @@
 		return
 
 	if ((usr.contents.Find(src) || ((get_dist(src, usr) <= 1) && istype(src.loc, /turf))))
-		usr.machine = src
+		src.add_dialog(usr)
 		if (href_list["oxygen"])
 			if (text2num(href_list["oxygen"]))
 				if (src.o2tanks > 0)
@@ -106,7 +106,7 @@
 					attack_hand(src.loc)
 		src.add_fingerprint(usr)
 		for(var/mob/M in viewers(1, src))
-			if ((M.client && M.machine == src))
+			if (M.using_dialog_of(src))
 				src.attack_hand(M)
 	else
 		usr.Browse(null, "window=dispenser")
@@ -164,7 +164,7 @@
 	attack_hand(mob/user as mob)
 		if(status & BROKEN)
 			return
-		user.machine = src
+		src.add_dialog(user)
 
 		var/dat = "<TT><B>Chemical Dispenser Unit</B><BR><HR><BR>"
 
@@ -240,7 +240,7 @@
 			return
 
 		if ((usr.contents.Find(src) || ((get_dist(src, usr) <= 1) && istype(src.loc, /turf))))
-			usr.machine = src
+			src.add_dialog(usr)
 
 			if (href_list["eject"])
 				if(src.active_vial)

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -970,7 +970,7 @@ About the new airlock wires panel:
 			return
 
 	//Separate interface for the AI.
-	user.machine = src
+	src.add_dialog(user)
 	var/t1 = text("<B>Airlock Control</B><br><br>")
 	t1 += "The access sensor reports the net identifier for this airlock is <i>[net_id]</i><br><br>"
 
@@ -1182,7 +1182,7 @@ About the new airlock wires panel:
 		return
 
 	if (src.p_open)
-		user.machine = src
+		src.add_dialog(user)
 		var/list/t1 = list(text("<B>Access Panel</B><br><br>"))
 		t1 += "An identifier is engraved under the airlock's card sensors: <i>[net_id]</i><br><br>"
 
@@ -1236,15 +1236,14 @@ About the new airlock wires panel:
 		return
 	if (href_list["close"])
 		usr.Browse(null, "window=airlock")
-		if (usr.machine==src)
-			usr.machine = null
-			return
+		src.remove_dialog(usr)
+		return
 	if (!isAIeye(usr))
 		if (!isrobot(usr) && !ishivebot(usr))
 			if (!src.p_open)
 				return
 		if ((in_range(src, usr) && istype(src.loc, /turf)))
-			usr.machine = src
+			src.add_dialog(usr)
 			if (href_list["wires"])
 				var/t1 = text2num(href_list["wires"])
 				if (!usr.find_tool_in_hand(TOOL_SNIPPING))

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -1550,7 +1550,7 @@ About the new airlock wires panel:
 		playsound(src.loc, 'sound/vox/door.ogg', 25, 1)
 	else
 		playsound(src.loc, src.sound_airlock, 25, 1)
-	src.current_user = usr
+
 	if (src.closeOther != null && istype(src.closeOther, /obj/machinery/door/airlock/) && !src.closeOther.density)
 		src.closeOther.close(1)
 

--- a/code/obj/machinery/door/door_timer.dm
+++ b/code/obj/machinery/door/door_timer.dm
@@ -254,7 +254,7 @@
 		return
 
 	var/dat = "<HTML><BODY><TT><B>[src.name] door controls</B>"
-	user.machine = src
+	src.add_dialog(user)
 	var/d2 = "<A href='?src=\ref[src];time=1'>Initiate Time</A><br>"
 	if (src.timing)
 		d2 = "<A href='?src=\ref[src];time=0'>Stop Timed</A><br>"
@@ -276,7 +276,7 @@
 	if (..())
 		return
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (issilicon(usr)))
-		usr.machine = src
+		src.add_dialog(usr)
 		if (href_list["time"])
 			if (src.allowed(usr))
 				if (src.timing == 0)

--- a/code/obj/machinery/door/forcefield_gen.dm
+++ b/code/obj/machinery/door/forcefield_gen.dm
@@ -17,7 +17,8 @@
 			return
 		if (href_list["close"])
 			usr.Browse(null, "window=forcefield")
-			if (usr.machine == src) usr.machine = null
+			if (usr.using_dialog_of(src))
+				src.remove_dialog(usr)
 			src.updateUsrDialog()
 			return
 

--- a/code/obj/machinery/floorflusher.dm
+++ b/code/obj/machinery/floorflusher.dm
@@ -188,7 +188,7 @@
 		if (open != 1)
 			return
 		if(status & BROKEN)
-			user.machine = null
+			src.remove_dialog(user)
 			return
 
 		//fall in hilariously

--- a/code/obj/machinery/glass_recycler.dm
+++ b/code/obj/machinery/glass_recycler.dm
@@ -83,7 +83,7 @@
 		if(..())
 			return
 		if ((usr.contents.Find(src) || ((get_dist(src, usr) <= 1) && istype(src.loc, /turf))) || (isAI(usr)))
-			usr.machine = src
+			src.add_dialog(usr)
 
 			if (href_list["type"])
 				create(lowertext(href_list["type"]))

--- a/code/obj/machinery/hologram.dm
+++ b/code/obj/machinery/hologram.dm
@@ -43,7 +43,7 @@
 
 /obj/machinery/hologram_ai/proc/show_console(var/mob/user as mob)
 	var/dat
-	user.machine = src
+	src.add_dialog(user)
 	if (src.temp)
 		dat = text("[]<BR><BR><A href='?src=\ref[];temp=1'>Clear</A>", src.temp, src)
 	else

--- a/code/obj/machinery/launcherloader.dm
+++ b/code/obj/machinery/launcherloader.dm
@@ -320,7 +320,7 @@
 
 		dat += "<BR><b><A href='?src=\ref[src];add=1'>Add Tag</A></b>"
 
-		user.machine = src
+		src.add_dialog(user)
 		user.Browse(dat, "title=Barcode Computer;window=bc_computer_[src];size=300x400")
 		onclose(user, "bc_computer_[src]")
 		return
@@ -396,7 +396,7 @@
 
 		//dat += "<BR><b><A href='?src=\ref[src];add=1'>Add Tag</A></b>"
 
-		user.machine = src
+		src.add_dialog(user)
 		// Attempting to diagnose an infinite window refresh I can't duplicate, reverting the display style back to plain HTML to see what results that gets me.
 		// Hooray for having a playerbase to test shit on
 		//user.Browse(dat, "title=Barcode Computer;window=bc_computer_[src];size=300x400")

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -225,7 +225,7 @@
 				if (src.manuf_zap(user, 33))
 					return
 
-		user.machine = src
+		src.add_dialog(user)
 		var/list/dat = list("<B>[src.name]</B>")
 
 		if (src.panelopen || isAI(user))
@@ -446,7 +446,7 @@
 					return
 
 		if ((usr.contents.Find(src) || ((get_dist(src, usr) <= 1 || isAI(usr)) && istype(src.loc, /turf))))
-			usr.machine = src
+			src.add_dialog(usr)
 
 			if (src.malfunction && prob(10))
 				src.flip_out()

--- a/code/obj/machinery/microwave.dm
+++ b/code/obj/machinery/microwave.dm
@@ -202,7 +202,7 @@ Please clean it before use!</TT><BR>
 	if(..())
 		return
 
-	usr.machine = src
+	src.add_dialog(usr)
 	src.add_fingerprint(usr)
 
 	if(href_list["cook"])

--- a/code/obj/machinery/navbeacon.dm
+++ b/code/obj/machinery/navbeacon.dm
@@ -217,7 +217,7 @@ Transponder Codes:<UL>"}
 			return
 		if ((in_range(src, usr) && istype(src.loc, /turf)) || (issilicon(usr)))
 			if(open && !locked)
-				usr.machine = src
+				src.add_dialog(usr)
 
 				if (href_list["freq"])
 					freq = sanitize_frequency(freq + text2num(href_list["freq"]))

--- a/code/obj/machinery/pipe/filter_control.dm
+++ b/code/obj/machinery/pipe/filter_control.dm
@@ -56,7 +56,7 @@
 
 	var/list/gases = list("O2", "N2", "Plasma", "CO2", "N2O")
 	var/dat
-	user.machine = src
+	src.add_dialog(user)
 
 	var/IGoodConnection = 0
 	var/IBadConnection = 0
@@ -90,7 +90,7 @@
 	if(..())
 		return
 	if ((((get_dist(src, usr) <= 1 || usr.telekinesis == 1) || isAI(usr)) && isturf(src.loc)))
-		usr.machine = src
+		src.add_dialog(usr)
 		if (src.allowed(usr) || src.emagged && !(status & BROKEN))
 			if (href_list["tg"])	//someone modified the html so I added a check here
 				// toggle gas

--- a/code/obj/machinery/pipe/pipe_dispenser.dm
+++ b/code/obj/machinery/pipe/pipe_dispenser.dm
@@ -31,7 +31,7 @@
 /obj/machinery/pipedispenser/Topic(href, href_list)
 	if(..())
 		return
-	usr.machine = src
+	src.add_dialog(usr)
 	src.add_fingerprint(usr)
 	if(href_list["make"])
 		var/p_type = text2num(href_list["make"])
@@ -78,7 +78,7 @@
 /obj/machinery/disposal_pipedispenser/Topic(href, href_list)
 	if(..())
 		return
-	usr.machine = src
+	src.add_dialog(usr)
 	src.add_fingerprint(usr)
 	if(href_list["dmake"])
 		var/p_type = text2num(href_list["dmake"])
@@ -98,7 +98,7 @@
 		C.update()
 
 		usr.Browse(null, "window=pipedispenser")
-		usr.machine = null
+		src.remove_dialog(usr)
 	return
 
 /obj/machinery/disposal_pipedispenser/mobile
@@ -126,7 +126,7 @@
 					for(var/obj/disposalpipe/pipe in old_loc)
 						qdel(pipe)
 			prev_dir = direction // might want to actually do this even when old_loc == loc but idk, it sucks with attempted diagonal movement
-	
+
 	proc/connect_pipe(var/turf/new_loc, var/new_dir)
 		var/free_dirs = 1 | 2 | 4 | 8
 		var/obj/disposalpipe/pipe = null
@@ -157,14 +157,14 @@
 
 		if(new_loc.intact && !istype(new_loc,/turf/space))
 			return
-		
+
 		var/obj/disposalpipe/junction/junction = locate(/obj/disposalpipe/junction) in new_loc
 		if(junction)
 			if(new_dir & junction.dpdir)
 				junction.dir = new_dir
 				junction.fix_sprite()
 				return
-		
+
 		var/free_dirs = 1 | 2 | 4 | 8
 		var/obj/disposalpipe/new_pipe = null
 		var/obj/disposalpipe/backup_pipe = null
@@ -201,12 +201,12 @@
 			new_pipe = new/obj/disposalpipe/segment(new_loc)
 			new_pipe.dir = new_dir
 			new_pipe.dpdir = new_pipe_dirs
-		
+
 		if(new_dir & free_dirs)
 			pipe_reconnect_disconnected(new_pipe, new_dir, 1)
 
 	Topic(href, href_list)
-		usr.machine = src
+		src.add_dialog(usr)
 		src.add_fingerprint(usr)
 		if(href_list["toggle_laying"])
 			src.removing_pipe = 0
@@ -259,7 +259,7 @@
 			C.update()
 
 			usr << browse(null, "window=pipedispenser")
-			usr.machine = null
+			src.remove_dialog(usr)
 		return
 
 /obj/machinery/disposal_pipedispenser/mobile/attack_hand(user as mob)

--- a/code/obj/machinery/pipe/pipe_filter.dm
+++ b/code/obj/machinery/pipe/pipe_filter.dm
@@ -173,7 +173,7 @@
 		return
 
 	var/list/gases = list("O2", "N2", "Plasma", "CO2", "N2O")
-	user.machine = src
+	src.add_dialog(user)
 	var/dat = "Filter Release Rate:<BR><br><A href='?src=\ref[src];fp=-[num2text(src.maxrate, 9)]'>M</A> <A href='?src=\ref[src];fp=-100000'>-</A> <A href='?src=\ref[src];fp=-10000'>-</A> <A href='?src=\ref[src];fp=-1000'>-</A> <A href='?src=\ref[src];fp=-100'>-</A> <A href='?src=\ref[src];fp=-1'>-</A> [src.f_per] <A href='?src=\ref[src];fp=1'>+</A> <A href='?src=\ref[src];fp=100'>+</A> <A href='?src=\ref[src];fp=1000'>+</A> <A href='?src=\ref[src];fp=10000'>+</A> <A href='?src=\ref[src];fp=100000'>+</A> <A href='?src=\ref[src];fp=[num2text(src.maxrate, 9)]'>M</A><BR><br>"
 	for (var/i = 1; i <= gases.len; i++)
 		dat += "[gases[i]]: <A HREF='?src=\ref[src];tg=[1 << (i - 1)]'>[(src.f_mask & 1 << (i - 1)) ? "Releasing" : "Passing"]</A><BR><br>"
@@ -199,7 +199,7 @@
 	if(usr.restrained() || usr.lying)
 		return
 	if ((((get_dist(src, usr) <= 1 || usr.telekinesis == 1) || isAI(usr)) && istype(src.loc, /turf)))
-		usr.machine = src
+		src.add_dialog(usr)
 		if (href_list["close"])
 			usr << browse(null, "window=pipefilter;")
 			usr.machine = null

--- a/code/obj/machinery/recharge_station.dm
+++ b/code/obj/machinery/recharge_station.dm
@@ -80,7 +80,7 @@
 			user.show_text("You must attach [src]'s floor bolts before the machine will work.", "red")
 			return
 
-		user.machine = src
+		src.add_dialog(user)
 
 		var/dat = "<B>[src.name]</B> <A href='?src=\ref[src];refresh=1'>(Refresh)</A><BR><HR>"
 
@@ -260,7 +260,7 @@
 			return
 
 		if ((usr.contents.Find(src) || src.contents.Find(usr) || ((get_dist(src, usr) <= 1) && istype(src.loc, /turf))))
-			usr.machine = src
+			src.add_dialog(usr)
 
 			if (href_list["refresh"])
 				src.updateUsrDialog()

--- a/code/obj/machinery/robot_fabricator.dm
+++ b/code/obj/machinery/robot_fabricator.dm
@@ -76,7 +76,7 @@ Please wait until completion...</TT><BR>
 	if (..())
 		return
 
-	usr.machine = src
+	src.add_dialog(usr)
 	src.add_fingerprint(usr)
 
 	if (href_list["make"])

--- a/code/obj/machinery/science_teleporter.dm
+++ b/code/obj/machinery/science_teleporter.dm
@@ -104,7 +104,7 @@ var/ZSUBTRACT = 0
 			for (var/datum/teleporter_bookmark/b in bookmarks)
 				dat += "<br>[b.name] ([b.x]/[b.y]/[b.z]) <A href='?src=\ref[src];restorebookmark=\ref[b]'>Restore</A> <A href='?src=\ref[src];deletebookmark=\ref[b]'>Delete</A>"
 
-		user.machine = src
+		src.add_dialog(user)
 		user.Browse("<TITLE>Teleport Computer</TITLE><b>Target Coordinates</b><BR>[dat]", "window=t_computer;size=400x600")
 		onclose(user, "t_computer")
 		return

--- a/code/obj/machinery/sec_lock.dm
+++ b/code/obj/machinery/sec_lock.dm
@@ -38,7 +38,7 @@
 		boutput(usr, "<span class='alert'>Error: Cannot interface with door security!</span>")
 		return
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf)) || (issilicon(usr))))
-		usr.machine = src
+		src.add_dialog(usr)
 		if (href_list["card"])
 			if (src.scan)
 				src.scan.set_loc(src.loc)

--- a/code/obj/machinery/shield_generators/shield_generator.dm
+++ b/code/obj/machinery/shield_generators/shield_generator.dm
@@ -398,15 +398,15 @@
 
 					if ("sgen_actvd")
 						src.print_text("<b>Alert:</b> Shield generator activated.")
-						if (master && master.current_user)
-							message_admins("<span class='notice'>[key_name(master.current_user)] activated shields</span>")
-							logTheThing("station", null, null, "[key_name(master.current_user)] activated shields")
+						if (usr)
+							message_admins("<span class='notice'>[key_name(usr)] activated shields</span>")
+							logTheThing("station", null, null, "[key_name(usr)] activated shields")
 
 					if ("sgen_dactvd")
 						src.print_text("<b>Alert:</b> Shield generator deactivated.")
-						if (master && master.current_user)
-							message_admins("<span class='notice'>[key_name(master.current_user)] deactivated shields</span>")
-							logTheThing("station", null, null, "[key_name(master.current_user)] deactivated shields")
+						if (usr)
+							message_admins("<span class='notice'>[key_name(usr)] deactivated shields</span>")
+							logTheThing("station", null, null, "[key_name(usr)] deactivated shields")
 				return
 		return
 

--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -1517,7 +1517,7 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 	if (usr.stat || usr.restrained() || usr.lying)
 		return
 	if ((in_range(src, usr) && istype(src.loc, /turf)))
-		usr.machine = src
+		src.add_dialog(usr)
 		switch(href_list["action"]) //Yeah, this is weirdly set up. Planning to expand it later.
 			if("trigger")
 				switch(href_list["spec"])
@@ -1595,7 +1595,7 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 	if (user.stat || user.restrained() || user.lying)
 		return
 	if ((get_dist(src, user) <= 1 && istype(src.loc, /turf)))
-		user.machine = src
+		src.add_dialog(user)
 		/*
 		var/dat = text("<TT><B>Timing Unit</B><br>[] []:[]<br><A href='?src=\ref[];tp=-30'>-</A> <A href='?src=\ref[];tp=-1'>-</A> <A href='?src=\ref[];tp=1'>+</A> <A href='?src=\ref[];tp=30'>+</A><br></TT>", (src.timing ? text("<A href='?src=\ref[];time=0'>Timing</A>", src) : text("<A href='?src=\ref[];time=1'>Not Timing</A>", src)), minute, second, src, src, src, src)
 		dat += "<BR><BR><A href='?src=\ref[src];close=1'>Close</A>"
@@ -1604,7 +1604,7 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 		onclose(user, "timer")
 	else
 		user.Browse(null, "window=timer")
-		user.machine = null
+		src.remove_dialog(user)
 
 	src.add_fingerprint(user)
 	return
@@ -1659,7 +1659,7 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 			attack_hand(src.loc)
 		else
 			for(var/mob/M in viewers(1, src))
-				if (M.client && (M.machine == src))
+				if (M.using_dialog_of(src))
 					src.attack_hand(M)
 
 	return

--- a/code/obj/machinery/sleeper.dm
+++ b/code/obj/machinery/sleeper.dm
@@ -141,7 +141,7 @@
 				return 1
 
 		src.add_fingerprint(user)
-		user.machine = src
+		src.add_dialog(user)
 
 		var/dat = ""
 
@@ -216,7 +216,7 @@
 			return
 
 		src.add_fingerprint(usr)
-		usr.machine = src
+		src.add_dialog(usr)
 
 		if (href_list["time"])
 			if (src.our_sleeper && src.our_sleeper.occupant)
@@ -260,7 +260,7 @@
 		if (href_list["eject_occupant"])
 			if (src.our_sleeper && src.our_sleeper.occupant)
 				src.our_sleeper.go_out()
-				usr.machine = null
+				src.remove_dialog(usr)
 				usr.Browse(null, "window=sleeper")
 
 		if (istype(src, /obj/machinery/sleep_console/portable))

--- a/code/obj/machinery/spaceheater.dm
+++ b/code/obj/machinery/spaceheater.dm
@@ -97,9 +97,9 @@
 			open = !open
 			user.visible_message("<span class='notice'>[user] [open ? "opens" : "closes"] the hatch on the [src].</span>", "<span class='notice'>You [open ? "open" : "close"] the hatch on the [src].</span>")
 			update_icon()
-			if(!open && user.machine == src)
+			if(!open && user.using_dialog_of(src))
 				user.Browse(null, "window=spaceheater")
-				user.machine = null
+				src.remove_dialog(user)
 		else if (istype(I, /obj/item/wrench))
 			if (user)
 				user.show_text("You [anchored ? "release" : "anchor"] the [src]", "blue")
@@ -129,7 +129,7 @@
 			dat += " <A href='?src=\ref[src];op=set_temp'> [set_temperature]&deg;C </A>"
 			dat += "<A href='?src=\ref[src];op=temp;val=5'>+</A> <A href='?src=\ref[src];op=temp;val=10'>++</A><BR>"
 
-			user.machine = src
+			src.add_dialog(user)
 			user.Browse("<HEAD><TITLE>Space Heater Control Panel</TITLE></HEAD><TT>[dat]</TT>", "window=spaceheater")
 			onclose(user, "spaceheater")
 
@@ -157,7 +157,7 @@
 		if (usr.stat)
 			return
 		if ((in_range(src, usr) && istype(src.loc, /turf)) || (issilicon(usr)))
-			usr.machine = src
+			src.add_dialog(usr)
 
 			switch(href_list["op"])
 				if("set_temp")
@@ -199,7 +199,7 @@
 			updateDialog()
 		else
 			usr.Browse(null, "window=spaceheater")
-			usr.machine = null
+			src.remove_dialog(usr)
 		return
 
 
@@ -322,9 +322,9 @@
 			open = !open
 			user.visible_message("<span class='notice'>[user] [open ? "opens" : "closes"] the hatch on the [src].</span>", "<span class='notice'>You [open ? "open" : "close"] the hatch on the [src].</span>")
 			update_icon()
-			if(!open && user.machine == src)
+			if(!open && user.using_dialog_of(src))
 				user.Browse(null, "window=saunastove")
-				user.machine = null
+				src.remove_dialog(user)
 		else
 			..()
 		return
@@ -349,7 +349,7 @@
 			dat += " [set_temperature]&deg;C "
 			dat += "<A href='?src=\ref[src];op=temp;val=5'>+</A> <A href='?src=\ref[src];op=temp;val=10'>++</A><BR>"
 
-			user.machine = src
+			src.add_dialog(user)
 			user.Browse("<HEAD><TITLE>Sauna Stove Control Panel</TITLE></HEAD><TT>[dat]</TT>", "window=saunastove")
 			onclose(user, "spaceheater")
 
@@ -372,7 +372,7 @@
 		if (usr.stat)
 			return
 		if ((in_range(src, usr) && istype(src.loc, /turf)) || (issilicon(usr)))
-			usr.machine = src
+			src.add_dialog(usr)
 
 			switch(href_list["op"])
 
@@ -405,7 +405,7 @@
 			updateDialog()
 		else
 			usr.Browse(null, "window=saunastove")
-			usr.machine = null
+			src.remove_dialog(usr)
 		return
 
 

--- a/code/obj/machinery/turret.dm
+++ b/code/obj/machinery/turret.dm
@@ -356,11 +356,11 @@
 			locked = !locked
 			boutput(user, "You [ locked ? "lock" : "unlock"] the panel.")
 			if (locked)
-				if (user.machine==src)
-					user.machine = null
+				if (user.using_dialog_of(src))
+					src.remove_dialog(user)
 					user.Browse(null, "window=turretid")
 			else
-				if (user.machine==src)
+				if (user.using_dialog_of(src))
 					src.attack_hand(usr)
 		else
 			boutput(user, "<span class='alert'>Access denied.</span>")
@@ -375,11 +375,11 @@
 	if ( (get_dist(src, user) > 1 ))
 		if (!issilicon(user) && !isAI(user) && !isAIeye(user))
 			boutput(user, text("Too far away."))
-			user.machine = null
+			src.remove_dialog(user)
 			user.Browse(null, "window=turretid")
 			return
 
-	user.machine = src
+	src.add_dialog(user)
 	var/loc = src.loc
 	if (istype(loc, /turf))
 		loc = loc:loc

--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -628,7 +628,7 @@
 		return
 
 	proc/generate_interface(var/mob/user as mob)
-		user.machine = src
+		src.add_dialog(user)
 
 		var/dat = "<BR><B>Magnet Status:</B><BR>"
 		dat += "<u>Condition:</u> "
@@ -710,7 +710,7 @@
 		if (!rangecheck)
 			boutput(usr, "<span class='alert'>You aren't in range of the controls.</span>")
 			return
-		usr.machine = src
+		src.add_dialog(usr)
 
 		if (!istype(src))
 			boutput(usr, "Error. Magnet not detected.")
@@ -840,7 +840,7 @@
 		if (istype(linked_magnet))
 			linked_magnet.generate_interface(user)
 		else
-			user.machine = src
+			src.add_dialog(user)
 			var/dat = "<B>Mineral Mining Magnet Terminal</B><HR>"
 			dat += "<A href='?src=\ref[src];scan_for_connection=1'>Scan for Magnets</A><BR><BR>"
 			dat += "<B>Choose linked magnet:</B><BR>"
@@ -864,7 +864,7 @@
 			return
 
 		if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (issilicon(usr)))
-			usr.machine = src
+			src.add_dialog(usr)
 
 		src.add_fingerprint(usr)
 

--- a/code/obj/noticeboard.dm
+++ b/code/obj/noticeboard.dm
@@ -40,7 +40,7 @@
 
 	..()
 
-	usr.machine = src
+	src.add_dialog(usr)
 	if (href_list["remove"])
 		var/obj/item/P = locate(href_list["remove"])
 		if ((P && P.loc == src))

--- a/code/obj/objDialog.dm
+++ b/code/obj/objDialog.dm
@@ -8,13 +8,13 @@ var/global/list/objects_using_dialogs
 	if (!objects_using_dialogs)
 		objects_using_dialogs = list(src)
 	else
-		if (!src in objects_using_dialogs)
+		if (!clients_operating || clients_operating.len <= 0)
 			objects_using_dialogs += src
 
 	if (!clients_operating)
 		clients_operating = list(user.client)
 	else
-		if (!user.client in clients_operating)
+		if (!(user.client in clients_operating))
 			clients_operating += user.client
 
 /obj/proc/remove_dialog(mob/user)
@@ -42,7 +42,7 @@ var/global/list/objects_using_dialogs
 			O.remove_dialog(src)
 
 /mob/proc/using_dialog_of(var/obj/O)
-	.= (src.client && src.client in O.clients_operating)
+	.= (src.client && (src.client in O.clients_operating))
 
 /mob/proc/using_dialog_of_type(var/type)
 	.= 0
@@ -51,45 +51,54 @@ var/global/list/objects_using_dialogs
 			.= O
 
 /obj/proc/updateUsrDialog()
-	for(var/client/C in clients_operating)
-		if (C.mob)
-			if (get_dist(C.mob,src) <= 1)
-				src.attack_hand(C.mob)
-			else
-				if (issilicon(C.mob))
-					src.attack_ai(usr)
-				else if (isAIeye(C.mob))
-					var/mob/dead/aieye/E = C.mob
-					src.attack_ai(E)
+	if (clients_operating?.len)
+		for(var/client/C in clients_operating)
+			if (C.mob)
+				if (get_dist(C.mob,src) <= 1)
+					src.attack_hand(C.mob)
+				else
+					if (issilicon(C.mob))
+						src.attack_ai(usr)
+					else if (isAIeye(C.mob))
+						var/mob/dead/aieye/E = C.mob
+						src.attack_ai(E)
+					else
+						src.remove_dialog(C.mob)
 
 /obj/proc/updateDialog()
-	for(var/client/C in clients_operating)
-		if (C.mob && get_dist(C.mob,src) <= 1)
-			src.attack_hand(C.mob)
-	AutoUpdateAI(src)
+	if (clients_operating?.len)
+		for(var/client/C in clients_operating)
+			if (C.mob)
+				if (get_dist(C.mob,src) <= 1)
+					src.attack_hand(C.mob)
+				else
+					src.remove_dialog(C.mob)
+
+		AutoUpdateAI(src)
 
 /obj/item/proc/updateSelfDialogFromTurf()	//It's weird, yes. only used for spy stickers as of now
+	if (clients_operating?.len)
+		for(var/client/C in clients_operating)
+			if (C.mob && get_dist(C.mob,src) <= 1)
+				src.attack_self(C.mob)
 
-	for(var/client/C in clients_operating)
-		if (C.mob && get_dist(C.mob,src) <= 1)
-			src.attack_self(C.mob)
-
-	for(var/mob/living/silicon/ai/M in AIs)
-		var/mob/AI = M
-		if (M.deployed_to_eyecam)
-			AI = M.eyecam
-		if ((AI.client && AI.client in clients_operating))
-			src.attack_self(AI)
+		for(var/mob/living/silicon/ai/M in AIs)
+			var/mob/AI = M
+			if (M.deployed_to_eyecam)
+				AI = M.eyecam
+			if (AI.client && (AI.client in clients_operating))
+				src.attack_self(AI)
 
 /obj/item/proc/updateSelfDialog()
-	var/mob/M = src.loc
-	if(istype(M))
-		if (isAI(M)) //Eyecam handling
-			var/mob/living/silicon/ai/AI = M
-			if (AI.deployed_to_eyecam)
-				M = AI.eyecam
-		if(M.client && M.client in clients_operating)
-			src.attack_self(M)
+	if (clients_operating?.len)
+		var/mob/M = src.loc
+		if(istype(M))
+			if (isAI(M)) //Eyecam handling
+				var/mob/living/silicon/ai/AI = M
+				if (AI.deployed_to_eyecam)
+					M = AI.eyecam
+			if(M.client && (M.client in clients_operating))
+				src.attack_self(M)
 
 
 /proc/AutoUpdateAI(obj/subject)
@@ -133,15 +142,22 @@ var/global/list/objects_using_dialogs
 
 
 /obj/machinery/power/apc/updateUsrDialog()
-	for(var/client/C in clients_operating)
-		if (C.mob)
-			if (get_dist(C.mob,src) <= 1)
-				src.interacted(C.mob)
-			else if (issilicon(C.mob) || isAI(C.mob))
-				src.interacted(C.mob)
+	if (clients_operating?.len)
+		for(var/client/C in clients_operating)
+			if (C.mob)
+				if (get_dist(C.mob,src) <= 1)
+					src.interacted(C.mob)
+				else if (issilicon(C.mob) || isAI(C.mob))
+					src.interacted(C.mob)
+				else
+					src.remove_dialog(C.mob)
 
 /obj/machinery/power/apc/updateDialog()
-	for(var/client/C in clients_operating)
-		if (C.mob && get_dist(C.mob,src) <= 1)
-			src.interacted(C.mob)
-	AutoUpdateAI(src)
+	if (clients_operating?.len)
+		for(var/client/C in clients_operating)
+			if (C.mob)
+				if (get_dist(C.mob,src) <= 1)
+					src.interacted(C.mob)
+				else
+					src.remove_dialog(C.mob)
+		AutoUpdateAI(src)

--- a/code/obj/objDialog.dm
+++ b/code/obj/objDialog.dm
@@ -1,3 +1,6 @@
+//hey, so later on you can convert most of the procs within this file to be #defines (or wait until lummox adds proc inlining)
+//keeping them procs for now so we can profile etc
+
 
 var/global/list/objects_using_dialogs
 /obj/var/list/clients_operating

--- a/code/obj/objDialog.dm
+++ b/code/obj/objDialog.dm
@@ -164,3 +164,16 @@ var/global/list/objects_using_dialogs
 				else
 					src.remove_dialog(C.mob)
 		AutoUpdateAI(src)
+
+
+
+/obj/npc/trader/updateUsrDialog()
+	if (clients_operating?.len)
+		for(var/client/C in clients_operating)
+			if (C.mob)
+				if (get_dist(C.mob,src) <= 1)
+					src.openTrade(C.mob)
+				else if (issilicon(C.mob) || isAI(C.mob))
+					src.openTrade(C.mob)
+				else
+					src.remove_dialog(C.mob)

--- a/code/obj/objDialog.dm
+++ b/code/obj/objDialog.dm
@@ -1,0 +1,118 @@
+
+var/global/list/objects_using_dialogs
+/obj/var/list/clients_operating
+
+/obj/proc/add_dialog(mob/user)
+	if (!user.client) return
+
+	if (!objects_using_dialogs)
+		objects_using_dialogs = list(src)
+	else
+		objects_using_dialogs += src
+
+	if (!clients_operating)
+		clients_operating = list(user.client)
+	else
+		clients_operating += user.client
+
+/obj/proc/remove_dialog(mob/user)
+	if (!user.client) return
+
+	if (!objects_using_dialogs)
+		objects_using_dialogs = list()
+	else
+		objects_using_dialogs -= src
+
+	if (!clients_operating)
+		clients_operating = list()
+	else
+		clients_operating -= user.client
+
+/mob/proc/remove_dialogs() //try to avoid using this, it wipes stuff that you might want
+	for (var/obj/O in objects_using_dialogs)
+		if (src.using_dialog_of(O))
+			O.remove_dialog(src)
+
+/mob/proc/using_dialog_of(var/obj/O)
+	.= src.client && src.client in O.clients_operating
+
+/mob/proc/using_dialog_of_type(var/type)
+	.= 0
+	for (var/obj/O in objects_using_dialogs)
+		if (src.using_dialog_of(O) && istype(O,type))
+			.= O
+
+/obj/proc/updateUsrDialog()
+	for(var/client/C in clients_operating)
+		if (C.mob)
+			if (get_dist(C.mob,src) <= 1)
+				src.attack_hand(C.mob)
+			else
+				if (issilicon(C.mob))
+					src.attack_ai(usr)
+				else if (isAIeye(C.mob))
+					var/mob/dead/aieye/E = C.mob
+					src.attack_ai(E)
+
+/obj/proc/updateDialog()
+	for(var/client/C in clients_operating)
+		if (C.mob && get_dist(C.mob,src) <= 1)
+			src.attack_hand(C.mob)
+	AutoUpdateAI(src)
+
+/obj/item/proc/updateSelfDialogFromTurf()	//It's weird, yes. only used for spy stickers as of now
+
+	for(var/client/C in clients_operating)
+		if (C.mob && get_dist(C.mob,src) <= 1)
+			src.attack_self(C.mob)
+
+	for(var/mob/living/silicon/ai/M in AIs)
+		var/mob/AI = M
+		if (M.deployed_to_eyecam)
+			AI = M.eyecam
+		if ((AI.client && AI.client in clients_operating))
+			src.attack_self(AI)
+
+/obj/item/proc/updateSelfDialog()
+	var/mob/M = src.loc
+	if(istype(M))
+		if (isAI(M)) //Eyecam handling
+			var/mob/living/silicon/ai/AI = M
+			if (AI.deployed_to_eyecam)
+				M = AI.eyecam
+		if(M.client && M.client in clients_operating)
+			src.attack_self(M)
+
+
+/proc/AutoUpdateAI(obj/subject)
+	if (!subject)
+		return
+	for(var/mob/living/silicon/ai/M in AIs)
+		var/mob/AI = M
+		if (M.deployed_to_eyecam)
+			AI = M.eyecam
+
+		if (AI && AI.using_dialog_of(subject))
+			subject.attack_ai(AI)
+
+
+
+
+
+/obj/machinery/power/apc/updateUsrDialog()
+	var/list/nearby = viewers(1, src)
+	if (!(status & BROKEN)) // unbroken
+		for(var/mob/M in nearby)
+			if (usr.using_dialog_of(src))
+				src.interacted(M)
+	if (issilicon(usr) || isAI(usr))
+		if (!(usr in nearby))
+			if (usr.client && usr.machine==src) // && M.machine == src is omitted because if we triggered this by using the dialog, it doesn't matter if our machine changed in between triggering it and this - the dialog is probably still supposed to refresh.
+				src.interacted(usr)
+
+/obj/machinery/power/apc/updateDialog()
+	if(!(status & BROKEN)) // unbroken
+		for(var/client/C)
+			if (C.mob?.machine == src && get_dist(C.mob,src) <= 1)
+				src.interacted(C.mob)
+	AutoUpdateAI(src)

--- a/code/obj/posters.dm
+++ b/code/obj/posters.dm
@@ -407,7 +407,7 @@ var/global/icon/wanted_poster_unknown = icon('icons/obj/decals/posters.dmi', "wa
 	attack_hand(mob/user as mob)
 		src.add_fingerprint(user)
 		if (user.client)
-			user.machine = src
+			src.add_dialog(user)
 			show_window(user.client)
 			onclose(user, "wp_station")
 

--- a/code/obj/radiotelescope.dm
+++ b/code/obj/radiotelescope.dm
@@ -226,7 +226,7 @@ var/list/telescope_computers = list()
 					</html>
 					"}
 
-		user.machine = src
+		src.add_dialog(user)
 		add_fingerprint(user)
 		user << browse(html, "window=telescope;size=800x435;can_resize=0;can_minimize=0;can_close=1")
 		onclose(user, "telescope", src)

--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -1291,7 +1291,7 @@
 	// Seems to be the only way to get this stuff to auto-refresh properly, sigh (Convair880).
 	proc/control_interface(mob/user as mob)
 		if (!user.hasStatus("handcuffed") && isalive(user))
-			user.machine = src
+			src.add_dialog(user)
 
 			var/dat = ""
 

--- a/code/obj/submachine/cooking.dm
+++ b/code/obj/submachine/cooking.dm
@@ -85,7 +85,7 @@
 	var/doing_a_thing = 0
 
 	attack_hand(var/mob/user as mob)
-		user.machine = src
+		src.add_dialog(user)
 		var/dat = "<b>Ice Cream-O-Mat 9900</b><br>"
 		if(src.cone)
 			dat += "<a href='?src=\ref[src];eject=cone'>Eject Cone</a><br>"
@@ -117,7 +117,7 @@
 				return
 
 			src.add_fingerprint(usr)
-			usr.machine = src
+			src.add_dialog(usr)
 
 			if(href_list["eject"])
 				switch(href_list["eject"])
@@ -253,7 +253,7 @@ var/list/oven_recipes = list()
 			return
 
 
-		user.machine = src
+		src.add_dialog(user)
 		var/dat = {"
 			<style type="text/css">
 table#cooktime {
@@ -1040,7 +1040,7 @@ var/list/mixer_recipes = list()
 
 	attack_hand(var/mob/user as mob)
 		if (!src.working)
-			user.machine = src
+			src.add_dialog(user)
 			var/dat = {"<B>KitchenHelper Mixer</B><BR>
 			<HR>
 			<B>Contents:</B><BR>"}
@@ -1052,7 +1052,7 @@ var/list/mixer_recipes = list()
 			user.Browse(dat, "window=mixer;size=400x500")
 			onclose(user, "mixer")
 		else
-			user.machine = src
+			src.add_dialog(user)
 			var/dat = {"<B>KitchenHelper Mixer</B><BR>
 			<HR><BR>
 			Mixing! Please wait!"}

--- a/code/obj/submachine/robotics.dm
+++ b/code/obj/submachine/robotics.dm
@@ -16,7 +16,7 @@
 		return src.attack_hand(user)
 
 	attack_hand(var/mob/user as mob)
-		user.machine = src
+		src.add_dialog(user)
 		if (!src.working)
 			var/dat = {"<B>Module Rewriter</B><BR>
 			<HR><BR>

--- a/code/obj/submachine/seed.dm
+++ b/code/obj/submachine/seed.dm
@@ -32,7 +32,7 @@
 		return attack_hand(user)
 
 	attack_hand(var/mob/user as mob)
-		user.machine = src
+		src.add_dialog(user)
 
 		//var/header_thing_chui_toggle = (user.client && !user.client.use_chui) ? "<html><head><meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge,chrome=1\"><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><meta http-equiv=\"pragma\" content=\"no-cache\"><style type='text/css'>body { font-family: Tahoma, sans-serif; font-size: 10pt; }</style></head><body>" : ""
 		var/dat = list()
@@ -752,7 +752,7 @@
 		return attack_hand(user)
 
 	attack_hand(var/mob/user as mob)
-		user.machine = src
+		src.add_dialog(user)
 
 		var/list/dat = list("<B>Reagent Extractor</B><BR><HR>")
 		if (src.mode == "overview")
@@ -1123,7 +1123,7 @@
 		return src.attack_hand(user)
 
 	attack_hand(var/mob/user as mob)
-		user.machine = src
+		src.add_dialog(user)
 		var/dat = "<B>[src.name]</B><BR><HR>"
 		dat += "<b>Amount to Vend</b>: <A href='?src=\ref[src];amount=1'>[src.vendamt]</A><br>"
 		if (src.category)

--- a/code/obj/submachine/slots.dm
+++ b/code/obj/submachine/slots.dm
@@ -37,7 +37,7 @@
 		return
 
 	attack_hand(var/mob/user as mob)
-		user.machine = src
+		src.add_dialog(user)
 		if (!src.scan)
 			var/dat = {"<B>Slot Machine</B><BR>
 			<HR><BR>
@@ -196,7 +196,7 @@
 		return
 
 	attack_hand(var/mob/user as mob)
-		user.machine = src
+		src.add_dialog(user)
 		if (!src.scan)
 			var/dat = {"<B>Slot Machine</B><BR>
 			<HR><BR>
@@ -329,7 +329,7 @@
 		..()
 
 	attack_hand(var/mob/user as mob)
-		user.machine = src
+		src.add_dialog(user)
 		if (src.working)
 			var/dat = {"<B>Slot Machine</B><BR>
 			<HR><BR>
@@ -426,7 +426,7 @@
 			pool(I)
 
 	attack_hand(var/mob/user as mob)
-		user.machine = src
+		src.add_dialog(user)
 		if (src.working)
 			var/dat = {"<B>Slot Machine</B><BR>
 			<HR><BR>

--- a/code/obj/submachine/virus_manipulator.dm
+++ b/code/obj/submachine/virus_manipulator.dm
@@ -27,7 +27,7 @@
 		return src.attack_hand(user)
 
 	attack_hand(var/mob/user as mob)
-		user.machine = src
+		src.add_dialog(user)
 		if (!src.working)
 			var/dat = {"<B>Virus Manipulator</B><BR>
 			<HR><BR>

--- a/code/procs/basketball.dm
+++ b/code/procs/basketball.dm
@@ -448,7 +448,7 @@
 	return
 
 /obj/item/bball_uplink/attack_self(mob/user as mob)
-	user.machine = src
+	src.add_dialog(user)
 	var/dat
 	if (src.selfdestruct)
 		dat = "Self Destructing..."
@@ -485,7 +485,7 @@
 	if (!( ishuman(H)))
 		return 1
 	if ((usr.contents.Find(src) || (in_range(src,usr) && istype(src.loc, /turf))))
-		usr.machine = src
+		src.add_dialog(usr)
 		if (href_list["spell_nova"])
 			if (src.uses >= 1)
 				src.uses -= 1
@@ -523,7 +523,7 @@
 */
 		else if (href_list["lock"] && src.origradio)
 			// presto chango, a regular radio again! (reset the freq too...)
-			usr.machine = null
+			src.remove_dialog(usr)
 			usr.Browse(null, "window=radio")
 			var/obj/item/device/radio/T = src.origradio
 			var/obj/item/bball_uplink/R = src

--- a/code/procs/gamehelpers.dm
+++ b/code/procs/gamehelpers.dm
@@ -201,16 +201,6 @@ var/obj/item/dummy/click_dummy = new
 			L = L.loc
 	return 0
 
-/proc/AutoUpdateAI(obj/subject)
-	if (!subject)
-		return
-	for(var/mob/living/silicon/ai/M in AIs)
-		var/mob/AI = M
-		if (M.deployed_to_eyecam)
-			AI = M.eyecam
-
-		if (AI && AI.client && AI.machine == subject)
-			subject.attack_ai(AI)
 
 /proc/get_viewing_AIs(center = null, distance = 7)
 	. = list()

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -754,10 +754,7 @@ proc/get_angle(atom/a, atom/b)
 	// no atomref specified (or not found)
 	// so just reset the user mob's machine var
 	if(src && src.mob)
-		//boutput(world, "[src] was [src.mob.machine], setting to null")
-		if(src.mob.machine && istype(src.mob.machine, /obj/machinery))
-			src.mob.machine.current_user = null
-		src.mob.machine = null
+		src.mob.remove_dialogs()
 	return
 
 /proc/get_turf_loc(var/atom/movable/M) //gets the location of the turf that the mob is on, or what the mob is in is on, etc

--- a/code/unused/airtunnel.dm
+++ b/code/unused/airtunnel.dm
@@ -150,7 +150,7 @@ obj/machinery/computer/airtunnel/attack_ai(user as mob)
 		return
 
 	var/dat = "<HTML><BODY><TT><B>Air Tunnel Controls</B><BR>"
-	user.machine = src
+	src.add_dialog(user)
 	if (SS13_airtunnel.operating == 1)
 		dat += "<B>Status:</B> RETRACTING<BR>"
 	else
@@ -225,7 +225,7 @@ obj/machinery/computer/airtunnel/attack_ai(user as mob)
 		return
 
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf)) || (issilicon(usr))))
-		usr.machine = src
+		src.add_dialog(usr)
 		if (href_list["retract"])
 			SS13_airtunnel.retract()
 		else if (href_list["stop"])
@@ -294,7 +294,7 @@ obj/machinery/computer/airtunnel/attack_ai(user as mob)
 		boutput(usr, "<span class='alert'>Error: Cannot interface with door security!</span>")
 		return
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf)) || (issilicon(usr))))
-		usr.machine = src
+		src.add_dialog(usr)
 		if (href_list["card"])
 			if (src.scan)
 				src.scan.set_loc(src.loc)

--- a/code/unused/engine_stuff.dm
+++ b/code/unused/engine_stuff.dm
@@ -387,7 +387,7 @@
 	interact(user)
 
 /obj/machinery/computer/laser_computer/proc/interact(mob/user)
-	user.machine = src
+	src.add_dialog(user)
 	var/polledemitters
 	for(var/obj/machinery/engine_laser_spawner/M in src.emitters)
 		if(M.health < 20)
@@ -412,7 +412,7 @@ text("<A href='?src=\ref[];pattern=1'>[src.pattern]</A>", src))
 
 /obj/machinery/computer/laser_computer/Topic(href, href_list)
 	boutput(world, "Topic, [href_list]")
-	usr.machine = src
+	src.add_dialog(usr)
 	if (href_list["testfire"])
 		if(!src.started)
 			src.testfire()

--- a/code/unused/heater.dm
+++ b/code/unused/heater.dm
@@ -75,7 +75,7 @@
 	if(status & (BROKEN|NOPOWER))
 		return
 
-	user.machine = src
+	src.add_dialog(user)
 	var/tt
 	switch(src.t_status)
 		if(1.0)
@@ -112,7 +112,7 @@
 	if (usr.stat || usr.restrained())
 		return
 	if (((get_dist(src, usr) <= 1 || usr.telekinesis == 1) && istype(src.loc, /turf)) || (isAI(usr)))
-		usr.machine = src
+		src.add_dialog(usr)
 		if (href_list["c"])
 			var/c = text2num(href_list["c"])
 			switch(c)

--- a/code/z_adventurezones/biodome.dm
+++ b/code/z_adventurezones/biodome.dm
@@ -534,7 +534,7 @@ SYNDICATE DRONE FACTORY AREAS
 		dat += "<A href='?src=\ref[src];south=1'>Touch the third rune</A><BR>"
 		dat += "<A href='?src=\ref[src];west=1'>Touch the fourth rune</A><BR>"
 
-		usr.machine = src
+		src.add_dialog(usr)
 		usr.Browse("[dat]", "window=rtab;size=400x300")
 		onclose(usr, "rtab")
 		return

--- a/code/z_adventurezones/luna.dm
+++ b/code/z_adventurezones/luna.dm
@@ -1281,7 +1281,7 @@ obj/machinery/embedded_controller/radio/maintpanel
 			icon_state = blinking ? "museum_control_blink" : "museum_control"
 
 	attack_hand(mob/user)
-		user.machine = src
+		src.add_dialog(user)
 		var/dat = {"<!DOCTYPE html>
 <html>
 <head>
@@ -1556,7 +1556,7 @@ obj/machinery/embedded_controller/radio/maintpanel
 		if(program)
 			program.receive_user_command(href_list["command"])
 
-		usr.machine = src
+		src.add_dialog(usr)
 
 	process()
 		if(!(status & NOPOWER) && program)
@@ -1567,7 +1567,7 @@ obj/machinery/embedded_controller/radio/maintpanel
 	updateUsrDialog(var/reason)
 		var/list/nearby = viewers(1, src)
 		for(var/mob/M in nearby)
-			if ((M.client && M.machine == src))
+			if (M.using_dialog_of(src))
 				if (reason || updateFlags)
 					src.dynamicUpdate(M, reason|updateFlags)
 					updateFlags = REASON_NONE
@@ -1576,7 +1576,7 @@ obj/machinery/embedded_controller/radio/maintpanel
 
 		if (issilicon(usr))
 			if (!(usr in nearby))
-				if (usr.client && usr.machine==src)
+				if (usr.using_dialog_of(src))
 					if (reason || updateFlags)
 						src.dynamicUpdate(usr, reason|updateFlags)
 						updateFlags = REASON_NONE

--- a/code/z_adventurezones/mad_mars.dm
+++ b/code/z_adventurezones/mad_mars.dm
@@ -794,7 +794,7 @@
 		if (..() || (status & (NOPOWER|BROKEN)))
 			return
 
-		user.machine = src
+		src.add_dialog(user)
 		add_fingerprint(user)
 
 		var/dat = "<center><h4>Vault Computer</h4></center>"
@@ -810,7 +810,7 @@
 	Topic(href, href_list)
 		if(..())
 			return
-		usr.machine = src
+		src.add_dialog(usr)
 		src.add_fingerprint(usr)
 
 		if (href_list["unlock"])

--- a/code/z_adventurezones/meatland.dm
+++ b/code/z_adventurezones/meatland.dm
@@ -1232,7 +1232,7 @@ var/global/list/default_meat_head_dialog = list("hello hello", "... it's not vir
 			return
 
 		if(src.host)
-			src.add_dialog(usr).host
+			src.host.add_dialog(usr)
 
 		if(href_list["key"] && istype(usr.equipped(), /obj/item/device/key))
 			boutput(usr, "<span class='alert'>It doesn't fit.  Must be the wrong key.</span>")
@@ -1265,7 +1265,7 @@ var/global/list/default_meat_head_dialog = list("hello hello", "... it's not vir
 			return
 
 		if(src.host)
-			src.add_dialog(usr).host
+			src.host.add_dialog(usr)
 
 		if(href_list["key"])
 			if(istype(usr.equipped(), /obj/item/device/key/cheget) && !src.inserted_key)

--- a/code/z_adventurezones/meatland.dm
+++ b/code/z_adventurezones/meatland.dm
@@ -973,7 +973,7 @@ var/global/list/default_meat_head_dialog = list("hello hello", "... it's not vir
 		return
 
 	attack_self(mob/user as mob)
-		user.machine = src
+		src.add_dialog(user)
 		add_fingerprint(user)
 		return show_lock_panel(user)
 
@@ -1232,7 +1232,7 @@ var/global/list/default_meat_head_dialog = list("hello hello", "... it's not vir
 			return
 
 		if(src.host)
-			usr.machine = src.host
+			src.add_dialog(usr).host
 
 		if(href_list["key"] && istype(usr.equipped(), /obj/item/device/key))
 			boutput(usr, "<span class='alert'>It doesn't fit.  Must be the wrong key.</span>")
@@ -1265,7 +1265,7 @@ var/global/list/default_meat_head_dialog = list("hello hello", "... it's not vir
 			return
 
 		if(src.host)
-			usr.machine = src.host
+			src.add_dialog(usr).host
 
 		if(href_list["key"])
 			if(istype(usr.equipped(), /obj/item/device/key/cheget) && !src.inserted_key)

--- a/code/z_adventurezones/void.dm
+++ b/code/z_adventurezones/void.dm
@@ -217,7 +217,7 @@ CONTENTS:
 
 	proc/display_ui(var/mob/user)
 		var/T
-		user.machine = src
+		src.add_dialog(user)
 		if(active)
 			if(!used)
 				T = {"<span style="display: block">

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -1028,6 +1028,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\obj\morgue.dm"
 #include "code\obj\noticeboard.dm"
 #include "code\obj\npc.dm"
+#include "code\obj\objDialog.dm"
 #include "code\obj\playable_piano.dm"
 #include "code\obj\portal.dm"
 #include "code\obj\posters.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
make machines dialog refresh Much Faster - instead of looping through nearby mobs or ALL clients, machines keep track of which clients are currently using them

removed mob.machine var and machine.current_user vars cause they were bad


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
optimize!

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)mbc:
(+)Did a big behind-the-scenes optimizing of machine popup window refresh handling. You shouldn't notice anything different, but if any new bugs turn up please report them.
```
