### PR TITLE
Remove the emote_lock variable

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -71,8 +71,6 @@
 	var/caneat = 1
 	var/candrink = 1
 
-	var/emote_lock = 0
-
 	var/canbegrabbed = 1
 	var/grabresistmessage = null //Format: target.visible_message("<span class='alert'><B>[src] tries to grab [target], [target.grabresistmessage]</B></span>")
 

--- a/code/mob/living/carbon/human/procs/Life.dm
+++ b/code/mob/living/carbon/human/procs/Life.dm
@@ -800,10 +800,6 @@
 			canmove = 0
 			return
 
-		if (emote_lock)
-			canmove = 0
-			return
-
 		canmove = 1
 
 	proc/handle_breath(datum/gas_mixture/breath, var/atom/underwater = 0, var/mult = 1) //'underwater' really applies for any reagent that gets deep enough. but what ever

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -1788,24 +1788,24 @@
 
 	src.remove_stamina(STAMINA_DEFAULT_FART_COST)
 
-/mob/living/carbon/human/proc/dabbify(var/mob/living/carbon/human/O)
-	O.render_target = "*\ref[O]"
-	var/image/left_arm = image(null, O)
-	left_arm.render_source = O.render_target
+/mob/living/carbon/human/proc/dabbify(var/mob/living/carbon/human/H)
+	H.render_target = "*\ref[H]"
+	var/image/left_arm = image(null, H)
+	left_arm.render_source = H.render_target
 	left_arm.filters += filter(type="alpha", icon=icon('icons/mob/humanmasks.dmi', "r_arm"))
 	left_arm.appearance_flags = KEEP_APART
-	var/image/right_arm = image(null, O)
-	right_arm.render_source = O.render_target
+	var/image/right_arm = image(null, H)
+	right_arm.render_source = H.render_target
 	right_arm.filters += filter(type="alpha", icon=icon('icons/mob/humanmasks.dmi', "l_arm"))
 	right_arm.appearance_flags = KEEP_APART
-	var/image/torso = image(null, O)
-	torso.render_source = O.render_target
+	var/image/torso = image(null, H)
+	torso.render_source = H.render_target
 	torso.filters += filter(type="alpha", icon=icon('icons/mob/humanmasks.dmi', "torso"))
 	torso.appearance_flags = KEEP_APART
-	O.emote_lock = TRUE
-	O.update_canmove()
-	O.dir = SOUTH
-	O.dir_locked = TRUE
+	APPLY_MOB_PROPERTY(H, PROP_CANTMOVE, "dabbify")
+	H.update_canmove()
+	H.dir = SOUTH
+	H.dir_locked = TRUE
 	sleep(0.1) //so the direction setting actually takes place
 	world << torso
 	world << right_arm
@@ -1828,7 +1828,7 @@
 		qdel(right_arm)
 		left_arm.loc = null
 		qdel(left_arm)
-		O.emote_lock = FALSE
-		O.update_canmove()
-		O.dir_locked = FALSE
-		O.render_target = "\ref[O]"
+		REMOVE_MOB_PROPERTY(H, PROP_CANTMOVE, "dabbify")
+		H.update_canmove()
+		H.dir_locked = FALSE
+		H.render_target = "\ref[H]"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This is just used to lock the character in place while dabbing. We have the property now.

Also I renamed `var/mob/living/carbon/human/O` to `var/mob/living/carbon/human/H` for readability at a glance.