### PR TITLE
raised the self-stun of missing a chairflip

### DIFF
--- a/code/datums/abilities/generic.dm
+++ b/code/datums/abilities/generic.dm
@@ -152,7 +152,7 @@
 
 /mob/throw_end(list/params)
 	if (src.throwing & THROW_CHAIRFLIP)
-		src.changeStatus("weakened", 1.7 SECONDS)
+		src.changeStatus("weakened", 3 SECONDS)
 		src.force_laydown_standup()
 
 	if (length(params) && params["stun"])

--- a/code/datums/abilities/generic.dm
+++ b/code/datums/abilities/generic.dm
@@ -152,7 +152,7 @@
 
 /mob/throw_end(list/params)
 	if (src.throwing & THROW_CHAIRFLIP)
-		src.changeStatus("weakened", 3 SECONDS)
+		src.changeStatus("weakened", 2.8 SECONDS)
 		src.force_laydown_standup()
 
 	if (length(params) && params["stun"])


### PR DESCRIPTION
self-stun when you miss is now equal to the stun you take for a successful hit. should make followups on a miss a bit easier


edit : i should mention this is only 1.3 seconds of stun added on