### PR TITLE
Makes iscritter macro check for /obj/critter

### DIFF
--- a/_std/code/_macros.dm
+++ b/_std/code/_macros.dm
@@ -29,7 +29,7 @@ var/list/detailed_spawn_dbg = list()
 #define iscarbon(x) istype(x, /mob/living/carbon)
 #define ismonkey(x) (istype(x, /mob/living/carbon/human) && istype(x:mutantrace, /datum/mutantrace/monkey))
 #define ishuman(x) istype(x, /mob/living/carbon/human)
-#define iscritter(x) istype(x, /mob/living/critter)
+#define iscritter(x) istype(x, /obj/critter)
 #define isintangible(x) istype(x, /mob/living/intangible)
 #define ismobcritter(x) istype(x, /mob/living/critter)
 

--- a/code/WorkInProgress/ItemSpecials.dm
+++ b/code/WorkInProgress/ItemSpecials.dm
@@ -1160,17 +1160,19 @@
 
 				if (flame_succ)
 					turf.hotspot_expose(T0C + 400, 400)
-					for(var/mob/A in turf)
-						if(isTarget(A))
-							if (iscritter(A))
-								var/obj/critter/crit = A
-								crit.blob_act(8) //REMOVE WHEN WE ADD BURNING OBJCRITTERS
-
-							if (A.getStatusDuration("burning"))
-								A.changeStatus("burning", tiny_time)
+					for(var/A in turf)
+						if(!isTarget(A))
+							continue
+						if(ismob(A))
+							var/mob/M = A
+							if (M.getStatusDuration("burning"))
+								M.changeStatus("burning", tiny_time)
 							else
-								A.changeStatus("burning", flame_succ ? time : tiny_time)
-							break
+								M.changeStatus("burning", flame_succ ? time : tiny_time)
+						else if(iscritter(A))
+							var/obj/critter/crit = A
+							crit.blob_act(8) //REMOVE WHEN WE ADD BURNING OBJCRITTERS
+						break
 
 					playsound(get_turf(master), 'sound/effects/flame.ogg', 50, 0)
 				else

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -1041,7 +1041,7 @@
 
 
 /atom/proc/interact(var/mob/user)
-	if (isdead(user) || (!iscarbon(user) && !iscritter(user) && !issilicon(usr)))
+	if (isdead(user) || (!iscarbon(user) && !ismobcritter(user) && !issilicon(usr)))
 		return
 
 	if (!istype(src.loc, /turf) || user.stat || user.hasStatus(list("paralysis", "stunned", "weakened")) || user.restrained())

--- a/code/datums/abilities/kudzumen.dm
+++ b/code/datums/abilities/kudzumen.dm
@@ -138,7 +138,7 @@
 		if (!M)
 			return 0
 
-		if (!(iscarbon(M) || iscritter(M)))
+		if (!(iscarbon(M) || ismobcritter(M)))
 			boutput(M, __red("You cannot use any powers in your current form."))
 			return 0
 

--- a/code/datums/abilities/vampire.dm
+++ b/code/datums/abilities/vampire.dm
@@ -4,7 +4,7 @@
 /////////////////////////////////////////////////// Setup //////////////////////////////////////////
 
 /mob/proc/make_vampire(var/shitty = 0)
-	if (ishuman(src) || iscritter(src))
+	if (ishuman(src) || ismobcritter(src))
 		if (ishuman(src))
 			var/datum/abilityHolder/vampire/A = src.get_ability_holder(/datum/abilityHolder/vampire)
 			if (A && istype(A))
@@ -25,7 +25,7 @@
 			SPAWN_DBG (25) // Don't remove.
 				if (src) src.assign_gimmick_skull()
 
-		else if (iscritter(src)) // For testing. Just give them all abilities that are compatible.
+		else if (ismobcritter(src)) // For testing. Just give them all abilities that are compatible.
 			var/mob/living/critter/C = src
 
 			if (isnull(C.abilityHolder)) // They do have a critter AH by default...or should.
@@ -500,7 +500,7 @@
 		if (!M)
 			return 0
 
-		if (!(iscarbon(M) || iscritter(M)))
+		if (!(iscarbon(M) || ismobcritter(M)))
 			boutput(M, __red("You cannot use any powers in your current form."))
 			return 0
 

--- a/code/datums/abilities/vampire/blood_tracking.dm
+++ b/code/datums/abilities/vampire/blood_tracking.dm
@@ -22,7 +22,7 @@
 		if (!M)
 			return 1
 
-		if (iscritter(M) && !istype(H))
+		if (ismobcritter(M) && !istype(H))
 			boutput(M, __red("Critter mobs currently don't have to worry about blood. Lucky you."))
 			return 1
 

--- a/code/datums/abilities/vampire/vampire_bite.dm
+++ b/code/datums/abilities/vampire/vampire_bite.dm
@@ -38,7 +38,7 @@
 		boutput(M, __red("Why would you want to bite yourself?"))
 		return 0
 
-	if (iscritter(M) && !istype(H))
+	if (ismobcritter(M) && !istype(H))
 		boutput(M, __red("Critter mobs currently don't have to worry about blood. Lucky you."))
 		return 0
 
@@ -168,7 +168,7 @@
 	if (src.blood_tally)
 		if (target in src.blood_tally)
 			.= src.blood_tally[target] < max_take_per_mob
-			
+
 /datum/abilityHolder/vampiric_zombie/proc/tally_bite(var/mob/living/carbon/human/target, var/blood_amt_taken)
 	if (!src.blood_tally)
 		src.blood_tally = list()
@@ -199,7 +199,7 @@
 		boutput(M, __red("Why would you want to bite yourself?"))
 		return 0
 
-	if (iscritter(M) && !istype(H))
+	if (ismobcritter(M) && !istype(H))
 		boutput(M, __red("Critter mobs currently don't have to worry about blood. Lucky you."))
 		return 0
 

--- a/code/datums/abilities/vampiric_zombie.dm
+++ b/code/datums/abilities/vampiric_zombie.dm
@@ -164,7 +164,7 @@
 		if (!M)
 			return 0
 
-		if (!(iscarbon(M) || iscritter(M)))
+		if (!(iscarbon(M) || ismobcritter(M)))
 			boutput(M, __red("You cannot use any powers in your current form."))
 			return 0
 

--- a/code/datums/abilities/wrestler.dm
+++ b/code/datums/abilities/wrestler.dm
@@ -4,8 +4,8 @@
 //////////////////////////////////////////// Setup //////////////////////////////////////////////////
 
 /mob/proc/make_wrestler(var/make_inherent = 0, var/belt_check = 0, var/remove_powers = 0)
-	if (ishuman(src) || iscritter(src))
-		if (iscritter(src))
+	if (ishuman(src) || ismobcritter(src))
+		if (ismobcritter(src))
 			var/mob/living/critter/C = src
 
 			if (remove_powers == 1)
@@ -199,7 +199,7 @@
 				HH.make_wrestler(0, 1, 1)
 				return 0
 
-		if (!(ishuman(M) || iscritter(M))) // Not all critters have arms to grab people with, but whatever.
+		if (!(ishuman(M) || ismobcritter(M))) // Not all critters have arms to grab people with, but whatever.
 			boutput(M, __red("You cannot use any powers in your current form."))
 			return 0
 

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -80,7 +80,7 @@
 						if (D)
 							D.data["imp"] = "\ref[I]"
 
-			var/give_access_implant = iscritter(M)
+			var/give_access_implant = ismobcritter(M)
 			if(!spawn_id && (access.len > 0 || access.len == 1 && access[1] != access_fuck_all))
 				give_access_implant = 1
 			if (give_access_implant)

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -674,7 +674,7 @@
 							message = copytext(message, 3)
 
 				else
-					if (ishuman(src) || iscritter(src) || isrobot(src)) // this is shit
+					if (ishuman(src) || ismobcritter(src) || isrobot(src)) // this is shit
 						message_mode = "secure headset"
 						secure_headset_mode = lowertext(copytext(message,2,3))
 					message = copytext(message, 3)

--- a/code/mob/living/carbon/human/npc.dm
+++ b/code/mob/living/carbon/human/npc.dm
@@ -380,7 +380,7 @@
 					//	src.a_intent = INTENT_HELP
 					if(ishuman(ai_target))
 						src.r_hand:attack(ai_target, src)
-					else if(iscritter(ai_target))
+					else if(ismobcritter(ai_target))
 						var/mob/living/critter/C = ai_target
 						if (isalive(C))
 							C.attackby(src.r_hand, src)

--- a/code/mob/living/silicon/ai/camera_handling.dm
+++ b/code/mob/living/silicon/ai/camera_handling.dm
@@ -290,7 +290,7 @@
 		//Target is not on station level
 		return (target.loc.z == 1) \
 				&& ((issilicon(target) && istype(target.loc, /turf) ) \
-				|| (iscritter(target) && istype(target.loc, /turf) ) \
+				|| (ismobcritter(target) && istype(target.loc, /turf) ) \
 				|| !((ishuman(target) \
 				&& istype(target:wear_id, /obj/item/card/id/syndicate)) \
 				|| (target:wear_id && istype(target:wear_id, /obj/item/device/pda2) && target:wear_id:ID_card && istype(target:wear_id:ID_card, /obj/item/card/id/syndicate)) \

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1578,7 +1578,7 @@ var/global/noir = 0
 				return
 
 			//they're nothing so turn them into a traitor!
-			if(ishuman(M) || isAI(M) || isrobot(M) || iscritter(M))
+			if(ishuman(M) || isAI(M) || isrobot(M) || ismobcritter(M))
 				var/traitorize = "Cancel"
 				traitorize = alert("Is not a traitor, make Traitor?", "Traitor", "Yes", "Cancel")
 				if(traitorize == "Cancel")
@@ -1586,7 +1586,7 @@ var/global/noir = 0
 				if(traitorize == "Yes")
 					if (issilicon(M))
 						evilize(M, "traitor")
-					else if (iscritter(M))
+					else if (ismobcritter(M))
 						// The only role that works for all critters at this point is hard-mode traitor, really. The majority of existing
 						// roles don't work for them, most can't wear clothes and some don't even have arms and/or can pick things up.
 						// That said, certain roles are mostly compatible and thus selectable.
@@ -3900,7 +3900,7 @@ var/global/noir = 0
 			M.mind.objectives += escape_objective
 	else
 		var/list/eligible_objectives = list()
-		if (ishuman(M) || iscritter(M))
+		if (ishuman(M) || ismobcritter(M))
 			eligible_objectives = typesof(/datum/objective/regular/) + typesof(/datum/objective/escape/)
 		else if (issilicon(M))
 			eligible_objectives = list(/datum/objective/regular,/datum/objective/regular/assassinate,
@@ -3966,7 +3966,7 @@ var/global/noir = 0
 		R.syndicate = 1
 		R.syndicate_possible = 1
 		R.handle_robot_antagonist_status("admin", 0, usr)
-	else if (ishuman(M) || iscritter(M))
+	else if (ishuman(M) || ismobcritter(M))
 		switch(traitor_type)
 			if("traitor")
 				M.show_text("<h2><font color=red><B>You have defected and become a traitor!</B></font></h2>", "red")

--- a/code/modules/antagonists/blob/blob_abilities.dm
+++ b/code/modules/antagonists/blob/blob_abilities.dm
@@ -545,7 +545,7 @@
 				if (A:decomp_stage != 4)
 					M = A
 					break
-			if (iscritter(A))
+			if (ismobcritter(A))
 				M = A
 				break
 
@@ -603,7 +603,7 @@
 			return
 
 		//This whole first bit is all still pretty ugly cause this ability works on both critters and humans. I didn't have it in me to rewrite the whole thing - kyle
-		if (iscritter(target))
+		if (ismobcritter(target))
 			target.gib()
 			target.visible_message("<span class='alert'><b>The blob tries to absorb [target.name], but something goes horribly right!</b></span>")
 			if (blob_o && blob_o.mind) //ahem ahem AI blobs exist

--- a/code/modules/antagonists/grinch/abilities/grinch.dm
+++ b/code/modules/antagonists/grinch/abilities/grinch.dm
@@ -4,7 +4,7 @@
 //////////////////////////////////////////// Setup //////////////////////////////////////////////////
 
 /mob/proc/make_grinch()
-	if (ishuman(src) || iscritter(src))
+	if (ishuman(src) || ismobcritter(src))
 		if (ishuman(src))
 			var/datum/abilityHolder/grinch/A = src.get_ability_holder(/datum/abilityHolder/grinch)
 			if (A && istype(A))
@@ -19,7 +19,7 @@
 			SPAWN_DBG (25) // Don't remove.
 				if (src) src.assign_gimmick_skull()
 
-		else if (iscritter(src))
+		else if (ismobcritter(src))
 			var/mob/living/critter/C = src
 
 			if (isnull(C.abilityHolder)) // They do have a critter AH by default...or should.
@@ -142,7 +142,7 @@
 		if (!M)
 			return 0
 
-		if (!(ishuman(M) || iscritter(M)))
+		if (!(ishuman(M) || ismobcritter(M)))
 			boutput(M, __red("You cannot use any powers in your current form."))
 			return 0
 

--- a/code/modules/antagonists/grinch/abilities/grinch_cloak.dm
+++ b/code/modules/antagonists/grinch/abilities/grinch_cloak.dm
@@ -21,7 +21,7 @@
 		if (!M)
 			return 1
 
-		if (iscritter(M)) // Placeholder because only humans use bioeffects at the moment.
+		if (ismobcritter(M)) // Placeholder because only humans use bioeffects at the moment.
 			if (M.invisibility != 0)
 				boutput(M, __red("You are already invisible."))
 				return 1
@@ -31,7 +31,7 @@
 			boutput(M, __blue("<b>Your cloak will remain active for the next [src.cloak_duration / 60] minutes.</b>"))
 
 			SPAWN_DBG (src.cloak_duration * 10)
-				if (M && iscritter(M))
+				if (M && ismobcritter(M))
 					M.invisibility = 0
 					M.UpdateOverlays(null, "shield")
 					boutput(M, __red("<b>You are no longer invisible.</b>"))

--- a/code/modules/atmospherics/machinery/unary/cryo_cell.dm
+++ b/code/modules/atmospherics/machinery/unary/cryo_cell.dm
@@ -120,7 +120,7 @@
 		if (src.occupant)
 			boutput(M, "<span class='notice'><B>The scanner is already occupied!</B></span>")
 			return 0
-		if(iscritter(target))
+		if(ismobcritter(target))
 			boutput(M, "<span class='alert'><B>The scanner doesn't support this body type.</B></span>")
 			return 0
 		if(!iscarbon(target) )

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -531,13 +531,13 @@ datum
 				if (!volume_passed)
 					return
 				var/mob/living/M = target
-				if (!iscarbon(M) && !iscritter(M))
+				if (!iscarbon(M) && !ismobcritter(M))
 					return
 				if ((method == INGEST || (method == TOUCH && prob(25))) && (isdead(M) || istype(get_area(M),/area/afterlife/bar)))
 					var/came_back_wrong = 0
 					if (M.get_brute_damage() + M.get_burn_damage() >= 150)
 						came_back_wrong = 1
-					if (iscritter(M))
+					if (ismobcritter(M))
 						M.full_heal() // same as with objcritters basically
 					else
 						M.take_oxygen_deprivation(-INFINITY)

--- a/code/modules/chemistry/tools/emergency_injectors.dm
+++ b/code/modules/chemistry/tools/emergency_injectors.dm
@@ -38,7 +38,7 @@
 		item_state = "emerg_inj-[label]"
 
 	attack(mob/M as mob, mob/user as mob)
-		if (iscarbon(M) || iscritter(M))
+		if (iscarbon(M) || ismobcritter(M))
 			if (src.empty || !src.reagents)
 				boutput(user, "<span class='alert'>There's nothing to inject, [src] has already been expended!</span>")
 				return
@@ -58,7 +58,7 @@
 			return
 
 	attack_self(mob/user)
-		if (iscarbon(user) || iscritter(user))
+		if (iscarbon(user) || ismobcritter(user))
 			if (src.empty || !src.reagents)
 				boutput(user, "<span class='alert'>There's nothing to inject, [src] has already been expended!</span>")
 				return

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -188,7 +188,7 @@
 			user.u_equip(src)
 			qdel(src)
 			return 0
-		if (iscarbon(M) || iscritter(M))
+		if (iscarbon(M) || ismobcritter(M))
 			if (M == user)
 				if (!bypass_utensils)
 					if (src.needfork && !user.find_type_in_hand(/obj/item/kitchen/utensil/fork))
@@ -477,7 +477,7 @@
 			boutput(user, "<span class='alert'>Nothing left in [src], oh no!</span>")
 			return 0
 
-		if (iscarbon(M) || iscritter(M))
+		if (iscarbon(M) || ismobcritter(M))
 			if (M == user)
 				M.visible_message("<span class='notice'>[M] takes a sip from [src].</span>")
 			else if (M.mob_flags & IS_RELIQUARY)

--- a/code/modules/chemistry/tools/patches.dm
+++ b/code/modules/chemistry/tools/patches.dm
@@ -105,7 +105,7 @@
 			user.show_text("This item is not designed with organic users in mind.", "red")
 			return
 
-		if (iscarbon(user) || iscritter(user))
+		if (iscarbon(user) || ismobcritter(user))
 			src.in_use = 1
 			user.visible_message("[user] applies [src] to [his_or_her(user)]self.",\
 			"<span class='notice'>You apply [src] to yourself.</span>")
@@ -116,7 +116,7 @@
 
 	throw_impact(mob/M as mob)
 		..()
-		if (src.medical && !borg && !src.in_use && (iscarbon(M) || iscritter(M)))
+		if (src.medical && !borg && !src.in_use && (iscarbon(M) || ismobcritter(M)))
 			if (prob(30) || good_throw && prob(70))
 				src.in_use = 1
 				M.visible_message("<span class='alert'>[src] lands on [M] sticky side down!</span>")
@@ -135,7 +135,7 @@
 
 		// No src.reagents check here because empty patches can be used to counteract bleeding.
 
-		if (iscarbon(M) || iscritter(M))
+		if (iscarbon(M) || ismobcritter(M))
 			src.in_use = 1
 			if (M == user)
 				//M.show_text("You put [src] on your arm.", "blue")
@@ -485,7 +485,7 @@
 			. = ..()
 
 	proc/can_operate_on(atom/A)
-		.= (iscarbon(A) || iscritter(A))
+		.= (iscarbon(A) || ismobcritter(A))
 
 	proc/update_icon()
 		src.overlays = null

--- a/code/modules/chemistry/tools/pills.dm
+++ b/code/modules/chemistry/tools/pills.dm
@@ -45,7 +45,7 @@
 			user.show_text("[src] doesn't contain any reagents.", "red")
 			return
 
-		if (iscarbon(user) || iscritter(user))
+		if (iscarbon(user) || ismobcritter(user))
 			user.visible_message("[user] swallows [src].",\
 			"<span class='notice'>You swallow [src].</span>")
 			logTheThing("combat", user, null, "swallows a pill [log_reagents(src)] at [log_loc(user)].")
@@ -62,7 +62,7 @@
 			user.show_text("[src] doesn't contain any reagents.", "red")
 			return
 
-		if (iscarbon(M) || iscritter(M))
+		if (iscarbon(M) || ismobcritter(M))
 			if (M == user)
 				//boutput(M, "<span class='notice'>You swallow [src].</span>")
 				user.visible_message("[user] swallows [src].",\

--- a/code/modules/chemistry/tools/syringes.dm
+++ b/code/modules/chemistry/tools/syringes.dm
@@ -161,7 +161,7 @@
 					boutput(user, "<span class='alert'>You cannot directly fill this object.</span>")
 					return
 
-				if (iscarbon(target) || iscritter(target))
+				if (iscarbon(target) || ismobcritter(target))
 					if (target != user)
 						for (var/mob/O in AIviewers(world.view, user))
 							O.show_message(text("<span class='alert'><B>[] is trying to inject []!</B></span>", user, target), 1)

--- a/code/modules/food_and_drink/bathbomb.dm
+++ b/code/modules/food_and_drink/bathbomb.dm
@@ -27,7 +27,7 @@
 			user.show_text("[src] doesn't contain any reagents.", "red")
 			return
 
-		if (iscarbon(M) || iscritter(M))
+		if (iscarbon(M) || ismobcritter(M))
 			..()
 		else
 			return 0

--- a/code/modules/holiday/halloween.dm
+++ b/code/modules/holiday/halloween.dm
@@ -45,8 +45,8 @@
 /obj/joeq/spooky
 	name = "Memorial Plaque"
 
-	get_desc(dist, mob/user)
-		. += "Here lies [user.real_name]. Loved by all. R.I.P."
+	examine(mob/user)
+		boutput(usr, "Here lies [user.real_name]. Loved by all. R.I.P.")
 
 /*
  *	Spooky TOMBSTONE.  It is a tombstone.

--- a/code/modules/holiday/halloween.dm
+++ b/code/modules/holiday/halloween.dm
@@ -45,8 +45,8 @@
 /obj/joeq/spooky
 	name = "Memorial Plaque"
 
-	examine(mob/user)
-		boutput(usr, "Here lies [user.real_name]. Loved by all. R.I.P.")
+	get_desc(dist, mob/user)
+		. += "Here lies [user.real_name]. Loved by all. R.I.P."
 
 /*
  *	Spooky TOMBSTONE.  It is a tombstone.

--- a/code/modules/medical/genetics/geneticsScanner.dm
+++ b/code/modules/medical/genetics/geneticsScanner.dm
@@ -95,7 +95,7 @@ var/list/genescanner_addresses = list()
 		if (src.occupant)
 			boutput(M, "<span class='notice'><B>The scanner is already occupied!</B></span>")
 			return 0
-		if(iscritter(target))
+		if(ismobcritter(target))
 			boutput(M, "<span class='alert'><B>The scanner doesn't support this body type.</B></span>")
 			return 0
 		if(!iscarbon(target) )

--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -926,7 +926,7 @@
 		boutput(boarder, "<span class='alert'>You can't squeeze your wide cube body through the access door!</span>")
 		return
 
-	if(iscritter(boarder) && boarder:ghost_spawned)
+	if(ismobcritter(boarder) && boarder:ghost_spawned)
 		boutput(boarder, "<span class='alert'>You have no idea how to work this.</span>")
 		return
 

--- a/code/obj/blob.dm
+++ b/code/obj/blob.dm
@@ -243,7 +243,7 @@ var/image/blob_icon_cache
 
 	attackby(var/obj/item/W, var/mob/user)
 		user.lastattacked = src
-		if(iscritter(user) && user:ghost_spawned || isghostdrone(user))
+		if(ismobcritter(user) && user:ghost_spawned || isghostdrone(user))
 			src.visible_message("<span class='combat'><b>[user.name]</b> feebly attacks [src] with [W], but is too weak to harm it!</span>")
 			return
 		if( istype(W,/obj/item/clothing/head) && overmind )
@@ -912,7 +912,7 @@ var/image/blob_icon_cache
 
 		//turrets can fire on humans, mobcritters and pods
 		for (var/mob/living/M in view(firing_range, src))
-			if ((ishuman(M) || (iscritter(M) && !M:ghost_spawned)) && !isdead(M) && !check_target_immunity(M))
+			if ((ishuman(M) || (ismobcritter(M) && !M:ghost_spawned)) && !isdead(M) && !check_target_immunity(M))
 				if (ishuman(M))
 					var/mob/living/carbon/human/H = M
 					if (H.mutantrace)

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -284,7 +284,7 @@
 /obj/item/proc/Eat(var/mob/M as mob, var/mob/user)
 	if (!src.edible && !(src.material && src.material.edible))
 		return 0
-	if (!iscarbon(M) && !iscritter(M))
+	if (!iscarbon(M) && !ismobcritter(M))
 		return 0
 
 	if (M == user)
@@ -891,7 +891,7 @@
 	if (world.time < M.next_click)
 		return //fuck youuuuu
 
-	if (isdead(M) || (!iscarbon(M) && !iscritter(M)))
+	if (isdead(M) || (!iscarbon(M) && !ismobcritter(M)))
 		return
 
 	if (!istype(src.loc, /turf) || !isalive(M) || M.getStatusDuration("paralysis") || M.getStatusDuration("stunned") || M.getStatusDuration("weakened") || M.restrained())
@@ -1010,7 +1010,7 @@
 /obj/item/proc/attack(mob/M as mob, mob/user as mob, def_zone, is_special = 0)
 	if (!M || !user) // not sure if this is the right thing...
 		return
-	if ((src.edible && (ishuman(M) || iscritter(M)) || (src.material && src.material.edible)) && src.Eat(M, user))
+	if ((src.edible && (ishuman(M) || ismobcritter(M)) || (src.material && src.material.edible)) && src.Eat(M, user))
 		return
 
 	if (surgeryCheck(M, user))		// Check for surgery-specific actions

--- a/code/obj/item/clothing/gimmick.dm
+++ b/code/obj/item/clothing/gimmick.dm
@@ -1089,7 +1089,7 @@
 					"You try to give [src] to [M], but [M] has no fingers to put [src] on!")
 					return
 
-				else if (iscritter(M))
+				else if (ismobcritter(M))
 					var/mob/living/critter/C = M
 					if (C.hand_count > 0) // we got hands!  hands that things can be put onto!  er, into, I guess.
 						if (C.put_in_hand(src))

--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -208,7 +208,7 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 					user.next_click = max(user.next_click, world.time + user.l_hand:shoot_delay)
 				SPAWN_DBG(0.2 SECONDS)
 					user.l_hand:shoot(target_turf,user_turf,user, pox+rand(-2,2), poy+rand(-2,2))
-		else if(iscritter(user))
+		else if(ismobcritter(user))
 			var/mob/living/critter/M = user
 			var/list/obj/item/gun/guns = list()
 			for(var/datum/handHolder/H in M.hands)

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -78,7 +78,7 @@ THROWING DARTS
 				crit_triggered = 0
 			if(death_triggered && isalive(H))
 				death_triggered = 0
-		else if (iscritter(src.owner))
+		else if (ismobcritter(src.owner))
 			var/mob/living/critter/C = owner
 			if (C.health < 0 && !crit_triggered && online)
 				on_crit()
@@ -266,7 +266,7 @@ THROWING DARTS
 				var/turf/T = get_turf(H)
 				if (istype(T))
 					return " at [T.x],[T.y],[T.z]"
-		else if (iscritter(src.owner))
+		else if (ismobcritter(src.owner))
 			var/mob/living/critter/C = src.owner
 			if (locate(/obj/item/implant/tracking) in C.implants)
 				var/turf/T = get_turf(C)
@@ -549,7 +549,7 @@ var/global/list/tracking_implants = list() // things were looping through world 
 				if (ishuman(owner))
 					var/mob/living/carbon/human/H = owner
 					H.implant -= src
-				else if (iscritter(owner))
+				else if (ismobcritter(owner))
 					var/mob/living/critter/C = owner
 					C.implants -= src
 
@@ -947,7 +947,7 @@ var/global/list/tracking_implants = list() // things were looping through world 
 		if (ishuman(M))
 			var/mob/living/carbon/human/H = M
 			H.implant.Add(src.imp)
-		else if (iscritter(M))
+		else if (ismobcritter(M))
 			var/mob/living/critter/C = M
 			C.implants.Add(src.imp)
 
@@ -958,7 +958,7 @@ var/global/list/tracking_implants = list() // things were looping through world 
 		src.update()
 
 	attack(mob/M as mob, mob/user as mob)
-		if (!ishuman(M) && !iscritter(M))
+		if (!ishuman(M) && !ismobcritter(M))
 			return ..()
 
 		if (src.imp && !src.imp.can_implant(M, user))
@@ -1572,7 +1572,7 @@ circuitry. As a result neurotoxins can cause massive damage.<BR>
 				H.implant.Add(my_implant)
 			else
 				my_implant.set_loc(get_turf(H))
-		else if (iscritter(hit))
+		else if (ismobcritter(hit))
 			var/mob/living/critter/C = hit
 			if (C.can_implant && my_implant.can_implant(C, implant_master))
 				my_implant.set_loc(C)

--- a/code/obj/item/mousetrap.dm
+++ b/code/obj/item/mousetrap.dm
@@ -217,7 +217,7 @@
 				H.visible_message("<span class='alert'><B>[H] accidentally steps on the mousetrap.</B></span>",\
 				"<span class='alert'><B>You accidentally step on the mousetrap!</B></span>")
 
-		else if ((iscritter(AM)) && (src.armed))
+		else if ((ismobcritter(AM)) && (src.armed))
 			var/mob/living/critter/C = AM
 			src.triggered(C)
 			C.visible_message("<span class='alert'><B>[C] accidentally triggers the mousetrap.</B></span>",\
@@ -260,7 +260,7 @@
 				affecting.take_damage(1, 0)
 				H.UpdateDamageIcon()
 
-		else if (iscritter(target))
+		else if (ismobcritter(target))
 			var/mob/living/critter/C = target
 			C.TakeDamage("All", 1)
 

--- a/code/obj/item/organ_holder.dm
+++ b/code/obj/item/organ_holder.dm
@@ -1151,7 +1151,7 @@
 
 	New(var/mob/living/L, var/obj/item/organ/brain/custom_brain_type)
 		..()
-		if (!iscritter(L))
+		if (!ismobcritter(L))
 			return
 		if (istype(L))
 			src.donor = L

--- a/code/obj/machinery/optable.dm
+++ b/code/obj/machinery/optable.dm
@@ -103,7 +103,7 @@
 	if (!ismob(O))
 		boutput(user, "<span class='alert'>You can't put that on the operating table!</span>")
 		return
-	if (iscritter(O))
+	if (ismobcritter(O))
 		boutput(user, "<span class='alert'>You don't know how to operate on this. You never went to vet school!</span>")
 		return
 	if (!ishuman(O))

--- a/code/obj/machinery/turret.dm
+++ b/code/obj/machinery/turret.dm
@@ -117,7 +117,7 @@
 		LAGCHECK(LAG_HIGH)
 		if (!C)
 			continue
-		if (!iscarbon(C) && !iscritter(C))
+		if (!iscarbon(C) && !ismobcritter(C))
 			continue
 		if (isdead(C))
 			continue
@@ -145,7 +145,7 @@
 	for(var/atom/AT in A)
 		var/mob/living/C = AT
 		if( istype(C) )
-			if (!iscarbon(C) && !iscritter(C))
+			if (!iscarbon(C) && !ismobcritter(C))
 				continue
 			if (isdead(C))
 				continue

--- a/code/obj/vehicle.dm
+++ b/code/obj/vehicle.dm
@@ -949,7 +949,7 @@ Contains:
 	if(!M)
 		..()
 		return
-	if (iscritter(M))
+	if (ismobcritter(M))
 		var/mob/living/critter/C = M
 		if (isghostcritter(C))
 			..()

--- a/code/procs/logging.dm
+++ b/code/procs/logging.dm
@@ -195,7 +195,7 @@ proc/log_shot(var/obj/projectile/P,var/obj/SHOT, var/target_is_immune = 0)
 
 /proc/log_health(var/mob/M)
 	var/log_health = ""
-	if (ishuman(M) || iscritter(M))
+	if (ishuman(M) || ismobcritter(M))
 		log_health += "[M.get_brain_damage()], [M.get_oxygen_deprivation()], [M.get_toxin_damage()], [M.get_burn_damage()], [M.get_brute_damage()]"
 	else if (issilicon(M))
 		log_health += "[M.get_burn_damage()], [M.get_brute_damage()]"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
`ismobcritter` checks for mob critters, `iscritter` should check for regular critters. This PR makes that happen. It also fixes two minor bugs - welder special attack not hitting objcritters properly and projectiles hitting objcritters playing the obj hit sound instead of mob hit sound.
