### PR TITLE
Makes fluid scooping respect the container volume

### DIFF
--- a/code/modules/chemistry/Chemistry-Tools.dm
+++ b/code/modules/chemistry/Chemistry-Tools.dm
@@ -210,13 +210,9 @@
 
 				F.group.reagents.skip_next_update = 1
 				F.group.update_amt_per_tile()
-				var/fill = min(F.group.amt_per_tile, F.group.reagents.total_volume)
-				boutput(user, "<span class='notice'>You fill [src] with [fill] units of [target].</span>")
-				F.group.reagents.trans_to_direct(src.reagents,fill)
-				if (!F.group) return
-				F.group.contained_amt = F.group.reagents.total_volume
-				F.group.remove(F,0,F.group.updating)
-
+				var/amt = min(F.group.amt_per_tile, reagents.maximum_volume - reagents.total_volume)
+				boutput(user, "<span class='notice'>You fill [src] with [amt] units of [target].</span>")
+				F.group.drain(F, amt / F.group.amt_per_tile, src) // drain uses weird units
 			else //trans_to to the FLOOR of the liquid, not the liquid itself. will call trans_to() for turf which has a little bit that handles turf application -> fluids
 				var/turf/T = get_turf(F)
 				logTheThing("combat", user, null, "transfers chemicals from [src] [log_reagents(src)] to [F] at [log_loc(user)].") // Added reagents (Convair880).

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -549,11 +549,9 @@
 
 				F.group.reagents.skip_next_update = 1
 				F.group.update_amt_per_tile()
-				boutput(user, "<span class='notice'>You fill [src] with [F.group.amt_per_tile] units of [target].</span>")
-				F.group.reagents.trans_to_direct(src.reagents,F.group.amt_per_tile)
-				if (!F.group) return
-				F.group.contained_amt = F.group.reagents.total_volume
-				F.group.remove(F,0,F.group.updating)
+				var/amt = min(F.group.amt_per_tile, reagents.maximum_volume - reagents.total_volume)
+				boutput(user, "<span class='notice'>You fill [src] with [amt] units of [target].</span>")
+				F.group.drain(F, amt / F.group.amt_per_tile, src) // drain uses weird units
 
 			else //trans_to to the FLOOR of the liquid, not the liquid itself. will call trans_to() for turf which has a little bit that handles turf application -> fluids
 				var/turf/T = get_turf(F)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Currently if you click a fluid tile containing 1000u of blood with a 50u beaker you transfer 50u of blood to the beaker and 950u disappears. this PR makes it so you remove only 50u and the fluid tile itself thus only disappears if it had less than 50u on it.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It is a bug.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)pali
(+)Scooping up fluids with a beaker now removes only as much fluid as can fit in the beaker
```
