### PR TITLE
Adds witchfinder outfit to chaplain closet

### DIFF
--- a/code/obj/item/clothing/shoes.dm
+++ b/code/obj/item/clothing/shoes.dm
@@ -539,9 +539,6 @@
 	kick_bonus = 1
 	step_sound = "step_wood"
 	step_priority = STEP_PRIORITY_LOW
-	setupProperties()
-		..()
-		setProperty("meleeprot", 5)
 
 /obj/item/clothing/shoes/jester
 	name = "jester's shoes"

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -1440,10 +1440,9 @@
 
 	setupProperties()
 		..()
-		setProperty("coldprot", 15)
-		setProperty("heatprot", 15)
-		setProperty("meleeprot", 0.5)
-		setProperty("rangedprot", 0.5)
+		setProperty("coldprot", 5)
+		setProperty("heatprot", 5)
+		setProperty("meleeprot", 2)
 
 /obj/item/clothing/suit/nursedress
 	name = "nurse dress"

--- a/code/obj/item/storage/clothing.dm
+++ b/code/obj/item/storage/clothing.dm
@@ -218,6 +218,13 @@
 	/obj/item/clothing/under/rank/bartender/tuxedo,
 	/obj/item/clothing/shoes/dress_shoes)
 
+/obj/item/storage/box/clothing/witchfinder
+	name = "\improper Witchfinder's equipment"
+	spawn_contents = list(/obj/item/clothing/under/gimmick/witchfinder,\
+	/obj/item/clothing/suit/witchfinder,\
+	/obj/item/clothing/head/witchfinder,\
+	/obj/item/clothing/shoes/witchfinder)
+
 /* ============================== */
 /* ---------- Costumes ---------- */
 /* ============================== */

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -615,7 +615,8 @@
 /obj/storage/secure/closet/civilian/chaplain
 	name = "\improper Religious supplies locker"
 	req_access = list(access_chapel_office)
-	spawn_contents = list(/obj/item/storage/box/clothing/chaplain,\
+	spawn_contents = list(/obj/item/storage/box/clothing/witchfinder,\
+	/obj/item/storage/box/clothing/chaplain,\
 	/obj/item/clothing/under/misc/chaplain/atheist,\
 	/obj/item/clothing/under/misc/chaplain,\
 	/obj/item/clothing/under/misc/chaplain/rabbi,\


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the Witchfinder outfit for chaplains to the religious supply locker. This outfit was previously only available on Manta (and possibly another map?), but I think it looked cool and it fits neatly into the chaplain theme.

I also adjusted some of the properties so they're basically on the same level as the other cosmetic robes; incase this gets merged I don't want it to become some weird meta where this set of gear is objectively better mechanically. It should remain a cosmetic thing in my opinion.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's a good set of sprites and I think it's a shame it doesn't get put to much use. 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)RichardGere:
(+)Added witchfinder outfit to religious supply lockers.
```
