### PR TITLE
Buff taser shotgun

### DIFF
--- a/code/modules/projectiles/special.dm
+++ b/code/modules/projectiles/special.dm
@@ -743,7 +743,7 @@
 	split_type = 0
 	shot_sound = 'sound/weapons/Taser.ogg'
 	hit_mob_sound = 'sound/effects/sparks6.ogg'
-	var/spread_angle = 30
+	var/spread_angle = 10
 	var/current_angle = 0
 	var/angle_adjust_per_pellet = 0
 	var/initial_angle_offset_mult = 0

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -398,7 +398,7 @@
 	shoot_delay = 6
 
 	New()
-		cell = new/obj/item/ammo/power_cell/self_charging/howitzer
+		cell = new/obj/item/ammo/power_cell/high_power
 		current_projectile = new/datum/projectile/special/spreader/tasershotgunspread
 		projectiles = list(current_projectile,new/datum/projectile/energy_bolt)
 		..()

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -394,11 +394,11 @@
 	item_state = "tasers"
 	force = 8.0
 	two_handed = 1
-	click_delay = 15
 	can_dual_wield = 0
+	shoot_delay = 6
 
 	New()
-		cell = new/obj/item/ammo/power_cell/high_power
+		cell = new/obj/item/ammo/power_cell/self_charging/howitzer
 		current_projectile = new/datum/projectile/special/spreader/tasershotgunspread
 		projectiles = list(current_projectile,new/datum/projectile/energy_bolt)
 		..()
@@ -410,6 +410,12 @@
 			set_icon_state("tasers[ratio]")
 			return
 
+	attack_self()
+		..()
+		if(istype(current_projectile, /datum/projectile/energy_bolt))
+			shoot_delay = 4
+		else
+			shoot_delay = 6
 
 
 ////////////////////////////////////VUVUV


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Tightens spread on taser shotgun and improves the rate of fire (6 ds delay down from 15)
Standard taser mode has standard 4 ds shoot delay


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Taser shotguns are currently slow, and underwhelming at anything but literal pointblanks.
Tightening the spread to 10 degrees makes the pellets cover a 3 tile spread at the end of their range, which feels much better


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Tarmunora:
(+)Buffed taser shotgun
```
