### PR TITLE
Lets admins and mentors through server player caps

### DIFF
--- a/code/client.dm
+++ b/code/client.dm
@@ -288,7 +288,7 @@
 			src.verbs += /client/proc/toggle_mentorhelps
 		ignore_player_cap = 1
 
-	if(ignore_player_cap && player_capa)
+	if(!ignore_player_cap && player_capa)
 		if(total_clients() >= player_cap)
 			if (!src.holder)
 				alert(src,"I'm sorry, the player cap of [player_cap] has been reached for this server.")

--- a/code/client.dm
+++ b/code/client.dm
@@ -276,8 +276,19 @@
 			SPAWN_DBG(0) del(src)
 			return
 */
+	//admins and mentors can enter a server through player caps. 
+	var/ignore_player_cap = 0
+	if (init_admin())
+		boutput(src, "<span class='ooc adminooc'>You are an admin! Time for crime.</span>")
+		control_freak = 0	// heh
+		ignore_player_cap = 1
+	else if (player.mentor)
+		boutput(src, "<span class='ooc mentorooc'>You are a mentor!</span>")
+		if (!src.holder)
+			src.verbs += /client/proc/toggle_mentorhelps
+		ignore_player_cap = 1
 
-	if(player_capa)
+	if(ignore_player_cap && player_capa)
 		if(total_clients() >= player_cap)
 			if (!src.holder)
 				alert(src,"I'm sorry, the player cap of [player_cap] has been reached for this server.")
@@ -287,13 +298,6 @@
 	if (join_motd)
 		boutput(src, "<div class=\"motd\">[join_motd]</div>")
 
-	if (init_admin())
-		boutput(src, "<span class='ooc adminooc'>You are an admin! Time for crime.</span>")
-		control_freak = 0	// heh
-	else if (player.mentor)
-		boutput(src, "<span class='ooc mentorooc'>You are a mentor!</span>")
-		if (!src.holder)
-			src.verbs += /client/proc/toggle_mentorhelps
 
 	Z_LOG_DEBUG("Client/New", "[src.ckey] - Running parent new")
 


### PR DESCRIPTION

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Lets admins and mentors connect to the server even if it has reached the player cap.

This is a very basic fix. Despite admins and mentors being let through the player cap, they will still count towards that player cap. I think it could be improved more, but I haven't had a discussion on what would be best thing that we want. Like if they should not be counted towards the player count at all? I'm not really sure, that might be better but it sounds like it could possibly lead to there being too many players on a server in times of very high population.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Admins and mentors should be able to enter the server even if the server has the player cap on and is filled.

