### PR TITLE
Weighted abstain for newvote (inc. ass jam modevote)

### DIFF
--- a/code/WorkInProgress/NewVote.dm
+++ b/code/WorkInProgress/NewVote.dm
@@ -175,6 +175,7 @@ var/global/obj/newVoteLink/newVoteLinkStat = new /obj/newVoteLink
 	var/vote_name = ""
 	var/vote_length = 1200 //2 Minutes
 	var/vote_started = 0
+	var/vote_abstain_weight = 0.2 //how much each non-participant counts for in votes that have a "No" result
 	var/data = null
 	var/vote_flags = 0
 	var/curr_win = ""
@@ -224,7 +225,7 @@ var/global/obj/newVoteLink/newVoteLinkStat = new /obj/newVoteLink
 					adjAbstain = options[A]
 					for(var/client/C in clients)
 						if(!((C.ckey in voted_ckey) || (C.computer_id in voted_id)))
-							adjAbstain = adjAbstain + 0.25
+							adjAbstain = adjAbstain + vote_abstain_weight
 					if(adjAbstain > winner_num)
 						winner_num = adjAbstain
 						winner = A
@@ -245,7 +246,7 @@ var/global/obj/newVoteLink/newVoteLinkStat = new /obj/newVoteLink
 					adjAbstain = options[A]
 					for(var/client/C in clients)
 						if(!((C.ckey in voted_ckey) || (C.computer_id in voted_id)))
-							adjAbstain = adjAbstain + 0.25
+							adjAbstain = adjAbstain + vote_abstain_weight
 					if(adjAbstain > winner_num)
 						winner_num = adjAbstain
 				else
@@ -290,6 +291,7 @@ var/global/obj/newVoteLink/newVoteLinkStat = new /obj/newVoteLink
 	details = "Restart the server?"
 	vote_name = "Vote restart"
 	vote_length = 1200 //2 Minutes
+	vote_abstain_weight = 0.5
 
 	end_vote()
 		. = ..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEAT][ASS-JAM]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Introduces a weighted abstain system to NewVote.dm, making people who didn't participate have a fractional "no" vote in any votes that contain a "no" outcome (defaulting to 0.2 votes). Also makes the report on the vote's current winner give the proper answer.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Makes mode vote more likely to go through while not being completely unhindered, and makes NewVote.dm more functional in general.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Kubius:
(+)Assjam mode vote has received weighted abstain - it's now much easier for the vote to succeed if people aren't actively objecting.
```
