### PR TITLE
Make Syndicate sponge capsule Space Spider aggressive

### DIFF
--- a/code/obj/critter/spider.dm
+++ b/code/obj/critter/spider.dm
@@ -298,6 +298,9 @@
 			if(spazzing < 0)
 				spazzing = 0
 
+/obj/critter/spider/aggressive
+	aggressive = 1
+
 /obj/critter/spider/baby
 	name = "li'l space spider"
 	desc = "A li'l tiny spider, from space. In space. A space spider."

--- a/code/obj/item/sponge_capsule.dm
+++ b/code/obj/item/sponge_capsule.dm
@@ -27,7 +27,7 @@
 	colors = list("#FF0000", "#7F0000", "#FF6A00", "#FFD800", "#7F3300", "#7F6A00")
 	animals = list(/obj/critter/microman,
 					/obj/critter/bear,
-					/obj/critter/spider,
+					/obj/critter/spider/aggressive,
 					/obj/critter/wendigo,
 					/obj/critter/bat/buff,
 					/obj/critter/spider/ice,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG][BALANCE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a new subtype to spacespider that's aggressive. Alter syndicate sponge capsule to spawn aggressive variant.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
All of the critters in syndicate sponge capsules are aggressive, with the exception of the space spider. Getting a space spider was effectively getting a dud pill


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Sovexe:
(+)Space spiders from syndicate sponge capsules are now aggressive.
```
