### PR TITLE
Reduce noise maker artifact volume

### DIFF
--- a/code/obj/artifacts/artifact_machines/noise_maker.dm
+++ b/code/obj/artifacts/artifact_machines/noise_maker.dm
@@ -36,7 +36,7 @@
 		src.sound_pitch /= 10
 		if(prob(10))
 			src.sound_pitch /= 10
-		src.volume = pick(prob(10);10, prob(20);30, prob(40);80, prob(20); 100, prob(10);200)
+		src.volume = pick(prob(25);20, prob(50);30, 40, prob(25);50)
 		src.extrarange = (200 - volume)/2 + rand(-20, 20)
 		if(prob(40))
 			src.extrarange = -10


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][REWORK][SOUND][INPUT] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Significantly reduces the maximum noise maker volume, and lowers the average noise volume

demo of new max loudness (volume 50) : https://streamable.com/ist6we

please offer any opinions.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
These things are absolutely miserable. Currently they go up to 200% volume too.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Sovexe:
(+)Significantly reduced the loudness of noise maker artifacts.
```
