### PR TITLE
Makes the clock slightly less shit. Still shit but not as shit

### DIFF
--- a/code/mob/living/carbon/human/procs/damage.dm
+++ b/code/mob/living/carbon/human/procs/damage.dm
@@ -68,7 +68,7 @@
 		switch(P.proj_data.damage_type)
 			if (D_KINETIC)
 				if (stun > 0)
-					src.remove_stamina(min(round(stun/armor_value_bullet) * 30, 125)) //thanks to the odd scaling i have to cap this.
+					src.remove_stamina(min(round(stun/armor_value_bullet, 0.5) * 30, 125)) //thanks to the odd scaling i have to cap this.
 					src.stamina_stun()
 
 				if (armor_value_bullet > 1)

--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -168,7 +168,7 @@ toxic - poisons
 		..()
 		if(ishuman(hit))
 			var/mob/living/carbon/human/M = hit
-			if(M.getStatusDuration("slowed") < 25)
+			if(M.getStatusDuration("slowed") < 2.5 SECONDS)
 				M.changeStatus("slowed", 1 SECOND)
 
 
@@ -1245,6 +1245,5 @@ toxic - poisons
 			T.hotspot_expose(700,125)
 			explosion_new(null, T, 300, 1)
 		return
-
 
 

--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -155,6 +155,7 @@ toxic - poisons
 	shot_sound = 'sound/weapons/9x19NATO.ogg'
 	power = 6
 	ks_ratio = 0.9
+	hit_ground_chance = 75
 	dissipation_rate = 2
 	dissipation_delay = 8
 	projectile_speed = 36
@@ -162,6 +163,14 @@ toxic - poisons
 	icon_turf_hit = "bhole-small"
 	implanted = /obj/item/implant/projectile/bullet_nine_mm_NATO
 	casing = /obj/item/casing/small
+
+	on_hit(atom/hit)
+		..()
+		if(ishuman(hit))
+			var/mob/living/carbon/human/M = hit
+			if(M.getStatusDuration("slowed") < 25)
+				M.changeStatus("slowed", 1 SECOND)
+
 
 /datum/projectile/bullet/nine_mm_NATO/burst
 	shot_number = 3

--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -169,7 +169,7 @@ toxic - poisons
 		if(ishuman(hit))
 			var/mob/living/carbon/human/M = hit
 			if(M.getStatusDuration("slowed") < 2.5 SECONDS)
-				M.changeStatus("slowed", 1 SECOND)
+				M.changeStatus("slowed", 1 SECOND, optional = 2)
 
 
 /datum/projectile/bullet/nine_mm_NATO/burst
@@ -1245,5 +1245,4 @@ toxic - poisons
 			T.hotspot_expose(700,125)
 			explosion_new(null, T, 300, 1)
 		return
-
 

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -402,6 +402,7 @@
 		product_list += new/datum/data/vending_product(/obj/item/clothing/head/helmet/hardhat/security, 4)
 		product_list += new/datum/data/vending_product(/obj/item/device/pda2/security, 2)
 		product_list += new/datum/data/vending_product(/obj/item/ammo/bullets/a38/stun, 2)
+		product_list += new/datum/data/vending_product(/obj/item/ammo/bullets/nine_mm_NATO, 2)
 		product_list += new/datum/data/vending_product(/obj/item/implantcase/antirev, 3)
 #ifdef RP_MODE
 		product_list += new/datum/data/vending_product(/obj/item/paper/book/space_law, 1)
@@ -435,6 +436,7 @@
 		product_list += new/datum/data/vending_product(/obj/item/ammo/bullets/abg, 6)
 		product_list += new/datum/data/vending_product(/obj/item/ammo/bullets/a38, 2)
 		product_list += new/datum/data/vending_product(/obj/item/ammo/bullets/a38/stun, 3)
+		product_list += new/datum/data/vending_product(/obj/item/ammo/bullets/nine_mm_NATO,3)
 		product_list += new/datum/data/vending_product(/obj/item/ammo/bullets/flare, 3)
 		product_list += new/datum/data/vending_product(/obj/item/ammo/bullets/smoke, 3)
 		product_list += new/datum/data/vending_product(/obj/item/ammo/bullets/tranq_darts, 3)

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -411,6 +411,7 @@
 	desc = "A reliable weapon used the world over... 50 years ago. Uses 9mm NATO rounds."
 	name = "Clock 188"
 	icon_state = "clock-188-beige"
+	shoot_delay = 2
 	w_class = 2.0
 	force = 7.0
 	caliber = 0.355


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes how kinetics do stuns, but the change actually only affects the clock since nothing else is that shit. Basically just rounds the number thats multiplied by 30 to get the stamina damage, rather than flooring it. This means the clock can actually do stamina damage to armored opponents now. Also increases its rate of fire, chance to hit lying down targets, and adds a slow thats capped at 3 seconds, to allow for follow up shots. Adds clock ammo the sectechs too.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The clock is, quite frankly, shit. This hopefully makes it less shit, so while its still better to steal a taser, its alright to use the clock instead, if you're feeling masochistic.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)TrustworthyFella:
(+)Makes the clock work on armored targets, gives it additional slow(capped at 3s), and increases fire rate. 9mm NATO also has a higher(75%) chance of hitting prone targets.
(+)Adds clock ammo to the Ammotech + Sectech
```
