### PR TITLE
ASSJAM: Added third emag stage to securitrons

### DIFF
--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -62,6 +62,7 @@
 	var/current_movepath = 0
 	var/datum/secbot_mover/mover = null
 	var/arrest_move_delay = 2.5
+	var/emag_stages = 2 //number of times we can emag this thing
 
 	var/blockcount = 0		//number of times retried a blocked path
 	var/awaiting_beacon	= 0	// count of pticks awaiting a beacon response
@@ -144,6 +145,9 @@
 		src.icon_state = "secbot[src.on]"
 		if (!src.our_baton || !istype(src.our_baton))
 			src.our_baton = new our_baton_type(src)
+		#if ASS_JAM
+		src.emag_stages = 3
+		#endif
 
 		add_simple_light("secbot", list(255, 255, 255, 0.4 * 255))
 
@@ -198,7 +202,7 @@ Report Arrests: <A href='?src=\ref[src];operation=report'>[report_arrests ? "On"
 			src.anchored = 0
 			src.mode = SECBOT_IDLE
 			walk_to(src,0)
-			src.icon_state = "secbot[src.on][(src.on && src.emagged == 2) ? "-spaz" : null]"
+			src.icon_state = "secbot[src.on][(src.on && src.emagged >= 2) ? "-spaz" : null]"
 			src.updateUsrDialog()
 
 		switch(href_list["operation"])
@@ -228,11 +232,11 @@ Report Arrests: <A href='?src=\ref[src];operation=report'>[report_arrests ? "On"
 		src.oldtarget_name = null
 		mode = SECBOT_IDLE
 		src.anchored = 0
-		src.icon_state = "secbot[src.on][(src.on && src.emagged == 2) ? "-spaz" : null]"
+		src.icon_state = "secbot[src.on][(src.on && src.emagged >= 2) ? "-spaz" : null]"
 		walk_to(src,0)
 
 	emag_act(var/mob/user, var/obj/item/card/emag/E)
-		if (src.emagged < 2)
+		if (src.emagged < emag_stages)
 			if (emagged)
 				if (user)
 					boutput(user, "<span class='alert'>You short out [src]'s system clock inhibition circuis.</span>")
@@ -246,9 +250,16 @@ Report Arrests: <A href='?src=\ref[src];operation=report'>[report_arrests ? "On"
 			src.anchored = 0
 			src.emagged++
 			src.on = 1
-			src.icon_state = "secbot[src.on][(src.on && src.emagged == 2) ? "-spaz" : null]"
+			src.icon_state = "secbot[src.on][(src.on && src.emagged >= 2) ? "-spaz" : null]"
 			mode = SECBOT_IDLE
 			src.target = null
+
+			#if ASS_JAM
+			if(src.emagged >= 3)
+				src.stun_type = "harm_classic"
+				arrest_move_delay = 1.5
+				playsound(src.loc, 'sound/effects/elec_bzzz.ogg', 99, 1, 0.1, 0.7)
+			#endif
 
 			if(user)
 				src.oldtarget_name = user.name
@@ -364,10 +375,10 @@ Report Arrests: <A href='?src=\ref[src];operation=report'>[report_arrests ? "On"
 
 				if (target)		// make sure target exists
 					if (get_dist(src, src.target) <= 1)		// if right next to perp
-						src.icon_state = "secbot-c[src.emagged == 2 ? "-spaz" : null]"
+						src.icon_state = "secbot-c[src.emagged >= 2 ? "-spaz" : null]"
 						var/mob/living/carbon/M = src.target
 						var/maxstuns = 4
-						var/stuncount = (src.emagged == 2) ? rand(5,10) : 1
+						var/stuncount = (src.emagged >= 2) ? rand(5,10) : 1
 
 						while (stuncount > 0 && src.target)
 							// No need for unnecessary hassle, just make it ignore charges entirely for the time being.
@@ -387,7 +398,7 @@ Report Arrests: <A href='?src=\ref[src];operation=report'>[report_arrests ? "On"
 								sleep(0.3 SECONDS)
 
 						SPAWN_DBG(0.2 SECONDS)
-							src.icon_state = "secbot[src.on][(src.on && src.emagged == 2) ? "-spaz" : null]"
+							src.icon_state = "secbot[src.on][(src.on && src.emagged >= 2) ? "-spaz" : null]"
 						if (src.target.getStatusDuration("weakened"))
 							mode = SECBOT_PREP_ARREST
 							src.anchored = 1
@@ -408,7 +419,7 @@ Report Arrests: <A href='?src=\ref[src];operation=report'>[report_arrests ? "On"
 								src.mover.master = null
 								src.mover = null
 							src.moving = 0
-							navigate_to(src.target,(src.emagged == 2) ? (arrest_move_delay/2) : arrest_move_delay)
+							navigate_to(src.target,(src.emagged >= 2) ? (arrest_move_delay/2) : arrest_move_delay)
 							return
 					/*
 						var/turf/olddist = get_dist(src, src.target)
@@ -914,7 +925,7 @@ Report Arrests: <A href='?src=\ref[src];operation=report'>[report_arrests ? "On"
 		return
 
 	speak(var/message)
-		if (src.emagged == 2)
+		if (src.emagged >= 2)
 			message = capitalize(ckeyEx(message))
 			..(message)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[ASS-JAM] [FEAT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title. The third stage is indicated by a zap sound, and works just like the second stage with the addition that he also beats the absolute shit out of his target.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Beepsky beating people up is always funny


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)RichardGere:
(*)Added a third emag stage to securitrons
```
