### PR TITLE
Prevent mindslaves from cutting out their own implant

### DIFF
--- a/code/modules/medical/surgery_procs.dm
+++ b/code/modules/medical/surgery_procs.dm
@@ -634,8 +634,10 @@ limbs are their own thing not included here.
 				// This is kinda important (Convair880).
 				if (istype(I, /obj/item/implant/mindslave))
 					if (patient.mind && (patient.mind.special_role == "mindslave"))
+						if(surgeon == patient) continue
 						remove_mindslave_status(patient, "mslave", "surgery")
 					else if (patient.mind && patient.mind.master)
+						if(surgeon == patient) continue
 						remove_mindslave_status(patient, "otherslave", "surgery")
 
 				patient.tri_message("<span class='alert'><b>[surgeon]</b> cuts out an implant from [patient == surgeon ? "[him_or_her(patient)]self" : "[patient]"] with [src]!</span>",\


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEAT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes mindslaves skip over mindslave implants if self-surgerying and mindslaved


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Because there isn't a valid reason I can think of for active mindslaves to be cutting those out, and it's super awkward when a mindslave goes to cut out shrapnel and accidentally hits the mindslave implant.