### PR TITLE
fix null-power explosions on humans

### DIFF
--- a/code/mob/living/carbon/human/procs/damage.dm
+++ b/code/mob/living/carbon/human/procs/damage.dm
@@ -314,6 +314,9 @@
 		qdel(src)
 		return
 
+	if(!power)
+		power = 8-severity*2
+
 	var/shielded = 0
 	var/spellshielded = 0
 	for (var/obj/item/device/shield/S in src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fix issue where ex_act() not called by explosion code would have little-to-no effect on humans


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Kinda broke wrestlers, and probably a couple others
