### PR TITLE
add link to observe a player in admin's "player options" screen

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -900,6 +900,21 @@ var/global/noir = 0
 			else
 				alert("You need to be at least a Secondary Adminstrator to jump to mobs.")
 
+		if ("observe")
+			if(src.level >= LEVEL_SA)
+				var/mob/M = locate(href_list["target"])
+				if (!M) return
+				if (isobserver(M))
+					boutput(usr, "<span class='alert'>You can't observe a ghost.</span>")
+				else
+					if (!istype(usr, /mob/dead/observer))
+						boutput(usr, "<span class='alert'>This command only works when you are a ghost.</span>")
+						return
+					var/mob/dead/observer/ghost = usr
+					ghost.insert_observer(M)
+			else
+				alert("You need to be at least a Secondary Adminstrator to observe mobs... For some reason.")
+
 		if ("jumptocoords")
 			if(src.level >= LEVEL_SA)
 				var/list/coords = splittext(href_list["target"], ",")

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -201,6 +201,7 @@
 					</div>
 					<div class='r'>
 						<a href='[playeropt_link(M, "jumpto")]'>Jump to</A> &bull;
+						<a href='[playeropt_link(M, "observe")]'>Observe</A> &bull;
 						<a href='[playeropt_link(M, "getmob")]'>Get</a> &bull;
 						<a href='[playeropt_link(M, "sendmob")]'>Send to...</a>
 						<br>Currently in [A]


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a button on the "player options" screen next to the buttons "jump to" and "get mob" that lets you immediately observe them.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This should have always existed. No longer do you need to keep jumping too a sprinting target clicking like a madman in order to observe them. Well, you always could have just used the observe verb, but I always forget about it.

