### PR TITLE
Remove underscore from fire elemental's limb_name

### DIFF
--- a/code/mob/living/critter/arena/fire_elemental.dm
+++ b/code/mob/living/critter/arena/fire_elemental.dm
@@ -40,7 +40,7 @@
 		HH.limb = new /datum/limb/gun/fire_elemental
 		HH.icon_state = "fire_essence"
 		HH.icon = 'icons/mob/critter_ui.dmi'
-		HH.limb_name = "fire_essence"
+		HH.limb_name = "fire essence"
 		HH.can_hold_items = 0
 		HH.can_attack = 0
 		HH.can_range_attack = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][TRIVIAL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Remove underscore from fire elemental's `limb_name` changing it from `fire_essence` to `fire essence`


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
![image](https://user-images.githubusercontent.com/33204415/85188605-0bad1900-b276-11ea-842d-a11b3502639d.png)