### PR TITLE
Swap fitness gene stability losses

### DIFF
--- a/code/modules/medical/genetics/bioEffects/beneficial.dm
+++ b/code/modules/medical/genetics/bioEffects/beneficial.dm
@@ -484,7 +484,7 @@ var/list/radio_brains = list()
 	lockedGaps = 1
 	lockedDiff = 3
 	lockedTries = 8
-	stability_loss = -5
+	stability_loss = 5
 	icon_state  = "strong"
 
 	OnAdd()

--- a/code/modules/medical/genetics/bioEffects/harmful.dm
+++ b/code/modules/medical/genetics/bioEffects/harmful.dm
@@ -722,7 +722,7 @@
 	lockedGaps = 1
 	lockedDiff = 3
 	lockedTries = 8
-	stability_loss = 5
+	stability_loss = -5
 	icon_state  = "bad"
 
 	OnAdd()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][MINOR] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Swap the `stability_loss` values of `fitness_buff` and `fitness_deff`


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
They are backwards, The bad gene is making you less stable and the good gene is making your more stable. This is the opposite of all other genes.