### PR TITLE
Sleeper Agent event refactor and now allows overriding player antag preferences

### DIFF
--- a/code/modules/events/sleeperagent.dm
+++ b/code/modules/events/sleeperagent.dm
@@ -14,8 +14,8 @@
 	var/frequency = 1459
 	var/sound_channel = 174
 	var/list/numbers = list(0,0,0,0,0,0)
-	var/list/listeners = list()
-	var/list/candidates = list()
+	var/list/listeners = null
+	var/list/candidates = null
 
 	admin_call(var/source)
 		if (..())
@@ -139,6 +139,10 @@
 			numbers += rand(1,99)
 
 	proc/gather_listeners()
+		//setup empty lists
+		src.listeners = list()
+		src.candidates = list()
+
 		for (var/mob/living/carbon/human/H in mobs)
 			if(!isalive(H))
 				continue
@@ -266,11 +270,11 @@
 			broadcast_sound(ogg)
 
 	proc/cleanup_event()
-		//clear lists of any mob references
-		src.listeners = list()
-		src.candidates = list()
+		//clear lists
+		src.listeners = null
+		src.candidates = null
 
-		//clean siwtches
+		//clear flags
 		src.admin_override = 0
 		src.override_player_pref = 0
 		src.lock = 0

--- a/code/modules/events/sleeperagent.dm
+++ b/code/modules/events/sleeperagent.dm
@@ -96,8 +96,6 @@
 				sleep(src.message_delay)
 				command_alert("[src.centcom_message]", "[src.centcom_headline]")
 
-			cleanup_event()
-
 	#if ASS_JAM // no idea what this does or who did it
 			var/list/sleepers = list()
 			for(var/mob/listener in listeners)
@@ -106,6 +104,8 @@
 			for(var/atom/sleeper in sleepers)
 				qdel(sleeper)
 	#endif
+
+			cleanup_event()
 		return
 
 	proc/awaken_sleeper_agent(var/mob/living/carbon/human/H)

--- a/code/modules/events/sleeperagent.dm
+++ b/code/modules/events/sleeperagent.dm
@@ -7,6 +7,7 @@
 	centcom_message = "A Syndicate radio station temporarily hijacked our communications. Be wary of individuals acting strangely."
 	message_delay = 5 SECONDS
 	var/num_agents = 0
+	var/override_player_pref = 0
 	var/lock = 0
 	var/admin_override = 0
 	var/signal_intro = 'sound/misc/sleeper_agent_hello.ogg'
@@ -20,15 +21,25 @@
 		if (..())
 			return
 
-		if (src.lock != 0)
-			message_admins("Setup of previous sleeper agents hasn't finished yet, aborting.")
+		if (src.lock)
+			message_admins("Setup of previous Awaken Sleeper Agents event hasn't finished yet, aborting.")
 			return
 
-		var/agents = input(usr, "How many sleeper agents to awaken?", "Sleeper Agents", 0) as num|null
-		if (isnull(agents))
+		src.num_agents = input(usr, "How many sleeper agents to awaken?", src.name, 0) as num|null
+		if (isnull(src.num_agents))
+			return
+		else if (src.num_agents < 1)
 			return
 		else
-			src.num_agents = agents
+			src.num_agents = round(src.num_agents)
+
+		switch (alert(usr, "Override player antagonist preferences?", src.name, "Yes", "No"))
+			if ("Yes")
+				src.override_player_pref = 1
+			if ("No")
+				src.override_player_pref = 0
+			else
+				return
 
 		src.admin_override = 1
 		src.event_effect(source)
@@ -44,12 +55,12 @@
 		SPAWN_DBG(0)
 			src.lock = 1
 			do_event(source=="spawn_antag")
-			src.lock = 0
 
 	proc/do_event(var/force_antags = 0)
 		gen_numbers()
 		gather_listeners()
 		if (!listeners.len)
+			cleanup_event()
 			return
 
 		if(!src.admin_override)
@@ -64,6 +75,7 @@
 				else
 					num_agents = 0
 		if(!num_agents)
+			cleanup_event()
 			return
 
 		SPAWN_DBG(10)
@@ -84,7 +96,8 @@
 				sleep(src.message_delay)
 				command_alert("[src.centcom_message]", "[src.centcom_headline]")
 
-			src.admin_override = initial(src.admin_override)
+			cleanup_event()
+
 	#if ASS_JAM // no idea what this does or who did it
 			var/list/sleepers = list()
 			for(var/mob/listener in listeners)
@@ -126,7 +139,6 @@
 			numbers += rand(1,99)
 
 	proc/gather_listeners()
-		listeners = list()
 		for (var/mob/living/carbon/human/H in mobs)
 			if(!isalive(H))
 				continue
@@ -134,7 +146,7 @@
 				if (Hs.frequency == frequency)
 					listeners += H
 					boutput(H, "<span class='notice'>A peculiar noise intrudes upon the radio frequency of your [Hs].</span>")
-					if(H.client && !checktraitor(H) && H.client.preferences.be_traitor && !(H.mind.assigned_role in list("Head of Security", "Security Officer")))
+					if(H.client && !checktraitor(H) && (H.client.preferences.be_traitor || src.override_player_pref) && !(H.mind.assigned_role in list("Head of Security", "Security Officer")))
 						candidates += H
 				break
 		for (var/mob/living/silicon/robot/R in mobs)
@@ -252,3 +264,13 @@
 		ogg = get_vox_by_string(sones)
 		if (ogg)
 			broadcast_sound(ogg)
+
+	proc/cleanup_event()
+		//clear lists of any mob references
+		src.listeners = list()
+		src.candidates = list()
+
+		//clean siwtches
+		src.admin_override = 0
+		src.override_player_pref = 0
+		src.lock = 0

--- a/strings/admin_changelog.txt
+++ b/strings/admin_changelog.txt
@@ -1,6 +1,6 @@
 (t)mon jun 22 20
 (u)Sovexe
-(*)TheAwaken Sleeper Agents event now allows you to override player antagonist preferences.
+(*)The Awaken Sleeper Agents event now allows you to override player antagonist preferences.
 (t)sun jun 21 20
 (u)Sovexe
 (*)The Antagonist Critter Spawn event now allows for customization in the form of critter type and quantity.

--- a/strings/admin_changelog.txt
+++ b/strings/admin_changelog.txt
@@ -1,3 +1,6 @@
+(t)mon jun 22 20
+(u)Sovexe
+(*)TheAwaken Sleeper Agents event now allows you to override player antagonist preferences.
 (t)sun jun 21 20
 (u)Sovexe
 (*)The Antagonist Critter Spawn event now allows for customization in the form of critter type and quantity.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][REWORK][FEATURE][BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Introduces `cleanup_event()` and `var/override_player_pref`

Allows admins to choose to override the preferences of players when determining who is eligible for becoming a sleeper


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
For fun

Fixes several bugs such as the event lock not actually preventing multiple sleeper events from attempting to run over one another, or players being valid candidates because they became valid once in the past

Cleans the listeners and candidates lists of refs when the event has finished executing

Adds input validation on number of agents to prevent negative or fractional inputs