### PR TITLE
Metalfoam improvements

### DIFF
--- a/code/modules/robotics/bot/floorbot.dm
+++ b/code/modules/robotics/bot/floorbot.dm
@@ -220,7 +220,7 @@ text("<A href='?src=\ref[src];operation=make'>[src.maketiles ? "Yes" : "No"]</A>
 		// Search for incomplete/damaged floor
 		if (src.improvefloors)
 			for (var/turf/simulated/floor/F in view(src.search_range, src))
-				if (F != src.oldtarget && (!F.intact || F.burnt || F.broken) && !(F in floorbottargets) && !should_ignore_tile(F))
+				if (F != src.oldtarget && (!F.intact || F.burnt || F.broken || istype(F, /turf/simulated/floor/metalfoam)) && !(F in floorbottargets) && !should_ignore_tile(F))
 					return F
 
 
@@ -347,7 +347,7 @@ text("<A href='?src=\ref[src];operation=make'>[src.maketiles ? "Yes" : "No"]</A>
 		src.repairing = 1
 		var/new_tile = 0
 
-		if (istype(target, /turf/space/))
+		if (istype(target, /turf/space/) || istype(target, /turf/simulated/floor/metalfoam))
 			src.visible_message("<span class='notice'>[src] begins building flooring.</span>")
 			new_tile = 1
 

--- a/code/obj/effects/foam.dm
+++ b/code/obj/effects/foam.dm
@@ -10,7 +10,7 @@
 	density = 0
 	layer = OBJ_LAYER + 0.9
 	mouse_opacity = 0
-	event_handler_flags = USE_HASENTERED
+	event_handler_flags = USE_HASENTERED | USE_CANPASS
 	var/foamcolor
 	var/amount = 3
 	var/expand = 1
@@ -195,3 +195,8 @@
 			reagents.reaction(M, TOUCH, 5)
 
 			M.show_text("You slip on the foam!", "red")
+
+/obj/effects/foam/CanPass(atom/movable/mover, turf/target)
+	if (src.metal && !mover)
+		return 0 // completely opaque to air
+	return 1

--- a/code/obj/effects/foam.dm
+++ b/code/obj/effects/foam.dm
@@ -67,7 +67,9 @@
 	//playsound(src, "sound/effects/bubbles2.ogg", 80, 1, -3)
 
 	update_icon()
-
+	if(metal)
+		if(istype(loc, /turf/space))
+			loc:ReplaceWithMetalFoam(metal)
 	SPAWN_DBG(3 + metal*3)
 		process()
 	SPAWN_DBG(12 SECONDS)

--- a/code/obj/item/building_materials.dm
+++ b/code/obj/item/building_materials.dm
@@ -1002,7 +1002,7 @@ MATERIAL
 			return
 		else
 			var/S = T
-			if (!( istype(S, /turf/space) ))
+			if (!( istype(S, /turf/space) || istype(S, /turf/simulated/floor/metalfoam)))
 				boutput(user, "You cannot build on or repair this turf!")
 				return
 			else

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -1104,6 +1104,17 @@
 
 	if(!C || !user)
 		return 0
+	if (istype(C, /obj/item/tile))
+		playsound(src, "sound/impact_sounds/Generic_Stab_1.ogg", 50, 1)
+		C:build(src)
+		C:amount--
+		if(C.material) src.setMaterial(C.material)
+		if (C:amount < 1)
+			user.u_equip(C)
+			qdel(C)
+			return
+		return
+
 	if(prob(75 - metal * 25))
 		ReplaceWithSpace()
 		boutput(user, "You easily smash through the foamed metal floor.")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEAT] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Metalfoam creates flooring as the foam spreads, sealing breaches
- Metalfoam floors can be directly upgraded to plating by using floortiles, without having to break the foam flooring
- Floorbots on 'upgrade' mode will replace metalfoam flooring with plating

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
From [forum thread](https://forum.ss13.co/showthread.php?tid=14530)

> - Metal foam grenades, or rather the metal foam itself should stop gasses from passing as soon as the foam spreads, not after it sets and becomes a wall/floor. This way you can use the metal foam grenades to quickly seal a breach without it venting all the atmosphere if you're quick/lucky enough.
> - Let tiles instantly create floor when used on metal foam floors like how it does now from space. The metal foam floors are meant to be temporary. They can be destroyed by hitting it with any item really. But to properly replace them, you need to destroy them, thus opening up the area to space for a fraction of a second. But that still removes more atmosphere which is already a low supply.
> - Floorbots should be able to target metal foam floors for replacement with steel tiles.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Tarmunora:
(+)Made metal foam a little better to use for sealing breaches
```
