### PR TITLE
changed ass_explosion

### DIFF
--- a/code/datums/abilities/wizard/rathens.dm
+++ b/code/datums/abilities/wizard/rathens.dm
@@ -31,5 +31,5 @@
 			smoke.set_up(5, 0, H:loc)
 			smoke.attach(H)
 			smoke.start()
-			ass_explosion(H, 1, 7)
+			ass_explosion(H, 1, 100)
 // See bigfart.dm for the ass_explosion() proc. The third value represents the probability of limb loss in percent.

--- a/code/modules/events/gimmick/bigfart.dm
+++ b/code/modules/events/gimmick/bigfart.dm
@@ -132,7 +132,7 @@
 				possible_limbs += H.limbs.r_leg
 
 			if (possible_limbs.len)
-				for (var/obj/item/parts/P in possible_limbs)
-					if (prob(limbloss_prob))
-						H.show_text("Your [P] was severed by the [magical ? "explosion" : "shockwave"]!", "red")
-						P.sever()
+				var/obj/item/parts/P = pick(possible_limbs)
+				if (prob(limbloss_prob))
+					H.show_text("Your [P] was severed by the [magical ? "explosion" : "shockwave"]!", "red")
+					P.sever()

--- a/code/modules/events/gimmick/bigfart.dm
+++ b/code/modules/events/gimmick/bigfart.dm
@@ -120,19 +120,19 @@
 		H.changeStatus("weakened", 3 SECONDS)
 		H.force_laydown_standup()
 
-	if (!is_bot)
-		var/list/possible_limbs = list()
-		if (H.limbs.l_arm)
-			possible_limbs += H.limbs.l_arm
-		if (H.limbs.r_arm)
-			possible_limbs += H.limbs.r_arm
-		if (H.limbs.l_leg)
-			possible_limbs += H.limbs.l_leg
-		if (H.limbs.r_leg)
-			possible_limbs += H.limbs.r_leg
+		if (!is_bot)
+			var/list/possible_limbs = list()
+			if (H.limbs.l_arm)
+				possible_limbs += H.limbs.l_arm
+			if (H.limbs.r_arm)
+				possible_limbs += H.limbs.r_arm
+			if (H.limbs.l_leg)
+				possible_limbs += H.limbs.l_leg
+			if (H.limbs.r_leg)
+				possible_limbs += H.limbs.r_leg
 
-		if (possible_limbs.len)
-			for (var/obj/item/parts/P in possible_limbs)
-				if (prob(limbloss_prob))
-					H.show_text("Your [P] was severed by the [magical ? "explosion" : "shockwave"]!", "red")
-					P.sever()
+			if (possible_limbs.len)
+				for (var/obj/item/parts/P in possible_limbs)
+					if (prob(limbloss_prob))
+						H.show_text("Your [P] was severed by the [magical ? "explosion" : "shockwave"]!", "red")
+						P.sever()

--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -1349,11 +1349,11 @@ PIPE BOMBS + CONSTRUCTION
 				if (butt > 1)
 					playsound(src.loc, "sound/voice/farts/superfart.ogg", 90, 1)
 					for (var/mob/M in view(3+butt,src.loc))
-						ass_explosion(M, 0, 1)
+						ass_explosion(M, 0, 5)
 				else
 					playsound(src.loc, "sound/voice/farts/poo2.ogg", 90, 1)
 					for (var/mob/M in view(3,src.loc))
-						ass_explosion(M, 0, 1)
+						ass_explosion(M, 0, 5)
 			if (confetti)
 				if (confetti > 1)
 					particleMaster.SpawnSystem(new /datum/particleSystem/confetti_more(src.loc))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE] [INPUT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This changes the ass_explosion proc to only roll to remove people's limbs if they have no ass.
This should mostly only affect the wizard spell.
Other places that use ass_explosion are butt-pipebombs, but those have only a 1% chance to delimb anyway, and the fartwaves caused by admins, but I don't care about admins. 🐸 

Do note that, according to my knowledge of probabilities, the current code will have approximately a 25% chance to take off at least one limb, if the person is missing an arse. (Seeing as rathen's secret has a 7% delimb chance.)
Perhaps this value should be changed, or ass_explosion changed altogether to always remove exactly one limb if the person has no arse.
If you have an opinion, please comment here or on the [forum thread](https://forum.ss13.co/showthread.php?tid=14579)!
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
There have been lots of complaints about Rathen's Secret recently.
I think that allowing people to reduce the potential damage to themselves by reattaching their butts before the spell gets used on them again provides a nice measure of counterplay, while still giving Rathen's Secret a good use as an AoE stun. 
In addition, if people do not reattach their butts, I think that making it so there is a 100% chance to detach exactly 1 limb would also make it a more reliable spell for wizards to use, as opposed to the rng fiesta it is right now.
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)zjdtmkhzt:
(*) Changed the Rathen's Secret wizard spell to only delimb if you have no arse. It also now always removes exactly one randomly chosen limb in that case.
```
