### PR TITLE
Tweaks nukie to crew ratio from 1:2 to 1:3 on ass jam

### DIFF
--- a/code/datums/gamemodes/nuclear.dm
+++ b/code/datums/gamemodes/nuclear.dm
@@ -38,7 +38,7 @@
 		if (player.client && player.ready)
 			num_players++
 #if ASS_JAM
-	var/num_synds = max(1, min(round(num_players / 2), agents_possible))
+	var/num_synds = max(1, min(round(num_players / 3), agents_possible))
 #else
 	var/num_synds = max(1, min(round(num_players / 4), agents_possible))
 #endif


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I had made the ratio of nukies to crew 1:2 for ass jam due to the kinetitech. This changes ass jam nukie balancing again, so its a 1:3 ratio of nukies to crew rather than the 1:2 it was before, but still more nukies than the default 1:4.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
After seeing 1:2 ingame, it was too much of a steamroll, so I reduced the number of nukies again.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)TrustworthyFella:
(+)Changed nukie to crew ratio on ass jam from 1:2 to 1:3
```
