### PR TITLE
UM-026 - Remove Ribosome Requirement from Blobs

### DIFF
--- a/code/mob/living/intangible/blob_overmind/ai.dm
+++ b/code/mob/living/intangible/blob_overmind/ai.dm
@@ -299,7 +299,7 @@
 					update_lists(T)
 					spread = locate(/datum/blob_ability/spread) in abilities
 					attack = locate(/datum/blob_ability/attack) in abilities
-					lipid = locate(/datum/blob_ability/build/ribosome) in abilities
+					//lipid = locate(/datum/blob_ability/build/ribosome) in abilities
 					mito = locate(/datum/blob_ability/build/mitochondria) in abilities
 					wall = locate(/datum/blob_ability/build/wall) in abilities
 					absorb = locate(/datum/blob_ability/absorb) in abilities

--- a/code/modules/antagonists/blob/blob_abilities.dm
+++ b/code/modules/antagonists/blob/blob_abilities.dm
@@ -95,8 +95,8 @@
 					var/obj/blob/B
 					if (prob(5))
 						B = new /obj/blob/lipid(T)
-					else if (prob(5))
-						B = new /obj/blob/ribosome(T)
+					//else if (prob(5))
+						//B = new /obj/blob/ribosome(T)
 					else if (prob(5))
 						B = new /obj/blob/mitochondria(T)
 					else if (prob(5))
@@ -236,7 +236,7 @@
 		owner.add_ability(/datum/blob_ability/repair)
 		owner.add_ability(/datum/blob_ability/absorb)
 		owner.add_ability(/datum/blob_ability/promote)
-		owner.add_ability(/datum/blob_ability/build/ribosome)
+		//owner.add_ability(/datum/blob_ability/build/ribosome)
 		owner.add_ability(/datum/blob_ability/build/lipid)
 		owner.add_ability(/datum/blob_ability/build/mitochondria)
 		owner.add_ability(/datum/blob_ability/build/wall)
@@ -341,13 +341,11 @@
 		B2.setOvermind(owner)
 
 		if (owner.blobs.len < 40)
-			cooldown_time = max(12 - owner.spread_upgrade * 10 - owner.spread_mitigation * 0.5, 0)
+			cooldown_time = max(12 - owner.spread_upgrade * 12 - owner.spread_mitigation * 0.5, 0)
 		else if (owner.blobs.len < 80)
-			cooldown_time = max(17 - owner.spread_upgrade * 10 - owner.spread_mitigation * 0.5, 0)
-		else if (owner.blobs.len < 160)
-			cooldown_time = max(27 - owner.spread_upgrade * 10 - owner.spread_mitigation * 0.5, 0)
+			cooldown_time = max(17 - owner.spread_upgrade * 12 - owner.spread_mitigation * 0.5, 0)
 		else
-			cooldown_time = max(27 + (owner.blobs.len - 160) * 0.08 - owner.spread_upgrade * 10 - owner.spread_mitigation * 0.5, 0)
+			cooldown_time = max(27 - owner.spread_upgrade * 12 - owner.spread_mitigation * 0.5, 0)
 
 		cooldown_time = max(cooldown_time, 6)
 
@@ -973,6 +971,7 @@
 	build_path = /obj/blob/lipid
 	buildname = "lipid"
 
+/* TODO: REPLACE RIBOSOMES WITH SOMETHING COOLER
 /datum/blob_ability/build/ribosome
 	name = "Build Ribosome Cell"
 	icon_state = "blob-ribosome"
@@ -980,6 +979,8 @@
 	bio_point_cost = 5
 	build_path = /obj/blob/ribosome
 	buildname = "ribosome"
+
+*/
 
 /datum/blob_ability/build/mitochondria
 	name = "Build Mitochondria Cell"
@@ -1148,8 +1149,8 @@
 	name = "Passive: Quicker Spread"
 	icon_state = "blob-quickspread"
 	desc = "Reduces the cooldown of your Spread ability by 1 second. Can be repeated. The cooldown of Spread cannot go below 1 second."
-	evo_point_cost = 3
-	scaling_cost_add = 7
+	evo_point_cost = 2
+	scaling_cost_add = 3
 	repeatable = -1
 	upgradename = "spread"
 

--- a/code/modules/antagonists/blob/blob_abilities.dm
+++ b/code/modules/antagonists/blob/blob_abilities.dm
@@ -340,9 +340,9 @@
 		var/obj/blob/B2 = new /obj/blob(T)
 		B2.setOvermind(owner)
 
-		if (owner.blobs.len < 40)
+		if (owner.blobs.len < 100)
 			cooldown_time = max(12 - owner.spread_upgrade * 12 - owner.spread_mitigation * 0.5, 0)
-		else if (owner.blobs.len < 80)
+		else if (owner.blobs.len < 200)
 			cooldown_time = max(17 - owner.spread_upgrade * 12 - owner.spread_mitigation * 0.5, 0)
 		else
 			cooldown_time = max(27 - owner.spread_upgrade * 12 - owner.spread_mitigation * 0.5, 0)

--- a/code/modules/tutorials/blob_tutorial.dm
+++ b/code/modules/tutorials/blob_tutorial.dm
@@ -384,7 +384,9 @@ var/global/list/blob_tutorial_areas = list(/area/blob/tutorial_zone_1, /area/blo
 		MayAdvance()
 			return 0
 
-	ribosomes
+		/* TODO: REPLACE WITH COOLER RIBOSOME STUFF - URS
+
+		ribosomes
 		name = "Ribosomes"
 		instructions = "Your most valuable assets are the ribosomes. As your size grows, so does the amount of time it takes for your spread ability to cool down. Ribosomes generate valuable structural materials for the blob, allowing it to mitigate this cooldown penalty. Place a ribosome on the marked blob tile to proceed."
 		var/turf/target
@@ -410,6 +412,8 @@ var/global/list/blob_tutorial_areas = list(/area/blob/tutorial_zone_1, /area/blo
 
 		MayAdvance()
 			return finished
+
+		*/
 
 	clickmove
 		name = "Click moving"
@@ -440,7 +444,7 @@ var/global/list/blob_tutorial_areas = list(/area/blob/tutorial_zone_1, /area/blo
 
 	hotkeys
 		name = "Repair and Hotkeying"
-		instructions = "In hot situations, you will be unable to move around quickly and perform actions at the same time. This is where hotkeying comes in. You may assign up to three abilities to three different hotkey: CTRL+Click, ALT+Click and SHIFT+Click. This lets you perform stuff on the tile you click on! To assign a hotkey, CTRL/ALT/SHIFT-click an ability. Let's try this: assign a hotkey to the repair ability, and repair your damaged ribosome without moving."
+		instructions = "In hot situations, you will be unable to move around quickly and perform actions at the same time. This is where hotkeying comes in. You may assign up to three abilities to three different hotkey: CTRL+Click, ALT+Click and SHIFT+Click. This lets you perform stuff on the tile you click on! To assign a hotkey, CTRL/ALT/SHIFT-click an ability. Let's try this: assign a hotkey to the repair ability, and repair your damaged cells without moving."
 		var/turf/target
 
 		SetUp()
@@ -728,7 +732,6 @@ proc/AddBlobSteps(var/datum/tutorial/blob/T)
 	T.AddStep(new /datum/tutorialStep/blob/cutscene)
 	T.AddStep(new /datum/tutorialStep/blob/firewall)
 	T.AddStep(new /datum/tutorialStep/blob/cutscene2)
-	T.AddStep(new /datum/tutorialStep/blob/ribosomes)
 	T.AddStep(new /datum/tutorialStep/blob/clickmove)
 	T.AddStep(new /datum/tutorialStep/blob/hotkeys)
 	T.AddStep(new /datum/tutorialStep/blob/upgrades)

--- a/code/obj/blob.dm
+++ b/code/obj/blob.dm
@@ -1141,6 +1141,7 @@ var/image/blob_icon_cache
 		B.color = overmind.color
 		qdel(src)
 
+// TODO: REPLACE WITH SOMETHING COOLER - URS
 /obj/blob/ribosome
 	name = "ribosome"
 	state_overlay = "new_ribosome"
@@ -1164,6 +1165,7 @@ var/image/blob_icon_cache
 		if (overmind)
 			overmind.spread_mitigation -= added
 			added = 0
+
 
 /obj/blob/wall
 	name = "thick membrane"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

1) Gets rid of ribosomes

2) Makes the spread-slowdown from getting bigger less severe

3) Makes spread speed upgrade worth buying

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

At the moment, Ribosomes are effectively just a semi-automatic BioPoint drain; they're basically required to be placed on cooldown in order to mitigate the chunky spread slowdowns. I don't really find this mechanic interesting, personally. It just ends up being one of those annoying newbie traps where newbies don't know you have to do it, and experienced players are just annoyed by the fact you have to keep doing it. It also made the Speed Upgrade another newbie trap, as in the old system the upgrade was basically just 20 Ribosomes with no other real effect.

In the future i might submit a followup PR to make ribosomes do something cooler. I dunno, send me your ideas in discord.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)UrsulaMajor:
(+)Blobs no longer need to make ribosomes to mitigate the blob size spread speed slowdown.
```
