### PR TITLE
Prevent wavegun EMP from utterly shredding the nuke

### DIFF
--- a/code/modules/projectiles/wavegun.dm
+++ b/code/modules/projectiles/wavegun.dm
@@ -74,10 +74,12 @@ toxic - poisons
 		if(P.power != 0) //avoid AoE on pointblank... but if you just shoot the guy beside you you're going to get EMPed
 			for(var/turf/tile in range(1,T))
 				for(var/atom/movable/O in tile.contents)
-					O.emp_act()
-		if(prob(P.power*1.25)) //chance to EMP main target again - better odds the further it travels. Has a meaningful effect on borgs/pods/doors
+					if(!istype(O, /obj/machinery/nuclearbomb)) //AoE emp does not affect nuke
+						O.emp_act()
+		if(prob(P.power * 1.25)) //chance to EMP main target again - better odds the further it travels. Has a meaningful effect on borgs/pods/doors
 			for(var/atom/movable/O in T.contents)
-				O.emp_act()
+				if(!istype(O, /obj/machinery/nuclearbomb) || prob(P.power * 0.5)) //Direct hit has a low chance to affect the nuke - 
+					O.emp_act()
 		var/datum/effects/system/spark_spread/s = unpool(/datum/effects/system/spark_spread)
 		s.set_up(5, 0, T)
 		s.start()

--- a/code/modules/projectiles/wavegun.dm
+++ b/code/modules/projectiles/wavegun.dm
@@ -72,7 +72,7 @@ toxic - poisons
 	on_hit(atom/H, angle, var/obj/projectile/P)
 		var/turf/T = get_turf(H)
 		if(P.power != 0) //avoid AoE on pointblank... but if you just shoot the guy beside you you're going to get EMPed
-			for(var/turf/tile in range(1,T))
+			for(var/turf/tile in range(1, T))
 				for(var/atom/movable/O in tile.contents)
 					if(!istype(O, /obj/machinery/nuclearbomb)) //AoE emp does not affect nuke
 						O.emp_act()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes wavegun EMP AoE not affect nuke, makes direct hit on nuke have to pass an additional RNG roll to apply the EMP to the nuke


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently, it only takes ~3-4 shots at range with a wavegun to delete the nuke. That's not good
Closes #1265 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Tarmunora:
(+)Nuclear bombs strongly resist wavegun EMP attacks.
```
