### PR TITLE
Make pathogens curable via suppression

### DIFF
--- a/code/modules/medical/pathology/pathogen.dm
+++ b/code/modules/medical/pathology/pathogen.dm
@@ -918,7 +918,7 @@ datum/pathogen
 
 	var/in_remission = 0							// Pathogens in remission are being cured by the body. Set by the curing reagent.
 	var/forced_microbody = null						// If not null, this pathogen will be generated with a specific microbody.
-	var/curable_by_suppression = 0 					// If not 0, represents a probability of becoming regressive through suppression. If negative, randomly generated.
+	var/curable_by_suppression = 10	// If not 0, represents a probability of becoming regressive through suppression. If negative, randomly generated.
 	var/rads = 0 									// The pathogen may mutate inside someone according to rads.
 	var/rad_mutate_cooldown = 0 					// The amount of ticks to wait before we can mutate again due to radiation.
 	var/ticked = 0

--- a/code/modules/medical/pathology/pathogen_suppressants.dm
+++ b/code/modules/medical/pathology/pathogen_suppressants.dm
@@ -216,6 +216,8 @@
 				P.infected.show_message("<span class='notice'>You feel better.</span>")
 		if (P.suppressed == 0)
 			P.suppressed = 1
+		if(P.curable_by_suppression && prob(param.amt>100?100:param.amt))      // just to make this a little more likely to actually cure, or else it's too hard
+			P.remission()
 
 	may_react_to()
 		return "Membrane patterns of the pathogen indicate it might be <b style='font-size:20px;color:red'>suppressed</b> by a reagent affecting neural activity."

--- a/code/modules/medical/surgery_tools.dm
+++ b/code/modules/medical/surgery_tools.dm
@@ -472,6 +472,11 @@ CONTAINS:
 
 		else
 			patient.Virus_ShockCure(100)
+
+			for (var/uid in patient.pathogens)
+				var/datum/pathogen/P = patient.pathogens[uid]
+				P.onshocked(35, 500)
+
 			var/sumdamage = patient.get_brute_damage() + patient.get_burn_damage() + patient.get_toxin_damage()
 			if (suiciding)
 

--- a/code/obj/item/device/radio.dm
+++ b/code/obj/item/device/radio.dm
@@ -758,6 +758,11 @@ var/global/list/tracking_beacons = list() // things were looping through world t
 #else
 			M.changeStatus("weakened", 10 SECONDS)
 #endif
+			if(istype(M, /mob/living/carbon/human))
+				var/mob/living/carbon/human/H = M
+				for (var/uid in H.pathogens)
+					var/datum/pathogen/P = H.pathogens[uid]
+					P.onshocked(35, 500)
 
 	if ((src.master && src.wires & WIRE_SIGNAL))
 		src.master.receive_signal()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE] [FIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Enables the possibility for pathogens to go into remission while they are suppressed. This chance per patho cycle is set to 10% right now, may need adjustments in the future, but it seemed alright to me for now.

Also did some touch-ups on muscle-relaxant type suppression.
- When shocked there is a chance to go into remission based on the amount of damage taken. (This is because you can't exactly electrocute a patient every life cycle to keep the pathogen suppressed.)
- Defibrillators and Electropacks now also trigger this kind of suppression.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
- A common complaint about pathogens has been that the pathology department is also required to cure them. Hopefully with this in addition to the CDC there should now be enough ways to cure a pathogen even if the pathology equipment has been destroyed.
- Defibrillators and Electropacks not working for suppressions that work via shocks was confusing and did not make sense.
- Actually making pathogen cures is still a viable, quick and very reliable way to cure people, especially for the more dangerous types of suppressants, like radiation.
- @UrsulaMejor 
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)zjdtmkhzt:
(+) Pathogens can now be cured via just keeping it suppressed in the patient. This change will be explained in more detail if pathology is ever reenabled, which it is not!
```
