### PR TITLE
Made spes-12 cost 6TC, and allowed dual wielding of it

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -56,7 +56,7 @@ proc/build_syndi_buylist_cache()
 /datum/syndicate_buylist/generic/shotgun
 	name = "Shotgun"
 	item = /obj/item/storage/box/shotgun
-	cost = 8
+	cost = 6
 	desc = "Not exactly stealthy, but it'll certainly make an impression."
 	not_in_crates = 1
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -456,7 +456,7 @@
 	caliber = 0.72
 	max_ammo_capacity = 8
 	auto_eject = 1
-	can_dual_wield = 0
+	can_dual_wield = 1
 
 	New()
 		if(prob(10))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE][ENHANCEMENT]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Decreased the cost of the shotgun traitors can buy from 8TC to 6TC, and allowed dual wielding for maximum coolness, wrists be damned.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The shotgun is too expensive for its power, as it has no AP rounds, can't fit other calibres than 12 gauge, and ammo for it is hard to come by. Compare this to the revolver, which is 6TC, can load .38 (lethals *and* stunners), has AP rounds, and can be dual wielded, and it doesn't make sense why its the most expensive weapon available for traitors to buy. This should hopefully let it see more use, and allow for more interesting traitor item combos, due to having more TC left over after buying one.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)TrustworthyFella:
(*)Reduced Spes-12 cost from 8TC to 6TC, and made it possible to dual wield it.
```
