### PR TITLE
Projectile falloff rework

### DIFF
--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -95,6 +95,10 @@
 			sleep(0.75) //Changed from 1, minor proj. speed buff
 		is_processing = 0
 
+	proc/get_power(obj/O)
+		return src.proj_data.power - max(0,((get_dist(src.orig_turf, get_turf(O)))-src.proj_data.dissipation_delay))*src.proj_data.dissipation_rate
+
+
 	proc/collide(atom/A as mob|obj|turf|area)
 		if (!A) return // you never know ok??
 		if (disposed || pooled) return // if disposed = true, pooled or set for garbage collection and shouldn't process bumps
@@ -105,7 +109,7 @@
 				return
 			if (src.proj_data) //ZeWaka: Fix for null.ticks_between_mob_hits
 				ticks_until_can_hit_mob = src.proj_data.ticks_between_mob_hits
-		src.power = src.proj_data.power - max(0,((get_dist(src.orig_turf, A))-src.proj_data.dissipation_delay))*src.proj_data.dissipation_rate
+		src.power = src.get_power(A)
 		// Necessary because the check in human.dm is ineffective (Convair880).
 		var/immunity = check_target_immunity(A, source = src)
 		if (immunity)

--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -105,7 +105,7 @@
 				return
 			if (src.proj_data) //ZeWaka: Fix for null.ticks_between_mob_hits
 				ticks_until_can_hit_mob = src.proj_data.ticks_between_mob_hits
-
+		src.power = src.proj_data.power - max(0,((get_dist(src.orig_turf, A))-src.proj_data.dissipation_delay))*src.proj_data.dissipation_rate
 		// Necessary because the check in human.dm is ineffective (Convair880).
 		var/immunity = check_target_immunity(A, source = src)
 		if (immunity)
@@ -352,9 +352,8 @@
 				y32 = -y32
 		var/max_t
 		if (proj_data.dissipation_rate && proj_data.max_range == 500) //500 is default maximum range
-			max_t = proj_data.dissipation_delay + round(proj_data.power / proj_data.dissipation_rate) + 1
-		else
-			max_t = proj_data.max_range // why not
+			proj_data.max_range = proj_data.dissipation_delay + round(proj_data.power / proj_data.dissipation_rate) + 1
+		max_t = proj_data.max_range // why not
 		var/next_x = x32 / 2
 		var/next_y = y32 / 2
 		var/ct = 0
@@ -420,12 +419,10 @@
 		src.dissipation_ticker++
 
 		// The bullet has expired/decayed.
-		if (src.dissipation_ticker > src.proj_data.dissipation_delay || src.dissipation_ticker > src.proj_data.max_range)
-			src.power -= src.proj_data.dissipation_rate
-			if (src.power <= 0 || src.dissipation_ticker > src.proj_data.max_range)
-				proj_data.on_max_range_die(src)
-				die()
-				return
+		if (src.dissipation_ticker > src.proj_data.max_range)
+			proj_data.on_max_range_die(src)
+			die()
+			return
 		proj_data.tick(src)
 		if (disposed)
 			return

--- a/code/modules/projectiles/wavegun.dm
+++ b/code/modules/projectiles/wavegun.dm
@@ -39,7 +39,7 @@ toxic - poisons
 /datum/projectile/wavegun/transverse //expensive taser shots that go through /everything/
 	shot_number = 1
 	power = 10 //half the power of a taser at range 1-3, delivers a nasty punch at the 4-tile sweetspot
-	dissipation_delay = 4
+	dissipation_delay = 3
 	dissipation_rate = -30
 	max_range = 5 //super short. about 4 tile max range
 	cost = 50


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[EXPERIMENTAL] [BALANCE] [REWORK]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes how projectile falloff is calculated (calculated on collide instead of incrementally as projectile travels)
Minorly increases the range on most projectiles, and reduces falloff on (almost) all projectiles (falloff ticks happen for every turf instead of every 28 pixels)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes issue where projectiles would experience double range falloff at 4 tile distance along a cardinal direction

