### PR TITLE
Fixes people being able to move while they're slipping

### DIFF
--- a/code/mob/living/carbon.dm
+++ b/code/mob/living/carbon.dm
@@ -420,14 +420,14 @@
 									break
 						*/
 						var/atom/target = get_edge_target_turf(src, src.dir)
-						SPAWN_DBG(0) src.throw_at(target, 12, 1)
+						SPAWN_DBG(0) src.throw_at(target, 12, 1, throw_type = THROW_CHAIRFLIP)
 					if (3) // superlube
 						src.pulling = null
 						src.changeStatus("weakened", 6 SECONDS)
 						playsound(T, "sound/misc/slip.ogg", 50, 1, -3)
 						boutput(src, "<span class='notice'>You slipped on the floor!</span>")
 						var/atom/target = get_edge_target_turf(src, src.dir)
-						SPAWN_DBG(0) src.throw_at(target, 30, 1)
+						SPAWN_DBG(0) src.throw_at(target, 30, 1, throw_type = THROW_CHAIRFLIP)
 						random_brute_damage(src, 10)
 
 /mob/living/carbon/relaymove(var/mob/user, direction)

--- a/code/mob/living/carbon.dm
+++ b/code/mob/living/carbon.dm
@@ -420,7 +420,7 @@
 									break
 						*/
 						var/atom/target = get_edge_target_turf(src, src.dir)
-						SPAWN_DBG(0) src.throw_at(target, 12, 1, throw_type = THROW_CHAIRFLIP)
+						SPAWN_DBG(0) src.throw_at(target, 12, 1, throw_type = THROW_GUNIMPACT)
 					if (3) // superlube
 						src.pulling = null
 						src.changeStatus("weakened", 6 SECONDS)

--- a/code/mob/living/carbon.dm
+++ b/code/mob/living/carbon.dm
@@ -427,7 +427,7 @@
 						playsound(T, "sound/misc/slip.ogg", 50, 1, -3)
 						boutput(src, "<span class='notice'>You slipped on the floor!</span>")
 						var/atom/target = get_edge_target_turf(src, src.dir)
-						SPAWN_DBG(0) src.throw_at(target, 30, 1, throw_type = THROW_CHAIRFLIP)
+						SPAWN_DBG(0) src.throw_at(target, 30, 1, throw_type = THROW_GUNIMPACT)
 						random_brute_damage(src, 10)
 
 /mob/living/carbon/relaymove(var/mob/user, direction)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MINOR]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
So there's an issue where people that are slipping on lube are still able to walk around and even fight back until they're finally knocked down. This fixes that.



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bugfix
