### PR TITLE
Move chemicompiler to processing ticks

### DIFF
--- a/code/modules/chemistry/Chemistry-Machinery.dm
+++ b/code/modules/chemistry/Chemistry-Machinery.dm
@@ -662,6 +662,7 @@ datum/chemicompiler_core/stationaryCore
 	icon_state = "chemicompiler_st_off"
 	mats = 15
 	flags = NOSPLASH
+	processing_tier = PROCESSING_FULL
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_MULTITOOL
 	var/datum/chemicompiler_executor/executor
 	var/datum/light/light

--- a/code/modules/chemistry/chemicompiler_core.dm
+++ b/code/modules/chemistry/chemicompiler_core.dm
@@ -281,7 +281,7 @@
 		return
 	if(running)
 		var/loopUsed
-		for (loopUsed = 0, loopUsed < 100, loopUsed++)
+		for (loopUsed = 0, loopUsed < 30, loopUsed++)
 			if(ip > currentProg.len)
 				running = 0
 				break
@@ -346,16 +346,12 @@
 				if("'")
 					ax = data[dp + 1]
 				if("$") //heat
-					loopUsed = 100
+					loopUsed = 30
 					var/heatTo = (273 - tx) + ax
 					heatReagents(sx, heatTo)
 				if("@") //transfer
-					loopUsed = min(100,loopUsed+(100/maxExpensiveOperations)-1)
-					var/sxt = sx // storing these by value for queued actions
-					var/txt = tx
-					var/axt = ax
-					SPAWN_DBG(loopUsed/5)
-						transferReagents(sxt, txt, axt)
+					loopUsed = 30
+					transferReagents(sx, tx, ax)
 				/*if("?") //compare *ptr to sx, using operation tx, store result in ax
 					switch(tx)
 						if(0) // =
@@ -373,13 +369,8 @@
 						else
 							ax = 0*/
 				if("#") //move individual reagent from container
-					loopUsed = min(100,loopUsed+(100/maxExpensiveOperations)-1)
-					var/sxt = sx
-					var/txt = tx
-					var/axt = ax
-					var/datat = data[dp+1]
-					SPAWN_DBG(loopUsed/5)
-						isolateReagent(sxt, txt, axt, datat)
+					loopUsed = 30
+					isolateReagent(sx, tx, ax, data[dp+1])
 				else
 
 			if(data.len < dp + 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Removes all SPAWNs from the chemicompiler's main loop
- Sets the Chemicompiler to use the processing tick created for it
- Remove the ability for the Chemicompiler to move reagents multiple times per tick.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Patch #156 moved the chemicompiler to SPAWNs to allow it to work within the confines of the machinery loop, which was far too slow at the time to be reasonable.
Since then, the machinery loop has been sped up to match the speed required to reasonably work the Chemicompiler.
