### PR TITLE
Prevent Genetics DNA Reclaimer from wiping out surplus materials

### DIFF
--- a/code/modules/medical/genetics/geneticsMachines.dm
+++ b/code/modules/medical/genetics/geneticsMachines.dm
@@ -797,7 +797,7 @@ var/list/genetics_computers = list()
 			boutput(usr, "<b>SCANNER:</b> Reclamation failed.")
 		else
 			var/waste = (E.reclaim_mats + genResearch.researchMaterial) - reclamation_cap
-			if (waste == E.reclaim_mats)
+			if (waste >= E.reclaim_mats)
 				boutput(usr, "<b>SCANNER ALERT:</b> Nothing would be gained from reclamation due to material capacity limit. Reclamation aborted.")
 				return
 			else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes a comparison operator from an == to an >=



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Using the DNA reclaimer with a large supply of research materials would wipe out anything more than 1.5 times your soft material cap


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Sovexe
(+)Fixed a bug that allowed DNA Reclaimer to wipe out surplus research materials
```
