### PR TITLE
Glowing nuclear bomb

### DIFF
--- a/code/obj/machinery/nuclearbomb.dm
+++ b/code/obj/machinery/nuclearbomb.dm
@@ -23,6 +23,8 @@
 	var/anyone_can_activate = 0 // allows non-nukies to deploy the bomb
 	var/boom_size = "nuke" // varedit to number to get an explosion instead
 
+	var/started_light_animation = 0
+
 	flags = FPRINT
 	var/image/image_light = null
 	p_class = 1.5
@@ -58,6 +60,11 @@
 				S.visible_message("<span class='alert'>[S] cannot withstand the intense radiation and crumbles to pieces!</span>")
 				qdel(S)
 
+		if(det_time && src.simple_light && !src.started_light_animation && det_time - ticker.round_elapsed_ticks <= 2 MINUTES)
+			src.started_light_animation = 1
+			var/matrix/trans = matrix()
+			trans.Scale(3)
+			animate(src.simple_light, time = 2 MINUTES, alpha = 255, color = "#ff4444", transform = trans)
 
 		if (det_time && ticker.round_elapsed_ticks >= det_time)
 			explode()

--- a/code/obj/machinery/nuclearbomb.dm
+++ b/code/obj/machinery/nuclearbomb.dm
@@ -134,6 +134,7 @@
 									src.UpdateOverlays(src.image_light, "light")
 								//src.icon_state = "nuclearbomb2"
 								src.det_time = ticker.round_elapsed_ticks + src.timer_default
+								src.add_simple_light("nuke", list(255, 127, 127, 127))
 								command_alert("\A [src] has been armed in [A]. It will detonate in [src.get_countdown_timer()] minutes. All personnel must report to [A] to disarm the bomb immediately.", "Nuclear Weapon Detected")
 								world << sound('sound/machines/bomb_planted.ogg')
 								logTheThing("bombing", user, null, "armed [src] at [log_loc(src)].")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Now:
![image](https://user-images.githubusercontent.com/358431/82478126-be9c2280-9ad0-11ea-84db-bbc60518eb52.png)
With the PR:
![image](https://user-images.githubusercontent.com/358431/82478102-b512ba80-9ad0-11ea-9338-23eb31858a01.png)
(Starts glowing when activated.)

Update: At 2 minutes left the nuke now starts slowly increasing the glow to be brighter, redder and larger:
![image](https://user-images.githubusercontent.com/358431/82481256-5865ce80-9ad5-11ea-890a-f4530aab3884.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Nukes are sometimes a bit too difficult to find in the dark which is not great, they should be the centerpiece of nukie rounds.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)pali
(+)Activated nuclear bombs now glow softly.
```
