### PR TITLE
Equipment properties

### DIFF
--- a/code/WorkInProgress/ObjectProperties.dm
+++ b/code/WorkInProgress/ObjectProperties.dm
@@ -48,16 +48,16 @@ var/list/globalPropList = null
 				if(X.id == propId)
 					X.onChange(src, src.properties[X], ((propVal != null) ? propVal : X.defaultValue))
 					src.properties[X] = propVal
-					return
+					return X
 
 			var/datum/objectProperty/P = globalPropList[propId]
 
 			src.properties.Add(P)
 			src.properties[P] = ((propVal != null) ? propVal : P.defaultValue)
 			P.onAdd(src, propVal)
+			return P
 		else
 			throw EXCEPTION("Invalid property ID passed to setProperty ([propId])")
-		return
 
 	proc/getProperty(var/propId) //Gets property value.
 		.= null
@@ -75,9 +75,9 @@ var/list/globalPropList = null
 		if(src.properties && src.properties.len)
 			for(var/datum/objectProperty/X in src.properties)
 				if(X.id == propId)
+					. = X
 					X.onRemove(src, src.properties[X])
 					src.properties.Remove(X)
-		return null
 
 	proc/hasProperty(var/propId) //Checks if property is on object.
 		.= 0

--- a/code/WorkInProgress/ObjectProperties.dm
+++ b/code/WorkInProgress/ObjectProperties.dm
@@ -206,33 +206,6 @@ var/list/globalPropList = null
 			getTooltipDesc(var/obj/propOwner, var/propVal)
 				return "[propVal] movement delay - 0 when worn in space."
 
-	radiationprot
-		name = "Resistance (Radiation)"
-		id = "radprot"
-		desc = "Protects from harmful radiation." //Value is % protection.
-		tooltipImg = "radiation.png"
-		defaultValue = 10
-		getTooltipDesc(var/obj/propOwner, var/propVal)
-			return "[propVal]%"
-
-	coldprot
-		name = "Resistance (Cold)"
-		id = "coldprot"
-		desc = "Protects from low temperatures." //Value is % protection.
-		tooltipImg = "cold.png"
-		defaultValue = 10
-		getTooltipDesc(var/obj/propOwner, var/propVal)
-			return "[propVal]%"
-
-	heatprot
-		name = "Resistance (Heat)"
-		id = "heatprot"
-		desc = "Protects from high temperatures." //Value is % protection.
-		tooltipImg = "heat.png"
-		defaultValue = 10
-		getTooltipDesc(var/obj/propOwner, var/propVal)
-			return "[propVal]%"
-
 	viralprot
 		name = "Resistance (Viral)"
 		id = "viralprot"
@@ -259,29 +232,6 @@ var/list/globalPropList = null
 		defaultValue = 0.1
 		getTooltipDesc(var/obj/propOwner, var/propVal)
 			return "[propVal * 100]% [propVal <= 0.2 ? "(Safe)":""]"
-
-	meleeprot
-		name = "Resistance (Melee)"
-		id = "meleeprot"
-		desc = "Protects from melee damage." //Value is flat damage reduction.
-		tooltipImg = "melee.png"
-		defaultValue = 2
-		getTooltipDesc(var/obj/propOwner, var/propVal)
-			return "-[propVal] dmg"
-
-		head //ugly hack im sorry, this is used for head, mask, glasses and ear clothing
-			id = "meleeprot_head"
-		all //ugly hack but I'm not sorry, this is used for barriers
-			id = "meleeprot_all"
-
-	rangedprot
-		name = "Resistance (Ranged)"
-		id = "rangedprot"
-		desc = "Protects from ranged damage." //Value is divisor applied to bullet power on hit. For humans, the sum of all equipment is used. Base value is 1, so one item with 1 additional armor = 2, half the damage
-		tooltipImg = "bullet.png"
-		defaultValue = 0.15
-		getTooltipDesc(var/obj/propOwner, var/propVal)
-			return "[propVal] prot."
 
 	stammax
 		name = "Max. Stamina"
@@ -399,3 +349,149 @@ var/list/globalPropList = null
 			defaultValue = 0
 			getTooltipDesc(var/obj/propOwner, var/propVal)
 				return "Burn Damage"
+
+/*
+For properties that are on equipment and should do stuff when the item is equipped / deequipped.
+
+Note for later: it might be worth it to make an intermediate step of /datum/objectProperty/item
+for stuff that should apply when the item with the property is picked up / dropped. But it's hard
+to say if there's demand for that.
+*/
+/datum/objectProperty/equipment
+	// Called when the property changes / gets added / gets equipped
+	proc/updateMob(obj/item/owner, mob/user, value, oldValue=null)
+		return
+
+	// Called when the property gets removed or owner gets unequipped
+	proc/removeFromMob(obj/item/owner, mob/user, value)
+		return
+
+	// Called when owner gets equipped into slot `slot`
+	proc/onEquipped(obj/item/owner, mob/user, value, slot)
+		src.updateMob(owner, user, value)
+
+	// Called when owner gets unequipped
+	proc/onUnequipped(obj/item/owner, mob/user, value)
+		src.removeFromMob(owner, user, value)
+
+	onAdd(obj/item/owner, value)
+		. = ..()
+		if(istype(owner.loc, /mob) && !isnull(owner.equipped_in_slot))
+			src.updateMob(owner, owner.loc, value)
+
+	onChange(obj/item/owner, oldValue, newValue)
+		. = ..()
+		if(istype(owner.loc, /mob) && !isnull(owner.equipped_in_slot))
+			src.updateMob(owner, owner.loc, newValue, oldValue)
+
+	onRemove(obj/item/owner, value)
+		. = ..()
+		if(istype(owner.loc, /mob) && !isnull(owner.equipped_in_slot))
+			src.removeFromMob(owner, owner.loc, value)
+
+// at the moment the mob property stuff only makes sense for human mobs!!
+// Also currently the "source" of the mob property is the owner of the property (the item).
+// If you are adding other properties granting some mob property make sure to use something like "\ref[owner]-something"
+// as the source. This might be useful for blocking properties for example.
+
+/datum/objectProperty/equipment/meleeprot
+	name = "Resistance (Melee)"
+	id = "meleeprot_parent"
+	desc = "Protects from melee damage." //Value is flat damage reduction.
+	tooltipImg = "melee.png"
+	defaultValue = 2
+	getTooltipDesc(var/obj/propOwner, var/propVal)
+		return "-[propVal] dmg"
+
+	body
+		id = "meleeprot"
+		updateMob(obj/item/owner, mob/user, value, oldValue=null)
+			. = ..()
+			APPLY_MOB_PROPERTY(user, PROP_MELEEPROT_BODY, owner, value)
+		removeFromMob(obj/item/owner, mob/user, value)
+			. = ..()
+			REMOVE_MOB_PROPERTY(user, PROP_MELEEPROT_BODY, owner)
+
+	head //ugly hack im sorry, this is used for head, mask, glasses and ear clothing
+		id = "meleeprot_head"
+		updateMob(obj/item/owner, mob/user, value, oldValue=null)
+			. = ..()
+			APPLY_MOB_PROPERTY(user, PROP_MELEEPROT_HEAD, owner, value)
+		removeFromMob(obj/item/owner, mob/user, value)
+			. = ..()
+			REMOVE_MOB_PROPERTY(user, PROP_MELEEPROT_HEAD, owner)
+
+	all //ugly hack but I'm not sorry, this is used for barriers
+		id = "meleeprot_all"
+		updateMob(obj/item/owner, mob/user, value, oldValue=null)
+			. = ..()
+			APPLY_MOB_PROPERTY(user, PROP_MELEEPROT_BODY, owner, value)
+			APPLY_MOB_PROPERTY(user, PROP_MELEEPROT_HEAD, owner, value)
+		removeFromMob(obj/item/owner, mob/user, value)
+			. = ..()
+			REMOVE_MOB_PROPERTY(user, PROP_MELEEPROT_BODY, owner)
+			REMOVE_MOB_PROPERTY(user, PROP_MELEEPROT_HEAD, owner)
+
+/datum/objectProperty/equipment/rangedprot
+	name = "Resistance (Ranged)"
+	id = "rangedprot"
+	desc = "Protects from ranged damage." //Value is divisor applied to bullet power on hit. For humans, the sum of all equipment is used. Base value is 1, so one item with 1 additional armor = 2, half the damage
+	tooltipImg = "bullet.png"
+	defaultValue = 0.15
+	getTooltipDesc(var/obj/propOwner, var/propVal)
+		return "[propVal] prot."
+
+	updateMob(obj/item/owner, mob/user, value, oldValue=null)
+		. = ..()
+		APPLY_MOB_PROPERTY(user, PROP_RANGEDPROT, owner, value)
+	removeFromMob(obj/item/owner, mob/user, value)
+		. = ..()
+		REMOVE_MOB_PROPERTY(user, PROP_RANGEDPROT, owner)
+
+/datum/objectProperty/equipment/radiationprot
+	name = "Resistance (Radiation)"
+	id = "radprot"
+	desc = "Protects from harmful radiation." //Value is % protection.
+	tooltipImg = "radiation.png"
+	defaultValue = 10
+	getTooltipDesc(var/obj/propOwner, var/propVal)
+		return "[propVal]%"
+
+	updateMob(obj/item/owner, mob/user, value, oldValue=null)
+		. = ..()
+		APPLY_MOB_PROPERTY(user, PROP_RADPROT, owner, value)
+	removeFromMob(obj/item/owner, mob/user, value)
+		. = ..()
+		REMOVE_MOB_PROPERTY(user, PROP_RADPROT, owner)
+
+/datum/objectProperty/equipment/coldprot
+	name = "Resistance (Cold)"
+	id = "coldprot"
+	desc = "Protects from low temperatures." //Value is % protection.
+	tooltipImg = "cold.png"
+	defaultValue = 10
+	getTooltipDesc(var/obj/propOwner, var/propVal)
+		return "[propVal]%"
+
+	updateMob(obj/item/owner, mob/user, value, oldValue=null)
+		. = ..()
+		APPLY_MOB_PROPERTY(user, PROP_COLDPROT, owner, value)
+	removeFromMob(obj/item/owner, mob/user, value)
+		. = ..()
+		REMOVE_MOB_PROPERTY(user, PROP_COLDPROT, owner)
+
+/datum/objectProperty/equipment/heatprot
+	name = "Resistance (Heat)"
+	id = "heatprot"
+	desc = "Protects from high temperatures." //Value is % protection.
+	tooltipImg = "heat.png"
+	defaultValue = 10
+	getTooltipDesc(var/obj/propOwner, var/propVal)
+		return "[propVal]%"
+
+	updateMob(obj/item/owner, mob/user, value, oldValue=null)
+		. = ..()
+		APPLY_MOB_PROPERTY(user, PROP_HEATPROT, owner, value)
+	removeFromMob(obj/item/owner, mob/user, value)
+		. = ..()
+		REMOVE_MOB_PROPERTY(user, PROP_HEATPROT, owner)

--- a/code/mob/living/carbon.dm
+++ b/code/mob/living/carbon.dm
@@ -515,6 +515,9 @@
 
 
 /mob/living/carbon/swap_hand()
+	var/obj/item/grab/block/B = src.check_block(ignoreStuns = 1)
+	if(B) 
+		qdel(B)
 	src.hand = !src.hand
 
 /mob/living/carbon/lastgasp()

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2479,6 +2479,9 @@
 		return 0
 
 /mob/living/carbon/human/swap_hand(var/specify=-1)
+	var/obj/item/grab/block/B = src.check_block(ignoreStuns = 1)
+	if(B && hand != specify)
+		qdel(B)
 	if (specify >= 0)
 		src.hand = specify
 	else

--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -197,8 +197,7 @@
 	if (S && !src.lying && !src.getStatusDuration("weakened") && !src.getStatusDuration("paralysis"))
 		S.buckle_in(src,src,1)
 	else
-		var/obj/item/grab/block/G = new /obj/item/grab/block(src)
-		G.assailant = src
+		var/obj/item/grab/block/G = new /obj/item/grab/block(src, src)
 		src.put_in_hand(G, src.hand)
 		G.affecting = src
 		src.grabbed_by += G
@@ -225,8 +224,7 @@
 	if (!I)
 		src.grab_self()
 	else
-		var/obj/item/grab/block/G = new /obj/item/grab/block(I)
-		G.assailant = src
+		var/obj/item/grab/block/G = new /obj/item/grab/block(I, src)
 		G.affecting = src
 		src.grabbed_by += G
 		G.loc = I
@@ -479,8 +477,8 @@
 
 #undef DISARM_WITH_ITEM_TEXT
 
-/mob/proc/check_block() //am i blocking?
-	if (!stat && !getStatusDuration("weakened") && !getStatusDuration("stunned") && !getStatusDuration("paralysis"))
+/mob/proc/check_block(ignoreStuns = 0) //am i blocking?
+	if (ignoreStuns || (!stat && !getStatusDuration("weakened") && !getStatusDuration("stunned") && !getStatusDuration("paralysis")))
 		var/obj/item/I = src.equipped()
 		if (I)
 			if (istype(I,/obj/item/grab/block))

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -45,6 +45,8 @@
 	var/image/inhand_image = null
 	var/inhand_image_icon = 'icons/mob/inhand/hand_general.dmi'
 
+	var/equipped_in_slot = null // null if not equipped, otherwise contains the slot in which it is
+
 	var/arm_icon = "" //set to an icon state in human.dmi minus _s/_l and l_arm_/r_arm_ to allow use as an arm
 	var/over_clothes = 0 //draw over clothes when used as a limb
 	var/override_attack_hand = 1 //when used as an arm, attack with item rather than using attack_hand
@@ -764,6 +766,9 @@
 	#ifdef COMSIG_ITEM_EQUIPPED
 	SEND_SIGNAL(src, COMSIG_ITEM_EQUIPPED, user, slot)
 	#endif
+	src.equipped_in_slot = slot
+	for(var/datum/objectProperty/equipment/prop in src.properties)
+		prop.onEquipped(src, user, src.properties[prop])
 	var/datum/movement_modifier/equipment/equipment_proxy = locate() in user.movement_modifiers
 	if (!equipment_proxy)
 		equipment_proxy = new
@@ -778,28 +783,13 @@
 		equipment_proxy.additive_slowdown += spacemove // compatibility hack for old code treating space & fluid movement capability as a slowdown
 		equipment_proxy.space_movement += spacemove
 
-	if (!ishuman(user)) //!!currently!! we only want to humans check for these stats, so just abort early if user isnt human, saves us time
-		return
-	if (src.hasProperty("meleeprot"))
-		APPLY_MOB_PROPERTY(user, PROP_MELEEPROT_BODY, src, src.getProperty("meleeprot"))
-	if (src.hasProperty("meleeprot_head"))
-		APPLY_MOB_PROPERTY(user, PROP_MELEEPROT_HEAD, src, src.getProperty("meleeprot_head"))
-	if (src.hasProperty("meleeprot_all"))
-		APPLY_MOB_PROPERTY(user, PROP_MELEEPROT_BODY, src, src.getProperty("meleeprot_all"))
-		APPLY_MOB_PROPERTY(user, PROP_MELEEPROT_HEAD, src, src.getProperty("meleeprot_all"))
-	if (src.hasProperty("rangedprot"))
-		APPLY_MOB_PROPERTY(user, PROP_RANGEDPROT, src, src.getProperty("rangedprot"))
-	if (src.hasProperty("radprot"))
-		APPLY_MOB_PROPERTY(user, PROP_RADPROT, src, src.getProperty("radprot"))
-	if (src.hasProperty("heatprot"))
-		APPLY_MOB_PROPERTY(user, PROP_HEATPROT, src, src.getProperty("heatprot"))
-	if (src.hasProperty("coldprot"))
-		APPLY_MOB_PROPERTY(user, PROP_COLDPROT, src, src.getProperty("coldprot"))
-
 /obj/item/proc/unequipped(var/mob/user)
 	#ifdef COMSIG_ITEM_UNEQUIPPED
 	SEND_SIGNAL(src, COMSIG_ITEM_UNEQUIPPED, user)
 	#endif
+	for(var/datum/objectProperty/equipment/prop in src.properties)
+		prop.onUnequipped(src, user, src.properties[prop])
+	src.equipped_in_slot = null
 	var/datum/movement_modifier/equipment/equipment_proxy = locate() in user.movement_modifiers
 	if (!equipment_proxy)
 		equipment_proxy = new
@@ -813,24 +803,6 @@
 	if (spacemove)
 		equipment_proxy.additive_slowdown -= spacemove
 		equipment_proxy.space_movement -= spacemove
-
-	if (!ishuman(user)) //!!currently!! we only want to humans check for these stats, so just abort early if user isnt human, saves us time
-		return
-	if (src.hasProperty("meleeprot"))
-		REMOVE_MOB_PROPERTY(user, PROP_MELEEPROT_BODY, src)
-	if (src.hasProperty("meleeprot_head"))
-		REMOVE_MOB_PROPERTY(user, PROP_MELEEPROT_HEAD, src)
-	if (src.hasProperty("meleeprot_all"))
-		REMOVE_MOB_PROPERTY(user, PROP_MELEEPROT_BODY, src)
-		REMOVE_MOB_PROPERTY(user, PROP_MELEEPROT_HEAD, src)
-	if (src.hasProperty("rangedprot"))
-		REMOVE_MOB_PROPERTY(user, PROP_RANGEDPROT, src)
-	if (src.hasProperty("radprot"))
-		REMOVE_MOB_PROPERTY(user, PROP_RADPROT, src)
-	if (src.hasProperty("heatprot"))
-		REMOVE_MOB_PROPERTY(user, PROP_HEATPROT, src)
-	if (src.hasProperty("coldprot"))
-		REMOVE_MOB_PROPERTY(user, PROP_COLDPROT, src)
 
 /obj/item/proc/afterattack(atom/target, mob/user, reach, params)
 	return

--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -18,7 +18,7 @@
 	var/can_pin = 1
 	var/dropped = 0
 
-	New(atom/loc)
+	New(atom/loc, mob/assailant = null)
 		..()
 
 		var/icon/hud_style = hud_style_selection[get_hud_style(src.assailant)]
@@ -33,6 +33,7 @@
 			ima.appearance_flags = RESET_COLOR | KEEP_APART | RESET_TRANSFORM
 
 			I.UpdateOverlays(ima, "grab", 0, 1)
+		src.assailant = assailant
 
 	proc/post_item_setup()//after grab is done being made with item
 		return
@@ -86,7 +87,7 @@
 		dropped += 1
 		if(src.assailant)
 			REMOVE_MOB_PROPERTY(src.assailant, PROP_CANTMOVE, src.type)
-		qdel(src)
+			qdel(src)
 
 	process(var/mult = 1)
 		if (check())
@@ -713,6 +714,9 @@
 		setProperty("I_disorient_resist", 15)
 
 	disposing()
+		for(var/datum/objectProperty/equipment/P in src.properties)
+			P.removeFromMob(src, src.assailant)
+
 		if (isitem(src.loc))
 			var/obj/item/I = src.loc
 			I.c_flags &= ~HAS_GRAB_EQUIP
@@ -743,6 +747,16 @@
 			playsound(assailant.loc, 'sound/impact_sounds/Generic_Shove_1.ogg', 50, 1, 0, 1.5)
 		qdel(src)
 
+	setProperty(propId, propVal)
+		var/datum/objectProperty/equipment/P = ..()
+		if(istype(P))
+			P.updateMob(src, src.assailant, propVal)
+
+	delProperty(propId)
+		var/propVal = getProperty(propId)
+		var/datum/objectProperty/equipment/P = ..()
+		if(istype(P))
+			P.removeFromMob(src, src.assailant, propVal)
 
 	proc/can_block(var/hit_type = null)
 		.= DEFAULT_BLOCK_PROTECTION_BONUS


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds `/datum/objectProperty/equipment` for properties that want to be notified when they owner gets equipped / unequipped. The `updateMob` and `removeFromMob` procs can be used to make this work nicely with mob properties.

Also semi-relatedly adds `equipped_in_slot` var to items that contains `null` if the item is not equipped and contains the slot in which it is equipped if it is equipped. (Based on what got passed into the `equipped()` proc of the item. Note 1: This doesn't work for mob critters because those don't call `equipped` at all. Note 2: What the hell even gets passed as `slot` of `equipped` for humans? IT seems like sometimes it's a number of the slot and sometimes a string?!)

This PR also makes it so `setProperty` and `delProperty` return the property on which you operate. Useful for chaining some stuff like `setProperty(blah, blah).updateMob(blah, blah)` if you want to trigger that manually.

Now also includes #910 .

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More modular code etc.