### PR TITLE
Cyborgs now leave a frame behind when "falling apart"

### DIFF
--- a/code/mob/living/life/statusupdate.dm
+++ b/code/mob/living/life/statusupdate.dm
@@ -173,7 +173,7 @@
 					if (newmob)
 						newmob.corpse = null
 				
-				new /obj/item/parts/robot_parts/robot_frame(get_truf(robot_owner))
+				new /obj/item/parts/robot_parts/robot_frame(robot_owner.get_turf())
 
 				qdel(robot_owner)
 

--- a/code/mob/living/life/statusupdate.dm
+++ b/code/mob/living/life/statusupdate.dm
@@ -173,7 +173,7 @@
 					if (newmob)
 						newmob.corpse = null
 				
-				new /obj/item/parts/robot_parts/robot_frame(robot_owner.get_turf())
+				new /obj/item/parts/robot_parts/robot_frame(get_turf(robot_owner))
 
 				qdel(robot_owner)
 

--- a/code/mob/living/life/statusupdate.dm
+++ b/code/mob/living/life/statusupdate.dm
@@ -173,7 +173,7 @@
 					if (newmob)
 						newmob.corpse = null
 				
-				new obj/item/parts/robot_parts/robot_frame(robot_owner.loc)
+				new /obj/item/parts/robot_parts/robot_frame(robot_owner.loc)
 
 				qdel(robot_owner)
 

--- a/code/mob/living/life/statusupdate.dm
+++ b/code/mob/living/life/statusupdate.dm
@@ -172,6 +172,8 @@
 					var/mob/dead/observer/newmob = robot_owner.ghostize()
 					if (newmob)
 						newmob.corpse = null
+				
+				new obj/item/parts/robot_parts/robot_frame(robot_owner.loc)
 
 				qdel(robot_owner)
 

--- a/code/mob/living/life/statusupdate.dm
+++ b/code/mob/living/life/statusupdate.dm
@@ -173,7 +173,7 @@
 					if (newmob)
 						newmob.corpse = null
 				
-				new /obj/item/parts/robot_parts/robot_frame(robot_owner.loc)
+				new /obj/item/parts/robot_parts/robot_frame(get_truf(robot_owner))
 
 				qdel(robot_owner)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Cyborgs leave behind a frame when fully disassembled / falling apart.
Fixes #1262


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Mainly because I took a cyborg fully apart while upgrading them, and that causes the frame to evaporate.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)MarkNstein:
(+)Cyborg frames no longer disappear after fully disassembling a borg.
```
