### PR TITLE
UM-017 - Biomagnetic Field Charge

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -529,9 +529,11 @@
 				var/datum/bioEffect/hidden/magnetic/src_effect = src.bioHolder.GetEffect("magnets_pos")
 				if(src_effect == null) src_effect = src.bioHolder.GetEffect("magnets_neg")
 
-				if(src_effect.active != 0 && tmob_effect.active != 0)
+				if(src_effect.active != 0 && tmob_effect.active != 0 && src_effect.charge > 0 && tmob_effect.charge > 0)
 					src_effect.deactivate(10)
+					src_effect.update_charge(-1)
 					tmob_effect.deactivate(10)
+					tmob_effect.update_charge(-1)
 					// like repels - bimp them away from each other
 					src.now_pushing = 0
 					var/atom/source = get_turf(tmob)
@@ -561,9 +563,12 @@
 				var/datum/bioEffect/hidden/magnetic/src_effect = src.bioHolder.GetEffect("magnets_pos")
 				if(src_effect == null) src_effect = src.bioHolder.GetEffect("magnets_neg")
 
-				if(src_effect.active != 0 && tmob_effect.active != 0)
+				if(src_effect.active != 0 && tmob_effect.active != 0 && src_effect.charge > 0 && tmob_effect.charge > 0)
+					var/throw_charge = (src_effect.charge + tmob_effect.charge)*2
 					src_effect.deactivate(10)
+					src_effect.update_charge(-src_effect.charge)
 					tmob_effect.deactivate(10)
+					tmob_effect.update_charge(-tmob_effect.charge)
 					// opposite attracts - fling everything nearby at these dumbasses
 					src.now_pushing = 1
 					tmob.now_pushing = 1
@@ -585,6 +590,10 @@
 					playsound(source, 'sound/effects/suck.ogg', 100, 1)
 					for(var/atom/movable/M in view(5, source))
 						if(M.anchored || M == source) continue
+						if(throw_charge > 0)
+							throw_charge--
+						else
+							break
 						M.throw_at(source, 20, 3)
 						LAGCHECK(LAG_MED)
 					sleep(5 SECONDS)

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -3528,6 +3528,12 @@
 			else if (move_dir == turn(last_move_dir,180))
 				sprint_particle_tiny(src,get_step(NewLoc,turn(move_dir,180)),turn(move_dir,180))
 				playsound(src.loc,"sound/effects/sprint_puff.ogg", 9, 1,extrarange = -25, pitch=2.9)
+				if(src.bioHolder.HasEffect("magnets_pos") || src.bioHolder.HasEffect("magnets_neg"))
+					var/datum/bioEffect/hidden/magnetic/src_effect = src.bioHolder.GetEffect("magnets_pos")
+					if(src_effect == null) src_effect = src.bioHolder.GetEffect("magnets_neg")
+					if(src_effect.update_charge(1))
+						playsound(get_turf(src), "sound/effects/sparks[rand(1,6)].ogg", 25, 1,extrarange = -25)
+
 
 			sustained_moves = 0
 	else

--- a/code/modules/medical/genetics/bioEffects/non_genetic.dm
+++ b/code/modules/medical/genetics/bioEffects/non_genetic.dm
@@ -189,7 +189,31 @@
 /datum/bioEffect/hidden/magnetic
 	name = "magnetic charge parent"
 	desc = "This shouldn't be used."
+	effectType = effectTypeDisability
+	isBad = 1
+	can_copy = 0
+	curable_by_mutadone = 0
+	occur_in_genepools = 0
 	var/active = 1
+
+	var/max_charge = 10
+	var/charge = 5
+
+	proc/update_charge(var/amount)
+		var/init_charge = src.charge
+		src.charge += amount
+		src.charge = clamp(src.charge,0,src.max_charge)
+		if(src.charge != init_charge)
+			src.update_overlay()
+			return 1
+		return 0
+
+	proc/update_overlay()
+		if(src.overlay_image)
+			if(isliving(owner))
+				src.overlay_image.alpha = charge/max_charge*255
+				var/mob/living/L = owner
+				L.UpdateOverlays(overlay_image, id)
 
 	proc/deactivate(var/time)
 		active = 0
@@ -201,11 +225,6 @@
 	desc = "This person is charged with a strong positive magnetic field."
 	id = "magnets_pos"
 	msgGain = "You notice odd red static sparking on your skin."
-	effectType = effectTypeDisability
-	isBad = 1
-	can_copy = 0
-	curable_by_mutadone = 0
-	occur_in_genepools = 0
 
 	OnAdd()
 		if (ishuman(owner))
@@ -219,10 +238,6 @@
 	id = "magnets_neg"
 	msgGain = "You notice odd blue static sparking on your skin."
 	effectType = effectTypeDisability
-	isBad = 1
-	can_copy = 0
-	curable_by_mutadone = 0
-	occur_in_genepools = 0
 
 	OnAdd()
 		if (ishuman(owner))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

1) Biomagnetic Fields now have a "charge" variable that builds up when you take tight turns

    - Blowouts consume all charge and fling items proportional to the charge spent

    - Getting flung consumes 1 charge

    - Default 5 charge, max of 10, min 0

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

1) Biomagnetic fields being infinite was a funny joke, but I think it's kindof overstayed its welcome for a lot of people. This ensures that people actually have the ability to mitigate their risk by walking deliberately in order to not build up charge. Now when you get ping ponged around, there's at least some element of it that's your fault, probably.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)UrsulaMajor:
(*)Biomagnetic Fields now use charge to produce their effects. Charge builds up when you take tight turns.
```
