### PR TITLE
Corrected robot HUD inventory arrow color updates

### DIFF
--- a/code/datums/hud/robot.dm
+++ b/code/datums/hud/robot.dm
@@ -124,7 +124,7 @@
 				next.color = COLOR_MATRIX_IDENTITY
 			else
 				next.icon_state = "down_dis"
-				prev.color = COLOR_MATRIX_GRAYSCALE
+				next.color = COLOR_MATRIX_GRAYSCALE
 
 			for (var/i = items_screen, i < i_max, i++)
 				if (i > master.module.modules.len)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The robot inventory arrow HUD code was incorrectly gray scaling the top arrow instead of the bottom when the inventory was scrolled to the end


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's a bug and Pali told me to fix it

![image](https://user-images.githubusercontent.com/33204415/81991233-be061680-960e-11ea-907b-6b02d76b49b3.png)
