### PR TITLE
Buffs derringers

### DIFF
--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -291,6 +291,7 @@ toxic - poisons
 	dissipation_rate = 50
 	damage_type = D_PIERCING
 	hit_type = DAMAGE_STAB
+	hit_ground_chance = 100
 	implanted = /obj/item/implant/projectile/bullet_41
 	ks_ratio = 0.66
 	caliber = 0.41

--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -286,13 +286,13 @@ toxic - poisons
 /datum/projectile/bullet/derringer
 	name = "bullet"
 	shot_sound = 'sound/weapons/derringer.ogg'
-	power = 100
+	power = 120
 	dissipation_delay = 1
-	dissipation_rate = 25
+	dissipation_rate = 50
 	damage_type = D_PIERCING
 	hit_type = DAMAGE_STAB
 	implanted = /obj/item/implant/projectile/bullet_41
-	ks_ratio = 0.5
+	ks_ratio = 0.66
 	caliber = 0.41
 	icon_turf_hit = "bhole"
 	casing = /obj/item/casing/derringer


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
~~Makes derringers do 120 stamina damage rather than 100~~, and 80 damage rather than 50. Falloff doubled to compensate, from 25 per tile to 50.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Derringers were nerfed when AP was made not shit, and as a result, became pretty shit. This should make them actually useful again without making them a basically guaranteed kill for 2TC.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)TrustworthyFella:
(+)Buffed derringer damage from 50 to 80. Higher falloff given to compensate.
```
