### PR TITLE
make tg hud the default hud for new players

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -310,6 +310,7 @@ menu "menu"
 		command = "set-tg-layout"
 		category = "&Interface"
 		can-check = true
+		is-checked = true
 		saved-params = "is-checked"
 	elem "tg_controls"
 		name = "&Use /TG/ style controls"


### PR DESCRIPTION
- for completely new players to the game, tghud has better conveyance and will help them adjust to the game in general if they are server hopping
- for anyone who's not new to the game in general, it likely means they want tghud anyway


note for merger : this patch edits skin.dmf, so it will force all players to quit and reload the game when it's pushed. wait for low population so you dont tank funtimes
