### PR TITLE
Add icons for the progress bars for when you put or remove items from someone 

### DIFF
--- a/code/datums/controllers/action_controls.dm
+++ b/code/datums/controllers/action_controls.dm
@@ -442,13 +442,15 @@ var/datum/action_controller/actions
 	var/mob/living/carbon/human/target  //The target of the action
 	var/obj/item/item				    //The item if any. If theres no item, we tried to remove something from that slot instead of putting an item there.
 	var/slot						    //The slot number
+	var/hidden
 
 
-	New(var/Source, var/Target, var/Item, var/Slot, var/ExtraDuration = 0)
+	New(var/Source, var/Target, var/Item, var/Slot, var/ExtraDuration = 0, var/Hidden = 0)
 		source = Source
 		target = Target
 		item = Item
 		slot = Slot
+		hidden = Hidden
 
 		if(item)
 			if(item.duration_put > 0)
@@ -470,7 +472,6 @@ var/datum/action_controller/actions
 		..()
 
 	onStart()
-		..()
 
 		target.add_fingerprint(source) // Added for forensics (Convair880).
 
@@ -492,11 +493,12 @@ var/datum/action_controller/actions
 				interrupt(INTERRUPT_ALWAYS)
 				return
 			logTheThing("combat", source, target, "tries to put \an [item] on %target% at at [log_loc(target)].")
+			icon = item.icon
+			icon_state = item.icon_state
 			for(var/mob/O in AIviewers(owner))
 				O.show_message("<span class='alert'><B>[source] tries to put [item] on [target]!</B></span>", 1)
 		else
 			var/obj/item/I = target.get_slot(slot)
-
 			if(!I)
 				boutput(source, "<span class='alert'>There's nothing in that slot.</span>")
 				interrupt(INTERRUPT_ALWAYS)
@@ -511,11 +513,17 @@ var/datum/action_controller/actions
 				interrupt(INTERRUPT_ALWAYS)
 				return
 			*/
-
 			logTheThing("combat", source, target, "tries to remove \an [I] from %target% at [log_loc(target)].")
+			var/name = "something"
+			if (!hidden)
+				icon = I.icon
+				icon_state = I.icon_state
+				name = I.name
 
 			for(var/mob/O in AIviewers(owner))
-				O.show_message("<span class='alert'><B>[source] tries to remove something from [target]!</B></span>", 1)
+				O.show_message("<span class='alert'><B>[source] tries to remove [name] from [target]!</B></span>", 1)
+
+		..() // we call our parents here because we need to set our icon and icon_state before calling them
 
 	onEnd()
 		..()

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -1568,7 +1568,7 @@
 		else if (href_list["slot"] == "internal")
 			actions.start(new/datum/action/bar/icon/internalsOther(src), usr)
 		else if (href_list["item"])
-			actions.start(new/datum/action/bar/icon/otherItem(usr, src, usr.equipped(), text2num(href_list["slot"])) , usr)
+			actions.start(new/datum/action/bar/icon/otherItem(usr, src, usr.equipped(), text2num(href_list["slot"]), 0, href_list["item"] == "pockets") , usr)
 
 /* ----------------------------------------------------------------------------------------------------------------- */
 

--- a/code/obj/item/clothing/glasses.dm
+++ b/code/obj/item/clothing/glasses.dm
@@ -46,7 +46,7 @@
 			if(target.glasses)
 				boutput(user, "<span class='alert'>[target] is already wearing something on their eyes!</span>")
 				return
-			actions.start(new/datum/action/bar/icon/otherItem(user, target, user.equipped() , target.slot_glasses, 1.3 SECONDS) , user) //Uses extended timer to make up for previously having to manually equip to someone's eyes.
+			actions.start(new/datum/action/bar/icon/otherItem(user, target, user.equipped(), target.slot_glasses, 1.3 SECONDS) , user) //Uses extended timer to make up for previously having to manually equip to someone's eyes.
 			return
 		..() //if not selecting the head of a human or monkey, just do normal attack.
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[ENHANCEMENT]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR adds icons for the progress bars for when you put or remove items from someone. There's one exception for when you try to remove an item from someone's pockets - the icon will just be a normal "grab". You can view a demo [here](https://streamable.com/6qf8al). 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

There was a suggestion thread [here](https://forum.ss13.co/showthread.php?tid=14431), I thought it was a good idea.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Flourish:
(+)When you try to put or remove something from someone, the progress bar will display the item's icon. Removing items from pockets will continue to show up as secret though! 
```
