### PR TITLE
Fix Glass Ceiling medal and crew objective from being erroneously awarded / succeeded

### DIFF
--- a/code/datums/crew_objective.dm
+++ b/code/datums/crew_objective.dm
@@ -629,7 +629,7 @@ ABSTRACT_TYPE(/datum/objective/crew/staffassistant)
 		check_completion()
 			if(owner.current && !isdead(owner.current) && ishuman(owner.current))
 				var/mob/living/carbon/human/H = owner.current
-				if(istype(get_area(H),map_settings.escape_centcom) && H.wear_id && H.wear_id:registered == H.real_name && H.wear_id:assignment != ("Technical Assistant" || "Staff Assistant" || "Medical Assistant")) return 1
+				if(istype(get_area(H),map_settings.escape_centcom) && H.wear_id && H.wear_id:registered == H.real_name && !(H.wear_id:assignment in list("Technical Assistant","Staff Assistant","Medical Assistant"))) return 1
 				else return 0
 	clown
 		explanation_text = "Escape on the shuttle alive wearing at least one piece of clown clothing."
@@ -706,7 +706,7 @@ ABSTRACT_TYPE(/datum/objective/crew/technicalassistant)
 		check_completion()
 			if(owner.current && !isdead(owner.current) && istype(get_area(owner.current),map_settings.escape_centcom)) //checking basic stuff - they escaped alive and have an ID
 				var/mob/living/carbon/human/H = owner.current
-				if(H.wear_id && H.wear_id:registered == H.real_name && H.wear_id:assignment != ("Technical Assistant" || "Staff Assistant" || "Medical Assistant")) return 1
+				if(H.wear_id && H.wear_id:registered == H.real_name && !(H.wear_id:assignment in list("Technical Assistant","Staff Assistant","Medical Assistant"))) return 1
 				else return 0
 	spacesuit
 		explanation_text = "Get your grubby hands on a spacesuit."
@@ -731,7 +731,7 @@ ABSTRACT_TYPE(/datum/objective/crew/medicalassistant)
 		check_completion()
 			if(owner.current && !isdead(owner.current) && istype(get_area(owner.current),map_settings.escape_centcom)) //checking basic stuff - they escaped alive and have an ID
 				var/mob/living/carbon/human/H = owner.current
-				if(H.wear_id && H.wear_id:registered == H.real_name && H.wear_id:assignment != ("Technical Assistant" || "Staff Assistant" || "Medical Assistant")) return 1
+				if(H.wear_id && H.wear_id:registered == H.real_name && !(H.wear_id:assignment in list("Technical Assistant","Staff Assistant","Medical Assistant"))) return 1
 				else return 0
 	healself
 		explanation_text = "Make sure you are completely unhurt when the escape shuttle leaves."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][MINOR] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The altered ID check would always return true if you escaped with an ID in your name regardless of assignment. It will now properly check to ensure that the ID assignment is not an assistant role before awarding the medal and completing the crew objective.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's a bug.