### PR TITLE
UM-010 - Give Suppressed 22 Box More HP Ammo, less Normal Ammo

### DIFF
--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -631,8 +631,8 @@
 	muzzle_flash = 0 //stealthy gun
 
 	New()
-		ammo = new/obj/item/ammo/bullets/bullet_22
-		current_projectile = new/datum/projectile/bullet/bullet_22
+		ammo = new/obj/item/ammo/bullets/bullet_22HP
+		current_projectile = new/datum/projectile/bullet/bullet_22/HP
 		..()
 
 	update_icon()

--- a/code/obj/item/storage/weapon_security.dm
+++ b/code/obj/item/storage/weapon_security.dm
@@ -69,8 +69,7 @@
 	desc = "A box containing a sneaky pistol and some ammo."
 	// this might be a terrible idea giving them so much ammo, but whatevs
 	spawn_contents = list(/obj/item/gun/kinetic/silenced_22,\
-	/obj/item/ammo/bullets/bullet_22 = 2,\
-	/obj/item/ammo/bullets/bullet_22HP = 2)
+	/obj/item/ammo/bullets/bullet_22HP = 6)
 
 /obj/item/storage/box/derringer
 	name = "derringer box"

--- a/code/obj/item/storage/weapon_security.dm
+++ b/code/obj/item/storage/weapon_security.dm
@@ -69,7 +69,7 @@
 	desc = "A box containing a sneaky pistol and some ammo."
 	// this might be a terrible idea giving them so much ammo, but whatevs
 	spawn_contents = list(/obj/item/gun/kinetic/silenced_22,\
-	/obj/item/ammo/bullets/bullet_22HP = 6)
+	/obj/item/ammo/bullets/bullet_22HP = 3)
 
 /obj/item/storage/box/derringer
 	name = "derringer box"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

1) Gives the Suppressed 22 Pistol Box More Bullet

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

1) More Bullet More Better

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)UrsulaMajor:
(+)Suppressed .22 Traitor Item now starts with all Hollow Point ammo
```
