### PR TITLE
Prevent broken matches from starting fires

### DIFF
--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -675,7 +675,7 @@
 	if (src.material)
 		src.material.triggerTemp(src ,1500)
 	if (src.burn_possible && src.burn_point <= 1500)
-		if ((istype(W, /obj/item/weldingtool) && W:welding) || (istype(W, /obj/item/clothing/head/cakehat) && W:on) || (istype(W, /obj/item/device/igniter)) || (istype(W, /obj/item/device/light/zippo) && W:on) || (istype(W, /obj/item/match) && W:on) || W.burning)
+		if ((istype(W, /obj/item/weldingtool) && W:welding) || (istype(W, /obj/item/clothing/head/cakehat) && W:on) || (istype(W, /obj/item/device/igniter)) || (istype(W, /obj/item/device/light/zippo) && W:on) || (istype(W, /obj/item/match) && (W:on > 0)) || W.burning)
 			src.combust()
 		else
 			..(W, user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][MINOR] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Broken matches have an `on` value of `-1` which causes `(istype(W, /obj/item/match) && W:on)` to return `true`. Will now check for a value greater than zero.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #809 