### PR TITLE
Voltagen/shock grenade buffs

### DIFF
--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -2737,9 +2737,9 @@ datum
 				if (exposed_temperature > T0C + 100)
 					reacting = 1
 					var/count = 0
-					for (var/mob/living/L in oview(5, holder.my_atom))
+					for (var/mob/living/L in oview(5, get_turf(holder.my_atom)))
 						count++
-					for (var/mob/living/L in oview(5, holder.my_atom))
+					for (var/mob/living/L in oview(5, get_turf(holder.my_atom)))
 						arcFlash(holder.my_atom, L, min(75000 * multiplier / count, volume * 1000 * multiplier / count))
 
 					holder.del_reagent(id)

--- a/code/modules/chemistry/tools/grenades.dm
+++ b/code/modules/chemistry/tools/grenades.dm
@@ -412,8 +412,13 @@
 	New()
 		..()
 		var/obj/item/reagent_containers/glass/B1 = new(src)
-		B1.reagents.add_reagent("voltagen", 40)
-		beakers += B1
+		var/obj/item/reagent_containers/glass/B2 = new(src)
+
+		B1.reagents.add_reagent("voltagen", 25)
+		B1.reagents.add_reagent("sugar",25)
+
+		B2.reagents.add_reagent("phosphorus", 25)
+		B2.reagents.add_reagent("potassium", 25)
 
 /obj/item/chem_grenade/pepper
 	name = "crowd dispersal grenade"

--- a/code/modules/chemistry/tools/grenades.dm
+++ b/code/modules/chemistry/tools/grenades.dm
@@ -181,7 +181,7 @@
 				if ( A == src ) continue
 				if (src && src.reagents) // Erik: fix for cannot execute null.grenade effects()
 					src.reagents.grenade_effects(src, A)
-					src.reagents.reaction(A, 1, 10)
+					src.reagents.reaction(A, 1, 10, 0)
 
 		invisibility = 100 //Why am i doing this?
 		if (src.master) src.master.invisibility = 100
@@ -413,6 +413,7 @@
 		..()
 		var/obj/item/reagent_containers/glass/B1 = new(src)
 		var/obj/item/reagent_containers/glass/B2 = new(src)
+		var/obj/item/reagent_containers/glass/B3 = new(src)
 
 		B1.reagents.add_reagent("voltagen", 25)
 		B1.reagents.add_reagent("sugar",25)
@@ -420,6 +421,12 @@
 		B2.reagents.add_reagent("phosphorus", 25)
 		B2.reagents.add_reagent("potassium", 25)
 
+		B3.reagents.add_reagent("voltagen", 25) //do a zap in addition to the smoke.
+
+		beakers += B1
+		beakers += B2
+		beakers += B3
+		
 /obj/item/chem_grenade/pepper
 	name = "crowd dispersal grenade"
 	desc = "An non-lethal grenade for use against protests, riots, vagrancy and loitering. Not to be used as a food additive."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE] [EXPERIMENTAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes voltagen to find targets from the holder's turf (i.e.: heating a beaker of voltagen in-hand will properly arcflash targets nearby you, instead of doing nothing)
Changes voltagen grenades to cause a smoke in addition to the initial zap, instead of leaving puddles of voltagen. This may be excessive.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Shock grenades were sad and weak. This may or may not be going too far in the other direction, but what do I know?


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Tarmunora:
(+)Tweaked the delivery mechanism in shock grenades; they now smoke voltagen instead of leaving puddles behind.
```
