### PR TITLE
Switches gloves forensics functionality

### DIFF
--- a/code/obj/item/clothing/gloves.dm
+++ b/code/obj/item/clothing/gloves.dm
@@ -17,7 +17,7 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 	var/activeweapon = 0 // Used for gloves that can be toggled to turn into a weapon (example, bladed gloves)
 
 	var/hide_prints = 1 // Seems more efficient to do this with one global proc and a couple of vars (Convair880).
-	var/scramble_prints = 0
+	var/scramble_prints = 1
 	var/material_prints = null
 
 	var/can_be_charged = 0 // Currently, there are provisions for icon state "yellow" only. You have to update this file and mob_procs.dm if you're wanna use other glove sprites (Convair880).
@@ -209,7 +209,6 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 	icon_state = "long_gloves"
 	item_state = "long_gloves"
 	protective_temperature = 550
-	scramble_prints = 1
 	material_prints = "synthetic silicone rubber fibers"
 	setupProperties()
 		..()
@@ -230,7 +229,6 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 	item_state = "bgloves"
 	protective_temperature = 1500
 	material_prints = "black leather fibers"
-	scramble_prints = 1
 
 	setupProperties()
 		..()
@@ -252,7 +250,7 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 	permeability_coefficient = 0.02
 	desc = "Thin gloves that offer minimal protection."
 	protective_temperature = 310
-	hide_prints = 1
+	scramble_prints = 0
 	material_prints = "white talcum powder"
 	setupProperties()
 		..()
@@ -278,7 +276,6 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 	icon_state = "latex"
 	item_state = "lgloves"
 	desc = "Custom made gloves."
-	scramble_prints = 1
 
 	insulating
 		onMaterialChanged()
@@ -322,7 +319,6 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 	item_state = "swat_syndie"
 	protective_temperature = 1100
 	material_prints = "high-quality synthetic fibers"
-	scramble_prints = 1
 	setupProperties()
 		..()
 		setProperty("heatprot", 10)
@@ -340,7 +336,6 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 	icon_state = "stun"
 	item_state = "stun"
 	material_prints = "insulative fibers, electrically charged"
-	scramble_prints = 1
 	stunready = 1
 	can_be_charged = 1
 	uses = 10
@@ -359,7 +354,6 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 	icon_state = "yellow"
 	item_state = "ygloves"
 	material_prints = "insulative fibers"
-	scramble_prints = 1
 	can_be_charged = 1
 	max_uses = 4
 	permeability_coefficient = 0.5
@@ -378,7 +372,6 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 /obj/item/clothing/gloves/yellow/unsulated
 	desc = "These gloves are not electrically insulated."
 	name = "unsulated gloves"
-	scramble_prints = 1
 	can_be_charged = 0
 	max_uses = 0
 	setupProperties()
@@ -391,7 +384,6 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 	icon_state = "boxinggloves"
 	item_state = "bogloves"
 	material_prints = "red leather fibers"
-	scramble_prints = 1
 	crit_override = 1
 	bonus_crit_chance = 0
 	stamina_dmg_mult = 0.35
@@ -444,7 +436,6 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 	material_prints = "insulative fibers and nanomachines"
 	can_be_charged = 1 // Quite pointless, but could be useful as a last resort away from powered wires? Hell, it's a traitor item and can get the buff (Convair880).
 	max_uses = 4
-	scramble_prints = 1
 	flags = HAS_EQUIP_CLICK
 
 	var/spam_flag = 0

--- a/code/obj/item/clothing/gloves.dm
+++ b/code/obj/item/clothing/gloves.dm
@@ -209,6 +209,7 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 	icon_state = "long_gloves"
 	item_state = "long_gloves"
 	protective_temperature = 550
+	scramble_prints = 1
 	material_prints = "synthetic silicone rubber fibers"
 	setupProperties()
 		..()
@@ -229,6 +230,7 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 	item_state = "bgloves"
 	protective_temperature = 1500
 	material_prints = "black leather fibers"
+	scramble_prints = 1
 
 	setupProperties()
 		..()
@@ -250,7 +252,8 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 	permeability_coefficient = 0.02
 	desc = "Thin gloves that offer minimal protection."
 	protective_temperature = 310
-	scramble_prints = 1
+	hide_prints = 1
+	material_prints = "white talcum powder"
 	setupProperties()
 		..()
 		setProperty("conductivity", 0.3)
@@ -319,6 +322,7 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 	item_state = "swat_syndie"
 	protective_temperature = 1100
 	material_prints = "high-quality synthetic fibers"
+	scramble_prints = 1
 	setupProperties()
 		..()
 		setProperty("heatprot", 10)
@@ -336,6 +340,7 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 	icon_state = "stun"
 	item_state = "stun"
 	material_prints = "insulative fibers, electrically charged"
+	scramble_prints = 1
 	stunready = 1
 	can_be_charged = 1
 	uses = 10
@@ -354,6 +359,7 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 	icon_state = "yellow"
 	item_state = "ygloves"
 	material_prints = "insulative fibers"
+	scramble_prints = 1
 	can_be_charged = 1
 	max_uses = 4
 	permeability_coefficient = 0.5
@@ -372,6 +378,7 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 /obj/item/clothing/gloves/yellow/unsulated
 	desc = "These gloves are not electrically insulated."
 	name = "unsulated gloves"
+	scramble_prints = 1
 	can_be_charged = 0
 	max_uses = 0
 	setupProperties()
@@ -384,6 +391,7 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 	icon_state = "boxinggloves"
 	item_state = "bogloves"
 	material_prints = "red leather fibers"
+	scramble_prints = 1
 	crit_override = 1
 	bonus_crit_chance = 0
 	stamina_dmg_mult = 0.35
@@ -436,6 +444,7 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 	material_prints = "insulative fibers and nanomachines"
 	can_be_charged = 1 // Quite pointless, but could be useful as a last resort away from powered wires? Hell, it's a traitor item and can get the buff (Convair880).
 	max_uses = 4
+	scramble_prints = 1
 	flags = HAS_EQUIP_CLICK
 
 	var/spam_flag = 0
@@ -453,7 +462,7 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 
 	equipment_click(atom/user, atom/target, params, location, control, origParams, slot)
 		if(target == user || spam_flag || user:a_intent == INTENT_HELP || user:a_intent == INTENT_GRAB) return 0
-		if(slot != SLOT_GLOVES) return 0 
+		if(slot != SLOT_GLOVES) return 0
 
 		var/netnum = 0
 		if(src.overridespecial)

--- a/code/obj/item/clothing/gloves.dm
+++ b/code/obj/item/clothing/gloves.dm
@@ -209,6 +209,7 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 	icon_state = "long_gloves"
 	item_state = "long_gloves"
 	protective_temperature = 550
+	scramble_prints = 0
 	material_prints = "synthetic silicone rubber fibers"
 	setupProperties()
 		..()
@@ -276,6 +277,7 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 	icon_state = "latex"
 	item_state = "lgloves"
 	desc = "Custom made gloves."
+	scramble_prints = 0
 
 	insulating
 		onMaterialChanged()
@@ -318,6 +320,7 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 	icon_state = "swat_syndie"
 	item_state = "swat_syndie"
 	protective_temperature = 1100
+	scramble_prints = 0
 	material_prints = "high-quality synthetic fibers"
 	setupProperties()
 		..()
@@ -329,6 +332,7 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 	desc = "A pair of Nanotrasen tactical gloves that are quite fire and electrically-resistant. They also help you block attacks. They do not specifically help you block against blocking though. Just regular attacks."
 	icon_state = "swat_NT"
 	item_state = "swat_NT"
+	scramble_prints = 0
 
 /obj/item/clothing/gloves/stungloves/
 	name = "Stungloves"
@@ -383,6 +387,7 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 	desc = "These gloves are for competitive boxing."
 	icon_state = "boxinggloves"
 	item_state = "bogloves"
+	scramble_prints = 0
 	material_prints = "red leather fibers"
 	crit_override = 1
 	bonus_crit_chance = 0


### PR DESCRIPTION
[BALANCE] [INPUT WANTED] [ENHANCEMENT]

## About the PR 
Removes the ability to hide your prints with the use of all gloves, excluding latex gloves. Instead all gloves now scramble your fingerprints. In addition, latex gloves are now the only gloves that hide fingerprints 

## Why's this needed?
Gloves forensics is broken currently. Having to run around and stopping people to find matching material fibres isn't fun nor is it good gameplay. I believe by reversing the functionality of hiding fingerprints, forensics would be more viable. It would also give detectives actual work to do, EG having to compile a list of prints, writing down their full strings and then identifying to whom they belong to.

Now, having to hide your tracks has to be intentional, not a side effect of wearing insulated gloves. I think latex gloves are pretty common mundane item so having to go the extra mile so that security doesn't find you should be worth it.

## Changelog
```
(u)Carbadox:
(*)All types of gloves, excluding latex, will no longer hide your fingerprints. Instead, they will now only scramble them instead. In addition, only latex gloves will hide your prints now.
```

There's kind of a bug where touching something with gloves that scramble once will leave your mark there twice. No clue how to resolve it and it was there before I got here so. 