### PR TITLE
Original Sin Medal Reward Rework

### DIFF
--- a/code/WorkInProgress/rewardsLocker.dm
+++ b/code/WorkInProgress/rewardsLocker.dm
@@ -809,9 +809,21 @@
 		if (activator.stat || activator.restrained() || activator.getStatusDuration("paralysis") || activator.getStatusDuration("stunned"))
 			boutput(activator, "<span style=\"color:red\">Absolutely Not.</span>")
 			return
+		var/blood_id = "blood"
+		var/blood_amount = 500
+		var/blood_mult = 6.9
+		var/mob/living/L = activator
+		if(istype(L))
+			var/mob/living/carbon/human/H = activator
+			if(L.blood_id)
+				blood_id = L.blood_id
+			if(istype(H) && H.blood_volume)
+				blood_amount = H.blood_volume
 		activator.suiciding = 1
 		var/turf/T = get_turf(activator)
-		T.fluid_react_single("blood",2000)
+		if(L?.traitHolder?.hasTrait("hemophilia"))
+			blood_mult = blood_mult + 3
+		T.fluid_react_single(blood_id,blood_mult * blood_amount)
 		activator.gib()
 		SPAWN_DBG(20 SECONDS)
 			if(activator && !isdead(activator))

--- a/code/modules/antagonists/changeling/abilities/changeling.dm
+++ b/code/modules/antagonists/changeling/abilities/changeling.dm
@@ -2,6 +2,9 @@
 	var/datum/abilityHolder/changeling/O = src.get_ability_holder(/datum/abilityHolder/changeling)
 	if (O)
 		return
+	var/mob/living/L = src
+	if(istype(L))
+		L.blood_id = "bloodc"
 
 	if (src.mind && !src.mind.is_changeling && (src.mind.special_role != "omnitraitor"))
 		src.Browse(grabResource("html/traitorTips/changelingTips.html"),"window=antagTips;size=600x400;title=Antagonist Tips")

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -1579,7 +1579,10 @@ datum
 				if (!M) M = holder.my_atom
 				//M.changeStatus("radiation", 30, 1)
 				if (!src.data) // Pull bioholder data from blood that's in the same reagentholder
-					var/datum/reagent/blood/cheating = holder.reagent_list["blood", "bloodc"]
+					if(holder.has_reagent("bloodc"))
+						var/datum/reagent/blood/cheating = holder.reagent_list["bloodc"]
+					else if(holder.has_reagent("blood"))
+						var/datum/reagent/blood/cheating = holder.reagent_list["blood"]
 					if (cheating && istype(cheating.data, /datum/bioHolder))
 						src.data = cheating.data
 

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -1581,10 +1581,12 @@ datum
 				if (!src.data) // Pull bioholder data from blood that's in the same reagentholder
 					if(holder.has_reagent("bloodc"))
 						var/datum/reagent/blood/cheating = holder.reagent_list["bloodc"]
+						if (cheating && istype(cheating.data, /datum/bioHolder))
+							src.data = cheating.data
 					else if(holder.has_reagent("blood"))
 						var/datum/reagent/blood/cheating = holder.reagent_list["blood"]
-					if (cheating && istype(cheating.data, /datum/bioHolder))
-						src.data = cheating.data
+						if (cheating && istype(cheating.data, /datum/bioHolder))
+							src.data = cheating.data
 
 				if (src.data && M.bioHolder && progress_timer <= 10)
 

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -1579,7 +1579,7 @@ datum
 				if (!M) M = holder.my_atom
 				//M.changeStatus("radiation", 30, 1)
 				if (!src.data) // Pull bioholder data from blood that's in the same reagentholder
-					var/datum/reagent/blood/cheating = holder.reagent_list["blood"]
+					var/datum/reagent/blood/cheating = holder.reagent_list["blood", "bloodc"]
 					if (cheating && istype(cheating.data, /datum/bioHolder))
 						src.data = cheating.data
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[ENHANCEMENT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Gives changelings a different `blood_id` than human, makes Original Sin use `blood_id`, `blood_volume`, and the hemophilia trait to decide what reagent the flood will be, and how much. Its a bit more blood than it was before, but I couldn't pass up the opportunity to make the multiplier 6.9.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Its pretty cool that the blood flood will use *your* blood, and ultimately, this has no effect on balance. It also allows people to make blood floods of different sizes  by being hypo/hypertensive, or having the hemophilia trait, which I think is also pretty cool.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)TrustworthyFella:
(+)Made Original Sin blood floods size and reagent depend on the amount of blood in you, and what your blood reagent is.
```
