### PR TITLE
Fix Finnish

### DIFF
--- a/code/procs/accents.dm
+++ b/code/procs/accents.dm
@@ -834,14 +834,14 @@
 
 
 /proc/finnishify(var/string)
-	var/modded = ""
-	var/datum/text_roamer/T = new/datum/text_roamer(string)
-
 	if(prob(50))
 		string = replacetextEx(string, " a ", "")
 		string = replacetextEx(string, " an ", "")
 	if(prob(25))
 		string = replacetextEx(string, " the ", "")
+
+	var/modded = ""
+	var/datum/text_roamer/T = new/datum/text_roamer(string)
 
 	for (var/i = 0, i < length(string), i=i)
 		var/datum/parse_result/P = finnish_parse(T)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Sometimes finnish speech would be cut off as described in #730 .
I believe this is the result of the words "an", "a" and "the" sometimes being cut out of finnish sentences, but the sentence parser is created before that, so only the length of the modified sentence would be affected.
I changed it so the parser is created after the words are cut out, this should fix the cut off ends of finnish sentences.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
So Fins can say "Malcolm Currry iss a ling!" rather than "Malcolm Curry is a l".