### PR TITLE
Fix custom pest playable search

### DIFF
--- a/code/modules/events/playable_pests.dm
+++ b/code/modules/events/playable_pests.dm
@@ -23,7 +23,7 @@
 		switch (alert(usr, "Choose the pest type?", src.name, "Random", "Custom"))
 			if ("Custom")
 				src.pest_type = input("Enter a /mob/living/critter path or partial name.", src.name, null) as null|text
-				src.pest_type = get_one_match(input, "/mob/living/critter")
+				src.pest_type = get_one_match(src.pest_type, "/mob/living/critter")
 				if (!src.pest_type)
 					return
 			if ("Random")

--- a/code/modules/events/playable_pests.dm
+++ b/code/modules/events/playable_pests.dm
@@ -19,7 +19,6 @@
 		if (..())
 			return
 
-		var/input = null
 		switch (alert(usr, "Choose the pest type?", src.name, "Random", "Custom"))
 			if ("Custom")
 				src.pest_type = input("Enter a /mob/living/critter path or partial name.", src.name, null) as null|text


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
correct var being passed to `get_one_match`

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes custom pest playable search. Currently it always shows the full list regardless of search term