### PR TITLE
Remove duplicate disposing() calls

### DIFF
--- a/code/obj/machinery/porters.dm
+++ b/code/obj/machinery/porters.dm
@@ -318,11 +318,6 @@ var/global/list/portable_machinery = list() // stop looping through world for th
 		src.homeloc = src.loc
 
 	disposing()
-		..()
-		if (islist(portable_machinery))
-			portable_machinery.Remove(src)
-
-	disposing()
 		if (islist(portable_machinery))
 			portable_machinery.Remove(src)
 		..()
@@ -682,11 +677,6 @@ var/global/list/portable_machinery = list() // stop looping through world for th
 						- list(/obj/critter/spider/ice/queen)
 
 	disposing()
-		..()
-		if (islist(portable_machinery))
-			portable_machinery.Remove(src)
-
-	disposing()
 		if (islist(portable_machinery))
 			portable_machinery.Remove(src)
 		..()
@@ -871,11 +861,6 @@ var/global/list/portable_machinery = list() // stop looping through world for th
 
 		//Hidden
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/emergency_injector/random, rand(1, 3), hidden=1)
-
-	disposing()
-		..()
-		if (islist(portable_machinery))
-			portable_machinery.Remove(src)
 
 	disposing()
 		if (islist(portable_machinery))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][CLEANLINESS] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes duplicate disposing() calls from the port-a-X remotes


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
When I asked why these objects had two disposing() calls, one calling the parent first, and one after, I was met with a messages that could be best summarized as"oh god why"

Per discussion with Pali and Naksu removing the ones that call parents first.