### PR TITLE
HoS can walk in/out of armory without authorizing it for security

### DIFF
--- a/code/obj/machinery/computer/security/riot.dm
+++ b/code/obj/machinery/computer/security/riot.dm
@@ -19,9 +19,10 @@
 		if (!armory_area || armory_area.contents.len <= 1)
 			armory_area = get_area_by_type(/area/station/security/armory)
 
-		for (var/obj/machinery/door/airlock/D in armory_area)
+		/*for (var/obj/machinery/door/airlock/D in armory_area)
 			if (D.has_access(access_maxsec))
 				D.no_access = 1
+		*/
 		..()
 
 
@@ -36,7 +37,7 @@
 		for (var/obj/machinery/door/airlock/D in armory_area)
 			if (D.has_access(access_maxsec))
 				D.req_access = list(access_security)
-				D.no_access = 0
+				//D.no_access = 0
 			LAGCHECK(LAG_REALTIME)
 
 		if (armory_area)


### PR DESCRIPTION


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)mbc:
(*)The HoS can now walk in/out of the armory without using the auth computer.
```
