### PR TITLE
Adds votes (e.g. ass day classic vote) to the Status tab

### DIFF
--- a/code/WorkInProgress/NewVote.dm
+++ b/code/WorkInProgress/NewVote.dm
@@ -34,6 +34,24 @@ var/const/recently_time = 6000 // 10 mins
 
 	vote_manager.show_vote(src)
 
+
+/obj/newVoteLink
+	name = "<span style='color: green; text-decoration: underline;'>Vote</span>"
+
+	Click()
+		var/client/C = usr.client
+		if (!C) return
+		vote_manager.show_vote(C)
+
+	examine()
+		return list()
+
+	proc/update_name(new_name="Vote")
+		src.name = "<span style='color: green; text-decoration: underline;'>[new_name]</span>"
+
+var/global/obj/newVoteLink/newVoteLinkStat = new /obj/newVoteLink
+
+
 /datum/vote_manager
 	var/datum/vote_new/active_vote = null
 
@@ -161,6 +179,7 @@ var/const/recently_time = 6000 // 10 mins
 			may_vote += C.ckey
 		vote_started = world.time
 		data = A
+		newVoteLinkStat.update_name(src.vote_name ? src.vote_name : "Vote")
 		process()
 		..()
 
@@ -219,6 +238,9 @@ var/const/recently_time = 6000 // 10 mins
 		qdel(src)
 		return
 
+	proc/time_left()
+
+
 /datum/vote_new/mode
 	options = list("Yes","No")
 	details = ""
@@ -236,18 +258,15 @@ var/const/recently_time = 6000 // 10 mins
 
 	end_vote()
 		vote_manager.active_vote = null
-		boutput(world, "<span class='success'><BIG><B>Vote gamemode result: [get_winner()]</B></BIG></span>")
-		if(get_winner() == "Yes")
-			if(get_winner_num() < round(clients.len * 0.5))
-				boutput(world, "<span class='success'><BIG><B>Minimum mode votes not reached (~50% of players).</B></BIG></span>")
-				qdel(src)
-				return
-			if(current_state == GAME_STATE_PREGAME)
-				boutput(world, "<span class='success'><BIG><B>Gamemode for upcoming round has been changed to [data].</B></BIG></span>")
-				master_mode = lowertext(data)
-			else
-				boutput(world, "<span class='success'><BIG><B>Gamemode will be changed to [data] at next round start.</B></BIG></span>")
-				world.save_mode(lowertext(data))
+		// boutput(world, "<span class='success'><BIG><B>Vote gamemode result: [get_winner()]</B></BIG></span>")
+		if(get_winner() != "Yes" || get_winner_num() < round(clients.len * 0.5))
+			boutput(world, "<span class='alert'><BIG><B>Minimum mode votes not reached (~50% of players), game mode not changed.</B></BIG></span>")
+		else if(current_state == GAME_STATE_PREGAME)
+			boutput(world, "<span class='success'><BIG><B>Gamemode for upcoming round has been changed to [data].</B></BIG></span>")
+			master_mode = lowertext(data)
+		else
+			boutput(world, "<span class='success'><BIG><B>Gamemode will be changed to [data] at next round start.</B></BIG></span>")
+			world.save_mode(lowertext(data))
 		qdel(src)
 		return
 

--- a/code/WorkInProgress/NewVote.dm
+++ b/code/WorkInProgress/NewVote.dm
@@ -49,6 +49,13 @@ var/const/recently_time = 6000 // 10 mins
 	proc/update_name(new_name="Vote")
 		src.name = "<span style='color: green; text-decoration: underline;'>[new_name]</span>"
 
+	proc/chat_link()
+		return "<a href='?src=\ref[src]'>[src]</a>"
+
+	Topic(href, href_list)
+		. = ..()
+		Click()
+
 var/global/obj/newVoteLink/newVoteLinkStat = new /obj/newVoteLink
 
 
@@ -180,7 +187,7 @@ var/global/obj/newVoteLink/newVoteLinkStat = new /obj/newVoteLink
 		vote_started = world.time
 		data = A
 		newVoteLinkStat.update_name(src.vote_name ? src.vote_name : "Vote")
-		process()
+		processing_items.Add(src)
 		..()
 
 	proc/process()
@@ -190,7 +197,6 @@ var/global/obj/newVoteLink/newVoteLinkStat = new /obj/newVoteLink
 			end_vote()
 			return
 		curr_win = get_winner()
-		SPAWN_DBG(2 SECONDS) process()
 
 	proc/show_to(var/client/C)
 		if(C in open_votes) return
@@ -198,7 +204,7 @@ var/global/obj/newVoteLink/newVoteLinkStat = new /obj/newVoteLink
 			boutput(C, "<span class='alert'><BIG>You may not vote as you were not present when the vote was started.</BIG></span>")
 			return
 		if((C.ckey in voted_ckey) || (C.computer_id in voted_id))
-			boutput(C, "<span class='alert'><BIG>You have already voted. Current winner : [curr_win]</BIG></span>")
+			boutput(C, "<span class='alert'><BIG>You have already voted. [curr_win ? "Current winner: [curr_win]":""]</BIG></span>")
 			return
 		open_votes += C
 		var/choice = input(C,details,vote_name,null) in options
@@ -238,7 +244,9 @@ var/global/obj/newVoteLink/newVoteLinkStat = new /obj/newVoteLink
 		qdel(src)
 		return
 
-	proc/time_left()
+	disposing()
+		processing_items.Remove(src)
+		. = ..()
 
 
 /datum/vote_new/mode
@@ -248,13 +256,8 @@ var/global/obj/newVoteLink/newVoteLinkStat = new /obj/newVoteLink
 	vote_length = 1200 //2 Minutes
 
 	New(var/A)
-		for(var/client/C in clients)
-			C.verbs += /client/proc/viewnewvote
-			may_vote += C.ckey
-		vote_started = world.time
-		data = A
+		..()
 		details = "Change gamemode to '[A]' ?"
-		process()
 
 	end_vote()
 		vote_manager.active_vote = null

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -66,7 +66,7 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 	boutput(world, "Please, setup your character and select ready. Game will start in [pregame_timeleft] seconds")
 	#if ASS_JAM
 	vote_manager.active_vote = new/datum/vote_new/mode("assday")
-	boutput(world, "<B>ASS JAM: Ass Day Classic vote has been started: [newVoteLinkStat.chat_link()]<br>(or click on the Status map as you do for map votes). Vote concludes in 120 seconds.</B>")
+	boutput(world, "<B>ASS JAM: Ass Day Classic vote has been started: [newVoteLinkStat.chat_link()] (120 seconds remaining)<br>(or click on the Status map as you do for map votes)</B>")
 	#endif
 
 	// let's try doing this here, yoloooo

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -65,8 +65,8 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 	boutput(world, "<B><FONT color='blue'>Welcome to the pre-game lobby!</FONT></B>")
 	boutput(world, "Please, setup your character and select ready. Game will start in [pregame_timeleft] seconds")
 	#if ASS_JAM
-	boutput(world, "<B>ASS JAM: Ass Day Classic vote has been started (click on the Status map as you do for map votes). Vote concludes in 120 seconds.</B>")
 	vote_manager.active_vote = new/datum/vote_new/mode("assday")
+	boutput(world, "<B>ASS JAM: Ass Day Classic vote has been started: [newVoteLinkStat.chat_link()]<br>(or click on the Status map as you do for map votes). Vote concludes in 120 seconds.</B>")
 	#endif
 
 	// let's try doing this here, yoloooo

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -65,7 +65,7 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 	boutput(world, "<B><FONT color='blue'>Welcome to the pre-game lobby!</FONT></B>")
 	boutput(world, "Please, setup your character and select ready. Game will start in [pregame_timeleft] seconds")
 	#if ASS_JAM
-	boutput(world, "<B>ASS JAM: Ass Day Classic vote has been started (use View Current Vote verb). Vote concludes in 120 seconds.</B>")
+	boutput(world, "<B>ASS JAM: Ass Day Classic vote has been started (click on the Status map as you do for map votes). Vote concludes in 120 seconds.</B>")
 	vote_manager.active_vote = new/datum/vote_new/mode("assday")
 	#endif
 

--- a/code/input.dm
+++ b/code/input.dm
@@ -333,6 +333,7 @@ var/list/dirty_keystates = list()
 			if ((src.move_scheduled - world.time) <= 0.01 + lmt || src.move_scheduled + lmt > next)
 
 				src.move_scheduled = next
+				message_admins("AAA")
 				SPAWN_DBG(max( actual_delay, world.tick_lag-0.01))
 					src.internal_process_move(src.client ? src.client.key_state : 0)
 

--- a/code/mob_stat.dm
+++ b/code/mob_stat.dm
@@ -11,7 +11,7 @@
 	var/is_construction_mode = 0
 
 	var/list/stats = list()
-	var/list/statNames = list("Map:","Next Map:","Vote Link:","Map Vote Time:","Map Vote Spacer","Game Mode:","Time To Start:","Server Load:","Shift Time Spacer","Shift Time:","Shuttle")
+	var/list/statNames = list("Map:","Next Map:","Map Vote Link:","Map Vote Time:","Map Vote Spacer","Vote Link:","Vote Time:","Vote Spacer","Game Mode:","Time To Start:","Server Load:","Shift Time Spacer","Shift Time:","Shuttle")
 	//above : ORDER IS IMPORANT
 
 	New()
@@ -19,9 +19,12 @@
 		//this shit is kind of messy to read but it is Quicker than repopulating the list each update()
 		stats["Map:"] = 0
 		stats["Next Map:"] = 0
-		stats["Vote Link:"] = 0
+		stats["Map Vote Link:"] = 0
 		stats["Map Vote Time:"] = 0
 		stats["Map Vote Spacer"] = -1
+		stats["Vote Link:"] = 0
+		stats["Vote Time:"] = 0
+		stats["Vote Spacer"] = -1
 		stats["Game Mode:"] = 0
 		stats["Time To Start:"] = 0
 		stats["Server Load:"] = 0
@@ -64,13 +67,23 @@
 				saveStat("Next Map:", nextMap)
 
 			if (mapSwitcher.playersVoting)
-				saveStat("Vote Link:",mapVoteLinkStat)
+				saveStat("Map Vote Link:",mapVoteLinkStat)
 
 				if (mapSwitcher.voteCurrentDuration)
 					saveStat("Map Vote Time:", "([round(((mapSwitcher.voteStartedAt + mapSwitcher.voteCurrentDuration) - world.time) / 10)] seconds remaining, [mapSwitcher.playerVotes.len] vote[mapSwitcher.playerVotes.len != 1 ? "s" : ""])")
 			else
-				stats["Vote Link:"] = 0
+				stats["Map Vote Link:"] = 0
 				stats["Map Vote Time:"] = 0
+
+		if (vote_manager?.active_vote)
+			stats["Vote Spacer"] = -1
+			saveStat("Vote Link:",newVoteLinkStat)
+			saveStat("Vote Time:", "([round(((vote_manager.active_vote.vote_started + vote_manager.active_vote.vote_length) - world.time) / 10)] seconds remaining, [vote_manager.active_vote.voted_ckey.len] vote[vote_manager.active_vote.voted_ckey.len != 1 ? "s" : ""])")
+			stats["Vote Spacer"] = -1
+		else
+			stats["Vote Link:"] = 0
+			stats["Vote Time:"] = 0
+			stats["Vote Spacer"] = 0
 
 		if (ticker)
 			saveStat("Game Mode:",ticker.hide_mode ? "secret" : "[master_mode]")

--- a/code/mob_stat.dm
+++ b/code/mob_stat.dm
@@ -75,8 +75,7 @@
 				stats["Map Vote Link:"] = 0
 				stats["Map Vote Time:"] = 0
 
-		if (vote_manager?.active_vote)
-			stats["Vote Spacer"] = -1
+		if (!isnull(vote_manager) && vote_manager.active_vote)
 			saveStat("Vote Link:",newVoteLinkStat)
 			saveStat("Vote Time:", "([round(((vote_manager.active_vote.vote_started + vote_manager.active_vote.vote_length) - world.time) / 10)] seconds remaining, [vote_manager.active_vote.voted_ckey.len] vote[vote_manager.active_vote.voted_ckey.len != 1 ? "s" : ""])")
 			stats["Vote Spacer"] = -1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
![image](https://user-images.githubusercontent.com/358431/81806555-eada0100-951c-11ea-8bd4-a69ac2151ce6.png)



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Using a verb for this is annoying and not intuitive, people are used to votes being in the status tab anyway because map votes.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)pali:
(*)Ass day classic vote now appears in the Status tab (just like map votes).
```
