### PR TITLE
patho symptom limit, microbody rebalance and error message change

### DIFF
--- a/code/modules/food_and_drink/sandwiches.dm
+++ b/code/modules/food_and_drink/sandwiches.dm
@@ -241,7 +241,7 @@
 
 	heal(var/mob/M)
 		#ifdef CREATE_PATHOGENS //PATHOLOGY REMOVAL
-			..()
+		..()
 		#else
 		boutput(M, "<span class='alert'>Oof, how old was that?.</span>")
 		if(prob(66))

--- a/code/modules/medical/pathology/pathogen.dm
+++ b/code/modules/medical/pathology/pathogen.dm
@@ -22,11 +22,11 @@
 // And for all:
 // RARITY_ABSTRACT: Used strictly for categorization. ABSTRACT symptoms will never appear.
 //                  ie. if lingual is a symptom category with multiple subsymptoms (for easy mutex), it should be abstract.
-#define RARITY_VERY_COMMON 10
-#define RARITY_COMMON 5
+#define RARITY_VERY_COMMON 1
+#define RARITY_COMMON 2
 #define RARITY_UNCOMMON 3
-#define RARITY_RARE 2
-#define RARITY_VERY_RARE 1
+#define RARITY_RARE 4
+#define RARITY_VERY_RARE 5
 #define RARITY_ABSTRACT 0
 
 datum/pathogen_cdc

--- a/code/modules/medical/pathology/pathogen_dna.dm
+++ b/code/modules/medical/pathology/pathogen_dna.dm
@@ -335,6 +335,16 @@ datum/pathogendna
 					this.reference.effects += pathogen_controller.path_to_symptom[sym]
 				else
 					return 0 // Somehow, we lost the DNA.
+
+		var/effectSeqSum = 0
+		for (var/effect in this.reference.effects)
+			if(istype(effect, /datum/pathogeneffects))
+				var/datum/pathogeneffects/E = effect
+				effectSeqSum += E.rarity
+		if(effectSeqSum > this.reference.body_type.seqMax && this.reference.body_type.seqMax != -1)
+			return 8 // too many symptoms for microbody type
+
+
 		// DNA has been completely evaluated if we reach this point in execution and it is a valid pathogen DNA. Hooray!
 		// Build the available symptom list for the pathogen.
 		this.reference.dnasample = this

--- a/code/modules/medical/pathology/pathogen_dna.dm
+++ b/code/modules/medical/pathology/pathogen_dna.dm
@@ -266,7 +266,7 @@ datum/pathogendna
 		if (!(parts[1] in pathogen_controller.UID_to_suppressant))
 			//log_game("[this.seqsplice] collapses: non-existent suppressant.")
 			qdel(this) // Bad DNA: Invalid suppressant.
-			return 0
+			return 2
 		else
 			if (this)
 				var/supp = pathogen_controller.UID_to_suppressant[parts[1]]
@@ -276,7 +276,7 @@ datum/pathogendna
 		if (parts[2] != "|")
 			//log_game("[this.seqsplice] collapses: no separator after suppressant.")
 			qdel(this)
-			return 0 // Bad DNA: no separator after suppressant.
+			return 3 // Bad DNA: no separator after suppressant.
 		var/pos = 2
 		if (parts[3] == "|")
 			pos = 4 // No carriers.
@@ -286,7 +286,7 @@ datum/pathogendna
 				if (!(parts[pos] in pathogen_controller.UID_to_carrier))
 					//log_game("[this.seqsplice] collapses: non-existent carrier.")
 					qdel(this) // Bad DNA: Invalid carrier
-					return 0
+					return 4
 				else
 					if (this)
 						this.reference.carriers += pathogen_controller.UID_to_carrier[parts[pos]]
@@ -296,7 +296,7 @@ datum/pathogendna
 			if (pos == parts.len)
 				//log_game("[this.seqsplice] collapses: no separator after carriers.")
 				qdel(this) // Bad DNA: No ending separator after carriers.
-				return 0
+				return 5
 			pos++
 
 		// Assemble the list of symptoms.
@@ -309,7 +309,7 @@ datum/pathogendna
 					if (!(symptom in pathogen_controller.UID_to_symptom))
 						//log_game("[this.seqsplice] collapses: non-existent symptom [symptom].")
 						qdel(this) // Bad DNA: DNA contains invalid symptom
-						return 0
+						return 6
 					else
 						if (this)
 							var/sym = pathogen_controller.UID_to_symptom[symptom]
@@ -320,7 +320,7 @@ datum/pathogendna
 				else
 					//log_game("[this.seqsplice] collapses: two adjacent symptom separators.")
 					qdel(this) // Bad DNA: DNA contains two adjacent separators
-					return 0
+					return 7
 			else
 				symptom += parts[pos]
 			pos++
@@ -328,7 +328,7 @@ datum/pathogendna
 			if (!(symptom in pathogen_controller.UID_to_symptom))
 				//log_game("[this.seqsplice] collapses: non-existent symptom [symptom].")
 				qdel(this) // Bad DNA: DNA contains invalid symptom
-				return 0
+				return 6
 			else
 				if (this)
 					var/sym = pathogen_controller.UID_to_symptom[symptom]

--- a/code/modules/medical/pathology/pathogen_machines.dm
+++ b/code/modules/medical/pathology/pathogen_machines.dm
@@ -920,7 +920,8 @@
 				var/success = 0
 
 				L.implode(src.manip.cache_target)
-				if (L.reevaluate())
+				var/result = L.reevaluate()
+				if (result == 1)
 					var/list/seqs = L.get_sequences()
 					for (var/s in seqs)
 						if (s in db.known_sequences)
@@ -956,7 +957,24 @@
 					var/datum/pathogendna/source = src.manip.slots[src.manip.splicesource]
 					logTheThing("pathology", usr, null, "splices pathogen [source.reference.name] into [oldname] creating [src.manip.loaded.reference.name].")
 				else
-					boutput(usr, "<span class='alert'>The DNA sequence is assembled by the manipulator, but it collapses!</span>")
+					// how about some more feedback for what went wrong? :)
+					var/reason = ""
+					switch(result)
+						if(2)
+							reason = ", because the suppressant code was invalid"
+						if(3)
+							reason = ", because there was no separator after the suppressant code"
+						if(4)
+							reason = ", because the carrier code was invalid"
+						if(5)
+							reason = ", because there was no separator after the carrier code"
+						if(6)
+							reason = ", due to an invalid symptom code"
+						if(7)
+							reason = ", because there was no symptom code between two separators"
+						if(8)
+							reason = ", because the microbody could not sustain the amount of symptoms"
+					boutput(usr, "<span class='alert'>The DNA sequence is assembled by the manipulator, but it collapses[reason]!</span>")
 					src.manip.loaded = null
 					new /obj/item/reagent_containers/glass/vial(get_turf(src.manip)) //Quit eating vials you fuck -Spy
 
@@ -1367,7 +1385,10 @@
 			else
 				output_text += "None<br><br>"
 			output_text += "<b>Research Budget:</b> [wagesystem.research_budget] Credits<br>"
-			output_text += "<a href='?src=\ref[src];buymats=1'>Synthesize a new pathogen sample for [synthesize_pathogen_cost] credits</a><br>"
+			output_text += "<a href='?src=\ref[src];buymats=1;microbody=virus'>Synthesize a new virus pathogen sample for [synthesize_pathogen_cost] credits</a><br>"
+			output_text += "<a href='?src=\ref[src];buymats=1;microbody=parasite'>Synthesize a new parasite pathogen sample for [synthesize_pathogen_cost] credits</a><br>"
+			output_text += "<a href='?src=\ref[src];buymats=1;microbody=bacterium'>Synthesize a new bacterium pathogen sample for [synthesize_pathogen_cost] credits</a><br>"
+			output_text += "<a href='?src=\ref[src];buymats=1;microbody=fungus'>Synthesize a new fungus pathogen sample for [synthesize_pathogen_cost] credits</a><br>"
 			output_text += "<br>"
 			output_text += "<b>Inserted vials:</b><br>"
 			for (var/i = 1, i <= 5, i++)
@@ -1551,7 +1572,15 @@
 							icon_state = "synth1"
 							for (var/mob/C in viewers(src))
 								C.show_message("The [src.name] shuts down and ejects a new pathogen sample.", 3)
-							new/obj/item/reagent_containers/glass/vial/prepared(src.loc)
+							switch(href_list["microbody"])
+								if("virus")
+									new /obj/item/reagent_containers/glass/vial/prepared/virus(src.loc)
+								if("parasite")
+									new /obj/item/reagent_containers/glass/vial/prepared/parasite(src.loc)
+								if("bacterium")
+									new /obj/item/reagent_containers/glass/vial/prepared/bacterium(src.loc)
+								if("fungus")
+									new /obj/item/reagent_containers/glass/vial/prepared/fungus(src.loc)
 				#else
 				boutput(usr, "<span class='alert'>[src] unable to complete task. Please contact your network administrator.</span>")
 				#endif

--- a/code/modules/medical/pathology/pathogen_microbodies.dm
+++ b/code/modules/medical/pathology/pathogen_microbodies.dm
@@ -71,6 +71,9 @@ datum/microbody
 	// The amount of nutrition of each type required per unit of pathogen to continue cultivation.
 	var/amount = 0.07
 
+	// The amount of sequences worth of symptoms the microbody can support. -1 is unlimited
+	var/seqMax = -1
+
 	disposing()
 		SHOULD_CALL_PARENT(FALSE) //Looks like these should never be deleted.
 		CRASH("ALERT MICROBODY IS BEING DELETED")
@@ -88,6 +91,8 @@ datum/microbody/virus
 	stages = 5
 
 	activity = list(1, 5, 20, 30, 40)
+
+	seqMax = 12
 
 	// Grows in eggs.
 	growth_medium = "egg"
@@ -108,9 +113,11 @@ datum/microbody/bacteria
 	maliciousness_multiplier = 1
 	mutation_speed_multiplier = 1
 
-	activity = list(7, 15, 25, 30, 35)
+	activity = list(30, 30, 30, 30, 30)
 
 	stages = 3
+
+	seqMax = 25
 
 	growth_medium = "bacterialmedium"
 
@@ -130,9 +137,9 @@ datum/microbody/fungi
 	maliciousness_multiplier = 2
 	mutation_speed_multiplier = 1
 
-	stages = 4
+	stages = 1
 
-	activity = list(7, 8, 10, 14, 25)
+	activity = list(10, 10, 10, 10, 10)
 
 	growth_medium = "fungalmedium"
 
@@ -153,7 +160,9 @@ datum/microbody/parasite
 
 	stages = 5
 
-	activity = list(30, 20, 10, 8, 8)
+	activity = list(50, 40, 30, 20, 10)
+
+	seqMax = 18
 
 	growth_medium = "parasiticmedium"
 

--- a/code/modules/medical/pathology/pathogen_tools.dm
+++ b/code/modules/medical/pathology/pathogen_tools.dm
@@ -276,12 +276,15 @@
 	icon = 'icons/obj/pathology.dmi'
 	icon_state = "vial0"
 	item_state = "vial"
+	var/datum/microbody/FM = null
 
 	New()
 		..()
 		SPAWN_DBG(2 SECONDS)
 			#ifdef CREATE_PATHOGENS // PATHOLOGY REMOVAL
 			var/datum/pathogen/P = unpool(/datum/pathogen)
+			if(FM)
+				P.forced_microbody = FM
 			P.create_weak()
 			var/datum/reagents/RE = src.reagents
 			RE.add_reagent("pathogen", 5)
@@ -291,6 +294,18 @@
 			var/datum/reagents/RE = src.reagents
 			RE.add_reagent("water", 5)
 			#endif
+
+/obj/item/reagent_containers/glass/vial/prepared/virus
+	FM = /datum/microbody/virus
+
+/obj/item/reagent_containers/glass/vial/prepared/parasite
+	FM = /datum/microbody/parasite
+
+/obj/item/reagent_containers/glass/vial/prepared/bacterium
+	FM = /datum/microbody/bacteria
+
+/obj/item/reagent_containers/glass/vial/prepared/fungus
+	FM = /datum/microbody/fungi
 
 /obj/item/reagent_containers/glass/beaker/parasiticmedium
 	name = "Beaker of Parasitic Medium"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[ENHANCEMENT][BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- A pathogen can now only be spliced with a specific number of symptoms, depending on their tier and the pathogen's microbody. For instance, a virus has a cap of 12, so it could support two t5 symptoms and two t1 symptoms. Trying to assemble anything higher by splicing will collapse.

Microbody stats have been changed around a bit:
- Virii have a symptom cap of 12 and trigger very rarely in low stages, but they have 5 stages and trigger very frequently in the higher stages.
- Parasites have a cap of 18 and trigger *very* frequently in the lower stages, but less frequently in the higher stages. This should make them spread more quickly than virii, but ultimately trigger their effects strongly less often as they progress. They also have 5 stages.
- Bacteria have a cap of 25 symptoms! But they only have 3 stages and trigger equally often in each stage, at a relatively quick rate (but not as quickly as Parasites at stage 1 or virii at stage 5.)
- Fungi are shit, they only have one stage and trigger relatively infrequently. But they can sustain an unlimited amount of symptoms, so their main use should be to get lots of dna sequences for use in the dna analyzer.
----------------------------------------------------------------------------------------------------
- To make this whole thing less RNG, the Synth-O-Matic now lets you pick what kind of microbody you want to synthesize (no Great Mutatis though).
- If you assemble a sequence incorrectly in the pathogen manipulator, it should now give you an error message of what exactly went wrong. Hopefully this will reduce confusion.
- Also fixed an indentation error with moldy burgers that only occured when pathology was enabled.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
- Microbody types have been notoriously badly balanced for a long time, with virii almost always being the best choice. This should help a little with that, though numbers are highly experimental and subject to change.
- Error messages will hopefully make correct splicing more easily learnable by newbies.
- A symptom limit makes it so a pathologist has to choose their symptoms carefully, rather than slapping on everything but the kitchen sink. (This was mainly an issue for harmful pathogens.) This will also make pathogens overall less deadly, so crewmembers have more time to cure them. In addition, I always found that pathogens with a specific theme like "Sets you on fire and makes you fart plasma" are more fun than ones that just do loads of different stuff.
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)zjdtmkhzt:
(+) Rebalanced microbody types and added a cap for amount of symptoms a pathogen can have. Pathology is still disabled.
```
@UrsulaMejor 