### PR TITLE
Slips can be avoided by slowing your movement manually (stutter step)

### DIFF
--- a/code/procs/mob_procs.dm
+++ b/code/procs/mob_procs.dm
@@ -114,10 +114,10 @@
 	if (!src.can_slip())
 		return
 
-	var/slip_delay = BASE_SPEED_SUSTAINED + (WALK_DELAY_ADD/3) //we need to fall under this movedelay value in order to slip :O
+	var/slip_delay = BASE_SPEED_SUSTAINED + (WALK_DELAY_ADD*0.6) //we need to fall under this movedelay value in order to slip :O
 	if (!walking_matters)
 		slip_delay = 10
-	var/movedelay = min(src.movement_delay(get_step(src,src.move_dir), running), world.time - src.next_move)
+	var/movedelay = max(src.movement_delay(get_step(src,src.move_dir), running), world.time - src.next_move)
 
 	if (movedelay < slip_delay)
 		var/intensity = (-0.33)+(6.033763-(-0.33))/(1+(movedelay/(0.4))-1.975308)  //y=d+(6.033763-d)/(1+(x/c)-1.975308)
@@ -136,7 +136,7 @@
 
 		var/turf/T = get_ranged_target_turf(src, src.last_move_dir, intensity)
 		SPAWN_DBG(0)
-			src.throw_at(T, intensity, 2, list("stun"=clamp(1 SECONDS * intensity, 1 SECOND, 5 SECONDS)), src.loc, throw_type = THROW_SLIP)
+			src.throw_at(T, intensity, 2, list("stun"=clamp(1.1 SECONDS * intensity, 1 SECOND, 5 SECONDS)), src.loc, throw_type = THROW_SLIP)
 		.= 1
 
 /mob/living/carbon/human/slip(walking_matters = 1, running = 0)

--- a/code/procs/mob_procs.dm
+++ b/code/procs/mob_procs.dm
@@ -114,7 +114,7 @@
 	if (!src.can_slip())
 		return
 
-	var/slip_delay = BASE_SPEED_SUSTAINED + (WALK_DELAY_ADD*0.6) //we need to fall under this movedelay value in order to slip :O
+	var/slip_delay = BASE_SPEED_SUSTAINED + (WALK_DELAY_ADD*0.9) //we need to fall under this movedelay value in order to slip :O
 	if (!walking_matters)
 		slip_delay = 10
 	var/movedelay = max(src.movement_delay(get_step(src,src.move_dir), running), world.time - src.next_move)

--- a/code/procs/mob_procs.dm
+++ b/code/procs/mob_procs.dm
@@ -114,10 +114,10 @@
 	if (!src.can_slip())
 		return
 
-	var/slip_delay = BASE_SPEED_SUSTAINED + WALK_DELAY_ADD //we need to fall under this movedelay value in order to slip :O
+	var/slip_delay = BASE_SPEED_SUSTAINED + (WALK_DELAY_ADD/3) //we need to fall under this movedelay value in order to slip :O
 	if (!walking_matters)
 		slip_delay = 10
-	var/movedelay = src.movement_delay(get_step(src,src.move_dir), running)
+	var/movedelay = min(src.movement_delay(get_step(src,src.move_dir), running), world.time - src.next_move)
 
 	if (movedelay < slip_delay)
 		var/intensity = (-0.33)+(6.033763-(-0.33))/(1+(movedelay/(0.4))-1.975308)  //y=d+(6.033763-d)/(1+(x/c)-1.975308)
@@ -136,7 +136,7 @@
 
 		var/turf/T = get_ranged_target_turf(src, src.last_move_dir, intensity)
 		SPAWN_DBG(0)
-			src.throw_at(T, intensity, 3, list("stun"=clamp(1 SECONDS * intensity, 1 SECOND, 10 SECONDS)), src.loc, throw_type = THROW_SLIP)
+			src.throw_at(T, intensity, 2, list("stun"=clamp(1 SECONDS * intensity, 1 SECOND, 5 SECONDS)), src.loc, throw_type = THROW_SLIP)
 		.= 1
 
 /mob/living/carbon/human/slip(walking_matters = 1, running = 0)


### PR DESCRIPTION
this change makes it so that when the game checks whether you should slip or not, it uses the minimum of your movedelay OR the time since last move

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)mbc:
(*)Slips can also be avoided by manually slowing your movement (tap keys slower instead of holding)
```
