### PR TITLE
Change deepfrier to transfer reagents to fryshell

### DIFF
--- a/code/obj/machinery/deep_fryer.dm
+++ b/code/obj/machinery/deep_fryer.dm
@@ -234,10 +234,8 @@
 			fryholder.amount = 5
 		else
 			fryholder.amount = src.fryitem.w_class
-		fryholder.reagents = src.fryitem.reagents
-		if(src.cooktime >= 60)
-			fryholder.reagents.maximum_volume += 25
-			fryholder.reagents.add_reagent("friedessence",25)
+		fryholder.reagents.maximum_volume += src.fryitem.reagents.total_volume
+		src.fryitem.reagents.trans_to(fryholder, src.fryitem.reagents.total_volume)
 		fryholder.reagents.my_atom = fryholder
 
 		src.fryitem.set_loc(fryholder)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Change deepfrier to transfer reagents to fryshell instead of having the fryshell share a `reagents` datum when removed from the deepfrier. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Caused a issues if you ate a fried monkey (eat the fryshell qdels it but not the fryitem - qdeling the fryshell would dispose the reagents - monkey would still have a reference to the disposed reagent datum - causes issues)

