### PR TITLE
Event antagonist critters loot tables, dropping items on death.

### DIFF
--- a/code/modules/events/antagonist_critter_ghost_respawn.dm
+++ b/code/modules/events/antagonist_critter_ghost_respawn.dm
@@ -19,7 +19,7 @@
 
 		if (pity_drop_atleast_one)
 			if (!length(dropped_items)) //dropped_items is empty, aka we didn't drop any item, initiate pity drop
-				dropped_items = list(pick(potential_drops))
+				dropped_items += pick(potential_drops)
 		return dropped_items
 
 	New(potential_drop_items, remove_dropped_items = 0, number_of_rolls = 1, percent_droprate = 100, pity_drop_atleast_one = 0)
@@ -40,7 +40,7 @@
 		var/datum/event_item_drop_table/drop_table
 		for (drop_table in src.drop_tables)
 			var/drop_table_dropped_items = drop_table.roll_for_items()
-			if (drop_table_dropped_items)
+			if (drop_table_dropped_items && length(drop_table_dropped_items))
 				items_to_drop.Add(drop_table.roll_for_items())
 
 		return items_to_drop
@@ -73,7 +73,7 @@
 					number_of_rolls = 6
 					),
 				new /datum/event_item_drop_table(  // but on the bright side it drops an egg!
-					potential_drop_items = list(/obj/item/reagent_containers/food/snacks/ingredient/egg/critter/clown, /obj/item/reagent_containers/food/snacks/ingredient/egg/critter/clown,
+					potential_drop_items = list(/obj/item/reagent_containers/food/snacks/ingredient/egg/critter/clown, /obj/item/reagent_containers/food/snacks/ingredient/egg/critter/cluwne,
 																			/obj/item/reagent_containers/food/snacks/ingredient/egg/critter/nicespider, /obj/item/reagent_containers/food/snacks/ingredient/egg/critter/parrot,
 																			/obj/item/reagent_containers/food/snacks/ingredient/egg/critter/skeleton, /obj/item/reagent_containers/food/snacks/ingredient/egg/critter/goose),
 					)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a functionality for loot tables, used to allow for defining a drop table for event antagonist critters.
A loot table is a list of items, coupled with various parameters for generating the list of items to drop: the amount of times it tries to roll from the table, probability to roll something, whether any acquired items should be removed from the further possible drops and also an option to ensure that at the very least one item is definitely dropped from a specific loot table.
The PR adds some items that can drop for each existing critter, their modification and/or addition of new ones should also be hopefully simple and malleable.

After personal testing and fixing this current version appears stable and bug-free, albeit the PR process might reveal some inefficiency in the code and/or other possible improvements, suggestions on either of which I'd be happy to hear.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Having some payoff to enduring the antagonist critter event might make the event less frustrating for some as there is some element of reward and also encourage the crew to fend off the invader.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Gerhazo:
(*)Random event antagonist critters now drop various loot after being slain.
```
