### PR TITLE
When Revs Gamemode: Show Command Slots as Filled when Late-Joining

### DIFF
--- a/code/mob/new_player.dm
+++ b/code/mob/new_player.dm
@@ -413,7 +413,7 @@ mob/new_player
 				c = limit
 
 			// if there's still an open space, show a final join link
-			if (limit == -1 || (limit > maxslots && c < J.limit))
+			if (limit == -1 || (limit > maxslots && c < limit))
 				slots += "<a href='byond://?src=\ref[src];SelectedJob=\ref[J]' class='latejoin-card' style='border-color: [J.linkcolor];' title='Join the round as [J.name].'>&#x2713;&#xFE0E;</a>"
 
 			// show slots up to the limit
@@ -423,7 +423,7 @@ mob/new_player
 
 			return {"
 				<tr><td class='latejoin-link'>
-					[(J.limit == -1 || c < J.limit) ? "<a href='byond://?src=\ref[src];SelectedJob=\ref[J]' style='color: [J.linkcolor];' title='Join the round as [J.name].'>[J.name]</a>" : "<span style='color: [J.linkcolor];' title='This job is full.'>[J.name]</span>"]
+					[(limit == -1 || c < limit) ? "<a href='byond://?src=\ref[src];SelectedJob=\ref[J]' style='color: [J.linkcolor];' title='Join the round as [J.name].'>[J.name]</a>" : "<span style='color: [J.linkcolor];' title='This job is full.'>[J.name]</span>"]
 					</td>
 					<td class='latejoin-cards'>[jointext(slots, " ")]</td>
 				</tr>

--- a/code/mob/new_player.dm
+++ b/code/mob/new_player.dm
@@ -267,8 +267,6 @@ mob/new_player
 			return 0
 		if (!JOB || !istype(JOB,/datum/job/) || JOB.limit == 0)
 			return 0
-		if((ticker && ticker.mode && istype(ticker.mode, /datum/game_mode/revolution)) && istype(JOB,/datum/job/command/))
-			return 0
 		if (!JOB.no_jobban_from_this_job && jobban_isbanned(src,JOB.name))
 			return 0
 		if (JOB.requires_whitelist)
@@ -409,6 +407,10 @@ mob/new_player
 			var/maxslots = 5
 			var/list/slots = list()
 			var/shown = min(max(c, (limit == -1 ? 99 : limit)), maxslots)
+
+			//If it's Revolution time, lets show all command jobs as filled to (try to) prevent metagaming.
+			if(istype(J, /datum/job/command/) && istype(ticker.mode, /datum/game_mode/revolution)) 
+				c = limit
 
 			// if there's still an open space, show a final join link
 			if (limit == -1 || (limit > maxslots && c < J.limit))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Currently: When late-joining, command roles are not shown/rendered in the job-select window.
This PR will render then like normal, except show that they are filled to capacity.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Dirty metagamers.

Maybe this can be considered a bugfix? 
Changelog seems super-minor. Let me know if I should remove it


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)MarkNstein:
(+)Command jobs now displayed as filled when late-joining during Rev-mode.
```
