### PR TITLE
Rebalance ordered funny packs to have fewer slots than regular funny packs

### DIFF
--- a/code/datums/supply_packs.dm
+++ b/code/datums/supply_packs.dm
@@ -664,11 +664,13 @@
 	name = "Comedy Equipment"
 	desc = "Entertainers burn bright but die young, outfit a new one with this crate!"
 	category = "Civilian Department"
-	contains = list(/obj/item/storage/box/costume/clown,
-					/obj/item/instrument/bikehorn,
-					/obj/item/bananapeel,
-					/obj/item/reagent_containers/food/snacks/pie/cream,
-					/obj/item/storage/box/balloonbox)
+	contains = list(
+		/obj/item/storage/box/costume/clown/recycled,
+		/obj/item/instrument/bikehorn,
+		/obj/item/bananapeel,
+		/obj/item/reagent_containers/food/snacks/pie/cream,
+		/obj/item/storage/box/balloonbox,
+	)
 	cost = 500
 	containertype = /obj/storage/crate/packing
 	containername = "Comedy Equipment"

--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -105,6 +105,11 @@
 	spawn_contents = list(/obj/item/storage/box/starter,\
 	/obj/item/storage/box/balloonbox)
 
+/obj/item/storage/fanny/funny/mini
+	name = "mini funny pack"
+	desc = "Haha, get it? Get it? 'Funny'! This one seems a little smaller, and made of even cheaper material."
+	slots = 3
+
 /obj/item/storage/fanny/syndie
 	name = "syndicate tactical espionage belt pack"
 	desc = "It's different than a fanny pack. It's tactical and action-packed!"

--- a/code/obj/item/storage/clothing.dm
+++ b/code/obj/item/storage/clothing.dm
@@ -236,6 +236,18 @@
 	/obj/item/card/id/clown,
 	/obj/item/device/pda2/clown)
 
+/obj/item/storage/box/costume/clown/recycled
+	name = "recycled clown costume"
+	desc = "A box that contains a clown costume. One clumsy former owner."
+	spawn_contents = list(
+		/obj/item/clothing/mask/clown_hat,
+		/obj/item/clothing/under/misc/clown,
+		/obj/item/clothing/shoes/clown_shoes,
+		/obj/item/storage/fanny/funny/mini,
+		/obj/item/card/id/clown,
+		/obj/item/device/pda2/clown,
+	)
+
 /obj/item/storage/box/costume/robuddy
 	name = "guardbuddy costume"
 	spawn_contents = list(/obj/item/clothing/suit/robuddy)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

* Adds a variant of the clown's "funny pack" that only has 3 slots (as opposed to the current default of 7).
* Makes ordered "comedy equipment" crates have the mini funny pack rather than the regular one.
* This PR does *not* alter the clown's funny pack or funny packs placed specifically in other places/gained in other ways.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Excluding poor fashion taste, funny packs are mechanically objectively superior to utility belts; fully-fledged funny packs (and fanny packs) should be in limited supply for this reason.

If you want a 7-slotted funny pack you can still accost the clown for his, as god intended.

The ordered "mini funny packs" are now a sidegrade over utility belts rather than an upgrade - while you can technically carry more in them (by putting containers in them, including utility belts) you lose ease of access to the contents, and have to (appropriately, given the item) juggle containers in your hands to get what is within (or deal with click-drag or containers closing on movement).

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Mordent:
(+)Added variant "mini funny pack" that replaces the regular version found in comedy equipment crates that cargo can order.
```