### PR TITLE
Correct canbomb light deletion proc call

### DIFF
--- a/code/obj/item/assembly/detonator.dm
+++ b/code/obj/item/assembly/detonator.dm
@@ -254,7 +254,8 @@
 		return
 
 	src.attachedTo.anchored = 0
-	src.remove_simple_light("canister")
+	src.attachedTo.remove_simple_light("canister")
+
 	if (src.defused)
 		src.attachedTo.visible_message("<b><span class='alert'>The cut detonation wire emits a spark. The detonator signal never reached the detonator unit.</span></b>")
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][MINOR] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Light removal was called by wrong object causing it to fail to delete.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's a bug and Flourish told me to fix it
closes #211 