### PR TITLE
Splits changelog into ass jam and non ass jam

### DIFF
--- a/.github/update_changelog.py
+++ b/.github/update_changelog.py
@@ -127,7 +127,8 @@ def main():
 		print("No changelog provided.")
 		return
 
-	status = update_changelog(repo, os.environ["CHANGELOG_PATH"], date_string, pr_data, "Changelog for #{}".format(pr.number))
+	changelog_path = os.environ["ASS_CHANGELOG_PATH"] if 'ass-jam' in pr.labels else os.environ["CHANGELOG_PATH"]
+	status = update_changelog(repo, changelog_path, date_string, pr_data, "Changelog for #{}".format(pr.number))
 
 	if not status:
 		sys.exit(1) # scream at people

--- a/.github/workflows/update_changelog.yml
+++ b/.github/workflows/update_changelog.yml
@@ -26,5 +26,6 @@ jobs:
         REPO: ${{ github.repository }}
         TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CHANGELOG_PATH: strings/changelog.txt
+        ASS_CHANGELOG_PATH: strings/ass_changelog.txt
         GIT_EMAIL: "65057909+robuddybot@users.noreply.github.com"
         GIT_NAME: "robuddybot"

--- a/browserassets/html/changelog.html
+++ b/browserassets/html/changelog.html
@@ -7,12 +7,16 @@
 	.links li span {position: absolute; top: 0; right: 0; bottom: 0; width: 1px; background: #ccc;}
 
 	.log {list-style-type: none; padding: 0; background: #f9f9f9; margin: 20px 5px; border: 1px solid #ccc; font-size: 1em; color: #333;}
+	.log.ass {background: #ffdefa;}
 	.log li {overflow: visible; padding: 5px 5px 5px 20px; border-top: 1px solid #ccc; line-height: 1.4}
 	.log li.title {background: #efefef; font-size: 1.7em; color: #115FD5; padding: 10px 10px; border-top: 0;}
 	.log li.date {background: #f1f1f1; font-size: 1.1em; font-weight: bold; padding: 8px 5px; border-bottom: 2px solid #bbb;}
+	.log.ass li.title {background: #fccbf4;}
+	.log.ass li.date {background: #fccbf4;}
 	.log li.admin {font-size: 1.2em; padding: 5px 5px 5px 10px;}
 	.log li.admin span {color: #2A76E7;}
 	.log li.collapse-button { background: rgb(243, 243, 243); padding-left: 5px; cursor: pointer;}
+	.log.ass li.collapse-button { background: #fcd9f6; }
 	.log .collapsible { max-height: 0; overflow: hidden; transition: max-height 0.2s ease-out;}
 
 	h3 {padding: 0 10px; margin: 0; color: #58B4DC;}
@@ -31,6 +35,10 @@
 
 	li.collapse-button.active, li.collapse-button:hover {
 		background: rgb(225, 225, 225);
+	}
+
+	.log.ass li.collapse-button.active, .log.ass li.collapse-button:hover {
+		background: #ffb0f2;
 	}
 
 	a.pr_link {

--- a/code/datums/changelog.dm
+++ b/code/datums/changelog.dm
@@ -39,13 +39,13 @@ ATTENTION: The changelog has moved into its own file: strings/changelog.txt
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 
-/proc/changelog_parse(var/changes, var/title)
+/proc/changelog_parse(var/changes, var/title, var/logclasses)
 	var/list/html=list()
 	var/text = changes
 	if (!text)
 		diary << "Failed to load changelog."
 	else
-		html += "<ul class=\"log\"><li class=\"title\"><i class=\"icon-bookmark\"></i> [title] as of [vcs_revision]</li>"
+		html += "<ul class=\"log[logclasses]\"><li class=\"title\"><i class=\"icon-bookmark\"></i> [title] as of [vcs_revision]</li>"
 
 		var/list/collapsible_html = list()
 		var/added_collapsible_author = 0
@@ -202,6 +202,9 @@ ATTENTION: The changelog has moved into its own file: strings/changelog.txt
     <li>Official Forums<br><strong>https://forum.ss13.co</strong></li>
 </ul>"}
 
+#if ASS_JAM
+	html += changelog_parse(file2text("strings/ass_changelog.txt"), "Ass Jam Changelog", " ass")
+#endif
 	html += changelog_parse(file2text("strings/changelog.txt"), "Changelog")
 	html += {"
 <h3>GoonStation 13 Development Team</h3>

--- a/strings/ass_changelog.txt
+++ b/strings/ass_changelog.txt
@@ -1,0 +1,45 @@
+
+(t)wed may 13 20
+(u)pali
+(p)676
+(e)🆕|enhancement
+(*)Ass day classic vote now appears in the Status tab (just like map votes).
+(t)tue may 12 20
+(u)RichardGere
+(p)665
+(e)🍑🆕|ass-jam, enhancement
+(*)ASS JAM: Added a third emag stage to securitrons
+(u)Tarmunora
+(p)541
+(e)🍑|ass-jam
+(+)ASS_JAM: experimental change to newsmoke spreading
+(t)fri may 08 20
+(u)Tarmunora
+(p)605
+(e)🍑|ass-jam
+(+)ASS JAM: Changed pulse to pullse
+(t)tue apr 28 20
+(u)Fosstar
+(p)450
+(e)🍑⚖🗺|ass-jam, balance, mapping
+(*)Modernized and fixed up Donut 2 a bunch. The map is available during Ass Jam!
+(t)mon apr 13 20
+(u)ASS_JAM
+(*)Hello It is ASS_JAM. Please remember, you must not grief on ASS_JAM as a non-antag. Just play as usual. The entertainment this month is brought to you by:
+(*)Pali - AIs have a 5% chance to start with legs, HoS locker contains The Loose Cannon, trinket pool is unrestricted (all items), 25% chance for the game to pick a mutation at roundstart and give it to everyone - and much more
+(*)Moonlol - New wizard spell: Timestop. "This very handy dandy feature surely wont cause any runtimes"
+(*)Polivilas - Disables zipgun, adds a slamgun. "I will pay out 100k spacebux for better sprites - contact 2027#2027 on discord for more details."
+(*)Kubius - 2 new maps: Fleet and Kondaru. Do they compile? A mystery!!
+(*)Warcrimes - Updated reskinned Trunkmap, a couple tweaks here and there. Also enabled voting for most of the maps in the codebase.
+(*)UrsulaMajor - Updated Density, map smol.
+(t)sun apr 12 20
+(u)Goonstation Administration Team
+(*)Hello, we're changing ass day! Griefing is no longer allowed and we're adding a bunch of small fun changes. Click <a target="_blank" href="https://forum.ss13.co/showthread.php?tid=14330">here</a> for more details.
+(t)sun apr 05 20
+(u)pali
+(*)Nukies on ass day can now get much wilder target locations.
+(t)wed nov 13 19
+(u)Firebarrage and Hyrdofloric
+(*)A new Ass Day event: The Ass Day Arena!
+(*)Travel there with your ghost ability buttons, just like the afterlife bar
+(*)In the arena is a special artifact. If you pick it up and dont let anyone else pick it up for 30 seconds you will respawn!

--- a/strings/changelog.txt
+++ b/strings/changelog.txt
@@ -4,23 +4,11 @@
 (p)669
 (e)⚖|balance
 (+)Reduced light machine gun slow effect by two thirds.
-(u)pali
-(p)676
-(e)🆕|enhancement
-(*)Ass day classic vote now appears in the Status tab (just like map votes).
 (t)tue may 12 20
-(u)RichardGere
-(p)665
-(e)🍑🆕|ass-jam, enhancement
-(*)ASS JAM: Added a third emag stage to securitrons
 (u)system86
 (p)616
 (e)🆕|enhancement
 (+)DWAINE "eval" improvements and additions. New/fixed commands: # . .s del ' (single quote)
-(u)Tarmunora
-(p)541
-(e)🍑|ass-jam
-(+)ASS_JAM: experimental change to newsmoke spreading
 (u)Sovexe
 (p)646
 (e)🆕🎨|enhancement, sprites
@@ -83,10 +71,6 @@
 (p)624
 (e)🆕|enhancement
 (+)Clicking an airlock that you don't have permission to open with the help intent will now cause you to knock on the door
-(u)Tarmunora
-(p)605
-(e)🍑|ass-jam
-(+)ASS JAM: Changed pulse to pullse
 (u)glassofmilk
 (p)597
 (e)🆕|enhancement
@@ -278,10 +262,6 @@
 (u)mbc
 (e)⚖|balance
 (*)Disorient statuseffect will no longer randomly make you drop items. Increased the likelihood of a changeling or vampire scream forcing you to drop items to compensate.
-(u)Fosstar
-(p)450
-(e)🍑⚖🗺|ass-jam, balance, mapping
-(*)Modernized and fixed up Donut 2 a bunch. The map is available during Ass Jam!
 (u)mbc
 (p)461
 (e)⚖|balance
@@ -568,14 +548,6 @@
 (+)Batch one of small improvements and fixes to Kondaru.
 (u)Erinexx
 (+)Resprited janitor equipment (mops, buckets, laundry machines, ...).
-(u)ASS_JAM
-(*)Hello It is ASS_JAM. Please remember, you must not grief on ASS_JAM as a non-antag. Just play as usual. The entertainment this month is brought to you by:
-(*)Pali - AIs have a 5% chance to start with legs, HoS locker contains The Loose Cannon, trinket pool is unrestricted (all items), 25% chance for the game to pick a mutation at roundstart and give it to everyone - and much more
-(*)Moonlol - New wizard spell: Timestop. "This very handy dandy feature surely wont cause any runtimes"
-(*)Polivilas - Disables zipgun, adds a slamgun. "I will pay out 100k spacebux for better sprites - contact 2027#2027 on discord for more details."
-(*)Kubius - 2 new maps: Fleet and Kondaru. Do they compile? A mystery!!
-(*)Warcrimes - Updated reskinned Trunkmap, a couple tweaks here and there. Also enabled voting for most of the maps in the codebase.
-(*)UrsulaMajor - Updated Density, map smol.
 (u)Flaborized
 (*)Added a few small items to the surplus crate!
 (u)Tarmunora
@@ -585,8 +557,6 @@
 (+)Changed pointblanking to hit with all the projectiles in a burst, not just one
 (+)Fixes up gunpoint grabs a little bit (should shoot more consistently)
 (t)sun apr 12 20
-(u)Goonstation Administration Team
-(*)Hello, we're changing ass day! Griefing is no longer allowed and we're adding a bunch of small fun changes. Click <a target="_blank" href="https://forum.ss13.co/showthread.php?tid=14330">here</a> for more details.
 (u)Enfaeutchie
 (+)The Lawgiver now comes with an instructional pamphlet.
 (+)Fixed a couple of Lawgiver typos, and a bug where knockout was listed as detain in examine text.
@@ -664,7 +634,6 @@
 (*)Added Roach and Saxophone as spacebux rewards.
 (*)Disaster mode now includes a wraith at roundstart.
 (u)pali
-(*)Nukies on ass day can now get much wilder target locations.
 (+)Until we rework matsci somewhat light bulbs, light tubes and tripod bulbs are now 5 times more expensive when it comes to material cost
 (u)adharainspace
 (*)Added fancy new RCD sprites, courtesy of Flaborized!
@@ -1589,11 +1558,6 @@
 (u)Warcrimes
 (*)Y'know those shitty "cigars" they sell at the gas station, two fer a buck? Ya got those now.
 (*)I hear there's a shady brand out there that loads em with all sorts a spice and junk, know what i'm sayin Big J?
-(t)wed nov 13 19
-(u)Firebarrage and Hyrdofloric
-(*)A new Ass Day event: The Ass Day Arena!
-(*)Travel there with your ghost ability buttons, just like the afterlife bar
-(*)In the arena is a special artifact. If you pick it up and dont let anyone else pick it up for 30 seconds you will respawn!
 (t)sat nov 09 19
 (u)Kyle
 (*)Merge functional plates and trays patch by adhara. Put items on plates or trays and carry them around with you. Find trays in the kitchen vendomat.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Ass jam entries won't be shown normally. If it is ass jam they will be shown *above* all other entries in the changelog. The ass-jam label is used to decide which changelog to use.
![dreamseeker_y9yQ0ZLUXX](https://user-images.githubusercontent.com/358431/81816813-24663880-952c-11ea-9652-1378201d486d.png)



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Removes clutter from regular changelog. Makes it easier to see what cool stuff is online this ass jam.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)pali:
(*)Ass jam changelog is now only shown during ass jam. Also it is pink and above the regular changelog.
```
