### PR TITLE
Added an icon update to removing items from satchels.

### DIFF
--- a/code/obj/item/satchel.dm
+++ b/code/obj/item/satchel.dm
@@ -70,7 +70,7 @@
 					user.visible_message("<span class='notice'><b>[usr]</b> takes \a [getItem.name] out of \the [src].</span>",\
 					"<span class='notice'>You take \a [getItem.name] from [src].</span>")
 					user.put_in_hand_or_drop(getItem)
-
+					src.satchel_updateicon()
 		return ..(user)
 
 	proc/search_through(mob/user as mob)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

A simple bugfix which makes Produce Satchels do an icon update when removing items from them one at a time with an empty hand.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The icon state would keep showing the bag being full even when emptied.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Avatharian:
(+)Produce satchels now update their icon when removing items by hand.
```