### PR TITLE
Lets traitor scientists and the barman buy the syringe gun

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -618,7 +618,7 @@ This is basically useless for anyone but miners.
 	item = /obj/item/gun/reagent/syringe
 	cost = 3
 	desc = "This stainless-steel, revolving wonder fires needles. Perfect for today's safari-loving Syndicate doctor! Loaded by transferring reagents to the gun's internal reservoir."
-	job = list("Medical Doctor","Medical Director", "Research Director")
+	job = list("Medical Doctor","Medical Director", "Research Director","Scientist","Barman")
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 
 /datum/syndicate_buylist/traitor/powergloves

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -618,7 +618,7 @@ This is basically useless for anyone but miners.
 	item = /obj/item/gun/reagent/syringe
 	cost = 3
 	desc = "This stainless-steel, revolving wonder fires needles. Perfect for today's safari-loving Syndicate doctor! Loaded by transferring reagents to the gun's internal reservoir."
-	job = list("Medical Doctor","Medical Director", "Research Director","Scientist","Barman")
+	job = list("Medical Doctor", "Medical Director", "Research Director", "Scientist", "Barman")
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 
 /datum/syndicate_buylist/traitor/powergloves


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Let's scientists and the barman buy the syringe gun in the traitor uplink, in addition to the jobs that can already buy it. (RD, MD, medical doctor) wow

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I see the syringe gun as a more interesting sorta sleepypen, I think it'd be fun if scientists could buy them as a more interesting means to administer their evil chemicals and if the barman could buy it to dispense booze or moonshine or what-have-you from a range. Good item, these two jobs should reasonably have it imo

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Flaborized:
(+)Traitor barmen and scientists can now buy the syringe gun
```
