### PR TITLE
Allow borgs to pickup mentor/admin mice

### DIFF
--- a/_std/code/_macros.dm
+++ b/_std/code/_macros.dm
@@ -48,6 +48,7 @@ var/list/detailed_spawn_dbg = list()
 #define isVRghost(x) (istype(x, /mob/living/carbon/human/virtual) && x:isghost)
 #define issmallanimal(x) istype(x, /mob/living/critter/small_animal)
 #define isghostcritter(x) (istype(x, /mob/living/critter/small_animal) && x:ghost_spawned)
+#define ishelpermouse(x) (istype(x, /mob/living/critter/small_animal/mouse/weak/mentor))//mentor and admin mice
 
 // I'm grump that we don't already have these so I'm adding them.  will we use all of them? probably not.  but we have them. - Haine
 // Hi, Marquesas here. Eliminating all ':' would be nice. Can we do that somehow? Thanks.

--- a/code/mob/living/silicon.dm
+++ b/code/mob/living/silicon.dm
@@ -172,7 +172,7 @@
 
 	var/inrange = in_range(target, src)
 	var/obj/item/equipped = src.equipped()
-	if (src.client.check_any_key(KEY_OPEN | KEY_BOLT | KEY_SHOCK | KEY_EXAMINE | KEY_POINT) || (equipped && (inrange || (equipped.flags & EXTRADELAY))) || istype(target, /turf)) // slightly hacky, oh well, tries to check whether we want to click normally or use attack_ai
+	if (src.client.check_any_key(KEY_OPEN | KEY_BOLT | KEY_SHOCK | KEY_EXAMINE | KEY_POINT) || (equipped && (inrange || (equipped.flags & EXTRADELAY))) || istype(target, /turf) || ishelpermouse(target)) // slightly hacky, oh well, tries to check whether we want to click normally or use attack_ai
 		..()
 	else
 		if (get_dist(src, target) > 0) // temporary fix for cyborgs turning by clicking

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -1329,7 +1329,7 @@
 
 	hand_attack(atom/target, params, location, control, origParams)
 		// Only allow it if the target is outside our contents or it is the equipped tool
-		if(!src.contents.Find(target) || target==src.equipped())
+		if(!src.contents.Find(target) || target==src.equipped() || ishelpermouse(target))
 			..()
 
 	attack_hand(mob/user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG][ENHANCEMENT] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Borgs can now hand_attack mentor mice and pick them up

adds a new macro, `ishelpermouse(x)` which returns true on both admin and mentor mice


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #1100


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Sovexe:
(+)Borgs can now pickup and carry mentor mice.
```
