### PR TITLE
Fixes issue with borgs dropping their hypos

### DIFF
--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -942,6 +942,8 @@
 
 	if (src.loc == user)
 		var/in_pocket = 0
+		if(issilicon(user)) //if it's a botg's shit, stop here
+			return 0
 		if (ishuman(user))
 			var/mob/living/carbon/human/H = user
 			if(H.l_store == src || H.r_store == src)

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -942,7 +942,7 @@
 
 	if (src.loc == user)
 		var/in_pocket = 0
-		if(issilicon(user)) //if it's a botg's shit, stop here
+		if(issilicon(user)) //if it's a borg's shit, stop here
 			return 0
 		if (ishuman(user))
 			var/mob/living/carbon/human/H = user


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes borgs return early from attack_hand on items in them, to stop them from dropping equipped items. I'm fairly confident this won't break anything


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Closes #568
