### PR TITLE
Throw_at parent calls now pass all args

### DIFF
--- a/code/modules/food_and_drink/plants.dm
+++ b/code/modules/food_and_drink/plants.dm
@@ -518,7 +518,7 @@
 			src.icon_state = "[base_icon_state]-spin-right"
 		else
 			src.icon_state = "[base_icon_state]-spin-left"
-		..(target, range, speed)
+		..()
 
 	attack_hand(mob/user as mob)
 		..()

--- a/code/obj/item/basketball.dm
+++ b/code/obj/item/basketball.dm
@@ -54,7 +54,7 @@
 
 /obj/item/basketball/throw_at(atom/target, range, speed, list/params, turf/thrown_from, throw_type = 1, allow_anchored = 0)
 	src.icon_state = "bball_spin"
-	..(target, range, speed)
+	..()
 
 /obj/item/basketball/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/plutonium_core))
@@ -290,7 +290,7 @@
 
 /obj/item/bloodbowlball/throw_at(atom/target, range, speed, list/params, turf/thrown_from, throw_type = 1, allow_anchored = 0)
 	src.icon_state = "bloodbowlball_air"
-	..(target, range, speed)
+	..()
 
 /obj/item/bloodbowlball/attack(target as mob, mob/user as mob)
 	playsound(target, "sound/impact_sounds/Flesh_Stab_1.ogg", 60, 1)

--- a/code/obj/item/bowling.dm
+++ b/code/obj/item/bowling.dm
@@ -41,7 +41,7 @@
 	throw_at(atom/target, range, speed, list/params, turf/thrown_from, throw_type = 1, allow_anchored = 0)
 		throw_unlimited = 1
 		src.icon_state = "bowling_ball_spin"
-		..(target, range, speed)
+		..()
 
 	attack_hand(mob/user as mob)
 		..()

--- a/code/obj/item/deployable_turret.dm
+++ b/code/obj/item/deployable_turret.dm
@@ -52,7 +52,7 @@
 	*/
 
 	throw_at(atom/target, range, speed, list/params, turf/thrown_from, throw_type = 1, allow_anchored = 0)
-		..(target,range,speed)
+		..()
 		if(src.quick_deploy_fuel > 0)
 			var/turf/thrown_to = get_turf(src)
 			var/spawn_direction = get_dir(thrown_to,thrown_from)

--- a/code/obj/item/football.dm
+++ b/code/obj/item/football.dm
@@ -253,7 +253,7 @@
 
 /obj/item/football/throw_at(atom/target, range, speed, list/params, turf/thrown_from, throw_type = 1, allow_anchored = 0)
 	src.icon_state = "football_air"
-	..(target, range, speed)
+	..()
 
 /obj/item/football/throw_impact(atom/hit_atom)
 	..(hit_atom)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][CLEANLINESS] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Per discussion with @UrsulaMejor resolves #1086 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
These throw_at procs accepted args that were neither used within themselves nor passed to the parent. changed the parent calls to `..()` so that parent will receive all of the args. Functionally this should make no difference. It would have only mattered if someone had overridden one of these  while also attempting to pass down one of the parameters that these in turn were not passing to the parent.