### PR TITLE
Block handling

### DIFF
--- a/code/mob/living/carbon.dm
+++ b/code/mob/living/carbon.dm
@@ -515,6 +515,9 @@
 
 
 /mob/living/carbon/swap_hand()
+	var/obj/item/grab/block/B = src.check_block()
+	if(B) 
+		qdel(B)
 	src.hand = !src.hand
 
 /mob/living/carbon/lastgasp()

--- a/code/mob/living/carbon.dm
+++ b/code/mob/living/carbon.dm
@@ -515,7 +515,7 @@
 
 
 /mob/living/carbon/swap_hand()
-	var/obj/item/grab/block/B = src.check_block()
+	var/obj/item/grab/block/B = src.check_block(ignoreStuns = 1)
 	if(B) 
 		qdel(B)
 	src.hand = !src.hand

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2479,6 +2479,9 @@
 		return 0
 
 /mob/living/carbon/human/swap_hand(var/specify=-1)
+	var/obj/item/grab/block/B = src.check_block()
+	if(B && hand != specify)
+		qdel(B)
 	if (specify >= 0)
 		src.hand = specify
 	else

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2479,7 +2479,7 @@
 		return 0
 
 /mob/living/carbon/human/swap_hand(var/specify=-1)
-	var/obj/item/grab/block/B = src.check_block()
+	var/obj/item/grab/block/B = src.check_block(ignoreStuns = 1)
 	if(B && hand != specify)
 		qdel(B)
 	if (specify >= 0)

--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -479,8 +479,8 @@
 
 #undef DISARM_WITH_ITEM_TEXT
 
-/mob/proc/check_block() //am i blocking?
-	if (!stat && !getStatusDuration("weakened") && !getStatusDuration("stunned") && !getStatusDuration("paralysis"))
+/mob/proc/check_block(ignoreStuns = 0) //am i blocking?
+	if (ignoreStuns || (!stat && !getStatusDuration("weakened") && !getStatusDuration("stunned") && !getStatusDuration("paralysis")))
 		var/obj/item/I = src.equipped()
 		if (I)
 			if (istype(I,/obj/item/grab/block))

--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -197,8 +197,7 @@
 	if (S && !src.lying && !src.getStatusDuration("weakened") && !src.getStatusDuration("paralysis"))
 		S.buckle_in(src,src,1)
 	else
-		var/obj/item/grab/block/G = new /obj/item/grab/block(src)
-		G.assailant = src
+		var/obj/item/grab/block/G = new /obj/item/grab/block(src, src)
 		src.put_in_hand(G, src.hand)
 		G.affecting = src
 		src.grabbed_by += G
@@ -225,8 +224,7 @@
 	if (!I)
 		src.grab_self()
 	else
-		var/obj/item/grab/block/G = new /obj/item/grab/block(I)
-		G.assailant = src
+		var/obj/item/grab/block/G = new /obj/item/grab/block(I, src)
 		G.affecting = src
 		src.grabbed_by += G
 		G.loc = I

--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -87,7 +87,7 @@
 		dropped += 1
 		if(src.assailant)
 			REMOVE_MOB_PROPERTY(src.assailant, PROP_CANTMOVE, src.type)
-		qdel(src)
+			qdel(src)
 
 	process(var/mult = 1)
 		if (check())

--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -713,6 +713,9 @@
 		setProperty("I_disorient_resist", 15)
 
 	disposing()
+		for(var/datum/objectProperty/equipment/P in src.properties)
+			P.removeFromMob(src, src.assailant)
+			src.properties.Remove(P)
 		if (isitem(src.loc))
 			var/obj/item/I = src.loc
 			I.c_flags &= ~HAS_GRAB_EQUIP
@@ -743,6 +746,15 @@
 			playsound(assailant.loc, 'sound/impact_sounds/Generic_Shove_1.ogg', 50, 1, 0, 1.5)
 		qdel(src)
 
+	setProperty(propId, propVal)
+		var/datum/objectProperty/equipment/P = ..()
+		if(istype(P))
+			P.updateMob(src, src.assailant, propVal)
+
+	delProperty(propId)
+		var/datum/objectProperty/equipment/P = ..()
+		if(istype(P))
+			P.removeFromMob(src, src.assailant)
 
 	proc/can_block(var/hit_type = null)
 		.= DEFAULT_BLOCK_PROTECTION_BONUS

--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -715,7 +715,7 @@
 	disposing()
 		for(var/datum/objectProperty/equipment/P in src.properties)
 			P.removeFromMob(src, src.assailant)
-			src.properties.Remove(P)
+
 		if (isitem(src.loc))
 			var/obj/item/I = src.loc
 			I.c_flags &= ~HAS_GRAB_EQUIP
@@ -754,7 +754,7 @@
 	delProperty(propId)
 		var/datum/objectProperty/equipment/P = ..()
 		if(istype(P))
-			P.removeFromMob(src, src.assailant)
+			P.removeFromMob(src, src.assailant, P.propVal)
 
 	proc/can_block(var/hit_type = null)
 		.= DEFAULT_BLOCK_PROTECTION_BONUS

--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -18,7 +18,7 @@
 	var/can_pin = 1
 	var/dropped = 0
 
-	New(atom/loc)
+	New(atom/loc, mob/assailant = null)
 		..()
 
 		var/icon/hud_style = hud_style_selection[get_hud_style(src.assailant)]
@@ -33,6 +33,7 @@
 			ima.appearance_flags = RESET_COLOR | KEEP_APART | RESET_TRANSFORM
 
 			I.UpdateOverlays(ima, "grab", 0, 1)
+		src.assailant = assailant
 
 	proc/post_item_setup()//after grab is done being made with item
 		return
@@ -752,9 +753,10 @@
 			P.updateMob(src, src.assailant, propVal)
 
 	delProperty(propId)
+		var/propVal = getProperty(propId)
 		var/datum/objectProperty/equipment/P = ..()
 		if(istype(P))
-			P.removeFromMob(src, src.assailant, P.propVal)
+			P.removeFromMob(src, src.assailant, propVal)
 
 	proc/can_block(var/hit_type = null)
 		.= DEFAULT_BLOCK_PROTECTION_BONUS


### PR DESCRIPTION
Adds handling for blocks
Additionally makes blocks in off-hand automatically end (saner than handling properties every time user swaps hands, and it wasn't communicated clearly that blocks only had an effect in the active hand anyways).