### PR TITLE
Slips adjust

### DIFF
--- a/code/obj/item/clown_items.dm
+++ b/code/obj/item/clown_items.dm
@@ -33,7 +33,7 @@ VUVUZELA
 		return
 	if (iscarbon(AM))
 		var/mob/M =	AM
-		if (M.slip())
+		if (M.slip(ignore_actual_delay = 1))
 			boutput(M, "<span class='notice'>You slipped on the banana peel!</span>")
 			if (ishuman(M))
 				var/mob/living/carbon/human/H = M

--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -150,7 +150,7 @@
 				return
 			if (iscarbon(AM))
 				var/mob/M = AM
-				if (M.slip())
+				if (M.slip(ignore_actual_delay = 1))
 					boutput(M, "<span class='notice'>You slipped on the PDA!</span>")
 					if (M.bioHolder.HasEffect("clumsy"))
 						M.changeStatus("weakened", 5 SECONDS)

--- a/code/procs/mob_procs.dm
+++ b/code/procs/mob_procs.dm
@@ -108,17 +108,22 @@
 	return 1
 
 
-/mob/proc/slip(walking_matters = 1, running = 0)
+/mob/proc/slip(walking_matters = 1, running = 0, ignore_actual_delay = 0)
 	.= 0
 
 	if (!src.can_slip())
 		return
 
 	var/slip_delay = BASE_SPEED_SUSTAINED + (WALK_DELAY_ADD*0.9) //we need to fall under this movedelay value in order to slip :O
+	if (src.m_intent == "walk")
+		slip_delay = BASE_SPEED_SUSTAINED - (WALK_DELAY_ADD*0.5)
+
 	if (!walking_matters)
 		slip_delay = 10
 	var/movement_delay_real = max(src.movement_delay(get_step(src,src.move_dir), running),world.tick_lag)
 	var/movedelay = max(movement_delay_real, min(world.time - src.next_move,world.time - src.last_pulled_time))
+	if (ignore_actual_delay)
+		movedelay = movement_delay_real
 
 	if (movedelay < slip_delay)
 		var/intensity = (-0.33)+(6.033763-(-0.33))/(1+(movement_delay_real/(0.4))-1.975308)  //y=d+(6.033763-d)/(1+(x/c)-1.975308)
@@ -139,8 +144,8 @@
 			src.throw_at(T, intensity, 2, list("stun"=clamp(1.1 SECONDS * intensity, 1 SECOND, 5 SECONDS)), src.loc, throw_type = THROW_SLIP)
 		.= 1
 
-/mob/living/carbon/human/slip(walking_matters = 1, running = 0)
-	..(walking_matters, (src.client?.check_key(KEY_RUN) && src.get_stamina() > STAMINA_SPRINT))
+/mob/living/carbon/human/slip(walking_matters = 1, running = 0, ignore_actual_delay = 0)
+	..(walking_matters, (src.client?.check_key(KEY_RUN) && src.get_stamina() > STAMINA_SPRINT), ignore_actual_delay)
 
 
 /mob/living/carbon/human/proc/skeletonize()


### PR DESCRIPTION
walking makes slips a bit more forgiving (not total immunity, but a shift in your favor)

added a param to clown slips that let it ignore the 'actual move delay' calc in slipping, to make pranks more viable like they used to be


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)mbc:
(+)Walk-slipping a bit more forgiving, and banana peel slips are a bit more suitable for pranks again.
```
