### PR TITLE
handling for making pre-placed turrets function

### DIFF
--- a/code/obj/item/deployable_turret.dm
+++ b/code/obj/item/deployable_turret.dm
@@ -113,6 +113,8 @@
 		src.transform = M.Turn(src.external_angle)
 		if (!(src in processing_items))
 			processing_items.Add(src)
+		if(active)
+			set_projectile()
 		
 	disposing()
 		processing_items.Remove(src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a bit of handling so that if you spawn a turret pre-activated, it will do the projectile setup upon creation



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
For if mappers/etc want to use deployable turrets in prefabs or smth I guess. Em told me to do it.
![image](https://user-images.githubusercontent.com/48066662/81757268-f0cfd380-9483-11ea-899c-f05ba5141f38.png)
