### PR TITLE
Add rounding to minimum reaction volume

### DIFF
--- a/_std/_setup.dm
+++ b/_std/_setup.dm
@@ -888,6 +888,7 @@ proc/default_frequency_color(freq)
 #define INGEST 2
 #define INJECT 3
 #define MAX_TEMP_REACTION_VARIANCE 8
+#define CHEM_EPSILON 0.0001
 
 //moved from communications.dm
 #define TRANSMISSION_WIRE	0

--- a/code/modules/chemistry/Chemistry-Holder.dm
+++ b/code/modules/chemistry/Chemistry-Holder.dm
@@ -419,7 +419,7 @@ datum
 						//end my copy+paste
 
 
-						if(round(amount, 0.0001) >= B_required_volume) //This will mean you can have < 1 stuff not react. This is fine.
+						if(round(amount, CHEM_EPSILON) >= B_required_volume) //This will mean you can have < 1 stuff not react. This is fine.
 							total_matching_reagents++
 							created_volume = min(created_volume, amount * (C.result_amount ? C.result_amount : 1) / B_required_volume)
 						else

--- a/code/modules/chemistry/Chemistry-Holder.dm
+++ b/code/modules/chemistry/Chemistry-Holder.dm
@@ -402,7 +402,7 @@ datum
 					var/total_matching_reagents = 0
 					var/created_volume = src.maximum_volume
 					for(var/B in C.required_reagents)
-						var/B_required_volume = max(1, round(C.required_reagents[B], 0.0001))
+						var/B_required_volume = max(1, C.required_reagents[B])
 
 
 						//var/amount = get_reagent_amount(B)
@@ -419,7 +419,7 @@ datum
 						//end my copy+paste
 
 
-						if(amount >= B_required_volume) //This will mean you can have < 1 stuff not react. This is fine.
+						if(round(amount, 0.0001) >= B_required_volume) //This will mean you can have < 1 stuff not react. This is fine.
 							total_matching_reagents++
 							created_volume = min(created_volume, amount * (C.result_amount ? C.result_amount : 1) / B_required_volume)
 						else

--- a/code/modules/chemistry/Chemistry-Holder.dm
+++ b/code/modules/chemistry/Chemistry-Holder.dm
@@ -402,7 +402,7 @@ datum
 					var/total_matching_reagents = 0
 					var/created_volume = src.maximum_volume
 					for(var/B in C.required_reagents)
-						var/B_required_volume = max(1, C.required_reagents[B])
+						var/B_required_volume = max(1, round(C.required_reagents[B], 0.0001))
 
 
 						//var/amount = get_reagent_amount(B)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a small rounding to allow marginally lower values of chems to react 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The chemicompiler, possibly among other things, has trouble with reactions when the volume of a reagent is exactly 1 owing to float issues - this rounds these volumes up, functionally setting the minimum volume to react to 0.99995

Fixes #755 
