### PR TITLE
Chem whitelist cleanup

### DIFF
--- a/code/modules/chemistry/tools/patches.dm
+++ b/code/modules/chemistry/tools/patches.dm
@@ -444,14 +444,6 @@
 
 
 //mender
-
-var/global/list/mender_chem_whitelist = list("antihol", "charcoal", "epinephrine", "insulin", "mutadone", "teporone",\
-"silver_sulfadiazine", "salbutamol", "perfluorodecalin", "omnizine", "stimulants", "synaptizine", "anti_rad",\
-"oculine", "mannitol", "penteticacid", "styptic_powder", "methamphetamine", "spaceacillin", "saline",\
-"salicylic_acid", "cryoxadone", "blood", "bloodc", "synthflesh",\
-"menthol", "cold_medicine", "antihistamine", "ipecac",\
-"booster_enzyme", "anti_fart", "goodnanites")
-
 /obj/item/reagent_containers/mender
 	name = "auto-mender"
 	desc = "A small electronic device designed to topically apply healing chemicals."
@@ -474,8 +466,8 @@ var/global/list/mender_chem_whitelist = list("antihol", "charcoal", "epinephrine
 
 	New()
 		..()
-		if (!tampered && islist(mender_chem_whitelist) && mender_chem_whitelist.len)
-			src.whitelist = mender_chem_whitelist
+		if (!tampered && islist(chem_whitelist) && chem_whitelist.len)
+			src.whitelist = chem_whitelist
 		if (src.reagents)
 			src.reagents.temperature_cap = 330
 			src.reagents.temperature_min = 270

--- a/code/obj/misc_junk.dm
+++ b/code/obj/misc_junk.dm
@@ -590,7 +590,7 @@
 	flags = FPRINT | TABLEPASS | OPENCONTAINER | ONBELT | NOSPLASH
 	var/emagged = 0
 	var/last_used = 0
-	var/list/safe_smokables = list("nicotine", "THC")
+	var/list/safe_smokables = list("nicotine", "THC", "CBD")
 	var/datum/effects/system/bad_smoke_spread/smoke
 	var/range = 1
 
@@ -706,19 +706,11 @@
 	item_state = "medivape"
 	icon_state = "medivape"
 
-	var/list/medical_cannabis = list("antihol", "charcoal", "epinephrine", "insulin", "mutadone", "teporone",\
-"silver_sulfadiazine", "salbutamol", "perfluorodecalin", "omnizine", "stimulants", "synaptizine", "anti_rad",\
-"oculine", "mannitol", "penteticacid", "styptic_powder", "methamphetamine", "spaceacillin", "saline",\
-"salicylic_acid", "cryoxadone", "nicotine", "THC")
-
 	New()
 		..()
-		safe_smokables = medical_cannabis
+		safe_smokables += chem_whitelist
 		src.reagents.clear_reagents()
-		src.reagents.add_reagent(pick("antihol", "charcoal", "epinephrine", "insulin", "mutadone", "teporone",\
-"silver_sulfadiazine", "salbutamol", "perfluorodecalin", "omnizine", "synaptizine", "anti_rad",\
-"oculine", "mannitol", "penteticacid", "styptic_powder", "methamphetamine", "spaceacillin", "saline",\
-"salicylic_acid", "cryoxadone", "nicotine", "THC"), 50)
+		src.reagents.add_reagent(pick(safe_smokables), 50)
 
 /obj/item/reagent_containers/vape/medical/o2 //sweet oxygen
 	desc = "Smoking, now in a doctor approved form! This one comes preloaded with salbutamol."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[CHORE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add CBD to vape whitelist. Unify medichem whitelists b/w hypo, mender, and medivape (adds full hypo whitelist to medivapes)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
No need to have 3 different medichem whitelists that only diverge when someone forgets to update one

