### PR TITLE
Fix: Latejoining during Revs: command jobs could appear open. (2)

### DIFF
--- a/code/mob/new_player.dm
+++ b/code/mob/new_player.dm
@@ -404,15 +404,14 @@ mob/new_player
 				// 0 slots, nobody in it, don't show it
 				return
 
-			// probalby could be a define but dont give a shite
-			var/maxslots = 5
-			var/list/slots = list()
-			var/shown = min(max(c, (limit == -1 ? 99 : limit)), maxslots)
-
 			//If it's Revolution time, lets show all command jobs as filled to (try to) prevent metagaming.
 			if(istype(J, /datum/job/command/) && istype(ticker.mode, /datum/game_mode/revolution))
 				c = limit
 
+			// probalby could be a define but dont give a shite
+			var/maxslots = 5
+			var/list/slots = list()
+			var/shown = min(max(c, (limit == -1 ? 99 : limit)), maxslots)
 			// if there's still an open space, show a final join link
 			if (limit == -1 || (limit > maxslots && c < limit))
 				slots += "<a href='byond://?src=\ref[src];SelectedJob=\ref[J]' class='latejoin-card' style='border-color: [J.linkcolor];' title='Join the round as [J.name].'>&#x2713;&#xFE0E;</a>"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MINOR]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The code to calculate how many "open boxes" to render was running before the code that faked the (command) player-count.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->\
Fixes my earlier PR, #971. 