### PR TITLE
Actually Fixes the Light Descriptions 

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -521,13 +521,13 @@
 
 	switch(light_status)
 		if(LIGHT_OK)
-			. += "[desc] It is turned [on? "on" : "off"]."
+			. += "It is turned [on? "on" : "off"]."
 		if(LIGHT_EMPTY)
-			. += "[desc] The [fitting] has been removed."
+			. += "The [fitting] has been removed."
 		if(LIGHT_BURNED)
-			. += "[desc] The [fitting] is burnt out."
+			. += "The [fitting] is burnt out."
 		if(LIGHT_BROKEN)
-			. += "[desc] The [fitting] has been smashed."
+			. += "The [fitting] has been smashed."
 
 
 


### PR DESCRIPTION
[FIX]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Closes #658 
For real this time. `desc` was being referenced again in `light_status` when it shouldn't have been.