### PR TITLE
Fixes random event wrestler antagonists.

### DIFF
--- a/code/modules/events/antag_ghost_respawn.dm
+++ b/code/modules/events/antag_ghost_respawn.dm
@@ -249,8 +249,9 @@
 					role = "wrestler"
 					objective_path = pick(typesof(/datum/objective_set/traitor/rp_friendly))
 
+					var/antag_type = src.antagonist_type
 					SPAWN_DBG (0)
-						R2.choose_name(3, src.antagonist_type, R2.real_name + " the " + src.antagonist_type)
+						R2.choose_name(3, antag_type, R2.real_name + " the " + antag_type)
 				else
 					failed = 1
 
@@ -262,8 +263,9 @@
 					role = "wrestler"
 					objective_path = pick(typesof(/datum/objective_set/traitor/rp_friendly))
 
+					var/antag_type = src.antagonist_type
 					SPAWN_DBG (0)
-						C.choose_name(3, src.antagonist_type, C.real_name + " the " + src.antagonist_type)
+						C.choose_name(3, antag_type, C.real_name + " the " + antag_type)
 				else
 					failed = 1
 

--- a/code/modules/events/antag_ghost_respawn.dm
+++ b/code/modules/events/antag_ghost_respawn.dm
@@ -245,7 +245,7 @@
 				var/mob/living/R2 = M3.humanize()
 				if (R2 && istype(R2))
 					M3 = R2
-					R2.make_wrestler()
+					R2.make_wrestler(1)
 					role = "wrestler"
 					objective_path = pick(typesof(/datum/objective_set/traitor/rp_friendly))
 
@@ -258,7 +258,7 @@
 				var/mob/living/critter/C = M3.critterize(/mob/living/critter/small_animal/bird/timberdoodle/strong)
 				if (C && istype(C))
 					M3 = C
-					C.make_wrestler()
+					C.make_wrestler(1)
 					role = "wrestler"
 					objective_path = pick(typesof(/datum/objective_set/traitor/rp_friendly))
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes wrestlers spawned from random events still requiring a wrestling belt to use their abilities, as well as the rename prompt using incorrect values.

The proc used to make someone a wrestler accepts optional arguments. One of them is to make the person an inherent wrestler, which separates people with wrestling belts from real wrestlers.
The random event's make_wrestler call did not provide the argument and the wrestlers it created still required a wrestling belt to use their abilities. This PR fixes that.

Also, wrestlers are given a rename prompt. It uses vars from the datum such as the currently selected antagonist type to give flavor to the prompt ("You are a wrestler, choose your name", "Bob the Wrestler" default name in the prompt). However, it's preceded with a spawn, which was causing the event to continue running before providing the prompt and call postevent which resets the vars to default values, which meant that by the time the rename prompt would be called the default value of "Blob" would be used, causing confusion (telling you incorrectly that you're a blob and hinting a name of one).


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Random event wrestlers no longer need a wrestling belt to use their abilities as intended and the rename prompt won't provide confusing incorrect values.
