### PR TITLE
Prevent observer and intangible mobs from getting radiation status effect

### DIFF
--- a/code/modules/status_system/statusSystem.dm
+++ b/code/modules/status_system/statusSystem.dm
@@ -467,7 +467,7 @@ var/list/statusGroupLimits = list("Food"=4)
 			return "You are [howMuch]irradiated.<br>Taking [damage_tox] toxin damage every [tickSpacing/10] sec.<br>Damage reduced by radiation resistance on gear."
 
 		preCheck(var/atom/A)
-			if(issilicon(A)) return 0
+			if(issilicon(A) || isobserver(A) || isintangible(A)) return 0
 			return 1
 
 		onAdd(var/optional=null)
@@ -581,6 +581,7 @@ var/list/statusGroupLimits = list("Food"=4)
 			return "You are [howMuch]irradiated by neutrons.<br>Taking [damage_tox] toxin damage every [tickSpacing/10] sec and [damage_brute] brute damage every [tickSpacing/10] sec."
 
 		preCheck(var/atom/A)
+			if(isobserver(A) || isintangible(A)) return 0
 			return 1
 
 		onAdd(var/optional=null)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds checks against observer and intangible mobs in the two radiation status effects


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #1018 