### PR TITLE
new medal - vehicular manslaughter

### DIFF
--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -582,7 +582,7 @@
 					M.throw_at(throw_at, movement_controller:velocity_magnitude, 2)
 				logTheThing("combat", src, target, "crashes into [target] [log_loc(src)].")
 				SPAWN_DBG(2.5 SECONDS)
-					if(M.health < 0) 
+					if(M.health > 0) 
 						vehicular_manslaughter = 0 //we now check if person was sent into crit after hit, if they did we get the achievement
 					if(vehicular_manslaughter && ishuman(M))
 						src.pilot.unlock_medal("Vehicular Manslaughter", 1)

--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -570,6 +570,9 @@
 				SPAWN_DBG(0.5 SECONDS)
 					hitmob = 0
 				var/mob/M = target
+				var/vehicular_manslaughter
+				if(isalive(M))
+					vehicular_manslaughter = 1 //we first check if the person is alive before hit, if yes we qualify for vehicular manslaughter achievement
 				//M.changeStatus("stunned", 1 SECOND)
 				//M.changeStatus("weakened", 1 SECOND)
 				M.TakeDamageAccountArmor("chest", power * 1.3, 0, 0, DAMAGE_BLUNT)
@@ -578,6 +581,11 @@
 				SPAWN_DBG(0)
 					M.throw_at(throw_at, movement_controller:velocity_magnitude, 2)
 				logTheThing("combat", src, target, "crashes into [target] [log_loc(src)].")
+				if(isalive(M))
+					vehicular_manslaughter = 0 //we now check if person is alive after hit, if they are dead they get the achievement
+				if(vehicular_manslaughter && ishuman(M))
+					src.pilot.unlock_medal("Vehicular Manslaughter", 1)
+				
 			else if(isturf(target) && power > 20)
 				if(istype(target, /turf/simulated/wall/r_wall || istype(target, /turf/simulated/wall/auto/reinforced)) && prob(power / 2))
 					return

--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -581,10 +581,11 @@
 				SPAWN_DBG(0)
 					M.throw_at(throw_at, movement_controller:velocity_magnitude, 2)
 				logTheThing("combat", src, target, "crashes into [target] [log_loc(src)].")
-				if(M.health < 0) 
-					vehicular_manslaughter = 0 //we now check if person was sent into crit after hit, if they did we get the achievement
-				if(vehicular_manslaughter && ishuman(M))
-					src.pilot.unlock_medal("Vehicular Manslaughter", 1)
+				SPAWN_DBG(2.5 SECONDS)
+					if(M.health < 0) 
+						vehicular_manslaughter = 0 //we now check if person was sent into crit after hit, if they did we get the achievement
+					if(vehicular_manslaughter && ishuman(M))
+						src.pilot.unlock_medal("Vehicular Manslaughter", 1)
 				
 			else if(isturf(target) && power > 20)
 				if(istype(target, /turf/simulated/wall/r_wall || istype(target, /turf/simulated/wall/auto/reinforced)) && prob(power / 2))

--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -571,8 +571,8 @@
 					hitmob = 0
 				var/mob/M = target
 				var/vehicular_manslaughter
-				if(isalive(M))
-					vehicular_manslaughter = 1 //we first check if the person is alive before hit, if yes we qualify for vehicular manslaughter achievement
+				if(M.health > 0)
+					vehicular_manslaughter = 1 //we first check if the person is not in crit before hit, if yes we qualify for vehicular manslaughter achievement
 				//M.changeStatus("stunned", 1 SECOND)
 				//M.changeStatus("weakened", 1 SECOND)
 				M.TakeDamageAccountArmor("chest", power * 1.3, 0, 0, DAMAGE_BLUNT)
@@ -581,8 +581,8 @@
 				SPAWN_DBG(0)
 					M.throw_at(throw_at, movement_controller:velocity_magnitude, 2)
 				logTheThing("combat", src, target, "crashes into [target] [log_loc(src)].")
-				if(isalive(M))
-					vehicular_manslaughter = 0 //we now check if person is alive after hit, if they are dead they get the achievement
+				if(M.health < 0) 
+					vehicular_manslaughter = 0 //we now check if person was sent into crit after hit, if they did we get the achievement
 				if(vehicular_manslaughter && ishuman(M))
 					src.pilot.unlock_medal("Vehicular Manslaughter", 1)
 				


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

adds "Vehicular Manslaughter" medal for causing someone's death by ramming them with a pod/miniputt/minisub/car

this needs someone to actually add the medal to byond hub so
image:
![image](https://i.imgur.com/b0yUpz3.png)
need some ideas for the medal description

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

some fun new medals that wont hurt anyone (just kidding they will hurt the one getting rammed)


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Fikou:
(*)New medal, Vehicular Manslaughter, obtainable by... you probably already know how.
```
