### PR TITLE
Allow admin customization of playable pest event

### DIFF
--- a/code/modules/events/antagonist_critter_ghost_respawn.dm
+++ b/code/modules/events/antagonist_critter_ghost_respawn.dm
@@ -40,6 +40,8 @@
 		//confirmation
 		if (alert(usr, "You have chosen to spawn [src.num_critters] [src.critter_type ? src.critter_type : "random critters"]. Is this correct?", src.name, "Yes", "No") == "Yes")
 			event_effect(source)
+		else
+			cleanup_event()
 
 	event_effect(var/source)
 		..()

--- a/code/modules/events/playable_pests.dm
+++ b/code/modules/events/playable_pests.dm
@@ -1,5 +1,8 @@
 /datum/random_event/major/player_spawn/pests
 	name = "Pests (playable)"
+	customization_available = 1
+	var/num_pests = 0
+	var/pest_type = null
 
 	required_elapsed_round_time = 5 MINUTES
 
@@ -12,10 +15,32 @@
 	list(/mob/living/critter/small_animal/frog/weak),\
 	list(/mob/living/critter/small_animal/cockroach/robo/weak),)
 
+	admin_call(var/source)
+		if (..())
+			return
 
+		var/input = null
+		switch (alert(usr, "Choose the pest type?", src.name, "Random", "Custom"))
+			if ("Custom")
+				src.pest_type = input("Enter a /mob/living/critter path or partial name.", src.name, null) as null|text
+				src.pest_type = get_one_match(input, "/mob/living/critter")
+				if (!src.pest_type)
+					return
+			if ("Random")
+				src.pest_type = null
 
+		src.num_pests = input(usr, "How many pests to spawn?", src.name, 0) as num|null
+		if (!src.num_pests || src.num_pests < 1)
+			cleanup_event()
+			return
+		else
+			src.num_pests = round(src.num_pests)
 
-	event_effect()
+		//confirmation
+		if (alert(usr, "You have chosen to spawn [src.num_pests] [src.pest_type ? src.pest_type : "random pests"]. Is this correct?", src.name, "Yes", "No") == "Yes")
+			event_effect(source)
+
+	event_effect(var/source)
 		..()
 
 		// 1: alert | 2: alert (chatbox) | 3: alert acknowledged (chatbox) | 4: no longer eligible (chatbox) | 5: waited too long (chatbox)
@@ -43,17 +68,35 @@
 				EV += latejoin
 				if (!EV.len)
 					message_admins("Pests event couldn't find a pest landmark!")
+					cleanup_event()
 					return
 
 			var/atom/pestlandmark = pick(EV)
 
-			var/list/select = pick(pest_invasion_critter_types)
-			for (var/datum/mind/M in candidates)
+			var/list/select = null
+			if (src.pest_type)
+				select = src.pest_type
+			else
+				select = pick(pest_invasion_critter_types)
+
+			if (src.num_pests)
+			 src.num_pests = min(src.num_pests, candidates.len)
+			else
+				src.num_pests = candidates.len
+
+			for (var/i in 1 to src.num_pests)
+				var/datum/mind/M = pick(candidates)
 				if (M.current)
-					M.current.make_ghost_critter(pestlandmark,select)
+					M.current.make_critter(pick(select), pestlandmark)
+				candidates -= M
 
 			pestlandmark.visible_message("A group of pests emerge from their hidey-hole!")
 
-			if (candidates.len >= 5)
+			if (src.num_pests >= 5)
 				command_alert("A large number of pests have been detected onboard.", "Pest invasion")
+		cleanup_event()
+
+	proc/cleanup_event()
+		src.num_pests = 0
+		src.pest_type = null
 

--- a/code/modules/events/playable_pests.dm
+++ b/code/modules/events/playable_pests.dm
@@ -79,7 +79,7 @@
 			if (src.pest_type)
 				select = src.pest_type
 			else
-				select = pick(pest_invasion_critter_types)
+				select = pick(src.pest_invasion_critter_types)
 
 			if (src.num_pests)
 				src.num_pests = min(src.num_pests, candidates.len)

--- a/code/modules/events/playable_pests.dm
+++ b/code/modules/events/playable_pests.dm
@@ -82,7 +82,7 @@
 				select = pick(pest_invasion_critter_types)
 
 			if (src.num_pests)
-			 src.num_pests = min(src.num_pests, candidates.len)
+				src.num_pests = min(src.num_pests, candidates.len)
 			else
 				src.num_pests = candidates.len
 

--- a/code/modules/events/playable_pests.dm
+++ b/code/modules/events/playable_pests.dm
@@ -87,6 +87,9 @@
 				src.num_pests = candidates.len
 
 			for (var/i in 1 to src.num_pests)
+				if (!candidates || !candidates.len)
+					break
+
 				var/datum/mind/M = pick(candidates)
 				if (M.current)
 					M.current.make_critter(pick(select), pestlandmark)

--- a/code/modules/events/playable_pests.dm
+++ b/code/modules/events/playable_pests.dm
@@ -39,6 +39,8 @@
 		//confirmation
 		if (alert(usr, "You have chosen to spawn [src.num_pests] [src.pest_type ? src.pest_type : "random pests"]. Is this correct?", src.name, "Yes", "No") == "Yes")
 			event_effect(source)
+		else
+			cleanup_event()
 
 	event_effect(var/source)
 		..()

--- a/code/modules/events/playable_pests.dm
+++ b/code/modules/events/playable_pests.dm
@@ -1,8 +1,8 @@
 /datum/random_event/major/player_spawn/pests
 	name = "Pests (playable)"
 	customization_available = 1
-	var/num_pests = 0
-	var/pest_type = null
+	var/num_pests = 0 //custom critter limit
+	var/pest_type = null //custom critter path
 
 	required_elapsed_round_time = 5 MINUTES
 
@@ -76,12 +76,12 @@
 			var/atom/pestlandmark = pick(EV)
 
 			var/list/select = null
-			if (src.pest_type)
+			if (src.pest_type) //customized
 				select = src.pest_type
 			else
 				select = pick(src.pest_invasion_critter_types)
 
-			if (src.num_pests)
+			if (src.num_pests) //customized
 				src.num_pests = min(src.num_pests, candidates.len)
 			else
 				src.num_pests = candidates.len

--- a/strings/admin_changelog.txt
+++ b/strings/admin_changelog.txt
@@ -1,3 +1,6 @@
+(t)tue jun 23 20
+(u)Sovexe
+(*)The Pests (playable) event now allows for customization in the form of critter type and quantity.
 (t)mon jun 22 20
 (u)Sovexe
 (*)The Awaken Sleeper Agents event now allows you to override player antagonist preferences.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][FEATURE][TRIVIAL][REWORK] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows admins to customize the playable pest event, choosing the type of pest and how many to spawn.

Running the event with random settings still uses the same behavior of choosing one of the whitelisted pests and allowing an unlimited number of players to sign up

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fun mostly