### PR TITLE
Disassembling assemblies in storage now drops the parts to the floor

### DIFF
--- a/code/obj/item/assembly/misc_assemblies.dm
+++ b/code/obj/item/assembly/misc_assemblies.dm
@@ -96,8 +96,8 @@ Contains:
 		return
 	if (iswrenchingtool(W) && !(src.status))
 		var/turf/T = src.loc
-		if (ismob(T))
-			T = T.loc
+		if (ismob(T) || istype(T, /obj/item/storage))
+			T = get_turf(src)
 		if (src.part1)
 			src.part1.set_loc(T)
 			src.part1.master = null
@@ -314,8 +314,8 @@ Contains:
 		return
 	if (iswrenchingtool(W) && !(src.status))
 		var/turf/T = src.loc
-		if (ismob(T))
-			T = T.loc
+		if (ismob(T) || istype(T, /obj/item/storage))
+			T = get_turf(src)
 		if (part1)
 			src.part1.set_loc(T)
 			src.part1.master = null
@@ -493,8 +493,8 @@ Contains:
 		return
 	if (iswrenchingtool(W) && !(src.status))
 		var/turf/T = src.loc
-		if (ismob(T))
-			T = T.loc
+		if (ismob(T) || istype(T, /obj/item/storage))
+			T = get_turf(src)
 		if (part1)
 			src.part1.set_loc(T)
 			src.part1.master = null
@@ -681,8 +681,8 @@ Contains:
 		return
 	if (iswrenchingtool(W) && !(src.status))
 		var/turf/T = src.loc
-		if (ismob(T))
-			T = T.loc
+		if (ismob(T) || istype(T, /obj/item/storage))
+			T = get_turf(src)
 		src.part1.set_loc(T)
 		src.part2.set_loc(T)
 		src.part1.master = null
@@ -771,8 +771,8 @@ obj/item/assembly/radio_horn/receive_signal()
 		return
 	if (iswrenchingtool(W) && !(src.status))
 		var/turf/T = src.loc
-		if (ismob(T))
-			T = T.loc
+		if (ismob(T) || istype(T, /obj/item/storage))
+			T = get_turf(src)
 		src.part1.set_loc(T)
 		src.part2.set_loc(T)
 		src.part1.master = null
@@ -842,8 +842,8 @@ obj/item/assembly/radio_horn/receive_signal()
 		return
 	if (iswrenchingtool(W) && !(src.status))
 		var/turf/T = src.loc
-		if (ismob(T))
-			T = T.loc
+		if (ismob(T) || istype(T, /obj/item/storage))
+			T = get_turf(src)
 		src.part1.set_loc(T)
 		src.part2.set_loc(T)
 		src.part1.master = null

--- a/code/obj/item/assembly/misc_assemblies.dm
+++ b/code/obj/item/assembly/misc_assemblies.dm
@@ -95,9 +95,7 @@ Contains:
 	if (!W)
 		return
 	if (iswrenchingtool(W) && !(src.status))
-		var/turf/T = src.loc
-		if (ismob(T) || istype(T, /obj/item/storage))
-			T = get_turf(src)
+		var/turf/T = get_turf(src)
 		if (src.part1)
 			src.part1.set_loc(T)
 			src.part1.master = null
@@ -313,9 +311,7 @@ Contains:
 	if (!W)
 		return
 	if (iswrenchingtool(W) && !(src.status))
-		var/turf/T = src.loc
-		if (ismob(T) || istype(T, /obj/item/storage))
-			T = get_turf(src)
+		var/turf/T = get_turf(src)
 		if (part1)
 			src.part1.set_loc(T)
 			src.part1.master = null
@@ -492,9 +488,7 @@ Contains:
 	if (!W)
 		return
 	if (iswrenchingtool(W) && !(src.status))
-		var/turf/T = src.loc
-		if (ismob(T) || istype(T, /obj/item/storage))
-			T = get_turf(src)
+		var/turf/T = get_turf(src)
 		if (part1)
 			src.part1.set_loc(T)
 			src.part1.master = null
@@ -680,9 +674,7 @@ Contains:
 	if (!W)
 		return
 	if (iswrenchingtool(W) && !(src.status))
-		var/turf/T = src.loc
-		if (ismob(T) || istype(T, /obj/item/storage))
-			T = get_turf(src)
+		var/turf/T = get_turf(src)
 		src.part1.set_loc(T)
 		src.part2.set_loc(T)
 		src.part1.master = null
@@ -770,9 +762,7 @@ obj/item/assembly/radio_horn/receive_signal()
 	if (!W)
 		return
 	if (iswrenchingtool(W) && !(src.status))
-		var/turf/T = src.loc
-		if (ismob(T) || istype(T, /obj/item/storage))
-			T = get_turf(src)
+		var/turf/T = get_turf(src)
 		src.part1.set_loc(T)
 		src.part2.set_loc(T)
 		src.part1.master = null
@@ -841,9 +831,7 @@ obj/item/assembly/radio_horn/receive_signal()
 	if (!W)
 		return
 	if (iswrenchingtool(W) && !(src.status))
-		var/turf/T = src.loc
-		if (ismob(T) || istype(T, /obj/item/storage))
-			T = get_turf(src)
+		var/turf/T = get_turf(src)
 		src.part1.set_loc(T)
 		src.part2.set_loc(T)
 		src.part1.master = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If an assembly is dismantled while in storage the parts will now appear on the floor beneath the storage that it was located within

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #377 
