### PR TITLE
Change cloner records to use files

### DIFF
--- a/code/datums/computerfiles.dm
+++ b/code/datums/computerfiles.dm
@@ -281,7 +281,7 @@
 
 /datum/computer/file/clone
 	name = "Clone Record"
-	extension = "CLN"
+	extension = "DNA"
 	size = 8
 	var/list/fields = list()
 

--- a/code/datums/computerfiles.dm
+++ b/code/datums/computerfiles.dm
@@ -279,6 +279,17 @@
 			src.contained_files = null
 		..()
 
+/datum/computer/file/clone
+	name = "Clone Record"
+	extension = "CLN"
+	size = 8
+	var/list/fields = list()
+
+	disposing()
+		fields = null
+		. = ..()
+
+
 /datum/computer/folder/link
 	name = "symlink"
 	gen = 10

--- a/code/obj/machinery/computer/cloning.dm
+++ b/code/obj/machinery/computer/cloning.dm
@@ -335,6 +335,12 @@
 	else if (href_list["disk"]) //Load or eject.
 		switch(href_list["disk"])
 			if("load")
+				if (src.diskette.read_only)
+					// The file needs to be deleted from the disk after loading the record
+					src.temp = "Load error - cannot transfer clone records from a disk in read only mode."
+					src.updateUsrDialog()
+					return
+
 				var/loaded = 0
 
 				for(var/datum/computer/file/clone/cloneRecord in src.diskette.root.contents)
@@ -360,11 +366,6 @@
 	else if (href_list["save_disk"]) //Save to disk!
 		if ((isnull(src.diskette)) || (src.diskette.read_only) || (isnull(src.active_record)))
 			src.temp = "Save error."
-			src.updateUsrDialog()
-			return
-
-		else if (src.diskette.data_type == "corrupt")
-			src.temp = "Save error. Disk corruption."
 			src.updateUsrDialog()
 			return
 

--- a/code/obj/machinery/computer/cloning.dm
+++ b/code/obj/machinery/computer/cloning.dm
@@ -556,25 +556,6 @@
 				src.icon_state = "c_unpowered"
 				status |= NOPOWER
 
-
-//New loading/storing records is a todo while I determine how it should work.
-/obj/machinery/computer/cloning/proc
-	load_record()
-		if (!src.diskette || !src.diskette.root)
-			return -1
-
-
-		return 0
-
-	save_record()
-		if (!src.diskette || !src.diskette.root)
-			return -1
-
-
-
-		return 0
-
-
 //Find a dead mob with a brain and client.
 /proc/find_dead_player(var/find_key, needbrain=0)
 	if (isnull(find_key))

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -440,7 +440,7 @@
 			if(JOB.receives_disk)
 				var/obj/item/disk/data/floppy/D = new /obj/item/disk/data/floppy(src)
 				src.equip_if_possible(D, slot_in_backpack)
-				var/datum/data/record/R = new /datum/data/record(  )
+				var/datum/computer/file/clone/R = new
 				R.fields["ckey"] = ckey(src.key)
 				R.fields["name"] = src.real_name
 				R.fields["id"] = copytext(md5(src.real_name), 2, 6)
@@ -461,8 +461,8 @@
 
 				R.fields["imp"] = null
 				R.fields["mind"] = src.mind
-				D.data = R.fields
-				D.data_type = "cloning_record"
+				R.name = "CloneRecord-[ckey(src.real_name)]"
+				D.root.add_file(R)
 				D.name = "data disk - '[src.real_name]'"
 
 			if(JOB.receives_badge)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[ENHANCEMENT]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Currently, cloner records are a property of a diskette. This PR changes that to make cloner records computer files. This change will also allow up to four clone scan records on a single floppy, and it doesn't destroy the floppy when the scan is loaded. If needed, these could be tweaked for balance reasons, but I don't really think it's necessary to make somebody track down a bunch of unused floppy disks. It's more ecologically friendly this way!

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
 This will provide better integration with Goonstation's (extremely neat) computer and packet systems. It's work toward more cool, non-disrupting things for computer nerds to do.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)glassofmilk:
(+)Clone scans now use the computer file system instead of being a property of floppy disks.
```
