### PR TITLE
UM-028 - Readd Riobosomes as Biopoint Producers, Spread Tweaks

### DIFF
--- a/code/mob/living/intangible/blob_overmind/ai.dm
+++ b/code/mob/living/intangible/blob_overmind/ai.dm
@@ -299,7 +299,7 @@
 					update_lists(T)
 					spread = locate(/datum/blob_ability/spread) in abilities
 					attack = locate(/datum/blob_ability/attack) in abilities
-					//lipid = locate(/datum/blob_ability/build/ribosome) in abilities
+					lipid = locate(/datum/blob_ability/build/ribosome) in abilities
 					mito = locate(/datum/blob_ability/build/mitochondria) in abilities
 					wall = locate(/datum/blob_ability/build/wall) in abilities
 					absorb = locate(/datum/blob_ability/absorb) in abilities

--- a/code/modules/antagonists/blob/blob_abilities.dm
+++ b/code/modules/antagonists/blob/blob_abilities.dm
@@ -95,8 +95,8 @@
 					var/obj/blob/B
 					if (prob(5))
 						B = new /obj/blob/lipid(T)
-					//else if (prob(5))
-						//B = new /obj/blob/ribosome(T)
+					else if (prob(5))
+						B = new /obj/blob/ribosome(T)
 					else if (prob(5))
 						B = new /obj/blob/mitochondria(T)
 					else if (prob(5))
@@ -236,7 +236,7 @@
 		owner.add_ability(/datum/blob_ability/repair)
 		owner.add_ability(/datum/blob_ability/absorb)
 		owner.add_ability(/datum/blob_ability/promote)
-		//owner.add_ability(/datum/blob_ability/build/ribosome)
+		owner.add_ability(/datum/blob_ability/build/ribosome)
 		owner.add_ability(/datum/blob_ability/build/lipid)
 		owner.add_ability(/datum/blob_ability/build/mitochondria)
 		owner.add_ability(/datum/blob_ability/build/wall)
@@ -341,11 +341,11 @@
 		B2.setOvermind(owner)
 
 		if (owner.blobs.len < 100)
-			cooldown_time = max(12 - owner.spread_upgrade * 12 - owner.spread_mitigation * 0.5, 0)
+			cooldown_time = max(15 - owner.spread_upgrade * 10 - owner.spread_mitigation * 0.5, 0)
 		else if (owner.blobs.len < 200)
-			cooldown_time = max(17 - owner.spread_upgrade * 12 - owner.spread_mitigation * 0.5, 0)
+			cooldown_time = max(20 - owner.spread_upgrade * 10 - owner.spread_mitigation * 0.5, 0)
 		else
-			cooldown_time = max(27 - owner.spread_upgrade * 12 - owner.spread_mitigation * 0.5, 0)
+			cooldown_time = max(25 - owner.spread_upgrade * 10 - owner.spread_mitigation * 0.5, 0)
 
 		cooldown_time = max(cooldown_time, 6)
 
@@ -971,16 +971,13 @@
 	build_path = /obj/blob/lipid
 	buildname = "lipid"
 
-/* TODO: REPLACE RIBOSOMES WITH SOMETHING COOLER
 /datum/blob_ability/build/ribosome
 	name = "Build Ribosome Cell"
 	icon_state = "blob-ribosome"
-	desc = "This will convert a blob tile into a Ribosome. Ribosomes reduce the penalty on spread cooldown induced by the size of the blob."
-	bio_point_cost = 5
+	desc = "This will convert a blob tile into a Ribosome. Ribosomes increase your generation of biopoints, allowing you to do more things."
+	bio_point_cost = 15
 	build_path = /obj/blob/ribosome
 	buildname = "ribosome"
-
-*/
 
 /datum/blob_ability/build/mitochondria
 	name = "Build Mitochondria Cell"

--- a/code/modules/tutorials/blob_tutorial.dm
+++ b/code/modules/tutorials/blob_tutorial.dm
@@ -384,11 +384,9 @@ var/global/list/blob_tutorial_areas = list(/area/blob/tutorial_zone_1, /area/blo
 		MayAdvance()
 			return 0
 
-		/* TODO: REPLACE WITH COOLER RIBOSOME STUFF - URS
-
 		ribosomes
 		name = "Ribosomes"
-		instructions = "Your most valuable assets are the ribosomes. As your size grows, so does the amount of time it takes for your spread ability to cool down. Ribosomes generate valuable structural materials for the blob, allowing it to mitigate this cooldown penalty. Place a ribosome on the marked blob tile to proceed."
+		instructions = "Your most valuable assets are the ribosomes. Ribosomes increase your biopoint generation, allowing you do do more things, faster. Place a ribosome on the marked blob tile to proceed."
 		var/turf/target
 		finished = 0
 
@@ -412,8 +410,6 @@ var/global/list/blob_tutorial_areas = list(/area/blob/tutorial_zone_1, /area/blo
 
 		MayAdvance()
 			return finished
-
-		*/
 
 	clickmove
 		name = "Click moving"

--- a/code/obj/blob.dm
+++ b/code/obj/blob.dm
@@ -1154,8 +1154,8 @@ var/image/blob_icon_cache
 
 	onAttach(var/mob/living/intangible/blob_overmind/O)
 		..()
-		O.spread_mitigation += 1
-		added = 1
+		O.gen_rate_bonus += 0.1
+		added = 0.1
 
 	update_icon()
 		return
@@ -1163,7 +1163,7 @@ var/image/blob_icon_cache
 	disposing()
 		..()
 		if (overmind)
-			overmind.spread_mitigation -= added
+			overmind.gen_rate_bonus -= added
 			added = 0
 
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

1) Readds ribosomes as biopoint producers

2) tweaks spread cooldown a bit; currently it's a tad too fast

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

1) Hopefully this reduces some of the "Must Buy" tax of the BP Generation ability + gives the crew something to target that the blob will actually care about

2) They're a tad too fast

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)UrsulaMajor:
(*)Blob Riobosomes now produce biopoints for the blob, making them much more important for the crew to target.
```
