### PR TITLE
block ghostcritters from using computers and SMES units

### DIFF
--- a/code/datums/limb.dm
+++ b/code/datums/limb.dm
@@ -1178,7 +1178,8 @@ var/list/ghostcritter_blocked = ghostcritter_blocked_objects()
 	/obj/machinery/vending,\
 	/obj/machinery/nuclearbomb,\
 	/obj/item/gun/kinetic/airzooka,\
-	/obj/machinery/computer/genetics) //Items that ghostcritters simply cannot interact, regardless of w_class
+	/obj/machinery/computer.\
+	/obj/machinery/power/smes) //Items that ghostcritters simply cannot interact, regardless of w_class
 	. = list()
 	for (var/blocked_type in blocked_types)
 		for (var/subtype in typesof(blocked_type))

--- a/code/datums/limb.dm
+++ b/code/datums/limb.dm
@@ -1178,7 +1178,7 @@ var/list/ghostcritter_blocked = ghostcritter_blocked_objects()
 	/obj/machinery/vending,\
 	/obj/machinery/nuclearbomb,\
 	/obj/item/gun/kinetic/airzooka,\
-	/obj/machinery/computer.\
+	/obj/machinery/computer,\
 	/obj/machinery/power/smes) //Items that ghostcritters simply cannot interact, regardless of w_class
 	. = list()
 	for (var/blocked_type in blocked_types)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Ghost critters are too silly to use computers, don't'ch'a know?
I don't think that special exceptions for mentormice is a great idea either, so I'm not doing it 🤷‍♂️ 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #1201
