### PR TITLE
Cleans up reagent temperature reactions and related code

### DIFF
--- a/code/modules/chemistry/Chemistry-Holder.dm
+++ b/code/modules/chemistry/Chemistry-Holder.dm
@@ -108,7 +108,7 @@ datum
 		proc/temperature_react() //Calls the temperature reaction procs without changing the temp.
 			for(var/reagent_id in reagent_list)
 				var/datum/reagent/current_reagent = reagent_list[reagent_id]
-				if(current_reagent && src.total_temperature > current_reagent.minimum_reaction_temperature)
+				if(current_reagent && src.total_temperature >= current_reagent.minimum_reaction_temperature)
 					current_reagent.reaction_temperature(src.total_temperature, 100)
 
 		proc/temperature_reagents(exposed_temperature, exposed_volume, divisor = 35, change_cap = 15) //This is what you use to change the temp of a reagent holder.

--- a/code/modules/chemistry/Chemistry-Holder.dm
+++ b/code/modules/chemistry/Chemistry-Holder.dm
@@ -108,20 +108,22 @@ datum
 		proc/temperature_react() //Calls the temperature reaction procs without changing the temp.
 			for(var/reagent_id in reagent_list)
 				var/datum/reagent/current_reagent = reagent_list[reagent_id]
-				if(current_reagent)
+				if(current_reagent && src.total_temperature > current_reagent.minimum_reaction_temperature)
 					current_reagent.reaction_temperature(src.total_temperature, 100)
 
 		proc/temperature_reagents(exposed_temperature, exposed_volume, divisor = 35, change_cap = 15) //This is what you use to change the temp of a reagent holder.
 			                                                      //Do not manually change the reagent unless you know what youre doing.
 			last_temp = total_temperature
 			var/difference = abs(total_temperature - exposed_temperature)
+			if (!difference)
+				return
 			var/change = min(max((difference / divisor), 1), change_cap)
 			if(exposed_temperature > total_temperature)
 				total_temperature += change
 			else if (exposed_temperature < total_temperature)
 				total_temperature -= change
 
-			total_temperature = max(min(total_temperature, temperature_cap), temperature_min) //Cap for the moment.
+			total_temperature = clamp(total_temperature, temperature_min, temperature_cap) //Cap for the moment.
 			temperature_react()
 
 			handle_reactions()

--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -47,6 +47,7 @@ datum
 		var/blocks_sight_gas = 0 //opacity
 		var/pierces_outerwear = 0//whether or not this penetrates outerwear that may protect the victim(e.g. biosuit)
 		var/stun_resist = 0
+		var/minimum_reaction_temperature = INFINITY // Minimum temperature for reaction_temperature() to occur, use -INFINITY to bypass this check
 
 		New()
 			..()

--- a/code/modules/chemistry/Reagents-Base.dm
+++ b/code/modules/chemistry/Reagents-Base.dm
@@ -390,6 +390,7 @@ datum
 			fluid_g = 40
 			fluid_b = 160
 			transparency = 222
+			minimum_reaction_temperature = T0C + 100
 			var/reacted_to_temp = 0 // prevent infinite loop in a fluid
 
 			pooled()
@@ -397,14 +398,13 @@ datum
 				reacted_to_temp = 0
 
 			reaction_temperature(exposed_temperature, exposed_volume)
-				if(exposed_temperature >= T0C + 100 && !reacted_to_temp)
+				if(!reacted_to_temp)
 					reacted_to_temp = 1
 					if(holder)
 						var/list/covered = holder.covered_turf()
 						for(var/turf/t in covered)
 							SPAWN_DBG(1 DECI SECOND) fireflash(t, min(max(0,((volume/covered.len)/15)),6))
 						holder.del_reagent(id)
-				return
 
 			on_mob_life(var/mob/M, var/mult = 1)
 				if(!M) M = holder.my_atom
@@ -727,6 +727,7 @@ datum
 			hygiene_value = 1.33
 			bladder_value = -0.2
 			taste = "bland"
+			minimum_reaction_temperature = -INFINITY
 			target_organs = list("left_kidney", "right_kidney")
 #ifdef UNDERWATER_MAP
 			block_slippy = 1
@@ -911,17 +912,16 @@ datum
 			transparency = 200
 			thirst_value = 0.8909
 			bladder_value = -0.2
+			minimum_reaction_temperature = T0C+1 // if it adds 1'C water, 1'C is good enough.
 			taste = "cold"
 
 			reaction_temperature(exposed_temperature, exposed_volume)
-				if(exposed_temperature > T0C)
-					var/prev_vol = volume
-					volume = 0
-					if(holder)
-						holder.add_reagent("water", prev_vol, null, T0C + 1)
-					if(holder)
-						holder.del_reagent(id)
-				return
+				var/prev_vol = volume
+				volume = 0
+				if(holder)
+					holder.add_reagent("water", prev_vol, null, T0C + 1)
+				if(holder)
+					holder.del_reagent(id)
 
 			reaction_obj(var/obj/O, var/volume)
 				src = null

--- a/code/modules/chemistry/Reagents-Drugs.dm
+++ b/code/modules/chemistry/Reagents-Drugs.dm
@@ -361,13 +361,12 @@ datum
 			value = 3 // 1c + 1c + 1c
 			viscosity = 0.2
 			thirst_value = -0.03
+			minimum_reaction_temperature = T0C+400
 
 			reaction_temperature(exposed_temperature, exposed_volume)
 				var/myvol = volume
-				if(exposed_temperature > T0C + 400) //Turns into a neurotoxin.
-					volume = 0
-					holder.add_reagent("neurotoxin", myvol, null)
-				return
+				holder.del_reagent(id)
+				holder.add_reagent("neurotoxin", myvol, null)
 
 			on_mob_life(var/mob/M, var/mult = 1)
 				if(!M) M = holder.my_atom

--- a/code/modules/chemistry/Reagents-ExplosiveFire.dm
+++ b/code/modules/chemistry/Reagents-ExplosiveFire.dm
@@ -148,6 +148,7 @@ datum
 			transparency = 255
 			viscosity = 0.4
 			volatility = 2
+			minimum_reaction_temperature = T0C+600
 
 			reaction_obj(var/obj/O, var/volume)
 				if (!holder)
@@ -157,21 +158,19 @@ datum
 					qdel(O)
 
 			reaction_temperature(exposed_temperature, exposed_volume)
-				if(exposed_temperature > T0C + 600)
-					var/radius = min(max(0,volume*0.15),8)
-					var/list/covered = holder.covered_turf()
-					var/list/affected = list()
-					for(var/turf/t in covered)
-						radius = min(max(0,(volume/covered.len)*0.15),8)
-						affected += fireflash_sm(t, radius, rand(3000, 6000), 500)
+				var/radius = min(max(0,volume*0.15),8)
+				var/list/covered = holder.covered_turf()
+				var/list/affected = list()
+				for(var/turf/t in covered)
+					radius = min(max(0,(volume/covered.len)*0.15),8)
+					affected += fireflash_sm(t, radius, rand(3000, 6000), 500)
 
-					for (var/turf/T in affected)
-						for (var/obj/steel_beams/O in T)
-							O.visible_message("<span class='alert'>[O] melts!</span>")
-							qdel(O)
-					if(holder)
-						holder.del_reagent(id)
-				return
+				for (var/turf/T in affected)
+					for (var/obj/steel_beams/O in T)
+						O.visible_message("<span class='alert'>[O] melts!</span>")
+						qdel(O)
+				if(holder)
+					holder.del_reagent(id)
 
 			reaction_turf(var/turf/simulated/T, var/volume)
 				if (!holder)
@@ -192,25 +191,19 @@ datum
 			fluid_b = 0
 			transparency = 255
 			volatility = 1.5
+			minimum_reaction_temperature = T0C+100
 
 			reaction_temperature(exposed_temperature, exposed_volume)
 				var/turf/simulated/A = holder.my_atom
 				if(!istype(A)) return
 
-				if(exposed_temperature >= T0C + 100 && (holder.get_reagent_amount(id) >= 15)) //no more thermiting walls with 1u tyvm
-					var/datum/reagents/Holder = holder
-					var/Id = id
-					var/Volume = volume
+				if(holder.get_reagent_amount(id) >= 15) //no more thermiting walls with 1u tyvm
+					var/id = src.id
+					var/datum/reagents/holder = src.holder
+					var/volume
 					src = null
-					Holder.del_reagent(Id)
-					fireflash_sm(A, 0, rand(20000, 25000) + Volume * 2500, 0, 0, 1) // Bypasses the RNG roll to melt walls (Convair880).
-
-					/*var/turf/simulated/floor/F = A.ReplaceWithFloor()
-					F.to_plating()
-					F.burn_tile()*/
-					return
-
-				return
+					holder.del_reagent(id)
+					fireflash_sm(A, 0, rand(20000, 25000) + volume * 2500, 0, 0, 1) // Bypasses the RNG roll to melt walls (Convair880).
 
 			reaction_mob(var/mob/M, var/method=TOUCH, var/volume)
 				src = null
@@ -241,6 +234,7 @@ datum
 			fluid_g = 200
 			fluid_b = 200
 			transparency = 230
+			minimum_reaction_temperature = T0C+25
 			var/ignited = 0
 
 			pooled()
@@ -248,7 +242,7 @@ datum
 				ignited = 0
 
 			reaction_temperature(exposed_temperature, exposed_volume)
-				if(exposed_temperature > T0C + 25 && !ignited)
+				if(!ignited)
 					ignited = 1
 					src=null
 					var/myid = id
@@ -267,6 +261,7 @@ datum
 			fluid_g = 200
 			fluid_b = 255
 			transparency = 230
+			minimum_reaction_temperature = T0C + 100
 			var/ignited = 0
 
 			pooled()
@@ -274,7 +269,7 @@ datum
 				ignited = 0
 
 			reaction_temperature(exposed_temperature, exposed_volume)
-				if(exposed_temperature > T0C + 100 && !ignited)
+				if(!ignited)
 					ignited = 1
 					src=null
 					var/myid = id
@@ -294,53 +289,55 @@ datum
 			fluid_b = 200
 			transparency = 230
 			penetrates_skin = 1 // coat them with it?
+			minimum_reaction_temperature = T0C+100
 			var/no_fluff = 0
 
 			reaction_temperature(exposed_temperature, exposed_volume)
-				if(reacting) return
-				if(exposed_temperature > T0C + 100)
-					reacting = 1
-					var/list/covered = holder.covered_turf()
-					var/location = covered.len ? covered[1] : 0
-					var/hootmode = prob(5)
+				if(reacting)
+					return
+
+				reacting = 1
+				var/list/covered = holder.covered_turf()
+				var/location = covered.len ? covered[1] : 0
+				var/hootmode = prob(5)
+
+				if (src.no_fluff == 0)
+					if (hootmode)
+						playsound(location, "sound/voice/animal/hoot.ogg", 100, 1)
+					else
+						playsound(location, "sound/weapons/flashbang.ogg", 25, 1)
+
+				for (var/mob/living/M in all_hearers(world.view, location))
+					if (issilicon(M) || isintangible(M))
+						continue
 
 					if (src.no_fluff == 0)
-						if (hootmode)
-							playsound(location, "sound/voice/animal/hoot.ogg", 100, 1)
+						if (!M.ears_protected_from_sound())
+							boutput(M, "<span class='alert'><b>[hootmode ? "HOOT" : "BANG"]</b></span>")
 						else
-							playsound(location, "sound/weapons/flashbang.ogg", 25, 1)
-
-					for (var/mob/living/M in all_hearers(world.view, location))
-						if (issilicon(M) || isintangible(M))
 							continue
 
-						if (src.no_fluff == 0)
-							if (!M.ears_protected_from_sound())
-								boutput(M, "<span class='alert'><b>[hootmode ? "HOOT" : "BANG"]</b></span>")
-							else
-								continue
+					var/checkdist = get_dist(M, location)
+					var/weak = max(0, holder.get_reagent_amount(id) * 0.2 * (3 - checkdist))
+					var/misstep = 40
+					var/ear_damage = max(0, holder.get_reagent_amount(id) * 0.2 * (3 - checkdist))
+					var/ear_tempdeaf = max(0, holder.get_reagent_amount(id) * 0.2 * (5 - checkdist)) //annoying and unfun so reduced dramatically
 
-						var/checkdist = get_dist(M, location)
-						var/weak = max(0, holder.get_reagent_amount(id) * 0.2 * (3 - checkdist))
-						var/misstep = 40
-						var/ear_damage = max(0, holder.get_reagent_amount(id) * 0.2 * (3 - checkdist))
-						var/ear_tempdeaf = max(0, holder.get_reagent_amount(id) * 0.2 * (5 - checkdist)) //annoying and unfun so reduced dramatically
+					M.apply_sonic_stun(weak, 0, misstep, 0, 0, ear_damage, ear_tempdeaf)
 
-						M.apply_sonic_stun(weak, 0, misstep, 0, 0, ear_damage, ear_tempdeaf)
+				for (var/mob/living/silicon/S in all_hearers(world.view, location))
+					if (src.no_fluff == 0)
+						if (!S.ears_protected_from_sound())
+							boutput(S, "<span class='alert'><b>[hootmode ? "HOOT" : "BANG"]</b></span>")
+						else
+							continue
 
-					for (var/mob/living/silicon/S in all_hearers(world.view, location))
-						if (src.no_fluff == 0)
-							if (!S.ears_protected_from_sound())
-								boutput(S, "<span class='alert'><b>[hootmode ? "HOOT" : "BANG"]</b></span>")
-							else
-								continue
+					var/checkdist = get_dist(S, location)
+					var/C_weak = max(0, holder.get_reagent_amount(id) * 0.2 * (3 - checkdist))
 
-						var/checkdist = get_dist(S, location)
-						var/C_weak = max(0, holder.get_reagent_amount(id) * 0.2 * (3 - checkdist))
+					S.apply_sonic_stun(C_weak, 0)
 
-						S.apply_sonic_stun(C_weak, 0)
-
-					holder.del_reagent(id)
+				holder.del_reagent(id)
 
 			on_mob_life(var/mob/M, var/mult = 1) // fuck you jerk chemists (todo: a thing to self-harm borgs too, maybe ex_act(3) to the holder? I D K
 				if(!M) M = holder.my_atom
@@ -367,78 +364,38 @@ datum
 			transparency = 230
 			penetrates_skin = 1 // coat them with it?
 			viscosity = 0.5
+			minimum_reaction_temperature = T0C+100
 
 			reaction_temperature(exposed_temperature, exposed_volume)
-				if(reacting) return // fix for a potential game crashing exploit with smokes
-				if(exposed_temperature > T0C + 100)
-					reacting = 1
-					var/list/covered = holder.covered_turf()
-					var/location = covered.len ? covered[1] : 0
-					var/datum/effects/system/spark_spread/s = unpool(/datum/effects/system/spark_spread)
-					s.set_up(2, 1, location)
-					s.start()
+				if(reacting)
+					return // fix for a potential game crashing exploit with smokes
 
-					for (var/mob/living/M in all_viewers(5, location))
-						if (issilicon(M) || isintangible(M))
-							continue
+				reacting = 1
+				var/list/covered = holder.covered_turf()
+				var/location = covered.len ? covered[1] : 0
+				var/datum/effects/system/spark_spread/s = unpool(/datum/effects/system/spark_spread)
+				s.set_up(2, 1, location)
+				s.start()
 
-						var/dist = get_dist(M, location)
-						var/stunned = max(0, holder.get_reagent_amount(id) * (3 - dist) * 0.1)
-						var/eye_damage = max(0, holder.get_reagent_amount(id) * (2 - dist) * 0.1)
-						var/eye_blurry = max(0, holder.get_reagent_amount(id) * (5 - dist) * 0.2)
+				for (var/mob/living/M in all_viewers(5, location))
+					if (issilicon(M) || isintangible(M))
+						continue
 
-						M.apply_flash(60, 0, max(0, stunned), 0, max(0, eye_blurry), max(0, eye_damage))
+					var/dist = get_dist(M, location)
+					var/stunned = max(0, holder.get_reagent_amount(id) * (3 - dist) * 0.1)
+					var/eye_damage = max(0, holder.get_reagent_amount(id) * (2 - dist) * 0.1)
+					var/eye_blurry = max(0, holder.get_reagent_amount(id) * (5 - dist) * 0.2)
 
-					for (var/mob/living/silicon/M in all_viewers(world.view, location))
-						var/checkdist = get_dist(M, location)
-						var/C_weakened = max(0, holder.get_reagent_amount(id) * (3 - checkdist) * 0.1)
-						var/C_stunned = max(0, holder.get_reagent_amount(id) * (5 - checkdist) * 0.1)
+					M.apply_flash(60, 0, max(0, stunned), 0, max(0, eye_blurry), max(0, eye_damage))
 
-						M.apply_flash(30, max(0, C_weakened), max(0, C_stunned))
+				for (var/mob/living/silicon/M in all_viewers(world.view, location))
+					var/checkdist = get_dist(M, location)
+					var/C_weakened = max(0, holder.get_reagent_amount(id) * (3 - checkdist) * 0.1)
+					var/C_stunned = max(0, holder.get_reagent_amount(id) * (5 - checkdist) * 0.1)
 
-					holder.del_reagent(id)
+					M.apply_flash(30, max(0, C_weakened), max(0, C_stunned))
 
-		//explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range)
-
-/*		combustible/merculite
-			name = "Merculite"
-			id = "merculite"
-			description = "Highly flammable and explosive compound. Very sticky."
-			reagent_state = LIQUID
-			fluid_r = 200
-			fluid_g = 125
-			fluid_b = 75
-			transparency = 175
-
-			reaction_temperature(exposed_temperature, exposed_volume)
-				if(temperature > 330)
-					var/extra_range = round(min(max((((temperature - T0C) / 10) - 6),0),3)) //Usually 0. Unless someone somehow manages to heat this without it exploding.
-					var/max_range = round(min(max((volume / 10),1),8),1) + extra_range
-					var/heavy_range = round(max((max_range / 2),1))
-					var/devastation_range = min(max(extra_range, 1),3)
-					explosion(get_turf(holder.my_atom), devastation_range, heavy_range, max_range, max_range)
-					holder.del_reagent(id)
-				return
-
-			reaction_obj(var/obj/O, var/volume)
-				src = null
-				if(!O.reagents) O.create_reagents(50)
-				O.reagents.add_reagent("merculite", 3, null)
-				return
-
-			reaction_turf(var/turf/T, var/volume)
-				src = null
-				if(!T.reagents) T.create_reagents(50)
-				T.reagents.add_reagent("merculite", 3, null)
-				return
-
-			reaction_mob(var/mob/M, var/method=TOUCH, var/volume)
-				src = null
-				if(method == TOUCH)
-					var/mob/living/L = M
-					if(istype(L) && L.burning)
-						L.set_burning(100)
-				return */
+				holder.del_reagent(id)
 
 		combustible/infernite // COGWERKS CHEM REVISION PROJECT. this could be Chlorine Triflouride, a really mean thing
 			name = "chlorine triflouride"
@@ -454,12 +411,6 @@ datum
 			dispersal = 2
 			hygiene_value = 2 // with purging fire
 			viscosity = 0.5
-
-			/*reaction_temperature(exposed_temperature, exposed_volume)
-				if(temperature > T0C + 15)
-					fireflash(get_turf(holder.my_atom), min(max(0,volume/10),3))
-					holder.del_reagent(id)
-				return*/
 
 			reaction_obj(var/obj/O, var/volume)
 				var/datum/reagents/old_holder = src.holder //mbc pls, ZeWaka fix: null.holder
@@ -538,20 +489,6 @@ datum
 			viscosity = 0.6
 			volatility = 4
 
-			/*reaction_temperature(exposed_temperature, exposed_volume)
-				if(temperature > T0C + 15)
-					fireflash(get_turf(holder.my_atom), min(max(0,volume/10),3))
-					holder.del_reagent(id)
-				return*/
-
-			/*reaction_obj(var/obj/O, var/volume)
-				src = null
-				if (O && ispath(O, /obj/item))
-					var/obj/item/I = O
-					if(!I.burning)
-						I.combust()
-				return*/
-
 			reaction_turf(var/turf/T, var/volume)
 				src = null
 				//if(!T.reagents) T.create_reagents(50)
@@ -599,10 +536,10 @@ datum
 			transparency = 150
 			viscosity = 0.7
 			volatility = 2.5
+			minimum_reaction_temperature = 1000
 
 			reaction_temperature(exposed_temperature, exposed_volume)
-				if(holder.total_temperature >= 1000) holder.del_reagent(id)
-				return
+				holder.del_reagent(id)
 
 			reaction_obj(var/obj/O, var/volume)
 				src = null
@@ -631,6 +568,8 @@ datum
 			transparency = 200
 			viscosity = 0.6
 			volatility = 3
+			minimum_reaction_temperature = -INFINITY
+
 
 			reaction_temperature(exposed_temperature, exposed_volume)
 				if(exposed_temperature < T0C)
@@ -639,7 +578,7 @@ datum
 						for(var/turf/t in covered)
 							explosion(t, t, 2, 3, 4, 1)
 						holder.del_reagent(id)
-				return
+
 			reaction_obj(var/obj/O, var/volume)
 				src = null
 				return
@@ -658,21 +597,22 @@ datum
 			transparency = 200
 			viscosity = 0.6
 			volatility = 1.25
+			minimum_reaction_temperature = T0C + 200
 
 			reaction_temperature(exposed_temperature, exposed_volume)
 				if(src.reacting)
 					return
-				if(exposed_temperature > T0C + 200)
-					src.reacting = 1
-					var/list/covered = holder.covered_turf()
-					for(var/atom/source in covered)
-						new/obj/decal/shockwave(source)
-						playsound(source, "sound/weapons/flashbang.ogg", 25, 1)
-						for(var/atom/movable/M in view(2 + (volume/covered.len > 30 ? 1:0), source))
-							if(M.anchored || M == source || M.throwing) continue
-							M.throw_at(get_edge_cheap(source, get_dir(source, M)), 20 + round(((volume/covered.len) * 2)), 1 + round((volume/covered.len) / 10))
-					holder.del_reagent(id)
-				return
+
+				src.reacting = 1
+				var/list/covered = holder.covered_turf()
+				for(var/atom/source in covered)
+					new/obj/decal/shockwave(source)
+					playsound(source, "sound/weapons/flashbang.ogg", 25, 1)
+					for(var/atom/movable/M in view(2 + (volume/covered.len > 30 ? 1:0), source))
+						if(M.anchored || M == source || M.throwing) continue
+						M.throw_at(get_edge_cheap(source, get_dir(source, M)), 20 + round(((volume/covered.len) * 2)), 1 + round((volume/covered.len) / 10))
+				holder.del_reagent(id)
+
 
 			reaction_mob(var/mob/M, var/method=TOUCH, var/volume)
 				return
@@ -688,6 +628,7 @@ datum
 			value = 6 // 3 1 1 1
 			viscosity = 0.9
 			volatility = 1.5 // lol no
+			minimum_reaction_temperature = T0C+200
 
 			reaction_temperature(exposed_temperature, exposed_volume)
 				if(src.reacting)
@@ -696,10 +637,9 @@ datum
 				if (covered.len > 1 && (exposed_volume/covered.len) > 0.5)
 					return
 
-				if(exposed_temperature > T0C + 200)
-					src.reacting = 1
-					ldmatter_reaction(holder, volume, id)
-				return
+				src.reacting = 1
+				ldmatter_reaction(holder, volume, id)
+
 
 			//Comment this out if you notice a lot of crashes. (It's probably a really bad idea to have this in)
 			/* i agree. also fuck snapcakes
@@ -738,6 +678,7 @@ datum
 			fluid_b = 0
 			transparency = 230
 			viscosity = 0.2
+			minimum_reaction_temperature = T0C + 200
 
 			var/max_radius = 7
 			var/min_radius = 0
@@ -748,43 +689,42 @@ datum
 			var/max_explosion_radius = 4
 			var/volume_explosion_radius_multiplier = 0.005
 			var/volume_explosion_radius_modifier = 0
-			var/combustion_temp = T0C + 200
+
 
 			var/caused_fireflash = 0
 			var/min_req_fluid = 0.10 //at least 10% of the fluid needs to be oil for it to ignite
 
 			reaction_temperature(exposed_temperature, exposed_volume)
-				if(exposed_temperature > combustion_temp)
-					if(volume < 1)
-						if (holder)
-							holder.del_reagent(id)
-						return
+				if(volume < 1)
+					if (holder)
+						holder.del_reagent(id)
+					return
 
-					if (caused_fireflash) return //Stop the fireflash from triggering reaction_temperature on myself (inf loop)
-					var/list/covered = holder.covered_turf()
-					if (covered.len < 4 || (volume / holder.total_volume) > min_req_fluid)
-						if(covered.len > 0) //possible fix for bug where caused_fireflash was set to 1 without fireflash going off, allowing fuel to reach any temp without igniting
-							caused_fireflash = 1
-						for(var/turf/turf in covered)
-							var/radius = min(max(min_radius, ((volume/covered.len) * volume_radius_multiplier + volume_radius_modifier)), max_radius)
-							fireflash_sm(turf, radius, 2200 + radius * 250, radius * 50)
-							if(holder && (volume/covered.len) >= explosion_threshold)
-								if(holder.my_atom)
-									holder.my_atom.visible_message("<span class='alert'><b>[holder.my_atom] explodes!</b></span>")
-									// Added log entries (Convair880).
-									message_admins("Fuel tank explosion ([holder.my_atom], reagent type: [id]) at [log_loc(holder.my_atom)]. Last touched by: [holder.my_atom.fingerprintslast ? "[holder.my_atom.fingerprintslast]" : "*null*"].")
-									logTheThing("bombing", holder.my_atom.fingerprintslast, null, "Fuel tank explosion ([holder.my_atom], reagent type: [id]) at [log_loc(holder.my_atom)]. Last touched by: [holder.my_atom.fingerprintslast ? "[holder.my_atom.fingerprintslast]" : "*null*"].")
-								else
-									turf.visible_message("<span class='alert'><b>[holder.my_atom] explodes!</b></span>")
-									// Added log entries (Convair880).
-									message_admins("Fuel explosion ([turf], reagent type: [id]) at [log_loc(turf)].")
-									logTheThing("bombing", null, null, "Fuel explosion ([turf], reagent type: [id]) at [log_loc(turf)].")
+				if (caused_fireflash)
+					return //Stop the fireflash from triggering reaction_temperature on myself (inf loop)
+				var/list/covered = holder.covered_turf()
+				if (covered.len < 4 || (volume / holder.total_volume) > min_req_fluid)
+					if(covered.len > 0) //possible fix for bug where caused_fireflash was set to 1 without fireflash going off, allowing fuel to reach any temp without igniting
+						caused_fireflash = 1
+					for(var/turf/turf in covered)
+						var/radius = min(max(min_radius, ((volume/covered.len) * volume_radius_multiplier + volume_radius_modifier)), max_radius)
+						fireflash_sm(turf, radius, 2200 + radius * 250, radius * 50)
+						if(holder && (volume/covered.len) >= explosion_threshold)
+							if(holder.my_atom)
+								holder.my_atom.visible_message("<span class='alert'><b>[holder.my_atom] explodes!</b></span>")
+								// Added log entries (Convair880).
+								message_admins("Fuel tank explosion ([holder.my_atom], reagent type: [id]) at [log_loc(holder.my_atom)]. Last touched by: [holder.my_atom.fingerprintslast ? "[holder.my_atom.fingerprintslast]" : "*null*"].")
+								logTheThing("bombing", holder.my_atom.fingerprintslast, null, "Fuel tank explosion ([holder.my_atom], reagent type: [id]) at [log_loc(holder.my_atom)]. Last touched by: [holder.my_atom.fingerprintslast ? "[holder.my_atom.fingerprintslast]" : "*null*"].")
+							else
+								turf.visible_message("<span class='alert'><b>[holder.my_atom] explodes!</b></span>")
+								// Added log entries (Convair880).
+								message_admins("Fuel explosion ([turf], reagent type: [id]) at [log_loc(turf)].")
+								logTheThing("bombing", null, null, "Fuel explosion ([turf], reagent type: [id]) at [log_loc(turf)].")
 
-								var/boomrange = min(max(min_explosion_radius, round((volume/covered.len) * volume_explosion_radius_multiplier + volume_explosion_radius_modifier)), max_explosion_radius)
-								explosion(holder.my_atom, turf, -1,-1,boomrange,1)
-						if (holder)
-							holder.del_reagent(id)
-				return
+							var/boomrange = min(max(min_explosion_radius, round((volume/covered.len) * volume_explosion_radius_multiplier + volume_explosion_radius_modifier)), max_explosion_radius)
+							explosion(holder.my_atom, turf, -1,-1,boomrange,1)
+					if (holder)
+						holder.del_reagent(id)
 
 			reaction_obj(var/obj/O, var/volume)
 				src = null
@@ -819,7 +759,7 @@ datum
 				transparency = 128
 				max_radius = 4
 				min_radius = 0
-				combustion_temp = T0C + 385
+				minimum_reaction_temperature = T0C + 385
 				volume_radius_multiplier = 0.05
 				explosion_threshold = 1000
 				volume_explosion_radius_modifier = -4.5
@@ -839,68 +779,68 @@ datum
 			transparency = 255
 			depletion_rate = 0.05
 			penetrates_skin = 1 // think of it as just being all over them i guess
+			minimum_reaction_temperature = T0C+200
 
 			reaction_temperature(exposed_temperature, exposed_volume)
 				if(src.reacting)
 					return
-				if(exposed_temperature > T0C + 200)
-					src.reacting = 1
-					var/list/covered = holder.covered_turf()
 
-					for(var/turf/location in covered)
-						var/our_amt = holder.get_reagent_amount(src.id) / covered.len
+				src.reacting = 1
+				var/list/covered = holder.covered_turf()
 
-						if (our_amt < 10 && covered.len > 5)
-							if (prob(min(covered.len/3,85)))
-								continue
+				for(var/turf/location in covered)
+					var/our_amt = holder.get_reagent_amount(src.id) / covered.len
 
-						var/datum/effects/system/spark_spread/s = unpool(/datum/effects/system/spark_spread)
-						s.set_up(2, 1, location)
-						s.start()
-						SPAWN_DBG(rand(5,15))
-							if(!holder || !holder.my_atom) return // runtime error fix
-							switch(our_amt)
-								if(0 to 20)
-									holder.my_atom.visible_message("<b>The black powder ignites!</b>")
-									if (covered.len < 5 || prob(5))
-										var/datum/effects/system/bad_smoke_spread/smoke = new /datum/effects/system/bad_smoke_spread()
-										smoke.set_up(1, 0, location)
-										smoke.start()
-									explosion(holder.my_atom, location, -1, -1, pick(0,1), 1)
-									if (covered.len > 1)
-										holder.remove_reagent(id, our_amt)
-									else
-										holder.del_reagent(id)
-								if(21 to 80)
-									holder.my_atom.visible_message("<b>[holder.my_atom] flares up!</b>")
-									fireflash(location,0)
-									explosion(holder.my_atom, location, -1, -1, 1, 2)
-									if (covered.len > 1)
-										holder.remove_reagent(id, our_amt)
-									else
-										holder.del_reagent(id)
-								if(81 to 160)
-									holder.my_atom.visible_message("<span class='alert'><b>[holder.my_atom] explodes!</b></span>")
-									explosion(holder.my_atom, location, -1, 1, 2, 3)
-									if (covered.len > 1)
-										holder.remove_reagent(id, our_amt)
-									else
-										holder.del_reagent(id)
-								if(161 to 300)
-									holder.my_atom.visible_message("<span class='alert'><b>[holder.my_atom] violently explodes!</b></span>")
-									explosion(holder.my_atom, location, 1, 3, 6, 8)
-									if (covered.len > 1)
-										holder.remove_reagent(id, our_amt)
-									else
-										holder.del_reagent(id)
-								if(301 to INFINITY)
-									holder.my_atom.visible_message("<span class='alert'><b>[holder.my_atom] detonates in a huge blast!</b></span>")
-									explosion(holder.my_atom, location, 3, 6, 12, 15)
-									if (covered.len > 1)
-										holder.remove_reagent(id, our_amt)
-									else
-										holder.del_reagent(id)
-				return
+					if (our_amt < 10 && covered.len > 5)
+						if (prob(min(covered.len/3,85)))
+							continue
+
+					var/datum/effects/system/spark_spread/s = unpool(/datum/effects/system/spark_spread)
+					s.set_up(2, 1, location)
+					s.start()
+					SPAWN_DBG(rand(5,15))
+						if(!holder || !holder.my_atom) return // runtime error fix
+						switch(our_amt)
+							if(0 to 20)
+								holder.my_atom.visible_message("<b>The black powder ignites!</b>")
+								if (covered.len < 5 || prob(5))
+									var/datum/effects/system/bad_smoke_spread/smoke = new /datum/effects/system/bad_smoke_spread()
+									smoke.set_up(1, 0, location)
+									smoke.start()
+								explosion(holder.my_atom, location, -1, -1, pick(0,1), 1)
+								if (covered.len > 1)
+									holder.remove_reagent(id, our_amt)
+								else
+									holder.del_reagent(id)
+							if(21 to 80)
+								holder.my_atom.visible_message("<b>[holder.my_atom] flares up!</b>")
+								fireflash(location,0)
+								explosion(holder.my_atom, location, -1, -1, 1, 2)
+								if (covered.len > 1)
+									holder.remove_reagent(id, our_amt)
+								else
+									holder.del_reagent(id)
+							if(81 to 160)
+								holder.my_atom.visible_message("<span class='alert'><b>[holder.my_atom] explodes!</b></span>")
+								explosion(holder.my_atom, location, -1, 1, 2, 3)
+								if (covered.len > 1)
+									holder.remove_reagent(id, our_amt)
+								else
+									holder.del_reagent(id)
+							if(161 to 300)
+								holder.my_atom.visible_message("<span class='alert'><b>[holder.my_atom] violently explodes!</b></span>")
+								explosion(holder.my_atom, location, 1, 3, 6, 8)
+								if (covered.len > 1)
+									holder.remove_reagent(id, our_amt)
+								else
+									holder.del_reagent(id)
+							if(301 to INFINITY)
+								holder.my_atom.visible_message("<span class='alert'><b>[holder.my_atom] detonates in a huge blast!</b></span>")
+								explosion(holder.my_atom, location, 3, 6, 12, 15)
+								if (covered.len > 1)
+									holder.remove_reagent(id, our_amt)
+								else
+									holder.del_reagent(id)
 
 			reaction_obj(var/obj/O, var/volume)
 				src = null
@@ -929,6 +869,7 @@ datum
 			fluid_r = 48
 			fluid_g = 22
 			fluid_b = 64
+			minimum_reaction_temperature = T0C+100
 			var/is_dry = 0
 
 			pooled()
@@ -987,8 +928,7 @@ datum
 					return make_cleanable(/obj/decal/cleanable/nitrotriiodide,T)
 
 			reaction_temperature(exposed_temperature, exposed_volume)
-				if(exposed_temperature > T0C + 100) //Fastest way to dry this. Also the most terrible idea.
-					dry()
+				dry()
 
 		combustible/nitrogentriiodide/wet
 			id = "nitrotri_wet"
@@ -1012,6 +952,7 @@ datum
 			description = "A chemical that is stable when in liquid form, but becomes extremely volatile when dry. This is dry. Uh oh."
 			is_dry = 1
 			reagent_state = SOLID
+			minimum_reaction_temperature = -INFINITY
 
 			New()
 				SPAWN_DBG(10 * rand(11,600)) //At least 11 seconds, at most 10 minutes

--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -149,6 +149,7 @@ datum
 			fluid_g = 64
 			fluid_b = 27
 			transparency = 190
+			minimum_reaction_temperature = -INFINITY
 
 			reaction_temperature(exposed_temperature, exposed_volume)
 				if(exposed_temperature <= T0C + 7)
@@ -1935,6 +1936,7 @@ datum
 			transparency = 255
 			hunger_value = 1
 			viscosity = 0.5
+			minimum_reaction_temperature = -INFINITY
 
 			reaction_temperature(exposed_temperature, exposed_volume)
 				if(it_is_ass_day)
@@ -2176,8 +2178,9 @@ datum
 			addiction_prob = 1
 			addiction_prob2 = 1
 			addiction_min = 10
+			minimum_reaction_temperature = -INFINITY
 
-			reaction_temperature(exposed_temperature, exposed_volume) //Just an example.
+			reaction_temperature(exposed_temperature, exposed_volume)
 				if (exposed_temperature <= T0C + 7)
 					name = "iced tea"
 					description = "Tea, but cold!"

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -11,6 +11,7 @@ datum
 			fluid_b = 255
 			transparency = 128
 			volatility = 3
+			minimum_reaction_temperature = -INFINITY
 
 			// These figures are for original nitro explosions, new calculation is strictly linear <-- false by zewaka
 			// power = SQRT(10V)
@@ -150,6 +151,7 @@ datum
 			fluid_r = 128
 			fluid_g = 128
 			fluid_b = 128
+			minimum_reaction_temperature = -INFINITY
 
 			proc/pop(var/turf/T, var/amount=5)
 				playsound(T, 'sound/weapons/Gunshot.ogg', rand(1, min(amount*10, 50)), 1)
@@ -617,9 +619,6 @@ datum
 			transparency = 200
 			value = 3 // 1 1 1
 			viscosity = 0.14
-
-			reaction_temperature(exposed_temperature, exposed_volume)
-				return
 
 			reaction_turf(var/turf/target, var/volume)
 				src = null
@@ -1116,10 +1115,11 @@ datum
 			hygiene_value = -1.5
 			value = 3 // 1c + 1c + 1c
 			viscosity = 0.13
+			minimum_reaction_temperature = T0C + 200
 			var/min_req_fluid = 0.25 //at least 1/4 of the fluid needs to be oil for it to ignite
 
 			reaction_temperature(exposed_temperature, exposed_volume)
-				if (exposed_temperature > T0C + 200 && !src.reacting && (holder && !holder.has_reagent("chlorine"))) // need this to be higher to make propylene possible
+				if (!src.reacting && (holder && !holder.has_reagent("chlorine"))) // need this to be higher to make propylene possible
 					src.reacting = 1
 					var/list/covered = holder.covered_turf()
 					if (covered.len < 4 || (volume / holder.total_volume) > min_req_fluid)
@@ -2714,6 +2714,7 @@ datum
 			transparency = 230
 			overdose = 20
 			viscosity = 0.3
+			minimum_reaction_temperature = T0C+100
 			var/multiplier = 1
 			var/grenade_handled = 0
 			pooled()
@@ -2737,17 +2738,17 @@ datum
 					M.shock(src.holder.my_atom, min(7500 * multiplier, vol * 100 * multiplier), "chest", 1, 1)
 
 			reaction_temperature(exposed_temperature, exposed_volume)
-				. = ..()
-				if (reacting) return
-				if (exposed_temperature > T0C + 100)
-					reacting = 1
-					var/count = 0
-					for (var/mob/living/L in oview(5, holder.my_atom))
-						count++
-					for (var/mob/living/L in oview(5, holder.my_atom))
-						arcFlash(holder.my_atom, L, min(75000 * multiplier / count, volume * 1000 * multiplier / count))
+				if (reacting)
+					return
 
-					holder.del_reagent(id)
+				reacting = 1
+				var/count = 0
+				for (var/mob/living/L in oview(5, holder.my_atom))
+					count++
+				for (var/mob/living/L in oview(5, holder.my_atom))
+					arcFlash(holder.my_atom, L, min(75000 * multiplier / count, volume * 1000 * multiplier / count))
+
+				holder.del_reagent(id)
 
 			on_mob_life(mob/M, var/mult = 1)
 
@@ -3071,19 +3072,19 @@ datum
 			id = "bloodc"
 			value = 3
 			hygiene_value = -4
+			minimum_reaction_temperature = T0C + 50
 
 			reaction_temperature(exposed_temperature, exposed_volume)
-				if (exposed_temperature > T0C + 50)
-					if (holder.my_atom)
-						for (var/mob/O in AIviewers(get_turf(holder.my_atom), null))
-							boutput(O, "<span class='alert'>The blood tries to climb out of [holder.my_atom] before sizzling away!</span>")
-					else
-						var/list/covered = holder.covered_turf()
-						for(var/turf/t in covered)
-							for (var/mob/O in AIviewers(t, null))
-								boutput(O, "<span class='alert'>The blood reacts, attempting to escape the heat before sizzling away!</span>")
-					holder.del_reagent(id)
-				return
+				if (holder.my_atom)
+					for (var/mob/O in AIviewers(get_turf(holder.my_atom), null))
+						boutput(O, "<span class='alert'>The blood tries to climb out of [holder.my_atom] before sizzling away!</span>")
+				else
+					var/list/covered = holder.covered_turf()
+					for(var/turf/t in covered)
+						for (var/mob/O in AIviewers(t, null))
+							boutput(O, "<span class='alert'>The blood reacts, attempting to escape the heat before sizzling away!</span>")
+				holder.del_reagent(id)
+
 
 		vomit
 			name = "vomit"
@@ -3423,6 +3424,7 @@ datum
 			transparency = 225
 			reagent_state = LIQUID
 			depletion_rate = 1
+			minimum_reaction_temperature = -INFINITY
 
 
 
@@ -3475,7 +3477,6 @@ datum
 
 
 			reaction_temperature(exposed_temperature, exposed_volume)
-				..()
 				//TODO: if cold temperature, take up all the reagents in the holder into contents, calculate distribution amount based on volume
 				if( exposed_temperature < (T0C - 50) && !hardened)
 					// -50C, solidify polymer

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -1559,16 +1559,6 @@ datum
 			pathogen_nutrition = list("dna_mutagen")
 
 			var/tmp/progress_timer = 1
-/*
-			reaction_temperature(exposed_temperature, exposed_volume)
-				var/myvol = volume
-
-				if (exposed_temperature > 50 && !holder.has_reagent("stabiliser") || exposed_temperature > 300)
-					volume = 0
-					holder.add_reagent("mutagen", myvol, null)
-
-				return
-*/
 
 			pooled()
 				..()

--- a/code/obj/artifacts/artifact_items/attack_wand.dm
+++ b/code/obj/artifacts/artifact_items/attack_wand.dm
@@ -125,7 +125,6 @@
 					R.maximum_volume = 15
 
 				R.add_reagent("sonicpowder_nofluff", 15, null, T0C + 200)
-				R.temperature_react()
 
 				if (R.total_volume)
 					R.clear_reagents()

--- a/code/obj/item/flamethrower.dm
+++ b/code/obj/item/flamethrower.dm
@@ -511,8 +511,7 @@ GETLINEEEEEEEEEEEEEEEEEEEEE
 		reagentperturf += increment
 		if(lit)
 			//currentturf.hotspot_expose(spray_temperature,2)
-			currentturf.reagents.set_reagent_temp(spray_temperature)
-			currentturf.reagents.temperature_react()
+			currentturf.reagents.set_reagent_temp(spray_temperature, TRUE)
 			spray_temperature = max(0,min(spray_temperature - temp_loss_per_tile, 700))
 
 		var/logString = log_reagents(part5)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example:  -->
[BUG] [CLEANLINESS]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a `minimum_reaction_temperature` var to reagents which controls when `reaction_temperature()` is run, this saves some effort running empty procs as very few reagents implement this proc, and many of the ones that require high temperatures for anything to happen.

Reagents inside people were adjusted towards body_temperature - 30, which caused wacky things to happen when body temperature was below 30. 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Naksu:
(+)Reagents inside mobs no longer get adjusted towards body temperature - 30, but body temperature. Reagent temperature reactions do not happen if there was no change in temperature.
```
