### PR TITLE
Change emergency shuttle call message to a station announcement

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -288,7 +288,7 @@ var/global/noir = 0
 						if(!call_reason)
 							return
 						emergency_shuttle.incall()
-						command_announcement(call_reason + "<br><b><span class='alert'>It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes.</span></b>", "The Emergency Shuttle Has Been Called", color = "notice")
+						command_announcement(call_reason + "<br><b><span class='alert'>It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes.</span></b>", "The Emergency Shuttle Has Been Called", css_class = "notice")
 						logTheThing("admin", usr, null,  "called the Emergency Shuttle (reason: [call_reason])")
 						logTheThing("diary", usr, null, "called the Emergency Shuttle (reason: [call_reason])", "admin")
 						message_admins("<span class='notice'>[key_name(usr)] called the Emergency Shuttle to the station</span>")
@@ -303,7 +303,7 @@ var/global/noir = 0
 								if(!call_reason)
 									call_reason = "No reason given."
 								emergency_shuttle.incall()
-								command_announcement(call_reason + "<br><b><span class='alert'>It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes.</span></b>", "The Emergency Shuttle Has Been Called", color = "notice")
+								command_announcement(call_reason + "<br><b><span class='alert'>It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes.</span></b>", "The Emergency Shuttle Has Been Called", css_class = "notice")
 								logTheThing("admin", usr, null, "called the Emergency Shuttle (reason: [call_reason])")
 								logTheThing("diary", usr, null, "called the Emergency Shuttle (reason: [call_reason])", "admin")
 								message_admins("<span class='notice'>[key_name(usr)] called the Emergency Shuttle to the station</span>")

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -284,13 +284,11 @@ var/global/noir = 0
 					if("1")
 						if ((!( ticker ) || emergency_shuttle.location))
 							return
-						var/call_reason = input("Enter the reason for the shuttle call (or just hit OK to give no reason)","Shuttle Call Reason","<span class='italic'>No reason given.</span>") as null|text
+						var/call_reason = input("Enter the reason for the shuttle call (or just hit OK to give no reason)","Shuttle Call Reason","No reason given.") as null|text
 						if(!call_reason)
 							return
 						emergency_shuttle.incall()
-						boutput(world, "<span class='notice'><B>Alert: The emergency shuttle has been called.</B></span>")
-						boutput(world, "<span class='notice'>- - - <b>Reason:</b> [call_reason]<B></span>")
-						boutput(world, "<span class='notice'><B>It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes.</B></span>")
+						command_announcement(call_reason + "<br><b><span class='alert'>It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes.</span></b>", "The Emergency Shuttle Has Been Called", color = "notice")
 						logTheThing("admin", usr, null,  "called the Emergency Shuttle (reason: [call_reason])")
 						logTheThing("diary", usr, null, "called the Emergency Shuttle (reason: [call_reason])", "admin")
 						message_admins("<span class='notice'>[key_name(usr)] called the Emergency Shuttle to the station</span>")
@@ -303,11 +301,9 @@ var/global/noir = 0
 								emergency_shuttle.incall()
 								var/call_reason = input("Enter the reason for the shuttle call (or just hit OK to give no reason)","Shuttle Call Reason","") as null|text
 								if(!call_reason)
-									call_reason = "<span class='italic'>No reason given.</span>"
+									call_reason = "No reason given."
 								emergency_shuttle.incall()
-								boutput(world, "<span class='notice'><B>Alert: The emergency shuttle has been called.</B></span>")
-								boutput(world, "<span class='notice'>- - - <b>Reason:</b> [call_reason]<B></span>")
-								boutput(world, "<span class='notice'><B>It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes.</B></span>")
+								command_announcement(call_reason + "<br><b><span class='alert'>It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes.</span></b>", "The Emergency Shuttle Has Been Called", color = "notice")
 								logTheThing("admin", usr, null, "called the Emergency Shuttle (reason: [call_reason])")
 								logTheThing("diary", usr, null, "called the Emergency Shuttle (reason: [call_reason])", "admin")
 								message_admins("<span class='notice'>[key_name(usr)] called the Emergency Shuttle to the station</span>")

--- a/code/obj/machinery/computer/communications.dm
+++ b/code/obj/machinery/computer/communications.dm
@@ -408,7 +408,7 @@
 		call_reason = "No reason given."
 
 	emergency_shuttle.incall()
-	command_announcement(call_reason + "<br><b><span class='alert'>It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes.</span></b>", "The Emergency Shuttle Has Been Called", color = "notice")
+	command_announcement(call_reason + "<br><b><span class='alert'>It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes.</span></b>", "The Emergency Shuttle Has Been Called", css_class = "notice")
 	return 0
 
 /proc/cancel_call_proc(var/mob/user)

--- a/code/obj/machinery/computer/communications.dm
+++ b/code/obj/machinery/computer/communications.dm
@@ -405,14 +405,10 @@
 	if(call_reason)
 		call_reason = copytext(html_decode(trim(strip_html(html_decode(call_reason)))), 1, 140)
 	if(!call_reason || length(call_reason) < 1)
-		call_reason = "<span class='italic'>No reason given.</span>"
-
+		call_reason = "No reason given."
 
 	emergency_shuttle.incall()
-	boutput(world, "<span class='notice'><B>Alert: The emergency shuttle has been called.</B></span>")
-	boutput(world, "<span class='notice'>- - - <b>Reason:</b> [call_reason]<B></span>")
-	boutput(world, "<span class='notice'><B>It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes.</B></span>")
-
+	command_announcement(call_reason + "<br><b><span class='alert'>It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes.</span></b>", "The Emergency Shuttle Has Been Called", color = "notice")
 	return 0
 
 /proc/cancel_call_proc(var/mob/user)

--- a/code/procs/command_alert.dm
+++ b/code/procs/command_alert.dm
@@ -14,7 +14,7 @@
 	if (sound_to_play && length(sound_to_play) > 0)
 		world << csound(sound_to_play)
 
-/proc/command_announcement(var/text, var/title, var/sound_to_play = "", var/color = "alert", var/do_sanitize = 1) //Slightly less conspicuous, but requires a title.
+/proc/command_announcement(var/text, var/title, var/sound_to_play = "", var/css_class = "alert", var/do_sanitize = 1) //Slightly less conspicuous, but requires a title.
 	if(!title || !text) return
 
 	if(do_sanitize)
@@ -23,7 +23,7 @@
 
 	boutput(world, "<h2 class='alert'>[title]</h2>")
 
-	boutput(world, "<span class='[color]'>[text]</span>")
+	boutput(world, "<span class='[css_class]'>[text]</span>")
 	boutput(world, "<br>")
 	if (sound_to_play && length(sound_to_play) > 0)
 		world << csound(sound_to_play)

--- a/code/procs/command_alert.dm
+++ b/code/procs/command_alert.dm
@@ -14,7 +14,7 @@
 	if (sound_to_play && length(sound_to_play) > 0)
 		world << csound(sound_to_play)
 
-/proc/command_announcement(var/text, var/title, var/sound_to_play = "", var/do_sanitize = 1) //Slightly less conspicuous, but requires a title.
+/proc/command_announcement(var/text, var/title, var/sound_to_play = "", var/color = "alert", var/do_sanitize = 1) //Slightly less conspicuous, but requires a title.
 	if(!title || !text) return
 
 	if(do_sanitize)
@@ -23,7 +23,7 @@
 
 	boutput(world, "<h2 class='alert'>[title]</h2>")
 
-	boutput(world, "<span class='alert'>[text]</span>")
+	boutput(world, "<span class='[color]'>[text]</span>")
 	boutput(world, "<br>")
 	if (sound_to_play && length(sound_to_play) > 0)
 		world << csound(sound_to_play)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[ENHANCEMENT]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR changes the emergency shuttle call message to a station announcement. It also adds a `color` var to the  `command_announcement()` proc to let you specify the color of the announcement's body text. Here's an example of what shuttle calls will now look like:

![image](https://user-images.githubusercontent.com/59894319/82623253-ba920280-9bad-11ea-8d67-ce456f909818.png)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

It's more eye-catching and fun. 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

I feel like this doesn't need a changelog because it's very self-explanatory; once someone sees it, they'll know that it's changed. However, for posterity, I guess there should be one.

```
(u)Flourish
(+)Made the emergency shuttle call message an actual station announcement.
```
