### PR TITLE
Heisenbee hat tier progression across rounds

### DIFF
--- a/_std/component_defines.dm
+++ b/_std/component_defines.dm
@@ -1,3 +1,6 @@
+/// `targget` to use for signals that are global and not tied to a single datum
+#define GLOBAL_SIGNAL preMapLoad // guaranteed to exist and that's all that matters
+
 /// Used to trigger signals and call procs registered for that signal
 /// The datum hosting the signal is automaticaly added as the first argument
 /// Returns a bitfield gathered from all registered procs
@@ -6,7 +9,6 @@
 
 /// A wrapper for _AddComponent that allows us to pretend we're using normal named arguments
 #define AddComponent(arguments...) _AddComponent(list(##arguments))
-
 
 /// Return this from `/datum/component/Initialize` or `datum/component/OnTransfer` to have the component be deleted if it's applied to an incorrect type.
 /// `parent` must not be modified if this is to be returned.
@@ -27,6 +29,9 @@
 /// each component of the same type is consulted as to whether the duplicate should be allowed
 #define COMPONENT_DUPE_SELECTIVE		5
 
+
+// global signals
+#define COMSIG_GLOBAL_REBOOT "global_reboot"
 
 // /datum signals
 /// when a component is added to a datum: (/datum/component)

--- a/_std/component_defines.dm
+++ b/_std/component_defines.dm
@@ -1,11 +1,15 @@
-/// `targget` to use for signals that are global and not tied to a single datum
-#define GLOBAL_SIGNAL preMapLoad // guaranteed to exist and that's all that matters
-
 /// Used to trigger signals and call procs registered for that signal
 /// The datum hosting the signal is automaticaly added as the first argument
 /// Returns a bitfield gathered from all registered procs
 /// Arguments given here are packaged in a list and given to _SendSignal
 #define SEND_SIGNAL(target, sigtype, arguments...) ( !target.comp_lookup || !target.comp_lookup[sigtype] ? 0 : target._SendSignal(sigtype, list(target, ##arguments)) )
+
+/// `targget` to use for signals that are global and not tied to a single datum.
+/// Note that this does NOT work with SEND_SIGNAL because of preprocessor weirdness.
+/// Use SEND_GLOBAL_SIGNAL instead.
+#define GLOBAL_SIGNAL preMapLoad // guaranteed to exist and that's all that matters
+#define SEND_GLOBAL_SIGNAL(sigtype, arguments...) ( !preMapLoad.comp_lookup || !preMapLoad.comp_lookup[sigtype] ? 0 : preMapLoad._SendSignal(sigtype, list(preMapLoad, ##arguments)) )
+
 
 /// A wrapper for _AddComponent that allows us to pretend we're using normal named arguments
 #define AddComponent(arguments...) _AddComponent(list(##arguments))

--- a/code/obj/critter/bee.dm
+++ b/code/obj/critter/bee.dm
@@ -245,7 +245,7 @@
 			///obj/item/clothing/head/butt,
 			/obj/item/clothing/head/paper_hat,
 			/obj/item/clothing/head/plunger,
-			/obj/item/clothing/head/helmet/bucket,
+			/obj/item/clothing/head/helmet/bucket/hat,
 			/obj/item/clothing/head/cakehat,
 			/obj/item/clothing/head/chefhat,
 			/obj/item/clothing/head/mailcap,

--- a/code/obj/critter/bee.dm
+++ b/code/obj/critter/bee.dm
@@ -238,14 +238,99 @@
 		generic = 0
 		var/jittered = 0
 		honey_color = rgb(0, 255, 255)
+		var/tier = 0
+		var/original_tier = 0
+		var/original_hat_ref = ""
+		var/static/hat_tier_list = list(
+			///obj/item/clothing/head/butt,
+			/obj/item/clothing/head/paper_hat,
+			/obj/item/clothing/head/plunger,
+			/obj/item/clothing/head/helmet/bucket,
+			/obj/item/clothing/head/cakehat,
+			/obj/item/clothing/head/chefhat,
+			/obj/item/clothing/head/mailcap,
+			/obj/item/clothing/head/helmet/hardhat,
+			/obj/item/clothing/head/det_hat,
+			/obj/item/clothing/head/mj_hat,
+			/obj/item/clothing/head/that,
+			/obj/item/clothing/head/NTberet,
+			/obj/item/clothing/head/helmet/HoS,
+			/obj/item/clothing/head/hosberet,
+			/obj/item/clothing/head/caphat,
+			/obj/item/clothing/head/fancy/captain,
+			/obj/item/clothing/head/apprentice,
+			/obj/item/clothing/head/wizard,
+			/obj/item/clothing/head/wizard/red,
+			/obj/item/clothing/head/helmet/viking,
+			/obj/item/clothing/head/void_crown
+		)
 
 		New()
+			src.tier = world.load_intra_round_value("heisenbee_tier")
+			src.original_tier = src.tier
+			src.RegisterSignal(GLOBAL_SIGNAL, COMSIG_GLOBAL_REBOOT, .proc/save_upgraded_tier)
+			heisentier_hat()
 			pets += src
 			..()
 
 		disposing()
+			UnregisterSignal(GLOBAL_SIGNAL, COMSIG_GLOBAL_REBOOT)
 			pets -= src
 			..()
+
+		proc/save_upgraded_tier()
+			if(src.alive)
+				world.save_intra_round_value("heisenbee_tier", src.tier + 1)
+
+		proc/heisentier_hat()
+			if(src.tier <= 0)
+				return
+			var/hat_type = src.hat_tier_list[(src.tier - 1) % length(src.hat_tier_list) + 1]
+			var/obj/item/clothing/head/hat = new hat_type(src)
+			var/ubertier = round((src.tier - 1) / length(src.hat_tier_list))
+			switch(ubertier)
+				if(0)
+					; // regular hat
+				if(1)
+					hat.setMaterial(getMaterial("gold"))
+				if(2)
+					hat.setMaterial(getMaterial("miracle"))
+				if(3)
+					hat.setMaterial(getMaterial("telecrystal"))
+				if(4)
+					hat.setMaterial(getMaterial("negativematter"))
+				if(5 to INFINITY)
+					hat.setMaterial(getMaterial("starstone"))
+					var/matrix/trans = new
+					trans.Scale((ubertier - 4) / 5) // mmm, large hat
+					hat.transform = trans
+			hat.name = "[src]'s [hat.name]"
+			src.original_hat_ref = ref(hat)
+			src.hat_that_bee(hat)
+			src.update_icon()
+
+		CritterDeath()
+			if(!src.alive)
+				return
+			world.save_intra_round_value("heisenbee_tier", 0)
+			if(src.hat)
+				src.hat.set_loc(src.loc)
+				src.hat = null
+				src.update_icon()
+			src.tier = 0 // No free hat with SR...
+			. = ..()
+
+		attackby(obj/item/W, mob/living/user)
+			if(!src.hat && ref(W) == src.original_hat_ref) // ...unless you return the hat!
+				if(src.alive)
+					boutput(user, "<span class='emote'>[src] bubmles happily at the sight of [W]!</span>")
+				src.tier = src.original_tier
+			. = ..()
+
+		get_desc(dist)
+			. = ..()
+			if(src.hat)
+				. += "Huh, is that \a [src.hat] on [src]? How did it even get there?"
 
 #ifdef HALLOWEEN
 		var/masked = 1

--- a/code/obj/critter/bee.dm
+++ b/code/obj/critter/bee.dm
@@ -302,7 +302,7 @@
 				if(5 to INFINITY)
 					hat.setMaterial(getMaterial("starstone"))
 					var/matrix/trans = new
-					trans.Scale((ubertier - 4) / 5) // mmm, large hat
+					trans.Scale((ubertier - 4) / 3) // mmm, large hat
 					hat.transform = trans
 			hat.name = "[src]'s [hat.name]"
 			src.original_hat_ref = ref(hat)

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -2451,3 +2451,12 @@ proc/time_to_text(var/time)
 	else if(time || !length(.))
 		. += "[round(time / (1 SECOND), 0.1)] seconds"
 	. = jointext(., " ")
+
+// this is dumb and bad but it makes the bicon not expand the line vertically and also centers it
+// also it assumes 32px height by default
+proc/inline_bicon(the_thing, height=32)
+	return {"<span style="display:inline-block;vertical-align:middle;height:0px;">
+	<div style="position:relative;top:-[height / 2]px">
+	[bicon(the_thing)]
+	</div>
+	</span>"}

--- a/code/procs/scorestats.dm
+++ b/code/procs/scorestats.dm
@@ -245,8 +245,50 @@ var/datum/score_tracker/score_tracker
 				var/obj/item/card/id/ID = I
 				. += ID.amount
 
+	proc/heisenhat_stats()
+		. = list()
+		. += "<B>Heisenbee's hat:</B> "
+		var/found_hb = 0
+		var/tier = world.load_intra_round_value("heisenbee_tier")
+		for(var/obj/critter/domestic_bee/heisenbee/HB in pets)
+			var/obj/item/hat = locate(HB.original_hat_ref)
+			if(hat)
+				if(hat.loc != HB)
+					var/atom/movable/L = hat.loc
+					while(istype(L) && !istype(L, /mob))
+						L = L.loc
+					. += "[hat][inline_bicon(getFlatIcon(hat, no_anim=TRUE))](tier [HB.original_tier])"
+					if(istype(L, /mob))
+						. += " \[STOLEN BY [L]\]"
+					else
+						. += " \[STOLEN!\]"
+					if(HB.hat)
+						var/dead = HB.alive ? "" : "(dead) "
+						. += "<BR>Also someone put [HB.hat] on [dead][HB][inline_bicon(getFlatIcon(HB, no_anim=TRUE))]but that doesn't count."
+				else if(!HB.alive)
+					. += "[hat][inline_bicon(getFlatIcon(HB, no_anim=TRUE))](tier [HB.original_tier])"
+					. += " \[🐝 MURDERED!\]"
+				else
+					. += "[hat][inline_bicon(getFlatIcon(HB, no_anim=TRUE))](tier [HB.original_tier])"
+			else if(HB.alive)
+				if(HB.tier == 0)
+					. += "No hat yet."
+				else
+					. += "\[DESTROYED!\]"
+			else
+				. += "\[DESTROYED!\] \[🐝 MURDERED!\]"
+			found_hb = 1
+			break
+		if(!found_hb)
+			if(tier)
+				. += "Heisenbee is missing but the hat is safe at tier [tier]."
+			else
+				. += "Heisenbee is missing and has no hat."
+		. += "<BR>"
+		return jointext(., "")
+
 	proc/escapee_facts()
-		. = ""
+		. = list()
 		//Richest Escapee | Most Damaged Escapee | Dr. Acula Blood Total | Clown Beatings
 		if (richest_escapee)		. += "<B>Richest Escapee:</B> [richest_escapee.real_name] : $[richest_total]<BR>"
 		if (most_damaged_escapee) 	. += "<B>Most Damaged Escapee:</B> [most_damaged_escapee.real_name] : [most_damaged_escapee.get_damage()]%<BR>"		//it'll be kinda different from when it's calculated, but whatever.
@@ -259,23 +301,7 @@ var/datum/score_tracker/score_tracker
 		if (acula_blood) 			. += "<B>Dr. Acula Blood Total:</B> [acula_blood]p<BR>"
 		if (beepsky_alive) 			. += "<B>Beepsky?:</B> Yes<BR>"
 
-		var/found_hb = 0
-		for(var/obj/critter/domestic_bee/heisenbee/HB in pets)
-			var/obj/item/hat = locate(HB.original_hat_ref)
-			if(hat && HB.alive)
-				. += "Heisenbee hat: [hat] [bicon(hat)] (tier [HB.tier])"
-			else if(HB.alive)
-				. += "Heisenbee hat: No hat yet."
-			else
-				. += "Heisenbee hat: Heisenbee was killed! Hat tier reset to 0."
-			found_hb = 1
-		if(!found_hb)
-			var/tier = world.load_intra_round_value("heisenbee_tier")
-			if(tier)
-				. += "Heisenbee hat: Heisenbee missing but hat is safe at tier [tier]."
-			else
-				. += "Heisenbee hat: Heisenbee missing and has no hat."
-		return .
+		return jointext(., "")
 
 
 /mob/proc/scorestats()
@@ -317,6 +343,7 @@ var/datum/score_tracker/score_tracker
 		*/
 		score_tracker.score_text += "<B><U>STATISTICS</U></B><BR>"
 		score_tracker.score_text += score_tracker.escapee_facts()
+		score_tracker.score_text += score_tracker.heisenhat_stats()
 
 		score_tracker.score_text += "<HR>"
 

--- a/code/procs/scorestats.dm
+++ b/code/procs/scorestats.dm
@@ -271,7 +271,7 @@ var/datum/score_tracker/score_tracker
 				else
 					. += "[hat][inline_bicon(getFlatIcon(HB, no_anim=TRUE))](tier [HB.original_tier])"
 			else if(HB.alive)
-				if(HB.tier == 0)
+				if(HB.original_tier == 0)
 					. += "No hat yet."
 				else
 					. += "\[DESTROYED!\]"

--- a/code/procs/scorestats.dm
+++ b/code/procs/scorestats.dm
@@ -258,6 +258,23 @@ var/datum/score_tracker/score_tracker
 
 		if (acula_blood) 			. += "<B>Dr. Acula Blood Total:</B> [acula_blood]p<BR>"
 		if (beepsky_alive) 			. += "<B>Beepsky?:</B> Yes<BR>"
+
+		var/found_hb = 0
+		for(var/obj/critter/domestic_bee/heisenbee/HB in pets)
+			var/obj/item/hat = locate(HB.original_hat_ref)
+			if(hat && HB.alive)
+				. += "Heisenbee hat: [hat] [bicon(hat)] (tier [HB.tier])"
+			else if(HB.alive)
+				. += "Heisenbee hat: No hat yet."
+			else
+				. += "Heisenbee hat: Heisenbee was killed! Hat tier reset to 0."
+			found_hb = 1
+		if(!found_hb)
+			var/tier = world.load_intra_round_value("heisenbee_tier")
+			if(tier)
+				. += "Heisenbee hat: Heisenbee missing but hat is safe at tier [tier]."
+			else
+				. += "Heisenbee hat: Heisenbee missing and has no hat."
 		return .
 
 

--- a/code/world.dm
+++ b/code/world.dm
@@ -642,6 +642,7 @@ var/f_color_selector_handler/F_Color_Selector
 
 	lagcheck_enabled = 0
 	processScheduler.stop()
+	SEND_SIGNAL(preMapLoad, COMSIG_GLOBAL_REBOOT)
 	save_intraround_jars()
 	save_tetris_highscores()
 	if (current_state < GAME_STATE_FINISHED)

--- a/code/world.dm
+++ b/code/world.dm
@@ -642,7 +642,7 @@ var/f_color_selector_handler/F_Color_Selector
 
 	lagcheck_enabled = 0
 	processScheduler.stop()
-	SEND_SIGNAL(preMapLoad, COMSIG_GLOBAL_REBOOT)
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOBAL_REBOOT)
 	save_intraround_jars()
 	save_tetris_highscores()
 	if (current_state < GAME_STATE_FINISHED)

--- a/strings/changelog.txt
+++ b/strings/changelog.txt
@@ -1,5 +1,9 @@
 
 (t)sun jun 07 20
+(u)Sovexe
+(p)978
+(e)|
+(+)Monkeys will now drop all equipped items when meat spiked
 (u)UrsulaMajor
 (p)969
 (e)⚖|balance


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Heisenbee has no hat. That's sad. This PR makes it so Heisenbee gets a hat if she survives the round. But wait, there's more! Heisenbee's hat tier increases for each consecutive round alive. Killing Heisenbee drops the treasured hat but resets the Hat Tier to 0. (But you can always use strange reagent to revive Heisenbee and then return the hat to make everything alright again!)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I think it's pretty much self-explanatory.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)pali
(*)Heisenbee gets better hats the more rounds she's alive. Killing Heisenbee resets this but drops the hat!
```
