### PR TITLE
UM - Welding Tool Refactor

### DIFF
--- a/code/WorkInProgress/EmergencyPodFab.dm
+++ b/code/WorkInProgress/EmergencyPodFab.dm
@@ -15,7 +15,7 @@
 		if (istype(W, /obj/item/crowbar))
 			boutput(user, "There's no maintenance panel to open.")
 			return
-		if (istype(W, /obj/item/weldingtool))
+		if (isweldingtool(W))
 			boutput(user, "You can't repair this pod.")
 			return
 		..()

--- a/code/WorkInProgress/ISNStuff2.dm
+++ b/code/WorkInProgress/ISNStuff2.dm
@@ -273,7 +273,7 @@
 			boutput(user, "<span class='notice'>You remove the metal bolts.</span>")
 			steps_until_pressable--
 			return
-		if (istype(W,/obj/item/weldingtool) && steps_until_pressable == 17)
+		if (isweldingtool(W) && W:welding && steps_until_pressable == 17)
 			boutput(user, "<span class='notice'>You un-weld the casing.</span>")
 			steps_until_pressable--
 			return

--- a/code/WorkInProgress/ISNStuff2.dm
+++ b/code/WorkInProgress/ISNStuff2.dm
@@ -273,7 +273,7 @@
 			boutput(user, "<span class='notice'>You remove the metal bolts.</span>")
 			steps_until_pressable--
 			return
-		if (isweldingtool(W) && W:welding && steps_until_pressable == 17)
+		if (isweldingtool(W) && W:try_weld(user,0,-1,0,0) && steps_until_pressable == 17)
 			boutput(user, "<span class='notice'>You un-weld the casing.</span>")
 			steps_until_pressable--
 			return

--- a/code/WorkInProgress/ItemSpecials.dm
+++ b/code/WorkInProgress/ItemSpecials.dm
@@ -1136,17 +1136,16 @@
 
 				var/flame_succ = 0
 				if (master)
-					if(istype(master,/obj/item/device/light/zippo))
+					if(istype(master,/obj/item/device/light/zippo) && master:on)
 						var/obj/item/device/light/zippo/Z = master
 						if (Z.reagents.get_reagent_amount("fuel"))
 							Z.reagents.remove_reagent("fuel", 1)
 							flame_succ = 1
 						else
 							flame_succ = 0
-					if (istype(master,/obj/item/weldingtool))
-						var/obj/item/weldingtool/WT = master
-						if (WT.reagents.get_reagent_amount("fuel"))
-							WT.reagents.remove_reagent("fuel", 1)
+					if (isweldingtool(master) && master:welding)
+						if (master.reagents.get_reagent_amount("fuel"))
+							master.reagents.remove_reagent("fuel", 1)
 							flame_succ = 1
 						else
 							flame_succ = 0

--- a/code/WorkInProgress/ItemSpecials.dm
+++ b/code/WorkInProgress/ItemSpecials.dm
@@ -1143,7 +1143,7 @@
 							flame_succ = 1
 						else
 							flame_succ = 0
-					if (isweldingtool(master) && master:welding)
+					if (isweldingtool(master) && master:try_weld(user,0,-1,0,0))
 						if (master.reagents.get_reagent_amount("fuel"))
 							master.reagents.remove_reagent("fuel", 1)
 							flame_succ = 1

--- a/code/WorkInProgress/mantaObjects.dm
+++ b/code/WorkInProgress/mantaObjects.dm
@@ -287,7 +287,7 @@ var/obj/manta_speed_lever/mantaLever = null
 				if (istype(I, /obj/item/cable_coil))
 					actions.start(new /datum/action/bar/icon/propeller_fix(src, I, 60), user)
 			if(5)
-				if (istype(I, /obj/item/weldingtool) && I:welding)
+				if (isweldingtool(I) && I:welding)
 					actions.start(new /datum/action/bar/icon/propeller_fix(src, I, 50), user)
 			if(6)
 				if (istool(I, TOOL_WRENCHING))
@@ -301,7 +301,7 @@ var/obj/manta_speed_lever/mantaLever = null
 					if (S.amount >= 5)
 						actions.start(new /datum/action/bar/icon/propeller_fix(src, I, 50), user)
 			if(9)
-				if (istype(I, /obj/item/weldingtool) && I:welding)
+				if (isweldingtool(I) && I:welding)
 					actions.start(new /datum/action/bar/icon/propeller_fix(src, I, 50), user)
 
 

--- a/code/WorkInProgress/mantaObjects.dm
+++ b/code/WorkInProgress/mantaObjects.dm
@@ -287,7 +287,7 @@ var/obj/manta_speed_lever/mantaLever = null
 				if (istype(I, /obj/item/cable_coil))
 					actions.start(new /datum/action/bar/icon/propeller_fix(src, I, 60), user)
 			if(5)
-				if (isweldingtool(I) && I:welding)
+				if (isweldingtool(I) && I:try_weld(user,0,-1,0,0))
 					actions.start(new /datum/action/bar/icon/propeller_fix(src, I, 50), user)
 			if(6)
 				if (istool(I, TOOL_WRENCHING))
@@ -301,7 +301,7 @@ var/obj/manta_speed_lever/mantaLever = null
 					if (S.amount >= 5)
 						actions.start(new /datum/action/bar/icon/propeller_fix(src, I, 50), user)
 			if(9)
-				if (isweldingtool(I) && I:welding)
+				if (isweldingtool(I) && I:try_weld(user,0,-1,0,0))
 					actions.start(new /datum/action/bar/icon/propeller_fix(src, I, 50), user)
 
 

--- a/code/WorkInProgress/recycling/disposal-construction.dm
+++ b/code/WorkInProgress/recycling/disposal-construction.dm
@@ -155,16 +155,15 @@
 				boutput(user, "You attach the pipe to the underfloor.")
 			playsound(src.loc, "sound/items/Ratchet.ogg", 100, 1)
 
-		else if(istype(I, /obj/item/weldingtool))
-			var/obj/item/weldingtool/W = I
-			if(W.try_weld(user, 2, noisy = 2))
+		else if(isweldingtool(I))
+			if(I:try_weld(user, 2, noisy = 2))
 				// check if anything changed over 2 seconds
 				var/turf/uloc = user.loc
-				var/atom/wloc = W.loc
+				var/atom/wloc = I.loc
 				var/turf/ploc = loc
 				boutput(user, "You begin welding [src] in place.")
 				sleep(0.1 SECONDS)
-				if(user.loc == uloc && wloc == W.loc)
+				if(user.loc == uloc && wloc == I.loc)
 					// REALLY? YOU DON'T FUCKING CARE ABOUT THE LOCATION OF THE PIPE? GET FUCKED <CODER>
 					if (ploc != loc)
 						boutput(user, "<span class='alert'>As you try to weld the pipe to a completely different floor than it was originally placed on it breaks!</span>")

--- a/code/WorkInProgress/recycling/disposal.dm
+++ b/code/WorkInProgress/recycling/disposal.dm
@@ -439,16 +439,14 @@
 		if (T.intact)
 			return		// prevent interaction with T-scanner revealed pipes
 
-		if (istype(I, /obj/item/weldingtool))
-			var/obj/item/weldingtool/W = I
-
-			if (W.try_weld(user, 3, noisy = 2))
+		if (isweldingtool(I))
+			if (I:try_weld(user, 3, noisy = 2))
 				// check if anything changed over 2 seconds
 				var/turf/uloc = user.loc
-				var/atom/wloc = W.loc
+				var/atom/wloc = I.loc
 				boutput(user, "You begin slicing [src].")
 				sleep(0.1 SECONDS)
-				if (user.loc == uloc && wloc == W.loc)
+				if (user.loc == uloc && wloc == I.loc)
 					welded(user)
 				else
 					boutput(user, "You must stay still while welding the pipe.")

--- a/code/datums/critter_mobs/health/structure.dm
+++ b/code/datums/critter_mobs/health/structure.dm
@@ -3,9 +3,8 @@
 	associated_damage_type = "brute"
 
 	on_attack(var/obj/item/I, var/mob/M)
-		if (istype(I, /obj/item/weldingtool))
-			var/obj/item/weldingtool/W = I
-			if (W.welding)
+		if (isweldingtool(I))
+			if (I:welding)
 				if (damaged())
 					holder.visible_message("<span class='notice'>[M] repairs some dents on [holder]!</span>")
 					HealDamage(5)

--- a/code/datums/critter_mobs/health/structure.dm
+++ b/code/datums/critter_mobs/health/structure.dm
@@ -4,7 +4,7 @@
 
 	on_attack(var/obj/item/I, var/mob/M)
 		if (isweldingtool(I))
-			if (I:welding)
+			if (I:try_weld(M,0))
 				if (damaged())
 					holder.visible_message("<span class='notice'>[M] repairs some dents on [holder]!</span>")
 					HealDamage(5)

--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -1057,18 +1057,17 @@
 		return
 
 	attackby(obj/item/W as obj, mob/user as mob)
-		if (istype(W, /obj/item/weldingtool))
+		if (isweldingtool(W))
 			user.lastattacked = src
 
 			if(health == max_health)
 				boutput(user, "<span class='notice'>The locker isn't damaged!</span>")
 				return
 
-			var/obj/item/weldingtool/welder = W
-			if(welder.welding)
-				if(welder.try_weld(user, 4))
+			if(W:welding)
+				if(W:try_weld(user, 4))
 					repair_damage(20)
-					user.visible_message("<span class='notice'>[user] repairs the [src] with [welder]!</span>")
+					user.visible_message("<span class='notice'>[user] repairs the [src] with [W]!</span>")
 					return
 
 		if (health <= 0)

--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -1064,11 +1064,10 @@
 				boutput(user, "<span class='notice'>The locker isn't damaged!</span>")
 				return
 
-			if(W:welding)
-				if(W:try_weld(user, 4))
-					repair_damage(20)
-					user.visible_message("<span class='notice'>[user] repairs the [src] with [W]!</span>")
-					return
+			if(W:try_weld(user, 4))
+				repair_damage(20)
+				user.visible_message("<span class='notice'>[user] repairs the [src] with [W]!</span>")
+				return
 
 		if (health <= 0)
 			boutput(user, "<span class='alert'>The locker is broken, it needs to be repaired first!</span>")

--- a/code/datums/gauntlet/podcolosseum.dm
+++ b/code/datums/gauntlet/podcolosseum.dm
@@ -1470,12 +1470,11 @@ proc/get_colosseum_message(var/name, var/message)
 			qdel(src)
 
 	attackby(obj/item/W as obj, mob/living/user as mob)
-		if (istype(W, /obj/item/weldingtool))
-			var/obj/item/weldingtool/T = W
+		if (isweldingtool(W))
 			if (health >= max_health)
 				boutput(user, "<span class='alert'>That putt is already at full health!</span>")
 				return
-			if (T.try_weld(user, 1))
+			if (W:try_weld(user, 1))
 				visible_message("<span class='notice'><b>[user]</b> repairs some dents on [src]!</span>")
 				message_pilot("<b>[user]</b> repairs some dents on [src]!")
 				repair_by(10)

--- a/code/mob/living/carbon/cube.dm
+++ b/code/mob/living/carbon/cube.dm
@@ -228,7 +228,7 @@
 					O.show_message(message, m_type)
 
 	attackby(obj/item/W as obj, mob/user as mob)
-		if (isweldingtool(W) && W:welding)
+		if (isweldingtool(W) && W:try_weld(user,0,-1,0,0))
 			pop()
 		else
 			..()

--- a/code/mob/living/carbon/cube.dm
+++ b/code/mob/living/carbon/cube.dm
@@ -228,7 +228,7 @@
 					O.show_message(message, m_type)
 
 	attackby(obj/item/W as obj, mob/user as mob)
-		if (istype(W, /obj/item/weldingtool) && W:welding)
+		if (isweldingtool(W) && W:welding)
 			pop()
 		else
 			..()

--- a/code/mob/living/carbon/wall.dm
+++ b/code/mob/living/carbon/wall.dm
@@ -49,7 +49,7 @@
 		return
 
 	attackby(obj/item/W as obj, mob/user as mob)
-		if (istype(W, /obj/item/weldingtool) && W:welding)
+		if (isweldingtool(W) && W:welding)
 			src.gib(1)
 		else
 			..()

--- a/code/mob/living/carbon/wall.dm
+++ b/code/mob/living/carbon/wall.dm
@@ -49,7 +49,7 @@
 		return
 
 	attackby(obj/item/W as obj, mob/user as mob)
-		if (isweldingtool(W) && W:welding)
+		if (isweldingtool(W) && W:try_weld(user,0,-1,0,0))
 			src.gib(1)
 		else
 			..()

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -281,10 +281,9 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 				src.dismantle_stage = 2
 		else ..()
 
-	else if (istype(W, /obj/item/weldingtool))
-		var/obj/item/weldingtool/WELD = W
+	else if (isweldingtool(W))
 		if(src.bruteloss)
-			if(WELD.try_weld(user, 1))
+			if(W:try_weld(user, 1))
 				src.add_fingerprint(user)
 				src.HealDamage(null, 15, 0)
 				src.visible_message("<span class='alert'><b>[user.name]</b> repairs some of the damage to [src.name]'s chassis.</span>")

--- a/code/mob/living/silicon/drone.dm
+++ b/code/mob/living/silicon/drone.dm
@@ -111,15 +111,14 @@
 		return tally
 
 	attackby(obj/item/W as obj, mob/user as mob)
-		if(istype(W, /obj/item/weldingtool))
-			var/obj/item/weldingtool/WELD = W
+		if(isweldingtool(W))
 			if (user.a_intent == INTENT_HARM)
-				if (WELD.welding)
+				if (W:welding)
 					user.visible_message("<span class='alert'><b>[user] burns [src] with [W]!</b></span>")
-					damage_heat(WELD.force)
+					damage_heat(W.force)
 				else
 					user.visible_message("<span class='alert'><b>[user] beats [src] with [W]!</b></span>")
-					damage_blunt(WELD.force)
+					damage_blunt(W.force)
 			else
 				if (src.health >= src.health_max)
 					boutput(user, "<span class='alert'>It isn't damaged!</span>")
@@ -127,9 +126,9 @@
 				if (get_fraction_of_percentage_and_whole(src.health,src.health_max) < 33)
 					boutput(user, "<span class='alert'>You need to use wire to fix the cabling first.</span>")
 					return
-				if(WELD.try_weld(user, 1))
+				if(W:try_weld(user, 1))
 					src.health = max(1,min(src.health + 10,src.health_max))
-					user.visible_message("<b>[user]</b> uses [WELD] to repair some of [src]'s damage.")
+					user.visible_message("<b>[user]</b> uses [W] to repair some of [src]'s damage.")
 					if (src.health == src.health_max)
 						boutput(user, "<span class='notice'><b>[src] looks fully repaired!</b></span>")
 
@@ -407,9 +406,8 @@
 				boutput(usr, "You can't figure out what to do with it. Maybe a closer examination is in order.")
 
 	attackby(obj/item/W as obj, mob/user as mob)
-		if(istype(W, /obj/item/weldingtool))
-			var/obj/item/weldingtool/WELD = W
-			if(WELD.try_weld(user, 1))
+		if(isweldingtool(W))
+			if(W:try_weld(user, 1))
 				switch(construct_stage)
 					if(0)
 						src.visible_message("<b>[user]</b> welds [src] back down to metal.")

--- a/code/mob/living/silicon/drone.dm
+++ b/code/mob/living/silicon/drone.dm
@@ -113,7 +113,7 @@
 	attackby(obj/item/W as obj, mob/user as mob)
 		if(isweldingtool(W))
 			if (user.a_intent == INTENT_HARM)
-				if (W:welding)
+				if (W:try_weld(user,0,-1,0,0))
 					user.visible_message("<span class='alert'><b>[user] burns [src] with [W]!</b></span>")
 					damage_heat(W.force)
 				else

--- a/code/mob/living/silicon/ghostdrone.dm
+++ b/code/mob/living/silicon/ghostdrone.dm
@@ -512,7 +512,7 @@
 	attackby(obj/item/W as obj, mob/user as mob)
 		if(isweldingtool(W))
 			if (user.a_intent == INTENT_HARM)
-				if (W:welding)
+				if (W:try_weld(user,0,-1,0,0))
 					user.visible_message("<span class='alert'><b>[user] burns [src] with [W]!</b></span>")
 					damage_heat(W.force)
 				else

--- a/code/mob/living/silicon/ghostdrone.dm
+++ b/code/mob/living/silicon/ghostdrone.dm
@@ -510,15 +510,14 @@
 		return 1
 
 	attackby(obj/item/W as obj, mob/user as mob)
-		if(istype(W, /obj/item/weldingtool))
-			var/obj/item/weldingtool/WELD = W
+		if(isweldingtool(W))
 			if (user.a_intent == INTENT_HARM)
-				if (WELD.welding)
+				if (W:welding)
 					user.visible_message("<span class='alert'><b>[user] burns [src] with [W]!</b></span>")
-					damage_heat(WELD.force)
+					damage_heat(W.force)
 				else
 					user.visible_message("<span class='alert'><b>[user] beats [src] with [W]!</b></span>")
-					damage_blunt(WELD.force)
+					damage_blunt(W.force)
 			else
 				if (src.health >= src.max_health)
 					boutput(user, "<span class='alert'>It isn't damaged!</span>")
@@ -526,9 +525,9 @@
 				if (get_fraction_of_percentage_and_whole(src.health,src.max_health) < 33)
 					boutput(user, "<span class='alert'>You need to use wire to fix the cabling first.</span>")
 					return
-				if(WELD.try_weld(user, 1))
+				if(W:try_weld(user, 1))
 					src.health = max(1,min(src.health + 5,src.max_health))
-					user.visible_message("<b>[user]</b> uses [WELD] to repair some of [src]'s damage.")
+					user.visible_message("<b>[user]</b> uses [W] to repair some of [src]'s damage.")
 					if (src.health == src.max_health)
 						boutput(user, "<span class='notice'><b>[src] looks fully repaired!</b></span>")
 				else

--- a/code/mob/living/silicon/hivebot.dm
+++ b/code/mob/living/silicon/hivebot.dm
@@ -514,7 +514,7 @@
 	return
 
 /mob/living/silicon/hivebot/attackby(obj/item/W as obj, mob/user as mob)
-	if (isweldingtool(W) && W:welding)
+	if (isweldingtool(W))
 		if (src.get_brute_damage() < 1)
 			boutput(user, "<span class='alert'>[src] has no dents to repair.</span>")
 			return

--- a/code/mob/living/silicon/hivebot.dm
+++ b/code/mob/living/silicon/hivebot.dm
@@ -514,7 +514,7 @@
 	return
 
 /mob/living/silicon/hivebot/attackby(obj/item/W as obj, mob/user as mob)
-	if (istype(W, /obj/item/weldingtool) && W:welding)
+	if (isweldingtool(W) && W:welding)
 		if (src.get_brute_damage() < 1)
 			boutput(user, "<span class='alert'>[src] has no dents to repair.</span>")
 			return

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -1029,9 +1029,8 @@
 		return !cleared
 
 	attackby(obj/item/W as obj, mob/user as mob)
-		if (istype(W, /obj/item/weldingtool))
-			var/obj/item/weldingtool/WELD = W
-			if(WELD.try_weld(user, 1))
+		if (isweldingtool(W))
+			if(W:try_weld(user, 1))
 				src.add_fingerprint(user)
 				var/repaired = HealDamage("All", 120, 0)
 				if(repaired || health < max_health)

--- a/code/modules/atmospherics/machinery/pipe.dm
+++ b/code/modules/atmospherics/machinery/pipe.dm
@@ -353,11 +353,10 @@ obj/machinery/atmospherics/pipe
 					boutput(user, "<span class='alert'>That isn't damaged!</span>")
 					return
 
-				if(!W:try_weld(user, 1, noisy=0))
+				if(!W:try_weld(user, 1, noisy=2))
 					return
 
 				boutput(user, "You start to repair the [src.name].")
-				playsound(src.loc, "sound/items/Welder2.ogg", 50, 1)
 
 				if (do_after(user, 20))
 					ruptured --

--- a/code/modules/atmospherics/machinery/pipe.dm
+++ b/code/modules/atmospherics/machinery/pipe.dm
@@ -347,7 +347,7 @@ obj/machinery/atmospherics/pipe
 
 
 		attackby(var/obj/item/W as obj, var/mob/user as mob)
-			if(istype(W, /obj/item/weldingtool) && W:welding)
+			if(isweldingtool(W) && W:welding)
 
 				if(!ruptured)
 					boutput(user, "<span class='alert'>That isn't damaged!</span>")

--- a/code/modules/atmospherics/machinery/pipe.dm
+++ b/code/modules/atmospherics/machinery/pipe.dm
@@ -347,7 +347,7 @@ obj/machinery/atmospherics/pipe
 
 
 		attackby(var/obj/item/W as obj, var/mob/user as mob)
-			if(isweldingtool(W) && W:welding)
+			if(isweldingtool(W))
 
 				if(!ruptured)
 					boutput(user, "<span class='alert'>That isn't damaged!</span>")
@@ -356,7 +356,6 @@ obj/machinery/atmospherics/pipe
 				if(!W:try_weld(user, 1, noisy=0))
 					return
 
-				W:eyecheck(user)
 				boutput(user, "You start to repair the [src.name].")
 				playsound(src.loc, "sound/items/Welder2.ogg", 50, 1)
 

--- a/code/modules/fluids/fluid_objects.dm
+++ b/code/modules/fluids/fluid_objects.dm
@@ -71,26 +71,24 @@
 
 	attackby(obj/item/I as obj, mob/user as mob)
 		if (isweldingtool(I))
-			if(I:welding)
-				if(!I:try_weld(user, 2))
-					return
-				I:eyecheck(user)
-
-				if (!src.welded)
-					src.welded = 1
-					logTheThing("station", user, null, "welded [name] shut at [log_loc(user)].")
-					user.show_text("You weld the drain shut.")
-				else
-					logTheThing("station", user, null, "un-welded [name] at [log_loc(user)].")
-					src.welded = 0
-					user.show_text("You unseal the drain with your welder.")
-
-				if (src.clogged)
-					src.clogged = 0
-					user.show_text("The drain clog melts away.")
-
-				src.update_icon()
+			if(!I:try_weld(user, 2))
 				return
+
+			if (!src.welded)
+				src.welded = 1
+				logTheThing("station", user, null, "welded [name] shut at [log_loc(user)].")
+				user.show_text("You weld the drain shut.")
+			else
+				logTheThing("station", user, null, "un-welded [name] at [log_loc(user)].")
+				src.welded = 0
+				user.show_text("You unseal the drain with your welder.")
+
+			if (src.clogged)
+				src.clogged = 0
+				user.show_text("The drain clog melts away.")
+
+			src.update_icon()
+			return
 		if (istype(I,/obj/item/material_piece/cloth))
 			var/obj/item/material_piece/cloth/C = I
 			src.clogged += (20 * C.amount) //One piece of cloth clogs for about 1 minute. (cause the machine loop updates ~3 second interval)

--- a/code/modules/fluids/fluid_objects.dm
+++ b/code/modules/fluids/fluid_objects.dm
@@ -70,12 +70,11 @@
 
 
 	attackby(obj/item/I as obj, mob/user as mob)
-		if (istype(I, /obj/item/weldingtool))
-			var/obj/item/weldingtool/W = I
-			if(W.welding)
-				if(!W.try_weld(user, 2))
+		if (isweldingtool(I))
+			if(I:welding)
+				if(!I:try_weld(user, 2))
 					return
-				W.eyecheck(user)
+				I:eyecheck(user)
 
 				if (!src.welded)
 					src.welded = 1

--- a/code/modules/networks/computer3/buildandrepair.dm
+++ b/code/modules/networks/computer3/buildandrepair.dm
@@ -76,7 +76,7 @@
 					boutput(user, "<span class='notice'>You wrench the frame into place.</span>")
 					src.anchored = 1
 					src.state = 1
-			if(istype(P, /obj/item/weldingtool))
+			if(isweldingtool(P))
 				playsound(src.loc, "sound/items/Welder.ogg", 50, 1)
 				if(do_after(user, 20))
 					boutput(user, "<span class='notice'>You deconstruct the frame.</span>")

--- a/code/modules/robotics/bot/cleanbot.dm
+++ b/code/modules/robotics/bot/cleanbot.dm
@@ -191,8 +191,6 @@
 
 	attackby(obj/item/W, mob/user as mob)
 		if (isweldingtool(W))
-			if (!W:welding)
-				return
 			if (src.health < initial(src.health))
 				if(W:try_weld(user, 1))
 					src.health = initial(src.health)

--- a/code/modules/robotics/bot/cleanbot.dm
+++ b/code/modules/robotics/bot/cleanbot.dm
@@ -190,12 +190,11 @@
 		return
 
 	attackby(obj/item/W, mob/user as mob)
-		if (istype(W, /obj/item/weldingtool))
-			var/obj/item/weldingtool/WT = W
-			if (!WT.welding)
+		if (isweldingtool(W))
+			if (!W:welding)
 				return
 			if (src.health < initial(src.health))
-				if(WT.try_weld(user, 1))
+				if(W:try_weld(user, 1))
 					src.health = initial(src.health)
 					src.visible_message("<span class='alert'><b>[user]</b> repairs the damage on [src].</span>")
 

--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -1071,7 +1071,7 @@ Report Arrests: <A href='?src=\ref[src];operation=report'>[report_arrests ? "On"
 
 
 /obj/item/secbot_assembly/attackby(obj/item/W as obj, mob/user as mob)
-	if ((istype(W, /obj/item/weldingtool)) && (!src.build_step))
+	if ((isweldingtool(W)) && (!src.build_step))
 		if(W:try_weld(user, 1))
 			src.build_step++
 			src.overlays += image('icons/obj/bots/aibots.dmi', "hs_hole")

--- a/code/modules/transport/pods/ships.dm
+++ b/code/modules/transport/pods/ships.dm
@@ -491,7 +491,7 @@
 				boutput(user, "You should probably finish putting these parts together. A wrench would do the trick!")
 
 		if(2)
-			if (istype(W, /obj/item/weldingtool))
+			if (isweldingtool(W))
 				if(!W:try_weld(user, 1))
 					return
 				boutput(user, "You begin to weld the joints of the frame...")
@@ -668,7 +668,7 @@
 				boutput(user, "You don't think you're going anywhere without a skin on this pod, do you? Get some armor!")
 
 		if(8)
-			if (istype(W, /obj/item/weldingtool))
+			if (isweldingtool(W))
 				if(!W:try_weld(user, 1))
 					return
 				boutput(user, "You begin to weld the exterior...")
@@ -1439,7 +1439,7 @@
 				boutput(user, "You should probably finish putting these parts together. A wrench would do the trick!")
 
 		if(2)
-			if (istype(W, /obj/item/weldingtool) && W:welding)
+			if (isweldingtool(W) && W:welding)
 				if(!W:try_weld(user, 1))
 					return
 				boutput(user, "You begin to weld the joints of the frame...")
@@ -1616,7 +1616,7 @@
 				boutput(user, "You don't think you're going anywhere without a skin on this pod, do you? Get some armor!")
 
 		if(8)
-			if (istype(W, /obj/item/weldingtool))
+			if (isweldingtool(W))
 				if(!W:try_weld(user, 1, burn_eyes = 1))
 					return
 				boutput(user, "You begin to weld the exterior...")

--- a/code/modules/transport/pods/ships.dm
+++ b/code/modules/transport/pods/ships.dm
@@ -498,7 +498,6 @@
 				if (!do_after(user, 30))
 					boutput(user, "<span class='alert'>You were interrupted!</span>")
 					return
-				W:eyecheck(user)
 				boutput(user, "You weld the joints of the frame together.")
 				stage = 3
 			else
@@ -675,7 +674,6 @@
 				if (!do_after(user, 30))
 					boutput(user, "<span class='alert'>You were interrupted!</span>")
 					return
-				W:eyecheck(user)
 				boutput(user, "You weld the seams of the outer skin to make it air-tight.")
 				stage = 9
 			else
@@ -1616,7 +1614,7 @@
 
 		if(8)
 			if (isweldingtool(W))
-				if(!W:try_weld(user, 1, burn_eyes = 1))
+				if(!W:try_weld(user, 1))
 					return
 				boutput(user, "You begin to weld the exterior...")
 				if (!do_after(user, 30))

--- a/code/modules/transport/pods/ships.dm
+++ b/code/modules/transport/pods/ships.dm
@@ -1439,14 +1439,13 @@
 				boutput(user, "You should probably finish putting these parts together. A wrench would do the trick!")
 
 		if(2)
-			if (isweldingtool(W) && W:welding)
+			if (isweldingtool(W))
 				if(!W:try_weld(user, 1))
 					return
 				boutput(user, "You begin to weld the joints of the frame...")
 				if (!do_after(user, 30))
 					boutput(user, "<span class='alert'>You were interrupted!</span>")
 					return
-				W:eyecheck(user)
 				boutput(user, "You weld the joints of the frame together.")
 				stage = 3
 			else

--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -97,7 +97,7 @@
 
 	attackby(obj/item/W as obj, mob/living/user as mob)
 		user.lastattacked = src
-		if (health < maxhealth && istype(W, /obj/item/weldingtool) && W:welding)
+		if (health < maxhealth && isweldingtool(W) && W:welding)
 			if(!W:try_weld(user, 1))
 				return
 			src.health += 30

--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -97,7 +97,7 @@
 
 	attackby(obj/item/W as obj, mob/living/user as mob)
 		user.lastattacked = src
-		if (health < maxhealth && isweldingtool(W) && W:welding)
+		if (health < maxhealth && isweldingtool(W))
 			if(!W:try_weld(user, 1))
 				return
 			src.health += 30

--- a/code/obj.dm
+++ b/code/obj.dm
@@ -366,7 +366,7 @@
 				qdel(C)
 			qdel(src)
 			return
-		if (istype(C, /obj/item/weldingtool) && C:welding)
+		if (isweldingtool(C) && C:welding)
 			boutput(user, "<span class='notice'>Slicing lattice joints ...</span>")
 			C:eyecheck(user)
 			new /obj/item/rods/steel(src.loc)
@@ -400,11 +400,10 @@
 			return
 
 	attackby(obj/item/W as obj, mob/user as mob)
-		if (istype(W, /obj/item/weldingtool))
-			var/obj/item/weldingtool/WELD = W
-			if(WELD.welding)
+		if (isweldingtool(W))
+			if(W:welding)
 				boutput(user, "<span class='notice'>You disassemble the barricade.</span>")
-				WELD.eyecheck(user)
+				W:eyecheck(user)
 				var/obj/item/rods/R = new /obj/item/rods/steel(src.loc)
 				R.amount = src.strength
 				qdel(src)

--- a/code/obj.dm
+++ b/code/obj.dm
@@ -368,7 +368,6 @@
 			return
 		if (isweldingtool(C) && C:try_weld(user,0))
 			boutput(user, "<span class='notice'>Slicing lattice joints ...</span>")
-			C:eyecheck(user)
 			new /obj/item/rods/steel(src.loc)
 			qdel(src)
 		if (istype(C, /obj/item/rods))

--- a/code/obj.dm
+++ b/code/obj.dm
@@ -366,7 +366,7 @@
 				qdel(C)
 			qdel(src)
 			return
-		if (isweldingtool(C) && C:welding)
+		if (isweldingtool(C) && C:try_weld(user,0))
 			boutput(user, "<span class='notice'>Slicing lattice joints ...</span>")
 			C:eyecheck(user)
 			new /obj/item/rods/steel(src.loc)
@@ -401,9 +401,8 @@
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (isweldingtool(W))
-			if(W:welding)
+			if(W:try_weld(user,1))
 				boutput(user, "<span class='notice'>You disassemble the barricade.</span>")
-				W:eyecheck(user)
 				var/obj/item/rods/R = new /obj/item/rods/steel(src.loc)
 				R.amount = src.strength
 				qdel(src)

--- a/code/obj/alien/weeds.dm
+++ b/code/obj/alien/weeds.dm
@@ -24,7 +24,6 @@
 		else if (istype(W, /obj/item/shard)) qdel(src)
 		else if (istype(W, /obj/item/sword)) qdel(src)
 		else if (istype(W, /obj/item/saw)) qdel(src)
-		else if (istype(W, /obj/item/weldingtool)) qdel(src)
 		..()
 
 	proc/Life()

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -225,13 +225,12 @@
 				else if (!ACT.activator && A.activated)
 					src.ArtifactDeactivated()
 
-	if (istype(W,/obj/item/weldingtool))
-		var/obj/item/weldingtool/WELD = W
-		if (WELD.welding)
-			WELD.eyecheck(user)
+	if (isweldingtool(W))
+		if (W:welding)
+			W:eyecheck(user)
 			src.ArtifactStimulus("heat", 800)
 			playsound(src.loc, "sound/items/Welder.ogg", 100, 1)
-			src.visible_message("<span class='alert'>[user.name] burns the artifact with [WELD]!</span>")
+			src.visible_message("<span class='alert'>[user.name] burns the artifact with [W]!</span>")
 			return 0
 
 	if (istype(W,/obj/item/device/light/zippo))

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -226,8 +226,7 @@
 					src.ArtifactDeactivated()
 
 	if (isweldingtool(W))
-		if (W:welding)
-			W:eyecheck(user)
+		if (W:try_weld(user,0,-1,0,0))
 			src.ArtifactStimulus("heat", 800)
 			playsound(src.loc, "sound/items/Welder.ogg", 100, 1)
 			src.visible_message("<span class='alert'>[user.name] burns the artifact with [W]!</span>")

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -226,9 +226,8 @@
 					src.ArtifactDeactivated()
 
 	if (isweldingtool(W))
-		if (W:try_weld(user,0,-1,0,0))
+		if (W:try_weld(user,0,-1,0,1))
 			src.ArtifactStimulus("heat", 800)
-			playsound(src.loc, "sound/items/Welder.ogg", 100, 1)
 			src.visible_message("<span class='alert'>[user.name] burns the artifact with [W]!</span>")
 			return 0
 

--- a/code/obj/critter/critter_parent.dm
+++ b/code/obj/critter/critter_parent.dm
@@ -1084,7 +1084,7 @@
 
 			src.critter_name = t
 
-		else if ((isweldingtool(W) && W:welding) || (istype(W, /obj/item/clothing/head/cakehat) && W:on) || istype(W, /obj/item/device/igniter) || ((istype(W, /obj/item/device/light/zippo) || istype(W, /obj/item/match) || istype(W, /obj/item/device/light/candle)) && W:on) || W.burning || W.hit_type == DAMAGE_BURN) // jesus motherfucking christ
+		else if ((isweldingtool(W) && W:try_weld(user,0,-1,0,0)) || (istype(W, /obj/item/clothing/head/cakehat) && W:on) || istype(W, /obj/item/device/igniter) || ((istype(W, /obj/item/device/light/zippo) || istype(W, /obj/item/match) || istype(W, /obj/item/device/light/candle)) && W:on) || W.burning || W.hit_type == DAMAGE_BURN) // jesus motherfucking christ
 			user.visible_message("<span class='alert'><b>[user]</b> warms [src] with [W].</span>",\
 			"<span class='alert'>You warm [src] with [W].</span>")
 			src.warm_count -= 2

--- a/code/obj/critter/critter_parent.dm
+++ b/code/obj/critter/critter_parent.dm
@@ -1084,7 +1084,7 @@
 
 			src.critter_name = t
 
-		else if ((istype(W, /obj/item/weldingtool) && W:welding) || (istype(W, /obj/item/clothing/head/cakehat) && W:on) || istype(W, /obj/item/device/igniter) || ((istype(W, /obj/item/device/light/zippo) || istype(W, /obj/item/match) || istype(W, /obj/item/device/light/candle)) && W:on) || W.burning || W.hit_type == DAMAGE_BURN) // jesus motherfucking christ
+		else if ((isweldingtool(W) && W:welding) || (istype(W, /obj/item/clothing/head/cakehat) && W:on) || istype(W, /obj/item/device/igniter) || ((istype(W, /obj/item/device/light/zippo) || istype(W, /obj/item/match) || istype(W, /obj/item/device/light/candle)) && W:on) || W.burning || W.hit_type == DAMAGE_BURN) // jesus motherfucking christ
 			user.visible_message("<span class='alert'><b>[user]</b> warms [src] with [W].</span>",\
 			"<span class='alert'>You warm [src] with [W].</span>")
 			src.warm_count -= 2

--- a/code/obj/decorations.dm
+++ b/code/obj/decorations.dm
@@ -749,7 +749,7 @@ obj/decoration/ceilingfan
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (!src.lit)
-			if (isweldingtool(W) && W:welding)
+			if (isweldingtool(W) && W:try_weld(user,0,-1,0,0))
 				boutput(user, "<span class='alert'><b>[user]</b> casually lights [src] with [W], what a badass.</span>")
 				src.lit = 1
 				update_icon()

--- a/code/obj/decorations.dm
+++ b/code/obj/decorations.dm
@@ -749,7 +749,7 @@ obj/decoration/ceilingfan
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (!src.lit)
-			if (istype(W, /obj/item/weldingtool) && W:welding)
+			if (isweldingtool(W) && W:welding)
 				boutput(user, "<span class='alert'><b>[user]</b> casually lights [src] with [W], what a badass.</span>")
 				src.lit = 1
 				update_icon()

--- a/code/obj/flock/furniture.dm
+++ b/code/obj/flock/furniture.dm
@@ -123,9 +123,8 @@
 	else if (istype(W, /obj/item/satchel/))
 		boutput(user, "<span class='alert'>It isn't really clear how to make this work.</span>")
 		return
-	else if (!src.open && istype(W, /obj/item/weldingtool))
-		var/obj/item/weldingtool/welder = W
-		if (welder.welding)
+	else if (!src.open && isweldingtool(W))
+		if (W:welding)
 			boutput(user, "<span class='alert'>It doesn't matter what you try, it doesn't seem to keep welded shut.</span>")
 		return
 	// smack the damn thing if it's closed
@@ -238,7 +237,7 @@
 			user.u_equip(C)
 			qdel(C)
 		qdel(src)
-	if (istype(C, /obj/item/weldingtool) && C:welding)
+	if (isweldingtool(C) && C:welding)
 		boutput(user, "<span class='notice'>The fibres burn away in the same way glass doesn't. Huh.</span>")
 		qdel(src)
 

--- a/code/obj/flock/furniture.dm
+++ b/code/obj/flock/furniture.dm
@@ -124,7 +124,7 @@
 		boutput(user, "<span class='alert'>It isn't really clear how to make this work.</span>")
 		return
 	else if (!src.open && isweldingtool(W))
-		if (W:welding)
+		if (W:try_weld(user,0,-1,0,0))
 			boutput(user, "<span class='alert'>It doesn't matter what you try, it doesn't seem to keep welded shut.</span>")
 		return
 	// smack the damn thing if it's closed
@@ -237,7 +237,7 @@
 			user.u_equip(C)
 			qdel(C)
 		qdel(src)
-	if (isweldingtool(C) && C:welding)
+	if (isweldingtool(C) && C:try_weld(user,0,-1,0,0))
 		boutput(user, "<span class='notice'>The fibres burn away in the same way glass doesn't. Huh.</span>")
 		qdel(src)
 

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -677,7 +677,7 @@
 	if (src.material)
 		src.material.triggerTemp(src ,1500)
 	if (src.burn_possible && src.burn_point <= 1500)
-		if ((isweldingtool(W) && W:welding) || (istype(W, /obj/item/clothing/head/cakehat) && W:on) || (istype(W, /obj/item/device/igniter)) || (istype(W, /obj/item/device/light/zippo) && W:on) || (istype(W, /obj/item/match) && (W:on > 0)) || W.burning)
+		if ((isweldingtool(W) && W:try_weld(user,0,-1,0,0)) || (istype(W, /obj/item/clothing/head/cakehat) && W:on) || (istype(W, /obj/item/device/igniter)) || (istype(W, /obj/item/device/light/zippo) && W:on) || (istype(W, /obj/item/match) && (W:on > 0)) || W.burning)
 			src.combust()
 		else
 			..(W, user)

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -677,7 +677,7 @@
 	if (src.material)
 		src.material.triggerTemp(src ,1500)
 	if (src.burn_possible && src.burn_point <= 1500)
-		if ((istype(W, /obj/item/weldingtool) && W:welding) || (istype(W, /obj/item/clothing/head/cakehat) && W:on) || (istype(W, /obj/item/device/igniter)) || (istype(W, /obj/item/device/light/zippo) && W:on) || (istype(W, /obj/item/match) && (W:on > 0)) || W.burning)
+		if ((isweldingtool(W) && W:welding) || (istype(W, /obj/item/clothing/head/cakehat) && W:on) || (istype(W, /obj/item/device/igniter)) || (istype(W, /obj/item/device/light/zippo) && W:on) || (istype(W, /obj/item/match) && (W:on > 0)) || W.burning)
 			src.combust()
 		else
 			..(W, user)

--- a/code/obj/item/assembly/single_tank_bomb.dm
+++ b/code/obj/item/assembly/single_tank_bomb.dm
@@ -95,7 +95,7 @@
 		//SN src = null
 		qdel(src)
 		return
-	if (!(isweldingtool(W) && W:welding))
+	if (!(isweldingtool(W) && W:try_weld(user,0,-1,0,0)))
 		return
 	if (!( src.status ))
 		src.status = 1
@@ -224,7 +224,7 @@
 		//SN src = null
 		qdel(src)
 		return
-	if (!(isweldingtool(W) && W:welding))
+	if (!(isweldingtool(W) && W:try_weld(user,0,-1,0,0)))
 		return
 	if (!( src.status ))
 		src.status = 1
@@ -309,7 +309,7 @@
 		//SN src = null
 		qdel(src)
 		return
-	if (!(isweldingtool(W) && W:welding))
+	if (!(isweldingtool(W) && W:try_weld(user,0,-1,0,0)))
 		return
 	if (!( src.status ))
 		src.status = 1

--- a/code/obj/item/assembly/single_tank_bomb.dm
+++ b/code/obj/item/assembly/single_tank_bomb.dm
@@ -95,7 +95,7 @@
 		//SN src = null
 		qdel(src)
 		return
-	if (!( istype(W, /obj/item/weldingtool) ))
+	if (!(isweldingtool(W) && W:welding))
 		return
 	if (!( src.status ))
 		src.status = 1
@@ -224,7 +224,7 @@
 		//SN src = null
 		qdel(src)
 		return
-	if (!( istype(W, /obj/item/weldingtool) ))
+	if (!(isweldingtool(W) && W:welding))
 		return
 	if (!( src.status ))
 		src.status = 1
@@ -309,7 +309,7 @@
 		//SN src = null
 		qdel(src)
 		return
-	if (!( istype(W, /obj/item/weldingtool) ))
+	if (!(isweldingtool(W) && W:welding))
 		return
 	if (!( src.status ))
 		src.status = 1

--- a/code/obj/item/building_materials.dm
+++ b/code/obj/item/building_materials.dm
@@ -812,7 +812,6 @@ MATERIAL
 			if(!W:try_weld(user, 1))
 				return
 
-			W:eyecheck(user)
 			if(!src.anchored) user.visible_message("<span class='alert'><B>[user.name] welds the [src.name] to the floor.</B></span>")
 			else user.visible_message("<span class='alert'><B>[user.name] cuts the [src.name] free from the floor.</B></span>")
 			src.anchored = !(src.anchored)

--- a/code/obj/item/building_materials.dm
+++ b/code/obj/item/building_materials.dm
@@ -652,8 +652,7 @@ MATERIAL
 			..(user)
 
 	attackby(obj/item/W as obj, mob/user as mob)
-		if (istype(W, /obj/item/weldingtool))
-			var/obj/item/weldingtool/WELD = W
+		if (isweldingtool(W))
 			if(src.amount < 2)
 				boutput(user, "<span class='alert'>You need at least two rods to make a material sheet.</span>")
 				return
@@ -663,7 +662,7 @@ MATERIAL
 				else
 					boutput(user, "<span class='alert'>You should probably put the rods down first.</span>")
 				return
-			if(!WELD.try_weld(user, 1))
+			if(!W:try_weld(user, 1))
 				return
 
 			var/weldinput = 1
@@ -678,7 +677,7 @@ MATERIAL
 			M.amount = weldinput
 			src.consume_rods(weldinput * 2)
 
-			WELD.eyecheck(user)
+			W:eyecheck(user)
 			user.visible_message("<span class='alert'><B>[user]</B> welds the rods together into sheets.</span>")
 			update_icon()
 			if(src.amount < 1)	qdel(src)
@@ -806,16 +805,15 @@ MATERIAL
 			..(user)
 
 	attackby(obj/item/W as obj, mob/user as mob)
-		if (istype(W, /obj/item/weldingtool))
-			var/obj/item/weldingtool/WELD = W
+		if (isweldingtool(W))
 			if(!src.anchored && !istype(src.loc,/turf/simulated/floor) && !istype(src.loc,/turf/unsimulated/floor))
 				boutput(user, "<span class='alert'>There's nothing to weld that to.</span>")
 				return
 
-			if(!WELD.try_weld(user, 1))
+			if(!W:try_weld(user, 1))
 				return
 
-			WELD.eyecheck(user)
+			W:eyecheck(user)
 			if(!src.anchored) user.visible_message("<span class='alert'><B>[user.name] welds the [src.name] to the floor.</B></span>")
 			else user.visible_message("<span class='alert'><B>[user.name] cuts the [src.name] free from the floor.</B></span>")
 			src.anchored = !(src.anchored)

--- a/code/obj/item/building_materials.dm
+++ b/code/obj/item/building_materials.dm
@@ -677,7 +677,6 @@ MATERIAL
 			M.amount = weldinput
 			src.consume_rods(weldinput * 2)
 
-			W:eyecheck(user)
 			user.visible_message("<span class='alert'><B>[user]</B> welds the rods together into sheets.</span>")
 			update_icon()
 			if(src.amount < 1)	qdel(src)

--- a/code/obj/item/cigarette.dm
+++ b/code/obj/item/cigarette.dm
@@ -139,7 +139,7 @@
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (src.on == 0)
-			if (istype(W, /obj/item/weldingtool) && W:welding)
+			if (isweldingtool(W) && W:welding)
 				src.light(user, "<span class='alert'><b>[user]</b> casually lights [src] with [W], what a badass.</span>")
 				return
 			else if (istype(W, /obj/item/sword) && W:active)

--- a/code/obj/item/cigarette.dm
+++ b/code/obj/item/cigarette.dm
@@ -139,7 +139,7 @@
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (src.on == 0)
-			if (isweldingtool(W) && W:welding)
+			if (isweldingtool(W) && W:try_weld(user,0,-1,0,0))
 				src.light(user, "<span class='alert'><b>[user]</b> casually lights [src] with [W], what a badass.</span>")
 				return
 			else if (istype(W, /obj/item/sword) && W:active)

--- a/code/obj/item/deployable_turret.dm
+++ b/code/obj/item/deployable_turret.dm
@@ -169,7 +169,7 @@
 
 
 	attackby(obj/item/W, mob/user)
-		if (istype(W, /obj/item/weldingtool) && !(src.active))
+		if (isweldingtool(W) && W:welding && !(src.active))
 			var/turf/T = user.loc
 			if(!W:try_weld(user, 1))
 				return
@@ -202,7 +202,7 @@
 					user.show_message("You weld the turret to the floor.")
 					src.anchored = 1
 
-		else if (istype(W, /obj/item/weldingtool) && (src.active))
+		else if (isweldingtool(W) && W:welding && (src.active))
 			var/turf/T = user.loc
 			if (src.health >= max_health)
 				user.show_message("<span class='notice'>The turret is already fully repaired!.</span>")

--- a/code/obj/item/deployable_turret.dm
+++ b/code/obj/item/deployable_turret.dm
@@ -169,7 +169,7 @@
 
 
 	attackby(obj/item/W, mob/user)
-		if (isweldingtool(W) && W:welding && !(src.active))
+		if (isweldingtool(W) && !(src.active))
 			var/turf/T = user.loc
 			if(!W:try_weld(user, 1))
 				return
@@ -194,7 +194,6 @@
 
 				if ((user.loc == T && user.equipped() == W))
 					user.show_message("You weld the turret to the floor.")
-					W:eyecheck(user)
 					src.anchored = 1
 
 
@@ -202,7 +201,7 @@
 					user.show_message("You weld the turret to the floor.")
 					src.anchored = 1
 
-		else if (isweldingtool(W) && W:welding && (src.active))
+		else if (isweldingtool(W) && (src.active))
 			var/turf/T = user.loc
 			if (src.health >= max_health)
 				user.show_message("<span class='notice'>The turret is already fully repaired!.</span>")
@@ -215,7 +214,6 @@
 			sleep(2 SECONDS)
 
 			if ((user.loc == T && user.equipped() == W))
-				W:eyecheck(user)
 				user.show_message("You repair some of the damage on the turret.")
 				src.health = min(src.max_health, (src.health + 10))
 				src.check_health()

--- a/code/obj/item/deployable_turret.dm
+++ b/code/obj/item/deployable_turret.dm
@@ -180,7 +180,6 @@
 
 				if ((user.loc == T && user.equipped() == W))
 					user.show_message("You unweld the turret from the floor.")
-					W:eyecheck(user)
 					src.anchored = 0
 
 

--- a/code/obj/item/device/lights.dm
+++ b/code/obj/item/device/lights.dm
@@ -132,7 +132,7 @@
 
 	//Can be heated. Has chance to explode when heated. After heating, can explode when thrown or fussed with!
 	attackby(obj/item/W as obj, mob/user as mob)
-		if ((istype(W, /obj/item/weldingtool) && W:welding) || istype(W, /obj/item/device/igniter) || ((istype(W, /obj/item/device/light/zippo) || istype(W, /obj/item/match) || istype(W, /obj/item/device/light/candle) || istype(W, /obj/item/clothing/mask/cigarette)) && W:on) || W.burning)
+		if ((isweldingtool(W) && W:welding) || istype(W, /obj/item/device/igniter) || ((istype(W, /obj/item/device/light/zippo) || istype(W, /obj/item/match) || istype(W, /obj/item/device/light/candle) || istype(W, /obj/item/clothing/mask/cigarette)) && W:on) || W.burning)
 			user.visible_message("<span class='alert'><b>[user]</b> heats [src] with [W].</span>")
 			src.heated += 1
 			if (src.heated >= 3 || prob(5 + (heated * 20)))
@@ -272,7 +272,7 @@
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (!src.on)
-			if (istype(W, /obj/item/weldingtool) && W:welding)
+			if (isweldingtool(W) && W:welding)
 				src.light(user, "<span class='alert'><b>[user]</b> casually lights [src] with [W], what a badass.</span>")
 
 			else if (istype(W, /obj/item/clothing/head/cakehat) && W:on)

--- a/code/obj/item/device/lights.dm
+++ b/code/obj/item/device/lights.dm
@@ -132,7 +132,7 @@
 
 	//Can be heated. Has chance to explode when heated. After heating, can explode when thrown or fussed with!
 	attackby(obj/item/W as obj, mob/user as mob)
-		if ((isweldingtool(W) && W:welding) || istype(W, /obj/item/device/igniter) || ((istype(W, /obj/item/device/light/zippo) || istype(W, /obj/item/match) || istype(W, /obj/item/device/light/candle) || istype(W, /obj/item/clothing/mask/cigarette)) && W:on) || W.burning)
+		if ((isweldingtool(W) && W:try_weld(user,0,-1,0,0)) || istype(W, /obj/item/device/igniter) || ((istype(W, /obj/item/device/light/zippo) || istype(W, /obj/item/match) || istype(W, /obj/item/device/light/candle) || istype(W, /obj/item/clothing/mask/cigarette)) && W:on) || W.burning)
 			user.visible_message("<span class='alert'><b>[user]</b> heats [src] with [W].</span>")
 			src.heated += 1
 			if (src.heated >= 3 || prob(5 + (heated * 20)))
@@ -272,7 +272,7 @@
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (!src.on)
-			if (isweldingtool(W) && W:welding)
+			if (isweldingtool(W) && W:try_weld(user,0,-1,0,0))
 				src.light(user, "<span class='alert'><b>[user]</b> casually lights [src] with [W], what a badass.</span>")
 
 			else if (istype(W, /obj/item/clothing/head/cakehat) && W:on)

--- a/code/obj/item/glass.dm
+++ b/code/obj/item/glass.dm
@@ -260,9 +260,8 @@ SHARDS
 
 /obj/item/shard/attackby(obj/item/W as obj, mob/user as mob)
 	..()
-	if (!(isweldingtool(W) && W:welding ))
+	if (!(isweldingtool(W) && try_weld(user,0,-1,1,0)))
 		return
-	W:eyecheck(user)
 	var/atom/A = new /obj/item/sheet/glass( user.loc )
 	if(src.material) A.setMaterial(src.material)
 	//SN src = null
@@ -312,9 +311,8 @@ SHARDS
 			else
 		return
 	attackby(obj/item/W as obj, mob/user as mob)
-		if (!(isweldingtool(W) && W:welding ))
+		if (!(isweldingtool(W) && W:try_weld(user,0,-1,1,0)))
 			return
-		W:eyecheck(user)
 		var/atom/A = new /obj/item/sheet/glass/crystal( user.loc )
 		if(src.material) A.setMaterial(src.material)
 		qdel(src)

--- a/code/obj/item/glass.dm
+++ b/code/obj/item/glass.dm
@@ -260,7 +260,7 @@ SHARDS
 
 /obj/item/shard/attackby(obj/item/W as obj, mob/user as mob)
 	..()
-	if (!( istype(W, /obj/item/weldingtool) && W:welding ))
+	if (!(isweldingtool(W) && W:welding ))
 		return
 	W:eyecheck(user)
 	var/atom/A = new /obj/item/sheet/glass( user.loc )
@@ -312,7 +312,7 @@ SHARDS
 			else
 		return
 	attackby(obj/item/W as obj, mob/user as mob)
-		if (!( istype(W, /obj/item/weldingtool) && W:welding ))
+		if (!(isweldingtool(W) && W:welding ))
 			return
 		W:eyecheck(user)
 		var/atom/A = new /obj/item/sheet/glass/crystal( user.loc )

--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -1144,10 +1144,9 @@ PIPE BOMBS + CONSTRUCTION
 				qdel(W)
 				qdel(src)
 		#endif
-		if(isweldingtool(W) && W:welding && state == 1)
+		if(isweldingtool(W) && state == 1)
 			if(!W:try_weld(user, 1))
 				return
-			W:eyecheck(user)
 			boutput(user, "<span class='notice'>You hollow out the pipe.</span>")
 			src.state = 2
 			icon_state = "Pipe_Hollow"

--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -1144,7 +1144,7 @@ PIPE BOMBS + CONSTRUCTION
 				qdel(W)
 				qdel(src)
 		#endif
-		if(istype(W, /obj/item/weldingtool) && state == 1)
+		if(isweldingtool(W) && W:welding && state == 1)
 			if(!W:try_weld(user, 1))
 				return
 			W:eyecheck(user)

--- a/code/obj/item/metal.dm
+++ b/code/obj/item/metal.dm
@@ -54,8 +54,7 @@ MATERIAL
 			..(user)
 
 	attackby(obj/item/W as obj, mob/user as mob)
-		if (istype(W, /obj/item/weldingtool))
-			var/obj/item/weldingtool/WELD = W
+		if (isweldingtool(W))
 			if(src.amount < 2)
 				boutput(user, "<span class='alert'>You need at least two rods to make a metal sheet.</span>")
 				return
@@ -65,7 +64,7 @@ MATERIAL
 				else
 					boutput(user, "<span class='alert'>You should probably put the rods down first.</span>")
 				return
-			if(!WELD.try_weld(user, 1))
+			if(!W:try_weld(user, 1))
 				return
 
 			var/weldinput = 1
@@ -80,7 +79,7 @@ MATERIAL
 			M.amount = weldinput
 			src.amount -= weldinput * 2
 
-			WELD.eyecheck(user)
+			W:eyecheck(user)
 			user.visible_message("<span class='alert'><B>[user]</B> welds the rods together into metal.</span>")
 			if(src.amount < 1)	qdel(src)
 			return

--- a/code/obj/item/metal.dm
+++ b/code/obj/item/metal.dm
@@ -79,7 +79,6 @@ MATERIAL
 			M.amount = weldinput
 			src.amount -= weldinput * 2
 
-			W:eyecheck(user)
 			user.visible_message("<span class='alert'><B>[user]</B> welds the rods together into metal.</span>")
 			if(src.amount < 1)	qdel(src)
 			return

--- a/code/obj/item/mob_parts/robot_parts.dm
+++ b/code/obj/item/mob_parts/robot_parts.dm
@@ -52,9 +52,8 @@
 		return standImage
 
 	attackby(obj/item/W as obj, mob/user as mob)
-		if(istype(W, /obj/item/weldingtool))
-			var/obj/item/weldingtool/WELD = W
-			if(!WELD.try_weld(user, 1))
+		if(isweldingtool(W))
+			if(!W:try_weld(user, 1))
 				return
 			if (src.ropart_get_damage_percentage(1) > 0)
 				src.ropart_mend_damage(20,0)
@@ -319,7 +318,7 @@
 			else
 				boutput(user, "<span class='alert'>You need at least two reinforced metal sheets to reinforce this component.</span>")
 				return
-		else if (istype(W, /obj/item/weldingtool))
+		else if (isweldingtool(W))
 			if(!W:try_weld(user, 1))
 				return
 			boutput(user, "<span class='notice'>You remove the reinforcement metals from [src].</span>")
@@ -349,7 +348,7 @@
 	weight = 0.4
 
 	attackby(obj/item/W as obj, mob/user as mob)
-		if (istype(W, /obj/item/weldingtool))
+		if (isweldingtool(W))
 			if(!W:try_weld(user, 1))
 				return
 			boutput(user, "<span class='notice'>You remove the reinforcement metals from [src].</span>")
@@ -496,7 +495,7 @@
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		//gonna hack this in with appearanceString
-		if ((appearanceString == "sturdy" || appearanceString == "heavy") && istype(W, /obj/item/weldingtool))
+		if ((appearanceString == "sturdy" || appearanceString == "heavy") && isweldingtool(W))
 			if(!W:try_weld(user, 1))
 				return
 			boutput(user, "<span class='notice'>You remove the reinforcement metals from [src].</span>")

--- a/code/obj/item/paper.dm
+++ b/code/obj/item/paper.dm
@@ -1028,9 +1028,8 @@ Only trained personnel should operate station systems. Follow all procedures car
 		user.drop_item()
 		W.set_loc(src)
 	else
-		if (istype(W, /obj/item/weldingtool))
-			var/obj/item/weldingtool/T = W
-			if ((T.welding && T.weldfuel > 0))
+		if (isweldingtool(W))
+			if ((T:welding && T:weldfuel > 0))
 				viewers(user, null) << text("[] burns the paper with the welding tool!", user)
 				SPAWN_DBG( 0 )
 					src.burn(1800000.0)

--- a/code/obj/item/paper.dm
+++ b/code/obj/item/paper.dm
@@ -1029,7 +1029,7 @@ Only trained personnel should operate station systems. Follow all procedures car
 		W.set_loc(src)
 	else
 		if (isweldingtool(W))
-			if ((T:welding && T:weldfuel > 0))
+			if ((T:try_weld(user,0,1,0,0) && T:weldfuel > 0))
 				viewers(user, null) << text("[] burns the paper with the welding tool!", user)
 				SPAWN_DBG( 0 )
 					src.burn(1800000.0)

--- a/code/obj/item/sparklers.dm
+++ b/code/obj/item/sparklers.dm
@@ -36,7 +36,7 @@
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (!src.on && sparks)
-			if (isweldingtool(W) && W:welding)
+			if (isweldingtool(W) && W:try_weld(user,0,-1,0,0))
 				src.light(user, "<span class='alert'><b>[user]</b> casually lights [src] with [W], what a badass.</span>")
 
 			else if (istype(W, /obj/item/clothing/head/cakehat) && W:on)

--- a/code/obj/item/sparklers.dm
+++ b/code/obj/item/sparklers.dm
@@ -36,7 +36,7 @@
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (!src.on && sparks)
-			if (istype(W, /obj/item/weldingtool) && W:welding)
+			if (isweldingtool(W) && W:welding)
 				src.light(user, "<span class='alert'><b>[user]</b> casually lights [src] with [W], what a badass.</span>")
 
 			else if (istype(W, /obj/item/clothing/head/cakehat) && W:on)

--- a/code/obj/item/tool/weldingtool.dm
+++ b/code/obj/item/tool/weldingtool.dm
@@ -272,7 +272,6 @@
 
 		if(!src.try_weld(user, 5))
 			return
-		eyecheck(user)
 
 		H.TakeDamage("chest",0,20)
 		if (prob(50)) H.emote("scream")
@@ -306,7 +305,6 @@
 
 		if(!src.try_weld(user, 5))
 			return
-		eyecheck(user)
 
 		H.TakeDamage("chest",0,20)
 		if (prob(50)) H.emote("scream")

--- a/code/obj/machinery/computer/buildandrepair.dm
+++ b/code/obj/machinery/computer/buildandrepair.dm
@@ -145,8 +145,7 @@
 					boutput(user, "<span class='notice'>You wrench the frame into place.</span>")
 					src.anchored = 1
 					src.state = 1
-			if (isweldingtool(P) && P:welding)
-				playsound(src.loc, "sound/items/Welder.ogg", 50, 1)
+			if (isweldingtool(P) && P:try_weld(user,0,-1,0,1))
 				if (do_after(user, 20))
 					boutput(user, "<span class='notice'>You deconstruct the frame.</span>")
 					var/obj/item/sheet/A = new /obj/item/sheet( src.loc )

--- a/code/obj/machinery/computer/buildandrepair.dm
+++ b/code/obj/machinery/computer/buildandrepair.dm
@@ -145,7 +145,7 @@
 					boutput(user, "<span class='notice'>You wrench the frame into place.</span>")
 					src.anchored = 1
 					src.state = 1
-			if (istype(P, /obj/item/weldingtool))
+			if (isweldingtool(P) && P:welding)
 				playsound(src.loc, "sound/items/Welder.ogg", 50, 1)
 				if (do_after(user, 20))
 					boutput(user, "<span class='notice'>You deconstruct the frame.</span>")

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -1457,9 +1457,8 @@ About the new airlock wires panel:
 		..()
 		return
 
-	if ((istype(C, /obj/item/weldingtool) && !( src.operating ) && src.density))
-		var/obj/item/weldingtool/W = C
-		if(!W.try_weld(user, 1, burn_eyes = 1))
+	if ((isweldingtool(C) && !( src.operating ) && src.density))
+		if(!C:try_weld(user, 1, burn_eyes = 1))
 			return
 		if (!src.welded)
 			src.welded = 1

--- a/code/obj/machinery/door/firedoor.dm
+++ b/code/obj/machinery/door/firedoor.dm
@@ -114,9 +114,8 @@
 
 /obj/machinery/door/firedoor/attackby(obj/item/C as obj, mob/user as mob)
 	src.add_fingerprint(user)
-	if ((istype(C, /obj/item/weldingtool) && !( src.operating ) && src.density))
-		var/obj/item/weldingtool/W = C
-		if(!W.try_weld(user, 1))
+	if ((isweldingtool(C) && !( src.operating ) && src.density))
+		if(!C:try_weld(user, 1))
 			return
 		if (!( src.blocked ))
 			src.blocked = 1

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -809,21 +809,20 @@
 			boutput(user, "You [src.panelopen ? "open" : "close"] the maintenance panel.")
 			src.build_icon()
 
-		else if (istype(W,/obj/item/weldingtool))
-			var/obj/item/weldingtool/WELD = W
+		else if (isweldingtool(W))
 			var/do_action = 0
-			if (istype(WELD,src.base_material_class) && src.accept_loading(user))
-				if (alert(user,"What do you want to do with [WELD]?","[src.name]","Repair","Load it in") == "Load it in")
+			if (istype(W,src.base_material_class) && src.accept_loading(user))
+				if (alert(user,"What do you want to do with [W]?","[src.name]","Repair","Load it in") == "Load it in")
 					do_action = 1
 			if (do_action == 1)
-				user.visible_message("<span class='notice'>[user] loads [WELD] into the [src].</span>", "<span class='notice'>You load [WELD] into the [src].</span>")
-				src.load_item(WELD,user)
+				user.visible_message("<span class='notice'>[user] loads [W] into the [src].</span>", "<span class='notice'>You load [W] into the [src].</span>")
+				src.load_item(W,user)
 			else
 				if (src.health < 50)
 					boutput(user, "<span class='alert'>It's too badly damaged. You'll need to replace the wiring first.</span>")
-				else if(WELD.try_weld(user, 1))
+				else if(W:try_weld(user, 1))
 					src.take_damage(-10)
-					user.visible_message("<b>[user]</b> uses [WELD] to repair some of [src]'s damage.")
+					user.visible_message("<b>[user]</b> uses [W] to repair some of [src]'s damage.")
 					if (src.health == 100)
 						boutput(user, "<span class='notice'><b>[src] looks fully repaired!</b></span>")
 

--- a/code/obj/machinery/pipe/pipe.dm
+++ b/code/obj/machinery/pipe/pipe.dm
@@ -392,19 +392,17 @@ var/linenums = 0
 	..()
 
 
-/obj/machinery/pipes/attackby(obj/item/weapon/W as obj, mob/user as mob)
+/obj/machinery/pipes/attackby(obj/item/W as obj, mob/user as mob)
 
-	if (isweldingtool(W) && W:welding)
+	if (isweldingtool(W))
 		if(!(status & BROKEN))
 			return
-		if (W:weldfuel < 2)
-			boutput(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
+		if(!W:try_weld(user,2))
 			return
-		W:weldfuel -= 2
 		status &= ~BROKEN
 		update()
 		for (var/mob/M in viewers(src))
-			M.show_message("<span class='alert'>The pipe has been mended by [user.name] with the weldingtool.</span>", 3, "<span class='alert'>You hear welding.</span>", 2)
+			M.show_message("<span class='alert'>The pipe has been mended by [user.name] with [W].</span>", 3, "<span class='alert'>You hear welding.</span>", 2)
 		return
 
 /obj/machinery/pipes/ex_act(severity)

--- a/code/obj/machinery/pipe/pipe.dm
+++ b/code/obj/machinery/pipe/pipe.dm
@@ -394,7 +394,7 @@ var/linenums = 0
 
 /obj/machinery/pipes/attackby(obj/item/weapon/W as obj, mob/user as mob)
 
-	if (istype(W, /obj/item/weapon/weldingtool) && W:welding)
+	if (isweldingtool(W) && W:welding)
 		if(!(status & BROKEN))
 			return
 		if (W:weldfuel < 2)

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -425,9 +425,9 @@
 				playsound(src.loc, "sound/items/Screwdriver.ogg", 100, 1)
 				src.anchored = 1
 
-		else if(istype(W, /obj/item/weldingtool) || istype(W, /obj/item/device/light/zippo) || istype(W, /obj/item/device/igniter))
+		else if(isweldingtool(W) || istype(W, /obj/item/device/light/zippo) || istype(W, /obj/item/device/igniter))
 			// These are for burning down plants with.
-			if(istype(W, /obj/item/weldingtool) && !W:try_weld(usr, 3, noisy = 0, burn_eyes = 1))
+			if(isweldingtool(W) && !W:try_weld(usr, 3, noisy = 0, burn_eyes = 1))
 				return
 			else if(istype(W, /obj/item/device/light/zippo) && !W:on)
 				boutput(user, "<span class='alert'>It would help if you lit it first, dumbass!</span>")

--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -976,7 +976,7 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 			desc = "Shoots a high power laser when active."
 			return
 
-	if(isweldingtool(W) && W:welding)
+	if(isweldingtool(W))
 
 		var/turf/T = user.loc
 
@@ -1459,7 +1459,7 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 			src.anchored = 0
 			return
 
-	if(isweldingtool(W) && W:welding)
+	if(isweldingtool(W))
 		if(timing)
 			boutput(user, "Stop the countdown first.")
 			return
@@ -1470,7 +1470,6 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 			return
 
 		if(state == 1)
-			W:eyecheck(user)
 			boutput(user, "You start to weld the bomb to the floor.")
 			sleep(5 SECONDS)
 

--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -563,16 +563,14 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 
 		var/turf/T = user.loc
 
-		if(!W:try_weld(user, 1, noisy = 2))
-			return
-
 		if(state == 1)
+			if(!W:try_weld(user, 1, noisy = 2))
+				return
 			boutput(user, "You start to weld the field generator to the floor.")
 			sleep(2 SECONDS)
 
 			if ((user.loc == T && user.equipped() == W))
 				state = 3
-				W:eyecheck(user)
 				boutput(user, "You weld the field generator to the floor.")
 				src.get_link() //Set up a link, now that we're secure!
 			else if((isrobot(user) && (user.loc == T)))
@@ -582,6 +580,8 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 			return
 
 		if(state == 3)
+			if(!W:try_weld(user, 1, noisy = 2))
+				return
 			boutput(user, "You start to cut the field generator free from the floor.")
 			sleep(2 SECONDS)
 
@@ -590,7 +590,6 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 				if(src.link) //Clear active link.
 					src.link.master = null
 					src.link = null
-				W:eyecheck(user)
 				boutput(user, "You cut the field generator free from the floor.")
 			else if((isrobot(user) && (user.loc == T)))
 				state = 1
@@ -980,11 +979,9 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 
 		var/turf/T = user.loc
 
-		if(!W:try_weld(user, 1, noisy = 2))
-			return
-
 		if(state == 1)
-			W:eyecheck(user)
+			if(!W:try_weld(user, 1, noisy = 2))
+				return
 			boutput(user, "You start to weld the emitter to the floor.")
 			sleep(2 SECONDS)
 
@@ -1000,6 +997,8 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 			return
 
 		if(state == 3)
+			if(!W:try_weld(user, 1, noisy = 2))
+				return
 			boutput(user, "You start to cut the emitter free from the floor.")
 			sleep(2 SECONDS)
 			if ((user.loc == T && user.equipped() == W))
@@ -1466,10 +1465,10 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 
 		var/turf/T = user.loc
 
-		if(!W:try_weld(user, 1, noisy = 2))
-			return
 
 		if(state == 1)
+			if(!W:try_weld(user, 1, noisy = 2))
+				return
 			boutput(user, "You start to weld the bomb to the floor.")
 			sleep(5 SECONDS)
 
@@ -1486,6 +1485,8 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 			return
 
 		if(state == 3)
+			if(!W:try_weld(user, 1, noisy = 2))
+				return
 			boutput(user, "You start to cut the bomb free from the floor.")
 			sleep(5 SECONDS)
 

--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -559,7 +559,7 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 			src.anchored = 0
 			return
 
-	if(istype(W, /obj/item/weldingtool))
+	if(isweldingtool(W))
 
 		var/turf/T = user.loc
 
@@ -976,7 +976,7 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 			desc = "Shoots a high power laser when active."
 			return
 
-	if(istype(W, /obj/item/weldingtool) && W:welding)
+	if(isweldingtool(W) && W:welding)
 
 		var/turf/T = user.loc
 
@@ -1459,7 +1459,7 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 			src.anchored = 0
 			return
 
-	if(istype(W, /obj/item/weldingtool) && W:welding)
+	if(isweldingtool(W) && W:welding)
 		if(timing)
 			boutput(user, "Stop the countdown first.")
 			return

--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -469,15 +469,14 @@
 			boutput(user, "<span class='alert'>It's way too dangerous to do that while it's active!</span>")
 			return
 
-		if (istype(W,/obj/item/weldingtool/))
-			var/obj/item/weldingtool/WELD = W
+		if (isweldingtool(W))
 			if (src.health < 50)
 				boutput(usr, "<span class='alert'>You need to use wire to fix the cabling first.</span>")
 				return
-			if(WELD.try_weld(user, 1))
+			if(W:try_weld(user, 1))
 				src.damage(-10)
 				src.malfunctioning = 0
-				user.visible_message("<b>[user]</b> uses [WELD] to repair some of [src]'s damage.")
+				user.visible_message("<b>[user]</b> uses [W] to repair some of [src]'s damage.")
 				if (src.health >= 100)
 					boutput(user, "<span class='notice'><b>[src] looks fully repaired!</b></span>")
 

--- a/code/obj/soup_pot.dm
+++ b/code/obj/soup_pot.dm
@@ -76,7 +76,7 @@
 
 		if (!src.on && src.pot)
 
-			if (istype(W, /obj/item/weldingtool) && W:welding)
+			if (isweldingtool(W) && W:welding)
 				src.light(user, "<span class='alert'><b>[user]</b> casually lights [src] with [W], what a badass.</span>")
 				return
 

--- a/code/obj/soup_pot.dm
+++ b/code/obj/soup_pot.dm
@@ -76,7 +76,7 @@
 
 		if (!src.on && src.pot)
 
-			if (isweldingtool(W) && W:welding)
+			if (isweldingtool(W) && W:try_weld(user,0,-1,0,0))
 				src.light(user, "<span class='alert'><b>[user]</b> casually lights [src] with [W], what a badass.</span>")
 				return
 

--- a/code/obj/storage/closets.dm
+++ b/code/obj/storage/closets.dm
@@ -403,22 +403,21 @@
 				return
 
 		if (src.open)
-			if (!src.is_short && istype(W, /obj/item/weldingtool))
+			if (!src.is_short && isweldingtool(W))
 				return
 
 			else if (iswrenchingtool(W))
 				return
 
-		else if (!src.open && istype(W, /obj/item/weldingtool))
-			var/obj/item/weldingtool/welder = W
-			if(!welder.try_weld(user, 1, burn_eyes = 1))
+		else if (!src.open && isweldingtool(W))
+			if(!W:try_weld(user, 1, burn_eyes = 1))
 				return
 			if (!src.welded)
-				src.weld(1, welder, user)
-				src.visible_message("<span class='alert'>[user] welds [src] closed with [welder].</span>")
+				src.weld(1, W, user)
+				src.visible_message("<span class='alert'>[user] welds [src] closed with [W].</span>")
 			else
-				src.weld(0, welder, user)
-				src.visible_message("<span class='alert'>[user] unwelds [src] with [welder].</span>")
+				src.weld(0, W, user)
+				src.visible_message("<span class='alert'>[user] unwelds [src] with [W].</span>")
 			return
 
 		if (src.secure)

--- a/code/obj/storage/large_storage_parent.dm
+++ b/code/obj/storage/large_storage_parent.dm
@@ -188,18 +188,17 @@
 				return
 
 		if (src.open)
-			if (!src.is_short && istype(W, /obj/item/weldingtool))
-				var/obj/item/weldingtool/welder = W
+			if (!src.is_short && isweldingtool(W))
 				if (!src.legholes)
-					if(!welder.try_weld(user, 1))
+					if(!W:try_weld(user, 1))
 						return
 					src.legholes = 1
-					src.visible_message("<span class='alert'>[user] adds some holes to the bottom of [src] with [welder].</span>")
+					src.visible_message("<span class='alert'>[user] adds some holes to the bottom of [src] with [W].</span>")
 					return
 				else if(!issilicon(user))
 					if(user.drop_item())
-						if (welder)
-							welder.set_loc(src.loc)
+						if (W)
+							W:set_loc(src.loc)
 					return
 
 			else if (iswrenchingtool(W))
@@ -212,16 +211,15 @@
 					if(W) W.set_loc(src.loc)
 				return
 
-		else if (!src.open && istype(W, /obj/item/weldingtool))
-			var/obj/item/weldingtool/welder = W
-			if(!welder.try_weld(user, 1, burn_eyes = 1))
+		else if (!src.open && isweldingtool(W))
+			if(!W:try_weld(user, 1, burn_eyes = 1))
 				return
 			if (!src.welded)
-				src.weld(1, welder, user)
-				src.visible_message("<span class='alert'>[user] welds [src] closed with [welder].</span>")
+				src.weld(1, W, user)
+				src.visible_message("<span class='alert'>[user] welds [src] closed with [W].</span>")
 			else
-				src.weld(0, welder, user)
-				src.visible_message("<span class='alert'>[user] unwelds [src] with [welder].</span>")
+				src.weld(0, W, user)
+				src.visible_message("<span class='alert'>[user] unwelds [src] with [W].</span>")
 			return
 
 		if (src.secure)

--- a/code/obj/storage/loot_crates.dm
+++ b/code/obj/storage/loot_crates.dm
@@ -370,9 +370,8 @@
 				lock.read_device(user)
 			if (istype(trap))
 				trap.read_device(user)
-		else if (istype(W, /obj/item/weldingtool))
-			var/obj/item/weldingtool/WELD = W
-			if (WELD.welding)
+		else if (isweldingtool(W))
+			if (W:welding)
 				boutput(user, "<span class='alert'>The crate seems to be resistant to welding.</span>")
 				return
 			else

--- a/code/obj/storage/loot_crates.dm
+++ b/code/obj/storage/loot_crates.dm
@@ -371,7 +371,7 @@
 			if (istype(trap))
 				trap.read_device(user)
 		else if (isweldingtool(W))
-			if (W:welding)
+			if (W:try_weld(user,0,-1,0,0))
 				boutput(user, "<span class='alert'>The crate seems to be resistant to welding.</span>")
 				return
 			else

--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -451,7 +451,7 @@
 		auto = 1
 
 	attackby(obj/item/W as obj, mob/user as mob)
-		if (istype(W, /obj/item/weldingtool) && W:welding)
+		if (isweldingtool(W) && W:welding)
 			if (src.status == 2)
 				actions.start(new /datum/action/bar/icon/table_tool_interact(src, W, TABLE_WEAKEN), user)
 				return

--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -451,7 +451,7 @@
 		auto = 1
 
 	attackby(obj/item/W as obj, mob/user as mob)
-		if (isweldingtool(W) && W:welding)
+		if (isweldingtool(W) && W:try_weld(user,1))
 			if (src.status == 2)
 				actions.start(new /datum/action/bar/icon/table_tool_interact(src, W, TABLE_WEAKEN), user)
 				return

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -1217,7 +1217,7 @@
 		var/obj/item/pen/P = C
 		P.write_on_turf(src, user, params)
 		return
-	else if ((isweldingtool(C) && C:welding) || iswrenchingtool(C))
+	else if ((isweldingtool(C) && C:try_weld(user,0,-1,0,0)) || iswrenchingtool(C))
 		boutput(user, "<span class='notice'>Loosening rods...</span>")
 		playsound(src, "sound/items/Ratchet.ogg", 80, 1)
 		if(do_after(user, 30))

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -1075,7 +1075,7 @@
 		color = O.color
 
 	attackby(var/obj/item/W, var/mob/user)
-		if (istype(W, /obj/item/weldingtool))
+		if (isweldingtool(W))
 			visible_message("<b>[user] hits [src] with [W]!</b>")
 			if (prob(25))
 				ReplaceWithSpace()
@@ -1217,7 +1217,7 @@
 		var/obj/item/pen/P = C
 		P.write_on_turf(src, user, params)
 		return
-	else if (isweldingtool(C) || iswrenchingtool(C))
+	else if ((isweldingtool(C) && C:welding) || iswrenchingtool(C))
 		boutput(user, "<span class='notice'>Loosening rods...</span>")
 		playsound(src, "sound/items/Ratchet.ogg", 80, 1)
 		if(do_after(user, 30))

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -1217,9 +1217,10 @@
 		var/obj/item/pen/P = C
 		P.write_on_turf(src, user, params)
 		return
-	else if ((isweldingtool(C) && C:try_weld(user,0,-1,0,0)) || iswrenchingtool(C))
+	else if ((isweldingtool(C) && C:try_weld(user,0,-1,0,1)) || iswrenchingtool(C))
 		boutput(user, "<span class='notice'>Loosening rods...</span>")
-		playsound(src, "sound/items/Ratchet.ogg", 80, 1)
+		if(iswrenchingtool(C))
+			playsound(src, "sound/items/Ratchet.ogg", 80, 1)
 		if(do_after(user, 30))
 			var/obj/R1 = new /obj/item/rods(src)
 			var/obj/R2 = new /obj/item/rods(src)

--- a/code/turf/turf_autoalign.dm
+++ b/code/turf/turf_autoalign.dm
@@ -146,9 +146,8 @@
 					boutput(user, "<span class='notice'>You removed the support lines.</span>")
 					return
 
-		else if (istype(W, /obj/item/weldingtool) && W:welding)
-			var/obj/item/weldingtool/Weld = W
-			Weld.eyecheck(user)
+		else if (isweldingtool(W) && W:welding)
+			W:eyecheck(user)
 			var/turf/T = user.loc
 			if (!(istype(T, /turf)))
 				return

--- a/code/turf/turf_autoalign.dm
+++ b/code/turf/turf_autoalign.dm
@@ -146,15 +146,15 @@
 					boutput(user, "<span class='notice'>You removed the support lines.</span>")
 					return
 
-		else if (isweldingtool(W) && W:welding)
-			W:eyecheck(user)
+		else if (isweldingtool(W))
 			var/turf/T = user.loc
 			if (!(istype(T, /turf)))
 				return
 
 			if (src.d_state == 2)
+				if(!W:try_weld(user,1,-1,1,1))
+					return
 				boutput(user, "<span class='notice'>Slicing metal cover.</span>")
-				playsound(src.loc, "sound/items/Welder.ogg", 100, 1)
 				sleep(2.5 SECONDS)
 				if (user.loc == T && (user.equipped() == W || isrobot(user)))
 					src.d_state = 3
@@ -162,8 +162,9 @@
 					return
 
 			else if (src.d_state == 5)
+				if(!W:try_weld(user,1,-1,1,1))
+					return
 				boutput(user, "<span class='notice'>Removing support rods.</span>")
-				playsound(src.loc, "sound/items/Welder.ogg", 100, 1)
 				sleep(2.5 SECONDS)
 				if (user.loc == T && (user.equipped() == W || isrobot(user)))
 					src.d_state = 6

--- a/code/turf/walls.dm
+++ b/code/turf/walls.dm
@@ -319,7 +319,7 @@
 		src.attach_light_fixture_parts(user, W) // Made this a proc to avoid duplicate code (Convair880).
 		return
 
-	else if (istype(W, /obj/item/weldingtool))
+	else if (isweldingtool(W))
 		var/turf/T = user.loc
 		if (!( istype(T, /turf) ))
 			return
@@ -405,7 +405,7 @@
 		src.attach_light_fixture_parts(user, W) // Made this a proc to avoid duplicate code (Convair880).
 		return
 
-	else if (istype(W, /obj/item/weldingtool) && W:welding)
+	else if (isweldingtool(W) && W:welding)
 		W:eyecheck(user)
 		var/turf/T = user.loc
 		if (!( istype(T, /turf) ))

--- a/code/turf/walls.dm
+++ b/code/turf/walls.dm
@@ -405,15 +405,15 @@
 		src.attach_light_fixture_parts(user, W) // Made this a proc to avoid duplicate code (Convair880).
 		return
 
-	else if (isweldingtool(W) && W:welding)
-		W:eyecheck(user)
+	else if (isweldingtool(W))
 		var/turf/T = user.loc
 		if (!( istype(T, /turf) ))
 			return
 
 		if (src.d_state == 2)
+			if(!W:try_weld(user,1,-1,1,1))
+				return
 			boutput(user, "<span class='notice'>Slicing metal cover.</span>")
-			playsound(src, "sound/items/Welder.ogg", 100, 1)
 			sleep(6 SECONDS)
 			if ((user.loc == T && user.equipped() == W))
 				src.d_state = 3
@@ -423,8 +423,9 @@
 				boutput(user, "<span class='notice'>You removed the metal cover.</span>")
 
 		else if (src.d_state == 5)
+			if(!W:try_weld(user,1,-1,1,1))
+				return
 			boutput(user, "<span class='notice'>Removing support rods.</span>")
-			playsound(src, "sound/items/Welder.ogg", 100, 1)
 			sleep(10 SECONDS)
 			if ((user.loc == T && user.equipped() == W))
 				src.d_state = 6

--- a/code/unused/ai_bot.dm
+++ b/code/unused/ai_bot.dm
@@ -71,9 +71,9 @@
 Yes yes stolen from APC code I know!
 To-do: Add overlays here */
 
-/obj/machinery/ai_bot/attackby(obj/item/weapon/W, mob/user)
+/obj/machinery/ai_bot/attackby(obj/item/W, mob/user)
 
-	if (istype(W, /obj/item/weapon/weldingtool))
+	if (isweldingtool(W))
 		if(!W:try_weld(user, 2))
 			return
 		src.health += 30
@@ -93,7 +93,7 @@ To-do: Add overlays here */
 				opened = 1
 				updateicon()
 
-	else if (istype(W, /obj/item/weapon/cell) && opened)	// trying to put a cell inside
+	else if (istype(W, /obj/item/cell) && opened)	// trying to put a cell inside
 		if(cell)
 			boutput(user, "There is a power cell already installed.")
 		else
@@ -114,7 +114,7 @@ To-do: Add overlays here */
 			boutput(user, "The wires have been [wiresexposed ? "exposed" : "unexposed"]")
 			updateicon()
 
-	else if (istype(W, /obj/item/weapon/card/id))			// trying to unlock the interface with an ID card
+	else if (istype(W, /obj/item/card/id))			// trying to unlock the interface with an ID card
 		if(emagged)
 			boutput(user, "The interface is broken")
 		else if(opened)
@@ -129,7 +129,7 @@ To-do: Add overlays here */
 			else
 				boutput(user, "<span class='alert'>Access denied.</span>")
 
-	else if (istype(W, /obj/item/weapon/card/emag) && !emagged)		// trying to unlock with an emag card
+	else if (istype(W, /obj/item/card/emag) && !emagged)		// trying to unlock with an emag card
 		if(opened)
 			boutput(user, "You must close the cover to swipe an ID card.")
 		else if(wiresexposed)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

1) Converted explicit typechecks for obj/item/weldingtool to isweldingtool() calls

2) Converted all explicit welding, eye burn, and fuel use checks to :try_weld checks

3) Fixed a bunch of weldingtool related weirdness
    a) Lots of eye checks were being done twice
    b) Lots of things weren't doing eye checks that reasonably should have (like repairing pipes)
    c) Lots of things let you weld with the welder off
    d) Some old crusty AI/Cyborg stuff checked for obj/item/weapon instead of object/item
    e) Some things did the try_weld check before the actual welding was done
    f) Made cutting down reinforced tables take fuel

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

1) Now you can make an item a welding tool by setting tool flags to have TOOL_WELDING...

2) ...and implementing proc/try_weld(mob/user, var/fuel_amt = 2, var/use_amt = -1, var/noisy=1, var/burn_eyes=1)

3) Buncha random bugfixes and minor nitpicks. Considering that most things now deal half the eye damage, adding some eye checks back is really not a big deal

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)UrsulaMajor:
(*)Refactored how welding tools work. Please report any bugs with the bug report button at the top right of the status pane.
```
