### PR TITLE
More donut3 fixes

### DIFF
--- a/code/map.dm
+++ b/code/map.dm
@@ -127,7 +127,7 @@ var/global/list/mapNames = list(
 
 /datum/map_settings/donut3
 	name = "DONUT3"
-	goonhub_map = "https://cdn.discordapp.com/attachments/469379618168897538/725462942853890097/donut3-28.png"
+	goonhub_map = "https://cdn.discordapp.com/attachments/469379618168897538/727936626147459192/donut3-30-FINAL2-lol.png"
 	airlock_style = "pyro"
 	walls = /turf/simulated/wall/auto/jen
 	rwalls = /turf/simulated/wall/auto/reinforced/jen

--- a/code/map.dm
+++ b/code/map.dm
@@ -138,6 +138,17 @@ var/global/list/mapNames = list(
 	escape_dir = NORTH
 	auto_windows = 1
 
+	windows = /obj/window/auto
+	windows_thin = /obj/window/pyro
+	rwindows = /obj/window/auto/reinforced
+	rwindows_thin = /obj/window/reinforced/pyro
+	windows_crystal = /obj/window/auto/crystal
+	windows_rcrystal = /obj/window/auto/crystal/reinforced
+	window_layer_full = COG2_WINDOW_LAYER
+	window_layer_north = GRILLE_LAYER+0.1
+	window_layer_south = FLY_LAYER+1
+	auto_windows = 1
+
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/destiny
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/destiny
 	merchant_right_centcom = /area/shuttle/merchant_shuttle/right_centcom/destiny

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -4974,7 +4974,9 @@
 	req_access_txt = "31"
 	},
 /obj/machinery/light/incandescent/warm{
-	dir = 1
+	dir = 1;
+	pixel_x = -10;
+	pixel_y = 24
 	},
 /obj/cable{
 	d2 = 4;
@@ -8669,15 +8671,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/nw)
-"coY" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	level = -1
-	},
-/turf/simulated/wall/auto/reinforced/jen/yellow{
-	icon_state = "6"
-	},
-/area/station/quartermaster/office)
 "cpa" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -9467,13 +9460,6 @@
 	dir = 4
 	},
 /area/station/chapel/main)
-"cCg" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/machinery/light/emergency,
-/turf/simulated/floor,
-/area/station/hallway/primary/west)
 "cCh" = (
 /obj/railing/orange,
 /obj/decal/cleanable/dirt/jen,
@@ -23645,6 +23631,15 @@
 /obj/machinery/light/incandescent/warm,
 /turf/simulated/floor/black,
 /area/station/quartermaster/refinery)
+"hej" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	level = -1
+	},
+/turf/simulated/wall/auto/reinforced/jen/yellow{
+	icon_state = "6"
+	},
+/area/station/quartermaster/office)
 "hek" = (
 /obj/cable{
 	d2 = 8;
@@ -30728,15 +30723,6 @@
 	dir = 4
 	},
 /area/station/turret_protected/AIsat)
-"jvZ" = (
-/obj/machinery/light/emergency{
-	dir = 8;
-	pixel_x = -12
-	},
-/turf/simulated/floor/redwhite{
-	dir = 8
-	},
-/area/station/security/quarters)
 "jwc" = (
 /obj/disposalpipe/segment{
 	dir = 8;
@@ -34206,12 +34192,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/south)
-"kDI" = (
-/obj/machinery/launcher_loader/south{
-	name = "Outbound"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/quartermaster/office)
 "kDJ" = (
 /obj/decal/tile_edge/line/blue{
 	dir = 5;
@@ -47453,6 +47433,15 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/sw)
+"oMI" = (
+/obj/machinery/light/emergency{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/redwhite{
+	dir = 4
+	},
+/area/station/security/quarters)
 "oML" = (
 /obj/decal/tile_edge/line/red{
 	dir = 5;
@@ -59889,12 +59878,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/gas)
-"sAs" = (
-/obj/machinery/launcher_loader/east{
-	name = "Outbound"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/quartermaster/office)
 "sAz" = (
 /obj/cable{
 	d1 = 2;
@@ -64720,6 +64703,12 @@
 /obj/railing/orange,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/se)
+"ueO" = (
+/obj/machinery/launcher_loader/south{
+	name = "Outbound"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/quartermaster/office)
 "ueX" = (
 /obj/disposalpipe/segment{
 	dir = 8;
@@ -65292,6 +65281,12 @@
 	},
 /turf/simulated/floor/purpleblack,
 /area/station/science)
+"upS" = (
+/obj/machinery/launcher_loader/east{
+	name = "Outbound"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/quartermaster/office)
 "upW" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/grille/catwalk/jen/side{
@@ -65312,6 +65307,13 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/north)
+"uqb" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/machinery/light/emergency,
+/turf/simulated/floor,
+/area/station/hallway/primary/west)
 "uqe" = (
 /obj/decal/tile_edge/line/purple{
 	dir = 4;
@@ -75673,15 +75675,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/westsolar)
-"xxq" = (
-/obj/machinery/light/emergency{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/simulated/floor/redwhite{
-	dir = 4
-	},
-/area/station/security/quarters)
 "xxr" = (
 /obj/cable{
 	d1 = 2;
@@ -76298,6 +76291,15 @@
 	icon_state = "catwalk_cross"
 	},
 /area)
+"xGi" = (
+/obj/machinery/light/emergency{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/redwhite{
+	dir = 8
+	},
+/area/station/security/quarters)
 "xGu" = (
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/plating/jen,
@@ -101203,7 +101205,7 @@ pPd
 uxN
 yfE
 nfO
-jvZ
+xGi
 qRP
 lJM
 lJM
@@ -101500,7 +101502,7 @@ vUK
 deh
 bDy
 nbm
-xxq
+oMI
 wyW
 mTo
 agB
@@ -106627,7 +106629,7 @@ eXl
 pse
 fNH
 ovT
-cCg
+uqb
 iHj
 cNV
 qfT
@@ -128677,8 +128679,8 @@ xDF
 xDF
 yaF
 vYX
-kDI
-sAs
+ueO
+upS
 oYJ
 vsH
 bAt
@@ -132607,7 +132609,7 @@ nHQ
 jyF
 ucZ
 aYq
-coY
+hej
 ffz
 ffz
 eIU

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -17114,6 +17114,12 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/medical/asylum/rec)
+"eYG" = (
+/obj/machinery/launcher_loader/south{
+	name = "Outbound"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/quartermaster/office)
 "eYN" = (
 /turf/simulated/floor/carpet/red/fancy/edge{
 	dir = 4
@@ -21114,6 +21120,15 @@
 	},
 /turf/simulated/floor/carpet/red/fancy,
 /area/station/crew_quarters/stockex)
+"gnl" = (
+/obj/machinery/light/emergency{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/redwhite{
+	dir = 8
+	},
+/area/station/security/quarters)
 "gnt" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -32561,6 +32576,13 @@
 /obj/disposalpipe/trunk/food,
 /turf/simulated/wall/auto/reinforced/supernorn/blackred,
 /area/station/security/brig/north_side)
+"kcL" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/machinery/light/emergency,
+/turf/simulated/floor,
+/area/station/hallway/primary/west)
 "kcP" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -32612,15 +32634,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/north)
-"kem" = (
-/obj/machinery/light/emergency{
-	dir = 8;
-	pixel_x = -12
-	},
-/turf/simulated/floor/redwhite{
-	dir = 8
-	},
-/area/station/security/quarters)
 "kev" = (
 /obj/cable{
 	d1 = 4;
@@ -34251,12 +34264,6 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
-"kEX" = (
-/obj/machinery/launcher_loader/south{
-	name = "Outbound"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/quartermaster/office)
 "kFd" = (
 /obj/disposalpipe/segment{
 	dir = 8;
@@ -37854,6 +37861,15 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
+"lMU" = (
+/obj/machinery/light/emergency{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/redwhite{
+	dir = 4
+	},
+/area/station/security/quarters)
 "lMW" = (
 /obj/machinery/vending/monkey,
 /turf/simulated/floor/plating/jen,
@@ -49911,7 +49927,9 @@
 /area/station/maintenance/outer/se)
 "pAD" = (
 /obj/machinery/light/incandescent/netural{
-	dir = 1
+	dir = 1;
+	pixel_x = 10;
+	pixel_y = 16
 	},
 /obj/table/reinforced/auto,
 /obj/random_item_spawner/tools/one,
@@ -51013,13 +51031,6 @@
 	dir = 1
 	},
 /area/station/crew_quarters/cafeteria)
-"pSt" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/machinery/light/emergency,
-/turf/simulated/floor,
-/area/station/hallway/primary/west)
 "pSH" = (
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
@@ -56351,12 +56362,6 @@
 "rtr" = (
 /turf/simulated/wall/auto/jen/purple,
 /area/station/science/teleporter)
-"rty" = (
-/obj/machinery/launcher_loader/east{
-	name = "Outbound"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/quartermaster/office)
 "rtB" = (
 /obj/cable{
 	d2 = 4;
@@ -58261,6 +58266,12 @@
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/garden)
+"rZm" = (
+/obj/machinery/launcher_loader/east{
+	name = "Outbound"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/quartermaster/office)
 "rZv" = (
 /obj/access_spawn/maint,
 /obj/decal/mule/dropoff,
@@ -62828,15 +62839,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/nw)
-"tzO" = (
-/obj/machinery/light/emergency{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/simulated/floor/redwhite{
-	dir = 4
-	},
-/area/station/security/quarters)
 "tzS" = (
 /obj/machinery/door/airlock/pyro/command{
 	dir = 1;
@@ -73884,7 +73886,8 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	pixel_y = 9
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 4
@@ -101184,7 +101187,7 @@ pPd
 uxN
 yfE
 nfO
-kem
+gnl
 qRP
 lJM
 lJM
@@ -101481,7 +101484,7 @@ vUK
 deh
 bDy
 nbm
-tzO
+lMU
 wyW
 mTo
 agB
@@ -106608,7 +106611,7 @@ eXl
 pse
 fNH
 ovT
-pSt
+kcL
 iHj
 cNV
 qfT
@@ -128658,8 +128661,8 @@ xDF
 xDF
 yaF
 vYX
-kEX
-rty
+eYG
+rZm
 oYJ
 vsH
 bAt

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -2165,6 +2165,12 @@
 /obj/floorpillstatue,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
+"akN" = (
+/obj/machinery/launcher_loader/east{
+	name = "Outbound"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/quartermaster/office)
 "alB" = (
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
@@ -6162,6 +6168,13 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/east)
+"bAn" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/machinery/light/emergency,
+/turf/simulated/floor,
+/area/station/hallway/primary/west)
 "bAq" = (
 /obj/machinery/disposal/small{
 	dir = 1;
@@ -13359,15 +13372,6 @@
 	},
 /turf/space,
 /area/station/solar/small_backup1)
-"dPW" = (
-/obj/machinery/light/emergency{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/simulated/floor/redwhite{
-	dir = 4
-	},
-/area/station/security/quarters)
 "dPY" = (
 /obj/table/auto,
 /obj/item/storage/toolbox/emergency{
@@ -23780,6 +23784,12 @@
 	dir = 9
 	},
 /area/station/medical/head)
+"hgz" = (
+/obj/machinery/launcher_loader/south{
+	name = "Outbound"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/quartermaster/office)
 "hgC" = (
 /obj/table/reinforced/chemistry/auto{
 	desc = "A black countertop table for storing kitchen-y objects.";
@@ -24534,15 +24544,6 @@
 	},
 /turf/simulated/floor/circuit/red,
 /area/station/security/main)
-"hsA" = (
-/obj/machinery/light/emergency{
-	dir = 8;
-	pixel_x = -12
-	},
-/turf/simulated/floor/redwhite{
-	dir = 8
-	},
-/area/station/security/quarters)
 "hsP" = (
 /obj/table/auto,
 /obj/decal/tile_edge/line/grey{
@@ -25178,12 +25179,6 @@
 "hBL" = (
 /turf/simulated/wall/auto/jen/blue,
 /area/station/crew_quarters/courtroom)
-"hBV" = (
-/obj/machinery/launcher_loader/east{
-	name = "Outbound"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/quartermaster/office)
 "hBW" = (
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -29013,12 +29008,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/inner)
-"iRV" = (
-/obj/machinery/launcher_loader/south{
-	name = "Outbound"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/quartermaster/office)
 "iRX" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1;
@@ -30425,6 +30414,15 @@
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/stairs/wide,
 /area/station/hallway/primary/west)
+"jrI" = (
+/obj/machinery/light/emergency{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/redwhite{
+	dir = 8
+	},
+/area/station/security/quarters)
 "jrK" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/decal/cleanable/rust/jen,
@@ -45906,7 +45904,7 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/access_spawn/maint,
+/obj/access_spawn/cargo,
 /turf/simulated/floor/plating/jen,
 /area/station/routingdepot)
 "ope" = (
@@ -54860,13 +54858,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/north)
-"qWW" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/machinery/light/emergency,
-/turf/simulated/floor,
-/area/station/hallway/primary/west)
 "qXj" = (
 /obj/cable{
 	d1 = 1;
@@ -61454,6 +61445,15 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/se)
+"tdT" = (
+/obj/machinery/light/emergency{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/redwhite{
+	dir = 4
+	},
+/area/station/security/quarters)
 "tdW" = (
 /obj/table/wood/auto,
 /obj/random_item_spawner/desk_stuff/g_clip_bin_pen/one,
@@ -101188,7 +101188,7 @@ pPd
 uxN
 yfE
 nfO
-hsA
+jrI
 qRP
 lJM
 lJM
@@ -101485,7 +101485,7 @@ vUK
 deh
 bDy
 nbm
-dPW
+tdT
 wyW
 mTo
 agB
@@ -106612,7 +106612,7 @@ eXl
 pse
 fNH
 ovT
-qWW
+bAn
 iHj
 cNV
 qfT
@@ -128662,8 +128662,8 @@ xDF
 xDF
 yaF
 vYX
-iRV
-hBV
+hgz
+akN
 oYJ
 vsH
 bAt

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -1019,13 +1019,10 @@
 /turf/simulated/floor/black,
 /area/station/security/equipment)
 "abB" = (
-/obj/machinery/light/incandescent/warm{
-	dir = 8
-	},
+/turf/space,
 /turf/simulated/floor/redwhite{
 	dir = 8
 	},
-/turf/space,
 /area/station/security/quarters)
 "abC" = (
 /obj/machinery/recharger/wall/sticky{
@@ -3623,6 +3620,13 @@
 	dir = 1
 	},
 /area/station/chapel/main)
+"aIX" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/machinery/light/emergency,
+/turf/simulated/floor,
+/area/station/hallway/primary/west)
 "aJo" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/railing/orange{
@@ -17114,12 +17118,6 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/medical/asylum/rec)
-"eYG" = (
-/obj/machinery/launcher_loader/south{
-	name = "Outbound"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/quartermaster/office)
 "eYN" = (
 /turf/simulated/floor/carpet/red/fancy/edge{
 	dir = 4
@@ -21120,15 +21118,6 @@
 	},
 /turf/simulated/floor/carpet/red/fancy,
 /area/station/crew_quarters/stockex)
-"gnl" = (
-/obj/machinery/light/emergency{
-	dir = 8;
-	pixel_x = -12
-	},
-/turf/simulated/floor/redwhite{
-	dir = 8
-	},
-/area/station/security/quarters)
 "gnt" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -28666,6 +28655,15 @@
 	},
 /turf/simulated/floor/yellowblack,
 /area/station/engine/inner)
+"iKx" = (
+/obj/machinery/light/emergency{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/redwhite{
+	dir = 4
+	},
+/area/station/security/quarters)
 "iKP" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/railing/orange{
@@ -32576,13 +32574,6 @@
 /obj/disposalpipe/trunk/food,
 /turf/simulated/wall/auto/reinforced/supernorn/blackred,
 /area/station/security/brig/north_side)
-"kcL" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/machinery/light/emergency,
-/turf/simulated/floor,
-/area/station/hallway/primary/west)
 "kcP" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -37861,15 +37852,6 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
-"lMU" = (
-/obj/machinery/light/emergency{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/simulated/floor/redwhite{
-	dir = 4
-	},
-/area/station/security/quarters)
 "lMW" = (
 /obj/machinery/vending/monkey,
 /turf/simulated/floor/plating/jen,
@@ -45257,6 +45239,15 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/engine/engineering)
+"oeT" = (
+/obj/machinery/light/emergency{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/redwhite{
+	dir = 8
+	},
+/area/station/security/quarters)
 "oeU" = (
 /obj/cable{
 	d1 = 2;
@@ -58266,12 +58257,6 @@
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/garden)
-"rZm" = (
-/obj/machinery/launcher_loader/east{
-	name = "Outbound"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/quartermaster/office)
 "rZv" = (
 /obj/access_spawn/maint,
 /obj/decal/mule/dropoff,
@@ -60337,6 +60322,12 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
+"sIM" = (
+/obj/machinery/launcher_loader/south{
+	name = "Outbound"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/quartermaster/office)
 "sIO" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/cable{
@@ -60426,7 +60417,9 @@
 /area/station/maintenance/outer/nw)
 "sKf" = (
 /obj/machinery/light/incandescent/netural{
-	dir = 1
+	dir = 1;
+	pixel_x = 10;
+	pixel_y = 16
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -68232,6 +68225,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/courtroom)
+"viu" = (
+/obj/machinery/launcher_loader/east{
+	name = "Outbound"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/quartermaster/office)
 "viz" = (
 /obj/storage/cart/trash,
 /obj/decal/cleanable/dirt/jen,
@@ -101187,7 +101186,7 @@ pPd
 uxN
 yfE
 nfO
-gnl
+oeT
 qRP
 lJM
 lJM
@@ -101484,7 +101483,7 @@ vUK
 deh
 bDy
 nbm
-lMU
+iKx
 wyW
 mTo
 agB
@@ -106611,7 +106610,7 @@ eXl
 pse
 fNH
 ovT
-kcL
+aIX
 iHj
 cNV
 qfT
@@ -128661,8 +128660,8 @@ xDF
 xDF
 yaF
 vYX
-eYG
-rZm
+sIM
+viu
 oYJ
 vsH
 bAt

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -8002,11 +8002,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science)
-"cdA" = (
-/obj/stool/bench/blue/auto,
-/obj/machinery/light/emergency,
-/turf/simulated/floor/escape,
-/area/station/hallway/secondary/exit)
 "cdH" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 8
@@ -11001,12 +10996,6 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
-"dbx" = (
-/obj/machinery/launcher_loader/south{
-	name = "Outbound"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/quartermaster/office)
 "dbP" = (
 /turf/simulated/wall/auto/reinforced/supernorn/yellow,
 /area/station/engine/inner)
@@ -14162,6 +14151,10 @@
 /obj/disposalpipe/trunk/mail{
 	dir = 1
 	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
 /turf/simulated/floor/escape{
 	dir = 10
 	},
@@ -14910,9 +14903,6 @@
 	color = "#ffccff";
 	dir = 5;
 	icon_state = "line2"
-	},
-/obj/machinery/light/incandescent/netural{
-	dir = 1
 	},
 /obj/table/auto,
 /obj/machinery/light/emergency{
@@ -22467,15 +22457,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering/ce)
-"gKY" = (
-/obj/machinery/light/emergency{
-	dir = 8;
-	pixel_x = -12
-	},
-/turf/simulated/floor/redwhite{
-	dir = 8
-	},
-/area/station/security/quarters)
 "gLe" = (
 /obj/machinery/light/small,
 /obj/decal/cleanable/dirt/jen,
@@ -32631,6 +32612,15 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/north)
+"kem" = (
+/obj/machinery/light/emergency{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/redwhite{
+	dir = 8
+	},
+/area/station/security/quarters)
 "kev" = (
 /obj/cable{
 	d1 = 4;
@@ -34261,6 +34251,12 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
+"kEX" = (
+/obj/machinery/launcher_loader/south{
+	name = "Outbound"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/quartermaster/office)
 "kFd" = (
 /obj/disposalpipe/segment{
 	dir = 8;
@@ -51017,6 +51013,13 @@
 	dir = 1
 	},
 /area/station/crew_quarters/cafeteria)
+"pSt" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/machinery/light/emergency,
+/turf/simulated/floor,
+/area/station/hallway/primary/west)
 "pSH" = (
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
@@ -51864,13 +51867,6 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/nw)
-"qfl" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/machinery/light/emergency,
-/turf/simulated/floor,
-/area/station/hallway/primary/west)
 "qfm" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
@@ -56355,6 +56351,12 @@
 "rtr" = (
 /turf/simulated/wall/auto/jen/purple,
 /area/station/science/teleporter)
+"rty" = (
+/obj/machinery/launcher_loader/east{
+	name = "Outbound"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/quartermaster/office)
 "rtB" = (
 /obj/cable{
 	d2 = 4;
@@ -57466,15 +57468,6 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/east)
-"rJI" = (
-/obj/machinery/light/emergency{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/simulated/floor/redwhite{
-	dir = 4
-	},
-/area/station/security/quarters)
 "rJM" = (
 /obj/machinery/dispenser{
 	pltanks = 0
@@ -57572,7 +57565,7 @@
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/pharmacy)
 "rLN" = (
-/obj/machinery/smelter,
+/obj/machinery/neosmelter,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
@@ -62835,6 +62828,15 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/nw)
+"tzO" = (
+/obj/machinery/light/emergency{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/redwhite{
+	dir = 4
+	},
+/area/station/security/quarters)
 "tzS" = (
 /obj/machinery/door/airlock/pyro/command{
 	dir = 1;
@@ -73608,12 +73610,6 @@
 	},
 /turf/simulated/floor/wood/six,
 /area/station/library/reading1)
-"wPz" = (
-/obj/machinery/launcher_loader/east{
-	name = "Outbound"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/quartermaster/office)
 "wPC" = (
 /obj/table/wood/auto,
 /obj/item/reagent_containers/food/drinks/drinkingglass/pitcher{
@@ -75217,10 +75213,7 @@
 /area/station/engine/monitoring)
 "xqb" = (
 /obj/stool/bench/blue/auto,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
+/obj/machinery/light/emergency,
 /turf/simulated/floor/escape,
 /area/station/hallway/secondary/exit)
 "xqn" = (
@@ -101191,7 +101184,7 @@ pPd
 uxN
 yfE
 nfO
-gKY
+kem
 qRP
 lJM
 lJM
@@ -101488,7 +101481,7 @@ vUK
 deh
 bDy
 nbm
-rJI
+tzO
 wyW
 mTo
 agB
@@ -106615,7 +106608,7 @@ eXl
 pse
 fNH
 ovT
-qfl
+pSt
 iHj
 cNV
 qfT
@@ -128665,8 +128658,8 @@ xDF
 xDF
 yaF
 vYX
-dbx
-wPz
+kEX
+rty
 oYJ
 vsH
 bAt
@@ -134969,7 +134962,7 @@ lCL
 qQq
 pUj
 mxH
-cdA
+xqb
 tSd
 lAM
 aDc
@@ -135271,7 +135264,7 @@ etV
 etV
 aeQ
 mxH
-xqb
+fXb
 tSd
 aaa
 aDc
@@ -135573,7 +135566,7 @@ xTu
 etV
 kRW
 mxH
-cdA
+xqb
 tSd
 aab
 aDc

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -1019,7 +1019,9 @@
 /turf/simulated/floor/black,
 /area/station/security/equipment)
 "abB" = (
-/turf/space,
+/turf/simulated/floor/redwhite{
+	dir = 8
+	},
 /turf/simulated/floor/redwhite{
 	dir = 8
 	},
@@ -3620,13 +3622,6 @@
 	dir = 1
 	},
 /area/station/chapel/main)
-"aIX" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/machinery/light/emergency,
-/turf/simulated/floor,
-/area/station/hallway/primary/west)
 "aJo" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/railing/orange{
@@ -13364,6 +13359,15 @@
 	},
 /turf/space,
 /area/station/solar/small_backup1)
+"dPW" = (
+/obj/machinery/light/emergency{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/redwhite{
+	dir = 4
+	},
+/area/station/security/quarters)
 "dPY" = (
 /obj/table/auto,
 /obj/item/storage/toolbox/emergency{
@@ -24530,6 +24534,15 @@
 	},
 /turf/simulated/floor/circuit/red,
 /area/station/security/main)
+"hsA" = (
+/obj/machinery/light/emergency{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/redwhite{
+	dir = 8
+	},
+/area/station/security/quarters)
 "hsP" = (
 /obj/table/auto,
 /obj/decal/tile_edge/line/grey{
@@ -25165,6 +25178,12 @@
 "hBL" = (
 /turf/simulated/wall/auto/jen/blue,
 /area/station/crew_quarters/courtroom)
+"hBV" = (
+/obj/machinery/launcher_loader/east{
+	name = "Outbound"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/quartermaster/office)
 "hBW" = (
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -28655,15 +28674,6 @@
 	},
 /turf/simulated/floor/yellowblack,
 /area/station/engine/inner)
-"iKx" = (
-/obj/machinery/light/emergency{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/simulated/floor/redwhite{
-	dir = 4
-	},
-/area/station/security/quarters)
 "iKP" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/railing/orange{
@@ -29003,6 +29013,12 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/inner)
+"iRV" = (
+/obj/machinery/launcher_loader/south{
+	name = "Outbound"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/quartermaster/office)
 "iRX" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1;
@@ -45239,15 +45255,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/engine/engineering)
-"oeT" = (
-/obj/machinery/light/emergency{
-	dir = 8;
-	pixel_x = -12
-	},
-/turf/simulated/floor/redwhite{
-	dir = 8
-	},
-/area/station/security/quarters)
 "oeU" = (
 /obj/cable{
 	d1 = 2;
@@ -54853,6 +54860,13 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/north)
+"qWW" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/machinery/light/emergency,
+/turf/simulated/floor,
+/area/station/hallway/primary/west)
 "qXj" = (
 /obj/cable{
 	d1 = 1;
@@ -60322,12 +60336,6 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
-"sIM" = (
-/obj/machinery/launcher_loader/south{
-	name = "Outbound"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/quartermaster/office)
 "sIO" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/cable{
@@ -68225,12 +68233,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/courtroom)
-"viu" = (
-/obj/machinery/launcher_loader/east{
-	name = "Outbound"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/quartermaster/office)
 "viz" = (
 /obj/storage/cart/trash,
 /obj/decal/cleanable/dirt/jen,
@@ -101186,7 +101188,7 @@ pPd
 uxN
 yfE
 nfO
-oeT
+hsA
 qRP
 lJM
 lJM
@@ -101483,7 +101485,7 @@ vUK
 deh
 bDy
 nbm
-iKx
+dPW
 wyW
 mTo
 agB
@@ -106610,7 +106612,7 @@ eXl
 pse
 fNH
 ovT
-aIX
+qWW
 iHj
 cNV
 qfT
@@ -128660,8 +128662,8 @@ xDF
 xDF
 yaF
 vYX
-sIM
-viu
+iRV
+hBV
 oYJ
 vsH
 bAt

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -8002,6 +8002,11 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science)
+"cdA" = (
+/obj/stool/bench/blue/auto,
+/obj/machinery/light/emergency,
+/turf/simulated/floor/escape,
+/area/station/hallway/secondary/exit)
 "cdH" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 8
@@ -10996,6 +11001,12 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
+"dbx" = (
+/obj/machinery/launcher_loader/south{
+	name = "Outbound"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/quartermaster/office)
 "dbP" = (
 /turf/simulated/wall/auto/reinforced/supernorn/yellow,
 /area/station/engine/inner)
@@ -12230,15 +12241,6 @@
 	},
 /turf/simulated/wall/auto/reinforced/jen,
 /area/station/chapel/main)
-"duZ" = (
-/obj/machinery/light/emergency{
-	dir = 8;
-	pixel_x = -12
-	},
-/turf/simulated/floor/redwhite{
-	dir = 8
-	},
-/area/station/security/quarters)
 "dvk" = (
 /obj/stool/chair,
 /obj/machinery/light/small/warm{
@@ -13315,15 +13317,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/west)
-"dPd" = (
-/obj/machinery/light/emergency{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/simulated/floor/redwhite{
-	dir = 4
-	},
-/area/station/security/quarters)
 "dPp" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -13947,7 +13940,6 @@
 /area/station/hallway/primary/east)
 "dYm" = (
 /obj/railing/orange{
-	dir = 6;
 	layer = 4
 	},
 /obj/decal/cleanable/dirt/jen,
@@ -14514,12 +14506,6 @@
 	},
 /turf/simulated/floor/carpet/blue/fancy/innercorner/omni,
 /area/station/medical/head)
-"ehD" = (
-/obj/machinery/launcher_loader/east{
-	name = "Outbound"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/quartermaster/office)
 "ehR" = (
 /obj/machinery/dispenser,
 /obj/machinery/light/incandescent/warm{
@@ -16320,12 +16306,6 @@
 /obj/decal/cleanable/rust/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/west)
-"eMI" = (
-/obj/machinery/launcher_loader/south{
-	name = "Outbound"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/quartermaster/office)
 "eML" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/airless/plating/jen,
@@ -22487,6 +22467,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering/ce)
+"gKY" = (
+/obj/machinery/light/emergency{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/redwhite{
+	dir = 8
+	},
+/area/station/security/quarters)
 "gLe" = (
 /obj/machinery/light/small,
 /obj/decal/cleanable/dirt/jen,
@@ -23202,6 +23191,9 @@
 /obj/decal/tile_edge/line/yellow{
 	dir = 8;
 	icon_state = "line1"
+	},
+/obj/item/cargotele{
+	pixel_x = -3
 	},
 /turf/simulated/floor/black,
 /area/station/quartermaster/refinery)
@@ -33487,11 +33479,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/west)
-"ktm" = (
-/obj/stool/bench/blue/auto,
-/obj/machinery/light/emergency,
-/turf/simulated/floor/escape,
-/area/station/hallway/secondary/exit)
 "ktA" = (
 /turf/simulated/floor/carpet/red/fancy/edge{
 	dir = 5
@@ -35714,13 +35701,6 @@
 	icon_state = "catwalk_cross"
 	},
 /area/station/solar/east)
-"lfp" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/machinery/light/emergency,
-/turf/simulated/floor,
-/area/station/hallway/primary/west)
 "lfx" = (
 /obj/table/wood/auto,
 /obj/item/plate{
@@ -37767,6 +37747,12 @@
 /obj/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
+	},
+/obj/machinery/door/poddoor/pyro{
+	dir = 8;
+	id = "qm_tohall";
+	layer = 3.1;
+	name = "QM Shutter"
 	},
 /turf/simulated/floor/caution/northsouth,
 /area/station/quartermaster/office)
@@ -42249,7 +42235,7 @@
 /area/station/chemistry)
 "nhf" = (
 /obj/disposalpipe/junction/right/north{
-	mail_tag = "cargo";
+	mail_tag = null;
 	name = "undeliverable mail router"
 	},
 /turf/simulated/floor,
@@ -43213,7 +43199,6 @@
 /area/station/science)
 "nxh" = (
 /obj/railing/orange{
-	dir = 10;
 	layer = 4
 	},
 /obj/decal/cleanable/dirt/jen,
@@ -51879,6 +51864,13 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/nw)
+"qfl" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/machinery/light/emergency,
+/turf/simulated/floor,
+/area/station/hallway/primary/west)
 "qfm" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
@@ -57474,6 +57466,15 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/east)
+"rJI" = (
+/obj/machinery/light/emergency{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/redwhite{
+	dir = 4
+	},
+/area/station/security/quarters)
 "rJM" = (
 /obj/machinery/dispenser{
 	pltanks = 0
@@ -73607,6 +73608,12 @@
 	},
 /turf/simulated/floor/wood/six,
 /area/station/library/reading1)
+"wPz" = (
+/obj/machinery/launcher_loader/east{
+	name = "Outbound"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/quartermaster/office)
 "wPC" = (
 /obj/table/wood/auto,
 /obj/item/reagent_containers/food/drinks/drinkingglass/pitcher{
@@ -101184,7 +101191,7 @@ pPd
 uxN
 yfE
 nfO
-duZ
+gKY
 qRP
 lJM
 lJM
@@ -101481,7 +101488,7 @@ vUK
 deh
 bDy
 nbm
-dPd
+rJI
 wyW
 mTo
 agB
@@ -106608,7 +106615,7 @@ eXl
 pse
 fNH
 ovT
-lfp
+qfl
 iHj
 cNV
 qfT
@@ -128658,8 +128665,8 @@ xDF
 xDF
 yaF
 vYX
-eMI
-ehD
+dbx
+wPz
 oYJ
 vsH
 bAt
@@ -134962,7 +134969,7 @@ lCL
 qQq
 pUj
 mxH
-ktm
+cdA
 tSd
 lAM
 aDc
@@ -135566,7 +135573,7 @@ xTu
 etV
 kRW
 mxH
-ktm
+cdA
 tSd
 aab
 aDc

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -2165,12 +2165,6 @@
 /obj/floorpillstatue,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
-"akN" = (
-/obj/machinery/launcher_loader/east{
-	name = "Outbound"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/quartermaster/office)
 "alB" = (
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
@@ -6168,13 +6162,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/east)
-"bAn" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/machinery/light/emergency,
-/turf/simulated/floor,
-/area/station/hallway/primary/west)
 "bAq" = (
 /obj/machinery/disposal/small{
 	dir = 1;
@@ -8682,6 +8669,15 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/nw)
+"coY" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	level = -1
+	},
+/turf/simulated/wall/auto/reinforced/jen/yellow{
+	icon_state = "6"
+	},
+/area/station/quartermaster/office)
 "cpa" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -9471,6 +9467,13 @@
 	dir = 4
 	},
 /area/station/chapel/main)
+"cCg" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/machinery/light/emergency,
+/turf/simulated/floor,
+/area/station/hallway/primary/west)
 "cCh" = (
 /obj/railing/orange,
 /obj/decal/cleanable/dirt/jen,
@@ -13288,6 +13291,12 @@
 /obj/disposalpipe/segment{
 	dir = 4;
 	level = -1
+	},
+/obj/machinery/door_control{
+	id = "qm_tohall_shutter";
+	name = "QM Shutter Control";
+	pixel_x = 23;
+	pixel_y = 11
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
@@ -23784,12 +23793,6 @@
 	dir = 9
 	},
 /area/station/medical/head)
-"hgz" = (
-/obj/machinery/launcher_loader/south{
-	name = "Outbound"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/quartermaster/office)
 "hgC" = (
 /obj/table/reinforced/chemistry/auto{
 	desc = "A black countertop table for storing kitchen-y objects.";
@@ -30414,15 +30417,6 @@
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/stairs/wide,
 /area/station/hallway/primary/west)
-"jrI" = (
-/obj/machinery/light/emergency{
-	dir = 8;
-	pixel_x = -12
-	},
-/turf/simulated/floor/redwhite{
-	dir = 8
-	},
-/area/station/security/quarters)
 "jrK" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/decal/cleanable/rust/jen,
@@ -30734,6 +30728,15 @@
 	dir = 4
 	},
 /area/station/turret_protected/AIsat)
+"jvZ" = (
+/obj/machinery/light/emergency{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/redwhite{
+	dir = 8
+	},
+/area/station/security/quarters)
 "jwc" = (
 /obj/disposalpipe/segment{
 	dir = 8;
@@ -34203,6 +34206,12 @@
 	dir = 8
 	},
 /area/station/hallway/primary/south)
+"kDI" = (
+/obj/machinery/launcher_loader/south{
+	name = "Outbound"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/quartermaster/office)
 "kDJ" = (
 /obj/decal/tile_edge/line/blue{
 	dir = 5;
@@ -37758,7 +37767,7 @@
 	},
 /obj/machinery/door/poddoor/pyro{
 	dir = 8;
-	id = "qm_tohall";
+	id = "qm_tohall_shutter";
 	layer = 3.1;
 	name = "QM Shutter"
 	},
@@ -59880,6 +59889,12 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/gas)
+"sAs" = (
+/obj/machinery/launcher_loader/east{
+	name = "Outbound"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/quartermaster/office)
 "sAz" = (
 /obj/cable{
 	d1 = 2;
@@ -61445,15 +61460,6 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/se)
-"tdT" = (
-/obj/machinery/light/emergency{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/simulated/floor/redwhite{
-	dir = 4
-	},
-/area/station/security/quarters)
 "tdW" = (
 /obj/table/wood/auto,
 /obj/random_item_spawner/desk_stuff/g_clip_bin_pen/one,
@@ -75667,6 +75673,15 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/westsolar)
+"xxq" = (
+/obj/machinery/light/emergency{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/redwhite{
+	dir = 4
+	},
+/area/station/security/quarters)
 "xxr" = (
 /obj/cable{
 	d1 = 2;
@@ -101188,7 +101203,7 @@ pPd
 uxN
 yfE
 nfO
-jrI
+jvZ
 qRP
 lJM
 lJM
@@ -101485,7 +101500,7 @@ vUK
 deh
 bDy
 nbm
-tdT
+xxq
 wyW
 mTo
 agB
@@ -106612,7 +106627,7 @@ eXl
 pse
 fNH
 ovT
-bAn
+cCg
 iHj
 cNV
 qfT
@@ -128662,8 +128677,8 @@ xDF
 xDF
 yaF
 vYX
-hgz
-akN
+kDI
+sAs
 oYJ
 vsH
 bAt
@@ -132592,7 +132607,7 @@ nHQ
 jyF
 ucZ
 aYq
-jnN
+coY
 ffz
 ffz
 eIU


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Delivery no longer ends with an infinite loop, undeliverable mail should not end up at QM
- Speaking of which, QM now has the shutter at their plastic flaps that I forgot to add, oops
- The Mining smelter is now the correct smelter
- Miners have an extra cargo transporter device
- Fixes the corrupted turf in Sec that is satan
- Routing Depot door access is QM-only
- Thindows are now illegal in Donut3
- The map button now shows an up-to-date map screenshot

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I fugged up


