### PR TITLE
Make NavBeacons respond to pings

### DIFF
--- a/code/obj/machinery/navbeacon.dm
+++ b/code/obj/machinery/navbeacon.dm
@@ -87,8 +87,13 @@
 				post_status()
 			return
 
-		if (!signal.data["address_1"] || signal.data["address_1"] != src.net_id || !signal.data["sender"])
+		if (!signal.data["address_1"] || !signal.data["sender"])
 			// Not for us, ignore
+			return
+
+		if (signal.data["address_1"] != src.net_id)
+			if (signal.data["address_1"] == "ping")
+				send_ping_response(signal.data["sender"])
 			return
 
 		switch (signal.data["command"])
@@ -128,6 +133,20 @@
 
 		frequency.post_signal(src, signal)
 
+	proc/send_ping_response(var/target)
+		var/datum/radio_frequency/frequency = radio_controller.return_frequency("[freq]")
+		if (!frequency || !target) return
+
+		var/datum/signal/pingsignal = get_free_signal()
+		pingsignal.source = src
+		pingsignal.data["device"] = "NAV_BEACON"
+		pingsignal.data["netid"] = src.net_id
+		pingsignal.data["sender"] = src.net_id
+		pingsignal.data["address_1"] = target
+		pingsignal.data["command"] = "ping_reply"
+		pingsignal.transmission_method = TRANSMISSION_RADIO
+
+		frequency.post_signal(src, pingsignal)
 
 	attackby(var/obj/item/I, var/mob/user)
 		var/turf/T = loc


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes NavBeacons respond to wireless pings in addition to findbeacon requests.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes NavBeacons more consistent, and allows using a low range ping tool to get beacon netids based on location.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)glassofmilk:
(+)Nav beacons now respond to wireless pings.
```
