### PR TITLE
Fake wrestling belt

### DIFF
--- a/code/datums/abilities/ability_parent.dm
+++ b/code/datums/abilities/ability_parent.dm
@@ -223,6 +223,8 @@
 		return A
 
 	proc/removeAbility(var/abilityType)
+		if (istext(abilityType))
+			abilityType = text2path(abilityType)
 		if (!ispath(abilityType))
 			return
 		for (var/datum/targetable/A in src.abilities)

--- a/code/datums/abilities/wrestler.dm
+++ b/code/datums/abilities/wrestler.dm
@@ -2,22 +2,24 @@
 // the opportunity to do some clean-up as well (Convair880).
 
 //////////////////////////////////////////// Setup //////////////////////////////////////////////////
-
-/mob/proc/make_wrestler(var/make_inherent = 0, var/belt_check = 0, var/remove_powers = 0)
+//fake_wrestler - For the fake wrestling belt, make it so all abilities do no damage or stuns.
+/mob/proc/make_wrestler(var/make_inherent = 0, var/belt_check = 0, var/remove_powers = 0, var/fake_wrestler = 0)
 	if (ishuman(src) || ismobcritter(src))
 		if (ismobcritter(src))
 			var/mob/living/critter/C = src
 
 			if (remove_powers == 1)
-				var/datum/abilityHolder/wrestler/A = C.get_ability_holder(/datum/abilityHolder/wrestler)
-				if (A && istype(A))
+				if (istype(C.get_ability_holder(/datum/abilityHolder/wrestler), /datum/abilityHolder/wrestler))
 					C.remove_ability_holder(/datum/abilityHolder/wrestler)
+				else if (fake_wrestler && istype(C.get_ability_holder(/datum/abilityHolder/wrestler/fake), /datum/abilityHolder/wrestler/fake))
+					C.remove_ability_holder(/datum/abilityHolder/wrestler)
+
 				else
-					C.abilityHolder.removeAbility(/datum/targetable/wrestler/kick)
-					C.abilityHolder.removeAbility(/datum/targetable/wrestler/strike)
-					C.abilityHolder.removeAbility(/datum/targetable/wrestler/drop)
-					C.abilityHolder.removeAbility(/datum/targetable/wrestler/throw)
-					C.abilityHolder.removeAbility(/datum/targetable/wrestler/slam)
+					C.abilityHolder.removeAbility("/datum/targetable/wrestler/kick[fake_wrestler ? "/fake" : ""]")
+					C.abilityHolder.removeAbility("/datum/targetable/wrestler/strike[fake_wrestler ? "/fake" : ""]")
+					C.abilityHolder.removeAbility("/datum/targetable/wrestler/drop[fake_wrestler ? "/fake" : ""]")
+					C.abilityHolder.removeAbility("/datum/targetable/wrestler/throw[fake_wrestler ? "/fake" : ""]")
+					C.abilityHolder.removeAbility("/datum/targetable/wrestler/slam[fake_wrestler ? "/fake" : ""]")
 
 				return
 
@@ -26,32 +28,39 @@
 					return
 
 				if (isnull(C.abilityHolder)) // But they do have a critter AH by default...or should.
-					var/datum/abilityHolder/wrestler/A2 = C.add_ability_holder(/datum/abilityHolder/wrestler)
+					var/datum/abilityHolder/wrestler/A2 
+					if (fake_wrestler)
+						A2 = C.add_ability_holder(/datum/abilityHolder/wrestler/fake)
+					else
+						A2 = C.add_ability_holder(/datum/abilityHolder/wrestler)
 					if (!A2 || !istype(A2, /datum/abilityHolder/))
 						return
-
-				C.abilityHolder.addAbility(/datum/targetable/wrestler/kick)
-				C.abilityHolder.addAbility(/datum/targetable/wrestler/strike)
-				C.abilityHolder.addAbility(/datum/targetable/wrestler/drop)
-				C.abilityHolder.addAbility(/datum/targetable/wrestler/throw)
-				C.abilityHolder.addAbility(/datum/targetable/wrestler/slam)
+				C.abilityHolder.addAbility("/datum/targetable/wrestler/kick[fake_wrestler ? "/fake" : ""]")
+				C.abilityHolder.addAbility("/datum/targetable/wrestler/strike[fake_wrestler ? "/fake" : ""]")
+				C.abilityHolder.addAbility("/datum/targetable/wrestler/drop[fake_wrestler ? "/fake" : ""]")
+				C.abilityHolder.addAbility("/datum/targetable/wrestler/throw[fake_wrestler ? "/fake" : ""]")
+				C.abilityHolder.addAbility("/datum/targetable/wrestler/slam[fake_wrestler ? "/fake" : ""]")
 
 		if (ishuman(src))
 			var/mob/living/carbon/human/H = src
 
 			if (remove_powers == 1)
 				var/datum/abilityHolder/wrestler/A3 = H.get_ability_holder(/datum/abilityHolder/wrestler)
-				if (A3 && istype(A3))
+				if (istype(A3))
 					if (belt_check == 1 && A3.is_inherent == 1) // Wrestler/omnitraitor vs wrestling belt.
 						return
 					H.remove_ability_holder(/datum/abilityHolder/wrestler)
+				else if (fake_wrestler && istype(H.get_ability_holder(/datum/abilityHolder/wrestler/fake), /datum/abilityHolder/wrestler/fake))
+					H.remove_ability_holder(/datum/abilityHolder/wrestler)
+
 				else
 					if (!isnull(H.abilityHolder))
-						H.abilityHolder.removeAbility(/datum/targetable/wrestler/kick)
-						H.abilityHolder.removeAbility(/datum/targetable/wrestler/strike)
-						H.abilityHolder.removeAbility(/datum/targetable/wrestler/drop)
-						H.abilityHolder.removeAbility(/datum/targetable/wrestler/throw)
-						H.abilityHolder.removeAbility(/datum/targetable/wrestler/slam)
+						H.abilityHolder.removeAbility("/datum/targetable/wrestler/kick[fake_wrestler ? "/fake" : ""]")
+						H.abilityHolder.removeAbility("/datum/targetable/wrestler/strike[fake_wrestler ? "/fake" : ""]")
+						H.abilityHolder.removeAbility("/datum/targetable/wrestler/drop[fake_wrestler ? "/fake" : ""]")
+						H.abilityHolder.removeAbility("/datum/targetable/wrestler/throw[fake_wrestler ? "/fake" : ""]")
+						H.abilityHolder.removeAbility("/datum/targetable/wrestler/slam[fake_wrestler ? "/fake" : ""]")
+
 
 				return
 
@@ -60,15 +69,23 @@
 					return
 
 				var/datum/abilityHolder/wrestler/A4 = H.get_ability_holder(/datum/abilityHolder/wrestler)
-				if (A4 && istype(A4))
+				if (istype(A4))
+					return
+				var/datum/abilityHolder/wrestler/fake/F = H.get_ability_holder(/datum/abilityHolder/wrestler/fake)
+				if (fake_wrestler && istype(F))
 					return
 
-				var/datum/abilityHolder/wrestler/A5 = H.add_ability_holder(/datum/abilityHolder/wrestler)
-				A5.addAbility(/datum/targetable/wrestler/kick)
-				A5.addAbility(/datum/targetable/wrestler/strike)
-				A5.addAbility(/datum/targetable/wrestler/drop)
-				A5.addAbility(/datum/targetable/wrestler/throw)
-				A5.addAbility(/datum/targetable/wrestler/slam)
+				var/datum/abilityHolder/wrestler/A5
+				if (fake_wrestler)
+					A5 = H.add_ability_holder(/datum/abilityHolder/wrestler/fake)
+				else
+					A5 = H.add_ability_holder(/datum/abilityHolder/wrestler)
+
+				A5.addAbility("/datum/targetable/wrestler/kick[fake_wrestler ? "/fake" : ""]")
+				A5.addAbility("/datum/targetable/wrestler/strike[fake_wrestler ? "/fake" : ""]")
+				A5.addAbility("/datum/targetable/wrestler/drop[fake_wrestler ? "/fake" : ""]")
+				A5.addAbility("/datum/targetable/wrestler/throw[fake_wrestler ? "/fake" : ""]")
+				A5.addAbility("/datum/targetable/wrestler/slam[fake_wrestler ? "/fake" : ""]")
 
 				if (make_inherent == 1)
 					A5.is_inherent = 1
@@ -115,7 +132,10 @@
 	tabName = "Wrestler"
 	notEnoughPointsMessage = "<span class='alert'>You aren't strong enough to use this ability.</span>"
 	var/is_inherent = 0 // Are we a wrestler as opposed to somebody with a wrestling belt?
+	var/fake = 0
 
+/datum/abilityHolder/wrestler/fake
+	fake = 1
 /////////////////////////////////////////////// Wrestler spell parent ////////////////////////////
 
 /datum/targetable/wrestler
@@ -128,6 +148,7 @@
 	preferred_holder_type = /datum/abilityHolder/wrestler
 	var/when_stunned = 0 // 0: Never | 1: Ignore mob.stunned and mob.weakened | 2: Ignore all incapacitation vars
 	var/not_when_handcuffed = 0
+	var/fake = 0
 
 	New()
 		var/obj/screen/ability/topBar/wrestler/B = new /obj/screen/ability/topBar/wrestler(null)

--- a/code/datums/abilities/wrestler/drop.dm
+++ b/code/datums/abilities/wrestler/drop.dm
@@ -75,7 +75,7 @@
 
 			if ((falling == 0 && get_dist(M, target) > src.max_range) || (falling == 1 && get_dist(M, target) > (src.max_range + 1))) // We climbed onto stuff.
 				M.pixel_y = 0
-				if (falling == 1)
+				if (falling == 1 && !fake)
 					M.visible_message("<span class='alert'><B>...and dives head-first into the ground, ouch!</b></span>")
 					M.TakeDamageAccountArmor("head", 15, 0, 0, DAMAGE_BLUNT)
 					M.changeStatus("weakened", 3 SECONDS)
@@ -101,20 +101,21 @@
 			playsound(M.loc, "swing_hit", 50, 1)
 			M.emote("scream")
 
-			if (falling == 1)
-				if (prob(33) || isdead(target))
-					target.ex_act(3)
+			if (!fake)
+				if (falling == 1)
+					if (prob(33) || isdead(target))
+						target.ex_act(3)
+					else
+						random_brute_damage(target, 25, 1)
 				else
-					random_brute_damage(target, 25, 1)
-			else
-				random_brute_damage(target, 15, 1)
+					random_brute_damage(target, 15, 1)
 
 			target.changeStatus("weakened", 1 SECOND)
 			target.changeStatus("stunned", 2 SECONDS)
 			target.force_laydown_standup()
 
 			M.pixel_y = 0
-			logTheThing("combat", M, target, "uses the drop wrestling move on %target% at [log_loc(M)].")
+			logTheThing("combat", M, target, "uses the [fake ? "fake " : ""]drop wrestling move on %target% at [log_loc(M)].")
 
 		else
 			if (M)
@@ -123,5 +124,5 @@
 		return 0
 
 
-
-
+/datum/targetable/wrestler/drop/fake
+	fake = 1

--- a/code/datums/abilities/wrestler/kick.dm
+++ b/code/datums/abilities/wrestler/kick.dm
@@ -48,16 +48,20 @@
 			shake_camera(C, 8, 3)
 
 		M.visible_message("<span class='alert'><B>[M.name] [pick_string("wrestling_belt.txt", "kick")]-kicks [target]!</B></span>")
-		random_brute_damage(target, 15, 1)
+		if (!fake)
+			random_brute_damage(target, 15, 1)
 		playsound(M.loc, "swing_hit", 60, 1)
 
 		var/turf/T = get_edge_target_turf(M, get_dir(M, get_step_away(target, M)))
-		if (T && isturf(T))
+		if (!fake && T && isturf(T))
 			SPAWN_DBG(0)
 				target.throw_at(T, 3, 2)
 				target.changeStatus("weakened", 2 SECONDS)
 				target.changeStatus("stunned", 2 SECONDS)
 				target.force_laydown_standup()
 
-		logTheThing("combat", M, target, "uses the kick wrestling move on %target% at [log_loc(M)].")
+		logTheThing("combat", M, target, "uses the [fake ? "fake " : ""]kick wrestling move on %target% at [log_loc(M)].")
 		return 0
+
+/datum/targetable/wrestler/kick/fake
+	fake = 1

--- a/code/datums/abilities/wrestler/slam.dm
+++ b/code/datums/abilities/wrestler/slam.dm
@@ -150,24 +150,25 @@
 			playsound(M.loc, "sound/impact_sounds/Flesh_Break_1.ogg", 75, 1)
 			M.visible_message("<span class='alert'><B>[M] [fluff] [HH]!</B></span>")
 
-			if (!isdead(HH))
-				HH.emote("scream")
-				HH.changeStatus("weakened", 2 SECONDS)
-				HH.changeStatus("stunned", 2 SECONDS)
-				HH.force_laydown_standup()
+			if (!fake)
+				if (!isdead(HH))
+					HH.emote("scream")
+					HH.changeStatus("weakened", 2 SECONDS)
+					HH.changeStatus("stunned", 2 SECONDS)
+					HH.force_laydown_standup()
 
-				switch (G.state)
-					if (2)
-						random_brute_damage(HH, 25, 1)
-					if (3)
-						HH.ex_act(3)
-					else
-						random_brute_damage(HH, 15, 1)
-			else
-				HH.ex_act(3)
+					switch (G.state)
+						if (2)
+							random_brute_damage(HH, 25, 1)
+						if (3)
+							HH.ex_act(3)
+						else
+							random_brute_damage(HH, 15, 1)
+				else
+					HH.ex_act(3)
 
 			qdel(G)
-			logTheThing("combat", M, HH, "uses the slam wrestling move on %target% at [log_loc(M)].")
+			logTheThing("combat", M, HH, "uses the [fake ? "fake " : ""]slam wrestling move on %target% at [log_loc(M)].")
 
 		else
 			if (M)
@@ -181,3 +182,6 @@
 			qdel(G)
 
 		return 0
+
+/datum/targetable/wrestler/slam/fake
+	fake = 1

--- a/code/datums/abilities/wrestler/strike.dm
+++ b/code/datums/abilities/wrestler/strike.dm
@@ -53,16 +53,20 @@
 						M.set_loc(T)
 
 			M.visible_message("<span class='alert'><b>[M] [pick_string("wrestling_belt.txt", "strike")] [target]!</b></span>")
-			random_brute_damage(target, 15, 1)
 			playsound(M.loc, "sound/impact_sounds/Flesh_Break_1.ogg", 75, 1)
 
-			target.changeStatus("paralysis", 2 SECONDS)
-			target.force_laydown_standup()
-			target.change_misstep_chance(25)
+			if (!fake)
+				random_brute_damage(target, 15, 1)
+				target.changeStatus("paralysis", 2 SECONDS)
+				target.force_laydown_standup()
+				target.change_misstep_chance(25)
 
-			logTheThing("combat", M, target, "uses the strike wrestling move on %target% at [log_loc(M)].")
+			logTheThing("combat", M, target, "uses the [fake ? "fake " : ""]strike wrestling move on %target% at [log_loc(M)].")
 
 		else
 			boutput(M, __red("You can't wrestle the target here!"))
 
 		return 0
+
+/datum/targetable/wrestler/strike/fake
+	fake = 1

--- a/code/datums/abilities/wrestler/throw.dm
+++ b/code/datums/abilities/wrestler/throw.dm
@@ -121,14 +121,21 @@
 				SPAWN_DBG(0)
 					if (!isdead(HH))
 						HH.emote("scream")
-					HH.throw_at(T, 10, 4)
-					HH.changeStatus("weakened", 2 SECONDS)
-					HH.force_laydown_standup()
-					HH.change_misstep_chance(33)
+					if (!fake)
+						HH.throw_at(T, 10, 4)
+						HH.changeStatus("weakened", 2 SECONDS)
+						HH.force_laydown_standup()
+						HH.change_misstep_chance(33)
+					else
+						HH.throw_at(T, 3, 1)
 
-			logTheThing("combat", M, HH, "uses the throw wrestling move on %target% at [log_loc(M)].")
+
+			logTheThing("combat", M, HH, "uses the [fake ? "fake " : ""]throw wrestling move on %target% at [log_loc(M)].")
 
 		if (G && istype(G)) // Target was gibbed before we could throw them, who knows.
 			qdel(G)
 
 		return 0
+
+/datum/targetable/wrestler/throw/fake
+	fake = 1

--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -411,14 +411,22 @@
 	contraband = 8
 	is_syndicate = 1
 	mats = 18 //SPACE IS THE PLACE FOR WRESTLESTATION 13
+	var/fake = 0		//So the moves are all fake.
 
 	equipped(var/mob/user)
 		..()
-		user.make_wrestler(0, 1, 0)
+		user.make_wrestler(0, 1, 0, fake)
 
 	unequipped(var/mob/user)
 		..()
-		user.make_wrestler(0, 1, 1)
+		user.make_wrestler(0, 1, 1, fake)
+
+/obj/item/storage/belt/wrestling/fake
+	name = "fake wrestling belt"
+	desc = "A haunted antique wrestling belt, imbued with the spirits of wrestlers past."
+	contraband = 0
+	is_syndicate = 0
+	fake = 1
 
 // I dunno where else to put these vOv
 /obj/item/inner_tube

--- a/code/obj/storage/closets.dm
+++ b/code/obj/storage/closets.dm
@@ -205,6 +205,15 @@
 	spawn_contents = list(/obj/item/clothing/head/helmet/welding = 3,
 	/obj/item/weldingtool = 3)
 
+/obj/storage/closet/wrestling
+	name = "wrestling supplies closet"
+	desc = "A handy closet full of everything an aspiring fake showboater wrestler needs to launch his career."
+	spawn_contents = list(/obj/item/storage/belt/wrestling/fake = 3,
+	/obj/item/clothing/under/shorts/random = 3,
+	/obj/item/clothing/mask/wrestling/black = 1,
+	/obj/item/clothing/mask/wrestling/blue = 1,
+	/obj/item/clothing/mask/wrestling/green = 1)
+
 /obj/storage/closet/office
 	name = "office supply closet"
 	desc = "Various supplies for the modern office."


### PR DESCRIPTION

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a fake wrestling belt object that allows you to do wrestling moves that don't actually harm people. Well, one move still can, the throw move, but since you already need them in an aggressive grab to throw them normally, there is no competitive advantage to clicking the wrestler throw ability instead of the regular throw button.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
wrestlemap wouldn't really be wrestlemap if people could only box and not wrestle.


## Changelog
```
(u)kyle:
(*)Added fake wrestling belts so you can wrestle to your heart's content without actually hurting your opponent! Just like "real" wrestling!
```
