### PR TITLE
Fix for non-humans being unable to connect mechanics components

### DIFF
--- a/code/WorkInProgress/MechanicMC14500.dm
+++ b/code/WorkInProgress/MechanicMC14500.dm
@@ -67,8 +67,8 @@ var/list/hex_digit_values = list("0" = 0, "1" = 1, "2" = 2, "3" = 3, "4" = 4, "5
 					if (user.stat || get_dist(user, src) > 2)
 						return
 
-					if (!(ishuman(usr) && usr.find_tool_in_hand(TOOL_PULSING)))
-						boutput(usr, "<span class='alert'>[MECHFAILSTRING]</span>")
+					if (!user.find_tool_in_hand(TOOL_PULSING))
+						boutput(user, "<span class='alert'>[MECHFAILSTRING]</span>")
 						return
 
 					. = uppertext(copytext(ckey(.), 1, 1+MAX_ROM_SIZE))

--- a/code/WorkInProgress/MechanicMadness.dm
+++ b/code/WorkInProgress/MechanicMadness.dm
@@ -347,7 +347,7 @@ var/list/mechanics_telepads = new/list()
 		if(usr.stat)
 			return
 
-		if(!(ishuman(usr) && usr.find_tool_in_hand(TOOL_PULSING)))
+		if (!usr.find_tool_in_hand(TOOL_PULSING))
 			boutput(usr, "<span class='alert'>[MECHFAILSTRING]</span>")
 			return
 

--- a/code/WorkInProgress/recycling/disposal.dm
+++ b/code/WorkInProgress/recycling/disposal.dm
@@ -1524,7 +1524,7 @@
 		if(usr.stat)
 			return
 
-		if(!(ishuman(usr) && usr.find_tool_in_hand(TOOL_PULSING)))
+		if (!usr.find_tool_in_hand(TOOL_PULSING))
 			boutput(usr, "<span class='alert'>[MECHFAILSTRING]</span>")
 			return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[BUG - MAJOR]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes the checks for connecting mechanics components via drag-and-drop, which previously was excluding non-humans. Now simply makes sure you have a pulsing tool in your hand (using the `find_tool_in_hand` proc which exists on `/mob` and is overridden where relevant).

Tested with: cyborg, AI shell, ghost drone, critter (that can hold a multitool, e.g. spider). As the proc exists on `/mob` this should be "safe" at the very least, and if a certain type of mob still cannot do this then it's indicative that there's a problem in their `find_tool_in_hand` proc.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Non-humans cannot connect mechanics components.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Mordent:
(+)Fixed non-humans being unable to connect mechanics components even if holding a multitool.
```