### PR TITLE
Disable chem reaction priority sorting

### DIFF
--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -8,9 +8,11 @@ datum
 		var/list/required_reagents = new/list()
 		var/list/inhibitors = list()
 		var/instant = 1
+#ifdef CHEM_REACTION_PRIORITIES
 		//lower priorities happen last
 		//higher priorities happen first
 		var/priority = 10
+#endif
 
 		var/min_temperature = -INFINITY		//Will not react if below this
 		var/required_temperature = -1 //Not used by default. -1 = not used. //Positive values for reaction to take place when hotter than value, negative to take place when cooler than abs(value)
@@ -32,8 +34,10 @@ datum
 		var/consume_all = 0 //If set to 1, the recipe will consume ALL of its components instead of just proportional parts.
 
 
+#ifdef CHEM_REACTION_PRIORITIES
 		proc/operator<(var/datum/chemical_reaction/reaction)
 			return priority > reaction.priority
+#endif
 
 		proc/on_reaction(var/datum/reagents/holder, var/created_volume)
 			return
@@ -580,7 +584,9 @@ datum
 			inhibitors = list("stabiliser")
 			instant = 1
 			mix_phrase = "The mixture implodes suddenly."
+#ifdef CHEM_REACTION_PRIORITY
 			priority = 20
+#endif
 			on_reaction(var/datum/reagents/holder, var/created_volume)
 				ldmatter_reaction(holder, created_volume)
 				return
@@ -1113,7 +1119,6 @@ datum
 			result = "rcola"
 			required_reagents = list("rum" = 1, "cola" = 1)
 			result_amount = 2
-			priority = 9
 			mix_phrase = "A sweet and bitter aroma fills the air."
 			mix_sound = 'sound/misc/drinkfizz.ogg'
 
@@ -1340,7 +1345,7 @@ datum
 
 		cocktail_longisland_rcola
 			name = "Long Island Iced Tea"
-			id = "longisland"
+			id = "longisland_rcola"
 			result = "longisland"
 			required_reagents = list("tequila" = 1, "screwdriver" = 1, "gin" = 1, "juice_lemon" = 1, "rcola" = 1)
 			result_amount = 6
@@ -2302,7 +2307,7 @@ datum
 			required_reagents = list("triplepiss" = 1, "histamine" = 1, "methamphetamine" = 1, "water_holy" = 1, "pacid" = 1, "neurotoxin" = 1)
 			//required_reagents = list("methamphetamine" = 1, "water_holy" = 1, "pacid" = 1, "neurotoxin" = 1, "formaldehyde" = 1)
 			result_amount = 2
-			priority = 9
+			inhibitors = list("stabiliser")
 			mix_phrase = "A sweet and sugary scent drifts from the unpleasant milky substance."
 			on_reaction(var/datum/reagents/holder)
 				if(prob(90))		// high chance of not working to piss them off
@@ -2605,7 +2610,9 @@ datum
 			// This should really require a closed container and an extreme phase change... or some other pseudo-science thing
 			mix_phrase = "A tiny point of light blooms within the material, and quickly grows to envelop the entire container. Your life flashes before your eyes."
 			required_temperature = T0C + 6344 // IMPOSSIBRUUUU
-			priority = INFINITY
+#ifdef CHEM_REACTION_PRIORITY
+			priority = INFINITY // should hopefully be handled in blacklists now
+#endif
 
 			on_reaction(var/datum/reagents/holder, var/created_volume)
 				var/turf/location = 0
@@ -2638,7 +2645,9 @@ datum
 			required_reagents = list("potassium" = 1, "sugar" = 1, "phosphorus" = 1, "stabiliser" = 1)
 			result_amount = 3
 			mix_phrase = "The mixture sets into a greyish powder!"
+#ifdef CHEM_REACTION_PRIORITY
 			priority = 9
+#endif
 
 		smoke
 			name = "Smoke"
@@ -2650,7 +2659,9 @@ datum
 			consume_all = 1
 			result_amount = 3
 			mix_phrase = "The mixture quickly turns into a pall of smoke!"
+#ifdef CHEM_REACTION_PRIORITY
 			priority = 9
+#endif
 			on_reaction(var/datum/reagents/holder, var/created_volume) //moved to a proc in Chemistry-Holder.dm so that the instant reaction and powder can use the same proc
 				if (holder)
 					holder.smoke_start(created_volume)
@@ -2662,7 +2673,9 @@ datum
 			required_reagents = list("chlorine" = 1, "sugar" = 1, "hydrogen" = 1, "platinum" = 1, "stabiliser" = 1)
 			result_amount = 3
 			mix_phrase = "The mixture becomes volatile and airborne."
+#ifdef CHEM_REACTION_PRIORITY
 			priority = 9
+#endif
 
 		unstable_propellant
 			name = "unstable propellant"
@@ -2673,7 +2686,9 @@ datum
 			special_log_handling = 1
 			consume_all = 1
 			mix_phrase = "The mixture violently sprays everywhere!"
+#ifdef CHEM_REACTION_PRIORITY
 			priority = 9
+#endif
 			on_reaction(var/datum/reagents/holder, var/created_volume)
 				classic_smoke_reaction(holder, min(round(created_volume / 5) + 1, 4), get_turf(holder.my_atom))
 
@@ -3953,7 +3968,6 @@ datum
 			result_amount = 9 //18
 			mix_phrase = "The mixture of particles settles together with so much ease that it seems like it has been waiting for this moment for a long time."
 			mix_sound = 'sound/misc/fuse.ogg'
-			priority = 14
 
 		good_cement //lime, alumina, magnesia, iron (iii) oxide, calcium sulfate
 			name = "good cement"
@@ -3963,7 +3977,7 @@ datum
 			result_amount = 5 //14
 			mix_phrase = "The mixture of particles settles together with ease."
 			mix_sound = 'sound/misc/fuse.ogg'
-			priority = 13
+			inhibitors = list("sulfur")
 
 		okay_cement //lime, alumina, magnesia, iron (iii) oxide
 			name = "okay cement"
@@ -3973,7 +3987,7 @@ datum
 			result_amount = 4 //13
 			mix_phrase = "The mixture of particles settles together complacently."
 			mix_sound = 'sound/misc/fuse.ogg'
-			priority = 12
+			inhibitors = list("gypsum")
 
 		poor_cement //lime, alumina, iron (iii) oxide
 			name = "poor cement"
@@ -3983,7 +3997,7 @@ datum
 			result_amount = 2 //
 			mix_phrase = "The mixture of particles settles together... barely."
 			mix_sound = 'sound/misc/fuse.ogg'
-			priority = 11
+			inhibitors = list("magnesium")
 
 		perfect_concrete
 			name = "perfect concrete"

--- a/code/modules/chemistry/Chemistry-Structure.dm
+++ b/code/modules/chemistry/Chemistry-Structure.dm
@@ -38,15 +38,19 @@
 		if(reagent_list.len)
 			for(var/R in reagent_list)
 				possible_reactions |= total_chem_reactions[R]
+#ifdef CHEM_REACTION_PRIORITIES
 		SortList(possible_reactions)//see: /datum/chemical_reaction/operator<()
+#endif
 
 	proc/append_possible_reactions(var/reagent_id)
 		chem_building_precaution
 		if(total_chem_reactions[reagent_id])
 			possible_reactions |= total_chem_reactions[reagent_id]
 			. = 1
+#ifdef CHEM_REACTION_PRIORITIES
 		// sorting it each time anew is bad and slow, especially since your sorting algorithm doesn't even work nicely with almost sorted lists!!
 		SortList(possible_reactions)//see: /datum/chemical_reaction/operator<()
+#endif
 
 	proc/remove_possible_reactions(var/reagent_id)
 		chem_building_precaution


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Possible chem reactions are currently re-sorted by priority every time a new reagent gets added to a chem container and the sorting proc is not fast at all. But barely any reactions define priority and those that do can for the most part be modified to use inhibitors instead. This PR does that. The only thing that's questionable is possibly smoke powder / propellant firing out of order sometimes but that's how the code used to be before January and back then I noticed no problems as a player. I expect there to be no noticeable difference from the side of players (apart from less lag!).

I have not deleted the priority code completely. It can be turned ony be a _setup.dm define.

Note that this will need two small changes in the secret repo.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Lag bad.