### PR TITLE
Map KEY_EXAMINE with new cube keymap for meatcubes

### DIFF
--- a/_stdlib/code/_controls.dm
+++ b/_stdlib/code/_controls.dm
@@ -424,6 +424,19 @@ var/list/key_names = list(
 						"E" = "exit",
 						"Q" = "exit"
 					))
+			if ("cube")
+				if (src.preferences.use_azerty)
+					return new /datum/keymap(list(
+							"ALT" = KEY_EXAMINE,
+						))
+				else if (src.tg_controls)
+					return new /datum/keymap(list(
+							"SHIFT" = KEY_EXAMINE,
+						))
+				else
+					return new /datum/keymap(list(
+							"ALT" = KEY_EXAMINE,
+						))
 	else
 		switch (name)
 			if ("general")
@@ -613,6 +626,15 @@ var/list/key_names = list(
 						"SOUTHEAST" = "attackself",
 						"NORTHWEST" = "unequip"
 					))
+			if ("cube")
+				if(src.tg_controls)
+					return new /datum/keymap(list(
+							"SHIFT" = KEY_EXAMINE,
+						))
+				else
+					return new /datum/keymap(list(
+							"ALT" = KEY_EXAMINE,
+						))
 			if ("pod")
 				return new /datum/keymap(list(
 						"SPACE" = "fire",

--- a/code/mob/living/carbon/cube.dm
+++ b/code/mob/living/carbon/cube.dm
@@ -97,6 +97,11 @@
 		pop()
 		return
 
+	/mob/living/carbon/cube/build_keymap(client/C)
+		var/datum/keymap/keymap = ..()
+		keymap.merge(client.get_keymap("human"))
+		return keymap
+
 	proc/get_cube_idle()
 		return "cubes cubily"
 

--- a/code/mob/living/carbon/cube.dm
+++ b/code/mob/living/carbon/cube.dm
@@ -99,7 +99,7 @@
 
 	/mob/living/carbon/cube/build_keymap(client/C)
 		var/datum/keymap/keymap = ..()
-		keymap.merge(client.get_keymap("human"))
+		keymap.merge(client.get_keymap("cube"))
 		return keymap
 
 	proc/get_cube_idle()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Assigns new `cube` keymap to meatcubes, which includes a bind for `KEY_EXAMINE`. Previously meat cube only had the `general` keymap. New keymap is automatically merged to `general` by `/mob/proc/build_keymap`


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #681 