### PR TITLE
UM-020 - Deconstruct Constructed Stuff W/O Access

### DIFF
--- a/code/WorkInProgress/Electronics.dm
+++ b/code/WorkInProgress/Electronics.dm
@@ -722,7 +722,7 @@
 				boutput(user, "<span class='alert'>[target] is under an access lock and must have its access requirements removed first.</span>")
 			return
 
-		if (!O.allowed(user) || O.is_syndicate)
+		if ((!O.allowed(user) || O.is_syndicate) && !(O.deconstruct_flags & DECON_BUILT))
 			boutput(user, "<span class='alert'>You cannot deconstruct [target] without sufficient access to operate it.</span>")
 			return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

1) If a mechanic builds a thing then you can deconstruct it without operating access

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Closes Issue #884

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)UrsulaMajor:
(+)You can now deconstruct everything a mechanic constructs (again)
```
