### PR TITLE
Prevent blank names

### DIFF
--- a/_stdlib/text.dm
+++ b/_stdlib/text.dm
@@ -22,9 +22,9 @@
 
 /**
   * Returns true if given string is just space characters
-	* [  ] is used instead of \s because apparently BYOND doesn't count non breaking spaces as whitespace AHHHHH - Sov
+	* Apparently BYOND doesn't count various whitespace characters as whitespace. - Sov
   */
-var/static/regex/is_blank_string_regex = new(@{"^[  ]*$"})
+var/global/regex/is_blank_string_regex = new(@{"^(\s|[\u00A0\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u2028\u205F\u3000])*$"}) // fuck me
 /proc/is_blank_string(var/txt)
 	if (is_blank_string_regex.Find(txt))
 		return 1

--- a/_stdlib/text.dm
+++ b/_stdlib/text.dm
@@ -22,7 +22,7 @@
 
 /**
   * Returns true if given string is just space characters
-	* Apparently BYOND doesn't count various whitespace characters as whitespace. - Sov
+  * Apparently BYOND doesn't count various whitespace characters as whitespace. - Sov
   */
 var/global/regex/is_blank_string_regex = new(@{"^(\s|[\u00A0\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u2028\u205F\u3000])*$"}) // fuck me
 /proc/is_blank_string(var/txt)

--- a/_stdlib/text.dm
+++ b/_stdlib/text.dm
@@ -18,4 +18,14 @@
 	return uppertext(copytext(t, 1, 2)) + copytext(t, 2)
 
 /proc/isVowel(var/t as text)
-	return findtextEx(lowertext(t), "aeiouåäö") > 0
+	return findtextEx(lowertext(t), "aeiouï¿½ï¿½ï¿½") > 0
+
+/**
+  * Returns true if given string is just space characters
+	* [ Â ] is used instead of \s because apparently BYOND doesn't count non breaking spaces as whitespace AHHHHH - Sov
+  */
+var/static/regex/is_blank_string_regex = new(@{"^[ Â ]*$"})
+/proc/is_blank_string(var/txt)
+	if (is_blank_string_regex.Find(txt))
+		return 1
+	return 0 //not blank

--- a/_stdlib/text.dm
+++ b/_stdlib/text.dm
@@ -18,7 +18,7 @@
 	return uppertext(copytext(t, 1, 2)) + copytext(t, 2)
 
 /proc/isVowel(var/t as text)
-	return findtextEx(lowertext(t), "aeiou���") > 0
+	return findtextEx(lowertext(t), "aeiouåäö") > 0
 
 /**
   * Returns true if given string is just space characters

--- a/_stdlib/text.dm
+++ b/_stdlib/text.dm
@@ -22,9 +22,9 @@
 
 /**
   * Returns true if given string is just space characters
-  * Apparently BYOND doesn't count various whitespace characters as whitespace. - Sov
+  * The explicitly defined entries are various blank unicode characters that don't get included as white space by \s
   */
-var/global/regex/is_blank_string_regex = new(@{"^(\s|[\u00A0\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u2028\u205F\u3000])*$"}) // fuck me
+var/global/regex/is_blank_string_regex = new(@{"^(\s|[\u00A0\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u2028\u205F\u3000])*$"})
 /proc/is_blank_string(var/txt)
 	if (is_blank_string_regex.Find(txt))
 		return 1

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -2157,8 +2157,11 @@ proc/get_mobs_trackable_by_AI()
 			return
 		else
 			newname = strip_html(newname, MOB_NAME_MAX_LENGTH, 1)
-			if (!length(newname) || copytext(newname,1,2) == " ")
+			if (!length(newname))
 				src.show_text("That name was too short after removing bad characters from it. Please choose a different name.", "red")
+				continue
+			else if (is_blank_string(newname))
+				src.show_text("Your name cannot contain only spaces. Please choose a different name.", "red")
 				continue
 			else
 				if (alert(src, "Use the name [newname]?", newname, "Yes", "No") == "Yes")

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -2161,7 +2161,7 @@ proc/get_mobs_trackable_by_AI()
 				src.show_text("That name was too short after removing bad characters from it. Please choose a different name.", "red")
 				continue
 			else if (is_blank_string(newname))
-				src.show_text("Your name cannot contain only spaces. Please choose a different name.", "red")
+				src.show_text("Your name cannot be blank. Please choose a different name.", "red")
 				continue
 			else
 				if (alert(src, "Use the name [newname]?", newname, "Yes", "No") == "Yes")

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -655,7 +655,7 @@
 					src.show_text("That name was too short after removing bad characters from it. Please choose a different name.", "red")
 					continue
 				else if (is_blank_string(newname))
-					src.show_text("Your name cannot contain only spaces. Please choose a different name.", "red")
+					src.show_text("Your name cannot be blank. Please choose a different name.", "red")
 					continue
 				else
 					if (alert(src, "Use the name [newname]?", newname, "Yes", "No") == "Yes")
@@ -819,7 +819,7 @@
 				dmgmult = 0.2
 			if(D_TOXIC)
 				dmgmult = 0
-		
+
 		if(P.proj_data.ks_ratio == 0)
 			src.do_disorient(clamp(P.power*4, P.proj_data.power*2, P.power+80), weakened = P.power*2, stunned = P.power*2, disorient = min(P.power, 80), remove_stamina_below_zero = 0) //bad hack, but it'll do
 			src.emote("twitch_v")// for the above, flooring stam based off the power of the datum is intentional

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -655,7 +655,7 @@
 					src.show_text("That name was too short after removing bad characters from it. Please choose a different name.", "red")
 					continue
 				else if (is_blank_string(newname))
-					src.show_text("Your name cannot contain only spaces.", "red")
+					src.show_text("Your name cannot contain only spaces. Please choose a different name.", "red")
 					continue
 				else
 					if (alert(src, "Use the name [newname]?", newname, "Yes", "No") == "Yes")

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -654,6 +654,9 @@
 				if (!length(newname))
 					src.show_text("That name was too short after removing bad characters from it. Please choose a different name.", "red")
 					continue
+				else if (is_blank_string(newname))
+					src.show_text("Your name cannot contain only spaces.", "red")
+					continue
 				else
 					if (alert(src, "Use the name [newname]?", newname, "Yes", "No") == "Yes")
 						src.real_name = newname

--- a/code/obj/item/ai_modules.dm
+++ b/code/obj/item/ai_modules.dm
@@ -265,6 +265,9 @@ AI MODULES
 	lawTarget = "404 Name Not Found"
 
 	get_law_text()
+		if (is_blank_string(lawTarget)) //no blank names allowed
+			lawTarget = pick(ai_names)
+			return lawTarget
 		return lawTarget
 
 	get_desc()

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -2209,18 +2209,6 @@ var/regex/nameRegex = regex("\\xFF.","g")
 	return text
 
 /**
-  * Returns true if given string is just space characters
-  */
-/proc/is_blank_string(var/txt)
-	if (!istext(txt))
-		return 1 // if it's not a string I guess it's kinda blank??
-	for (var/i=1, i <= length(txt), i++)
-		if (copytext(txt, i, i+1) != " ")
-			return 0 // we say NAW GURL IT'S GOT OTHER STUFF TOO,
-
-	return 1 // otherwise YEAH GURL THAT SHIT IS HELLA BLANK
-
-/**
   * Returns true if given mob/client/mind is an admin
   */
 /proc/isadmin(person)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- improves is_blank_string(txt) to use regex rather than looping through the string checking for non space characters. Also moves it to text.dm where it belongs
- Borgs and AI can no longer have blank names. Nor can they sneakily use a non breaking space or other exotic Unicode characters to bypass the check for a name consisting of only whitespace characters (probably, unless there's others I don't know about)
- Players can no longer give themselves blank name's in the character creator
- You can no longer rename an AI to have a blank name using the rename module. It will instead just pick a name from the list of defaults

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Blank names cause confusion and shouldn't be allowed. Currently blank names can be obtained by utilizing exotic characters or by taking advantage of a lack of whitespace name checks.

closes #720 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Sovexe:
(+)AIs and Borgs can no longer be given blank names.
(+)You can no longer specify a blank name in the character creator.
```
