### PR TITLE
Armory authorization computer

### DIFF
--- a/code/obj/item/clothing/armor.dm
+++ b/code/obj/item/clothing/armor.dm
@@ -314,7 +314,7 @@
 		setProperty("meleeprot", 12)
 		setProperty("rangedprot", 3)
 		setProperty("pierceprot",25)
-		setProperty("disorient_resist", 25)
+		setProperty("disorient_resist", 45)
 		setProperty("movespeed", 2)
 
 /obj/item/clothing/suit/armor/death_commando

--- a/code/obj/machinery/computer/security/riot.dm
+++ b/code/obj/machinery/computer/security/riot.dm
@@ -103,7 +103,7 @@
 			if (user in src.authorized)
 				boutput(user, "You have already authorized! [src.auth_need - src.authorized.len] authorizations from others are still needed.")
 				return
-			if (W:registered in src.authorized)
+			if (W:registered in src.authorized_registered)
 				boutput(user, "This ID has already issued an authorization! [src.auth_need - src.authorized.len] authorizations from others are still needed.")
 				return
 			if (access_maxsec in W:access)

--- a/code/obj/machinery/computer/security/riot.dm
+++ b/code/obj/machinery/computer/security/riot.dm
@@ -1,27 +1,59 @@
 /obj/machinery/computer/riotgear
-	name = "Riot Gear Authorization"
-	icon_state = "drawbr0 "//drawbr-alert
+	name = "Armory Authorization"
+	icon_state = "drawbr0"
 	var/auth_need = 3.0
 	var/list/authorized
-	desc = "A computer that controls the movement of the nearby shuttle."
+	desc = "Use this computer to authorize security access to the Armory. You need an ID with security access to do so."
 
-	lr = 0.6
-	lg = 1
-	lb = 0.1
+	lr = 1
+	lg = 0.3
+	lb = 0.3
 
+	var/authed = 0
+
+	initialize()
+		for (var/obj/machinery/door/airlock/D in doors)
+			if (D.has_access(access_maxsec))
+				D.no_access = 1
+		..()
+
+
+	proc/authorize()
+		command_announcement("<br><b><span class='alert'>Armory weapons access has been authorized for all security personnel.</span></b>", "Security Level Increased", "sound/misc/announcement_1.ogg")
+		authed = 1
+		icon_state = "drawbr-alert"
+		for (var/obj/machinery/door/airlock/D in doors)
+			if (D.has_access(access_maxsec))
+				D.req_access = list(access_security)
+				D.no_access = 0
+			LAGCHECK(LAG_REALTIME)
+
+
+	proc/print_auth_needed()
+		for (var/mob/O in hearers(src, null))
+			O.show_message("<span class='subtle'><span class='game say'><span class='name'>[src]</span> beeps, \"[src.auth_need - src.authorized.len] authorizations needed until shuttle is launched early.\"</span></span>", 2)
+
+
+/obj/machinery/computer/riotgear/attack_hand(mob/user as mob)
+	if (ishuman(user))
+		return src.attackby(user:wear_id, user)
+	..()
 
 //kinda copy paste from shuttle auth :)
-/obj/machinery/computer/shuttle/attackby(var/obj/item/W as obj, var/mob/user as mob)
+/obj/machinery/computer/riotgear/attackby(var/obj/item/W as obj, var/mob/user as mob)
+	interact_particle(user,src)
 	if(status & (BROKEN|NOPOWER))
 		return ..()
 	if (!user)
 		return ..()
+	if(authed)
+		boutput(user, "Armory has already been authorized!")
+		return
+
 	if (istype(W, /obj/item/device/pda2) && W:ID_card)
 		W = W:ID_card
 	if (!istype(W, /obj/item/card))
 		return ..()
-
-
 
 	if (!W:access) //no access
 		boutput(user, "The access level of [W:registered]\'s card is not high enough. ")
@@ -32,32 +64,34 @@
 		boutput(user, "The access level of [W:registered]\'s card is not high enough. ")
 		return
 
-	if(!(access_sec in W:access)) //doesn't have this access
+	if(!(access_security in W:access)) //doesn't have this access
 		boutput(user, "The access level of [W:registered]\'s card is not high enough. ")
 		return 0
 
-	if(src.authorized && src.authorized.len >= src.auth_need)
-		boutput(user, "Riot gear has already been opened!")
-		return
+	if (!src.authorized)
+		src.authorized = list()
+
 
 	var/choice = alert(user, text("Would you like to (un)authorize access to riot gear? [] authorization\s are still needed.", src.auth_need - src.authorized.len), "Authorize", "Repeal")
 	if(get_dist(user, src) > 1) return
 	switch(choice)
 		if("Authorize")
-			if (!src.authorized)
-				src.authorized = list()
 			if (!W:registered)
 				boutput(user, "ERROR : ID is not registered in any crewmember's name!")
 			if (W:registered in src.authorized)
 				boutput(user, "You have already authorized! [] authorization\s from others are still needed.")
 
 			src.authorized += W:registered
+			if (access_maxsec in W:access)
+				authorize()
+				src.authorized = null
+
 			if (src.authorized.len < auth_need)
-				boutput(world, text("<span class='notice'><B>Alert: [] authorizations needed until shuttle is launched early</B></span>", src.auth_need - src.authorized.len))
+				print_auth_needed()
 			else
-				boutput(world, "<span class='notice'><B>Alert: Shuttle launch time shortened to 60 seconds!</B></span>")
+				authorize()
 				src.authorized = null
 
 		if("Repeal")
 			src.authorized -= W:registered
-			boutput(world, text("<span class='notice'><B>Alert: [] authorizations needed until shuttle is launched early</B></span>", src.auth_need - src.authorized.len))
+			print_auth_needed()

--- a/code/obj/machinery/computer/security/riot.dm
+++ b/code/obj/machinery/computer/security/riot.dm
@@ -10,8 +10,13 @@
 	lb = 0.3
 
 	var/authed = 0
+	var/area/armory_area
 
 	initialize()
+		armory_area = get_area_by_type(/area/station/ai_monitored/armory)
+		if (!armory_area || armory_area.contents.len <= 1)
+			armory_area = get_area_by_type(/area/station/security/armory)
+
 		for (var/obj/machinery/door/airlock/D in doors)
 			if (D.has_access(access_maxsec))
 				D.no_access = 1
@@ -22,16 +27,30 @@
 		command_announcement("<br><b><span class='alert'>Armory weapons access has been authorized for all security personnel.</span></b>", "Security Level Increased", "sound/misc/announcement_1.ogg")
 		authed = 1
 		icon_state = "drawbr-alert"
+
 		for (var/obj/machinery/door/airlock/D in doors)
 			if (D.has_access(access_maxsec))
 				D.req_access = list(access_security)
 				D.no_access = 0
 			LAGCHECK(LAG_REALTIME)
 
+		if (armory_area)
+			for(var/obj/O in armory_area)
+				if (istype(O,/obj/storage/secure/crate))
+					O.req_access = list(access_security)
+				else if (istype(O,/obj/machinery/vending))
+					O.req_access = list(access_security)
 
-	proc/print_auth_needed()
-		for (var/mob/O in hearers(src, null))
-			O.show_message("<span class='subtle'><span class='game say'><span class='name'>[src]</span> beeps, \"[src.auth_need - src.authorized.len] authorizations needed until shuttle is launched early.\"</span></span>", 2)
+				LAGCHECK(LAG_REALTIME)
+
+
+	proc/print_auth_needed(var/mob/author)
+		if (author)
+			for (var/mob/O in hearers(src, null))
+				O.show_message("<span class='subtle'><span class='game say'><span class='name'>[src]</span> beeps, \"[author] request accepted. [src.auth_need - src.authorized.len] authorizations needed until shuttle is launched early.\"</span></span>", 2)
+		else
+			for (var/mob/O in hearers(src, null))
+				O.show_message("<span class='subtle'><span class='game say'><span class='name'>[src]</span> beeps, \"[src.auth_need - src.authorized.len] authorizations needed until shuttle is launched early.\"</span></span>", 2)
 
 
 /obj/machinery/computer/riotgear/attack_hand(mob/user as mob)
@@ -53,45 +72,45 @@
 	if (istype(W, /obj/item/device/pda2) && W:ID_card)
 		W = W:ID_card
 	if (!istype(W, /obj/item/card))
+		boutput(user, "No ID given.")
 		return ..()
 
 	if (!W:access) //no access
-		boutput(user, "The access level of [W:registered]\'s card is not high enough. ")
+		boutput(user, "The access level of [W] is not high enough.")
 		return
 
 	var/list/cardaccess = W:access
 	if(!istype(cardaccess, /list) || !cardaccess.len) //no access
-		boutput(user, "The access level of [W:registered]\'s card is not high enough. ")
+		boutput(user, "The access level of [W] is not high enough.")
 		return
 
 	if(!(access_security in W:access)) //doesn't have this access
-		boutput(user, "The access level of [W:registered]\'s card is not high enough. ")
-		return 0
+		boutput(user, "The access level of [W] is not high enough.")
+		return
 
 	if (!src.authorized)
 		src.authorized = list()
 
-
-	var/choice = alert(user, text("Would you like to (un)authorize access to riot gear? [] authorization\s are still needed.", src.auth_need - src.authorized.len), "Authorize", "Repeal")
+	var/choice = alert(user, text("Would you like to (un)authorize access to riot gear? [] authorization\s are still needed.", src.auth_need - src.authorized.len), "Armory Auth", "Authorize", "Repeal")
 	if(get_dist(user, src) > 1) return
 	switch(choice)
 		if("Authorize")
-			if (!W:registered)
-				boutput(user, "ERROR : ID is not registered in any crewmember's name!")
-			if (W:registered in src.authorized)
-				boutput(user, "You have already authorized! [] authorization\s from others are still needed.")
-
-			src.authorized += W:registered
+			if (user in src.authorized)
+				boutput(user, "You have already authorized! [src.auth_need - src.authorized.len] authorizations from others are still needed.")
+				return
 			if (access_maxsec in W:access)
 				authorize()
 				src.authorized = null
+				return
+
+			src.authorized += user //authorize by USER, not by registered ID. prevent the captain from printing out 3 unique ID cards and getting in by themselves.
 
 			if (src.authorized.len < auth_need)
-				print_auth_needed()
+				print_auth_needed(user)
 			else
 				authorize()
 				src.authorized = null
 
 		if("Repeal")
-			src.authorized -= W:registered
-			print_auth_needed()
+			src.authorized -= user
+			print_auth_needed(user)

--- a/code/obj/machinery/computer/security/riot.dm
+++ b/code/obj/machinery/computer/security/riot.dm
@@ -110,14 +110,28 @@
 				authorize()
 				return
 
-			src.authorized += user //authorize by USER, not by registered ID. prevent the captain from printing out 3 unique ID cards and getting in by themselves.
+			if (ishuman(user))
+				var/mob/living/carbon/human/H = user
+				if (H.bioHolder.Uid in src.authorized)
+					boutput(user, "You have already authorized - fingerprints on file! [src.auth_need - src.authorized.len] authorizations from others are still needed.")
+					return
+				src.authorized += H.bioHolder.Uid
+			else
+				src.authorized += user //authorize by USER, not by registered ID. prevent the captain from printing out 3 unique ID cards and getting in by themselves.
 			src.authorized_registered += W:registered
+
 			if (src.authorized.len < auth_need)
 				print_auth_needed(user)
 			else
 				authorize()
 
 		if("Repeal")
-			src.authorized -= user
+
+			if (ishuman(user))
+				var/mob/living/carbon/human/H = user
+				src.authorized -= H.bioHolder.Uid
+			else
+				src.authorized -= user
 			src.authorized_registered -= W:registered
+
 			print_auth_needed(user)

--- a/code/obj/machinery/computer/security/riot.dm
+++ b/code/obj/machinery/computer/security/riot.dm
@@ -1,0 +1,63 @@
+/obj/machinery/computer/riotgear
+	name = "Riot Gear Authorization"
+	icon_state = "drawbr0 "//drawbr-alert
+	var/auth_need = 3.0
+	var/list/authorized
+	desc = "A computer that controls the movement of the nearby shuttle."
+
+	lr = 0.6
+	lg = 1
+	lb = 0.1
+
+
+//kinda copy paste from shuttle auth :)
+/obj/machinery/computer/shuttle/attackby(var/obj/item/W as obj, var/mob/user as mob)
+	if(status & (BROKEN|NOPOWER))
+		return ..()
+	if (!user)
+		return ..()
+	if (istype(W, /obj/item/device/pda2) && W:ID_card)
+		W = W:ID_card
+	if (!istype(W, /obj/item/card))
+		return ..()
+
+
+
+	if (!W:access) //no access
+		boutput(user, "The access level of [W:registered]\'s card is not high enough. ")
+		return
+
+	var/list/cardaccess = W:access
+	if(!istype(cardaccess, /list) || !cardaccess.len) //no access
+		boutput(user, "The access level of [W:registered]\'s card is not high enough. ")
+		return
+
+	if(!(access_sec in W:access)) //doesn't have this access
+		boutput(user, "The access level of [W:registered]\'s card is not high enough. ")
+		return 0
+
+	if(src.authorized && src.authorized.len >= src.auth_need)
+		boutput(user, "Riot gear has already been opened!")
+		return
+
+	var/choice = alert(user, text("Would you like to (un)authorize access to riot gear? [] authorization\s are still needed.", src.auth_need - src.authorized.len), "Authorize", "Repeal")
+	if(get_dist(user, src) > 1) return
+	switch(choice)
+		if("Authorize")
+			if (!src.authorized)
+				src.authorized = list()
+			if (!W:registered)
+				boutput(user, "ERROR : ID is not registered in any crewmember's name!")
+			if (W:registered in src.authorized)
+				boutput(user, "You have already authorized! [] authorization\s from others are still needed.")
+
+			src.authorized += W:registered
+			if (src.authorized.len < auth_need)
+				boutput(world, text("<span class='notice'><B>Alert: [] authorizations needed until shuttle is launched early</B></span>", src.auth_need - src.authorized.len))
+			else
+				boutput(world, "<span class='notice'><B>Alert: Shuttle launch time shortened to 60 seconds!</B></span>")
+				src.authorized = null
+
+		if("Repeal")
+			src.authorized -= W:registered
+			boutput(world, text("<span class='notice'><B>Alert: [] authorizations needed until shuttle is launched early</B></span>", src.auth_need - src.authorized.len))

--- a/code/obj/machinery/computer/security/riot.dm
+++ b/code/obj/machinery/computer/security/riot.dm
@@ -17,7 +17,7 @@
 		if (!armory_area || armory_area.contents.len <= 1)
 			armory_area = get_area_by_type(/area/station/security/armory)
 
-		for (var/obj/machinery/door/airlock/D in doors)
+		for (var/obj/machinery/door/airlock/D in armory_area)
 			if (D.has_access(access_maxsec))
 				D.no_access = 1
 		..()
@@ -28,7 +28,7 @@
 		authed = 1
 		icon_state = "drawbr-alert"
 
-		for (var/obj/machinery/door/airlock/D in doors)
+		for (var/obj/machinery/door/airlock/D in armory_area)
 			if (D.has_access(access_maxsec))
 				D.req_access = list(access_security)
 				D.no_access = 0

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -100,6 +100,8 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	var/HTML = null
 	var/has_panel = 1
 
+	var/no_access = 0
+
 	autoclose = 1
 	power_usage = 50
 	operation_time = 6
@@ -115,6 +117,12 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	disposing()
 		. = ..()
 		STOP_TRACKING
+
+
+/obj/machinery/door/airlock/check_access(obj/item/I)
+	if (no_access) //we are weldmagged or some shit... skip the rest of the ID checks, its not gonna open.
+		return 0							//and look i know this appears to be the same as isblocked... DO NOT call isblocked. it is inherited by children and will kill access
+	.= ..()
 
 /obj/machinery/door/airlock/command
 	icon = 'icons/obj/doors/Doorcom.dmi'

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -120,8 +120,8 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 
 
 /obj/machinery/door/airlock/check_access(obj/item/I)
-	if (no_access) //we are weldmagged or some shit... skip the rest of the ID checks, its not gonna open.
-		return 0							//and look i know this appears to be the same as isblocked... DO NOT call isblocked. it is inherited by children and will kill access
+	if (no_access) //nope :)
+		return 0
 	.= ..()
 
 /obj/machinery/door/airlock/command

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -153,6 +153,31 @@
 			return 1
 	return 0
 
+//put in access num, check if i have that
+/obj/proc/has_access(var/acc)
+	// no requirements
+	if (!src.req_access)
+		return 1
+	// something's very wrong
+	if (!istype(src.req_access, /list))
+		return 1
+	// no requirements (also clean up src.req_access)
+	if (src.req_access.len == 0)
+		src.req_access = null
+		return 1
+
+	for (var/req_access_group in src.req_access)
+		// access group is a list
+		if (islist(req_access_group))
+			var/list/req_access_group_list = req_access_group
+			if (acc in req_access_group_list)
+				return 1
+		// access group is a single number
+		else if (req_access_group == acc)
+			return 1
+
+	return 0
+
 /**
  * @param {mob} M Mob of which to check the implanted credentials
  * @return {bool} Whether mob has sufficient access via its implant

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -1395,6 +1395,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\obj\machinery\computer\stock_market.dm"
 #include "code\obj\machinery\computer\teleporter.dm"
 #include "code\obj\machinery\computer\workstation.dm"
+#include "code\obj\machinery\computer\security\riot.dm"
 #include "code\obj\machinery\computer\security\sec_camera_move.dm"
 #include "code\obj\machinery\computer\security\security_cameras_chui.dm"
 #include "code\obj\machinery\computer\tetris\tetris.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This allows members of security to vote together to open up the Armory.
3 votes are required from unique crewmembers (no gaming the system with multiple IDs) to open Armory access. A single HoS vote can open things up as well.
This isn't actually added to any maps yet - i will do that after merging
