### PR TITLE
changed uguu to use existing mask

### DIFF
--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -453,8 +453,10 @@
 					else
 						playsound(get_turf(src), 'sound/voice/uguu.ogg', 80, 0, 0, src.get_age_pitch())
 					SPAWN_DBG(1 SECOND)
+						var/obj/item/clothing/mask/anime/mask = src.wear_mask
+						mask.set_loc(src.loc)
+						src.wear_mask = null
 						src.gib()
-						new /obj/item/clothing/mask/anime(src.loc)
 						return
 				else
 					src.show_text("You just don't feel kawaii enough to uguu right now!", "red")

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -453,8 +453,7 @@
 					else
 						playsound(get_turf(src), 'sound/voice/uguu.ogg', 80, 0, 0, src.get_age_pitch())
 					SPAWN_DBG(1 SECOND)
-						var/obj/item/clothing/mask/anime/mask = src.wear_mask
-						mask.set_loc(src.loc)
+						src.wear_mask.set_loc(src.loc)
 						src.wear_mask = null
 						src.gib()
 						return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[TRIVIAL][ENHANCEMENT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the *uguu emote to drop the actual mask that the offender was using instead of creating a new one, as the *tip emote already does.
Before it would create a new mask, but as the offender was gibbed before that happened, it didn't  seem to actually work as the loc was null.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This would allow players to personalize their masks by (for instance) turning them into gold while preserving these modifications for future generations of anime lovers that wish to follow in their footsteps.
