### PR TITLE
Fixed power cells not properly reporting their charge status

### DIFF
--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -923,7 +923,7 @@
 			if (amt > 0)
 				src.charge = min(src.charge + amt, src.max_charge)
 				src.update_icon()
-				return 1
+				return src.charge < src.max_charge //if we're fully charged, let other things know immediately
 			else
 				return 0
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Power cells currently report the charge status using the return value of `charge()`, where a return value of 0 means it's finished recharging, and a return value of 1 means it's not. 

There's currently a minor bug with rechargers where the "finished" state of the recharger is triggered on the `process()` tick directly _after_ the one that finished the recharge. This fixes that.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bug fix
