### PR TITLE
Enables faster levels of machinery processing support

### DIFF
--- a/_stdlib/machinery.dm
+++ b/_stdlib/machinery.dm
@@ -1,12 +1,15 @@
 #define PROCESSING_FULL      1
 #define PROCESSING_HALF      2
-
-// Uncomment and adjust PROCESSING_MAX_IN_USE as needed
 #define PROCESSING_QUARTER   3
-//#define PROCESSING_EIGHTH    4
-//#define PROCESSING_SIXTEENTH 5
+#define PROCESSING_EIGHTH    4
+#define PROCESSING_SIXTEENTH 5
+#define PROCESSING_32TH			 6
+// Uncomment and adjust PROCESSING_MAX_IN_USE as needed
 
-#define PROCESSING_MAX_IN_USE PROCESSING_QUARTER
+//
+//
+
+#define PROCESSING_MAX_IN_USE PROCESSING_32TH
 
 #define MACHINES_CONVEYORS				1 // Conveyor belts
 #define MACHINES_ATMOSALERTS			2 // /obj/machinery/computer/atmosphere/alerts
@@ -52,7 +55,7 @@ var/global/list/machine_registry = generate_machine_registry()
 /proc/generate_machinery_processing_buckets()
 	. = new /list(PROCESSING_MAX_IN_USE)
 	for(var/i in 1 to PROCESSING_MAX_IN_USE)
-		.[i] = new /list(1<<(i-1)) // 1 list for index 1, 2 for 2, 4 for 3, 8 for 4, 16 for 5
+		.[i] = new /list(1<<(i-1)) // 1 list for index 1, 2 for 2, 4 for 3, 8 for 4, 16 for 5, 32 for 6
 		for (var/j in 1 to length(.[i]))
 			.[i][j] = list()
 

--- a/code/datums/controllers/process/machines.dm
+++ b/code/datums/controllers/process/machines.dm
@@ -8,7 +8,7 @@ datum/controller/process/machines
 
 	setup()
 		name = "Machine"
-		schedule_interval = 33
+		schedule_interval = 4
 
 		Station_VNet = new /datum/v_space/v_space_network()
 
@@ -19,48 +19,50 @@ datum/controller/process/machines
 	doWork()
 		var/c = 0
 
-		src.atmos_machines = global.atmos_machines
-		for(var/X in atmos_machines)
-			var/obj/machinery/machine = X
-			if( !machine || machine.z == 4 && !Z4_ACTIVE ) continue
-#ifdef MACHINE_PROCESSING_DEBUG
-			var/t = world.time
-#endif
-			machine.process()
-#ifdef MACHINE_PROCESSING_DEBUG
-			register_machine_time(machine, world.time - t)
-#endif
+		if (ticker % 8 == 0)
+			src.atmos_machines = global.atmos_machines
+			for(var/X in atmos_machines)
+				var/obj/machinery/machine = X
+				if( !machine || machine.z == 4 && !Z4_ACTIVE ) continue
+	#ifdef MACHINE_PROCESSING_DEBUG
+				var/t = world.time
+	#endif
+				machine.process()
+	#ifdef MACHINE_PROCESSING_DEBUG
+				register_machine_time(machine, world.time - t)
+	#endif
 
-			if (!(c++ % 100))
-				scheck()
+				if (!(c++ % 100))
+					scheck()
+		if (ticker % 8 == 1)
+			src.pipe_networks = global.pipe_networks
+			for(var/X in src.pipe_networks)
+				if(!X) continue
+				var/datum/pipe_network/network = X
+	#ifdef MACHINE_PROCESSING_DEBUG
+				var/t = world.time
+	#endif
+				network.process()
+	#ifdef MACHINE_PROCESSING_DEBUG
+				register_machine_time(network, world.time - t)
+	#endif
+				if (!(c++ % 100))
+					scheck()
 
-		src.pipe_networks = global.pipe_networks
-		for(var/X in src.pipe_networks)
-			if(!X) continue
-			var/datum/pipe_network/network = X
-#ifdef MACHINE_PROCESSING_DEBUG
-			var/t = world.time
-#endif
-			network.process()
-#ifdef MACHINE_PROCESSING_DEBUG
-			register_machine_time(network, world.time - t)
-#endif
-			if (!(c++ % 100))
-				scheck()
-
-		src.powernets = global.powernets
-		for(var/X in src.powernets)
-			if(!X) continue
-			var/datum/powernet/PN = X
-#ifdef MACHINE_PROCESSING_DEBUG
-			var/t = world.time
-#endif
-			PN.reset()
-#ifdef MACHINE_PROCESSING_DEBUG
-			register_machine_time(PN, world.time - t)
-#endif
-			if (!(c++ % 100))
-				scheck()
+		if (ticker % 8 == 2)
+			src.powernets = global.powernets
+			for(var/X in src.powernets)
+				if(!X) continue
+				var/datum/powernet/PN = X
+	#ifdef MACHINE_PROCESSING_DEBUG
+				var/t = world.time
+	#endif
+				PN.reset()
+	#ifdef MACHINE_PROCESSING_DEBUG
+				register_machine_time(PN, world.time - t)
+	#endif
+				if (!(c++ % 100))
+					scheck()
 
 		src.machines = global.processing_machines
 

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -72,7 +72,7 @@
 	anchored = 1
 	density = 1
 	directwired = 1
-	processing_tier = PROCESSING_QUARTER // Uncomment this and line 175 for an experimental optimization
+	processing_tier = PROCESSING_32TH // Uncomment this and line 175 for an experimental optimization
 	var/health = 10.0
 	var/id = 1
 	var/obscured = 0

--- a/code/obj/machinery.dm
+++ b/code/obj/machinery.dm
@@ -20,7 +20,7 @@
 	var/wire_powered = 0
 	var/allow_stunned_dragndrop = 0
 	var/processing_bucket = 1
-	var/processing_tier = PROCESSING_FULL
+	var/processing_tier = PROCESSING_EIGHTH
 	var/current_processing_tier
 	var/machine_registry_idx // List index for misc. machines registry, used in loops where machines of a specific type are needed
 
@@ -34,7 +34,7 @@
 		machine_registry[initial(machine_registry_idx)] += src
 
 	var/static/machines_counter = 0
-	src.processing_bucket = machines_counter++ & 15 // this is just modulo 16 but faster due to power-of-two memes
+	src.processing_bucket = machines_counter++ & 31 // this is just modulo 32 but faster due to power-of-two memes
 	SubscribeToProcess()
 	if (current_state > GAME_STATE_WORLD_INIT)
 		SPAWN_DBG(5 DECI SECONDS)

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -68,7 +68,7 @@
 	density = 1
 	mats = 2
 	flags = NOSPLASH
-	processing_tier = PROCESSING_HALF
+	processing_tier = PROCESSING_SIXTEENTH
 	machine_registry_idx = MACHINES_PLANTPOTS
 	var/datum/plant/current = null // What is currently growing in the plant pot
 	var/datum/plantgenes/plantgenes = null // Set this up in New


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This makes machinery process every 4 ticks (8 times as often, -+1 tick), and the current machinery processing levels have been adjusted to the existing 1/8 and 1/16 levels, and a new 1/32 level.
The full, half, and 1/4 levels are unused, but may be used by the chemicompiler. Smearing machinery processing ticks across 8 different ticks maybe makes the game a little bit smoother? 
I also made atmos, pipelines and powernets happen on separate ticks.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Honestly I don't know the specifics but the chemicompiler would apparently really benefit from faster ticks?
