### PR TITLE
Noah's Shuttle medal & some pet refactoring

### DIFF
--- a/code/WorkInProgress/Hydrothings.dm
+++ b/code/WorkInProgress/Hydrothings.dm
@@ -783,6 +783,7 @@ obj/item/gnomechompski/elf
 	flying = 0
 	death_text = "%src% tips over, its joints seizing and locking up.  It does not move again."
 	angertext = "seems to stare at"
+	is_pet = 0
 
 	var/does_creepy_stuff = 1
 	var/typeName = "Generic"

--- a/code/WorkInProgress/Hydrothings.dm
+++ b/code/WorkInProgress/Hydrothings.dm
@@ -698,6 +698,7 @@ obj/item/gnomechompski/elf
 	flying = 0
 	death_text = "%src% tips over, its joints seizing and locking up.  It does not move again."
 	angertext = "seems to stare at"
+	is_pet = 0
 
 	var/does_creepy_stuff = 1
 	var/typeName = "Generic"

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -456,6 +456,15 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 	//logTheThing("debug", null, null, "Zamujasa: [world.timeofday] round_end_data")
 	round_end_data(1) //Export round end packet (normal completion)
 
+	var/pets_rescued = 0
+	for(var/pet in pets)
+		if(iscritter(pet))
+			var/obj/critter/P = pet
+			if(P.alive && in_centcom(P)) pets_rescued++
+		else if(ismobcritter(pet))
+			var/mob/living/critter/P = pet
+			if(isalive(P) && in_centcom(P)) pets_rescued++
+
 	//logTheThing("debug", null, null, "Zamujasa: [world.timeofday] Processing end-of-round generic medals")
 	for(var/mob/living/player in mobs)
 		if (player.client)
@@ -463,6 +472,8 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 				if (in_centcom(player))
 					player.unlock_medal("100M dash", 1)
 				player.unlock_medal("Survivor", 1)
+				if (pets_rescued >= 6)
+					player.unlock_medal("Noah's Shuttle", 1)
 
 				if (player.check_contents_for(/obj/item/gnomechompski))
 					player.unlock_medal("Guardin' gnome", 1)

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -523,8 +523,6 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 	else
 		final_score = 100
 
-	boutput(world, score_tracker.escapee_facts())
-
 
 	//logTheThing("debug", null, null, "Zamujasa: [world.timeofday] ai law display")
 	for (var/mob/living/silicon/ai/aiPlayer in AIs)

--- a/code/datums/gauntlet/podcolosseum.dm
+++ b/code/datums/gauntlet/podcolosseum.dm
@@ -97,7 +97,7 @@
 	var/boss_counter = 0
 	var/boss_count = 1
 	var/list/drone_templates = list()
-	var/list/bosses = list(/obj/critter/gunbot/drone/helldrone, /obj/critter/gunbot/drone/iridium, /obj/critter/gunbot/drone/iridium/whydrone)
+	var/list/bosses = list(/obj/critter/gunbot/drone/helldrone, /obj/critter/gunbot/drone/iridium, /obj/critter/gunbot/drone/iridium/whydrone, /obj/critter/gunbot/drone/iridium/whydrone/horse)
 	var/list/current_bosses = null
 	var/list/actors = list()
 

--- a/code/mob/living/critter/aquatic.dm
+++ b/code/mob/living/critter/aquatic.dm
@@ -29,10 +29,23 @@
 	var/out_of_water_to_in_water = 0 // did they enter an area with insufficient water from an area with sufficient water?
 	var/in_water_buff = 1 // buff amount for being in water
 
+	var/is_pet = null // null for automatic detection
+
+/mob/living/critter/aquatic/New(loc)
+	if(isnull(src.is_pet))
+		src.is_pet = (copytext(src.name, 1, 2) in uppercase_letters)
+	if(in_centcom(loc) || current_state >= GAME_STATE_PLAYING)
+		src.is_pet = 0
+	if(src.is_pet)
+		pets += src
+	..()
+
 /mob/living/critter/aquatic/disposing()
 	if(ai)
 		ai.dispose()
 	ai = null
+	if(src.is_pet)
+		pets -= src
 	..()
 
 /mob/living/critter/aquatic/setup_healths()

--- a/code/mob/living/critter/aquatic.dm
+++ b/code/mob/living/critter/aquatic.dm
@@ -38,6 +38,7 @@
 		src.is_pet = 0
 	if(src.is_pet)
 		pets += src
+	src.update_water_status(loc)
 	..()
 
 /mob/living/critter/aquatic/disposing()
@@ -79,14 +80,23 @@
 		if (Bu && Bu.maximum_value > Bu.value && !is_heat_resistant())
 			Bu.TakeDamage(-in_water_buff)
 
+/mob/living/critter/aquatic/set_loc(newloc)
+	. = ..()
+	src.update_water_status()
+
 /mob/living/critter/aquatic/Move(NewLoc, direct)
 	. = ..()
-	if(istype(src.loc, /turf/space/fluid)) // question: is this logic viable? too messy?
+	src.update_water_status()
+
+/mob/living/critter/aquatic/update_water_status(loc = null)
+	if(isnull(loc))
+		loc = src.loc
+	if(istype(loc, /turf/space/fluid)) // question: is this logic viable? too messy?
 		if(src.water_need)
 			src.water_need = 0
 			src.out_of_water_to_in_water = 1
-	else if(isturf(src.loc))
-		var/turf/T = src.loc
+	else if(isturf(loc))
+		var/turf/T = loc
 		if (T.active_liquid)
 			if(T.active_liquid.last_depth_level > 3)
 				if(src.water_need)

--- a/code/mob/living/critter/aquatic.dm
+++ b/code/mob/living/critter/aquatic.dm
@@ -88,7 +88,7 @@
 	. = ..()
 	src.update_water_status()
 
-/mob/living/critter/aquatic/update_water_status(loc = null)
+/mob/living/critter/aquatic/proc/update_water_status(loc = null)
 	if(isnull(loc))
 		loc = src.loc
 	if(istype(loc, /turf/space/fluid)) // question: is this logic viable? too messy?

--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -63,6 +63,22 @@ todo: add more small animals!
 	var/fur_color = 0
 	var/eye_color = 0
 
+	var/is_pet = null // null = autodetect
+
+	New(loc)
+		if(isnull(src.is_pet))
+			src.is_pet = (copytext(src.name, 1, 2) in uppercase_letters)
+		if(in_centcom(loc) || current_state >= GAME_STATE_PLAYING)
+			src.is_pet = 0
+		if(src.is_pet)
+			pets += src
+		..()
+
+	disposing()
+		if(src.is_pet)
+			pets -= src
+		..()
+
 	setup_healths()
 		add_hh_flesh(-(src.health_brute), src.health_brute, src.health_brute_vuln)
 		add_hh_flesh_burn(-(src.health_burn), src.health_burn, src.health_burn_vuln)

--- a/code/obj/critter/bee.dm
+++ b/code/obj/critter/bee.dm
@@ -238,6 +238,7 @@
 		generic = 0
 		var/jittered = 0
 		honey_color = rgb(0, 255, 255)
+		is_pet = 2
 		var/tier = 0
 		var/original_tier = 0
 		var/original_hat_ref = ""

--- a/code/obj/critter/bee.dm
+++ b/code/obj/critter/bee.dm
@@ -270,12 +270,10 @@
 			src.original_tier = src.tier
 			src.RegisterSignal(GLOBAL_SIGNAL, COMSIG_GLOBAL_REBOOT, .proc/save_upgraded_tier)
 			heisentier_hat()
-			pets += src
 			..()
 
 		disposing()
 			UnregisterSignal(GLOBAL_SIGNAL, COMSIG_GLOBAL_REBOOT)
-			pets -= src
 			..()
 
 		proc/save_upgraded_tier()

--- a/code/obj/critter/big_animals.dm
+++ b/code/obj/critter/big_animals.dm
@@ -489,6 +489,7 @@ obj/critter/bear/care
 	icon_state = "batdoctor"
 	health = 30
 	generic = 0
+	is_pet = 2
 
 	drink_blood(var/atom/target)
 		..()

--- a/code/obj/critter/big_animals.dm
+++ b/code/obj/critter/big_animals.dm
@@ -490,14 +490,6 @@ obj/critter/bear/care
 	health = 30
 	generic = 0
 
-	New()
-		pets += src
-		..()
-
-	disposing()
-		pets -= src
-		..()
-
 	drink_blood(var/atom/target)
 		..()
 		JOB_XP(target, "Medical Doctor", 1)

--- a/code/obj/critter/critter_parent.dm
+++ b/code/obj/critter/critter_parent.dm
@@ -81,7 +81,7 @@
 	var/generic = 1 // if yes, critter can be randomized a bit
 	var/max_quality = 100
 	var/min_quality = -100
-	var/is_pet = null // if null gets determined based on capitalization
+	var/is_pet = null // if null gets determined based on capitalization, 0 = not pet, 1 = pet, 2 = command pet
 
 	var/can_revive = 1 // resurrectable with strange reagent
 

--- a/code/obj/critter/critter_parent.dm
+++ b/code/obj/critter/critter_parent.dm
@@ -81,6 +81,7 @@
 	var/generic = 1 // if yes, critter can be randomized a bit
 	var/max_quality = 100
 	var/min_quality = -100
+	var/is_pet = null // if null gets determined based on capitalization
 
 	var/can_revive = 1 // resurrectable with strange reagent
 
@@ -848,11 +849,17 @@
 		return 1
 
 
-	New()
+	New(loc)
 		if(!src.reagents) src.create_reagents(100)
 		wander_check = rand(5,20)
 		critters += src
 		report_spawn()
+		if(isnull(src.is_pet))
+			src.is_pet = !generic && (copytext(src.name, 1, 2) in uppercase_letters)
+		if(in_centcom(loc) || current_state >= GAME_STATE_PLAYING)
+			src.is_pet = 0
+		if(src.is_pet)
+			pets += src
 		if(generic)
 			src.quality = rand(min_quality,max_quality)
 			var/nickname = getCritterQuality(src.quality)
@@ -865,6 +872,8 @@
 		critters -= src
 		if(registered_area)
 			registered_area.registered_critters -= src
+		if(src.is_pet)
+			pets -= src
 		..()
 
 	proc/seek_target()

--- a/code/obj/critter/pets_small_animals.dm
+++ b/code/obj/critter/pets_small_animals.dm
@@ -134,14 +134,7 @@
 	icon_state = "remy"
 	health = 33
 	aggressive = 0
-
-	New()
-		pets += src
-		..()
-
-	disposing()
-		pets -= src
-		..()
+	generic = 0
 
 /obj/critter/opossum
 	name = "space opossum"
@@ -396,14 +389,6 @@ var/list/cat_names = list("Gary", "Mittens", "Mr. Jingles", "Rex", "Jasmine", "L
 	generic = 0
 	var/swiped = 0
 
-	New()
-		pets += src
-		..()
-
-	disposing()
-		pets -= src
-		..()
-
 	emag_act(var/mob/user, var/obj/item/card/emag/E)
 		if (!src.alive || cattype == "-emagged")
 			return 0
@@ -482,13 +467,10 @@ var/list/cat_names = list("Gary", "Mittens", "Mr. Jingles", "Rex", "Jasmine", "L
 
 	New()
 		. = ..()
-		if (!isrestrictedz(src.loc.z)) //I don't want the other centcom dogs thanks
-			pets += src
 		START_TRACKING
 
 	disposing()
 		. = ..()
-		pets -= src
 		STOP_TRACKING
 /*
 	seek_target()
@@ -1782,7 +1764,7 @@ var/list/shiba_names = list("Maru", "Coco", "Foxtrot", "Nectarine", "Moose", "Pe
 		return F
 
 /obj/critter/boogiebot
-	name = "Boogiebot"
+	name = "boogiebot"
 	desc = "A robot that looks ready to get down at any moment."
 	icon_state = "boogie"
 	density = 1
@@ -1968,15 +1950,6 @@ var/list/shiba_names = list("Maru", "Coco", "Foxtrot", "Nectarine", "Moose", "Pe
 	generic = 0 // no let's not have "vile Piggy" or "busted Piggy" tia
 	lock_color = 1
 
-	New()
-		if (!isrestrictedz(src.loc.z)) //don't want the centcom ferrets
-			pets += src
-		..()
-
-	disposing()
-		pets -= src
-		..()
-
 //Wire: Another special ferret based on my OTHER now dead IRL ferret. Has similar paradox naming.
 /obj/critter/meatslinky/monkey
 	name = "Monkey"
@@ -1984,15 +1957,6 @@ var/list/shiba_names = list("Maru", "Coco", "Foxtrot", "Nectarine", "Moose", "Pe
 	health = 50
 	generic = 0
 	lock_color = 1
-
-	New()
-		if (!isrestrictedz(src.loc.z)) //don't want the centcom ferrets
-			pets += src
-		..()
-
-	disposing()
-		pets -= src
-		..()
 
 /obj/critter/raccoon
 	name = "space raccoon"

--- a/code/obj/critter/pets_small_animals.dm
+++ b/code/obj/critter/pets_small_animals.dm
@@ -236,6 +236,8 @@ var/list/cat_names = list("Gary", "Mittens", "Mr. Jingles", "Rex", "Jasmine", "L
 	event_handler_flags = USE_HASENTERED | USE_PROXIMITY | USE_FLUID_ENTER
 
 	New()
+		if(src.name == "jons the catte")
+			src.is_pet = 1
 		..()
 		if (src.randomize_cat)
 			src.name = pick(cat_names)

--- a/code/obj/critter/pets_small_animals.dm
+++ b/code/obj/critter/pets_small_animals.dm
@@ -387,6 +387,7 @@ var/list/cat_names = list("Gary", "Mittens", "Mr. Jingles", "Rex", "Jasmine", "L
 	health = 30
 	randomize_cat = 0
 	generic = 0
+	is_pet = 2
 	var/swiped = 0
 
 	emag_act(var/mob/user, var/obj/item/card/emag/E)
@@ -555,6 +556,7 @@ var/list/cat_names = list("Gary", "Mittens", "Mr. Jingles", "Rex", "Jasmine", "L
 	name = "Blair"
 	icon_state = "pug"
 	doggy = "pug"
+	is_pet = 2
 
 var/list/shiba_names = list("Maru", "Coco", "Foxtrot", "Nectarine", "Moose", "Pecan", "Daikon", "Seaweed")
 

--- a/code/obj/critter/turtle.dm
+++ b/code/obj/critter/turtle.dm
@@ -153,14 +153,6 @@
 	icon_state = "turtle"		//I kinda wanna make sylvester stand out a bit amongs other turtles, even without the hat.
 	health = 100
 	generic = 0
-
-	New()
-		pets += src
-		..()
-
-	disposing()
-		pets -= src
-		..()
 //Starts with the beret on!
 /obj/critter/turtle/sylvester/HoS
 

--- a/code/obj/critter/turtle.dm
+++ b/code/obj/critter/turtle.dm
@@ -153,6 +153,7 @@
 	icon_state = "turtle"		//I kinda wanna make sylvester stand out a bit amongs other turtles, even without the hat.
 	health = 100
 	generic = 0
+	is_pet = 2
 //Starts with the beret on!
 /obj/critter/turtle/sylvester/HoS
 

--- a/code/obj/critter/zombie.dm
+++ b/code/obj/critter/zombie.dm
@@ -15,6 +15,7 @@
 	brutevuln = 0.5
 	butcherable = 1
 	chase_text = "slams into"
+	is_pet = 0
 
 	var/punch_damage_max = 9
 	var/punch_damage_min = 3

--- a/code/procs/scorestats.dm
+++ b/code/procs/scorestats.dm
@@ -29,6 +29,7 @@ var/datum/score_tracker/score_tracker
 	var/beepsky_alive = null
 	var/clown_beatings = null
 	var/list/pets_escaped = null
+	var/list/command_pets_escaped = null
 
 
 	proc/calculate_score()
@@ -220,13 +221,26 @@ var/datum/score_tracker/score_tracker
 					richest_total = cash_total
 					richest_escapee = M
 
+		command_pets_escaped = list()
 		pets_escaped = list()
 
-		for (var/obj/critter/P in pets)
-			if (in_centcom(P) && P.alive)
-				pets_escaped += P
-				if (istype(P, /obj/critter/bat/doctor))
-					acula_blood = P:blood_volume //this only gets populated if Dr. Acula escapes
+		for (var/pet in pets)
+			if(iscritter(pet))
+				var/obj/critter/P = pet
+				if (in_centcom(P) && P.alive)
+					if(P.is_pet == 2)
+						command_pets_escaped += P
+					else if(P.is_pet)
+						pets_escaped += P
+					if (istype(P, /obj/critter/bat/doctor))
+						acula_blood = P:blood_volume //this only gets populated if Dr. Acula escapes
+			else if(ismobcritter(pet))
+				var/mob/living/critter/P = pet
+				if (in_centcom(pet) && isalive(P))
+					if(pet:is_pet == 2)
+						command_pets_escaped += pet
+					else if(pet:is_pet)
+						pets_escaped += pet
 
 		if (length(by_type[/obj/machinery/bot/secbot/beepsky]))
 			beepsky_alive = 1
@@ -294,11 +308,16 @@ var/datum/score_tracker/score_tracker
 		//Richest Escapee | Most Damaged Escapee | Dr. Acula Blood Total | Clown Beatings
 		if (richest_escapee)		. += "<B>Richest Escapee:</B> [richest_escapee.real_name] : $[richest_total]<BR>"
 		if (most_damaged_escapee) 	. += "<B>Most Damaged Escapee:</B> [most_damaged_escapee.real_name] : [most_damaged_escapee.get_damage()]%<BR>"		//it'll be kinda different from when it's calculated, but whatever.
-		if (islist(pets_escaped) && pets_escaped.len)		//The reason I don't just use the pets_escaped list is because that list will send the info to goonhub, and I don't wanna send the bicons too.
+		if (length(command_pets_escaped))
+			var/list/who_escaped = list()
+			for (var/atom/A in command_pets_escaped)
+				who_escaped += "[A.name] [bicon(A)]"
+			. += "<B>Command Pets Escaped:</B> [who_escaped.Join(" ")]<BR><BR>"
+		if (length(pets_escaped))
 			var/list/who_escaped = list()
 			for (var/atom/A in pets_escaped)
 				who_escaped += "[A.name] [bicon(A)]"
-			. += "<B>Pets Escaped:</B> [who_escaped.Join(" ")]<BR><BR>"
+			. += "<B>Other Pets Escaped:</B> [who_escaped.Join(" ")]<BR><BR>"
 
 		if (acula_blood) 			. += "<B>Dr. Acula Blood Total:</B> [acula_blood]p<BR>"
 		if (beepsky_alive) 			. += "<B>Beepsky?:</B> Yes<BR>"

--- a/code/procs/scorestats.dm
+++ b/code/procs/scorestats.dm
@@ -209,8 +209,7 @@ var/datum/score_tracker/score_tracker
 		richest_total = 0
 		//search mobs in centcom
 		for (var/mob/M in mobs)
-			var/area/A = get_area(M)
-			if (istype(A, /area/shuttle/escape/centcom))// || istype(A, /area/centcom))
+			if(in_centcom(M))
 				if (!most_damaged_escapee)
 					most_damaged_escapee = M
 				else if (M.get_damage() < most_damaged_escapee.get_damage())

--- a/code/z_adventurezones/luna.dm
+++ b/code/z_adventurezones/luna.dm
@@ -1073,6 +1073,7 @@ var/list/lunar_fx_sounds = list('sound/ambience/loop/Wind_Low.ogg','sound/ambien
 	flying = 0
 	death_text = "%src% tips over, its joints seizing and locking up.  It does not move again."
 	angertext = "seems to stare at"
+	is_pet = 0
 
 	var/does_creepy_stuff = 0
 	var/typeName = "Generic"

--- a/code/z_adventurezones/meatland.dm
+++ b/code/z_adventurezones/meatland.dm
@@ -218,6 +218,7 @@ var/list/meatland_fx_sounds = list('sound/ambience/spooky/Meatzone_Squishy.ogg',
 	firevuln = 0.15
 	angertext = "bares jagged fangs at"
 	generic = 0
+	is_pet = 0
 
 
 	floor

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -3294,7 +3294,7 @@
 "blr" = (/obj/machinery/conveyor{dir = 4; name = "cargo belt - east"; operating = 1},/turf/simulated/floor/plating,/area/station/maintenance/east)
 "bls" = (/obj/disposalpipe/segment,/obj/machinery/cargo_router/Router6,/turf/simulated/floor/plating,/area/station/maintenance/east)
 "blt" = (/obj/machinery/launcher_loader/east,/turf/simulated/floor/caution/northsouth,/area/station/maintenance/east)
-"blu" = (/obj/fluid_spawner{amount = 1200},/turf/simulated/floor/sand,/area/station/chapel/main)
+"blu" = (/obj/fluid_spawner{amount = 1700},/turf/simulated/floor/sand,/area/station/chapel/main)
 "blv" = (/obj/item/bananapeel,/obj/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/disposalpipe/segment/morgue,/turf/simulated/floor/delivery,/area/station/maintenance/disposal)
 "blw" = (/obj/machinery/launcher_loader/north,/turf/simulated/floor/plating/airless,/area)
 "blx" = (/turf/space,/area/shuttle/merchant_shuttle/left_station/cogmap)

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -5207,7 +5207,7 @@
 "bWg" = (/turf/simulated/floor/bot,/area/station/security/main)
 "bWh" = (/obj/storage/secure/closet/brig/automatic/solitary2,/turf/simulated/floor/grime,/area/station/security/main)
 "bWi" = (/obj/grille/steel,/obj/window/auto/reinforced,/turf/simulated/floor/plating,/area/station/security/main)
-"bWj" = (/obj/fluid_spawner{amount = 1800},/turf/simulated/floor/sand,/area)
+"bWj" = (/obj/fluid_spawner{amount = 2000},/turf/simulated/floor/sand,/area)
 "bWk" = (/obj/machinery/teleport/portal_ring,/turf/simulated/floor/delivery,/area/station/teleporter)
 "bWl" = (/obj/machinery/teleport/portal_generator,/turf/simulated/floor/bot,/area/station/teleporter)
 "bWm" = (/obj/machinery/computer/teleporter{dir = 4},/turf/simulated/floor/bot,/area/station/teleporter)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a "Noah's Shuttle" medal for rescuing 6 pets on the escape shuttle. Everyone on the shuttle gets the reward when it docks.
Pets are now split into command pets (Jones, Heisenbee, Blair, Dr. Acula, Sylvester) and other pets.
Other pets now include pretty much any named station critter which are autodetected for the most part. (And some named animals that aren't on the station, like jons the catte.)
Oh, and in order to make some station pets not die constantly I refilled the aquariums on cog1 and cog2 to acceptable levels.

My proposed medal picture: (feel free to suggest a better one)
![noahs_shuttle-export](https://user-images.githubusercontent.com/358431/84284733-e06f4f00-ab3c-11ea-99f8-b79e6bc18c7d.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I think having the crew attempt to rescue 6 pets alive while a traitor tries to thwart their plans could be a fun and interesting dynamic. Also splittling pets into command pets and other pets might finally stop the endless arguments about Morty.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)pali
(*)Added Noah's Shuttle medal for rescuing 6 station pets on the shuttle.
```