### PR TITLE
make stun gloves cheaper to charge

### DIFF
--- a/code/obj/item/clothing/gloves.dm
+++ b/code/obj/item/clothing/gloves.dm
@@ -111,7 +111,7 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 		if (istype(W, /obj/item/cell)) // Moved from cell.dm (Convair880).
 			var/obj/item/cell/C = W
 
-			if (C.charge < 2500)
+			if (C.charge < 1500)
 				user.show_text("[C] needs more charge before you can do that.", "red")
 				return
 			if (!src.stunready)
@@ -126,7 +126,7 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 				if (src.uses < 0)
 					src.uses = 0
 				src.uses = min(src.uses + 1, src.max_uses)
-				C.use(2500)
+				C.use(1500)
 				src.icon_state = "stun"
 				src.item_state = "stun"
 				src.overridespecial = 1

--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -1027,7 +1027,7 @@
 		if (istype(W, /obj/item/cell)) // Moved from cell.dm (Convair880).
 			var/obj/item/cell/C = W
 
-			if (C.charge < 2500)
+			if (C.charge < 1500)
 				user.show_text("[C] needs more charge before you can do that.", "red")
 				return
 			if (!src.stunready)
@@ -1041,7 +1041,7 @@
 			if (src.uses < 0)
 				src.uses = 0
 			src.uses = min(src.uses + 1, src.max_uses)
-			C.use(2500)
+			C.use(1500)
 			src.icon_state = text("[]-stun",src.icon_state)
 			src.item_state = text("[]-stun",src.item_state)
 			C.updateicon()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes stun gloves 40% cheaper to charge (previously were changed in a way that made them take 4 charges to be fully charged instead of 1)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It takes over half a cell to charge a pair of gloves currently, this would let you get 2.5 full charges from one cell instead of 1.5


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Tarmunora:
(+)Made stun gloves take less power to charge.
```
