### PR TITLE
prevents prox sensor from seeing invisible

### DIFF
--- a/code/obj/item/device/prox_sensor.dm
+++ b/code/obj/item/device/prox_sensor.dm
@@ -69,7 +69,7 @@
 	return
 
 /obj/item/device/prox_sensor/HasProximity(atom/movable/AM as mob|obj)
-	if (istype(AM, /obj/projectile))
+	if (istype(AM, /obj/projectile) || AM.invisibility > 0)
 		return
 	if (AM.move_speed < 12)
 		src.sense()

--- a/code/obj/item/device/prox_sensor.dm
+++ b/code/obj/item/device/prox_sensor.dm
@@ -69,7 +69,7 @@
 	return
 
 /obj/item/device/prox_sensor/HasProximity(atom/movable/AM as mob|obj)
-	if (istype(AM, /obj/projectile) || AM.invisibility > 0)
+	if (istype(AM, /obj/projectile) || AM.invisibility > 2)
 		return
 	if (AM.move_speed < 12)
 		src.sense()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FIX] ~~[BALANCE]?~~
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes prox sensor not react to invisible things (ghosts, etc). Should still be able to sense through cloaking devices


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Closes #939 