### PR TITLE
Donut3 fixes 4: Fluck Pumbled

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -3042,22 +3042,12 @@
 	},
 /area/station/engine/singcore)
 "aAW" = (
-/obj/table/auto,
-/obj/item/device/light/lava_lamp{
-	pixel_x = -6;
-	pixel_y = 16
-	},
-/obj/item/cargotele{
-	pixel_x = 7;
-	pixel_y = 7
-	},
-/obj/item/hand_labeler{
-	pixel_x = -2;
-	pixel_y = -1
-	},
 /obj/decal/tile_edge/line/green{
 	dir = 6;
 	icon_state = "line2"
+	},
+/obj/machinery/chem_master{
+	dir = 8
 	},
 /turf/simulated/floor/wood/five,
 /area/station/hydroponics)
@@ -11016,6 +11006,12 @@
 	},
 /obj/cable,
 /obj/machinery/power/data_terminal,
+/obj/machinery/door_control{
+	id = "treatment_exit";
+	name = "Treatment Exit Door Control";
+	pixel_x = 24;
+	pixel_y = 8
+	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/treatment)
 "dcz" = (
@@ -22804,7 +22800,8 @@
 "gQx" = (
 /obj/decal/mule/dropoff,
 /obj/machinery/door/airlock/pyro/glass{
-	dir = 8
+	dir = 8;
+	id = "scanning_exit"
 	},
 /obj/access_spawn/medical,
 /obj/firedoor_spawn,
@@ -40667,7 +40664,8 @@
 "mGr" = (
 /obj/decal/mule/dropoff,
 /obj/machinery/door/airlock/pyro/glass{
-	dir = 4
+	dir = 4;
+	id = "treatment_exit"
 	},
 /obj/access_spawn/medical,
 /obj/firedoor_spawn,
@@ -49327,7 +49325,14 @@
 /obj/disposalpipe/segment/mail,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = -24;
+	pixel_y = 6
+	},
+/obj/machinery/door_control{
+	id = "scanning_exit";
+	name = "Clone-Scanning Exit Door Control";
+	pixel_x = -24;
+	pixel_y = -6
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
@@ -50344,7 +50349,19 @@
 	icon_state = "line1"
 	},
 /obj/machinery/light/incandescent/netural,
-/obj/decorative_pot,
+/obj/table/auto,
+/obj/item/hand_labeler{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/cargotele{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/device/light/lava_lamp{
+	pixel_x = -6;
+	pixel_y = 16
+	},
 /turf/simulated/floor/wood/five,
 /area/station/hydroponics)
 "pGt" = (
@@ -56480,7 +56497,9 @@
 /area/station/chapel/main)
 "ruY" = (
 /obj/machinery/light/incandescent/warm{
-	dir = 1
+	dir = 1;
+	pixel_x = 10;
+	pixel_y = 20
 	},
 /obj/landmark{
 	name = "monkeyspawn_normal"
@@ -57435,7 +57454,7 @@
 /turf/simulated/floor/green/corner,
 /area/station/hydroponics)
 "rIG" = (
-/obj/submachine/robomoduler{
+/obj/machinery/computer/robot_module_rewriter{
 	dir = 8
 	},
 /obj/machinery/light/incandescent/cool/very{
@@ -69527,7 +69546,8 @@
 "vDd" = (
 /obj/decal/mule/dropoff,
 /obj/machinery/door/airlock/pyro/glass{
-	dir = 4
+	dir = 4;
+	id = "treatment_exit"
 	},
 /obj/access_spawn/medical,
 /obj/firedoor_spawn,
@@ -71918,7 +71938,8 @@
 "wpE" = (
 /obj/decal/mule/dropoff,
 /obj/machinery/door/airlock/pyro/glass{
-	dir = 8
+	dir = 8;
+	id = "scanning_exit"
 	},
 /obj/access_spawn/medical,
 /obj/firedoor_spawn,

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -73,7 +73,7 @@
 /obj/machinery/light/incandescent/warm/very{
 	dir = 1
 	},
-/turf/space,
+/turf/simulated/floor,
 /turf/simulated/floor,
 /area/station/ai_monitored/armory)
 "aae" = (
@@ -86,7 +86,7 @@
 	pixel_x = -10;
 	tag = ""
 	},
-/turf/space,
+/turf/simulated/floor/engine,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "aaf" = (
@@ -100,7 +100,7 @@
 	pixel_x = 23
 	},
 /obj/stool,
-/turf/space,
+/turf/simulated/floor/engine,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "aag" = (
@@ -113,7 +113,7 @@
 	dir = 4;
 	pixel_x = 23
 	},
-/turf/space,
+/turf/simulated/floor/engine,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "aai" = (
@@ -406,7 +406,7 @@
 	pixel_x = 1;
 	pixel_y = 41
 	},
-/turf/space,
+/turf/simulated/floor/black/grime,
 /turf/simulated/floor/black/grime,
 /area/station/security/brig/north_side)
 "aaC" = (
@@ -557,7 +557,7 @@
 	anchored = 1
 	},
 /obj/decal/mule/beacon,
-/turf/space,
+/turf/simulated/floor/black/grime,
 /turf/simulated/floor/black/grime,
 /area/station/security/brig/north_side)
 "aaP" = (
@@ -617,7 +617,7 @@
 /area/station/solar/east)
 "aaV" = (
 /obj/wingrille_spawn/auto/crystal,
-/turf/space,
+/turf/simulated/floor/plating,
 /turf/simulated/floor/plating,
 /area/station/security/brig/north_side)
 "aaW" = (
@@ -652,7 +652,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/space,
+/turf/simulated/floor/bot/white,
 /turf/simulated/floor/bot/white,
 /area/station/hangar/sec)
 "aaZ" = (
@@ -684,7 +684,7 @@
 	dir = 10;
 	icon_state = "tile1"
 	},
-/turf/space,
+/turf/simulated/floor/black/grime,
 /turf/simulated/floor/black/grime,
 /area/station/security/brig/north_side)
 "abc" = (
@@ -701,7 +701,7 @@
 	dir = 10;
 	icon_state = "tile1"
 	},
-/turf/space,
+/turf/simulated/floor/black/grime,
 /turf/simulated/floor/black/grime,
 /area/station/security/brig/north_side)
 "abd" = (
@@ -748,7 +748,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/space,
+/turf/simulated/floor/grime,
 /turf/simulated/floor/grime,
 /area/station/security/brig/south_side)
 "abg" = (
@@ -773,7 +773,9 @@
 /obj/machinery/light/incandescent/warm{
 	dir = 8
 	},
-/turf/space,
+/turf/simulated/floor/redblack{
+	dir = 8
+	},
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
@@ -791,7 +793,7 @@
 	icon_state = "0-2"
 	},
 /obj/cable,
-/turf/space,
+/turf/simulated/floor/grime,
 /turf/simulated/floor/grime,
 /area/station/security/brig/south_side)
 "abj" = (
@@ -870,7 +872,10 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/space,
+/turf/simulated/floor/carpet{
+	dir = 9;
+	icon_state = "red2"
+	},
 /turf/simulated/floor/carpet{
 	dir = 9;
 	icon_state = "red2"
@@ -882,7 +887,7 @@
 	},
 /obj/machinery/light/incandescent/warm,
 /obj/disposalpipe/segment/mail,
-/turf/space,
+/turf/simulated/floor/grime,
 /turf/simulated/floor/grime,
 /area/station/security/brig/south_side)
 "abp" = (
@@ -914,7 +919,10 @@
 /obj/machinery/light/incandescent/warm{
 	dir = 8
 	},
-/turf/space,
+/turf/simulated/floor/carpet{
+	dir = 8;
+	icon_state = "red2"
+	},
 /turf/simulated/floor/carpet{
 	dir = 8;
 	icon_state = "red2"
@@ -933,7 +941,9 @@
 /obj/machinery/disposal/mail/small/autoname/security/north{
 	pixel_y = 24
 	},
-/turf/space,
+/turf/simulated/floor/redblack{
+	dir = 1
+	},
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
@@ -1015,7 +1025,7 @@
 /obj/decal/mule/beacon,
 /obj/item/clothing/gloves/fingerless,
 /obj/item/clothing/head/helmet/siren,
-/turf/space,
+/turf/simulated/floor/black,
 /turf/simulated/floor/black,
 /area/station/security/equipment)
 "abB" = (
@@ -1032,7 +1042,9 @@
 	pixel_x = 1;
 	pixel_y = 25
 	},
-/turf/space,
+/turf/simulated/floor/redblack{
+	dir = 1
+	},
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
@@ -1128,7 +1140,7 @@
 /obj/machinery/recharger/wall/sticky{
 	pixel_y = -24
 	},
-/turf/space,
+/turf/simulated/floor/redblack,
 /turf/simulated/floor/redblack,
 /area/station/security/equipment)
 "abK" = (
@@ -1156,7 +1168,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/space,
+/turf/simulated/floor/carpet/grime,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/quarters)
 "abM" = (
@@ -1270,10 +1282,10 @@
 /obj/machinery/light/incandescent/warm{
 	dir = 4
 	},
-/turf/simulated/floor/white,
 /turf/simulated/floor/redwhite{
 	dir = 6
 	},
+/turf/simulated/floor/white,
 /area/station/security/quarters)
 "abV" = (
 /obj/machinery/power/apc/autoname_west,
@@ -1318,7 +1330,9 @@
 /turf/simulated/floor/redwhite{
 	dir = 6
 	},
-/turf/space,
+/turf/simulated/floor/redwhite{
+	dir = 6
+	},
 /area/station/security/quarters)
 "abY" = (
 /obj/stool/bed,
@@ -15348,7 +15362,7 @@
 /obj/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/space,
+/turf/simulated/floor/carpet/grime,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/quarters)
 "eyj" = (
@@ -32432,7 +32446,9 @@
 /area/station/science)
 "kat" = (
 /obj/storage/closet/wardrobe/orange,
-/turf/space,
+/turf/simulated/floor/redwhite{
+	dir = 8
+	},
 /turf/simulated/floor/redwhite{
 	dir = 8
 	},
@@ -64981,18 +64997,6 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
-"ukl" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/black/grime,
-/area/station/security/brig/north_side)
 "uku" = (
 /obj/cable{
 	d1 = 1;
@@ -102419,7 +102423,7 @@ jJd
 fAb
 czV
 cgK
-ukl
+czV
 rCp
 xxf
 nug

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -131930,7 +131930,7 @@ dms
 dms
 dms
 dms
-dms
+dET
 dms
 dms
 dms
@@ -139779,7 +139779,7 @@ djp
 dkX
 dny
 dny
-dmw
+dRB
 dmw
 dmw
 dmw


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Adds lighting to dark spots around the shuttle at Centcomm
- Adds exit buttons to the exit doors around the Medbay lobby
- Replaces old module writer in Robotics with the new one
- Adds a ChemMaster to Hydroponics' back room
- Kills many corrupted Sec turfs... now Sec should be breathable


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
- Because we need these fixes they good yes
