### PR TITLE
Fixed a number of bugs related to AI brains

### DIFF
--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -435,12 +435,10 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 	src.death()
 	if (src.mind)
 		var/mob/dead/observer/newmob = src.ghostize()
-		if (!newmob || !istype(newmob, /mob/dead/observer))
-			return
-		newmob.corpse = null //Otherwise they could return to a brainless body.  And that is weird.
-		newmob.mind.brain = src.brain
-		src.brain.owner = newmob.mind
-
+		if (newmob && istype(newmob, /mob/dead/observer))
+			newmob.corpse = null //Otherwise they could return to a brainless body.  And that is weird.
+			newmob.mind.brain = src.brain
+			src.brain.owner = newmob.mind
 	if (user)
 		user.put_in_hand_or_drop(src.brain)
 	else
@@ -472,12 +470,15 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 
 
 /mob/living/silicon/ai/proc/turn_it_back_on()
-	if (src.health >= 50 && isdead(src))
+	if (src.health >= 50 && isdead(src) && src.brain)
 		setalive(src)
-		if (src.ghost && src.ghost.mind)
-			src.ghost.show_text("<span class='alert'><B>You feel your self being pulled back from whatever afterlife AIs have!</B></span>")
-			src.ghost.mind.transfer_to(src)
-			qdel(src.ghost)
+		if (src.brain.owner && src.brain.owner.current)
+			if (!isobserver(src.brain.owner.current))
+				return
+			var/mob/ghost = src.brain.owner.current
+			ghost.show_text("<span class='alert'><B>You feel your self being pulled back from the afterlife!</B></span>")
+			ghost.mind.transfer_to(src)
+			qdel(ghost)
 		return 1
 	return 0
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes these issues:

- AI could be revived by toggling the area power, despite having no brain.
- The AI brain would not eject properly if the inserted brain was not a ghost player.
- If AI was revived, it would completely ignore the mind of the brain and instead only look at whatever mind was previously tied to its mob. This worked fine when you wanted to swap a player in (since it'd use the `mind/proc/transfer_to` proc), but if you put in a non-player brain inside, the AI player would be revived again.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bugfixes
resolves https://github.com/goonstation/goonstation/issues/1200


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)RichardGere:
(+)Fixed a number of AI related bugs.
```
