### PR TITLE
Surgical Tray refactor to allow right clicking of items on the tray

### DIFF
--- a/code/modules/medical/surgery_tools.dm
+++ b/code/modules/medical/surgery_tools.dm
@@ -1455,15 +1455,12 @@ keeping this here because I want to make something else with it eventually
 	proc/attach(obj/item/I as obj)
 		src.attached_objs.Add(I) // attach the item to the table
 		I.glide_size = 0 // required for smooth movement with the tray
-		RegisterSignal(I, COMSIG_ITEM_PICKUP, .proc/detach) // register for pickup
-		RegisterSignal(I, COMSIG_MOVABLE_MOVED, .proc/detach) // register for being pulled off the table
-		RegisterSignal(I, COMSIG_PARENT_PRE_DISPOSING, .proc/detach) //register for item deletion while attached to table
+		// register for pickup, register for being pulled off the table, register for item deletion while attached to table
+		RegisterSignal(I, list(COMSIG_ITEM_PICKUP, COMSIG_MOVABLE_MOVED, COMSIG_PARENT_PRE_DISPOSING), .proc/detach)
 
 	proc/detach(obj/item/I as obj) //remove from the attached items list and deregister signals
 		src.attached_objs.Remove(I)
-		UnregisterSignal(I, COMSIG_ITEM_PICKUP)
-		UnregisterSignal(I, COMSIG_MOVABLE_MOVED)
-		UnregisterSignal(I, COMSIG_PARENT_PRE_DISPOSING)
+		UnregisterSignal(I, list(COMSIG_ITEM_PICKUP, COMSIG_MOVABLE_MOVED, COMSIG_PARENT_PRE_DISPOSING))
 
 /* ---------- Surgery Tray Parts ---------- */
 /obj/item/furniture_parts/surgery_tray

--- a/code/modules/medical/surgery_tools.dm
+++ b/code/modules/medical/surgery_tools.dm
@@ -1361,7 +1361,6 @@ CONTAINS:
 	icon_state = "tray"
 	density = 1
 	anchored = 0
-	var/list/stuff_to_move = null
 	var/max_to_move = 10
 	p_class = 1.5
 
@@ -1389,6 +1388,7 @@ keeping this here because I want to make something else with it eventually
 
 	New()
 		..()
+		src.layer -= 0.01
 		if (!islist(src.attached_objs))
 			src.attached_objs = list()
 		if (!ticker) // pre-roundstart, this is a thing made on the map so we want to grab whatever's been placed on top of us automatically
@@ -1454,6 +1454,7 @@ keeping this here because I want to make something else with it eventually
 
 	proc/attach(obj/item/I as obj)
 		src.attached_objs.Add(I) // attach the item to the table
+		I.glide_size = 0 // required for smooth movement with the tray
 		RegisterSignal(I, COMSIG_ITEM_PICKUP, .proc/detach) // register for pickup
 		RegisterSignal(I, COMSIG_MOVABLE_MOVED, .proc/detach) // register for being pulled off the table
 		RegisterSignal(I, COMSIG_PARENT_PRE_DISPOSING, .proc/detach) //register for item deletion while attached to table

--- a/code/modules/medical/surgery_tools.dm
+++ b/code/modules/medical/surgery_tools.dm
@@ -1458,7 +1458,7 @@ keeping this here because I want to make something else with it eventually
 		RegisterSignal(I, COMSIG_MOVABLE_MOVED, .proc/detach) // register for being pulled off the table
 		RegisterSignal(I, COMSIG_PARENT_PRE_DISPOSING, .proc/detach) //register for item deletion while attached to table
 
-	proc/detach(obj/item/I as obj, mob/user as mob) //remove from the attached items list and deregister signals
+	proc/detach(obj/item/I as obj) //remove from the attached items list and deregister signals
 		src.attached_objs.Remove(I)
 		UnregisterSignal(I, COMSIG_ITEM_PICKUP)
 		UnregisterSignal(I, COMSIG_MOVABLE_MOVED)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][ENHANCEMENT][REWORK] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Refactors the surgery tray to place objects into its `attached_obj` list rather than `contents` and `vis_contents`. Additionally signals are used to handle detaching objects when they are picked up, moved, or otherwise deleted.

Creates two new procs, `proc/attach` and `proc/detach` to manage items in the `attached_obj` list and register/unregister signals

Finally sets up a `disposing` proc to cleanup the list and signals in the event the tray is destroyed or dismantled.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allows you to right click the tray and actually see a list of items. Previously the only method available was pixel clicking the correct tool.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Sovexe:
(+)Items on surgical trays now appear in the right-click context menu. Additionally items won't appear under the tray, and will now glide smoothly with the tray.
```
