### PR TITLE
Refactor drone shoot proc, allow drones to shoot projectiles again

### DIFF
--- a/code/obj/critter/drone.dm
+++ b/code/obj/critter/drone.dm
@@ -239,46 +239,10 @@
 		if(target == start)
 			return
 
-		SPAWN_DBG(-1)
-			if (!current_projectile)
-				current_projectile = new projectile_type()
-			for (var/i = 0, i < (max(1,current_projectile.shot_number)), i++) //ARRRRGHHH WHY ISNT THIS USING THE NORMAL PROJECTILE SHOT PROCS
-				var/obj/projectile/A = unpool(/obj/projectile)
-				if(!A)	return
-				A.set_loc(src.loc)
-				A.proj_data = current_projectile
-				A.proj_data.master = A
-				A.set_icon()
-				A.power = A.proj_data.power
-				if(src.current_projectile.shot_sound)
-					playsound(src, src.current_projectile.shot_sound, 60)
-
-				if (!istype(target, /turf))
-					A.die()
-					return
-				A.target = target
-
-				if(istype(target, /obj/machinery/cruiser))
-					A.yo = (target:y + 2) - start:y
-					A.xo = (target:x + 2) - start:x
-				else
-					A.yo = target:y - start:y
-					A.xo = target:x - start:x
-
-
-				if (projectile_spread)
-					if (projectile_spread < 0)
-						projectile_spread = -projectile_spread
-					var/spread = rand(projectile_spread * 10) / 10
-					A.rotateDirection(prob(50) ? spread : -spread)
-
-				A.shooter = src
-				src.dir = get_dir(src, target)
-				SPAWN_DBG( 0 )
-					A.process()
-
-				if (current_projectile.shot_delay)
-					sleep(current_projectile.shot_delay)
+		if(istype(target, /obj/machinery/cruiser))
+			shoot_projectile_ST_pixel_spread(src, current_projectile, target, (target:x + 2) - start:x, (target:y + 2)- start:x, projectile_spread)
+		else
+			shoot_projectile_ST_pixel_spread(src, current_projectile, target, target:x - start:x, target:y - start:y, projectile_spread)
 		return
 
 	process() // override so drones don't just loaf all fuckin day
@@ -847,27 +811,14 @@
 				playsound(src,"sound/machines/signal.ogg", 60, 0)
 			return
 
-
-
 		Shoot(var/target, var/start, var/user, var/bullet = 0)
 			if(target == start)
 				return
 
-
 			src.dir = get_dir(src, target)
 
-			var/obj/projectile/P1 =	new/obj/projectile(src.loc)
-			var/obj/projectile/P2 =	new/obj/projectile(src.loc)
-			P1.proj_data = new current_projectile.type
-			P2.proj_data = new current_projectile.type
-			P1.set_icon()
-			P2.set_icon()
-			P1.shooter = src
-			P2.shooter = src
-			P1.target = target
-			P2.target = target
-			if(src.current_projectile.shot_sound)
-				playsound(src.loc, src.current_projectile.shot_sound, 60)
+			var/obj/projectile/P1 =	initialize_projectile(src.loc, current_projectile, 0, 0, src)
+			var/obj/projectile/P2 =	initialize_projectile(src.loc, current_projectile, 0, 0, src)
 
 			switch(src.dir) // linked fire, directional offsets so they don't hit the ship itself // these need more work still
 				if(NORTH)
@@ -877,6 +828,8 @@
 					P2.xo = 0
 					P1.set_loc(locate(src.x, src.y+2, src.z))
 					P2.set_loc(locate(src.x+2,src.y+2, src.z))
+					P1.orig_turf = P1.loc //our orig_turf was set in initialize_projectile() but that was before we moved it to the side of the ship
+					P2.orig_turf = P2.loc
 				if(EAST)
 					P1.yo = 0
 					P1.xo = 96
@@ -884,6 +837,8 @@
 					P2.xo = 96
 					P1.set_loc(locate(src.x+2,src.y+2,src.z))
 					P2.set_loc(locate(src.x+2,src.y,src.z))
+					P1.orig_turf = P1.loc
+					P2.orig_turf = P2.loc
 				if(WEST)
 					P1.yo = 0
 					P1.xo = -96
@@ -891,6 +846,8 @@
 					P2.xo = -96
 					P1.set_loc(locate(src.x,src.y, src.z))
 					P2.set_loc(locate(src.x,src.y+2, src.z))
+					P1.orig_turf = P1.loc
+					P2.orig_turf = P2.loc
 				else
 					P1.yo = -96
 					P1.xo = 0
@@ -898,13 +855,13 @@
 					P2.xo = 0
 					P1.set_loc(locate(src.x+2,src.y, src.z))
 					P2.set_loc(locate(src.x, src.y, src.z))
+					P1.orig_turf = P1.loc
+					P2.orig_turf = P2.loc
 
 			SPAWN_DBG(0)
-				P1.process()
+				P1.launch() // FIRE!
 			SPAWN_DBG(0)
-				P2.process()
-
-			return
+				P2.launch()
 
 		New()
 			..()
@@ -972,22 +929,8 @@
 
 		src.dir = get_dir(src, target)
 
-		var/obj/projectile/P1 = unpool(/obj/projectile/precursor_sphere)
-		var/obj/projectile/P2 = unpool(/obj/projectile/precursor_sphere)
-		P1.loc = src.loc
-		P2.loc = P1.loc
-		P1.proj_data = new current_projectile.type
-		P2.proj_data = new current_projectile.type
-		P1.power = P1.proj_data.power
-		P2.power = P2.proj_data.power
-		P1.set_icon()
-		P2.set_icon()
-		P1.shooter = src
-		P2.shooter = src
-		P1.target = target
-		P2.target = target
-		if(src.current_projectile.shot_sound)
-			playsound(src.loc, src.current_projectile.shot_sound, 60)
+		var/obj/projectile/P1 = initialize_projectile(src.loc, current_projectile, 0, 0, src)
+		var/obj/projectile/P2 = initialize_projectile(src.loc, current_projectile, 0, 0, src)
 
 		switch(src.dir) // linked fire, directional offsets so they don't hit the ship itself // these need more work still
 			if(NORTH)
@@ -997,6 +940,8 @@
 				P2.xo = 0
 				P1.set_loc(locate(src.x, src.y+2, src.z))
 				P2.set_loc(locate(src.x+2,src.y+2, src.z))
+				P1.orig_turf = P1.loc //our orig_turf was set in initialize_projectile() but that was before we moved it to the side of the ship
+				P2.orig_turf = P2.loc
 			if(EAST)
 				P1.yo = 0
 				P1.xo = 96
@@ -1004,6 +949,8 @@
 				P2.xo = 96
 				P1.set_loc(locate(src.x+2,src.y+2,src.z))
 				P2.set_loc(locate(src.x+2,src.y,src.z))
+				P1.orig_turf = P1.loc
+				P2.orig_turf = P2.loc
 			if(WEST)
 				P1.yo = 0
 				P1.xo = -96
@@ -1011,6 +958,8 @@
 				P2.xo = -96
 				P1.set_loc(locate(src.x,src.y, src.z))
 				P2.set_loc(locate(src.x,src.y+2, src.z))
+				P1.orig_turf = P1.loc
+				P2.orig_turf = P2.loc
 			else
 				P1.yo = -96
 				P1.xo = 0
@@ -1018,12 +967,13 @@
 				P2.xo = 0
 				P1.set_loc(locate(src.x+2,src.y, src.z))
 				P2.set_loc(locate(src.x, src.y, src.z))
+				P1.orig_turf = P1.loc
+				P2.orig_turf = P2.loc
 
 		SPAWN_DBG(0)
-			P1.process()
+			P1.launch()
 		SPAWN_DBG(0)
-			P2.process()
-
+			P2.launch()
 
 	proc/elec_zap()
 		playsound(src, "sound/effects/elec_bigzap.ogg", 40, 1)
@@ -1117,61 +1067,45 @@
 
 		src.dir = get_dir(src, target)
 
-		var/obj/projectile/sphere = unpool(/obj/projectile/precursor_sphere)
-		sphere.loc = src.loc
-		sphere.proj_data = new sphere_projectile.type
-		sphere.set_icon()
-		sphere.shooter = src
-		sphere.target = target
-		if(src.current_projectile.shot_sound)
-			playsound(src.loc, src.current_projectile.shot_sound, 60)
+		var/obj/projectile/sphere = initialize_projectile(src.loc, sphere_projectile, 0, 0, src)
 
 		switch(src.dir)
 			if(NORTH)
 				sphere.yo = 96
 				sphere.xo = 0
-				sphere.set_loc(locate(src.x, src.y+2, src.z))
+				sphere.set_loc(locate(src.x+1, src.y+2, src.z))
+				sphere.orig_turf = sphere.loc
 			if(EAST)
 				sphere.yo = 0
 				sphere.xo = 96
-				sphere.set_loc(locate(src.x+2,src.y+2,src.z))
+				sphere.set_loc(locate(src.x+2,src.y+1,src.z))
+				sphere.orig_turf = sphere.loc
 			if(WEST)
 				sphere.yo = 0
 				sphere.xo = -96
-				sphere.set_loc(locate(src.x,src.y, src.z))
+				sphere.set_loc(locate(src.x,src.y+1, src.z))
+				sphere.orig_turf = sphere.loc
 			else
 				sphere.yo = -96
 				sphere.xo = 0
-				sphere.set_loc(locate(src.x+2,src.y, src.z))
+				sphere.set_loc(locate(src.x+1,src.y, src.z))
+				sphere.orig_turf = sphere.loc
 
 		SPAWN_DBG(0)
-			sphere.process()
+			sphere.launch()
 
 		if (bounds_dist(src, target) >= 2*32) // dont murder ourself with explosives
-			var/obj/projectile/P1 = unpool(/obj/projectile)
-			var/obj/projectile/P2 = unpool(/obj/projectile)
-			P1.loc = sphere.loc
-			P2.loc = sphere.loc
-			P1.proj_data = new current_projectile.type
-			P2.proj_data = new current_projectile.type
-			P1.set_icon()
-			P2.set_icon()
-			P1.shooter = src
-			P2.shooter = src
-			P1.target = target
-			P2.target = target
-
-			P1.yo = sphere.yo
-			P1.xo = sphere.xo
+			var/obj/projectile/P1 = initialize_projectile(src.loc, current_projectile, sphere.xo, sphere.yo, src)
+			var/obj/projectile/P2 = initialize_projectile(src.loc, current_projectile, sphere.xo, sphere.yo, src)
 			P1.set_loc(sphere.loc)
-			P2.yo = sphere.yo
-			P2.xo = sphere.xo
 			P2.set_loc(sphere.loc)
+			P1.orig_turf = P1.loc
+			P2.orig_turf = P2.loc
 
 			SPAWN_DBG(0)
-				P1.process()
+				P1.launch()
 			SPAWN_DBG(0)
-				P2.process()
+				P2.launch()
 
 
 	/*proc/elec_zap()

--- a/code/obj/critter/drone.dm
+++ b/code/obj/critter/drone.dm
@@ -240,9 +240,9 @@
 			return
 
 		if(istype(target, /obj/machinery/cruiser))
-			shoot_projectile_ST_pixel_spread(src, current_projectile, target, (target:x + 2) - start:x, (target:y + 2)- start:x, projectile_spread)
+			shoot_projectile_ST_pixel_spread(src, current_projectile, target, 64, 64, projectile_spread)
 		else
-			shoot_projectile_ST_pixel_spread(src, current_projectile, target, target:x - start:x, target:y - start:y, projectile_spread)
+			shoot_projectile_ST_pixel_spread(src, current_projectile, target, 0, 0, projectile_spread)
 		return
 
 	process() // override so drones don't just loaf all fuckin day
@@ -1271,5 +1271,4 @@
 			task = "sleeping"
 			src.health = 0
 			src.CritterDeath()
-
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][MAJOR][CLEANLINESS][REWORK] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Refactor of the `/obj/critter/gunbot/drone` `shoot()` proc as well `shoot()` for the y-drone, helldrone, whydrone, and the four horsemen drone. These were also using some homebrew projectile building code. The refactor brings them in line with using the modern procs. Finally I offset the projectiles for the why/horse drone as it was cloned from the Y drone resulting in it shooting from the side. However because it only had one line of projectiles it looked super silly. It will now shoot from the center.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
With the exception of the X-drone none of the drones (including the "melee" buzz drones) are currently capable of properly firing projectiles. The fired projectiles are instantly deleted in the `do_step()` proc due to having a null `orig_turf` var

closes #1116

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Sovexe:
(+)Drones are now capable of shooting projectiles properly again. Don't get shot.
```
