### PR TITLE
mapvote for the next round will occur in the pre-game lobby

### DIFF
--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -82,6 +82,8 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 	pregame_timeleft = 0
 	#endif
 
+	handle_mapvote()
+
 	while(current_state <= GAME_STATE_PREGAME)
 		sleep(1 SECOND)
 		if (!game_start_delayed)
@@ -248,17 +250,6 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 		//Tell the participation recorder that we're done FAFFING ABOUT
 		participationRecorder.releaseHold()
 
-	var/bustedMapSwitcher = isMapSwitcherBusted()
-	if (!bustedMapSwitcher)
-		SPAWN_DBG (mapSwitcher.autoVoteDelay)
-			//Trigger the automatic map vote
-			try
-				mapSwitcher.startMapVote(duration = mapSwitcher.autoVoteDuration)
-			catch (var/exception/e)
-				logTheThing("admin", usr ? usr : src, null, "the automated map switch vote couldn't run because: [e.name]")
-				logTheThing("diary", usr ? usr : src, null, "the automated map switch vote couldn't run because: [e.name]", "admin")
-				message_admins("[key_name(usr ? usr : src)] the automated map switch vote couldn't run because: [e.name]")
-
 	SPAWN_DBG (6000) // 10 minutes in
 		for(var/obj/machinery/power/generatorTemp/E in machine_registry[MACHINES_POWER])
 			LAGCHECK(LAG_LOW)
@@ -271,6 +262,19 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 	if (total_clients() >= OVERLOAD_PLAYERCOUNT)
 		world.tick_lag = OVERLOADED_WORLD_TICKLAG
 
+//Okay this is kinda stupid, but mapSwitcher.autoVoteDelay which is now set to 30 seconds, (used to be 5 min). 
+//The voting will happen 30 seconds into the pre-game lobby. This is probably fine to leave. But if someone changes that var then it might start before the lobby timer ends.
+/datum/controller/gameticker/proc/handle_mapvote()
+	var/bustedMapSwitcher = isMapSwitcherBusted()
+	if (!bustedMapSwitcher)
+		SPAWN_DBG (mapSwitcher.autoVoteDelay)
+			//Trigger the automatic map vote
+			try
+				mapSwitcher.startMapVote(duration = mapSwitcher.autoVoteDuration)
+			catch (var/exception/e)
+				logTheThing("admin", usr ? usr : src, null, "the automated map switch vote couldn't run because: [e.name]")
+				logTheThing("diary", usr ? usr : src, null, "the automated map switch vote couldn't run because: [e.name]", "admin")
+				message_admins("[key_name(usr ? usr : src)] the automated map switch vote couldn't run because: [e.name]")
 
 /datum/controller/gameticker
 	proc/distribute_jobs()

--- a/code/mapSwitching.dm
+++ b/code/mapSwitching.dm
@@ -25,7 +25,7 @@ var/global/datum/mapSwitchHandler/mapSwitcher
 	var/playersVoting = 0 //are players currently voting on the map?
 	var/voteStartedAt = 0 //timestamp when the map vote was started
 	var/autoVoteDelay = 30 SECONDS //how long should we wait after round start to trigger to automatic map vote?
-	var/autoVoteDuration = 1200 //how long (in byond deciseconds) the automatic map vote should last (1200 = 2 mins)
+	var/autoVoteDuration = 7 MINUTES //how long (in byond deciseconds) the automatic map vote should last (1200 = 2 mins)
 	var/voteCurrentDuration = 0 //how long is the current vote set to last?
 	var/queuedVoteCompile = 0 //is a player map vote scheduled for after the current compilation?
 	var/voteChosenMap = "" //the map that the players voted to switch to

--- a/code/mapSwitching.dm
+++ b/code/mapSwitching.dm
@@ -24,7 +24,7 @@ var/global/datum/mapSwitchHandler/mapSwitcher
 	var/votingAllowed = 1 //is map voting allowed?
 	var/playersVoting = 0 //are players currently voting on the map?
 	var/voteStartedAt = 0 //timestamp when the map vote was started
-	var/autoVoteDelay = 3000 //how long should we wait after round start to trigger to automatic map vote? (3000 = 5 mins)
+	var/autoVoteDelay = 30 SECONDS //how long should we wait after round start to trigger to automatic map vote?
 	var/autoVoteDuration = 1200 //how long (in byond deciseconds) the automatic map vote should last (1200 = 2 mins)
 	var/voteCurrentDuration = 0 //how long is the current vote set to last?
 	var/queuedVoteCompile = 0 //is a player map vote scheduled for after the current compilation?


### PR DESCRIPTION
##  About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This moves the mapvote to happen ~30 seconds into the pre-game lobby and lasts 7 minutes. Instead of 5 minutes into the round and lasting 2 minutes.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Possibly might increase voter turnout. This idea has been floated before so we're trying it out.

The one issue with this I can find is that it could possibly confuse players into thinking that they are voting for the map of the *current* round instead of the next one. Honestly making that change I think would be the most preferable, but that's likely more of an undertaking than this.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)kyle:
(+)Mapvoting for the succeeding round will now begin ~30 seconds into the pre-game lobby.
```
