### PR TITLE
Responsive health updates

### DIFF
--- a/code/mob/living/carbon.dm
+++ b/code/mob/living/carbon.dm
@@ -560,7 +560,7 @@
 
 /mob/living/carbon/take_toxin_damage(var/amount)
 	if (..())
-		return
+		return 1
 #if ASS_JAM //pausing damage for timestop
 	if(paused)
 		src.pausedtox = max(0,src.pausedtox + amount)
@@ -578,7 +578,7 @@
 
 /mob/living/carbon/take_oxygen_deprivation(var/amount)
 	if (..())
-		return
+		return 1
 
 	if (src.bioHolder && src.bioHolder.HasEffect("breathless"))
 		src.oxyloss = 0

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -45,6 +45,8 @@
 	var/image/l_leg_damage_standing = null
 	var/image/r_leg_damage_standing = null
 
+	var/updatingHealthDelay = 0
+
 	var/image/image_eyes = null
 	var/image/image_cust_one = null
 	var/image/image_cust_two = null

--- a/code/mob/living/carbon/human/procs/Life.dm
+++ b/code/mob/living/carbon/human/procs/Life.dm
@@ -1602,7 +1602,7 @@
 
 	proc/handle_regular_status_updates(datum/controller/process/mobs/parent,var/mult = 1)
 
-		health = max_health - (get_oxygen_deprivation() + get_toxin_damage() + get_burn_damage() + get_brute_damage())
+		updatehealth()
 		var/death_health = src.health + (src.get_oxygen_deprivation() * 0.5) - (get_burn_damage() * 0.67) - (get_brute_damage() * 0.67) //lower weight of oxy, increase weight of brute/burn here
 		// I don't think the revenant needs any of this crap - Marq
 		if (src.bioHolder && src.bioHolder.HasEffect("revenant") || isdead(src)) //You also don't need to do a whole lot of this if the dude's dead.

--- a/code/mob/living/carbon/human/procs/damage.dm
+++ b/code/mob/living/carbon/human/procs/damage.dm
@@ -555,7 +555,7 @@
 	//Bandaid fix for tox damage being mysteriously unhooked in here.
 	if (tox)
 		tox = max(0, tox)
-		take_toxin_damage(tox)
+		take_toxin_damage(tox, updatedamage = 0)
 
 	if (zone == "All")
 		var/organCount = 0
@@ -850,7 +850,7 @@
 			themob.TakeDamage(pick(zones), 0, damage, 0, DAMAGE_BURN)
 
 //ignore_organs if true. Needed for when non-functioning/missing kidney/liver genetates tox damage
-/mob/living/carbon/human/take_toxin_damage(var/amount, var/ignore_organs = 0)
+/mob/living/carbon/human/take_toxin_damage(var/amount, var/ignore_organs = 0, var/updatedamage = 1)
 	if (..())
 		return
 	if (!ignore_organs)
@@ -861,7 +861,15 @@
 				src.organHolder.damage_organ(0, 0, amount/5, "right_kidney")
 			if (prob(30))
 				src.organHolder.damage_organ(0, 0, amount/12, "liver")
+	if(updatedamage)
+		src.UpdateDamage()
 	return
+
+/mob/living/carbon/human/take_oxygen_deprivation(var/amount, var/updatedamage = 1)
+	if(..())
+		return
+	if(updatedamage)
+		src.UpdateDamage()
 
 /mob/living/carbon/human/take_brain_damage(var/amount)
 	if (!isnum(amount) || amount == 0)
@@ -888,3 +896,12 @@
 		return src.organHolder.brain.get_damage()
 	//leaving this just in case, should never be called I assume
 	..()
+
+/mob/living/carbon/human/UpdateDamage()
+	if(updatingHealthDelay)
+		return
+	else
+		updatingHealthDelay = 1
+		SPAWN_DBG(1 DECI SECONDS)
+			src.updatehealth()
+			updatingHealthDelay = 0

--- a/code/mob/living/carbon/human/procs/update_icon.dm
+++ b/code/mob/living/carbon/human/procs/update_icon.dm
@@ -1233,10 +1233,9 @@ var/list/update_body_limbs = list("r_arm" = "stump_arm_right", "l_arm" = "stump_
 	else
 		src.maptext = ""
 #else
-/mob/living/carbon/human/tdummy/UpdateDamage()
-	..()
+/mob/living/carbon/human/tdummy/updatehealth()
 	var/prev = health
-	src.updatehealth()
+	..()
 	if (!isdead(src))
 		var/h_color = "#999999"
 		var/h_pct = round((health / (max_health != 0 ? max_health : 1)) * 100)
@@ -1252,12 +1251,6 @@ var/list/update_body_limbs = list("r_arm" = "stump_arm_right", "l_arm" = "stump_
 			new /obj/maptext_junk/damage(get_turf(src), change = health - prev)
 	else
 		src.maptext = ""
-
-/mob/living/carbon/human/tdummy/Life(datum/controller/process/mobs/parent)
-	if (..(parent))
-		return 1
-	src.UpdateDamage()
-
 #endif
 
 /mob/living/carbon/human/UpdateDamageIcon()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[WIP]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Automatically queues up a health update after taking damage
Currently using a spawn and a flag to 'batch' these into a single update/tick at most (so that if someone gets hit 100 times at once, it only updates their health once, instead of 100 times)

TODO: 
- clean up a bunch of no-longer-needed updatehealth() calls
- fix up assjam health maptext
- Optimise?

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Having the effects of taking damage be felt (almost) instantly instead of sometimes waiting until the next life tick feels, well, a lot more intuitive and is something people have been asking for

