### PR TITLE
fix tooltip caching for small storage and reagent containers

### DIFF
--- a/_std/_setup.dm
+++ b/_std/_setup.dm
@@ -257,6 +257,13 @@
 #define BLOCK_BURN					32768	//block an extra point of burn damage when used to block
 #define BLOCK_BLUNT					65536	//block an extra point of blunt damage when used to block
 
+//tooltip flags for rebuilding
+#define REBUILD_ALWAYS				1		//rebuild tooltip every single time without exception
+#define REBUILD_DIST				2		//force rebuild if dist does not match cache
+#define REBUILD_USER				4		//force rebuild if viewer has changed at all
+#define REBUILD_SPECTRO				8		//force rebuild if spectrospec status of viewer has changed
+
+
 //clothing dirty flags (not used for anything other than submerged overlay update currently. eventually merge into update_clothing)
 #define C_BACK 1
 #define C_MASK 2

--- a/_std/mob_properties.dm
+++ b/_std/mob_properties.dm
@@ -173,6 +173,8 @@ To remove:
 #define PROP_HEATPROT(x) x("heatprot", APPLY_MOB_PROPERTY_SUM, REMOVE_MOB_PROPERTY_SUM)
 #define PROP_EXPLOPROT(x) x("exploprot", APPLY_MOB_PROPERTY_SUM, REMOVE_MOB_PROPERTY_SUM)
 #define PROP_REFLECTPROT(x) x("reflection", APPLY_MOB_PROPERTY_SIMPLE, REMOVE_MOB_PROPERTY_SIMPLE)
+#define PROP_SPECTRO(x) x("spectrovision", APPLY_MOB_PROPERTY_SIMPLE, REMOVE_MOB_PROPERTY_SIMPLE)
+
 
 // In lieu of comments, these are the indexes used for list access in the macros below.
 #define MOB_PROPERTY_ACTIVE_VALUE 1

--- a/code/WorkInProgress/MechanicMadness.dm
+++ b/code/WorkInProgress/MechanicMadness.dm
@@ -423,6 +423,7 @@ var/list/mechanics_telepads = new/list()
 							inp = 1000000
 							user.show_text("[src] is not designed to handle such large transactions. Input has been set to the allowable limit.", "red")
 						price = inp
+						tooltip_rebuild = 1
 						boutput(user, "Price set to [inp]")
 				if ("Set Code")
 					if (code)
@@ -458,6 +459,7 @@ var/list/mechanics_telepads = new/list()
 					user.put_in_hand_or_drop(C)
 
 				collected += price
+				tooltip_rebuild = 1
 				current_buffer = 0
 
 				usr.drop_item()
@@ -476,6 +478,7 @@ var/list/mechanics_telepads = new/list()
 			var/obj/item/spacecash/S = unpool(/obj/item/spacecash)
 			S.setup(get_turf(src), collected)
 			collected = 0
+			tooltip_rebuild = 1
 		return
 
 /obj/item/mechanics/flushcomp
@@ -884,6 +887,7 @@ var/list/mechanics_telepads = new/list()
 					inp = max(inp, 10)
 					if(inp)
 						delay = inp
+						tooltip_rebuild = 1
 						boutput(user, "Set delay to [inp]")
 				if("Toggle Signal Changing")
 					changesig = !changesig
@@ -938,6 +942,7 @@ var/list/mechanics_telepads = new/list()
 					var/inp = input(user, "Enter Time Frame in 10ths of a second:", "Set Time Frame", timeframe) as num
 					if(inp)
 						timeframe = inp
+						tooltip_rebuild = 1
 						boutput(user, "Set Time Frame to [inp]")
 
 	proc/fire1(var/datum/mechanicsMessage/input)
@@ -1049,6 +1054,7 @@ var/list/mechanics_telepads = new/list()
 					if(length(inp))
 						inp = strip_html(html_decode(inp))
 						mechanics.triggerSignal = inp
+						tooltip_rebuild = 1
 						boutput(user, "Trigger Field set to [inp]")
 
 	proc/split(var/datum/mechanicsMessage/input)
@@ -1124,6 +1130,7 @@ var/list/mechanics_telepads = new/list()
 					if(length(inp))
 						expressionrepl = inp
 						boutput(user, "Replacement set to [html_encode(inp)]")
+			tooltip_rebuild = 1
 
 	proc/checkstr(var/datum/mechanicsMessage/input)
 		if(level == 2 || !length(expressionpatt)) return
@@ -1141,9 +1148,11 @@ var/list/mechanics_telepads = new/list()
 		return
 	proc/setregex(var/datum/mechanicsMessage/input)
 		expression = input.signal
+		tooltip_rebuild = 1
 
 	proc/setregexreplace(var/datum/mechanicsMessage/input)
 		expressionrepl = input.signal
+		tooltip_rebuild = 1
 
 	updateIcon()
 		icon_state = "[under_floor ? "u":""]comp_regrep"
@@ -1192,9 +1201,11 @@ var/list/mechanics_telepads = new/list()
 				if("Toggle Signal replacing")
 					replacesignal = !replacesignal
 					boutput(user, "[replacesignal ? "Now forwarding own Signal":"Now forwarding found String"]")
+			tooltip_rebuild = 1
 
 	proc/setregex(var/datum/mechanicsMessage/input)
 		expression = input.signal
+		tooltip_rebuild = 1
 	proc/checkstr(var/datum/mechanicsMessage/input)
 		if(level == 2 || !length(expression)) return
 		var/regex/R = new(expressionpatt, expressionflag)
@@ -1251,7 +1262,7 @@ var/list/mechanics_telepads = new/list()
 				if("Toggle Replace Signal")
 					changesig = !changesig
 					boutput(user, "Signal changing now [changesig ? "on":"off"]")
-
+			tooltip_rebuild = 1
 	proc/checkstr(var/datum/mechanicsMessage/input)
 		if(level == 2) return
 		if(findtext(input.signal, mechanics.triggerSignal))
@@ -1266,6 +1277,7 @@ var/list/mechanics_telepads = new/list()
 
 	proc/settrigger(var/datum/mechanicsMessage/input)
 		mechanics.triggerSignal = input.signal
+		tooltip_rebuild = 1
 
 	updateIcon()
 		icon_state = "[under_floor ? "u":""]comp_check"
@@ -1295,6 +1307,7 @@ var/list/mechanics_telepads = new/list()
 				if("Toggle Exact Match")
 					mechanics.exact_match = !mechanics.exact_match
 					boutput(user, "Exact match mode now [mechanics.exact_match ? "on" : "off"]")
+					tooltip_rebuild = 1
 
 	proc/dispatch(var/datum/mechanicsMessage/input)
 		if (level == 2) return
@@ -1344,10 +1357,11 @@ var/list/mechanics_telepads = new/list()
 					inp = strip_html(inp)
 					astr = inp
 					boutput(user, "String set to [inp]")
-
+			tooltip_rebuild = 1
 	proc/clrbff(var/datum/mechanicsMessage/input)
 		if(level == 2) return
 		buffer = ""
+		tooltip_rebuild = 1
 		return
 
 	proc/sendstr(var/datum/mechanicsMessage/input)
@@ -1357,16 +1371,19 @@ var/list/mechanics_telepads = new/list()
 		input.signal = finished
 		mechanics.fireOutgoing(input)
 		buffer = ""
+		tooltip_rebuild = 1
 		return
 
 	proc/addstr(var/datum/mechanicsMessage/input)
 		if(level == 2) return
 		buffer = "[buffer][input.signal]"
+		tooltip_rebuild = 1
 		return
 
 	proc/addstrsend(var/datum/mechanicsMessage/input)
 		if(level == 2) return
 		buffer = "[buffer][input.signal]"
+		tooltip_rebuild = 1
 		sendstr(input)
 		return
 
@@ -1399,6 +1416,7 @@ var/list/mechanics_telepads = new/list()
 				if("Toggle Signal Changing")
 					changesig = !changesig
 					boutput(user, "Signal changing now [changesig ? "on":"off"]")
+			tooltip_rebuild = 1
 
 	proc/relay(var/datum/mechanicsMessage/input)
 		if(level == 2 || !ready) return
@@ -1453,11 +1471,13 @@ var/list/mechanics_telepads = new/list()
 	proc/storefile(var/datum/mechanicsMessage/input)
 		if (level == 2 || !input.data_file) return
 		src.stored_file = input.data_file.copy_file()
+		tooltip_rebuild = 1
 		animate_flash_color_fill(src,"#00FF00",2, 2)
 
 	proc/deletefile(var/datum/mechanicsMessage/input)
 		if (level == 2 || !src.stored_file) return
 		src.stored_file = null
+		tooltip_rebuild = 1
 		animate_flash_color_fill(src,"#00FF00",2, 2)
 
 	updateIcon()
@@ -1520,7 +1540,7 @@ var/list/mechanics_telepads = new/list()
 				if("Toggle Forward All")
 					send_full = !send_full
 					boutput(user, "[send_full ? "Now forwarding all Radio Messages as they are.":"Now processing only sendmsg and normal PDA messages."]")
-
+			tooltip_rebuild = 1
 	proc/setfreq(var/datum/mechanicsMessage/input)
 		var/newfreq = text2num(input.signal)
 		if(!newfreq) return
@@ -1597,6 +1617,7 @@ var/list/mechanics_telepads = new/list()
 
 	proc/set_frequency(new_frequency)
 		if(!radio_controller) return
+		tooltip_rebuild = 1
 		new_frequency = max(1000, min(new_frequency, 1500))
 		radio_controller.remove_object(src, "[frequency]")
 		frequency = new_frequency
@@ -1698,12 +1719,14 @@ var/list/mechanics_telepads = new/list()
 				if("Toggle Allow Duplicate Entries")
 					allowDuplicates = !allowDuplicates
 					boutput(user, "[allowDuplicates ? "Allowing addition of duplicate items." : "Not allowing addition of duplicate items."]")
+			tooltip_rebuild = 1
 
 	proc/selitem(var/datum/mechanicsMessage/input)
 		if(!input) return
 
 		if(signals.Find(input.signal))
 			current_index = signals.Find(input.signal)
+			tooltip_rebuild = 1
 
 		if(announce)
 			componentSay("Current Selection : [signals[current_index]]")
@@ -1714,6 +1737,7 @@ var/list/mechanics_telepads = new/list()
 
 		if(signals.Find(input.signal))
 			current_index = signals.Find(input.signal)
+			tooltip_rebuild = 1
 		else
 			return // Don't send out a signal if not found
 
@@ -1730,6 +1754,7 @@ var/list/mechanics_telepads = new/list()
 
 		if(signals.Find(input.signal))
 			signals.Remove(input.signal)
+			tooltip_rebuild = 1
 			if(announce)
 				componentSay("Removed : [input.signal]")
 
@@ -1740,6 +1765,7 @@ var/list/mechanics_telepads = new/list()
 
 		for(var/s in signals)
 			signals.Remove(s)
+		tooltip_rebuild = 1
 
 		if(announce)
 			componentSay("Removed all signals.")
@@ -1752,12 +1778,14 @@ var/list/mechanics_telepads = new/list()
 		if(allowDuplicates)
 			signals.Add(input.signal)
 			signals[input.signal] = 1
+			tooltip_rebuild = 1
 			if(announce)
 				componentSay("Added: [input.signal]")
 
 		else
 			if(!signals[input.signal])
 				signals[input.signal] = 1
+				tooltip_rebuild = 1
 				if(announce)
 					componentSay("Added: [input.signal]")
 			else if(announce)
@@ -1790,6 +1818,7 @@ var/list/mechanics_telepads = new/list()
 			current_index = 1
 		else
 			current_index++
+		tooltip_rebuild = 1
 
 		if(announce)
 			componentSay("Current Selection : [signals[current_index]]")
@@ -1802,6 +1831,7 @@ var/list/mechanics_telepads = new/list()
 			current_index = 1
 		else
 			current_index++
+		tooltip_rebuild = 1
 
 		if(announce)
 			componentSay("Current Selection : [signals[current_index]]")
@@ -1816,6 +1846,7 @@ var/list/mechanics_telepads = new/list()
 			current_index = signals.len
 		else
 			current_index--
+		tooltip_rebuild = 1
 
 		if(announce)
 			componentSay("Current Selection : [signals[current_index]]")
@@ -1828,6 +1859,7 @@ var/list/mechanics_telepads = new/list()
 			current_index = signals.len
 		else
 			current_index--
+		tooltip_rebuild = 1
 
 		if(announce)
 			componentSay("Current Selection : [signals[current_index]]")
@@ -1879,11 +1911,13 @@ var/list/mechanics_telepads = new/list()
 						inp = adminscrub(inp)
 						signal_off = inp
 						boutput(user, "Off-Signal set to [inp]")
+			tooltip_rebuild = 1
 
 	proc/activate(var/datum/mechanicsMessage/input)
 		if(level == 2) return
 		on = 1
 		input.signal = signal_on
+		tooltip_rebuild = 1
 		updateIcon()
 		SPAWN_DBG(0)
 			mechanics.fireOutgoing(input)
@@ -1893,6 +1927,7 @@ var/list/mechanics_telepads = new/list()
 		if(level == 2) return
 		on = 0
 		input.signal = signal_off
+		tooltip_rebuild = 1
 		updateIcon()
 		SPAWN_DBG(0)
 			mechanics.fireOutgoing(input)
@@ -1902,6 +1937,7 @@ var/list/mechanics_telepads = new/list()
 		if(level == 2) return
 		on = !on
 		input.signal = (on ? signal_on : signal_off)
+		tooltip_rebuild = 1
 		updateIcon()
 		SPAWN_DBG(0)
 			mechanics.fireOutgoing(input)
@@ -1957,11 +1993,13 @@ var/list/mechanics_telepads = new/list()
 					else
 						src.overlays.Cut()
 					boutput(user, "Send-only Mode now [send_only ? "on":"off"]")
+			tooltip_rebuild = 1
 
 	proc/setidmsg(var/datum/mechanicsMessage/input)
 		if(level == 2) return
 		if(input.signal)
 			teleID = input.signal
+			tooltip_rebuild = 1
  		componentSay("ID Changed to : [input.signal]")
 		return
 
@@ -2050,7 +2088,7 @@ var/list/mechanics_telepads = new/list()
 					blue = min(blue, 1.0)
 
 					selcolor = rgb(red * 255, green * 255, blue * 255)
-
+					tooltip_rebuild = 1
 					light.set_color(red, green, blue)
 				if("Set Range")
 					var/inp = input(user,"Please enter Range(1 - 7):","Range setting", light_level) as num
@@ -2077,6 +2115,7 @@ var/list/mechanics_telepads = new/list()
 			if(active)
 				color = input.signal
 			selcolor = input.signal
+			tooltip_rebuild = 1
 			SPAWN_DBG(0) light.set_color(GetRedPart(selcolor) / 255, GetGreenPart(selcolor) / 255, GetBluePart(selcolor) / 255)
 
 	proc/turnon(var/datum/mechanicsMessage/input)
@@ -2195,6 +2234,7 @@ var/list/mechanics_telepads = new/list()
 		radio_controller.remove_object(src, "[frequency]")
 		frequency = new_frequency
 		radio_connection = radio_controller.add_object(src, "[frequency]")
+		tooltip_rebuild = 1
 
 	proc/hear_radio(mob/M as mob, msg, lang_id)
 		if (level == 2) return
@@ -2289,6 +2329,7 @@ var/list/mechanics_telepads = new/list()
 		if(..(W, user)) return
 		else if(ispulsingtool(W))
 			src.modify_configs()
+			tooltip_rebuild = 1
 			return
 		attack_hand(user)
 
@@ -2363,6 +2404,7 @@ var/list/mechanics_telepads = new/list()
 						if(!to_remove || to_remove == "*CANCEL*") return
 						src.active_buttons.Remove(to_remove)
 						boutput(user, "Removed button labeled [to_remove]")
+			tooltip_rebuild = 1
 
 	get_desc()
 		. += "<br><span class='notice'>Buttons:</span>"
@@ -2422,6 +2464,7 @@ var/list/mechanics_telepads = new/list()
 						logTheThing("station", user, null, "removes [Gun] from [src] at [log_loc(src)].")
 						Gun.loc = get_turf(src)
 						Gun = null
+						tooltip_flags &= ~REBUILD_ALWAYS
 					else
 						boutput(user, "<span class='alert'>There is no gun inside this component.</span>")
 		else if(istype(W, src.compatible_guns))
@@ -2431,6 +2474,7 @@ var/list/mechanics_telepads = new/list()
 				usr.drop_item()
 				Gun = W
 				Gun.loc = src
+				tooltip_flags |= REBUILD_ALWAYS
 			else
 				boutput(usr, "There is already a [Gun] inside the [src]")
 		else
@@ -2486,11 +2530,14 @@ var/list/mechanics_telepads = new/list()
 	process()
 		..()
 		if(level == 2)
-			if(charging) charging = 0
+			if(charging)
+				charging = 0
+				tooltip_rebuild = 1
 			return
 
 		if(!Gun && charging)
 			charging = 0
+			tooltip_rebuild = 1
 			updateIcon()
 
 		if(!istype(Gun, /obj/item/gun/energy) || !charging)
@@ -2503,12 +2550,14 @@ var/list/mechanics_telepads = new/list()
 			src.visible_message("<span class='game say'><span class='name'>[src]</span> beeps, \"This gun cannot be recharged manually.\"</span>")
 			playsound(src.loc, "sound/machines/buzz-two.ogg", 50, 0)
 			charging = 0
+			tooltip_rebuild = 1
 			updateIcon()
 			return
 
 		if (E.cell)
 			if (E.cell.charge(15) != 1) // Same as other recharger.
 				src.charging = 0
+				tooltip_rebuild = 1
 				src.updateIcon()
 
 		E.update_icon()
@@ -2518,6 +2567,7 @@ var/list/mechanics_telepads = new/list()
 		if(charging || !Gun || level == 2) return
 		if(!istype(Gun, /obj/item/gun/energy)) return
 		charging = 1
+		tooltip_rebuild = 1
 		updateIcon()
 		return
 
@@ -2580,6 +2630,7 @@ var/list/mechanics_telepads = new/list()
 						logTheThing("station", user, null, "removes [instrument] from [src] at [log_loc(src)].")
 						instrument.loc = get_turf(src)
 						instrument = null
+						tooltip_rebuild = 1
 					else
 						boutput(user, "<span class='alert'>There is no instrument inside this component.</span>")
 			return
@@ -2616,6 +2667,7 @@ var/list/mechanics_telepads = new/list()
 			logTheThing("station", usr, null, "adds [W] to [src] at [log_loc(src)].")
 			usr.drop_item()
 			instrument.loc = src
+			tooltip_rebuild = 1
 
 /obj/item/mechanics/math
 	name = "Arithmetic Component"
@@ -2656,14 +2708,17 @@ var/list/mechanics_telepads = new/list()
 						B = input
 				if("Set Mode")
 					mode = input("Set the math mode to what?", "Mode Selector", mode) in list("add","mul","div","sub","mod","pow","rng","eq","neq","gt","lt","gte","lte")
+			tooltip_rebuild = 1
 
 	proc/setA(var/datum/mechanicsMessage/input)
 		if (!isnull(text2num(input.signal)))
 			A = text2num(input.signal)
+			tooltip_rebuild = 1
 
 	proc/setB(var/datum/mechanicsMessage/input)
 		if (!isnull(text2num(input.signal)))
 			B = text2num(input.signal)
+			tooltip_rebuild = 1
 
 	proc/evaluate()
 		switch(mode)

--- a/code/WorkInProgress/infernal_contracts.dm
+++ b/code/WorkInProgress/infernal_contracts.dm
@@ -342,7 +342,7 @@
 		else
 			return list("A strange piece of old crinkled paper, covered in mysterious gibberish legalese.")
 
-	get_desc(dist)
+	get_desc()
 		if (src.limiteduse == 0)
 			. += "Somehow, it seems like an endless number of signatures could fit on this thing."
 		else if (src.contractlines - src.used == 1)
@@ -432,6 +432,7 @@ obj/item/contract/satan
 			boutput(user, "<span style=\"color:red; font-size:150%\"><b>Note that you are not an antagonist (unless you were already one), you simply have some of the powers of one.</b></span>")
 			if (src.limiteduse == 1)
 				src.used++
+				tooltip_rebuild = 1
 				SPAWN_DBG(0)
 					if (src.used >= src.contractlines)
 						src.vanish(user, badguy)
@@ -451,6 +452,7 @@ obj/item/contract/macho
 			boutput(user, "<span style=\"color:red; font-size:150%\"><b>Note that you are not an antagonist (unless you were already one), you simply have some of the powers of one.</b></span>")
 			if (src.limiteduse == 1)
 				src.used++
+				tooltip_rebuild = 1
 				SPAWN_DBG(0)
 					if (src.used >= src.contractlines)
 						src.vanish(user, badguy)
@@ -482,6 +484,7 @@ obj/item/contract/wrestle
 			ticker.mode.Agimmicks.Add(user)
 			if (src.limiteduse == 1)
 				src.used++
+				tooltip_rebuild = 1
 				SPAWN_DBG(0)
 					if (src.used >= src.contractlines)
 						src.vanish(user, badguy)
@@ -501,6 +504,7 @@ obj/item/contract/yeti
 			boutput(user, "<span style=\"color:red; font-size:150%\"><b>Note that you are not an antagonist (unless you were already one), you simply have some of the powers of one.</b></span>")
 			if (src.limiteduse == 1)
 				src.used++
+				tooltip_rebuild = 1
 				SPAWN_DBG(0)
 					if (src.used >= src.contractlines)
 						src.vanish(user, badguy)
@@ -531,6 +535,7 @@ obj/item/contract/genetic
 						ticker.mode.Agimmicks.Add(user)
 			if (src.limiteduse == 1)
 				src.used++
+				tooltip_rebuild = 1
 				SPAWN_DBG(0)
 					if (src.used >= src.contractlines)
 						src.vanish(user, badguy)
@@ -577,6 +582,7 @@ obj/item/contract/horse
 			ticker.mode.Agimmicks.Add(user)
 			if (src.limiteduse == 1)
 				src.used++
+				tooltip_rebuild = 1
 				SPAWN_DBG(0)
 					if (src.used >= src.contractlines)
 						src.vanish(user, badguy)
@@ -606,6 +612,7 @@ obj/item/contract/mummy
 				L.organHolder.drop_organ("all")
 		if (src.limiteduse == 1)
 			src.used++
+			tooltip_rebuild = 1
 			SPAWN_DBG(0)
 				if (src.used >= src.contractlines)
 					src.vanish(user, badguy)
@@ -629,6 +636,7 @@ obj/item/contract/vampire
 			boutput(user, "<span style=\"color:red; font-size:150%\"><b>Note that you are not an antagonist (unless you were already one), you simply have some of the powers of one.</b></span>")
 			if (src.limiteduse == 1)
 				src.used++
+				tooltip_rebuild = 1
 				SPAWN_DBG(0)
 					if (src.used >= src.contractlines)
 						src.vanish(user, badguy)
@@ -646,6 +654,7 @@ obj/item/contract/juggle
 			user.bioHolder.AddEffect("juggler", 0, 0, 1)
 			if (src.limiteduse == 1)
 				src.used++
+				tooltip_rebuild = 1
 				SPAWN_DBG(0)
 					if (src.used >= src.contractlines)
 						src.vanish(user, badguy)
@@ -663,6 +672,7 @@ obj/item/contract/fart
 			user.bioHolder.AddEffect("linkedfart", 0, 0, 1)
 			if (src.limiteduse == 1)
 				src.used++
+				tooltip_rebuild = 1
 				SPAWN_DBG(0)
 					if (src.used >= src.contractlines)
 						src.vanish(user, badguy)
@@ -680,6 +690,7 @@ obj/item/contract/bee
 			user.bioHolder.AddEffect("drunk_bee", 0, 0, 1)
 			if (src.limiteduse == 1)
 				src.used++
+				tooltip_rebuild = 1
 				SPAWN_DBG(0)
 					if (src.used >= src.contractlines)
 						src.vanish(user, badguy)
@@ -699,6 +710,7 @@ obj/item/contract/rested
 			user.bioHolder.AddEffect("narcolepsy_super", 0, 0, 1) //basically, the signer's very vulnerable but exceptionally difficult to actually kill.
 			if (src.limiteduse == 1)
 				src.used++
+				tooltip_rebuild = 1
 				SPAWN_DBG(0)
 					if (src.used >= src.contractlines)
 						src.vanish(user, badguy)
@@ -720,6 +732,7 @@ obj/item/contract/reversal
 			boutput(user, "<span class='notice'>You feel like you could take a shotgun blast to the face without getting a scratch on you!</span>")
 			if (src.limiteduse == 1)
 				src.used++
+				tooltip_rebuild = 1
 				SPAWN_DBG(0)
 					if (src.used >= src.contractlines)
 						src.vanish(user, badguy)
@@ -737,6 +750,7 @@ obj/item/contract/chemical
 			user.bioHolder.AddEffect("drunk_random", 0, 0, 1)
 			if (src.limiteduse == 1)
 				src.used++
+				tooltip_rebuild = 1
 				SPAWN_DBG(0)
 					if (src.used >= src.contractlines)
 						src.vanish(user, badguy)
@@ -760,6 +774,7 @@ obj/item/contract/hair
 					H.bioHolder.mobAppearance.customization_first = "None"
 			if (src.limiteduse == 1)
 				src.used++
+				tooltip_rebuild = 1
 				SPAWN_DBG(0)
 					if (src.used >= src.contractlines)
 						src.vanish(user, badguy)
@@ -798,6 +813,7 @@ obj/item/contract/greed
 					H.become_gold_statue(1)
 			if (src.limiteduse == 1)
 				src.used++
+				tooltip_rebuild = 1
 				SPAWN_DBG(0)
 					if (src.used >= src.contractlines)
 						src.vanish(user, badguy)

--- a/code/datums/hud/storage.dm
+++ b/code/datums/hud/storage.dm
@@ -146,6 +146,9 @@
 			I.screen_loc = final_loc
 			src.obj_locs[obj_loc] = I
 			i++
+		if(isitem(master))
+			var/obj/item/I = master
+			I.tooltip_rebuild = 1
 		master.update_icon()
 
 	proc/add_item(obj/item/I)

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -1742,6 +1742,7 @@
 					if(istype(I, /obj/item/card/id/dabbing_license)) // if we are using a dabbing license, save it so we can increment stats
 						dab_id = I
 						dab_id.dab_count++
+						dab_id.tooltip_rebuild = 1
 					karma_update(4, "SIN", src)
 					if(!dab_id && locate(/obj/machinery/bot/secbot/beepsky) in view(7, get_turf(src)))
 						// determine the name of the perp (goes by ID if wearing one)

--- a/code/modules/chemistry/Chemistry-Holder.dm
+++ b/code/modules/chemistry/Chemistry-Holder.dm
@@ -564,7 +564,9 @@ datum
 						del_reagent(current_id)
 					else
 						total_volume += current_reagent.volume
-
+			if(isitem(my_atom))
+				var/obj/item/I = my_atom
+				I.tooltip_rebuild = 1
 			return 0
 
 		proc/clear_reagents()

--- a/code/modules/chemistry/Chemistry-Holder.dm
+++ b/code/modules/chemistry/Chemistry-Holder.dm
@@ -861,23 +861,7 @@ datum
 
 			// check to see if user wearing the spectoscopic glasses (or similar)
 			// if so give exact readout on what reagents are present
-			var/spectro = 0
-			if (ishuman(user))
-				var/mob/living/carbon/human/H = user
-				if (istype(H.glasses, /obj/item/clothing/glasses/spectro))
-					spectro = 1
-				else if (H.eye_istype(/obj/item/organ/eye/cyber/spectro))
-					spectro = 1
-			else if (isrobot(user))
-				// check if they have an activated spectroscopic upgrade
-				var/mob/living/silicon/robot/R = user
-				for (var/obj/item/roboupgrade/U in R.upgrades)
-					if (istype(U, /obj/item/roboupgrade/spectro))
-						if (U.activated)
-							spectro = 1
-							break
-
-			if (spectro)
+			if (HAS_MOB_PROPERTY(user, PROP_SPECTRO))
 				if("cloak_juice" in reagent_list)
 					var/datum/reagent/cloaker = reagent_list["cloak_juice"]
 					if(cloaker.volume >= 5)

--- a/code/modules/chemistry/Chemistry-Tools.dm
+++ b/code/modules/chemistry/Chemistry-Tools.dm
@@ -19,6 +19,7 @@
 	w_class = 1
 	flags = FPRINT | TABLEPASS | SUPPRESSATTACK
 	var/rc_flags = RC_VISIBLE | RC_FULLNESS | RC_SPECTRO
+	tooltip_flags = REBUILD_SPECTRO | REBUILD_DIST
 	var/amount_per_transfer_from_this = 5
 	var/initial_volume = 50
 	var/list/initial_reagents = null // can be a list, an associative list (reagent=amt), or a string.  list will add an equal chunk of each reagent, associative list will add amt of reagent, string will add initial_volume of reagent

--- a/code/modules/chemistry/tools/extinguisher.dm
+++ b/code/modules/chemistry/tools/extinguisher.dm
@@ -7,6 +7,7 @@
 	var/extinguisher_special = 0
 	hitsound = 'sound/impact_sounds/Metal_Hit_1.ogg'
 	flags = FPRINT | EXTRADELAY | TABLEPASS | CONDUCT | OPENCONTAINER
+	tooltip_flags = REBUILD_DIST
 	throwforce = 10
 	w_class = 3.0
 	throw_speed = 2

--- a/code/modules/food_and_drink/plants.dm
+++ b/code/modules/food_and_drink/plants.dm
@@ -289,6 +289,7 @@
 	desc = "You probably shouldn't eat this, unless you happen to be able to eat metal."
 	icon_state = "orange-clockwork"
 	validforhat = 0
+	tooltip_flags = REBUILD_ALWAYS
 
 	get_desc()
 		. += "[pick("The time is", "It's", "It's currently", "It reads", "It says")] [o_clock_time()]."

--- a/code/modules/food_and_drink/snacks.dm
+++ b/code/modules/food_and_drink/snacks.dm
@@ -2728,5 +2728,5 @@ var/list/valid_jellybean_reagents = childrentypesof(/datum/reagent)
 		phrase = pick(src.heart_phrases)
 		return
 
-	get_desc(dist)
+	get_desc()
 		. = "<br><span class='notice'>It says: [phrase]</span>"

--- a/code/modules/materials/Mat_Mining.dm
+++ b/code/modules/materials/Mat_Mining.dm
@@ -76,11 +76,10 @@
 		return
 
 	buildTooltipContent()
-		var/Tcontent = ..()
-		Tcontent += "<br>"
-		Tcontent += "<div><img src='[resource("images/tooltips/mining.png")]' alt='' class='icon' /><span>Mining Power: [power]</span></div>"
-
-		return Tcontent
+		. = ..()
+		. += "<br>"
+		. += "<div><img src='[resource("images/tooltips/mining.png")]' alt='' class='icon' /><span>Mining Power: [power]</span></div>"
+		lastTooltipContent = .
 
 /obj/item/mining_tools/pick
 	name = "Mining Pick"

--- a/code/modules/medical/pathology/pathogen_machines.dm
+++ b/code/modules/medical/pathology/pathogen_machines.dm
@@ -1775,7 +1775,7 @@
 		if(lowNutrients)
 			src.target.reagents.add_reagent(medium, 5)
 
-	get_desc(dist)
+	get_desc()
 		if(src.target)
 			if (src.target.reagents.has_reagent("pathogen"))
 				. += "<br>The petri dish inside contains [src.target.reagents.reagent_list["pathogen"].volume] units of pathogen."

--- a/code/modules/medical/surgery_tools.dm
+++ b/code/modules/medical/surgery_tools.dm
@@ -413,7 +413,7 @@ CONTAINS:
 			src.cell.dispose()
 			src.cell = null
 
-	get_desc(dist)
+	get_desc()
 		..()
 		if (istype(src.cell))
 			if (src.cell.artifact)
@@ -528,6 +528,7 @@ CONTAINS:
 				if (prob(25 + suiciding))
 					cell.zap(user)
 				cell.use(cell.charge)
+				src.tooltip_rebuild = 1
 
 			if (emagged && !faulty && prob(10))
 				user.show_text("[src]'s on board scanner indicates that the target is undergoing a cardiac arrest!", "red")
@@ -648,7 +649,7 @@ CONTAINS:
 	var/in_use = 0
 	hide_attack = 2
 
-	get_desc(dist)
+	get_desc()
 		..()
 		if (src.uses >= 0)
 			switch (src.uses)
@@ -796,6 +797,7 @@ CONTAINS:
 				var/obj/item/bandage/B = tool
 				B.in_use = 0
 				B.uses --
+				B.tooltip_rebuild = 1
 				B.update_icon()
 			else if (istype(tool, /obj/item/material_piece/cloth))
 				ownerMob.u_equip(tool)

--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -128,6 +128,7 @@ toxic - poisons
 
 /datum/projectile/bullet/revolver_38
 	name = "bullet"
+	sname = "execute"
 	power = 35
 	ks_ratio = 1.0
 	implanted = /obj/item/implant/projectile/bullet_38
@@ -268,6 +269,7 @@ toxic - poisons
 
 	//haha gannets, fuck you I stole ur shit! - kyle
 	law_giver
+		sname = "knockout"
 		caliber = 0.355
 		casing = /obj/item/casing/small
 		shot_sound = 'sound/weapons/tranq_pistol.ogg'
@@ -433,6 +435,7 @@ toxic - poisons
 
 	lawbringer
 		name = "lawbringer"
+		sname = "bigshot"
 		power = 1
 		cost = 150
 
@@ -615,6 +618,7 @@ toxic - poisons
 
 /datum/projectile/bullet/flare
 	name = "flare"
+	sname = "hotshot"
 	shot_sound = 'sound/weapons/flaregun.ogg'
 	power = 20
 	cost = 1
@@ -898,6 +902,7 @@ toxic - poisons
 
 /datum/projectile/bullet/smoke
 	name = "smoke grenade"
+	sname = "smokeshot"
 	window_pass = 0
 	icon_state = "40mmB"
 	damage_type = D_KINETIC
@@ -1208,6 +1213,7 @@ toxic - poisons
 
 /datum/projectile/bullet/clownshot
 	name = "clownshot"
+	sname = "clownshot"
 	power = 1
 	cost = 15				//This should either cost a lot or a little I don't know. On one hand if it costs nothing you can truly tormet clowns with it, but on the other hand if it costs your full charge, then the clown will know how much you hate it because of how much you sacraficed to harm it. I settled for a med amount...
 	damage_type = D_KINETIC

--- a/code/modules/projectiles/energy_bolt.dm
+++ b/code/modules/projectiles/energy_bolt.dm
@@ -219,6 +219,7 @@ toxic - poisons
 /datum/projectile/energy_bolt/aoe
 	icon = 'icons/obj/projectiles.dmi'
 	icon_state = "detain-projectile"
+	sname = "detain"
 	power = 20
 	cost = 50
 	dissipation_rate = 5

--- a/code/modules/projectiles/pickpocket.dm
+++ b/code/modules/projectiles/pickpocket.dm
@@ -152,6 +152,7 @@
 				if ("r_leg", "l_leg") // Tie shoelaces
 					if (M.shoes && M.shoes.laces == LACES_NORMAL)
 						M.shoes.laces = LACES_TIED
+						M.shoes.tooltip_rebuild = 1
 						if (istype(M.shoes, /obj/item/clothing/shoes/clown_shoes))
 							boutput(M, "Your shoes give out one sad, final squeak. Oh no.")
 							M.shoes.step_sound = null

--- a/code/modules/robotics/robot/upgrade/spectro_scanner.dm
+++ b/code/modules/robotics/robot/upgrade/spectro_scanner.dm
@@ -3,3 +3,13 @@
 	desc = "Fitted with a sensor array that provides a readout of the chemical composition of substances that are examined."
 	icon_state = "up-spectro"
 	drainrate = 5
+
+/obj/item/roboupgrade/spectro/upgrade_activate(var/mob/living/silicon/robot/user as mob)
+	if (..())
+		return
+	APPLY_MOB_PROPERTY(user, PROP_SPECTRO, src)
+
+/obj/item/roboupgrade/spectro/upgrade_deactivate(var/mob/living/silicon/robot/user as mob)
+	if (..())
+		return
+	REMOVE_MOB_PROPERTY(user, PROP_SPECTRO, src)

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -28,6 +28,7 @@
 	flags = FPRINT | TABLEPASS
 	var/tool_flags = 0
 	var/c_flags = null
+	var/tooltip_flags = null
 
 	pressure_resistance = 50
 	var/obj/item/master = null
@@ -77,6 +78,10 @@
 	var/showTooltipDesc = 1
 	var/lastTooltipTitle = null
 	var/lastTooltipContent = null
+	var/lastTooltipName = null
+	var/lastTooltipDist = null
+	var/lastTooltipUser = null
+	var/lastTooltipSpectro = null
 	var/tooltip_rebuild = 1
 	var/rarity = ITEM_RARITY_COMMON //Just a little thing to indicate item rarity. RPG fluff.
 
@@ -153,7 +158,10 @@
 		if (showTooltip && usr.client.tooltipHolder)
 			var/show = 1
 
-			if (!lastTooltipContent || !lastTooltipTitle)
+			if (!lastTooltipContent || !lastTooltipTitle || tooltip_flags & REBUILD_ALWAYS\
+			 || (HAS_MOB_PROPERTY(usr, PROP_SPECTRO) && tooltip_flags & REBUILD_SPECTRO)\
+			 || (usr != lastTooltipUser && tooltip_flags & REBUILD_USER)\
+			 || (get_dist(src, usr) != lastTooltipDist && tooltip_flags & REBUILD_DIST))
 				tooltip_rebuild = 1
 
 			//If user has tooltips to always show, and the item is in world, and alt key is NOT pressed, deny
@@ -161,12 +169,13 @@
 				show = 0
 
 			var/title
-			if (tooltip_rebuild)
+			if (tooltip_rebuild || lastTooltipName != src.name)
 				if(rarity >= 7)
 					title = "<span class=\"rainbow\">[capitalize(src.name)]</span>"
 				else
 					title = "<span style=\"color:[RARITY_COLOR[rarity] || "#fff"]\">[capitalize(src.name)]</span>"
 				lastTooltipTitle = title
+				lastTooltipName = src.name
 			else
 				title = lastTooltipTitle
 

--- a/code/obj/item/ai_modules.dm
+++ b/code/obj/item/ai_modules.dm
@@ -39,6 +39,7 @@ AI MODULES
 			return
 		var/answer = input(user, text, title, default) as null|text
 		lawTarget = copytext(adminscrub(answer), 1, MAX_MESSAGE_LEN)
+		tooltip_rebuild = 1
 		boutput(user, "\The [src] now reads, \"[get_law_text()]\".")
 
 	proc/get_law_text()

--- a/code/obj/item/building_materials.dm
+++ b/code/obj/item/building_materials.dm
@@ -945,6 +945,7 @@ MATERIAL
 	stamina_damage = 25
 	stamina_cost = 25
 	stamina_crit_chance = 15
+	tooltip_flags = REBUILD_DIST
 
 	New()
 		..()
@@ -979,6 +980,7 @@ MATERIAL
 				F.setMaterial(getMaterial("steel"))
 			F.amount = 1
 			src.amount--
+			tooltip_rebuild = 1
 			user.put_in_hand_or_drop(F)
 			if (src.amount < 1)
 				//SN src = null
@@ -1004,6 +1006,7 @@ MATERIAL
 			else
 				src.build(S)
 				src.amount--
+				tooltip_rebuild = 1
 		if (src.amount < 1)
 			user.u_equip(src)
 			//SN src = null
@@ -1025,8 +1028,11 @@ MATERIAL
 		if (W.amount + src.amount > src.max_stack)
 			src.amount = W.amount + src.amount - src.max_stack
 			W.amount = src.max_stack
+			tooltip_rebuild = 1
+			W.tooltip_rebuild = 1
 		else
 			W.amount += src.amount
+			W.tooltip_rebuild = 1
 			//SN src = null
 			qdel(src)
 			return

--- a/code/obj/item/cameras.dm
+++ b/code/obj/item/cameras.dm
@@ -118,6 +118,7 @@
 	var/list/signed = list()
 	var/written = null
 	var/image/my_writing = null
+	tooltip_flags = REBUILD_DIST
 
 	New(location, var/image/IM, var/icon/IC, var/nname, var/ndesc)
 		..(location)
@@ -162,6 +163,7 @@
 				signature.layer = OBJ_LAYER + 0.01
 				src.overlays += signature
 				signed += "<span style='color: [P.font_color]'>[t]</span>"
+				tooltip_rebuild = 1
 			else if (signwrite == "write")
 				var/image/writing = image(icon='icons/misc/photo_writing.dmi',icon_state="[signwrite]")
 				writing.color = P.font_color
@@ -172,7 +174,7 @@
 				else
 					src.overlays -= src.my_writing
 					written = "[src.written] <span style='color: [P.font_color]'>[t]</span>"
-
+				tooltip_rebuild = 1
 				src.my_writing = writing
 				src.overlays += writing
 		return

--- a/code/obj/item/card.dm
+++ b/code/obj/item/card.dm
@@ -160,7 +160,7 @@ GAUNTLET CARDS
 		access = list()
 		..()
 
-	get_desc(dist)
+	get_desc()
 		. = {"<br>
 		Dabs performed: [dab_count]<br/>
 		Arms lost: [arm_count]<br/>

--- a/code/obj/item/cigarette.dm
+++ b/code/obj/item/cigarette.dm
@@ -771,7 +771,7 @@
 	var/match_amt = 6 // -1 for infinite
 	rand_pos = 1
 
-	get_desc(dist)
+	get_desc()
 		if (src.match_amt == -1)
 			. += "There's a whole lot of matches left."
 		else if (src.match_amt >= 1)
@@ -789,6 +789,7 @@
 				user.put_in_hand_or_drop(W)
 				if (src.match_amt != -1)
 					src.match_amt --
+					tooltip_rebuild = 1
 			src.update_icon()
 		else
 			return ..()

--- a/code/obj/item/clothing/glasses.dm
+++ b/code/obj/item/clothing/glasses.dm
@@ -503,6 +503,14 @@
 		..()
 		setProperty("disorient_resist_eye", 5)
 
+	equipped(mob/user, slot)
+		. = ..()
+		APPLY_MOB_PROPERTY(user, PROP_SPECTRO, src)
+
+	unequipped(mob/user)
+		. = ..()
+		REMOVE_MOB_PROPERTY(user, PROP_SPECTRO, src)
+
 // testing thing for static overlays
 /obj/item/clothing/glasses/staticgoggles
 	name = "goggles"

--- a/code/obj/item/clothing/gloves.dm
+++ b/code/obj/item/clothing/gloves.dm
@@ -399,7 +399,7 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 		..()
 		boutput(user, "<span class='notice'><b>You have to put the gloves on your hands first, silly!</b></span>")
 
-	get_desc(dist)
+	get_desc()
 		if (src.weighted)
 			. += "These things are pretty heavy!"
 
@@ -410,6 +410,7 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 			return
 		boutput(user, "You slip the horseshoe inside one of the gloves.")
 		src.weighted = 1
+		tooltip_rebuild = 1
 		qdel(W)
 	else
 		return ..()

--- a/code/obj/item/clothing/shoes.dm
+++ b/code/obj/item/clothing/shoes.dm
@@ -19,7 +19,7 @@
 	burn_output = 800
 	burn_possible = 1
 	health = 25
-
+	tooltip_flags = REBUILD_DIST
 	var/step_sound = "step_default"
 	var/step_priority = STEP_PRIORITY_NONE
 	var/step_lots = 0 //classic steps (used for clown shoos)
@@ -61,6 +61,7 @@
 		if (src.laces == LACES_TIED && istool(W, TOOL_CUTTING | TOOL_SNIPPING))
 			boutput(user, "You neatly cut the knot and most of the laces away. Problem solved forever!")
 			src.laces = LACES_CUT
+			tooltip_rebuild = 1
 
 /obj/item/clothing/shoes/rocket
 	name = "rocket shoes"
@@ -404,12 +405,14 @@
 	icon_state = "swatheavy"
 	step_sound = "step_heavyboots"
 	step_priority = STEP_PRIORITY_LOW
+	tooltip_flags = REBUILD_DIST | REBUILD_USER
 
 	get_desc(var/dist, var/mob/user)
 		if (user.mind && user.mind.assigned_role == "Head of Security")
 			. = "Still fit like a glove! Or a shoe."
 		else
 			. = "Looks like some big shoes to fill!"
+		. = ..()
 
 /obj/item/clothing/shoes/fuzzy //not boolean slippers
 	name = "fuzzy slippers"
@@ -445,6 +448,7 @@
 	step_priority = STEP_PRIORITY_LOW
 	var/on = 1
 	var/obj/item/tank/tank = null
+	tooltip_flags = REBUILD_ALWAYS
 
 	New()
 		..()

--- a/code/obj/item/clothing/trash_bags.dm
+++ b/code/obj/item/clothing/trash_bags.dm
@@ -11,6 +11,7 @@
 	w_class = 1.0
 	rand_pos = 1
 	flags = FPRINT | TABLEPASS | NOSPLASH
+	tooltip_flags = REBUILD_DIST
 	body_parts_covered = TORSO
 	var/base_state = "trashbag"
 	var/max_stuff = 12 // can't hold more than this many stuff
@@ -99,6 +100,7 @@
 		for (var/obj/item/I in src.contents)
 			src.w_class = max(I.w_class, src.w_class) // as it turns out there are some w_class things above 5 so fuck it this is just a max() now
 			src.current_stuff += I.w_class
+			tooltip_rebuild = 1
 		if (src.contents.len == 1)
 			src.icon_state = src.base_state
 			src.item_state = src.base_state

--- a/code/obj/item/deployable_turret.dm
+++ b/code/obj/item/deployable_turret.dm
@@ -22,7 +22,7 @@
 		..()
 		icon_state = "[src.icon_tag]_deployer"
 
-	get_desc(dist)
+	get_desc()
 		. = "<br><span class='notice'>It looks [damage_words]</span>"
 
 
@@ -357,6 +357,7 @@
 		//deployer.emagged = src.emagged
 		deployer.damage_words = src.damage_words
 		deployer.quick_deploy_fuel = src.quick_deploy_fuel
+		deployer.tooltip_rebuild = 1
 		return deployer
 
 

--- a/code/obj/item/device/chameleon.dm
+++ b/code/obj/item/device/chameleon.dm
@@ -77,6 +77,7 @@
 	var/obj/overlay/anim = null //The toggle animation overlay will also be retained
 	var/obj/dummy/chameleon/cham = null //No sense creating / destroying this
 	var/active = 0
+	tooltip_flags = REBUILD_DIST
 
 	is_syndicate = 1
 	mats = 14
@@ -136,6 +137,7 @@
 			cham.icon_state = target.icon_state
 			cham.dir = target.dir
 			can_use = 1
+			tooltip_rebuild = 1
 		else
 			user.show_text("\The [target] is not compatible with the scanner.", "red")
 
@@ -185,8 +187,10 @@
 				A.set_loc(get_turf(cham))
 			cham.loc = src
 			can_use = 0
+			tooltip_rebuild = 1
 			SPAWN_DBG (100)
 				can_use = 1
+				tooltip_rebuild = 1
 
 /obj/item/device/chameleon/bomb
 	name = "chameleon bomb"

--- a/code/obj/item/device/mic_amp_etc.dm
+++ b/code/obj/item/device/mic_amp_etc.dm
@@ -14,6 +14,7 @@
 
 	attack_self(mob/user as mob)
 		src.on = !(src.on)
+		tooltip_rebuild = 1
 		user.show_text("You switch [src] [src.on ? "on" : "off"].")
 		if (src.on && prob(5))
 			if (locate(/obj/loudspeaker) in range(2, user))

--- a/code/obj/item/device/scanners.dm
+++ b/code/obj/item/device/scanners.dm
@@ -357,6 +357,7 @@ that cannot be itched
 	module_research = list("analysis" = 2, "science" = 2, "devices" = 1)
 	module_research_type = /obj/item/device/reagentscanner
 	hide_attack = 2
+	tooltip_flags = REBUILD_DIST
 
 	attack(mob/M as mob, mob/user as mob)
 		return
@@ -366,6 +367,7 @@ that cannot be itched
 		"<span class='notice'>You scan [A] with [src]!</span>")
 
 		src.scan_results = scan_reagents(A, visible = 1)
+		tooltip_rebuild = 1
 
 		if (!isnull(A.reagents))
 			if (A.reagents.reagent_list.len > 0)

--- a/code/obj/item/dice.dm
+++ b/code/obj/item/dice.dm
@@ -102,7 +102,7 @@ var/list/rollList = list()
 		else
 			src.last_roll = null
 			src.visible_message("[src] shows... um. Something. It hurts to look at. [pick("What the fuck?", "You should probably find the chaplain.")]")
-
+		tooltip_rebuild = 1
 		if (src.dicePals.len)
 			shuffle_list(src.dicePals) // so they don't all roll in the same order they went into the pile
 			for (var/obj/item/dice/D in src.dicePals)
@@ -508,7 +508,7 @@ var/list/rollList = list()
 		else
 			src.last_roll = null
 			src.visible_message("[src] shows... um. This isn't a number. It hurts to look at. [pick("What the fuck?", "You should probably find the chaplain.")]")
-
+		tooltip_rebuild = 1
 	attack_self(var/mob/user as mob)
 		src.roll_dat_thang()
 
@@ -612,6 +612,7 @@ var/list/rollList = list()
 		for(var/i=1, i<=dicelist.len, i++) //shuffle the overlay colors to give the illusion of dice rolling inside the cup?
 			if (src.dicelist[i].sides && isnum(src.dicelist[i].sides)) //index out of bounds
 				src.dicelist[i].last_roll = rand(1, src.dicelist[i].sides)
+				src.dicelist[i].tooltip_rebuild = 1
 				src.localRollList.Add(list(list("sides"=src.dicelist[i].sides,"roll"=src.dicelist[i].last_roll,"color"=src.dicelist[i].color))) //need a check for dice without a color
 				if(src.dicelist[i].sides == 6)
 					src.dicelist[i].icon_state = "d6_[src.dicelist[i].last_roll]"

--- a/code/obj/item/generic_box.dm
+++ b/code/obj/item/generic_box.dm
@@ -262,7 +262,7 @@
 					if (istype(thing, src.contained_item))
 						src.item_amount++
 
-	get_desc(dist)
+	get_desc()
 		if (src.item_amount > 15 || src.item_amount == -1)
 			. += "There's a whole, whole lot of things inside. Dang!"
 		else if (src.item_amount >= 1)
@@ -362,11 +362,13 @@
 		if (myItem)
 			if (src.item_amount >= 1)
 				src.item_amount--
+				tooltip_rebuild = 1
 			src.update_icon()
 			return myItem
 		else if (src.item_amount != 0) // should be either a positive number or -1
 			if (src.item_amount >= 1)
 				src.item_amount--
+				tooltip_rebuild = 1
 			var/obj/item/newItem = new src.contained_item(src)
 			src.update_icon()
 			return newItem
@@ -393,6 +395,7 @@
 				return 0
 			if (src.item_amount != -1)
 				src.item_amount ++
+				tooltip_rebuild = 1
 			src.update_icon()
 			if (user && show_messages)
 				boutput(user, "You stuff [I] into [src].")

--- a/code/obj/item/gift.dm
+++ b/code/obj/item/gift.dm
@@ -11,6 +11,7 @@
 	stamina_damage = 1
 	stamina_cost = 1
 	stamina_crit_chance = 1
+	tooltip_flags = REBUILD_DIST
 	var/style = "r"
 
 	New()
@@ -36,6 +37,7 @@
 				return
 			else
 				src.amount -= a_used
+				tooltip_rebuild = 1
 				user.drop_item()
 				var/obj/item/gift/G = new /obj/item/gift(src.loc)
 				G.size = W.w_class
@@ -73,6 +75,7 @@
 			var/obj/spresent/present = new /obj/spresent (target.loc)
 			present.icon_state = "strange-[src.style]"
 			src.amount -= 2
+			tooltip_rebuild = 1
 
 			target.set_loc(present)
 		else

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1049,6 +1049,7 @@
 	custom_cell_max_capacity = 100
 	module_research = list("medicine" = 2, "science" = 2, "weapons" = 2, "energy" = 2, "miniaturization" = 10)
 	var/obj/item/heldItem = null
+	tooltip_flags = REBUILD_DIST
 
 	New()
 		current_projectile = new/datum/projectile/pickpocket/steal
@@ -1071,6 +1072,7 @@
 				boutput(user, "You remove \the [heldItem.name] from the gun.")
 				user.put_in_hand_or_drop(heldItem)
 				heldItem = null
+				tooltip_rebuild = 1
 			else
 				boutput(user, "The gun does not contain anything.")
 		else
@@ -1085,6 +1087,7 @@
 			user.u_equip(I)
 			I.dropped(user)
 			boutput(user, "You insert \the [heldItem.name] into the gun's gripper.")
+			tooltip_rebuild = 1
 		return ..()
 
 	attack(mob/M as mob, mob/user as mob)
@@ -1171,6 +1174,7 @@
 	icon = 'icons/obj/items/gun.dmi'
 	item_state = "lawg-detain"
 	icon_state = "lawbringer0"
+	desc = "A gun with a microphone. Fascinating."
 	var/old = 0
 	m_amt = 5000
 	g_amt = 2000
@@ -1219,6 +1223,7 @@
 			if (H.bioHolder)
 				owner_prints = H.bioHolder.uid_hash
 				src.name = "HoS [H.real_name]'s Lawbringer"
+				tooltip_rebuild = 1
 
 	//stolen the heartalk of microphone. the microphone can hear you from one tile away. unless you wanna
 	hear_talk(mob/M as mob, msg, real_name, lang_id)
@@ -1395,56 +1400,6 @@
 			if (current_projectile.type == /datum/projectile/bullet/flare)
 				shoot_fire_hotspots(target, start, user)
 		return ..(target, start, user)
-
-	//gotta override this to set the desc name to the proper thing
-	special_desc()
-		var/output = "This is \an [src.name]."
-		// Added for forensics (Convair880).
-		if (isitem(src) && src.blood_DNA)
-			output = "<span class='alert'>This is a bloody [src.name].</span>"
-			if (src.desc && src.blood_DNA == "--conductive_substance--")
-				output += "<br>[src.desc] <span class='alert'>It seems to be covered in an odd azure liquid!</span>"
-			if (src.desc)
-				output += "<br>[src.desc] <span class='alert'>It seems to be covered in blood!</span>"
-		else if (src.desc)
-			output += "<br>[src.desc]"
-		var/dist = get_dist(src, usr)
-		var/extra = src.get_desc(dist, usr)
-		if (extra)
-			output += " [extra]"
-
-	get_desc()
-		set src in usr
-		var/gun_setting_name = "detain"
-		if(current_projectile.type == /datum/projectile/energy_bolt/aoe)
-			gun_setting_name = "detain"
-		else if (current_projectile.type == /datum/projectile/bullet/revolver_38)
-			gun_setting_name = "execute"
-		else if (current_projectile.type == /datum/projectile/bullet/smoke)
-			gun_setting_name = "smokeshot"
-		else if (current_projectile.type == /datum/projectile/bullet/tranq_dart/law_giver)
-			gun_setting_name = "knockout"
-		else if (current_projectile.type == /datum/projectile/bullet/flare)
-			gun_setting_name = "hotshot"
-		else if (current_projectile.type == /datum/projectile/bullet/aex/lawbringer)
-			gun_setting_name = "bigshot"
-		else if (current_projectile.type == /datum/projectile/bullet/clownshot)
-			gun_setting_name = "clownshot"
-		else if (current_projectile.type == /datum/projectile/energy_bolt/pulse)		//clownshot - pink
-			gun_setting_name = "pulse"
-
-		src.desc = "It is set to [gun_setting_name]."
-		if(src.cell)
-				//[src.projectiles ? "It will use the projectile: [src.current_projectile.sname]. " : ""]
-			src.desc += " There are [src.cell.charge]/[src.cell.max_charge] PUs left!"
-		else
-			src.desc += " There is no cell loaded!"
-		if(current_projectile)
-			src.desc += " Each shot will currently use [src.current_projectile.cost] PUs!"
-		else
-			src.desc += " <span class='alert'>*ERROR* No output selected!</span>"
-		return
-
 
 /obj/item/gun/energy/lawbringer/emag_act(var/mob/user, var/obj/item/card/emag/E)
 	if (user)

--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -47,11 +47,10 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 	var/shoot_delay = 4
 
 	buildTooltipContent()
-		var/Tcontent = ..()
+		. = ..()
 		if(current_projectile)
-			Tcontent += "<br><img style=\"display:inline;margin:0\" src=\"[resource("images/tooltips/ranged.png")]\" width=\"10\" height=\"10\" /> Bullet Power: [current_projectile.power] - [current_projectile.ks_ratio * 100]% lethal"
-
-		return Tcontent
+			. += "<br><img style=\"display:inline;margin:0\" src=\"[resource("images/tooltips/ranged.png")]\" width=\"10\" height=\"10\" /> Bullet Power: [current_projectile.power] - [current_projectile.ks_ratio * 100]% lethal"
+		lastTooltipContent = .
 
 	New()
 		SPAWN_DBG(2 SECONDS)

--- a/code/obj/item/gun/reagent.dm
+++ b/code/obj/item/gun/reagent.dm
@@ -104,6 +104,7 @@
 	capacity = 90
 	projectile_reagents = 1
 	dump_reagents_on_turf = 1
+	tooltip_flags = REBUILD_DIST
 
 	get_desc(dist)
 		if (dist > 2)

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -870,6 +870,7 @@ var/global/list/tracking_implants = list() // things were looping through world 
 	impcolor = "g"
 	var/uses = 8
 	var/obj/item/card/id/access = new /obj/item/card/id
+	tooltip_flags = REBUILD_DIST
 
 	get_desc(dist)
 		if (dist <= 1)
@@ -883,6 +884,7 @@ var/global/list/tracking_implants = list() // things were looping through world 
 			return 0
 		else
 			uses -= 1
+			tooltip_rebuild = 1
 		return 1
 
 	infinite
@@ -919,6 +921,7 @@ var/global/list/tracking_implants = list() // things were looping through world 
 	w_class = 2.0
 	hide_attack = 2
 	var/sneaky = 0
+	tooltip_flags = REBUILD_DIST
 
 	New()
 		..()
@@ -930,6 +933,7 @@ var/global/list/tracking_implants = list() // things were looping through world 
 			. += "It appears to contain \a [src.imp.name]."
 
 	proc/update()
+		tooltip_rebuild = 1
 		if (src.imp)
 			src.icon_state = src.imp.impcolor ? "implanter1-[imp.impcolor]" : "implanter1-g"
 		else
@@ -1127,6 +1131,7 @@ var/global/list/tracking_implants = list() // things were looping through world 
 	throw_range = 5
 	w_class = 1.0
 	var/implant_type = /obj/item/implant/tracking
+	tooltip_flags = REBUILD_DIST
 
 /obj/item/implantcase/tracking
 	name = "glass case - 'Tracking'"
@@ -1209,6 +1214,7 @@ var/global/list/tracking_implants = list() // things were looping through world 
 		. += "It appears to contain \a [src.imp.name]."
 
 /obj/item/implantcase/proc/update()
+	tooltip_rebuild = 1
 	if (src.imp)
 		src.icon_state = src.imp.impcolor ? "implantcase-[imp.impcolor]" : "implantcase-g"
 	else
@@ -1227,6 +1233,7 @@ var/global/list/tracking_implants = list() // things were looping through world 
 			src.name = "glass case - '[t]'"
 		else
 			src.name = "glass case"
+		tooltip_rebuild = 1
 		return
 	else if (istype(I, /obj/item/implanter))
 		var/obj/item/implanter/Imp = I
@@ -1504,6 +1511,7 @@ circuitry. As a result neurotoxins can cause massive damage.<BR>
 				return
 
 			my_implant = I
+			tooltip_rebuild = 1
 
 			if (istype(W, /obj/item/implant))
 				user.u_equip(W)
@@ -1548,6 +1556,7 @@ circuitry. As a result neurotoxins can cause massive damage.<BR>
 			return ..()
 		my_implant.set_loc(P)
 		my_implant = null
+		tooltip_rebuild = 1
 
 /datum/projectile/implanter
 	name = "implant bullet"

--- a/code/obj/item/kitchen.dm
+++ b/code/obj/item/kitchen.dm
@@ -340,6 +340,7 @@ TRAYS
 	var/box_type = "donutbox"
 	var/contained_food = /obj/item/reagent_containers/food/snacks/donut/random
 	var/contained_food_name = "donut"
+	tooltip_flags = REBUILD_DIST
 
 	donut_box
 		name = "donut box"
@@ -386,6 +387,7 @@ TRAYS
 				user.drop_item()
 				W.set_loc(src)
 				src.amount ++
+				tooltip_rebuild = 1
 				boutput(user, "You place [W] into [src].")
 				src.update()
 			else return ..()
@@ -402,11 +404,13 @@ TRAYS
 		if(myFood)
 			if(src.amount >= 1)
 				src.amount--
+				tooltip_rebuild = 1
 			user.put_in_hand_or_drop(myFood)
 			boutput(user, "You take [myFood] out of [src].")
 		else
 			if(src.amount >= 1)
 				src.amount--
+				tooltip_rebuild = 1
 				var/obj/item/reagent_containers/food/snacks/newFood = new src.contained_food(src.loc)
 				user.put_in_hand_or_drop(newFood)
 				boutput(user, "You take [newFood] out of [src].")
@@ -437,6 +441,7 @@ TRAYS
 	var/max_food = 2
 	var/list/throw_targets = list()
 	var/throw_dist = 3
+	tooltip_flags = REBUILD_DIST
 
 	New()
 		..()
@@ -444,9 +449,11 @@ TRAYS
 
 	proc/add_contents(var/obj/item/W)
 		ordered_contents += W
+		tooltip_rebuild = 1
 
 	proc/remove_contents(var/obj/item/W)
 		ordered_contents -= W
+		tooltip_rebuild = 1
 
 	proc/update_icon()
 		for (var/i = 1, i <= ordered_contents.len, i++)
@@ -770,6 +777,7 @@ TRAYS
 			qdel(src)
 			return
 		tray_health--
+		tooltip_rebuild = 1
 
 		src.visible_message("\The [src] looks less sturdy now.")
 

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -228,6 +228,7 @@
 		take_bleeding_damage(user, user, 5)
 		JOB_XP(user, "Clown", 1)
 	src.active = !( src.active )
+	tooltip_rebuild = 1
 	if (src.active)
 		BLOCK_ALL
 		var/datum/component/holdertargeting/simple_light/light_c = src.GetComponent(/datum/component/holdertargeting/simple_light)
@@ -1059,6 +1060,7 @@
 	throwforce = 5.0
 	delimb_prob = 1
 	contraband = 4
+	tooltip_flags = REBUILD_USER
 
 	get_desc(var/dist, var/mob/user)
 		if (user.mind && user.mind.assigned_role == "Captain")
@@ -1205,6 +1207,7 @@
 	ih_sheathed_state = "scabbard-cap1"
 	ih_sheath_state = "scabbard-cap0"
 	sword_path = /obj/item/katana/captain
+	tooltip_flags = REBUILD_USER
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (W.type == /obj/item/katana)

--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -19,6 +19,7 @@ WET FLOOR SIGN
 	w_class = 2.0
 	throw_speed = 2
 	throw_range = 10
+	tooltip_flags = REBUILD_DIST | REBUILD_SPECTRO
 
 /obj/item/spraybottle/New()
 	var/datum/reagents/R = new/datum/reagents(100) // cogwerks - lowered from 1000 (what the hell) to 100

--- a/code/obj/item/organs/brain.dm
+++ b/code/obj/item/organs/brain.dm
@@ -16,6 +16,7 @@
 	module_research_type = /obj/item/organ/brain
 	FAIL_DAMAGE = 120
 	MAX_DAMAGE = 120
+	tooltip_flags = REBUILD_ALWAYS //fuck it, nobody examines brains that often
 
 	disposing()
 		if (owner && owner.brain == src)

--- a/code/obj/item/organs/eye.dm
+++ b/code/obj/item/organs/eye.dm
@@ -262,6 +262,14 @@
 	color_b = 0.95
 	change_iris = 0
 
+	on_transplant(mob/M)
+		. = ..()
+		APPLY_MOB_PROPERTY(M, PROP_SPECTRO, src)
+
+	on_removal()
+		REMOVE_MOB_PROPERTY(donor, PROP_SPECTRO, src)
+		. = ..()
+
 /obj/item/organ/eye/cyber/prodoc
 	name = "\improper ProDoc Healthview cybereye"
 	organ_name = "\improper ProDoc Healthview cybereye"

--- a/code/obj/item/organs/head.dm
+++ b/code/obj/item/organs/head.dm
@@ -15,6 +15,7 @@
 	edible = 0
 	rand_pos = 0 // we wanna override it below
 	made_from = "bone"
+	tooltip_flags = REBUILD_ALWAYS //TODO: handle better??
 	MAX_DAMAGE = INFINITY
 
 	var/obj/item/organ/brain/brain = null

--- a/code/obj/item/paper.dm
+++ b/code/obj/item/paper.dm
@@ -984,6 +984,7 @@ Only trained personnel should operate station systems. Follow all procedures car
 
 
 /obj/item/paper_bin/proc/update()
+	tooltip_rebuild = 1
 	src.icon_state = "paper_bin[(src.amount || locate(/obj/item/paper, src)) ? "1" : null]"
 	return
 

--- a/code/obj/item/pens_writing_etc.dm
+++ b/code/obj/item/pens_writing_etc.dm
@@ -539,6 +539,7 @@
 		if(!user.literate)
 			boutput(user, "<span class='alert'>You don't know how to write.</span>")
 			return
+		tooltip_rebuild = 1
 		var/str = copytext(html_encode(input(usr,"Label text?","Set label","") as null|text), 1, 32)
 		if(url_regex && url_regex.Find(str))
 			str = null
@@ -754,6 +755,7 @@
 	w_class = 3.0
 	throw_speed = 3
 	throw_range = 10
+	tooltip_flags = REBUILD_DIST
 
 	attackby(var/obj/item/W as obj, var/mob/user as mob)
 		if (istype(W, /obj/item/paper))
@@ -762,6 +764,7 @@
 				user.drop_item()
 				W.set_loc(src)
 				src.amount++
+				tooltip_rebuild = 1
 
 	attack_self(var/mob/user as mob)
 		show_window(user)
@@ -775,6 +778,7 @@
 
 		if(href_list["action"] == "retrieve")
 			usr.put_in_hand_or_drop(src.contents[text2num(href_list["id"])], usr)
+			tooltip_rebuild = 1
 			usr.visible_message("[usr] takes a piece of paper out of the folder.")
 		show_window(usr) // to refresh the window
 

--- a/code/obj/item/playing_cards.dm
+++ b/code/obj/item/playing_cards.dm
@@ -51,6 +51,7 @@
 	burn_output = 500
 	burn_possible = 1
 	health = 10
+	tooltip_flags = REBUILD_DIST
 	var/list/cards = list()
 	var/face_up = 0
 	var/card_name = "blank card"
@@ -75,7 +76,7 @@
 		if (!src.cards.len)
 			qdel(src)
 			return
-
+		tooltip_rebuild = 1
 		src.overlays = null
 		switch (src.cards.len)
 			if (-INFINITY to 0)

--- a/code/obj/item/rcd.dm
+++ b/code/obj/item/rcd.dm
@@ -88,7 +88,7 @@ Broken RCD + Effects
 	// What index into mode list we are (used for updating)
 	var/internal_mode = 1
 
-	get_desc(dist)
+	get_desc()
 		. += "<br>It holds [matter]/[max_matter] matter units. It is currently set to "
 		switch (src.mode)
 			if (RCD_MODE_FLOORSWALLS)
@@ -139,6 +139,7 @@ Broken RCD + Effects
 				src.matter += R.matter
 				R.matter = 0
 				qdel(R)
+			R.tooltip_rebuild = 1
 			src.update_icon()
 			playsound(get_turf(src), "sound/machines/click.ogg", 50, 1)
 			boutput(user, "\The [src] now holds [src.matter]/[src.max_matter] matter-units.")
@@ -169,7 +170,6 @@ Broken RCD + Effects
 				boutput(user, "Changed mode to 'Pod Door Control'")
 				boutput(user, "<span class='notice'>Place a door control on a wall, then place any amount of pod doors on floors.</span>")
 				boutput(user, "<span class='notice'>You can also select an existing door control by whacking it with \the [src].</span>")
-
 		// Gonna change this so it doesn't shit sparks when mode switched
 		// Just that it does it only after actually doing something
 		//src.shitSparks()
@@ -414,6 +414,7 @@ Broken RCD + Effects
 		if (GetOverlayImage("mode"))
 			src.ClearSpecificOverlays("mode")
 		var/ammo_amt = 0
+		tooltip_rebuild = 1
 		switch (round((src.matter / src.max_matter) * 100)) //is the round() necessary? yell at me if it isnt
 			if (10 to 34)
 				ammo_amt = 1

--- a/code/obj/item/satchel.dm
+++ b/code/obj/item/satchel.dm
@@ -136,6 +136,7 @@
 		src.satchel_updateicon()
 
 	proc/satchel_updateicon()
+		tooltip_rebuild = 1
 		var/perc
 		if (src.contents.len > 0 && src.maxitems > 0)
 			perc = (src.contents.len / src.maxitems) * 100

--- a/code/obj/item/space_cash.dm
+++ b/code/obj/item/space_cash.dm
@@ -288,6 +288,7 @@
 		set_amt(amt)
 
 	proc/set_amt(var/amt = 1 as num)
+		tooltip_rebuild = 1
 		src.amount = amt
 		src.update_stack_appearance()
 

--- a/code/obj/item/sponge_capsule.dm
+++ b/code/obj/item/sponge_capsule.dm
@@ -128,6 +128,7 @@
 			user.put_in_hand_or_drop(S)
 			if(caps_amt != -1)
 				caps_amt--
+				tooltip_rebuild = 1
 		update_icon()
 	else
 		return ..()

--- a/code/obj/item/stickers.dm
+++ b/code/obj/item/stickers.dm
@@ -153,6 +153,7 @@
 
 			// words here, info there, result is same: SCREEAAAAAAAMMMMMMMMMMMMMMMMMMM
 			src.words += "[src.words ? "<br>" : ""]<b>\[[S.current_mode]\]</b>"
+			tooltip_rebuild = 1
 			boutput(user, "<span class='notice'>You stamp \the [src].</span>")
 			return
 
@@ -181,6 +182,7 @@
 				else
 					src.icon_state = "postit-writing"
 			src.words += "[src.words ? "<br>" : ""][t]"
+			tooltip_rebuild = 1
 			pen.in_use = 0
 			src.add_fingerprint(user)
 			return

--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -276,9 +276,9 @@
 		. += "There are [src.charge]/[src.maxCharge] PU left."
 
 	buildTooltipContent()
-		var/content = ..()
-		content += "<br>There are [src.charge]/[src.maxCharge] PU left."
-		return content
+		. = ..()
+		. += "<br>There are [src.charge]/[src.maxCharge] PU left."
+		lastTooltipContent = .
 
 /obj/item/storage/belt/utility/prepared
 	spawn_contents = list(/obj/item/crowbar,

--- a/code/obj/item/storage/secure_safe.dm
+++ b/code/obj/item/storage/secure_safe.dm
@@ -58,6 +58,7 @@
 		if (isscrewingtool(W) && (src.locked == 1))
 			sleep(0.6 SECONDS)
 			src.open =! src.open
+			tooltip_rebuild = 1
 			user.show_message("<span class='notice'>You [src.open ? "open" : "close"] the service panel.</span>")
 			return
 

--- a/code/obj/item/storage/small_storage_parent.dm
+++ b/code/obj/item/storage/small_storage_parent.dm
@@ -27,11 +27,10 @@
 	health = 10
 
 	buildTooltipContent()
-		var/Tcontent = ..()
+		. = ..()
 		var/list/L = get_contents()
-		Tcontent += "<br>Holding [L.len]/[slots] objects"
-
-		return Tcontent
+		. += "<br>Holding [L.len]/[slots] objects"
+		lastTooltipContent = .
 
 	New()
 		hud = new(src)

--- a/code/obj/item/tool/omnitool.dm
+++ b/code/obj/item/tool/omnitool.dm
@@ -56,6 +56,7 @@
 		return 1
 
 	proc/change_mode(var/new_mode, var/mob/holder)
+		tooltip_rebuild = 1
 		switch (new_mode)
 			if ("prying")
 				src.omni_mode = "prying"

--- a/code/obj/soup_pot.dm
+++ b/code/obj/soup_pot.dm
@@ -282,6 +282,7 @@
 	w_class = 5.0
 	var/image/fluid_icon
 	var/datum/custom_soup/my_soup
+	tooltip_flags = REBUILD_DIST
 
 	New()
 		..()
@@ -376,6 +377,7 @@
 			else if (L.my_soup)
 				if(L.my_soup == src.my_soup)
 					src.total_wclass++
+					tooltip_rebuild = 1
 					L.my_soup = null
 					L.overlays = null
 					user.visible_message("[user] empties [L] into [src].", "You empty [L] into [src]")
@@ -383,6 +385,7 @@
 					boutput(user,"<span class='alert'><b>You can't mix soups! That'd be ridiculous!</span>")
 			else
 				src.total_wclass--
+				tooltip_rebuild = 1
 				L.my_soup = src.my_soup
 				L.add_soup_overlay(fluid_icon.color)
 				if(src.total_wclass <= 0)
@@ -405,6 +408,7 @@
 					if(src.my_soup)
 						usr.visible_message("<span class='alert'>[usr] dumps the soup out of [src] and onto [T]!</span>")
 						src.total_wclass = 0
+						tooltip_rebuild = 1
 						src.my_soup = null
 						src.on_reagent_change()
 						return
@@ -426,6 +430,7 @@
 		..()
 
 	proc/update_wclass_total()
+		tooltip_rebuild = 1
 		src.total_wclass = 0
 		for(var/obj/item/I in src.contents)
 			src.total_wclass += I.w_class

--- a/code/obj/submachine/robotics.dm
+++ b/code/obj/submachine/robotics.dm
@@ -299,6 +299,7 @@ ported and crapped up by: haine
 	icon_state = "juicer"
 	amount_per_transfer_from_this = 10
 	initial_volume = 200
+	tooltip_flags = REBUILD_DIST
 
 	afterattack(obj/target, mob/user)
 		if (get_dist(user, src) > 1 || get_dist(user, target) > 1)
@@ -372,6 +373,7 @@ ported and crapped up by: haine
 	var/list/hydro_reagent_names = list() // the tank creation proc adds the names of the above reagents to this list
 	var/list/tanks = list() // what tanks we have
 	var/obj/item/reagent_containers/borghose_tank/active_tank = null // what tank is active
+	tooltip_flags = REBUILD_DIST //if anyone implements this, add some rebuilds
 
 	New() // So this goes through and adds all the reagents to the hose on creation. Pretty good for expandability.
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FIX] [MAJOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
~~Forces tooltip rebuilds when storage contents are updated or on reagent change~~
~~Probably missing a few things yet~~
fuck. That's a *lot* of things
Adds tooltip rebuilds to things when needed, adds more things that get cached to help with that
~~this is gonna take time~~

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #1108 
Fixes #1091 
~~Fixes mbc's mistakes~~