### PR TITLE
Refactor obj critter deaths and add a new COMSIG_OBJ_CRITTER_DEATH signal

### DIFF
--- a/_std/component_defines.dm
+++ b/_std/component_defines.dm
@@ -84,3 +84,7 @@
 // projectile signals
 /// After a projectile makes a valid hit on an atom (after immunity/other early returns, before other effects)
 #define COMSIG_PROJ_COLLIDE "proj_collide_atom"
+
+// obj/critter signals
+// When an obj/critter dies
+#define COMSIG_OBJ_CRITTER_DEATH "obj_critter_death"

--- a/code/WorkInProgress/Azungarstuff.dm
+++ b/code/WorkInProgress/Azungarstuff.dm
@@ -1232,6 +1232,7 @@
 			src.attacking = 0
 
 	CritterDeath()
+		..()
 		qdel(src)
 
 /obj/item/rpcargotele

--- a/code/WorkInProgress/Hydrothings.dm
+++ b/code/WorkInProgress/Hydrothings.dm
@@ -1011,6 +1011,7 @@ obj/critter/madnessowl/switchblade
 	icon = 'icons/misc/owlzone.dmi'
 	icon_state = "owlmutant"
 	dead_state = "owlmutant-dead"
+	death_text = "%src% <b>collapses, releasing a final hoot and regurgitating a Hootonium Core. What? </b>"
 	health = 666
 	flying = 1
 	firevuln = 1
@@ -1031,14 +1032,9 @@ obj/critter/madnessowl/switchblade
 
 	CritterDeath()
 		if (src.alive)
+			..()
 			playsound(src.loc, "sound/voice/animal/hoot.ogg", 65, 1)
-			src.visible_message("<b> [src] collapses, releasing a final hoot and regurgitating a Hootonium Core. What? <b/>")
-			src.alive = 0
-			walk_to(src,0)
-			anchored = 0
-			set_density(0)
 			layer = initial(layer)
-			icon = "owlmutant-dead"
 			new /obj/item/plutonium_core/hootonium_core (src.loc)
 
 	seek_target()

--- a/code/WorkInProgress/customcritter.dm
+++ b/code/WorkInProgress/customcritter.dm
@@ -190,19 +190,16 @@
 	CritterDeath()
 		if (!src.alive)
 			return
-		//src.icon_state += "-dead"
-		src.alive = 0
-		src.anchored = 0
-		src.set_density(0)
+		..()
 		loot_table.drop()
 		if (dead_change_icon)
 			icon = dead_icon
 			icon_state = dead_icon_state
-		tokenized_message(death_text, null)
+		else // ughh, admins and their custom critters
+			src.icon_state = replacetext(src.icon_state, "-dead", "") //can't assume it's going to have a dead state...
 		play_optional_sound(death_sound)
 		if (on_death)
 			on_death.doOnDeath()
-		walk_to(src,0)
 
 	clone()
 		var/obj/critter/custom/C = ..()

--- a/code/WorkInProgress/warcrimes.dm
+++ b/code/WorkInProgress/warcrimes.dm
@@ -757,6 +757,7 @@ Urs' Hauntdog critter
 	desc = "A very, <i>very</i> haunted hotdog. Hopping around. Hopdog."
 	icon = 'icons/misc/hauntdog.dmi'
 	icon_state = "hauntdog"
+	death_text = null
 	health = 30
 	density = 0
 
@@ -784,6 +785,7 @@ Urs' Hauntdog critter
 
 	CritterDeath()
 		if (!src.alive) return
+		..()
 		src.visible_message("<b>[src]</b> stops moving.",2)
 		var/obj/item/reagent_containers/food/snacks/hotdog/H = new /obj/item/reagent_containers/food/snacks/hotdog(get_turf(src))
 

--- a/code/mob/living/carbon/human/machoman.dm
+++ b/code/mob/living/carbon/human/machoman.dm
@@ -1322,7 +1322,7 @@ var/list/snd_macho_idle = list('sound/voice/macho/macho_alert16.ogg', 'sound/voi
 			M.changeStatus("weakened", 2 SECONDS)
 			random_brute_damage(M, rand(1,2))
 	CritterDeath()
-		src.alive = 0
+		..()
 		playsound(src.loc, "sound/impact_sounds/Slimy_Splat_1.ogg", 75, 1)
 		var/obj/decal/cleanable/blood/gibs/gib = null
 		gib = make_cleanable(/obj/decal/cleanable/blood/gibs,src.loc)

--- a/code/modules/holiday/spacemas.dm
+++ b/code/modules/holiday/spacemas.dm
@@ -306,13 +306,8 @@ var/list/seal_names = list("Fluffles","Ronan","Selena","Selkie","Ukog","Ategev",
 
 	CritterDeath()
 		if (!src.alive) return
-		src.icon_state += "-dead"
-		src.alive = 0
-		src.anchored = 0
-		src.set_density(0)
+		..()
 		src.desc = "The lifeless corpse of [src.name], why would anyone do such a thing?"
-		walk_to(src,0)
-		src.visible_message("<b>[src]</b> dies!")
 		modify_christmas_cheer(-20)
 		src.name = "dead space seal pup"
 		for (var/obj/critter/sealpup/S in view(7,src))

--- a/code/obj/critter/bee.dm
+++ b/code/obj/critter/bee.dm
@@ -1554,11 +1554,7 @@
 			..()
 
 	CritterDeath()
-		src.alive = 0
-		set_density(0)
-		src.icon_state = "[initial(src.icon_state)]-dead"
-		walk_to(src,0)
-		src.visible_message("<b>[src]</b> dies!")
+		..()
 
 		modify_christmas_cheer(-5)
 		for (var/obj/critter/domestic_bee/fellow_bee in view(7,src))

--- a/code/obj/critter/critter_parent.dm
+++ b/code/obj/critter/critter_parent.dm
@@ -60,6 +60,7 @@
 	var/attacker = null // used for defensive tracking
 	var/angertext = "charges at" // comes between critter name and target name
 	var/pet_text = "pets"
+	var/post_pet_text = null
 	var/death_text = "%src% dies!"
 	var/atk_text = "bites"
 	var/chase_text = "leaps on"
@@ -406,7 +407,8 @@
 				on_grump()
 		else
 			var/pet_verb = islist(src.pet_text) ? pick(src.pet_text) : src.pet_text
-			src.visible_message("<span class='notice'><b>[user]</b> [pet_verb] [src]!</span>", 1)
+			var/post_pet_verb = islist(src.post_pet_text) ? pick(src.post_pet_text) : src.post_pet_text
+			src.visible_message("<span class='notice'><b>[user]</b> [pet_verb] [src]![post_pet_verb]</span>", 1)
 			on_pet()
 
 	proc/patrol_step()
@@ -937,7 +939,13 @@
 		return 1
 
 	proc/CritterDeath()
+		SHOULD_CALL_PARENT(TRUE)
 		if (!src.alive) return
+
+		#ifdef COMSIG_OBJ_CRITTER_DEATH
+		SEND_SIGNAL(src, COMSIG_OBJ_CRITTER_DEATH)
+		#endif
+
 		if (!dead_state)
 			src.icon_state = "[initial(src.icon_state)]-dead"
 		else
@@ -945,7 +953,7 @@
 		src.alive = 0
 		src.anchored = 0
 		src.set_density(0)
-		walk_to(src,0)
+		walk_to(src,0) //halt walking
 		report_death()
 		src.tokenized_message(death_text)
 

--- a/code/obj/critter/miningcritters.dm
+++ b/code/obj/critter/miningcritters.dm
@@ -15,6 +15,7 @@
 	firevuln = 0.1
 	brutevuln = 1
 	angertext = "hisses at"
+	death_text = null //has custom death message logic
 	butcherable = 1
 	var/eaten = 0
 
@@ -51,12 +52,9 @@
 
 	CritterDeath()
 		if (!alive) return
-		src.alive = 0
+		..()
 		src.target = null
 		src.task = "dead"
-		set_density(0)
-		src.icon_state = "rockworm-dead"
-		walk_to(src,0)
 		if (eaten >= 10)
 			src.visible_message("<b>[src]</b> vomits something up and dies!")
 		else

--- a/code/obj/critter/misc.dm
+++ b/code/obj/critter/misc.dm
@@ -58,6 +58,7 @@
 	name = "plasma spore"
 	desc = "A barely intelligent colony of organisms. Very volatile."
 	icon_state = "spore"
+	death_text = "%src% ruptures and explodes!"
 	density = 1
 	health = 1
 	aggressive = 0
@@ -71,8 +72,7 @@
 	flying = 1
 
 	CritterDeath()
-		src.visible_message("<b>[src]</b> ruptures and explodes!")
-		src.alive = 0
+		..()
 		var/turf/T = get_turf(src.loc)
 		if(T)
 			T.hotspot_expose(700,125)
@@ -1053,6 +1053,9 @@
 	name = "???"
 	desc = "What the hell is that?"
 	icon_state = "ancientrobot"
+	dead_state = "ancientrobot" // fades away
+	death_text = "%src% fades away."
+	post_pet_text = " For some reason! Not like that's weird or anything!"
 	invisibility = 10
 	health = 30
 	firevuln = 0
@@ -1066,13 +1069,10 @@
 	var/boredom_countdown = 0
 
 	CritterDeath()
-		src.visible_message("<b>[src]</b> fades away.")
-		src.alive = 0
-		walk_to(src,0)
+		..()
 		flick("ancientrobot-disappear",src)
-		src.invisibility = 10
-		critters -= src
-		src.dispose()
+		SPAWN_DBG(16) //maybe let the animation actually play
+			qdel(src)
 
 	seek_target()
 		src.anchored = 0
@@ -1092,43 +1092,12 @@
 			break
 
 	attackby(obj/item/W as obj, mob/living/user as mob)
-
-		if (!src.alive)
-			..()
-			return
-
-		switch(W.hit_type)
-			if(DAMAGE_BURN)
-				src.health -= W.force * src.firevuln
-			if(DAMAGE_BLUNT)
-				src.health -= W.force * src.brutevuln
-
-		if (src.alive && src.health <= 0) src.CritterDeath()
-
+		..()
 		src.boredom_countdown = rand(5,10)
-		src.target = user
-		src.oldtarget_name = user.name
-		src.task = "chasing"
 
 	attack_hand(var/mob/user as mob)
-
-		if (!src.alive)
-			..()
-			return
-		if (user.a_intent == "harm")
-			src.health -= rand(1,2) * src.brutevuln
-			for(var/mob/O in viewers(src, null))
-				O.show_message("<span class='combat'><b>[user]</b> punches [src]!</span>", 1)
-			playsound(src.loc, "punch", 50, 1)
-			if (src.alive && src.health <= 0) src.CritterDeath()
-
-			src.boredom_countdown = rand(5,10)
-			src.target = user
-			src.oldtarget_name = user.name
-			src.task = "chasing"
-		else
-			src.visible_message("<span class='combat'><b>[user]</b> pets [src]!<br>For some reason! Not like that's weird or anything!</span>", 1)
-
+		..()
+		src.boredom_countdown = rand(5,10)
 
 	ChaseAttack(mob/M)
 		return
@@ -1218,9 +1187,8 @@
 		return ..()
 
 	CritterDeath()
+		..()
 		speak( pick("There...is...nothing...","It's dark.  Oh god, oh god, it's dark.","Thank you.","Oh wow. Oh wow. Oh wow.") )
-		src.icon_state = "crunched-dead"
-		src.alive = 0
 		SPAWN_DBG(1.5 SECONDS)
 			qdel(src)
 

--- a/code/obj/critter/pets_small_animals.dm
+++ b/code/obj/critter/pets_small_animals.dm
@@ -340,11 +340,8 @@ var/list/cat_names = list("Gary", "Mittens", "Mr. Jingles", "Rex", "Jasmine", "L
 		return
 
 	CritterDeath()
-		src.alive = 0
-		set_density(0)
+		..()
 		src.icon_state = "cat[cattype]-dead"
-		walk_to(src,0)
-		src.visible_message("<b>[src]</b> dies!")
 		if(prob(5))
 			SPAWN_DBG(3 SECONDS)
 				src.visible_message("<b>[src]</b> comes back to life, good thing he has 9 lives!")
@@ -474,6 +471,7 @@ var/list/cat_names = list("Gary", "Mittens", "Mr. Jingles", "Rex", "Jasmine", "L
 	firevuln = 1
 	brutevuln = 1
 	angertext = "growls at"
+	death_text = null // he's just asleep
 	atk_brute_amt = 2
 	crit_brute_amt = 4
 	chase_text = "jumps on"
@@ -548,10 +546,8 @@ var/list/cat_names = list("Gary", "Mittens", "Mr. Jingles", "Rex", "Jasmine", "L
 		return
 
 	CritterDeath()
-		src.alive = 0
-		set_density(0)
+		..()
 		src.icon_state = "[src.doggy]-lying"
-		walk_to(src,0)
 		for(var/mob/O in hearers(src, null))
 			O.show_message("<span class='combat'><b>[src]</b> [pick("tires","tuckers out","gets pooped")] and lies down!</span>")
 		SPAWN_DBG(1 MINUTE)

--- a/code/obj/critter/spider.dm
+++ b/code/obj/critter/spider.dm
@@ -110,6 +110,7 @@
 	CritterDeath()
 		if(!src.alive) return
 		..()
+		if (honk) return // clown spiders have special deaths
 		playsound(src.loc, src.deathsound, 50, 0)
 		src.reagents.add_reagent(venom1, 50, null)
 		src.reagents.add_reagent(venom2, 50, null)
@@ -514,7 +515,7 @@
 		else ..()
 
 	CritterDeath()
-		src.alive = 0
+		..()
 		playsound(src.loc, "sound/impact_sounds/Slimy_Splat_1.ogg", 75, 1)
 		var/obj/decal/cleanable/blood/gibs/gib = null
 		gib = make_cleanable(/obj/decal/cleanable/blood/gibs,src.loc)
@@ -564,7 +565,7 @@
 			break
 
 	CritterDeath()
-		src.alive = 0
+		..()
 		playsound(src.loc, "sound/impact_sounds/Slimy_Splat_1.ogg", 75, 1)
 		var/obj/decal/cleanable/blood/gibs/gib = null
 		gib = make_cleanable( /obj/decal/cleanable/blood/gibs,src.loc)

--- a/code/obj/critter/wendigo.dm
+++ b/code/obj/critter/wendigo.dm
@@ -46,15 +46,10 @@
 		..()
 
 	CritterDeath()
-		if (src.alive)
-			playsound(src.loc, "sound/voice/animal/wendigo_cry.ogg", 60, 1)
-			src.visible_message("<b>[src]</b> dies!")
-			src.alive = 0
-			walk_to(src,0)
-			src.update_dead_icon()
-			anchored = 0
-			set_density(0)
-			layer = initial(layer)
+		..()
+		layer = initial(layer)
+		if (king) return // king has his own death noises, spooky
+		playsound(src.loc, "sound/voice/animal/wendigo_cry.ogg", 60, 1)
 
 	seek_target()
 		src.anchored = 0
@@ -397,6 +392,7 @@
 /obj/critter/wendigo/king
 	name = "wendigo king"
 	desc = "You should run."
+	death_text = "%src% collapses in a heap!"
 	health = 500
 	icon_state = "wendigoking"
 	king = 1
@@ -408,13 +404,9 @@
 		quality = 200 // for the limbs
 
 	CritterDeath()
+		..()
 		playsound(src.loc, "sound/voice/animal/wendigo_roar.ogg", 75, 1)
 		playsound(src.loc, "sound/voice/animal/wendigo_cry.ogg", 75, 1)
-		src.visible_message("<b>[src]</b> collapses in a heap!")
-		src.alive = 0
-		walk_to(src,0)
-		icon_state = "wendigoking-dead"
-		set_density(0)
 
 ////////////////
 ////// e-egg?

--- a/code/obj/critter/zombie.dm
+++ b/code/obj/critter/zombie.dm
@@ -231,8 +231,9 @@
 		..()
 		if (istype(src, /obj/critter/zombie/h7)) return //special death
 		gibs(src.loc) //cmon let's let them really make a mess
-		qdel (src)
 		playsound(src.loc, "sound/impact_sounds/Slimy_Splat_1.ogg", 100, 1)
+		qdel (src)
+
 
 /obj/critter/zombie/scientist
 	name = "Shambling Scientist"

--- a/code/obj/critter/zombie.dm
+++ b/code/obj/critter/zombie.dm
@@ -228,14 +228,11 @@
 				src.attacking = 0
 
 	CritterDeath()
-		src.alive = 0
-		playsound(src.loc, "sound/impact_sounds/Slimy_Splat_1.ogg", 100, 1)
-		var/obj/decal/cleanable/blood/gibs/gib = null
-		gib = make_cleanable( /obj/decal/cleanable/blood/gibs,src.loc)
-		if (prob(30))
-			gib.icon_state = "gibup1"
-		gib.streak(list(NORTH, NORTHEAST, NORTHWEST))
+		..()
+		if (istype(src, /obj/critter/zombie/h7)) return //special death
+		gibs(src.loc) //cmon let's let them really make a mess
 		qdel (src)
+		playsound(src.loc, "sound/impact_sounds/Slimy_Splat_1.ogg", 100, 1)
 
 /obj/critter/zombie/scientist
 	name = "Shambling Scientist"
@@ -263,12 +260,6 @@
 			src.CritterAttack(M)
 		return
 
-	CritterDeath()
-		src.alive = 0
-		playsound(src.loc, "sound/impact_sounds/Slimy_Splat_1.ogg", 100, 1)
-		gibs(src.loc)
-		qdel (src)
-
 /obj/critter/zombie/h7
 	name = "Biosuit Shambler"
 	desc = "This does not reassure one about biosuit reliability."
@@ -285,7 +276,7 @@
 		return
 
 	CritterDeath()
-		src.alive = 0
+		..()
 		src.visible_message("<span class='alert'>Black mist flows from the broken suit!</span>")
 		playsound(src.loc, "sound/machines/hiss.ogg", 50, 1)
 
@@ -340,9 +331,6 @@
 		M.changeStatus("radiation", 80, 4)
 
 	CritterDeath()
+		..()
 		src.remove_simple_light("rad")
-		src.alive = 0
-		playsound(src.loc, "sound/impact_sounds/Slimy_Splat_1.ogg", 100, 1)
-		gibs(src.loc)
 		make_cleanable( /obj/decal/cleanable/greenglow,src.loc)
-		qdel (src)

--- a/code/z_adventurezones/lavamoon.dm
+++ b/code/z_adventurezones/lavamoon.dm
@@ -570,6 +570,7 @@ var/sound/iomoon_alarm_sound = null
 	firevuln = 0.1
 	brutevuln = 0.4
 	angertext = "grumbles at"
+	death_text = "%src% flops over dead!"
 	butcherable = 0
 
 	CritterAttack(mob/M)
@@ -587,12 +588,7 @@ var/sound/iomoon_alarm_sound = null
 		return CritterAttack(M)
 
 	CritterDeath()
-		src.alive = 0
-		set_density(0)
-		anchored = 0
-		src.icon_state = "lavacrab-dead"
-		walk_to(src,0)
-		src.visible_message("<b>[src]</b> flops over dead!")
+		..()
 
 	ai_think()
 		. = ..()
@@ -613,6 +609,7 @@ var/sound/iomoon_alarm_sound = null
 	firevuln = 0.1
 	brutevuln = 0.6
 	angertext = "beeps at"
+	death_text = "%src% blows apart!"
 	butcherable = 0
 	attack_range = 3
 	flying = 1
@@ -634,10 +631,7 @@ var/sound/iomoon_alarm_sound = null
 
 	CritterDeath()
 		if (!src.alive) return
-		src.alive = 0
-		walk_to(src,0)
-		src.visible_message("<b>[src]</b> blows apart!")
-
+		..()
 		SPAWN_DBG(0)
 			var/datum/effects/system/spark_spread/s = unpool(/datum/effects/system/spark_spread)
 			s.set_up(3, 1, src)

--- a/code/z_adventurezones/luna.dm
+++ b/code/z_adventurezones/luna.dm
@@ -1123,7 +1123,7 @@ var/list/lunar_fx_sounds = list('sound/ambience/loop/Wind_Low.ogg','sound/ambien
 	sleeping_icon_state = "drone_service_bot_off"
 	flying = 0
 	generic = 0
-	death_text = "%src% stops moving."
+	death_text = "%src% blows apart! But not in a way at all like surveillance equipment. More like a washing machine or something."
 
 	var/static/list/non_spy_weapons = list("something that isn't a high gain microphone", "an object distinct from a tape recorder", "object that is, in all likelihood, not a spy camera")
 
@@ -1142,7 +1142,6 @@ var/list/lunar_fx_sounds = list('sound/ambience/loop/Wind_Low.ogg','sound/ambien
 	CritterDeath()
 		if (!src.alive) return
 		..()
-		src.visible_message("<b>[src]</b> blows apart!  But not in a way at all like surveillance equipment.  More like a washing machine or something.") //this has two death messages? Uh sure...
 
 		SPAWN_DBG(0)
 			var/datum/effects/system/spark_spread/s = unpool(/datum/effects/system/spark_spread)

--- a/code/z_adventurezones/luna.dm
+++ b/code/z_adventurezones/luna.dm
@@ -1141,9 +1141,8 @@ var/list/lunar_fx_sounds = list('sound/ambience/loop/Wind_Low.ogg','sound/ambien
 
 	CritterDeath()
 		if (!src.alive) return
-		src.alive = 0
-		walk_to(src,0)
-		src.visible_message("<b>[src]</b> blows apart!  But not in a way at all like surveillance equipment.  More like a washing machine or something.")
+		..()
+		src.visible_message("<b>[src]</b> blows apart!  But not in a way at all like surveillance equipment.  More like a washing machine or something.") //this has two death messages? Uh sure...
 
 		SPAWN_DBG(0)
 			var/datum/effects/system/spark_spread/s = unpool(/datum/effects/system/spark_spread)

--- a/code/z_adventurezones/mad_mars.dm
+++ b/code/z_adventurezones/mad_mars.dm
@@ -305,6 +305,7 @@
 	name = "Inactive Robot"
 	desc = "It looks like it hasn't been in service for decades."
 	icon_state = "mars_bot"
+	death_text = "%src% collapses!"
 	density = 1
 	health = 55
 	aggressive = 1
@@ -386,12 +387,7 @@
 
 	CritterDeath()
 		if (!src.alive) return
-		src.icon_state += "-dead"
-		src.alive = 0
-		src.anchored = 0
-		src.set_density(0)
-		walk_to(src,0)
-		src.visible_message("<b>[src]</b> collapses!")
+		..()
 		playsound(src.loc, 'sound/voice/screams/robot_scream.ogg', 50, 1)
 		speak("aaaaaaalkaAAAA##AAAAAAAAAAAAAAAAA'ERRAAAAAAAA!!!")
 

--- a/code/z_adventurezones/meatland.dm
+++ b/code/z_adventurezones/meatland.dm
@@ -345,12 +345,8 @@ var/global/list/default_meat_head_dialog = list("hello hello", "... it's not vir
 
 	CritterDeath()
 		if (!src.alive) return
-		src.icon_state = "meatboss_dead"
-		src.alive = 0
-		src.anchored = 1
-		walk_to(src,0)
-		src.visible_message("<b>[src]</b> dies!")
-
+		..()
+		src.icon_state = "meatboss_dead" // why can't you just use a - like everyone else
 
 	ai_think()
 		if(task == "chasing")
@@ -491,6 +487,7 @@ var/global/list/default_meat_head_dialog = list("hello hello", "... it's not vir
 
 /obj/critter/blobman/meaty_martha
 	generic = 0
+	death_text = "%src% collapses into viscera..."
 
 	New()
 		..()
@@ -534,7 +531,7 @@ var/global/list/default_meat_head_dialog = list("hello hello", "... it's not vir
 
 	CritterDeath()
 		if (!src.alive) return
-		src.visible_message("<b>[src]</b> collapses into viscera...")
+		..()
 		if (src.loc)
 			gibs(src.loc)
 		qdel(src)

--- a/code/z_adventurezones/precursor.dm
+++ b/code/z_adventurezones/precursor.dm
@@ -1011,6 +1011,7 @@
 	name = "darkness"
 	desc = "Oh god."
 	icon_state = "shade"
+	dead_state = "shade" //doesn't have a dead icon, just fades away
 	death_text = null //has special spooky voice lines
 	health = 10
 	brutevuln = 0.5
@@ -1068,7 +1069,6 @@
 
 	CritterDeath()
 		..()
-		src.icon_state = replacetext(src.icon_state, "-dead", "") //fades away doesn't have a dead icon
 		speak( pick("��r...�a ina ��r-kug z�h-bi!", "�d, �d, �u...bar...", "n�-nam-nu-kal...", "lugal-me taru, lugal-me galam!", "me-li-e-a...") )
 		// sing the sacred song to the bitter end // go out, exit, release // nothing is precious // our king will return, our king will ascend // woe is me
 		SPAWN_DBG(1.5 SECONDS)
@@ -1122,6 +1122,7 @@
 	desc = "Something is terribly wrong with them."
 	icon = 'icons/mob/human.dmi'
 	icon_state = "body_m"
+	dead_state = "body_m" //doesn't have a dead icon
 	alpha = 192
 	color = "#676767"
 	health = 100

--- a/code/z_adventurezones/precursor.dm
+++ b/code/z_adventurezones/precursor.dm
@@ -1011,6 +1011,7 @@
 	name = "darkness"
 	desc = "Oh god."
 	icon_state = "shade"
+	death_text = null //has special spooky voice lines
 	health = 10
 	brutevuln = 0.5
 	firevuln = 0
@@ -1066,9 +1067,10 @@
 		return ..()
 
 	CritterDeath()
+		..()
+		src.icon_state = replacetext(src.icon_state, "-dead", "") //fades away doesn't have a dead icon
 		speak( pick("��r...�a ina ��r-kug z�h-bi!", "�d, �d, �u...bar...", "n�-nam-nu-kal...", "lugal-me taru, lugal-me galam!", "me-li-e-a...") )
 		// sing the sacred song to the bitter end // go out, exit, release // nothing is precious // our king will return, our king will ascend // woe is me
-		src.alive = 0
 		SPAWN_DBG(1.5 SECONDS)
 			qdel(src)
 
@@ -1149,11 +1151,7 @@
 	CritterDeath()
 		if (!alive)
 			return
-		src.alive = 0
-		src.anchored = 0
-		src.set_density(0)
-		walk_to(src,0)
-		report_death()
+		..()
 		particleMaster.SpawnSystem(new /datum/particleSystem/localSmoke("#000000", 5, get_turf(src)))
 		qdel(src)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][REWORK][CLEANLINESS][BUG][STYLE][SECRET] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Refactors many `obj/critter` `critterDeath()` to all call their parent
- Requires `obj/critter` `critterDeath()` to call their parents - ungrateful kids...
- Scraps a bunch of pointless code that's already handled by parents
- Fixes a number of bugs with critter deaths
- Ancient thing has a few additional fixes because it was so scuffed you couldn't even attack it properly (either not at all or unlimited rapid fire)
- Adds new COMSIG_OBJ_CRITTER_DEATH signal

There's still a lot of other critter code that could be refactored but let's just take this one step at a time

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
- Fixes a number of bugs
- Allows for new more advanced critter death fired triggers that I wish to make use of
- Critter code was (still is...) all over the place