### PR TITLE
PDA disposing now handles packet sniffer and ping tool. Sniffer and Ping Tool no longer break messaging

### DIFF
--- a/code/obj/item/device/pda2/diagnostics.dm
+++ b/code/obj/item/device/pda2/diagnostics.dm
@@ -131,7 +131,8 @@
 				result += "[signal.data["device"]] \[[signal.data["netid"]]\] [signal.data["data"]]<BR>"
 
 	proc/adjust_frequency(var/old_freq, var/new_freq)
-		radio_controller.remove_object(master, "[old_freq]")
+		if (old_freq != 1149) // don't unregister the PDA itself
+			radio_controller.remove_object(master, "[old_freq]")
 		radio_controller.add_object(master, "[new_freq]")
 
 

--- a/code/obj/item/device/pda2/diagnostics.dm
+++ b/code/obj/item/device/pda2/diagnostics.dm
@@ -283,7 +283,8 @@
 
 
 	proc/adjust_frequency(var/old_freq, var/new_freq)
-		radio_controller.remove_object(master, "[old_freq]")
+		if (old_freq != 1149) // don't unregister the PDA itself
+			radio_controller.remove_object(master, "[old_freq]")
 		radio_controller.add_object(master, "[new_freq]")
 
 

--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -251,6 +251,9 @@
 
 /obj/item/device/pda2/disposing()
 	if (src.cartridge)
+		for (var/datum/computer/file/pda_program/P in src.cartridge.root.contents)
+			if (P.name == "Packet Sniffer")
+				radio_controller.remove_object(src, "[P:scan_freq]")
 		src.cartridge.dispose()
 		src.cartridge = null
 
@@ -259,6 +262,9 @@
 	src.scan_program = null
 
 	if (src.hd)
+		for (var/datum/computer/file/pda_program/P in src.hd.root.contents)
+			if (P.name == "Packet Sniffer")
+				radio_controller.remove_object(src, "[P:scan_freq]")
 		src.hd.dispose()
 		src.hd = null
 

--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -254,6 +254,9 @@
 		for (var/datum/computer/file/pda_program/P in src.cartridge.root.contents)
 			if (P.name == "Packet Sniffer")
 				radio_controller.remove_object(src, "[P:scan_freq]")
+				continue
+			if (P.name == "Ping Tool")
+				radio_controller.remove_object(src, "[P:send_freq]")
 		src.cartridge.dispose()
 		src.cartridge = null
 
@@ -265,6 +268,9 @@
 		for (var/datum/computer/file/pda_program/P in src.hd.root.contents)
 			if (P.name == "Packet Sniffer")
 				radio_controller.remove_object(src, "[P:scan_freq]")
+				continue
+			if (P.name == "Ping Tool")
+				radio_controller.remove_object(src, "[P:send_freq]")
 		src.hd.dispose()
 		src.hd = null
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adjusting the frequency of a PDA packet sniffer and ping tool apps will no longer run `radio_controller.remove_object` on frequency 1149. Further adjusting the frequency to other channels will still remove them from `radio_controller` as normal. `radio_controller.add_object` prevents the introduction of duplicate entries so there is no issue with configuring the apps back onto 1149

Additionally the `disposing()` proc of PDAs will now check if there are any packet sniffer and ping tool apps on the PDA HD or cartridge and run `radio_controller.remove_object` on their configured `scan_freq` / ` send_freq` value

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #1117

Removes references that would cause hard deletes