### PR TITLE
Make halop drowsiness much more consistant

### DIFF
--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -738,7 +738,7 @@ datum
 						if(istype(virus.master,/datum/ailment/disease/space_madness) || istype(virus.master,/datum/ailment/disease/berserker))
 							M.cure_disease(virus)
 				if(prob(20)) M.take_brain_damage(1 * mult)
-				if(prob(50)) M.drowsyness = max(M.drowsyness, 3)
+				if(prob(50)) M.drowsyness = max(M.drowsyness, 6)
 				if(prob(10)) M.emote("drool")
 				..()
 				return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Doubles the drowsiness applied by haloperidol 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Haloperidol feels very inconsistant as a tranquilizer, as the victim's drowsiness will occasionally expire, leaving them zooming off at full speed. This makes it such that one is less likely to become non-drowsy naturally with halop still in one's blood


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Tarmunora:
(+)Haloperidol is slightly better at tranquilizing.
```
