### PR TITLE
Add a Return Credits button to oxygen vendors

### DIFF
--- a/code/obj/machinery/air_vendor.dm
+++ b/code/obj/machinery/air_vendor.dm
@@ -109,7 +109,7 @@ obj/machinery/air_vendor
 		src.add_dialog(user)
 		var/html = ""
 		html += "<TT><b>Welcome!</b><br>"
-		html += "<b>Current balance: [src.credits] credits</b> <a href='byond://?src=\ref[src];return_credits=1'>Return Credits</A><br>"
+		html += "<b>Current balance: <a href='byond://?src=\ref[src];return_credits=1'>[src.credits] credits</a></b><br>"
 		if (src.scan)
 			var/datum/data/record/account = null
 			account = FindBankAccountByName(src.scan.registered)

--- a/code/obj/machinery/air_vendor.dm
+++ b/code/obj/machinery/air_vendor.dm
@@ -109,7 +109,7 @@ obj/machinery/air_vendor
 		src.add_dialog(user)
 		var/html = ""
 		html += "<TT><b>Welcome!</b><br>"
-		html += "<b>Current balance: [src.credits] credits</b><br>"
+		html += "<b>Current balance: [src.credits] credits</b> <a href='byond://?src=\ref[src];return_credits=1'>Return Credits</A><br>"
 		if (src.scan)
 			var/datum/data/record/account = null
 			account = FindBankAccountByName(src.scan.registered)
@@ -172,6 +172,16 @@ obj/machinery/air_vendor
 					boutput(usr, "<span class='alert'>Insufficient funds.</span>")
 				else
 					boutput(usr, "<span class='alert'>There is no tank to fill up!</span>")
+
+			if (href_list["return_credits"])
+				if (src.credits > 0)
+					var/obj/item/spacecash/returned = unpool(/obj/item/spacecash)
+					returned.setup(src.loc, src.credits)
+
+					usr.put_in_hand_or_eject(returned)
+					src.credits = 0
+					boutput(usr, "<span class='notice'>You receive [returned].</span>")
+
 			src.updateUsrDialog()
 			src.add_fingerprint(usr)
 			update_icon()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add's a return credits button to oxygen vending machines

![image](https://user-images.githubusercontent.com/33204415/83218535-17586480-a13c-11ea-89e4-8d9ae006054e.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
So I can get my change back