### PR TITLE
Antagonist Critter Spawn possible null path fix

### DIFF
--- a/code/modules/events/antagonist_critter_ghost_respawn.dm
+++ b/code/modules/events/antagonist_critter_ghost_respawn.dm
@@ -88,7 +88,7 @@
 			else //random selected
 				src.num_critters = rand(1,min(3,candidates.len))
 
-			for (var/i in 0 to src.num_critters)
+			for (var/i in 1 to src.num_critters)
 				if (!candidates || !candidates.len)
 					break
 

--- a/code/modules/events/antagonist_critter_ghost_respawn.dm
+++ b/code/modules/events/antagonist_critter_ghost_respawn.dm
@@ -23,19 +23,19 @@
 
 		switch (alert(usr, "Choose the critter type?", src.name, "Random", "Custom"))
 			if ("Custom")
-				src.critter_type = input("Enter a /mob/living/critter path", src.name, null) as null|text
+				src.critter_type = input("Enter a /mob/living/critter path or partial name", src.name, null) as null|text
 				src.critter_type = get_one_match(src.critter_type, "/mob/living/critter")
+				if (!src.critter_type)//invalid entry
+					cleanup_event()
+					return
 			if ("Random") //random
 				src.critter_type = null
-			else
+			else //closed out of prompt
 				cleanup_event()
 				return
 
 		src.num_critters = input(usr, "How many critter antagonists to spawn?", src.name, 0) as num|null
-		if (!src.num_critters)
-			cleanup_event()
-			return
-		else if(src.num_critters < 1)
+		if (!src.num_critters || src.num_critters < 1)
 			cleanup_event()
 			return
 		else

--- a/code/modules/events/antagonist_critter_ghost_respawn.dm
+++ b/code/modules/events/antagonist_critter_ghost_respawn.dm
@@ -28,12 +28,15 @@
 			if ("Random") //random
 				src.critter_type = null
 			else
+				cleanup_event()
 				return
 
 		src.num_critters = input(usr, "How many critter antagonists to spawn?", src.name, 0) as num|null
 		if (!src.num_critters)
+			cleanup_event()
 			return
 		else if(src.num_critters < 1)
+			cleanup_event()
 			return
 		else
 			src.num_critters = round(src.num_critters)

--- a/code/modules/events/antagonist_critter_ghost_respawn.dm
+++ b/code/modules/events/antagonist_critter_ghost_respawn.dm
@@ -26,13 +26,9 @@
 				src.critter_type = input("Enter a /mob/living/critter path or partial name", src.name, null) as null|text
 				src.critter_type = get_one_match(src.critter_type, "/mob/living/critter")
 				if (!src.critter_type)//invalid entry
-					cleanup_event()
 					return
 			if ("Random") //random
 				src.critter_type = null
-			else //closed out of prompt
-				cleanup_event()
-				return
 
 		src.num_critters = input(usr, "How many critter antagonists to spawn?", src.name, 0) as num|null
 		if (!src.num_critters || src.num_critters < 1)

--- a/code/modules/events/antagonist_critter_ghost_respawn.dm
+++ b/code/modules/events/antagonist_critter_ghost_respawn.dm
@@ -3,6 +3,7 @@
 	name = "Antagonist Critter Spawn"
 	customization_available = 1
 	var/num_critters = 0
+	var/critter_type = null
 #ifdef RP_MODE
 	disabled = 1
 #endif
@@ -20,14 +21,14 @@
 		if (..())
 			return
 
-		var/input = alert(usr, "Choose the critter type?", src.name, "Random", "Custom")
-		if (!input)
-			return
-		else if (input == "Custom")
-			input = input("Enter a /mob/living/critter path", src.name, null) as null|text
-			input = get_one_match(input, "/mob/living/critter")
-		else //random
-			input = null
+		switch (alert(usr, "Choose the critter type?", src.name, "Random", "Custom"))
+			if ("Custom")
+				src.critter_type = input("Enter a /mob/living/critter path", src.name, null) as null|text
+				src.critter_type = get_one_match(src.critter_type, "/mob/living/critter")
+			if ("Random") //random
+				src.critter_type = null
+			else
+				return
 
 		src.num_critters = input(usr, "How many critter antagonists to spawn?", src.name, 0) as num|null
 		if (!src.num_critters)
@@ -38,16 +39,11 @@
 			src.num_critters = round(src.num_critters)
 
 		//confirmation
-		if (alert(usr, "You have chosen to spawn [src.num_critters] [input ? input : "random critters"]. Is this correct?", src.name, "Yes", "No") == "Yes")
-			event_effect(input)
+		if (alert(usr, "You have chosen to spawn [src.num_critters] [src.critter_type ? src.critter_type : "random critters"]. Is this correct?", src.name, "Yes", "No") == "Yes")
+			event_effect(source)
 
 	event_effect(var/source)
 		..()
-
-		//true if you choose to run with random settings in the event controls
-		if (source == "Triggered by [key_name(usr)]") //oh god
-			source = null
-			src.num_critters = 0
 
 		// 1: alert | 2: alert (chatbox) | 3: alert acknowledged (chatbox) | 4: no longer eligible (chatbox) | 5: waited too long (chatbox)
 		var/list/text_messages = list()
@@ -73,13 +69,14 @@
 				EV += latejoin
 				if (!EV.len)
 					message_admins("Pests event couldn't find a pest landmark!")
+					cleanup_event()
 					return
 
 			var/atom/pestlandmark = pick(EV)
 
 			var/list/select = null
-			if (source)
-				select = source
+			if (src.critter_type)
+				select = src.critter_type
 			else
 				select = pick(src.pest_invasion_critter_types)
 
@@ -99,3 +96,8 @@
 				candidates -= M
 
 			command_alert("Our sensors have detected a hostile nonhuman lifeform in the vicinity of the station.", "Hostile Critter")
+		cleanup_event()
+
+	proc/cleanup_event()
+		src.critter_type = null
+		src.num_critters = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
discovered a bug when working on this same sort of patch but for the pest event and decided to fix this first. Adds a new `var/critter_type` and unhooks proc from using `var/source` which was kind of weird to use in this way anyway. Additionally added `event_cleanup()` as simpler to understand cleanup of the vars after each run or early return.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
prevent possible events that could cause critter path to be invalid or null