### PR TITLE
Adds a couple of ways to check for multiple statuses, makes some code use them

### DIFF
--- a/code/WorkInProgress/AbilityItem.dm
+++ b/code/WorkInProgress/AbilityItem.dm
@@ -805,7 +805,7 @@
 			return 0
 		if (!src.the_mob)
 			return 0
-		if (src.the_mob.hasStatus("paralysis") || src.the_mob.hasStatus("stunned") || src.the_mob.hasStatus("weakened")) //stun check
+		if (src.the_mob.hasStatus(list("paralysis", "stunned", "weakened"))) //stun check
 			return 0
 		if (src.the_mob && ishuman(src.the_mob)) //cuff, straightjacket, nolimb check
 			var/mob/living/carbon/human/H = the_mob

--- a/code/WorkInProgress/AnimationLibrary.dm
+++ b/code/WorkInProgress/AnimationLibrary.dm
@@ -574,7 +574,7 @@ proc/muzzle_flash_attack_particle(var/mob/M, var/turf/origin, var/turf/target, v
 		sleep(0.2 SECONDS)
 
 		//Look i know this check looks janky. that's because IT IS. violent_twitch is ONLY called for disorient. okay. this stops it fucking up rest animation
-		if (!A.hasStatus("weakened") && !A.hasStatus("paralysis"))
+		if (!A.hasStatus(list("weakened", "paralysis")))
 			A.transform = start
 		A.pixel_x = old_x
 		A.pixel_y = old_y

--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -121,7 +121,7 @@
 	//
 	MouseDrop_T(mob/target, mob/user)
 		//jesus fucking christ
-		if (!istype(target) || target.buckled || get_dist(user, src) > 1 || get_dist(user, target) > 1 || user.stat || user.getStatusDuration("paralysis") || user.getStatusDuration("stunned") || user.getStatusDuration("weakened") || isAI(user) || isAI(target) || isghostcritter(user))
+		if (!istype(target) || target.buckled || get_dist(user, src) > 1 || get_dist(user, target) > 1 || user.stat || user.hasStatus(list("weakened", "paralysis", "stunned")) || isAI(user) || isAI(target) || isghostcritter(user))
 			return
 
 		if (istype(src, /obj/machinery/disposal/mail) && isliving(target))
@@ -134,7 +134,7 @@
 		var/turf/Q = target.loc
 		sleep (5)
 		//heyyyy maybe we should check distance AFTER the sleep??											//If you get stunned while *climbing* into a chute, you can still go in
-		if (target.buckled || get_dist(user, src) > 1 || get_dist(user, target) > 1 || ((user.stat || user.getStatusDuration("paralysis") || user.getStatusDuration("stunned") || user.getStatusDuration("weakened")) && user != target))
+		if (target.buckled || get_dist(user, src) > 1 || get_dist(user, target) > 1 || ((user.stat || hasStatus(list("weakened", "paralysis", "stunned"))) && user != target))
 			return
 
 		if(target == user && !user.stat)	// if drop self, then climbed in

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -1030,7 +1030,7 @@
 	if (isdead(user) || (!iscarbon(user) && !iscritter(user) && !issilicon(usr)))
 		return
 
-	if (!istype(src.loc, /turf) || user.stat || user.getStatusDuration("paralysis") || user.getStatusDuration("stunned") || user.getStatusDuration("weakened") || user.restrained())
+	if (!istype(src.loc, /turf) || user.stat || user.hasStatus(list("paralysis", "stunned", "weakened")) || user.restrained())
 		return
 
 	if (!can_reach(user, src))

--- a/code/datums/abilities/critter.dm
+++ b/code/datums/abilities/critter.dm
@@ -77,7 +77,7 @@
 
 	proc/incapacitationCheck()
 		var/mob/living/M = holder.owner
-		return M.restrained() || M.stat || M.getStatusDuration("paralysis") || M.getStatusDuration("stunned") || M.getStatusDuration("weakened")
+		return M.restrained() || M.stat || M.hasStatus(list("paralysis", "stunned", "weakened"))
 
 	castcheck()
 		if (incapacitationCheck())

--- a/code/datums/abilities/diabolical.dm
+++ b/code/datums/abilities/diabolical.dm
@@ -105,7 +105,7 @@
 
 		switch (stunned_only_is_okay)
 			if (0)
-				if (!isalive(M) || M.getStatusDuration("stunned") > 0 || M.getStatusDuration("paralysis") > 0 || M.getStatusDuration("weakened"))
+				if (!isalive(M) || M.hasStatus(list("stunned", "paralysis", "weakened")))
 					return 0
 				else
 					return 1

--- a/code/datums/abilities/werewolf.dm
+++ b/code/datums/abilities/werewolf.dm
@@ -429,7 +429,7 @@
 
 		switch (stunned_only_is_okay)
 			if (0)
-				if (!isalive(M) || M.getStatusDuration("stunned") > 0 || M.getStatusDuration("paralysis") > 0 || M.getStatusDuration("weakened"))
+				if (!isalive(M) || M.hasStatus(list("stunned", "paralysis", "weakened")))
 					return 0
 				else
 					return 1

--- a/code/datums/abilities/wrestler.dm
+++ b/code/datums/abilities/wrestler.dm
@@ -169,7 +169,7 @@
 
 		switch (stunned_only_is_okay)
 			if (0)
-				if (!isalive(M) || M.getStatusDuration("stunned") > 0 || M.getStatusDuration("paralysis") > 0 || M.getStatusDuration("weakened"))
+				if (!isalive(M) || M.hasStatus(list("stunned", "paralysis", "weakened")))
 					return 0
 				else
 					return 1

--- a/code/mob/dead/ai-camera.dm
+++ b/code/mob/dead/ai-camera.dm
@@ -113,7 +113,7 @@
 	click(atom/target, params, location, control)
 		if (!src.mainframe) return
 
-		if (!src.mainframe.stat && !src.mainframe.restrained() && !src.mainframe.getStatusDuration("weakened") && !src.mainframe.getStatusDuration("paralysis") && !src.mainframe.getStatusDuration("stunned"))
+		if (!src.mainframe.stat && !src.mainframe.restrained() && !src.mainframe.hasStatus(list("weakened", "paralysis", "stunned")))
 			if(src.client.check_any_key(KEY_OPEN | KEY_BOLT | KEY_SHOCK) && istype(target, /obj) )
 				var/obj/O = target
 				O.receive_silicon_hotkey(src)

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -252,7 +252,7 @@
 			W.afterattack(target, src, reach, params)
 
 /mob/living/onMouseDrag(src_object,over_object,src_location,over_location,src_control,over_control,params)
-	if (!src.stat && !src.restrained() && !src.getStatusDuration("weakened") && !src.getStatusDuration("paralysis") && !src.getStatusDuration("stunned"))
+	if (!src.stat && !src.restrained() && !src.hasStatus(list("weakened", "paralysis", "stunned")))
 		var/obj/item/W = src.equipped()
 		if (W) //nah dude, don't typecheck. just assume that mobs can only hold items, this proc gets called a fuckload
 			W.onMouseDrag(src_object,over_object,src_location,over_location,src_control,over_control,params)
@@ -268,14 +268,14 @@
 	return
 */
 /mob/living/onMouseDown(object,location,control,params)
-	if (!src.stat && !src.restrained() && !src.getStatusDuration("weakened") && !src.getStatusDuration("paralysis") && !src.getStatusDuration("stunned"))
+	if (!src.stat && !src.restrained() && !src.hasStatus(list("weakened", "paralysis", "stunned")))
 		var/obj/item/W = src.equipped()
 		if (W && istype(W))
 			W.onMouseDown(object,location,control,params)
 	return
 
 /mob/living/onMouseUp(object,location,control,params)
-	if (!src.stat && !src.restrained() && !src.getStatusDuration("weakened") && !src.getStatusDuration("paralysis") && !src.getStatusDuration("stunned"))
+	if (!src.stat && !src.restrained() && !src.hasStatus(list("weakened", "paralysis", "stunned")))
 		var/obj/item/W = src.equipped()
 		if (W && istype(W))
 			W.onMouseUp(object,location,control,params)
@@ -348,7 +348,7 @@
 			boutput(src, "<span class='alert'>You are handcuffed! Use Resist to attempt removal.</span>")
 		return
 
-	if (!src.stat && !src.getStatusDuration("weakened") && !src.getStatusDuration("paralysis") && !src.getStatusDuration("stunned"))
+	if (!src.stat && !hasStatus(list("weakened", "paralysis", "stunned")))
 		if (target != src && ishuman(src))
 			var/mob/living/carbon/human/S = src
 			if (S.sims)
@@ -823,7 +823,7 @@
 
 			switch (message_mode)
 				if ("internal 1")
-					if (R1 && !(A.stat || A.getStatusDuration("stunned")|| A.getStatusDuration("weakened"))) // Mainframe may be stunned when the shell isn't.
+					if (R1 && !(A.stat || A.hasStatus(list("stunned", "weakened")))) // Mainframe may be stunned when the shell isn't.
 						R1.talk_into(src, messages, null, A.name, lang_id)
 						italics = 1
 						skip_open_mics_in_range = 1 // First AI intercom broadcasts everything by default.
@@ -831,7 +831,7 @@
 					else
 						src.show_text("Mainframe radio inoperable or unavailable.", "red")
 				if ("internal 2")
-					if (R2 && !(A.stat || A.getStatusDuration("stunned") || A.getStatusDuration("weakened")))
+					if (R2 && !(A.stat || A.hasStatus(list("stunned", "weakened"))))
 						R2.talk_into(src, messages, null, A.name, lang_id)
 						italics = 1
 						skip_open_mics_in_range = 1
@@ -839,7 +839,7 @@
 					else
 						src.show_text("Mainframe radio inoperable or unavailable.", "red")
 				if ("monitor")
-					if (R3 && !(A.stat || A.getStatusDuration("stunned") || A.getStatusDuration("weakened")))
+					if (R3 && !(A.stat || A.hasStatus(list("stunned", "weakened"))))
 						R3.talk_into(src, messages, secure_headset_mode, A.name, lang_id)
 						italics = 1
 						skip_open_mics_in_range = 1

--- a/code/mob/living/carbon/human/npc.dm
+++ b/code/mob/living/carbon/human/npc.dm
@@ -546,7 +546,7 @@
 	else return 0
 
 /mob/living/carbon/human/proc/ai_incapacitated()
-	if(stat || hasStatus("stunned") || getStatusDuration("paralysis") || !sight_check(1) || getStatusDuration("weakened")) return 1
+	if(stat || hasStatus(list("stunned", "paralysis", "weakened")) || !sight_check(1)) return 1
 	else return 0
 
 /mob/living/carbon/human/proc/ai_validpath()

--- a/code/mob/living/carbon/human/procs/Life.dm
+++ b/code/mob/living/carbon/human/procs/Life.dm
@@ -1818,7 +1818,9 @@
 		var/lying_old = src.lying
 		var/cant_lie = (src.limbs && istype(src.limbs.l_leg, /obj/item/parts/robot_parts/leg/left/treads) && istype(src.limbs.r_leg, /obj/item/parts/robot_parts/leg/right/treads) && !locate(/obj/table, src.loc) && !locate(/obj/machinery/optable, src.loc))
 
-		var/must_lie = hasStatus("resting") || (!cant_lie && src.limbs && !src.limbs.l_leg && !src.limbs.r_leg) //hasn't got a leg to stand on... haaa
+		var/list/statusList = src.getStatusList()
+
+		var/must_lie = statusList["resting"] || (!cant_lie && src.limbs && !src.limbs.l_leg && !src.limbs.r_leg) //hasn't got a leg to stand on... haaa
 
 		var/changeling_fakedeath = 0
 		var/datum/abilityHolder/changeling/C = get_ability_holder(/datum/abilityHolder/changeling)
@@ -1826,20 +1828,21 @@
 			changeling_fakedeath = 1
 
 		if (!isdead(src)) //Alive.
-			if (src.hasStatus("paralysis") || src.hasStatus("stunned") || src.hasStatus("weakened") || hasStatus("pinned") || changeling_fakedeath || src.hasStatus("resting")) //Stunned etc.
+			if (statusList["paralysis"] || statusList["stunned"] || statusList["weakened"] || statusList["pinned"] || changeling_fakedeath || statusList["resting"]) //Stunned etc.
 				var/setStat = src.stat
 				var/oldStat = src.stat
-				if (src.hasStatus("stunned"))
+				if (statusList["stunned"])
 					setStat = 0
-				if (src.hasStatus("weakened") || src.hasStatus("pinned") && !src.fakedead)
-					if (!cant_lie) src.lying = 1
+				if (statusList["weakened"] || statusList["pinned"] && !src.fakedead)
+					if (!cant_lie)
+						src.lying = 1
 					setStat = 0
-				if (src.hasStatus("paralysis"))
-					if (!cant_lie) src.lying = 1
+				if (statusList["paralysis"])
+					if (!cant_lie)
+						src.lying = 1
 					setStat = 1
-				if (isalive(src) && setStat == 1)
-					if (src && src.mind)
-						src.lastgasp() // calling lastgasp() here because we just got knocked out
+				if (isalive(src) && setStat == 1 && src.mind)
+					src.lastgasp() // calling lastgasp() here because we just got knocked out
 				if (must_lie)
 					src.lying = 1
 
@@ -1870,7 +1873,7 @@
 						else if (healtype == 4)
 							src.HealDamage("All", 0, 0, 0.2) ///adjsfkaljdsklf;ajs
 
-				else if ((oldStat == 1) && (!getStatusDuration("paralysis") && !getStatusDuration("stunned") && !getStatusDuration("weakened") && !changeling_fakedeath))
+				else if ((oldStat == 1) && (!statusList["paralysis"] && !statusList["stunned"] && !statusList["weakened"] && !changeling_fakedeath))
 					src << sound('sound/misc/molly_revived.ogg', volume=50)
 					setalive(src)
 

--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -689,7 +689,7 @@
 		handle_hud_overlays()
 		src.antagonist_overlay_refresh(0, 0)
 
-		if (getStatusDuration("paralysis") || getStatusDuration("stunned") || getStatusDuration("weakened") || getStatusDuration("dormant"))
+		if (src.hasStatus(list("weakened", "paralysis", "stunned", "dormant")))
 			canmove = 0
 		else
 			canmove = 1
@@ -702,7 +702,7 @@
 			if (!sleeping)
 				src.on_wake()
 
-		var/may_deliver_recovery_warning = (getStatusDuration("paralysis") || getStatusDuration("stunned") || getStatusDuration("weakened"))
+		var/may_deliver_recovery_warning = (src.hasStatus(list("weakened", "paralysis", "stunned")))
 
 		if (may_deliver_recovery_warning)
 			empty_hands()

--- a/code/mob/living/silicon.dm
+++ b/code/mob/living/silicon.dm
@@ -60,7 +60,7 @@
 					src.updateOverlaysClient(x.client)
 
 /mob/living/silicon/proc/update_canmove()
-	canmove = !(getStatusDuration("paralysis") || getStatusDuration("stunned") || getStatusDuration("weakened") || buckled)
+	canmove = !(src.hasStatus(list("weakened", "paralysis", "stunned")) || buckled)
 
 /mob/living/silicon/proc/use_power()
 	return

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -813,7 +813,7 @@ var/zapLimiter = 0
 
 
 /obj/machinery/power/apc/proc/cut(var/wireColor)
-	if (usr.getStatusDuration("stunned") > 0 || usr.getStatusDuration("weakened") || usr.getStatusDuration("paralysis") > 0 || !isalive(usr))
+	if (usr.hasStatus(list("weakened", "paralysis", "stunned")) || !isalive(usr))
 		usr.show_text("Not when you're incapacitated.", "red")
 		return
 
@@ -836,7 +836,7 @@ var/zapLimiter = 0
 //		if(APC_WIRE_IDSCAN)		nothing happens when you cut this wire, add in something if you want whatever
 
 /obj/machinery/power/apc/proc/bite(var/wireColor) // are you fuckin huffing or somethin
-	if (usr.getStatusDuration("stunned") > 0 || usr.getStatusDuration("weakened") || usr.getStatusDuration("paralysis") > 0 || !isalive(usr))
+	if (usr.hasStatus(list("weakened", "paralysis", "stunned")) || !isalive(usr))
 		usr.show_text("Not when you're incapacitated.", "red")
 		return
 
@@ -862,7 +862,7 @@ var/zapLimiter = 0
 
 
 /obj/machinery/power/apc/proc/mend(var/wireColor)
-	if (usr.getStatusDuration("stunned") > 0 || usr.getStatusDuration("weakened") || usr.getStatusDuration("paralysis") > 0 || !isalive(usr))
+	if (usr.hasStatus(list("weakened", "paralysis", "stunned")) || !isalive(usr))
 		usr.show_text("Not when you're incapacitated.", "red")
 		return
 
@@ -889,7 +889,7 @@ var/zapLimiter = 0
 //		if(APC_WIRE_IDSCAN)		nothing happens when you cut this wire, add in something if you want whatever
 
 /obj/machinery/power/apc/proc/pulse(var/wireColor)
-	if (usr.getStatusDuration("stunned") > 0 || usr.getStatusDuration("weakened") || usr.getStatusDuration("paralysis") > 0 || !isalive(usr))
+	if (usr.hasStatus(list("weakened", "paralysis", "stunned")) || !isalive(usr))
 		usr.show_text("Not when you're incapacitated.", "red")
 		return
 

--- a/code/modules/status_system/statusSystem.dm
+++ b/code/modules/status_system/statusSystem.dm
@@ -246,14 +246,29 @@ var/list/statusGroupLimits = list("Food"=4)
 					break
 
 	proc/hasStatus(statusId, optionalArgs = null)
-		.= null
 		if(statusEffects)
-			var/datum/statusEffect/status = 0
-			for(var/S in statusEffects) //dont typecheck as we loop through StatusEffects - Assume everything inside must be a statuseffect
+			if (!islist(statusId))
+				var/datum/statusEffect/status
+				for(var/S in statusEffects) //dont typecheck as we loop through StatusEffects - Assume everything inside must be a statuseffect
+					status = S
+					if(status.id == statusId && ((optionalArgs && status.onCheck(optionalArgs)) || (!optionalArgs)))
+						return status
+			else
+				var/list/idlist = statusId
+				var/datum/statusEffect/status
+				for(var/S in statusEffects)
+					status = S
+					if((status.id in idlist) && ((optionalArgs && status.onCheck(optionalArgs)) || (!optionalArgs)))
+						return status
+
+	proc/getStatusList(optionalArgs = null)
+		. = list()
+		if (statusEffects)
+			var/datum/statusEffect/status
+			for(var/S in statusEffects)
 				status = S
-				if(status.id == statusId && ((optionalArgs && status.onCheck(optionalArgs)) || (!optionalArgs)))
-					.= status
-					break
+				if((optionalArgs && status.onCheck(optionalArgs)) || (!optionalArgs))
+					.[status.id] = status
 
 	proc/delStatus(var/status)
 		if(statusEffects == null)
@@ -755,7 +770,7 @@ var/list/statusGroupLimits = list("Food"=4)
 		onRemove()
 			..()
 			if(!owner) return
-			if (!owner.hasStatus("stunned") && !owner.hasStatus("weakened") && !owner.hasStatus("paralysis") && !owner.hasStatus("pinned")) //consider later : a way to group effects to check a bunch in one proc call and save sonme cpu
+			if (!owner.hasStatus(list("stunned", "weakened", "paralysis", "pinned"))) //consider later : a way to group effects to check a bunch in one proc call and save sonme cpu
 				if (isliving(owner))
 					var/mob/living/L = owner
 					L.force_laydown_standup()
@@ -924,7 +939,7 @@ var/list/statusGroupLimits = list("Food"=4)
 
 		onUpdate(var/timedPassed)
 			counter += timedPassed
-			if (counter >= count && owner && !owner.hasStatus("weakened") && !owner.hasStatus("paralysis"))
+			if (counter >= count && owner && !owner.hasStatus(list("weakened", "paralysis")) )
 				counter -= count
 				playsound(get_turf(owner), sound, 17, 1, 0.4, 1.6)
 				violent_twitch(owner)
@@ -1181,9 +1196,14 @@ var/list/statusGroupLimits = list("Food"=4)
 					if (H.bleeding && prob(100*buff_mult))
 						repair_bleeding_damage(H, 5, 1)
 
-					if(H.hasStatus("paralysis")) H.changeStatus("paralysis", -3*buff_mult)
-					if(H.hasStatus("stunned")) H.changeStatus("stunned", -3*buff_mult)
-					if(H.hasStatus("weakened")) H.changeStatus("weakened", -3*buff_mult)
+					var/list/statusList = H.getStatusList()
+
+					if(statusList["paralysis"])
+						H.changeStatus("paralysis", -3*buff_mult)
+					if(statusList["stunned"])
+						H.changeStatus("stunned", -3*buff_mult)
+					if(statusList["weakened"])
+						H.changeStatus("weakened", -3*buff_mult)
 
 					H.updatehealth()
 			else

--- a/code/modules/status_system/statusSystem.dm
+++ b/code/modules/status_system/statusSystem.dm
@@ -770,7 +770,7 @@ var/list/statusGroupLimits = list("Food"=4)
 		onRemove()
 			..()
 			if(!owner) return
-			if (!owner.hasStatus(list("stunned", "weakened", "paralysis", "pinned"))) //consider later : a way to group effects to check a bunch in one proc call and save sonme cpu
+			if (!owner.hasStatus(list("stunned", "weakened", "paralysis", "pinned"))) 
 				if (isliving(owner))
 					var/mob/living/L = owner
 					L.force_laydown_standup()

--- a/code/obj/item/deployable_turret.dm
+++ b/code/obj/item/deployable_turret.dm
@@ -115,7 +115,7 @@
 			processing_items.Add(src)
 		if(active)
 			set_projectile()
-		
+
 	disposing()
 		processing_items.Remove(src)
 		..()
@@ -405,7 +405,7 @@
 			return 0
 		if (istype(C,/mob/living/carbon/human))
 			var/mob/living/carbon/human/H = C
-			if (H.hasStatus("resting") || H.hasStatus("weakened") || H.hasStatus("stunned") || H.hasStatus("paralysis")) // stops it from uselessly firing at people who are already suppressed. It's meant to be a suppression weapon!
+			if (H.hasStatus(list("resting", "weakened", "stunned", "paralysis"))) // stops it from uselessly firing at people who are already suppressed. It's meant to be a suppression weapon!
 				return 0
 		if (is_friend(C))
 			return 0

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -150,7 +150,7 @@
 		var/obj/item/sword/S = H.find_type_in_hand(/obj/item/sword, "right")
 		if (!S)
 			S = H.find_type_in_hand(/obj/item/sword, "left")
-		if (S && S.active && !(H.lying || isdead(H) || H.hasStatus("stunned") || H.hasStatus("weakened") || H.hasStatus("paralysis")))
+		if (S && S.active && !(H.lying || isdead(H) || H.hasStatus("stunned", "weakened", "paralysis")))
 			var/obj/itemspecialeffect/clash/C = unpool(/obj/itemspecialeffect/clash)
 			if(target.gender == MALE) playsound(get_turf(target), pick('sound/weapons/male_cswordattack1.ogg','sound/weapons/male_cswordattack2.ogg'), 70, 0, 0, max(0.7, min(1.2, 1.0 + (30 - H.bioHolder.age)/60)))
 			else playsound(get_turf(target), pick('sound/weapons/female_cswordattack1.ogg','sound/weapons/female_cswordattack2.ogg'), 70, 0, 0, max(0.7, min(1.4, 1.0 + (30 - H.bioHolder.age)/50)))

--- a/code/obj/item/pens_writing_etc.dm
+++ b/code/obj/item/pens_writing_etc.dm
@@ -772,7 +772,7 @@
 	Topic(var/href, var/href_list)
 		if (get_dist(src, usr) > 1 || !isliving(usr) || iswraith(usr) || isintangible(usr))
 			return
-		if (usr.hasStatus("paralysis") || usr.hasStatus("stunned") || usr.hasStatus("weakened") || usr.hasStatus("resting"))
+		if (usr.hasStatus("paralysis", "stunned", "weakened", "resting"))
 			return
 		..()
 

--- a/code/obj/machinery/porters.dm
+++ b/code/obj/machinery/porters.dm
@@ -446,7 +446,7 @@ var/global/list/portable_machinery = list() // stop looping through world for th
 	verb/move_eject()
 		set src in oview(1)
 		set category = "Local"
-		if (!isalive(usr) || usr.getStatusDuration("stunned") > 0 || usr.getStatusDuration("paralysis") > 0 || usr.getStatusDuration("weakened") || usr.hasStatus("handcuffed"))
+		if (!isalive(usr) || usr.hasStatus(list("stunned", "paralysis", "weakened", "handcuffed")))
 			return
 		src.go_out()
 		add_fingerprint(usr)

--- a/code/obj/storage/filing_cabinet.dm
+++ b/code/obj/storage/filing_cabinet.dm
@@ -24,9 +24,7 @@
 
 	Topic(var/href, var/href_list)
 
-		if (get_dist(src, usr) > 1 || !isliving(usr) || iswraith(usr) || isintangible(usr))
-			return
-		if (usr.hasStatus("paralysis") || usr.hasStatus("stunned") || usr.hasStatus("weakened") || usr.hasStatus("resting"))
+		if (get_dist(src, usr) > 1 || !isliving(usr) || iswraith(usr) || isintangible(usr) || usr.hasStatus(list("paralysis", "stunned", "weakened", "resting")))
 			return
 		..()
 

--- a/code/obj/vehicle.dm
+++ b/code/obj/vehicle.dm
@@ -43,7 +43,7 @@ Contains:
 		if(rider && rider_visible && W.force)
 			W.attack(rider, user)
 			user.lastattacked = src
-			if (attacks_fast_eject || rider.getStatusDuration("weakened") || rider.getStatusDuration("stunned") || rider.getStatusDuration("paralysis"))
+			if (attacks_fast_eject || rider.hasStatus(list("weakened", "paralysis", "stunned")))
 				eject_rider()
 			W.visible_message("<span class='alert'>[user] swings at [rider] with [W]!</span>")
 		return
@@ -1441,7 +1441,7 @@ obj/vehicle/clowncar/proc/log_me(var/mob/rider, var/mob/pax, var/action = "", va
 			M.set_loc(src.loc)
 
 /obj/vehicle/cat/MouseDrop_T(mob/living/carbon/human/target, mob/user)
-	if (rider || !istype(target) || target.buckled || get_dist(user, src) > 1 || get_dist(user, target) > 1 || user.getStatusDuration("paralysis") || user.getStatusDuration("stunned") || user.getStatusDuration("weakened") || user.stat || isAI(user))
+	if (rider || !istype(target) || target.buckled || get_dist(user, src) > 1 || get_dist(user, target) > 1 || user.hasStatus(list("weakened", "paralysis", "stunned")) || user.stat || isAI(user))
 		return
 
 	var/msg


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
`hasStatus(statusId, optionalArgs = null)` now accepts a list of statusIds as well, removing the need to call the proc multiple times to loop through statuses for each checked status.
 
`proc/getStatusList(optionalArgs = null)` has been added to return an assoc list with the `list("statusId" = status)` structure. This is useful for places like Life that check for multiple status effects in multiple places, or for code that wants to access the statuses themselves. 

Perhaps a `PROP_INCAPACITATED` could be added to test for stunned/paralyzed/weakened, maybe dormant too?

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's cleaner and faster.
