### PR TITLE
add maptext points displays for all abilityholders

### DIFF
--- a/code/datums/abilities/ability_parent.dm
+++ b/code/datums/abilities/ability_parent.dm
@@ -46,9 +46,6 @@
 			if (ishuman(owner))
 				var/mob/living/carbon/human/H = owner
 				H.hud?.update_ability_hotbar()
-//			else if (iscritter(owner))
-//				var/mob/living/critter/C = owner
-//				C.hud?.update_ability_hotbar()
 
 	disposing()
 		for (var/obj/screen/S in hud.objects)

--- a/code/datums/abilities/ability_parent.dm
+++ b/code/datums/abilities/ability_parent.dm
@@ -1134,7 +1134,7 @@
 
 		if (src.topBarRendered)
 			src.updateText(0, x_occupied, y_occupied)
-			src.abilitystat?.update_on_hud(x_occupied+1,x_occupied)
+			src.abilitystat?.update_on_hud(x_occupied,y_occupied)
 
 	updateText(var/called_by_owner = 0)
 		if (!abilitystat)

--- a/code/datums/abilities/diabolical.dm
+++ b/code/datums/abilities/diabolical.dm
@@ -49,8 +49,9 @@
 
 	onAbilityStat() // In the "Souls" tab.
 		..()
-		stat("Total number of souls collected:", total_souls_sold)
-		stat("Number of unspent souls:", total_souls_value)
+		.= list()
+		.["Souls:"] = total_souls_value
+		.["Total Collected:"] = total_souls_sold
 		return
 
 /////////////////////////////////////////////// Merchant spell parent ////////////////////////////

--- a/code/datums/abilities/kudzumen.dm
+++ b/code/datums/abilities/kudzumen.dm
@@ -59,10 +59,6 @@
 		qdel(nutrients_meter)
 		..()
 
-	onAbilityStat()
-		..()
-		return
-
 	onLife(var/mult = 1)
 		if(..()) return
 		if (nutrients_meter)

--- a/code/datums/abilities/vampire.dm
+++ b/code/datums/abilities/vampire.dm
@@ -219,8 +219,9 @@
 
 	onAbilityStat() // In the 'Vampire' tab.
 		..()
-		stat("Blood:", src.vamp_blood)
-		stat("Blood remaining:", src.points)
+		.= list()
+		.["Blood:"] = src.points
+		.["Total:"] = src.vamp_blood
 		return
 
 	onLife(var/mult = 1)

--- a/code/datums/abilities/vampiric_zombie.dm
+++ b/code/datums/abilities/vampiric_zombie.dm
@@ -74,12 +74,13 @@
 
 	onAbilityStat() // In the 'Vampire' tab.
 		..()
+		.= list()
 		if (ishuman(owner))
 			var/mob/living/carbon/human/H = owner
 			if (istype(H.mutantrace, /datum/mutantrace/vamp_zombie))
 				var/datum/mutantrace/vamp_zombie/V = H.mutantrace
-				stat("Blood Points:", V.blood_points)
-				stat("Max Health (based on blood):", H.max_health)
+				.["Blood:"] = V.blood_points
+				.["Max Health:"] = H.max_health
 
 	proc/msg_to_master(var/msg)
 		if (master)

--- a/code/datums/abilities/werewolf.dm
+++ b/code/datums/abilities/werewolf.dm
@@ -358,13 +358,13 @@
 
 	onAbilityStat() // In the 'Werewolf' tab.
 		..()
-
+		.= list()
 		if (src.owner && src.owner.mind && src.owner.mind.special_role == "werewolf")
 			for (var/datum/objective/specialist/werewolf/feed/O in src.owner.mind.objectives)
 				src.feed_objective = O
 
 			if (src.feed_objective && istype(src.feed_objective))
-				stat("No. of victims:", src.feed_objective.feed_count)
+				.["Feedings:"] = src.feed_objective.feed_count
 
 		return
 

--- a/code/datums/abilities/wrestler.dm
+++ b/code/datums/abilities/wrestler.dm
@@ -28,7 +28,7 @@
 					return
 
 				if (isnull(C.abilityHolder)) // But they do have a critter AH by default...or should.
-					var/datum/abilityHolder/wrestler/A2 
+					var/datum/abilityHolder/wrestler/A2
 					if (fake_wrestler)
 						A2 = C.add_ability_holder(/datum/abilityHolder/wrestler/fake)
 					else

--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -123,7 +123,7 @@
 				if (ispath(abil))
 					abilityHolder.addAbility(abil)
 
-		SPAWN_DBG(0.5 SECONDS) //mbc what the fuck. i dont know why but if i don't spawn, no abilities even show up
+		SPAWN_DBG(0.5 SECONDS) //if i don't spawn, no abilities even show up
 			if (abilityHolder)
 				abilityHolder.updateButtons()
 

--- a/code/mob/living/critter/changeling_critters.dm
+++ b/code/mob/living/critter/changeling_critters.dm
@@ -109,7 +109,8 @@
 /datum/abilityHolder/critter/handspider
 	onAbilityStat()
 		..()
-		stat("Collected DNA Points:", owner:absorbed_dna)
+		.= list()
+		.["DNA Collected:"] = owner:absorbed_dna
 
 
 /mob/living/critter/changeling/handspider
@@ -258,9 +259,10 @@
 /datum/abilityHolder/critter/eyespider
 	onAbilityStat()
 		..()
+		.= list()
 		var/mob/T = owner:marked_target
 		if(istype(T))
-			stat("Mark:", T)
+			.["Mark:"] = T
 			// let's stop eyespiders from helping their masters game the adventure zone (taken from clairvoyance)
 			var/atom/target_loc = T.loc
 			var/locName = ""
@@ -278,9 +280,9 @@
 					locName = "No longer confined to this world we understand"
 			else
 				locName = "In [target_loc.loc]"
-			stat("Location:", locName)
+			.["Location:"] = locName
 		else
-			stat("No Marked Target")
+			.["Mark:"] = "None"
 
 /mob/living/critter/changeling/eyespider
 	name = "eyespider"

--- a/code/modules/antagonists/changeling/abilities/changeling.dm
+++ b/code/modules/antagonists/changeling/abilities/changeling.dm
@@ -272,10 +272,10 @@
 
 	onAbilityStat()
 		..()
+		.= list()
 		//On Changeling tab
-		stat("Absorbed DNA:", absorbtions)
-		stat("DNA Points:", points)
-
+		.["DNA:"] = points
+		.["Total:"] = absorbtions
 
 	onAbilityHolderInstanceAdd()
 		..()


### PR DESCRIPTION
Remove statpanel hud stuff completely, now its all onscreen. And your observers will be able to see it too!

![image](https://user-images.githubusercontent.com/5776372/86193905-1e97d700-bb1b-11ea-97a4-7347852e5d0d.png)

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)mbc:
(*)Moved antagonist points display (changeling DNA etc) to onscreen text instead of the stat panel.
```

