### PR TITLE
Makes the corpse spacebux purchase not carry over between rounds

### DIFF
--- a/code/modules/economy/persistent_bank_purchases.dm
+++ b/code/modules/economy/persistent_bank_purchases.dm
@@ -390,6 +390,7 @@ var/global/list/persistent_bank_purchaseables =	list(\
 	corpse
 		name = "Corpse"
 		cost = 15000
+		carries_over = 0
 
 		Create(var/mob/living/M)
 			setdead(M)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
It's what it says on the tin.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Because we get ahelps about it constantly and no one wants to be dead *every* round. One is enough.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)pali:
(+)"Corpse" spacebux purchase now doesn't carry over between rounds.
```
