### PR TITLE
Blob passive fire resist fix

### DIFF
--- a/code/obj/blob.dm
+++ b/code/obj/blob.dm
@@ -208,14 +208,14 @@ var/image/blob_icon_cache
 
 	temperature_expose(datum/gas_mixture/air, temperature, volume)
 		var/temp_difference = abs(temperature - src.ideal_temp)
-
+		var/tolerance = temp_tolerance
 		if (material)
 			material.triggerTemp(src, temperature)
 
 		if (src.has_upgrade(/datum/blob_upgrade/fire_resist))
-			temp_tolerance *= 3
-		if(temp_difference > temp_tolerance)
-			temp_difference = abs(temp_difference - temp_tolerance)
+			tolerance *= 3
+		if(temp_difference > tolerance)
+			temp_difference = abs(temp_difference - tolerance)
 
 			src.take_damage(temp_difference / heat_divisor, 1, "burn")
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG] [BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fire resist no longer triples temp tolerance every time it is checked
Note that this effectively makes flamers/etc more powerful vs blobs with fire resist, as it used to give complete immunity *if* the individual blob tiles could survive a few flamer shots (most notable with blob nuclei)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's horribly unintuitive and presumably unintended behaviour


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->
I don't think this needs a changelog but it *does* affect a key(?) blob power so 🤷 feel free to add one
