### PR TITLE
Announcement computer ejects ID when inserting a second ID card

### DIFF
--- a/code/obj/machinery/computer/announcement.dm
+++ b/code/obj/machinery/computer/announcement.dm
@@ -57,6 +57,9 @@
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (istype(W, /obj/item/card/id))
+			if (src.ID)
+				src.ID.set_loc(src.loc)
+				boutput(user, "<span class='notice'>[src.ID] is ejected from the ID scanner.</span>")
 			usr.drop_item()
 			W.set_loc(src)
 			src.ID = W


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][MINOR] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Force the announcement computer to eject the already inserted ID card when attempting to insert a second one.

If you instead want it do something else, like preventing the ID from being inserted please let me know.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Closes #1011 
