### PR TITLE
Makes anti-histamine stroger. Epi no longer remove histamine.

### DIFF
--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -791,8 +791,6 @@ datum
 				M.drowsyness = max(M.drowsyness-5, 0)
 				if(M.sleeping && prob(5)) M.sleeping = 0
 				if(M.get_brain_damage() && prob(5)) M.take_brain_damage(-1)
-				if(holder.has_reagent("histamine"))
-					holder.remove_reagent("histamine", 15 * mult)
 				if(M.losebreath > 3)
 					M.losebreath -= (1 * mult)
 				if(M.get_oxygen_deprivation() > 35)
@@ -1192,7 +1190,7 @@ datum
 				if(!M) M = holder.my_atom
 				M.jitteriness = max(M.jitteriness-20,0)
 				if(holder.has_reagent("histamine"))
-					holder.remove_reagent("histamine", 3 * mult)
+					holder.remove_reagent("histamine", 15 * mult)
 				if(holder.has_reagent("itching"))
 					holder.remove_reagent("itching", 3 * mult)
 				if(prob(7)) M.emote("yawn")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Diphenhydramine now removes 15u histamine (from 3u). Epinephrine no longer removes any.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Epinephrine was removing 15u (*mult) histamine per tick. Anti-histamine was removing 3u.
That's whack.
Also I think Diphenhydramine could use a boost.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)MarkNstein:
(+)Anti-histamine is 5 times stronger. Epinephrine no longer removes histamine.
```