### PR TITLE
Abstract type annotations, typesof caching and more!

### DIFF
--- a/.github/CODE_GUIDELINES.md
+++ b/.github/CODE_GUIDELINES.md
@@ -79,6 +79,37 @@ See: `if(x)` vs `if (x)`
 
 Nobody cares about this. This is heavily frowned upon for changing with little to no reason.
 
+### Abstract types an typesof
+
+Some types exist just as a parent and should never be created in-game (e.g. `/obj/item`). Mark those using the `ABSTRACT_TYPE(type)` macro. You can check if a type is abstract using the `IS_ABSTRACT(type)` macro.
+
+To get a list of all concrete (non-abstract) subtypes of a type you should use `concrete_typesof(type)`, the result is cached so no need to store it yourself. (As a consequence please `.Copy` the list if you want to make changes to it locally.) Proper usage of `ABSTRACT_TYPE` + `concrete_typesof` is preferred to using `typesof` and `childrentypesof` *usually* though exceptions apply.
+
+If you want to filter the results of `concrete_typesof` further (e.g. by the value of a var or by a blacklist) consider using `filtered_concrete_typesof(type, filter)`. `filter` is a proc that should return 1 if you want to include the item. Again, the result is cached (so the `filter` proc should not depend on outisde variables or randomness).
+
+Example:
+```javascript
+ABSTRACT_TYPE(/obj/item/hat)
+/obj/item/hat
+	var/is_cool = 0
+
+/obj/item/hat/uncool
+	name = "Uncool Hat"
+
+/obj/item/hat/cool
+	name = "Cool hat"
+	is_cool = 1
+
+proc/is_hat_cool(hat_type)
+	var/obj/item/hat/hat = hat_type
+	return initial(hat.is_cool)
+
+proc/random_cool_hat()
+	return pick(filtered_concrete_typesof(/obj/item/hat, /proc/is_hat_cool))
+```
+
+See `_stdlib/_types.dm` for details.
+
 ## Whack BYOND shit
 
 ### Startup/Runtime trade-offs with lists and the "hidden" init() proc

--- a/_stdlib/__build.dm
+++ b/_stdlib/__build.dm
@@ -33,7 +33,7 @@ o+`        `-` ``..-:yooos-..----------..`
 //////////// OPTIONS TO GO FAST
 
 //#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // Skip setup for atmos, Z5, don't show changelogs, skip pregame lobby
-#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the map Atlas, no other zlevels. Boots way faster
+//#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the map Atlas, no other zlevels. Boots way faster
 //#define Z_LOG_ENABLE 1  // Enable additional world.log logging
 
 

--- a/_stdlib/__build.dm
+++ b/_stdlib/__build.dm
@@ -33,7 +33,7 @@ o+`        `-` ``..-:yooos-..----------..`
 //////////// OPTIONS TO GO FAST
 
 //#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // Skip setup for atmos, Z5, don't show changelogs, skip pregame lobby
-//#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the map Atlas, no other zlevels. Boots way faster
+#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the map Atlas, no other zlevels. Boots way faster
 //#define Z_LOG_ENABLE 1  // Enable additional world.log logging
 
 
@@ -65,6 +65,11 @@ o+`        `-` ``..-:yooos-..----------..`
 // Queue worker statistics
 // Probably hefty
 //#define QUEUE_STAT_DEBUG
+
+// Makes the code crash / log when an abstract type is instantiated.
+// see _stadlib/_types.dm for details
+// #define ABSTRACT_VIOLATION_CRASH
+// #define ABSTRACT_VIOLATION_WARN
 
 
 //////////// MAP OVERRIDES

--- a/_stdlib/_types.dm
+++ b/_stdlib/_types.dm
@@ -19,7 +19,23 @@ for(var/type in typesof(/datum/test))
 Useful for parent types you don't want to be instantiated in places that use istype like this
 Note that the ABSTRACT_TYPE annotation *WILL* mark all predecesors of the type abstract too!
 That is a feature, not a bug.
+
+Turn on ABSTRACT_VIOLATION_CRASH or ABSTRACT_VIOLATION_WARN to get the server to yell at you
+when you instantiate an abstract type. CRASH will runtime, WARN will log it. Don't turn it on
+*permanently* on the live server (though turning it on once in a while is probably fine to see
+if there are any violations).
 */
+#ifdef ABSTRACT_VIOLATION_CRASH
+/datum/New()
+	..()
+	if(IS_ABSTRACT(src.type))
+		CRASH("Attempt to instantiate abstract type '[src.type]'.")
+#elif defined(ABSTRACT_VIOLATION_WARN)
+/datum/New()
+	..()
+	if(IS_ABSTRACT(src.type))
+		logTheThing("debug", src, null, "Attempt to instantiate abstract type '[src.type]'.")
+#endif
 
 
 /*

--- a/_stdlib/_types.dm
+++ b/_stdlib/_types.dm
@@ -1,0 +1,76 @@
+#define childrentypesof(x) (typesof(x) - x)
+// consider declaring the base type abstract instead and using concrete_typesof instead of childrentypesof
+
+#define ABSTRACT_TYPE(type) /datum/_is_abstract ## type
+#define IS_ABSTRACT(type) text2path("/datum/_is_abstract[type]")
+/*
+usage:
+
+ABSTRACT_TYPE(/datum/atest)
+/datum/test
+/datum/test/child
+
+then you can do:
+for(var/type in typesof(/datum/test))
+	if(IS_ABSTRACT(type))
+		continue
+	do_stuff_with_type(type)
+
+Useful for parent types you don't want to be instantiated in places that use istype like this
+Note that the ABSTRACT_TYPE annotation *WILL* mark all predecesors of the type abstract too!
+That is a feature, not a bug.
+*/
+
+
+/*
+typesof but only for concrete (not abstract) types
+it caches the result so you don't need to worry about doing that manually
+so subsequent calls on the same type will be very fast
+just don't modify the result of the call directly
+OKAY: var/list/hats = concrete_typesof(/obj/item/clothing/head) - /obj/item/clothing/head/hosberet
+ALSO OKAY: var/list/hats = concrete_typesof(/obj/item/clothing/head).Copy()
+           hats -= /obj/item/clothing/head/hosberet
+NOT OKAY: var/list/hats = concrete_typesof(/obj/item/clothing/head)
+          hats -= /obj/item/clothing/head/hosberet
+*/
+var/global/list/cached_concrete_types
+proc/concrete_typesof(type)
+	if(isnull(cached_concrete_types))
+		cached_concrete_types = list()
+	if(type in cached_concrete_types)
+		return cached_concrete_types[type]
+	. = list()
+	for(var/subtype in typesof(type))
+		if(!IS_ABSTRACT(subtype))
+			. += subtype
+	cached_concrete_types[type] = .
+
+/*
+The same thing but now you can filter the types using a proc. Also cached.
+The filter proc takes a type and should return 1 if we want to include it and 0 otherwise.
+That proc should also be pure (always return the same thing for the same arguments) because of the caching.
+If you want to use non-pure proc do the filtering manually yourself and don't use this.
+Note that the first call to filtered_concrete_typesof with a given type and filter will be (possibly a lot)
+*slower* than doing it manually. The benefit of this proc only shows itself for future calls which are
+very fast due to caching.
+
+Example:
+proc/filter_is_syndicate(type)
+	var/obj/fake_instance = type
+	return initial(fake_instance.is_syndicate)
+
+var/syndie_thing_type = pick(filtered_concrete_typesof(/obj/item, /proc/filter_is_syndicate))
+*/
+var/global/list/cached_filtered_types
+proc/filtered_concrete_typesof(type, filter)
+	if(isnull(cached_filtered_types))
+		cached_filtered_types = list()
+	if((type in cached_filtered_types) && (filter in cached_filtered_types[type]))
+		return cached_filtered_types[type][filter]
+	. = list()
+	for(var/subtype in typesof(type))
+		if(!IS_ABSTRACT(subtype) && call(filter)(subtype))
+			. += subtype
+	if(!(type in cached_filtered_types))
+		cached_filtered_types[type] = list()
+	cached_filtered_types[type][filter] = .

--- a/_stdlib/code/_macros.dm
+++ b/_stdlib/code/_macros.dm
@@ -87,8 +87,6 @@ var/list/detailed_spawn_dbg = list()
 
 #define isitem(x) istype(x, /obj/item)
 
-#define childrentypesof(x) (typesof(x) - x)
-
 #define istool(x,y) (isitem(x) && (x:tool_flags & (y)))
 #define iscuttingtool(x) (istool(x, TOOL_CUTTING))
 #define ispulsingtool(x) (istool(x, TOOL_PULSING))

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -21,6 +21,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "_stdlib\_mapDefines.dm"
 #include "_stdlib\_setup.dm"
 #include "_stdlib\code\_macros.dm"
+#include "_stdlib\_types.dm"
 #include "_stdlib\color.dm"
 #include "_stdlib\component_defines.dm"
 #include "_stdlib\movement_modifiers.dm"
@@ -1613,6 +1614,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\z_dmm_suite\writer.dm"
 #include "interface\skin.dmf"
 #include "maps\config\map.dm"
+#include "maps\config\pamgoc.dm"
 // END_INCLUDE
 
 #ifdef SECRETS_ENABLED

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -1614,7 +1614,6 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\z_dmm_suite\writer.dm"
 #include "interface\skin.dmf"
 #include "maps\config\map.dm"
-#include "maps\config\pamgoc.dm"
 // END_INCLUDE
 
 #ifdef SECRETS_ENABLED


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a macro to annotate a type as abstract and a macro to check if a type is abstract. This is meant to make it easier to mark which types are only parents and shouldn't be instantiated directly. Useful in `for(var/x in typesof(y))` loops.

To make those easier and potentially faster I also added the `concrete_typesof` proc that does typesof but only returns non-abstract types. This can be slow so the proc caches its results.

Furthermore sometimes you want to also filter the types a bit more and also want to cache that. To do this I added `filtered_concrete_typesof` which does that automatically.

If the tools from this PR get used they should hopefully make some code cleaner (by removing various ugly `typesof(x) - y` hardcoded things) and also potentially faster for stuff that currently calls typesof every time, subtracts something from it and doesn't cache the results. (Note that this PR only adds these tools and doesn't replace any current `typesof` or `childrentypesof` calls with this.)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes code cleaner and more extensible. Arguably faster in some places (and slower in others).
