### PR TITLE
Moves Manta Arrivals - PROPERLY THIS TIME AAA

### DIFF
--- a/code/WorkInProgress/ZeWakasStuff.dm
+++ b/code/WorkInProgress/ZeWakasStuff.dm
@@ -3,7 +3,7 @@
  * 90 101 87 97 107 97 39 115  83 116 117 102 102
  */
 
-//foo 12: bodacious grandiose bargaloo mambo
+//foo 13: bodacious grandiose bargaloo mambo
 
 //everything here is wip, this can also be ascertained by the location of this file
 

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -1440,8 +1440,7 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperport)
 "acT" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crewquarters/cryotron)
 "acU" = (
 /obj/decal/tile_edge/line/blue{
@@ -1452,9 +1451,8 @@
 /turf/simulated/floor,
 /area/station/hallway/portupperhallway)
 "acV" = (
-/turf/simulated/floor/arrival{
-	dir = 1
-	},
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
 /area/station/crewquarters/cryotron)
 "acW" = (
 /obj/machinery/power/apc/autoname_north,
@@ -1465,10 +1463,8 @@
 /obj/machinery/light/incandescent/netural{
 	dir = 8
 	},
-/turf/simulated/floor/arrival{
-	dir = 9
-	},
-/area/station/crewquarters/cryotron)
+/turf/simulated/floor,
+/area/station/construction/under_construction)
 "acX" = (
 /obj/marker/supplymarker,
 /turf/simulated/floor/grime,
@@ -3116,12 +3112,8 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperport)
 "ain" = (
-/obj/landmark{
-	name = "Observer-Start"
-	},
-/turf/simulated/floor{
-	icon_state = "nt_logo"
-	},
+/obj/disposalpipe/segment/mail,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crewquarters/cryotron)
 "aio" = (
 /obj/stool/chair/blue{
@@ -7431,7 +7423,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/wall/auto/supernorn,
-/area/station/construction/under_construction)
+/area/station/crewquarters/cryotron)
 "arT" = (
 /obj/decal/tile_edge/check{
 	icon_state = "check1";
@@ -7543,8 +7535,10 @@
 /obj/machinery/light/incandescent/netural{
 	dir = 1
 	},
-/turf/simulated/floor,
-/area/station/construction/under_construction)
+/turf/simulated/floor/arrival{
+	dir = 1
+	},
+/area/station/crewquarters/cryotron)
 "asg" = (
 /obj/disposalpipe/segment/mail{
 	dir = 1;
@@ -7560,8 +7554,14 @@
 	dir = 8;
 	nostick = 1
 	},
-/turf/simulated/floor,
-/area/station/construction/under_construction)
+/obj/stool/chair/blue{
+	anchored = 0;
+	dir = 4
+	},
+/turf/simulated/floor/arrival{
+	dir = 8
+	},
+/area/station/crewquarters/cryotron)
 "asi" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor,
@@ -7570,19 +7570,24 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/table/glass/auto,
+/obj/random_item_spawner/desk_stuff/g_clip_bin_pen,
 /turf/simulated/floor,
-/area/station/construction/under_construction)
+/area/station/crewquarters/cryotron)
 "ask" = (
 /obj/disposalpipe/segment/mail{
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/light/incandescent/netural{
-	dir = 4;
-	nostick = 1
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor,
-/area/station/construction/under_construction)
+/turf/simulated/floor/arrival{
+	dir = 4
+	},
+/area/station/crewquarters/cryotron)
 "asl" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
@@ -8214,7 +8219,6 @@
 /area/mantaSpace)
 "atV" = (
 /obj/machinery/door/airlock/pyro/security{
-	dir = 2;
 	name = "Armory"
 	},
 /obj/firedoor_spawn,
@@ -8575,9 +8579,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/engineering/breakroom)
 "auL" = (
-/obj/item/device/radio/intercom/loudspeaker/speaker/west{
-	dir = 8
-	},
+/obj/item/device/radio/intercom/loudspeaker/speaker/west,
 /obj/machinery/light/small/cool,
 /turf/simulated/floor/sanitary,
 /area/station/engine/engineering/restroom)
@@ -8644,9 +8646,7 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/device/radio/intercom/loudspeaker/speaker/east{
-	dir = 4
-	},
+/obj/item/device/radio/intercom/loudspeaker/speaker/east,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -8985,9 +8985,7 @@
 /area/station/engine/storage)
 "avE" = (
 /obj/machinery/dispenser,
-/obj/item/device/radio/intercom/loudspeaker/speaker/west{
-	dir = 8
-	},
+/obj/item/device/radio/intercom/loudspeaker/speaker/west,
 /turf/simulated/floor/bot,
 /area/station/engine/storage)
 "avF" = (
@@ -10140,9 +10138,7 @@
 /turf/simulated/floor,
 /area/station/hangar/security)
 "axT" = (
-/obj/item/device/radio/intercom/loudspeaker/speaker/east{
-	dir = 4
-	},
+/obj/item/device/radio/intercom/loudspeaker/speaker/east,
 /obj/decal/tile_edge/line/black{
 	dir = 8;
 	icon_state = "line1"
@@ -10177,9 +10173,7 @@
 	},
 /obj/decoration/decorativeplant/plant6,
 /obj/machinery/light/incandescent/netural,
-/obj/item/device/radio/intercom/loudspeaker/speaker/east{
-	dir = 4
-	},
+/obj/item/device/radio/intercom/loudspeaker/speaker/east,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "yellowblackcorner"
@@ -10701,7 +10695,6 @@
 	},
 /obj/machinery/computer/riotgear{
 	dir = 4;
-	icon_state = "drawbr0";
 	pixel_x = -28
 	},
 /turf/simulated/floor/redblack{
@@ -14440,27 +14433,43 @@
 /area/station/maintenance/upperport)
 "aGY" = (
 /turf/simulated/floor/arrival{
-	dir = 8
+	dir = 6
 	},
 /area/station/crewquarters/cryotron)
 "aGZ" = (
+/turf/simulated/floor/arrival{
+	dir = 1
+	},
+/area/station/crewquarters/cryotron)
+"aHa" = (
 /obj/cryotron{
 	layer = 3.9
 	},
-/turf/simulated/floor,
-/area/station/crewquarters/cryotron)
-"aHa" = (
-/obj/landmark/start/latejoin,
 /turf/simulated/floor/arrival{
 	dir = 1
 	},
 /area/station/crewquarters/cryotron)
 "aHb" = (
-/turf/simulated/floor,
+/obj/landmark/start/latejoin,
+/turf/simulated/floor/arrival{
+	dir = 1
+	},
 /area/station/crewquarters/cryotron)
 "aHc" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/arrival{
-	dir = 4
+	dir = 5
 	},
 /area/station/crewquarters/cryotron)
 "aHd" = (
@@ -14472,15 +14481,18 @@
 /turf/simulated/floor,
 /area/station/hallway/starboardupperhallway)
 "aHe" = (
-/turf/simulated/floor{
-	icon_state = "blugreencorner"
+/obj/disposalpipe/segment/mail{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
+/turf/simulated/wall/auto/supernorn,
 /area/station/crewquarters/cryotron)
 "aHf" = (
-/obj/voting_box,
-/turf/simulated/floor/arrival{
-	dir = 6
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
+/obj/table/glass/auto,
+/turf/simulated/floor,
 /area/station/crewquarters/cryotron)
 "aHg" = (
 /obj/machinery/firealarm{
@@ -14496,13 +14508,14 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperport)
 "aHh" = (
-/obj/stool/chair/blue{
-	anchored = 0;
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/floor/arrival{
+/obj/stool/chair/blue{
+	anchored = 0;
 	dir = 8
 	},
+/turf/simulated/floor,
 /area/station/crewquarters/cryotron)
 "aHi" = (
 /obj/machinery/light/incandescent/netural{
@@ -14522,13 +14535,10 @@
 	},
 /area/station/crew_quarters/quartersB)
 "aHj" = (
-/obj/stool/chair/blue{
-	anchored = 0;
-	dir = 8
-	},
-/turf/simulated/floor/arrival{
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/turf/simulated/floor,
 /area/station/crewquarters/cryotron)
 "aHk" = (
 /obj/disposalpipe/segment/mail{
@@ -14538,17 +14548,26 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/quartermaster/cargobay)
 "aHl" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/crewquarters/cryotron)
-"aHm" = (
-/obj/stool/chair/blue{
-	anchored = 0;
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/floor/arrival{
-	dir = 10
+/obj/landmark{
+	name = "Observer-Start"
+	},
+/turf/simulated/floor{
+	icon_state = "nt_logo"
 	},
 /area/station/crewquarters/cryotron)
+"aHm" = (
+/obj/disposalpipe/segment,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor,
+/area/station/hallway/portlowerhallway)
 "aHn" = (
 /obj/cable{
 	d1 = 4;
@@ -16967,8 +16986,14 @@
 /turf/simulated/floor/yellow,
 /area/station/engine/inner)
 "aMx" = (
-/turf/space/fluid/manta,
-/area)
+/obj/stool/chair/blue{
+	anchored = 0;
+	dir = 4
+	},
+/turf/simulated/floor/arrival{
+	dir = 8
+	},
+/area/station/crewquarters/cryotron)
 "aMA" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 8
@@ -17924,18 +17949,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/lowerstarboard)
-"aOG" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 4
-	},
-/obj/decal/poster/wallsign/teaparty{
-	desc = "Pre-eliminary signing up for Nanotrasen's newest military vessel NSS Manta has now begun. Reach out to your head of personnel or a local Nanotrasen recruiting officer to find out more about new job oppurtunities aboard NSS Manta!  ... Hold on just a minute, aren't you already there?";
-	pixel_y = 32
-	},
-/turf/simulated/floor/arrival{
-	dir = 5
-	},
-/area/station/crewquarters/cryotron)
 "aOH" = (
 /obj/table/reinforced/chemistry/auto,
 /obj/machinery/door/airlock/pyro/glass/windoor{
@@ -32529,6 +32542,7 @@
 /area/station/construction/under_construction)
 "bsO" = (
 /obj/disposalpipe/segment/mail,
+/obj/item/constructioncone,
 /obj/machinery/light/incandescent/netural{
 	dir = 4;
 	nostick = 1
@@ -32979,36 +32993,17 @@
 /area/station/quartermaster/cargobay)
 "btR" = (
 /obj/wingrille_spawn/auto,
-/obj/cable{
-	icon_state = "0-2"
-	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/construction/under_construction)
 "btS" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/construction/under_construction)
+/obj/table/glass/auto,
+/turf/simulated/floor,
+/area/station/crewquarters/cryotron)
 "btT" = (
 /obj/disposalpipe/segment,
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 8;
-	icon_state = "line1"
-	},
 /obj/decal/fakeobjects{
 	desc = "Under construction";
 	dir = 1;
@@ -33019,29 +33014,10 @@
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
 "btU" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/door/airlock/pyro/engineering{
-	dir = 4;
-	name = "Mining"
-	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
-/obj/disposalpipe/segment{
+/obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
 /obj/firedoor_spawn,
-/obj/access_spawn/mining,
 /turf/simulated/floor/orange,
 /area/station/construction/under_construction)
 "btV" = (
@@ -33052,10 +33028,6 @@
 /turf/simulated/floor,
 /area/station/construction/under_construction)
 "btW" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable,
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/mail{
 	dir = 2;
@@ -33065,7 +33037,6 @@
 /area/station/construction/under_construction)
 "btX" = (
 /obj/wingrille_spawn/auto,
-/obj/cable,
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/plating,
 /area/station/construction/under_construction)
@@ -33493,15 +33464,12 @@
 /turf/simulated/floor,
 /area/station/hangar/starboard)
 "buX" = (
-/obj/disposalpipe/segment,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	tag = ""
+/obj/stool/chair/blue{
+	anchored = 0;
+	dir = 8
 	},
 /turf/simulated/floor,
-/area/station/hallway/portlowerhallway)
+/area/station/crewquarters/cryotron)
 "buY" = (
 /obj/decal/tile_edge/line/green{
 	color = "#ba9a65";
@@ -33799,7 +33767,7 @@
 /turf/simulated/floor,
 /area/station/hangar/starboard)
 "bvG" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
+/turf/simulated/floor,
 /area/station/crewquarters/cryotron)
 "bvH" = (
 /obj/decal/tile_edge/stripe/extra_big{
@@ -34505,13 +34473,14 @@
 /turf/simulated/floor,
 /area/station/hallway/starboardlowerhallway)
 "bxn" = (
+/obj/disposalpipe/segment/mail,
 /obj/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/arrival{
-	dir = 8
+	dir = 4
 	},
 /area/station/crewquarters/cryotron)
 "bxo" = (
@@ -35188,17 +35157,15 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/blue/checker,
-/area/station/crewquarters/cryotron)
+/area/station/construction/under_construction)
 "byQ" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/arrival{
-	dir = 8
-	},
-/area/station/crewquarters/cryotron)
+/turf/simulated/floor,
+/area/station/construction/under_construction)
 "byR" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -35207,10 +35174,8 @@
 	pixel_x = 10;
 	tag = ""
 	},
-/turf/simulated/floor/arrival{
-	dir = 4
-	},
-/area/station/crewquarters/cryotron)
+/turf/simulated/floor,
+/area/station/construction/under_construction)
 "byS" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -35629,11 +35594,6 @@
 "bzI" = (
 /obj/disposalpipe/junction{
 	dir = 1
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 10;
-	icon_state = "line1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
@@ -36628,34 +36588,29 @@
 /obj/machinery/light/incandescent/netural{
 	dir = 8
 	},
-/turf/simulated/floor/arrival{
-	dir = 8
-	},
-/area/station/crewquarters/cryotron)
+/turf/simulated/floor,
+/area/station/construction/under_construction)
 "bBQ" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 4
 	},
-/turf/simulated/floor/arrival{
-	dir = 4
-	},
-/area/station/crewquarters/cryotron)
+/turf/simulated/floor,
+/area/station/construction/under_construction)
 "bBR" = (
 /obj/decal/cleanable/dirt/dirt3,
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/port)
 "bBS" = (
-/obj/disposalpipe/segment,
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 8;
-	icon_state = "line1"
-	},
-/obj/disposalpipe/segment/mail{
+/obj/machinery/door/airlock/pyro/glass{
 	dir = 4
 	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
-/area/station/hallway/portlowerhallway)
+/area/station/crewquarters/cryotron)
 "bBU" = (
 /obj/machinery/door/airlock/pyro/security{
 	dir = 4;
@@ -37359,9 +37314,19 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperport)
 "bDo" = (
-/obj/table/glass/auto,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/mail,
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/portlowerhallway)
 "bDp" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 9;
@@ -37827,21 +37792,19 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/lowerstarboard)
 "bEx" = (
-/obj/random_item_spawner/desk_stuff/g_clip_bin_pen,
-/obj/table/glass/auto,
-/turf/simulated/floor/arrival,
+/obj/decal/poster/wallsign/teaparty{
+	pixel_x = -32
+	},
+/turf/simulated/floor/arrival{
+	dir = 10
+	},
 /area/station/crewquarters/cryotron)
 "bEy" = (
-/obj/table/glass/auto,
 /turf/simulated/floor/arrival,
 /area/station/crewquarters/cryotron)
 "bEz" = (
-/obj/stool/chair/blue{
-	anchored = 0;
+/turf/simulated/floor/arrival/corner{
 	dir = 8
-	},
-/turf/simulated/floor/arrival{
-	dir = 6
 	},
 /area/station/crewquarters/cryotron)
 "bEA" = (
@@ -38107,14 +38070,11 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/lowerport)
 "bFh" = (
-/obj/disposalpipe/segment,
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 8;
-	icon_state = "line1"
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/arrival{
+	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/hallway/portlowerhallway)
+/area/station/crewquarters/cryotron)
 "bFi" = (
 /obj/cable{
 	d1 = 4;
@@ -38743,34 +38703,15 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/lowerport)
 "bGJ" = (
-/obj/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2"
+/obj/voting_box,
+/turf/simulated/floor/arrival{
+	dir = 10
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 8;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/portlowerhallway)
+/area/station/crewquarters/cryotron)
 "bGK" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment/mail,
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/portlowerhallway)
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/arrival,
+/area/station/crewquarters/cryotron)
 "bGL" = (
 /obj/cable{
 	d1 = 4;
@@ -40788,11 +40729,6 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 9;
-	icon_state = "line1"
-	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
 "bLD" = (
@@ -41103,11 +41039,12 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/lowerport)
 "bMl" = (
-/obj/disposalpipe/junction{
-	dir = 1
-	},
 /obj/cable{
 	icon_state = "2-4"
+	},
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
@@ -44434,9 +44371,7 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/obj/item/device/radio/intercom/loudspeaker/speaker/west{
-	dir = 8
-	},
+/obj/item/device/radio/intercom/loudspeaker/speaker/west,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "yellowblack"
@@ -45773,6 +45708,12 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
+"nHa" = (
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/arrival{
+	dir = 6
+	},
+/area/station/crewquarters/cryotron)
 "ofD" = (
 /obj/decal/tile_edge/line/purple{
 	icon_state = "line3"
@@ -77394,11 +77335,11 @@ aCb
 bgr
 box
 arS
-asc
-asg
-arU
-arU
-arU
+ain
+aHe
+acT
+acT
+acT
 arU
 arU
 arU
@@ -77695,13 +77636,13 @@ bnK
 aJJ
 bgr
 box
-arU
-ase
+acT
+aGY
 ash
-bSI
-bSI
-bSI
-bSI
+aMx
+bEx
+acT
+ase
 bsN
 bSI
 bSI
@@ -77997,12 +77938,12 @@ bnL
 aJJ
 bgr
 box
-bSH
-bSI
+acV
+aGZ
 asj
-bSI
-bSI
-bSI
+btS
+bEy
+acT
 bSI
 bSI
 bSI
@@ -78299,12 +78240,12 @@ bnM
 boV
 bgr
 box
-bSH
-bSI
-asj
-bSI
-bSI
-bSI
+acV
+aGZ
+aHf
+btS
+bEy
+acT
 bSI
 bSI
 bSI
@@ -78601,13 +78542,13 @@ bnL
 aJJ
 bfs
 box
-bSH
+acV
 asf
-asj
-bSI
-bSI
-bSI
-bSI
+aHh
+buX
+bEy
+acT
+acT
 bSI
 bSI
 bSI
@@ -78903,13 +78844,13 @@ bnN
 aJJ
 bgr
 box
-bSH
-bSI
-asj
-bSI
-bSI
-bSI
-bSI
+acV
+aHa
+aHj
+bvG
+bEz
+bGJ
+acT
 bSI
 bSI
 bSI
@@ -79205,13 +79146,13 @@ aEi
 aEi
 bho
 box
-bSH
-bSI
-asj
-bSI
-bSI
-bSI
-bSI
+acV
+aHb
+aHl
+bvG
+bvG
+bGK
+acT
 bSI
 bSI
 bSI
@@ -79507,13 +79448,13 @@ bnO
 aNs
 bgr
 bqf
-arU
-ase
+acT
+aHc
 ask
-asl
-asl
-asl
-asl
+bxn
+bFh
+nHa
+ain
 bsO
 asl
 asl
@@ -79809,16 +79750,16 @@ bnP
 boW
 bhQ
 bqk
-arU
-arU
-arU
-arU
-arU
-arU
-arU
+acT
+acT
+acV
+bBS
+acV
+acT
+acT
 arU
 btR
-btS
+bSH
 btU
 btW
 btX
@@ -80113,17 +80054,17 @@ bgr
 bql
 bcj
 bsZ
-bcj
-buX
+aHm
+bGV
 bcj
 bsZ
 byk
 bzI
-bBS
+bjW
 btT
-bGJ
+bcj
 btT
-bFh
+bcj
 bLC
 bsZ
 bjW
@@ -80416,14 +80357,14 @@ bqg
 brE
 bta
 bta
-bta
+bDo
 bta
 bta
 bym
 bsb
 czS
 bFj
-bGK
+bta
 bIx
 bIW
 bLL
@@ -86757,14 +86698,14 @@ bdg
 bqM
 bse
 bte
-acT
-acT
+bSH
+bSH
 byP
-acT
-acT
-aHl
-aHl
-aHl
+bSH
+bSH
+arU
+arU
+arU
 boc
 boc
 bJv
@@ -86989,7 +86930,7 @@ ajK
 aiu
 agD
 aaa
-aMx
+aaa
 ajW
 aab
 aaa
@@ -87060,13 +87001,13 @@ bdg
 aZM
 bte
 acW
-bxn
+bSZ
 byQ
-aGY
+bSI
 bBP
-aHh
-aHm
-acT
+bSI
+bSI
+bSH
 bqV
 boc
 brV
@@ -87291,7 +87232,7 @@ ajL
 ajV
 agD
 aaa
-aMx
+aaa
 adx
 aab
 aab
@@ -87361,14 +87302,14 @@ aNo
 aNo
 aNo
 aCM
-acV
-aGZ
-aHb
-aHb
-aHb
-bDo
-bEx
-acT
+bSI
+bSI
+bSI
+bSI
+bSI
+bSI
+bSI
+bSH
 boc
 boc
 bJy
@@ -87663,14 +87604,14 @@ bqt
 brF
 aEL
 aCM
-acV
-aHa
-aHb
-ain
-aHb
-bDo
-bEy
-acT
+bSI
+bSI
+bSI
+bSI
+bSI
+bSI
+bSI
+bSH
 boc
 bIy
 btc
@@ -87965,14 +87906,14 @@ bqt
 brG
 bsP
 aCM
-acV
-aHb
-aHb
-aHe
+bSI
+bSI
+bSI
+bSI
 bBQ
-aHj
-bEz
-acT
+bSI
+bSI
+bSH
 boc
 bIh
 bqT
@@ -88267,14 +88208,14 @@ bqu
 brH
 bsQ
 aCM
-aOG
-aHc
+bBQ
+bSI
 byR
-aHf
-bvG
-bvG
-bvG
-bvG
+bSI
+bSJ
+bSJ
+bSJ
+bSJ
 bHh
 bIg
 bHh
@@ -88569,11 +88510,11 @@ aDd
 aDd
 aDd
 aCM
-bvG
-bvG
-bvG
-bvG
-bvG
+bSJ
+bSJ
+bSJ
+bSJ
+bSJ
 bvH
 bxo
 aiq

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -90421,8 +90421,8 @@ amt
 amC
 amK
 amT
-and
 amT
+and
 ann
 akH
 any


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves Manta Arrivals away from Escape, placing it in the empty space next to QM instead.

Except this time I did it properly WITHOUT fucking everything up.
(I hope)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
As it is, It's extremely easy to accidentally damage Arrivals due to its poor placement of it being right next to Escape and Engineering.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Comrade f191:
(*)Moved Arrivals on Manta to QM rather than Escape.
```