### PR TITLE
fix random_brute_damage always respecting armor

### DIFF
--- a/code/mob/living/carbon/human/procs/damage.dm
+++ b/code/mob/living/carbon/human/procs/damage.dm
@@ -828,14 +828,24 @@
 	if (!themob || !ismob(themob))
 		return //???
 	var/list/zones = themob.get_valid_target_zones()
-	if (!zones || !zones.len)
-		themob.TakeDamageAccountArmor("All", damage, 0, 0, DAMAGE_BLUNT)
-	else
-		if (prob(100 / zones.len + 1))
+	if(checkarmor)
+		if (!zones || !zones.len)
 			themob.TakeDamageAccountArmor("All", damage, 0, 0, DAMAGE_BLUNT)
 		else
-			var/zone=pick(zones)
-			themob.TakeDamageAccountArmor(zone, damage, 0, 0, DAMAGE_BLUNT)
+			if (prob(100 / zones.len + 1))
+				themob.TakeDamageAccountArmor("All", damage, 0, 0, DAMAGE_BLUNT)
+			else
+				var/zone=pick(zones)
+				themob.TakeDamageAccountArmor(zone, damage, 0, 0, DAMAGE_BLUNT)
+	else
+		if (!zones || !zones.len)
+			themob.TakeDamage("All", damage, 0, 0, DAMAGE_BLUNT)
+		else
+			if (prob(100 / zones.len + 1))
+				themob.TakeDamage("All", damage, 0, 0, DAMAGE_BLUNT)
+			else
+				var/zone=pick(zones)
+				themob.TakeDamage(zone, damage, 0, 0, DAMAGE_BLUNT)
 
 /proc/random_burn_damage(var/mob/themob, var/damage) // do burn damage to a random organ
 	if (!themob || !ismob(themob))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I was maybe too drunk coding this initially, and forgot to actually handle armor in here properly, so every call of `random_brute_damage()` was getting funneled through `TakeDamageAccountArmor()`, which was not the intent


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Some things shouldn't be respecting armor that are. What exactly that is I could no longer say, so this maybe isn't even needed at all?

