### PR TITLE
belts no longer fit in backpacks

### DIFF
--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -136,6 +136,7 @@
 	stamina_damage = 10
 	stamina_cost = 5
 	stamina_crit_chance = 5
+	w_class = 4.0
 
 	New()
 		..()


### PR DESCRIPTION
by stuffing your backpack with loaded belts, you can become a one-man army carrying the entire loadout of a medical doctor, security officer, and an engineer combined. Unlike backpack boxes, this comes with the added convenience of being able to quickswap your belts so you lose no time to rummaging. 

i think this is bad, what do YOU think????


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)mbc:
(*)Belts will no longer fit inside backpacks
```
