### PR TITLE
Can't throw people who aren't next to you

### DIFF
--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -385,7 +385,8 @@
 	//returns an atom to be thrown if any
 	proc/handle_throw(var/mob/living/user, var/atom/target)
 		if (!src.affecting) return 0
-
+		if (get_dist(user, src.affecting) > 1)
+			return 0
 		if ((src.state < 1 && !(src.affecting.getStatusDuration("paralysis") || src.affecting.getStatusDuration("weakened") || src.affecting.stat)) || !isturf(user.loc))
 			user.visible_message("<span class='alert'>[src.affecting] stumbles a little!</span>")
 			user.u_equip(src)


### PR DESCRIPTION

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes issue: #558 
Previously, throwing a mob you had grabbed did not check if the distance between the thrower and the throwee was close enough when the throw was attempted. Now it does.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix

