### PR TITLE
Changes Alcohol Crate to Alcohol Resupply Crate

### DIFF
--- a/code/datums/supply_packs.dm
+++ b/code/datums/supply_packs.dm
@@ -471,8 +471,8 @@
 					/obj/item/reagent_containers/food/drinks/bottle/bojackson,
 					/obj/item/reagent_containers/food/drinks/curacao,
 					/obj/item/reagent_containers/food/drinks/cocktailshaker,
-					/obj/item/storage/box/cocktail_umbrellas = 4,
-					/obj/item/storage/box/cocktail_doodads = 4,
+					/obj/item/storage/box/cocktail_umbrellas = 2,
+					/obj/item/storage/box/cocktail_doodads = 2,
 					/obj/item/storage/box/fruit_wedges = 1,
 					/obj/item/shaker/salt = 1)
 	cost = 500

--- a/code/datums/supply_packs.dm
+++ b/code/datums/supply_packs.dm
@@ -457,8 +457,8 @@
 	containername = "Emergency Equipment"
 
 /datum/supply_packs/alcohol
-	name = "Alcohol Crate"
-	desc = "x9 Assorted Liquor"
+	name = "Alcohol Resupply Crate"
+	desc = "Nine assorted liquors and related mixology equipment in case of stationwide alcohol deficiency"
 	category = "Civilian Department"
 	contains = list(/obj/item/storage/box/beer,
 					/obj/item/reagent_containers/food/drinks/bottle/beer,
@@ -469,8 +469,13 @@
 					/obj/item/reagent_containers/food/drinks/bottle/vodka,
 					/obj/item/reagent_containers/food/drinks/bottle/tequila,
 					/obj/item/reagent_containers/food/drinks/bottle/bojackson,
-					/obj/item/reagent_containers/food/drinks/curacao)
-	cost = 400
+					/obj/item/reagent_containers/food/drinks/curacao,
+					/obj/item/reagent_containers/food/drinks/cocktailshaker,
+					/obj/item/storage/box/cocktail_umbrellas = 4,
+					/obj/item/storage/box/cocktail_doodads = 4,
+					/obj/item/storage/box/fruit_wedges = 1,
+					/obj/item/shaker/salt = 1)
+	cost = 500
 	containertype = /obj/storage/crate
 	containername = "Alcohol Crate"
 

--- a/code/datums/supply_packs.dm
+++ b/code/datums/supply_packs.dm
@@ -458,7 +458,7 @@
 
 /datum/supply_packs/alcohol
 	name = "Alcohol Resupply Crate"
-	desc = "Nine assorted liquors and related mixology equipment in case of stationwide alcohol deficiency"
+	desc = "A collection of nine assorted liquors in case of stationwide alcohol deficiency"
 	category = "Civilian Department"
 	contains = list(/obj/item/storage/box/beer,
 					/obj/item/reagent_containers/food/drinks/bottle/beer,
@@ -469,15 +469,23 @@
 					/obj/item/reagent_containers/food/drinks/bottle/vodka,
 					/obj/item/reagent_containers/food/drinks/bottle/tequila,
 					/obj/item/reagent_containers/food/drinks/bottle/bojackson,
-					/obj/item/reagent_containers/food/drinks/curacao,
-					/obj/item/reagent_containers/food/drinks/cocktailshaker,
+					/obj/item/reagent_containers/food/drinks/curacao)
+	cost = 400
+	containertype = /obj/storage/crate
+	containername = "Alcohol Crate"
+
+/datum/supply_packs/cocktailparty
+	name = "Cocktail Party Supplies"
+	desc = "All the equipment you need to be the next up and coming amateur mixologist."
+	category = "Civilian Department"
+	contains = list(/obj/item/reagent_containers/food/drinks/cocktailshaker,
 					/obj/item/storage/box/cocktail_umbrellas = 2,
 					/obj/item/storage/box/cocktail_doodads = 2,
 					/obj/item/storage/box/fruit_wedges = 1,
 					/obj/item/shaker/salt = 1)
-	cost = 500
+	cost = 100
 	containertype = /obj/storage/crate
-	containername = "Alcohol Crate"
+	containername = "Cocktail Party Supplies"
 
 /datum/supply_packs/robot
 	name = "Robotics Crate"

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -1207,6 +1207,7 @@
 		product_list += new/datum/data/vending_product(/obj/item/storage/box/cocktail_doodads, 4)
 		product_list += new/datum/data/vending_product(/obj/item/storage/box/fruit_wedges, 1)
 		product_list += new/datum/data/vending_product(/obj/item/shaker/salt, 1)
+		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/food/drinks/cocktailshaker, 1)
 
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/food/drinks/bottle/hobo_wine, 2, hidden=1)
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/food/drinks/bottle/thegoodstuff, 1, hidden=1)


### PR DESCRIPTION
[ENHANCEMENT]

## About the PR
Renamed Alcohol Crate to Alcohol Resupply Crate + changed up the description.
Added cocktail shaker and cocktail doodads to crate.
Added a cocktail shaker to the Booze Vending machine
Raised price to 500 credits

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allows other people outside of the bartender from getting to mess around with a new toy. Also makes the alcohol crate better in general.

## Changelog

```
(u)Carbadox:
(+)Added a cocktail party supplies crate. Available through QM!
(+)Added a cocktail shaker to the booze vending machine.
```
