### PR TITLE
fix attack stamina usage

### DIFF
--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -719,6 +719,9 @@
 
 		msgs.base_attack_message = "<span class='alert'><B>[src] [src.punchMessage] [target][msgs.stamina_crit ? " and lands a devastating hit!" : "!"]</B></span>"
 
+		if (!src.traitHolder?.hasTrait("glasscannon"))
+			msgs.stamina_self += STAMINA_HTH_COST
+
 	var/attack_resistance = target.check_attack_resistance()
 	if (attack_resistance)
 		damage = 0
@@ -965,10 +968,6 @@
 						step_away(target, owner, 1)
 			else
 				target.deliver_move_trigger("bump")
-
-		else
-			if (owner.traitHolder && !owner.traitHolder.hasTrait("glasscannon"))
-				owner.process_stamina(STAMINA_HTH_COST)
 
 #ifdef DATALOGGER
 			game_stats.Increment("violence")


### PR DESCRIPTION
this fixes a bug where the hand-to-hand melee attack cost was being added to the cost of all item attacks. This meant every item cost 20 more stamina to swing than was intended

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)mbc:
(*)Fixed a bug where the hand-to-hand melee attack cost was being added to the cost of all item attacks. This meant every item cost 20 more stamina to swing than was intended
```
