### PR TITLE
Adds upgraded atmos analyzer to borgs

### DIFF
--- a/code/modules/robotics/robot/module_tool_creator/modules.dm
+++ b/code/modules/robotics/robot/module_tool_creator/modules.dm
@@ -72,7 +72,7 @@
 		/obj/item/tool/omnitool,
 		/obj/item/device/analyzer/healthanalyzer/borg,
 		/obj/item/device/reagentscanner,
-		/obj/item/device/analyzer/atmospheric,
+		/obj/item/device/analyzer/atmospheric/upgraded,
 		/obj/item/robojumper,
 	)
 

--- a/code/obj/item/device/scanners.dm
+++ b/code/obj/item/device/scanners.dm
@@ -464,6 +464,10 @@ that cannot be itched
 					det.detonate()
 		return
 
+/obj/item/device/analyzer/atmospheric/upgraded //for borgs because JESUS FUCK
+	analyzer_upgrade = 1
+	icon_state = "atmos"
+
 /obj/item/device/analyzer/atmosanalyzer_upgrade
 	name = "atmospherics analyzer upgrade"
 	desc = "A small upgrade card that allows standard atmospherics analyzers to detect environmental information at a distance."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes all borgs atmos analyzers upgraded.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I thought it was a bit strange that health analyzers were upgraded fully for all borgs but not atmos analyzers


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Moonlol:
(+)Borg atmos analyzers are now upgraded
```
