### PR TITLE
prevent nukie grenade launcher from being attached as an item arm

### DIFF
--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -967,6 +967,7 @@
 	max_ammo_capacity = 4 // to fuss with if i want 6 packs of ammo
 	two_handed = 1
 	can_dual_wield = 0
+	object_flags = NO_ARM_ATTACH
 
 	New()
 		ammo = new/obj/item/ammo/bullets/grenade_round/explosive


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
prevents nukie grenade launcher from being attached as an item arm


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Matches behavior of other 2H nukie class-crate guns


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Tarmunora:
(+)Added nukie grenade launcher to the pool of items ineligible for arm surgery
```
