### PR TITLE
Mob properties

### DIFF
--- a/_stdlib/mob_properties.dm
+++ b/_stdlib/mob_properties.dm
@@ -1,9 +1,165 @@
+/* MOB PROPERTIES */
+
+/*
+
+Contains a system to apply fast-to-check properties onto mobs, with different stacking behaviors.
+
+To get the value of ANY property regardless of the behavior used, use:area
+
+	GET_MOB_PROPERTY(mob, property)
+
+If you only want to know whether a property exists, use:
+
+	HAS_MOB_PROPERTY(mob, property)
+
+Behavior-dependent macros:
+
+In the context of these macros, "source" is where the property is being applied/removed from. The actual value of the source argument depends
+on what makes sense in context, for example things where multiple objects of the same type may apply stacking properties it might make sense
+to use the caller's src as the source; but for things where the property should be per-type unique, src.type may make more sense. A string
+might make sense for when multiple types should overwrite eachothers applications of the property.
+
+To modify already-applied values, just run the APPLY macro again.
+
+SIMPLE PROPERTIES
+
+There work like flags, carrying no value. Their existence itself "is" the value.
+
+To set:
+
+	APPLY_MOB_PROPERTY_SIMPLE(mob, property, source)
+
+	for example:
+
+	/obj/item/example_stick/attack_self(mob/user)
+		APPLY_MOB_PROPERTY_SIMPLE(user, PROP_EXAMPLE, src.type)
+
+To remove:
+
+	REMOVE_MOB_PROPERTY_SIMPLE(mob, property, source)
+
+	for example:
+
+	/obj/item/unexample_stick/attack_self(mob/user)
+		REMOVE_MOB_PROPERTY_SIMPLE(user, PROP_EXAMPLE, /obj/item/example_stick)
+
+
+
+SUM PROPERTIES
+
+The value of a sum property is the sum of applied values of the property from all sources.
+
+To set:
+
+	APPLY_MOB_PROPERTY_SUM(mob, property, source, value)
+
+	for example:
+
+	/obj/item/example_stick_1/attack_self(mob/user)
+		APPLY_MOB_PROPERTY_SUM(user, PROP_EXAMPLE, src.type, 1)
+
+	/obj/item/example_stick_2/attack_self(mob/user)
+		APPLY_MOB_PROPERTY_SUM(user, PROP_EXAMPLE, src.type, 2)
+
+	Using example_stick_1 gives the user a PROP_EXAMPLE value of 1 if no value existed prior. Using example_stick_2 right after makes the value 3.
+
+To remove:
+
+	REMOVE_MOB_PROPERTY_SUM(mob, property, source)
+
+	for example:
+
+	/obj/item/unexample_stick_1/attack_self(mob/user)
+		REMOVE_MOB_PROPERTY_SUM(user, PROP_EXAMPLE, /obj/item/example_stick_1)
+
+
+
+MAX PROPERTIES
+
+The value of a max property is the largest of the applied values on the property.
+
+To set:
+
+	APPLY_MOB_PROPERTY_MAX(mob, property, source, value)
+
+	for example:
+
+	/obj/item/example_stick_1/attack_self(mob/user)
+		APPLY_MOB_PROPERTY_MAX(user, PROP_EXAMPLE, src.type, 1)
+
+	/obj/item/example_stick_2/attack_self(mob/user)
+		APPLY_MOB_PROPERTY_MAX(user, PROP_EXAMPLE, src.type, 2)
+
+	Using example_stick_1 gives the user a PROP_EXAMPLE value of 1 if no value existed prior,
+	or the existing value was smaller than 1.
+	Using example_stick_2 right after makes the value 2, as 2 is larger than 1[citation needed].
+
+To remove:
+
+	REMOVE_MOB_PROPERTY_MAX(mob, property, source)
+
+	for example:
+
+	/obj/item/unexample_stick_2/attack_self(mob/user)
+		REMOVE_MOB_PROPERTY_MAX(user, PROP_EXAMPLE, /obj/item/example_stick_2)
+
+	Using unexample_stick_2 returns the value to 1, assuming both sticks have been applied.
+
+
+
+PRIORITY PROPERTIES
+
+The value of a priority property is the value with the largest priority
+
+To set:
+
+	APPLY_MOB_PROPERTY_MAX(mob, property, source, value, priority)
+
+	for example:
+
+	/obj/item/example_stick_1/attack_self(mob/user)
+		APPLY_MOB_PROPERTY_MAX(user, PROP_EXAMPLE, src.type, 1, 100)
+
+	/obj/item/example_stick_2/attack_self(mob/user)
+		APPLY_MOB_PROPERTY_MAX(user, PROP_EXAMPLE, src.type, -300, 200)
+
+	Using example_stick_1 gives the user a PROP_EXAMPLE value of 1 if no value existed prior,
+	or the existing value came from a priority smaller than 100.
+	Using example_stick_2 right after makes the value -300, as 200 is a higher priority than
+	the applied 100.
+
+To remove:
+
+	REMOVE_MOB_PROPERTY_PRIORITY(mob, property, source)
+
+	for example:
+
+	/obj/item/unexample_stick_2/attack_self(mob/user)
+		REMOVE_MOB_PROPERTY_PRIORITY(user, PROP_EXAMPLE, /obj/item/example_stick_2)
+
+	Using unexample_stick_2 returns the value to 1, assuming both sticks have been applied.
+
+
+*/
+
 #define MOB_PROPERTY_ACTIVE_VALUE 1
 #define MOB_PROPERTY_SOURCES_LIST 2
+#define MOB_PROPERTY_PRIORITY_PRIO 1
+#define MOB_PROPERTY_PRIORITY_VALUE 2
 
 #define PROP_CANTMOVE "cantmove"
 
-#define APPLY_MOB_PROPERTY(target, property, source, value) \
+
+
+
+
+#define GET_MOB_PROPERTY(target, property) (target.mob_properties[property] ? target.mob_properties[property][MOB_PROPERTY_ACTIVE_VALUE] : null)
+
+// sliiiiiiiightly faster if you don't care about the value
+#define HAS_MOB_PROPERTY(target, property) (target.mob_properties[property] ? TRUE : FALSE)
+
+
+#define APPLY_MOB_PROPERTY_MAX(target, property, source, value) \
 	do { \
 		var/list/_L = target.mob_properties; \
 		var/_V = value; \
@@ -12,18 +168,13 @@
 			_L[property][MOB_PROPERTY_SOURCES_LIST][_S] = _V; \
 			if (_L[property][MOB_PROPERTY_ACTIVE_VALUE] < _V) { \
 				_L[property][MOB_PROPERTY_ACTIVE_VALUE] = _V; \
-			}; \
+			} \
 		} else { \
 			_L[property] = list(_V, list(_S = _V)); \
-		}; \
+		} \
 	} while (0)
 
-#define GET_MOB_PROPERTY(target, property) (target.mob_properties[property] ? target.mob_properties[property][MOB_PROPERTY_ACTIVE_VALUE] : null)
-
-// sliiiiiiiightly faster if you don't care about the value
-#define HAS_MOB_PROPERTY(target, property) (target.mob_properties[property] ? TRUE : FALSE)
-
-#define REMOVE_MOB_PROPERTY(target, property, source) \
+#define REMOVE_MOB_PROPERTY_MAX(target, property, source) \
 	do { \
 		var/list/_L = target.mob_properties; \
 		if (_L[property]) { \
@@ -31,12 +182,117 @@
 			if (!length(_L[property][MOB_PROPERTY_SOURCES_LIST])) { \
 				_L -= property; \
 			} else { \
-				_L[property][MOB_PROPERTY_ACTIVE_VALUE] = 0; \
+				_L[property][MOB_PROPERTY_ACTIVE_VALUE] = -INFINITY; \
 				for(var/_S in _L[property][MOB_PROPERTY_SOURCES_LIST]) { \
 					if (_L[property][MOB_PROPERTY_ACTIVE_VALUE] < _L[property][MOB_PROPERTY_SOURCES_LIST][_S]) { \
 						_L[property][MOB_PROPERTY_ACTIVE_VALUE] = _L[property][MOB_PROPERTY_SOURCES_LIST][_S]; \
 					} \
 				} \
+			} \
+		} \
+	} while (0)
+
+#define APPLY_MOB_PROPERTY_SIMPLE(target, property, source) \
+	do { \
+		var/list/_L = target.mob_properties; \
+		var/_S = source; \
+		if (_L[property]) { \
+			_L[property][MOB_PROPERTY_SOURCES_LIST] |= source; \
+		} else { \
+			_L[property] = list(1, list(_S)); \
+		} \
+	} while (0)
+
+#define REMOVE_MOB_PROPERTY_SIMPLE(target, property, source) \
+	do { \
+		var/list/_L = target.mob_properties; \
+		if (_L[property]) { \
+			_L[property][MOB_PROPERTY_SOURCES_LIST] -= source; \
+			if (!length(_L[property][MOB_PROPERTY_SOURCES_LIST])) { \
+				_L -= property; \
+			} \
+		} \
+	} while (0)
+
+#define APPLY_MOB_PROPERTY_SUM(target, property, source, value) \
+	do { \
+		var/list/_L = target.mob_properties; \
+		var/_V = value; \
+		var/_S = source; \
+		if (_L[property]) { \
+			if (_L[property][MOB_PROPERTY_SOURCES_LIST][_S]) { \ /* if the value already exists from this source, adjust */ \
+				_L[property][MOB_PROPERTY_ACTIVE_VALUE] -= _L[property][MOB_PROPERTY_SOURCES_LIST][_S]; \
+				_L[property][MOB_PROPERTY_SOURCES_LIST][_S] = _V; \
+				_L[property][MOB_PROPERTY_ACTIVE_VALUE] += _V; \
+			} else { \
+				_L[property][MOB_PROPERTY_SOURCES_LIST][_S] = _V; \
+				_L[property][MOB_PROPERTY_ACTIVE_VALUE] += _V; \
+			} \
+		} else { \
+			_L[property] = list(_V, list(_S = _V)); \
+		} \
+	} while (0)
+
+#define REMOVE_MOB_PROPERTY_SUM(target, property, source) \
+	do { \
+		var/list/_L = target.mob_properties; \
+		var/_S = source; \
+		if (_L[property]) { \
+			if (_L[property][MOB_PROPERTY_SOURCES_LIST][_S]) { \
+				_L[property][MOB_PROPERTY_ACTIVE_VALUE] -= _L[property][MOB_PROPERTY_SOURCES_LIST][_S]; \
+				_L[property][MOB_PROPERTY_SOURCES_LIST] -= _S; \
+			} \
+			if (!length(_L[property][MOB_PROPERTY_SOURCES_LIST])) { \
+				_L -= property; \
+			} \
+		} \
+	} while (0)
+
+#define APPLY_MOB_PROPERTY_PRIORITY(target, property, source, value, priority) \
+	do { \
+		var/list/_L = target.mob_properties; \
+		var/_V = value; \
+		var/_P = priority; \
+		var/_S = source; \
+		if (_L[property]) { \
+			_L[property][MOB_PROPERTY_SOURCES_LIST][_S] = list(_P, _V); \
+			if (_L[property][MOB_PROPERTY_ACTIVE_VALUE] != _V) { \
+				var/_TO_APPLY_PRIO = -INFINITY; \
+				var/_TO_APPLY_VALUE; \
+				for (var/list/_K in _L[property][MOB_PROPERTY_SOURCES_LIST]) { \
+					var/list/_PRIOLIST = _L[property][MOB_PROPERTY_SOURCES_LIST][_K]; \
+					if (_PRIOLIST[MOB_PROPERTY_PRIORITY_PRIO] > _TO_APPLY_PRIO) { \
+						_TO_APPLY_PRIO = _PRIOLIST[MOB_PROPERTY_PRIORITY_PRIO]; \
+						_TO_APPLY_VALUE = _PRIOLIST[MOB_PROPERTY_PRIORITY_VALUE]; \
+					} \
+				} \
+				_L[property][MOB_PROPERTY_ACTIVE_VALUE] = _TO_APPLY_VALUE; \
+			} \
+		} else { \
+			_L[property] = list(_V, list(_S = list(_P, _V))); \
+		}; \
+	} while (0)
+
+#define REMOVE_MOB_PROPERTY_PRIORITY(target, property, source) \
+	do { \
+		var/list/_L = target.mob_properties; \
+		var/_S = source; \
+		if (_L[property]) { \
+			var/_S_V = _L[property][MOB_PROPERTY_SOURCES_LIST][_S][MOB_PROPERTY_PRIORITY_VALUE];\
+			_L[property][MOB_PROPERTY_SOURCES_LIST] -= source; \
+			if (!length(_L[property][MOB_PROPERTY_SOURCES_LIST])) { \
+				_L -= property; \
+			} else if (_L[property_MOB_PROPERTY_ACTIVE_VALUE] == _S_V) { \ /* we removed the active value */ \
+				var/_TO_APPLY_PRIO = -INFINITY; \
+				var/_TO_APPLY_VALUE; \
+				for (var/list/_K in _L[property][MOB_PROPERTY_SOURCES_LIST]) { \
+					var/list/_PRIOLIST = _L[property][MOB_PROPERTY_SOURCES_LIST][_K]; \
+					if (_PRIOLIST[MOB_PROPERTY_PRIORITY_PRIO] > _TO_APPLY_PRIO) { \
+						_TO_APPLY_PRIO = _PRIOLIST[MOB_PROPERTY_PRIORITY_PRIO]; \
+						_TO_APPLY_VALUE = _PRIOLIST[MOB_PROPERTY_PRIORITY_VALUE]; \
+					} \
+				} \
+				_L[property][MOB_PROPERTY_ACTIVE_VALUE] = _TO_APPLY_VALUE; \
 			} \
 		} \
 	} while (0)

--- a/_stdlib/mob_properties.dm
+++ b/_stdlib/mob_properties.dm
@@ -12,14 +12,14 @@ If you only want to know whether a property exists, use:
 
 	HAS_MOB_PROPERTY(mob, property)
 
-To set the values of properties, helper procs exist on the mob type:
+To set the values of properties:
 
-	/mob/proc/apply_property(property, source, value = null, priority = null)
+	APPLY_MOB_PROPERTY(mob, property, source[, value[, priority]])
 
-	/mob/proc/remove_property(property, source)
+	value is REQUIRED for any property other than simple properties, omitting it will result in a compile error "incorrect number of macro arguments."
+	priority is likewise REQUIRED for priority properties.
 
-These work regardless of the type of property, as long as the property is properly prefixed (see property definitions below).
-
+	REMOVE_MOB_PROPERTY(mob, property, source)
 
 Behavior-dependent macros:
 
@@ -36,21 +36,21 @@ There work like flags, carrying no value. Their existence itself "is" the value.
 
 To set:
 
-	APPLY_MOB_PROPERTY_SIMPLE(mob, property, source)
+	APPLY_MOB_PROPERTY(mob, property, source)
 
 	for example:
 
 	/obj/item/example_stick/attack_self(mob/user)
-		APPLY_MOB_PROPERTY_SIMPLE(user, PROP_EXAMPLE, src.type)
+		APPLY_MOB_PROPERTY(user, PROP_EXAMPLE, src.type)
 
 To remove:
 
-	REMOVE_MOB_PROPERTY_SIMPLE(mob, property, source)
+	REMOVE_MOB_PROPERTY(mob, property, source)
 
 	for example:
 
 	/obj/item/unexample_stick/attack_self(mob/user)
-		REMOVE_MOB_PROPERTY_SIMPLE(user, PROP_EXAMPLE, /obj/item/example_stick)
+		REMOVE_MOB_PROPERTY(user, PROP_EXAMPLE, /obj/item/example_stick)
 
 
 
@@ -60,26 +60,26 @@ The value of a sum property is the sum of applied values of the property from al
 
 To set:
 
-	APPLY_MOB_PROPERTY_SUM(mob, property, source, value)
+	APPLY_MOB_PROPERTY(mob, property, source, value)
 
 	for example:
 
 	/obj/item/example_stick_1/attack_self(mob/user)
-		APPLY_MOB_PROPERTY_SUM(user, PROP_EXAMPLE, src.type, 1)
+		APPLY_MOB_PROPERTY(user, PROP_EXAMPLE, src.type, 1)
 
 	/obj/item/example_stick_2/attack_self(mob/user)
-		APPLY_MOB_PROPERTY_SUM(user, PROP_EXAMPLE, src.type, 2)
+		APPLY_MOB_PROPERTY(user, PROP_EXAMPLE, src.type, 2)
 
 	Using example_stick_1 gives the user a PROP_EXAMPLE value of 1 if no value existed prior. Using example_stick_2 right after makes the value 3.
 
 To remove:
 
-	REMOVE_MOB_PROPERTY_SUM(mob, property, source)
+	REMOVE_MOB_PROPERTY(mob, property, source)
 
 	for example:
 
 	/obj/item/unexample_stick_1/attack_self(mob/user)
-		REMOVE_MOB_PROPERTY_SUM(user, PROP_EXAMPLE, /obj/item/example_stick_1)
+		REMOVE_MOB_PROPERTY(user, PROP_EXAMPLE, /obj/item/example_stick_1)
 
 
 
@@ -89,15 +89,15 @@ The value of a max property is the largest of the applied values on the property
 
 To set:
 
-	APPLY_MOB_PROPERTY_MAX(mob, property, source, value)
+	APPLY_MOB_PROPERTY(mob, property, source, value)
 
 	for example:
 
 	/obj/item/example_stick_1/attack_self(mob/user)
-		APPLY_MOB_PROPERTY_MAX(user, PROP_EXAMPLE, src.type, 1)
+		APPLY_MOB_PROPERTY(user, PROP_EXAMPLE, src.type, 1)
 
 	/obj/item/example_stick_2/attack_self(mob/user)
-		APPLY_MOB_PROPERTY_MAX(user, PROP_EXAMPLE, src.type, 2)
+		APPLY_MOB_PROPERTY(user, PROP_EXAMPLE, src.type, 2)
 
 	Using example_stick_1 gives the user a PROP_EXAMPLE value of 1 if no value existed prior,
 	or the existing value was smaller than 1.
@@ -105,12 +105,12 @@ To set:
 
 To remove:
 
-	REMOVE_MOB_PROPERTY_MAX(mob, property, source)
+	REMOVE_MOB_PROPERTY(mob, property, source)
 
 	for example:
 
 	/obj/item/unexample_stick_2/attack_self(mob/user)
-		REMOVE_MOB_PROPERTY_MAX(user, PROP_EXAMPLE, /obj/item/example_stick_2)
+		REMOVE_MOB_PROPERTY(user, PROP_EXAMPLE, /obj/item/example_stick_2)
 
 	Using unexample_stick_2 returns the value to 1, assuming both sticks have been applied.
 
@@ -122,15 +122,15 @@ The value of a priority property is the value with the largest priority
 
 To set:
 
-	APPLY_MOB_PROPERTY_MAX(mob, property, source, value, priority)
+	APPLY_MOB_PROPERTY(mob, property, source, value, priority)
 
 	for example:
 
 	/obj/item/example_stick_1/attack_self(mob/user)
-		APPLY_MOB_PROPERTY_MAX(user, PROP_EXAMPLE, src.type, 1, 100)
+		APPLY_MOB_PROPERTY(user, PROP_EXAMPLE, src.type, 1, 100)
 
 	/obj/item/example_stick_2/attack_self(mob/user)
-		APPLY_MOB_PROPERTY_MAX(user, PROP_EXAMPLE, src.type, -300, 200)
+		APPLY_MOB_PROPERTY(user, PROP_EXAMPLE, src.type, -300, 200)
 
 	Using example_stick_1 gives the user a PROP_EXAMPLE value of 1 if no value existed prior,
 	or the existing value came from a priority smaller than 100.
@@ -151,22 +151,26 @@ To remove:
 
 */
 
+// Property defines
+//
+// These must be defined as macros in the format PROP_<yourproperty>(x) x("property key name", MACRO TO APPLY THE PROPERTY, MACRO TO REMOVE THE PROPERTY)
+
+/*  Macros used for testing, left here as examples:
+	#define PROP_TESTSIMPLE(x) x("test_simple", APPLY_MOB_PROPERTY_SIMPLE, REMOVE_MOB_PROPERTY_SIMPLE)
+	#define PROP_TESTSUM(x) x("test_sum", APPLY_MOB_PROPERTY_SUM, REMOVE_MOB_PROPERTY_SUM)
+	#define PROP_TESTMAX(x) x("test_max", APPLY_MOB_PROPERTY_MAX, REMOVE_MOB_PROPERTY_MAX)
+	#define PROP_TESTPRIO(x) x("test_prio", APPLY_MOB_PROPERTY_PRIORITY, REMOVE_MOB_PROPERTY_PRIORITY)
+*/
+
+#define PROP_CANTMOVE(x) x("cantmove", APPLY_MOB_PROPERTY_SIMPLE, REMOVE_MOB_PROPERTY_SIMPLE)
+
+
+// In lieu of comments, these are the indexes used for list access in the macros below.
 #define MOB_PROPERTY_ACTIVE_VALUE 1
 #define MOB_PROPERTY_SOURCES_LIST 2
 #define MOB_PROPERTY_PRIORITY_PRIO 1
 #define MOB_PROPERTY_PRIORITY_VALUE 2
 
-
-// Property defines
-//
-// Property strings must be prefixed with the following identifiers:
-//
-// Simple properties: i
-// Max properties: m
-// Sum properties: s
-// Priority properties: p
-
-#define PROP_CANTMOVE(x) x("i_cantmove", APPLY_MOB_PROPERTY_SIMPLE, REMOVE_MOB_PROPERTY_SIMPLE)
 #define TRIPLE_GET_1ST(a, b, c) a
 #define TRIPLE_GET_2ND(a, b, c) b
 #define TRIPLE_GET_3RD(a, b, c) c
@@ -179,7 +183,7 @@ To remove:
 
 #define REMOVE_MOB_PROPERTY(target, property, source) TRIPLE_3RD(property)(target, TRIPLE_1ST(property), source)
 
-#define GET_MOB_PROPERTY(target, property) (target.mob_properties[property] ? target.mob_properties[TRIPLE_1ST(property)][MOB_PROPERTY_ACTIVE_VALUE] : null)
+#define GET_MOB_PROPERTY(target, property) (target.mob_properties[TRIPLE_1ST(property)] ? target.mob_properties[TRIPLE_1ST(property)][MOB_PROPERTY_ACTIVE_VALUE] : null)
 
 // sliiiiiiiightly faster if you don't care about the value
 #define HAS_MOB_PROPERTY(target, property) (target.mob_properties[TRIPLE_1ST(property)] ? TRUE : FALSE)
@@ -285,9 +289,9 @@ To remove:
 			if (_L[property][MOB_PROPERTY_ACTIVE_VALUE] != _V) { \
 				var/_TO_APPLY_PRIO = -INFINITY; \
 				var/_TO_APPLY_VALUE; \
-				for (var/list/_K in _L[property][MOB_PROPERTY_SOURCES_LIST]) { \
-					var/list/_PRIOLIST = _L[property][MOB_PROPERTY_SOURCES_LIST][_K]; \
-					if (_PRIOLIST[MOB_PROPERTY_PRIORITY_PRIO] > _TO_APPLY_PRIO) { \
+				for (var/_SOURCE in _L[property][MOB_PROPERTY_SOURCES_LIST]) { \
+					var/list/_PRIOLIST = _L[property][MOB_PROPERTY_SOURCES_LIST][_SOURCE]; \
+					if (_PRIOLIST[MOB_PROPERTY_PRIORITY_PRIO] >= _TO_APPLY_PRIO) { \
 						_TO_APPLY_PRIO = _PRIOLIST[MOB_PROPERTY_PRIORITY_PRIO]; \
 						_TO_APPLY_VALUE = _PRIOLIST[MOB_PROPERTY_PRIORITY_VALUE]; \
 					} \
@@ -311,9 +315,9 @@ To remove:
 			} else if (_L[property][MOB_PROPERTY_ACTIVE_VALUE] == _S_V) { \
 				var/_TO_APPLY_PRIO = -INFINITY; \
 				var/_TO_APPLY_VALUE; \
-				for (var/list/_K in _L[property][MOB_PROPERTY_SOURCES_LIST]) { \
-					var/list/_PRIOLIST = _L[property][MOB_PROPERTY_SOURCES_LIST][_K]; \
-					if (_PRIOLIST[MOB_PROPERTY_PRIORITY_PRIO] > _TO_APPLY_PRIO) { \
+				for (var/_SOURCE in _L[property][MOB_PROPERTY_SOURCES_LIST]) { \
+					var/list/_PRIOLIST = _L[property][MOB_PROPERTY_SOURCES_LIST][_SOURCE]; \
+					if (_PRIOLIST[MOB_PROPERTY_PRIORITY_PRIO] >= _TO_APPLY_PRIO) { \
 						_TO_APPLY_PRIO = _PRIOLIST[MOB_PROPERTY_PRIORITY_PRIO]; \
 						_TO_APPLY_VALUE = _PRIOLIST[MOB_PROPERTY_PRIORITY_VALUE]; \
 					} \
@@ -322,4 +326,3 @@ To remove:
 			} \
 		} \
 	} while (0)
-

--- a/_stdlib/mob_properties.dm
+++ b/_stdlib/mob_properties.dm
@@ -18,7 +18,8 @@ To set the values of properties, helper procs exist on the mob type:
 
 	/mob/proc/remove_property(property, source)
 
-These work regardless of the type of property, as long as the property is properly prefixed (see property definitions below)
+These work regardless of the type of property, as long as the property is properly prefixed (see property definitions below).
+
 
 Behavior-dependent macros:
 
@@ -165,14 +166,23 @@ To remove:
 // Sum properties: s
 // Priority properties: p
 
-#define PROP_CANTMOVE "i_cantmove"
+#define PROP_CANTMOVE(x) x("i_cantmove", APPLY_MOB_PROPERTY_SIMPLE, REMOVE_MOB_PROPERTY_SIMPLE)
+#define TRIPLE_GET_1ST(a, b, c) a
+#define TRIPLE_GET_2ND(a, b, c) b
+#define TRIPLE_GET_3RD(a, b, c) c
 
+#define TRIPLE_1ST(x) x(TRIPLE_GET_1ST)
+#define TRIPLE_2ND(x) x(TRIPLE_GET_2ND)
+#define TRIPLE_3RD(x) x(TRIPLE_GET_3RD)
 
+#define APPLY_MOB_PROPERTY(target, property, etc...) TRIPLE_2ND(property)(target, TRIPLE_1ST(property), ##etc)
 
-#define GET_MOB_PROPERTY(target, property) (target.mob_properties[property] ? target.mob_properties[property][MOB_PROPERTY_ACTIVE_VALUE] : null)
+#define REMOVE_MOB_PROPERTY(target, property, source) TRIPLE_3RD(property)(target, TRIPLE_1ST(property), source)
+
+#define GET_MOB_PROPERTY(target, property) (target.mob_properties[property] ? target.mob_properties[TRIPLE_1ST(property)][MOB_PROPERTY_ACTIVE_VALUE] : null)
 
 // sliiiiiiiightly faster if you don't care about the value
-#define HAS_MOB_PROPERTY(target, property) (target.mob_properties[property] ? TRUE : FALSE)
+#define HAS_MOB_PROPERTY(target, property) (target.mob_properties[TRIPLE_1ST(property)] ? TRUE : FALSE)
 
 
 #define APPLY_MOB_PROPERTY_MAX(target, property, source, value) \
@@ -312,3 +322,4 @@ To remove:
 			} \
 		} \
 	} while (0)
+

--- a/_stdlib/mob_properties.dm
+++ b/_stdlib/mob_properties.dm
@@ -4,13 +4,16 @@
 
 Contains a system to apply fast-to-check properties onto mobs, with different stacking behaviors.
 
-To get the value of ANY property regardless of the behavior used, use:area
+To get the value of ANY property regardless of the behavior used, use:
 
 	GET_MOB_PROPERTY(mob, property)
 
 If you only want to know whether a property exists, use:
 
 	HAS_MOB_PROPERTY(mob, property)
+
+To set the values of properties, helper procs exist on the mob type:
+
 
 Behavior-dependent macros:
 
@@ -147,9 +150,17 @@ To remove:
 #define MOB_PROPERTY_PRIORITY_PRIO 1
 #define MOB_PROPERTY_PRIORITY_VALUE 2
 
-#define PROP_CANTMOVE "cantmove"
 
+// Property defines
+//
+// Property strings must be prefixed with the following identifiers:
+//
+// Simple properties: i
+// Max properties: m
+// Sum properties: s
+// Priority properties: p
 
+#define PROP_CANTMOVE "i_cantmove"
 
 
 
@@ -282,7 +293,7 @@ To remove:
 			_L[property][MOB_PROPERTY_SOURCES_LIST] -= source; \
 			if (!length(_L[property][MOB_PROPERTY_SOURCES_LIST])) { \
 				_L -= property; \
-			} else if (_L[property_MOB_PROPERTY_ACTIVE_VALUE] == _S_V) { \ /* we removed the active value */ \
+			} else if (_L[property][MOB_PROPERTY_ACTIVE_VALUE] == _S_V) { \ /* we removed the active value */ \
 				var/_TO_APPLY_PRIO = -INFINITY; \
 				var/_TO_APPLY_VALUE; \
 				for (var/list/_K in _L[property][MOB_PROPERTY_SOURCES_LIST]) { \

--- a/_stdlib/mob_properties.dm
+++ b/_stdlib/mob_properties.dm
@@ -1,6 +1,8 @@
 #define MOB_PROPERTY_ACTIVE_VALUE 1
 #define MOB_PROPERTY_SOURCES_LIST 2
 
+#define PROP_CANTMOVE "cantmove"
+
 #define APPLY_MOB_PROPERTY(target, property, source, value) \
 	do { \
 		var/list/_L = target.mob_properties; \
@@ -10,10 +12,10 @@
 			_L[property][MOB_PROPERTY_SOURCES_LIST][_S] = _V; \
 			if (_L[property][MOB_PROPERTY_ACTIVE_VALUE] < _V) { \
 				_L[property][MOB_PROPERTY_ACTIVE_VALUE] = _V; \
-			} \
+			}; \
 		} else { \
-			_L[property] = list(_V, list(_S = _V); \
-		} \
+			_L[property] = list(_V, list(_S = _V)); \
+		}; \
 	} while (0)
 
 #define GET_MOB_PROPERTY(target, property) (target.mob_properties[property] ? target.mob_properties[property][MOB_PROPERTY_ACTIVE_VALUE] : null)
@@ -25,7 +27,7 @@
 	do { \
 		var/list/_L = target.mob_properties; \
 		if (_L[property]) { \
-			_L[property][MOB_PROPERTY_SOURCES_LIST] -= sources; \
+			_L[property][MOB_PROPERTY_SOURCES_LIST] -= source; \
 			if (!length(_L[property][MOB_PROPERTY_SOURCES_LIST])) { \
 				_L -= property; \
 			} else { \

--- a/_stdlib/mob_properties.dm
+++ b/_stdlib/mob_properties.dm
@@ -14,6 +14,11 @@ If you only want to know whether a property exists, use:
 
 To set the values of properties, helper procs exist on the mob type:
 
+	/mob/proc/apply_property(property, source, value = null, priority = null)
+
+	/mob/proc/remove_property(property, source)
+
+These work regardless of the type of property, as long as the property is properly prefixed (see property definitions below)
 
 Behavior-dependent macros:
 
@@ -231,7 +236,7 @@ To remove:
 		var/_V = value; \
 		var/_S = source; \
 		if (_L[property]) { \
-			if (_L[property][MOB_PROPERTY_SOURCES_LIST][_S]) { \ /* if the value already exists from this source, adjust */ \
+			if (_L[property][MOB_PROPERTY_SOURCES_LIST][_S]) { \
 				_L[property][MOB_PROPERTY_ACTIVE_VALUE] -= _L[property][MOB_PROPERTY_SOURCES_LIST][_S]; \
 				_L[property][MOB_PROPERTY_SOURCES_LIST][_S] = _V; \
 				_L[property][MOB_PROPERTY_ACTIVE_VALUE] += _V; \
@@ -293,7 +298,7 @@ To remove:
 			_L[property][MOB_PROPERTY_SOURCES_LIST] -= source; \
 			if (!length(_L[property][MOB_PROPERTY_SOURCES_LIST])) { \
 				_L -= property; \
-			} else if (_L[property][MOB_PROPERTY_ACTIVE_VALUE] == _S_V) { \ /* we removed the active value */ \
+			} else if (_L[property][MOB_PROPERTY_ACTIVE_VALUE] == _S_V) { \
 				var/_TO_APPLY_PRIO = -INFINITY; \
 				var/_TO_APPLY_VALUE; \
 				for (var/list/_K in _L[property][MOB_PROPERTY_SOURCES_LIST]) { \

--- a/code/datums/mob_properties.dm
+++ b/code/datums/mob_properties.dm
@@ -1,0 +1,40 @@
+#define MOB_PROPERTY_ACTIVE_VALUE 1
+#define MOB_PROPERTY_SOURCES_LIST 2
+
+#define APPLY_MOB_PROPERTY(target, property, source, value) \
+	do { \
+		var/list/_L = target.mob_properties; \
+		var/_V = value; \
+		var/_S = source; \
+		if (_L[property]) { \
+			_L[property][MOB_PROPERTY_SOURCES_LIST][_S] = _V; \
+			if (_L[property][MOB_PROPERTY_ACTIVE_VALUE] < _V) { \
+				_L[property][MOB_PROPERTY_ACTIVE_VALUE] = _V; \
+			} \
+		} else { \
+			_L[property] = list(_V, list(_S = _V); \
+		} \
+	} while (0)
+
+#define GET_MOB_PROPERTY(target, property) (target.mob_properties[property] ? target.mob_properties[property][MOB_PROPERTY_ACTIVE_VALUE] : null)
+
+// sliiiiiiiightly faster if you don't care about the value
+#define HAS_MOB_PROPERTY(target, property) (target.mob_properties[property] ? TRUE : FALSE)
+
+#define REMOVE_MOB_PROPERTY(target, property, source) \
+	do { \
+		var/list/_L = target.mob_properties; \
+		if (_L[property]) { \
+			_L[property][MOB_PROPERTY_SOURCES_LIST] -= sources; \
+			if (!length(_L[property][MOB_PROPERTY_SOURCES_LIST])) { \
+				_L -= property; \
+			} else { \
+				_L[property][MOB_PROPERTY_ACTIVE_VALUE] = 0; \
+				for(var/_S in _L[property][MOB_PROPERTY_SOURCES_LIST]) { \
+					if (_L[property][MOB_PROPERTY_ACTIVE_VALUE] < _L[property][MOB_PROPERTY_SOURCES_LIST][_S]) { \
+						_L[property][MOB_PROPERTY_ACTIVE_VALUE] = _L[property][MOB_PROPERTY_SOURCES_LIST][_S]; \
+					} \
+				} \
+			} \
+		} \
+	} while (0)

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -215,6 +215,7 @@
 	var/dir_locked = FALSE
 
 	var/list/cooldowns = null
+	var/list/mob_properties
 
 //obj/item/setTwoHanded calls this if the item is inside a mob to enable the mob to handle UI and hand updates as the item changes to or from 2-hand
 /mob/proc/updateTwoHanded(var/obj/item/I, var/twoHanded = 1)
@@ -231,12 +232,14 @@
 	render_special = new
 	traitHolder = new(src)
 	cooldowns = new
-	if (!src.bioHolder) src.bioHolder = new /datum/bioHolder ( src )
+	if (!src.bioHolder)
+		src.bioHolder = new /datum/bioHolder ( src )
 	attach_hud(render_special)
 	. = ..()
 	mobs.Add(src)
 	src.lastattacked = src //idk but it fixes bug
 	render_target = "\ref[src]"
+	mob_properties = list()
 
 /mob/proc/is_spacefaring()
 	return 0

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -2927,41 +2927,6 @@
 		var/obj/item/device/pda2/pda = src.equipped()
 		return pda.ID_card
 
-
-/mob/proc/apply_property(property, source, value = null, priority = null)
-	if (!source)
-		CRASH("Attempted to set priority without a source")
-	switch(property[1])
-		if ("i")
-			APPLY_MOB_PROPERTY_SIMPLE(src, property, source)
-		if ("p")
-			if (!value || !priority)
-				CRASH("Attempted to set priority property [property] without value or priority")
-			APPLY_MOB_PROPERTY_PRIORITY(src, property, source, value, priority)
-		if ("s")
-			if (!value)
-				CRASH("Attempted to set sum property [property] without a value")
-			APPLY_MOB_PROPERTY_SUM(src, property, source, value)
-		if ("m")
-			if (!value || !priority)
-				CRASH("Attempted to set max property [property] without value or priority")
-			APPLY_MOB_PROPERTY_MAX(src, property, source, value)
-		else
-			CRASH("Invalid mob property: [property]")
-
-/mob/proc/remove_property(property, source)
-	switch(property[1])
-		if ("i")
-			REMOVE_MOB_PROPERTY_SIMPLE(src, property, source)
-		if ("p")
-			REMOVE_MOB_PROPERTY_PRIORITY(src, property, source)
-		if ("s")
-			REMOVE_MOB_PROPERTY_SUM(src, property, source)
-		if ("m")
-			REMOVE_MOB_PROPERTY_MAX(src, property, source)
-		else
-			CRASH("Invalid mob property: [property]")
-
 // http://www.byond.com/forum/post/1326139&page=2
 //MOB VERBS ARE FASTER THAN OBJ VERBS, ELIMINATE ALL OBJ VERBS WHERE U CAN
 // ALSO EXCLUSIVE VERBS (LIKE ADMIN VERBS) ARE BAD FOR RCLICK TOO, TRY NOT TO USE THOSE OK

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -2927,6 +2927,41 @@
 		var/obj/item/device/pda2/pda = src.equipped()
 		return pda.ID_card
 
+
+/mob/proc/apply_property(property, source, value = null, priority = null)
+	if (!source)
+		CRASH("Attempted to set priority without a source")
+	switch(property[1])
+		if ("i")
+			APPLY_MOB_PROPERTY_SIMPLE(src, property, source)
+		if ("p")
+			if (!value || !priority)
+				CRASH("Attempted to set priority property [property] without value or priority")
+			APPLY_MOB_PROPERTY_PRIORITY(src, property, source, value, priority)
+		if ("s")
+			if (!value)
+				CRASH("Attempted to set sum property [property] without a value")
+			APPLY_MOB_PROPERTY_SUM(src, property, source, value)
+		if ("m")
+			if (!value || !priority)
+				CRASH("Attempted to set max property [property] without value or priority")
+			APPLY_MOB_PROPERTY_MAX(src, property, source, value)
+		else
+			CRASH("Invalid mob property: [property]")
+
+/mob/proc/remove_property(property, source)
+	switch(property[1])
+		if ("i")
+			REMOVE_MOB_PROPERTY_SIMPLE(src, property, source)
+		if ("p")
+			REMOVE_MOB_PROPERTY_PRIORITY(src, property, source)
+		if ("s")
+			REMOVE_MOB_PROPERTY_SUM(src, property, source)
+		if ("m")
+			REMOVE_MOB_PROPERTY_MAX(src, property, source)
+		else
+			CRASH("Invalid mob property: [property]")
+
 // http://www.byond.com/forum/post/1326139&page=2
 //MOB VERBS ARE FASTER THAN OBJ VERBS, ELIMINATE ALL OBJ VERBS WHERE U CAN
 // ALSO EXCLUSIVE VERBS (LIKE ADMIN VERBS) ARE BAD FOR RCLICK TOO, TRY NOT TO USE THOSE OK

--- a/code/mob/living/carbon/human/procs/Life.dm
+++ b/code/mob/living/carbon/human/procs/Life.dm
@@ -813,12 +813,7 @@
 		return null
 
 	proc/update_canmove()
-		if (hasStatus("paralysis") || hasStatus("stunned") || hasStatus("weakened") || hasStatus("pinned"))
-			canmove = 0
-			return
-
-		var/datum/abilityHolder/changeling/C = get_ability_holder(/datum/abilityHolder/changeling)
-		if (C && C.in_fakedeath)
+		if (HAS_MOB_PROPERTY(src, PROP_CANTMOVE))
 			canmove = 0
 			return
 
@@ -839,12 +834,6 @@
 		if (emote_lock)
 			canmove = 0
 			return
-
-		//cant move while we pin someone down
-		for (var/obj/item/grab/G in src.equipped_list(check_for_magtractor = 0))
-			if (G.state == GRAB_PIN)
-				canmove = 0
-				return
 
 		canmove = 1
 

--- a/code/modules/antagonists/changeling/abilities/regeneration.dm
+++ b/code/modules/antagonists/changeling/abilities/regeneration.dm
@@ -33,7 +33,7 @@
 				implants += I
 
 			H.in_fakedeath = 1
-			APPLY_MOB_PROPERTY(C, PROP_CANTMOVE, "fakedeath")
+			APPLY_MOB_PROPERTY(C, PROP_CANTMOVE, src.type)
 
 			C.lying = 1
 			C.canmove = 0

--- a/code/modules/antagonists/changeling/abilities/regeneration.dm
+++ b/code/modules/antagonists/changeling/abilities/regeneration.dm
@@ -33,7 +33,7 @@
 				implants += I
 
 			H.in_fakedeath = 1
-			APPLY_MOB_PROPERTY(C, PROP_CANTMOVE, "fakedeath", 1)
+			APPLY_MOB_PROPERTY_SIMPLE(C, PROP_CANTMOVE, "fakedeath")
 
 			C.lying = 1
 			C.canmove = 0
@@ -70,7 +70,7 @@
 
 				C.set_clothing_icon_dirty()
 				H.in_fakedeath = 0
-				REMOVE_MOB_PROPERTY(C, PROP_CANTMOVE, src.type)
+				REMOVE_MOB_PROPERTY_SIMPLE(C, PROP_CANTMOVE, src.type)
 		return 0
 
 /proc/changeling_super_heal_step(var/mob/living/carbon/human/healed, var/limb_regen_prob = 25, var/eye_regen_prob = 25, var/mult = 1, var/changer = 1)

--- a/code/modules/antagonists/changeling/abilities/regeneration.dm
+++ b/code/modules/antagonists/changeling/abilities/regeneration.dm
@@ -33,7 +33,7 @@
 				implants += I
 
 			H.in_fakedeath = 1
-			APPLY_MOB_PROPERTY_SIMPLE(C, PROP_CANTMOVE, "fakedeath")
+			APPLY_MOB_PROPERTY(C, PROP_CANTMOVE, "fakedeath")
 
 			C.lying = 1
 			C.canmove = 0
@@ -70,7 +70,7 @@
 
 				C.set_clothing_icon_dirty()
 				H.in_fakedeath = 0
-				REMOVE_MOB_PROPERTY_SIMPLE(C, PROP_CANTMOVE, src.type)
+				REMOVE_MOB_PROPERTY(C, PROP_CANTMOVE, src.type)
 		return 0
 
 /proc/changeling_super_heal_step(var/mob/living/carbon/human/healed, var/limb_regen_prob = 25, var/eye_regen_prob = 25, var/mult = 1, var/changer = 1)

--- a/code/modules/antagonists/changeling/abilities/regeneration.dm
+++ b/code/modules/antagonists/changeling/abilities/regeneration.dm
@@ -33,6 +33,7 @@
 				implants += I
 
 			H.in_fakedeath = 1
+			APPLY_MOB_PROPERTY(C, PROP_CANTMOVE, "fakedeath", 1)
 
 			C.lying = 1
 			C.canmove = 0
@@ -69,6 +70,7 @@
 
 				C.set_clothing_icon_dirty()
 				H.in_fakedeath = 0
+				REMOVE_MOB_PROPERTY(C, PROP_CANTMOVE, src.type)
 		return 0
 
 /proc/changeling_super_heal_step(var/mob/living/carbon/human/healed, var/limb_regen_prob = 25, var/eye_regen_prob = 25, var/mult = 1, var/changer = 1)

--- a/code/modules/status_system/statusSystem.dm
+++ b/code/modules/status_system/statusSystem.dm
@@ -772,13 +772,13 @@ var/list/statusGroupLimits = list("Food"=4)
 				. = ..()
 				if (ismob(owner))
 					var/mob/mob_owner = owner
-					APPLY_MOB_PROPERTY(mob_owner, PROP_CANTMOVE, src.type, 1)
+					APPLY_MOB_PROPERTY_SIMPLE(mob_owner, PROP_CANTMOVE, src.type)
 
 			onRemove()
 				. = ..()
 				if (ismob(owner))
 					var/mob/mob_owner = owner
-					REMOVE_MOB_PROPERTY(mob_owner, PROP_CANTMOVE, src.type)
+					REMOVE_MOB_PROPERTY_SIMPLE(mob_owner, PROP_CANTMOVE, src.type)
 
 		weakened
 			id = "weakened"
@@ -792,13 +792,13 @@ var/list/statusGroupLimits = list("Food"=4)
 				. = ..()
 				if (ismob(owner))
 					var/mob/mob_owner = owner
-					APPLY_MOB_PROPERTY(mob_owner, PROP_CANTMOVE, src.type, 1)
+					APPLY_MOB_PROPERTY_SIMPLE(mob_owner, PROP_CANTMOVE, src.type)
 
 			onRemove()
 				. = ..()
 				if (ismob(owner))
 					var/mob/mob_owner = owner
-					REMOVE_MOB_PROPERTY(mob_owner, PROP_CANTMOVE, src.type)
+					REMOVE_MOB_PROPERTY_SIMPLE(mob_owner, PROP_CANTMOVE, src.type)
 
 			pinned
 				id = "pinned"
@@ -849,13 +849,13 @@ var/list/statusGroupLimits = list("Food"=4)
 				. = ..()
 				if (ismob(owner))
 					var/mob/mob_owner = owner
-					APPLY_MOB_PROPERTY(mob_owner, PROP_CANTMOVE, src.type, 1)
+					APPLY_MOB_PROPERTY_SIMPLE(mob_owner, PROP_CANTMOVE, src.type)
 
 			onRemove()
 				. = ..()
 				if (ismob(owner))
 					var/mob/mob_owner = owner
-					REMOVE_MOB_PROPERTY(mob_owner, PROP_CANTMOVE, src.type)
+					REMOVE_MOB_PROPERTY_SIMPLE(mob_owner, PROP_CANTMOVE, src.type)
 
 		dormant
 			id = "dormant"

--- a/code/modules/status_system/statusSystem.dm
+++ b/code/modules/status_system/statusSystem.dm
@@ -772,13 +772,13 @@ var/list/statusGroupLimits = list("Food"=4)
 				. = ..()
 				if (ismob(owner))
 					var/mob/mob_owner = owner
-					APPLY_MOB_PROPERTY_SIMPLE(mob_owner, PROP_CANTMOVE, src.type)
+					APPLY_MOB_PROPERTY(mob_owner, PROP_CANTMOVE, src.type)
 
 			onRemove()
 				. = ..()
 				if (ismob(owner))
 					var/mob/mob_owner = owner
-					REMOVE_MOB_PROPERTY_SIMPLE(mob_owner, PROP_CANTMOVE, src.type)
+					REMOVE_MOB_PROPERTY(mob_owner, PROP_CANTMOVE, src.type)
 
 		weakened
 			id = "weakened"
@@ -792,13 +792,13 @@ var/list/statusGroupLimits = list("Food"=4)
 				. = ..()
 				if (ismob(owner))
 					var/mob/mob_owner = owner
-					APPLY_MOB_PROPERTY_SIMPLE(mob_owner, PROP_CANTMOVE, src.type)
+					APPLY_MOB_PROPERTY(mob_owner, PROP_CANTMOVE, src.type)
 
 			onRemove()
 				. = ..()
 				if (ismob(owner))
 					var/mob/mob_owner = owner
-					REMOVE_MOB_PROPERTY_SIMPLE(mob_owner, PROP_CANTMOVE, src.type)
+					REMOVE_MOB_PROPERTY(mob_owner, PROP_CANTMOVE, src.type)
 
 			pinned
 				id = "pinned"
@@ -849,13 +849,13 @@ var/list/statusGroupLimits = list("Food"=4)
 				. = ..()
 				if (ismob(owner))
 					var/mob/mob_owner = owner
-					APPLY_MOB_PROPERTY_SIMPLE(mob_owner, PROP_CANTMOVE, src.type)
+					APPLY_MOB_PROPERTY(mob_owner, PROP_CANTMOVE, src.type)
 
 			onRemove()
 				. = ..()
 				if (ismob(owner))
 					var/mob/mob_owner = owner
-					REMOVE_MOB_PROPERTY_SIMPLE(mob_owner, PROP_CANTMOVE, src.type)
+					REMOVE_MOB_PROPERTY(mob_owner, PROP_CANTMOVE, src.type)
 
 		dormant
 			id = "dormant"

--- a/code/modules/status_system/statusSystem.dm
+++ b/code/modules/status_system/statusSystem.dm
@@ -768,6 +768,18 @@ var/list/statusGroupLimits = list("Food"=4)
 			unique = 1
 			maxDuration = 30 SECONDS
 
+			onAdd(var/optional=null)
+				. = ..()
+				if (ismob(owner))
+					var/mob/mob_owner = owner
+					APPLY_MOB_PROPERTY(mob_owner, PROP_CANTMOVE, src.type, 1)
+
+			onRemove()
+				. = ..()
+				if (ismob(owner))
+					var/mob/mob_owner = owner
+					REMOVE_MOB_PROPERTY(mob_owner, PROP_CANTMOVE, src.type)
+
 		weakened
 			id = "weakened"
 			name = "Knocked-down"
@@ -775,6 +787,18 @@ var/list/statusGroupLimits = list("Food"=4)
 			icon_state = "weakened"
 			unique = 1
 			maxDuration = 30 SECONDS
+
+			onAdd(var/optional=null)
+				. = ..()
+				if (ismob(owner))
+					var/mob/mob_owner = owner
+					APPLY_MOB_PROPERTY(mob_owner, PROP_CANTMOVE, src.type, 1)
+
+			onRemove()
+				. = ..()
+				if (ismob(owner))
+					var/mob/mob_owner = owner
+					REMOVE_MOB_PROPERTY(mob_owner, PROP_CANTMOVE, src.type)
 
 			pinned
 				id = "pinned"
@@ -820,6 +844,18 @@ var/list/statusGroupLimits = list("Food"=4)
 			icon_state = "paralysis"
 			unique = 1
 			maxDuration = 30 SECONDS
+
+			onAdd(var/optional=null)
+				. = ..()
+				if (ismob(owner))
+					var/mob/mob_owner = owner
+					APPLY_MOB_PROPERTY(mob_owner, PROP_CANTMOVE, src.type, 1)
+
+			onRemove()
+				. = ..()
+				if (ismob(owner))
+					var/mob/mob_owner = owner
+					REMOVE_MOB_PROPERTY(mob_owner, PROP_CANTMOVE, src.type)
 
 		dormant
 			id = "dormant"

--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -84,7 +84,7 @@
 
 	dropped()
 		dropped += 1
-		REMOVE_MOB_PROPERTY(src.assailant, PROP_CANTMOVE, src.type)
+		REMOVE_MOB_PROPERTY_SIMPLE(src.assailant, PROP_CANTMOVE, src.type)
 		qdel(src)
 
 	process(var/mult = 1)
@@ -256,7 +256,7 @@
 				for (var/mob/O in AIviewers(src.assailant, null))
 					O.show_message("<span class='alert'>[src.assailant] has tightened [his_or_her(assailant)] grip on [src.affecting]'s neck!</span>", 1)
 		src.state = GRAB_KILL
-		REMOVE_MOB_PROPERTY(src.assailant, PROP_CANTMOVE, src.type)
+		REMOVE_MOB_PROPERTY_SIMPLE(src.assailant, PROP_CANTMOVE, src.type)
 		src.assailant.lastattacked = src.affecting
 		src.affecting.lastattacker = src.assailant
 		src.affecting.lastattackertime = world.time
@@ -299,7 +299,7 @@
 
 		if (ishuman(src.assailant))
 			var/mob/living/carbon/human/H = src.assailant
-			APPLY_MOB_PROPERTY(H, PROP_CANTMOVE, src.type, 1)
+			APPLY_MOB_PROPERTY_SIMPLE(H, PROP_CANTMOVE, src.type)
 			H.update_canmove()
 
 		if (ishuman(src.affecting))

--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -84,7 +84,7 @@
 
 	dropped()
 		dropped += 1
-		REMOVE_MOB_PROPERTY_SIMPLE(src.assailant, PROP_CANTMOVE, src.type)
+		REMOVE_MOB_PROPERTY(src.assailant, PROP_CANTMOVE, src.type)
 		qdel(src)
 
 	process(var/mult = 1)
@@ -256,7 +256,7 @@
 				for (var/mob/O in AIviewers(src.assailant, null))
 					O.show_message("<span class='alert'>[src.assailant] has tightened [his_or_her(assailant)] grip on [src.affecting]'s neck!</span>", 1)
 		src.state = GRAB_KILL
-		REMOVE_MOB_PROPERTY_SIMPLE(src.assailant, PROP_CANTMOVE, src.type)
+		REMOVE_MOB_PROPERTY(src.assailant, PROP_CANTMOVE, src.type)
 		src.assailant.lastattacked = src.affecting
 		src.affecting.lastattacker = src.assailant
 		src.affecting.lastattackertime = world.time
@@ -299,7 +299,7 @@
 
 		if (ishuman(src.assailant))
 			var/mob/living/carbon/human/H = src.assailant
-			APPLY_MOB_PROPERTY_SIMPLE(H, PROP_CANTMOVE, src.type)
+			APPLY_MOB_PROPERTY(H, PROP_CANTMOVE, src.type)
 			H.update_canmove()
 
 		if (ishuman(src.affecting))

--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -75,7 +75,8 @@
 				logTheThing("combat", src.assailant, src.affecting, "drops their pin on %target%")
 			else
 				logTheThing("combat", src.assailant, src.affecting, "drops their grab on %target%")
-			if (affecting.grabbed_by) affecting.grabbed_by -= src
+			if (affecting.grabbed_by)
+				affecting.grabbed_by -= src
 			affecting = null
 
 		assailant = null
@@ -83,6 +84,7 @@
 
 	dropped()
 		dropped += 1
+		REMOVE_MOB_PROPERTY(src.assailant, PROP_CANTMOVE, src.type)
 		qdel(src)
 
 	process(var/mult = 1)
@@ -101,6 +103,7 @@
 			if (ishuman(src.assailant))
 				var/mob/living/carbon/human/HH = src.assailant
 				HH.remove_stamina(STAMINA_REGEN * 0.5 * mult)
+
 
 		if (src.state == GRAB_KILL)
 			//src.affecting.losebreath++
@@ -253,6 +256,7 @@
 				for (var/mob/O in AIviewers(src.assailant, null))
 					O.show_message("<span class='alert'>[src.assailant] has tightened [his_or_her(assailant)] grip on [src.affecting]'s neck!</span>", 1)
 		src.state = GRAB_KILL
+		REMOVE_MOB_PROPERTY(src.assailant, PROP_CANTMOVE, src.type)
 		src.assailant.lastattacked = src.affecting
 		src.affecting.lastattacker = src.assailant
 		src.affecting.lastattackertime = world.time
@@ -295,6 +299,7 @@
 
 		if (ishuman(src.assailant))
 			var/mob/living/carbon/human/H = src.assailant
+			APPLY_MOB_PROPERTY(H, PROP_CANTMOVE, src.type, 1)
 			H.update_canmove()
 
 		if (ishuman(src.affecting))

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -32,6 +32,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "_stdlib\math.dm"
 #include "_stdlib\pathfinding.dm"
 #include "_stdlib\text.dm"
+#include "_stdlib\mob_properties.dm"
 #include "_stdlib\code\spaceman_dmm.dm"
 
 #include "_stdlib\code\_antag_popups.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This adds a system for "mob properties", a fast-to-check system useful for many things. Included are a couple of variants:

- Simple properties, which function like multi-source flags (similar to tg traits),
- Sum properties, where the value is the sum of all applied sources
- Max properties, where the value is the largest of all applied sources
- Priority properties, where the value is the same as the source with the largest priority value

A simple property is used to refactor `update_canmove()` a bit. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
hasStatus loops through status effects, which is fairly inconvenient when a lot of status effects have similar effects on the mob. It would be better if the status effects set a prop like this instead.