### PR TITLE
adds proper event handler flag to soulsteel items

### DIFF
--- a/code/modules/materials/Mat_MaterialProcs.dm
+++ b/code/modules/materials/Mat_MaterialProcs.dm
@@ -463,6 +463,13 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 				boutput(C, "Your [I] melts from your body heat!")
 				qdel(I)
 		return
+		
+/datum/materialProc/soulsteel_add
+	desc = "It is almost impossible to grasp."
+
+	execute(var/atom/owner)
+		owner.event_handler_flags |= USE_HASENTERED
+		return
 
 /datum/materialProc/soulsteel_entered
 	var/lastTrigger = 0

--- a/code/modules/materials/Mat_MaterialProcs.dm
+++ b/code/modules/materials/Mat_MaterialProcs.dm
@@ -465,8 +465,6 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 		return
 		
 /datum/materialProc/soulsteel_add
-	desc = "It is almost impossible to grasp."
-
 	execute(var/atom/owner)
 		owner.event_handler_flags |= USE_HASENTERED
 		return

--- a/code/modules/materials/Mat_Materials.dm
+++ b/code/modules/materials/Mat_Materials.dm
@@ -414,6 +414,7 @@
 	New()
 		setProperty("density", 65)
 		addTrigger(triggersOnEntered, new /datum/materialProc/soulsteel_entered())
+		addTrigger(triggersOnAdd, new /datum/materialProc/soulsteel_add())
 		return ..()
 
 // Crystals
@@ -1198,6 +1199,7 @@
 		setProperty("permeable", 10)
 		addTrigger(triggersOnAdd, new /datum/materialProc/ethereal_add())
 		addTrigger(triggersOnEntered, new /datum/materialProc/soulsteel_entered())
+		addTrigger(triggersOnAdd, new /datum/materialProc/soulsteel_add())
 		return ..()
 
 /datum/material/fabric/cloth/ectofibre


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a material add trigger to soulsteel and hauntium that gives them the USE_HASENTERED flag, fixing issue where soulsteel items would not be possessible when moved off their original turf


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
🤷 