### PR TITLE
Invert moveslow on nukie guns - fix/cleanup some equipped() stuff

### DIFF
--- a/_std/_setup.dm
+++ b/_std/_setup.dm
@@ -239,23 +239,23 @@
 #define ARMS			8
 
 // other clothing-specific bitflags, applied via the c_flags var
-#define SPACEWEAR 1				// combined HEADSPACE and SUITSPACE into this because seriously??
-#define MASKINTERNALS 2			// mask allows internals
-#define COVERSEYES 4			// combined COVERSEYES, COVERSEYES and COVERSEYES into this
-#define COVERSMOUTH 8			// combined COVERSMOUTH and COVERSMOUTH into this.
-#define ONESIZEFITSALL 16		// can be worn by fatties (or children? ugh)
-#define NOSLIP 32				// for galoshes/magic sandals/etc that prevent slipping on things
-#define SLEEVELESS 64			// ain't got no sleeeeeves
-#define BLOCKSMOKE 128			//block smoke inhalations (gas mask)
-#define IS_JETPACK 256
-#define EQUIPPED_WHILE_HELD 512			//doesn't need to be worn to appear in the 'get_equipped_items' list and apply itemproperties (protections resistances etc)! for stuff like shields
-#define EQUIPPED_WHILE_HELD_ACTIVE 1024	//doesn't need to be worn to appear in the 'get_equipped_items' list and apply itemproperties (protections resistances etc)! for stuff like shields
-#define HAS_GRAB_EQUIP 2048 			//similar effect as above, but this flag is applied to any item held when the item is being used for a certain type of grab
-#define BLOCK_TOOLTIP 4096				//whether or not we should show extra tooltip info about blocking with this item
-#define BLOCK_CUT 8192					//block an extra point of cut damage when used to block
-#define BLOCK_STAB 16384				//block an extra point of stab damage when used to block
-#define BLOCK_BURN 32768				//block an extra point of burn damage when used to block
-#define BLOCK_BLUNT 65536				//block an extra point of blunt damage when used to block
+#define SPACEWEAR					1		// combined HEADSPACE and SUITSPACE into this because seriously??
+#define MASKINTERNALS				2		// mask allows internals
+#define COVERSEYES					4		// combined COVERSEYES, COVERSEYES and COVERSEYES into this
+#define COVERSMOUTH					8		// combined COVERSMOUTH and COVERSMOUTH into this.
+#define ONESIZEFITSALL				16		// can be worn by fatties (or children? ugh)
+#define NOSLIP						32		// for galoshes/magic sandals/etc that prevent slipping on things
+#define SLEEVELESS					64		// ain't got no sleeeeeves
+#define BLOCKSMOKE					128		//block smoke inhalations (gas mask)
+#define IS_JETPACK					256
+#define EQUIPPED_WHILE_HELD			512		//doesn't need to be worn to appear in the 'get_equipped_items' list and apply itemproperties (protections resistances etc)! for stuff like shields
+#define NOT_EQUIPPED_WHEN_WORN		1024	//return early out of equipped/unequipped, unless in SLOT_L_HAND or SLOT_R_HAND (i.e.: if EQUIPPED_WHILE_HELD)
+#define HAS_GRAB_EQUIP				2048 	//if we currently have a grab (or by extention, a block) attached to us
+#define BLOCK_TOOLTIP				4096	//whether or not we should show extra tooltip info about blocking with this item
+#define BLOCK_CUT					8192	//block an extra point of cut damage when used to block
+#define BLOCK_STAB					16384	//block an extra point of stab damage when used to block
+#define BLOCK_BURN					32768	//block an extra point of burn damage when used to block
+#define BLOCK_BLUNT					65536	//block an extra point of blunt damage when used to block
 
 //clothing dirty flags (not used for anything other than submerged overlay update currently. eventually merge into update_clothing)
 #define C_BACK 1

--- a/code/WorkInProgress/HaineWhatever.dm
+++ b/code/WorkInProgress/HaineWhatever.dm
@@ -161,7 +161,7 @@
 			src.reagents.add_reagent(src.initial_reagent, 5)
 
 	equipped(var/mob/user, var/slot)
-		if (slot == "mask" && istype(user))
+		if (slot == SLOT_WEAR_MASM && istype(user))
 			src.chewer = user
 			if (!(src in processing_items))
 				processing_items.Add(src)

--- a/code/WorkInProgress/blueprints.dm
+++ b/code/WorkInProgress/blueprints.dm
@@ -668,6 +668,7 @@
 		return
 
 	equipped(var/mob/user, var/slot)
+		..()
 		using = user
 		updateOverlays()
 		return

--- a/code/WorkInProgress/ud5/urs_dungeon.dm
+++ b/code/WorkInProgress/ud5/urs_dungeon.dm
@@ -213,6 +213,7 @@
 		return
 #else
 	equipped(var/mob/user, var/slot)
+		..()
 		user.visible_message("<span class='notice'>[user] puts on the goggles, but nothing particularly special happens!</span>")
 		user.u_equip(src)
 		src.set_loc(get_turf(user))
@@ -231,8 +232,9 @@
 		..()
 
 	equipped(var/mob/user, var/slot)
+		..()
 		var/mob/living/carbon/human/H = user
-		if(istype(H) && slot == "eyes")
+		if(istype(H) && slot == SLOT_GLASSES)
 			SPAWN_DBG(1 SECOND)
 				exit_urs_dungeon(user)
 		return

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -490,7 +490,7 @@
 
 /mob/living/carbon/human/disposing()
 	for(var/obj/item/I in src)
-		if(I.equipped_in_slot != slot_w_uniform && I.equipped_in_slot != "i_clothing")
+		if(I.equipped_in_slot != slot_w_uniform)
 			src.u_equip(I)
 	if(src.w_uniform) // last because pockets etc.
 		src.u_equip(src.w_uniform)
@@ -2271,14 +2271,14 @@
 			if (!src.back)
 				src.back = I
 				hud.add_object(I, HUD_LAYER+2, hud.layouts[hud.layout_style]["back"])
-				I.equipped(src, "back")
+				I.equipped(src, slot_back)
 				equipped = 1
 				clothing_dirty |= C_BACK
 		if (slot_wear_mask)
 			if (!src.wear_mask && src.organHolder && src.organHolder.head)
 				src.wear_mask = I
 				hud.add_other_object(I, hud.layouts[hud.layout_style]["mask"])
-				I.equipped(src, "mask")
+				I.equipped(src, slot_wear_mask)
 				equipped = 1
 				clothing_dirty |= C_MASK
 		if (slot_l_hand)
@@ -2291,42 +2291,42 @@
 			if (!src.belt)
 				src.belt = I
 				hud.add_object(I, HUD_LAYER+2, hud.layouts[hud.layout_style]["belt"])
-				I.equipped(src, "belt")
+				I.equipped(src, slot_belt)
 				equipped = 1
 				clothing_dirty |= C_BELT
 		if (slot_wear_id)
 			if (!src.wear_id)
 				src.wear_id = I
 				hud.add_other_object(I, hud.layouts[hud.layout_style]["id"])
-				I.equipped(src, "id")
+				I.equipped(src, slot_wear_id)
 				equipped = 1
 				clothing_dirty |= C_ID
 		if (slot_ears)
 			if (!src.ears && src.organHolder && src.organHolder.head)
 				src.ears = I
 				hud.add_other_object(I, hud.layouts[hud.layout_style]["ears"])
-				I.equipped(src, "ears")
+				I.equipped(src, slot_ears)
 				equipped = 1
 				clothing_dirty |= C_EARS
 		if (slot_glasses)
 			if (!src.glasses && src.organHolder && src.organHolder.head)
 				src.glasses = I
 				hud.add_other_object(I, hud.layouts[hud.layout_style]["glasses"])
-				I.equipped(src, "eyes")
+				I.equipped(src, slot_glasses)
 				equipped = 1
 				clothing_dirty |= C_GLASSES
 		if (slot_gloves)
 			if (!src.gloves)
 				src.gloves = I
 				hud.add_other_object(I, hud.layouts[hud.layout_style]["gloves"])
-				I.equipped(src, "gloves")
+				I.equipped(src, slot_gloves)
 				equipped = 1
 				clothing_dirty |= C_GLOVES
 		if (slot_head)
 			if (!src.head && src.organHolder && src.organHolder.head)
 				src.head = I
 				hud.add_other_object(I, hud.layouts[hud.layout_style]["head"])
-				I.equipped(src, "head")
+				I.equipped(src, slot_head)
 				equipped = 1
 				src.update_hair_layer()
 				clothing_dirty |= C_HEAD
@@ -2334,14 +2334,14 @@
 			if (!src.shoes)
 				src.shoes = I
 				hud.add_other_object(I, hud.layouts[hud.layout_style]["shoes"])
-				I.equipped(src, "shoes")
+				I.equipped(src, slot_shoes)
 				equipped = 1
 				clothing_dirty |= C_SHOES
 		if (slot_wear_suit)
 			if (!src.wear_suit)
 				src.wear_suit = I
 				hud.add_other_object(I, hud.layouts[hud.layout_style]["suit"])
-				I.equipped(src, "o_clothing")
+				I.equipped(src, slot_wear_suit)
 				equipped = 1
 				src.update_hair_layer()
 				clothing_dirty |= C_SUIT
@@ -2349,7 +2349,7 @@
 			if (!src.w_uniform)
 				src.w_uniform = I
 				hud.add_other_object(I, hud.layouts[hud.layout_style]["under"])
-				I.equipped(src, "i_clothing")
+				I.equipped(src, slot_w_uniform)
 				equipped = 1
 				clothing_dirty |= C_UNIFORM
 		if (slot_l_store)

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -762,6 +762,9 @@
 	return
 
 /obj/item/proc/equipped(var/mob/user, var/slot)
+	SHOULD_CALL_PARENT(1)
+	if(src.c_flags & NOT_EQUIPPED_WHEN_WORN && slot != SLOT_L_HAND && slot != SLOT_R_HAND)
+		return
 	#ifdef COMSIG_ITEM_EQUIPPED
 	SEND_SIGNAL(src, COMSIG_ITEM_EQUIPPED, user, slot)
 	#endif
@@ -783,6 +786,9 @@
 		equipment_proxy.space_movement += spacemove
 
 /obj/item/proc/unequipped(var/mob/user)
+	SHOULD_CALL_PARENT(1)
+	if(src.c_flags & NOT_EQUIPPED_WHEN_WORN && src.equipped_in_slot != SLOT_L_HAND && src.equipped_in_slot != SLOT_R_HAND)
+		return
 	#ifdef COMSIG_ITEM_UNEQUIPPED
 	SEND_SIGNAL(src, COMSIG_ITEM_UNEQUIPPED, user)
 	#endif

--- a/code/obj/item/clothing/gimmick.dm
+++ b/code/obj/item/clothing/gimmick.dm
@@ -61,6 +61,7 @@
 	see_face = 0.0
 
 	equipped(var/mob/user)
+		..()
 		if (ishuman(user))
 			var/mob/living/carbon/human/H = user
 			if (H.w_uniform && istype(H.w_uniform, /obj/item/clothing/under/gimmick/owl))
@@ -92,6 +93,7 @@
 	compatible_species = list("human", "monkey")
 
 	equipped(var/mob/user)
+		..()
 		if (!user)
 			return 0
 		if (ishuman(user))
@@ -331,8 +333,9 @@
 	cant_other_remove = 0
 
 /obj/item/clothing/mask/cursedclown_hat/equipped(var/mob/user, var/slot)
+	..()
 	var/mob/living/carbon/human/Victim = user
-	if(istype(Victim) && slot == "mask")
+	if(istype(Victim) && slot == SLOT_WEAR_MASM)
 		boutput(user, "<span class='alert'><B> The mask grips your face!</B></span>")
 		src.desc = "This is never coming off... oh god..."
 		// Mostly for spawning a cluwne car and clothes manually.
@@ -733,7 +736,8 @@
 	cant_self_remove = 1
 	cant_other_remove = 1
 	equipped(var/mob/user, var/slot)
-		if(slot == "i_clothing" && ishuman(user))
+		..()
+		if(slot == SLOT_W_UNIFORM && ishuman(user))
 			var/mob/living/carbon/human/H = user
 			if(H.shoes != null)
 				var/obj/item/clothing/shoes/c = H.shoes
@@ -1173,7 +1177,7 @@
 	material_prints = "deep scratches"
 
 	equipped(var/mob/user, var/slot)
-		if (slot == "gloves")
+		if (slot == SLOT_GLOVES)
 			if (!user.bioHolder || !user.bioHolder.HasEffect("hulk"))
 				boutput(user, "You feel your muscles swell to an immense size.")
 			APPLY_MOVEMENT_MODIFIER(user, /datum/movement_modifier/hulkstrong, src.type)
@@ -1313,7 +1317,7 @@
 	item_state = "lightgreen"
 
 	equipped(var/mob/user, var/slot)
-		if (slot == "i_clothing" && user.bioHolder)
+		if (slot == SLOT_W_UNIFORM && user.bioHolder)
 			user.bioHolder.AddEffect("jumpy_suit", 0, 0, 0, 1) // id, variant, time left, do stability, magical
 			SPAWN_DBG(0) // bluhhhhhhhh this doesn't work without a spawn
 				if (ishuman(user))

--- a/code/obj/item/clothing/glasses.dm
+++ b/code/obj/item/clothing/glasses.dm
@@ -85,12 +85,14 @@
 					H.vision.set_scan(0)
 
 	equipped(var/mob/living/user, var/slot)
+		..()
 		if(!isliving(user))
 			return
-		if (slot == "eyes" && on)
+		if (slot == SLOT_GLASSES && on)
 			user.vision.set_scan(1)
 
 	unequipped(var/mob/living/user)
+		..()
 		if(!isliving(user))
 			return
 		user.vision.set_scan(0)
@@ -138,7 +140,7 @@
 
 /obj/item/clothing/glasses/sunglasses/equipped(var/mob/user, var/slot)
 	var/mob/living/carbon/human/H = user
-	if(istype(H) && slot == "eyes")
+	if(istype(H) && slot == SLOT_GLASSES)
 		if(H.mind)
 			if(H.mind.assigned_role == "Detective" && !src.already_worn)
 				src.already_worn = 1
@@ -198,7 +200,8 @@
 					assigned.images.Add(I)
 
 	equipped(var/mob/user, var/slot)
-		if (slot == "eyes")
+		..()
+		if (slot == SLOT_GLASSES)
 			assigned = user.client
 			SPAWN_DBG(-1)
 				if (!(src in processing_items))
@@ -206,6 +209,7 @@
 		return
 
 	unequipped(var/mob/user)
+		..()
 		if (assigned)
 			assigned.images.Remove(arrestIconsAll)
 			assigned = null
@@ -264,13 +268,15 @@
 		setProperty("disorient_resist_eye", 15)
 
 	equipped(var/mob/living/user, var/slot)
+		..()
 		if(!isliving(user))
 			return
-		if (slot == "eyes")
+		if (slot == SLOT_GLASSES)
 			user.vision.set_scan(1)
 		return
 
 	unequipped(var/mob/living/user)
+		..()
 		if(!isliving(user))
 			return
 		user.vision.set_scan(0)
@@ -292,7 +298,7 @@
 
 	equipped(var/mob/user, var/slot)
 		var/mob/living/carbon/human/H = user
-		if(istype(H) && slot == "eyes")
+		if(istype(H) && slot == SLOT_GLASSES)
 			equipper = user//todo: this is prooobably redundant
 		return ..()
 
@@ -356,14 +362,16 @@
 		..()
 
 	equipped(var/mob/user, var/slot)
+		..()
 		var/mob/living/carbon/human/H = user
-		if(istype(H) && slot == "eyes" && !H.network_device)
+		if(istype(H) && slot == SLOT_GLASSES && !H.network_device)
 			user.network_device = src
 			//user.verbs += /mob/proc/jack_in
 			Station_VNet.Enter_Vspace(H, src,src.network)
 		return
 
 	unequipped(var/mob/user)
+		..()
 		if(ishuman(user) && user:network_device == src)
 			//user.verbs -= /mob/proc/jack_in
 			user:network_device = null
@@ -376,6 +384,7 @@
 	item_state = "sunglasses"
 
 	unequipped(var/mob/user)
+		..()
 		if(istype(user, /mob/living/carbon/human/virtual) && user:body)
 			//Station_VNet.Leave_Vspace(user)
 			user.death()
@@ -429,7 +438,8 @@
 					assigned.images.Add(I)
 
 	equipped(var/mob/user, var/slot)
-		if (slot == "eyes")
+		..()
+		if (slot == SLOT_GLASSES)
 			assigned = user.client
 			SPAWN_DBG(-1)
 				//updateIcons()
@@ -438,6 +448,7 @@
 		return
 
 	unequipped(var/mob/user)
+		..()
 		if (assigned)
 			assigned.images.Remove(health_mon_icons)
 			assigned = null
@@ -524,7 +535,8 @@
 					assigned.images.Add(I)
 
 	equipped(var/mob/user, var/slot)
-		if (slot == "eyes")
+		..()
+		if (slot == SLOT_GLASSES)
 			assigned = user.client
 			SPAWN_DBG(-1)
 				//updateIcons()
@@ -533,6 +545,7 @@
 		return
 
 	unequipped(var/mob/user)
+		..()
 		if (assigned)
 			assigned.images.Remove(mob_static_icons)
 			assigned = null
@@ -545,11 +558,13 @@
 	icon_state = "noir"
 	mats = 4
 	equipped(var/mob/user, var/slot)
+		..()
 		var/mob/living/carbon/human/H = user
-		if(istype(H) && slot == "eyes")
+		if(istype(H) && slot == SLOT_GLASSES)
 			if(H.client)
 				animate_fade_grayscale(H.client, 5)
 	unequipped(var/mob/user, var/slot)
+		..()
 		var/mob/living/carbon/human/H = user
 		if(istype(H))
 			if (H.client)

--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -762,7 +762,7 @@
 
 	equipped(var/mob/user, var/slot)
 		..()
-		if (slot == "head" && ishuman(user))
+		if (slot == SLOT_HEAD && ishuman(user))
 			var/mob/living/carbon/human/H = user
 			H.set_mutantrace(/datum/mutantrace/dwarf)
 
@@ -885,6 +885,7 @@
 				light.attach(src)
 
 	equipped(var/mob/user, var/slot)
+		..()
 		boutput(user, "<span class='notice'>You better start running! It's kill or be killed now, buddy!</span>")
 		SPAWN_DBG(1 SECOND)
 			playsound(src.loc, "sound/vox/time.ogg", 100, 1)

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -254,12 +254,14 @@
 							H.vision.set_scan(0)
 
 			equipped(var/mob/living/user, var/slot)
+				..()
 				if(!isliving(user))
 					return
-				if (slot == "head" && on)
+				if (slot == SLOT_HEAD && on)
 					user.vision.set_scan(1)
 
 			unequipped(var/mob/living/user)
+				..()
 				if(!isliving(user))
 					return
 				user.vision.set_scan(0)
@@ -294,7 +296,8 @@
 							assigned.images.Add(I)
 
 			equipped(var/mob/user, var/slot)
-				if (slot == "head")
+				..()
+				if (slot == SLOT_HEAD)
 					assigned = user.client
 					SPAWN_DBG(-1)
 						//updateIcons()
@@ -303,6 +306,7 @@
 				return
 
 			unequipped(var/mob/user)
+				..()
 				if (assigned)
 					assigned.images.Remove(health_mon_icons)
 					assigned = null
@@ -618,6 +622,7 @@
 			weeoo_in_progress = 0
 
 	unequipped(var/mob/user)
+		..()
 		if (src.weeoo_in_progress)
 			src.weeoo_in_progress = 0
 

--- a/code/obj/item/clothing/injector_mask_belt.dm
+++ b/code/obj/item/clothing/injector_mask_belt.dm
@@ -24,7 +24,8 @@ There's A LOT of duplicate code here, which isn't ideal to say the least. Should
 	var/inj_amount = -1
 
 	equipped(var/mob/user, var/slot)
-		if(slot == "belt")
+		..()
+		if(slot == SLOT_BELT)
 			owner = user
 			if (container && container.reagents.total_volume && condition)
 				active = 1
@@ -43,6 +44,7 @@ There's A LOT of duplicate code here, which isn't ideal to say the least. Should
 		return
 
 	unequipped(mob/user as mob)
+		..()
 		owner = null
 		active = 0
 		return
@@ -170,7 +172,8 @@ There's A LOT of duplicate code here, which isn't ideal to say the least. Should
 	var/inj_amount = -1
 
 	equipped(var/mob/user, var/slot)
-		if(slot == "mask")
+		..()
+		if(slot == SLOT_WEAR_MASM)
 			owner = user
 			if (container && container.reagents.total_volume && condition)
 				active = 1
@@ -189,6 +192,7 @@ There's A LOT of duplicate code here, which isn't ideal to say the least. Should
 		return
 
 	unequipped(mob/user as mob)
+		..()
 		owner = null
 		active = 0
 		return

--- a/code/obj/item/clothing/masks.dm
+++ b/code/obj/item/clothing/masks.dm
@@ -261,7 +261,7 @@
 	equipped(var/mob/user, var/slot)
 		. = ..()
 		var/mob/living/carbon/human/H = user
-		if(istype(H) && slot == "mask")
+		if(istype(H) && slot == SLOT_WEAR_MASM)
 			if ( user.mind && user.mind.assigned_role=="Clown" && istraitor(user) )
 				src.cant_other_remove = 1.0
 				src.cant_self_remove = 0.0

--- a/code/obj/item/clothing/shoes.dm
+++ b/code/obj/item/clothing/shoes.dm
@@ -291,6 +291,7 @@
 	mats = 2
 
 	equipped(var/mob/user, var/slot)
+		..()
 		user.visible_message("<b>[user]</b> starts hopping around!","You start hopping around.")
 		src.moonloop(user)
 		return

--- a/code/obj/item/clothing/trash_bags.dm
+++ b/code/obj/item/clothing/trash_bags.dm
@@ -28,6 +28,7 @@
 				. += "It's [get_fullness(current_stuff / max_stuff * 100)]."
 
 	equipped(var/mob/user)
+		..()
 		if (src.contents.len)
 			for (var/i=src.contents.len, i>0, i--)
 				if (prob(66))

--- a/code/obj/item/device/energy_shield_device.dm
+++ b/code/obj/item/device/energy_shield_device.dm
@@ -24,9 +24,6 @@
 	pickup(mob/user)
 		return
 
-	equipped(var/mob/user, var/slot)
-		return
-
 	attack_self()
 		if(!active)
 			boutput(usr, "<span class='notice'>You activate the shield.</span>")

--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -697,7 +697,7 @@
 
 
 /obj/item/grab/block
-	c_flags = EQUIPPED_WHILE_HELD_ACTIVE
+	c_flags = EQUIPPED_WHILE_HELD
 	item_grab_overlay_state = "grab_block_small"
 	icon_state = "grab_block"
 	name = "block"

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -934,6 +934,7 @@
 
 	flags =  FPRINT | TABLEPASS | CONDUCT | USEDELAY | EXTRADELAY | ONBACK
 	object_flags = NO_ARM_ATTACH
+	c_flags = NOT_EQUIPPED_WHEN_WORN | EQUIPPED_WHILE_HELD
 
 	spread_angle = 8
 	can_dual_wield = 0
@@ -1126,7 +1127,7 @@
 	auto_eject = 1
 	flags =  FPRINT | TABLEPASS | CONDUCT | USEDELAY | EXTRADELAY | ONBACK
 	object_flags = NO_ARM_ATTACH
-
+	c_flags = NOT_EQUIPPED_WHEN_WORN | EQUIPPED_WHILE_HELD
 	slowdown = 7
 	slowdown_time = 5
 

--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -413,9 +413,11 @@
 	mats = 18 //SPACE IS THE PLACE FOR WRESTLESTATION 13
 
 	equipped(var/mob/user)
+		..()
 		user.make_wrestler(0, 1, 0)
 
 	unequipped(var/mob/user)
+		..()
 		user.make_wrestler(0, 1, 1)
 
 // I dunno where else to put these vOv

--- a/code/obj/storage/loot_crates.dm
+++ b/code/obj/storage/loot_crates.dm
@@ -662,6 +662,7 @@
 		two.overlays += two.gemstone
 
 	equipped(var/mob/user, var/slot)
+		..()
 		if (!user)
 			return
 		if (src.twin && ishuman(src.twin.loc))
@@ -673,6 +674,7 @@
 				boutput(psy, "<span class='alert'>You suddenly begin hearing and seeing things. What the hell?</span>")
 
 	unequipped(var/mob/user)
+		..()
 		if (!user)
 			return
 		if (src.twin && ishuman(src.twin.loc))

--- a/code/procs/gamehelpers.dm
+++ b/code/procs/gamehelpers.dm
@@ -368,23 +368,20 @@ var/obj/item/dummy/click_dummy = new
 	if(src.l_hand)
 		if (src.l_hand.c_flags & EQUIPPED_WHILE_HELD)
 			. += src.l_hand
-		else if (src.l_hand.c_flags & EQUIPPED_WHILE_HELD_ACTIVE && src.hand == 1)
-			. += src.l_hand
+
 
 		if (src.l_hand.c_flags & HAS_GRAB_EQUIP)
 			for(var/obj/item/grab/G in src.l_hand)
-				if (G.c_flags & EQUIPPED_WHILE_HELD || (G.c_flags & EQUIPPED_WHILE_HELD_ACTIVE && src.hand == 1))
+				if (G.c_flags & EQUIPPED_WHILE_HELD)
 					. += G
 
 	if(src.r_hand)
 		if (src.r_hand.c_flags & EQUIPPED_WHILE_HELD)
 			. += src.r_hand
-		else if (src.r_hand.c_flags & EQUIPPED_WHILE_HELD_ACTIVE && src.hand == 0)
-			. += src.r_hand
 
 		if (src.r_hand.c_flags & HAS_GRAB_EQUIP)
 			for(var/obj/item/grab/G in src.r_hand)
-				if (G.c_flags & EQUIPPED_WHILE_HELD || (G.c_flags & EQUIPPED_WHILE_HELD_ACTIVE && src.hand == 0))
+				if (G.c_flags & EQUIPPED_WHILE_HELD)
 					. += G
 
 

--- a/code/z_adventurezones/biodome.dm
+++ b/code/z_adventurezones/biodome.dm
@@ -625,6 +625,7 @@ SYNDICATE DRONE FACTORY AREAS
 // spookycoders are welcome to contribute to this thing
 
 /obj/item/clothing/suit/armor/ancient/equipped(var/mob/user, var/slot)
+	..()
 	boutput(user, "<span class='notice'>The armor plates creak oddly as you put on [src].</span>")
 	playsound(src.loc, 'sound/machines/ArtifactEld2.ogg', 30, 1)
 	user.reagents.add_reagent("itching", 10)

--- a/code/z_adventurezones/hemera.dm
+++ b/code/z_adventurezones/hemera.dm
@@ -323,6 +323,7 @@ Obsidian Crown
 	var/max_damage = 0
 
 	equipped(var/mob/user, var/slot)
+		..()
 		cant_self_remove = 1
 		cant_other_remove = 1
 		if (!src.processing)


### PR DESCRIPTION
Add parent calls for all equipped()/unequipped()
Change all equipped() to use SLOT_FOO instead of "foo"

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[CHORE] [FIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Invert behavior on nukie guns to slow in-hand, but not on back. This is the intended behavior per @Gannets 
May wish to take a look at firing slowdown values in light of this change

Add parent calls for all equipped()/unequipped() - fixes bug where some equipment was not giving armor/heatres/etc
Change all equipped() to use SLOT_FOO instead of "foo" - consistency

Removes `EQUIPPED_WHILE_HELD_ACTIVE` flag, adds `NOT_EQUIPPED_WHILE_WORN` flag

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Heavy nukie weapons were supposed to slow in-hand, and not on back.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Tarmunora:
(+)Fixes moveslow on nukie LMG and sniper - now slows in-hand, but not on back
```
