### PR TITLE
Makes complete darkness completely black

### DIFF
--- a/code/RobustLight2.dm
+++ b/code/RobustLight2.dm
@@ -57,7 +57,7 @@ proc/get_moving_lights_stats()
 #define RL_Atten_Quadratic 2.2 // basically just brightness scaling atm
 #define RL_Atten_Constant -0.11 // constant subtracted at every point to make sure it goes <0 after some distance
 #define RL_MaxRadius 6 // maximum allowed light.radius value. if any light ends up needing more than this it'll cap and look screwy
-#define DLL 0.01 //Darkness Lower Limit, at 0 things can get absolutely pitch black.
+#define DLL 0 //Darkness Lower Limit, at 0 things can get absolutely pitch black.
 
 #define D_BRIGHT 1
 #define D_COLOR 2

--- a/code/base_lighting.dm
+++ b/code/base_lighting.dm
@@ -13,7 +13,7 @@
 /area
 	var
 		force_fullbright = 0
-		ambient_light = rgb(0.025 * 255, 0.025 * 255, 0.025 * 255)
+		ambient_light = "#000000" //rgb(0.025 * 255, 0.025 * 255, 0.025 * 255)
 
 	New()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If there's no light shining upon a tile all of its pixels will be completely black instead of just being very very dark:
![A1e2LMxrnk](https://user-images.githubusercontent.com/358431/81613905-85ccc100-93df-11ea-93fe-4acb78a64ce1.png)

For comparison how it looks now:
![image](https://user-images.githubusercontent.com/358431/81614619-9a5d8900-93e0-11ea-9ba9-3e95e44d4b47.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Previous behaviour gave advantage to people who turned up their brightness way too much. Moreover the new behaviour makes breaking lights in maint and waiting in maint shadows for victims a more viable strategy which sounds just excellent to me.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)pali:
(*)Complete darkness is now black.
```
