### PR TITLE
Fill in missing source field in peripheral signals

### DIFF
--- a/code/modules/networks/computer3/peripherals.dm
+++ b/code/modules/networks/computer3/peripherals.dm
@@ -196,6 +196,7 @@
 					newsignal.data_file = signal.data_file.copy_file()
 				newsignal.encryption = src.code
 				newsignal.transmission_method = TRANSMISSION_RADIO
+				newsignal.source = src
 				if(src.net_mode)
 					if(!newsignal.data["address_1"])
 						//Net_mode demands an address_1 value!
@@ -230,6 +231,7 @@
 				newsignal.data["address_1"] = "ping"
 				newsignal.data["sender"] = src.net_id
 				newsignal.transmission_method = TRANSMISSION_RADIO
+				newsignal.source = src
 				src.radio_connection.post_signal(src, newsignal, broadcast_range)
 				return 0
 
@@ -261,7 +263,7 @@
 			if(signal.data["address_1"] != src.net_id)
 				if((signal.data["address_1"] == "ping") && signal.data["sender"])
 					var/datum/signal/pingsignal = get_free_signal()
-					pingsignal.source = host
+					pingsignal.source = src
 					pingsignal.data["device"] = "WNET_ADAPTER"
 					pingsignal.data["netid"] = src.net_id
 					pingsignal.data["address_1"] = signal.data["sender"]
@@ -358,6 +360,7 @@
 			newsignal.data["sender"] = src.net_id //Override whatever jerk info they put here.
 			newsignal.encryption = src.code
 			newsignal.transmission_method = TRANSMISSION_WIRE
+			newsignal.source = src
 			src.link.post_signal(src, newsignal)
 			return 0
 
@@ -379,6 +382,7 @@
 				newsignal.data["net"] = "[net_number]"
 
 			newsignal.transmission_method = TRANSMISSION_WIRE
+			newsignal.source = src
 			src.link.post_signal(src, newsignal)
 			return 0
 
@@ -419,6 +423,7 @@
 				pingsignal.data["address_1"] = signal.data["sender"]
 				pingsignal.data["command"] = "ping_reply"
 				pingsignal.transmission_method = TRANSMISSION_WIRE
+				pingsignal.source = src
 				SPAWN_DBG(0.5 SECONDS) //Send a reply for those curious jerks
 					src.link.post_signal(src, pingsignal)
 
@@ -488,6 +493,7 @@
 				newsignal.data["sender"] = src.net_id //Override whatever jerk info they put here.
 				newsignal.encryption = src.code
 				newsignal.transmission_method = TRANSMISSION_WIRE
+				newsignal.source = src
 				src.link.post_signal(src, newsignal)
 
 
@@ -550,6 +556,7 @@
 						newsignal.data["net"] = "[net_number]"
 
 					newsignal.transmission_method = TRANSMISSION_WIRE
+					newsignal.source = src
 					src.link.post_signal(src, newsignal)
 
 				else if (dd_hasprefix(command, "subnet"))
@@ -617,6 +624,7 @@
 					if (src.mode == 1)
 						newsignal.data["sender"] = src.net_id
 					newsignal.transmission_method = TRANSMISSION_RADIO
+					newsignal.source = src
 					src.wireless_link.post_signal(src, newsignal, (src.mode == 1 ? 0 : src.wireless_range))
 					return 0
 
@@ -632,6 +640,7 @@
 
 					newsignal.data["sender"] = src.net_id
 					newsignal.transmission_method = TRANSMISSION_WIRE
+					newsignal.source = src
 					src.wired_link.post_signal(src, newsignal)
 					return 0
 
@@ -690,6 +699,7 @@
 						newsignal.data["sender"] = src.net_id
 
 						newsignal.transmission_method = TRANSMISSION_RADIO
+						newsignal.source = src
 						src.wireless_link.post_signal(src, newsignal)
 
 						return 0
@@ -710,6 +720,7 @@
 							newsignal.data["net"] = "[subnet]"
 
 						newsignal.transmission_method = TRANSMISSION_WIRE
+						newsignal.source = src
 						src.wired_link.post_signal(src, newsignal)
 
 						return 0
@@ -752,6 +763,7 @@
 				pingsignal.data["address_1"] = signal.data["sender"]
 				pingsignal.data["command"] = "ping_reply"
 				pingsignal.transmission_method = src.mode == 2 ? TRANSMISSION_WIRE : TRANSMISSION_RADIO
+				pingsignal.source = src
 				SPAWN_DBG(0.5 SECONDS) //Send a reply for those curious jerks
 					if (src.mode == 2 && src.wired_link)
 						src.wired_link.post_signal(src, pingsignal)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The signals sent by computer peripherals were missing source info. That caused range checks to fail, which in turn made the signals not appear on Packet Sniffer. I don't think it makes any difference on the wired network though.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's a bug


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Jicksaw:
(+)Wireless computer signals now appear on Packet Sniffer
```
