### PR TITLE
Fix hand tele portal location weirdness

### DIFF
--- a/code/obj/item/teleportation.dm
+++ b/code/obj/item/teleportation.dm
@@ -245,6 +245,11 @@ Frequency:
 			user.show_text("Error: invalid coordinates detected, please try again.", "red")
 			return
 
+		our_loc = get_turf(src)
+		if (our_loc && isrestrictedz(our_loc.z))
+			user.show_text("The [src.name] does not seem to work here!", "red")
+			return
+
 		var/obj/portal/P = unpool(/obj/portal)
 		P.set_loc(our_loc)
 		portals += P


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes a bug I accidentally introduced where hand teles would spawn their portal at their activation location rather than the user's current location if they moved while they had the menu open. The fix should also prevent possible weirdness where the user activates the hand tele in a valid location and moves to an invalid one before they pick their teleporter.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

It's a weird and possibly abusable bug.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Dabir
(+)Fixed a bug where when you moved after activating a hand tele but before picking your teleporter, the hand tele's portal would incorrectly appear on the spot it was first activated.
```
