### PR TITLE
fix tmeth stun resist

### DIFF
--- a/code/modules/chemistry/Reagents-Drugs.dm
+++ b/code/modules/chemistry/Reagents-Drugs.dm
@@ -797,12 +797,12 @@ datum
 			bladder_value = -0.1
 			hunger_value = -0.3
 			thirst_value = -0.2
-			stun_resist = 98
 
 			on_remove()
 				if(ismob(holder?.my_atom))
 					var/mob/M = holder.my_atom
 					M.remove_stam_mod_regen("triplemeth")
+					M.remove_stun_resist_mod("triplemeth")
 
 				if(hascall(holder.my_atom,"removeOverlayComposition"))
 					holder.my_atom:removeOverlayComposition(/datum/overlayComposition/triplemeth)
@@ -813,7 +813,7 @@ datum
 				if(!M) M = holder.my_atom
 
 				if(holder.has_reagent("methamphetamine")) return ..() //Since is created by a meth overdose, dont react while meth is in their system.
-
+				M.add_stun_resist_mod("triplemeth", 1000)
 				M.add_stam_mod_regen("triplemeth", 1000)
 
 				if(hascall(holder.my_atom,"addOverlayComposition"))

--- a/code/modules/chemistry/Reagents-Drugs.dm
+++ b/code/modules/chemistry/Reagents-Drugs.dm
@@ -813,7 +813,7 @@ datum
 				if(!M) M = holder.my_atom
 
 				if(holder.has_reagent("methamphetamine")) return ..() //Since is created by a meth overdose, dont react while meth is in their system.
-				M.add_stun_resist_mod("triplemeth", 1000)
+				M.add_stun_resist_mod("triplemeth", 98)
 				M.add_stam_mod_regen("triplemeth", 1000)
 
 				if(hascall(holder.my_atom,"addOverlayComposition"))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes issue where triplemeth would give stun resist in the circumstance where it is not supposed to have an effect.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Enabled getting 98% stun resist from tmeth trivially without the other side effects (drug-screen/misstep) of tmeth