### PR TITLE
Attempt to put item in storage container if you hit it with the container

### DIFF
--- a/code/obj/item/storage/small_storage_parent.dm
+++ b/code/obj/item/storage/small_storage_parent.dm
@@ -93,6 +93,8 @@
 			user.drop_item()
 			SPAWN_DBG(1 DECI SECOND)
 				O.attack_hand(user)
+		else if (isitem(O))
+			src.attackby(O, user)
 
 	attackby(obj/item/W, mob/user, params, obj/item/storage/T) // T for transfer - transferring items from one storage obj to another
 		if (W.cant_drop)


### PR DESCRIPTION

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If you attack an item with a handheld storage item, it tries to put the item in the container.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Why not? It's useful I suppose


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)kyle:
(+)Clicking an item with an item storage container attempts to place it in the storage item.
```
