### PR TITLE
only autoclick asteroids if mining tool is available

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -973,6 +973,9 @@
 						return
 			src.now_pushing = 0
 			//..()
+			if(AM)
+				AM.last_bumped = world.timeofday
+				AM.Bumped(src)
 			if (!istype(AM, /atom/movable))
 				return
 			if (!src.now_pushing)
@@ -981,9 +984,6 @@
 					var/t = get_dir(src, AM)
 					step(AM, t)
 				src.now_pushing = null
-			if(AM)
-				AM.last_bumped = world.timeofday
-				AM.Bumped(src)
 			return
 		return
 

--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -1101,11 +1101,14 @@
 // XXXXX SHIT IS HERE zamujasa HONK FARTRIUM
 
 	Bumped(var/atom/A) //This is a bit hacky, sorry. Better than duplicating all the code.
-		if(ishuman(A))
-			var/mob/living/carbon/human/H = A
-			var/obj/item/held = H.equipped()
-			if(istype(held, /obj/item/mining_tool) || istype(held, /obj/item/mining_tools) || (isnull(held) && (H.is_hulk() || istype(H.gloves, /obj/item/clothing/gloves/concussive))))
-				H.click(src, list(), null, null)
+		if(isliving(A))
+			var/mob/living/L = A
+			var/mob/living/carbon/human/H
+			if(ishuman(L))
+				H = L
+			var/obj/item/held = L.equipped()
+			if(istype(held, /obj/item/mining_tool) || istype(held, /obj/item/mining_tools) || (isnull(held) && H && (H.is_hulk() || istype(H.gloves, /obj/item/clothing/gloves/concussive))))
+				L.click(src, list(), null, null)
 			return
 
 	attackby(obj/item/W as obj, mob/user as mob)

--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -1101,9 +1101,11 @@
 // XXXXX SHIT IS HERE zamujasa HONK FARTRIUM
 
 	Bumped(var/atom/A) //This is a bit hacky, sorry. Better than duplicating all the code.
-		if(isliving(A))
-			var/mob/living/L = A
-			L.click(src, list(), null, null)
+		if(ishuman(A))
+			var/mob/living/carbon/human/H = A
+			var/obj/item/held = H.equipped()
+			if(istype(held, /obj/item/mining_tool) || istype(held, /obj/item/mining_tools) || (isnull(held) && (H.is_hulk() || istype(H.gloves, /obj/item/clothing/gloves/concussive))))
+				H.click(src, list(), null, null)
 			return
 
 	attackby(obj/item/W as obj, mob/user as mob)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[ENHANCEMENT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This changes the effect of bumping into an asteroid tile so it is only automatically clicked if the person is holding a mining tool in their active hand or their active hand is empty and they are wearing concussive gloves or have hulk.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This prevents accidentally using things like ore satchels or artbeakers on asteroids when bumping into them.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)zjdtmkhzt:
(+)Only mining tools will now be automatically used when bumping into asteroid tiles. (This prevents things like emptying ore holders on accident.)
(+)Borgs can now also automatically use their mining tools without having to click.
```
