### PR TITLE
Disable mid-round OOC for RP mode

### DIFF
--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -143,11 +143,12 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 #ifdef RP_MODE
 	looc_allowed = 1
 	boutput(world, "<B>LOOC has been automatically enabled.</B>")
+	ooc_allowed = 0
+	boutput(world, "<B>OOC has been automatically disabled until the round ends.</B>")
 #else
 	if (it_is_ass_day || istype(src.mode, /datum/game_mode/construction))
 		looc_allowed = 1
 		boutput(world, "<B>LOOC has been automatically enabled.</B>")
-
 	else
 		ooc_allowed = 0
 		boutput(world, "<B>OOC has been automatically disabled until the round ends.</B>")
@@ -262,7 +263,7 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 	if (total_clients() >= OVERLOAD_PLAYERCOUNT)
 		world.tick_lag = OVERLOADED_WORLD_TICKLAG
 
-//Okay this is kinda stupid, but mapSwitcher.autoVoteDelay which is now set to 30 seconds, (used to be 5 min). 
+//Okay this is kinda stupid, but mapSwitcher.autoVoteDelay which is now set to 30 seconds, (used to be 5 min).
 //The voting will happen 30 seconds into the pre-game lobby. This is probably fine to leave. But if someone changes that var then it might start before the lobby timer ends.
 /datum/controller/gameticker/proc/handle_mapvote()
 	var/bustedMapSwitcher = isMapSwitcherBusted()

--- a/code/procs/mobprocs/chatprocs.dm
+++ b/code/procs/mobprocs/chatprocs.dm
@@ -487,7 +487,7 @@
 		return
 	else if (!src.client.preferences.listen_ooc)
 		return
-	else if (!ooc_allowed)// && !src.client.holder)
+	else if (!ooc_allowed && !src.client.holder)
 		boutput(usr, "OOC is currently disabled. For gameplay questions, try <a href='byond://winset?command=mentorhelp'>mentorhelp</a>.")
 		return
 	else if (!dooc_allowed && !src.client.holder && (src.client.deadchat != 0))

--- a/code/procs/mobprocs/chatprocs.dm
+++ b/code/procs/mobprocs/chatprocs.dm
@@ -487,8 +487,8 @@
 		return
 	else if (!src.client.preferences.listen_ooc)
 		return
-	else if (!ooc_allowed && !src.client.holder)
-		boutput(usr, "OOC is currently disabled.")
+	else if (!ooc_allowed)// && !src.client.holder)
+		boutput(usr, "OOC is currently disabled. For gameplay questions, try <a href='byond://winset?command=mentorhelp'>mentorhelp</a>.")
 		return
 	else if (!dooc_allowed && !src.client.holder && (src.client.deadchat != 0))
 		boutput(usr, "OOC for dead mobs has been turned off.")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Disables the OOC channel mid-round for the RP server. Admins are excluded, as usual. Has no effect on LOOC.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

General consensus that mid-round OOC is bad - use LOOC for local mentoring, and encourage use of mentorhelp for game mechanics questions.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Mordent:
(*)OOC channel disabled mid-round on RP server
```