### PR TITLE
fix infinite speed regen with athlete trait

### DIFF
--- a/code/modules/antagonists/changeling/abilities/regeneration.dm
+++ b/code/modules/antagonists/changeling/abilities/regeneration.dm
@@ -173,7 +173,7 @@
 			return 1
 		boutput(holder.owner, __blue("Your skin begins reforming around your skeleton."))
 
-		while(C.health < 100 || !C.limbs.l_arm || !C.limbs.r_arm || !C.limbs.l_leg || !C.limbs.r_leg)
+		while(C.health < C.max_health || !C.limbs.l_arm || !C.limbs.r_arm || !C.limbs.l_leg || !C.limbs.r_leg)
 			if(isdead(C))
 				break
 			sleep(3 SECONDS)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
speed regen would run infinitely with athlete b/c - changed to check health<max_health instead of health<100


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
infinite speed regen bad

