### PR TITLE
Monkeys now drop all gear when meat spiked

### DIFF
--- a/code/obj/kitchenspike.dm
+++ b/code/obj/kitchenspike.dm
@@ -24,6 +24,7 @@
 		if (G.affecting.client)
 			newmob = new/mob/dead/observer(G.affecting)
 			G.affecting:client:mob = newmob
+		G.affecting.unequip_all()
 		qdel(G.affecting)
 		qdel(G)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][MINOR] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Monkeys now drop all gear when meat spiked


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Gear was deleted along with mob when meat spiking
closes #962 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Sovexe:
(+)Monkeys will now drop all equipped items when meat spiked
```
