### PR TITLE
Make ghost critter overlays pull from client preferences, fix eye color bug

### DIFF
--- a/code/mob/dead/observer.dm
+++ b/code/mob/dead/observer.dm
@@ -266,6 +266,7 @@
 			src.hell_respawn(src.mind)
 			return null
 		var/mob/dead/observer/O = new/mob/dead/observer(src)
+		O.bioHolder.CopyOther(src.bioHolder, copyActiveEffects = 0)
 		if (isghostrestrictedz(O.z) && !restricted_z_allowed(O, get_turf(O)) && !(src.client && src.client.holder))
 			var/OS = observer_start.len ? pick(observer_start) : locate(150, 150, 1)
 			if (OS)
@@ -349,11 +350,6 @@
 		O.wig.wear_image = image(O.wig.wear_image_icon, O.wig.icon_state)
 		O.wig.wear_image.color = src.bioHolder.mobAppearance.customization_first_color
 
-
-
-		var/datum/bioHolder/newbio = new/datum/bioHolder(O)
-		newbio.CopyOther(src.bioHolder, copyActiveEffects = 0)
-		O.bioHolder = newbio
 
 	return O
 

--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -1191,11 +1191,6 @@
 		if (!O)
 			return null
 
-		if (src.bioHolder) //Not necessary for ghost appearance, but this will be useful if the ghost decides to respawn as critter
-			var/datum/bioHolder/newbio = new/datum/bioHolder(O)
-			newbio.CopyOther(src.bioHolder)
-			O.bioHolder = newbio
-
 		O.icon = ghost_icon
 		O.icon_state = ghost_icon_state
 

--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -123,16 +123,14 @@ todo: add more small animals!
 		eye_color = "#FFFFF"
 
 	setup_overlays()
-		if (src.bioHolder)
-			fur_color = src.bioHolder.mobAppearance.customization_first_color
-			eye_color = src.bioHolder.mobAppearance.e_color
-
+		fur_color = src.client?.preferences.AH.customization_first_color
+		eye_color = src.client?.preferences.AH.e_color
 		var/image/overlay = image('icons/misc/critter.dmi', "mouse_colorkey")
 		overlay.color = fur_color
 		src.UpdateOverlays(overlay, "hair")
 
 		var/image/overlay_eyes = image('icons/misc/critter.dmi', "mouse_eyes")
-		overlay.color = eye_color
+		overlay_eyes.color = eye_color
 		src.UpdateOverlays(overlay_eyes, "eyes")
 
 	death()
@@ -1245,16 +1243,15 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 	fits_under_table = 1
 
 	setup_overlays()
-		if (src.bioHolder)
-			fur_color = src.bioHolder.mobAppearance.customization_first_color
-			eye_color = src.bioHolder.mobAppearance.e_color
+		fur_color = src.client?.preferences.AH.customization_first_color
+		eye_color = src.client?.preferences.AH.e_color
 
 		var/image/overlay = image('icons/misc/critter.dmi', "roach_colorkey")
 		overlay.color = fur_color
 		src.UpdateOverlays(overlay, "hair")
 
 		var/image/overlay_eyes = image('icons/misc/critter.dmi', "roach_eyes")
-		overlay.color = eye_color
+		overlay_eyes.color = eye_color
 		src.UpdateOverlays(overlay_eyes, "eyes")
 
 	death()
@@ -2427,17 +2424,14 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 	setup_overlays()
 		if(!src.colorkey_overlays)
 			return
-		if (src.bioHolder)
-			// purple only
-			// fur_color = src.bioHolder.mobAppearance.customization_first_color
-			eye_color = src.bioHolder.mobAppearance.e_color
+		eye_color = src.client?.preferences.AH.e_color
 
 		var/image/overlay = image('icons/misc/critter.dmi', "mouse_colorkey")
 		overlay.color = fur_color
 		src.UpdateOverlays(overlay, "hair")
 
 		var/image/overlay_eyes = image('icons/misc/critter.dmi', "mouse_eyes")
-		overlay.color = eye_color
+		overlay_eyes.color = eye_color
 		src.UpdateOverlays(overlay_eyes, "eyes")
 
 	death()

--- a/code/mob/transform_procs.dm
+++ b/code/mob/transform_procs.dm
@@ -196,9 +196,6 @@
 		var/datum/bioHolder/original = new/datum/bioHolder(W)
 		original.CopyOther(src.bioHolder)
 		W.bioHolder = original
-	if (issmallanimal(W))
-		var/mob/living/critter/small_animal/small = W
-		small.setup_overlays()
 
 	var/mob/selfmob = src
 	src = null
@@ -213,6 +210,11 @@
 			ticker.minds += W.mind
 			W.mind.key = key
 			W.mind.current = W
+
+	if (issmallanimal(W))
+		var/mob/living/critter/small_animal/small = W
+		small.setup_overlays() // this requires the small animal to have a client to set things up properly
+
 	SPAWN_DBG(1 DECI SECOND)
 		qdel(selfmob)
 	return W


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[MINOR] [CLEAN]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR makes ghost critter overlay colors pull from client preferences and not mob bioholder (to make things more consistent) and fixes a small bug where eye color wasn't properly being set. It also has all mobs copy bioholders in their `ghostize()` instead of just critters and humans. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Tiny improvement.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->
