### PR TITLE
Guardbot, secscanner, secbot, sechud suspect evaluation rework, firearm permit split into firearm and contraband permits.

### DIFF
--- a/_std/_accessLevels.dm
+++ b/_std/_accessLevels.dm
@@ -41,48 +41,49 @@
 #define access_mail 36 // Unused.
 #define access_maxsec 37 // The HoS' armory.
 #define access_securitylockers 38
-#define access_carrypermit 39 // Are allowed to carry sidearms as far as guardbuddies and secbots are concerned.
-#define access_contrabandpermit 40 // Are allowed to handle contraband as far as guardbuddies and secbots are concerned.
-#define access_engineering 41 // General engineering area and substations.
-#define access_engineering_storage 42 // Main metal/tool storage things.
-#define access_engineering_eva 43 // Engineering space suits. Currently unused.
-#define access_engineering_power 44 // APCs and related supplies.
-#define access_engineering_engine 45 // Engine room.
-#define access_engineering_mechanic 46 // Electronics lab.
-#define access_engineering_atmos 47 // Engineering's supply of gas canisters.
-#define access_engineering_control 49 // Engine control room.
-#define access_engineering_chief 50 // CE's office.
+#define access_carrypermit 39 // Are allowed to carry sidearms as far as guardbuddies and secbots are concerned. Contraband permit defined at 75.
+#define access_engineering 40 // General engineering area and substations.
+#define access_engineering_storage 41 // Main metal/tool storage things.
+#define access_engineering_eva 42 // Engineering space suits. Currently unused.
+#define access_engineering_power 43 // APCs and related supplies.
+#define access_engineering_engine 44 // Engine room.
+#define access_engineering_mechanic 45 // Electronics lab.
+#define access_engineering_atmos 46 // Engineering's supply of gas canisters.
+#define access_engineering_control 48 // Engine control room.
+#define access_engineering_chief 49 // CE's office.
 
-#define access_mining_shuttle 48
-#define access_mining 51
-#define access_mining_outpost 52
+#define access_mining_shuttle 47
+#define access_mining 50
+#define access_mining_outpost 51
 
-#define access_syndicate_shuttle 53 // Also to the listening post.
-#define access_medical_director 54
-#define access_head_of_personnel 56
+#define access_syndicate_shuttle 52 // Also to the listening post.
+#define access_medical_director 53
+#define access_head_of_personnel 55
 
-#define access_special_club 55 //Shouldnt be used for general gameplay. Used for adminevents.
+#define access_special_club 54 //Shouldnt be used for general gameplay. Used for adminevents.
 
-#define access_ghostdrone 57 // drooooones
+#define access_ghostdrone 56 // drooooones
 
-#define access_centcom 58 // self-explanatory?  :v
+#define access_centcom 57 // self-explanatory?  :v
 
 // skipping a few here to reserve a block
 // for terra 8 and syndicate security clearances
-#define access_syndicate_4 61
-#define access_syndicate_8 62
-#define access_syndicate_16 63
-#define access_syndicate_32 64
-#define access_syndicate_64 65 // level needed for access to terra8 underside
-#define access_syndicate_128 66
-#define access_syndicate_256 67 // highest level documents in terra8
-#define access_syndicate_512 68 // allude to this but don't use it except for super special things
+#define access_syndicate_4 60
+#define access_syndicate_8 61
+#define access_syndicate_16 62
+#define access_syndicate_32 63
+#define access_syndicate_64 64 // level needed for access to terra8 underside
+#define access_syndicate_128 65
+#define access_syndicate_256 66 // highest level documents in terra8
+#define access_syndicate_512 67 // allude to this but don't use it except for super special things
 
 //Owlzone access
-#define access_owlerymaint 71
-#define access_owlerysec 72
-#define access_owlerycommand 73
+#define access_owlerymaint 70
+#define access_owlerysec 71
+#define access_owlerycommand 72
 
 //Polaris access
-#define access_polariscargo 74
-#define access_polarisimportant 75
+#define access_polariscargo 73
+#define access_polarisimportant 74
+
+#define access_contrabandpermit 75

--- a/_std/_accessLevels.dm
+++ b/_std/_accessLevels.dm
@@ -42,46 +42,47 @@
 #define access_maxsec 37 // The HoS' armory.
 #define access_securitylockers 38
 #define access_carrypermit 39 // Are allowed to carry sidearms as far as guardbuddies and secbots are concerned.
-#define access_engineering 40 // General engineering area and substations.
-#define access_engineering_storage 41 // Main metal/tool storage things.
-#define access_engineering_eva 42 // Engineering space suits. Currently unused.
-#define access_engineering_power 43 // APCs and related supplies.
-#define access_engineering_engine 44 // Engine room.
-#define access_engineering_mechanic 45 // Electronics lab.
-#define access_engineering_atmos 46 // Engineering's supply of gas canisters.
-#define access_engineering_control 48 // Engine control room.
-#define access_engineering_chief 49 // CE's office.
+#define access_contrabandpermit 40 // Are allowed to handle contraband as far as guardbuddies and secbots are concerned.
+#define access_engineering 41 // General engineering area and substations.
+#define access_engineering_storage 42 // Main metal/tool storage things.
+#define access_engineering_eva 43 // Engineering space suits. Currently unused.
+#define access_engineering_power 44 // APCs and related supplies.
+#define access_engineering_engine 45 // Engine room.
+#define access_engineering_mechanic 46 // Electronics lab.
+#define access_engineering_atmos 47 // Engineering's supply of gas canisters.
+#define access_engineering_control 49 // Engine control room.
+#define access_engineering_chief 50 // CE's office.
 
-#define access_mining_shuttle 47
-#define access_mining 50
-#define access_mining_outpost 51
+#define access_mining_shuttle 48
+#define access_mining 51
+#define access_mining_outpost 52
 
-#define access_syndicate_shuttle 52 // Also to the listening post.
-#define access_medical_director 53
-#define access_head_of_personnel 55
+#define access_syndicate_shuttle 53 // Also to the listening post.
+#define access_medical_director 54
+#define access_head_of_personnel 56
 
-#define access_special_club 54 //Shouldnt be used for general gameplay. Used for adminevents.
+#define access_special_club 55 //Shouldnt be used for general gameplay. Used for adminevents.
 
-#define access_ghostdrone 56 // drooooones
+#define access_ghostdrone 57 // drooooones
 
-#define access_centcom 57 // self-explanatory?  :v
+#define access_centcom 58 // self-explanatory?  :v
 
 // skipping a few here to reserve a block
 // for terra 8 and syndicate security clearances
-#define access_syndicate_4 60
-#define access_syndicate_8 61
-#define access_syndicate_16 62
-#define access_syndicate_32 63
-#define access_syndicate_64 64 // level needed for access to terra8 underside
-#define access_syndicate_128 65
-#define access_syndicate_256 66 // highest level documents in terra8
-#define access_syndicate_512 67 // allude to this but don't use it except for super special things
+#define access_syndicate_4 61
+#define access_syndicate_8 62
+#define access_syndicate_16 63
+#define access_syndicate_32 64
+#define access_syndicate_64 65 // level needed for access to terra8 underside
+#define access_syndicate_128 66
+#define access_syndicate_256 67 // highest level documents in terra8
+#define access_syndicate_512 68 // allude to this but don't use it except for super special things
 
 //Owlzone access
-#define access_owlerymaint 70
-#define access_owlerysec 71
-#define access_owlerycommand 72
+#define access_owlerymaint 71
+#define access_owlerysec 72
+#define access_owlerycommand 73
 
 //Polaris access
-#define access_polariscargo 73
-#define access_polarisimportant 74
+#define access_polariscargo 74
+#define access_polarisimportant 75

--- a/code/mob/living/carbon/human/procs/Life.dm
+++ b/code/mob/living/carbon/human/procs/Life.dm
@@ -310,18 +310,43 @@
 
 				if (!myID)
 					myID = wear_id
-				if (myID && (access_carrypermit in myID.access))
+				if (myID && (access_carrypermit in myID.access) && (access_contrabandpermit in myID.access)) // has all permissions for contraband, don't check
 					myID = null
 				else
 					var/contrabandLevel = 0
-					if (l_hand)
-						contrabandLevel += l_hand.contraband
-					if (!contrabandLevel && r_hand)
-						contrabandLevel += r_hand.contraband
-					if (!contrabandLevel && belt)
-						contrabandLevel += belt.contraband
-					if (!contrabandLevel && wear_suit)
-						contrabandLevel += wear_suit.contraband
+					if (myID)
+						var/has_carry_permit = (access_carrypermit in myID.access)
+						var/has_contraband_permit = (access_contrabandpermit in myID.access)
+						if (l_hand)
+							if (istype(l_hand, /obj/item/gun/))
+								if(!has_carry_permit)
+									contrabandLevel += l_hand.contraband
+							else
+								if(!has_contraband_permit)
+									contrabandLevel += l_hand.contraband
+
+						if (!contrabandLevel && r_hand)
+							if (istype(r_hand, /obj/item/gun/))
+								if(!has_carry_permit)
+									contrabandLevel += r_hand.contraband
+							else
+								if(!has_contraband_permit)
+									contrabandLevel += r_hand.contraband
+
+						if (!contrabandLevel && !has_contraband_permit)
+							if (belt)
+								contrabandLevel += belt.contraband
+							if (!contrabandLevel && wear_suit)
+								contrabandLevel += wear_suit.contraband
+					else
+						if (l_hand)
+							contrabandLevel += l_hand.contraband
+						if (!contrabandLevel && r_hand)
+							contrabandLevel += r_hand.contraband
+						if (!contrabandLevel && belt)
+							contrabandLevel += belt.contraband
+						if (!contrabandLevel && wear_suit)
+							contrabandLevel += wear_suit.contraband
 
 					if (contrabandLevel > 0)
 						arrestState = "Contraband"

--- a/code/mob/living/carbon/human/procs/Life.dm
+++ b/code/mob/living/carbon/human/procs/Life.dm
@@ -333,11 +333,18 @@
 								if(!has_contraband_permit)
 									contrabandLevel += r_hand.contraband
 
-						if (!contrabandLevel && !has_contraband_permit)
-							if (belt)
-								contrabandLevel += belt.contraband
-							if (!contrabandLevel && wear_suit)
+						if (!contrabandLevel && belt)
+							if (istype(belt, /obj/item/gun/))
+								if(!has_carry_permit)
+									contrabandLevel += belt.contraband
+							else
+								if(!has_contraband_permit)
+									contrabandLevel += belt.contraband
+
+						if (!contrabandLevel && wear_suit)
+							if(!has_contraband_permit)
 								contrabandLevel += wear_suit.contraband
+
 					else
 						if (l_hand)
 							contrabandLevel += l_hand.contraband

--- a/code/mob/living/carbon/human/procs/Life.dm
+++ b/code/mob/living/carbon/human/procs/Life.dm
@@ -275,9 +275,15 @@
 
 		//TODO : move this code somewhere else that updates from an event trigger instead of constantly
 		var/arrestState = ""
-		var/visibleName = name
-		if (wear_id)
-			visibleName = wear_id.registered_owner()
+
+		var/see_face = 1
+		if (istype(src.wear_mask) && !src.wear_mask.see_face)
+			see_face = 0
+		else if (istype(src.head) && !src.head.see_face)
+			see_face = 0
+		else if (istype(src.wear_suit) && !src.wear_suit.see_face)
+			see_face = 0
+		var/visibleName = see_face ? src.real_name : src.name
 
 		for (var/security_record in data_core.security)
 			var/datum/data/record/R = security_record

--- a/code/modules/robotics/bot/guardbot.dm
+++ b/code/modules/robotics/bot/guardbot.dm
@@ -1677,6 +1677,7 @@
 		var/tmp/last_cute_action = 0
 
 		var/weapon_access = access_carrypermit //These guys can use guns, ok!
+		var/contraband_access = access_contrabandpermit
 		var/lethal = 0 //Do we use lethal force (if possible) ?
 		var/panic = 0 //Martial law! Arrest all kinds!!
 		var/no_patrol = 1 //Don't patrol.
@@ -2146,24 +2147,40 @@
 				if (!istype(perp_id))
 					perp_id = perp.wear_id
 
-				if(perp_id)
+				var/has_carry_permit = 0
+				var/has_contraband_permit = 0
+
+				if(perp_id) //Checking for targets and permits
 					if(ckey(perp_id.registered) in target_names)
 						return 7
-
 					if(weapon_access in perp_id.access)
-						return 0
+						has_carry_permit = 1
+					if(contraband_access in perp_id.access)
+						has_contraband_permit = 1
 
 				if (istype(perp.l_hand))
-					. += perp.l_hand.contraband
+					if (istype(perp.l_hand, /obj/item/gun/)) // perp is carrying a gun
+						if(!has_carry_permit)
+							. += perp.l_hand.contraband
+					else // not carrying a gun, but potential contraband?
+						if(!has_contraband_permit)
+							. += perp.l_hand.contraband
 
 				if (istype(perp.r_hand))
-					. += perp.r_hand.contraband
+					if (istype(perp.r_hand, /obj/item/gun/)) // perp is carrying a gun
+						if(!has_carry_permit)
+							. += perp.r_hand.contraband
+					else // not carrying a gun, but potential contraband?
+						if(!has_contraband_permit)
+							. += perp.r_hand.contraband
+
 				if(ishuman(perp))
 					if (istype(perp.belt))
 						. += perp.belt.contraband * 0.5
 
 					if (istype(perp.wear_suit))
-						. += perp.wear_suit.contraband
+						if(!has_contraband_permit)
+							. += perp.wear_suit.contraband
 
 				if(perp.mutantrace && perp.mutantrace.jerk)
 //					if(istype(perp.mutantrace, /datum/mutantrace/zombie))

--- a/code/modules/robotics/bot/guardbot.dm
+++ b/code/modules/robotics/bot/guardbot.dm
@@ -2174,11 +2174,16 @@
 						if(!has_contraband_permit)
 							. += perp.r_hand.contraband
 
-				if(!has_contraband_permit)
-					if (istype(perp.belt))
-						. += perp.belt.contraband * 0.5
+				if (istype(perp.belt))
+					if (istype(perp.belt, /obj/item/gun/))
+						if (!has_carry_permit)
+							. += perp.belt.contraband * 0.5
+					else
+						if (!has_contraband_permit)
+							. += perp.belt.contraband * 0.5
 
-					if (istype(perp.wear_suit))
+				if (istype(perp.wear_suit))
+					if (!has_contraband_permit)
 						. += perp.wear_suit.contraband
 
 				if(perp.mutantrace && perp.mutantrace.jerk)

--- a/code/modules/robotics/bot/guardbot.dm
+++ b/code/modules/robotics/bot/guardbot.dm
@@ -2174,13 +2174,12 @@
 						if(!has_contraband_permit)
 							. += perp.r_hand.contraband
 
-				if(ishuman(perp))
+				if(!has_contraband_permit)
 					if (istype(perp.belt))
 						. += perp.belt.contraband * 0.5
 
 					if (istype(perp.wear_suit))
-						if(!has_contraband_permit)
-							. += perp.wear_suit.contraband
+						. += perp.wear_suit.contraband
 
 				if(perp.mutantrace && perp.mutantrace.jerk)
 //					if(istype(perp.mutantrace, /datum/mutantrace/zombie))

--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -15,6 +15,7 @@
 //	weight = 1.0E7
 	req_access = list(access_security)
 	var/weapon_access = access_carrypermit
+	var/contraband_access = access_contrabandpermit
 	var/obj/item/baton/secbot/our_baton // Our baton
 
 	on = 1
@@ -862,14 +863,21 @@ Report Arrests: <A href='?src=\ref[src];operation=report'>[report_arrests ? "On"
 
 		if(src.emagged) return 10 //Everyone is a criminal!
 
-		if((src.idcheck) || (isnull(perp:wear_id)) || (istype(perp:wear_id, /obj/item/card/id/syndicate)))
+		if((src.idcheck)) // bot is set to actively search for contraband
 			var/obj/item/card/id/perp_id = perp.equipped()
 			if (!istype(perp_id))
 				perp_id = perp.wear_id
 
-			if(perp_id && (weapon_access in perp_id.access)) //Corrupt cops cannot exist, beep boop
-				return 0
-/*
+			var/has_carry_permit = 0
+			var/has_contraband_permit = 0
+
+			if(perp_id) //Checking for permits
+				if(weapon_access in perp_id.access)
+					has_carry_permit = 1
+				if(contraband_access in perp_id.access)
+					has_contraband_permit = 1
+
+			/*
 			if(istype(perp.l_hand, /obj/item/gun) || istype(perp.l_hand, /obj/item/baton) || istype(perp.l_hand, /obj/item/sword))
 				threatcount += 4
 
@@ -881,36 +889,61 @@ Report Arrests: <A href='?src=\ref[src];operation=report'>[report_arrests ? "On"
 
 			if(istype(perp:wear_suit, /obj/item/clothing/suit/wizrobe))
 				threatcount += 4
-*/
+			*/
 			if (istype(perp.l_hand))
-				threatcount += perp.l_hand.contraband
+				if (istype(perp.l_hand, /obj/item/gun/)) // perp is carrying a gun
+					if(!has_carry_permit)
+						threatcount += perp.l_hand.contraband
+				else // not carrying a gun, but potential contraband?
+					if(!has_contraband_permit)
+						threatcount += perp.l_hand.contraband
 
 			if (istype(perp.r_hand))
-				threatcount += perp.r_hand.contraband
+				if (istype(perp.r_hand, /obj/item/gun/)) // perp is carrying a gun
+					if(!has_carry_permit)
+						threatcount += perp.r_hand.contraband
+				else // not carrying a gun, but potential contraband?
+					if(!has_contraband_permit)
+						threatcount += perp.r_hand.contraband
 
-			if (istype(perp.belt))
-				threatcount += perp.belt.contraband * 0.5
+			if(!has_contraband_permit)
+				if (istype(perp.belt))
+					threatcount += perp.belt.contraband * 0.5
 
-			if (istype(perp.wear_suit))
-				threatcount += perp.wear_suit.contraband
+				if (istype(perp.wear_suit))
+					threatcount += perp.wear_suit.contraband
 
-			if(istype(perp.mutantrace, /datum/mutantrace/abomination))
-				threatcount += 5
+		if(istype(perp.mutantrace, /datum/mutantrace/abomination))
+			threatcount += 5
 
-	//Agent cards lower threatlevel when normal idchecking is off.
-			if((istype(perp.wear_id, /obj/item/card/id/syndicate)) && src.idcheck)
-				threatcount -= 2
+		//Agent cards lower threat level
+		if((istype(perp.wear_id, /obj/item/card/id/syndicate)))
+			threatcount -= 2
 
-		if (src.check_records)
-			for (var/datum/data/record/E in data_core.general)
-				var/perpname = perp.name
-				if (perp:wear_id && perp:wear_id:registered)
-					perpname = perp.wear_id:registered
+		// we have grounds to make an arrest, don't bother with further analysis
+		if(threatcount >= 4)
+			return threatcount
+
+		if (src.check_records) // bot is set to actively compare security records
+			var/see_face = 1
+			if (istype(perp.wear_mask) && !perp.wear_mask.see_face)
+				see_face = 0
+			else if (istype(perp.head) && !perp.head.see_face)
+				see_face = 0
+			else if (istype(perp.wear_suit) && !perp.wear_suit.see_face)
+				see_face = 0
+
+			var/perpname = see_face ? perp.real_name : perp.name
+
+			for (var/i in data_core.general)
+				var/datum/data/record/E = i
 				if (E.fields["name"] == perpname)
-					for (var/datum/data/record/R in data_core.security)
+					for (var/j in data_core.security)
+						var/datum/data/record/R = j
 						if ((R.fields["id"] == E.fields["id"]) && (R.fields["criminal"] == "*Arrest*"))
 							threatcount = 4
 							break
+					break
 
 		return threatcount
 

--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -189,7 +189,7 @@ Behaviour controls are [src.locked ? "locked" : "unlocked"]"}
 
 		if(!src.locked)
 			dat += {"<hr>
-Check for Weapon Authorization: <A href='?src=\ref[src];operation=idcheck'>[src.idcheck ? "Yes" : "No"]</A><BR>
+Check for Unauthorised Equipment: <A href='?src=\ref[src];operation=idcheck'>[src.idcheck ? "Yes" : "No"]</A><BR>
 Check Security Records: <A href='?src=\ref[src];operation=ignorerec'>[src.check_records ? "Yes" : "No"]</A><BR>
 Operating Mode: <A href='?src=\ref[src];operation=switchmode'>[src.arrest_type ? "Detain" : "Arrest"]</A><BR>
 Auto Patrol: <A href='?src=\ref[src];operation=patrol'>[auto_patrol ? "On" : "Off"]</A><BR>

--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -906,11 +906,16 @@ Report Arrests: <A href='?src=\ref[src];operation=report'>[report_arrests ? "On"
 					if(!has_contraband_permit)
 						threatcount += perp.r_hand.contraband
 
-			if(!has_contraband_permit)
-				if (istype(perp.belt))
-					threatcount += perp.belt.contraband * 0.5
+			if (istype(perp.belt))
+				if (istype(perp.belt, /obj/item/gun/))
+					if (!has_carry_permit)
+						threatcount += perp.belt.contraband * 0.5
+				else
+					if (!has_contraband_permit)
+						threatcount += perp.belt.contraband * 0.5
 
-				if (istype(perp.wear_suit))
+			if (istype(perp.wear_suit))
+				if (!has_contraband_permit)
 					threatcount += perp.wear_suit.contraband
 
 		if(istype(perp.mutantrace, /datum/mutantrace/abomination))

--- a/code/obj/machinery/computer/card.dm
+++ b/code/obj/machinery/computer/card.dm
@@ -125,7 +125,7 @@
 			var/research_access = list("<br>Science and Medical:")
 			var/list/research_access_list = list(access_medical, access_tox, access_tox_storage, access_medlab, access_medical_lockers, access_research, access_robotics, access_chemistry)
 			var/security_access = list("<br>Security:")
-			var/list/security_access_list = list(access_security, access_brig, access_forensics_lockers, access_maxsec, access_securitylockers, access_carrypermit)
+			var/list/security_access_list = list(access_security, access_brig, access_forensics_lockers, access_maxsec, access_securitylockers, access_carrypermit, access_contrabandpermit)
 			var/command_access = list("<br>Command:")
 			var/list/command_access_list = list(access_research_director, access_emergency_storage, access_change_ids, access_ai_upload, access_teleporter, access_eva, access_heads, access_captain, access_engineering_chief, access_medical_director, access_head_of_personnel, access_ghostdrone)
 

--- a/code/obj/machinery/secscanner.dm
+++ b/code/obj/machinery/secscanner.dm
@@ -229,40 +229,48 @@
 					threatcount += perp.r_hand.contraband
 
 		if (istype(perp.wear_suit))
-			if(!has_contraband_permit)
+			if (!has_contraband_permit)
 				threatcount += perp.wear_suit.contraband
 
 		if (istype(perp.belt))
 			if (istype(perp.belt, /obj/item/gun/))
-				if(!has_carry_permit)
+				if (!has_carry_permit)
 					threatcount += perp.belt.contraband * 0.5
 			else
-				if(!has_contraband_permit)
+				if (!has_contraband_permit)
 					threatcount += perp.belt.contraband * 0.5
 				for( var/obj/item/item in perp.belt.contents )
-					if(istype(item, /obj/item/gun/) && !has_carry_permit)
-						threatcount += item.contraband * 0.5
-					else if(!has_contraband_permit)
-						threatcount += item.contraband * 0.5
+					if (istype(item, /obj/item/gun/))
+						if (!has_carry_permit)
+							threatcount += item.contraband * 0.5
+					else
+						if (!has_contraband_permit)
+							threatcount += item.contraband * 0.5
 
 		if (istype(perp.l_store))
-			if(istype(perp.l_store, /obj/item/gun/) && !has_carry_permit)
-				threatcount += perp.l_store.contraband * 0.5
-			else if(!has_contraband_permit)
-				threatcount += perp.l_store.contraband * 0.5
+			if (istype(perp.l_store, /obj/item/gun/))
+				if (!has_carry_permit)
+					threatcount += perp.l_store.contraband * 0.5
+			else
+				if (!has_contraband_permit)
+					threatcount += perp.l_store.contraband * 0.5
 
 		if (istype(perp.r_store))
-			if(istype(perp.r_store, /obj/item/gun/) && !has_carry_permit)
-				threatcount += perp.r_store.contraband * 0.5
-			else if(!has_contraband_permit)
-				threatcount += perp.r_store.contraband * 0.5
+			if (istype(perp.r_store, /obj/item/gun/))
+				if (!has_carry_permit)
+					threatcount += perp.r_store.contraband * 0.5
+			else
+				if (!has_contraband_permit)
+					threatcount += perp.r_store.contraband * 0.5
 
 		if (istype(perp.back))
 			for( var/obj/item/item in perp.back.contents )
-				if(istype(item, /obj/item/gun/) && !has_carry_permit)
-					threatcount += item.contraband * 0.5
-				else if(!has_contraband_permit)
-					threatcount += item.contraband * 0.5
+				if(istype(item, /obj/item/gun/))
+					if(!has_carry_permit)
+						threatcount += item.contraband * 0.5
+				else
+					if(!has_contraband_permit)
+						threatcount += item.contraband * 0.5
 
 		//Agent cards lower threatlevel
 		if((istype(perp.wear_id, /obj/item/card/id/syndicate)))

--- a/code/obj/machinery/secscanner.dm
+++ b/code/obj/machinery/secscanner.dm
@@ -233,13 +233,17 @@
 				threatcount += perp.wear_suit.contraband
 
 		if (istype(perp.belt))
-			if(!has_contraband_permit)
-				threatcount += perp.belt.contraband * 0.5
-			for( var/obj/item/item in perp.belt.contents )
-				if(istype(item, /obj/item/gun/) && !has_carry_permit)
-					threatcount += item.contraband * 0.5
-				else if(!has_contraband_permit)
-					threatcount += item.contraband * 0.5
+			if (istype(perp.belt, /obj/item/gun/))
+				if(!has_carry_permit)
+					threatcount += perp.belt.contraband * 0.5
+			else
+				if(!has_contraband_permit)
+					threatcount += perp.belt.contraband * 0.5
+				for( var/obj/item/item in perp.belt.contents )
+					if(istype(item, /obj/item/gun/) && !has_carry_permit)
+						threatcount += item.contraband * 0.5
+					else if(!has_contraband_permit)
+						threatcount += item.contraband * 0.5
 
 		if (istype(perp.l_store))
 			if(istype(perp.l_store, /obj/item/gun/) && !has_carry_permit)

--- a/code/obj/machinery/secscanner.dm
+++ b/code/obj/machinery/secscanner.dm
@@ -15,6 +15,7 @@
 	var/fail_sound = 'sound/machines/alarm_a.ogg'
 
 	var/weapon_access = access_carrypermit
+	var/contraband_access = access_contrabandpermit
 	var/report_scans = 1
 	var/check_records = 1
 
@@ -150,8 +151,6 @@
 				if (ishuman(target))
 					var/mob/living/carbon/human/H = target
 					var/perpname = H.name
-					if (H:wear_id && H:wear_id:registered)
-						perpname = H.wear_id:registered
 
 					if (perpname != last_perp || contraband != last_contraband)
 						var/datum/radio_frequency/transmit_connection = radio_controller.return_frequency("1149")
@@ -204,47 +203,91 @@
 		if (!istype(perp_id))
 			perp_id = perp.wear_id
 
-		if(perp_id && (weapon_access in perp_id.access)) //Corrupt cops cannot exist, beep boop
-			return 0
+		var/has_carry_permit = 0
+		var/has_contraband_permit = 0
+
+		if(perp_id) //Checking for permits
+			if(weapon_access in perp_id.access)
+				has_carry_permit = 1
+			if(contraband_access in perp_id.access)
+				has_contraband_permit = 1
 
 		if (istype(perp.l_hand))
-			threatcount += perp.l_hand.contraband
+			if (istype(perp.l_hand, /obj/item/gun/))  // perp is carrying a gun
+				if(!has_carry_permit)
+					threatcount += perp.l_hand.contraband
+			else // not carrying a gun
+				if(!has_contraband_permit)
+					threatcount += perp.l_hand.contraband
 
 		if (istype(perp.r_hand))
-			threatcount += perp.r_hand.contraband
+			if (istype(perp.r_hand, /obj/item/gun/)) // perp is carrying a gun
+				if(!has_carry_permit)
+					threatcount += perp.r_hand.contraband
+			else // not carrying a gun, but potential contraband?
+				if(!has_contraband_permit)
+					threatcount += perp.r_hand.contraband
 
 		if (istype(perp.wear_suit))
-			threatcount += perp.wear_suit.contraband
+			if(!has_contraband_permit)
+				threatcount += perp.wear_suit.contraband
 
 		if (istype(perp.belt))
-			threatcount += perp.belt.contraband * 0.5
+			if(!has_contraband_permit)
+				threatcount += perp.belt.contraband * 0.5
 			for( var/obj/item/item in perp.belt.contents )
-				threatcount += item.contraband * 0.5
+				if(istype(item, /obj/item/gun/) && !has_carry_permit)
+					threatcount += item.contraband * 0.5
+				else if(!has_contraband_permit)
+					threatcount += item.contraband * 0.5
 
 		if (istype(perp.l_store))
-			threatcount += perp.l_store.contraband * 0.5
+			if(istype(perp.l_store, /obj/item/gun/) && !has_carry_permit)
+				threatcount += perp.l_store.contraband * 0.5
+			else if(!has_contraband_permit)
+				threatcount += perp.l_store.contraband * 0.5
 
 		if (istype(perp.r_store))
-			threatcount += perp.r_store.contraband * 0.5
+			if(istype(perp.r_store, /obj/item/gun/) && !has_carry_permit)
+				threatcount += perp.r_store.contraband * 0.5
+			else if(!has_contraband_permit)
+				threatcount += perp.r_store.contraband * 0.5
 
 		if (istype(perp.back))
 			for( var/obj/item/item in perp.back.contents )
-				threatcount += item.contraband * 0.5
+				if(istype(item, /obj/item/gun/) && !has_carry_permit)
+					threatcount += item.contraband * 0.5
+				else if(!has_contraband_permit)
+					threatcount += item.contraband * 0.5
 
-//Agent cards lower threatlevel when normal idchecking is off.
+		//Agent cards lower threatlevel
 		if((istype(perp.wear_id, /obj/item/card/id/syndicate)))
 			threatcount -= 2
 
+		// we have grounds to make an arrest, don't bother with further analysis
+		if(threatcount >= 4)
+			return threatcount
+
 		if (src.check_records)
-			for (var/datum/data/record/E in data_core.general)
-				var/perpname = perp.name
-				if (perp?.wear_id?:registered)
-					perpname = perp.wear_id:registered
+			var/see_face = 1
+			if (istype(perp.wear_mask) && !perp.wear_mask.see_face)
+				see_face = 0
+			else if (istype(perp.head) && !perp.head.see_face)
+				see_face = 0
+			else if (istype(perp.wear_suit) && !perp.wear_suit.see_face)
+				see_face = 0
+
+			var/perpname = see_face ? perp.real_name : perp.name
+
+			for (var/i in data_core.general)
+				var/datum/data/record/E = i
 				if (E.fields["name"] == perpname)
-					for (var/datum/data/record/R in data_core.security)
+					for (var/j in data_core.security)
+						var/datum/data/record/R = j
 						if ((R.fields["id"] == E.fields["id"]) && (R.fields["criminal"] == "*Arrest*"))
 							threatcount = max(4,threatcount)
 							break
+					break
 				LAGCHECK(LAG_REALTIME)
 
 		return threatcount

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -199,7 +199,7 @@
 		if("Captain")
 			return get_all_accesses()
 		if("Head of Personnel")
-			return list(access_security, access_carrypermit, access_brig, access_forensics_lockers, access_armory,
+			return list(access_security, access_carrypermit, access_contrabandpermit, access_brig, access_forensics_lockers, access_armory,
 						access_tox, access_tox_storage, access_chemistry, access_medical, access_medlab,
 						access_emergency_storage, access_change_ids, access_eva, access_heads, access_head_of_personnel, access_medical_lockers,
 						access_all_personal_lockers, access_tech_storage, access_maint_tunnels, access_bar, access_janitor,
@@ -211,7 +211,7 @@
 			hos_access += access_maxsec
 			return hos_access
 #else
-			return list(access_security, access_carrypermit, access_maxsec, access_brig, access_securitylockers, access_forensics_lockers, access_armory,
+			return list(access_security, access_carrypermit, access_contrabandpermit, access_maxsec, access_brig, access_securitylockers, access_forensics_lockers, access_armory,
 						access_tox, access_tox_storage, access_chemistry, access_medical, access_morgue, access_medlab,
 						access_emergency_storage, access_change_ids, access_eva, access_heads, access_medical_lockers,
 						access_all_personal_lockers, access_tech_storage, access_maint_tunnels, access_bar, access_janitor,
@@ -244,7 +244,7 @@
 #ifdef RP_MODE // trying out giving them more access for RP
 			return list(access_security, access_brig, access_forensics_lockers, access_armory,
 				access_medical, access_medlab, access_morgue, access_securitylockers,
-				access_tox, access_tox_storage, access_chemistry, access_carrypermit,
+				access_tox, access_tox_storage, access_chemistry, access_carrypermit, access_contrabandpermit,
 				access_emergency_storage, access_chapel_office, access_kitchen, access_medical_lockers,
 				access_bar, access_janitor, access_crematorium, access_robotics, access_cargo, access_construction, access_hydro, access_mail,
 				access_engineering, access_maint_tunnels, access_external_airlocks,
@@ -253,14 +253,14 @@
 				access_engineering_control, access_engineering_mechanic, access_mining, access_mining_outpost,
 				access_research, access_engineering_atmos, access_hangar)
 #else
-			return list(access_security, access_carrypermit, access_securitylockers, access_brig, access_maint_tunnels,
+			return list(access_security, access_carrypermit, access_contrabandpermit, access_securitylockers, access_brig, access_maint_tunnels,
 			access_medical, access_morgue, access_crematorium, access_research, access_cargo, access_engineering,
 			access_chemistry, access_bar, access_kitchen, access_hydro)
 #endif
 		if("Vice Officer")
-			return list(access_security, access_carrypermit, access_securitylockers, access_brig, access_maint_tunnels,access_hydro,access_bar,access_kitchen)
+			return list(access_security, access_carrypermit, access_contrabandpermit, access_securitylockers, access_brig, access_maint_tunnels,access_hydro,access_bar,access_kitchen)
 		if("Detective", "Forensic Technician")
-			return list(access_brig, access_carrypermit, access_security, access_forensics_lockers, access_morgue, access_maint_tunnels, access_crematorium, access_medical, access_research)
+			return list(access_brig, access_carrypermit, access_contrabandpermit, access_security, access_forensics_lockers, access_morgue, access_maint_tunnels, access_crematorium, access_medical, access_research)
 		if("Lawyer")
 			return list(access_maint_tunnels, access_security, access_brig)
 
@@ -331,7 +331,7 @@
 
 		//////////////////////////// Other or gimmick
 		if("VIP")
-			return list(access_heads, access_carrypermit) // Their cane is contraband.
+			return list(access_heads, access_contrabandpermit) // Their cane is contraband.
 		if("Diplomat")
 			return list(access_heads)
 		if("Space Cowboy")
@@ -349,7 +349,7 @@
 /proc/get_all_accesses()  // not adding the special stuff to this
 	return list(access_security, access_brig, access_forensics_lockers, access_armory,
 	            access_medical, access_medlab, access_morgue, access_securitylockers,
-	            access_tox, access_tox_storage, access_chemistry, access_carrypermit,
+	            access_tox, access_tox_storage, access_chemistry, access_carrypermit, access_contrabandpermit,
 	            access_emergency_storage, access_change_ids, access_ai_upload,
 	            access_teleporter, access_eva, access_heads, access_captain, access_all_personal_lockers, access_head_of_personnel,
 	            access_chapel_office, access_kitchen, access_medical_lockers,
@@ -489,6 +489,8 @@ var/list/access_name_lookup //Generated at round start.
 			return "Hangar"
 		if(access_carrypermit)
 			return "Firearms Carry Permit"
+		if(access_contrabandpermit)
+			return "Handling of Contraband Permit"
 		if(access_medical_director)
 			return "Medical Director's Office"
 		if(access_robotics)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Splits the firearm permit into two: a firearm permit and a handling of contraband permit.
Reworks guardbuddies', secbots', secscanners', sechuds' assessments of suspects.
Adds some additional logic to support the forementioned as well as optimizations to already existing code.

Review of the code is welcome as it is some additional logic to stuff that runs fairly often, so any possible optimizations as well as correction of mistakes is great.

I've tested the code for errors and having fixed any issues that propped up functionality-wise it seems to work as supposed to, albeit there are many possible cases and I'll continue making sure that there aren't apparent issues, along with potential expansion and/or fixes based on anything that's pointed out/suggested.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
All of the forementioned used to only care about the ID of the people they were examining. Now, if the person's identity isn't obscured, they prioritize their real identity and only rely on ID cards if the target can't be identified by face.

In addition, if their targets had firearm permits, the assessment function used to just flat out agree on the person not being suspicious, no matter what. This meant that whether they were set to wanted in records, were carrying multiple contraband or otherwise they were seen as always fine. 

Now, the firearm permit has been split into a firearm permit and a contraband permit. Suspicious items are evaluated separately on being a firearm or not and depending on possessed permits their contraband value may or may not be used in evaluation of a person.

The secscanner also now displays the person's visible name, this means that a format in example of "PersonName (as OtherName)", further reinforcing that suspects need to be sneakier and hide their identity, else they risk their cover in stolen ID cards being blown.

The summary of these changes means that you can't just evade being detected by bots through carrying any single additional ID (even a blank one from an ID box) without also hiding your face and also having a gun permit doesn't flat-out protect you from any bot scanning anymore either.

The divide into a firearm and contraband permit also allows giving selective permissions to just certain kind of items, for example letting someone handle a taser but not batons or energy swords without being tagged as a suspect.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Gerhazo:
(*)Added a "handling of contraband permit" access level present on appropriate jobs' ID cards and identification computers. Firearm permit now only permits you to carry firearms, other kinds of contraband apply under this new permit, which scanners and bots will take into account.
(*)Security sechud glasses, securitrons, guardbuddies and security scanners now prioritise a person's real identity rather than just the ID card they're holding, if the target's face is not concealed.
```
