### PR TITLE
Fix for removed user.machine var in new robot module rewriter

### DIFF
--- a/code/modules/robotics/robot/robot_module_rewriter.dm
+++ b/code/modules/robotics/robot/robot_module_rewriter.dm
@@ -54,7 +54,6 @@
 /obj/machinery/computer/robot_module_rewriter/attack_hand(mob/user as mob)
 	if (!user)
 		return
-	user.machine = src
 	src.add_fingerprint(user)
 	if (src.status & (BROKEN | NOPOWER))
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Removes usage of `user.machine` from `/obj/machinery/computer/robot_module_rewriter`.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

That var was removed in PR #650, and as such should no longer exist.