### PR TITLE
QM sold credits are returned instead of lost

### DIFF
--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -155,6 +155,9 @@
 							qdel(O)
 						duckets += add
 						break
+					else if (istype(O, /obj/item/spacecash))
+						duckets += O:amount
+						pool(O)
 		else // Please excuse this duplicate code, I'm gonna change trader commodity lists into associative ones later I swear
 			for(var/obj/O in sell_crate.contents)
 				for (var/datum/commodity/C in commodities_list)
@@ -169,6 +172,9 @@
 							qdel(O)
 						duckets += add
 						break
+					else if (istype(O, /obj/item/spacecash))
+						duckets += O:amount
+						pool(O)
 		qdel(sell_crate)
 
 		var/datum/radio_frequency/transmit_connection = radio_controller.return_frequency("1149")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
"Selling" credits using QM either to vendor or just in an unmarked crate now credits them back to you as profit instead of deleting them.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #455


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Sovexe:
(+)Credits "sold" via QM crate are now refunded as profit instead of lost.
```
