### PR TITLE
Increases max mob name length from 32 to 50

### DIFF
--- a/_stdlib/_setup.dm
+++ b/_stdlib/_setup.dm
@@ -170,7 +170,7 @@
 
 //Don't set this very much higher then 1024 unless you like inviting people in to dos your server with message spam
 #define MAX_MESSAGE_LEN 1024
-
+#define MOB_NAME_MAX_LENGTH 50
 
 #define R_IDEAL_GAS_EQUATION	8.31 //kPa*L/(K*mol)
 #define ONE_ATMOSPHERE		101.325	//kPa

--- a/code/datums/preferences.dm
+++ b/code/datums/preferences.dm
@@ -1605,8 +1605,8 @@ datum/preferences
 					alert( user, "You have hit your cloud save limit. Please write over an existing save." )
 				else
 					var/newname = input( user, "What would you like to name the save?", "Save Name" ) as text
-					if( length( newname ) < 3 || length( newname ) > 32 )
-						alert( user, "The name must be between 3 and 32 letters!" )
+					if( length( newname ) < 3 || length( newname ) > MOB_NAME_MAX_LENGTH )
+						alert( user, "The name must be between 3 and [MOB_NAME_MAX_LENGTH] letters!" )
 					else
 						var/ret = src.cloudsave_save( user.client, newname )
 						if( istext( ret ) )

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -2660,7 +2660,7 @@
 		if (!newname)
 			return
 		else
-			newname = strip_html(newname, 32, 1)
+			newname = strip_html(newname, MOB_NAME_MAX_LENGTH, 1)
 			if (!length(newname) || copytext(newname,1,2) == " ")
 				src.show_text("That name was too short after removing bad characters from it. Please choose a different name.", "red")
 				continue

--- a/code/mob/living/silicon.dm
+++ b/code/mob/living/silicon.dm
@@ -509,7 +509,7 @@ var/global/list/module_editors = list()
 			src.name = src.real_name
 			return
 		else
-			newname = strip_html(newname, 32, 1)
+			newname = strip_html(newname, MOB_NAME_MAX_LENGTH, 1)
 			if (!length(newname) || copytext(newname,1,2) == " ")
 				src.show_text("That name was too short after removing bad characters from it. Please choose a different name.", "red")
 				continue

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -2156,7 +2156,7 @@ proc/get_mobs_trackable_by_AI()
 			src.name = src.real_name
 			return
 		else
-			newname = strip_html(newname, 32, 1)
+			newname = strip_html(newname, MOB_NAME_MAX_LENGTH, 1)
 			if (!length(newname) || copytext(newname,1,2) == " ")
 				src.show_text("That name was too short after removing bad characters from it. Please choose a different name.", "red")
 				continue

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -650,7 +650,7 @@
 				src.internal_pda.owner = "[src]"
 				return
 			else
-				newname = strip_html(newname, 32, 1)
+				newname = strip_html(newname, MOB_NAME_MAX_LENGTH, 1)
 				if (!length(newname))
 					src.show_text("That name was too short after removing bad characters from it. Please choose a different name.", "red")
 					continue

--- a/code/modules/antagonists/changeling/abilities/mimic_voice.dm
+++ b/code/modules/antagonists/changeling/abilities/mimic_voice.dm
@@ -37,7 +37,7 @@
 
 		logTheThing("say", holder.owner, mimic_name, "[mimic_message] (<b>Mimicing (%target%)</b>)")
 		var/original_name = holder.owner.real_name
-		holder.owner.real_name = copytext(mimic_name, 1, 32)
+		holder.owner.real_name = copytext(mimic_name, 1, MOB_NAME_MAX_LENGTH)
 		holder.owner.say(mimic_message)
 		holder.owner.real_name = original_name
 

--- a/code/modules/telescience/radiostation.dm
+++ b/code/modules/telescience/radiostation.dm
@@ -176,7 +176,7 @@
 		var/message = html_encode(input("Choose something to say:","Message","") as null|text)
 		logTheThing("say", usr, voice, "SAY: [message] (Synthesizing the voice of <b>(%target%)</b>)")
 		var/original_name = usr.real_name
-		usr.real_name = copytext(voice, 1, 32)
+		usr.real_name = copytext(voice, 1, MOB_NAME_MAX_LENGTH)
 		usr.say(message)
 		usr.real_name = original_name
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I changed all instances of mob name limiting to use a new macro which I changed to 50. Let me know if I missed anything. Also let me know if 50 is a bad number.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
No more "Benjamin Smith the Radio Show Ho".


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)pali:
(+)Increased max name length to 50 letters.
```
