### PR TITLE
disable antag weighting

### DIFF
--- a/code/datums/antag_weighting.dm
+++ b/code/datums/antag_weighting.dm
@@ -7,7 +7,7 @@ var/global/datum/antagWeighter/antagWeighter
 
 /datum/antagWeighter
 	var/debug = 0 //print a shit load of debug messages or not
-	var/variance = 10 //percentage probability *per choice* to ignore weighting for a single antag role (instead picking some random dude)
+	var/variance = 100 //percentage probability *per choice* to ignore weighting for a single antag role (instead picking some random dude)
 	var/minPlayed = 5 //minimum amount of rounds participated in required for the antag weighter to consider a person a valid choice
 
 
@@ -241,7 +241,7 @@ var/global/datum/antagWeighter/antagWeighter
 
 			//Variance triggered, go pick a random player
 			if (historyLookup.len && prob(src.variance))
-				cckey = pick(historyLookup)
+				cckey = pick(ckeyMinds)
 				weight = historyLookup[cckey]["weight"]
 				seen = historyLookup[cckey]["seen"]
 				historyLookup -= cckey

--- a/code/datums/antag_weighting.dm
+++ b/code/datums/antag_weighting.dm
@@ -228,7 +228,7 @@ var/global/datum/antagWeighter/antagWeighter
 		//Set up segmented list for variance
 		var/list/historyLookup = list()
 		if (history.len > amount)
-			historyLookup = history.Copy(amount + 1)
+			historyLookup = history.Copy()
 
 		//Build our final list of chosen people, to the max of "amount"
 		var/cCount = 0
@@ -241,7 +241,7 @@ var/global/datum/antagWeighter/antagWeighter
 
 			//Variance triggered, go pick a random player
 			if (historyLookup.len && prob(src.variance))
-				cckey = pick(ckeyMinds)
+				cckey = pick(historyLookup)
 				weight = historyLookup[cckey]["weight"]
 				seen = historyLookup[cckey]["seen"]
 				historyLookup -= cckey

--- a/code/datums/antag_weighting.dm
+++ b/code/datums/antag_weighting.dm
@@ -227,8 +227,7 @@ var/global/datum/antagWeighter/antagWeighter
 
 		//Set up segmented list for variance
 		var/list/historyLookup = list()
-		if (history.len > amount)
-			historyLookup = history.Copy()
+		historyLookup = history.Copy()
 
 		//Build our final list of chosen people, to the max of "amount"
 		var/cCount = 0


### PR DESCRIPTION
for Reasons, the current system is kinda busted and tends to choose players who have played a lot of cumulative rounds way more frequently than newer players. Disabling it temporarily until we put together a new weight system.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)mbc
(*)Temporarily disabled antag weighting.
```