### PR TITLE
Fix flashlight issues

### DIFF
--- a/code/SimpleLight.dm
+++ b/code/SimpleLight.dm
@@ -247,7 +247,7 @@
 	show_mdir_light()
 
 	if (mdir_light_rgbas.len == 1) //dont loop/average if list only contains 1 thing
-		for(var/obj/overlay/simple_light/medium/directional/mdir_light in src.medium_lights)
+		for(var/obj/overlay/simple_light/medium/directional/mdir_light in src.mdir_lights)
 			if(mdir_light.dist == mdir_light_dists[mdir_light_dists.len])
 				mdir_light.color = rgb(rgba[1], rgba[2], rgba[3], min(255, rgba[4]))
 			else

--- a/code/WorkInProgress/AbilityItem.dm
+++ b/code/WorkInProgress/AbilityItem.dm
@@ -337,11 +337,7 @@
 
 	execute_ability()
 		var/obj/item/device/light/flashlight/J = the_item
-		if (ismob(J.loc))
-			J.light.attach(J.loc)
-		J.attack_self(the_mob)
-		if(J.on) icon_state = "off"
-		else  icon_state = "on"
+		J.toggle()
 		..()
 
 ////////////////////////////////////////////////////////////

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -953,9 +953,9 @@
 		I = G.handle_throw(src, target)
 		if (!I) return
 
-	u_equip(I)
-
 	I.set_loc(src.loc)
+
+	u_equip(I)
 
 	if (get_dist(src, target) > 0)
 		src.dir = get_dir(src, target)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fix light not attaching to flashlight when thrown.
Fix flashlights being too bright (bug caused flashlights to be #ff0000 at alpha 255)
Fix toggle button for flashlights

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fixes #1115 


closes #1112 
closes #1113 
(kinda. It fixes the issue by making a single flashlight less bright, because that was the *actual* bug.)