### PR TITLE
Improve handling in unarmedblock component

### DIFF
--- a/code/datums/components/itemblock/_unarmedblock.dm
+++ b/code/datums/components/itemblock/_unarmedblock.dm
@@ -8,12 +8,13 @@
 		if((slot in valid_slots) && istype(equipper, mobtype))
 			RegisterSignal(equipper, COMSIG_UNARMED_BLOCK_BEGIN, .proc/on_block_begin, TRUE)
 			RegisterSignal(equipper, COMSIG_UNARMED_BLOCK_END, .proc/on_block_end, TRUE)
+			var/obj/item/grab/block/B
 			if(istype(equipper.l_hand, /obj/item/grab/block))
-				affectedBlock = equipper.l_hand
+				B = equipper.l_hand
 			else if(istype(equipper.r_hand, /obj/item/grab/block))
-				affectedBlock = equipper.r_hand
-			if(affectedBlock)
-				on_block_begin(equipper, affectedBlock)
+				B = equipper.r_hand
+			if(B)
+				on_block_begin(equipper, B)
 		else
 			UnregisterSignal(equipper, COMSIG_UNARMED_BLOCK_BEGIN)
 			UnregisterSignal(equipper, COMSIG_UNARMED_BLOCK_END)
@@ -31,8 +32,7 @@
 /datum/component/wearertargeting/unarmedblock/proc/on_block_begin(var/mob/living/carbon/source, var/obj/item/grab/block/B)
 	if(affectedBlock)
 		on_block_end(source, affectedBlock)
-	else
-		affectedBlock = B
+	affectedBlock = B
 	RegisterSignal(source, signals, proctype, TRUE)
 	SHOULD_CALL_PARENT(1)
 

--- a/code/datums/components/itemblock/_unarmedblock.dm
+++ b/code/datums/components/itemblock/_unarmedblock.dm
@@ -1,5 +1,6 @@
 /datum/component/wearertargeting/unarmedblock
 	mobtype = /mob/living/carbon
+	var/obj/item/grab/block/affectedBlock //we will only be working on one block at a time. This helps us keep track
 
 	on_equip(datum/source, mob/equipper, slot)
 		SHOULD_CALL_PARENT(0)
@@ -7,6 +8,12 @@
 		if((slot in valid_slots) && istype(equipper, mobtype))
 			RegisterSignal(equipper, COMSIG_UNARMED_BLOCK_BEGIN, .proc/on_block_begin, TRUE)
 			RegisterSignal(equipper, COMSIG_UNARMED_BLOCK_END, .proc/on_block_end, TRUE)
+			if(istype(equipper.l_hand, /obj/item/grab/block))
+				affectedBlock = equipper.l_hand
+			else if(istype(equipper.r_hand, /obj/item/grab/block))
+				affectedBlock = equipper.r_hand
+			if(affectedBlock)
+				on_block_begin(equipper, affectedBlock)
 		else
 			UnregisterSignal(equipper, COMSIG_UNARMED_BLOCK_BEGIN)
 			UnregisterSignal(equipper, COMSIG_UNARMED_BLOCK_END)
@@ -16,13 +23,22 @@
 		SHOULD_CALL_PARENT(0)
 		SHOULD_NOT_OVERRIDE(1)
 		UnregisterSignal(user, COMSIG_UNARMED_BLOCK_BEGIN)
+		if(affectedBlock)
+			on_block_end(user, affectedBlock)
 		UnregisterSignal(user, COMSIG_UNARMED_BLOCK_END)
 
 
 /datum/component/wearertargeting/unarmedblock/proc/on_block_begin(var/mob/living/carbon/source, var/obj/item/grab/block/B)
+	if(affectedBlock)
+		on_block_end(source, affectedBlock)
+	else
+		affectedBlock = B
 	RegisterSignal(source, signals, proctype, TRUE)
 	SHOULD_CALL_PARENT(1)
 
+//Must clean up anything you're doing to the block in here - this also gets called when the item is unequipped, so that we unmodify our block
 /datum/component/wearertargeting/unarmedblock/proc/on_block_end(var/mob/living/carbon/source, var/obj/item/grab/block/B)
+	if(affectedBlock)
+		affectedBlock = null
 	UnregisterSignal(source, signals)
 	SHOULD_CALL_PARENT(1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Now handles equipping/unequipping while having a block active. Fairly certain this is now in a point where it can be safely used.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Forgot to handle equipping/unequipping the item while in the middle of a block, this should clean that up