### PR TITLE
Unsplit stun bullet hit from bullet_act

### DIFF
--- a/code/mob/living/carbon/human/procs/damage.dm
+++ b/code/mob/living/carbon/human/procs/damage.dm
@@ -56,8 +56,7 @@
 	var/stun = 0 //HEY this doesnt actually stun. its the number to reduce stamina. gosh.
 	if (P.proj_data)  //ZeWaka: Fix for null.ks_ratio
 		damage = round((P.power*P.proj_data.ks_ratio), 1.0)
-		if (P.proj_data.ks_ratio > 0 || (src.getStatusDuration("weakened") || src.getStatusDuration("stunned") || src.getStatusDuration("paralysis") )) //only if ks_ratio exceeds 0. we already make stuns and stamina apply in proj_data.on_hit. I dont wanna apply both this effect AND that one
-			stun = round((P.power*(1.0-P.proj_data.ks_ratio)), 1.0)
+		stun = round((P.power*(1.0-P.proj_data.ks_ratio)), 1.0)
 
 	var/armor_value_bullet = 1
 
@@ -180,8 +179,8 @@
 
 			if (D_ENERGY)
 				if (stun > 0)
-					src.remove_stamina(min(round(stun/armor_value_bullet) * 30, 125)) //thanks to the odd scaling i have to cap this.
-					src.stamina_stun()
+					src.do_disorient(clamp(stun*4, P.proj_data.power*(1-P.proj_data.ks_ratio)*2, stun+80), weakened = stun*2, stunned = stun*2, disorient = min(stun,  80), remove_stamina_below_zero = 0)
+					src.emote("twitch_v")// for the above, flooring stam based off the power of the datum is intentional
 
 				if (isalive(src)) lastgasp()
 

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -816,6 +816,10 @@
 				dmgmult = 0.2
 			if(D_TOXIC)
 				dmgmult = 0
+		
+		if(P.proj_data.ks_ratio == 0)
+			src.do_disorient(clamp(P.power*4, P.proj_data.power*2, P.power+80), weakened = P.power*2, stunned = P.power*2, disorient = min(P.power, 80), remove_stamina_below_zero = 0) //bad hack, but it'll do
+			src.emote("twitch_v")// for the above, flooring stam based off the power of the datum is intentional
 
 		log_shot(P,src)
 		src.visible_message("<span class='alert'><b>[src]</b> is struck by [P]!</span>")

--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -629,9 +629,9 @@ datum/projectile
 		on_hit(atom/hit, angle, var/obj/projectile/O) //MBC : what the fuck shouldn't this all be in bullet_act on human in damage.dm?? this split is giving me bad vibes
 			if(ks_ratio == 0) //stun projectiles only
 				impact_image_effect("T", hit)
-				if (isliving(hit))
-					var/mob/living/L = hit
-					stun_bullet_hit(O,L)
+//				if (isliving(hit))
+//					var/mob/living/L = hit
+//					stun_bullet_hit(O,L)
 			return
 		tick(var/obj/projectile/O)
 			return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[CLEANLINESS] [BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Takes the handling for stun weapons out of `projectile/proc/on_hit` and moves it into `bullet_act()`
BALANCE: because this removes bug/feature where stun weapons would do massive stamina damage to stunned targets due to doubledipping in both on_hit and bullet_act

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Cleans up the code a little, maybe. Paves the way for poking these things further