### PR TITLE
UM-037 - Empty Taser Rack and New Sec Vendor

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -2234,9 +2234,6 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "fR" = (
-/obj/rack,
-/obj/item/gun/kinetic/riot40mm,
-/obj/item/gun/implanter,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 4;
@@ -2244,6 +2241,7 @@
 	pixel_x = -10;
 	tag = ""
 	},
+/obj/submachine/weapon_vendor/security,
 /turf/simulated/floor/red/side{
 	dir = 8
 	},
@@ -2410,7 +2408,7 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "gp" = (
-/obj/machinery/weapon_stand/taser_rack/recharger,
+/obj/machinery/weapon_stand/taser_rack/recharger/empty,
 /turf/simulated/floor/red/side{
 	dir = 4
 	},
@@ -4409,6 +4407,8 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon19,
+/obj/rack,
+/obj/item/gun/implanter,
 /turf/simulated/floor/red,
 /area/station/security/main)
 "lM" = (

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -5802,9 +5802,12 @@
 	},
 /area/station/hangar/sec)
 "ajw" = (
-/obj/table/reinforced/auto,
-/obj/item/device/light/zippo,
-/obj/item/cigpacket/random,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname  - SS13"
+	},
+/obj/submachine/weapon_vendor/security,
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
@@ -6012,11 +6015,6 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname  - SS13"
 	},
 /turf/simulated/floor/black,
 /area/station/hangar/sec)
@@ -23462,8 +23460,8 @@
 /obj/item/device/radio/headset/medical,
 /obj/item/device/radio/headset/medical,
 /obj/item/device/radio/intercom/bridge{
-	dir = 4;
-	broadcasting = 0
+	broadcasting = 0;
+	dir = 4
 	},
 /turf/simulated/floor/carpet{
 	dir = 8;
@@ -23684,11 +23682,7 @@
 	pixel_y = 24;
 	text = "NF"
 	},
-/obj/machinery/computer3/generic/secure_data,
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	icon_state = "0-2"
-	},
+/obj/submachine/weapon_vendor/security,
 /turf/simulated/floor,
 /area/station/security/main)
 "aSn" = (
@@ -23920,8 +23914,8 @@
 	dir = 4
 	},
 /obj/item/device/radio/intercom/bridge{
-	dir = 4;
 	broadcasting = 0;
+	dir = 4;
 	layer = 6.02
 	},
 /obj/item_dispenser/idcarddispenser{
@@ -28394,8 +28388,8 @@
 	},
 /obj/item/paper/book/space_law,
 /obj/item/device/radio/intercom/bridge{
-	dir = 4;
 	broadcasting = 0;
+	dir = 4;
 	layer = 6.02
 	},
 /turf/simulated/floor/carpet{
@@ -32979,7 +32973,7 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/hos)
 "biL" = (
-/obj/machinery/weapon_stand/taser_rack/recharger,
+/obj/machinery/weapon_stand/taser_rack/recharger/empty,
 /turf/simulated/floor,
 /area/station/security/main)
 "biM" = (
@@ -33686,8 +33680,8 @@
 	},
 /obj/disposalpipe/segment/mail,
 /obj/item/device/radio/intercom/bridge{
-	dir = 4;
 	broadcasting = 0;
+	dir = 4;
 	layer = 6.02
 	},
 /turf/simulated/floor/escape{
@@ -40847,8 +40841,8 @@
 /obj/machinery/power/data_terminal,
 /obj/cable,
 /obj/item/device/radio/intercom/bridge{
-	dir = 4;
-	broadcasting = 0
+	broadcasting = 0;
+	dir = 4
 	},
 /obj/item/device/radio/intercom/bridge{
 	dir = 4
@@ -49084,10 +49078,25 @@
 /obj/machinery/vending/janitor,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor)
+"jKb" = (
+/obj/window/reinforced/north,
+/obj/table/reinforced/auto,
+/obj/item/cigpacket/random,
+/obj/item/device/light/zippo,
+/turf/simulated/floor/white/checker{
+	dir = 5
+	},
+/area/station/hallway/secondary/exit)
 "mFQ" = (
 /obj/machinery/drone_recharger,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
+"oCF" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/security/main)
 "pNt" = (
 /obj/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -75677,7 +75686,7 @@ agr
 aeN
 ahc
 ahu
-ahX
+jKb
 ait
 aiX
 aju
@@ -77524,7 +77533,7 @@ aOu
 aPB
 aQR
 aSm
-aTL
+oCF
 biL
 aWB
 aXN

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -4670,8 +4670,8 @@
 	dir = 1
 	},
 /obj/item/device/radio/intercom{
-	dir = 4;
-	broadcasting = 0
+	broadcasting = 0;
+	dir = 4
 	},
 /obj/landmark/start{
 	name = "Staff Assistant"
@@ -4862,6 +4862,10 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
+/obj/machinery/light_switch{
+	name = "N light switch";
+	pixel_y = 24
+	},
 /turf/simulated/floor/red/side{
 	dir = 9
 	},
@@ -4888,9 +4892,8 @@
 /obj/item/device/radio/intercom{
 	dir = 8
 	},
-/obj/machinery/light_switch{
-	name = "N light switch";
-	pixel_y = 24
+/obj/machinery/recharger/wall/sticky{
+	dir = 1
 	},
 /turf/simulated/floor/red/side{
 	dir = 5
@@ -5195,12 +5198,12 @@
 	icon_state = "1-8"
 	},
 /obj/item/storage/box/stinger_kit{
-	pixel_y = 8;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 8
 	},
 /obj/item/reagent_containers/food/snacks/donut/frosted{
-	pixel_y = -6;
-	pixel_x = 7
+	pixel_x = 7;
+	pixel_y = -6
 	},
 /turf/simulated/floor/black,
 /area/station/security/armory)
@@ -6245,8 +6248,6 @@
 	},
 /area/station/security/checkpoint/arrivals)
 "aoo" = (
-/obj/table/reinforced/auto,
-/obj/machinery/recharger,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -6257,6 +6258,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/submachine/weapon_vendor/security,
 /turf/simulated/floor/red/side,
 /area/station/security/checkpoint/arrivals)
 "aop" = (
@@ -6905,9 +6907,9 @@
 "apL" = (
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
+	dir = 1;
 	frequency = 1446;
-	name = "Botany Intercom";
-	dir = 1
+	name = "Botany Intercom"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
@@ -8229,8 +8231,8 @@
 /area/station/hangar/sec)
 "asR" = (
 /obj/item/device/radio/intercom{
-	dir = 4;
 	broadcasting = 0;
+	dir = 4;
 	frequency = 1489;
 	name = "Brig Intercom"
 	},
@@ -8314,8 +8316,8 @@
 /area/station/security/brig)
 "atb" = (
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 1;
+	dir = 8;
 	frequency = 1489;
 	name = "Brig Intercom"
 	},
@@ -12230,8 +12232,8 @@
 /area/station/security/brig)
 "aBx" = (
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 1;
+	dir = 8;
 	frequency = 1489;
 	name = "Brig Intercom"
 	},
@@ -16021,15 +16023,8 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aIY" = (
-/obj/rack,
-/obj/item/ammo/bullets/smoke,
-/obj/item/ammo/bullets/smoke,
-/obj/item/gun/kinetic/riot40mm,
-/obj/item/gun/kinetic/riot40mm,
-/obj/item/wrench,
-/obj/item/wrench,
-/obj/item/gun/implanter,
-/turf/simulated/floor/bot,
+/obj/submachine/weapon_vendor/security,
+/turf/simulated/floor,
 /area/station/security/main)
 "aIZ" = (
 /obj/landmark{
@@ -17365,8 +17360,8 @@
 "aLL" = (
 /obj/shrub,
 /obj/item/device/radio/intercom{
-	dir = 4;
 	broadcasting = 0;
+	dir = 4;
 	frequency = 1485;
 	name = "Security Intercom"
 	},
@@ -17515,8 +17510,8 @@
 /area/station/maintenance/westsolar)
 "aMi" = (
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 0;
+	dir = 8;
 	frequency = 1485;
 	name = "Security Intercom"
 	},
@@ -17810,8 +17805,8 @@
 /area/station/security/main)
 "aML" = (
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 0;
+	dir = 8;
 	frequency = 1485;
 	name = "Security Intercom"
 	},
@@ -17962,8 +17957,8 @@
 	tag = ""
 	},
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 0;
+	dir = 8;
 	frequency = 1455;
 	name = "Supply Intercom"
 	},
@@ -18318,8 +18313,8 @@
 	dir = 4
 	},
 /obj/item/device/radio/intercom{
-	dir = 1;
 	broadcasting = 0;
+	dir = 1;
 	frequency = 1445;
 	name = "Medical Intercom"
 	},
@@ -18334,8 +18329,8 @@
 	dir = 4
 	},
 /obj/item/device/radio/intercom{
-	dir = 1;
 	broadcasting = 0;
+	dir = 1;
 	frequency = 1485;
 	name = "Security Intercom"
 	},
@@ -18351,15 +18346,15 @@
 	dir = 4
 	},
 /obj/item/device/radio/intercom{
-	dir = 1;
 	broadcasting = 0;
+	dir = 1;
 	frequency = 1441;
 	name = "Engineering Intercom"
 	},
 /obj/table/auto,
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 0;
+	dir = 8;
 	frequency = 1455;
 	name = "Supply Intercom"
 	},
@@ -18794,8 +18789,8 @@
 "aOA" = (
 /obj/disposalpipe/segment,
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 0;
+	dir = 8;
 	frequency = 1445;
 	name = "Medical Intercom"
 	},
@@ -20013,8 +20008,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 0;
+	dir = 8;
 	frequency = 1485;
 	name = "Station Intercom (Security)"
 	},
@@ -21105,7 +21100,7 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/pool)
 "aTr" = (
-/obj/machinery/weapon_stand/taser_rack/recharger,
+/obj/machinery/weapon_stand/taser_rack/recharger/empty,
 /turf/simulated/floor/caution/east,
 /area/station/security/main)
 "aTs" = (
@@ -21305,8 +21300,8 @@
 	},
 /obj/disposalpipe/segment/mail,
 /obj/item/device/radio/intercom{
-	dir = 4;
-	broadcasting = 1
+	broadcasting = 1;
+	dir = 4
 	},
 /turf/simulated/floor/carpet{
 	dir = 9;
@@ -21744,8 +21739,8 @@
 /area/station/crew_quarters/jazz)
 "aUJ" = (
 /obj/item/device/radio/intercom{
-	dir = 4;
 	broadcasting = 0;
+	dir = 4;
 	frequency = 1489;
 	name = "Brig Intercom"
 	},
@@ -22402,8 +22397,8 @@
 /area/station/crew_quarters/jazz)
 "aWd" = (
 /obj/item/device/radio/intercom{
-	dir = 4;
 	broadcasting = 0;
+	dir = 4;
 	frequency = 1485;
 	name = "Security Intercom"
 	},
@@ -24711,8 +24706,8 @@
 /area/station/bridge)
 "baV" = (
 /obj/item/device/radio/intercom{
-	dir = 1;
 	broadcasting = 0;
+	dir = 1;
 	frequency = 1485;
 	name = "Security Intercom"
 	},
@@ -24720,8 +24715,8 @@
 /area/station/bridge)
 "baW" = (
 /obj/item/device/radio/intercom{
-	dir = 1;
 	broadcasting = 0;
+	dir = 1;
 	frequency = 1441;
 	name = "Engineering Intercom"
 	},
@@ -27514,7 +27509,6 @@
 /obj/stool/chair{
 	dir = 4
 	},
-/obj/machinery/recharger/wall/sticky,
 /turf/simulated/floor/black,
 /area/station/security/main)
 "bgm" = (
@@ -27529,8 +27523,8 @@
 /obj/machinery/power/data_terminal,
 /obj/machinery/light_switch{
 	name = "N light switch";
-	pixel_y = 24;
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = 24
 	},
 /obj/filing_cabinet,
 /obj/cable{
@@ -27624,7 +27618,14 @@
 	},
 /area/station/janitor)
 "bgx" = (
-/obj/machinery/recharger/wall/sticky,
+/obj/rack,
+/obj/item/ammo/bullets/smoke,
+/obj/item/ammo/bullets/smoke,
+/obj/item/gun/kinetic/riot40mm,
+/obj/item/gun/kinetic/riot40mm,
+/obj/item/wrench,
+/obj/item/wrench,
+/obj/item/gun/implanter,
 /turf/simulated/floor/caution/west,
 /area/station/security/main)
 "bgy" = (
@@ -29275,8 +29276,8 @@
 /area/station/routingdepot)
 "bjZ" = (
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 0;
+	dir = 8;
 	frequency = 1455;
 	name = "Supply Intercom"
 	},
@@ -30019,8 +30020,8 @@
 	pixel_y = -24
 	},
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 0;
+	dir = 8;
 	frequency = 1455;
 	name = "Supply Intercom"
 	},
@@ -32659,8 +32660,8 @@
 "bra" = (
 /obj/machinery/computer/barcode,
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 0;
+	dir = 8;
 	frequency = 1455;
 	name = "Supply Intercom"
 	},
@@ -32853,8 +32854,8 @@
 /area/station/routingdepot/engine)
 "brw" = (
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 0;
+	dir = 8;
 	frequency = 1455;
 	name = "Supply Intercom"
 	},
@@ -32950,8 +32951,8 @@
 /area/station/maintenance/east)
 "brK" = (
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 0;
+	dir = 8;
 	frequency = 1455;
 	name = "Supply Intercom"
 	},
@@ -34113,8 +34114,8 @@
 /area/station/crew_quarters/info)
 "btZ" = (
 /obj/item/device/radio/intercom{
-	dir = 1;
 	broadcasting = 0;
+	dir = 1;
 	frequency = 1485;
 	name = "Security Intercom"
 	},
@@ -34122,8 +34123,8 @@
 /area/station/crew_quarters/info)
 "bua" = (
 /obj/item/device/radio/intercom{
-	dir = 1;
 	broadcasting = 0;
+	dir = 1;
 	frequency = 1441;
 	name = "Engineering Intercom"
 	},
@@ -34555,8 +34556,8 @@
 	dir = 4
 	},
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 1;
+	dir = 8;
 	frequency = 1447;
 	name = "AI Intercom"
 	},
@@ -36350,8 +36351,8 @@
 	dir = 4
 	},
 /obj/item/device/radio/intercom{
-	dir = 1;
 	broadcasting = 0;
+	dir = 1;
 	frequency = 1441;
 	name = "Engineering Intercom"
 	},
@@ -36434,8 +36435,8 @@
 	dir = 4
 	},
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 0;
+	dir = 8;
 	frequency = 1455;
 	name = "Supply Intercom"
 	},
@@ -36443,8 +36444,8 @@
 /area/station/quartermaster/office)
 "byN" = (
 /obj/item/device/radio/intercom{
-	dir = 1;
 	broadcasting = 0;
+	dir = 1;
 	frequency = 1441;
 	name = "Engineering Intercom"
 	},
@@ -45071,8 +45072,8 @@
 "bQo" = (
 /obj/stool/bed,
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 0;
+	dir = 8;
 	frequency = 1441;
 	name = "Engineering Intercom"
 	},
@@ -45662,8 +45663,8 @@
 /obj/table/auto,
 /obj/item/hand_labeler,
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 0;
+	dir = 8;
 	frequency = 1455;
 	name = "Supply Intercom"
 	},
@@ -45813,8 +45814,8 @@
 /area/station/engine/elect)
 "bRH" = (
 /obj/item/device/radio/intercom{
-	dir = 1;
 	broadcasting = 0;
+	dir = 1;
 	frequency = 1441;
 	name = "Engineering Intercom"
 	},
@@ -45940,8 +45941,8 @@
 /area/station/storage/warehouse)
 "bRY" = (
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 0;
+	dir = 8;
 	frequency = 1455;
 	name = "Supply Intercom"
 	},
@@ -47359,8 +47360,8 @@
 	dir = 8
 	},
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 0;
+	dir = 8;
 	frequency = 1455;
 	name = "Supply Intercom"
 	},
@@ -47447,8 +47448,8 @@
 	pixel_y = 5
 	},
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 0;
+	dir = 8;
 	frequency = 1445;
 	name = "Station Intercom (Medical)"
 	},
@@ -51594,8 +51595,8 @@
 /area/station/science/artifact)
 "cei" = (
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 0;
+	dir = 8;
 	frequency = 1445;
 	name = "Station Intercom (Medical)"
 	},
@@ -51863,6 +51864,9 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
+/obj/machinery/recharger/wall/sticky{
+	dir = 8
+	},
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/cargo)
 "cfa" = (
@@ -51880,6 +51884,9 @@
 /area/station/mining)
 "cfb" = (
 /obj/storage/closet/wardrobe/orange,
+/obj/machinery/door_timer/minibrig{
+	pixel_y = -24
+	},
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/cargo)
 "cfc" = (
@@ -52475,11 +52482,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "cgr" = (
-/obj/table/auto,
-/obj/machinery/recharger,
-/obj/machinery/door_timer/minibrig{
-	pixel_y = -24
-	},
+/obj/submachine/weapon_vendor/security,
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/cargo)
 "cgs" = (
@@ -52663,8 +52666,8 @@
 /area/station/science)
 "cgM" = (
 /obj/item/device/radio/intercom{
-	dir = 1;
 	broadcasting = 0;
+	dir = 1;
 	frequency = 1485;
 	name = "Security Intercom"
 	},
@@ -52673,8 +52676,8 @@
 /area/station/science)
 "cgN" = (
 /obj/item/device/radio/intercom{
-	dir = 1;
 	broadcasting = 0;
+	dir = 1;
 	frequency = 1441;
 	name = "Engineering Intercom"
 	},
@@ -53332,8 +53335,8 @@
 	name = "Cyborg"
 	},
 /obj/item/device/radio/intercom{
-	dir = 4;
 	broadcasting = 0;
+	dir = 4;
 	frequency = 1445;
 	name = "Medical Intercom"
 	},
@@ -54749,8 +54752,8 @@
 /area/station/medical/morgue)
 "cla" = (
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 0;
+	dir = 8;
 	frequency = 1445;
 	name = "Medical Intercom"
 	},
@@ -62050,8 +62053,8 @@
 /area/listeningpost)
 "cAa" = (
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 0;
+	dir = 8;
 	frequency = 1485;
 	name = "Security Intercom"
 	},
@@ -62123,8 +62126,8 @@
 /area/listeningpost)
 "cAh" = (
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 1;
+	dir = 8;
 	frequency = 1489;
 	name = "Brig Intercom"
 	},
@@ -62637,8 +62640,8 @@
 "cBu" = (
 /obj/lattice,
 /obj/decal/floatingtiles{
-	icon_state = "floattiles3";
-	dir = 4
+	dir = 4;
+	icon_state = "floattiles3"
 	},
 /turf/space,
 /area)
@@ -62656,8 +62659,8 @@
 	icon_state = "lattice-dir"
 	},
 /obj/decal/floatingtiles{
-	icon_state = "floattiles3";
-	dir = 8
+	dir = 8;
+	icon_state = "floattiles3"
 	},
 /obj/structure/girder/displaced,
 /turf/space,
@@ -62712,8 +62715,8 @@
 "cBE" = (
 /obj/lattice,
 /obj/decal/floatingtiles{
-	icon_state = "floattiles3";
-	dir = 8
+	dir = 8;
+	icon_state = "floattiles3"
 	},
 /turf/space,
 /area)
@@ -62769,8 +62772,8 @@
 /area/abandonedship)
 "cBM" = (
 /obj/decal/floatingtiles{
-	icon_state = "floattiles4";
-	dir = 4
+	dir = 4;
+	icon_state = "floattiles4"
 	},
 /turf/simulated/floor/airless/plating/scorched,
 /area/abandonedship)
@@ -62824,8 +62827,8 @@
 /area)
 "cBV" = (
 /obj/decal/floatingtiles{
-	icon_state = "floattiles4";
-	dir = 8
+	dir = 8;
+	icon_state = "floattiles4"
 	},
 /turf/space,
 /area)
@@ -63244,8 +63247,8 @@
 /obj/item/storage/firstaid/brain,
 /obj/item/clothing/glasses/spectro,
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 0;
+	dir = 8;
 	frequency = 1445;
 	name = "Medical Intercom"
 	},
@@ -63295,8 +63298,8 @@
 /obj/item/storage/toolbox/emergency,
 /obj/machinery/light,
 /obj/item/device/radio/intercom{
-	dir = 1;
 	broadcasting = 0;
+	dir = 1;
 	frequency = 1445;
 	name = "Medical Intercom"
 	},
@@ -64086,8 +64089,8 @@
 /area/station/engine/core)
 "tXN" = (
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 0;
+	dir = 8;
 	frequency = 1441;
 	name = "Engineering Intercom"
 	},
@@ -64184,8 +64187,8 @@
 /area/station/engine/core)
 "vSl" = (
 /obj/item/device/radio/intercom{
-	dir = 4;
 	broadcasting = 0;
+	dir = 4;
 	frequency = 1441;
 	name = "Engineering Intercom"
 	},

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -29985,8 +29985,7 @@
 	},
 /area/station/catwalk/north)
 "bqH" = (
-/obj/table/auto,
-/obj/item/storage/box/trackimp_kit2,
+/obj/machinery/vending/cigarette,
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
@@ -34273,6 +34272,10 @@
 /obj/item/paper/book/space_law,
 /obj/machinery/door_timer/solitary{
 	pixel_x = -5
+	},
+/obj/item/storage/box/trackimp_kit2{
+	pixel_x = 8;
+	pixel_y = 3
 	},
 /turf/simulated/floor/carpet{
 	icon_state = "red2"
@@ -41117,18 +41120,8 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
 "bLq" = (
-/obj/table/reinforced/auto,
-/obj/machinery/power/data_terminal,
-/obj/machinery/networked/printer{
-	name = "Printer - Checkpoint";
-	pixel_y = 5;
-	print_id = "CheckpointW"
-	},
 /obj/disposalpipe/segment/mail/bent/east,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
+/obj/submachine/weapon_vendor/security,
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
@@ -41136,9 +41129,6 @@
 "bLr" = (
 /obj/disposalpipe/segment/transport,
 /obj/disposalpipe/segment/mail/horizontal,
-/obj/cable{
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
@@ -42128,8 +42118,6 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
 "bNb" = (
-/obj/table/reinforced/auto,
-/obj/machinery/recharger,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 4;
@@ -42138,6 +42126,17 @@
 	tag = ""
 	},
 /obj/disposalpipe/trunk/mail/north,
+/obj/table/reinforced/auto,
+/obj/machinery/networked/printer{
+	name = "Printer - Checkpoint";
+	pixel_y = 5;
+	print_id = "CheckpointW"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
 /obj/machinery/disposal/mail/small/autoname/checkpoint/podbay/east,
 /turf/simulated/floor/black,
 /area/station/security/checkpoint/podbay)
@@ -44222,7 +44221,7 @@
 /turf/simulated/floor/bot,
 /area/station/security/main)
 "bRf" = (
-/obj/machinery/vending/cigarette,
+/obj/submachine/weapon_vendor/security,
 /turf/simulated/floor/bot,
 /area/station/security/main)
 "bRg" = (
@@ -48322,7 +48321,7 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bZU" = (
-/obj/machinery/weapon_stand/taser_rack/recharger,
+/obj/machinery/weapon_stand/taser_rack/recharger/empty,
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/main)
 "bZV" = (
@@ -49057,10 +49056,10 @@
 /area/station/catwalk/south)
 "cbt" = (
 /obj/disposalpipe/segment/transport,
-/obj/cable{
-	icon_state = "1-4"
-	},
 /obj/machinery/flasher/portable,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/black,
 /area/station/security/checkpoint/podbay)
 "cbu" = (
@@ -54532,13 +54531,13 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/item/device/radio/intercom/security,
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/escape)
 "cod" = (
 /obj/stool/chair/office/red{
 	dir = 8
 	},
-/obj/item/device/radio/intercom/security,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -54553,6 +54552,9 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/machinery/recharger/wall/sticky{
+	dir = 1
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/checkpoint/escape)
@@ -56080,14 +56082,13 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/checkpoint/escape)
 "crG" = (
-/obj/table/reinforced/auto,
-/obj/machinery/recharger,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 10;
 	name = "autoname - SS13";
 	tag = ""
 	},
+/obj/submachine/weapon_vendor/security,
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/checkpoint/escape)
 "crH" = (
@@ -58466,8 +58467,10 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/light_switch/north,
 /obj/submachine/poster_creator,
+/obj/machinery/recharger/wall/sticky{
+	dir = 1
+	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/checkpoint/cargo)
 "cwP" = (
@@ -58482,8 +58485,7 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/checkpoint/cargo)
 "cwQ" = (
-/obj/table/reinforced/auto,
-/obj/machinery/recharger,
+/obj/submachine/weapon_vendor/security,
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/checkpoint/cargo)
 "cwR" = (
@@ -58501,6 +58503,7 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
+/obj/machinery/light_switch/north,
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/checkpoint/cargo)
 "cwS" = (
@@ -78747,6 +78750,10 @@
 "hRi" = (
 /turf/space,
 /area/shuttle/arrival/station)
+"pFA" = (
+/obj/submachine/weapon_vendor/security,
+/turf/simulated/floor/specialroom/bar,
+/area/station/security/checkpoint/chapel)
 "pTS" = (
 /obj/item/storage/wall/random,
 /obj/machinery/vending/janitor,
@@ -126594,7 +126601,7 @@ aIn
 aGE
 aLi
 aMy
-aNP
+pFA
 aOU
 aNP
 aQr

--- a/maps/density.dmm
+++ b/maps/density.dmm
@@ -20,8 +20,8 @@
 /area/station/maintenance)
 "ae" = (
 /obj/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance)
@@ -34,9 +34,9 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance)
@@ -45,9 +45,9 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance)
@@ -56,9 +56,9 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -69,9 +69,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance)
@@ -81,21 +81,21 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance)
 "al" = (
 /obj/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -106,21 +106,21 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance)
 "an" = (
 /obj/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating,
@@ -300,8 +300,8 @@
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance)
@@ -448,26 +448,26 @@
 "bb" = (
 /obj/storage/secure/crate/weapon/armory/tranquilizer,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
 "bc" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
 "bd" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
@@ -481,8 +481,8 @@
 /area/station/maintenance)
 "bf" = (
 /obj/stool/chair/office/red{
-	icon_state = "office_chair_red";
-	dir = 4
+	dir = 4;
+	icon_state = "office_chair_red"
 	},
 /obj/landmark/start{
 	name = "Security Officer"
@@ -491,8 +491,8 @@
 /area/station/security/main)
 "bg" = (
 /obj/machinery/computer/secure_data{
-	icon_state = "datasec";
-	dir = 8
+	dir = 8;
+	icon_state = "datasec"
 	},
 /turf/simulated/floor/red,
 /area/station/security/main)
@@ -535,17 +535,17 @@
 	name = "Warden Hooty"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bm" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/red,
 /area/station/security/main)
@@ -554,23 +554,26 @@
 	name = "SECURITY-SCANNER-HERE-PLEASE"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bo" = (
 /obj/table/reinforced/auto,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/deskclutter,
 /obj/item/kitchen/food_box/donut_box{
 	desc = "It appears to be a Martian brand of donuts.";
 	name = "Robust Donuts"
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 7
 	},
 /turf/simulated/floor/red,
 /area/station/security/main)
@@ -589,21 +592,19 @@
 	network = "arcadevr"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bq" = (
-/obj/table/reinforced/auto,
-/obj/machinery/recharger,
-/obj/item/storage/toolbox/mechanical,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
+/obj/machinery/vending/security,
 /turf/simulated/floor/red,
 /area/station/security/main)
 "br" = (
@@ -616,18 +617,18 @@
 	req_access_txt = "0"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/access_spawn/hos,
 /turf/simulated/floor/red,
 /area/station/ai_monitored/armory)
 "bs" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
@@ -646,7 +647,8 @@
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bv" = (
-/obj/machinery/vending/security,
+/obj/machinery/flasher/portable,
+/obj/machinery/flasher/portable,
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bw" = (
@@ -683,8 +685,8 @@
 /area/station/security/main)
 "bA" = (
 /obj/morgue{
-	icon_state = "morgue1";
-	dir = 2
+	dir = 2;
+	icon_state = "morgue1"
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -737,9 +739,9 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance)
@@ -748,9 +750,9 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/main)
@@ -761,9 +763,9 @@
 	name = "CMDS Outlet"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -828,7 +830,7 @@
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bO" = (
-/obj/machinery/flasher/portable,
+/obj/submachine/weapon_vendor/security,
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bP" = (
@@ -854,8 +856,8 @@
 /area/station/security/main)
 "bS" = (
 /obj/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/specialroom/freezer,
 /area/station/security/main)
@@ -879,8 +881,8 @@
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance)
@@ -954,8 +956,8 @@
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer/supplycomp,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/bot,
 /area/station/quartermaster/office)
@@ -969,15 +971,15 @@
 /area/station/maintenance)
 "cj" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 2
+	dir = 2;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area)
 "ck" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 9
+	dir = 9;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area)
@@ -995,30 +997,30 @@
 /area)
 "cm" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 4
+	dir = 4;
+	icon_state = "lattice-dir"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/space,
 /area)
 "cn" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance)
 "co" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance)
@@ -1028,9 +1030,9 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -1041,8 +1043,8 @@
 /area/station/maintenance)
 "cq" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 1
+	dir = 1;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area)
@@ -1055,8 +1057,8 @@
 /area/station/maintenance)
 "cs" = (
 /obj/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/security/main)
@@ -1155,9 +1157,9 @@
 /area/station/maintenance)
 "cJ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -1176,9 +1178,9 @@
 /area/station/crew_quarters/garden)
 "cM" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -1187,9 +1189,9 @@
 /area/station/maintenance)
 "cN" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
 /obj/cable{
@@ -1201,9 +1203,9 @@
 /area/station/maintenance)
 "cO" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -1227,27 +1229,27 @@
 /area/station/security/main)
 "cQ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/neutral,
 /area/station/quartermaster/office)
 "cR" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/neutral,
 /area/station/quartermaster/office)
@@ -1339,8 +1341,8 @@
 /area/station/crew_quarters/clown)
 "da" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 5
+	dir = 5;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area)
@@ -1383,8 +1385,8 @@
 /area/station/crew_quarters/garden)
 "dg" = (
 /obj/window/cubicle{
-	icon_state = "cubicle";
-	dir = 1
+	dir = 1;
+	icon_state = "cubicle"
 	},
 /turf/simulated/floor/neutral,
 /area/station/crew_quarters/garden)
@@ -1396,8 +1398,8 @@
 /area/station/storage/warehouse)
 "di" = (
 /obj/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance)
@@ -1413,8 +1415,8 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/decal/cleanable/cobweb,
@@ -1446,20 +1448,20 @@
 	dir = 4
 	},
 /obj/decal/cleanable/blood/tracks{
-	icon_state = "tracks";
-	dir = 4
+	dir = 4;
+	icon_state = "tracks"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance)
 "do" = (
 /obj/disposalpipe/junction{
-	icon_state = "pipe-j1";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-j1"
 	},
 /obj/creepy_sound_trigger,
 /obj/decal/cleanable/blood/tracks{
-	icon_state = "tracks";
-	dir = 4
+	dir = 4;
+	icon_state = "tracks"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance)
@@ -1485,14 +1487,14 @@
 /area/station/engine/elect)
 "ds" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -1680,9 +1682,9 @@
 /obj/item/clothing/head/helmet/space/engineer,
 /obj/item/tank/jetpack,
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -1699,9 +1701,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -1838,9 +1840,9 @@
 /area/station/storage/warehouse)
 "ej" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -1858,41 +1860,41 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/stool/chair/couch/blue{
-	icon_state = "chair_couch-blue";
-	dir = 8
+	dir = 8;
+	icon_state = "chair_couch-blue"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance)
 "el" = (
 /obj/stool/chair/couch/blue{
-	icon_state = "chair_couch-blue";
-	dir = 4
+	dir = 4;
+	icon_state = "chair_couch-blue"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance)
 "em" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	icon_state = "intact";
-	dir = 6
+	dir = 6;
+	icon_state = "intact"
 	},
 /turf/space,
 /area/station/engine/coldloop)
 "en" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /turf/space,
 /area/station/engine/coldloop)
 "eo" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	icon_state = "intact";
-	dir = 10
+	dir = 10;
+	icon_state = "intact"
 	},
 /obj/machinery/atmospherics/pipe/vent{
 	dir = 4
@@ -1915,22 +1917,22 @@
 /area/station/engine/elect)
 "er" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/elect)
 "es" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/elect)
@@ -2139,8 +2141,8 @@
 /area/mining/magnet)
 "eP" = (
 /obj/grille/catwalk{
-	icon_state = "catwalk_cross";
-	dir = 5
+	dir = 5;
+	icon_state = "catwalk_cross"
 	},
 /obj/landmark/magnet_shield,
 /obj/securearea{
@@ -2172,8 +2174,8 @@
 /area/mining/magnet)
 "eQ" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /turf/space,
 /area/station/engine/coldloop)
@@ -2203,9 +2205,9 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/elect)
@@ -2355,8 +2357,8 @@
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance)
@@ -2461,22 +2463,22 @@
 "fz" = (
 /obj/storage/secure/closet/command/chief_engineer,
 /turf/simulated/floor/carpet{
-	icon_state = "fblue2";
-	dir = 9
+	dir = 9;
+	icon_state = "fblue2"
 	},
 /area/station/bridge)
 "fA" = (
 /obj/storage/secure/closet/command/captain,
 /turf/simulated/floor/carpet{
-	icon_state = "fblue2";
-	dir = 1
+	dir = 1;
+	icon_state = "fblue2"
 	},
 /area/station/bridge)
 "fB" = (
 /obj/storage/secure/closet/command/hop,
 /turf/simulated/floor/carpet{
-	icon_state = "fblue2";
-	dir = 5
+	dir = 5;
+	icon_state = "fblue2"
 	},
 /area/station/bridge)
 "fC" = (
@@ -2517,8 +2519,8 @@
 /area/station/maintenance)
 "fH" = (
 /obj/machinery/door/airlock/pyro/external{
-	icon_state = "airlock_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "airlock_closed"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -2530,19 +2532,19 @@
 /area/station/engine/core)
 "fJ" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	icon_state = "intact";
-	dir = 10
+	dir = 10;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "fK" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
+	dir = 1;
+	icon_state = "term"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/landmark/start{
 	name = "Engineer"
@@ -2632,8 +2634,8 @@
 /area/station/janitor/supply)
 "fX" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 6
+	dir = 6;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area)
@@ -2644,36 +2646,36 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fblue2";
-	dir = 8
+	dir = 8;
+	icon_state = "fblue2"
 	},
 /area/station/bridge)
 "fZ" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fblue1";
-	dir = 8
+	dir = 8;
+	icon_state = "fblue1"
 	},
 /area/station/bridge)
 "ga" = (
 /obj/stool/chair/comfy/blue{
-	icon_state = "chair_comfy-blue";
-	dir = 4
+	dir = 4;
+	icon_state = "chair_comfy-blue"
 	},
 /obj/landmark/start{
 	name = "Research Director"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fblue2";
-	dir = 4
+	dir = 4;
+	icon_state = "fblue2"
 	},
 /area/station/bridge)
 "gb" = (
@@ -2697,8 +2699,8 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
@@ -2709,10 +2711,10 @@
 /area/station/maintenance)
 "gg" = (
 /obj/machinery/atmospherics/binary/passive_gate{
-	icon_state = "intact_off";
 	dir = 1;
-	pixel_y = 1;
+	icon_state = "intact_off";
 	on = 1;
+	pixel_y = 1;
 	target_pressure = 1e+031
 	},
 /turf/simulated/floor/engine,
@@ -2736,10 +2738,10 @@
 	can_rupture = 0
 	},
 /obj/machinery/atmospherics/binary/passive_gate{
-	icon_state = "intact_off";
 	dir = 1;
-	pixel_y = 1;
+	icon_state = "intact_off";
 	on = 1;
+	pixel_y = 1;
 	target_pressure = 1e+031
 	},
 /turf/simulated/floor/engine,
@@ -2821,9 +2823,9 @@
 /area/station/bridge)
 "gt" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -2837,23 +2839,23 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fblue2";
-	dir = 8
+	dir = 8;
+	icon_state = "fblue2"
 	},
 /area/station/bridge)
 "gv" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -2862,21 +2864,21 @@
 	name = "Captain"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fblue1";
-	dir = 8
+	dir = 8;
+	icon_state = "fblue1"
 	},
 /area/station/bridge)
 "gw" = (
 /obj/stool/chair/comfy/blue{
-	icon_state = "chair_comfy-blue";
-	dir = 4
+	dir = 4;
+	icon_state = "chair_comfy-blue"
 	},
 /obj/landmark/start{
 	name = "Medical Director"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fblue2";
-	dir = 4
+	dir = 4;
+	icon_state = "fblue2"
 	},
 /area/station/bridge)
 "gx" = (
@@ -2897,17 +2899,17 @@
 /area/station/crew_quarters/bar)
 "gA" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/grass,
 /area/station/crew_quarters/garden)
 "gB" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/grass,
 /area/station/crew_quarters/garden)
@@ -2918,9 +2920,9 @@
 	name = "CMDS Outlet"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -2938,9 +2940,9 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance)
@@ -2954,20 +2956,20 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/junction{
-	icon_state = "pipe-j1";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-j1"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance)
 "gF" = (
 /obj/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -2993,8 +2995,8 @@
 /area/station/engine/core)
 "gJ" = (
 /obj/machinery/atmospherics/pipe/manifold{
-	icon_state = "manifold";
 	dir = 4;
+	icon_state = "manifold";
 	level = 2
 	},
 /obj/machinery/light{
@@ -3007,8 +3009,8 @@
 /area/station/engine/core)
 "gK" = (
 /obj/machinery/atmospherics/pipe/manifold{
-	icon_state = "manifold";
 	dir = 8;
+	icon_state = "manifold";
 	level = 2
 	},
 /turf/simulated/floor/engine,
@@ -3073,13 +3075,13 @@
 /area/station/janitor/supply)
 "gT" = (
 /obj/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/janitor/supply)
@@ -3107,16 +3109,16 @@
 /area/station/janitor/supply)
 "gV" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 9
+	dir = 9;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area)
 "gW" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/computer/announcement{
 	announces_arrivals = 1;
@@ -3124,35 +3126,35 @@
 	icon_state = "comm"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fblue2";
-	dir = 8
+	dir = 8;
+	icon_state = "fblue2"
 	},
 /area/station/bridge)
 "gX" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fblue1";
-	dir = 8
+	dir = 8;
+	icon_state = "fblue1"
 	},
 /area/station/bridge)
 "gY" = (
 /obj/stool/chair/comfy/blue{
-	icon_state = "chair_comfy-blue";
-	dir = 4
+	dir = 4;
+	icon_state = "chair_comfy-blue"
 	},
 /obj/landmark/start{
 	name = "Chief Engineer"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fblue2";
-	dir = 4
+	dir = 4;
+	icon_state = "fblue2"
 	},
 /area/station/bridge)
 "gZ" = (
@@ -3171,22 +3173,22 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/grass,
 /area/station/crew_quarters/garden)
 "hc" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/grass,
 /area/station/crew_quarters/garden)
@@ -3202,8 +3204,8 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
@@ -3274,8 +3276,8 @@
 "hl" = (
 /obj/storage/secure/closet/command/medical_director,
 /turf/simulated/floor/carpet{
-	icon_state = "fblue2";
-	dir = 10
+	dir = 10;
+	icon_state = "fblue2"
 	},
 /area/station/bridge)
 "hm" = (
@@ -3283,15 +3285,15 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fblue2";
-	dir = 2
+	dir = 2;
+	icon_state = "fblue2"
 	},
 /area/station/bridge)
 "hn" = (
 /obj/storage/secure/closet/command/research_director,
 /turf/simulated/floor/carpet{
-	icon_state = "fblue2";
-	dir = 6
+	dir = 6;
+	icon_state = "fblue2"
 	},
 /area/station/bridge)
 "ho" = (
@@ -3322,9 +3324,9 @@
 /area/station/crew_quarters/garden)
 "hs" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/grass,
 /area/station/crew_quarters/garden)
@@ -3349,14 +3351,14 @@
 /area/station/security/checkpoint/customs)
 "hv" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/command{
 	name = "Customs";
@@ -3413,8 +3415,8 @@
 /area/station/turret_protected/ai)
 "hD" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/mainframe/zeta{
@@ -3442,8 +3444,8 @@
 /area/station/security/main)
 "hF" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/storage/tape_drive{
@@ -3464,8 +3466,8 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
@@ -3495,14 +3497,14 @@
 /area/station/crew_quarters/garden)
 "hK" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
@@ -3517,17 +3519,17 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/maintenance)
 "hM" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 8;
@@ -3550,14 +3552,14 @@
 /area/station/engine/hotloop)
 "hP" = (
 /obj/machinery/atmospherics/unary/vent_pump{
-	icon_state = "in";
 	dir = 4;
-	initialize_directions = 1;
-	on = 1;
-	pump_direction = 0;
 	external_pressure_bound = 0;
+	icon_state = "in";
+	initialize_directions = 1;
 	internal_pressure_bound = 4000;
-	pressure_checks = 2
+	on = 1;
+	pressure_checks = 2;
+	pump_direction = 0
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/hotloop)
@@ -3605,9 +3607,9 @@
 /area/station/science/lab)
 "hV" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/white,
 /area/station/science/lab)
@@ -3624,14 +3626,14 @@
 /area/station/science/lab)
 "hX" = (
 /obj/machinery/computer/robotics{
-	icon_state = "robotics";
-	dir = 4
+	dir = 4;
+	icon_state = "robotics"
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -3643,9 +3645,9 @@
 /area/station/turret_protected/ai)
 "hY" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
@@ -3655,8 +3657,8 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/machinery/light{
@@ -3676,8 +3678,8 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
@@ -3716,9 +3718,9 @@
 /area/station/security/checkpoint/customs)
 "ii" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/landmark/start{
 	name = "Head of Personnel"
@@ -3789,9 +3791,9 @@
 /area/mining/magnet)
 "il" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -3805,8 +3807,8 @@
 "in" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/test_apparatus/gas_sensor{
@@ -3817,9 +3819,9 @@
 "io" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/landmark{
 	name = "Observer-Start"
@@ -3828,9 +3830,9 @@
 /area/station/engine/hotloop)
 "ip" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/hotloop)
@@ -3841,9 +3843,9 @@
 /obj/window/crystal/reinforced/east,
 /obj/window/crystal/reinforced/south,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
@@ -3855,16 +3857,16 @@
 	pixel_y = 0
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/computer/atmosphere/pumpcontrol{
 	dir = 2;
 	frequency = 1229
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
@@ -3877,9 +3879,9 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/bot/white,
@@ -3889,21 +3891,21 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
 /area/station/science/lab)
 "iu" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold{
-	icon_state = "manifold";
 	dir = 1;
+	icon_state = "manifold";
 	level = 2
 	},
 /obj/landmark/start{
@@ -3916,14 +3918,14 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/science/lab)
@@ -3954,8 +3956,8 @@
 	},
 /obj/grille/steel,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
 	dir = 2;
@@ -3988,8 +3990,8 @@
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
@@ -4013,8 +4015,8 @@
 	},
 /obj/grille/steel,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
 	dir = 2;
@@ -4022,8 +4024,8 @@
 	},
 /obj/cable,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
@@ -4036,8 +4038,8 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
@@ -4060,42 +4062,42 @@
 /area/station/hydroponics)
 "iD" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/grass,
 /area/station/hydroponics)
 "iE" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/grass,
 /area/station/chapel/main/main)
 "iF" = (
 /obj/stool/chair/wooden,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 9
+	dir = 9;
+	icon_state = "fred2"
 	},
 /area/station/chapel/main/main)
 "iG" = (
 /obj/stool/chair/wooden,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 5
+	dir = 5;
+	icon_state = "fred2"
 	},
 /area/station/chapel/main/main)
 "iH" = (
@@ -4116,8 +4118,8 @@
 /area/station/crew_quarters/garden)
 "iJ" = (
 /obj/machinery/computer/card{
-	icon_state = "id";
-	dir = 4
+	dir = 4;
+	icon_state = "id"
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable,
@@ -4134,8 +4136,8 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/decal/cleanable/dirt,
@@ -4154,9 +4156,9 @@
 /area/station/bridge)
 "iN" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
 /obj/grille/steel,
@@ -4174,22 +4176,22 @@
 /area/station/storage/warehouse)
 "iQ" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	icon_state = "intact";
-	dir = 9
+	dir = 9;
+	icon_state = "intact"
 	},
 /turf/space,
 /area/station/engine/coldloop)
 "iR" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/hotloop)
 "iS" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	icon_state = "intact";
-	dir = 9
+	dir = 9;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/hotloop)
@@ -4250,9 +4252,9 @@
 /area/station/science/lab)
 "iZ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/science/lab)
@@ -4279,9 +4281,9 @@
 /obj/item/assembly/time_ignite,
 /obj/item/clothing/glasses/vr{
 	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
+	network = "bombtest";
 	pixel_x = 2;
-	pixel_y = 5;
-	network = "bombtest"
+	pixel_y = 5
 	},
 /obj/item/device/audio_log,
 /obj/item/chem_grenade/firefighting,
@@ -4306,8 +4308,8 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
@@ -4336,14 +4338,14 @@
 /area/station/chapel/main/main)
 "jj" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 8
+	dir = 8;
+	icon_state = "fred2"
 	},
 /area/station/chapel/main/main)
 "jk" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 4
+	dir = 4;
+	icon_state = "fred2"
 	},
 /area/station/chapel/main/main)
 "jl" = (
@@ -4379,8 +4381,8 @@
 /area/station/science)
 "jp" = (
 /obj/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science)
@@ -4401,9 +4403,9 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/science/lab)
@@ -4424,9 +4426,9 @@
 	pixel_x = -28
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
@@ -4456,8 +4458,8 @@
 /area/station/turret_protected/ai)
 "jx" = (
 /obj/window/cubicle{
-	icon_state = "cubicle";
-	dir = 2
+	dir = 2;
+	icon_state = "cubicle"
 	},
 /obj/item/storage/toilet{
 	dir = 4
@@ -4472,8 +4474,8 @@
 /area/station/crew_quarters/bathroom)
 "jy" = (
 /obj/window/cubicle{
-	icon_state = "cubicle";
-	dir = 2
+	dir = 2;
+	icon_state = "cubicle"
 	},
 /obj/reagent_dispensers/compostbin,
 /turf/simulated/floor/white,
@@ -4496,8 +4498,8 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 8
+	dir = 8;
+	icon_state = "fred2"
 	},
 /area/station/chapel/main/main)
 "jC" = (
@@ -4507,14 +4509,14 @@
 	pixel_x = 2
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 4
+	dir = 4;
+	icon_state = "fred2"
 	},
 /area/station/chapel/main/main)
 "jD" = (
 /obj/morgue{
-	icon_state = "morgue1";
-	dir = 2
+	dir = 2;
+	icon_state = "morgue1"
 	},
 /turf/simulated/floor/grass,
 /area/station/chapel/main/main)
@@ -4529,8 +4531,8 @@
 /area/station/crew_quarters/garden)
 "jF" = (
 /obj/window/cubicle{
-	icon_state = "cubicle";
-	dir = 2
+	dir = 2;
+	icon_state = "cubicle"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/garden)
@@ -4578,16 +4580,16 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance)
 "jK" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/disposalpipe/junction{
 	dir = 8;
@@ -4606,9 +4608,9 @@
 /area/station/quartermaster/office)
 "jM" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -4632,26 +4634,26 @@
 /area/station/crew_quarters/garden)
 "jO" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/white,
 /area/station/science)
 "jP" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
 /area/station/science)
 "jQ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -4663,9 +4665,9 @@
 /area/station/science)
 "jR" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -4675,9 +4677,9 @@
 /area/station/science)
 "jS" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk{
@@ -4687,9 +4689,9 @@
 /area/station/science)
 "jT" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/medical{
 	name = "Toxins Lab";
@@ -4700,9 +4702,9 @@
 /area/station/science/lab)
 "jU" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/command{
 	name = "AI Chamber";
@@ -4720,8 +4722,8 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
@@ -4746,8 +4748,8 @@
 /area/station/crew_quarters/bathroom)
 "jY" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 10
+	dir = 10;
+	icon_state = "fred2"
 	},
 /area/station/chapel/main/main)
 "jZ" = (
@@ -4757,8 +4759,8 @@
 /obj/storage/closet/wardrobe/black/chaplain,
 /obj/machinery/light,
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 6
+	dir = 6;
+	icon_state = "fred2"
 	},
 /area/station/chapel/main/main)
 "ka" = (
@@ -4778,9 +4780,9 @@
 	dir = 8
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -4802,8 +4804,8 @@
 /area/station/storage/warehouse)
 "kf" = (
 /obj/window/cubicle{
-	icon_state = "cubicle";
-	dir = 1
+	dir = 1;
+	icon_state = "cubicle"
 	},
 /obj/disposalpipe/trunk{
 	dir = 4
@@ -4821,8 +4823,8 @@
 /area/station/crew_quarters/garden)
 "kg" = (
 /obj/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance)
@@ -4867,9 +4869,9 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -4878,9 +4880,9 @@
 /area/station/science)
 "kn" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -4889,9 +4891,9 @@
 /area/station/science)
 "ko" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -4910,9 +4912,9 @@
 /area/station/science)
 "kp" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -4927,9 +4929,9 @@
 /area/station/science)
 "kq" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -4948,9 +4950,9 @@
 /area/station/science)
 "kr" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -5062,9 +5064,9 @@
 /area/station/science/teleporter)
 "kH" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/medical{
 	name = "Telescience";
@@ -5089,9 +5091,9 @@
 /area/station/science/artifact)
 "kL" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/medical{
 	name = "Artifact Research";
@@ -5109,8 +5111,8 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
@@ -5148,8 +5150,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/clonepod{
 	gen_analysis = 0
@@ -5172,9 +5174,9 @@
 /area/station/science/teleporter)
 "kU" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -5187,9 +5189,9 @@
 /area/station/science/teleporter)
 "kV" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -5210,9 +5212,9 @@
 /area/station/chemistry)
 "kY" = (
 /obj/machinery/power/monitor/smes{
-	name = "Engine Output Monitoring";
+	dir = 1;
 	icon_state = "power";
-	dir = 1
+	name = "Engine Output Monitoring"
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -5238,9 +5240,9 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/science/artifact)
@@ -5262,8 +5264,8 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
@@ -5273,8 +5275,8 @@
 /area/shuttle_sound_spawn)
 "ld" = (
 /obj/machinery/computer/genetics{
-	icon_state = "scanner";
-	dir = 1
+	dir = 1;
+	icon_state = "scanner"
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -5286,9 +5288,9 @@
 /area/station/medical/research)
 "le" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/research)
@@ -5333,9 +5335,9 @@
 /area/station/science/teleporter)
 "lh" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -5375,16 +5377,16 @@
 "lk" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/white,
 /area/station/science/artifact)
 "ll" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -5417,8 +5419,8 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/decal/cleanable/dirt,
@@ -5438,9 +5440,9 @@
 	name = "Roboticist"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/research)
@@ -5473,16 +5475,16 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/landmark/start{
 	name = "Scientist"
 	},
 /obj/stool/chair/office{
-	icon_state = "office_chair";
-	dir = 8
+	dir = 8;
+	icon_state = "office_chair"
 	},
 /turf/simulated/floor/engine{
 	allows_vehicles = 0
@@ -5497,8 +5499,8 @@
 /area/station/chemistry)
 "lv" = (
 /obj/stool/chair/office{
-	icon_state = "office_chair";
-	dir = 8
+	dir = 8;
+	icon_state = "office_chair"
 	},
 /obj/landmark/start{
 	name = "Scientist"
@@ -5518,8 +5520,8 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -5536,9 +5538,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -5571,8 +5573,8 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
@@ -5583,9 +5585,9 @@
 /area/station/medical/research)
 "lC" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/research)
@@ -5668,8 +5670,8 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/white,
 /area/station/science/artifact)
@@ -5685,16 +5687,16 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/landmark/start{
 	name = "Scientist"
 	},
 /obj/stool/chair/office{
-	icon_state = "office_chair";
-	dir = 8
+	dir = 8;
+	icon_state = "office_chair"
 	},
 /turf/simulated/floor/white,
 /area/station/science/artifact)
@@ -5717,17 +5719,17 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/maintenance)
 "lM" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/medical{
 	name = "Medical Research";
@@ -5752,8 +5754,8 @@
 	print_id = "Artlab"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/item/storage/box/tapebox,
 /obj/item/disk/data/tape{
@@ -5804,8 +5806,8 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
@@ -5819,9 +5821,9 @@
 /area/station/medical/medbay)
 "lV" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -5870,8 +5872,8 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
@@ -5926,9 +5928,9 @@
 /area/station/medical/medbay)
 "ml" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -5969,8 +5971,8 @@
 /area/station/medical/medbay)
 "mp" = (
 /obj/machinery/atmospherics/pipe/manifold{
-	icon_state = "manifold";
 	dir = 1;
+	icon_state = "manifold";
 	level = 2
 	},
 /obj/landmark/start{
@@ -6001,9 +6003,9 @@
 /area/station/medical/cdc)
 "ms" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/submachine/chef_sink/chem_sink{
 	pixel_y = 12
@@ -6012,8 +6014,8 @@
 /area/station/medical/cdc)
 "mt" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -6039,9 +6041,9 @@
 	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /obj/machinery/door/airlock/pyro/medical{
@@ -6078,9 +6080,9 @@
 /area/station/medical/cdc)
 "mB" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
@@ -6102,8 +6104,8 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
@@ -6118,9 +6120,9 @@
 /area/station/science/storage)
 "mG" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/white,
@@ -6168,9 +6170,9 @@
 	name = "Medical Doctor"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
@@ -6295,8 +6297,8 @@
 	icon_state = "1-8"
 	},
 /obj/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
@@ -6372,8 +6374,8 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/sleeper{
 	dir = 4
@@ -6397,8 +6399,8 @@
 /area/station/medical/medbay)
 "nh" = (
 /obj/decal/tile_edge/line/green{
-	icon_state = "line4";
-	dir = 5
+	dir = 5;
+	icon_state = "line4"
 	},
 /obj/table/reinforced/auto,
 /obj/item/storage/box/patchbox,
@@ -6462,9 +6464,9 @@
 /area/station/maintenance)
 "nq" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -6532,9 +6534,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment,
 /obj/disposalpipe/segment{
@@ -6568,9 +6570,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance)
@@ -6671,8 +6673,8 @@
 "nO" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/landmark{
 	name = "AI-Sat"
@@ -6770,9 +6772,9 @@
 /area/station/storage/warehouse)
 "nZ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -6823,8 +6825,8 @@
 /obj/machinery/networked/artifact_console,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -7029,8 +7031,8 @@
 /area/mining/magnet)
 "ov" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/grille/catwalk{
 	dir = 10;
@@ -7056,8 +7058,8 @@
 /area/station/engine/coldloop)
 "ow" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/grille/catwalk{
 	dir = 6
@@ -7071,8 +7073,8 @@
 /area/station/engine/coldloop)
 "ox" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/grille/catwalk{
 	dir = 6;
@@ -7086,16 +7088,16 @@
 /area/station/engine/coldloop)
 "oy" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/grille/catwalk{
 	dir = 6;
 	icon_state = "catwalk_cross"
 	},
 /obj/machinery/computer/magnet{
-	icon_state = "mmagnet";
-	dir = 4
+	dir = 4;
+	icon_state = "mmagnet"
 	},
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
@@ -7108,8 +7110,8 @@
 	dir = 4
 	},
 /obj/window/cubicle{
-	icon_state = "cubicle";
-	dir = 2
+	dir = 2;
+	icon_state = "cubicle"
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -7173,6 +7175,16 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
+"vP" = (
+/obj/machinery/weapon_stand/taser_rack/recharger/empty,
+/turf/simulated/floor/red,
+/area/station/security/main)
+"Ri" = (
+/obj/machinery/recharger/wall/sticky{
+	dir = 1
+	},
+/turf/simulated/floor/red,
+/area/station/security/main)
 
 (1,1,1) = {"
 aa
@@ -54416,7 +54428,7 @@ aB
 aq
 aq
 aq
-ax
+Ri
 bo
 ax
 by
@@ -55025,7 +55037,7 @@ bq
 ax
 bz
 ax
-bO
+vP
 cK
 ce
 cQ

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -3318,9 +3318,7 @@
 	dir = 1;
 	icon_state = "line1"
 	},
-/obj/machinery/recharger{
-	pixel_y = 22
-	},
+/obj/submachine/weapon_vendor/security,
 /turf/simulated/floor/red,
 /area/station/security/checkpoint{
 	name = "Security Checkpoint"
@@ -3330,7 +3328,9 @@
 	dir = 1;
 	icon_state = "line1"
 	},
-/obj/item/storage/wall/office,
+/obj/machinery/recharger{
+	pixel_y = 22
+	},
 /turf/simulated/floor/red,
 /area/station/security/checkpoint{
 	name = "Security Checkpoint"
@@ -13319,10 +13319,10 @@
 /obj/decal/poster/wallsign/poster_nt{
 	pixel_x = 28
 	},
-/obj/machinery/weapon_stand/taser_rack/recharger,
 /obj/decal/poster/wallsign/poster_y4nt{
 	pixel_x = 32
 	},
+/obj/machinery/weapon_stand/taser_rack/recharger/empty,
 /turf/simulated/floor/caution/misc{
 	dir = 1
 	},
@@ -32962,15 +32962,19 @@
 /turf/simulated/floor/black,
 /area/station/security/brig)
 "bfU" = (
+/obj/disposalpipe/trunk/mail{
+	dir = 1
+	},
+/obj/rack,
+/obj/item/ammo/bullets/smoke,
+/obj/item/ammo/bullets/smoke,
+/obj/item/gun/kinetic/riot40mm,
 /obj/machinery/disposal/mail/small{
 	dir = 4;
 	mail_tag = "security";
 	mailgroup = "security";
 	message = "1";
 	name = "mail chute-'Security'"
-	},
-/obj/disposalpipe/trunk/mail{
-	dir = 1
 	},
 /turf/simulated/floor,
 /area/station/security/main)
@@ -36332,15 +36336,12 @@
 /obj/machinery/light/emergency{
 	dir = 4
 	},
-/obj/rack,
-/obj/item/ammo/bullets/smoke,
-/obj/item/ammo/bullets/smoke,
-/obj/item/gun/kinetic/riot40mm,
 /obj/machinery/computer/riotgear{
 	dir = 8;
 	icon_state = "drawbr0";
 	pixel_x = 28
 	},
+/obj/submachine/weapon_vendor/security,
 /turf/simulated/floor/caution/westeast,
 /area/station/security/main)
 "blt" = (

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -21582,12 +21582,7 @@
 	},
 /area/station/security/secoffquarters)
 "aWD" = (
-/obj/table/reinforced/auto,
-/obj/machinery/recharger,
-/obj/item/device/detective_scanner{
-	pixel_x = 6;
-	pixel_y = 6
-	},
+/obj/submachine/weapon_vendor/security,
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
@@ -21602,7 +21597,7 @@
 	},
 /area/station/security/secoffquarters)
 "aWF" = (
-/obj/machinery/weapon_stand/taser_rack/recharger,
+/obj/machinery/weapon_stand/taser_rack/recharger/empty,
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
@@ -24010,6 +24005,10 @@
 /obj/item/ammo/bullets/smoke,
 /obj/item/ammo/bullets/smoke,
 /obj/item/gun/kinetic/riot40mm,
+/obj/item/device/detective_scanner{
+	pixel_x = 6;
+	pixel_y = 6
+	},
 /turf/simulated/floor/redblack{
 	dir = 6
 	},
@@ -44910,7 +44909,9 @@
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
 "cuz" = (
-/obj/machinery/recharger/wall/sticky,
+/obj/machinery/recharger/wall/sticky{
+	dir = 8
+	},
 /turf/simulated/floor/redblack{
 	dir = 8
 	},

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -4420,7 +4420,7 @@
 /area/station/crew_quarters/kitchen)
 "ajz" = (
 /obj/disposalpipe/segment/mail,
-/obj/machinery/weapon_stand/taser_rack/recharger,
+/obj/machinery/weapon_stand/taser_rack/recharger/empty,
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
@@ -8949,9 +8949,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/head)
 "atP" = (
-/obj/table/auto,
-/obj/machinery/recharger,
-/obj/machinery/light_switch/auto,
+/obj/submachine/weapon_vendor/security,
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/medical)
 "atQ" = (
@@ -9623,6 +9621,7 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/machinery/light_switch/auto,
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/medical)
 "avp" = (
@@ -10057,6 +10056,9 @@
 /obj/disposalpipe/segment/brig,
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/recharger/wall/sticky{
+	dir = 4
 	},
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/medical)
@@ -16267,6 +16269,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/light/incandescent/netural,
+/obj/machinery/recharger/wall/sticky{
+	dir = 8
+	},
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/west)
 "aKG" = (
@@ -16276,9 +16281,7 @@
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/west)
 "aKH" = (
-/obj/table/auto,
-/obj/machinery/recharger,
-/obj/item/storage/wall/office,
+/obj/submachine/weapon_vendor/security,
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/west)
 "aKI" = (
@@ -19745,6 +19748,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/storage/closet/wardrobe/red/security_gimmick,
 /turf/simulated/floor/red,
 /area/station/security/main)
 "aTa" = (
@@ -31332,6 +31336,7 @@
 	tag = ""
 	},
 /obj/machinery/light_switch/auto,
+/obj/submachine/weapon_vendor/security,
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/escape)
 "bvY" = (
@@ -38523,7 +38528,7 @@
 /turf/simulated/floor/grime,
 /area)
 "bNx" = (
-/obj/storage/closet/wardrobe/red/security_gimmick,
+/obj/submachine/weapon_vendor/security,
 /turf/simulated/floor/red/side{
 	dir = 9
 	},

--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -37259,6 +37259,9 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
+/obj/machinery/recharger/wall/sticky{
+	dir = 4
+	},
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/cargo)
 "brv" = (
@@ -37778,6 +37781,10 @@
 	dir = 2;
 	name = "autoname - SS13";
 	tag = ""
+	},
+/obj/machinery/light_switch{
+	name = "N light switch";
+	pixel_y = 24
 	},
 /turf/simulated/floor/red/side{
 	dir = 5
@@ -39592,9 +39599,8 @@
 /obj/item/device/radio/intercom{
 	dir = 4
 	},
-/obj/machinery/light_switch{
-	name = "N light switch";
-	pixel_y = 24
+/obj/machinery/recharger/wall/sticky{
+	dir = 1
 	},
 /turf/simulated/floor/red/side{
 	dir = 9
@@ -51906,7 +51912,7 @@
 /turf/simulated/floor/black,
 /area/station/security/armory)
 "bUq" = (
-/obj/machinery/weapon_stand/taser_rack/recharger,
+/obj/machinery/weapon_stand/taser_rack/recharger/empty,
 /turf/simulated/floor/caution/west,
 /area/station/security/main)
 "bUr" = (
@@ -52257,14 +52263,7 @@
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
 "bVb" = (
-/obj/rack,
-/obj/item/ammo/bullets/smoke,
-/obj/item/ammo/bullets/smoke,
-/obj/item/gun/kinetic/riot40mm,
-/obj/item/gun/kinetic/riot40mm,
-/obj/item/wrench,
-/obj/item/wrench,
-/obj/item/gun/implanter,
+/obj/submachine/weapon_vendor/security,
 /turf/simulated/floor/bot,
 /area/station/security/main)
 "bVc" = (
@@ -56446,6 +56445,9 @@
 /area/station/crew_quarters/locker)
 "cei" = (
 /obj/storage/closet/wardrobe/orange,
+/obj/machinery/door_timer/minibrig{
+	pixel_y = -24
+	},
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/cargo)
 "cej" = (
@@ -59941,11 +59943,7 @@
 	},
 /area/station/security/brig)
 "ckM" = (
-/obj/table/auto,
-/obj/machinery/recharger,
-/obj/machinery/door_timer/minibrig{
-	pixel_y = -24
-	},
+/obj/submachine/weapon_vendor/security,
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/cargo)
 "ckN" = (
@@ -60871,8 +60869,6 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "cmC" = (
-/obj/table/reinforced/auto,
-/obj/machinery/recharger,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -60883,6 +60879,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/submachine/weapon_vendor/security,
 /turf/simulated/floor/red/side,
 /area/station/security/checkpoint/arrivals)
 "cmD" = (
@@ -65494,6 +65491,17 @@
 	icon_state = "aplaceholder"
 	},
 /area)
+"gwu" = (
+/obj/rack,
+/obj/item/ammo/bullets/smoke,
+/obj/item/ammo/bullets/smoke,
+/obj/item/gun/kinetic/riot40mm,
+/obj/item/gun/kinetic/riot40mm,
+/obj/item/wrench,
+/obj/item/wrench,
+/obj/item/gun/implanter,
+/turf/simulated/floor/caution/east,
+/area/station/security/main)
 
 (1,1,1) = {"
 cCO
@@ -127826,7 +127834,7 @@ bSh
 ctU
 beZ
 ctU
-ctU
+gwu
 aAA
 bqL
 beW

--- a/maps/unused/donut2_new_walls.dmm
+++ b/maps/unused/donut2_new_walls.dmm
@@ -17,8 +17,8 @@
 /area)
 "aae" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 2
+	dir = 2;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area)
@@ -28,8 +28,8 @@
 /area/listeningpost)
 "aag" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 6
+	dir = 6;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area)
@@ -45,16 +45,16 @@
 /area/listeningpost)
 "aai" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 1
+	dir = 1;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area)
 "aaj" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/airless,
 /area/listeningpost)
@@ -73,9 +73,9 @@
 /area)
 "aam" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/shuttle/wall,
 /area/listeningpost)
@@ -93,8 +93,8 @@
 /area)
 "aap" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 6
+	dir = 6;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area)
@@ -131,16 +131,16 @@
 /area/listeningpost)
 "aav" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/circuit,
 /area/listeningpost)
 "aaw" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/caution/west,
 /area/listeningpost)
@@ -154,13 +154,13 @@
 /area/listeningpost)
 "aay" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/monitor,
 /turf/simulated/floor/plating,
@@ -179,8 +179,8 @@
 /area/listeningpost)
 "aaA" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 8
+	dir = 8;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area)
@@ -211,22 +211,22 @@
 /area/listeningpost)
 "aaE" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/caution/west,
 /area/listeningpost)
 "aaF" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/stairs{
 	dir = 8
@@ -242,12 +242,12 @@
 /area/listeningpost)
 "aaH" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
+	dir = 1;
+	icon_state = "term"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/listeningpost)
@@ -274,9 +274,9 @@
 /area/listeningpost)
 "aaM" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock,
 /turf/simulated/floor/bot,
@@ -322,9 +322,9 @@
 /area/listeningpost)
 "aaT" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/red,
 /area/listeningpost)
@@ -335,8 +335,8 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/grey/side{
 	dir = 8
@@ -365,16 +365,16 @@
 /area)
 "aaY" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/plating/airless,
 /area/listeningpost)
 "aaZ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light_switch{
 	name = "W light switch";
@@ -443,9 +443,9 @@
 /area/listeningpost)
 "abj" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/red,
 /area/listeningpost)
@@ -454,8 +454,8 @@
 /area/listeningpost)
 "abl" = (
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 0;
+	dir = 8;
 	frequency = 1485;
 	name = "Security Intercom"
 	},
@@ -474,9 +474,9 @@
 /area/listeningpost)
 "abn" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -487,9 +487,9 @@
 /area/listeningpost)
 "abo" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/grey/side{
 	dir = 8
@@ -497,25 +497,25 @@
 /area/listeningpost)
 "abp" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/delivery,
 /area/listeningpost)
 "abq" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
 /area/listeningpost)
 "abr" = (
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 1;
+	dir = 8;
 	frequency = 1489;
 	name = "Brig Intercom"
 	},
@@ -528,8 +528,8 @@
 /area/listeningpost)
 "abt" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /obj/item/clothing/under/misc/syndicate,
 /obj/item/clothing/under/misc/syndicate,
@@ -539,8 +539,8 @@
 /area/listeningpost)
 "abu" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/recharger,
 /obj/table/wood/auto{
@@ -552,8 +552,8 @@
 /area/listeningpost)
 "abv" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/grey/side{
 	dir = 8
@@ -620,8 +620,8 @@
 "abF" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 9
+	dir = 9;
+	icon_state = "fred2"
 	},
 /area/listeningpost)
 "abG" = (
@@ -629,21 +629,21 @@
 	credit = 12
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 1
+	dir = 1;
+	icon_state = "fred2"
 	},
 /area/listeningpost)
 "abH" = (
 /obj/submachine/chef_sink/chem_sink,
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 5
+	dir = 5;
+	icon_state = "fred2"
 	},
 /area/listeningpost)
 "abI" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -673,35 +673,35 @@
 	},
 /obj/decal/glow{
 	brightness = 3;
-	invisibility = 101;
-	luminosity = 0;
-	name = "glow - WHITE";
 	color_b = 0.35;
 	color_g = 0.35;
-	color_r = 0.35
+	color_r = 0.35;
+	invisibility = 101;
+	luminosity = 0;
+	name = "glow - WHITE"
 	},
 /turf/simulated/floor/red,
 /area/listeningpost)
 "abK" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 8
+	dir = 8;
+	icon_state = "fred2"
 	},
 /area/listeningpost)
 "abL" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fred1";
-	dir = 8
+	dir = 8;
+	icon_state = "fred1"
 	},
 /area/listeningpost)
 "abM" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 4
+	dir = 4;
+	icon_state = "fred2"
 	},
 /area/listeningpost)
 "abN" = (
@@ -711,8 +711,8 @@
 /area/listeningpost)
 "abO" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor4"
@@ -726,8 +726,8 @@
 /area/listeningpost)
 "abQ" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 4
+	dir = 4;
+	icon_state = "fred2"
 	},
 /area/listeningpost)
 "abR" = (
@@ -752,8 +752,8 @@
 	dir = 5
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 10
+	dir = 10;
+	icon_state = "fred2"
 	},
 /area/listeningpost)
 "abU" = (
@@ -763,8 +763,8 @@
 	dir = 5
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 2
+	dir = 2;
+	icon_state = "fred2"
 	},
 /area/listeningpost)
 "abV" = (
@@ -774,8 +774,8 @@
 	dir = 5
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 6
+	dir = 6;
+	icon_state = "fred2"
 	},
 /area/listeningpost)
 "abW" = (
@@ -799,8 +799,8 @@
 /area)
 "abZ" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 10
+	dir = 10;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area)
@@ -822,15 +822,15 @@
 /area)
 "ace" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 5
+	dir = 5;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area)
 "acf" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 9
+	dir = 9;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area)
@@ -842,8 +842,8 @@
 /area/station/science/teleporter)
 "aci" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/engine,
 /area/station/science/teleporter)
@@ -920,8 +920,8 @@
 /area)
 "acr" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/telepad,
@@ -932,8 +932,8 @@
 /area/station/science/teleporter)
 "acs" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/teleconsole{
@@ -945,15 +945,15 @@
 /area/station/science/teleporter)
 "act" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	icon_state = "chair"
 	},
 /turf/simulated/floor/white,
 /area/station/science/teleporter)
 "acu" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/orangeblack/side/white{
 	dir = 4
@@ -961,8 +961,8 @@
 /area/station/science/teleporter)
 "acv" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 9
+	dir = 9;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area)
@@ -983,8 +983,8 @@
 /area)
 "acy" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 5
+	dir = 5;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area)
@@ -1025,15 +1025,15 @@
 /area/station/science/teleporter)
 "acF" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 1
+	dir = 1;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area)
 "acG" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 2
+	dir = 2;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area)
@@ -1111,8 +1111,8 @@
 /area/station/science/teleporter)
 "acQ" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 2
+	dir = 2;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area/shuttle/brig/outpost)
@@ -1133,9 +1133,9 @@
 /area/station/science/teleporter)
 "acT" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
 /area/station/science/teleporter)
@@ -1144,9 +1144,9 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/white,
 /area/station/science/teleporter)
@@ -1168,15 +1168,15 @@
 /area/station/science)
 "acY" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 9
+	dir = 9;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/shuttle/brig/outpost)
 "acZ" = (
 /obj/grille/catwalk{
-	icon_state = "catwalk";
-	dir = 10
+	dir = 10;
+	icon_state = "catwalk"
 	},
 /obj/machinery/light/runway_light,
 /turf/space,
@@ -1188,8 +1188,8 @@
 /area/shuttle/brig/outpost)
 "ada" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 5
+	dir = 5;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/shuttle/brig/outpost)
@@ -1226,9 +1226,9 @@
 /area/station/science/teleporter)
 "adf" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -1237,9 +1237,9 @@
 /area/station/science/teleporter)
 "adg" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/orangeblack/side/white,
 /area/station/science/teleporter)
@@ -1288,9 +1288,9 @@
 /area/station/chemistry)
 "adm" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/overlay{
 	anchored = 1;
@@ -1349,9 +1349,9 @@
 /area/shuttle/brig/outpost)
 "adu" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/medical{
@@ -1383,9 +1383,9 @@
 /area/station/chemistry)
 "adx" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
@@ -1433,25 +1433,25 @@
 "adE" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /obj/securearea{
-	name = "VACUUM AREA";
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space"
+	icon_state = "space";
+	name = "VACUUM AREA"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced,
 /turf/simulated/floor/plating,
@@ -1470,9 +1470,9 @@
 /area/station/science/teleporter)
 "adH" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/orangeblack/side/white{
 	dir = 1
@@ -1491,9 +1491,9 @@
 "adJ" = (
 /obj/grille/steel,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/window/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -1501,9 +1501,9 @@
 "adK" = (
 /obj/grille/steel,
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
 	icon_state = "2-8"
@@ -1540,8 +1540,8 @@
 /area/station/science)
 "adQ" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 4
+	dir = 4;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area)
@@ -1555,9 +1555,9 @@
 /area/station/security/prison)
 "adT" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/science/teleporter)
@@ -1596,9 +1596,9 @@
 /area/station/chemistry)
 "adZ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/item/reagent_containers/glass/bottle/antitoxin{
 	pixel_x = 4;
@@ -1641,8 +1641,8 @@
 /area/station/chemistry)
 "aed" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/caution/north,
 /area/station/science)
@@ -1651,8 +1651,8 @@
 /area/station/science)
 "aef" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/caution/north,
 /area/station/science)
@@ -1669,13 +1669,13 @@
 /area/station/crew_quarters/hor)
 "aej" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/white,
 /area/station/science/teleporter)
@@ -1728,9 +1728,9 @@
 /area/station/chemistry)
 "aes" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purplewhite/corner{
 	dir = 2
@@ -1834,9 +1834,9 @@
 /area/station/chemistry)
 "aeL" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 4
@@ -1888,23 +1888,23 @@
 /area/station/science/storage)
 "aeT" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/black,
 /area/station/security/prison)
 "aeU" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/black,
 /area/station/security/prison)
 "aeV" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/blueblack{
 	dir = 4
@@ -1918,8 +1918,8 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/item/reagent_containers/food/snacks/beefood,
 /turf/simulated/floor/white,
@@ -1985,8 +1985,8 @@
 /area/station/chemistry)
 "aff" = (
 /obj/stool/chair/office/purple{
-	icon_state = "office_chair_purple";
-	dir = 8
+	dir = 8;
+	icon_state = "office_chair_purple"
 	},
 /turf/simulated/floor/white,
 /area/station/chemistry)
@@ -1997,8 +1997,8 @@
 /area/station/chemistry)
 "afh" = (
 /obj/stool/chair/office/purple{
-	icon_state = "office_chair_purple";
-	dir = 8
+	dir = 8;
+	icon_state = "office_chair_purple"
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 8
@@ -2030,8 +2030,8 @@
 "afl" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/computer3frame{
 	anchored = 1;
@@ -2043,22 +2043,22 @@
 "afm" = (
 /obj/stool/chair,
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/redblack,
 /area/station/security/prison)
 "afn" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/disposal/mail{
 	mail_tag = "zeta_sec";
@@ -2069,17 +2069,17 @@
 /area/station/security/prison)
 "afo" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/redblack,
 /area/station/security/prison)
 "afp" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -2092,22 +2092,22 @@
 /area/station/security/prison)
 "afq" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/security/prison)
 "afr" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/blueblack{
 	dir = 4
@@ -2115,9 +2115,9 @@
 /area/station/security/prison)
 "afs" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
@@ -2130,9 +2130,9 @@
 /area/station/crew_quarters/hor)
 "aft" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -2146,17 +2146,17 @@
 /area/station/crew_quarters/hor)
 "afu" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/hor)
 "afv" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/stool/chair{
 	dir = 4
@@ -2165,9 +2165,9 @@
 /area/station/crew_quarters/hor)
 "afw" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/item/disk/data/tape/master/readonly,
 /obj/table/auto,
@@ -2196,8 +2196,8 @@
 /area/station/ai_monitored/storage/secure)
 "afz" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/stool/bench/green/auto,
 /turf/simulated/floor,
@@ -2214,9 +2214,9 @@
 /area/station/chemistry)
 "afC" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/landmark/start{
 	name = "Chemist"
@@ -2243,15 +2243,15 @@
 /area/station/chemistry)
 "afG" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/science)
 "afH" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/science)
@@ -2281,9 +2281,9 @@
 /area/station/science/storage)
 "afL" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/table/reinforced/auto,
 /turf/simulated/floor/red,
@@ -2300,9 +2300,9 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
 /area/station/security/prison)
@@ -2323,8 +2323,8 @@
 /area/station/security/prison)
 "afP" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/light_switch{
 	name = "W light switch";
@@ -2338,21 +2338,21 @@
 	network = "Zeta"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/hor)
 "afQ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/recharger{
 	pixel_y = 3
@@ -2362,13 +2362,13 @@
 /area/station/crew_quarters/hor)
 "afR" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/white,
 /area/station/science/teleporter)
@@ -2396,8 +2396,8 @@
 /area/station/ai_monitored/storage/secure)
 "afV" = (
 /obj/machinery/atmospherics/pipe/simple{
-	icon_state = "intact";
 	dir = 10;
+	icon_state = "intact";
 	layer = 3;
 	level = 2
 	},
@@ -2412,19 +2412,19 @@
 "afX" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
 	dir = 8
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor6"
@@ -2443,8 +2443,8 @@
 "afZ" = (
 /obj/machinery/chem_dispenser,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 8
@@ -2452,9 +2452,9 @@
 /area/station/chemistry)
 "aga" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purplewhite/corner{
 	dir = 8
@@ -2467,9 +2467,9 @@
 /area/station/chemistry)
 "agc" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/purplewhite/corner{
 	dir = 1
@@ -2477,16 +2477,16 @@
 /area/station/chemistry)
 "agd" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/submachine/chem_extractor{
 	dir = 8
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 4
@@ -2494,32 +2494,32 @@
 /area/station/chemistry)
 "age" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/chemistry)
 "agf" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/science)
 "agg" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/storage)
 "agh" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -2536,25 +2536,25 @@
 "agi" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "agj" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "agk" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/science/storage)
@@ -2564,8 +2564,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/nuclear_charge,
@@ -2576,9 +2576,9 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/red/checker{
 	dir = 4
@@ -2586,14 +2586,14 @@
 /area/station/security/prison)
 "agn" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/red,
 /area/station/security/prison)
@@ -2616,9 +2616,9 @@
 /area/station/security/prison)
 "agq" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
 /area/station/security/prison)
@@ -2640,9 +2640,9 @@
 "agt" = (
 /obj/stool/chair,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -2729,9 +2729,9 @@
 /area/station/ai_monitored/storage/secure)
 "agB" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance{
@@ -2768,8 +2768,8 @@
 /area/station/chemistry)
 "agG" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 2;
@@ -2780,35 +2780,35 @@
 /area/station/chemistry)
 "agH" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/purplewhite,
 /area/station/chemistry)
 "agI" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/purplewhite,
 /area/station/chemistry)
 "agJ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/disposal/mail{
 	mail_tag = "chemistry";
@@ -2820,9 +2820,9 @@
 /area/station/chemistry)
 "agK" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -2852,9 +2852,9 @@
 /area/station/science/storage)
 "agN" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/science/storage)
@@ -2869,9 +2869,9 @@
 /area/station/science/storage)
 "agP" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/item/crowbar,
 /turf/simulated/floor/plating,
@@ -2890,9 +2890,9 @@
 /area/station/security/prison)
 "agS" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/red,
 /area/station/security/prison)
@@ -2938,8 +2938,8 @@
 "agX" = (
 /obj/landmark/artifact,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
 	dir = 8
@@ -2949,16 +2949,16 @@
 "agY" = (
 /obj/landmark/artifact,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/engine,
 /area/station/crew_quarters/hor)
 "agZ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/orangeblack/side/white,
 /area/station/science/teleporter)
@@ -2974,8 +2974,8 @@
 	sensor_tag = "tox_airlock_sensor"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/item/assembly/time_ignite,
 /obj/item/assembly/time_ignite,
@@ -2989,8 +2989,8 @@
 /area/station/ai_monitored/storage/secure)
 "ahb" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /obj/machinery/ignition_switch{
 	id = "mixingsparker";
@@ -3001,8 +3001,8 @@
 /area/station/ai_monitored/storage/secure)
 "ahc" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	icon_state = "intact";
-	dir = 10
+	dir = 10;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/white,
 /area/station/ai_monitored/storage/secure)
@@ -3066,8 +3066,8 @@
 /area/shuttle/research/outpost)
 "ahj" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/disposal/mail{
 	mail_tag = "research";
@@ -3087,9 +3087,9 @@
 /area/station/chemistry)
 "ahl" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/medical{
@@ -3142,25 +3142,25 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/science/artifact)
 "ahr" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/storage)
 "ahs" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/red,
@@ -3179,9 +3179,9 @@
 /area/station/science/teleporter)
 "ahv" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/medical{
 	name = "Teleporter Control Room";
@@ -3191,8 +3191,8 @@
 /area/station/science/teleporter)
 "ahw" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/storage/bomb_tester{
@@ -3205,16 +3205,16 @@
 /area/station/ai_monitored/storage/secure)
 "ahy" = (
 /obj/machinery/atmospherics/pipe/manifold{
-	icon_state = "manifold";
 	dir = 8;
+	icon_state = "manifold";
 	level = 2
 	},
 /turf/simulated/floor/white,
 /area/station/ai_monitored/storage/secure)
 "ahz" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/machinery/atmospherics/valve,
 /turf/simulated/floor/white,
@@ -3281,25 +3281,25 @@
 "ahH" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /obj/securearea{
-	name = "VACUUM AREA";
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space"
+	icon_state = "space";
+	name = "VACUUM AREA"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced,
 /turf/simulated/floor/plating,
@@ -3307,8 +3307,8 @@
 "ahI" = (
 /obj/grille/steel,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/window/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -3330,9 +3330,9 @@
 /area/station/science)
 "ahL" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 1
@@ -3391,22 +3391,22 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/science)
 "ahT" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -3417,9 +3417,9 @@
 /area/station/science)
 "ahU" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
 	pixel_y = 24;
@@ -3434,9 +3434,9 @@
 	rigged = 0
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/red/corner{
 	dir = 4
@@ -3444,9 +3444,9 @@
 /area/station/science)
 "ahW" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/red/side{
 	dir = 1
@@ -3454,9 +3454,9 @@
 /area/station/science)
 "ahX" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -3464,9 +3464,9 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/red/side{
 	dir = 1
@@ -3474,9 +3474,9 @@
 /area/station/science)
 "ahY" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/item/storage/wall/medical{
 	pixel_y = 32
@@ -3492,8 +3492,8 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -3505,9 +3505,9 @@
 /area/station/science)
 "aia" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/camera{
 	c_tag = "Central Hallway East";
@@ -3519,9 +3519,9 @@
 /area/station/science)
 "aib" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/pyro{
 	dir = 4
@@ -3535,9 +3535,9 @@
 	rigged = 0
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/orangeblack/corner{
 	dir = 4
@@ -3545,9 +3545,9 @@
 /area/station/science)
 "aid" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -3560,9 +3560,9 @@
 /area/station/science)
 "aie" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/orangeblack/corner{
 	dir = 1
@@ -3576,8 +3576,8 @@
 /area/station/science)
 "aig" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -3594,9 +3594,9 @@
 /obj/cable,
 /obj/item/clothing/glasses/vr{
 	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
+	network = "bombtest";
 	pixel_x = 2;
-	pixel_y = 5;
-	network = "bombtest"
+	pixel_y = 5
 	},
 /obj/item/clothing/glasses/vr{
 	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
@@ -3640,20 +3640,20 @@
 "aik" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor6"
@@ -3691,22 +3691,22 @@
 	location = "Zeta_West"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/science)
 "aip" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
 	d1 = 1;
@@ -3724,14 +3724,14 @@
 /area/station/science)
 "aiq" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/science)
@@ -3742,16 +3742,16 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/science)
 "ais" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/machinery/power/data_terminal,
@@ -3759,9 +3759,9 @@
 /area/station/science)
 "ait" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Zeta_North";
@@ -3771,9 +3771,9 @@
 /area/station/science)
 "aiu" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/medical{
@@ -3799,16 +3799,16 @@
 /area/station/ai_monitored/storage/secure)
 "aix" = (
 /obj/machinery/computer/atmosphere/pumpcontrol{
-	icon_state = "computer_generic";
-	dir = 8
+	dir = 8;
+	icon_state = "computer_generic"
 	},
 /turf/simulated/floor/white,
 /area/station/ai_monitored/storage/secure)
 "aiy" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/greenwhite/other{
 	dir = 8
@@ -3846,9 +3846,9 @@
 /area/station/science)
 "aiE" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "orange"
@@ -3870,9 +3870,9 @@
 /area/station/science)
 "aiH" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/science)
@@ -3882,17 +3882,17 @@
 /area/station/science)
 "aiJ" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/neutral/corner,
 /area/station/science)
 "aiK" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 2
@@ -3900,9 +3900,9 @@
 /area/station/science)
 "aiL" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/neutral/corner{
 	dir = 8
@@ -3910,9 +3910,9 @@
 /area/station/science)
 "aiM" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -3922,17 +3922,17 @@
 /area/station/science)
 "aiN" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/ai_monitored/storage/secure)
 "aiO" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/item/screwdriver{
 	pixel_y = 20
@@ -3952,9 +3952,9 @@
 /area/station/ai_monitored/storage/secure)
 "aiP" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/white,
 /area/station/ai_monitored/storage/secure)
@@ -4012,8 +4012,8 @@
 /area/station/science/artifact)
 "aiX" = (
 /obj/machinery/atmospherics/pipe/simple{
-	icon_state = "intact";
 	dir = 9;
+	icon_state = "intact";
 	layer = 3;
 	level = 2
 	},
@@ -4076,27 +4076,27 @@
 /area/station/crew_quarters/observatory)
 "ajd" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/science)
 "aje" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/science)
 "ajf" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 4
@@ -4128,8 +4128,8 @@
 	pixel_x = -24
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/item/weldingtool,
 /obj/item/screwdriver{
@@ -4142,9 +4142,9 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/wrench,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/ai_monitored/storage/secure)
@@ -4154,8 +4154,8 @@
 /area/station/ai_monitored/storage/secure)
 "ajn" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/portables_connector,
 /turf/simulated/floor/bot/white,
@@ -4168,8 +4168,8 @@
 /area/shuttle/research/outpost)
 "ajp" = (
 /obj/window{
-	icon_state = "rwindow";
 	dir = 1;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /obj/stool/bed,
@@ -4185,8 +4185,8 @@
 /area/shuttle/research/outpost)
 "ajr" = (
 /obj/window{
-	icon_state = "rwindow";
 	dir = 1;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /obj/table/auto,
@@ -4200,9 +4200,9 @@
 /area/shuttle/research/outpost)
 "ajs" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/grille/catwalk,
 /turf/space,
@@ -4227,8 +4227,8 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/white/checker2{
 	dir = 4
@@ -4236,14 +4236,14 @@
 /area/station/science/artifact)
 "ajv" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/white/checker2{
 	dir = 8
@@ -4251,9 +4251,9 @@
 /area/station/science/artifact)
 "ajw" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white/checker2{
 	dir = 4
@@ -4261,9 +4261,9 @@
 /area/station/science/artifact)
 "ajx" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -4323,9 +4323,9 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/observatory)
@@ -4335,8 +4335,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/observatory)
@@ -4348,39 +4348,39 @@
 "ajH" = (
 /obj/stool/bed,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/item/storage/firstaid/regular,
 /turf/simulated/floor,
 /area/station/crew_quarters/observatory)
 "ajI" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/science)
 "ajJ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/science)
 "ajK" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 4
@@ -4400,8 +4400,8 @@
 /area/station/science/bot_storage)
 "ajN" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
 /obj/storage/closet/emergency,
@@ -4409,12 +4409,12 @@
 /area/station/science/bot_storage)
 "ajO" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -4424,22 +4424,22 @@
 /area/station/science/bot_storage)
 "ajP" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/science/bot_storage)
 "ajQ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/science/bot_storage)
@@ -4464,9 +4464,9 @@
 /area/station/ai_monitored/storage/secure)
 "ajT" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/valve{
 	dir = 4
@@ -4482,13 +4482,13 @@
 /area/station/ai_monitored/storage/secure)
 "ajV" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/grille/catwalk{
 	dir = 9
@@ -4540,8 +4540,8 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/white/checker2{
 	dir = 4
@@ -4549,8 +4549,8 @@
 /area/station/science/artifact)
 "akc" = (
 /obj/stool/chair/office{
-	icon_state = "office_chair";
-	dir = 1
+	dir = 1;
+	icon_state = "office_chair"
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -4561,9 +4561,9 @@
 /area/station/science/artifact)
 "akd" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/white/checker2{
 	dir = 8
@@ -4572,8 +4572,8 @@
 "ake" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/test_apparatus/impact_pad,
@@ -4593,13 +4593,13 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/stool/chair/office{
-	icon_state = "office_chair";
-	dir = 4
+	dir = 4;
+	icon_state = "office_chair"
 	},
 /turf/simulated/floor/white/checker2{
 	dir = 8
@@ -4628,9 +4628,9 @@
 /area/station/crew_quarters/observatory)
 "akk" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/observatory)
@@ -4643,15 +4643,15 @@
 /area/station/crew_quarters/observatory)
 "akm" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/observatory)
 "akn" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -4671,9 +4671,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/science/bot_storage)
@@ -4684,9 +4684,9 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/science/bot_storage)
@@ -4696,8 +4696,8 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/guardbot_dock,
@@ -4712,9 +4712,9 @@
 /area)
 "aks" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/ai_monitored/storage/secure)
@@ -4726,8 +4726,8 @@
 "aku" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
 	dir = 2;
@@ -4746,8 +4746,8 @@
 "akv" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
 	dir = 2;
@@ -4763,16 +4763,16 @@
 "akw" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
 	dir = 2;
 	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/decal/fakeobjects/shuttleengine{
 	icon_state = "alt_heater-R"
@@ -4791,8 +4791,8 @@
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/test_apparatus/heater,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/white/checker2{
 	dir = 4
@@ -4810,9 +4810,9 @@
 /area/station/science/artifact)
 "akA" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -4825,9 +4825,9 @@
 /area/station/science/artifact)
 "akB" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/white/checker2{
 	dir = 8
@@ -4835,9 +4835,9 @@
 /area/station/science/artifact)
 "akC" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -4867,8 +4867,8 @@
 /area/station/medical/cdc)
 "akG" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/white,
@@ -4890,9 +4890,9 @@
 /area/station/crew_quarters/observatory)
 "akJ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -4905,8 +4905,8 @@
 "akK" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/guardbot_dock,
 /obj/machinery/bot/guardbot,
@@ -4918,8 +4918,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /turf/simulated/floor,
@@ -4930,8 +4930,8 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/guardbot_dock,
@@ -4940,8 +4940,8 @@
 /area/station/science/bot_storage)
 "akN" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -4949,8 +4949,8 @@
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/grille/catwalk{
 	dir = 4
@@ -4963,8 +4963,8 @@
 /area/station/solar/west)
 "akO" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/storage/tape_drive{
@@ -4978,9 +4978,9 @@
 /area/station/science/artifact)
 "akP" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -4994,9 +4994,9 @@
 "akQ" = (
 /obj/machinery/light,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/disposal/mail{
 	mail_tag = "artlab";
@@ -5080,8 +5080,8 @@
 /area/station/medical/cdc)
 "akX" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/camera{
 	c_tag = "Specimen Containment";
@@ -5113,8 +5113,8 @@
 "alb" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/guardbot_dock,
 /turf/simulated/floor/bot,
@@ -5126,9 +5126,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -5139,9 +5139,9 @@
 /area/station/science/bot_storage)
 "ald" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/science/bot_storage)
@@ -5157,8 +5157,8 @@
 /area/station/science/bot_storage)
 "alf" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/solar{
 	id = "rozetasolar";
@@ -5186,8 +5186,8 @@
 /area/station/science/artifact)
 "ali" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/landmark{
 	name = "monkeyspawn_normal"
@@ -5278,9 +5278,9 @@
 "als" = (
 /obj/machinery/light,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/storage/crate{
 	name = "Spare Parts"
@@ -5306,9 +5306,9 @@
 /area/station/science/bot_storage)
 "alu" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -5335,12 +5335,12 @@
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/grille/catwalk{
-	icon_state = "catwalk";
-	dir = 5
+	dir = 5;
+	icon_state = "catwalk"
 	},
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
@@ -5380,8 +5380,8 @@
 /area/station/crew_quarters/observatory)
 "alC" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -5389,8 +5389,8 @@
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/grille/catwalk{
 	dir = 9
@@ -5404,9 +5404,9 @@
 /area/station/solar/west)
 "alD" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/camera{
 	c_tag = "Central Hallway South";
@@ -5421,9 +5421,9 @@
 /area/station/turret_protected/Zeta)
 "alF" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/turret_protected/Zeta)
@@ -5473,8 +5473,8 @@
 /area/station/crew_quarters/observatory)
 "alL" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/observatory)
@@ -5490,16 +5490,16 @@
 /area/station/science)
 "alN" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/turret_protected/Zeta)
 "alO" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -5521,8 +5521,8 @@
 	dir = 4
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/Zeta)
@@ -5534,14 +5534,14 @@
 /area/station/turret_protected/Zeta)
 "alR" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -5561,8 +5561,8 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -5572,9 +5572,9 @@
 /area/station/turret_protected/Zeta)
 "alT" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -5585,9 +5585,9 @@
 /area/station/turret_protected/Zeta)
 "alU" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/Zeta)
@@ -5624,8 +5624,8 @@
 /area/station/turret_protected/Zeta)
 "amb" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/Zeta)
@@ -5634,9 +5634,9 @@
 /area/station/turret_protected/Zeta)
 "amd" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -5681,8 +5681,8 @@
 /area)
 "ami" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/table,
 /obj/item/storage/box/vialbox,
@@ -5730,17 +5730,17 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/science)
 "amr" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 4
@@ -5748,9 +5748,9 @@
 /area/station/science)
 "ams" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/command{
@@ -5762,28 +5762,28 @@
 /area/station/turret_protected/Zeta)
 "amt" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
 "amu" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/window{
-	icon = 'icons/obj/doors/windoor.dmi';
-	dir = 8
+	dir = 8;
+	icon = 'icons/obj/doors/windoor.dmi'
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
 "amv" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -5798,14 +5798,14 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/stool,
 /turf/simulated/floor/black,
@@ -5817,12 +5817,12 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/machinery/computer3/terminal/zeta{
 	dir = 8;
@@ -5837,8 +5837,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/networked/mainframe/zeta{
 	tag = "ZETA_MAINFRAME"
@@ -5856,9 +5856,9 @@
 /area/station/turret_protected/Zeta)
 "amA" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/grille/catwalk,
 /turf/space,
@@ -5871,13 +5871,13 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/grille/catwalk{
 	dir = 6
@@ -5898,8 +5898,8 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/white/checker2{
 	dir = 9
@@ -5929,14 +5929,14 @@
 /area/station/science)
 "amG" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/Zeta)
@@ -6036,9 +6036,9 @@
 /area/station/science)
 "amQ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Zeta_East";
@@ -6055,40 +6055,40 @@
 /area/station/turret_protected/Zeta)
 "amS" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/turret{
-	icon_state = "grey_target_prism";
-	dir = 1
+	dir = 1;
+	icon_state = "grey_target_prism"
 	},
 /turf/simulated/floor/bot,
 /area/station/turret_protected/Zeta)
 "amT" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/Zeta)
 "amU" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/Zeta)
@@ -6115,16 +6115,16 @@
 /area)
 "amX" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/disposalpipe/segment/mail,
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/cdc)
 "amY" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/cable{
 	d1 = 1;
@@ -6132,8 +6132,8 @@
 	icon_state = "1-4"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/white/checker2{
 	dir = 9
@@ -6144,8 +6144,8 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/white/checker2{
 	dir = 9
@@ -6160,8 +6160,8 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/stairs{
 	dir = 4;
@@ -6173,8 +6173,8 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/greenwhite{
 	dir = 8
@@ -6185,8 +6185,8 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
@@ -6198,8 +6198,8 @@
 	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/greenwhite{
 	dir = 4
@@ -6211,8 +6211,8 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
@@ -6227,8 +6227,8 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/green/side{
 	dir = 8
@@ -6241,8 +6241,8 @@
 	icon_state = "1-8"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor,
 /area/station/science)
@@ -6266,22 +6266,22 @@
 /area/shuttle/arrival/station)
 "ank" = (
 /obj/machinery/shuttle/engine/propulsion{
-	icon_state = "alt_propulsion";
-	dir = 9
+	dir = 9;
+	icon_state = "alt_propulsion"
 	},
 /turf/space,
 /area/shuttle/arrival/station)
 "anl" = (
 /obj/machinery/shuttle/engine/propulsion{
-	icon_state = "alt_propulsion";
-	dir = 10
+	dir = 10;
+	icon_state = "alt_propulsion"
 	},
 /turf/space,
 /area/shuttle/arrival/station)
 "anm" = (
 /obj/machinery/shuttle/engine/propulsion{
-	icon_state = "alt_propulsion";
-	dir = 5
+	dir = 5;
+	icon_state = "alt_propulsion"
 	},
 /turf/space,
 /area/shuttle/arrival/station)
@@ -6297,13 +6297,13 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/grille/catwalk{
 	dir = 4
@@ -6352,8 +6352,8 @@
 /area/station/medical/cdc)
 "anv" = (
 /obj/stool/chair/office{
-	icon_state = "office_chair";
-	dir = 4
+	dir = 4;
+	icon_state = "office_chair"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
@@ -6421,17 +6421,17 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/grille/catwalk{
-	icon_state = "catwalk";
-	dir = 5
+	dir = 5;
+	icon_state = "catwalk"
 	},
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
@@ -6460,57 +6460,57 @@
 /area/shuttle/arrival/station)
 "anH" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /obj/grille/steel,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/machinery/shuttle/engine/heater{
-	icon_state = "alt_heater-R";
-	dir = 1
+	dir = 1;
+	icon_state = "alt_heater-R"
 	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "anI" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /obj/grille/steel,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/machinery/shuttle/engine/heater{
-	icon_state = "alt_heater-M";
-	dir = 1
+	dir = 1;
+	icon_state = "alt_heater-M"
 	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "anJ" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /obj/grille/steel,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/machinery/shuttle/engine/heater{
-	icon_state = "alt_heater-L";
-	dir = 1
+	dir = 1;
+	icon_state = "alt_heater-L"
 	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
@@ -6535,8 +6535,8 @@
 /obj/table/auto,
 /obj/bedsheetbin,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/securearea{
 	desc = "A warning sign which reads 'Biohazard'";
@@ -6567,12 +6567,12 @@
 "anQ" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /obj/decal/poster/wallsign/chsl,
 /turf/simulated/floor/plating,
@@ -6792,8 +6792,8 @@
 /obj/item/bloodslide,
 /obj/item/bloodslide,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/table/reinforced/chemistry/auto,
 /turf/simulated/floor/greenwhite{
@@ -6807,8 +6807,8 @@
 "aou" = (
 /obj/machinery/microscope,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/table/reinforced/chemistry/auto,
 /turf/simulated/floor/greenwhite{
@@ -6818,8 +6818,8 @@
 "aov" = (
 /obj/storage/closet/wardrobe/mixed,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
@@ -6828,8 +6828,8 @@
 /area/shuttle/arrival/station)
 "aox" = (
 /obj/machinery/door/airlock/pyro/external{
-	icon_state = "airlock_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "airlock_closed"
 	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
@@ -6838,8 +6838,8 @@
 /area/station/hallway/secondary/shuttle)
 "aoz" = (
 /obj/machinery/door/airlock/pyro/external{
-	icon_state = "airlock_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "airlock_closed"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/shuttle)
@@ -6929,15 +6929,15 @@
 /area/shuttle/arrival/station)
 "aoL" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "aoM" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/arrival{
 	dir = 8
@@ -6954,16 +6954,16 @@
 "aoP" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
@@ -7009,16 +7009,16 @@
 "aoW" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
@@ -7035,16 +7035,16 @@
 /area/station/quartermaster/office)
 "aoZ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/tug_cart,
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "apa" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/camera{
 	c_tag = "Arrival Hallway";
@@ -7146,9 +7146,9 @@
 "apn" = (
 /obj/grille/steel,
 /obj/securearea{
-	name = "VACUUM AREA";
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space"
+	icon_state = "space";
+	name = "VACUUM AREA"
 	},
 /obj/window/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -7184,8 +7184,8 @@
 /area/station/hangar/main)
 "apu" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -7196,17 +7196,17 @@
 /area/station/hangar/main)
 "apv" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
 "apw" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -7226,9 +7226,9 @@
 	text = "NF"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
@@ -7246,8 +7246,8 @@
 /area/station/hallway/secondary/shuttle)
 "apA" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/shuttle)
@@ -7305,8 +7305,8 @@
 "apK" = (
 /obj/machinery/manufacturer/robotics,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -7314,9 +7314,9 @@
 /area/station/quartermaster/office)
 "apL" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/storage/crate,
 /obj/item/storage/toolbox/mechanical,
@@ -7340,9 +7340,9 @@
 /obj/grille/steel,
 /obj/window/auto/reinforced,
 /obj/securearea{
-	name = "VACUUM AREA";
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space"
+	icon_state = "space";
+	name = "VACUUM AREA"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
@@ -7371,16 +7371,16 @@
 /area/station/hangar/main)
 "apT" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
 "apU" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 10
+	dir = 10;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area)
@@ -7403,8 +7403,8 @@
 /area/station/quartermaster/office)
 "apZ" = (
 /obj/grille/catwalk{
-	icon_state = "catwalk";
-	dir = 10
+	dir = 10;
+	icon_state = "catwalk"
 	},
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
@@ -7415,8 +7415,8 @@
 /area)
 "aqa" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer/supplycomp,
@@ -7478,15 +7478,15 @@
 "aqj" = (
 /turf/space,
 /turf/simulated/shuttle/wall/cockpit{
-	icon_state = "shuttlecock";
-	dir = 1
+	dir = 1;
+	icon_state = "shuttlecock"
 	},
 /area/shuttle/arrival/station)
 "aqk" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/machinery/manufacturer/hangar,
 /turf/simulated/floor/yellow/side{
@@ -7495,26 +7495,26 @@
 /area/station/quartermaster/office)
 "aql" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "aqm" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/storage/crate,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "aqn" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -7533,9 +7533,9 @@
 /area/station/quartermaster/office)
 "aqo" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/computer/barcode/qm,
 /turf/simulated/floor/yellow/side{
@@ -7548,17 +7548,17 @@
 	id = "QMLoad"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/caution/westeast,
 /area/station/quartermaster/office)
 "aqq" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/table/auto,
 /obj/machinery/recharger{
@@ -7611,9 +7611,9 @@
 /area/station/hangar/main)
 "aqx" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
@@ -7622,9 +7622,9 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -7639,86 +7639,86 @@
 	pixel_x = 0
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/main)
 "aqA" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 4
+	dir = 4;
+	icon_state = "lattice-dir"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/space,
 /area)
 "aqB" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 4
+	dir = 4;
+	icon_state = "lattice-dir"
 	},
 /obj/machinery/light/runway_light,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/space,
 /area)
 "aqC" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 4
+	dir = 4;
+	icon_state = "lattice-dir"
 	},
 /obj/machinery/light/runway_light/delay2,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/space,
 /area)
 "aqD" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 4
+	dir = 4;
+	icon_state = "lattice-dir"
 	},
 /obj/machinery/light/runway_light/delay3,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/space,
 /area)
 "aqE" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 4
+	dir = 4;
+	icon_state = "lattice-dir"
 	},
 /obj/machinery/light/runway_light/delay4,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/space,
 /area)
 "aqF" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 4
+	dir = 4;
+	icon_state = "lattice-dir"
 	},
 /obj/machinery/light/runway_light/delay5,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/space,
 /area)
@@ -7737,9 +7737,9 @@
 /obj/grille/steel,
 /obj/window/auto/reinforced,
 /obj/securearea{
-	name = "VACUUM AREA";
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space"
+	icon_state = "space";
+	name = "VACUUM AREA"
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/shuttle)
@@ -7772,8 +7772,8 @@
 /area/station/hallway/secondary/shuttle)
 "aqN" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/escape{
 	dir = 1
@@ -7786,13 +7786,13 @@
 /area/station/hallway/secondary/shuttle)
 "aqP" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/manufacturer/medical,
 /turf/simulated/floor/yellow/side{
@@ -7823,8 +7823,8 @@
 /area/station/quartermaster/office)
 "aqU" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/door_control{
 	id = "QMLoaddoor";
@@ -7841,8 +7841,8 @@
 /area/station/quartermaster/office)
 "aqV" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/stool/chair/couch/green{
@@ -7931,9 +7931,9 @@
 /area/station/maintenance/north)
 "arj" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
@@ -7969,16 +7969,17 @@
 "arp" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer/security{
 	dir = 4
 	},
+/obj/item/device/flash,
 /obj/item/device/radio/intercom{
-	dir = 4;
 	broadcasting = 0;
+	dir = 4;
 	frequency = 1485;
 	name = "Station Intercom (Security)"
 	},
@@ -7993,12 +7994,7 @@
 	},
 /area/station/hallway/secondary/shuttle)
 "arr" = (
-/obj/table/auto,
-/obj/machinery/recharger{
-	pixel_y = 3
-	},
-/obj/item/crowbar,
-/obj/item/device/flash,
+/obj/submachine/weapon_vendor/security,
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
@@ -8008,6 +8004,7 @@
 	dir = 4
 	},
 /obj/storage/secure/closet/security/equipment,
+/obj/item/crowbar,
 /turf/simulated/floor/redblack{
 	dir = 5
 	},
@@ -8025,9 +8022,9 @@
 /area/station/hallway/secondary/shuttle)
 "arv" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo Bay West";
@@ -8042,22 +8039,22 @@
 /area/station/quartermaster/office)
 "arw" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "arx" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 4
@@ -8080,29 +8077,29 @@
 /area/station/quartermaster/office)
 "arA" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor,
 /area/station/maintenance/north)
 "arB" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/maintenance/north)
 "arC" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/stool,
 /turf/simulated/floor/plating,
@@ -8138,9 +8135,9 @@
 /area/station/hangar/main)
 "arH" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/hangar/main)
@@ -8183,17 +8180,20 @@
 /area/station/maintenance/west)
 "arP" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer/card{
 	dir = 4
+	},
+/obj/machinery/recharger/wall/sticky{
+	dir = 8
 	},
 /turf/simulated/floor/redblack{
 	dir = 8
@@ -8201,31 +8201,31 @@
 /area/station/hallway/secondary/shuttle)
 "arQ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/stool/chair/office/red,
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/shuttle)
 "arR" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/shuttle)
 "arS" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/redblack{
 	dir = 4
@@ -8241,8 +8241,8 @@
 /area/station/hallway/secondary/shuttle)
 "arU" = (
 /obj/machinery/light/emergency{
-	icon_state = "ebulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "ebulb1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/shuttle)
@@ -8275,9 +8275,9 @@
 /area/station/quartermaster/office)
 "arX" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
@@ -8299,16 +8299,16 @@
 	pixel_x = -7
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 1
+	dir = 1;
+	icon_state = "fred2"
 	},
 /area/station/chapel/office)
 "asb" = (
 /obj/stool/chair/yellow,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4;
@@ -8354,16 +8354,16 @@
 /area/station/quartermaster/office)
 "asf" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 8
+	dir = 8;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "asg" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/scorched,
 /area/station/maintenance/north)
@@ -8405,12 +8405,12 @@
 /area/ghostdrone_factory)
 "aso" = (
 /obj/decal/fakeobjects{
-	name = "downed server";
+	anchored = 1;
+	density = 1;
 	desc = "A large rack of server modules.  It doesn't seem to be in service.";
 	icon = 'icons/obj/networked.dmi';
 	icon_state = "tapedrive-p";
-	density = 1;
-	anchored = 1
+	name = "downed server"
 	},
 /turf/simulated/grimycarpet,
 /area/ghostdrone_factory)
@@ -8446,8 +8446,8 @@
 /area/ghostdrone_factory)
 "ast" = (
 /obj/machinery/door/airlock/pyro/external{
-	icon_state = "airlock_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "airlock_closed"
 	},
 /turf/simulated/floor/caution/west,
 /area/station/hallway/secondary/shuttle)
@@ -8457,48 +8457,48 @@
 	dir = 8
 	},
 /obj/machinery/light/emergency{
-	icon_state = "ebulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "ebulb1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/shuttle)
 "asv" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "asw" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "asx" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "asy" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "asz" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/shuttle)
@@ -8506,8 +8506,8 @@
 /obj/grille/steel,
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/window/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -8538,8 +8538,8 @@
 /area/station/hallway/secondary/shuttle)
 "asE" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/shuttle)
@@ -8567,14 +8567,14 @@
 /area/station/quartermaster/office)
 "asI" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4;
@@ -8584,9 +8584,9 @@
 /area/station/quartermaster/office)
 "asJ" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/disposal/mail{
 	mail_tag = "cargo";
@@ -8603,25 +8603,25 @@
 /obj/grille/steel,
 /obj/window/auto/reinforced,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "asL" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/table/reinforced,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/item/hand_labeler,
 /turf/simulated/floor/yellow,
@@ -8629,9 +8629,9 @@
 "asM" = (
 /obj/table/reinforced,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/window/northleft{
 	name = "Cargo Office";
@@ -8648,8 +8648,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/wall,
 /area/station/quartermaster/office)
@@ -8668,17 +8668,17 @@
 /area/station/quartermaster/office)
 "asQ" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/maintenance/north)
 "asR" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -8715,18 +8715,10 @@
 "asX" = (
 /turf/simulated/grimycarpet,
 /area/ghostdrone_factory)
-"asY" = (
-/obj/cable{
-	icon_state = "1-2";
-	d1 = 1;
-	d2 = 2
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "asZ" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/item/storage/toilet/random{
 	dir = 4;
@@ -8759,8 +8751,8 @@
 	pixel_y = -24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/stool/chair{
 	dir = 1
@@ -8782,9 +8774,9 @@
 /area/station/hallway/secondary/shuttle)
 "ate" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/red/side{
 	dir = 1
@@ -8827,9 +8819,9 @@
 /area/station/quartermaster/office)
 "atk" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
 /obj/machinery/door/window/northleft{
@@ -8874,12 +8866,12 @@
 	pixel_y = 32
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/machinery/door/window/southleft,
 /turf/simulated/floor/delivery,
@@ -8894,9 +8886,9 @@
 /area/station/quartermaster/office)
 "atr" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/landmark{
 	name = "blobstart"
@@ -8972,9 +8964,9 @@
 /area/station/crew_quarters/locker)
 "atB" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/secondary/shuttle)
@@ -8996,9 +8988,9 @@
 /area/station/hallway/secondary/shuttle)
 "atF" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "L5"
@@ -9055,13 +9047,13 @@
 /area/station/quartermaster)
 "atN" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -9069,14 +9061,14 @@
 /area/station/quartermaster)
 "atO" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4;
@@ -9088,9 +9080,9 @@
 /area/station/quartermaster)
 "atP" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -9101,9 +9093,9 @@
 /area/station/quartermaster)
 "atQ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 8;
@@ -9115,8 +9107,8 @@
 /area/station/quartermaster)
 "atR" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/cable{
 	d2 = 8;
@@ -9158,8 +9150,8 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/grime,
 /area/station/hangar/main)
@@ -9192,8 +9184,8 @@
 /area/ghostdrone_factory)
 "aua" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer/research_shuttle{
@@ -9217,15 +9209,15 @@
 /area/station/crew_quarters/locker)
 "aud" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/locker)
 "aue" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/locker)
@@ -9247,27 +9239,27 @@
 /area/station/maintenance/west)
 "auh" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aui" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/secondary/shuttle)
@@ -9276,25 +9268,25 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/shuttle)
 "auk" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "L2"
@@ -9302,9 +9294,9 @@
 /area/station/hallway/secondary/shuttle)
 "aul" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "L4"
@@ -9317,9 +9309,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "L6"
@@ -9327,9 +9319,9 @@
 /area/station/hallway/secondary/shuttle)
 "aun" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "L8"
@@ -9337,9 +9329,9 @@
 /area/station/hallway/secondary/shuttle)
 "auo" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "L10"
@@ -9347,9 +9339,9 @@
 /area/station/hallway/secondary/shuttle)
 "aup" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "L12"
@@ -9357,9 +9349,9 @@
 /area/station/hallway/secondary/shuttle)
 "auq" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "L14"
@@ -9368,9 +9360,9 @@
 "aur" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "L16"
@@ -9378,9 +9370,9 @@
 /area/station/hallway/secondary/shuttle)
 "aus" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/shuttle)
@@ -9390,49 +9382,49 @@
 	},
 /obj/disposalpipe/segment,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/grime,
 /area/station/hallway/secondary/shuttle)
 "auu" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/quartermaster/office)
 "auv" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/caution/north,
 /area/station/quartermaster/office)
 "auw" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/caution/north,
 /area/station/quartermaster/office)
 "aux" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/poddoor/pyro{
 	dir = 4;
@@ -9446,9 +9438,9 @@
 "auy" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 8
@@ -9456,22 +9448,22 @@
 /area/station/quartermaster)
 "auz" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster)
 "auA" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
@@ -9504,47 +9496,47 @@
 /area/station/hangar/main)
 "auG" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/hangar/main)
 "auH" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hangar/main)
 "auI" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/grime,
 /area/station/hangar/main)
 "auJ" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/hangar/main)
 "auK" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	icon_state = "2-8"
@@ -9642,23 +9634,23 @@
 /area/station/quartermaster)
 "avb" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/yellow/side,
 /area/station/quartermaster)
 "avc" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow/side,
 /area/station/quartermaster)
@@ -9695,9 +9687,9 @@
 /area/station/hangar/main)
 "avh" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hangar/main)
@@ -9724,32 +9716,32 @@
 /area/ghostdrone_factory)
 "avm" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 6
+	dir = 6;
+	icon_state = "lattice-dir-b"
 	},
 /obj/machinery/light/runway_light,
 /turf/space,
 /area)
 "avn" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 4
+	dir = 4;
+	icon_state = "lattice-dir"
 	},
 /obj/machinery/light/runway_light/delay2,
 /turf/space,
 /area)
 "avo" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 4
+	dir = 4;
+	icon_state = "lattice-dir"
 	},
 /obj/machinery/light/runway_light/delay3,
 /turf/space,
 /area)
 "avp" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 5
+	dir = 5;
+	icon_state = "lattice-dir"
 	},
 /obj/machinery/light/runway_light/delay4,
 /turf/space,
@@ -9759,14 +9751,14 @@
 /area/station/maintenance/west)
 "avr" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -9795,9 +9787,9 @@
 "avw" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/maintenance,
 /turf/simulated/floor/plating,
@@ -9846,9 +9838,9 @@
 /area/station/quartermaster)
 "avD" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
 /obj/disposalpipe/segment{
@@ -9905,9 +9897,9 @@
 /area/station/maintenance/north)
 "avK" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -9940,8 +9932,8 @@
 /area/station/hangar/main)
 "avP" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
@@ -10050,8 +10042,8 @@
 	pixel_x = -8
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/toilets)
@@ -10068,8 +10060,8 @@
 /area/station/crew_quarters/toilets)
 "awj" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/neutral/corner{
 	dir = 8
@@ -10077,9 +10069,9 @@
 /area/station/hallway/primary/north)
 "awk" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -10134,9 +10126,9 @@
 /area/station/hallway/primary/north)
 "awt" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -10144,9 +10136,9 @@
 /area/station/hallway/primary/north)
 "awu" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -10154,9 +10146,9 @@
 /area/station/hallway/primary/north)
 "awv" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/yellow/side{
@@ -10181,8 +10173,8 @@
 /area/station/hallway/primary/north)
 "awy" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/neutral/corner{
 	dir = 0
@@ -10190,14 +10182,14 @@
 /area/station/hallway/primary/north)
 "awz" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/table/auto,
 /obj/machinery/light_switch{
@@ -10221,9 +10213,9 @@
 /area/station/storage/emergency2)
 "awB" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/item/clothing/shoes/moon,
 /turf/simulated/floor/plating,
@@ -10256,19 +10248,19 @@
 /area/station/chapel/office)
 "awH" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 9
+	dir = 9;
+	icon_state = "fred2"
 	},
 /area/station/chapel/office)
 "awI" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/grille/catwalk{
 	dir = 9
@@ -10286,20 +10278,20 @@
 	name = "Chaplain"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 1
+	dir = 1;
+	icon_state = "fred2"
 	},
 /area/station/chapel/office)
 "awK" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 1
+	dir = 1;
+	icon_state = "fred2"
 	},
 /area/station/chapel/office)
 "awL" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 5
+	dir = 5;
+	icon_state = "fred2"
 	},
 /area/station/chapel/office)
 "awM" = (
@@ -10326,8 +10318,8 @@
 /area/ghostdrone_factory)
 "awQ" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 6
+	dir = 6;
+	icon_state = "lattice-dir"
 	},
 /obj/machinery/light/runway_light,
 /turf/space,
@@ -10368,8 +10360,8 @@
 /area/station/crew_quarters/toilets)
 "awX" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 2;
@@ -10383,9 +10375,9 @@
 /area/station/crew_quarters/toilets)
 "awY" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light_switch{
 	name = "S light switch";
@@ -10395,9 +10387,9 @@
 /area/station/crew_quarters/toilets)
 "awZ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
@@ -10409,9 +10401,9 @@
 /area/station/crew_quarters/toilets)
 "axa" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 8
@@ -10419,14 +10411,14 @@
 /area/station/hallway/primary/north)
 "axb" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
@@ -10492,9 +10484,9 @@
 /area/station/hallway/primary/north)
 "axi" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
@@ -10524,8 +10516,8 @@
 /area/station/hallway/primary/north)
 "axl" = (
 /obj/machinery/light/emergency{
-	icon_state = "ebulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "ebulb1"
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 4
@@ -10533,9 +10525,9 @@
 /area/station/hallway/primary/north)
 "axm" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/storage/emergency2)
@@ -10548,9 +10540,9 @@
 	})
 "axo" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass{
@@ -10564,9 +10556,9 @@
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
@@ -10577,8 +10569,8 @@
 /area/station/maintenance/north)
 "axr" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 10
+	dir = 10;
+	icon_state = "fred2"
 	},
 /area/station/chapel/office)
 "axs" = (
@@ -10587,24 +10579,24 @@
 	},
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 2
+	dir = 2;
+	icon_state = "fred2"
 	},
 /area/station/chapel/office)
 "axt" = (
 /obj/table/wood/auto,
 /obj/item/storage/bible,
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 2
+	dir = 2;
+	icon_state = "fred2"
 	},
 /area/station/chapel/office)
 "axu" = (
 /obj/table/wood/auto,
 /obj/item/reagent_containers/glass/bottle/holywater,
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 2
+	dir = 2;
+	icon_state = "fred2"
 	},
 /area/station/chapel/office)
 "axv" = (
@@ -10612,21 +10604,21 @@
 	dir = 6
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 2
+	dir = 2;
+	icon_state = "fred2"
 	},
 /area/station/chapel/office)
 "axw" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 6
+	dir = 6;
+	icon_state = "fred2"
 	},
 /area/station/chapel/office)
 "axx" = (
 /obj/stool,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 5
@@ -10706,8 +10698,8 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/locker)
@@ -10737,9 +10729,9 @@
 /area/station/hallway/primary/north)
 "axO" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/morgue{
 	name = "crematorium pipe"
@@ -10755,24 +10747,24 @@
 /area/station/hallway/primary/north)
 "axQ" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/machinery/light,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "axR" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/machinery/light/emergency,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "axS" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -10793,15 +10785,15 @@
 "axU" = (
 /obj/disposalpipe/segment,
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "axV" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/machinery/door/firedoor/pyro{
 	dir = 4
@@ -10810,8 +10802,8 @@
 /area/station/hallway/primary/north)
 "axW" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/machinery/power/apc{
 	dir = 2;
@@ -10819,20 +10811,20 @@
 	pixel_y = -24
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "axX" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/cable{
 	d1 = 1;
@@ -10843,8 +10835,8 @@
 /area/station/hallway/primary/north)
 "axY" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/neutral/corner{
@@ -10862,8 +10854,8 @@
 /area/station/hallway/primary/north)
 "aya" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/neutral/side,
 /area/station/hallway/primary/north)
@@ -10878,8 +10870,8 @@
 /area/station/hallway/primary/north)
 "ayc" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/neutral/side,
@@ -10910,14 +10902,14 @@
 /area/station/storage/emergency2)
 "ayh" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/securearea{
 	desc = "A poster that reads 'CLEAN HANDS SAVE LIVES'.";
@@ -10929,9 +10921,9 @@
 /area/station/storage/emergency2)
 "ayi" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/rack,
 /obj/item/tank/oxygen,
@@ -10940,8 +10932,8 @@
 /area/station/storage/emergency2)
 "ayj" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -10953,9 +10945,9 @@
 /area/station/storage/emergency2)
 "ayk" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/rack,
 /obj/item/clothing/mask/gas/emergency,
@@ -10963,9 +10955,9 @@
 /area/station/storage/emergency2)
 "ayl" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/storage/closet/wardrobe/grey,
 /turf/simulated/floor/grime,
@@ -10977,16 +10969,16 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/grime,
 /area/station/storage/emergency2)
 "ayn" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -11008,9 +11000,9 @@
 /area/station/chapel/main)
 "ayp" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/main)
@@ -11021,8 +11013,8 @@
 /area/station/chapel/main)
 "ayr" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 2;
@@ -11030,8 +11022,8 @@
 	pixel_y = -24
 	},
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 6
+	dir = 6;
+	icon_state = "shrub"
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/office)
@@ -11071,8 +11063,8 @@
 /area/station/chapel/main)
 "ayy" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 6
@@ -11084,8 +11076,8 @@
 	dir = 8
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 10
@@ -11138,32 +11130,32 @@
 /area/ghostdrone_factory)
 "ayG" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 9
+	dir = 9;
+	icon_state = "lattice-dir-b"
 	},
 /obj/machinery/light/runway_light,
 /turf/space,
 /area)
 "ayH" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "ayI" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/storage/closet/wardrobe/grey,
 /turf/simulated/floor,
 /area/station/crew_quarters/locker)
 "ayJ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/locker)
@@ -11174,8 +11166,8 @@
 /area/station/crew_quarters/locker)
 "ayL" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/storage/closet/emergency,
 /turf/simulated/floor,
@@ -11241,9 +11233,9 @@
 /area/station/hallway/primary/north)
 "ayV" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/north)
@@ -11276,16 +11268,16 @@
 	},
 /obj/machinery/space_heater,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/grime,
 /area/station/storage/emergency2)
 "azb" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/storage/emergency2)
@@ -11297,9 +11289,9 @@
 /area/station/storage/emergency2)
 "aze" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/submachine/chef_sink/chem_sink{
 	dir = 8;
@@ -11317,9 +11309,9 @@
 /area/station/chapel/main)
 "azg" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
@@ -11332,9 +11324,9 @@
 /area/station/chapel/main)
 "azi" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/chapel/office)
@@ -11358,9 +11350,9 @@
 /area/station/chapel/office)
 "azl" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 9
@@ -11368,9 +11360,9 @@
 /area/station/chapel/main)
 "azm" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 5
@@ -11378,9 +11370,9 @@
 /area/station/chapel/main)
 "azn" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 9
@@ -11432,8 +11424,8 @@
 /area/ghostdrone_factory)
 "azu" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/solar{
 	id = "solar_port";
@@ -11447,8 +11439,8 @@
 "azv" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/communications_dish{
 	name = "Auxiliary Communications dish"
@@ -11457,17 +11449,17 @@
 /area)
 "azw" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area)
 "azx" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/landmark{
 	name = "NASSA spawn"
@@ -11476,9 +11468,9 @@
 /area)
 "azy" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/west)
@@ -11488,8 +11480,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -11502,9 +11494,9 @@
 /area/station/crew_quarters/locker)
 "azC" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/locker)
@@ -11533,8 +11525,8 @@
 /area/station/crew_quarters/locker)
 "azH" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/cable{
@@ -11542,8 +11534,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/grille/catwalk{
 	dir = 4
@@ -11557,16 +11549,16 @@
 "azI" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/grille/catwalk{
 	dir = 4
@@ -11603,9 +11595,9 @@
 /area/station/hallway/primary/north)
 "azM" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/disposalpipe/segment/mail,
@@ -11613,34 +11605,34 @@
 /area/station/hallway/primary/north)
 "azN" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/north)
 "azO" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/reagent_dispensers/foamtank,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
 "azP" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
 "azQ" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
@@ -11676,9 +11668,9 @@
 /area/station/maintenance/inner)
 "azX" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating,
@@ -11755,9 +11747,9 @@
 /area/station/storage/emergency2)
 "aAj" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/storage/crate,
 /obj/item/crowbar,
@@ -11766,8 +11758,8 @@
 /area/station/storage/emergency2)
 "aAk" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/table/wood/auto{
 	dir = 6
@@ -11778,22 +11770,22 @@
 /area/station/chapel/main)
 "aAl" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/main)
 "aAm" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 8
@@ -11801,9 +11793,9 @@
 /area/station/chapel/main)
 "aAn" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/stool,
 /turf/simulated/floor/specialroom/chapel,
@@ -11868,9 +11860,9 @@
 /area/station/chapel/main)
 "aAv" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 10
@@ -11878,8 +11870,8 @@
 /area/station/chapel/main)
 "aAw" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 6
@@ -11887,8 +11879,8 @@
 /area/station/chapel/main)
 "aAx" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/machinery/driver_button{
 	id = "chapelgun";
@@ -11950,8 +11942,8 @@
 	dir = 10
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -11983,16 +11975,16 @@
 "aAG" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/grille/catwalk{
-	icon_state = "catwalk";
-	dir = 5
+	dir = 5;
+	icon_state = "catwalk"
 	},
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
@@ -12002,9 +11994,7 @@
 	},
 /area/station/solar/west)
 "aAH" = (
-/obj/item/device/radio/intercom{
-	
-	},
+/obj/item/device/radio/intercom,
 /obj/storage/crate,
 /obj/item/clothing/under/gimmick/princess,
 /obj/item/clothing/suit/jacket/plastic/random_color,
@@ -12083,14 +12073,14 @@
 /area/station/crew_quarters/toilets)
 "aAR" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -12100,9 +12090,9 @@
 /area/station/maintenance/inner)
 "aAS" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -12112,9 +12102,9 @@
 /area/station/maintenance/inner)
 "aAT" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/junction{
 	dir = 8;
@@ -12125,9 +12115,9 @@
 "aAU" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -12137,9 +12127,9 @@
 /area/station/maintenance/inner)
 "aAV" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/junction{
 	dir = 8;
@@ -12149,14 +12139,14 @@
 /area/station/maintenance/inner)
 "aAW" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -12196,8 +12186,8 @@
 "aBb" = (
 /obj/disposalpipe/segment/mail,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 8
@@ -12219,9 +12209,9 @@
 "aBf" = (
 /obj/grille/steel,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/window/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -12233,12 +12223,12 @@
 /area/station/chapel/main)
 "aBh" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /turf/simulated/floor/specialroom/chapel{
@@ -12349,9 +12339,9 @@
 /area/station/chapel/main)
 "aBt" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -12383,8 +12373,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quarters)
@@ -12394,9 +12384,9 @@
 /area/station/crew_quarters/locker)
 "aBz" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass,
@@ -12423,8 +12413,8 @@
 /area/station/hallway/primary/north)
 "aBD" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 1
@@ -12432,8 +12422,8 @@
 /area/station/hallway/primary/north)
 "aBE" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/machinery/firealarm{
 	pixel_y = 24;
@@ -12445,8 +12435,8 @@
 /area/station/hallway/primary/north)
 "aBF" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -12458,8 +12448,8 @@
 /area/station/hallway/primary/north)
 "aBG" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/neutral/corner{
 	dir = 1
@@ -12467,8 +12457,8 @@
 /area/station/hallway/primary/north)
 "aBH" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/disposalpipe/segment/morgue{
 	name = "crematorium pipe"
@@ -12492,9 +12482,9 @@
 /area/station/maintenance/inner)
 "aBL" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -12517,9 +12507,9 @@
 /obj/grille/steel,
 /obj/window/auto/reinforced,
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/substation/north)
@@ -12539,9 +12529,9 @@
 /area/station/maintenance/inner)
 "aBS" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
@@ -12562,13 +12552,13 @@
 /area/station/hallway/primary/north)
 "aBW" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 5
@@ -12583,39 +12573,39 @@
 	dir = 6
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 9
+	dir = 9;
+	icon_state = "fred2"
 	},
 /area/station/chapel/main)
 "aBY" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 5
+	dir = 5;
+	icon_state = "fred2"
 	},
 /area/station/chapel/main)
 "aBZ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/main)
 "aCa" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 10
@@ -12623,9 +12613,9 @@
 /area/station/chapel/main)
 "aCb" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 6
@@ -12638,9 +12628,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 10
@@ -12673,9 +12663,9 @@
 /area)
 "aCg" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -12710,8 +12700,8 @@
 /area/station/crew_quarters/quarters)
 "aCm" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 1
+	dir = 1;
+	icon_state = "shrub"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/locker)
@@ -12757,8 +12747,8 @@
 	},
 /obj/machinery/vending/snack,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/grime,
 /area/station/hallway/primary/north)
@@ -12779,9 +12769,9 @@
 /area/station/maintenance/inner)
 "aCu" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 8;
@@ -12801,9 +12791,9 @@
 /area/station/engine/substation/north)
 "aCx" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/grime,
 /area/station/engine/substation/north)
@@ -12817,25 +12807,25 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
 "aCA" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/storage/emergency)
 "aCB" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/trunk{
 	dir = 1
@@ -12845,9 +12835,9 @@
 /area/station/storage/emergency)
 "aCC" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/camera{
 	c_tag = "Emergency Storage";
@@ -12897,9 +12887,9 @@
 /area/station/hallway/primary/north)
 "aCI" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
@@ -12920,23 +12910,23 @@
 	icon_state = "plant"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 8
+	dir = 8;
+	icon_state = "fred2"
 	},
 /area/station/chapel/main)
 "aCK" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
 	name = "crematorium pipe"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred1";
-	dir = 8
+	dir = 8;
+	icon_state = "fred1"
 	},
 /area/station/chapel/main)
 "aCL" = (
@@ -12945,8 +12935,8 @@
 	name = "crematorium pipe"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 1
+	dir = 1;
+	icon_state = "fred2"
 	},
 /area/station/chapel/main)
 "aCM" = (
@@ -12955,8 +12945,8 @@
 	name = "crematorium pipe"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 5
+	dir = 5;
+	icon_state = "fred2"
 	},
 /area/station/chapel/main)
 "aCN" = (
@@ -13013,9 +13003,9 @@
 "aCS" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
@@ -13024,9 +13014,9 @@
 /area/station/maintenance/NEmaint)
 "aCT" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4;
@@ -13036,21 +13026,21 @@
 /area/station/maintenance/NEmaint)
 "aCU" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "aCV" = (
 /obj/grille/steel,
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/window/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -13095,8 +13085,8 @@
 "aDb" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/computer3frame{
 	anchored = 1;
@@ -13107,9 +13097,9 @@
 /area/station/maintenance/west)
 "aDc" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -13125,8 +13115,8 @@
 /area/station/maintenance/inner)
 "aDe" = (
 /obj/window/cubicle{
-	icon_state = "cubicle";
-	dir = 1
+	dir = 1;
+	icon_state = "cubicle"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quarters)
@@ -13172,8 +13162,8 @@
 "aDl" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/light/emergency{
-	icon_state = "ebulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "ebulb1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -13189,9 +13179,9 @@
 /area/station/engine/substation/north)
 "aDo" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light_switch{
 	name = "E light switch";
@@ -13218,9 +13208,9 @@
 /area/station/hallway/primary/north)
 "aDr" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 4
@@ -13235,15 +13225,15 @@
 /area/station/chapel/main)
 "aDt" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 8
+	dir = 8;
+	icon_state = "fred2"
 	},
 /area/station/chapel/main)
 "aDu" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet,
 /area/station/chapel/main)
@@ -13252,8 +13242,8 @@
 /area/station/chapel/main)
 "aDw" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 4
+	dir = 4;
+	icon_state = "fred2"
 	},
 /area/station/chapel/main)
 "aDx" = (
@@ -13314,9 +13304,9 @@
 /area/station/maintenance/NEmaint)
 "aDF" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
@@ -13377,8 +13367,8 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/stool/chair{
 	dir = 1
@@ -13447,8 +13437,8 @@
 "aDV" = (
 /obj/disposalpipe/segment/mail,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/orangeblack/corner,
 /area/station/hallway/primary/north)
@@ -13458,45 +13448,45 @@
 "aDX" = (
 /obj/machinery/power/monitor,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/substation/north)
 "aDY" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/grime,
 /area/station/engine/substation/north)
 "aDZ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/substation/north)
 "aEa" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/inner)
 "aEb" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/inner)
@@ -13509,9 +13499,9 @@
 /area/station/maintenance/inner)
 "aEd" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -13637,9 +13627,9 @@
 /area)
 "aEw" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -13661,8 +13651,8 @@
 /area/station/solar/west)
 "aEx" = (
 /obj/machinery/door/airlock/pyro/external{
-	icon_state = "airlock_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "airlock_closed"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -13699,9 +13689,9 @@
 /area/station/crew_quarters/quarters)
 "aEB" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/green/side{
 	dir = 4
@@ -13709,18 +13699,18 @@
 /area/station/crew_quarters/quarters)
 "aEC" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/decal/cleanable/rust,
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/quarters)
 "aED" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/quarters)
@@ -13730,12 +13720,12 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/green/side{
 	dir = 8
@@ -13743,22 +13733,22 @@
 /area/station/crew_quarters/quarters)
 "aEF" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters)
 "aEG" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass{
@@ -13770,17 +13760,17 @@
 /area/station/crew_quarters/quarters)
 "aEH" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/locker)
 "aEI" = (
 /obj/storage/secure/closet/personal,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/locker)
@@ -13800,8 +13790,8 @@
 /area/station/hallway/primary/north)
 "aEL" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/grille/steel,
 /obj/window/auto/reinforced,
@@ -13885,17 +13875,17 @@
 /area)
 "aEQ" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
 "aER" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -13906,9 +13896,9 @@
 /area/station/maintenance/inner)
 "aES" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/storage/crate,
 /obj/item/dice,
@@ -13917,14 +13907,14 @@
 /area/station/maintenance/inner)
 "aET" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/landmark/start{
 	name = "Engineer"
@@ -13933,13 +13923,13 @@
 /area/station/engine/substation/north)
 "aEU" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -13948,25 +13938,25 @@
 /area/station/engine/substation/north)
 "aEV" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/inner)
 "aEW" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/inner)
 "aEX" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
@@ -13988,8 +13978,8 @@
 "aFa" = (
 /obj/disposalpipe/segment,
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
@@ -14060,30 +14050,30 @@
 /area/station/crew_quarters/pool)
 "aFf" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "aFg" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "aFh" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -14101,18 +14091,18 @@
 "aFi" = (
 /obj/grille/steel,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/window/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/chapel/main)
 "aFj" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/shrub{
 	dir = 2;
@@ -14120,8 +14110,8 @@
 	icon_state = "plant"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 8
+	dir = 8;
+	icon_state = "fred2"
 	},
 /area/station/chapel/main)
 "aFk" = (
@@ -14131,20 +14121,20 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred1";
-	dir = 8
+	dir = 8;
+	icon_state = "fred1"
 	},
 /area/station/chapel/main)
 "aFl" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 2
+	dir = 2;
+	icon_state = "fred2"
 	},
 /area/station/chapel/main)
 "aFm" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 6
+	dir = 6;
+	icon_state = "fred2"
 	},
 /area/station/chapel/main)
 "aFn" = (
@@ -14192,8 +14182,8 @@
 "aFu" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 8
+	dir = 8;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -14204,8 +14194,8 @@
 /area/station/maintenance/west)
 "aFw" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/table/auto,
 /obj/machinery/microwave,
@@ -14235,9 +14225,9 @@
 /area/station/crew_quarters/quarters)
 "aFA" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/green/corner{
 	dir = 1
@@ -14248,9 +14238,9 @@
 /area/station/crew_quarters/quarters)
 "aFC" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/quarters)
@@ -14263,13 +14253,13 @@
 /area/station/crew_quarters/locker)
 "aFE" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/grille/steel,
 /obj/window/auto/reinforced,
@@ -14285,9 +14275,9 @@
 /area/station/ai_monitored/storage/eva)
 "aFF" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/rack,
 /obj/item/clothing/suit/space,
@@ -14302,9 +14292,9 @@
 /area/station/ai_monitored/storage/eva)
 "aFG" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/item/caution{
 	desc = "Caution! Construction Zone!";
@@ -14353,8 +14343,8 @@
 /area/station/maintenance/inner)
 "aFM" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/machinery/power/apc{
@@ -14367,8 +14357,8 @@
 /area/station/engine/substation/north)
 "aFN" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable,
 /obj/machinery/power/terminal,
@@ -14380,17 +14370,17 @@
 /area/station/engine/substation/north)
 "aFO" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/substation/north)
 "aFP" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/inner)
@@ -14447,8 +14437,8 @@
 /area/station/hallway/primary/north)
 "aFX" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -14460,8 +14450,8 @@
 /area/station/hallway/primary/north)
 "aFY" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/chapel/main)
@@ -14474,8 +14464,8 @@
 	dir = 6
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 10
+	dir = 10;
+	icon_state = "fred2"
 	},
 /area/station/chapel/main)
 "aGa" = (
@@ -14502,8 +14492,8 @@
 /area/station/chapel/main)
 "aGc" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 8
+	dir = 8;
+	icon_state = "bulb1"
 	},
 /obj/machinery/camera{
 	c_tag = "Private Confessional";
@@ -14539,8 +14529,8 @@
 /area/station/medical/crematorium)
 "aGf" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 4;
@@ -14558,9 +14548,9 @@
 "aGh" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/camera{
 	c_tag = "North East Maintenance";
@@ -14600,12 +14590,12 @@
 	pixel_x = -30
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /obj/machinery/door/window{
 	base_state = "right";
@@ -14620,16 +14610,16 @@
 /area/station/crew_quarters/quarters)
 "aGp" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters)
 "aGq" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters)
@@ -14676,9 +14666,9 @@
 /area/station/ai_monitored/storage/eva)
 "aGu" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/storage/crate/rcd,
 /turf/simulated/floor,
@@ -14688,8 +14678,8 @@
 	pltanks = 0
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
@@ -14707,9 +14697,9 @@
 /area/station/maintenance/inner)
 "aGy" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/substation/north)
@@ -14725,25 +14715,25 @@
 /area/station/engine/substation/north)
 "aGA" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/substation/north)
 "aGB" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area)
 "aGC" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area)
@@ -14769,9 +14759,9 @@
 "aGH" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -14810,9 +14800,9 @@
 /area/station/chapel/main)
 "aGN" = (
 /obj/shrub{
+	dir = 4;
 	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "plant";
-	dir = 4
+	icon_state = "plant"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 8
@@ -14833,9 +14823,9 @@
 /area/station/medical/crematorium)
 "aGR" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
 /area/station/medical/crematorium)
@@ -14846,9 +14836,9 @@
 /area/station/medical/crematorium)
 "aGT" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4;
@@ -14858,8 +14848,8 @@
 /area/station/maintenance/NEmaint)
 "aGU" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/NEmaint)
@@ -14930,9 +14920,9 @@
 /area/station/crew_quarters/quarters)
 "aHe" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/table/auto,
 /obj/item/game_kit,
@@ -14940,9 +14930,9 @@
 /area/station/crew_quarters/quarters)
 "aHf" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/stool/chair{
 	dir = 8
@@ -14951,9 +14941,9 @@
 /area/station/crew_quarters/quarters)
 "aHg" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -14975,19 +14965,19 @@
 /area/station/crew_quarters/locker)
 "aHi" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 1
+	dir = 1;
+	icon_state = "shrub"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/locker)
 "aHj" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/locker)
@@ -14996,8 +14986,8 @@
 	name = "crematorium pipe"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 8
@@ -15020,8 +15010,8 @@
 /area/station/hallway/primary/north)
 "aHm" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/rack,
 /obj/item/clothing/suit/space,
@@ -15048,9 +15038,9 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/item/storage/box/lightbox/tubes,
 /obj/item/storage/box/lightbox/tubes,
@@ -15111,9 +15101,9 @@
 /area/station/crew_quarters/pool)
 "aHt" = (
 /obj/pool/perspective{
-	tag = "icon-pool (NORTHWEST)";
+	dir = 9;
 	icon_state = "pool";
-	dir = 9
+	tag = "icon-pool (NORTHWEST)"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
@@ -15121,9 +15111,9 @@
 /area/station/crew_quarters/pool)
 "aHu" = (
 /obj/pool/perspective{
-	tag = "icon-pool (NORTH)";
+	dir = 1;
 	icon_state = "pool";
-	dir = 1
+	tag = "icon-pool (NORTH)"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
@@ -15152,9 +15142,9 @@
 /area/station/crew_quarters/pool)
 "aHw" = (
 /obj/pool/perspective{
-	tag = "icon-pool (NORTHEAST)";
+	dir = 5;
 	icon_state = "pool";
-	dir = 5
+	tag = "icon-pool (NORTHEAST)"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
@@ -15172,9 +15162,9 @@
 "aHy" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
@@ -15269,9 +15259,9 @@
 /area/station/storage/tech)
 "aHJ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -15281,9 +15271,9 @@
 /area/station/medical/crematorium)
 "aHK" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/plating,
@@ -15333,8 +15323,8 @@
 /area/station/crew_quarters/quarters)
 "aHR" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/disposalpipe/segment/morgue{
 	name = "crematorium pipe"
@@ -15371,13 +15361,13 @@
 /area/station/ai_monitored/storage/eva)
 "aHW" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/rack,
 /obj/item/clothing/suit/space,
@@ -15389,17 +15379,17 @@
 /area/station/ai_monitored/storage/eva)
 "aHX" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/ai_monitored/storage/eva)
 "aHY" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -15410,8 +15400,8 @@
 /area/station/maintenance/inner)
 "aHZ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
@@ -15419,9 +15409,9 @@
 /area/station/crew_quarters/pool)
 "aIa" = (
 /obj/pool/perspective{
-	tag = "icon-pool (WEST)";
+	dir = 8;
 	icon_state = "pool";
-	dir = 8
+	tag = "icon-pool (WEST)"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
@@ -15432,9 +15422,9 @@
 /area/station/crew_quarters/pool)
 "aIc" = (
 /obj/pool/perspective{
-	tag = "icon-pool (EAST)";
+	dir = 4;
 	icon_state = "pool";
-	dir = 4
+	tag = "icon-pool (EAST)"
 	},
 /obj/pool_springboard,
 /turf/simulated/floor/grass{
@@ -15443,8 +15433,8 @@
 /area/station/crew_quarters/pool)
 "aId" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
@@ -15452,9 +15442,9 @@
 /area/station/crew_quarters/pool)
 "aIe" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
@@ -15494,8 +15484,8 @@
 /area/station/hallway/primary/east)
 "aIk" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/computer/teleporter,
 /turf/simulated/floor/blueblack{
@@ -15505,8 +15495,8 @@
 "aIl" = (
 /obj/machinery/teleport/portal_generator,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/camera{
 	c_tag = "Teleporter";
@@ -15519,8 +15509,8 @@
 "aIm" = (
 /obj/machinery/teleport/portal_ring,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/blueblack{
 	dir = 1
@@ -15528,8 +15518,8 @@
 /area/station/teleporter)
 "aIn" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -15555,8 +15545,8 @@
 /area/station/storage/tech)
 "aIp" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/stool,
@@ -15564,8 +15554,8 @@
 /area/station/storage/tech)
 "aIq" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/table/reinforced/auto,
 /obj/item/reagent_containers/glass/bottle/morphine,
@@ -15587,23 +15577,23 @@
 /area/station/medical/crematorium)
 "aIs" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/black,
 /area/station/medical/crematorium)
 "aIt" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
@@ -15615,9 +15605,9 @@
 "aIu" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
@@ -15629,55 +15619,55 @@
 	},
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "aIw" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "aIx" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "aIy" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "aIz" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/table/reinforced/auto,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/item/clipboard,
 /obj/item/paper_bin,
@@ -15715,8 +15705,8 @@
 /area/station/bridge)
 "aIC" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 8
+	dir = 8;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -15753,9 +15743,9 @@
 /area/station/maintenance/west)
 "aII" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -15827,9 +15817,9 @@
 /area/station/crew_quarters/pool)
 "aIR" = (
 /obj/pool/perspective{
-	tag = "icon-pool (EAST)";
+	dir = 4;
 	icon_state = "pool";
-	dir = 4
+	tag = "icon-pool (EAST)"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
@@ -15837,9 +15827,9 @@
 /area/station/crew_quarters/pool)
 "aIS" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/camera{
 	c_tag = "East Hallway North";
@@ -15874,8 +15864,8 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 8
+	dir = 8;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/blueblack{
 	dir = 8
@@ -15888,9 +15878,9 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/teleporter)
@@ -15901,12 +15891,12 @@
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/black,
 /area/station/teleporter)
@@ -15922,8 +15912,8 @@
 /area/station/teleporter)
 "aJa" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -15938,9 +15928,9 @@
 "aJb" = (
 /obj/item/screwdriver,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
@@ -15956,9 +15946,9 @@
 /area/station/storage/tech)
 "aJd" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/crematorium)
@@ -15989,9 +15979,9 @@
 /area/station/maintenance/NEmaint)
 "aJj" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/command{
@@ -16008,8 +15998,8 @@
 "aJk" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/computer3/generic/med_data{
 	dir = 4
@@ -16045,27 +16035,27 @@
 /area/station/maintenance/west)
 "aJo" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aJp" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aJq" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/north)
@@ -16107,9 +16097,9 @@
 /area/station/ai_monitored/storage/eva)
 "aJv" = (
 /obj/pool/perspective{
-	tag = "icon-pool (SOUTHWEST)";
+	dir = 10;
 	icon_state = "pool";
-	dir = 10
+	tag = "icon-pool (SOUTHWEST)"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
@@ -16123,9 +16113,9 @@
 /area/station/crew_quarters/pool)
 "aJx" = (
 /obj/pool/perspective{
-	tag = "icon-pool (SOUTHEAST)";
+	dir = 6;
 	icon_state = "pool";
-	dir = 6
+	tag = "icon-pool (SOUTHEAST)"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
@@ -16150,8 +16140,8 @@
 /area/station/hallway/primary/east)
 "aJA" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
@@ -16176,23 +16166,23 @@
 /area/station/teleporter)
 "aJF" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/blueblack,
 /area/station/teleporter)
 "aJG" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/rack,
 /obj/item/hand_tele,
@@ -16202,9 +16192,9 @@
 /area/station/teleporter)
 "aJH" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/storage/tech)
@@ -16215,9 +16205,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/storage/crate,
 /obj/item/peripheral/card_scanner,
@@ -16232,9 +16222,9 @@
 /area/station/storage/tech)
 "aJJ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -16246,8 +16236,8 @@
 "aJK" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -16259,9 +16249,9 @@
 /area/station/storage/tech)
 "aJL" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -16272,9 +16262,9 @@
 /area/station/storage/tech)
 "aJM" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "2-8"
@@ -16283,9 +16273,9 @@
 /area/station/storage/tech)
 "aJN" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "2-8"
@@ -16312,9 +16302,9 @@
 /area/station/maintenance/NEmaint)
 "aJQ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/NEmaint)
@@ -16337,9 +16327,9 @@
 	dir = 5
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
@@ -16424,9 +16414,9 @@
 	dir = 1
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/white/checker2{
 	dir = 1
@@ -16473,9 +16463,9 @@
 /area/station/crew_quarters/stockex)
 "aKh" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 6
@@ -16506,8 +16496,8 @@
 /area/station/hallway/primary/north)
 "aKl" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/orangeblack/corner{
 	dir = 4
@@ -16545,9 +16535,9 @@
 /area/station/crew_quarters/pool)
 "aKq" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/shrub,
 /turf/simulated/floor/grass{
@@ -16556,17 +16546,17 @@
 /area/station/crew_quarters/pool)
 "aKr" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/pool)
 "aKs" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -16581,8 +16571,8 @@
 /area/station/hallway/primary/east)
 "aKt" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
@@ -16596,9 +16586,9 @@
 /area/station/teleporter)
 "aKv" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/primary/east)
@@ -16647,14 +16637,14 @@
 /area/station/maintenance/NEmaint)
 "aKD" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment/ejection{
 	dir = 2;
@@ -16676,8 +16666,8 @@
 /area/station/maintenance/NEmaint)
 "aKF" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/camera{
@@ -16692,9 +16682,9 @@
 /area/station/maintenance/NEmaint)
 "aKG" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
 	d1 = 1;
@@ -16728,8 +16718,8 @@
 	tag = ""
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
@@ -16774,8 +16764,8 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/specialroom/medbay{
 	dir = 2
@@ -16786,8 +16776,8 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/white/checker2{
 	dir = 1
@@ -16798,8 +16788,8 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/specialroom/medbay{
 	dir = 2
@@ -16812,13 +16802,13 @@
 	pixel_x = 6
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/white/checker2{
 	dir = 1
@@ -16826,8 +16816,8 @@
 /area/station/medical/head)
 "aKS" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/head)
@@ -16838,8 +16828,8 @@
 	icon_state = "plant"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 8
@@ -16856,8 +16846,8 @@
 /area/station/hallway/primary/west)
 "aKV" = (
 /obj/machinery/light/emergency{
-	icon_state = "ebulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "ebulb1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
@@ -16884,17 +16874,17 @@
 /area/station/hallway/primary/north)
 "aKZ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "aLa" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/morgue{
 	name = "crematorium pipe"
@@ -16903,9 +16893,9 @@
 /area/station/hallway/primary/north)
 "aLb" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/grille/steel,
 /obj/window/auto/reinforced,
@@ -16913,14 +16903,14 @@
 /area/station/hallway/primary/north)
 "aLc" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
@@ -16948,9 +16938,9 @@
 /area/station/crew_quarters/pool)
 "aLg" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
@@ -16962,8 +16952,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 2;
@@ -16991,9 +16981,9 @@
 "aLk" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor,
@@ -17005,8 +16995,8 @@
 /area/station/hallway/primary/east)
 "aLm" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/blue/corner{
 	dir = 4
@@ -17014,12 +17004,12 @@
 /area/station/hallway/primary/east)
 "aLn" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/machinery/light/emergency{
-	icon_state = "ebulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "ebulb1"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 1
@@ -17027,8 +17017,8 @@
 /area/station/hallway/primary/east)
 "aLo" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 1
@@ -17036,9 +17026,9 @@
 /area/station/hallway/primary/east)
 "aLp" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -17046,8 +17036,8 @@
 	rigged = 0
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 1
@@ -17055,8 +17045,8 @@
 /area/station/hallway/primary/east)
 "aLq" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/arrival/corner{
 	dir = 1
@@ -17082,25 +17072,25 @@
 /area/station/hallway/primary/east)
 "aLt" = (
 /obj/disposalpipe/segment/ejection{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/storage/tech)
 "aLu" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/grille/steel,
 /obj/disposalpipe/segment/mail,
 /obj/disposalpipe/segment/ejection{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
@@ -17110,13 +17100,13 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/grille/steel,
 /obj/disposalpipe/segment/ejection{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
@@ -17126,8 +17116,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable,
 /obj/grille/steel,
@@ -17143,8 +17133,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/grille/steel,
 /turf/simulated/floor/plating,
@@ -17155,8 +17145,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/grille/steel{
 	density = 0;
@@ -17186,22 +17176,22 @@
 /area/station/maintenance/NEmaint)
 "aLB" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "aLC" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -17209,18 +17199,18 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "aLD" = (
 /obj/grille/steel,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/window/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -17280,25 +17270,25 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
 "aLJ" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aLK" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
@@ -17309,9 +17299,9 @@
 /area/station/medical/robotics)
 "aLL" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black/side{
 	dir = 9
@@ -17319,9 +17309,9 @@
 /area/station/medical/robotics)
 "aLM" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/black/side{
 	dir = 1
@@ -17385,9 +17375,9 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light,
 /obj/storage/secure/closet/medical/chemical,
@@ -17402,9 +17392,9 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white/checker2{
 	dir = 1
@@ -17416,14 +17406,14 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
 	d1 = 1;
@@ -17436,9 +17426,9 @@
 /area/station/medical/head)
 "aLU" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass{
@@ -17452,9 +17442,9 @@
 /area/station/medical/head)
 "aLV" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 8
@@ -17478,8 +17468,8 @@
 /area/station/maintenance/inner)
 "aMa" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/plating,
@@ -17492,17 +17482,17 @@
 /area/station/maintenance/inner)
 "aMc" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/arcade)
 "aMd" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
@@ -17519,16 +17509,16 @@
 /area/station/hallway/primary/east)
 "aMg" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aMh" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
@@ -17536,8 +17526,8 @@
 "aMi" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
@@ -17546,15 +17536,15 @@
 /area/station/maintenance/NEmaint)
 "aMj" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "aMk" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -17567,16 +17557,16 @@
 	dir = 0
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "aMm" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 8;
@@ -17643,9 +17633,9 @@
 /area/station/medical/robotics)
 "aMr" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
@@ -17658,8 +17648,8 @@
 /obj/table/auto,
 /obj/item/circular_saw,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/item/circular_saw{
 	pixel_x = 3;
@@ -17690,13 +17680,13 @@
 /area/station/medical/head)
 "aMw" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 8
@@ -17783,9 +17773,9 @@
 /area/station/crew_quarters/arcade)
 "aMI" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -17794,9 +17784,9 @@
 /area/station/crew_quarters/arcade)
 "aMJ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/camera{
 	c_tag = "Inner Maintenance East Airlock";
@@ -17809,22 +17799,22 @@
 "aMK" = (
 /obj/machinery/computer/arcade,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "aML" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
@@ -17834,39 +17824,39 @@
 /area/station/hallway/primary/east)
 "aMN" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aMO" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light,
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aMP" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aMQ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 1;
@@ -17876,9 +17866,9 @@
 /area/station/hallway/primary/east)
 "aMR" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 2;
@@ -17888,9 +17878,9 @@
 /area/station/hallway/primary/east)
 "aMS" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -17901,9 +17891,9 @@
 /area/station/maintenance/NEmaint)
 "aMT" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/landmark{
 	name = "kudzustart"
@@ -17912,14 +17902,14 @@
 /area/station/maintenance/NEmaint)
 "aMU" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
@@ -17983,8 +17973,8 @@
 /area/station/medical/robotics)
 "aNe" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -18047,9 +18037,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/table/reinforced/bar/auto{
 	name = "table"
@@ -18059,19 +18049,19 @@
 /obj/item/pen,
 /obj/item/pen/fancy,
 /turf/simulated/floor/carpet{
-	icon_state = "fred1";
-	dir = 8
+	dir = 8;
+	icon_state = "fred1"
 	},
 /area/station/bridge)
 "aNk" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/black/side{
 	dir = 4
@@ -18088,8 +18078,8 @@
 /area/station/hallway/primary/west)
 "aNm" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/disposalpipe/segment/morgue{
 	name = "crematorium pipe"
@@ -18130,9 +18120,9 @@
 /area/station/crew_quarters/fitness)
 "aNs" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/east)
@@ -18146,8 +18136,8 @@
 /area/station/hallway/primary/east)
 "aNu" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/escape/corner,
@@ -18171,16 +18161,16 @@
 /area/station/security/detectives_office)
 "aNy" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/grille/steel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "aNz" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/cable{
@@ -18192,8 +18182,8 @@
 /area/station/maintenance/NEmaint)
 "aNA" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /obj/machinery/drainage,
 /obj/machinery/vending/medical,
@@ -18226,9 +18216,9 @@
 /area/station/medical/morgue)
 "aNF" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/spook,
 /turf/simulated/floor/plating,
@@ -18261,9 +18251,9 @@
 /area/station/medical/robotics)
 "aNJ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/landmark/start{
 	name = "Roboticist"
@@ -18305,9 +18295,9 @@
 /area/station/hallway/primary/west)
 "aNO" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black/side{
 	dir = 4
@@ -18369,24 +18359,24 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "aNW" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "aNX" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
@@ -18418,14 +18408,14 @@
 /area/station/crew_quarters/fitness)
 "aOb" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/computer/arcade,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
@@ -18445,8 +18435,8 @@
 "aOd" = (
 /obj/machinery/computer/secure_data/detective_computer,
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
@@ -18461,15 +18451,15 @@
 	icon_state = "plant"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aOf" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
@@ -18499,9 +18489,9 @@
 /area/station/security/detectives_office)
 "aOj" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/turret_protected/ai_upload{
@@ -18512,8 +18502,8 @@
 	pixel_x = -24
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload{
@@ -18549,8 +18539,8 @@
 /area/station/crew_quarters/fitness)
 "aOn" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/bar)
@@ -18573,16 +18563,16 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aOs" = (
 /obj/cable{
-	tag = "icon-1-4";
-	icon_state = "1-4"
+	icon_state = "1-4";
+	tag = "icon-1-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -18608,38 +18598,38 @@
 /area/station/medical/robotics)
 "aOv" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "aOw" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "aOx" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "aOy" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black/side{
 	dir = 4
@@ -18647,9 +18637,9 @@
 /area/station/medical/robotics)
 "aOz" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass{
@@ -18663,9 +18653,9 @@
 /area/station/hallway/primary/west)
 "aOA" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -18678,18 +18668,18 @@
 /area/station/hallway/primary/west)
 "aOB" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "aOC" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/morgue{
 	name = "crematorium pipe"
@@ -18698,9 +18688,9 @@
 /area/station/hallway/primary/west)
 "aOD" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/west)
@@ -18733,8 +18723,8 @@
 /area/station/crew_quarters/arcade)
 "aOI" = (
 /obj/decal/boxingrope{
-	icon_state = "ringrope";
-	dir = 9
+	dir = 9;
+	icon_state = "ringrope"
 	},
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
@@ -18748,8 +18738,8 @@
 /area/station/crew_quarters/fitness)
 "aOK" = (
 /obj/decal/boxingrope{
-	icon_state = "ringrope";
-	dir = 5
+	dir = 5;
+	icon_state = "ringrope"
 	},
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
@@ -18757,9 +18747,9 @@
 /area/station/crew_quarters/fitness)
 "aOL" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
@@ -18791,8 +18781,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 9
+	dir = 9;
+	icon_state = "fred2"
 	},
 /area/station/security/detectives_office)
 "aOQ" = (
@@ -18805,8 +18795,8 @@
 	pixel_y = -3
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 1
+	dir = 1;
+	icon_state = "fred2"
 	},
 /area/station/security/detectives_office)
 "aOR" = (
@@ -18818,20 +18808,20 @@
 	icon_state = "chair_comfy-red"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 1
+	dir = 1;
+	icon_state = "fred2"
 	},
 /area/station/security/detectives_office)
 "aOS" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 1
+	dir = 1;
+	icon_state = "fred2"
 	},
 /area/station/security/detectives_office)
 "aOT" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 5
+	dir = 5;
+	icon_state = "fred2"
 	},
 /area/station/security/detectives_office)
 "aOU" = (
@@ -18842,12 +18832,12 @@
 /area/station/security/detectives_office)
 "aOV" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/turret{
-	icon_state = "grey_target_prism";
-	dir = 6
+	dir = 6;
+	icon_state = "grey_target_prism"
 	},
 /turf/simulated/floor/bot,
 /area/station/turret_protected/ai_upload{
@@ -18858,9 +18848,9 @@
 	dir = 1
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/turret_protected/ai_upload{
@@ -18873,8 +18863,8 @@
 	})
 "aOY" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/turret_protected/ai_upload{
@@ -18882,8 +18872,8 @@
 	})
 "aOZ" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -18897,9 +18887,9 @@
 "aPb" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -18917,26 +18907,26 @@
 	name = "Roboticist"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black/side,
 /area/station/medical/robotics)
 "aPf" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/item/device/radio/intercom{
-	dir = 1;
 	broadcasting = 0;
+	dir = 1;
 	frequency = 1445;
 	name = "Medical Intercom"
 	},
@@ -18944,18 +18934,18 @@
 /area/station/medical/robotics)
 "aPg" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/black/side,
 /area/station/medical/robotics)
 "aPh" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/submachine/cargopad{
 	name = "Robotics Pad"
@@ -18964,9 +18954,9 @@
 /area/station/medical/robotics)
 "aPi" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light_switch{
 	name = "S light switch";
@@ -18995,8 +18985,8 @@
 /area/station/medical/robotics)
 "aPm" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/black/side{
 	dir = 4
@@ -19023,9 +19013,9 @@
 "aPq" = (
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
@@ -19034,8 +19024,8 @@
 /area/station/crew_quarters/fitness)
 "aPs" = (
 /obj/decal/boxingrope{
-	icon_state = "ringrope";
-	dir = 8
+	dir = 8;
+	icon_state = "ringrope"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -19053,14 +19043,14 @@
 /area/station/crew_quarters/fitness)
 "aPv" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
@@ -19068,18 +19058,18 @@
 /area/station/crew_quarters/fitness)
 "aPw" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/window/westleft,
 /turf/simulated/floor,
 /area/station/crew_quarters/fitness)
 "aPx" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/red/side{
@@ -19088,21 +19078,21 @@
 /area/station/hallway/primary/east)
 "aPy" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/security/detectives_office)
 "aPz" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/item/device/radio/intercom{
-	dir = 4;
 	broadcasting = 0;
+	dir = 4;
 	frequency = 1485;
 	name = "Station Intercom (Security)"
 	},
@@ -19110,20 +19100,20 @@
 /area/station/security/detectives_office)
 "aPA" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 10
+	dir = 10;
+	icon_state = "fred2"
 	},
 /area/station/security/detectives_office)
 "aPB" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/table/wood/auto{
 	dir = 10
@@ -19131,15 +19121,15 @@
 /obj/deskclutter,
 /obj/machinery/light/lamp/green,
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 2
+	dir = 2;
+	icon_state = "fred2"
 	},
 /area/station/security/detectives_office)
 "aPC" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/table/wood/auto,
 /obj/item/camera_test{
@@ -19148,8 +19138,8 @@
 	pictures_left = 30
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 2
+	dir = 2;
+	icon_state = "fred2"
 	},
 /area/station/security/detectives_office)
 "aPD" = (
@@ -19159,14 +19149,14 @@
 /obj/item/clothing/glasses/thermal,
 /obj/item/cigpacket,
 /turf/simulated/floor/carpet{
-	icon_state = "fred1";
-	dir = 8
+	dir = 8;
+	icon_state = "fred1"
 	},
 /area/station/security/detectives_office)
 "aPE" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 4
+	dir = 4;
+	icon_state = "fred2"
 	},
 /area/station/security/detectives_office)
 "aPF" = (
@@ -19187,19 +19177,19 @@
 	})
 "aPH" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/turret_protected/ai_upload{
@@ -19221,9 +19211,9 @@
 	})
 "aPJ" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/turret_protected/ai_upload{
@@ -19231,8 +19221,8 @@
 	})
 "aPK" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 10
+	dir = 10;
+	icon_state = "shrub"
 	},
 /turf/simulated/floor,
 /area/station/turret_protected/ai_upload{
@@ -19245,8 +19235,8 @@
 /area/station/medical/morgue)
 "aPM" = (
 /obj/morgue{
-	icon_state = "morgue1";
-	dir = 8
+	dir = 8;
+	icon_state = "morgue1"
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
@@ -19283,8 +19273,8 @@
 /area/station/medical/morgue)
 "aPQ" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/storage/closet/wardrobe/black/formalwear,
 /turf/simulated/floor/black,
@@ -19310,8 +19300,8 @@
 /obj/grille/steel,
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/window/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -19359,8 +19349,8 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage{
@@ -19388,8 +19378,8 @@
 /area/station/crew_quarters/fitness)
 "aQd" = (
 /obj/decal/boxingrope{
-	icon_state = "ringrope";
-	dir = 4
+	dir = 4;
+	icon_state = "ringrope"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -19404,8 +19394,8 @@
 "aQf" = (
 /obj/disposalpipe/segment/mail,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -19416,22 +19406,22 @@
 /area/station/security/detectives_office)
 "aQh" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aQi" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 10
+	dir = 10;
+	icon_state = "fred2"
 	},
 /area/station/security/detectives_office)
 "aQj" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 6
+	dir = 6;
+	icon_state = "fred2"
 	},
 /area/station/security/detectives_office)
 "aQk" = (
@@ -19441,8 +19431,8 @@
 	})
 "aQl" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/machinery/power/apc{
@@ -19466,8 +19456,8 @@
 "aQm" = (
 /obj/cable,
 /obj/machinery/turret{
-	icon_state = "grey_target_prism";
-	dir = 1
+	dir = 1;
+	icon_state = "grey_target_prism"
 	},
 /turf/simulated/floor/bot,
 /area/station/turret_protected/ai_upload{
@@ -19494,8 +19484,8 @@
 /area/station/medical/morgue)
 "aQq" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -19504,9 +19494,9 @@
 /area/station/crew_quarters/bar)
 "aQr" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/critter/opossum/morty,
 /turf/simulated/floor/sanitary/white,
@@ -19523,9 +19513,9 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment/morgue{
 	dir = 4
@@ -19557,14 +19547,14 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -19597,8 +19587,8 @@
 /obj/item/device/analyzer/healthanalyzer,
 /obj/item/clothing/mask/surgical_shield,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/redwhite{
 	dir = 5
@@ -19611,9 +19601,9 @@
 /area/station/medical/medbay)
 "aQB" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/blackwhite/corner{
 	dir = 1
@@ -19621,8 +19611,8 @@
 /area/station/medical/medbay)
 "aQC" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /obj/table/auto,
 /obj/item/clothing/suit/straight_jacket,
@@ -19670,9 +19660,9 @@
 	})
 "aQI" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage{
@@ -19680,13 +19670,13 @@
 	})
 "aQJ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
@@ -19722,8 +19712,8 @@
 "aQO" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 2;
@@ -19739,9 +19729,9 @@
 /area/station/security/detectives_office)
 "aQP" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -19753,9 +19743,9 @@
 /area/station/security/detectives_office)
 "aQQ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/table/wood/auto{
 	dir = 9
@@ -19764,9 +19754,9 @@
 /area/station/security/detectives_office)
 "aQR" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/table/wood/auto{
 	dir = 5
@@ -19777,9 +19767,9 @@
 /area/station/security/detectives_office)
 "aQS" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/turret_protected/ai_upload{
@@ -19802,9 +19792,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/table/auto,
 /obj/item/aiModule/oneHuman,
@@ -19840,9 +19830,9 @@
 /area/station/medical/morgue)
 "aQX" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
@@ -19932,8 +19922,8 @@
 /area/station/medical/medbay/surgery)
 "aRg" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/storage/secure/closet/fridge/blood,
 /obj/disposalpipe/segment/morgue{
@@ -19953,9 +19943,9 @@
 /area/station/medical/medbay)
 "aRi" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
@@ -20019,16 +20009,16 @@
 	name = "crematorium pipe"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "aRp" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/maintenance,
 /turf/simulated/floor/plating,
@@ -20064,17 +20054,17 @@
 "aRv" = (
 /obj/decal/cleanable/fungus,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/inner)
 "aRw" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	icon_state = "1-8"
@@ -20083,8 +20073,8 @@
 /area/station/maintenance/inner)
 "aRx" = (
 /obj/decal/boxingrope{
-	icon_state = "ringrope";
-	dir = 9
+	dir = 9;
+	icon_state = "ringrope"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -20094,16 +20084,16 @@
 /area/station/crew_quarters/fitness)
 "aRz" = (
 /obj/decal/boxingrope{
-	icon_state = "ringrope";
-	dir = 5
+	dir = 5;
+	icon_state = "ringrope"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "aRA" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/table,
 /obj/item/storage/firstaid,
@@ -20161,9 +20151,9 @@
 	})
 "aRI" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/table/auto,
 /obj/item/card/id/captains_spare,
@@ -20267,8 +20257,8 @@
 	pixel_y = 0
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/redwhite{
 	dir = 4
@@ -20276,21 +20266,21 @@
 /area/station/medical/medbay/surgery)
 "aRU" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "aRV" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/cable{
 	icon_state = "1-8"
@@ -20346,30 +20336,30 @@
 /area/station/crew_quarters/stockex)
 "aSc" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/stockex)
 "aSd" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/stockex)
 "aSe" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/stairs{
 	dir = 4
@@ -20377,27 +20367,27 @@
 /area/station/crew_quarters/stockex)
 "aSf" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/stockex)
 "aSg" = (
 /obj/table/auto,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/stockex)
 "aSh" = (
 /obj/machinery/computer/stockexchange,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/stockex)
@@ -20437,9 +20427,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area)
@@ -20455,8 +20445,8 @@
 	})
 "aSn" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage{
@@ -20486,13 +20476,13 @@
 /obj/item/clothing/under/shorts/black,
 /obj/item/clothing/under/shorts/trashsinglet,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/item/clothing/gloves/boxing,
 /obj/item/clothing/gloves/boxing,
@@ -20504,15 +20494,15 @@
 /area/station/crew_quarters/fitness)
 "aSr" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aSs" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -20536,9 +20526,9 @@
 /area/station/crew_quarters/captain)
 "aSv" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
@@ -20578,8 +20568,8 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/iv_stand,
 /obj/item/reagent_containers/iv_drip/blood,
@@ -20598,8 +20588,8 @@
 /area/station/medical/medbay/surgery)
 "aSD" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/storage/secure/closet/medical/anesthetic,
 /turf/simulated/floor/redwhite{
@@ -20611,16 +20601,16 @@
 /area/station/medical/medbay)
 "aSF" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "aSG" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /obj/storage/secure/closet/medical/medkit,
 /turf/simulated/floor/neutral,
@@ -20638,8 +20628,8 @@
 /area/station/medical/medbay)
 "aSI" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 8
@@ -20658,9 +20648,9 @@
 /area/station/crew_quarters/stockex)
 "aSK" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/stockex)
@@ -20677,8 +20667,8 @@
 /area/station/crew_quarters/stockex)
 "aSO" = (
 /obj/stool/chair/office/blue{
-	icon_state = "office_chair_blue";
-	dir = 1
+	dir = 1;
+	icon_state = "office_chair_blue"
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/stockex)
@@ -20690,16 +20680,16 @@
 /area/station/crew_quarters/stockex)
 "aSQ" = (
 /obj/machinery/computer/stockexchange{
-	icon_state = "QMreq";
-	dir = 8
+	dir = 8;
+	icon_state = "QMreq"
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/stockex)
 "aSR" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area)
@@ -20717,25 +20707,25 @@
 /area)
 "aSU" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area)
 "aSV" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage{
@@ -20744,16 +20734,16 @@
 "aSW" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage{
@@ -20784,9 +20774,9 @@
 /area/station/crew_quarters/fitness)
 "aTb" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/fitness)
@@ -20848,9 +20838,9 @@
 /area/station/crew_quarters/captain)
 "aTh" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light_switch{
 	name = "N light switch";
@@ -20860,17 +20850,17 @@
 /area/station/crew_quarters/captain)
 "aTi" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
 "aTj" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -20880,14 +20870,14 @@
 /area/station/crew_quarters/captain)
 "aTk" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
@@ -20904,8 +20894,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -20916,16 +20906,16 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/medical/medbay/surgery)
 "aTo" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/surgery_tray,
 /obj/item/circular_saw{
@@ -20937,9 +20927,9 @@
 /area/station/medical/medbay/surgery)
 "aTp" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/landmark/start{
 	name = "Medical Doctor"
@@ -20949,9 +20939,9 @@
 /area/station/medical/medbay/surgery)
 "aTq" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
@@ -20961,9 +20951,9 @@
 	req_access_txt = "5"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/redwhite{
 	dir = 4
@@ -20971,9 +20961,9 @@
 /area/station/medical/medbay/surgery)
 "aTs" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -21011,16 +21001,16 @@
 "aTy" = (
 /obj/table/auto,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/stockex)
 "aTz" = (
 /obj/table/auto,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/item/reagent_containers/food/drinks/drinkingglass/flute{
 	pixel_x = -8;
@@ -21040,8 +21030,8 @@
 /area)
 "aTB" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 10
+	dir = 10;
+	icon_state = "lattice-dir"
 	},
 /obj/machinery/emitter{
 	dir = 8
@@ -21066,13 +21056,13 @@
 /area/station/maintenance/inner)
 "aTE" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 8
+	dir = 8;
+	icon_state = "bulb1"
 	},
 /obj/cable{
 	icon_state = "1-4"
@@ -21081,35 +21071,35 @@
 /area/station/maintenance/inner)
 "aTF" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/fitness/stacklifter,
 /turf/simulated/floor/wood,
 /area/station/maintenance/inner)
 "aTG" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
 /area/station/maintenance/inner)
 "aTH" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/fitness/weightlifter,
 /turf/simulated/floor/wood,
 /area/station/maintenance/inner)
 "aTI" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
 	brightness = 2;
@@ -21119,14 +21109,14 @@
 /area/station/maintenance/inner)
 "aTJ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/inner)
@@ -21138,8 +21128,8 @@
 "aTL" = (
 /obj/disposalpipe/segment/mail,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
@@ -21154,8 +21144,8 @@
 	dir = 4
 	},
 /obj/machinery/power/monitor{
-	icon_state = "power";
-	dir = 4
+	dir = 4;
+	icon_state = "power"
 	},
 /obj/cable{
 	d2 = 4;
@@ -21169,9 +21159,9 @@
 "aTN" = (
 /obj/stool,
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/orangeblack/side{
@@ -21220,8 +21210,8 @@
 /area/station/crew_quarters/captain)
 "aTS" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 2;
@@ -21232,14 +21222,14 @@
 /area/station/crew_quarters/captain)
 "aTT" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
@@ -21249,8 +21239,8 @@
 /area/station/crew_quarters/captain)
 "aTV" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/space,
 /area)
@@ -21260,21 +21250,21 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aTX" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/junction{
-	icon_state = "pipe-j1";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-j1"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -21322,8 +21312,8 @@
 /area/station/medical/medbay/surgery)
 "aUd" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk{
@@ -21335,8 +21325,8 @@
 /area/station/medical/medbay/surgery)
 "aUe" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /obj/table/auto,
 /obj/bedsheetbin,
@@ -21350,8 +21340,8 @@
 	name = "Medical Doctor"
 	},
 /obj/item/device/radio/intercom{
-	dir = 1;
 	broadcasting = 0;
+	dir = 1;
 	frequency = 1445;
 	name = "Medical Intercom"
 	},
@@ -21363,8 +21353,8 @@
 /area/station/maintenance/inner)
 "aUh" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 10
+	dir = 10;
+	icon_state = "lattice-dir"
 	},
 /obj/item/basketball{
 	desc = "Something beautiful overwhelms you when you look at this ball.";
@@ -21458,9 +21448,9 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
@@ -21469,9 +21459,9 @@
 /area/station/maintenance/inner)
 "aUq" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/camera{
 	c_tag = "Inner Maintenance"
@@ -21496,9 +21486,9 @@
 	})
 "aUt" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/engine/eva{
@@ -21506,8 +21496,8 @@
 	})
 "aUu" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/power/apc{
 	dir = 4;
@@ -21516,8 +21506,8 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/orangeblack/side{
@@ -21528,9 +21518,9 @@
 	})
 "aUv" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/command{
 	name = "Captain's Quarters";
@@ -21545,8 +21535,8 @@
 /area/station/bridge)
 "aUx" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /turf/space,
 /area)
@@ -21586,13 +21576,13 @@
 /area/station/medical/medbay/surgery)
 "aUC" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /obj/disposalpipe/segment/morgue,
 /turf/simulated/floor{
-	icon_state = "corner_east";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_east"
 	},
 /area/station/medical/medbay/surgery)
 "aUD" = (
@@ -21603,8 +21593,8 @@
 /obj/item/clothing/mask/surgical_shield,
 /obj/item/surgical_spoon,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/redwhite,
 /area/station/medical/medbay/surgery)
@@ -21619,12 +21609,12 @@
 /obj/item/suture,
 /obj/item/hemostat,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/redwhite{
 	dir = 6
@@ -21632,9 +21622,9 @@
 /area/station/medical/medbay/surgery)
 "aUF" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -21661,8 +21651,8 @@
 /area/station/hallway/primary/west)
 "aUJ" = (
 /obj/machinery/computer/stockexchange{
-	icon_state = "QMreq";
-	dir = 4
+	dir = 4;
+	icon_state = "QMreq"
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/stockex)
@@ -21678,8 +21668,8 @@
 /area/station/crew_quarters/stockex)
 "aUM" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 8
+	dir = 8;
+	icon_state = "lattice-dir"
 	},
 /obj/machinery/emitter{
 	dir = 1
@@ -21711,8 +21701,8 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/door/firedoor/pyro,
 /turf/simulated/floor,
@@ -21739,8 +21729,8 @@
 /area/station/hallway/primary/east)
 "aUS" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/eva{
@@ -21748,8 +21738,8 @@
 	})
 "aUT" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/engine/eva{
@@ -21757,8 +21747,8 @@
 	})
 "aUU" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/cable{
 	d1 = 1;
@@ -21782,9 +21772,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/engine/eva{
@@ -21792,9 +21782,9 @@
 	})
 "aUW" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
@@ -21809,17 +21799,17 @@
 	})
 "aUX" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
 "aUY" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light_switch{
 	name = "N light switch";
@@ -21833,22 +21823,22 @@
 	pixel_x = -1
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
 "aVa" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
@@ -21875,8 +21865,8 @@
 "aVe" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/computer3frame{
 	anchored = 1;
@@ -21896,8 +21886,8 @@
 "aVg" = (
 /obj/machinery/clone_scanner,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/red/corner{
 	dir = 8
@@ -21905,8 +21895,8 @@
 /area/station/medical/medbay/cloner)
 "aVh" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer/cloning,
@@ -21915,8 +21905,8 @@
 "aVi" = (
 /obj/machinery/clonepod,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
@@ -21929,8 +21919,8 @@
 	dir = 2
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/clonegrinder,
 /turf/simulated/floor/white,
@@ -21941,8 +21931,8 @@
 /obj/item/reagent_containers/syringe,
 /obj/item/paper/Cloning,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -21962,8 +21952,8 @@
 "aVm" = (
 /obj/machinery/vending/medical,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -21978,8 +21968,8 @@
 /area/station/medical/medbay)
 "aVo" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -21989,8 +21979,8 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "red2";
-	dir = 9
+	dir = 9;
+	icon_state = "red2"
 	},
 /area/station/medical/medbay/lobby)
 "aVq" = (
@@ -22003,18 +21993,18 @@
 	text = "NF"
 	},
 /obj/stool/chair/couch/blue{
-	icon_state = "chair_couch-blue";
-	dir = 8
+	dir = 8;
+	icon_state = "chair_couch-blue"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "red2";
-	dir = 1
+	dir = 1;
+	icon_state = "red2"
 	},
 /area/station/medical/medbay/lobby)
 "aVr" = (
 /obj/stool/chair/couch/blue{
-	icon_state = "chair_couch-blue";
-	dir = 4
+	dir = 4;
+	icon_state = "chair_couch-blue"
 	},
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
@@ -22022,8 +22012,8 @@
 	name = "Medical Intercom"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "red2";
-	dir = 5
+	dir = 5;
+	icon_state = "red2"
 	},
 /area/station/medical/medbay/lobby)
 "aVs" = (
@@ -22039,43 +22029,43 @@
 /area/station/hallway/primary/west)
 "aVu" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/morgue{
 	name = "crematorium pipe"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "aVv" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
 "aVw" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
@@ -22122,8 +22112,8 @@
 /area)
 "aVG" = (
 /obj/machinery/door/airlock/pyro/external{
-	icon_state = "airlock_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "airlock_closed"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
@@ -22137,9 +22127,9 @@
 /area/station/maintenance/inner)
 "aVI" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
@@ -22185,8 +22175,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	icon_state = "12";
 	dir = 4;
+	icon_state = "12";
 	initialize_directions = 12
 	},
 /turf/simulated/floor/specialroom/freezer{
@@ -22196,45 +22186,45 @@
 /area/station/crew_quarters/kitchen)
 "aVN" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
 "aVO" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 9
+	dir = 9;
+	icon_state = "fred2"
 	},
 /area/station/bridge)
 "aVP" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 1
+	dir = 1;
+	icon_state = "fred2"
 	},
 /area/station/bridge)
 "aVQ" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 1
+	dir = 1;
+	icon_state = "fred2"
 	},
 /area/station/bridge)
 "aVR" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 5
+	dir = 5;
+	icon_state = "fred2"
 	},
 /area/station/bridge)
 "aVS" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
@@ -22263,9 +22253,9 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -22274,9 +22264,9 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
@@ -22290,9 +22280,9 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -22308,9 +22298,9 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -22318,8 +22308,8 @@
 	icon_state = "1-4"
 	},
 /obj/stool/chair/office/blue{
-	icon_state = "office_chair_blue";
-	dir = 1
+	dir = 1;
+	icon_state = "office_chair_blue"
 	},
 /obj/landmark/start{
 	name = "Medical Doctor"
@@ -22333,9 +22323,9 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -22346,25 +22336,25 @@
 /area/station/medical/medbay/cloner)
 "aWa" = (
 /obj/disposalpipe/junction{
-	icon_state = "pipe-y";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-y"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
 "aWb" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "2-4"
@@ -22373,22 +22363,22 @@
 /area/station/medical/medbay)
 "aWc" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/morgue,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "aWd" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -22398,21 +22388,21 @@
 	req_access_txt = "5"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "aWf" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -22428,25 +22418,25 @@
 /area/station/medical/medbay)
 "aWg" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /obj/submachine/chef_sink/chem_sink{
 	dir = 8;
 	pixel_x = 6
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "aWh" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay)
@@ -22456,40 +22446,40 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/stool/chair/comfy/blue{
-	icon_state = "chair_comfy-blue";
-	dir = 4
+	dir = 4;
+	icon_state = "chair_comfy-blue"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "red2";
-	dir = 10
+	dir = 10;
+	icon_state = "red2"
 	},
 /area/station/medical/medbay/lobby)
 "aWj" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "red2";
-	dir = 2
+	dir = 2;
+	icon_state = "red2"
 	},
 /area/station/medical/medbay/lobby)
 "aWk" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
 	dir = 6;
@@ -22500,17 +22490,17 @@
 /obj/grille/steel,
 /obj/window/auto/reinforced,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/lobby)
 "aWm" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 8
@@ -22545,25 +22535,25 @@
 "aWq" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
 "aWr" = (
 /obj/machinery/power/monitor,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/substation/west)
 "aWs" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/substation/west)
@@ -22592,8 +22582,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area)
@@ -22620,8 +22610,8 @@
 	icon_state = "0-2"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area)
@@ -22638,25 +22628,25 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area)
 "aWB" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/pyro,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
 "aWC" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light/emergency{
 	dir = 8;
@@ -22715,22 +22705,22 @@
 	pixel_x = -1
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
 "aWI" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fred1";
-	dir = 8
+	dir = 8;
+	icon_state = "fred1"
 	},
 /area/station/bridge)
 "aWJ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet,
 /area/station/bridge)
@@ -22739,20 +22729,20 @@
 /area/station/bridge)
 "aWL" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 5
+	dir = 5;
+	icon_state = "fred2"
 	},
 /area/station/bridge)
 "aWM" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/computer3/generic/med_data{
 	dir = 8
@@ -22765,8 +22755,8 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/redwhite{
 	dir = 10
@@ -22791,8 +22781,8 @@
 /area/station/medical/medbay/cloner)
 "aWS" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -22806,8 +22796,8 @@
 "aWU" = (
 /obj/machinery/vending/port_a_nanomed,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/specialroom/medbay{
 	dir = 2
@@ -22818,9 +22808,9 @@
 /area/station/medical/medbay)
 "aWW" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/specialroom/medbay{
 	dir = 2
@@ -22828,8 +22818,8 @@
 /area/station/medical/medbay)
 "aWX" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/table/reinforced/auto,
 /obj/item/device/analyzer/healthanalyzer,
@@ -22840,9 +22830,9 @@
 /area/station/medical/medbay)
 "aWY" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/reagent_dispensers/watertank/fountain,
 /turf/simulated/floor/bluewhite{
@@ -22859,8 +22849,8 @@
 	name = "crematorium pipe"
 	},
 /obj/machinery/light/emergency{
-	icon_state = "ebulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "ebulb1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
@@ -22873,17 +22863,17 @@
 	name = "Engineer"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/engine/substation/west)
 "aXd" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light_switch{
 	name = "E light switch";
@@ -22920,15 +22910,15 @@
 	pixel_x = -24
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
 "aXk" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 8
+	dir = 8;
+	icon_state = "fred2"
 	},
 /area/station/bridge)
 "aXl" = (
@@ -22938,16 +22928,16 @@
 	pixel_y = 1
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/table/reinforced/bar/auto{
 	name = "table"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred1";
-	dir = 8
+	dir = 8;
+	icon_state = "fred1"
 	},
 /area/station/bridge)
 "aXm" = (
@@ -22956,24 +22946,24 @@
 	name = "table"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred1";
-	dir = 8
+	dir = 8;
+	icon_state = "fred1"
 	},
 /area/station/bridge)
 "aXn" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 4
+	dir = 4;
+	icon_state = "fred2"
 	},
 /area/station/bridge)
 "aXo" = (
@@ -22983,8 +22973,8 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
@@ -23077,8 +23067,8 @@
 /area/station/medical/medbay/cloner)
 "aXw" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /obj/disposalpipe/segment/morgue{
 	dir = 4
@@ -23090,8 +23080,8 @@
 /area/station/medical/medbay)
 "aXx" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/disposalpipe/junction{
 	dir = 1;
@@ -23102,8 +23092,8 @@
 /area/station/medical/medbay)
 "aXy" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /obj/machinery/disposal/mail{
 	mail_tag = "medbay";
@@ -23116,8 +23106,8 @@
 /area/station/medical/medbay)
 "aXz" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/specialroom/medbay{
 	dir = 2
@@ -23125,13 +23115,13 @@
 /area/station/medical/medbay)
 "aXA" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/blue/checker,
 /area/station/medical/medbay)
@@ -23140,8 +23130,8 @@
 	name = "Medical Doctor"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/stool/chair/office/blue{
 	dir = 4
@@ -23156,8 +23146,8 @@
 	req_access_txt = "5"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/table/reinforced/auto,
 /obj/machinery/cashreg,
@@ -23165,13 +23155,13 @@
 /area/station/medical/medbay)
 "aXD" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 8
@@ -23179,8 +23169,8 @@
 /area/station/medical/medbay/lobby)
 "aXE" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
@@ -23198,8 +23188,8 @@
 /area/station/medical/morgue)
 "aXG" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 8
@@ -23207,19 +23197,19 @@
 /area/station/hallway/primary/west)
 "aXH" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "aXI" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/disposalpipe/segment/morgue{
 	name = "crematorium pipe"
@@ -23228,8 +23218,8 @@
 /area/station/hallway/primary/west)
 "aXJ" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/west)
@@ -23244,22 +23234,22 @@
 /area/station/maintenance/inner)
 "aXL" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/engine/substation/west)
 "aXM" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -23268,17 +23258,17 @@
 /area/station/engine/substation/west)
 "aXN" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/substation/west)
 "aXO" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area)
@@ -23290,14 +23280,14 @@
 /area)
 "aXQ" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area)
@@ -23309,14 +23299,14 @@
 /area)
 "aXS" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area)
@@ -23379,31 +23369,31 @@
 /area/station/bridge)
 "aYb" = (
 /obj/stool/chair/comfy/blue{
-	icon_state = "chair_comfy-blue";
-	dir = 4
+	dir = 4;
+	icon_state = "chair_comfy-blue"
 	},
 /obj/landmark/start{
 	name = "Medical Director"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred1";
-	dir = 8
+	dir = 8;
+	icon_state = "fred1"
 	},
 /area/station/bridge)
 "aYc" = (
 /obj/item/wrapping_paper,
 /obj/item/wirecutters,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/table/reinforced/bar/auto{
 	name = "table"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred1";
-	dir = 8
+	dir = 8;
+	icon_state = "fred1"
 	},
 /area/station/bridge)
 "aYd" = (
@@ -23413,39 +23403,39 @@
 	name = "table"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred1";
-	dir = 8
+	dir = 8;
+	icon_state = "fred1"
 	},
 /area/station/bridge)
 "aYe" = (
 /obj/stool/chair/comfy/blue{
-	icon_state = "chair_comfy-blue";
-	dir = 8
+	dir = 8;
+	icon_state = "chair_comfy-blue"
 	},
 /obj/landmark/start{
 	name = "Captain"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred1";
-	dir = 8
+	dir = 8;
+	icon_state = "fred1"
 	},
 /area/station/bridge)
 "aYf" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 4
+	dir = 4;
+	icon_state = "fred2"
 	},
 /area/station/bridge)
 "aYg" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/computer3/generic/secure_data{
 	dir = 8
@@ -23497,8 +23487,8 @@
 /area/station/medical/medbay)
 "aYm" = (
 /obj/disposalpipe/junction{
-	icon_state = "pipe-j1";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-j1"
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -23507,8 +23497,8 @@
 /area/station/medical/medbay)
 "aYn" = (
 /obj/disposalpipe/segment{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/cable{
 	d1 = 1;
@@ -23519,8 +23509,8 @@
 /area/station/medical/medbay)
 "aYo" = (
 /obj/disposalpipe/segment{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/disposalpipe/segment/morgue,
 /turf/simulated/floor/white,
@@ -23531,8 +23521,8 @@
 	req_access_txt = "5"
 	},
 /obj/disposalpipe/segment{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/specialroom/medbay{
 	dir = 2
@@ -23540,20 +23530,20 @@
 /area/station/medical/medbay)
 "aYq" = (
 /obj/disposalpipe/segment{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/blue/checker,
 /area/station/medical/medbay)
 "aYr" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/specialroom/medbay{
 	dir = 2
@@ -23580,9 +23570,9 @@
 /area/station/maintenance/SWmaint)
 "aYu" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 8
@@ -23593,8 +23583,8 @@
 /area/station/medical/medbay/lobby)
 "aYw" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/machinery/door/firedoor/pyro{
 	dir = 4
@@ -23621,9 +23611,9 @@
 /area/station/hallway/primary/west)
 "aYz" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment/mail,
 /obj/machinery/camera{
@@ -23639,34 +23629,34 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
 "aYB" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/engine/substation/west)
 "aYC" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/camera{
 	c_tag = "West Electrical Substation";
@@ -23676,9 +23666,9 @@
 /area/station/engine/substation/west)
 "aYD" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area)
@@ -23703,17 +23693,17 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area)
 "aYI" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -23724,9 +23714,9 @@
 /area)
 "aYJ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/r_wall,
 /area/station/engine/substation/east)
@@ -23736,8 +23726,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/terminal{
 	dir = 4
@@ -23761,30 +23751,30 @@
 /area/station/engine/substation/east)
 "aYM" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
 "aYN" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/east)
 "aYO" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -23811,9 +23801,9 @@
 /area/station/medical/medbay/lobby)
 "aYQ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/bridge)
@@ -23826,9 +23816,9 @@
 	opacity = 0
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/window/eastright{
 	name = "Bridge";
@@ -23840,41 +23830,41 @@
 /area/station/bridge)
 "aYS" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
 "aYT" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 8
+	dir = 8;
+	icon_state = "fred2"
 	},
 /area/station/bridge)
 "aYU" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/stool/chair/comfy/blue{
-	icon_state = "chair_comfy-blue";
-	dir = 4
+	dir = 4;
+	icon_state = "chair_comfy-blue"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred1";
-	dir = 8
+	dir = 8;
+	icon_state = "fred1"
 	},
 /area/station/bridge)
 "aYV" = (
@@ -23892,35 +23882,35 @@
 /area/station/bridge)
 "aYW" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/table/reinforced/bar/auto{
 	name = "table"
 	},
 /obj/machinery/light/lamp,
 /turf/simulated/floor/carpet{
-	icon_state = "fred1";
-	dir = 8
+	dir = 8;
+	icon_state = "fred1"
 	},
 /area/station/bridge)
 "aYX" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/stool/chair/comfy/blue{
-	icon_state = "chair_comfy-blue";
-	dir = 8
+	dir = 8;
+	icon_state = "chair_comfy-blue"
 	},
 /obj/landmark/start{
 	name = "Head of Personnel"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred1";
-	dir = 8
+	dir = 8;
+	icon_state = "fred1"
 	},
 /area/station/bridge)
 "aYY" = (
@@ -23930,13 +23920,13 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 4
+	dir = 4;
+	icon_state = "fred2"
 	},
 /area/station/bridge)
 "aYZ" = (
@@ -23953,8 +23943,8 @@
 /area/station/bridge)
 "aZa" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -23967,8 +23957,8 @@
 /area/station/medical/medbay)
 "aZc" = (
 /obj/item/device/radio/intercom{
-	dir = 1;
 	broadcasting = 0;
+	dir = 1;
 	frequency = 1445;
 	name = "Medical Intercom"
 	},
@@ -23978,8 +23968,8 @@
 /area/station/medical/medbay)
 "aZd" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /obj/storage/secure/closet/medical/medkit,
 /turf/simulated/floor/blue/checker,
@@ -24006,9 +23996,9 @@
 /area/station/medical/medbay)
 "aZg" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/specialroom/medbay{
@@ -24017,8 +24007,8 @@
 /area/station/medical/medbay)
 "aZh" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/machinery/computer3/generic/med_data{
 	dir = 8
@@ -24032,13 +24022,13 @@
 /area/station/medical/medbay)
 "aZi" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 8
@@ -24046,9 +24036,9 @@
 /area/station/medical/medbay/lobby)
 "aZj" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/plating,
@@ -24056,8 +24046,8 @@
 "aZk" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/terminal,
 /turf/simulated/floor,
@@ -24084,9 +24074,9 @@
 /area)
 "aZn" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/substation/east)
@@ -24103,9 +24093,9 @@
 /area/station/engine/substation/east)
 "aZp" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light_switch{
 	name = "E light switch";
@@ -24123,8 +24113,8 @@
 /area/station/maintenance/inner)
 "aZr" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/door_control{
 	id = "lockdown";
@@ -24136,9 +24126,9 @@
 /area/station/bridge)
 "aZs" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -24149,9 +24139,9 @@
 /area/station/bridge)
 "aZt" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/item/disk/data/floppy/read_only/communications,
 /obj/item/crowbar,
@@ -24159,8 +24149,8 @@
 	name = "table"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred1";
-	dir = 8
+	dir = 8;
+	icon_state = "fred1"
 	},
 /area/station/bridge)
 "aZu" = (
@@ -24170,9 +24160,9 @@
 	},
 /obj/item/reagent_containers/syringe,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/table/reinforced/bar/auto{
 	name = "table"
@@ -24182,58 +24172,58 @@
 	pixel_y = 9
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred1";
-	dir = 8
+	dir = 8;
+	icon_state = "fred1"
 	},
 /area/station/bridge)
 "aZv" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/stool/chair/comfy/blue{
-	icon_state = "chair_comfy-blue";
-	dir = 8
+	dir = 8;
+	icon_state = "chair_comfy-blue"
 	},
 /obj/landmark/start{
 	name = "Chief Engineer"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred1";
-	dir = 8
+	dir = 8;
+	icon_state = "fred1"
 	},
 /area/station/bridge)
 "aZw" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 4
+	dir = 4;
+	icon_state = "fred2"
 	},
 /area/station/bridge)
 "aZx" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
 "aZy" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -24300,12 +24290,12 @@
 /area/station/medical/medbay)
 "aZE" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/bluewhite/corner{
 	dir = 2
@@ -24327,12 +24317,12 @@
 /area/station/medical/medbay)
 "aZH" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/bluewhite/corner{
 	dir = 4
@@ -24344,8 +24334,8 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/bluewhite/corner{
 	dir = 2
@@ -24357,13 +24347,13 @@
 /area/station/medical/medbay)
 "aZK" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /obj/item/remote/porter/port_a_nanomed,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /obj/table/reinforced/auto,
 /turf/simulated/floor/specialroom/medbay{
@@ -24372,8 +24362,8 @@
 /area/station/medical/medbay)
 "aZL" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /obj/health_scanner/wall{
 	find_in_range = 0;
@@ -24411,8 +24401,8 @@
 /obj/item/reagent_containers/glass/bottle/antitoxin,
 /obj/item/reagent_containers/syringe,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /obj/table/reinforced/auto,
 /obj/disposalpipe/segment,
@@ -24420,12 +24410,12 @@
 /area/station/medical/medbay)
 "aZO" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /obj/item/kitchen/food_box/lollipop,
 /obj/table/reinforced/auto,
@@ -24458,8 +24448,8 @@
 /area/station/engine/substation/west)
 "aZR" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 8
+	dir = 8;
+	icon_state = "lattice-dir"
 	},
 /obj/machinery/field_generator,
 /turf/space,
@@ -24473,8 +24463,8 @@
 /area)
 "aZT" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -24489,9 +24479,9 @@
 /area/station/engine/substation/east)
 "aZU" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -24512,16 +24502,16 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
 "aZW" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 8
+	dir = 8;
+	icon_state = "bulb1"
 	},
 /obj/table/reinforced/bar/auto{
 	name = "sturdy wooden table"
@@ -24533,14 +24523,14 @@
 /obj/item/device/light/zippo,
 /obj/item/instrument/harmonica,
 /turf/simulated/floor/carpet{
-	icon_state = "fred6";
-	dir = 10
+	dir = 10;
+	icon_state = "fred6"
 	},
 /area/station/maintenance/inner)
 "aZX" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/cable{
@@ -24555,16 +24545,16 @@
 /area/station/bridge)
 "aZY" = (
 /obj/shrub{
+	dir = 1;
 	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "plant";
-	dir = 1
+	icon_state = "plant"
 	},
 /turf/simulated/floor,
 /area/station/bridge)
 "aZZ" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -24576,9 +24566,9 @@
 /area/station/bridge)
 "baa" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -24593,8 +24583,8 @@
 	name = "table"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred1";
-	dir = 8
+	dir = 8;
+	icon_state = "fred1"
 	},
 /area/station/bridge)
 "bac" = (
@@ -24603,8 +24593,8 @@
 	name = "table"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred1";
-	dir = 8
+	dir = 8;
+	icon_state = "fred1"
 	},
 /area/station/bridge)
 "bad" = (
@@ -24623,8 +24613,8 @@
 /area/station/medical/medbay)
 "baf" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -24635,8 +24625,8 @@
 /area/station/medical/medbay)
 "bag" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /obj/machinery/atmospherics/unary/cryo_cell/east,
 /turf/simulated/floor/bluewhite{
@@ -24663,8 +24653,8 @@
 /area/station/medical/medbay)
 "baj" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/machinery/atmospherics/unary/cryo_cell/west,
 /turf/simulated/floor/bluewhite{
@@ -24707,9 +24697,9 @@
 /area/station/medical/medbay/lobby)
 "ban" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 1
@@ -24740,9 +24730,9 @@
 /area/station/medical/medbay/lobby)
 "baq" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/bluewhite/corner{
 	dir = 1
@@ -24803,8 +24793,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area)
@@ -24822,8 +24812,8 @@
 /area)
 "bax" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/monitor{
 	dir = 4
@@ -24832,9 +24822,9 @@
 /area/station/engine/substation/east)
 "bay" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -24854,9 +24844,9 @@
 /area/station/bridge)
 "baB" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -24870,14 +24860,14 @@
 /area/station/bridge)
 "baC" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/machinery/door_control{
 	id = "east blast";
@@ -24889,26 +24879,26 @@
 /area/station/bridge)
 "baD" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/bridge)
 "baE" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/item/device/radio/intercom{
-	dir = 4;
 	broadcasting = 0;
+	dir = 4;
 	frequency = 1485;
 	name = "Station Intercom (Security)"
 	},
@@ -24921,21 +24911,21 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
 "baG" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 10
+	dir = 10;
+	icon_state = "fred2"
 	},
 /area/station/bridge)
 "baH" = (
@@ -24945,24 +24935,24 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 6
+	dir = 6;
+	icon_state = "fred2"
 	},
 /area/station/bridge)
 "baI" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
@@ -24976,8 +24966,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "blue2";
-	dir = 9
+	dir = 9;
+	icon_state = "blue2"
 	},
 /area/station/medical/medbay)
 "baK" = (
@@ -24991,8 +24981,8 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "blue2";
-	dir = 5
+	dir = 5;
+	icon_state = "blue2"
 	},
 /area/station/medical/medbay)
 "baL" = (
@@ -25020,8 +25010,8 @@
 /area/station/medical/medbay)
 "baO" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/table/auto,
 /obj/item/paper/cryo,
@@ -25032,8 +25022,8 @@
 /area/station/medical/medbay)
 "baP" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/table/auto,
 /obj/item/remote/porter/port_a_medbay,
@@ -25041,9 +25031,9 @@
 /area/station/medical/medbay)
 "baQ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/stairs{
 	dir = 8;
@@ -25071,9 +25061,9 @@
 /area/station/medical/medbay/lobby)
 "baU" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/table/auto,
 /obj/item/aiModule/freeform,
@@ -25087,9 +25077,9 @@
 	})
 "baV" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -25106,9 +25096,9 @@
 /area/station/engine/substation/west)
 "baX" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/engineering{
 	name = "Solar Substation"
@@ -25129,28 +25119,28 @@
 /area/station/medical/medbay)
 "bba" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
 "bbb" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 10
+	dir = 10;
+	icon_state = "fred2"
 	},
 /area/station/bridge)
 "bbc" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 2
+	dir = 2;
+	icon_state = "fred2"
 	},
 /area/station/bridge)
 "bbd" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 6
+	dir = 6;
+	icon_state = "fred2"
 	},
 /area/station/bridge)
 "bbe" = (
@@ -25177,14 +25167,14 @@
 	icon_state = "1-4"
 	},
 /obj/item/device/radio/intercom{
-	dir = 1;
 	broadcasting = 0;
+	dir = 1;
 	frequency = 1445;
 	name = "Medical Intercom"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "blue2";
-	dir = 10
+	dir = 10;
+	icon_state = "blue2"
 	},
 /area/station/medical/medbay)
 "bbh" = (
@@ -25198,8 +25188,8 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "blue2";
-	dir = 6
+	dir = 6;
+	icon_state = "blue2"
 	},
 /area/station/medical/medbay)
 "bbi" = (
@@ -25210,8 +25200,8 @@
 /area/station/medical/medbay)
 "bbj" = (
 /obj/machinery/atmospherics/pipe/manifold{
-	icon_state = "manifold";
 	dir = 4;
+	icon_state = "manifold";
 	level = 2
 	},
 /obj/landmark/start{
@@ -25221,8 +25211,8 @@
 /area/station/medical/medbay)
 "bbk" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/table/auto,
 /obj/item/reagent_containers/glass/beaker/cryoxadone,
@@ -25233,8 +25223,8 @@
 /area/station/medical/medbay)
 "bbl" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 1
+	dir = 1;
+	icon_state = "chair"
 	},
 /obj/disposalpipe/segment/morgue{
 	dir = 1;
@@ -25324,8 +25314,8 @@
 	name = "crematorium pipe"
 	},
 /obj/machinery/light/emergency{
-	icon_state = "ebulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "ebulb1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
@@ -25365,9 +25355,9 @@
 /area/station/maintenance/inner)
 "bbB" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -25376,31 +25366,31 @@
 /area/station/maintenance/inner)
 "bbC" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
 "bbD" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/pyro,
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "bbE" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/disposalpipe/segment/mail,
@@ -25410,17 +25400,17 @@
 /area/station/hallway/primary/east)
 "bbF" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/bridge)
 "bbG" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/vehicle/segway,
 /turf/simulated/floor/black,
@@ -25456,8 +25446,8 @@
 /area/station/medical/medbay)
 "bbK" = (
 /obj/machinery/atmospherics/pipe/simple{
-	icon_state = "intact";
 	dir = 9;
+	icon_state = "intact";
 	layer = 3;
 	level = 2
 	},
@@ -25467,8 +25457,8 @@
 /area/station/medical/medbay)
 "bbL" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/table/auto,
 /obj/item/device/analyzer/healthanalyzer,
@@ -25497,9 +25487,9 @@
 /area/station/hallway/primary/west)
 "bbP" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -25514,21 +25504,21 @@
 /area/station/maintenance/inner)
 "bbQ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
 "bbR" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 2;
@@ -25542,12 +25532,12 @@
 /area)
 "bbT" = (
 /obj/stool/chair/couch{
-	icon_state = "chair_couch-brown";
-	dir = 8
+	dir = 8;
+	icon_state = "chair_couch-brown"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred6";
-	dir = 9
+	dir = 9;
+	icon_state = "fred6"
 	},
 /area/station/maintenance/inner)
 "bbU" = (
@@ -25556,19 +25546,19 @@
 	},
 /obj/stool/chair/couch,
 /turf/simulated/floor/carpet{
-	icon_state = "fred6";
-	dir = 1
+	dir = 1;
+	icon_state = "fred6"
 	},
 /area/station/maintenance/inner)
 "bbV" = (
 /obj/stool/chair/couch{
-	icon_state = "chair_couch-brown";
-	dir = 4
+	dir = 4;
+	icon_state = "chair_couch-brown"
 	},
 /obj/item/cigpacket/propuffs,
 /turf/simulated/floor/carpet{
-	icon_state = "fred6";
-	dir = 5
+	dir = 5;
+	icon_state = "fred6"
 	},
 /area/station/maintenance/inner)
 "bbW" = (
@@ -25601,8 +25591,8 @@
 /area/station/hallway/primary/east)
 "bca" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/bridge)
@@ -25649,9 +25639,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
@@ -25694,44 +25684,44 @@
 "bcm" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
 "bcn" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
 "bco" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
@@ -25744,47 +25734,47 @@
 /area/station/engine/inner)
 "bcq" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 10
+	dir = 10;
+	icon_state = "shrub"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred6";
-	dir = 9
+	dir = 9;
+	icon_state = "fred6"
 	},
 /area/station/maintenance/inner)
 "bcr" = (
 /obj/critter/dog/george,
 /turf/simulated/floor/carpet{
-	icon_state = "fred4";
-	dir = 9
+	dir = 9;
+	icon_state = "fred4"
 	},
 /area/station/maintenance/inner)
 "bcs" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fred3";
-	dir = 1
+	dir = 1;
+	icon_state = "fred3"
 	},
 /area/station/maintenance/inner)
 "bct" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fred4";
-	dir = 5
+	dir = 5;
+	icon_state = "fred4"
 	},
 /area/station/maintenance/inner)
 "bcu" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 10
+	dir = 10;
+	icon_state = "shrub"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred6";
-	dir = 5
+	dir = 5;
+	icon_state = "fred6"
 	},
 /area/station/maintenance/inner)
 "bcv" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 8
+	dir = 8;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
@@ -25795,8 +25785,8 @@
 /obj/item/storage/dicepouch,
 /obj/item/reagent_containers/food/drinks/bottle/hobo_wine,
 /turf/simulated/floor/carpet{
-	icon_state = "fred6";
-	dir = 6
+	dir = 6;
+	icon_state = "fred6"
 	},
 /area/station/maintenance/inner)
 "bcx" = (
@@ -25809,8 +25799,8 @@
 "bcy" = (
 /obj/cable,
 /obj/disposalpipe/segment{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/machinery/manufacturer/personnel,
 /turf/simulated/floor/black,
@@ -25819,8 +25809,8 @@
 /obj/machinery/light,
 /obj/storage/closet/office,
 /obj/disposalpipe/segment{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
@@ -25857,9 +25847,9 @@
 /area/station/bridge)
 "bcE" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
@@ -25868,13 +25858,13 @@
 	c_tag = "Kitchen"
 	},
 /obj/shrub{
+	dir = 4;
 	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "plant";
-	dir = 4
+	icon_state = "plant"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
@@ -25896,8 +25886,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/caution/north,
 /area/station/engine/inner)
@@ -25909,8 +25899,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/caution/north,
 /area/station/engine/inner)
@@ -25922,12 +25912,12 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -25946,18 +25936,18 @@
 /area/station/engine/inner)
 "bcM" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fred6";
-	dir = 8
+	dir = 8;
+	icon_state = "fred6"
 	},
 /area/station/maintenance/inner)
 "bcN" = (
 /obj/stool/chair/comfy{
-	icon_state = "chair_comfy";
-	dir = 4
+	dir = 4;
+	icon_state = "chair_comfy"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred3";
-	dir = 8
+	dir = 8;
+	icon_state = "fred3"
 	},
 /area/station/maintenance/inner)
 "bcO" = (
@@ -25970,18 +25960,18 @@
 /area/station/maintenance/inner)
 "bcP" = (
 /obj/stool/chair/comfy{
-	icon_state = "chair_comfy";
-	dir = 8
+	dir = 8;
+	icon_state = "chair_comfy"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred3";
-	dir = 4
+	dir = 4;
+	icon_state = "fred3"
 	},
 /area/station/maintenance/inner)
 "bcQ" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fred6";
-	dir = 4
+	dir = 4;
+	icon_state = "fred6"
 	},
 /area/station/maintenance/inner)
 "bcR" = (
@@ -25996,8 +25986,8 @@
 "bcT" = (
 /obj/table/auto,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/item/storage/firstaid/regular{
 	pixel_x = -6;
@@ -26012,9 +26002,9 @@
 /area/station/bridge)
 "bcV" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/command{
 	dir = 2;
@@ -26030,31 +26020,31 @@
 /area/station/bridge)
 "bcX" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /turf/space,
 /area)
 "bcY" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 2
+	dir = 2;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area)
 "bcZ" = (
 /obj/disposalpipe/segment{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -26065,9 +26055,9 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -26077,9 +26067,9 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -26093,17 +26083,17 @@
 "bdd" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
 "bde" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 8
+	dir = 8;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor,
 /area/station/engine/inner)
@@ -26137,9 +26127,9 @@
 /area/station/engine/inner)
 "bdi" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/inner)
@@ -26163,18 +26153,18 @@
 	pixel_y = -24
 	},
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 10
+	dir = 10;
+	icon_state = "shrub"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred6";
-	dir = 10
+	dir = 10;
+	icon_state = "fred6"
 	},
 /area/station/maintenance/inner)
 "bdl" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fred4";
-	dir = 10
+	dir = 10;
+	icon_state = "fred4"
 	},
 /area/station/maintenance/inner)
 "bdm" = (
@@ -26184,15 +26174,15 @@
 	name = "peststart"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred3";
-	dir = 2
+	dir = 2;
+	icon_state = "fred3"
 	},
 /area/station/maintenance/inner)
 "bdn" = (
 /obj/critter/boogiebot,
 /turf/simulated/floor/carpet{
-	icon_state = "fred4";
-	dir = 6
+	dir = 6;
+	icon_state = "fred4"
 	},
 /area/station/maintenance/inner)
 "bdo" = (
@@ -26205,12 +26195,12 @@
 	icon_state = "bulb1"
 	},
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 10
+	dir = 10;
+	icon_state = "shrub"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred6";
-	dir = 6
+	dir = 6;
+	icon_state = "fred6"
 	},
 /area/station/maintenance/inner)
 "bdp" = (
@@ -26234,14 +26224,14 @@
 	icon_state = "bedsheet-hop"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen6";
-	dir = 9
+	dir = 9;
+	icon_state = "fgreen6"
 	},
 /area/station/crew_quarters/heads)
 "bds" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -26254,8 +26244,8 @@
 	icon_state = "camera"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen2";
-	dir = 1
+	dir = 1;
+	icon_state = "fgreen2"
 	},
 /area/station/crew_quarters/heads)
 "bdt" = (
@@ -26265,20 +26255,20 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen2";
-	dir = 1
+	dir = 1;
+	icon_state = "fgreen2"
 	},
 /area/station/crew_quarters/heads)
 "bdu" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -26289,15 +26279,15 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen2";
-	dir = 1
+	dir = 1;
+	icon_state = "fgreen2"
 	},
 /area/station/crew_quarters/heads)
 "bdv" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/genetics_booth,
 /turf/simulated/floor/bluewhite{
@@ -26306,18 +26296,18 @@
 /area/station/medical/medbay/lobby)
 "bdw" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen2";
-	dir = 1
+	dir = 1;
+	icon_state = "fgreen2"
 	},
 /area/station/crew_quarters/heads)
 "bdx" = (
@@ -26327,12 +26317,12 @@
 /area/station/crew_quarters/heads)
 "bdy" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 4
+	dir = 4;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area)
@@ -26342,9 +26332,9 @@
 /area/station/maintenance/west)
 "bdA" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -26353,8 +26343,8 @@
 /area/station/maintenance/west)
 "bdB" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -26369,18 +26359,18 @@
 /area/station/maintenance/west)
 "bdC" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/camera,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "bdD" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/space_heater,
 /obj/decal/cleanable/cobweb2,
@@ -26388,9 +26378,9 @@
 /area/station/maintenance/west)
 "bdE" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/vending/medical_public,
 /turf/simulated/floor/blue/side{
@@ -26399,9 +26389,9 @@
 /area/station/hallway/primary/west)
 "bdF" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/blue/side{
@@ -26410,9 +26400,9 @@
 /area/station/hallway/primary/west)
 "bdG" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 0
@@ -26420,9 +26410,9 @@
 /area/station/hallway/primary/west)
 "bdH" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/blue/corner{
 	dir = 8
@@ -26430,14 +26420,14 @@
 /area/station/hallway/primary/west)
 "bdI" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
@@ -26448,8 +26438,8 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor,
 /area/station/engine/inner)
@@ -26543,15 +26533,15 @@
 /obj/item/instrument/large/jukebox,
 /obj/decal/glow{
 	brightness = 3;
-	invisibility = 101;
-	name = "glow - YELLOW";
 	color_b = 0.2;
 	color_g = 0.45;
-	color_r = 0.5
+	color_r = 0.5;
+	invisibility = 101;
+	name = "glow - YELLOW"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred6";
-	dir = 2
+	dir = 2;
+	icon_state = "fred6"
 	},
 /area/station/maintenance/inner)
 "bdW" = (
@@ -26585,13 +26575,13 @@
 	},
 /obj/item/organ/liver,
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat,
 /obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat{
@@ -26628,9 +26618,9 @@
 /area/station/crew_quarters/kitchen)
 "bdX" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/red/corner{
 	dir = 2
@@ -26666,8 +26656,8 @@
 /area/station/bridge)
 "bed" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/storage/secure/closet/civilian/bartender,
 /obj/window/cubicle{
@@ -26677,24 +26667,24 @@
 /area/station/crew_quarters/bar)
 "bee" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/item/device/radio/intercom{
-	dir = 4;
 	broadcasting = 0;
+	dir = 4;
 	frequency = 1485;
 	name = "Station Intercom (Security)"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen2";
-	dir = 8
+	dir = 8;
+	icon_state = "fgreen2"
 	},
 /area/station/crew_quarters/heads)
 "bef" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen1";
-	dir = 1
+	dir = 1;
+	icon_state = "fgreen1"
 	},
 /area/station/crew_quarters/heads)
 "beg" = (
@@ -26706,22 +26696,22 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen1";
-	dir = 8
+	dir = 8;
+	icon_state = "fgreen1"
 	},
 /area/station/crew_quarters/heads)
 "beh" = (
 /obj/stool/chair,
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen1";
-	dir = 8
+	dir = 8;
+	icon_state = "fgreen1"
 	},
 /area/station/crew_quarters/heads)
 "bei" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -26729,8 +26719,8 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen1";
-	dir = 1
+	dir = 1;
+	icon_state = "fgreen1"
 	},
 /area/station/crew_quarters/heads)
 "bej" = (
@@ -26743,8 +26733,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen2";
-	dir = 4
+	dir = 4;
+	icon_state = "fgreen2"
 	},
 /area/station/crew_quarters/heads)
 "bek" = (
@@ -26760,9 +26750,9 @@
 /area/station/maintenance/west)
 "bel" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
 /obj/machinery/camera{
@@ -26777,8 +26767,8 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor,
 /area/station/engine/inner)
@@ -26803,8 +26793,8 @@
 	pixel_y = -24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/rack,
 /obj/item/tank/jetpack,
@@ -26832,13 +26822,13 @@
 /area/station/engine/inner)
 "ber" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -26856,15 +26846,15 @@
 /obj/disposalpipe/trunk,
 /obj/machinery/disposal,
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen6";
-	dir = 10
+	dir = 10;
+	icon_state = "fgreen6"
 	},
 /area/station/crew_quarters/heads)
 "bev" = (
 /obj/storage/secure/closet/command/hop,
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen2";
-	dir = 2
+	dir = 2;
+	icon_state = "fgreen2"
 	},
 /area/station/crew_quarters/heads)
 "bew" = (
@@ -26873,8 +26863,8 @@
 	},
 /obj/machinery/light/lamp,
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen2";
-	dir = 2
+	dir = 2;
+	icon_state = "fgreen2"
 	},
 /area/station/crew_quarters/heads)
 "bex" = (
@@ -26886,23 +26876,23 @@
 	dir = 8
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen6";
-	dir = 5
+	dir = 5;
+	icon_state = "fgreen6"
 	},
 /area/station/crew_quarters/heads)
 "bey" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/table/wood/auto,
 /obj/machinery/recharger{
 	pixel_y = 3
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen2";
-	dir = 2
+	dir = 2;
+	icon_state = "fgreen2"
 	},
 /area/station/crew_quarters/heads)
 "bez" = (
@@ -26912,8 +26902,8 @@
 /obj/item/coin,
 /obj/item/reagent_containers/food/drinks/rum_spaced,
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen2";
-	dir = 2
+	dir = 2;
+	icon_state = "fgreen2"
 	},
 /area/station/crew_quarters/heads)
 "beA" = (
@@ -26921,8 +26911,8 @@
 /area/station/crew_quarters/heads)
 "beB" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /turf/space,
 /area)
@@ -26943,9 +26933,9 @@
 /area/station/medical/research)
 "beG" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/inner)
@@ -26962,9 +26952,9 @@
 /area/station/engine/inner)
 "beJ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/camera{
 	c_tag = "Inner Maintenance";
@@ -26974,9 +26964,9 @@
 /area/station/maintenance/inner)
 "beK" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -27003,8 +26993,8 @@
 /obj/decal/cleanable/cobweb,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -27018,9 +27008,9 @@
 /area/station/crew_quarters/heads)
 "beS" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/heads)
@@ -27030,8 +27020,8 @@
 "beU" = (
 /obj/machinery/genetics_scanner,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/greenwhite{
 	dir = 9
@@ -27040,8 +27030,8 @@
 "beV" = (
 /obj/machinery/computer/genetics,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/greenwhite{
@@ -27076,8 +27066,8 @@
 /area/station/medical/research)
 "beZ" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -27106,8 +27096,8 @@
 	name = "monkeyspawn_normal"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /mob/living/carbon/human/monkey,
 /turf/simulated/floor/grass/random,
@@ -27123,16 +27113,16 @@
 /area/station/medical/research)
 "bff" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "bfg" = (
 /obj/reagent_dispensers/foamtank,
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 8
+	dir = 8;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
@@ -27160,17 +27150,17 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bfl" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/junction{
 	dir = 0;
@@ -27180,9 +27170,9 @@
 /area/station/maintenance/east)
 "bfm" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 8;
@@ -27192,25 +27182,25 @@
 /area/station/maintenance/east)
 "bfn" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bfo" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bfp" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -27222,8 +27212,8 @@
 /area/station/maintenance/east)
 "bfr" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/solar{
 	id = "aisolar";
@@ -27255,12 +27245,12 @@
 /area)
 "bfu" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/space,
 /area)
@@ -27281,21 +27271,21 @@
 /area/station/medical/research)
 "bfw" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/landmark/start{
 	name = "Geneticist"
 	},
 /obj/stool/chair/office/purple{
-	icon_state = "office_chair_purple";
-	dir = 1
+	dir = 1;
+	icon_state = "office_chair_purple"
 	},
 /turf/simulated/floor/white/checker2{
 	dir = 5
@@ -27311,9 +27301,9 @@
 /area/station/medical/research)
 "bfz" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/stool/chair{
 	dir = 4
@@ -27367,9 +27357,9 @@
 	c_tag = "Inner Maintenance South North"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
@@ -27385,9 +27375,9 @@
 /area/station/engine/inner)
 "bfI" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4;
@@ -27397,25 +27387,25 @@
 /area/station/maintenance/inner)
 "bfJ" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
 "bfK" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/cable{
 	d1 = 1;
@@ -27426,27 +27416,27 @@
 /area/station/maintenance/inner)
 "bfL" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
 "bfM" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/east)
 "bfN" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -27454,8 +27444,8 @@
 /area/station/hallway/primary/east)
 "bfO" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/machinery/camera{
 	c_tag = "East Maintenance Access";
@@ -27479,9 +27469,9 @@
 /area/station/maintenance/east)
 "bfR" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -27492,20 +27482,20 @@
 /area/station/maintenance/east)
 "bfS" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/external{
-	icon_state = "airlock_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "airlock_closed"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bfT" = (
 /obj/machinery/door/airlock/pyro/external{
-	icon_state = "airlock_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "airlock_closed"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -27522,9 +27512,9 @@
 /area/station/medical/research)
 "bfW" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white/checker2{
 	dir = 9
@@ -27537,9 +27527,9 @@
 /area/station/medical/research)
 "bfY" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/research)
@@ -27577,8 +27567,8 @@
 	},
 /obj/stool/bench/green/auto,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/white/checker2{
 	dir = 5
@@ -27618,8 +27608,8 @@
 /area/station/maintenance/inner)
 "bgh" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/item/sheet/glass{
 	amount = 50
@@ -27639,8 +27629,8 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/door/airlock/pyro/external{
-	icon_state = "airlock_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "airlock_closed"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
@@ -27655,9 +27645,9 @@
 /area/station/maintenance/inner)
 "bgl" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/grime,
 /area/station/engine/inner)
@@ -27711,9 +27701,9 @@
 /area/station/medical/research)
 "bgv" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white/checker2{
 	dir = 5
@@ -27771,8 +27761,8 @@
 /area/station/medical/research)
 "bgE" = (
 /obj/machinery/light/emergency{
-	icon_state = "ebulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "ebulb1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
@@ -27793,21 +27783,21 @@
 /area/station/hallway/primary/south)
 "bgJ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 8
+	dir = 8;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
 "bgK" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/caution/south{
 	dir = 2
@@ -27825,9 +27815,9 @@
 /area/station/security/hos)
 "bgO" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/hos)
@@ -27836,8 +27826,8 @@
 /area/station/security/armory)
 "bgQ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/disposal/mail{
 	mail_tag = "genetics";
@@ -27853,8 +27843,8 @@
 /area/station/medical/research)
 "bgR" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/landmark{
 	icon_state = "x3";
@@ -27869,8 +27859,8 @@
 	icon_state = "1-4"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/white/checker2{
 	dir = 9
@@ -27878,18 +27868,18 @@
 /area/station/medical/research)
 "bgT" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/table/auto,
 /obj/item/paper_bin,
@@ -27902,13 +27892,13 @@
 /area/station/medical/research)
 "bgU" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/table/auto,
 /obj/item/pen{
@@ -27918,13 +27908,13 @@
 /area/station/medical/research)
 "bgV" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/research)
@@ -27935,28 +27925,28 @@
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/research)
 "bgX" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/greenwhite{
 	dir = 4
@@ -27965,13 +27955,13 @@
 "bgY" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/grille/steel,
 /obj/window/auto/reinforced,
@@ -27979,45 +27969,45 @@
 /area/station/medical/research)
 "bgZ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/research)
 "bha" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/research)
 "bhb" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/white/checker2{
 	dir = 9
@@ -28025,13 +28015,13 @@
 /area/station/medical/research)
 "bhc" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/white/checker2{
 	dir = 5
@@ -28040,13 +28030,13 @@
 "bhd" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
@@ -28057,13 +28047,13 @@
 /area/station/medical/research)
 "bhe" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/green/side{
 	dir = 10
@@ -28071,31 +28061,31 @@
 /area/station/medical/research)
 "bhf" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/green/side,
 /area/station/medical/research)
 "bhg" = (
 /obj/machinery/door/window/eastright,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/green/side{
 	dir = 6
@@ -28103,13 +28093,13 @@
 /area/station/medical/research)
 "bhh" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/green/side{
 	dir = 8
@@ -28122,29 +28112,29 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "bhj" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "bhk" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -28181,29 +28171,29 @@
 	pixel_y = 32
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/machinery/door/window/southright,
 /turf/simulated/floor/delivery,
 /area/station/hallway/primary/south)
 "bhr" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/substation/pylon)
 "bhs" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/engineering,
 /turf/simulated/floor/delivery,
@@ -28221,8 +28211,8 @@
 	rigged = 0
 	},
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 6
+	dir = 6;
+	icon_state = "shrub"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -28241,9 +28231,9 @@
 /area/station/hallway/primary/east)
 "bhx" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -28270,8 +28260,8 @@
 "bhB" = (
 /obj/stool,
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 8
+	dir = 8;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
@@ -28294,8 +28284,8 @@
 	dir = 1
 	},
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	icon_state = "chair"
 	},
 /turf/simulated/floor/black,
 /area/station/security/hos)
@@ -28304,8 +28294,8 @@
 /area/station/security/hos)
 "bhG" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 9
+	dir = 9;
+	icon_state = "fred2"
 	},
 /area/station/security/hos)
 "bhH" = (
@@ -28315,18 +28305,18 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 1
+	dir = 1;
+	icon_state = "fred2"
 	},
 /area/station/security/hos)
 "bhI" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 1
+	dir = 1;
+	icon_state = "fred2"
 	},
 /area/station/security/hos)
 "bhJ" = (
@@ -28337,8 +28327,8 @@
 	req_access_txt = "37"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 1
+	dir = 1;
+	icon_state = "fred2"
 	},
 /area/station/security/hos)
 "bhK" = (
@@ -28346,8 +28336,8 @@
 /obj/cable,
 /obj/machinery/computer/security,
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 5
+	dir = 5;
+	icon_state = "fred2"
 	},
 /area/station/security/hos)
 "bhL" = (
@@ -28363,8 +28353,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen6";
-	dir = 6
+	dir = 6;
+	icon_state = "fgreen6"
 	},
 /area/station/crew_quarters/heads)
 "bhN" = (
@@ -28415,9 +28405,9 @@
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
@@ -28434,9 +28424,9 @@
 /area/station/engine/substation/pylon)
 "bhX" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/pyro,
 /turf/simulated/floor/caution/north,
@@ -28448,9 +28438,9 @@
 	})
 "bhZ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Engineering Hallway";
@@ -28507,26 +28497,26 @@
 /area/station/security/hos)
 "big" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 9
+	dir = 9;
+	icon_state = "fred2"
 	},
 /area/station/security/hos)
 "bih" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/table/auto,
 /obj/item/device/camera_viewer,
 /turf/simulated/floor/carpet{
-	icon_state = "fred1";
-	dir = 8
+	dir = 8;
+	icon_state = "fred1"
 	},
 /area/station/security/hos)
 "bii" = (
@@ -28536,9 +28526,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/table/auto,
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
@@ -28546,21 +28536,21 @@
 /area/station/security/hos)
 "bij" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet,
 /area/station/security/hos)
 "bik" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 4
+	dir = 4;
+	icon_state = "fred2"
 	},
 /area/station/security/hos)
 "bil" = (
@@ -28575,9 +28565,9 @@
 /area/station/security/armory)
 "bim" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
 /area/station/security/armory)
@@ -28608,8 +28598,8 @@
 /area/station/medical/research)
 "bir" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/white/checker2{
 	dir = 5
@@ -28620,9 +28610,9 @@
 /area/station/maintenance/SWmaint)
 "bit" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
@@ -28635,12 +28625,12 @@
 "biv" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 8
+	dir = 8;
+	icon_state = "bulb1"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -28653,17 +28643,17 @@
 /area/station/engine/substation/pylon)
 "biw" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/engine/substation/pylon)
 "bix" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/item/extinguisher{
 	pixel_y = 8
@@ -28705,8 +28695,8 @@
 	})
 "biB" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/computer/aiupload,
 /obj/machinery/light{
@@ -28744,9 +28734,9 @@
 /area/station/hallway/primary/east)
 "biG" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/east)
@@ -28760,9 +28750,9 @@
 /area/station/hallway/primary/east)
 "biI" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/red/side{
 	dir = 6
@@ -28798,13 +28788,13 @@
 /area/station/security/hos)
 "biO" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 10
+	dir = 10;
+	icon_state = "fred2"
 	},
 /area/station/security/hos)
 "biP" = (
@@ -28817,21 +28807,21 @@
 	name = "spaghetti arrabbiata"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 2
+	dir = 2;
+	icon_state = "fred2"
 	},
 /area/station/security/hos)
 "biQ" = (
 /obj/stool/chair/comfy{
-	icon_state = "chair_comfy";
-	dir = 8
+	dir = 8;
+	icon_state = "chair_comfy"
 	},
 /obj/landmark/start{
 	name = "Head of Security"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 2
+	dir = 2;
+	icon_state = "fred2"
 	},
 /area/station/security/hos)
 "biR" = (
@@ -28840,8 +28830,8 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 2
+	dir = 2;
+	icon_state = "fred2"
 	},
 /area/station/security/hos)
 "biS" = (
@@ -28851,8 +28841,8 @@
 	icon_state = "bedsheet-red"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 2
+	dir = 2;
+	icon_state = "fred2"
 	},
 /area/station/security/hos)
 "biT" = (
@@ -28860,14 +28850,14 @@
 	req_access_txt = "37"
 	},
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 0;
+	dir = 8;
 	frequency = 1485;
 	name = "Security Intercom"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2";
-	dir = 6
+	dir = 6;
+	icon_state = "fred2"
 	},
 /area/station/security/hos)
 "biU" = (
@@ -28910,12 +28900,12 @@
 /area/station/security/armory)
 "biW" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/storage/secure/crate/plasma/armory/anti_biological,
 /obj/item/gun/kinetic/flaregun,
@@ -28924,20 +28914,20 @@
 /area/station/security/armory)
 "biX" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /turf/space,
 /area)
 "biY" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/greenwhite{
 	dir = 8
@@ -28945,14 +28935,14 @@
 /area/station/medical/research)
 "biZ" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/landmark/start{
 	name = "Geneticist"
@@ -29001,20 +28991,20 @@
 /obj/disposalpipe/segment,
 /obj/grille/steel,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/research)
@@ -29039,8 +29029,8 @@
 /area/station/medical/research)
 "bjj" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/storage/secure/closet/medical/uniforms,
 /turf/simulated/floor/white,
@@ -29071,9 +29061,9 @@
 /area/station/crew_quarters/kitchen)
 "bjn" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/kitchen)
@@ -29098,8 +29088,8 @@
 /area/station/hallway/primary/south)
 "bjs" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -29113,17 +29103,17 @@
 /area/station/engine/substation/pylon)
 "bju" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/caution/west,
 /area/station/engine/substation/pylon)
 "bjv" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/caution/east{
 	dir = 8
@@ -29136,9 +29126,9 @@
 	})
 "bjx" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/landmark/start{
 	name = "Cyborg"
@@ -29149,9 +29139,9 @@
 	})
 "bjy" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/camera{
 	c_tag = "Inner Maintenance";
@@ -29165,8 +29155,8 @@
 /area/station/hallway/primary/south)
 "bjA" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -29181,9 +29171,9 @@
 /area/station/security/main)
 "bjD" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/main)
@@ -29197,9 +29187,9 @@
 /area/station/security/main)
 "bjG" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/glass,
 /obj/machinery/secscanner{
@@ -29255,8 +29245,8 @@
 "bjN" = (
 /obj/grille/steel,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
@@ -29267,9 +29257,9 @@
 /area/station/security/hos)
 "bjO" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/security{
 	dir = 2;
@@ -29331,9 +29321,9 @@
 /area/station/maintenance/SWmaint)
 "bjW" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold,
 /turf/simulated/floor/plating,
@@ -29344,8 +29334,8 @@
 	glass_amt = 20
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fblue2";
-	dir = 1
+	dir = 1;
+	icon_state = "fblue2"
 	},
 /area/station/crew_quarters/bar)
 "bjY" = (
@@ -29358,13 +29348,13 @@
 /area/station/crew_quarters/kitchen)
 "bjZ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/gibber,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
@@ -29376,8 +29366,8 @@
 "bka" = (
 /obj/submachine/slot_machine,
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
@@ -29386,16 +29376,16 @@
 	c_tag = "Bar"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/machinery/vending/snack,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
 "bkc" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/machinery/vending/fortune,
 /turf/simulated/floor/specialroom/bar,
@@ -29403,13 +29393,13 @@
 "bkd" = (
 /obj/machinery/vending/cola/red,
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/disposalpipe/segment/mail,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
@@ -29434,9 +29424,9 @@
 /area/station/crew_quarters/market)
 "bkh" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
@@ -29468,8 +29458,8 @@
 "bkl" = (
 /obj/grille/steel,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
@@ -29484,8 +29474,8 @@
 "bkn" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/rack,
@@ -29497,9 +29487,9 @@
 /area/station/engine/substation/pylon)
 "bko" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -29513,16 +29503,16 @@
 /area/station/engine/substation/pylon)
 "bkp" = (
 /obj/machinery/turret{
-	icon_state = "grey_target_prism";
-	dir = 1
+	dir = 1;
+	icon_state = "grey_target_prism"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/delivery,
 /area/station/turret_protected/AIbasecore1{
@@ -29530,9 +29520,9 @@
 	})
 "bkq" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/landmark/start{
 	name = "Cyborg"
@@ -29547,13 +29537,13 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/circuit/off,
 /area/station/turret_protected/AIbasecore1{
@@ -29566,8 +29556,8 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/delivery,
 /area/station/turret_protected/AIbasecore1{
@@ -29592,6 +29582,9 @@
 	dir = 4;
 	pixel_y = 0
 	},
+/obj/machinery/recharger/wall/sticky{
+	dir = 1
+	},
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
@@ -29601,9 +29594,9 @@
 	dir = 1
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 2;
@@ -29639,9 +29632,9 @@
 /area/station/security/main)
 "bkB" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/redblack{
 	dir = 1
@@ -29655,12 +29648,12 @@
 /area/station/security/main)
 "bkD" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/pipe/simple{
-	icon_state = "intact";
 	dir = 5;
+	icon_state = "intact";
 	level = 2
 	},
 /obj/machinery/computer/security/telescreen{
@@ -29673,8 +29666,8 @@
 /area/station/security/brig)
 "bkE" = (
 /obj/machinery/atmospherics/pipe/simple{
-	icon_state = "intact";
 	dir = 10;
+	icon_state = "intact";
 	layer = 3;
 	level = 2
 	},
@@ -29684,6 +29677,7 @@
 /obj/table/auto,
 /obj/item/paper_bin,
 /obj/item/paper/book/space_law,
+/obj/item/kitchen/food_box/donut_box,
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
@@ -29715,9 +29709,9 @@
 /area/station/security/brig)
 "bkK" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/security/brig)
@@ -29827,8 +29821,8 @@
 	pixel_x = 8
 	},
 /obj/window/cubicle{
-	icon_state = "cubicle";
-	dir = 2
+	dir = 2;
+	icon_state = "cubicle"
 	},
 /obj/window/cubicle{
 	dir = 4
@@ -29838,8 +29832,8 @@
 "bkY" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/southeast,
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 6
+	dir = 6;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area)
@@ -29871,8 +29865,8 @@
 /area/station/maintenance/SWmaint)
 "ble" = (
 /obj/cable{
-	tag = "icon-1-4";
-	icon_state = "1-4"
+	icon_state = "1-4";
+	tag = "icon-1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 1
@@ -29881,17 +29875,17 @@
 /area/station/maintenance/SWmaint)
 "blf" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area)
 "blg" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold,
 /turf/simulated/floor/plating,
@@ -29912,9 +29906,9 @@
 /area/station/crew_quarters/bar)
 "blk" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 4;
@@ -29936,9 +29930,9 @@
 /area/station/crew_quarters/market)
 "bln" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
@@ -29987,17 +29981,17 @@
 /obj/grille/steel,
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/window/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/market)
 "blv" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/pyro,
 /turf/simulated/floor/caution/south{
@@ -30006,9 +30000,9 @@
 /area/station/engine/substation/pylon)
 "blw" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/circuit/off,
 /area/station/turret_protected/AIbasecore1{
@@ -30036,16 +30030,16 @@
 /area/station/hallway/primary/south)
 "blz" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/south)
 "blA" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/south)
@@ -30088,9 +30082,9 @@
 /area/station/security/main)
 "blF" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
@@ -30100,8 +30094,8 @@
 /area/station/security/main)
 "blH" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/red/side{
 	dir = 6
@@ -30109,8 +30103,8 @@
 /area/station/security/main)
 "blI" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/securearea{
 	pixel_x = -32
@@ -30122,17 +30116,17 @@
 /area/station/security/main)
 "blJ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
 /area/station/security/main)
 "blK" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area)
@@ -30144,15 +30138,15 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "blM" = (
 /obj/machinery/atmospherics/pipe/simple{
-	icon_state = "intact";
 	dir = 1;
+	icon_state = "intact";
 	level = 2
 	},
 /turf/simulated/floor,
@@ -30177,9 +30171,9 @@
 /area/station/security/brig)
 "blQ" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment/ejection{
 	dir = 4;
@@ -30189,9 +30183,9 @@
 /area/station/security/brig)
 "blR" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -30210,14 +30204,14 @@
 /area/station/security/brig)
 "blS" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -30231,9 +30225,9 @@
 /area/station/security/brig)
 "blT" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/ejection{
 	dir = 4
@@ -30242,9 +30236,9 @@
 /area/station/security/brig)
 "blU" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/junction{
 	dir = 8;
@@ -30255,14 +30249,14 @@
 /area/station/security/brig)
 "blV" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/ejection{
 	dir = 4
@@ -30309,9 +30303,9 @@
 /area/station/maintenance/SWmaint)
 "bmb" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/insulated/cold/horizontal,
@@ -30324,18 +30318,18 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
 "bmd" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/junction/east,
 /turf/simulated/wall/auto/supernorn,
@@ -30349,14 +30343,14 @@
 /area)
 "bmf" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	icon_state = "12";
 	dir = 4;
+	icon_state = "12";
 	initialize_directions = 12
 	},
 /turf/simulated/floor/specialroom/freezer{
@@ -30368,32 +30362,32 @@
 /obj/machinery/chem_dispenser,
 /obj/item/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/carpet{
-	icon_state = "fblue2";
-	dir = 1
+	dir = 1;
+	icon_state = "fblue2"
 	},
 /area/station/crew_quarters/bar)
 "bmh" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fblue2";
-	dir = 1
+	dir = 1;
+	icon_state = "fblue2"
 	},
 /area/station/crew_quarters/bar)
 "bmi" = (
 /turf/simulated/floor/carpet{
-	icon_state = "blue1";
-	dir = 2
+	dir = 2;
+	icon_state = "blue1"
 	},
 /area/station/crew_quarters/bar)
 "bmj" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/item/device/radio/intercom{
 	dir = 8;
@@ -30421,8 +30415,8 @@
 /obj/stool,
 /obj/machinery/bot/guardbot,
 /turf/simulated/floor/carpet{
-	icon_state = "fblue2";
-	dir = 5
+	dir = 5;
+	icon_state = "fblue2"
 	},
 /area/station/crew_quarters/bar)
 "bmm" = (
@@ -30441,8 +30435,8 @@
 "bmn" = (
 /obj/rack,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
@@ -30453,8 +30447,8 @@
 "bmp" = (
 /obj/rack,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
@@ -30478,21 +30472,17 @@
 /area/station/security/main)
 "bmt" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/main)
 "bmu" = (
-/obj/table/auto,
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
-/obj/machinery/recharger{
-	pixel_y = 3
-	},
-/obj/item/kitchen/food_box/donut_box,
+/obj/submachine/weapon_vendor/security,
 /turf/simulated/floor/red/side{
 	dir = 8
 	},
@@ -30536,9 +30526,9 @@
 /area/station/security/main)
 "bmA" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/brig{
 	dir = 4;
@@ -30550,13 +30540,13 @@
 /area/station/security/main)
 "bmB" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/brig{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/machinery/door/airlock/pyro/security{
 	dir = 4;
@@ -30568,9 +30558,9 @@
 /area/station/security/main)
 "bmC" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -30578,20 +30568,20 @@
 	icon_state = "1-8"
 	},
 /obj/disposalpipe/segment/brig{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor,
 /area/station/security/brig)
 "bmD" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple{
-	icon_state = "intact";
 	dir = 1;
+	icon_state = "intact";
 	level = 2
 	},
 /obj/disposalpipe/junction{
@@ -30602,34 +30592,34 @@
 /area/station/security/brig)
 "bmE" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/ejection,
 /obj/disposalpipe/segment/brig{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor,
 /area/station/security/brig)
 "bmF" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/brig{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor,
 /area/station/security/brig)
 "bmG" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/brig{
 	dir = 2;
@@ -30640,9 +30630,9 @@
 "bmH" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/security/brig)
@@ -30696,8 +30686,8 @@
 "bmN" = (
 /obj/grille/steel,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable,
 /obj/window/auto/crystal/reinforced,
@@ -30710,8 +30700,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/window/auto/crystal/reinforced,
 /turf/simulated/floor/plating,
@@ -30719,9 +30709,9 @@
 "bmP" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/vertical,
 /obj/lattice{
-	tag = "icon-lattice-dir (SOUTHEAST)";
+	dir = 6;
 	icon_state = "lattice-dir";
-	dir = 6
+	tag = "icon-lattice-dir (SOUTHEAST)"
 	},
 /turf/space,
 /area)
@@ -30743,8 +30733,8 @@
 "bmT" = (
 /obj/stool,
 /turf/simulated/floor/carpet{
-	icon_state = "fblue2";
-	dir = 4
+	dir = 4;
+	icon_state = "fblue2"
 	},
 /area/station/crew_quarters/bar)
 "bmU" = (
@@ -30755,9 +30745,9 @@
 /area/station/crew_quarters/bar)
 "bmV" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/command,
 /turf/simulated/floor/grey/side,
@@ -30778,17 +30768,17 @@
 /area/station/crew_quarters/market)
 "bmY" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/engineering)
 "bmZ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/caution/north,
 /area/station/engine/engineering)
@@ -30808,9 +30798,9 @@
 	})
 "bnc" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -30821,17 +30811,17 @@
 /area/station/maintenance/inner)
 "bnd" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/south)
 "bne" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light/emergency{
 	dir = 8;
@@ -30841,9 +30831,9 @@
 /area/station/hallway/primary/south)
 "bnf" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -30876,8 +30866,8 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/red/side{
 	dir = 1
@@ -30906,15 +30896,15 @@
 "bnm" = (
 /obj/storage/secure/closet/security/equipment,
 /obj/disposalpipe/segment/brig{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/bot,
 /area/station/security/main)
 "bnn" = (
 /obj/disposalpipe/segment/brig{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/main)
@@ -30930,8 +30920,8 @@
 /area/station/security/main)
 "bnp" = (
 /obj/disposalpipe/segment/brig{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/black,
 /area/station/security/main)
@@ -30953,8 +30943,8 @@
 /area/station/security/brig)
 "bnt" = (
 /obj/machinery/atmospherics/pipe/simple{
-	icon_state = "intact";
 	dir = 1;
+	icon_state = "intact";
 	level = 2
 	},
 /obj/machinery/disposal/brig,
@@ -30973,20 +30963,20 @@
 "bnv" = (
 /obj/disposalpipe/segment,
 /obj/disposalpipe/segment/brig{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor,
 /area/station/security/brig)
 "bnw" = (
 /obj/disposalpipe/segment/ejection,
 /obj/disposalpipe/segment/brig{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 0;
+	dir = 8;
 	frequency = 1485;
 	name = "Security Intercom"
 	},
@@ -30994,23 +30984,23 @@
 /area/station/security/brig)
 "bnx" = (
 /obj/disposalpipe/segment/brig{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/brig)
 "bny" = (
 /obj/storage/secure/closet/brig/automatic/genpop,
 /obj/disposalpipe/segment/brig{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bnz" = (
 /obj/disposalpipe/segment/brig{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
@@ -31059,8 +31049,8 @@
 "bnG" = (
 /obj/table/reinforced/bar/auto,
 /turf/simulated/floor/carpet{
-	icon_state = "blue1";
-	dir = 2
+	dir = 2;
+	icon_state = "blue1"
 	},
 /area/station/crew_quarters/bar)
 "bnH" = (
@@ -31068,8 +31058,8 @@
 /obj/machinery/chem_dispenser/alcohol,
 /obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
 /turf/simulated/floor/carpet{
-	icon_state = "blue1";
-	dir = 2
+	dir = 2;
+	icon_state = "blue1"
 	},
 /area/station/crew_quarters/bar)
 "bnI" = (
@@ -31083,9 +31073,9 @@
 "bnJ" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/horizontal,
 /obj/lattice{
-	tag = "icon-lattice-dir (SOUTHWEST)";
+	dir = 10;
 	icon_state = "lattice-dir";
-	dir = 10
+	tag = "icon-lattice-dir (SOUTHWEST)"
 	},
 /turf/space,
 /area)
@@ -31110,8 +31100,8 @@
 /obj/table/reinforced/bar/auto,
 /obj/machinery/cashreg,
 /turf/simulated/floor/carpet{
-	icon_state = "blue1";
-	dir = 2
+	dir = 2;
+	icon_state = "blue1"
 	},
 /area/station/crew_quarters/bar)
 "bnO" = (
@@ -31121,8 +31111,8 @@
 	},
 /obj/stool,
 /turf/simulated/floor/carpet{
-	icon_state = "fblue2";
-	dir = 4
+	dir = 4;
+	icon_state = "fblue2"
 	},
 /area/station/crew_quarters/bar)
 "bnP" = (
@@ -31131,9 +31121,9 @@
 /area/station/crew_quarters/market)
 "bnQ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/table/reinforced/auto,
 /obj/machinery/cashreg,
@@ -31186,9 +31176,9 @@
 /area/station/crew_quarters/kitchen)
 "bnS" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/table/reinforced/auto,
 /obj/machinery/cashreg,
@@ -31196,9 +31186,9 @@
 /area/station/crew_quarters/market)
 "bnT" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/table/reinforced/auto,
 /turf/simulated/floor,
@@ -31210,8 +31200,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/window/auto/reinforced,
@@ -31219,16 +31209,16 @@
 /area/station/crew_quarters/market)
 "bnV" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 10
+	dir = 10;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area/station/crew_quarters/market)
 "bnW" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
 	brightness = 2;
@@ -31239,9 +31229,9 @@
 "bnX" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/command{
 	name = "AI Upload";
@@ -31253,16 +31243,16 @@
 	})
 "bnY" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bnZ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -31284,9 +31274,9 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/machinery/door/firedoor/pyro{
 	dir = 4
@@ -31295,23 +31285,23 @@
 /area/station/security/main)
 "bob" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/stool/chair/office/red{
-	tag = "icon-office_chair_red (WEST)";
+	dir = 8;
 	icon_state = "office_chair_red";
-	dir = 8
+	tag = "icon-office_chair_red (WEST)"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/red/side{
 	dir = 8
@@ -31319,22 +31309,22 @@
 /area/station/security/main)
 "boc" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
 "bod" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -31349,9 +31339,9 @@
 /area/station/security/main)
 "boe" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -31424,8 +31414,8 @@
 /area/station/security/brig)
 "bom" = (
 /obj/machinery/atmospherics/pipe/simple{
-	icon_state = "intact";
 	dir = 1;
+	icon_state = "intact";
 	level = 2
 	},
 /obj/disposalpipe/segment/ejection{
@@ -31534,9 +31524,9 @@
 /area/station/crew_quarters/market)
 "boB" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
@@ -31547,16 +31537,16 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/light/emergency{
-	icon_state = "ebulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "ebulb1"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "boD" = (
 /obj/grille/steel,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/window/auto/reinforced,
@@ -31567,18 +31557,18 @@
 /area/station/crew_quarters/market)
 "boF" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/decal/cleanable/fungus,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/engineering)
 "boG" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/grime,
 /area/station/engine/engineering)
@@ -31610,9 +31600,9 @@
 	})
 "boJ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -31624,9 +31614,9 @@
 	})
 "boK" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/turret_protected/AIbasecore1{
@@ -31634,9 +31624,9 @@
 	})
 "boL" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
@@ -31659,14 +31649,14 @@
 /area/station/security/main)
 "boO" = (
 /obj/stool/chair/office/red{
-	tag = "icon-office_chair_red (EAST)";
+	dir = 4;
 	icon_state = "office_chair_red";
-	dir = 4
+	tag = "icon-office_chair_red (EAST)"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/red/side,
 /area/station/security/main)
@@ -31687,15 +31677,15 @@
 /area/station/security/main)
 "boR" = (
 /obj/disposalpipe/segment/brig{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/red/side,
 /area/station/security/main)
 "boS" = (
 /obj/disposalpipe/segment/brig{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
@@ -31724,8 +31714,8 @@
 /area/station/security/main)
 "boU" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/machinery/door/window{
 	dir = 4;
@@ -31736,8 +31726,8 @@
 	pixel_x = -31
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/delivery,
 /area/station/security/main)
@@ -31761,8 +31751,8 @@
 /area/station/security/brig)
 "boY" = (
 /obj/machinery/atmospherics/pipe/simple{
-	icon_state = "intact";
 	dir = 1;
+	icon_state = "intact";
 	level = 2
 	},
 /turf/simulated/floor/caution/west,
@@ -31784,9 +31774,9 @@
 /area/station/security/brig)
 "bpc" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/table/auto,
 /obj/item/kitchen/rollingpin,
@@ -31813,23 +31803,23 @@
 	pixel_x = -27
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "blue1";
-	dir = 2
+	dir = 2;
+	icon_state = "blue1"
 	},
 /area/station/crew_quarters/bar)
 "bpe" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/table,
 /obj/item/reagent_containers/food/snacks/breadloaf,
 /obj/item/reagent_containers/food/snacks/breadloaf,
 /obj/item/reagent_containers/food/snacks/breadloaf,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/item/kitchen/utensil/knife/bread,
 /turf/unsimulated/floor/specialroom/cafeteria,
@@ -31840,8 +31830,8 @@
 	name = "Barman"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "blue1";
-	dir = 2
+	dir = 2;
+	icon_state = "blue1"
 	},
 /area/station/crew_quarters/bar)
 "bpg" = (
@@ -31855,24 +31845,24 @@
 "bph" = (
 /obj/machinery/chem_dispenser/soda,
 /turf/simulated/floor/carpet{
-	icon_state = "blue1";
-	dir = 2
+	dir = 2;
+	icon_state = "blue1"
 	},
 /area/station/crew_quarters/bar)
 "bpi" = (
 /obj/table/reinforced/bar/auto,
 /obj/random_item_spawner/tableware/five,
 /turf/simulated/floor/carpet{
-	icon_state = "blue1";
-	dir = 2
+	dir = 2;
+	icon_state = "blue1"
 	},
 /area/station/crew_quarters/bar)
 "bpj" = (
 /obj/stool,
 /obj/machinery/bot/guardbot/old/tourguide,
 /turf/simulated/floor/carpet{
-	icon_state = "fblue2";
-	dir = 4
+	dir = 4;
+	icon_state = "fblue2"
 	},
 /area/station/crew_quarters/bar)
 "bpk" = (
@@ -31888,8 +31878,8 @@
 /area/station/crew_quarters/bar)
 "bpm" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/stool,
 /turf/simulated/floor/specialroom/bar,
@@ -31905,12 +31895,12 @@
 /area/station/crew_quarters/market)
 "bpp" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /obj/machinery/door/window/northright,
 /obj/submachine/ATM{
@@ -31920,12 +31910,12 @@
 /area/station/crew_quarters/market)
 "bpq" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/machinery/door/window/northleft,
 /obj/submachine/ATM{
@@ -31935,8 +31925,8 @@
 /area/station/crew_quarters/market)
 "bpr" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 1
+	dir = 1;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/station/crew_quarters/market)
@@ -31947,9 +31937,9 @@
 	})
 "bpt" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
@@ -31957,8 +31947,8 @@
 "bpu" = (
 /obj/disposalpipe/segment/mail,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -31968,8 +31958,8 @@
 /obj/grille/steel,
 /obj/window/auto/reinforced,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/red,
 /area/station/security/main)
@@ -32016,8 +32006,8 @@
 /area/station/security/brig)
 "bpC" = (
 /obj/machinery/atmospherics/pipe/simple{
-	icon_state = "intact";
 	dir = 1;
+	icon_state = "intact";
 	level = 2
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -32059,8 +32049,8 @@
 /area/station/security/brig)
 "bpH" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 6
+	dir = 6;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area/station/turret_protected/ai_upload_foyer)
@@ -32069,15 +32059,15 @@
 /area/station/turret_protected/ai_upload_foyer)
 "bpJ" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 10
+	dir = 10;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area/station/turret_protected/ai_upload_foyer)
 "bpK" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 1;
@@ -32087,15 +32077,15 @@
 /area/station/crew_quarters/kitchen)
 "bpL" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/unsimulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "bpM" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/landmark/start{
 	name = "Chef"
@@ -32111,21 +32101,21 @@
 /area/station/crew_quarters/kitchen)
 "bpO" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/bar)
 "bpP" = (
 /obj/grille/catwalk{
-	icon_state = "catwalk";
-	dir = 10
+	dir = 10;
+	icon_state = "catwalk"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
 	icon_state = "2-4"
@@ -32146,8 +32136,8 @@
 /obj/stool,
 /obj/machinery/bot/guardbot/gunner,
 /turf/simulated/floor/carpet{
-	icon_state = "fblue2";
-	dir = 4
+	dir = 4;
+	icon_state = "fblue2"
 	},
 /area/station/crew_quarters/bar)
 "bpS" = (
@@ -32163,13 +32153,13 @@
 /area/station/crew_quarters/courtroom)
 "bpT" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fblue2";
-	dir = 2
+	dir = 2;
+	icon_state = "fblue2"
 	},
 /area/station/crew_quarters/bar)
 "bpU" = (
@@ -32178,7 +32168,7 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
 "bpV" = (
-/obj/machinery/weapon_stand/taser_rack/recharger,
+/obj/machinery/weapon_stand/taser_rack/recharger/empty,
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
@@ -32198,9 +32188,9 @@
 /area/station/engine/storage)
 "bpZ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering Pylon South";
@@ -32225,17 +32215,17 @@
 /area/station/hallway/primary/south)
 "bqc" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/south)
 "bqd" = (
 /obj/grille/steel,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -32246,34 +32236,34 @@
 /area/station/crew_quarters/courtroom)
 "bqe" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
 "bqf" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
 "bqg" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
 "bqh" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
 	pixel_y = 24;
@@ -32284,22 +32274,22 @@
 /area/station/crew_quarters/courtroom)
 "bqi" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
 "bqj" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/storage/crate/bin/lostandfound,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
@@ -32307,21 +32297,21 @@
 /obj/grille/steel,
 /obj/window/auto/reinforced,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/courtroom)
 "bql" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/item/hand_labeler,
 /obj/table/reinforced/bar/auto{
@@ -32339,8 +32329,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer/card,
@@ -32353,9 +32343,9 @@
 /area/station/crew_quarters/courtroom)
 "bqn" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/computer/security,
 /turf/simulated/floor/wood{
@@ -32369,9 +32359,9 @@
 /obj/vehicle/segway,
 /obj/disposalpipe/segment/ejection,
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
@@ -32458,9 +32448,9 @@
 /area/station/crew_quarters/kitchen)
 "bqA" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/table,
 /obj/item/shaker/ketchup{
@@ -32491,19 +32481,19 @@
 /area/station/crew_quarters/kitchen)
 "bqB" = (
 /obj/machinery/chem_master{
-	icon_state = "mixer0";
-	dir = 4
+	dir = 4;
+	icon_state = "mixer0"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "blue1";
-	dir = 2
+	dir = 2;
+	icon_state = "blue1"
 	},
 /area/station/crew_quarters/bar)
 "bqC" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/horizontal,
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 10
+	dir = 10;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area)
@@ -32520,8 +32510,8 @@
 /area)
 "bqF" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -32623,9 +32613,9 @@
 /area/station/engine/storage)
 "bqR" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
 	brightness = 2;
@@ -32636,12 +32626,12 @@
 /area/station/engine/engineering)
 "bqS" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 10
+	dir = 10;
+	icon_state = "shrub"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 1
@@ -32654,8 +32644,8 @@
 /area/station/hallway/primary/south)
 "bqU" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 1
+	dir = 1;
+	icon_state = "shrub"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 1
@@ -32669,8 +32659,8 @@
 "bqW" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -32682,8 +32672,8 @@
 "bqX" = (
 /obj/disposalpipe/segment/mail,
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 8
+	dir = 8;
+	icon_state = "shrub"
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -32694,8 +32684,8 @@
 /area/station/crew_quarters/courtroom)
 "bqZ" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/machinery/power/apc{
@@ -32708,9 +32698,9 @@
 /area/station/crew_quarters/courtroom)
 "bra" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
@@ -32747,9 +32737,9 @@
 /area/station/crew_quarters/courtroom)
 "brg" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/unsimulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
@@ -32761,14 +32751,14 @@
 "bri" = (
 /obj/disposalpipe/segment/ejection,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
@@ -32791,16 +32781,16 @@
 /area/station/maintenance/east)
 "brl" = (
 /obj/machinery/atmospherics/pipe/simple{
-	icon_state = "intact";
 	dir = 5;
+	icon_state = "intact";
 	level = 2
 	},
 /turf/simulated/floor,
 /area/station/maintenance/east)
 "brm" = (
 /obj/machinery/atmospherics/portables_connector{
-	icon_state = "intact";
-	dir = 8
+	dir = 8;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -32835,15 +32825,15 @@
 /area/station/turret_protected/ai_upload_foyer)
 "brt" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 8
+	dir = 8;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/station/turret_protected/ai_upload_foyer)
 "bru" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 4
+	dir = 4;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/station/turret_protected/ai_upload_foyer)
@@ -32857,25 +32847,25 @@
 /area/station/maintenance/east)
 "brx" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/market)
 "bry" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/storage/secure/crate/weapon/armory/tranquilizer,
 /turf/simulated/floor/caution/west,
 /area/station/security/armory)
 "brz" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/table,
 /obj/machinery/microwave,
@@ -32883,8 +32873,8 @@
 /area/station/crew_quarters/kitchen)
 "brA" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 8
+	dir = 8;
+	icon_state = "lattice-dir"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -32911,9 +32901,9 @@
 /area/station/crew_quarters/kitchen)
 "brD" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/table/auto,
 /obj/item/reagent_containers/food/drinks/juicer{
@@ -32950,24 +32940,24 @@
 /area/station/crew_quarters/kitchen)
 "brF" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/vending/alcohol,
 /turf/simulated/floor/carpet{
-	icon_state = "fblue2";
-	dir = 2
+	dir = 2;
+	icon_state = "fblue2"
 	},
 /area/station/crew_quarters/bar)
 "brG" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fblue2";
-	dir = 6
+	dir = 6;
+	icon_state = "fblue2"
 	},
 /area/station/crew_quarters/bar)
 "brH" = (
@@ -32981,17 +32971,17 @@
 "brI" = (
 /obj/grille/catwalk,
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
 	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
@@ -33017,8 +33007,8 @@
 	},
 /obj/machinery/disposal,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
@@ -33035,8 +33025,8 @@
 "brO" = (
 /obj/grille/steel,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/window/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -33062,8 +33052,8 @@
 	amount = 50
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/item/sheet/steel/reinforced,
 /turf/simulated/floor,
@@ -33084,23 +33074,23 @@
 /area/station/engine/storage)
 "brR" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/engineering,
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "brS" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/grime,
 /area/station/engine/engineering)
@@ -33134,9 +33124,9 @@
 /area/station/hallway/primary/south)
 "brY" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -33159,9 +33149,9 @@
 "bsb" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -33169,9 +33159,9 @@
 /area/station/hallway/primary/south)
 "bsc" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
@@ -33186,14 +33176,14 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
@@ -33230,9 +33220,9 @@
 /area/station/crew_quarters/courtroom)
 "bsi" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/ejection,
 /turf/simulated/floor/wood{
@@ -33274,43 +33264,43 @@
 "bsq" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/window{
-	icon_state = "window";
-	dir = 1
+	dir = 1;
+	icon_state = "window"
 	},
 /turf/simulated/floor/red/side,
 /area/station/maintenance/east)
 "bsr" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 9
+	dir = 9;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area/station/turret_protected/ai_upload_foyer)
 "bss" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 10
+	dir = 10;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/station/turret_protected/ai_upload_foyer)
 "bst" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 5
+	dir = 5;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area/station/turret_protected/ai_upload_foyer)
 "bsu" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 6
+	dir = 6;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/station/turret_protected/ai_upload_foyer)
 "bsv" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 1
+	dir = 1;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/station/turret_protected/ai_upload_foyer)
@@ -33355,8 +33345,8 @@
 "bsC" = (
 /obj/disposalpipe/segment/mail,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/green/side,
 /area/station/hallway/primary/south)
@@ -33376,8 +33366,8 @@
 "bsG" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
@@ -33397,17 +33387,17 @@
 /area/station/engine/storage)
 "bsI" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/engine/storage)
 "bsJ" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/storage)
@@ -33424,9 +33414,9 @@
 /area/station/engine/storage)
 "bsM" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/caution/south{
 	dir = 2
@@ -33442,8 +33432,8 @@
 /area/station/storage/autolathe)
 "bsP" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/vending/pda,
 /turf/simulated/floor,
@@ -33481,9 +33471,9 @@
 /area/station/hallway/primary/south)
 "bsX" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purple/side,
 /area/station/hallway/primary/south)
@@ -33495,8 +33485,8 @@
 /area/station/hallway/primary/south)
 "bsZ" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/grille/steel,
 /obj/window/auto/reinforced,
@@ -33504,9 +33494,9 @@
 /area/station/crew_quarters/courtroom)
 "bta" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -33517,12 +33507,12 @@
 /area/station/crew_quarters/courtroom)
 "btb" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/stool/chair{
 	dir = 4
@@ -33531,8 +33521,8 @@
 /area/station/crew_quarters/courtroom)
 "btc" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/machinery/light/small,
 /obj/machinery/door/window/eastleft{
@@ -33552,9 +33542,9 @@
 /area/station/crew_quarters/courtroom)
 "bte" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
@@ -33579,9 +33569,9 @@
 /area/station/crew_quarters/courtroom)
 "btg" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/manufacturer/personnel,
 /turf/simulated/floor/wood{
@@ -33621,9 +33611,9 @@
 /area/station/turret_protected/ai_upload_foyer)
 "btm" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/grille/steel,
 /turf/simulated/floor/plating/airless,
@@ -33645,9 +33635,9 @@
 /area/station/crew_quarters/bar)
 "btp" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
@@ -33716,8 +33706,8 @@
 /area/station/hydroponics)
 "btA" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/machinery/door/window/southleft{
 	name = "Hydroponics Delivery";
@@ -33732,8 +33722,8 @@
 /area/station/hydroponics)
 "btC" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/green/side{
 	dir = 8
@@ -33743,17 +33733,17 @@
 /obj/grille/steel,
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/window/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/engine/storage)
 "btE" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/engine/storage)
@@ -33767,9 +33757,9 @@
 /area/station/engine/storage)
 "btG" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/storage)
@@ -33817,17 +33807,17 @@
 /area/station/storage/autolathe)
 "btM" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/storage/autolathe)
 "btN" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -33838,9 +33828,9 @@
 /area/station/storage/autolathe)
 "btO" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/storage/autolathe)
@@ -33862,8 +33852,8 @@
 /area/station/storage/autolathe)
 "btQ" = (
 /obj/machinery/light/emergency{
-	icon_state = "ebulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "ebulb1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -33873,9 +33863,9 @@
 /area/station/hallway/primary/south)
 "btS" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro{
 	name = "Custodial Closet";
@@ -33894,9 +33884,9 @@
 /area/station/crew_quarters/juryroom)
 "btV" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -33944,9 +33934,9 @@
 	})
 "bua" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/storage{
@@ -34027,9 +34017,9 @@
 /area/station/turret_protected/ai_upload_foyer)
 "bum" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/r_wall,
 /area/station/turret_protected/ai_upload_foyer)
@@ -34099,8 +34089,8 @@
 	pixel_y = 0
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /obj/machinery/plantpot{
 	anchored = 1
@@ -34111,9 +34101,9 @@
 /area/station/hydroponics)
 "buv" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
@@ -34122,9 +34112,9 @@
 "buw" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/plantpot{
 	anchored = 1
@@ -34139,9 +34129,9 @@
 	dir = 2
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
@@ -34149,9 +34139,9 @@
 /area/station/hydroponics)
 "buy" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/plantpot{
 	anchored = 1
@@ -34307,34 +34297,34 @@
 "buM" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "buN" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/engineering)
 "buO" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk,
@@ -34347,9 +34337,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/bot/firebot,
 /turf/simulated/floor,
@@ -34390,9 +34380,9 @@
 /area/station/janitor)
 "buW" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white/checker{
 	dir = 4
@@ -34430,16 +34420,16 @@
 /area/station/maintenance/disposal)
 "bvc" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/juryroom)
 "bvd" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 1
+	dir = 1;
+	icon_state = "chair"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/juryroom)
@@ -34450,8 +34440,8 @@
 	},
 /obj/disposalpipe/segment,
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 1
+	dir = 1;
+	icon_state = "chair"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/juryroom)
@@ -34469,9 +34459,9 @@
 	})
 "bvg" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/storage{
@@ -34558,8 +34548,8 @@
 	name = "autoname - SS13"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -34570,17 +34560,17 @@
 /area/station/hangar/sec)
 "bvt" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
 "bvu" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -34600,9 +34590,9 @@
 	text = "NF"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
@@ -34612,8 +34602,8 @@
 /area/station/hangar/sec)
 "bvx" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 2
+	dir = 2;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/station/turret_protected/ai_upload_foyer)
@@ -34622,9 +34612,9 @@
 /area/station/turret_protected/ai_upload_foyer)
 "bvz" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai_upload_foyer)
@@ -34648,22 +34638,22 @@
 "bvC" = (
 /obj/disposalpipe/segment,
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/green,
 /area/station/hydroponics)
 "bvD" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/green,
 /area/station/hydroponics)
 "bvE" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
@@ -34687,9 +34677,9 @@
 /area/station/hydroponics)
 "bvH" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
@@ -34707,8 +34697,8 @@
 /obj/grille/steel,
 /obj/cable,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/window/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -34716,8 +34706,8 @@
 "bvK" = (
 /obj/grille/steel,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -34728,8 +34718,8 @@
 /area/station/engine/storage)
 "bvL" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable,
 /obj/cable{
@@ -34737,8 +34727,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/door/window{
 	name = "Engineering Storage";
@@ -34761,8 +34751,8 @@
 /area/station/engine/storage)
 "bvO" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -34777,19 +34767,19 @@
 /area/station/engine/engineering)
 "bvP" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
@@ -34810,9 +34800,9 @@
 /area/station/engine/engineering)
 "bvQ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 2
@@ -34820,14 +34810,14 @@
 /area/station/engine/engineering)
 "bvR" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/landmark/start{
 	name = "Engineer"
@@ -34863,8 +34853,8 @@
 "bvU" = (
 /obj/grille/steel,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable,
 /obj/window/auto/reinforced,
@@ -34872,9 +34862,9 @@
 /area/station/storage/autolathe)
 "bvV" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/window,
 /turf/simulated/floor,
@@ -34886,8 +34876,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/window/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -34903,8 +34893,8 @@
 /area/station/storage/autolathe)
 "bvY" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -34925,9 +34915,9 @@
 /area/station/janitor)
 "bvZ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/landmark/start{
 	name = "Janitor"
@@ -34947,9 +34937,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white/checker{
 	dir = 4
@@ -34987,9 +34977,9 @@
 /area/station/crew_quarters/juryroom)
 "bwf" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/juryroom)
@@ -35010,9 +35000,7 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/juryroom)
 "bwi" = (
-/obj/item/device/radio/intercom{
-	
-	},
+/obj/item/device/radio/intercom,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/juryroom)
 "bwj" = (
@@ -35031,14 +35019,14 @@
 	})
 "bwl" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/storage{
@@ -35050,9 +35038,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -35063,9 +35051,9 @@
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -35075,9 +35063,9 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/grime,
 /area/station/maintenance/east)
@@ -35087,25 +35075,25 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/grime,
 /area/station/maintenance/east)
 "bwq" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/east)
 "bwr" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 1;
@@ -35115,9 +35103,9 @@
 /area/station/maintenance/east)
 "bws" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -35138,17 +35126,17 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/red,
 /area/station/maintenance/east)
 "bwu" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -35159,9 +35147,9 @@
 "bwv" = (
 /obj/item/device/multitool,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -35180,17 +35168,17 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/red,
 /area/station/hangar/sec)
 "bwx" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -35202,9 +35190,9 @@
 /area/station/hangar/sec)
 "bwy" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -35216,9 +35204,9 @@
 /area/station/hangar/sec)
 "bwz" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 2;
@@ -35228,14 +35216,14 @@
 /area/station/hangar/sec)
 "bwA" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
@@ -35311,8 +35299,8 @@
 /area/station/hydroponics)
 "bwK" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/landmark/start{
 	name = "Botanist"
@@ -35323,8 +35311,8 @@
 /area/station/hydroponics)
 "bwL" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/machinery/plantpot{
 	anchored = 1
@@ -35335,13 +35323,13 @@
 /area/station/hydroponics)
 "bwM" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
@@ -35349,8 +35337,8 @@
 /area/station/hydroponics)
 "bwN" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/green/side{
 	dir = 8
@@ -35358,8 +35346,8 @@
 /area/station/hydroponics)
 "bwO" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/green/side{
 	dir = 4
@@ -35367,9 +35355,9 @@
 /area/station/hydroponics)
 "bwP" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/grille/catwalk{
 	dir = 4
@@ -35393,15 +35381,15 @@
 /area/station/hallway/primary/south)
 "bwR" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bwS" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/yellow/corner{
 	dir = 4
@@ -35409,8 +35397,8 @@
 /area/station/hallway/primary/south)
 "bwT" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -35423,8 +35411,8 @@
 	icon_state = "1-4"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -35432,14 +35420,14 @@
 /area/station/hallway/primary/south)
 "bwV" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 2;
@@ -35451,9 +35439,9 @@
 /area/station/hallway/primary/south)
 "bwW" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/yellow/side{
@@ -35462,9 +35450,9 @@
 /area/station/hallway/primary/south)
 "bwX" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/camera{
 	c_tag = "South Primary Hallway Midport";
@@ -35472,8 +35460,8 @@
 	},
 /obj/decal/cleanable/cobweb2,
 /obj/machinery/light/emergency{
-	icon_state = "ebulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "ebulb1"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 5
@@ -35481,9 +35469,9 @@
 /area/station/hallway/primary/south)
 "bwY" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/table/reinforced/auto,
 /obj/machinery/door/window{
@@ -35492,8 +35480,8 @@
 	req_access_txt = "40"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
@@ -35504,9 +35492,9 @@
 /area/station/engine/engineering)
 "bxa" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
@@ -35571,9 +35559,9 @@
 	dir = 1
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/mopbucket,
 /turf/simulated/floor/white/checker{
@@ -35591,9 +35579,7 @@
 	},
 /area/station/janitor)
 "bxm" = (
-/obj/item/device/radio/intercom{
-	
-	},
+/obj/item/device/radio/intercom,
 /obj/storage/secure/closet/civilian/janitor,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor)
@@ -35611,32 +35597,32 @@
 "bxp" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bxq" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -35666,9 +35652,9 @@
 /area/station/hangar/sec)
 "bxv" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
@@ -35716,14 +35702,14 @@
 /area/station/hydroponics)
 "bxC" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/green/side{
 	dir = 8
@@ -35731,9 +35717,9 @@
 /area/station/hydroponics)
 "bxD" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/stool/chair/office/green{
 	dir = 4
@@ -35744,9 +35730,9 @@
 /area/station/hydroponics)
 "bxE" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/table/reinforced/auto,
 /obj/machinery/door/window/eastright{
@@ -35758,9 +35744,9 @@
 /area/station/hydroponics)
 "bxF" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail,
 /obj/machinery/navbeacon{
@@ -35773,22 +35759,22 @@
 /area/station/hallway/primary/south)
 "bxG" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bxH" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -35824,9 +35810,9 @@
 /area/station/engine/engineering)
 "bxM" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/landmark/start{
 	name = "Engineer"
@@ -35859,12 +35845,12 @@
 	pixel_x = 32
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /obj/machinery/door/window/westleft,
 /turf/simulated/floor/delivery,
@@ -35875,9 +35861,9 @@
 /area/station/janitor)
 "bxR" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	name = "Custodial Closet";
@@ -35924,17 +35910,17 @@
 /area/station/maintenance/SWmaint)
 "bxY" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bxZ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
 	pixel_y = 24;
@@ -35944,14 +35930,14 @@
 /area/station/maintenance/east)
 "bya" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -35976,8 +35962,8 @@
 /area/station/maintenance/east)
 "byd" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/solar{
 	id = "solar_starboard";
@@ -36000,9 +35986,9 @@
 /area/station/hangar/sec)
 "byf" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/turret_protected/ai_upload_foyer)
@@ -36028,9 +36014,9 @@
 /area/station/hydroponics)
 "byk" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/green/side{
 	dir = 8
@@ -36039,8 +36025,8 @@
 "byl" = (
 /obj/table/reinforced/auto,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
 	dir = 2;
@@ -36051,20 +36037,20 @@
 "bym" = (
 /obj/disposalpipe/segment/mail,
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 4
+	dir = 4;
+	icon_state = "shrub"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "byn" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 2
@@ -36083,8 +36069,8 @@
 /area/station/hallway/primary/south)
 "byq" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 4
@@ -36096,21 +36082,21 @@
 	dir = 8
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /obj/item/clothing/gloves/yellow,
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
 "bys" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/monitor,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/yellow/corner{
 	dir = 4
@@ -36134,9 +36120,9 @@
 /area/station/engine/engineering)
 "byv" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk,
@@ -36154,8 +36140,8 @@
 /obj/disposalpipe/segment/mail,
 /obj/storage/secure/closet/engineering/engineer,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/yellow/corner{
 	dir = 1
@@ -36163,8 +36149,8 @@
 /area/station/engine/engineering)
 "byy" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/yellow/side{
@@ -36187,9 +36173,9 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
@@ -36245,8 +36231,8 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -36263,9 +36249,9 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -36275,9 +36261,9 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/camera{
 	c_tag = "East Maintenance Solar";
@@ -36391,9 +36377,9 @@
 /area/station/hangar/sec)
 "byV" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/sec)
@@ -36454,8 +36440,8 @@
 	},
 /obj/table/reinforced/auto,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
 	dir = 1
@@ -36465,9 +36451,9 @@
 /area/station/engine/elect)
 "bzd" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 2;
@@ -36514,9 +36500,9 @@
 /area/station/engine/engineering)
 "bzk" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -36550,44 +36536,44 @@
 /area/station/hallway/primary/south)
 "bzq" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bzr" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bzs" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bzt" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/camera{
 	c_tag = "Waste Disposal Exterior";
@@ -36597,35 +36583,35 @@
 /area/station/maintenance/disposal)
 "bzu" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bzv" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/decal/cleanable/oil,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bzw" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bzx" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/classic{
 	dir = 4;
@@ -36652,23 +36638,23 @@
 /area/station/maintenance/eastsolar)
 "bzB" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/eastsolar)
 "bzC" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/storage/secure/closet/security/armory{
 	req_access_txt = "37"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /obj/item/gun/kinetic/riotgun,
 /obj/item/gun/kinetic/riotgun,
@@ -36683,16 +36669,16 @@
 /area/station/crew_quarters/kitchen)
 "bzE" = (
 /obj/grille/catwalk{
-	icon_state = "catwalk";
-	dir = 10
+	dir = 10;
+	icon_state = "catwalk"
 	},
 /obj/cable{
 	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
@@ -36741,8 +36727,8 @@
 /area/station/maintenance/SWmaint)
 "bzK" = (
 /obj/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/hydroponics)
@@ -36759,9 +36745,9 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/hydroponics)
@@ -36785,9 +36771,9 @@
 /area/station/engine/elect)
 "bzP" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 1;
@@ -36843,8 +36829,8 @@
 /area/station/hallway/primary/south)
 "bzW" = (
 /obj/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -36893,9 +36879,9 @@
 /area/station/hallway/primary/south)
 "bAb" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -36905,8 +36891,8 @@
 	c_tag = "South Primary Hallway"
 	},
 /obj/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -36928,8 +36914,8 @@
 	pixel_y = 0
 	},
 /obj/machinery/light/emergency{
-	icon_state = "ebulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "ebulb1"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -36937,8 +36923,8 @@
 /area/station/hallway/primary/south)
 "bAe" = (
 /obj/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/yellow/corner{
 	dir = 1
@@ -37009,9 +36995,9 @@
 /area/station/maintenance/disposal)
 "bAn" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/spook,
 /turf/simulated/floor/plating,
@@ -37041,9 +37027,9 @@
 /area/station/maintenance/eastsolar)
 "bAs" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/eastsolar)
@@ -37054,9 +37040,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/camera{
 	c_tag = "East Solar Control"
@@ -37085,8 +37071,8 @@
 "bAv" = (
 /obj/submachine/foodprocessor,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/unsimulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
@@ -37176,9 +37162,9 @@
 /area/station/engine/elect)
 "bAJ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -37192,8 +37178,8 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
@@ -37202,9 +37188,9 @@
 /area/station/engine/elect)
 "bAM" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
@@ -37224,8 +37210,8 @@
 /area/station/hallway/primary/south)
 "bAR" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
@@ -37238,9 +37224,9 @@
 /area/station/hallway/primary/south)
 "bAT" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Bar Hallway";
@@ -37343,25 +37329,25 @@
 /area/station/maintenance/east)
 "bBf" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
+	dir = 1;
+	icon_state = "term"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/eastsolar)
 "bBg" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/eastsolar)
@@ -37379,8 +37365,8 @@
 /area/station/maintenance/eastsolar)
 "bBi" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 9
+	dir = 9;
+	icon_state = "lattice-dir"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -37394,8 +37380,8 @@
 /area)
 "bBj" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/solar{
 	id = "aisolar";
@@ -37408,9 +37394,9 @@
 /area)
 "bBk" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai_upload_foyer)
@@ -37431,17 +37417,17 @@
 /area/station/maintenance/SWmaint)
 "bBn" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/table/reinforced/auto,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/item/clipboard,
 /obj/item/pen/marker/blue,
@@ -37484,9 +37470,9 @@
 /area/station/engine/elect)
 "bBs" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/engine/elect)
@@ -37496,9 +37482,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
@@ -37525,8 +37511,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
@@ -37540,23 +37526,23 @@
 /area/station/hallway/primary/south)
 "bBy" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/reagent_dispensers/foamtank,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bBz" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/blue/corner,
 /area/station/hallway/primary/south)
 "bBA" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/machinery/door/firedoor/pyro{
 	dir = 4
@@ -37567,8 +37553,8 @@
 /area/station/hallway/primary/south)
 "bBB" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 0
@@ -37576,8 +37562,8 @@
 /area/station/hallway/primary/south)
 "bBC" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/item/caution{
 	desc = "Caution! Room full of death!";
@@ -37589,8 +37575,8 @@
 /area/station/hallway/primary/south)
 "bBD" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/blue/side{
@@ -37599,13 +37585,13 @@
 /area/station/hallway/primary/south)
 "bBE" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/blue/corner{
 	dir = 8
@@ -37622,16 +37608,16 @@
 /area/station/hallway/primary/south)
 "bBG" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/machinery/light,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bBH" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/shrub{
 	dir = 8;
@@ -37642,8 +37628,8 @@
 /area/station/hallway/primary/south)
 "bBI" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/grille/steel,
 /obj/window/auto/reinforced,
@@ -37651,15 +37637,15 @@
 /area/station/storage/tools)
 "bBJ" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor,
 /area/station/storage/tools)
 "bBK" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/table/auto,
 /obj/item/storage/toolbox/mechanical,
@@ -37668,8 +37654,8 @@
 /area/station/storage/tools)
 "bBL" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/table/auto,
 /obj/item/crowbar,
@@ -37679,8 +37665,8 @@
 /area/station/storage/tools)
 "bBM" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/table/auto,
 /obj/item/storage/belt/utility,
@@ -37689,8 +37675,8 @@
 /area/station/storage/tools)
 "bBN" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
@@ -37700,15 +37686,15 @@
 /area/station/storage/tools)
 "bBO" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/delivery,
 /area/station/storage/tools)
 "bBP" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/disposal)
@@ -37757,9 +37743,9 @@
 /area/station/maintenance/eastsolar)
 "bBW" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/external{
 	name = "External Access";
@@ -37769,16 +37755,16 @@
 /area/station/maintenance/eastsolar)
 "bBX" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/solar{
 	id = "solar_starboard";
 	name = "East Solars"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/airless{
 	icon_state = "solarpanel";
@@ -37810,24 +37796,24 @@
 	},
 /obj/machinery/disposal,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/unsimulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "bCb" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/turret,
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai_upload_foyer)
 "bCc" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai_upload_foyer)
@@ -37837,28 +37823,28 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai_upload_foyer)
 "bCe" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai_upload_foyer)
 "bCf" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 10
+	dir = 10;
+	icon_state = "lattice-dir"
 	},
 /obj/machinery/atmospherics/pipe/simple/junction/west,
 /turf/space,
@@ -37909,9 +37895,9 @@
 /area/station/engine/elect)
 "bCm" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/manufacturer/mechanic,
 /turf/simulated/floor/yellow,
@@ -37960,9 +37946,9 @@
 /area/station/atmos)
 "bCt" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/atmos)
@@ -38103,9 +38089,9 @@
 /area/station/turret_protected/ai_upload_foyer)
 "bCM" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -38142,9 +38128,9 @@
 /area/station/turret_protected/ai_upload_foyer)
 "bCQ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -38181,9 +38167,9 @@
 /area/station/maintenance/south)
 "bCX" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/engine/elect)
@@ -38206,8 +38192,8 @@
 /area/station/maintenance/south)
 "bDb" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/computer/general_alert,
 /obj/decal/cleanable/cobweb,
@@ -38247,16 +38233,16 @@
 	opacity = 0
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor,
 /area/station/atmos)
@@ -38268,9 +38254,9 @@
 /area/station/atmos)
 "bDh" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/tank/air_repressurization,
 /turf/simulated/floor/grime,
@@ -38309,8 +38295,8 @@
 /area/station/atmos)
 "bDo" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/vending/standard,
 /turf/simulated/floor,
@@ -38323,8 +38309,8 @@
 /area/station/storage/tools)
 "bDq" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/reagent_dispensers/fueltank,
 /turf/simulated/floor,
@@ -38338,8 +38324,8 @@
 /area/station/maintenance/disposal)
 "bDs" = (
 /obj/disposalpipe/segment/mail{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
@@ -38413,8 +38399,8 @@
 /area/station/solar/east)
 "bDA" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai_upload_foyer)
@@ -38424,8 +38410,8 @@
 /area/station/turret_protected/ai_upload_foyer)
 "bDC" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai_upload_foyer)
@@ -38438,9 +38424,9 @@
 /area/station/maintenance/south)
 "bDE" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
@@ -38451,8 +38437,8 @@
 "bDG" = (
 /obj/disposalpipe/segment,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/item/storage/toolbox/mechanical,
 /obj/table/auto,
@@ -38470,9 +38456,9 @@
 /area/station/maintenance/south)
 "bDI" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/grime,
 /area/station/atmos)
@@ -38496,12 +38482,12 @@
 	opacity = 0
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
 	dir = 2;
@@ -38511,9 +38497,9 @@
 /area/station/atmos)
 "bDM" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/valve,
 /turf/simulated/floor/grime,
@@ -38561,8 +38547,8 @@
 /area/station/maintenance/disposal)
 "bDV" = (
 /obj/machinery/door/airlock/pyro/external{
-	icon_state = "airlock_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "airlock_closed"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
@@ -38582,33 +38568,33 @@
 "bDY" = (
 /obj/grille/steel,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/ai_upload_foyer)
 "bDZ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/r_wall,
 /area/station/turret_protected/ai_upload_foyer)
 "bEa" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai_upload_foyer)
 "bEb" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/turret_protected/ai_upload_foyer)
@@ -38627,21 +38613,21 @@
 	charge = 5e+006
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai_upload_foyer)
 "bEe" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai_upload_foyer)
@@ -38653,8 +38639,8 @@
 	broadcasting = 1
 	},
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 0;
+	dir = 8;
 	frequency = 1447
 	},
 /obj/item/device/radio/intercom{
@@ -38662,8 +38648,8 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/landmark{
 	name = "AI-Sat"
@@ -38672,14 +38658,14 @@
 /area/station/turret_protected/ai_upload_foyer)
 "bEg" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai_upload_foyer)
@@ -38698,8 +38684,8 @@
 	dir = 8
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai_upload_foyer)
@@ -38715,17 +38701,17 @@
 /area/station/maintenance/east)
 "bEk" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
 "bEl" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
@@ -38736,9 +38722,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
@@ -38767,9 +38753,9 @@
 /area/station/maintenance/south)
 "bEq" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/window{
 	dir = 2
@@ -38791,9 +38777,9 @@
 /area/station/atmos)
 "bEt" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/decal/cleanable/cobweb{
 	icon_state = "cobweb"
@@ -38878,8 +38864,8 @@
 	},
 /obj/cable,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
@@ -38893,9 +38879,9 @@
 /area/station/crew_quarters/bar)
 "bEH" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/grille/catwalk/cross{
 	dir = 9
@@ -38908,18 +38894,18 @@
 /area/station/solar/east)
 "bEI" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai_upload_foyer)
@@ -38935,26 +38921,26 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/r_wall,
 /area/station/turret_protected/ai_upload_foyer)
 "bEK" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai_upload_foyer)
@@ -38963,9 +38949,9 @@
 /area/station/maintenance/southsolar)
 "bEM" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/engineering{
 	name = "Solar Substation"
@@ -38993,24 +38979,24 @@
 /area/station/atmos)
 "bEQ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/grime,
 /area/station/atmos)
 "bER" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/atmos)
 "bES" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -39028,21 +39014,21 @@
 /area/station/atmos)
 "bET" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/grime,
 /area/station/atmos)
 "bEU" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/grille/steel,
 /obj/window/auto/reinforced,
@@ -39054,8 +39040,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/grille/steel,
 /obj/window/auto/reinforced,
@@ -39116,8 +39102,8 @@
 "bFe" = (
 /obj/machinery/turret,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai_upload_foyer)
@@ -39137,8 +39123,8 @@
 /area/station/turret_protected/ai_upload_foyer)
 "bFh" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/solar{
 	id = "solar_aft";
@@ -39156,16 +39142,16 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southsolar)
 "bFj" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
@@ -39181,9 +39167,9 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southsolar)
@@ -39231,14 +39217,14 @@
 /area/station/atmos)
 "bFr" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/firealarm{
 	pixel_y = 24;
@@ -39253,17 +39239,17 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/atmos)
 "bFt" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -39273,24 +39259,24 @@
 "bFu" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/grime,
 /area/station/atmos)
 "bFv" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/atmos)
 "bFw" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
@@ -39334,9 +39320,9 @@
 	dir = 1
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -39350,16 +39336,16 @@
 "bFB" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/grille/catwalk{
 	dir = 4
@@ -39373,8 +39359,8 @@
 "bFC" = (
 /obj/table/reinforced/auto,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
 	dir = 1
@@ -39392,16 +39378,16 @@
 "bFD" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/grille/catwalk{
-	icon_state = "catwalk";
-	dir = 5
+	dir = 5;
+	icon_state = "catwalk"
 	},
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
@@ -39413,12 +39399,12 @@
 "bFE" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/grille/catwalk{
 	dir = 9
@@ -39432,18 +39418,18 @@
 /area/station/solar/east)
 "bFF" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/grille/catwalk{
-	icon_state = "catwalk";
-	dir = 10
+	dir = 10;
+	icon_state = "catwalk"
 	},
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
@@ -39455,16 +39441,16 @@
 "bFG" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/grille/catwalk/cross{
 	dir = 6
@@ -39482,29 +39468,29 @@
 	name = "South Solar Control"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southsolar)
 "bFI" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southsolar)
 "bFJ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southsolar)
@@ -39514,8 +39500,8 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
+	dir = 1;
+	icon_state = "term"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -39539,8 +39525,8 @@
 /area/station/maintenance/south)
 "bFN" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 4;
@@ -39569,9 +39555,9 @@
 /area/station/atmos)
 "bFR" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor/grime,
@@ -39597,9 +39583,9 @@
 /obj/item/wirecutters,
 /obj/item/device/light/flashlight,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/item/device/gps,
 /turf/simulated/floor,
@@ -39635,9 +39621,7 @@
 "bFX" = (
 /obj/table/auto,
 /obj/item/device/radio/signaler,
-/obj/item/device/radio/intercom{
-	
-	},
+/obj/item/device/radio/intercom,
 /obj/item/device/radio/signaler{
 	pixel_x = 2;
 	pixel_y = -2
@@ -39667,8 +39651,8 @@
 	name = "East Solars"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/airless{
 	icon_state = "solarpanel";
@@ -39677,8 +39661,8 @@
 /area/station/solar/east)
 "bGb" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 9
+	dir = 9;
+	icon_state = "lattice-dir-b"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -39715,9 +39699,9 @@
 /area/station/maintenance/southsolar)
 "bGf" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/external{
 	name = "External Access";
@@ -39741,30 +39725,30 @@
 "bGi" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
 "bGj" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
 "bGk" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/storage/tools)
@@ -39777,9 +39761,9 @@
 /area/station/storage/tools)
 "bGm" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/grille/catwalk,
 /turf/space,
@@ -39794,9 +39778,9 @@
 	dir = 9
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
 	d1 = 1;
@@ -39815,9 +39799,9 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
 	d1 = 1;
@@ -39835,8 +39819,8 @@
 /area)
 "bGq" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/terminal{
 	dir = 4
@@ -39848,8 +39832,8 @@
 	charge = 5e+006
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/black,
@@ -39866,9 +39850,9 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
@@ -39879,17 +39863,17 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
 "bGv" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
 	pixel_y = 24;
@@ -39899,9 +39883,9 @@
 /area/station/maintenance/south)
 "bGw" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -39910,9 +39894,9 @@
 /area/station/maintenance/south)
 "bGx" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -39923,9 +39907,9 @@
 /area/station/maintenance/south)
 "bGy" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
@@ -39951,21 +39935,21 @@
 "bGB" = (
 /obj/machinery/door/airlock/external,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/turret_protected/ai_upload_foyer)
 "bGC" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/plating,
@@ -39999,9 +39983,9 @@
 	dir = 5
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
@@ -40045,9 +40029,9 @@
 /area)
 "bGJ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/external,
 /turf/simulated/floor/plating,
@@ -40058,9 +40042,9 @@
 /area/station/maintenance/south)
 "bGL" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/external,
 /turf/simulated/floor/engine,
@@ -40075,8 +40059,8 @@
 /area/station/maintenance/south)
 "bGO" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 6
+	dir = 6;
+	icon_state = "lattice-dir"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -40090,8 +40074,8 @@
 /area)
 "bGP" = (
 /obj/grille/catwalk{
-	icon_state = "catwalk";
-	dir = 5
+	dir = 5;
+	icon_state = "catwalk"
 	},
 /obj/landmark{
 	name = "Loot spawn"
@@ -40124,8 +40108,8 @@
 "bGS" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 0;
@@ -40160,9 +40144,9 @@
 /area/station/quartermaster/refinery)
 "bGY" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable,
 /obj/cable{
@@ -40210,8 +40194,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 4;
@@ -40240,13 +40224,13 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/grille/catwalk{
 	dir = 6
@@ -40261,8 +40245,8 @@
 "bHd" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
@@ -40284,9 +40268,9 @@
 /area/station/solar/east)
 "bHe" = (
 /obj/machinery/door/airlock/pyro/engineering{
-	name = "Mining";
-	icon_state = "eng_closed";
 	dir = 8;
+	icon_state = "eng_closed";
+	name = "Mining";
 	req_access_txt = "50"
 	},
 /turf/simulated/floor/plating,
@@ -40301,12 +40285,12 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/grille/catwalk{
-	icon_state = "catwalk";
-	dir = 5
+	dir = 5;
+	icon_state = "catwalk"
 	},
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
@@ -40345,22 +40329,22 @@
 "bHi" = (
 /obj/machinery/door/airlock/external,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/turret_protected/ai_upload_foyer)
 "bHj" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/engineering{
-	name = "Mining";
-	icon_state = "eng_closed";
 	dir = 8;
+	icon_state = "eng_closed";
+	name = "Mining";
 	req_access_txt = "50"
 	},
 /turf/simulated/floor/plating,
@@ -40386,8 +40370,8 @@
 /area/station/quartermaster/refinery)
 "bHn" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/caution/north,
 /area/station/quartermaster/refinery)
@@ -40403,9 +40387,9 @@
 /area/station/turret_protected/ai_upload_foyer)
 "bHp" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/ai_upload_foyer)
@@ -40432,8 +40416,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 4;
@@ -40451,9 +40435,9 @@
 /area/station/quartermaster/refinery)
 "bHw" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/quartermaster/refinery)
@@ -40501,9 +40485,9 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
@@ -40514,8 +40498,8 @@
 /area)
 "bHB" = (
 /obj/grille/catwalk{
-	icon_state = "catwalk";
-	dir = 5
+	dir = 5;
+	icon_state = "catwalk"
 	},
 /obj/cable{
 	d1 = 1;
@@ -40523,9 +40507,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
@@ -40550,9 +40534,9 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/grille/catwalk/cross,
 /turf/space,
@@ -40599,9 +40583,9 @@
 /area)
 "bHH" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/external,
 /turf/simulated/floor/plating/airless,
@@ -40612,8 +40596,8 @@
 /area/station/quartermaster/refinery)
 "bHJ" = (
 /obj/grille/catwalk{
-	icon_state = "catwalk";
-	dir = 5
+	dir = 5;
+	icon_state = "catwalk"
 	},
 /obj/cable{
 	icon_state = "2-8"
@@ -40633,12 +40617,12 @@
 "bHK" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/grille/catwalk{
 	dir = 9
@@ -40653,16 +40637,16 @@
 "bHL" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/grille/catwalk{
 	dir = 4
@@ -40684,8 +40668,8 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
@@ -40711,22 +40695,22 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/space,
 /area)
 "bHQ" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/grille/catwalk/cross{
-	tag = "icon-catwalk_cross (NORTHEAST)";
+	dir = 5;
 	icon_state = "catwalk_cross";
-	dir = 5
+	tag = "icon-catwalk_cross (NORTHEAST)"
 	},
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
@@ -40736,9 +40720,9 @@
 /area/station/solar/south)
 "bHR" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/grille/catwalk,
 /turf/space,
@@ -40749,9 +40733,9 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/space,
 /area)
@@ -40765,21 +40749,21 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/space,
 /area)
 "bHU" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -40801,12 +40785,12 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/grille/catwalk{
 	dir = 6
@@ -40860,8 +40844,8 @@
 /area)
 "bIc" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/cable{
@@ -40869,8 +40853,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/grille/catwalk{
 	dir = 4
@@ -40883,8 +40867,8 @@
 /area/station/solar/east)
 "bId" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/cable{
@@ -40892,8 +40876,8 @@
 	icon_state = "0-8"
 	},
 /obj/grille/catwalk{
-	icon_state = "catwalk";
-	dir = 5
+	dir = 5;
+	icon_state = "catwalk"
 	},
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
@@ -40914,9 +40898,9 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/grille/catwalk/cross,
 /turf/space,
@@ -40929,16 +40913,16 @@
 "bIf" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/grille/catwalk{
 	dir = 6
@@ -40971,16 +40955,16 @@
 "bIi" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/grille/catwalk{
-	icon_state = "catwalk";
-	dir = 5
+	dir = 5;
+	icon_state = "catwalk"
 	},
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
@@ -40991,13 +40975,13 @@
 /area/station/solar/south)
 "bIj" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/grille/catwalk{
 	dir = 9
@@ -41011,8 +40995,8 @@
 /area/station/solar/south)
 "bIk" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 1
+	dir = 1;
+	icon_state = "lattice-dir"
 	},
 /obj/grille/catwalk{
 	dir = 4
@@ -41027,8 +41011,8 @@
 /area)
 "bIl" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/cable{
@@ -41036,8 +41020,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/grille/catwalk{
 	dir = 4
@@ -41056,9 +41040,9 @@
 /area)
 "bIn" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -41101,18 +41085,18 @@
 "bIq" = (
 /obj/grille/catwalk,
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area)
 "bIr" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/grille/catwalk/cross{
 	dir = 9
@@ -41132,9 +41116,9 @@
 "bIt" = (
 /obj/grille/catwalk,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
@@ -41151,9 +41135,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/grille/catwalk/cross,
 /turf/space,
@@ -41314,9 +41298,9 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
@@ -41332,9 +41316,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
@@ -41364,9 +41348,9 @@
 /area/mining/magnet)
 "bIG" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/grille/catwalk/cross{
 	dir = 6
@@ -41379,9 +41363,9 @@
 /area)
 "bIH" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/grille/catwalk/cross{
 	dir = 9
@@ -41457,13 +41441,13 @@
 /area)
 "bIN" = (
 /obj/grille/catwalk{
-	icon_state = "catwalk";
-	dir = 5
+	dir = 5;
+	icon_state = "catwalk"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
@@ -41474,9 +41458,9 @@
 /area)
 "bIO" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/grille/catwalk/cross,
 /turf/space,
@@ -56911,8 +56895,8 @@ arN
 arN
 arN
 asv
-asY
-asY
+aQv
+aQv
 aNF
 aOt
 arN
@@ -59916,7 +59900,7 @@ awR
 axG
 arN
 azz
-asY
+aQv
 aBt
 aCg
 aDc
@@ -62629,9 +62613,9 @@ atx
 aua
 atB
 avr
-asY
-asY
-asY
+aQv
+aQv
+aQv
 avs
 azA
 aAK
@@ -63832,10 +63816,10 @@ ara
 aqh
 arN
 asv
-asY
-asY
-asY
-asY
+aQv
+aQv
+aQv
+aQv
 avs
 arN
 aAP
@@ -66550,8 +66534,8 @@ ara
 aqh
 arO
 asy
-asY
-asY
+aQv
+aQv
 aug
 arN
 avu
@@ -67761,7 +67745,7 @@ aom
 atc
 atB
 auh
-asY
+aQv
 avw
 awk
 axb

--- a/maps/unused/mushroom_new_walls.dmm
+++ b/maps/unused/mushroom_new_walls.dmm
@@ -7,8 +7,8 @@
 /area/shuttle/escape/station/cogmap2)
 "aac" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/solar{
 	id = "westsolar";
@@ -25,12 +25,12 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/solar/west)
@@ -53,8 +53,8 @@
 /area/station/hallway/secondary/shuttle)
 "aag" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 9
+	dir = 9;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area)
@@ -64,8 +64,8 @@
 	name = "Hangar Beacon"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/space,
 /area)
@@ -77,8 +77,8 @@
 	pixel_x = -20
 	},
 /obj/machinery/door/airlock/pyro/security{
-	icon_state = "sec_closed";
-	dir = 8
+	dir = 8;
+	icon_state = "sec_closed"
 	},
 /obj/access_spawn/security,
 /turf/simulated/floor,
@@ -100,13 +100,13 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/solar/west)
@@ -162,8 +162,8 @@
 /area/station/hallway/secondary/shuttle)
 "aau" = (
 /obj/machinery/light/emergency{
-	icon_state = "ebulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "ebulb1"
 	},
 /turf/simulated/floor/escape{
 	dir = 9
@@ -257,8 +257,8 @@
 /area/station/hallway/secondary/shuttle)
 "aaJ" = (
 /obj/machinery/light/emergency{
-	icon_state = "ebulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "ebulb1"
 	},
 /turf/simulated/floor/escape{
 	dir = 5
@@ -295,8 +295,8 @@
 /area/station/hallway/secondary/shuttle)
 "aaO" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/wingrille_spawn/auto,
@@ -313,9 +313,9 @@
 /area/station/hallway/primary/north)
 "aaQ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/shuttle)
@@ -347,9 +347,9 @@
 /area/station/hallway/secondary/shuttle)
 "aaU" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -364,17 +364,17 @@
 /area/station/hallway/secondary/shuttle)
 "aaW" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/solar/west)
 "aaX" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
 /area/station/hallway/secondary/shuttle)
@@ -389,9 +389,9 @@
 /area)
 "aba" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/engineering{
@@ -414,9 +414,9 @@
 "abc" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
@@ -448,9 +448,9 @@
 /area/shuttle/mining/station)
 "abh" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -462,12 +462,12 @@
 /area/station/hallway/secondary/shuttle)
 "abi" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -479,9 +479,9 @@
 /area/station/security/checkpoint)
 "abj" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/table/auto,
 /obj/item/device/flash,
@@ -489,19 +489,18 @@
 /area/station/security/checkpoint)
 "abk" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/table/auto,
-/obj/item/crowbar,
+/obj/submachine/weapon_vendor/security,
 /turf/simulated/floor,
 /area/station/security/checkpoint)
 "abl" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/table/auto,
 /obj/machinery/recharger{
@@ -515,6 +514,7 @@
 	brightness = 2;
 	dir = 4
 	},
+/obj/item/crowbar,
 /turf/simulated/floor,
 /area/station/security/checkpoint)
 "abm" = (
@@ -552,9 +552,9 @@
 /area/station/security/checkpoint)
 "abr" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/security/checkpoint)
@@ -563,9 +563,9 @@
 /area/station/security/checkpoint)
 "abt" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -605,8 +605,8 @@
 /area/station/hallway/secondary/shuttle)
 "abx" = (
 /obj/item/device/radio/intercom{
-	dir = 4;
 	broadcasting = 0;
+	dir = 4;
 	frequency = 1485;
 	name = "Station Intercom (Security)"
 	},
@@ -628,8 +628,8 @@
 	},
 /obj/machinery/computer/card,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/security/checkpoint)
@@ -663,13 +663,13 @@
 /area/station/hallway/secondary/shuttle)
 "abF" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/table/reinforced{
-	tag = "icon-reinf_tabledir";
-	icon_state = "reinf_tabledir"
+	icon_state = "reinf_tabledir";
+	tag = "icon-reinf_tabledir"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/item/pen,
@@ -688,25 +688,25 @@
 "abI" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint)
 "abJ" = (
 /obj/table/reinforced{
-	tag = "icon-reinf_tabledir";
-	icon_state = "reinf_tabledir"
+	icon_state = "reinf_tabledir";
+	tag = "icon-reinf_tabledir"
 	},
 /obj/machinery/door/firedoor/pyro,
 /turf/simulated/floor,
 /area/station/security/checkpoint)
 "abK" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/pyro{
 	dir = 8
@@ -716,8 +716,8 @@
 "abL" = (
 /obj/cable,
 /obj/cable{
-	tag = "icon-0-2";
-	icon_state = "0-2"
+	icon_state = "0-2";
+	tag = "icon-0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -735,8 +735,8 @@
 /area/station/hallway/secondary/shuttle)
 "abN" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/shuttle)
@@ -759,17 +759,17 @@
 /area/station/hallway/secondary/shuttle)
 "abR" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/shuttle)
 "abS" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance,
@@ -778,9 +778,9 @@
 /area/station/maintenance/NEmaint)
 "abT" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/shuttle)
@@ -803,9 +803,9 @@
 /area/station/hallway/secondary/shuttle)
 "abW" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/noticeboard{
 	name = "Complaint Board";
@@ -815,14 +815,14 @@
 /area/station/hallway/secondary/shuttle)
 "abX" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/shuttle)
@@ -838,55 +838,55 @@
 /area/station/hallway/secondary/shuttle)
 "aca" = (
 /turf/simulated/floor{
-	tag = "icon-L1";
-	icon_state = "L1"
+	icon_state = "L1";
+	tag = "icon-L1"
 	},
 /area/station/hallway/secondary/shuttle)
 "acb" = (
 /turf/simulated/floor{
-	tag = "icon-L3";
-	icon_state = "L3"
+	icon_state = "L3";
+	tag = "icon-L3"
 	},
 /area/station/hallway/secondary/shuttle)
 "acc" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	tag = "icon-L5";
-	icon_state = "L5"
+	icon_state = "L5";
+	tag = "icon-L5"
 	},
 /area/station/hallway/secondary/shuttle)
 "acd" = (
 /turf/simulated/floor{
-	tag = "icon-L7";
-	icon_state = "L7"
+	icon_state = "L7";
+	tag = "icon-L7"
 	},
 /area/station/hallway/secondary/shuttle)
 "ace" = (
 /turf/simulated/floor{
-	tag = "icon-L9";
-	icon_state = "L9"
+	icon_state = "L9";
+	tag = "icon-L9"
 	},
 /area/station/hallway/secondary/shuttle)
 "acf" = (
 /turf/simulated/floor{
-	tag = "icon-L11";
-	icon_state = "L11"
+	icon_state = "L11";
+	tag = "icon-L11"
 	},
 /area/station/hallway/secondary/shuttle)
 "acg" = (
 /turf/simulated/floor{
-	tag = "icon-L13";
-	icon_state = "L13"
+	icon_state = "L13";
+	tag = "icon-L13"
 	},
 /area/station/hallway/secondary/shuttle)
 "ach" = (
 /turf/simulated/floor{
-	tag = "icon-L15";
-	icon_state = "L15"
+	icon_state = "L15";
+	tag = "icon-L15"
 	},
 /area/station/hallway/secondary/shuttle)
 "aci" = (
@@ -900,14 +900,14 @@
 /area/station/hallway/secondary/shuttle)
 "acj" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance{
-	icon_state = "maint_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "maint_closed"
 	},
 /obj/access_spawn/maint,
 /turf/simulated/floor/plating,
@@ -921,8 +921,8 @@
 /area/station/maintenance/NEmaint)
 "acl" = (
 /obj/machinery/door/airlock/pyro/external{
-	icon_state = "airlock_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "airlock_closed"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
@@ -941,8 +941,8 @@
 /area/station/maintenance/NEmaint)
 "acn" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/solar{
 	id = "eastsolar";
@@ -955,12 +955,12 @@
 /area/station/solar/east)
 "aco" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -996,55 +996,55 @@
 /area/station/maintenance/westsolar)
 "act" = (
 /turf/simulated/floor{
-	tag = "icon-L2";
-	icon_state = "L2"
+	icon_state = "L2";
+	tag = "icon-L2"
 	},
 /area/station/hallway/secondary/shuttle)
 "acu" = (
 /turf/simulated/floor{
-	tag = "icon-L4";
-	icon_state = "L4"
+	icon_state = "L4";
+	tag = "icon-L4"
 	},
 /area/station/hallway/secondary/shuttle)
 "acv" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	tag = "icon-L6";
-	icon_state = "L6"
+	icon_state = "L6";
+	tag = "icon-L6"
 	},
 /area/station/hallway/secondary/shuttle)
 "acw" = (
 /turf/simulated/floor{
-	tag = "icon-L8";
-	icon_state = "L8"
+	icon_state = "L8";
+	tag = "icon-L8"
 	},
 /area/station/hallway/secondary/shuttle)
 "acx" = (
 /turf/simulated/floor{
-	tag = "icon-L10";
-	icon_state = "L10"
+	icon_state = "L10";
+	tag = "icon-L10"
 	},
 /area/station/hallway/secondary/shuttle)
 "acy" = (
 /turf/simulated/floor{
-	tag = "icon-L12";
-	icon_state = "L12"
+	icon_state = "L12";
+	tag = "icon-L12"
 	},
 /area/station/hallway/secondary/shuttle)
 "acz" = (
 /turf/simulated/floor{
-	tag = "icon-L14";
-	icon_state = "L14"
+	icon_state = "L14";
+	tag = "icon-L14"
 	},
 /area/station/hallway/secondary/shuttle)
 "acA" = (
 /turf/simulated/floor{
-	tag = "icon-L16";
-	icon_state = "L16"
+	icon_state = "L16";
+	tag = "icon-L16"
 	},
 /area/station/hallway/secondary/shuttle)
 "acB" = (
@@ -1061,29 +1061,29 @@
 /area/station/maintenance/NEmaint)
 "acD" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "acE" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "acF" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -1093,9 +1093,9 @@
 /area/station/solar/east)
 "acG" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -1106,9 +1106,9 @@
 /area/station/solar/west)
 "acH" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/solar/west)
@@ -1119,41 +1119,41 @@
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/solar/west)
 "acJ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/westsolar)
 "acK" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
 "acL" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/landmark/start{
 	name = "predator"
@@ -1162,17 +1162,17 @@
 /area/station/maintenance/westsolar)
 "acM" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
 "acN" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass,
@@ -1180,27 +1180,27 @@
 /area/station/hallway/secondary/shuttle)
 "acO" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light/emergency,
 /turf/simulated/floor,
 /area/station/hallway/secondary/shuttle)
 "acP" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light,
 /turf/simulated/floor,
 /area/station/hallway/secondary/shuttle)
 "acQ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -1215,17 +1215,17 @@
 	},
 /obj/machinery/door/window/westright,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/shuttle)
 "acS" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
@@ -1241,9 +1241,9 @@
 /area/station/maintenance/westsolar)
 "acW" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
@@ -1257,9 +1257,9 @@
 /area/station/hallway/secondary/shuttle)
 "acZ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/command{
@@ -1275,17 +1275,17 @@
 /area/station/ai_monitored/storage/eva)
 "adb" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating/airless,
 /area)
 "adc" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area)
@@ -1296,8 +1296,8 @@
 "ade" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
@@ -1311,8 +1311,8 @@
 	name = "Station Intercom (Engineering)"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
@@ -1329,8 +1329,8 @@
 "adh" = (
 /obj/rack,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
@@ -1382,9 +1382,9 @@
 /area/station/hallway/secondary/shuttle)
 "adp" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -1456,9 +1456,9 @@
 /area/station/maintenance/NEmaint)
 "adx" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/NEmaint)
@@ -1471,13 +1471,13 @@
 /area)
 "adz" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -1487,14 +1487,14 @@
 /area/station/solar/east)
 "adA" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -1502,8 +1502,8 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/door/airlock/pyro/external{
-	icon_state = "airlock_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "airlock_closed"
 	},
 /obj/access_spawn/engineering,
 /turf/simulated/floor/plating,
@@ -1515,9 +1515,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
@@ -1541,9 +1541,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
@@ -1558,21 +1558,21 @@
 /area/station/crew_quarters/market)
 "adH" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "adI" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/door/airlock/pyro/maintenance{
-	icon_state = "maint_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "maint_closed"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
@@ -1597,8 +1597,8 @@
 	name = "Astronaut Pen"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
@@ -1624,8 +1624,8 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/item/crowbar,
 /turf/simulated/floor/orangeblack/side{
@@ -1634,16 +1634,16 @@
 /area/station/ai_monitored/storage/eva)
 "adO" = (
 /obj/cable{
-	tag = "icon-0-2";
-	icon_state = "0-2"
+	icon_state = "0-2";
+	tag = "icon-0-2"
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "adP" = (
 /obj/cable{
-	tag = "icon-0-2";
-	icon_state = "0-2"
+	icon_state = "0-2";
+	tag = "icon-0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/camera{
@@ -1679,20 +1679,18 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
 "adU" = (
-/obj/item/device/radio/intercom{
-	
-	},
+/obj/item/device/radio/intercom,
 /obj/machinery/computer/stockexchange{
-	icon_state = "QMreq";
-	dir = 4
+	dir = 4;
+	icon_state = "QMreq"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "adV" = (
 /obj/machinery/door_control{
+	id = "store2";
 	name = "Door Toggle";
-	pixel_y = -24;
-	id = "store2"
+	pixel_y = -24
 	},
 /obj/stool,
 /turf/simulated/floor,
@@ -1704,14 +1702,14 @@
 /area/station/crew_quarters/market)
 "adX" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
@@ -1722,22 +1720,22 @@
 /area/station/hallway/primary/north)
 "adZ" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage/eva)
 "aea" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/item/sheet/glass{
 	amount = 50
@@ -1751,9 +1749,9 @@
 /area/station/ai_monitored/storage/eva)
 "aeb" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/ai_monitored/storage/eva)
@@ -1784,9 +1782,9 @@
 	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
@@ -1809,9 +1807,9 @@
 /area/station/ai_monitored/storage/eva)
 "aeg" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -1827,22 +1825,22 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "aei" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
 	brightness = 2;
@@ -1870,8 +1868,8 @@
 /area/station/maintenance/westsolar)
 "ael" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -1889,22 +1887,22 @@
 /area/station/crew_quarters/market)
 "aem" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "aen" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -1924,9 +1922,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/item/weldingtool,
 /obj/item/device/light/flashlight,
@@ -1966,9 +1964,7 @@
 /obj/stool/chair{
 	dir = 4
 	},
-/obj/item/device/radio/intercom{
-	
-	},
+/obj/item/device/radio/intercom,
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "aeu" = (
@@ -1991,18 +1987,18 @@
 /area/station/maintenance/NEmaint)
 "aex" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/solar/east)
 "aey" = (
 /obj/lattice,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/space,
 /area)
@@ -2030,22 +2026,22 @@
 /area/station/crew_quarters/market)
 "aeD" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "aeE" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=arrivals";
@@ -2055,17 +2051,17 @@
 /area/station/hallway/primary/north)
 "aeF" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "aeG" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
@@ -2083,9 +2079,9 @@
 /area/station/maintenance/NEmaint)
 "aeI" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -2098,9 +2094,9 @@
 /area/station/ai_monitored/storage/eva)
 "aeJ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
@@ -2116,14 +2112,14 @@
 /area/station/janitor)
 "aeL" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
@@ -2139,8 +2135,8 @@
 /area/station/maintenance/NEmaint)
 "aeN" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/terminal{
 	dir = 8
@@ -2153,8 +2149,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/solar_control{
 	id = "eastsolar";
@@ -2165,31 +2161,31 @@
 /area/station/maintenance/NEmaint)
 "aeP" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "aeQ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/solar/east)
 "aeR" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -2200,22 +2196,22 @@
 /area/station/solar/east)
 "aeS" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/scorched,
 /area/station/solar/east)
 "aeT" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -2227,9 +2223,9 @@
 "aeU" = (
 /obj/lattice,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/space,
 /area)
@@ -2243,8 +2239,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable,
 /turf/simulated/floor/plating/airless,
@@ -2263,8 +2259,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/door/window/westleft{
 	name = "Chapel Mass Driver"
@@ -2273,8 +2269,8 @@
 /area/station/chapel/main)
 "aeZ" = (
 /obj/table/reinforced{
-	tag = "icon-reinf_tabledir";
-	icon_state = "reinf_tabledir"
+	icon_state = "reinf_tabledir";
+	tag = "icon-reinf_tabledir"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
@@ -2283,8 +2279,8 @@
 "afa" = (
 /obj/item/wrench,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
@@ -2292,14 +2288,14 @@
 /area/station/ai_monitored/storage/eva)
 "afb" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
@@ -2308,17 +2304,17 @@
 	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "afd" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/NEmaint)
@@ -2328,9 +2324,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
@@ -2398,35 +2394,35 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/market)
 "afm" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "afn" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -2435,8 +2431,8 @@
 	name = "monkeyspawn_albert"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/light/emergency,
 /turf/simulated/floor/orangeblack/side{
@@ -2564,13 +2560,13 @@
 /area/station/maintenance/NEmaint)
 "afB" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -2580,18 +2576,18 @@
 /area/station/solar/east)
 "afC" = (
 /obj/securearea{
-	tag = "icon-space";
-	name = "VACUUM AREA";
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space"
+	icon_state = "space";
+	name = "VACUUM AREA";
+	tag = "icon-space"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/quartermaster/office)
 "afD" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/pyro,
 /turf/simulated/floor/plating,
@@ -2699,8 +2695,8 @@
 "afU" = (
 /obj/storage/closet/biohazard,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/janitor)
@@ -2721,9 +2717,7 @@
 "afX" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet,
-/obj/item/device/radio/intercom{
-	
-	},
+/obj/item/device/radio/intercom,
 /turf/simulated/floor,
 /area/station/janitor)
 "afY" = (
@@ -2759,12 +2753,12 @@
 /area/station/maintenance/NEmaint)
 "agd" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
@@ -2776,9 +2770,7 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "age" = (
-/obj/item/device/radio/intercom{
-	
-	},
+/obj/item/device/radio/intercom,
 /obj/machinery/light/small{
 	dir = 1;
 	status = 2
@@ -2788,9 +2780,9 @@
 /area/station/maintenance/disposal)
 "agf" = (
 /obj/disposalpipe/trunk{
-	tag = "icon-pipe-t (NORTH)";
+	dir = 1;
 	icon_state = "pipe-t";
-	dir = 1
+	tag = "icon-pipe-t (NORTH)"
 	},
 /obj/machinery/disposal,
 /turf/simulated/floor/plating,
@@ -2878,14 +2870,14 @@
 /area/station/crew_quarters/market)
 "agp" = (
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/delivery,
@@ -2912,8 +2904,8 @@
 	name = "kudzustart"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -2944,8 +2936,8 @@
 /area/station/janitor)
 "agy" = (
 /obj/cable{
-	tag = "icon-0-2";
-	icon_state = "0-2"
+	icon_state = "0-2";
+	tag = "icon-0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 4;
@@ -2961,9 +2953,9 @@
 /area/station/janitor)
 "agz" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/camera{
 	c_tag = "FS Maintenance - Center";
@@ -2977,8 +2969,8 @@
 /area/station/maintenance/disposal)
 "agB" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -3069,17 +3061,17 @@
 /area/station/crew_quarters/market)
 "agO" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/north)
 "agP" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass,
@@ -3087,14 +3079,14 @@
 /area/station/hallway/primary/north)
 "agQ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/door/firedoor/pyro{
 	dir = 8
@@ -3126,14 +3118,14 @@
 /area/station/janitor)
 "agV" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light_switch{
 	name = "E light switch";
@@ -3148,17 +3140,17 @@
 /area/station/janitor)
 "agW" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/janitor)
 "agX" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -3169,9 +3161,9 @@
 /area/station/maintenance/NEmaint)
 "agY" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -3181,9 +3173,9 @@
 /area/station/maintenance/disposal)
 "aha" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
@@ -3193,25 +3185,25 @@
 /area/station/maintenance/disposal)
 "ahc" = (
 /obj/lattice{
-	tag = "icon-lattice-dir (NORTHWEST)";
+	dir = 9;
 	icon_state = "lattice-dir";
-	dir = 9
+	tag = "icon-lattice-dir (NORTHWEST)"
 	},
 /turf/space,
 /area)
 "ahd" = (
 /obj/lattice{
-	tag = "icon-lattice-dir (WEST)";
+	dir = 8;
 	icon_state = "lattice-dir";
-	dir = 8
+	tag = "icon-lattice-dir (WEST)"
 	},
 /turf/space,
 /area)
 "ahe" = (
 /obj/lattice{
-	tag = "icon-lattice-dir (EAST)";
+	dir = 4;
 	icon_state = "lattice-dir";
-	dir = 4
+	tag = "icon-lattice-dir (EAST)"
 	},
 /turf/space,
 /area)
@@ -3239,8 +3231,8 @@
 /area/station/quartermaster/office)
 "ahh" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
@@ -3259,9 +3251,9 @@
 /area/station/quartermaster/office)
 "ahj" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
@@ -3292,21 +3284,21 @@
 /area/station/hallway/primary/north)
 "aho" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/storage/autolathe)
 "ahp" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/storage/closet,
 /obj/machinery/light{
@@ -3328,47 +3320,45 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/storage/closet,
 /turf/simulated/floor,
 /area/station/storage/autolathe)
 "ahr" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/storage/autolathe)
 "ahs" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/item/storage/box/mousetraps,
 /obj/item/storage/box/mousetraps,
 /obj/item/storage/box/mousetraps,
-/obj/item/device/radio/intercom{
-	
-	},
+/obj/item/device/radio/intercom,
 /turf/simulated/floor/grime,
 /area/station/janitor)
 "aht" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/janitor)
 "ahu" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/reagent_dispensers/watertank,
 /obj/machinery/light,
@@ -3472,9 +3462,9 @@
 /area/station/hallway/primary/north)
 "ahI" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -3497,8 +3487,8 @@
 /area/station/storage/autolathe)
 "ahL" = (
 /obj/machinery/door/airlock/pyro/maintenance{
-	icon_state = "maint_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "maint_closed"
 	},
 /obj/access_spawn/maint,
 /turf/simulated/floor/plating,
@@ -3518,17 +3508,17 @@
 /area/station/maintenance/disposal)
 "ahO" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "ahP" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -3539,9 +3529,9 @@
 /area/station/maintenance/disposal)
 "ahQ" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
@@ -3567,9 +3557,9 @@
 /area/station/maintenance/disposal)
 "ahT" = (
 /obj/lattice{
-	tag = "icon-lattice-dir (SOUTHWEST)";
+	dir = 10;
 	icon_state = "lattice-dir";
-	dir = 10
+	tag = "icon-lattice-dir (SOUTHWEST)"
 	},
 /turf/space,
 /area)
@@ -3579,9 +3569,9 @@
 /area/station/quartermaster/office)
 "ahV" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4;
@@ -3612,8 +3602,8 @@
 "aia" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance{
-	icon_state = "maint_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "maint_closed"
 	},
 /obj/access_spawn/maint,
 /turf/simulated/floor/plating,
@@ -3670,9 +3660,9 @@
 	pixel_y = 0
 	},
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
+	dir = 8;
 	icon_state = "bulb1";
-	dir = 8
+	tag = "icon-bulb1 (WEST)"
 	},
 /obj/machinery/air_vendor,
 /turf/simulated/floor,
@@ -3742,8 +3732,8 @@
 /area/station/quartermaster/office)
 "aiv" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 4;
@@ -3815,17 +3805,17 @@
 	operating = 1
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "aiE" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -3835,9 +3825,9 @@
 /area/station/solar/east)
 "aiF" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/table/reinforced,
 /obj/machinery/cashreg,
@@ -3848,8 +3838,8 @@
 /area/station/quartermaster/office)
 "aiG" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 4;
@@ -3909,8 +3899,8 @@
 "aiP" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance{
-	icon_state = "maint_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "maint_closed"
 	},
 /obj/access_spawn/maint,
 /turf/simulated/floor/plating,
@@ -3927,9 +3917,9 @@
 /area/station/chapel/main)
 "aiS" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/chapel/main)
@@ -3997,9 +3987,9 @@
 /area/station/hallway/primary/north)
 "aja" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -4039,18 +4029,18 @@
 /area/station/maintenance/NEmaint)
 "aje" = (
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-s (EAST)";
+	dir = 4;
 	icon_state = "pipe-s";
-	dir = 4
+	tag = "icon-pipe-s (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "ajf" = (
 /obj/disposalpipe/segment,
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-s (EAST)";
+	dir = 4;
 	icon_state = "pipe-s";
-	dir = 4
+	tag = "icon-pipe-s (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
@@ -4079,9 +4069,9 @@
 /area/station/chapel/main)
 "ajj" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/camera{
 	c_tag = "Chapel Launcher";
@@ -4131,14 +4121,14 @@
 /area/station/quartermaster/office)
 "ajo" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/pyro{
 	dir = 8
@@ -4154,8 +4144,8 @@
 /area/station/quartermaster)
 "ajq" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -4196,9 +4186,9 @@
 /area/station/chapel/main)
 "ajx" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
@@ -4206,8 +4196,8 @@
 /area/station/chapel/main)
 "ajy" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 9
@@ -4215,8 +4205,8 @@
 /area/station/chapel/main)
 "ajz" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 5
@@ -4250,9 +4240,9 @@
 	pixel_y = 28
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/machinery/door/window/southleft,
 /obj/disposalpipe/segment{
@@ -4265,17 +4255,17 @@
 /area/station/quartermaster)
 "ajD" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster)
 "ajE" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=market";
@@ -4331,9 +4321,9 @@
 /area/station/chapel/main)
 "ajM" = (
 /obj/pool/perspective{
-	tag = "icon-pool (NORTHWEST)";
+	dir = 9;
 	icon_state = "pool";
-	dir = 9
+	tag = "icon-pool (NORTHWEST)"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
@@ -4349,22 +4339,22 @@
 /area/station/chapel/main)
 "ajP" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/main)
 "ajQ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/window/eastleft{
 	name = "Chapel Office"
@@ -4399,8 +4389,8 @@
 "ajU" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
@@ -4427,9 +4417,9 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/pyro{
 	dir = 8
@@ -4441,8 +4431,8 @@
 "ajX" = (
 /obj/disposalpipe/segment,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
@@ -4450,9 +4440,9 @@
 /area/station/quartermaster)
 "ajY" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/pyro{
 	dir = 8
@@ -4463,14 +4453,14 @@
 /area/station/quartermaster)
 "ajZ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -4496,8 +4486,8 @@
 "akd" = (
 /obj/shrub,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/item/paper/book/critter_compendium,
 /turf/simulated/floor/specialroom/chapel{
@@ -4538,9 +4528,9 @@
 /area/station/com_dish/auxdish)
 "akj" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/com_dish/auxdish)
@@ -4557,9 +4547,9 @@
 /area/station/com_dish/auxdish)
 "akl" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 5
@@ -4567,9 +4557,9 @@
 /area/station/chapel/main)
 "akm" = (
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 1
@@ -4577,9 +4567,9 @@
 /area/station/chapel/main)
 "akn" = (
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
@@ -4597,8 +4587,8 @@
 "akp" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -4614,12 +4604,12 @@
 /area/station/quartermaster/office)
 "akr" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -4632,8 +4622,8 @@
 /area/station/quartermaster)
 "akt" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -4668,8 +4658,8 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/pyro/maintenance{
-	icon_state = "maint_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "maint_closed"
 	},
 /obj/access_spawn/maint,
 /turf/simulated/floor/plating,
@@ -4682,20 +4672,20 @@
 /area/station/chapel/main)
 "akz" = (
 /obj/stool/chair/pew{
-	icon_state = "pew";
-	dir = 4
+	dir = 4;
+	icon_state = "pew"
 	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/main)
 "akA" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/stool/chair/pew{
-	icon_state = "pew";
-	dir = 4
+	dir = 4;
+	icon_state = "pew"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 6
@@ -4703,9 +4693,9 @@
 /area/station/chapel/main)
 "akB" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 10
@@ -4714,25 +4704,25 @@
 "akC" = (
 /obj/disposalpipe/segment,
 /obj/stool/chair/pew{
-	icon_state = "pew";
-	dir = 4
+	dir = 4;
+	icon_state = "pew"
 	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/main)
 "akD" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/stool/chair/pew{
-	icon_state = "pew";
-	dir = 4
+	dir = 4;
+	icon_state = "pew"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 5
@@ -4745,9 +4735,9 @@
 /area/station/chapel/main)
 "akF" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/table/wood/auto,
 /obj/candle_light,
@@ -4774,9 +4764,9 @@
 /area/station/quartermaster/office)
 "akI" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
@@ -4784,21 +4774,21 @@
 /area/station/quartermaster/office)
 "akJ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "akK" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -4810,9 +4800,9 @@
 /area/station/quartermaster)
 "akM" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/orangeblack/side{
@@ -4826,9 +4816,9 @@
 	pixel_y = -24
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo Bay Lobby";
@@ -4838,13 +4828,13 @@
 /area/station/quartermaster)
 "akO" = (
 /obj/machinery/turret{
-	tag = "icon-grey_target_prism (SOUTHEAST)";
+	dir = 6;
 	icon_state = "grey_target_prism";
-	dir = 6
+	tag = "icon-grey_target_prism (SOUTHEAST)"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -4856,14 +4846,14 @@
 /area/station/turret_protected/ai_upload_foyer)
 "akP" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/orangeblack/side,
 /area/station/quartermaster)
@@ -4881,21 +4871,21 @@
 /area/station/chapel/main)
 "akS" = (
 /obj/cable{
-	tag = "icon-6-8";
-	icon_state = "6-8"
+	icon_state = "6-8";
+	tag = "icon-6-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	tag = "icon-1-10";
-	icon_state = "1-10"
+	icon_state = "1-10";
+	tag = "icon-1-10"
 	},
 /obj/stool/chair/pew{
-	icon_state = "pew";
-	dir = 4
+	dir = 4;
+	icon_state = "pew"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
@@ -4903,9 +4893,9 @@
 /area/station/chapel/main)
 "akT" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 9
@@ -4913,14 +4903,14 @@
 /area/station/chapel/main)
 "akU" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment,
 /obj/stool/chair/pew{
-	icon_state = "pew";
-	dir = 4
+	dir = 4;
+	icon_state = "pew"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 5
@@ -4928,17 +4918,17 @@
 /area/station/chapel/main)
 "akV" = (
 /obj/cable{
-	tag = "icon-4-10";
-	icon_state = "4-10"
+	icon_state = "4-10";
+	tag = "icon-4-10"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	tag = "icon-1-6";
-	icon_state = "1-6"
+	icon_state = "1-6";
+	tag = "icon-1-6"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 1
@@ -4946,25 +4936,25 @@
 /area/station/chapel/main)
 "akW" = (
 /obj/cable{
-	tag = "icon-5-8";
-	icon_state = "5-8"
+	icon_state = "5-8";
+	tag = "icon-5-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	tag = "icon-1-10";
-	icon_state = "1-10"
+	icon_state = "1-10";
+	tag = "icon-1-10"
 	},
 /obj/cable{
-	tag = "icon-4-6";
-	icon_state = "4-6"
+	icon_state = "4-6";
+	tag = "icon-4-6"
 	},
 /obj/stool/chair/pew{
-	icon_state = "pew";
-	dir = 4
+	dir = 4;
+	icon_state = "pew"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 6
@@ -4972,14 +4962,14 @@
 /area/station/chapel/main)
 "akX" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 9
@@ -4987,9 +4977,9 @@
 /area/station/chapel/main)
 "akY" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -4997,20 +4987,20 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	tag = "icon-4-9";
-	icon_state = "4-9"
+	icon_state = "4-9";
+	tag = "icon-4-9"
 	},
 /obj/stool/chair/pew{
-	icon_state = "pew";
-	dir = 4
+	dir = 4;
+	icon_state = "pew"
 	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/main)
 "akZ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/table/wood/auto,
 /obj/loudspeaker,
@@ -5038,9 +5028,9 @@
 "alc" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/access_spawn/maint,
@@ -5059,8 +5049,8 @@
 /area/station/quartermaster)
 "alg" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -5087,17 +5077,17 @@
 /area/station/chapel/main)
 "alj" = (
 /obj/cable{
-	tag = "icon-2-6";
-	icon_state = "2-6"
+	icon_state = "2-6";
+	tag = "icon-2-6"
 	},
 /obj/cable{
-	tag = "icon-4-6";
-	icon_state = "4-6"
+	icon_state = "4-6";
+	tag = "icon-4-6"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 10
@@ -5105,22 +5095,22 @@
 /area/station/chapel/main)
 "alk" = (
 /obj/cable{
-	tag = "icon-2-10";
-	icon_state = "2-10"
+	icon_state = "2-10";
+	tag = "icon-2-10"
 	},
 /obj/cable{
-	tag = "icon-8-10";
-	icon_state = "8-10"
+	icon_state = "8-10";
+	tag = "icon-8-10"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /obj/stool/chair/pew{
-	icon_state = "pew";
-	dir = 4
+	dir = 4;
+	icon_state = "pew"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 6
@@ -5128,9 +5118,9 @@
 /area/station/chapel/main)
 "all" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
 	d1 = 1;
@@ -5138,8 +5128,8 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	tag = "icon-5-8";
-	icon_state = "5-8"
+	icon_state = "5-8";
+	tag = "icon-5-8"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 8
@@ -5157,21 +5147,21 @@
 /area/station/maintenance/disposal)
 "aln" = (
 /obj/cable{
-	tag = "icon-4-9";
-	icon_state = "4-9"
+	icon_state = "4-9";
+	tag = "icon-4-9"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	tag = "icon-1-6";
-	icon_state = "1-6"
+	icon_state = "1-6";
+	tag = "icon-1-6"
 	},
 /obj/cable{
-	tag = "icon-8-10";
-	icon_state = "8-10"
+	icon_state = "8-10";
+	tag = "icon-8-10"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 10
@@ -5179,8 +5169,8 @@
 /area/station/chapel/main)
 "alo" = (
 /obj/cable{
-	tag = "icon-6-8";
-	icon_state = "6-8"
+	icon_state = "6-8";
+	tag = "icon-6-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -5188,12 +5178,12 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	tag = "icon-2-9";
-	icon_state = "2-9"
+	icon_state = "2-9";
+	tag = "icon-2-9"
 	},
 /obj/stool/chair/pew{
-	icon_state = "pew";
-	dir = 4
+	dir = 4;
+	icon_state = "pew"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
@@ -5201,9 +5191,9 @@
 /area/station/chapel/main)
 "alp" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/table/wood/auto,
 /obj/item/storage/bible,
@@ -5236,9 +5226,9 @@
 /area/station/maintenance/NWmaint)
 "alx" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
@@ -5278,9 +5268,9 @@
 /area/station/chapel/office)
 "alD" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/office)
@@ -5294,9 +5284,9 @@
 /area/station/medical/morgue)
 "alF" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 1
@@ -5304,14 +5294,14 @@
 /area/station/chapel/main)
 "alG" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
@@ -5319,9 +5309,9 @@
 /area/station/chapel/main)
 "alH" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/specialroom/chapel{
@@ -5335,21 +5325,21 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	tag = "icon-4-10";
-	icon_state = "4-10"
+	icon_state = "4-10";
+	tag = "icon-4-10"
 	},
 /obj/cable{
-	tag = "icon-5-6";
-	icon_state = "5-6"
+	icon_state = "5-6";
+	tag = "icon-5-6"
 	},
 /obj/stool/chair/pew{
-	icon_state = "pew";
-	dir = 4
+	dir = 4;
+	icon_state = "pew"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 5
@@ -5357,12 +5347,12 @@
 /area/station/chapel/main)
 "alJ" = (
 /obj/cable{
-	tag = "icon-1-5";
-	icon_state = "1-5"
+	icon_state = "1-5";
+	tag = "icon-1-5"
 	},
 /obj/cable{
-	tag = "icon-4-5";
-	icon_state = "4-5"
+	icon_state = "4-5";
+	tag = "icon-4-5"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 1
@@ -5370,17 +5360,17 @@
 /area/station/chapel/main)
 "alK" = (
 /obj/cable{
-	tag = "icon-1-9";
-	icon_state = "1-9"
+	icon_state = "1-9";
+	tag = "icon-1-9"
 	},
 /obj/cable{
-	tag = "icon-8-9";
-	icon_state = "8-9"
+	icon_state = "8-9";
+	tag = "icon-8-9"
 	},
 /obj/disposalpipe/segment,
 /obj/stool/chair/pew{
-	icon_state = "pew";
-	dir = 4
+	dir = 4;
+	icon_state = "pew"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
@@ -5393,17 +5383,17 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	tag = "icon-6-8";
-	icon_state = "6-8"
+	icon_state = "6-8";
+	tag = "icon-6-8"
 	},
 /obj/cable{
-	tag = "icon-9-10";
-	icon_state = "9-10"
+	icon_state = "9-10";
+	tag = "icon-9-10"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 9
@@ -5422,8 +5412,8 @@
 /area/station/chapel/office)
 "alN" = (
 /obj/cable{
-	tag = "icon-4-10";
-	icon_state = "4-10"
+	icon_state = "4-10";
+	tag = "icon-4-10"
 	},
 /obj/cable{
 	d1 = 1;
@@ -5431,8 +5421,8 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	tag = "icon-2-5";
-	icon_state = "2-5"
+	icon_state = "2-5";
+	tag = "icon-2-5"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 1
@@ -5449,9 +5439,9 @@
 /area/station/storage/warehouse)
 "alP" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 5
@@ -5493,8 +5483,8 @@
 /area/station/storage/tech)
 "alU" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/firealarm{
@@ -5502,8 +5492,8 @@
 	text = "NF"
 	},
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
@@ -5560,9 +5550,9 @@
 "amb" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
@@ -5573,17 +5563,17 @@
 /area/station/medical/morgue)
 "amc" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/main)
 "amd" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
@@ -5591,9 +5581,9 @@
 /area/station/chapel/main)
 "ame" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 8
@@ -5606,19 +5596,19 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	tag = "icon-2-5";
-	icon_state = "2-5"
+	icon_state = "2-5";
+	tag = "icon-2-5"
 	},
 /obj/cable{
-	tag = "icon-4-5";
-	icon_state = "4-5"
+	icon_state = "4-5";
+	tag = "icon-4-5"
 	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/main)
 "amg" = (
 /obj/cable{
-	tag = "icon-4-9";
-	icon_state = "4-9"
+	icon_state = "4-9";
+	tag = "icon-4-9"
 	},
 /obj/cable{
 	d1 = 1;
@@ -5626,8 +5616,8 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	tag = "icon-2-5";
-	icon_state = "2-5"
+	icon_state = "2-5";
+	tag = "icon-2-5"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 10
@@ -5635,8 +5625,8 @@
 /area/station/chapel/main)
 "amh" = (
 /obj/cable{
-	tag = "icon-5-8";
-	icon_state = "5-8"
+	icon_state = "5-8";
+	tag = "icon-5-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -5644,8 +5634,8 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	tag = "icon-2-9";
-	icon_state = "2-9"
+	icon_state = "2-9";
+	tag = "icon-2-9"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 6
@@ -5658,12 +5648,12 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	tag = "icon-2-9";
-	icon_state = "2-9"
+	icon_state = "2-9";
+	tag = "icon-2-9"
 	},
 /obj/cable{
-	tag = "icon-8-9";
-	icon_state = "8-9"
+	icon_state = "8-9";
+	tag = "icon-8-9"
 	},
 /obj/machinery/camera{
 	c_tag = "Chapel";
@@ -5675,9 +5665,9 @@
 /area/station/chapel/main)
 "amj" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 9
@@ -5695,9 +5685,9 @@
 	pixel_y = 21
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 5
@@ -5748,9 +5738,9 @@
 	pixel_y = -2
 	},
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
+	dir = 8;
 	icon_state = "bulb1";
-	dir = 8
+	tag = "icon-bulb1 (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
@@ -5767,8 +5757,8 @@
 /area/station/storage/tech)
 "amr" = (
 /obj/cable{
-	tag = "icon-0-2";
-	icon_state = "0-2"
+	icon_state = "0-2";
+	tag = "icon-0-2"
 	},
 /obj/cable{
 	d2 = 8;
@@ -5791,9 +5781,9 @@
 /area/station/hallway/primary/north)
 "amv" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/NWmaint)
@@ -5803,9 +5793,9 @@
 /area/station/maintenance/NWmaint)
 "amx" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/pyro,
 /turf/simulated/floor,
@@ -5936,21 +5926,21 @@
 /area)
 "amM" = (
 /obj/cable{
-	tag = "icon-0-2";
-	icon_state = "0-2"
+	icon_state = "0-2";
+	tag = "icon-0-2"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "amN" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/table/auto,
 /obj/item/storage/box/diskbox,
@@ -5958,9 +5948,9 @@
 /area/station/storage/tech)
 "amO" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
@@ -5991,9 +5981,9 @@
 /area/station/hallway/primary/central)
 "amU" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/pyro,
 /turf/simulated/floor,
@@ -6032,9 +6022,9 @@
 /area/station/chapel/main)
 "amZ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 6
@@ -6078,8 +6068,8 @@
 /area/station/chapel/main)
 "ang" = (
 /obj/item/device/radio/intercom{
-	dir = 4;
 	broadcasting = 1;
+	dir = 4;
 	frequency = 1453;
 	name = "Station Intercom (Confessional)"
 	},
@@ -6124,16 +6114,16 @@
 "anm" = (
 /obj/cable,
 /obj/cable{
-	tag = "icon-0-2";
-	icon_state = "0-2"
+	icon_state = "0-2";
+	tag = "icon-0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "ann" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable,
 /obj/wingrille_spawn/auto,
@@ -6153,9 +6143,9 @@
 /area/station/storage/tech)
 "anq" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
+	dir = 8;
 	icon_state = "bulb1";
-	dir = 8
+	tag = "icon-bulb1 (WEST)"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 10
@@ -6163,31 +6153,31 @@
 /area/station/turret_protected/ai_upload_foyer)
 "anr" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "ans" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance{
-	icon_state = "maint_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "maint_closed"
 	},
 /obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "ant" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/landmark/start{
 	name = "Technical Assistant"
@@ -6196,15 +6186,15 @@
 /area/station/maintenance/NWmaint)
 "anu" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/table/wood/auto,
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/machinery/camera{
 	c_tag = "FP Maintenance - Storage";
@@ -6216,35 +6206,35 @@
 /area/station/maintenance/NWmaint)
 "anv" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/NWmaint)
 "anw" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "anx" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
@@ -6253,9 +6243,9 @@
 /area/station/hallway/primary/central)
 "anz" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -6279,9 +6269,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/light{
-	tag = "icon-tube1 (NORTH)";
+	dir = 1;
 	icon_state = "tube1";
-	dir = 1
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/floor/black,
 /area/station/medical/morgue)
@@ -6318,8 +6308,8 @@
 /area/station/chapel/main)
 "anH" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -6338,8 +6328,8 @@
 "anJ" = (
 /obj/table/wood/auto,
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 1;
+	dir = 8;
 	frequency = 1453;
 	name = "Station Intercom (Confessional)"
 	},
@@ -6361,9 +6351,9 @@
 /area/station/chapel/main)
 "anM" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload_foyer)
@@ -6379,9 +6369,9 @@
 /area/station/storage/autolathe)
 "anQ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/table/auto,
 /obj/item/device/flash,
@@ -6390,23 +6380,23 @@
 /area/station/storage/tech)
 "anR" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "anS" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
@@ -6418,9 +6408,9 @@
 /area/station/storage/tech)
 "anT" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/light/small{
 	brightness = 2;
@@ -6455,8 +6445,8 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -6470,9 +6460,9 @@
 /area/station/medical/morgue)
 "aoa" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/black,
 /area/station/medical/morgue)
@@ -6488,14 +6478,14 @@
 /area/station/medical/morgue)
 "aoc" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/main)
@@ -6511,8 +6501,8 @@
 /area/station/chapel/main)
 "aog" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/monitor,
 /turf/simulated/floor/plating,
@@ -6549,22 +6539,22 @@
 /area/station/turret_protected/ai_upload_foyer)
 "aok" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload_foyer)
 "aol" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/purple,
 /area/station/turret_protected/ai_upload_foyer)
@@ -6594,9 +6584,9 @@
 /area/station/storage/tech)
 "aoo" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -6636,9 +6626,9 @@
 /area/station/storage/tech)
 "aor" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -6662,9 +6652,9 @@
 /area/station/maintenance/NWmaint)
 "aou" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/pyro,
 /turf/simulated/floor/plating,
@@ -6674,9 +6664,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/vent{
-	tag = "icon-exposed (EAST)";
+	dir = 4;
 	icon_state = "exposed";
-	dir = 4
+	tag = "icon-exposed (EAST)"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -6706,9 +6696,9 @@
 "aoy" = (
 /obj/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/vent{
-	tag = "icon-exposed-f (WEST)";
+	dir = 8;
 	icon_state = "exposed-f";
-	dir = 8
+	tag = "icon-exposed-f (WEST)"
 	},
 /turf/simulated/floor/black,
 /area/station/medical/morgue)
@@ -6732,15 +6722,15 @@
 "aoB" = (
 /obj/machinery/computer/teleporter,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/teleporter)
 "aoC" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/camera{
 	c_tag = "Teleporter";
@@ -6751,16 +6741,16 @@
 /area/station/teleporter)
 "aoD" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/teleport/portal_ring,
 /turf/simulated/floor/orangeblack,
 /area/station/teleporter)
 "aoE" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -6789,9 +6779,9 @@
 	},
 /obj/item/instrument/large/organ,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 1
@@ -6799,9 +6789,9 @@
 /area/station/chapel/main)
 "aoJ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/chapel/main)
@@ -6816,9 +6806,9 @@
 /area/station/medical/robotics)
 "aoN" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purple,
 /area/station/turret_protected/ai_upload_foyer)
@@ -6831,9 +6821,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
@@ -6846,16 +6836,16 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "aoR" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/camera{
 	c_tag = "FP Maintenance - Central";
@@ -6877,8 +6867,8 @@
 /area/station/hallway/primary/central)
 "aoU" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/black,
 /area/station/medical/morgue)
@@ -6896,8 +6886,8 @@
 /area/station/chapel/main)
 "aoX" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/orangeblack/corner{
 	dir = 4
@@ -6905,14 +6895,14 @@
 /area/station/teleporter)
 "aoY" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 1
@@ -6925,9 +6915,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 1
@@ -6958,9 +6948,9 @@
 /area/station/chapel/main)
 "ape" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/damaged1,
 /area/station/chapel/main)
@@ -6978,22 +6968,22 @@
 	req_access_txt = "19"
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 8;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 1;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload_foyer)
 "aph" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/window{
 	dir = 1
@@ -7002,14 +6992,14 @@
 /area/station/turret_protected/ai_upload_foyer)
 "api" = (
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	invisibility = 0;
 	reinf = 1
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 1;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /turf/simulated/floor/circuit,
@@ -7075,9 +7065,9 @@
 /area/station/maintenance/NWmaint)
 "apu" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/engine,
 /area/station/hallway/secondary/shuttle)
@@ -7092,9 +7082,9 @@
 /area/station/maintenance/NWmaint)
 "apx" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/command{
@@ -7106,9 +7096,9 @@
 "apy" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/window/southleft,
 /turf/simulated/floor/grey/side{
@@ -7125,9 +7115,9 @@
 /area/station/teleporter)
 "apA" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/teleporter)
@@ -7159,8 +7149,8 @@
 /area/station/chapel/main)
 "apG" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
 /obj/computer3frame{
@@ -7171,14 +7161,14 @@
 /area/station/chapel/main)
 "apH" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plating,
@@ -7204,8 +7194,8 @@
 	dir = 8
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -7215,14 +7205,14 @@
 /area/station/turret_protected/ai_upload)
 "apM" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/purple,
 /area/station/turret_protected/ai_upload)
@@ -7240,13 +7230,13 @@
 "apO" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/emitter{
-	tag = "icon-Emitter (NORTH)";
+	dir = 1;
 	icon_state = "Emitter";
-	dir = 1
+	tag = "icon-Emitter (NORTH)"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 2
@@ -7255,8 +7245,8 @@
 "apP" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 2
@@ -7314,9 +7304,9 @@
 /area/station/hallway/primary/central)
 "apZ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/turret_protected/ai_upload_foyer)
@@ -7330,9 +7320,9 @@
 /area/station/turret_protected/ai_upload_foyer)
 "aqc" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 1
@@ -7349,9 +7339,9 @@
 /area/station/turret_protected/ai_upload_foyer)
 "aqf" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	icon_state = "1-8"
@@ -7362,9 +7352,9 @@
 /area/station/chapel/main)
 "aqg" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purple,
 /area/station/turret_protected/ai_upload)
@@ -7373,16 +7363,16 @@
 	dir = 8
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
 "aqi" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
@@ -7413,9 +7403,9 @@
 /area/station/maintenance/NWmaint)
 "aqn" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
 	pixel_y = 24;
@@ -7434,17 +7424,17 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "aqp" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -7452,9 +7442,9 @@
 "aqq" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/command{
 	name = "Teleporter Access"
@@ -7464,22 +7454,22 @@
 /area/station/teleporter)
 "aqr" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "aqs" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -7526,9 +7516,9 @@
 /area/station/turret_protected/ai_upload_foyer)
 "aqz" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/landmark{
 	name = "kudzustart"
@@ -7543,8 +7533,8 @@
 	dir = 2
 	},
 /obj/machinery/light/emergency{
-	icon_state = "ebulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "ebulb1"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 1
@@ -7560,13 +7550,11 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "aqC" = (
-/obj/item/device/radio/intercom{
-	
-	},
+/obj/item/device/radio/intercom,
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
+	dir = 8;
 	icon_state = "bulb1";
-	dir = 8
+	tag = "icon-bulb1 (WEST)"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 9
@@ -7574,9 +7562,9 @@
 /area/station/turret_protected/ai_upload_foyer)
 "aqD" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/purple/corner{
 	dir = 1
@@ -7584,9 +7572,9 @@
 /area/station/turret_protected/ai_upload_foyer)
 "aqE" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -7597,16 +7585,16 @@
 /area/station/turret_protected/ai_upload_foyer)
 "aqF" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/turret_protected/ai_upload_foyer)
 "aqG" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 5
@@ -7617,9 +7605,9 @@
 /area/station/turret_protected/ai_upload)
 "aqI" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
@@ -7637,8 +7625,8 @@
 /area/station/engine/engineering)
 "aqL" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
@@ -7651,12 +7639,12 @@
 /area/station/engine/engineering)
 "aqN" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -7671,17 +7659,17 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
 "aqP" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/external{
 	name = "Singularity Core"
@@ -7695,13 +7683,13 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
@@ -7738,9 +7726,9 @@
 /area/station/hallway/primary/central)
 "aqZ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -7751,18 +7739,18 @@
 /area/station/hallway/primary/central)
 "ara" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "arb" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -7773,22 +7761,22 @@
 /area/station/hallway/primary/central)
 "arc" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "ard" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 4
@@ -7796,9 +7784,9 @@
 /area/station/hallway/primary/central)
 "are" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/pyro{
 	dir = 4
@@ -7813,9 +7801,9 @@
 /area/station/turret_protected/ai_upload)
 "arf" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 8
@@ -7823,17 +7811,17 @@
 /area/station/turret_protected/ai_upload_foyer)
 "arg" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/turret_protected/ai_upload_foyer)
 "arh" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 4
@@ -7842,9 +7830,9 @@
 "ari" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/pyro{
 	dir = 4
@@ -7858,9 +7846,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/turret_protected/ai_upload_foyer)
@@ -7869,9 +7857,9 @@
 /area/station/turret_protected/ai_upload_foyer)
 "arl" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
 	d1 = 1;
@@ -7882,30 +7870,30 @@
 /area/station/turret_protected/ai_upload_foyer)
 "arm" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/purple,
 /area/station/turret_protected/ai_upload)
 "arn" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/maintenance{
-	icon_state = "maint_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "maint_closed"
 	},
 /obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "aro" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
@@ -7917,17 +7905,17 @@
 /area/station/turret_protected/ai_upload)
 "arp" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/purple,
 /area/station/turret_protected/ai_upload)
 "arq" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -7935,9 +7923,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/purple,
 /area/station/turret_protected/ai_upload)
@@ -7974,8 +7962,8 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/engine/engineering)
@@ -7986,13 +7974,13 @@
 /obj/machinery/power/data_terminal,
 /obj/machinery/field_generator,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/engine/engineering)
@@ -8008,8 +7996,8 @@
 "ary" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
@@ -8034,9 +8022,9 @@
 /area/station/hallway/primary/central)
 "arC" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purple/side,
 /area/station/hallway/primary/central)
@@ -8106,14 +8094,14 @@
 /area/station/turret_protected/ai_upload_foyer)
 "arO" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/turret_protected/ai_upload_foyer)
@@ -8131,8 +8119,8 @@
 	dir = 8
 	},
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 6
@@ -8143,8 +8131,8 @@
 	pixel_x = 24
 	},
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/purple,
 /area/station/turret_protected/ai_upload)
@@ -8157,29 +8145,29 @@
 /area/station/turret_protected/ai_upload)
 "arT" = (
 /obj/item/device/radio/intercom{
-	dir = 8 frequency = 1447;
-	broadcasting = 1
+	broadcasting = 1;
+	dir = 8 frequency = 1447
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
 "arU" = (
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
 "arV" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -8201,14 +8189,14 @@
 /area/station/engine/engineering)
 "arZ" = (
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
@@ -8259,13 +8247,13 @@
 /area/station/hallway/primary/central)
 "ash" = (
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-c";
+	dir = 2;
 	icon_state = "pipe-c";
-	dir = 2
+	tag = "icon-pipe-c"
 	},
 /obj/machinery/light/emergency{
-	icon_state = "ebulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "ebulb1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -8283,9 +8271,9 @@
 /area/station/maintenance/inner)
 "asl" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/central)
@@ -8333,8 +8321,8 @@
 	dir = 8
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/camera/motion{
 	c_tag = "AI Upload";
@@ -8375,9 +8363,9 @@
 /area/station/engine/engineering)
 "asx" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 4
@@ -8385,23 +8373,23 @@
 /area/station/engine/engineering)
 "asy" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/engineering{
-	icon_state = "eng_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "eng_closed"
 	},
 /obj/access_spawn/engineering,
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
 "asz" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 8
@@ -8409,17 +8397,17 @@
 /area/station/engine/engineering)
 "asA" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "asB" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 4
@@ -8435,9 +8423,9 @@
 /area/station/chapel/main)
 "asD" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 8
@@ -8445,35 +8433,35 @@
 /area/station/hallway/primary/central)
 "asE" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "asF" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "asG" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
@@ -8505,9 +8493,9 @@
 /area/station/hallway/primary/central)
 "asL" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -8540,8 +8528,8 @@
 /obj/item/scissors,
 /obj/item/razor_blade,
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor,
 /area/station/maintenance/east)
@@ -8550,8 +8538,8 @@
 	dir = 8
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/circuit,
@@ -8563,9 +8551,9 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/purple,
 /area/station/turret_protected/ai_upload)
@@ -8584,9 +8572,9 @@
 /area/station/turret_protected/ai_upload)
 "asV" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4;
@@ -8604,9 +8592,9 @@
 /area/station/engine/engineering)
 "asX" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4;
@@ -8618,9 +8606,9 @@
 /area/station/engine/engineering)
 "asY" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/table/auto,
 /obj/random_item_spawner/tools_w_igloves,
@@ -8662,9 +8650,9 @@
 /area/station/hallway/primary/central)
 "ate" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 2
@@ -8694,9 +8682,9 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellow/corner{
 	dir = 8
@@ -8704,47 +8692,47 @@
 /area/station/hallway/primary/central)
 "atj" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance{
-	icon_state = "maint_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "maint_closed"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
 "atk" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
 "atl" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
 "atm" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -8754,9 +8742,9 @@
 /area/station/maintenance/inner)
 "atn" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -8779,9 +8767,9 @@
 /area/station/maintenance/inner)
 "atp" = (
 /obj/disposalpipe/switch_junction/biofilter{
-	tag = "icon-pipe-sj1 (EAST)";
+	dir = 4;
 	icon_state = "pipe-sj1";
-	dir = 4
+	tag = "icon-pipe-sj1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
@@ -8797,9 +8785,9 @@
 /area/station/maintenance/inner)
 "atr" = (
 /obj/disposalpipe/switch_junction/biofilter{
-	tag = "icon-pipe-sj1 (WEST)";
+	dir = 8;
 	icon_state = "pipe-sj1";
-	dir = 8
+	tag = "icon-pipe-sj1 (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
@@ -8842,9 +8830,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -8885,9 +8873,9 @@
 /area/station/maintenance/east)
 "atC" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/table/auto,
 /obj/random_item_spawner/tools,
@@ -8895,9 +8883,9 @@
 /area/station/engine/engineering)
 "atD" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance,
@@ -8933,9 +8921,9 @@
 /area/station/storage/warehouse)
 "atI" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/poddoor{
 	id = "emergencyinternals";
@@ -8959,8 +8947,8 @@
 "atL" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance{
-	icon_state = "maint_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "maint_closed"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
@@ -8975,9 +8963,9 @@
 "atN" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -9021,9 +9009,9 @@
 /area/station/engine/engineering)
 "atV" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light_switch{
 	name = "E light switch";
@@ -9038,9 +9026,9 @@
 "atW" = (
 /obj/storage/crate/furnacefuel,
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
+	dir = 8;
 	icon_state = "bulb1";
-	dir = 8
+	tag = "icon-bulb1 (WEST)"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
@@ -9063,17 +9051,17 @@
 /area/station/maintenance/west)
 "aua" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aub" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/table/wood/auto,
 /obj/candle_light,
@@ -9093,9 +9081,9 @@
 /area/station/storage/emergency)
 "auf" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment,
 /obj/machinery/portable_atmospherics/scrubber,
@@ -9111,9 +9099,9 @@
 /area/station/storage/emergency)
 "auh" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 8
@@ -9121,8 +9109,8 @@
 /area/station/hallway/primary/central)
 "aui" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -9176,8 +9164,8 @@
 "aup" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -9194,12 +9182,12 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/engine/engineering)
@@ -9207,16 +9195,16 @@
 /obj/machinery/power/data_terminal,
 /obj/machinery/field_generator,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/engine/engineering)
@@ -9227,17 +9215,17 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
 "aut" = (
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
@@ -9248,13 +9236,13 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/emitter{
-	tag = "icon-Emitter (WEST)";
+	dir = 8;
 	icon_state = "Emitter";
-	dir = 8
+	tag = "icon-Emitter (WEST)"
 	},
 /turf/simulated/floor/bot,
 /area/station/engine/engineering)
@@ -9264,8 +9252,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 4;
@@ -9276,14 +9264,14 @@
 /area/station/engine/engineering)
 "auw" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
@@ -9323,9 +9311,9 @@
 /area/mining/magnet)
 "auy" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
@@ -9339,14 +9327,14 @@
 /area/station/storage/emergency)
 "auA" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /obj/machinery/portable_atmospherics/scrubber,
@@ -9355,9 +9343,9 @@
 "auB" = (
 /obj/storage/closet/emergency,
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
+	dir = 8;
 	icon_state = "bulb1";
-	dir = 8
+	tag = "icon-bulb1 (WEST)"
 	},
 /turf/simulated/floor/grime,
 /area/station/storage/warehouse)
@@ -9367,9 +9355,9 @@
 /area/station/storage/warehouse)
 "auD" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/storage/closet/emergency,
 /turf/simulated/floor/grime,
@@ -9396,13 +9384,11 @@
 	c_tag = "Lounge";
 	dir = 4
 	},
-/obj/item/device/radio/intercom{
-	
-	},
+/obj/item/device/radio/intercom,
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
+	dir = 8;
 	icon_state = "bulb1";
-	dir = 8
+	tag = "icon-bulb1 (WEST)"
 	},
 /turf/simulated/floor,
 /area/station/maintenance/east)
@@ -9434,21 +9420,21 @@
 /area/station/maintenance/east)
 "auM" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "auN" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable,
 /obj/wingrille_spawn/auto,
@@ -9456,22 +9442,22 @@
 /area/station/engine/engineering)
 "auO" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
 "auP" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 4
@@ -9505,9 +9491,9 @@
 /area/mining/magnet)
 "auS" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/engine/power)
@@ -9552,14 +9538,14 @@
 /area/mining/magnet)
 "auW" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment,
 /obj/machinery/portable_atmospherics/scrubber,
@@ -9573,8 +9559,8 @@
 /area/station/storage/emergency)
 "auX" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -9587,9 +9573,9 @@
 /area/station/storage/warehouse)
 "ava" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/grime,
 /area/station/storage/warehouse)
@@ -9631,67 +9617,67 @@
 /area/station/hallway/primary/south)
 "avh" = (
 /obj/cable{
-	tag = "icon-1-4";
-	icon_state = "1-4"
+	icon_state = "1-4";
+	tag = "icon-1-4"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "avi" = (
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
 "avj" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
 "avk" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
 "avl" = (
 /obj/machinery/power/collector_array,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
 "avm" = (
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/machinery/power/collector_control,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -9702,33 +9688,33 @@
 "avn" = (
 /obj/machinery/power/collector_array,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
 "avo" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/engine/power)
 "avp" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/engine/power)
@@ -9742,9 +9728,9 @@
 /area/station/engine/power)
 "avr" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/power)
@@ -9760,16 +9746,16 @@
 /area/station/engine/power)
 "avt" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "avu" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
@@ -9785,9 +9771,9 @@
 /area/station/engine/engineering)
 "avv" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -9799,8 +9785,8 @@
 /area/station/engine/engineering)
 "avw" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -9812,9 +9798,9 @@
 /area/station/storage/emergency)
 "avx" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /obj/disposalpipe/segment,
@@ -9822,9 +9808,9 @@
 /area/station/storage/emergency)
 "avy" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/camera{
 	c_tag = "Habitation Ring West";
@@ -9836,9 +9822,9 @@
 /area/station/hallway/primary/central)
 "avz" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/storage/warehouse)
@@ -9864,9 +9850,9 @@
 /area/station/hallway/primary/central)
 "avE" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/disposalpipe/segment{
@@ -9883,8 +9869,8 @@
 /area/station/maintenance/east)
 "avG" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -9910,9 +9896,9 @@
 /area/station/maintenance/east)
 "avJ" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -9923,9 +9909,9 @@
 "avK" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro{
 	dir = 4
@@ -9934,9 +9920,9 @@
 /area/station/storage/emergency)
 "avL" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -9946,26 +9932,26 @@
 /area/station/maintenance/east)
 "avM" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "avN" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -9994,24 +9980,24 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
 "avR" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/wingrille_spawn/auto,
@@ -10019,8 +10005,8 @@
 /area/station/engine/power)
 "avS" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/machinery/power/terminal{
@@ -10045,8 +10031,8 @@
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor,
 /area/station/engine/power)
@@ -10075,17 +10061,17 @@
 /area/station/storage/emergency)
 "avY" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/storage/emergency)
 "avZ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -10101,14 +10087,14 @@
 /area/station/maintenance/east)
 "awb" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 8
@@ -10144,9 +10130,9 @@
 /area/station/storage/warehouse)
 "awh" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/pyro,
 /turf/simulated/floor/yellow/side{
@@ -10171,17 +10157,17 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "awk" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -10192,16 +10178,16 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "awm" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -10231,8 +10217,8 @@
 /area/station/medical/robotics)
 "aws" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 4;
@@ -10270,9 +10256,9 @@
 /area/station/maintenance/east)
 "aww" = (
 /obj/machinery/emitter{
-	tag = "icon-Emitter (WEST)";
+	dir = 8;
 	icon_state = "Emitter";
-	dir = 8
+	tag = "icon-Emitter (WEST)"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
@@ -10296,9 +10282,9 @@
 /area/station/engine/power)
 "awz" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/camera{
 	c_tag = "Emergency Storage Maintenance";
@@ -10389,8 +10375,8 @@
 /obj/machinery/manufacturer/robotics,
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
@@ -10470,8 +10456,8 @@
 /area/station/medical/research)
 "awS" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -10520,9 +10506,9 @@
 /area/station/engine/engineering)
 "awY" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -10541,8 +10527,8 @@
 /area/station/engine/power)
 "axa" = (
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 0;
+	dir = 8;
 	frequency = 1441;
 	name = "Station Intercom (Engineering)"
 	},
@@ -10575,14 +10561,14 @@
 /area/station/mining/magnet)
 "axh" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 8
@@ -10663,9 +10649,9 @@
 /area/station/medical/robotics)
 "axu" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/blueblack/corner,
 /area/station/medical/robotics)
@@ -10707,9 +10693,9 @@
 /area/station/medical/research)
 "axz" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
 /area/station/medical/research)
@@ -10723,13 +10709,13 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/landmark/artifact{
 	name = "artifact spawner (10%)";
@@ -10739,21 +10725,21 @@
 /area/station/solar/west)
 "axC" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/storage/emergency)
 "axD" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -10774,9 +10760,9 @@
 /area/station/engine/engineering)
 "axG" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/engineering,
 /obj/access_spawn/engineering,
@@ -10794,9 +10780,9 @@
 /area/station/hydroponics)
 "axI" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/power)
@@ -10807,8 +10793,8 @@
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor,
 /area/station/engine/power)
@@ -10822,17 +10808,17 @@
 /area/station/engine/power)
 "axL" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "axM" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -10846,18 +10832,18 @@
 /area/station/maintenance/west)
 "axO" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/camera{
 	c_tag = "Habitation Ring West";
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 8
@@ -10869,9 +10855,9 @@
 /area/station/storage/warehouse)
 "axQ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/item/wirecutters,
 /turf/simulated/floor/grime,
@@ -10896,16 +10882,16 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "axT" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -10931,8 +10917,8 @@
 	dir = 4
 	},
 /obj/machinery/light/emergency{
-	icon_state = "ebulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "ebulb1"
 	},
 /turf/simulated/floor/yellow/corner{
 	dir = 1
@@ -10991,8 +10977,8 @@
 "ayf" = (
 /obj/item/extinguisher,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/medical/robotics)
@@ -11018,30 +11004,30 @@
 /area/station/medical/research)
 "ayk" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/critter/opossum/morty,
 /turf/simulated/floor/black,
 /area/station/medical/research)
 "ayl" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/engineering{
-	icon_state = "eng_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "eng_closed"
 	},
 /obj/access_spawn/engineering,
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "aym" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -11059,9 +11045,9 @@
 	dir = 8
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
@@ -11074,13 +11060,13 @@
 /area/station/maintenance/west)
 "ays" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -11103,9 +11089,9 @@
 "ayv" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Pod Bay"
@@ -11134,8 +11120,8 @@
 	pixel_y = 0
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/blueblack/corner,
 /area/station/medical/robotics)
@@ -11147,14 +11133,14 @@
 /area/station/medical/robotics)
 "ayz" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/landmark/start{
 	name = "Roboticist"
@@ -11163,9 +11149,9 @@
 /area/station/medical/robotics)
 "ayA" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/landmark/start{
 	name = "Roboticist"
@@ -11181,9 +11167,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/optable,
 /turf/simulated/floor/blueblack/corner,
@@ -11283,9 +11269,9 @@
 /area/station/storage/warehouse)
 "ayN" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/dummy_pad,
 /turf/simulated/floor/grime,
@@ -11306,9 +11292,9 @@
 /area/station/hallway/primary/central)
 "ayR" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/neutral/side{
@@ -11322,9 +11308,9 @@
 /area/station/hallway/primary/central)
 "ayT" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/blueblack/corner,
 /area/station/medical/robotics)
@@ -11361,30 +11347,30 @@
 /area/station/maintenance/east)
 "ayX" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable,
 /turf/simulated/floor/black,
 /area/station/medical/research)
 "ayY" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/medical/research)
 "ayZ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/research)
@@ -11421,8 +11407,8 @@
 /obj/table/reinforced,
 /obj/item/item_box/medical_patches/styptic,
 /turf/simulated/floor{
-	tag = "icon-0,6";
-	icon_state = "0,6"
+	icon_state = "0,6";
+	tag = "icon-0,6"
 	},
 /area/station/crew_quarters/fitness)
 "azf" = (
@@ -11491,9 +11477,9 @@
 /area/station/engine/engineering)
 "azm" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -11526,8 +11512,8 @@
 	dir = 4
 	},
 /obj/machinery/light/emergency{
-	icon_state = "ebulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "ebulb1"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -11535,9 +11521,9 @@
 /area/station/hallway/primary/central)
 "azq" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellow/corner{
 	dir = 1
@@ -11555,29 +11541,29 @@
 "azt" = (
 /obj/disposalpipe/segment,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "azu" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "azv" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/east)
@@ -11591,17 +11577,17 @@
 "azx" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "azy" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -11621,9 +11607,9 @@
 /area/station/medical/robotics)
 "azA" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/blueblack/corner{
 	dir = 1
@@ -11694,24 +11680,24 @@
 "azJ" = (
 /obj/lattice,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/space,
 /area)
 "azK" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
+	dir = 8;
 	icon_state = "bulb1";
-	dir = 8
+	tag = "icon-bulb1 (WEST)"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "azL" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -11719,12 +11705,12 @@
 	icon_state = "1-4"
 	},
 /obj/stool/chair/office/purple{
-	icon_state = "office_chair_purple";
-	dir = 1
+	dir = 1;
+	icon_state = "office_chair_purple"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "red2";
-	dir = 2
+	dir = 2;
+	icon_state = "red2"
 	},
 /area/station/crew_quarters/hor)
 "azM" = (
@@ -11746,9 +11732,9 @@
 /area/station/mining/magnet)
 "azO" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellow/corner{
 	dir = 1
@@ -11756,22 +11742,22 @@
 /area/station/engine/engineering)
 "azP" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "azQ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -11803,9 +11789,9 @@
 /area)
 "azU" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/item/sheet/glass{
 	amount = 50
@@ -11825,9 +11811,9 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -11919,9 +11905,9 @@
 /area/station/medical/research)
 "aAk" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/item/crowbar,
 /obj/machinery/light{
@@ -11945,8 +11931,8 @@
 /area/station/medical/robotics)
 "aAm" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /turf/space,
 /area)
@@ -11973,9 +11959,9 @@
 /area/station/engine/engineering)
 "aAr" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 2
@@ -11983,9 +11969,9 @@
 /area/station/engine/engineering)
 "aAs" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellow/corner{
 	dir = 8
@@ -12010,9 +11996,9 @@
 /area/station/mining/magnet)
 "aAv" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/storage/warehouse)
@@ -12032,22 +12018,22 @@
 /area/station/storage/warehouse)
 "aAy" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "aAz" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/camera{
 	c_tag = "S Maintenance - Medical Junction";
@@ -12083,9 +12069,9 @@
 	})
 "aAE" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc{
@@ -12093,14 +12079,14 @@
 	})
 "aAF" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 9
@@ -12108,8 +12094,8 @@
 /area/station/science/artifact)
 "aAG" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -12120,9 +12106,9 @@
 /area/station/medical/research)
 "aAH" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/clone_scanner,
 /obj/cable{
@@ -12141,9 +12127,9 @@
 	})
 "aAJ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc{
@@ -12151,9 +12137,9 @@
 	})
 "aAK" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light_switch{
 	name = "N light switch";
@@ -12197,8 +12183,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -12206,8 +12192,8 @@
 "aAO" = (
 /obj/lattice,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /turf/space,
 /area)
@@ -12236,8 +12222,8 @@
 /area/station/storage/warehouse)
 "aAT" = (
 /obj/machinery/door/window{
-	icon = 'icons/obj/doors/windoor.dmi';
-	dir = 8
+	dir = 8;
+	icon = 'icons/obj/doors/windoor.dmi'
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/warehouse)
@@ -12257,9 +12243,9 @@
 /area/station/hallway/primary/central)
 "aAW" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -12274,8 +12260,8 @@
 /area/station/maintenance/east)
 "aAY" = (
 /obj/grille/catwalk{
-	icon_state = "catwalk_cross-0";
-	dir = 5
+	dir = 5;
+	icon_state = "catwalk_cross-0"
 	},
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
@@ -12285,9 +12271,9 @@
 /area/station/mining/magnet)
 "aAZ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/engineering{
@@ -12299,9 +12285,9 @@
 "aBa" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor,
@@ -12315,17 +12301,17 @@
 "aBc" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "aBd" = (
 /obj/disposalpipe/segment,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/greenwhite{
 	dir = 8
@@ -12333,13 +12319,13 @@
 /area/station/medical/research)
 "aBe" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/genetics_scanner,
 /turf/simulated/floor/greenwhite{
@@ -12349,9 +12335,9 @@
 "aBf" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/greenwhite{
 	dir = 8
@@ -12439,9 +12425,9 @@
 	name = "Quartermaster"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
@@ -12449,9 +12435,9 @@
 /area/station/quartermaster/office)
 "aBs" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/table/auto,
 /obj/item/device/light/flashlight,
@@ -12460,8 +12446,8 @@
 /area/station/storage/warehouse)
 "aBt" = (
 /obj/machinery/door/airlock/pyro/engineering{
-	icon_state = "eng_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "eng_closed"
 	},
 /obj/access_spawn/engineering,
 /turf/simulated/floor/plating,
@@ -12490,9 +12476,9 @@
 /area/station/storage/warehouse)
 "aBy" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -12509,8 +12495,8 @@
 /area/station/storage/warehouse)
 "aBA" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -12532,9 +12518,9 @@
 /area/station/mining/magnet)
 "aBD" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -12553,9 +12539,9 @@
 	})
 "aBF" = (
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-c";
+	dir = 2;
 	icon_state = "pipe-c";
-	dir = 2
+	tag = "icon-pipe-c"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc{
@@ -12573,17 +12559,17 @@
 /area/station/medical/research)
 "aBI" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/computer/genetics,
 /turf/simulated/floor/greenwhite{
@@ -12601,17 +12587,17 @@
 "aBK" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/research)
 "aBL" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/grille/catwalk/cross{
 	dir = 9
@@ -12632,9 +12618,9 @@
 /area/station/maintenance/west)
 "aBN" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -12650,9 +12636,9 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -12664,9 +12650,9 @@
 	trader_area = "/area/station/crew_quarters/clown"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -12703,9 +12689,9 @@
 /area/station/hallway/primary/central)
 "aBU" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/central)
@@ -12716,8 +12702,8 @@
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -12743,9 +12729,9 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -12755,13 +12741,13 @@
 	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -12782,9 +12768,9 @@
 /area/station/storage/warehouse)
 "aCb" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/primary/central)
@@ -12829,9 +12815,9 @@
 /area/station/maintenance/west)
 "aCh" = (
 /obj/disposalpipe/junction{
-	tag = "icon-pipe-j1 (WEST)";
+	dir = 8;
 	icon_state = "pipe-j1";
-	dir = 8
+	tag = "icon-pipe-j1 (WEST)"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc{
@@ -12839,9 +12825,9 @@
 	})
 "aCi" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
 	d2 = 8;
@@ -12869,22 +12855,22 @@
 /area/station/security/brig)
 "aCm" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/blue/checker,
 /area/station/medical/research)
 "aCn" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -12923,9 +12909,9 @@
 /area/station/maintenance/west)
 "aCr" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/firealarm{
 	dir = 8;
@@ -12949,9 +12935,9 @@
 /area/station/hallway/primary/central)
 "aCt" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/pyro{
 	dir = 8
@@ -12971,9 +12957,9 @@
 /area/station/hallway/primary/central)
 "aCw" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 1
@@ -12987,9 +12973,9 @@
 /area/station/hallway/primary/central)
 "aCy" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 1
@@ -12997,9 +12983,9 @@
 /area/station/hallway/primary/central)
 "aCz" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 1
@@ -13007,9 +12993,9 @@
 /area/station/hallway/primary/central)
 "aCA" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/neutral/corner{
 	dir = 1
@@ -13017,14 +13003,14 @@
 /area/station/hallway/primary/central)
 "aCB" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc{
@@ -13032,9 +13018,9 @@
 	})
 "aCC" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/trunk{
 	dir = 1
@@ -13057,9 +13043,9 @@
 /area/station/storage/warehouse)
 "aCE" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
 /obj/item/extinguisher,
@@ -13069,9 +13055,9 @@
 	})
 "aCF" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/storage/secure/closet/medical{
 	name = "locker"
@@ -13086,25 +13072,25 @@
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/research)
 "aCH" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/blue/checker,
 /area/station/medical/research)
 "aCI" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/firealarm{
 	pixel_y = 24;
@@ -13137,8 +13123,8 @@
 	text = "NF"
 	},
 /obj/machinery/light/emergency{
-	icon_state = "ebulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "ebulb1"
 	},
 /turf/simulated/floor/blackwhite{
 	dir = 5
@@ -13176,8 +13162,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -13198,8 +13184,8 @@
 /area/station/medical/research)
 "aCR" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -13215,18 +13201,18 @@
 /area/station/medical/research)
 "aCT" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/west)
 "aCU" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -13245,9 +13231,9 @@
 /area/station/hallway/primary/central)
 "aCX" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=crew";
@@ -13268,22 +13254,22 @@
 /area/station/hallway/primary/central)
 "aDa" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "aDb" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=chapel";
@@ -13307,8 +13293,8 @@
 /area/station/maintenance/east)
 "aDe" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/bot/white,
 /area/station/medical/cdc{
@@ -13341,9 +13327,9 @@
 /area/station/hydroponics)
 "aDj" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/plantpot,
 /obj/machinery/camera,
@@ -13369,8 +13355,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -13381,9 +13367,9 @@
 	dir = 2
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -13406,13 +13392,13 @@
 /area/station/maintenance/west)
 "aDo" = (
 /obj/grille/catwalk{
-	icon_state = "catwalk_cross-0";
-	dir = 5
+	dir = 5;
+	icon_state = "catwalk_cross-0"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
@@ -13427,9 +13413,9 @@
 /area/station/hallway/primary/central)
 "aDq" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /obj/machinery/door/firedoor/pyro,
@@ -13455,8 +13441,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
@@ -13471,8 +13457,8 @@
 /area/station/hallway/primary/central)
 "aDv" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/dummy_pad,
 /obj/landmark/start/latejoin,
@@ -13481,12 +13467,12 @@
 "aDw" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/Zeta)
@@ -13536,8 +13522,8 @@
 	},
 /obj/machinery/meter,
 /obj/machinery/light/emergency{
-	icon_state = "ebulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "ebulb1"
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 1
@@ -13546,8 +13532,8 @@
 "aDD" = (
 /obj/storage/closet/biohazard,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 9
@@ -13575,8 +13561,8 @@
 /area/station/hallway/primary/central)
 "aDH" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 1
@@ -13590,9 +13576,9 @@
 /area/station/chemistry)
 "aDJ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /obj/storage/secure/closet/personal,
@@ -13630,9 +13616,9 @@
 "aDN" = (
 /obj/machinery/chem_heater,
 /turf/simulated/floor{
-	tag = "icon-corner_east";
+	dir = 2;
 	icon_state = "corner_east";
-	dir = 2
+	tag = "icon-corner_east"
 	},
 /area/station/chemistry)
 "aDO" = (
@@ -13656,8 +13642,8 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -13673,9 +13659,9 @@
 /area/station/hydroponics)
 "aDS" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf";
@@ -13684,9 +13670,9 @@
 /area/station/hydroponics)
 "aDT" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/plantpot,
 /turf/simulated/floor/grass{
@@ -13700,8 +13686,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -13743,9 +13729,9 @@
 /area/station/hallway/primary/central)
 "aEb" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
@@ -13858,8 +13844,8 @@
 /area/station/chemistry)
 "aEp" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 4
@@ -13872,22 +13858,22 @@
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hydroponics)
 "aEr" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/machinery/plantpot,
 /turf/simulated/floor/grass{
@@ -13897,9 +13883,9 @@
 /area/station/hydroponics)
 "aEs" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf";
@@ -13944,9 +13930,9 @@
 "aEz" = (
 /obj/grille/catwalk,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
@@ -13986,8 +13972,8 @@
 /area/station/medical/medbay)
 "aEE" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/sleeper/port_a_medbay,
 /turf/simulated/floor/blue,
@@ -14014,8 +14000,8 @@
 /obj/item/reagent_containers/glass/beaker/cryoxadone,
 /obj/item/reagent_containers/glass/beaker/cryoxadone,
 /obj/window/reinforced/west{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 2
@@ -14027,8 +14013,8 @@
 /obj/item/wrench,
 /obj/item/paper/cryo,
 /obj/window/reinforced/west{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /obj/item/item_box/medical_patches/styptic,
 /turf/simulated/floor/bluewhite{
@@ -14041,9 +14027,9 @@
 /obj/iv_stand,
 /obj/item/reagent_containers/iv_drip/saline,
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 8
@@ -14069,10 +14055,10 @@
 /area/station/chemistry)
 "aEM" = (
 /obj/submachine/chef_sink{
-	name = "utility sink";
 	desc = "A common utility sink.";
+	dir = 8;
 	icon_state = "sink";
-	dir = 8
+	name = "utility sink"
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 4
@@ -14107,9 +14093,9 @@
 /area/station/hydroponics)
 "aEQ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/plantpot,
 /obj/machinery/light{
@@ -14142,8 +14128,8 @@
 	name = "Botany Pad"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/plating,
 /area/station/hydroponics)
@@ -14154,22 +14140,22 @@
 /area)
 "aEW" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aEX" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -14179,9 +14165,9 @@
 /area/station/maintenance/west)
 "aEY" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/switch_junction{
 	dir = 4;
@@ -14234,8 +14220,8 @@
 /area/station/medical/robotics)
 "aFe" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 2
+	dir = 2;
+	icon_state = "lattice-dir"
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -14260,8 +14246,8 @@
 	dir = 4
 	},
 /obj/item/device/radio/intercom{
-	dir = 4;
 	broadcasting = 0;
+	dir = 4;
 	frequency = 1445;
 	name = "Station Intercom (Medical)"
 	},
@@ -14288,8 +14274,8 @@
 	pipe_direction = 8
 	},
 /obj/window/reinforced/west{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 6
@@ -14299,15 +14285,15 @@
 /obj/window/reinforced/west,
 /obj/storage/secure/closet/command/medical_director,
 /obj/window/reinforced/west{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "aFk" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 8
@@ -14329,8 +14315,8 @@
 /area/station/medical/medbay)
 "aFm" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/blue,
@@ -14340,17 +14326,17 @@
 "aFn" = (
 /obj/storage/secure/closet/research/chemical,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
 /area/station/chemistry)
 "aFo" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/white,
 /area/station/chemistry)
@@ -14426,8 +14412,8 @@
 "aFy" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/blue,
@@ -14441,8 +14427,8 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -14467,8 +14453,8 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/camera{
 	c_tag = "Hydroponics Shipping";
@@ -14478,17 +14464,17 @@
 /area/station/hydroponics)
 "aFB" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hydroponics)
 "aFC" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/hydroponics)
@@ -14511,9 +14497,9 @@
 /area/station/hydroponics)
 "aFF" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/damaged1,
 /area/station/maintenance/west)
@@ -14569,9 +14555,9 @@
 /area/station/hallway/primary/south)
 "aFO" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
@@ -14600,8 +14586,8 @@
 	},
 /obj/stool/bench/blue/auto,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc{
@@ -14613,8 +14599,8 @@
 /area/station/hydroponics)
 "aFU" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer3/generic/med_data,
@@ -14636,12 +14622,12 @@
 /area/station/medical/research)
 "aFX" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /obj/machinery/vending/medical,
 /turf/simulated/floor/bluewhite{
@@ -14664,8 +14650,8 @@
 /obj/item/device/analyzer/healthanalyzer,
 /obj/item/clothing/mask/surgical_shield,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 6
@@ -14673,8 +14659,8 @@
 /area/station/medical/medbay)
 "aGa" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 4;
@@ -14697,14 +14683,14 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/white,
 /area/station/chemistry)
@@ -14792,9 +14778,9 @@
 /area/station/hydroponics)
 "aGp" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hydroponics)
@@ -14815,9 +14801,9 @@
 /area/station/hydroponics/lobby)
 "aGt" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 8
@@ -14852,16 +14838,16 @@
 /area/station/hydroponics/lobby)
 "aGy" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "aGz" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/external{
@@ -14940,9 +14926,9 @@
 /area/station/hallway/primary/south)
 "aGH" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -14973,8 +14959,8 @@
 	pixel_y = 0
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 9
@@ -15032,8 +15018,8 @@
 	})
 "aGP" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /turf/simulated/wall/auto/supernorn,
@@ -15048,9 +15034,9 @@
 /area/station/medical/medbay)
 "aGR" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
@@ -15060,8 +15046,8 @@
 	pipe_direction = 4
 	},
 /obj/window/reinforced/west{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 10
@@ -15086,9 +15072,9 @@
 /area/station/medical/medbay)
 "aGV" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/external{
@@ -15128,9 +15114,9 @@
 /area/station/hydroponics)
 "aGZ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -15138,9 +15124,9 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf";
@@ -15149,9 +15135,9 @@
 /area/station/hydroponics)
 "aHa" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/landmark/start{
 	name = "Botanist"
@@ -15163,9 +15149,9 @@
 /area/station/hydroponics)
 "aHb" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/stairs/wide/middle{
 	dir = 4
@@ -15173,9 +15159,9 @@
 /area/station/hydroponics)
 "aHc" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/stool,
 /obj/item/reagent_containers/glass/bottle/topcrop,
@@ -15184,15 +15170,15 @@
 /area/station/hydroponics)
 "aHd" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/table/wood/auto,
 /obj/item/plate,
 /obj/item/reagent_containers/food/snacks/sandwich/meat_s{
-	name = "all-natural organic synthmeat sandwich";
 	desc = "It's confusing, I know.";
+	name = "all-natural organic synthmeat sandwich";
 	pixel_x = 2;
 	pixel_y = 3
 	},
@@ -15202,9 +15188,9 @@
 /area/station/hydroponics)
 "aHe" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/stool,
 /obj/item/reagent_containers/glass/bottle/powerplant,
@@ -15213,9 +15199,9 @@
 /area/station/hydroponics)
 "aHf" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/stairs/wide/middle{
 	dir = 8
@@ -15223,9 +15209,9 @@
 /area/station/hydroponics)
 "aHg" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -15239,14 +15225,14 @@
 /area/station/hydroponics)
 "aHh" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment,
 /obj/disposalpipe/switch_junction{
@@ -15262,9 +15248,9 @@
 /area/station/hydroponics)
 "aHi" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -15277,9 +15263,9 @@
 /area/station/hydroponics)
 "aHj" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -15297,14 +15283,14 @@
 /area/station/hydroponics)
 "aHk" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -15317,13 +15303,13 @@
 /area/station/hydroponics)
 "aHl" = (
 /obj/grille/catwalk{
-	icon_state = "catwalk";
-	dir = 5
+	dir = 5;
+	icon_state = "catwalk"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
@@ -15334,9 +15320,9 @@
 /area/station/mining/magnet)
 "aHm" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -15348,9 +15334,9 @@
 /area/station/hydroponics)
 "aHn" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -15379,9 +15365,9 @@
 /area/station/hydroponics)
 "aHq" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -15437,8 +15423,8 @@
 	pixel_y = 0
 	},
 /obj/machinery/light/emergency{
-	icon_state = "ebulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "ebulb1"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 1
@@ -15446,9 +15432,9 @@
 /area/station/hydroponics/lobby)
 "aHw" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -15464,9 +15450,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/light{
-	tag = "icon-tube1 (NORTH)";
+	dir = 1;
 	icon_state = "tube1";
-	dir = 1
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
@@ -15517,8 +15503,8 @@
 	pixel_y = 0
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/green,
 /area/station/hydroponics/lobby)
@@ -15539,9 +15525,9 @@
 	dir = 4
 	},
 /obj/shrub{
+	dir = 4;
 	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "plant";
-	dir = 4
+	icon_state = "plant"
 	},
 /turf/simulated/floor/green/side{
 	dir = 8
@@ -15568,14 +15554,14 @@
 /area/station/hallway/primary/south)
 "aHI" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/junction{
 	dir = 8;
@@ -15590,17 +15576,17 @@
 /area/station/engine/elect)
 "aHK" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -15615,9 +15601,9 @@
 /area/station/hallway/primary/south)
 "aHN" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -15627,14 +15613,14 @@
 /area/station/hallway/primary/south)
 "aHO" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/junction{
-	tag = "icon-pipe-y (WEST)";
+	dir = 8;
 	icon_state = "pipe-y";
-	dir = 8
+	tag = "icon-pipe-y (WEST)"
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=outerbar";
@@ -15645,9 +15631,9 @@
 "aHQ" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	name = "Engineering Maintenance"
@@ -15657,26 +15643,26 @@
 /area/station/maintenance/west)
 "aHR" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "aHS" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "aHT" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 4
@@ -15684,9 +15670,9 @@
 /area/station/hallway/primary/south)
 "aHU" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance,
@@ -15704,9 +15690,9 @@
 	})
 "aHW" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/medical/cdc{
@@ -15714,9 +15700,9 @@
 	})
 "aHX" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 4
@@ -15726,9 +15712,9 @@
 	})
 "aHY" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/pyro{
 	dir = 4
@@ -15753,9 +15739,9 @@
 "aIa" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc{
@@ -15776,14 +15762,14 @@
 /area/station/medical/medbay)
 "aIc" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc{
@@ -15791,9 +15777,9 @@
 	})
 "aId" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
@@ -15807,8 +15793,8 @@
 /obj/item/reagent_containers/hypospray,
 /obj/item/reagent_containers/hypospray,
 /obj/window/reinforced/west{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/item/remote/porter/port_a_medbay,
 /obj/item/remote/porter/port_a_nanomed{
@@ -15820,8 +15806,8 @@
 /area/station/medical/medbay)
 "aIg" = (
 /obj/window/reinforced/west{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/machinery/vending/medical,
 /turf/simulated/floor/bluewhite{
@@ -15830,9 +15816,9 @@
 /area/station/medical/medbay)
 "aIi" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/landmark{
 	name = "peststart"
@@ -15867,9 +15853,9 @@
 "aIl" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purple,
 /area/station/science)
@@ -15890,8 +15876,8 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor,
 /area/station/science/artifact)
@@ -15902,8 +15888,8 @@
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/test_apparatus/impact_pad,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor,
 /area/station/science/artifact)
@@ -15925,9 +15911,9 @@
 /area/station/hydroponics)
 "aIu" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/grass{
@@ -15958,9 +15944,9 @@
 /area/station/hydroponics)
 "aIy" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
@@ -15968,9 +15954,9 @@
 /area/station/hydroponics)
 "aIz" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/grille/catwalk/cross,
 /turf/space,
@@ -15982,9 +15968,9 @@
 /area/station/mining/magnet)
 "aIA" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
@@ -15992,30 +15978,30 @@
 /area/station/hydroponics/lobby)
 "aIB" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hydroponics/lobby)
 "aIC" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/hydroponics/lobby)
 "aID" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -16044,9 +16030,9 @@
 /area/station/mining/magnet)
 "aIF" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/green/side{
 	dir = 4
@@ -16054,9 +16040,9 @@
 /area/station/hydroponics/lobby)
 "aIG" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -16066,14 +16052,14 @@
 /area/station/hydroponics/lobby)
 "aIH" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 8;
@@ -16094,23 +16080,23 @@
 /area/station/mining/magnet)
 "aIJ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "aIK" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -16167,8 +16153,8 @@
 /area/station/hallway/primary/south)
 "aIS" = (
 /obj/cable{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 6
@@ -16185,9 +16171,9 @@
 	})
 "aIU" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 0
@@ -16205,8 +16191,8 @@
 	})
 "aIW" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/bluewhite/corner{
 	dir = 1
@@ -16216,9 +16202,9 @@
 	})
 "aIX" = (
 /obj/disposalpipe/junction{
-	tag = "icon-pipe-j1 (WEST)";
+	dir = 8;
 	icon_state = "pipe-j1";
-	dir = 8
+	tag = "icon-pipe-j1 (WEST)"
 	},
 /turf/simulated/floor/bluewhite/corner{
 	dir = 4
@@ -16241,9 +16227,9 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc{
@@ -16257,8 +16243,8 @@
 	})
 "aJb" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -16269,8 +16255,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/table/auto/desk,
@@ -16284,9 +16270,9 @@
 	})
 "aJd" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
@@ -16300,9 +16286,9 @@
 	pixel_x = -10
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
@@ -16315,13 +16301,13 @@
 "aJg" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/maintenance{
-	icon_state = "maint_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "maint_closed"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -16357,9 +16343,9 @@
 "aJj" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -16370,9 +16356,9 @@
 /area/station/science)
 "aJk" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/purple,
 /area/station/science)
@@ -16395,22 +16381,22 @@
 /area/station/science/artifact)
 "aJn" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/caution/south,
 /area/station/science/artifact)
 "aJo" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/orangeblack/corner{
 	dir = 8
@@ -16418,8 +16404,8 @@
 /area/station/science/artifact)
 "aJp" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/science/artifact)
@@ -16488,8 +16474,8 @@
 /area/station/hydroponics)
 "aJE" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 10
@@ -16504,16 +16490,16 @@
 /area/station/hydroponics/lobby)
 "aJG" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/orangeblack/side,
 /area/station/hydroponics/lobby)
 "aJH" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 6
@@ -16527,18 +16513,18 @@
 /area/station/hydroponics/lobby)
 "aJJ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/green,
 /area/station/hydroponics/lobby)
 "aJK" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/green,
 /area/station/hydroponics/lobby)
@@ -16563,9 +16549,9 @@
 /area/station/hydroponics/lobby)
 "aJO" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/green/side{
 	dir = 8
@@ -16586,14 +16572,14 @@
 /area/station/hallway/primary/south)
 "aJR" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/junction{
-	tag = "icon-pipe-j2 (NORTH)";
+	dir = 1;
 	icon_state = "pipe-j2";
-	dir = 1
+	tag = "icon-pipe-j2 (NORTH)"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -16620,8 +16606,8 @@
 /area/station/quartermaster)
 "aJU" = (
 /obj/cable{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/south)
@@ -16635,8 +16621,8 @@
 "aJW" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 4;
@@ -16648,14 +16634,14 @@
 /area/station/hydroponics)
 "aJX" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc{
@@ -16669,14 +16655,14 @@
 	})
 "aJZ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/cdc{
@@ -16684,8 +16670,8 @@
 	})
 "aKa" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor/white,
@@ -16737,8 +16723,8 @@
 	dir = 4
 	},
 /obj/window/reinforced/west{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/machinery/vending/port_a_nanomed,
 /turf/simulated/floor/bluewhite{
@@ -16762,8 +16748,8 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/purple/corner{
 	dir = 1
@@ -16780,9 +16766,9 @@
 /area/station/science)
 "aKk" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -16793,9 +16779,9 @@
 /area/station/science)
 "aKl" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/purple,
 /area/station/science)
@@ -16811,9 +16797,9 @@
 /area/station/mining/magnet)
 "aKn" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 1
@@ -16821,9 +16807,9 @@
 /area/station/science/artifact)
 "aKo" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
 /area/station/science/artifact)
@@ -16845,14 +16831,14 @@
 /area/station/science/artifact)
 "aKr" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/caution/west,
 /area/station/science/artifact)
@@ -16876,9 +16862,9 @@
 /area/station/hydroponics)
 "aKu" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/grass{
@@ -16889,9 +16875,9 @@
 "aKv" = (
 /obj/reagent_dispensers/watertank/big,
 /obj/machinery/light{
-	tag = "icon-tube1 (NORTH)";
+	dir = 1;
 	icon_state = "tube1";
-	dir = 1
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf";
@@ -16900,9 +16886,9 @@
 /area/station/hydroponics)
 "aKw" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (NORTH)";
+	dir = 1;
 	icon_state = "tube1";
-	dir = 1
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf";
@@ -16922,9 +16908,9 @@
 /area/station/hydroponics)
 "aKz" = (
 /obj/pool/perspective{
-	tag = "icon-pool (NORTH)";
+	dir = 1;
 	icon_state = "pool";
-	dir = 1
+	tag = "icon-pool (NORTH)"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
@@ -16939,17 +16925,17 @@
 /area/station/crew_quarters/pool)
 "aKB" = (
 /obj/pool/perspective{
-	tag = "icon-pool (NORTHEAST)";
+	dir = 5;
 	icon_state = "pool";
-	dir = 5
+	tag = "icon-pool (NORTHEAST)"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
 "aKC" = (
 /obj/pool/perspective{
-	tag = "icon-pool (WEST)";
+	dir = 8;
 	icon_state = "pool";
-	dir = 8
+	tag = "icon-pool (WEST)"
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -16965,8 +16951,8 @@
 	pixel_x = -24
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -16995,8 +16981,8 @@
 /area/station/maintenance/SEmaint)
 "aKJ" = (
 /obj/cable{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
@@ -17013,9 +16999,9 @@
 /area/station/maintenance/SEmaint)
 "aKM" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
@@ -17033,14 +17019,14 @@
 	})
 "aKP" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/random_item_spawner/desk_stuff,
 /obj/table/glass/auto,
@@ -17053,8 +17039,8 @@
 "aKQ" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/cdc{
@@ -17065,9 +17051,9 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
@@ -17096,9 +17082,9 @@
 /area/station/science)
 "aKW" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purple,
 /area/station/science)
@@ -17108,8 +17094,8 @@
 /area/station/science)
 "aKY" = (
 /obj/cable{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/light_switch{
 	name = "W light switch";
@@ -17127,14 +17113,14 @@
 /area/station/science/artifact)
 "aKZ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/white,
 /area/station/science/artifact)
@@ -17157,9 +17143,9 @@
 /area/station/science/artifact)
 "aLc" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/caution/west,
 /area/station/science/artifact)
@@ -17172,9 +17158,9 @@
 /area/station/hydroponics)
 "aLe" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/plantpot,
 /obj/disposalpipe/segment,
@@ -17192,22 +17178,22 @@
 /area/station/crew_quarters/pool)
 "aLh" = (
 /obj/pool/perspective{
-	tag = "icon-pool (EAST)";
+	dir = 4;
 	icon_state = "pool";
-	dir = 4
+	tag = "icon-pool (EAST)"
 	},
 /obj/pool_springboard,
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
 "aLi" = (
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /turf/simulated/floor{
-	tag = "icon-0,6";
-	icon_state = "0,6"
+	icon_state = "0,6";
+	tag = "icon-0,6"
 	},
 /area/station/crew_quarters/fitness)
 "aLj" = (
@@ -17217,8 +17203,8 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -17227,8 +17213,8 @@
 	rigged = 0
 	},
 /turf/simulated/floor{
-	tag = "icon-0,6";
-	icon_state = "0,6"
+	icon_state = "0,6";
+	tag = "icon-0,6"
 	},
 /area/station/crew_quarters/fitness)
 "aLk" = (
@@ -17240,25 +17226,25 @@
 	rigged = 0
 	},
 /turf/simulated/floor{
-	tag = "icon-0,6";
-	icon_state = "0,6"
+	icon_state = "0,6";
+	tag = "icon-0,6"
 	},
 /area/station/crew_quarters/fitness)
 "aLl" = (
 /turf/simulated/floor{
-	tag = "icon-0,6";
-	icon_state = "0,6"
+	icon_state = "0,6";
+	tag = "icon-0,6"
 	},
 /area/station/crew_quarters/fitness)
 "aLm" = (
 /obj/decal/boxingrope{
-	tag = "icon-ringrope (NORTHEAST)";
+	dir = 5;
 	icon_state = "ringrope";
-	dir = 5
+	tag = "icon-ringrope (NORTHEAST)"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -17270,9 +17256,9 @@
 /area/station/maintenance/SWmaint)
 "aLp" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
@@ -17319,9 +17305,9 @@
 "aLx" = (
 /obj/storage/closet/wardrobe/green,
 /obj/machinery/light{
-	tag = "icon-tube1 (NORTH)";
+	dir = 1;
 	icon_state = "tube1";
-	dir = 1
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/quarters)
@@ -17416,29 +17402,29 @@
 /area/station/maintenance/SEmaint)
 "aLK" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "aLL" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "aLM" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
@@ -17452,9 +17438,9 @@
 	})
 "aLO" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -17469,8 +17455,8 @@
 	})
 "aLP" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/guardbot_dock,
@@ -17479,8 +17465,8 @@
 /area/station/science)
 "aLQ" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/bot/guardbot/ranger,
@@ -17494,8 +17480,8 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/guardbot_dock,
@@ -17546,8 +17532,8 @@
 /area/station/science)
 "aLV" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 6
@@ -17566,8 +17552,8 @@
 	},
 /obj/cable,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 8
@@ -17575,8 +17561,8 @@
 /area/station/science/artifact)
 "aLY" = (
 /obj/cable{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -17592,8 +17578,8 @@
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/test_apparatus/heater,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor,
 /area/station/science/artifact)
@@ -17619,9 +17605,9 @@
 /area/station/hydroponics)
 "aMc" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf";
@@ -17630,9 +17616,9 @@
 /area/station/hydroponics)
 "aMd" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/grass{
@@ -17642,9 +17628,9 @@
 /area/station/hydroponics)
 "aMe" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/plantpot,
 /turf/simulated/floor/grass{
@@ -17655,8 +17641,8 @@
 "aMf" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment{
@@ -17683,8 +17669,8 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf";
@@ -17700,9 +17686,9 @@
 /area/station/crew_quarters/pool)
 "aMj" = (
 /obj/pool/perspective{
-	tag = "icon-pool (WEST)";
+	dir = 8;
 	icon_state = "pool";
-	dir = 8
+	tag = "icon-pool (WEST)"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
@@ -17727,23 +17713,23 @@
 /obj/item/clothing/under/shorts/black,
 /obj/item/clothing/under/shorts/black,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/item/clothing/under/shorts/black,
 /obj/item/clothing/gloves/boxing,
 /obj/item/device/radio,
 /turf/simulated/floor{
-	tag = "icon-0,6";
-	icon_state = "0,6"
+	icon_state = "0,6";
+	tag = "icon-0,6"
 	},
 /area/station/crew_quarters/fitness)
 "aMm" = (
 /obj/table/reinforced{
-	tag = "icon-reinf_tabledir (SOUTHWEST)";
+	dir = 10;
 	icon_state = "reinf_tabledir";
-	dir = 10
+	tag = "icon-reinf_tabledir (SOUTHWEST)"
 	},
 /obj/item/clothing/gloves/boxing,
 /obj/item/clothing/under/shorts/blue,
@@ -17751,15 +17737,15 @@
 /obj/item/clothing/under/shorts/blue,
 /obj/item/clothing/gloves/boxing,
 /turf/simulated/floor{
-	tag = "icon-0,6";
-	icon_state = "0,6"
+	icon_state = "0,6";
+	tag = "icon-0,6"
 	},
 /area/station/crew_quarters/fitness)
 "aMn" = (
 /obj/decal/boxingrope{
-	tag = "icon-ringrope (NORTHWEST)";
+	dir = 9;
 	icon_state = "ringrope";
-	dir = 9
+	tag = "icon-ringrope (NORTHWEST)"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -17769,9 +17755,9 @@
 /area/station/crew_quarters/fitness)
 "aMp" = (
 /obj/decal/boxingrope{
-	tag = "icon-ringrope (NORTHEAST)";
+	dir = 5;
 	icon_state = "ringrope";
-	dir = 5
+	tag = "icon-ringrope (NORTHEAST)"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -17781,8 +17767,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/wingrille_spawn/auto,
@@ -17791,8 +17777,8 @@
 "aMr" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/quarters)
@@ -17839,9 +17825,9 @@
 /area/station/maintenance/SEmaint)
 "aMz" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/SEmaint)
@@ -17851,8 +17837,8 @@
 /area/station/maintenance/SEmaint)
 "aMB" = (
 /obj/cable{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/SEmaint)
@@ -17926,14 +17912,14 @@
 	})
 "aMJ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 1
@@ -17946,9 +17932,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 1
@@ -17999,15 +17985,15 @@
 /area/station/science)
 "aMQ" = (
 /obj/item/device/radio/intercom{
-	dir = 4;
 	broadcasting = 0;
+	dir = 4;
 	frequency = 1445;
 	name = "Station Intercom (Medical)"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 8
@@ -18015,8 +18001,8 @@
 /area/station/science/artifact)
 "aMR" = (
 /obj/cable{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -18032,9 +18018,9 @@
 /area/station/science/artifact)
 "aMS" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -18045,9 +18031,9 @@
 /area/station/science/artifact)
 "aMT" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -18075,9 +18061,9 @@
 /area/station/crew_quarters/pool)
 "aMW" = (
 /obj/pool/perspective{
-	tag = "icon-pool (EAST)";
+	dir = 4;
 	icon_state = "pool";
-	dir = 4
+	tag = "icon-pool (EAST)"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
@@ -18103,14 +18089,14 @@
 /area/station/crew_quarters/pool)
 "aMZ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/fitness/weightlifter,
 /turf/simulated/floor{
-	tag = "icon-0,6";
-	icon_state = "0,6"
+	icon_state = "0,6";
+	tag = "icon-0,6"
 	},
 /area/station/crew_quarters/fitness)
 "aNa" = (
@@ -18142,8 +18128,8 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/wingrille_spawn/auto,
@@ -18171,9 +18157,9 @@
 /area/station/engine/elect)
 "aNh" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow/corner{
 	dir = 1
@@ -18181,17 +18167,17 @@
 /area/station/engine/elect)
 "aNi" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow/corner,
 /area/station/engine/elect)
 "aNj" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/disposalpipe/segment,
@@ -18199,31 +18185,31 @@
 /area/station/maintenance/SEmaint)
 "aNk" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "aNl" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "aNm" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/landmark{
 	name = "kudzustart"
@@ -18233,9 +18219,9 @@
 "aNn" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
@@ -18247,9 +18233,9 @@
 /area/station/engine/engineering)
 "aNo" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -18273,8 +18259,8 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 1
@@ -18332,8 +18318,8 @@
 /obj/machinery/networked/test_apparatus/xraymachine,
 /obj/cable,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/science/artifact)
@@ -18348,8 +18334,8 @@
 /area/station/hydroponics)
 "aNy" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -18379,9 +18365,9 @@
 /area/station/crew_quarters/pool)
 "aNB" = (
 /obj/pool/perspective{
-	tag = "icon-pool (SOUTHWEST)";
+	dir = 10;
 	icon_state = "pool";
-	dir = 10
+	tag = "icon-pool (SOUTHWEST)"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
@@ -18406,35 +18392,35 @@
 /area/station/crew_quarters/pool)
 "aNF" = (
 /obj/pool/perspective{
-	tag = "icon-pool (SOUTHEAST)";
+	dir = 6;
 	icon_state = "pool";
-	dir = 6
+	tag = "icon-pool (SOUTHEAST)"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
 "aNG" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	tag = "icon-0,6";
-	icon_state = "0,6"
+	icon_state = "0,6";
+	tag = "icon-0,6"
 	},
 /area/station/crew_quarters/fitness)
 "aNH" = (
 /obj/decal/boxingrope{
-	tag = "icon-ringrope (EAST)";
+	dir = 4;
 	icon_state = "ringrope";
-	dir = 4
+	tag = "icon-ringrope (EAST)"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "aNI" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/wingrille_spawn/auto,
@@ -18442,22 +18428,22 @@
 /area/station/maintenance/SWmaint)
 "aNJ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
 "aNK" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/landmark{
 	name = "blobstart"
@@ -18493,9 +18479,9 @@
 /area/station/crew_quarters/quarters)
 "aNQ" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -18507,14 +18493,14 @@
 /area/station/engine/elect)
 "aNR" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow/corner{
 	dir = 1
@@ -18529,9 +18515,9 @@
 /area/station/maintenance/SEmaint)
 "aNT" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 2;
@@ -18581,9 +18567,9 @@
 	})
 "aNZ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -18620,8 +18606,8 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -18687,17 +18673,17 @@
 /area/station/crew_quarters/cafeteria)
 "aOm" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/pool)
 "aOn" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/table/wood/auto,
 /obj/item/clothing/under/shorts/blue{
@@ -18727,9 +18713,9 @@
 /area/station/crew_quarters/pool)
 "aOo" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor{
@@ -18740,9 +18726,9 @@
 /area/station/crew_quarters/pool)
 "aOp" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/overlay{
 	anchored = 1;
@@ -18765,9 +18751,9 @@
 /area/station/crew_quarters/pool)
 "aOq" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon = 'icons/misc/beach.dmi';
@@ -18777,9 +18763,9 @@
 /area/station/crew_quarters/pool)
 "aOr" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/item/beach_ball,
 /turf/simulated/floor{
@@ -18790,9 +18776,9 @@
 /area/station/crew_quarters/pool)
 "aOs" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/critter/sealpup,
 /turf/simulated/floor{
@@ -18803,14 +18789,14 @@
 /area/station/crew_quarters/pool)
 "aOt" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor{
 	icon = 'icons/misc/beach.dmi';
@@ -18820,25 +18806,25 @@
 /area/station/crew_quarters/pool)
 "aOu" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/window/westleft,
 /turf/simulated/floor{
-	tag = "icon-0,6";
-	icon_state = "0,6"
+	icon_state = "0,6";
+	tag = "icon-0,6"
 	},
 /area/station/crew_quarters/fitness)
 "aOv" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	tag = "icon-0,6";
-	icon_state = "0,6"
+	icon_state = "0,6";
+	tag = "icon-0,6"
 	},
 /area/station/crew_quarters/fitness)
 "aOw" = (
@@ -18856,20 +18842,20 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	tag = "icon-0,6";
-	icon_state = "0,6"
+	icon_state = "0,6";
+	tag = "icon-0,6"
 	},
 /area/station/crew_quarters/fitness)
 "aOx" = (
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/fitness/speedbag/captain,
 /turf/simulated/floor{
-	tag = "icon-0,6";
-	icon_state = "0,6"
+	icon_state = "0,6";
+	tag = "icon-0,6"
 	},
 /area/station/crew_quarters/fitness)
 "aOy" = (
@@ -18881,30 +18867,30 @@
 	tag = "icon-ringrope (WEST)"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "aOz" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "aOA" = (
 /obj/decal/boxingrope{
-	tag = "icon-ringrope (EAST)";
+	dir = 4;
 	icon_state = "ringrope";
-	dir = 4
+	tag = "icon-ringrope (EAST)"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -18918,14 +18904,14 @@
 /area/station/crew_quarters/bar)
 "aOC" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
@@ -18949,16 +18935,16 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/quarters)
 "aOF" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/quarters)
@@ -18980,12 +18966,12 @@
 /area/station/hallway/primary/west)
 "aOI" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/wingrille_spawn/auto,
@@ -18993,23 +18979,23 @@
 /area/station/maintenance/SWmaint)
 "aOK" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "aOL" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Med-Sci"
@@ -19049,17 +19035,17 @@
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "aOP" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance{
@@ -19070,8 +19056,8 @@
 /area/station/maintenance/west)
 "aOQ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/purple,
 /area/station/science)
@@ -19083,9 +19069,9 @@
 /area/station/science)
 "aOS" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/purple,
 /area/station/science)
@@ -19136,8 +19122,8 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 1
@@ -19155,8 +19141,8 @@
 "aOY" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/networked/storage/bomb_tester{
 	bank_id = "Mixer"
@@ -19169,9 +19155,9 @@
 /obj/table/auto,
 /obj/item/clothing/glasses/vr{
 	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
+	network = "bombtest";
 	pixel_x = 2;
-	pixel_y = 5;
-	network = "bombtest"
+	pixel_y = 5
 	},
 /obj/item/clothing/glasses/vr{
 	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
@@ -19220,9 +19206,9 @@
 	},
 /obj/item/card_box/suit,
 /turf/simulated/floor{
-	tag = "icon-carpet2 (WEST)";
+	dir = 8;
 	icon_state = "carpet2";
-	dir = 8
+	tag = "icon-carpet2 (WEST)"
 	},
 /area/station/crew_quarters/cafeteria)
 "aPf" = (
@@ -19285,8 +19271,8 @@
 /area/station/crew_quarters/pool)
 "aPl" = (
 /obj/cable{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/light,
 /turf/simulated/floor{
@@ -19298,8 +19284,8 @@
 "aPm" = (
 /obj/machinery/light,
 /turf/simulated/floor{
-	tag = "icon-0,6";
-	icon_state = "0,6"
+	icon_state = "0,6";
+	tag = "icon-0,6"
 	},
 /area/station/crew_quarters/fitness)
 "aPn" = (
@@ -19307,8 +19293,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	tag = "icon-0,6";
-	icon_state = "0,6"
+	icon_state = "0,6";
+	tag = "icon-0,6"
 	},
 /area/station/crew_quarters/fitness)
 "aPo" = (
@@ -19324,9 +19310,9 @@
 /area/station/mining/magnet)
 "aPq" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/quarters)
@@ -19399,9 +19385,9 @@
 /area/station/hallway/primary/west)
 "aPy" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/junction{
 	dir = 1
@@ -19508,8 +19494,8 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 9
@@ -19517,14 +19503,14 @@
 /area/station/science/teleporter)
 "aPK" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 1
@@ -19532,8 +19518,8 @@
 /area/station/science/teleporter)
 "aPL" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/lrteleporter,
 /turf/simulated/floor/purple,
@@ -19546,23 +19532,23 @@
 /area/station/maintenance/SWmaint)
 "aPN" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/purple,
 /area/station/science)
 "aPO" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/purple,
 /area/station/science)
@@ -19589,9 +19575,9 @@
 "aPT" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor,
@@ -19607,9 +19593,9 @@
 /area/station/science)
 "aPV" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 5
@@ -19623,9 +19609,9 @@
 /area/station/storage/warehouse)
 "aPX" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 9
@@ -19633,14 +19619,14 @@
 /area/station/science/lab)
 "aPY" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -19738,16 +19724,16 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/pyro/maintenance{
-	icon_state = "maint_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "maint_closed"
 	},
 /obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aQm" = (
 /obj/cable{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/pool)
@@ -19765,13 +19751,13 @@
 "aQp" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/engineering{
-	icon_state = "eng_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "eng_closed"
 	},
 /obj/access_spawn/engineering,
 /obj/access_spawn/mining,
@@ -19783,16 +19769,16 @@
 /area/station/storage/warehouse)
 "aQr" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/SWmaint)
 "aQs" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/wingrille_spawn/auto,
@@ -19828,9 +19814,9 @@
 /area/station/maintenance/SEmaint)
 "aQw" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -19860,8 +19846,8 @@
 	pixel_y = 0
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 4
@@ -19873,9 +19859,9 @@
 /area/station/crew_quarters/quarters)
 "aQB" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance{
@@ -19905,17 +19891,17 @@
 /area/station/turret_protected/Zeta)
 "aQF" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/turret_protected/Zeta)
 "aQG" = (
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/machinery/light_switch{
 	name = "N light switch";
@@ -19925,9 +19911,9 @@
 /area/station/turret_protected/Zeta)
 "aQH" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/camera{
 	c_tag = "Research Sector Lobby";
@@ -19959,17 +19945,17 @@
 "aQJ" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purple,
 /area/station/science/lab)
 "aQK" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -19995,23 +19981,23 @@
 /obj/table/reinforced/bar/auto,
 /obj/item/clothing/head/cakehat,
 /turf/simulated/floor{
-	tag = "icon-carpet2 (WEST)";
+	dir = 8;
 	icon_state = "carpet2";
-	dir = 8
+	tag = "icon-carpet2 (WEST)"
 	},
 /area/station/crew_quarters/cafeteria)
 "aQN" = (
 /obj/stool/bar,
 /turf/simulated/floor{
-	tag = "icon-carpetE (WEST)";
+	dir = 8;
 	icon_state = "carpetE";
-	dir = 8
+	tag = "icon-carpetE (WEST)"
 	},
 /area/station/crew_quarters/cafeteria)
 "aQO" = (
 /obj/stool/chair/wooden{
-	icon_state = "chair_wooden";
-	dir = 4
+	dir = 4;
+	icon_state = "chair_wooden"
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
@@ -20032,22 +20018,22 @@
 /area/station/crew_quarters/cafeteria)
 "aQR" = (
 /obj/stool/chair/wooden{
-	icon_state = "chair_wooden";
-	dir = 8
+	dir = 8;
+	icon_state = "chair_wooden"
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
 "aQS" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Robotics"
@@ -20114,8 +20100,8 @@
 /area/station/hallway/primary/west)
 "aQY" = (
 /obj/cable{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -20127,9 +20113,9 @@
 /area/station/hallway/primary/west)
 "aQZ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -20145,9 +20131,9 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 1
@@ -20171,9 +20157,9 @@
 /area/station/hallway/primary/west)
 "aRc" = (
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-s (EAST)";
+	dir = 4;
 	icon_state = "pipe-s";
-	dir = 4
+	tag = "icon-pipe-s (EAST)"
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 1
@@ -20181,9 +20167,9 @@
 /area/station/hallway/primary/west)
 "aRd" = (
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-s (EAST)";
+	dir = 4;
 	icon_state = "pipe-s";
-	dir = 4
+	tag = "icon-pipe-s (EAST)"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/neutral/side{
@@ -20254,9 +20240,9 @@
 /area/station/crew_quarters/hor)
 "aRm" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/critter/domestic_bee{
 	name = "Heisenbee"
@@ -20285,13 +20271,13 @@
 /area/station/crew_quarters/hor)
 "aRp" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -20303,17 +20289,17 @@
 /area/station/turret_protected/Zeta)
 "aRq" = (
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/Zeta)
 "aRr" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/window/northleft,
 /turf/simulated/floor/specialroom/arcade,
@@ -20323,9 +20309,9 @@
 /area/station/turret_protected/Zeta)
 "aRt" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/Zeta)
@@ -20373,9 +20359,9 @@
 /area/station/science/lab)
 "aRz" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	tag = "icon-intact (NORTH)";
+	dir = 1;
 	icon_state = "intact";
-	dir = 1
+	tag = "icon-intact (NORTH)"
 	},
 /turf/simulated/floor/purple,
 /area/station/science/lab)
@@ -20403,8 +20389,8 @@
 /area/station/science/lab)
 "aRB" = (
 /turf/simulated/floor/carpet{
-	icon_state = "red2";
-	dir = 9
+	dir = 9;
+	icon_state = "red2"
 	},
 /area/station/crew_quarters/cafeteria)
 "aRC" = (
@@ -20413,9 +20399,9 @@
 	name = "monkeyspawn_horse"
 	},
 /turf/simulated/floor{
-	tag = "icon-carpet2 (WEST)";
+	dir = 8;
 	icon_state = "carpet2";
-	dir = 8
+	tag = "icon-carpet2 (WEST)"
 	},
 /area/station/crew_quarters/cafeteria)
 "aRD" = (
@@ -20427,21 +20413,21 @@
 /area/station/crew_quarters/cafeteria)
 "aRE" = (
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-s (EAST)";
+	dir = 4;
 	icon_state = "pipe-s";
-	dir = 4
+	tag = "icon-pipe-s (EAST)"
 	},
 /obj/stool/chair/wooden{
-	icon_state = "chair_wooden";
-	dir = 4
+	dir = 4;
+	icon_state = "chair_wooden"
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
 "aRF" = (
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-s (EAST)";
+	dir = 4;
 	icon_state = "pipe-s";
-	dir = 4
+	tag = "icon-pipe-s (EAST)"
 	},
 /obj/table/reinforced/bar/auto,
 /obj/item/plate,
@@ -20449,9 +20435,9 @@
 /area/station/crew_quarters/cafeteria)
 "aRG" = (
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-s (EAST)";
+	dir = 4;
 	icon_state = "pipe-s";
-	dir = 4
+	tag = "icon-pipe-s (EAST)"
 	},
 /obj/table/reinforced/bar/auto,
 /obj/item/kitchen/utensil/spoon,
@@ -20462,20 +20448,20 @@
 /area/station/crew_quarters/cafeteria)
 "aRH" = (
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-s (EAST)";
+	dir = 4;
 	icon_state = "pipe-s";
-	dir = 4
+	tag = "icon-pipe-s (EAST)"
 	},
 /obj/stool/chair/wooden{
-	icon_state = "chair_wooden";
-	dir = 8
+	dir = 8;
+	icon_state = "chair_wooden"
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
 "aRI" = (
 /obj/cable{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass,
@@ -20483,8 +20469,8 @@
 /area/station/hallway/primary/west)
 "aRJ" = (
 /obj/grille/catwalk{
-	icon_state = "catwalk_cross";
-	dir = 10
+	dir = 10;
+	icon_state = "catwalk_cross"
 	},
 /obj/cable{
 	d1 = 1;
@@ -20499,9 +20485,9 @@
 /area/station/mining/magnet)
 "aRK" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -20516,9 +20502,9 @@
 "aRL" = (
 /obj/disposalpipe/segment,
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-s (EAST)";
+	dir = 4;
 	icon_state = "pipe-s";
-	dir = 4
+	tag = "icon-pipe-s (EAST)"
 	},
 /turf/simulated/floor/neutral/corner{
 	dir = 8
@@ -20526,9 +20512,9 @@
 /area/station/hallway/primary/west)
 "aRM" = (
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-s (EAST)";
+	dir = 4;
 	icon_state = "pipe-s";
-	dir = 4
+	tag = "icon-pipe-s (EAST)"
 	},
 /turf/simulated/floor/neutral/corner{
 	dir = 8
@@ -20536,9 +20522,9 @@
 /area/station/hallway/primary/west)
 "aRN" = (
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-s (EAST)";
+	dir = 4;
 	icon_state = "pipe-s";
-	dir = 4
+	tag = "icon-pipe-s (EAST)"
 	},
 /obj/cable{
 	d1 = 1;
@@ -20546,9 +20532,9 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/neutral/corner{
 	dir = 8
@@ -20556,14 +20542,14 @@
 /area/station/hallway/primary/west)
 "aRO" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-s (EAST)";
+	dir = 4;
 	icon_state = "pipe-s";
-	dir = 4
+	tag = "icon-pipe-s (EAST)"
 	},
 /turf/simulated/floor/neutral/corner{
 	dir = 8
@@ -20571,9 +20557,9 @@
 /area/station/hallway/primary/west)
 "aRP" = (
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-s (EAST)";
+	dir = 4;
 	icon_state = "pipe-s";
-	dir = 4
+	tag = "icon-pipe-s (EAST)"
 	},
 /obj/cable{
 	d1 = 1;
@@ -20581,9 +20567,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/neutral/corner{
 	dir = 8
@@ -20591,13 +20577,13 @@
 /area/station/hallway/primary/west)
 "aRQ" = (
 /obj/grille/catwalk{
-	icon_state = "catwalk-0";
-	dir = 6
+	dir = 6;
+	icon_state = "catwalk-0"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
@@ -20608,9 +20594,9 @@
 /area/station/mining/magnet)
 "aRR" = (
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-s (EAST)";
+	dir = 4;
 	icon_state = "pipe-s";
-	dir = 4
+	tag = "icon-pipe-s (EAST)"
 	},
 /turf/simulated/floor/neutral/corner{
 	dir = 1
@@ -20618,14 +20604,14 @@
 /area/station/hallway/primary/west)
 "aRS" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-s (EAST)";
+	dir = 4;
 	icon_state = "pipe-s";
-	dir = 4
+	tag = "icon-pipe-s (EAST)"
 	},
 /turf/simulated/floor/neutral/corner{
 	dir = 1
@@ -20633,9 +20619,9 @@
 /area/station/hallway/primary/west)
 "aRT" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/purple,
 /area/station/science/teleporter)
@@ -20650,9 +20636,9 @@
 	})
 "aRV" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/purple,
 /area/station/science/teleporter)
@@ -20661,9 +20647,9 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
@@ -20673,9 +20659,9 @@
 /area/station/mining/magnet)
 "aRX" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/purple/side{
@@ -20695,20 +20681,20 @@
 /area/station/science/teleporter)
 "aRZ" = (
 /turf/simulated/floor/carpet{
-	icon_state = "red2";
-	dir = 9
+	dir = 9;
+	icon_state = "red2"
 	},
 /area/station/crew_quarters/hor)
 "aSa" = (
 /turf/simulated/floor/carpet{
-	icon_state = "red2";
-	dir = 1
+	dir = 1;
+	icon_state = "red2"
 	},
 /area/station/crew_quarters/hor)
 "aSb" = (
 /turf/simulated/floor/carpet{
-	icon_state = "red2";
-	dir = 5
+	dir = 5;
+	icon_state = "red2"
 	},
 /area/station/crew_quarters/hor)
 "aSc" = (
@@ -20729,14 +20715,14 @@
 /area/station/crew_quarters/hor)
 "aSd" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/turret{
-	tag = "icon-grey_target_prism (NORTH)";
+	dir = 1;
 	icon_state = "grey_target_prism";
-	dir = 1
+	tag = "icon-grey_target_prism (NORTH)"
 	},
 /obj/cable,
 /turf/simulated/floor/bot,
@@ -20757,9 +20743,9 @@
 "aSh" = (
 /obj/machinery/atmospherics/valve,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purple,
 /area/station/science/lab)
@@ -20769,14 +20755,14 @@
 	level = 2
 	},
 /obj/machinery/embedded_controller/radio/airlock_controller{
+	airpump_tag = "tox_airlock_pump";
+	exterior_door_tag = "tox_airlock_exterior";
+	id_tag = "tox_airlock_control";
+	interior_door_tag = "tox_airlock_interior";
 	pixel_x = 24;
 	pixel_y = -7;
-	id_tag = "tox_airlock_control";
-	exterior_door_tag = "tox_airlock_exterior";
-	interior_door_tag = "tox_airlock_interior";
-	airpump_tag = "tox_airlock_pump";
-	sensor_tag = "tox_airlock_sensor";
-	sanitize_external = 1
+	sanitize_external = 1;
+	sensor_tag = "tox_airlock_sensor"
 	},
 /obj/machinery/door_control{
 	id = "mixvent";
@@ -20801,9 +20787,9 @@
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
@@ -20831,40 +20817,40 @@
 /area/station/science/lab)
 "aSo" = (
 /obj/machinery/door/poddoor/pyro{
-	name = "Mixing Vent";
-	icon_state = "pdoor1";
 	dir = 8;
+	icon_state = "pdoor1";
+	id = "mixvent";
 	layer = 8;
-	id = "mixvent"
+	name = "Mixing Vent"
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "aSp" = (
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-s (EAST)";
+	dir = 4;
 	icon_state = "pipe-s";
-	dir = 4
+	tag = "icon-pipe-s (EAST)"
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
 "aSq" = (
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-s (EAST)";
+	dir = 4;
 	icon_state = "pipe-s";
-	dir = 4
+	tag = "icon-pipe-s (EAST)"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "red2";
-	dir = 8
+	dir = 8;
+	icon_state = "red2"
 	},
 /area/station/crew_quarters/cafeteria)
 "aSr" = (
 /obj/table/reinforced/bar/auto,
 /obj/random_item_spawner/tableware,
 /turf/simulated/floor{
-	tag = "icon-carpet2 (WEST)";
+	dir = 8;
 	icon_state = "carpet2";
-	dir = 8
+	tag = "icon-carpet2 (WEST)"
 	},
 /area/station/crew_quarters/cafeteria)
 "aSs" = (
@@ -20884,8 +20870,8 @@
 	location = "bar"
 	},
 /obj/stool/chair/wooden{
-	icon_state = "chair_wooden";
-	dir = 1
+	dir = 1;
+	icon_state = "chair_wooden"
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
@@ -20896,9 +20882,9 @@
 /area/station/hallway/primary/west)
 "aSw" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
@@ -20940,8 +20926,8 @@
 /area/station/hallway/primary/west)
 "aSA" = (
 /obj/cable{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -20953,9 +20939,9 @@
 /area/station/hallway/primary/west)
 "aSB" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -20976,8 +20962,8 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 2
@@ -20989,9 +20975,9 @@
 	dir = 1
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -21003,9 +20989,9 @@
 /area/station/hallway/primary/west)
 "aSE" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /obj/cable{
@@ -21048,9 +21034,9 @@
 /area/station/hallway/primary/south)
 "aSI" = (
 /obj/disposalpipe/junction{
-	tag = "icon-pipe-j2 (NORTH)";
+	dir = 1;
 	icon_state = "pipe-j2";
-	dir = 1
+	tag = "icon-pipe-j2 (NORTH)"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -21060,9 +21046,9 @@
 	name = "VACUUM AREA"
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/science/lab)
@@ -21082,9 +21068,9 @@
 	})
 "aSM" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -21114,27 +21100,27 @@
 	},
 /obj/stool/chair,
 /turf/simulated/floor/carpet{
-	icon_state = "red2";
-	dir = 1
+	dir = 1;
+	icon_state = "red2"
 	},
 /area/station/crew_quarters/hor)
 "aSQ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "red2";
-	dir = 8
+	dir = 8;
+	icon_state = "red2"
 	},
 /area/station/crew_quarters/hor)
 "aSR" = (
 /obj/table/wood/auto,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/deskclutter,
 /obj/item/reagent_containers/food/drinks/rum_spaced,
@@ -21156,29 +21142,29 @@
 /area/station/crew_quarters/pool)
 "aST" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/Zeta)
 "aSU" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/Zeta)
 "aSV" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/cable{
@@ -21195,14 +21181,14 @@
 /area/station/turret_protected/Zeta)
 "aSW" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/Zeta)
@@ -21250,23 +21236,23 @@
 /area/station/science/lab)
 "aTa" = (
 /obj/machinery/atmospherics/pipe/manifold{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8;
-	level = 2
+	icon_state = "manifold";
+	level = 2;
+	tag = "icon-manifold (WEST)"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purple,
 /area/station/science/lab)
 "aTb" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance,
@@ -21276,9 +21262,9 @@
 "aTc" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -21289,8 +21275,8 @@
 	location = "bar"
 	},
 /obj/stool/chair/wooden{
-	icon_state = "chair_wooden";
-	dir = 1
+	dir = 1;
+	icon_state = "chair_wooden"
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
@@ -21300,8 +21286,8 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "red2";
-	dir = 10
+	dir = 10;
+	icon_state = "red2"
 	},
 /area/station/crew_quarters/cafeteria)
 "aTf" = (
@@ -21312,9 +21298,9 @@
 /area/station/crew_quarters/bar)
 "aTh" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
@@ -21327,9 +21313,9 @@
 "aTi" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/access_spawn/research,
@@ -21478,15 +21464,15 @@
 /obj/item/disk/data/tape/master/readonly,
 /obj/item/reagent_containers/food/snacks/cookie/chocolate_chip,
 /turf/simulated/floor/carpet{
-	icon_state = "red2";
-	dir = 4
+	dir = 4;
+	icon_state = "red2"
 	},
 /area/station/crew_quarters/hor)
 "aTF" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/table/wood/auto,
 /obj/cable{
@@ -21508,16 +21494,16 @@
 "aTH" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer3/terminal/zeta{
 	setup_os_string = "ZETA_MAINFRAME"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/turret_protected/Zeta)
@@ -21539,8 +21525,8 @@
 /obj/item/device/igniter,
 /obj/item/device/igniter,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 8
@@ -21570,9 +21556,9 @@
 /area/station/crew_quarters/barber_shop)
 "aTN" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 2;
@@ -21652,9 +21638,9 @@
 "aTW" = (
 /obj/disposalpipe/segment,
 /obj/shrub{
-	tag = "icon-shrub (WEST)";
+	dir = 8;
 	icon_state = "shrub";
-	dir = 8
+	tag = "icon-shrub (WEST)"
 	},
 /obj/item/plant/herb/cannabis,
 /obj/item/plant/wheat,
@@ -21665,8 +21651,8 @@
 "aTX" = (
 /obj/machinery/camera,
 /obj/stool/chair/couch/green{
-	icon_state = "chair_couch-green";
-	dir = 8
+	dir = 8;
+	icon_state = "chair_couch-green"
 	},
 /obj/item/device/light/zippo,
 /turf/simulated/floor{
@@ -21675,8 +21661,8 @@
 /area/station/crew_quarters/bar)
 "aTY" = (
 /obj/stool/chair/couch/green{
-	icon_state = "chair_couch-green";
-	dir = 4
+	dir = 4;
+	icon_state = "chair_couch-green"
 	},
 /turf/simulated/floor{
 	icon_state = "carpet2"
@@ -21707,9 +21693,9 @@
 /area/station/crew_quarters/bar)
 "aUb" = (
 /obj/shrub{
-	tag = "icon-shrub (NORTH)";
+	dir = 1;
 	icon_state = "shrub";
-	dir = 1
+	tag = "icon-shrub (NORTH)"
 	},
 /obj/item/clothing/head/helmet/space/santahat,
 /obj/machinery/light/small{
@@ -21721,8 +21707,8 @@
 /area/station/owlery)
 "aUc" = (
 /obj/cable{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/simulated/floor/grass/random{
 	dir = 2
@@ -21760,9 +21746,9 @@
 "aUh" = (
 /obj/stool/chair/comfy,
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
+	dir = 8;
 	icon_state = "bulb1";
-	dir = 8
+	tag = "icon-bulb1 (WEST)"
 	},
 /turf/simulated/floor{
 	icon_state = "carpetS"
@@ -21770,8 +21756,8 @@
 /area/station/crew_quarters/barber_shop)
 "aUi" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -21852,8 +21838,8 @@
 /area/station/maintenance/east)
 "aUs" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 2
+	dir = 2;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/station/turret_protected/ai)
@@ -21875,8 +21861,8 @@
 /area/station/hallway/primary/south)
 "aUv" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
@@ -21910,8 +21896,8 @@
 /area/station/security/detectives_office)
 "aUA" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -21934,9 +21920,9 @@
 /obj/item/device/radio/headset/multifreq,
 /obj/storage/crate,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purple,
 /area/station/science/teleporter)
@@ -21948,16 +21934,16 @@
 /area/station/science/teleporter)
 "aUD" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/engine,
 /area/station/science/teleporter)
 "aUE" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 4;
@@ -21978,14 +21964,14 @@
 /area/station/bridge)
 "aUG" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/stool{
 	desc = "A soft little bed the general size and shape of a space bee.";
@@ -22020,8 +22006,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/storage/tape_drive{
@@ -22031,8 +22017,8 @@
 	setup_drive_type = /obj/item/disk/data/tape/master
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 6
@@ -22048,8 +22034,8 @@
 "aUK" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/mainframe/zeta{
@@ -22068,9 +22054,9 @@
 /area/station/turret_protected/Zeta)
 "aUM" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door_control{
 	id = "dwaine_core";
@@ -22082,14 +22068,14 @@
 /area/station/turret_protected/Zeta)
 "aUN" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -22097,9 +22083,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/purple/corner{
 	dir = 1
@@ -22116,9 +22102,9 @@
 /area/station/medical/research)
 "aUP" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 4
@@ -22131,9 +22117,9 @@
 /area/station/science/lab)
 "aUR" = (
 /obj/machinery/atmospherics/portables_connector{
-	tag = "icon-intact (WEST)";
+	dir = 8;
 	icon_state = "intact";
-	dir = 8
+	tag = "icon-intact (WEST)"
 	},
 /turf/simulated/floor/purple,
 /area/station/science/lab)
@@ -22148,9 +22134,9 @@
 /area/station/science/lab)
 "aUU" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/wall/auto/supernorn,
@@ -22166,11 +22152,11 @@
 /area/station/science/lab)
 "aUW" = (
 /obj/machinery/atmospherics/pipe/simple{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9;
+	icon_state = "intact";
 	layer = 3;
-	level = 2
+	level = 2;
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
@@ -22178,8 +22164,8 @@
 /obj/table/reinforced/bar,
 /obj/machinery/glass_recycler,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 8;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /obj/window/reinforced/north,
@@ -22223,9 +22209,9 @@
 "aVd" = (
 /obj/table/reinforced/bar/auto,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced/north,
 /obj/item/kitchen/food_box/donut_box{
@@ -22288,9 +22274,9 @@
 /area/station/mining/magnet)
 "aVk" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
 	d1 = 1;
@@ -22303,9 +22289,9 @@
 /area/station/owlery)
 "aVl" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/grass/random{
 	dir = 2
@@ -22313,9 +22299,9 @@
 /area/station/owlery)
 "aVm" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/critter/owl,
 /turf/simulated/floor/grass/random{
@@ -22324,9 +22310,9 @@
 /area/station/owlery)
 "aVn" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/unpowered/wood{
 	name = "The Snip"
@@ -22335,9 +22321,9 @@
 /area/station/crew_quarters/barber_shop)
 "aVo" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/barber_shop)
@@ -22348,26 +22334,26 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/barber_shop)
 "aVq" = (
 /obj/machinery/door/unpowered/wood,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/barber_shop)
 "aVr" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/barber_shop)
@@ -22376,14 +22362,14 @@
 /area/station/crew_quarters/bar)
 "aVt" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 1;
@@ -22406,22 +22392,22 @@
 /area/station/hallway/primary/west)
 "aVw" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/sanitary,
 /area/station/hallway/primary/west)
 "aVx" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 4
+	dir = 4;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/station/turret_protected/ai)
 "aVy" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 6
+	dir = 6;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area/station/turret_protected/ai)
@@ -22437,9 +22423,9 @@
 /area/station/hallway/primary/south)
 "aVB" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/security{
 	dir = 4;
@@ -22452,9 +22438,9 @@
 "aVC" = (
 /obj/table/wood/auto,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/item/hand_labeler,
 /obj/item/device/audio_log{
@@ -22467,9 +22453,9 @@
 /area/station/security/detectives_office)
 "aVD" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/stool/chair,
 /obj/landmark/start{
@@ -22508,8 +22494,8 @@
 /area/station/science/teleporter)
 "aVJ" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 10
+	dir = 10;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area/station/turret_protected/ai)
@@ -22596,9 +22582,9 @@
 /area/station/crew_quarters/bar)
 "aVX" = (
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/reagent_dispensers/beerkeg,
 /turf/simulated/floor/black,
@@ -22624,8 +22610,8 @@
 	pixel_y = -28
 	},
 /obj/stool/chair/comfy/green{
-	icon_state = "chair_comfy-green";
-	dir = 8
+	dir = 8;
+	icon_state = "chair_comfy-green"
 	},
 /turf/simulated/floor{
 	icon_state = "carpet2"
@@ -22650,8 +22636,8 @@
 "aWg" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -22659,9 +22645,9 @@
 	pixel_y = 24
 	},
 /obj/machinery/light{
-	tag = "icon-tube1 (NORTH)";
+	dir = 1;
 	icon_state = "tube1";
-	dir = 1
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/floor/black,
 /area/station/security/hos)
@@ -22699,9 +22685,9 @@
 /area/station/turret_protected/Zeta)
 "aWl" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
@@ -22720,17 +22706,17 @@
 /area/station/security/detectives_office)
 "aWo" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/table/wood/auto,
 /obj/item/cigpacket,
 /obj/item/clothing/glasses/thermal,
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor{
 	icon_state = "carpetS"
@@ -22744,9 +22730,9 @@
 	pictures_left = 30
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "carpetS"
@@ -22756,9 +22742,9 @@
 /obj/table/wood/auto,
 /obj/item/storage/secure/sbriefcase,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "carpetSE"
@@ -22766,17 +22752,17 @@
 /area/station/security/detectives_office)
 "aWr" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aWs" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/security{
-	icon_state = "sec_closed";
-	dir = 8
+	dir = 8;
+	icon_state = "sec_closed"
 	},
 /obj/access_spawn/security,
 /turf/simulated/floor,
@@ -22785,16 +22771,16 @@
 /obj/disposalpipe/segment,
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
@@ -22804,8 +22790,8 @@
 /area/station/maintenance/SEmaint)
 "aWu" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /turf/space,
 /area)
@@ -22830,9 +22816,9 @@
 /area/station/science/storage)
 "aWz" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/science/storage)
@@ -22887,14 +22873,14 @@
 /area/station/crew_quarters/bar)
 "aWH" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/machinery/door/firedoor/pyro{
 	dir = 4
@@ -22915,8 +22901,8 @@
 /area/station/crew_quarters/cafeteria)
 "aWJ" = (
 /obj/stool/chair/comfy/green{
-	icon_state = "chair_comfy-green";
-	dir = 4
+	dir = 4;
+	icon_state = "chair_comfy-green"
 	},
 /turf/simulated/floor{
 	icon_state = "carpet2"
@@ -22943,8 +22929,8 @@
 /obj/item/crowbar,
 /obj/item/item_box/medical_patches/mini_styptic,
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen3";
-	dir = 2
+	dir = 2;
+	icon_state = "fgreen3"
 	},
 /area/station/bridge)
 "aWN" = (
@@ -22958,9 +22944,9 @@
 /area/station/crew_quarters/bar)
 "aWO" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
+	dir = 8;
 	icon_state = "bulb1";
-	dir = 8
+	tag = "icon-bulb1 (WEST)"
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/barber_shop)
@@ -22993,9 +22979,9 @@
 /obj/item/dye_bottle,
 /obj/item/mop,
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
+	dir = 8;
 	icon_state = "bulb1";
-	dir = 8
+	tag = "icon-bulb1 (WEST)"
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/barber_shop)
@@ -23025,14 +23011,14 @@
 /area/station/medical/research)
 "aWY" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
@@ -23074,9 +23060,9 @@
 /area/station/maintenance/SEmaint)
 "aXd" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 2;
@@ -23098,18 +23084,18 @@
 "aXg" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
+	dir = 8;
 	icon_state = "bulb1";
-	dir = 8
+	tag = "icon-bulb1 (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "aXh" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -23146,13 +23132,13 @@
 /area/station/science/storage)
 "aXk" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/storage/secure/closet/medical{
 	name = "locker"
@@ -23171,8 +23157,8 @@
 /area/station/science/storage)
 "aXn" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 8
+	dir = 8;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/station/turret_protected/ai)
@@ -23181,8 +23167,8 @@
 /area/station/security/detectives_office)
 "aXp" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 9
+	dir = 9;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area/station/turret_protected/ai)
@@ -23192,8 +23178,8 @@
 /area/station/crew_quarters/kitchen)
 "aXr" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc{
@@ -23285,9 +23271,9 @@
 /area/station/maintenance/SWmaint)
 "aXC" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -23329,9 +23315,9 @@
 "aXI" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -23445,9 +23431,9 @@
 	name = "Staff Assistant"
 	},
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
+	dir = 8;
 	icon_state = "bulb1";
-	dir = 8
+	tag = "icon-bulb1 (WEST)"
 	},
 /turf/simulated/floor/sanitary,
 /area/station/hallway/primary/west)
@@ -23487,8 +23473,8 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/storage/secure/closet/civilian/kitchen,
 /turf/simulated/floor/specialroom/cafeteria{
@@ -23499,9 +23485,9 @@
 /obj/disposalpipe/trunk,
 /obj/machinery/disposal,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/cafeteria{
 	dir = 8
@@ -23509,17 +23495,17 @@
 /area/station/crew_quarters/kitchen)
 "aXY" = (
 /obj/machinery/shower{
-	tag = "icon-showerhead (WEST)";
+	dir = 8;
 	icon_state = "showerhead";
-	dir = 8
+	tag = "icon-showerhead (WEST)"
 	},
 /turf/simulated/floor/sanitary,
 /area/station/hallway/primary/west)
 "aXZ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 1;
@@ -23532,9 +23518,9 @@
 /area/station/crew_quarters/kitchen)
 "aYa" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -23546,9 +23532,9 @@
 /area/station/crew_quarters/kitchen)
 "aYb" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -23565,9 +23551,9 @@
 /area/station/crew_quarters/kitchen)
 "aYc" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/disposal/mail{
 	mail_tag = "kitchen";
@@ -23594,9 +23580,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/grass/random{
 	dir = 2
@@ -23616,8 +23602,8 @@
 /area/station/crew_quarters/arcade)
 "aYh" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -23668,9 +23654,9 @@
 /area/station/crew_quarters/arcade)
 "aYl" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -23728,8 +23714,8 @@
 /area/station/security/main)
 "aYr" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer3/generic/secure_data,
@@ -23739,14 +23725,14 @@
 /area/station/security/main)
 "aYs" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/red/side{
 	dir = 1
@@ -23774,8 +23760,7 @@
 	},
 /area/station/security/main)
 "aYv" = (
-/obj/table/auto,
-/obj/machinery/recharger,
+/obj/submachine/weapon_vendor/security,
 /turf/simulated/floor/red/side{
 	dir = 5
 	},
@@ -23801,9 +23786,9 @@
 "aYz" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
@@ -23823,8 +23808,8 @@
 /area)
 "aYB" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -23836,9 +23821,9 @@
 "aYD" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
@@ -23889,9 +23874,9 @@
 /area/station/crew_quarters/kitchen)
 "aYJ" = (
 /obj/shrub{
-	tag = "icon-shrub (WEST)";
+	dir = 8;
 	icon_state = "shrub";
-	dir = 8
+	tag = "icon-shrub (WEST)"
 	},
 /turf/simulated/floor/grass/random{
 	dir = 2
@@ -23909,9 +23894,9 @@
 /area/station/owlery)
 "aYL" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/critter/owl{
 	desc = "His name is Carl.";
@@ -23923,22 +23908,22 @@
 /area/station/owlery)
 "aYN" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "aYO" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
@@ -23978,17 +23963,17 @@
 /area/station/crew_quarters/arcade)
 "aYT" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
 "aYU" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -24020,9 +24005,9 @@
 /area/station/storage/primary)
 "aYY" = (
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-s (EAST)";
+	dir = 4;
 	icon_state = "pipe-s";
-	dir = 4
+	tag = "icon-pipe-s (EAST)"
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -24039,9 +24024,9 @@
 /area/station/security/main)
 "aZa" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/stool/chair,
 /obj/landmark/start{
@@ -24136,8 +24121,8 @@
 /obj/item/reagent_containers/food/snacks/ice_cream_cone,
 /obj/item/reagent_containers/food/snacks/ice_cream_cone,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/specialroom/cafeteria{
 	dir = 8
@@ -24145,9 +24130,9 @@
 /area/station/crew_quarters/kitchen)
 "aZl" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
+	dir = 8;
 	icon_state = "bulb1";
-	dir = 8
+	tag = "icon-bulb1 (WEST)"
 	},
 /turf/simulated/floor/grass/random{
 	dir = 2
@@ -24158,8 +24143,8 @@
 /area/station/crew_quarters/arcade)
 "aZo" = (
 /obj/cable{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
@@ -24190,9 +24175,9 @@
 /area/station/medical/research)
 "aZs" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/kitchen)
@@ -24209,9 +24194,9 @@
 	maxcharge = 15000
 	},
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
+	dir = 8;
 	icon_state = "bulb1";
-	dir = 8
+	tag = "icon-bulb1 (WEST)"
 	},
 /turf/simulated/floor,
 /area/station/storage/primary)
@@ -24264,9 +24249,9 @@
 /obj/table/auto,
 /obj/item/storage/box/revimp_kit,
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-c";
+	dir = 2;
 	icon_state = "pipe-c";
-	dir = 2
+	tag = "icon-pipe-c"
 	},
 /obj/item/clothing/glasses/thermal,
 /turf/simulated/floor,
@@ -24297,8 +24282,8 @@
 /area/station/security/detectives_office)
 "aZG" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/storage/crate/bartending,
 /turf/simulated/floor/specialroom/freezer,
@@ -24316,8 +24301,8 @@
 "aZJ" = (
 /obj/machinery/vending/kitchen,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/specialroom/cafeteria{
 	dir = 8
@@ -24354,9 +24339,9 @@
 /area/station/owlery)
 "aZO" = (
 /obj/shrub{
-	tag = "icon-shrub (NORTH)";
+	dir = 1;
 	icon_state = "shrub";
-	dir = 1
+	tag = "icon-shrub (NORTH)"
 	},
 /turf/simulated/floor/grass/random{
 	dir = 2
@@ -24392,9 +24377,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc{
@@ -24418,9 +24403,9 @@
 /area/station/storage/primary)
 "aZV" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /obj/machinery/navbeacon{
@@ -24437,8 +24422,8 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/camera{
 	c_tag = "Security West";
@@ -24450,12 +24435,12 @@
 /area/station/security/main)
 "aZX" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/table/auto,
-/obj/item/storage/toolbox/mechanical,
+/obj/machinery/recharger,
 /turf/simulated/floor,
 /area/station/security/main)
 "aZY" = (
@@ -24465,9 +24450,9 @@
 /area/station/security/main)
 "aZZ" = (
 /obj/stool/chair{
-	tag = "icon-chair (WEST)";
+	dir = 8;
 	icon_state = "chair";
-	dir = 8
+	tag = "icon-chair (WEST)"
 	},
 /obj/landmark/start{
 	name = "Security Officer"
@@ -24476,15 +24461,15 @@
 /area/station/security/main)
 "baa" = (
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 0;
+	dir = 8;
 	frequency = 1485;
 	name = "Station Intercom (Security)"
 	},
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -24492,46 +24477,46 @@
 /area/station/security/main)
 "bab" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/security/main)
 "bac" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/stool/chair{
-	tag = "icon-chair (NORTH)";
+	dir = 1;
 	icon_state = "chair";
-	dir = 1
+	tag = "icon-chair (NORTH)"
 	},
 /turf/simulated/floor/black,
 /area/station/security/main)
 "bad" = (
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-s (EAST)";
+	dir = 4;
 	icon_state = "pipe-s";
-	dir = 4
+	tag = "icon-pipe-s (EAST)"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/main)
 "bae" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/main)
 "baf" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -24593,9 +24578,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -24629,9 +24614,9 @@
 /area/station/hallway/primary/south)
 "bat" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -24639,17 +24624,17 @@
 /area/station/hallway/primary/south)
 "bau" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/SWmaint)
 "bav" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -24667,9 +24652,9 @@
 /area/station/security/main)
 "baw" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/stool/chair{
 	dir = 4
@@ -24687,9 +24672,9 @@
 	},
 /obj/table/auto,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/recharger,
 /turf/simulated/floor,
@@ -24697,30 +24682,33 @@
 "bay" = (
 /obj/table/auto,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/item/wrench,
+/obj/disposalpipe/segment,
 /obj/item/kitchen/food_box/donut_box{
 	desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038."
 	},
-/obj/disposalpipe/segment,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 3
+	},
 /turf/simulated/floor,
 /area/station/security/main)
 "baz" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
 "baA" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -24746,8 +24734,8 @@
 "baF" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance{
-	icon_state = "maint_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "maint_closed"
 	},
 /obj/access_spawn/maint,
 /turf/simulated/floor,
@@ -24758,36 +24746,36 @@
 /area/station/maintenance/SEmaint)
 "baH" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/arcade)
 "baI" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 6
+	dir = 6;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area)
 "baJ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/main)
 "baK" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 10
+	dir = 10;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area)
@@ -24886,9 +24874,9 @@
 /area/station/crew_quarters/bar)
 "baY" = (
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/machinery/door/window/eastright,
 /obj/submachine/ATM{
@@ -24927,8 +24915,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -24936,17 +24924,17 @@
 "bbd" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/arcade)
 "bbe" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -24965,9 +24953,9 @@
 /area/station/maintenance/SWmaint)
 "bbf" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -24980,9 +24968,9 @@
 /area/station/maintenance/SWmaint)
 "bbh" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -24991,9 +24979,9 @@
 /area/station/storage/primary)
 "bbi" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -25034,9 +25022,9 @@
 /area/station/hallway/primary/south)
 "bbm" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /obj/disposalpipe/segment{
@@ -25051,9 +25039,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -25083,9 +25071,9 @@
 /area/station/security/main)
 "bbq" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -25118,8 +25106,8 @@
 "bbu" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -25166,12 +25154,12 @@
 /area/ghostdrone_factory)
 "bbB" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -25227,8 +25215,8 @@
 /area/station/storage/primary)
 "bbG" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -25253,9 +25241,9 @@
 /area/station/storage/primary)
 "bbI" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance,
@@ -25264,9 +25252,9 @@
 /area/station/maintenance/SWmaint)
 "bbJ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/yellow/side{
@@ -25275,15 +25263,15 @@
 /area/station/hallway/primary/south)
 "bbK" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -25309,14 +25297,14 @@
 /area/station/security/main)
 "bbP" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/red/corner{
 	dir = 4
@@ -25324,9 +25312,9 @@
 /area/station/security/main)
 "bbQ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/storage/secure/closet/security/equipment,
 /turf/simulated/floor/red/side{
@@ -25345,9 +25333,9 @@
 /area/station/security/main)
 "bbT" = (
 /obj/stool/chair{
-	tag = "icon-chair (WEST)";
+	dir = 8;
 	icon_state = "chair";
-	dir = 8
+	tag = "icon-chair (WEST)"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
@@ -25368,8 +25356,8 @@
 /area/station/security/main)
 "bbW" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
@@ -25405,16 +25393,16 @@
 /area/ghostdrone_factory)
 "bcc" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 1
+	dir = 1;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area)
 "bcd" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
@@ -25461,17 +25449,17 @@
 /area/station/security/main)
 "bck" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
 "bcl" = (
 /obj/disposalpipe/trunk{
-	tag = "icon-pipe-t (NORTH)";
+	dir = 1;
 	icon_state = "pipe-t";
-	dir = 1
+	tag = "icon-pipe-t (NORTH)"
 	},
 /obj/machinery/disposal,
 /obj/machinery/light_switch{
@@ -25532,8 +25520,8 @@
 /area/ghostdrone_factory)
 "bcs" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 5
+	dir = 5;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area)
@@ -25553,8 +25541,8 @@
 /area/station/maintenance/SWmaint)
 "bcv" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/yellow/corner{
 	dir = 4
@@ -25590,9 +25578,9 @@
 /area/station/hallway/primary/south)
 "bcz" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/disposalpipe/segment,
@@ -25668,8 +25656,8 @@
 /area/ghostdrone_factory)
 "bcL" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -25680,9 +25668,9 @@
 /area/station/crew_quarters/arcade)
 "bcM" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -25710,9 +25698,9 @@
 /area/station/security/main)
 "bcP" = (
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /turf/simulated/floor/red,
 /area/station/security/brig)
@@ -25736,9 +25724,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/red,
 /area/station/security/brig)
@@ -25747,14 +25735,14 @@
 /area/station/security/brig)
 "bcT" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/machinery/door/airlock/pyro/security,
 /obj/access_spawn/security,
@@ -25766,8 +25754,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -25797,35 +25785,35 @@
 /area/ghostdrone_factory)
 "bcZ" = (
 /obj/lattice{
-	tag = "icon-lattice-dir (WEST)";
+	dir = 8;
 	icon_state = "lattice-dir";
-	dir = 8
+	tag = "icon-lattice-dir (WEST)"
 	},
 /obj/machinery/light/runway_light,
 /turf/space,
 /area)
 "bda" = (
 /obj/lattice{
-	tag = "icon-lattice-dir (EAST)";
+	dir = 4;
 	icon_state = "lattice-dir";
-	dir = 4
+	tag = "icon-lattice-dir (EAST)"
 	},
 /obj/machinery/light/runway_light/delay2,
 /turf/space,
 /area)
 "bdb" = (
 /obj/lattice{
-	tag = "icon-lattice-dir (EAST)";
+	dir = 4;
 	icon_state = "lattice-dir";
-	dir = 4
+	tag = "icon-lattice-dir (EAST)"
 	},
 /obj/machinery/light/runway_light/delay3,
 /turf/space,
 /area)
 "bdc" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 5
+	dir = 5;
+	icon_state = "lattice-dir"
 	},
 /obj/machinery/light/runway_light/delay4,
 /turf/space,
@@ -25835,8 +25823,8 @@
 /area)
 "bde" = (
 /obj/machinery/door/airlock/pyro/external{
-	icon_state = "airlock_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "airlock_closed"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
@@ -25847,9 +25835,9 @@
 /area/station/bridge)
 "bdg" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 4
@@ -25865,17 +25853,17 @@
 /area/station/science/lab)
 "bdi" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/security/brig)
 "bdj" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/red,
 /area/station/security/brig)
@@ -25885,9 +25873,9 @@
 /area/station/engine/engineering)
 "bdl" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -25904,18 +25892,18 @@
 	pixel_y = -24
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/access_spawn/brig,
 /turf/simulated/floor/red/side,
 /area/station/security/brig)
 "bdn" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/clonepod,
 /obj/cable,
@@ -25925,9 +25913,9 @@
 	})
 "bdo" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/red,
 /area/station/security/brig)
@@ -25937,17 +25925,17 @@
 /area/ghostdrone_factory)
 "bdq" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/red/side,
 /area/station/security/brig)
 "bdr" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/camera{
 	c_tag = "Brig - Solitary 3";
@@ -25959,8 +25947,8 @@
 /area/station/security/brig)
 "bds" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -25968,9 +25956,9 @@
 "bdt" = (
 /obj/lattice,
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /turf/space,
 /area)
@@ -26021,14 +26009,14 @@
 /area/ghostdrone_factory)
 "bdz" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
@@ -26059,14 +26047,14 @@
 /area/station/security/brig)
 "bdD" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -26074,9 +26062,9 @@
 /area/station/security/main)
 "bdE" = (
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-s (EAST)";
+	dir = 4;
 	icon_state = "pipe-s";
-	dir = 4
+	tag = "icon-pipe-s (EAST)"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/brig)
@@ -26087,22 +26075,22 @@
 /area/station/security/brig)
 "bdG" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-s (EAST)";
+	dir = 4;
 	icon_state = "pipe-s";
-	dir = 4
+	tag = "icon-pipe-s (EAST)"
 	},
 /turf/simulated/floor,
 /area/station/security/brig)
 "bdH" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -26120,9 +26108,9 @@
 /area/station/security/brig)
 "bdJ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/storage/secure/closet/brig/automatic/solitary{
 	id = "solitary3";
@@ -26155,8 +26143,8 @@
 /area/ghostdrone_factory)
 "bdN" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 10
+	dir = 10;
+	icon_state = "lattice-dir"
 	},
 /obj/machinery/light/runway_light,
 /turf/space,
@@ -26196,9 +26184,9 @@
 /area/station/maintenance/SWmaint)
 "bdS" = (
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-s (EAST)";
+	dir = 4;
 	icon_state = "pipe-s";
-	dir = 4
+	tag = "icon-pipe-s (EAST)"
 	},
 /obj/machinery/door/window/brigdoor/solitary3/eastleft,
 /obj/access_spawn/brig,
@@ -26206,9 +26194,9 @@
 /area/station/security/brig)
 "bdT" = (
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-s (EAST)";
+	dir = 4;
 	icon_state = "pipe-s";
-	dir = 4
+	tag = "icon-pipe-s (EAST)"
 	},
 /obj/machinery/door/window/brigdoor/solitary/westright{
 	name = "Cell #1"
@@ -26218,9 +26206,9 @@
 /area/station/security/brig)
 "bdU" = (
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-s (EAST)";
+	dir = 4;
 	icon_state = "pipe-s";
-	dir = 4
+	tag = "icon-pipe-s (EAST)"
 	},
 /obj/machinery/door/window/brigdoor/solitary2/westright,
 /obj/access_spawn/brig,
@@ -26228,8 +26216,8 @@
 /area/station/security/brig)
 "bdV" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
@@ -26240,25 +26228,25 @@
 /area/station/security/brig)
 "bdW" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "bdX" = (
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-s (EAST)";
+	dir = 4;
 	icon_state = "pipe-s";
-	dir = 4
+	tag = "icon-pipe-s (EAST)"
 	},
 /obj/machinery/camera{
 	c_tag = "Brig North";
 	dir = 4
 	},
 /obj/item/device/radio/intercom{
-	dir = 4;
 	broadcasting = 0;
+	dir = 4;
 	frequency = 1485;
 	name = "Station Intercom (Security)"
 	},
@@ -26268,9 +26256,9 @@
 /area/station/security/brig)
 "bdY" = (
 /obj/disposalpipe/junction{
-	tag = "icon-pipe-j2 (NORTH)";
+	dir = 1;
 	icon_state = "pipe-j2";
-	dir = 1
+	tag = "icon-pipe-j2 (NORTH)"
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -26300,9 +26288,9 @@
 /area/station/turret_protected/ai)
 "bec" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/stool,
 /turf/simulated/floor/red/side,
@@ -26322,9 +26310,9 @@
 /area/station/security/brig)
 "bee" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/stool/bed/brig,
 /obj/machinery/light/small,
@@ -26332,24 +26320,24 @@
 /area/station/security/brig)
 "bef" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/south)
 "beg" = (
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /turf/space,
 /area)
 "beh" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 9
+	dir = 9;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area)
@@ -26363,9 +26351,9 @@
 /area/station/hallway/primary/south)
 "bej" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
@@ -26408,8 +26396,8 @@
 /area/station/crew_quarters/courtroom)
 "beq" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 5
+	dir = 5;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area/station/turret_protected/ai)
@@ -26419,9 +26407,9 @@
 /area/station/crew_quarters/courtroom)
 "bes" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
@@ -26455,17 +26443,17 @@
 /area/station/crew_quarters/courtroom)
 "bev" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "bew" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/pyro{
 	dir = 4
@@ -26496,9 +26484,9 @@
 /area/station/crew_quarters/courtroom)
 "bey" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -26510,17 +26498,17 @@
 /area/station/crew_quarters/courtroom)
 "bez" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "beA" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/security/brig)
@@ -26564,9 +26552,9 @@
 /area/station/crew_quarters/courtroom)
 "beH" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/stool/chair,
 /turf/simulated/floor,
@@ -26591,9 +26579,9 @@
 /area/station/crew_quarters/courtroom)
 "beK" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/stool,
 /obj/machinery/light/small,
@@ -26615,25 +26603,25 @@
 "beM" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "beN" = (
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-s (EAST)";
+	dir = 4;
 	icon_state = "pipe-s";
-	dir = 4
+	tag = "icon-pipe-s (EAST)"
 	},
 /turf/simulated/floor,
 /area/station/security/brig)
 "beO" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -26645,9 +26633,9 @@
 "beP" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -26669,9 +26657,9 @@
 /area/station/hallway/primary/west)
 "beT" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/red/corner{
 	dir = 8
@@ -26689,8 +26677,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -26703,26 +26691,26 @@
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "beX" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/storage/secure/closet/brig/automatic/solitary{
 	id = "solitary2";
 	name = "Automatic Locker (Cell #2)"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/red/side{
 	dir = 1
@@ -26730,12 +26718,12 @@
 /area/station/security/brig)
 "beY" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -26769,17 +26757,17 @@
 	icon_state = "pipe-c"
 	},
 /obj/stool/chair{
-	tag = "icon-chair (WEST)";
+	dir = 8;
 	icon_state = "chair";
-	dir = 8
+	tag = "icon-chair (WEST)"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "bfe" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -26795,18 +26783,18 @@
 /area/station/crew_quarters/courtroom)
 "bff" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/delivery,
 /area/station/crew_quarters/courtroom)
 "bfg" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -26832,8 +26820,8 @@
 /area/station/security/brig)
 "bfi" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/red/side{
 	dir = 8
@@ -26846,8 +26834,8 @@
 /area/station/security/brig)
 "bfk" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable,
 /obj/wingrille_spawn/auto,
@@ -26893,8 +26881,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -26920,8 +26908,8 @@
 	dir = 4
 	},
 /obj/cable{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/simulated/floor,
 /area/station/security/brig)
@@ -26942,9 +26930,9 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/access_spawn/brig,
 /turf/simulated/floor/red/side{
@@ -26965,9 +26953,9 @@
 /area/station/bridge)
 "bfv" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -26977,9 +26965,9 @@
 /area/station/security/brig)
 "bfw" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/disposalpipe/segment,
@@ -27008,19 +26996,19 @@
 /area/station/security/brig)
 "bfA" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/junction{
-	tag = "icon-pipe-y (NORTH)";
+	dir = 1;
 	icon_state = "pipe-y";
-	dir = 1
+	tag = "icon-pipe-y (NORTH)"
 	},
 /obj/stool/chair{
-	tag = "icon-chair (WEST)";
+	dir = 8;
 	icon_state = "chair";
-	dir = 8
+	tag = "icon-chair (WEST)"
 	},
 /turf/simulated/floor,
 /area/station/security/brig)
@@ -27058,9 +27046,9 @@
 /area/station/crew_quarters/courtroom)
 "bfG" = (
 /obj/stool/chair{
-	tag = "icon-chair (WEST)";
+	dir = 8;
 	icon_state = "chair";
-	dir = 8
+	tag = "icon-chair (WEST)"
 	},
 /obj/landmark/halloween,
 /turf/simulated/floor,
@@ -27080,8 +27068,8 @@
 	pixel_y = -24
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -27103,9 +27091,9 @@
 /area/station/security/brig)
 "bfK" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/junction{
 	dir = 4
@@ -27149,12 +27137,12 @@
 /area/station/crew_quarters/courtroom)
 "bfQ" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -27177,8 +27165,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -27242,13 +27230,13 @@
 /area/station/bridge)
 "bgd" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable,
 /obj/cable{
-	tag = "icon-0-2";
-	icon_state = "0-2"
+	icon_state = "0-2";
+	tag = "icon-0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer/card,
@@ -27260,9 +27248,9 @@
 /area/station/bridge)
 "bge" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/stool/chair{
 	dir = 1
@@ -27276,9 +27264,9 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/bridge)
@@ -27288,13 +27276,13 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -27310,8 +27298,8 @@
 	pixel_x = -10
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fblue1";
-	dir = 2
+	dir = 2;
+	icon_state = "fblue1"
 	},
 /area/station/bridge)
 "bgj" = (
@@ -27324,18 +27312,18 @@
 /area/station/security/brig)
 "bgl" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/red,
 /area/station/security/brig)
 "bgm" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/mining/magnet)
@@ -27393,18 +27381,18 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/red,
 /area/station/security/brig)
 "bgv" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -27415,9 +27403,9 @@
 /area/station/security/brig)
 "bgw" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/red/side,
 /area/station/security/brig)
@@ -27431,9 +27419,9 @@
 /area/station/hydroponics)
 "bgy" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/red/side{
 	dir = 10
@@ -27449,8 +27437,8 @@
 /area/station/hallway/primary/south)
 "bgA" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/solar{
 	id = "aisolar";
@@ -27463,16 +27451,16 @@
 /area/station/turret_protected/ai)
 "bgB" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/ai)
@@ -27503,9 +27491,9 @@
 /area/station/bridge)
 "bgG" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/bridge)
@@ -27525,8 +27513,8 @@
 /area/station/security/hos)
 "bgK" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -27541,17 +27529,17 @@
 /area/station/crew_quarters/cafeteria)
 "bgN" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/ai)
@@ -27569,8 +27557,8 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/table/wood/auto,
 /obj/item/storage/firstaid/regular,
@@ -27593,17 +27581,17 @@
 "bgR" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "bgS" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -27630,9 +27618,9 @@
 "bgU" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/medical{
@@ -27643,9 +27631,9 @@
 /area/station/chemistry)
 "bgV" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/table/wood/auto,
 /obj/item/device/camera_viewer,
@@ -27672,24 +27660,24 @@
 /area)
 "bha" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/heads)
 "bhb" = (
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /turf/space,
 /area)
 "bhc" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
@@ -27710,17 +27698,17 @@
 /area/station/crew_quarters/heads)
 "bhe" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/stool/chair{
 	dir = 8
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/heads)
@@ -27738,9 +27726,9 @@
 /area/station/bridge)
 "bhh" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/trunk{
 	dir = 4
@@ -27783,8 +27771,8 @@
 	pixel_y = 3
 	},
 /obj/item/device/radio/intercom{
-	dir = 4;
 	broadcasting = 0;
+	dir = 4;
 	frequency = 1485;
 	name = "Station Intercom (Security)"
 	},
@@ -27792,20 +27780,20 @@
 /area/station/security/hos)
 "bhl" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
 /obj/stool/chair/comfy{
-	tag = "icon-chair_comfy (WEST)";
+	dir = 8;
 	icon_state = "chair_comfy";
-	dir = 8
+	tag = "icon-chair_comfy (WEST)"
 	},
 /obj/cable{
 	d1 = 1;
@@ -27819,17 +27807,17 @@
 /area/station/security/hos)
 "bhm" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/security/hos)
 "bhn" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/computer/security,
 /turf/simulated/floor/red,
@@ -27837,8 +27825,8 @@
 "bho" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -27849,8 +27837,8 @@
 /area)
 "bhq" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -27861,9 +27849,9 @@
 	},
 /obj/table/wood/auto,
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
+	dir = 8;
 	icon_state = "bulb1";
-	dir = 8
+	tag = "icon-bulb1 (WEST)"
 	},
 /turf/simulated/floor/green/side{
 	dir = 8
@@ -27871,14 +27859,14 @@
 /area/station/crew_quarters/heads)
 "bhs" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/heads)
@@ -27914,9 +27902,9 @@
 /area/station/crew_quarters/kitchen)
 "bhv" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
@@ -27945,9 +27933,9 @@
 /area/station/security/hos)
 "bhy" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/black,
@@ -27958,16 +27946,16 @@
 /area/station/security/hos)
 "bhA" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/heads)
 "bhB" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
@@ -27984,9 +27972,9 @@
 /area/station/crew_quarters/heads)
 "bhD" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -27997,17 +27985,17 @@
 /area/station/crew_quarters/heads)
 "bhE" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/heads)
 "bhF" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -28021,9 +28009,9 @@
 /area/station/hallway/primary/central)
 "bhG" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
@@ -28034,9 +28022,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
@@ -28049,9 +28037,9 @@
 /area/station/bridge)
 "bhJ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 1;
@@ -28075,9 +28063,9 @@
 	req_access_txt = "37"
 	},
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/red,
 /area/station/security/hos)
@@ -28144,14 +28132,14 @@
 /area/station/bridge)
 "bhU" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/carpet{
 	dir = 1;
@@ -28160,9 +28148,9 @@
 /area/station/bridge)
 "bhV" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
 	dir = 1;
@@ -28176,8 +28164,8 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -28196,9 +28184,9 @@
 /area/station/bridge)
 "bhX" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/item/storage/wall/fire{
 	dir = 1;
@@ -28237,8 +28225,8 @@
 "bib" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -28286,19 +28274,19 @@
 "big" = (
 /obj/critter/cat/jones,
 /turf/simulated/floor/carpet{
-	icon_state = "fblue1";
-	dir = 2
+	dir = 2;
+	icon_state = "fblue1"
 	},
 /area/station/bridge)
 "bih" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fblue1";
-	dir = 2
+	dir = 2;
+	icon_state = "fblue1"
 	},
 /area/station/bridge)
 "bii" = (
@@ -28319,8 +28307,8 @@
 /area/station/bridge)
 "bik" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fblue1";
-	dir = 2
+	dir = 2;
+	icon_state = "fblue1"
 	},
 /area/station/bridge)
 "bil" = (
@@ -28330,9 +28318,9 @@
 /area/station/security/hos)
 "bim" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/blueblack{
 	dir = 8
@@ -28340,9 +28328,9 @@
 /area/station/crew_quarters/captain)
 "bin" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/captain)
@@ -28364,13 +28352,13 @@
 /area/station/hallway/primary/south)
 "bip" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen2";
-	dir = 1
+	dir = 1;
+	icon_state = "fgreen2"
 	},
 /area/station/bridge)
 "biq" = (
@@ -28380,13 +28368,13 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen2";
-	dir = 1
+	dir = 1;
+	icon_state = "fgreen2"
 	},
 /area/station/bridge)
 "bir" = (
@@ -28395,8 +28383,8 @@
 	},
 /obj/stool/chair/comfy,
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen2";
-	dir = 1
+	dir = 1;
+	icon_state = "fgreen2"
 	},
 /area/station/bridge)
 "bis" = (
@@ -28405,8 +28393,8 @@
 	},
 /obj/stool/chair/comfy/green,
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen2";
-	dir = 1
+	dir = 1;
+	icon_state = "fgreen2"
 	},
 /area/station/bridge)
 "bit" = (
@@ -28415,8 +28403,8 @@
 	},
 /obj/stool/chair/comfy/red,
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen2";
-	dir = 1
+	dir = 1;
+	icon_state = "fgreen2"
 	},
 /area/station/bridge)
 "biu" = (
@@ -28425,14 +28413,14 @@
 	},
 /obj/stool/chair/comfy/purple,
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen2";
-	dir = 1
+	dir = 1;
+	icon_state = "fgreen2"
 	},
 /area/station/bridge)
 "biv" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen2";
-	dir = 1
+	dir = 1;
+	icon_state = "fgreen2"
 	},
 /area/station/bridge)
 "biw" = (
@@ -28454,41 +28442,41 @@
 "biy" = (
 /obj/critter/cat,
 /turf/simulated/floor/carpet{
-	icon_state = "fblue1";
-	dir = 2
+	dir = 2;
+	icon_state = "fblue1"
 	},
 /area/station/bridge)
 "biz" = (
 /obj/item/device/radio/intercom{
-	dir = 4;
 	broadcasting = 0;
+	dir = 4;
 	frequency = 1485;
 	name = "Station Intercom (Security)"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen3";
-	dir = 2
+	dir = 2;
+	icon_state = "fgreen3"
 	},
 /area/station/bridge)
 "biA" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/table/wood/auto,
 /obj/item/storage/box/trackimp_kit2,
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen3";
-	dir = 2
+	dir = 2;
+	icon_state = "fgreen3"
 	},
 /area/station/bridge)
 "biB" = (
 /obj/table/wood/auto,
 /obj/item/disk/data/floppy/read_only/communications,
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen3";
-	dir = 2
+	dir = 2;
+	icon_state = "fgreen3"
 	},
 /area/station/bridge)
 "biC" = (
@@ -28507,8 +28495,8 @@
 	name = "Pill bottle (Cat Cimetidine)"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen3";
-	dir = 2
+	dir = 2;
+	icon_state = "fgreen3"
 	},
 /area/station/bridge)
 "biE" = (
@@ -28516,8 +28504,8 @@
 /obj/item/wrapping_paper,
 /obj/item/wirecutters,
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen3";
-	dir = 2
+	dir = 2;
+	icon_state = "fgreen3"
 	},
 /area/station/bridge)
 "biF" = (
@@ -28528,14 +28516,14 @@
 	pixel_y = 1
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen3";
-	dir = 2
+	dir = 2;
+	icon_state = "fgreen3"
 	},
 /area/station/bridge)
 "biG" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen3";
-	dir = 1
+	dir = 1;
+	icon_state = "fgreen3"
 	},
 /area/station/bridge)
 "biH" = (
@@ -28571,25 +28559,25 @@
 	})
 "biL" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/table/wood/auto,
 /obj/item/device/infra,
 /obj/item/handcuffs,
 /obj/item/clothing/glasses/blindfold,
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen3";
-	dir = 1
+	dir = 1;
+	icon_state = "fgreen3"
 	},
 /area/station/bridge)
 "biM" = (
 /obj/table/wood/auto,
 /obj/item/storage/box/PDAbox,
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen3";
-	dir = 1
+	dir = 1;
+	icon_state = "fgreen3"
 	},
 /area/station/bridge)
 "biN" = (
@@ -28600,8 +28588,8 @@
 	},
 /obj/item/reagent_containers/syringe,
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen3";
-	dir = 1
+	dir = 1;
+	icon_state = "fgreen3"
 	},
 /area/station/bridge)
 "biO" = (
@@ -28612,30 +28600,30 @@
 	},
 /obj/item/reagent_containers/syringe,
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen3";
-	dir = 1
+	dir = 1;
+	icon_state = "fgreen3"
 	},
 /area/station/bridge)
 "biP" = (
 /obj/table/wood/auto,
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen3";
-	dir = 1
+	dir = 1;
+	icon_state = "fgreen3"
 	},
 /area/station/bridge)
 "biQ" = (
 /obj/table/wood/auto,
 /obj/item/storage/box/glassbox,
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen3";
-	dir = 1
+	dir = 1;
+	icon_state = "fgreen3"
 	},
 /area/station/bridge)
 "biR" = (
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 0;
+	dir = 8;
 	frequency = 1485;
 	name = "Station Intercom (Security)"
 	},
@@ -28644,19 +28632,19 @@
 	dir = 8
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen3";
-	dir = 1
+	dir = 1;
+	icon_state = "fgreen3"
 	},
 /area/station/bridge)
 "biS" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -28664,8 +28652,8 @@
 "biT" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -28678,9 +28666,9 @@
 /area/station/crew_quarters/captain)
 "biU" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -28691,9 +28679,9 @@
 /area/station/crew_quarters/captain)
 "biV" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/door_control{
 	id = "emergencyinternals";
@@ -28715,31 +28703,31 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen2";
-	dir = 2
+	dir = 2;
+	icon_state = "fgreen2"
 	},
 /area/station/bridge)
 "biX" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen2";
-	dir = 2
+	dir = 2;
+	icon_state = "fgreen2"
 	},
 /area/station/bridge)
 "biY" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen2";
-	dir = 2
+	dir = 2;
+	icon_state = "fgreen2"
 	},
 /area/station/bridge)
 "biZ" = (
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen3";
-	dir = 2
+	dir = 2;
+	icon_state = "fgreen3"
 	},
 /area/station/bridge)
 "bja" = (
@@ -28747,12 +28735,12 @@
 	name = "Medical Director"
 	},
 /obj/stool/chair/comfy/blue{
-	icon_state = "chair_comfy-blue";
-	dir = 1
+	dir = 1;
+	icon_state = "chair_comfy-blue"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen2";
-	dir = 2
+	dir = 2;
+	icon_state = "fgreen2"
 	},
 /area/station/bridge)
 "bjb" = (
@@ -28760,29 +28748,29 @@
 	name = "Captain"
 	},
 /obj/stool/chair/comfy/green{
-	icon_state = "chair_comfy-green";
-	dir = 1
+	dir = 1;
+	icon_state = "chair_comfy-green"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen2";
-	dir = 2
+	dir = 2;
+	icon_state = "fgreen2"
 	},
 /area/station/bridge)
 "bjc" = (
 /obj/stool/chair/comfy{
-	icon_state = "chair_comfy";
-	dir = 1
+	dir = 1;
+	icon_state = "chair_comfy"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen2";
-	dir = 2
+	dir = 2;
+	icon_state = "fgreen2"
 	},
 /area/station/bridge)
 "bjd" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/disposalpipe/segment{
@@ -28814,42 +28802,42 @@
 	pixel_x = 10
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen2";
-	dir = 2
+	dir = 2;
+	icon_state = "fgreen2"
 	},
 /area/station/bridge)
 "bjg" = (
 /obj/machinery/computer/general_alert{
-	icon_state = "alert:0";
-	dir = 8
+	dir = 8;
+	icon_state = "alert:0"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fblue1";
-	dir = 2
+	dir = 2;
+	icon_state = "fblue1"
 	},
 /area/station/bridge)
 "bjh" = (
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/lattice,
 /turf/space,
 /area)
 "bji" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
+	dir = 8;
 	icon_state = "bulb1";
-	dir = 8
+	tag = "icon-bulb1 (WEST)"
 	},
 /turf/simulated/floor/blue,
 /area/station/crew_quarters/captain)
 "bjj" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/camera{
 	c_tag = "Bridge Storage";
@@ -28859,59 +28847,59 @@
 /area/station/crew_quarters/captain)
 "bjk" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "blue2";
-	dir = 2
+	dir = 2;
+	icon_state = "blue2"
 	},
 /area/station/bridge)
 "bjl" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "blue2";
-	dir = 2
+	dir = 2;
+	icon_state = "blue2"
 	},
 /area/station/bridge)
 "bjm" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "blue2";
-	dir = 2
+	dir = 2;
+	icon_state = "blue2"
 	},
 /area/station/bridge)
 "bjn" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "blue2";
-	dir = 2
+	dir = 2;
+	icon_state = "blue2"
 	},
 /area/station/bridge)
 "bjo" = (
@@ -28927,15 +28915,15 @@
 	pixel_x = -10
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fblue1";
-	dir = 2
+	dir = 2;
+	icon_state = "fblue1"
 	},
 /area/station/bridge)
 "bjp" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/captain)
@@ -28948,9 +28936,9 @@
 /area/station/crew_quarters/captain)
 "bjr" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/table/wood/auto,
 /obj/machinery/recharger{
@@ -28969,19 +28957,19 @@
 	icon_state = "comm"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fblue1";
-	dir = 2
+	dir = 2;
+	icon_state = "fblue1"
 	},
 /area/station/bridge)
 "bjt" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "blue2";
-	dir = 2
+	dir = 2;
+	icon_state = "blue2"
 	},
 /area/station/bridge)
 "bju" = (
@@ -28997,8 +28985,8 @@
 	pixel_y = 4
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "blue2";
-	dir = 2
+	dir = 2;
+	icon_state = "blue2"
 	},
 /area/station/bridge)
 "bjv" = (
@@ -29020,8 +29008,8 @@
 "bjy" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -29029,12 +29017,12 @@
 "bjz" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -29046,20 +29034,20 @@
 "bjB" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/captain)
 "bjC" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -29079,50 +29067,50 @@
 /area/station/bridge)
 "bjF" = (
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/lattice,
 /turf/space,
 /area)
 "bjG" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/turret_protected/ai)
 "bjH" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable,
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/ai)
 "bjI" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/ai)
 "bjJ" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -29141,26 +29129,26 @@
 /area/station/turret_protected/ai)
 "bjL" = (
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/lattice,
 /turf/space,
 /area)
 "bjM" = (
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /turf/space,
 /area)
 "bjN" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/ai)
@@ -29170,9 +29158,9 @@
 /area/station/turret_protected/ai)
 "bjP" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/grille/steel,
 /turf/simulated/floor/plating/airless,
@@ -29180,16 +29168,16 @@
 "bjQ" = (
 /obj/machinery/camera,
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 9
+	dir = 9;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area/station/turret_protected/ai)
 "bjR" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/turret_protected/ai)
@@ -29198,9 +29186,9 @@
 /area/station/turret_protected/ai)
 "bjT" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai)
@@ -29216,9 +29204,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/turret_protected/ai)
@@ -29239,8 +29227,8 @@
 /area/station/turret_protected/ai)
 "bjY" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/solar{
 	id = "aisolar";
@@ -29253,41 +29241,41 @@
 /area/station/turret_protected/ai)
 "bjZ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "bka" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/ai)
 "bkb" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/ai)
 "bkc" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
@@ -29297,17 +29285,17 @@
 /area/station/turret_protected/ai)
 "bkd" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/turret,
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "bke" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
@@ -29317,21 +29305,21 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "bkg" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
@@ -29354,20 +29342,20 @@
 /area/station/crew_quarters/courtroom)
 "bkj" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/ai)
 "bkk" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
@@ -29391,9 +29379,9 @@
 /area/station/turret_protected/ai)
 "bkm" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -29430,9 +29418,9 @@
 /area/station/turret_protected/ai)
 "bkq" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -29443,38 +29431,38 @@
 /area/station/turret_protected/ai)
 "bkr" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/ai)
 "bks" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/space,
 /area/station/turret_protected/ai)
 "bkt" = (
 /obj/grille/steel,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/ai)
 "bku" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/sleep_console{
 	dir = 8
@@ -29483,9 +29471,9 @@
 /area/station/medical/medbay)
 "bkv" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai)
@@ -29517,30 +29505,30 @@
 	charge = 5e+006
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "bkz" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "bkA" = (
 /obj/machinery/vending/monkey,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -29554,14 +29542,14 @@
 /area/station/crew_quarters/kitchen)
 "bkB" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
@@ -29580,16 +29568,16 @@
 	dir = 8
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "bkE" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
@@ -29618,8 +29606,8 @@
 "bkG" = (
 /obj/machinery/turret,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
@@ -29634,15 +29622,15 @@
 "bkI" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/ai)
 "bkJ" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/terminal{
 	dir = 4
@@ -29654,8 +29642,8 @@
 	charge = 5e+006
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
@@ -29669,9 +29657,9 @@
 /area/station/medical/research)
 "bkN" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -29685,8 +29673,8 @@
 /area/station/hallway/primary/south)
 "bkO" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 2
+	dir = 2;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area)
@@ -29696,8 +29684,8 @@
 /area/station/turret_protected/ai)
 "bkQ" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 6
+	dir = 6;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area)
@@ -29717,8 +29705,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/table/auto/desk,
@@ -29734,9 +29722,9 @@
 	})
 "bkT" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/airless,
 /area)
@@ -29755,9 +29743,9 @@
 /area)
 "bkW" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/shuttle/wall{
 	icon_state = "wall3"
@@ -29795,9 +29783,9 @@
 /area/listeningpost/power)
 "bld" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/shuttle/wall{
 	icon_state = "wall3"
@@ -29829,9 +29817,9 @@
 /area/listeningpost/power)
 "blh" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/circuit,
 /area/listeningpost/power)
@@ -29853,13 +29841,13 @@
 /area/listeningpost/power)
 "blk" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/monitor,
 /turf/simulated/floor/plating,
@@ -29878,8 +29866,8 @@
 /area/listeningpost/power)
 "blm" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 8
+	dir = 8;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area)
@@ -29910,22 +29898,22 @@
 /area/listeningpost/power)
 "blq" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/caution/west,
 /area/listeningpost/power)
 "blr" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/stairs{
 	dir = 8
@@ -29941,12 +29929,12 @@
 /area/listeningpost/power)
 "blt" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
+	dir = 1;
+	icon_state = "term"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/listeningpost/power)
@@ -29972,9 +29960,9 @@
 /area/listeningpost)
 "blx" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock,
 /obj/access_spawn/syndie_shuttle,
@@ -29995,9 +29983,9 @@
 "blA" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
@@ -30036,9 +30024,9 @@
 /area/listeningpost)
 "blF" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/red,
 /area/listeningpost)
@@ -30080,9 +30068,9 @@
 /area)
 "blL" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light_switch{
 	name = "W light switch";
@@ -30144,9 +30132,9 @@
 /area/listeningpost)
 "blV" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/red,
 /area/listeningpost)
@@ -30155,8 +30143,8 @@
 /area/listeningpost)
 "blX" = (
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 0;
+	dir = 8;
 	frequency = 1485;
 	name = "Security Intercom"
 	},
@@ -30165,12 +30153,12 @@
 /area/listeningpost)
 "blY" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/ai)
@@ -30180,8 +30168,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable,
 /turf/simulated/floor/plating/airless,
@@ -30192,8 +30180,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/ai)
@@ -30207,9 +30195,9 @@
 /area/listeningpost)
 "bmc" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -30220,9 +30208,9 @@
 /area/listeningpost)
 "bmd" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/grey/side{
 	dir = 8
@@ -30230,9 +30218,9 @@
 /area/listeningpost)
 "bme" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass,
 /obj/access_spawn/syndie_shuttle,
@@ -30240,29 +30228,29 @@
 /area/listeningpost)
 "bmf" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/listeningpost)
 "bmg" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/listeningpost)
 "bmh" = (
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 1;
+	dir = 8;
 	frequency = 1489;
 	name = "Brig Intercom"
 	},
@@ -30276,8 +30264,8 @@
 	on = 0
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/black,
 /area/listeningpost)
@@ -30331,8 +30319,8 @@
 	pixel_y = 0
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/listeningpost)
@@ -30369,8 +30357,8 @@
 	credit = 12
 	},
 /turf/simulated/floor{
-	icon_state = "carpetN";
-	dir = 4
+	dir = 4;
+	icon_state = "carpetN"
 	},
 /area/listeningpost)
 "bmw" = (
@@ -30381,8 +30369,8 @@
 /area/listeningpost)
 "bmx" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -30412,12 +30400,12 @@
 	},
 /obj/decal/glow{
 	brightness = 3;
-	invisibility = 101;
-	luminosity = 0;
-	name = "glow - WHITE";
 	color_b = 0.35;
 	color_g = 0.35;
-	color_r = 0.35
+	color_r = 0.35;
+	invisibility = 101;
+	luminosity = 0;
+	name = "glow - WHITE"
 	},
 /turf/simulated/floor/red,
 /area/listeningpost)
@@ -30434,8 +30422,8 @@
 /area/listeningpost)
 "bmB" = (
 /turf/simulated/floor{
-	icon_state = "carpet2";
-	dir = 4
+	dir = 4;
+	icon_state = "carpet2"
 	},
 /area/listeningpost)
 "bmC" = (
@@ -30483,8 +30471,8 @@
 /obj/item/plate,
 /obj/item/reagent_containers/food/snacks/snack_cake/golden,
 /turf/simulated/floor{
-	icon_state = "carpetS";
-	dir = 4
+	dir = 4;
+	icon_state = "carpetS"
 	},
 /area/listeningpost)
 "bmJ" = (
@@ -30524,17 +30512,17 @@
 /area/station/hallway/primary/south)
 "bmO" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/landmark/artifact{
 	name = "artifact spawner (10%)";
@@ -30579,9 +30567,9 @@
 /area/station/security/main)
 "bmU" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 8
@@ -30595,9 +30583,9 @@
 /area/station/medical/robotics)
 "bmW" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/blackwhite{
 	dir = 1
@@ -30607,9 +30595,9 @@
 	})
 "bmX" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/table/auto,
 /obj/item/storage/firstaid/brain,
@@ -30634,7 +30622,7 @@
 	},
 /area/station/security/main)
 "bna" = (
-/obj/machinery/weapon_stand/taser_rack/recharger,
+/obj/machinery/weapon_stand/taser_rack/recharger/empty,
 /turf/simulated/floor/red/side{
 	dir = 8
 	},
@@ -30714,9 +30702,9 @@
 	})
 "bnj" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 1
@@ -30731,14 +30719,14 @@
 	},
 /obj/item/remote/porter/port_a_sci,
 /turf/simulated/floor/carpet{
-	icon_state = "red2";
-	dir = 2
+	dir = 2;
+	icon_state = "red2"
 	},
 /area/station/crew_quarters/hor)
 "bnl" = (
 /turf/simulated/floor/carpet{
-	icon_state = "red2";
-	dir = 10
+	dir = 10;
+	icon_state = "red2"
 	},
 /area/station/crew_quarters/hor)
 "bnm" = (
@@ -30774,21 +30762,21 @@
 /area/station/crew_quarters/hor)
 "bno" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/Zeta)
 "bnp" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purple,
 /area/station/turret_protected/Zeta)
@@ -30803,9 +30791,9 @@
 /area/station/science/lab)
 "bnr" = (
 /obj/machinery/atmospherics/pipe/tank/air{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/purple,
 /area/station/science/lab)
@@ -30814,9 +30802,9 @@
 	dir = 1
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purple,
 /area/station/science/lab)
@@ -30829,17 +30817,17 @@
 /area/station/science/lab)
 "bnu" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purple/side,
 /area/station/science)
 "bnv" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/purple/corner{
 	dir = 1
@@ -30883,9 +30871,9 @@
 /area/station/medical/research)
 "bnA" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 4
@@ -30898,9 +30886,9 @@
 /area/station/medical/research)
 "bnC" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 2
@@ -30913,9 +30901,9 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 2
@@ -30923,9 +30911,9 @@
 /area/station/medical/research)
 "bnE" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/stool/chair,
 /obj/landmark/start{
@@ -30947,8 +30935,8 @@
 	pixel_y = 0
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/red/side{
 	dir = 8
@@ -30977,9 +30965,9 @@
 	name = "monkeyspawn_horse"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf";
@@ -31000,9 +30988,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/red/side,
@@ -31045,16 +31033,16 @@
 /area/station/medical/medbay)
 "bnQ" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 6
+	dir = 6;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/station/turret_protected/ai)
 "bnR" = (
 /obj/shrub{
+	dir = 4;
 	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "plant";
-	dir = 4
+	icon_state = "plant"
 	},
 /turf/simulated/floor/green/side{
 	dir = 8
@@ -31065,16 +31053,16 @@
 /area/station/hydroponics/lobby)
 "bnT" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/green,
 /area/station/hydroponics/lobby)
 "bnU" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon = 'icons/misc/beach.dmi';
@@ -31084,9 +31072,9 @@
 /area/station/crew_quarters/pool)
 "bnV" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "1-8"
@@ -31099,38 +31087,38 @@
 /area/station/crew_quarters/pool)
 "bnW" = (
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
 "bnX" = (
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/fitness/speedbag/syndie,
 /turf/simulated/floor{
-	tag = "icon-0,6";
-	icon_state = "0,6"
+	icon_state = "0,6";
+	tag = "icon-0,6"
 	},
 /area/station/crew_quarters/fitness)
 "bnY" = (
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/fitness/speedbag/wizard,
 /turf/simulated/floor{
-	tag = "icon-0,6";
-	icon_state = "0,6"
+	icon_state = "0,6";
+	tag = "icon-0,6"
 	},
 /area/station/crew_quarters/fitness)
 "bnZ" = (
@@ -31154,8 +31142,8 @@
 /area/station/science/teleporter)
 "boa" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -31198,8 +31186,8 @@
 	},
 /obj/machinery/computer/ordercomp,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 10
@@ -31207,14 +31195,14 @@
 /area/station/quartermaster)
 "boi" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 6
@@ -31237,12 +31225,12 @@
 /area/station/quartermaster/office)
 "bol" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /obj/cable,
@@ -31250,8 +31238,8 @@
 /area/station/engine/engineering)
 "bom" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
@@ -31259,8 +31247,8 @@
 /area/station/hallway/primary/north)
 "boo" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 5
+	dir = 5;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area)
@@ -31271,8 +31259,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -31348,8 +31336,8 @@
 /area/station/crew_quarters/barber_shop)
 "boL" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 1
+	dir = 1;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/station/turret_protected/ai)
@@ -31363,8 +31351,8 @@
 /area/station/bridge)
 "boN" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -31414,9 +31402,9 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
+	dir = 8;
 	icon_state = "bulb1";
-	dir = 8
+	tag = "icon-bulb1 (WEST)"
 	},
 /obj/machinery/door_control{
 	id = "publicscienceteleporter";
@@ -31442,8 +31430,8 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/computer3/generic/communications,
 /turf/simulated/floor/caution/west,
@@ -31452,8 +31440,8 @@
 /obj/disposalpipe/segment,
 /obj/machinery/shieldgenerator/meteorshield,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/storage/emergency)
@@ -31469,8 +31457,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /obj/cable,
@@ -31526,9 +31514,9 @@
 /area/station/security/armory)
 "bph" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/red/side{
 	dir = 1
@@ -31587,9 +31575,9 @@
 /area/station/security/brig)
 "bpo" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/red/side,
@@ -31645,9 +31633,9 @@
 /area/station/science/lab)
 "bpw" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/bluewhite/corner{
 	dir = 4
@@ -31655,9 +31643,9 @@
 /area/station/medical/medbay)
 "bpx" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 6
@@ -31675,14 +31663,14 @@
 "bpz" = (
 /obj/disposalpipe/segment,
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-s (EAST)";
+	dir = 4;
 	icon_state = "pipe-s";
-	dir = 4
+	tag = "icon-pipe-s (EAST)"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/neutral/corner{
 	dir = 1
@@ -31698,9 +31686,9 @@
 /area/station/crew_quarters/courtroom)
 "bpB" = (
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-s (EAST)";
+	dir = 4;
 	icon_state = "pipe-s";
-	dir = 4
+	tag = "icon-pipe-s (EAST)"
 	},
 /obj/cable{
 	d1 = 1;
@@ -31713,9 +31701,9 @@
 /area/station/hallway/primary/west)
 "bpC" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/camera,
 /turf/simulated/floor/black,
@@ -31742,8 +31730,8 @@
 	pixel_x = 10
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen2";
-	dir = 1
+	dir = 1;
+	icon_state = "fgreen2"
 	},
 /area/station/bridge)
 "bpH" = (
@@ -31774,13 +31762,13 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
@@ -31791,25 +31779,25 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
 "bpM" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
@@ -31824,9 +31812,9 @@
 /area/station/engine/engineering)
 "bpO" = (
 /obj/machinery/emitter{
-	tag = "icon-Emitter (EAST)";
+	dir = 4;
 	icon_state = "Emitter";
-	dir = 4
+	tag = "icon-Emitter (EAST)"
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -31845,9 +31833,9 @@
 /area/station/engine/engineering)
 "bpQ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -31873,22 +31861,22 @@
 /area/station/engine/engineering)
 "bpV" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
 "bpW" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
@@ -31902,8 +31890,8 @@
 /area/station/engine/engineering)
 "bpY" = (
 /obj/cable{
-	tag = "icon-1-4";
-	icon_state = "1-4"
+	icon_state = "1-4";
+	tag = "icon-1-4"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 9
@@ -31911,9 +31899,9 @@
 /area/station/engine/engineering)
 "bpZ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
@@ -31922,9 +31910,9 @@
 /area/mining/magnet)
 "bqb" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -31981,17 +31969,17 @@
 /area/station/engine/elect)
 "bqh" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/engine/elect)
 "bqi" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light_switch{
 	name = "W light switch";
@@ -32054,9 +32042,9 @@
 /area/station/crew_quarters/courtroom)
 "bqs" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/stool/chair,
 /turf/simulated/floor/neutral/side{
@@ -32084,9 +32072,9 @@
 /area/station/crew_quarters/courtroom)
 "bqw" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /obj/table/wood/auto,
@@ -32099,9 +32087,9 @@
 /area/station/storage/warehouse)
 "bqy" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/storage/closet/office,
 /turf/simulated/floor,
@@ -32128,8 +32116,8 @@
 "bqC" = (
 /obj/machinery/camera,
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 5
+	dir = 5;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area/station/turret_protected/ai)
@@ -32180,9 +32168,9 @@
 "bqK" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/medical{
 	dir = 8;
@@ -32196,9 +32184,9 @@
 /area/station/science/artifact)
 "bqL" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /obj/machinery/door/firedoor/pyro,
@@ -32232,9 +32220,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
@@ -32308,16 +32296,14 @@
 	},
 /area/station/quartermaster/office)
 "bqX" = (
-/obj/item/device/radio/intercom{
-	
-	},
+/obj/item/device/radio/intercom,
 /obj/machinery/light,
 /turf/simulated/floor/orangeblack/side,
 /area/station/quartermaster/office)
 "bqY" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 10
+	dir = 10;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/station/turret_protected/ai)
@@ -32326,9 +32312,9 @@
 /area/station/quartermaster/office)
 "bra" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -32359,9 +32345,9 @@
 /area/station/hallway/primary/south)
 "bre" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light/emergency,
 /turf/simulated/floor/purple,
@@ -32376,14 +32362,14 @@
 /area/station/science)
 "brg" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
 /obj/machinery/light/emergency{
-	icon_state = "ebulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "ebulb1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -32399,8 +32385,8 @@
 "bri" = (
 /obj/disposalpipe/segment,
 /obj/machinery/light/emergency{
-	icon_state = "ebulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "ebulb1"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
@@ -32416,8 +32402,8 @@
 /area/station/medical/medbay)
 "brk" = (
 /obj/machinery/light/emergency{
-	icon_state = "ebulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "ebulb1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -32437,8 +32423,8 @@
 	pixel_y = -24
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -32456,8 +32442,8 @@
 	c_tag = "Escape Shuttle Dock"
 	},
 /obj/machinery/light/emergency{
-	icon_state = "ebulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "ebulb1"
 	},
 /turf/simulated/floor/escape{
 	dir = 1
@@ -32465,16 +32451,16 @@
 /area/station/hallway/secondary/shuttle)
 "brp" = (
 /obj/machinery/light/emergency{
-	icon_state = "ebulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "ebulb1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/shuttle)
 "brq" = (
 /obj/storage/closet,
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/greenwhite{
 	dir = 6
@@ -32487,9 +32473,9 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc{
@@ -32507,22 +32493,22 @@
 /area/station/maintenance/SWmaint)
 "brt" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "bru" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor,
@@ -32539,9 +32525,9 @@
 /area/station/hallway/primary/central)
 "brw" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/security{
@@ -32581,16 +32567,16 @@
 /area/station/hydroponics)
 "brE" = (
 /obj/cable{
-	tag = "icon-1-4";
-	icon_state = "1-4"
+	icon_state = "1-4";
+	tag = "icon-1-4"
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "brF" = (
 /obj/machinery/camera,
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 2
+	dir = 2;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/station/turret_protected/ai)
@@ -32655,8 +32641,8 @@
 /area/station/mining/magnet)
 "brO" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/caution/north,
 /area/station/mining/magnet)
@@ -32668,8 +32654,8 @@
 /area/station/mining/magnet)
 "brQ" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 1
+	dir = 1;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area)
@@ -32690,9 +32676,9 @@
 /area/station/mining/magnet)
 "brV" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/mining/magnet)
@@ -32752,9 +32738,9 @@
 /area/station/security/brig)
 "bsc" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/external,
 /obj/access_spawn/mining,
@@ -32767,9 +32753,9 @@
 /area/station/mining/magnet)
 "bse" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -32783,9 +32769,9 @@
 "bsf" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/grass,
 /area/station/medical/research)
@@ -32835,9 +32821,9 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/space,
 /area/station/mining/magnet)
@@ -32856,9 +32842,9 @@
 /area/station/security/brig)
 "bsn" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/engineering{
@@ -32874,9 +32860,9 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/space,
 /area/station/mining/magnet)
@@ -32890,9 +32876,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/space,
 /area/station/mining/magnet)
@@ -32902,9 +32888,9 @@
 /area/mining/magnet)
 "bsr" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/pyro{
 	dir = 4
@@ -32921,9 +32907,9 @@
 /area/station/science)
 "bss" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/engineering{
@@ -32945,15 +32931,15 @@
 /area)
 "bsu" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 4
+	dir = 4;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area)
 "bsv" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 2
+	dir = 2;
+	icon_state = "lattice-dir"
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -32992,9 +32978,9 @@
 "bsB" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
@@ -33008,16 +32994,16 @@
 /area/station/science/teleporter)
 "bsC" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 10
+	dir = 10;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area)
 "bsD" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/command{
@@ -33069,8 +33055,8 @@
 /area/station/crew_quarters/courtroom)
 "bsJ" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 1
+	dir = 1;
+	icon_state = "lattice-dir"
 	},
 /obj/grille/catwalk{
 	dir = 4
@@ -33112,9 +33098,9 @@
 "bsN" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/medical{
 	dir = 8;
@@ -33128,9 +33114,9 @@
 /area/station/science/lab)
 "bsO" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 9
@@ -33143,9 +33129,9 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -33153,15 +33139,15 @@
 /area/station/engine/engineering)
 "bsQ" = (
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 0;
+	dir = 8;
 	frequency = 1441;
 	name = "Station Intercom (Engineering)"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
@@ -33186,9 +33172,9 @@
 /area/station/science/teleporter)
 "bsU" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/red/corner{
 	dir = 1
@@ -33202,8 +33188,8 @@
 	broadcasting = 1
 	},
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 0;
+	dir = 8;
 	frequency = 1447
 	},
 /obj/item/device/radio/intercom{
@@ -33211,8 +33197,8 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
@@ -33229,8 +33215,8 @@
 /area/station/crew_quarters/hor)
 "bsY" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 2
+	dir = 2;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area)
@@ -33280,8 +33266,8 @@
 /area/station/security/brig)
 "btg" = (
 /turf/simulated/floor/carpet{
-	icon_state = "red2";
-	dir = 1
+	dir = 1;
+	icon_state = "red2"
 	},
 /area/station/hallway/primary/west)
 "bth" = (
@@ -33341,32 +33327,32 @@
 	name = "Cafeteria"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "red2";
-	dir = 5
+	dir = 5;
+	icon_state = "red2"
 	},
 /area/station/hallway/primary/west)
 "bto" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance{
-	icon_state = "maint_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "maint_closed"
 	},
 /obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "btp" = (
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-s (EAST)";
+	dir = 4;
 	icon_state = "pipe-s";
-	dir = 4
+	tag = "icon-pipe-s (EAST)"
 	},
 /turf/simulated/floor/carpet,
 /area/station/hallway/primary/west)
 "btq" = (
 /obj/stool/bench/blue/auto,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 8
@@ -33376,9 +33362,9 @@
 	})
 "btr" = (
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-s (EAST)";
+	dir = 4;
 	icon_state = "pipe-s";
-	dir = 4
+	tag = "icon-pipe-s (EAST)"
 	},
 /obj/disposalpipe/segment,
 /obj/machinery/door/firedoor/pyro{
@@ -33390,8 +33376,8 @@
 	name = "Cafeteria"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "red2";
-	dir = 4
+	dir = 4;
+	icon_state = "red2"
 	},
 /area/station/hallway/primary/west)
 "bts" = (
@@ -33400,8 +33386,8 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "red2";
-	dir = 2
+	dir = 2;
+	icon_state = "red2"
 	},
 /area/station/hallway/primary/west)
 "btt" = (
@@ -33413,9 +33399,9 @@
 /area)
 "btu" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/wingrille_spawn/crystal/full,
 /turf/simulated/floor/plating,
@@ -33460,8 +33446,8 @@
 /area/station/com_dish/comdish)
 "btB" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/communications_dish{
@@ -33471,9 +33457,9 @@
 /area/station/com_dish/comdish)
 "btC" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/com_dish/comdish)
@@ -33569,9 +33555,9 @@
 /area/station/security/detectives_office)
 "btM" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
@@ -33618,9 +33604,9 @@
 /area/station/crew_quarters/courtroom)
 "btT" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/command{
@@ -33635,9 +33621,9 @@
 /area/station/crew_quarters/heads)
 "btU" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/command{
@@ -33650,9 +33636,9 @@
 /area/station/crew_quarters/captain)
 "btV" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/window/southleft,
 /obj/access_spawn/captain,
@@ -33660,9 +33646,9 @@
 /area/station/crew_quarters/captain)
 "btW" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/door/airlock/pyro/external,
 /obj/access_spawn/ai_upload,
@@ -33670,9 +33656,9 @@
 /area/station/turret_protected/ai)
 "btX" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/external,
 /obj/access_spawn/ai_upload,
@@ -33680,9 +33666,9 @@
 /area/station/turret_protected/ai)
 "btY" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/external,
 /obj/access_spawn/ai_upload,
@@ -33690,14 +33676,14 @@
 /area/station/turret_protected/ai)
 "uJW" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/engineering{
-	icon_state = "eng_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "eng_closed"
 	},
 /obj/access_spawn/engineering,
 /obj/access_spawn/mining,

--- a/maps/unused/trunkmap.dmm
+++ b/maps/unused/trunkmap.dmm
@@ -49,8 +49,8 @@
 	name = "Outpost Solar Array"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/airless{
 	icon_state = "solarpanel";
@@ -60,19 +60,19 @@
 "aam" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /turf/simulated/floor/plating/airless,
 /area)
@@ -91,8 +91,8 @@
 	name = "Outpost Solar Array"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/airless{
 	icon_state = "solarpanel";
@@ -102,16 +102,16 @@
 "aar" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating/airless,
 /area)
@@ -132,9 +132,9 @@
 "aat" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /turf/simulated/floor/plating/airless,
 /area)
@@ -144,9 +144,9 @@
 "aav" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /turf/simulated/floor/plating/airless,
 /area)
@@ -164,14 +164,14 @@
 "aax" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /turf/simulated/floor/plating/airless,
 /area)
@@ -186,19 +186,19 @@
 "aaA" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
@@ -217,42 +217,42 @@
 "aaD" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /turf/simulated/floor/plating/airless,
 /area)
 "aaE" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /turf/simulated/floor/plating/airless,
 /area)
 "aaF" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
@@ -261,17 +261,17 @@
 /area/russian)
 "aaH" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating/airless,
 /area)
@@ -291,45 +291,45 @@
 "aaK" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
 "aaL" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
 "aaM" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
@@ -339,36 +339,36 @@
 "aaO" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
 "aaP" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
@@ -378,24 +378,24 @@
 "aaR" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/securearea{
-	tag = "icon-space";
-	name = "VACUUM AREA";
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space"
+	icon_state = "space";
+	name = "VACUUM AREA";
+	tag = "icon-space"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
@@ -410,37 +410,37 @@
 "aaT" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/securearea{
-	tag = "icon-space";
-	name = "VACUUM AREA";
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space"
+	icon_state = "space";
+	name = "VACUUM AREA";
+	tag = "icon-space"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
 "aaU" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
@@ -450,14 +450,14 @@
 "aaW" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
@@ -478,8 +478,8 @@
 /area/russian)
 "abb" = (
 /obj/decal/cleanable/blood/splatter{
-	tag = "icon-gibbl3";
-	icon_state = "gibbl3"
+	icon_state = "gibbl3";
+	tag = "icon-gibbl3"
 	},
 /turf/simulated/floor/white,
 /area/russian)
@@ -492,8 +492,8 @@
 /area/russian)
 "abd" = (
 /obj/decal/cleanable/blood/splatter{
-	tag = "icon-floor6";
-	icon_state = "floor6"
+	icon_state = "floor6";
+	tag = "icon-floor6"
 	},
 /turf/simulated/floor/white,
 /area/russian)
@@ -541,19 +541,19 @@
 "abo" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
@@ -568,83 +568,83 @@
 "abr" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/mining)
 "abs" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/mining)
 "abt" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/mining)
 "abu" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall,
 /area/station/mining)
 "abv" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/mining)
 "abw" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/white,
 /area/russian)
@@ -667,9 +667,9 @@
 /area/russian)
 "abz" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor,
 /area/russian)
@@ -680,9 +680,9 @@
 /area/russian)
 "abB" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /turf/simulated/floor/airless/plating/damaged2,
@@ -696,9 +696,9 @@
 /area/station/mining)
 "abE" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/caution/west,
 /area/station/mining)
@@ -708,19 +708,19 @@
 "abG" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/station/mining)
@@ -758,8 +758,8 @@
 	name = "Outpost solar control"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -773,9 +773,9 @@
 	pixel_x = -1
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/storage/crate{
 	desc = "Storage for space GPSes.";
@@ -793,49 +793,49 @@
 "abN" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/mining/refinery)
 "abO" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/mining/refinery)
 "abP" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/mining/refinery)
@@ -861,30 +861,30 @@
 /area/russian)
 "abU" = (
 /obj/machinery/atmospherics/pipe/simple{
-	tag = "icon-intact (SOUTHEAST)";
-	icon_state = "intact";
 	dir = 6;
+	icon_state = "intact";
 	layer = 3;
-	level = 2
+	level = 2;
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/floor/white,
 /area/russian)
 "abV" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4;
@@ -908,8 +908,8 @@
 "abY" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/computer3frame,
 /turf/simulated/floor,
@@ -917,9 +917,9 @@
 "abZ" = (
 /obj/stool/chair,
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/russian)
@@ -943,9 +943,9 @@
 	opacity = 1
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/airless,
 /area/russian)
@@ -967,18 +967,18 @@
 "acg" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/mining)
@@ -990,9 +990,9 @@
 /area/station/mining)
 "aci" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "1-4"
@@ -1001,17 +1001,17 @@
 /area/station/mining)
 "acj" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/caution/south,
 /area/station/mining)
 "ack" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/mining)
@@ -1022,25 +1022,25 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/mining)
 "acm" = (
 /obj/machinery/power/terminal{
-	tag = "icon-term (NORTH)";
+	dir = 1;
 	icon_state = "term";
-	dir = 1
+	tag = "icon-term (NORTH)"
 	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor,
 /area/station/mining)
@@ -1056,9 +1056,9 @@
 /area/station/mining/refinery)
 "acp" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor,
 /area/russian)
@@ -1089,116 +1089,116 @@
 "acu" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
 "acv" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
 "acw" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
 "acx" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
 "acy" = (
 /obj/table/reinforced/auto,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/russian)
 "acz" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
 "acA" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /obj/table/auto,
 /turf/simulated/floor,
 /area/russian)
 "acB" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/russian)
@@ -1244,9 +1244,9 @@
 "acL" = (
 /obj/table/auto,
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /obj/item/scalpel,
 /turf/simulated/floor/white,
@@ -1256,8 +1256,8 @@
 	id = 8
 	},
 /obj/decal/cleanable/blood/splatter{
-	tag = "icon-itemblood";
-	icon_state = "itemblood"
+	icon_state = "itemblood";
+	tag = "icon-itemblood"
 	},
 /turf/simulated/floor/white,
 /area/russian)
@@ -1280,9 +1280,9 @@
 /area/russian)
 "acQ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/russian)
@@ -1304,27 +1304,27 @@
 /area/russian)
 "acT" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/white,
 /area/russian)
 "acU" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
@@ -1360,26 +1360,26 @@
 /area/station/mining)
 "ada" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/mining)
 "adb" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/caution/north,
 /area/station/mining)
 "adc" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -1426,14 +1426,14 @@
 /obj/grille/steel,
 /obj/window/reinforced,
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
@@ -1452,33 +1452,33 @@
 "adn" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
 "ado" = (
 /obj/decal/cleanable/blood/splatter{
-	tag = "icon-gibbl2";
-	icon_state = "gibbl2"
+	icon_state = "gibbl2";
+	tag = "icon-gibbl2"
 	},
 /turf/simulated/floor,
 /area/russian)
 "adp" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/computer3frame,
@@ -1494,9 +1494,9 @@
 /area/station/mining)
 "ads" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/mining)
@@ -1552,35 +1552,35 @@
 	},
 /obj/creepy_sound_trigger,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/russian)
 "adB" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
 "adC" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/r_wall,
 /area/russian)
@@ -1601,9 +1601,9 @@
 	name = "broken door"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/russian)
@@ -1611,19 +1611,19 @@
 /obj/grille/steel,
 /obj/window/reinforced,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
@@ -1632,8 +1632,8 @@
 	pixel_y = 32
 	},
 /obj/decal/cleanable/blood/splatter{
-	tag = "icon-floor5";
-	icon_state = "floor5"
+	icon_state = "floor5";
+	tag = "icon-floor5"
 	},
 /turf/simulated/floor/white,
 /area/russian)
@@ -1654,18 +1654,18 @@
 "adJ" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/mining)
@@ -1676,9 +1676,9 @@
 "adL" = (
 /obj/storage/crate,
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/mining/refinery)
@@ -1689,28 +1689,28 @@
 "adN" = (
 /obj/storage/crate,
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/mining/refinery)
 "adO" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/securearea{
-	tag = "icon-space";
-	name = "VACUUM AREA";
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space"
+	icon_state = "space";
+	name = "VACUUM AREA";
+	tag = "icon-space"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
@@ -1732,17 +1732,17 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/russian)
 "adS" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/russian)
@@ -1753,17 +1753,17 @@
 	rigged = 0
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/russian)
 "adU" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -1786,8 +1786,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor,
 /area/russian)
@@ -1797,8 +1797,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable,
 /turf/simulated/floor,
@@ -1806,17 +1806,17 @@
 "adX" = (
 /obj/decal/fakeobjects/firelock_broken,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/russian)
 "adY" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -1827,28 +1827,28 @@
 /area/russian)
 "adZ" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/russian)
 "aeb" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/mining)
@@ -1876,19 +1876,19 @@
 "aeg" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/station/mining/refinery)
@@ -1906,21 +1906,21 @@
 /area/russian)
 "aek" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor,
 /area/russian)
 "ael" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/russian)
@@ -1931,9 +1931,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/russian)
@@ -1951,30 +1951,30 @@
 	req_access_txt = ""
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
 /area/russian)
 "aep" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
 /area/russian)
 "aeq" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/white,
 /area/russian)
@@ -1990,14 +1990,14 @@
 "aes" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/mining)
@@ -2006,9 +2006,9 @@
 /obj/item/clothing/mask/breath,
 /obj/item/tank/jetpack,
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /obj/item/clothing/suit/space/engineer,
 /obj/item/clothing/head/helmet/space/engineer,
@@ -2022,76 +2022,76 @@
 "aev" = (
 /obj/storage/secure/closet/engineering/mining,
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor,
 /area/station/mining)
 "aew" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/mining/refinery)
 "aex" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
 "aey" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
 "aez" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/securearea{
-	tag = "icon-space";
-	name = "VACUUM AREA";
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space"
+	icon_state = "space";
+	name = "VACUUM AREA";
+	tag = "icon-space"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
@@ -2101,8 +2101,8 @@
 /area/russian)
 "aeB" = (
 /obj/decal/cleanable/blood/splatter{
-	tag = "icon-floor2";
-	icon_state = "floor2"
+	icon_state = "floor2";
+	tag = "icon-floor2"
 	},
 /turf/simulated/floor,
 /area/russian)
@@ -2121,44 +2121,44 @@
 "aeE" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/mining/refinery)
 "aeF" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/mining/refinery)
 "aeG" = (
 /obj/storage/closet/emergency,
 /obj/decal/cleanable/blood/splatter{
-	tag = "icon-floor6";
-	icon_state = "floor6"
+	icon_state = "floor6";
+	tag = "icon-floor6"
 	},
 /turf/simulated/floor,
 /area/russian)
@@ -2176,39 +2176,39 @@
 "aeJ" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
 "aeK" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -2216,30 +2216,30 @@
 	},
 /obj/cable,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
 "aeL" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
@@ -2252,9 +2252,9 @@
 /area/russian)
 "aeN" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall,
 /area/russian)
@@ -2268,18 +2268,18 @@
 "aeP" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
@@ -2289,8 +2289,8 @@
 /area/russian)
 "aeR" = (
 /obj/decal/cleanable/blood/splatter{
-	tag = "icon-gibbl2";
-	icon_state = "gibbl2"
+	icon_state = "gibbl2";
+	tag = "icon-gibbl2"
 	},
 /turf/simulated/floor/white,
 /area/russian)
@@ -2332,32 +2332,32 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/terminal{
-	tag = "icon-term (NORTH)";
+	dir = 1;
 	icon_state = "term";
-	dir = 1
+	tag = "icon-term (NORTH)"
 	},
 /turf/simulated/floor/white,
 /area/russian)
 "aeW" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
@@ -2385,9 +2385,9 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/stool/chair{
 	dir = 4
@@ -2486,8 +2486,8 @@
 /area/russian)
 "afq" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 2
+	dir = 2;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area)
@@ -2497,8 +2497,8 @@
 /area/listeningpost)
 "afs" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 6
+	dir = 6;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area)
@@ -2520,24 +2520,24 @@
 /area/listeningpost)
 "afv" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 1
+	dir = 1;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area)
 "afw" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/airless,
 /area/listeningpost)
 "afx" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/shuttle/wall{
 	icon_state = "wall3"
@@ -2545,8 +2545,8 @@
 /area/listeningpost)
 "afy" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 6
+	dir = 6;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area)
@@ -2575,16 +2575,16 @@
 /area/listeningpost)
 "afC" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/circuit,
 /area/listeningpost)
 "afD" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/caution/west,
 /area/listeningpost)
@@ -2598,13 +2598,13 @@
 /area/listeningpost)
 "afF" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/monitor,
 /turf/simulated/floor/plating,
@@ -2623,8 +2623,8 @@
 /area/listeningpost)
 "afH" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 8
+	dir = 8;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area)
@@ -2655,38 +2655,38 @@
 /area/listeningpost)
 "afL" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/caution/west,
 /area/listeningpost)
 "afM" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
 "afN" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
@@ -2697,21 +2697,21 @@
 "afP" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
 "afQ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/stairs{
 	dir = 8
@@ -2727,12 +2727,12 @@
 /area/listeningpost)
 "afS" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
+	dir = 1;
+	icon_state = "term"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/listeningpost)
@@ -2754,9 +2754,9 @@
 /area/listeningpost)
 "afW" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock,
 /turf/simulated/floor/bot,
@@ -2782,27 +2782,27 @@
 "aga" = (
 /obj/grille/steel,
 /obj/securearea{
-	tag = "icon-space";
-	name = "VACUUM AREA";
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space"
+	icon_state = "space";
+	name = "VACUUM AREA";
+	tag = "icon-space"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
@@ -2816,46 +2816,46 @@
 "agc" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
 "agd" = (
 /obj/grille/steel,
 /obj/securearea{
-	tag = "icon-space";
-	name = "VACUUM AREA";
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space"
+	icon_state = "space";
+	name = "VACUUM AREA";
+	tag = "icon-space"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/russian)
@@ -2875,9 +2875,9 @@
 /area/listeningpost)
 "agg" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/red,
 /area/listeningpost)
@@ -2888,8 +2888,8 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/grey/side{
 	dir = 8
@@ -2904,16 +2904,16 @@
 /area)
 "agj" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/plating/airless,
 /area/listeningpost)
 "agk" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light_switch{
 	name = "W light switch";
@@ -2978,9 +2978,9 @@
 /area/listeningpost)
 "agu" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/red,
 /area/listeningpost)
@@ -2989,8 +2989,8 @@
 /area/listeningpost)
 "agw" = (
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 0;
+	dir = 8;
 	frequency = 1485;
 	name = "Security Intercom"
 	},
@@ -3007,9 +3007,9 @@
 /area/listeningpost)
 "agy" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -3020,9 +3020,9 @@
 /area/listeningpost)
 "agz" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/grey/side{
 	dir = 8
@@ -3030,38 +3030,38 @@
 /area/listeningpost)
 "agA" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/delivery,
 /area/listeningpost)
 "agB" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/listeningpost)
 "agC" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/listeningpost)
 "agD" = (
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 1;
+	dir = 8;
 	frequency = 1489;
 	name = "Brig Intercom"
 	},
@@ -3087,8 +3087,8 @@
 "agG" = (
 /obj/machinery/vending/pathology,
 /turf/simulated/floor/greenwhite{
-	icon_state = "greenwhite";
-	dir = 9
+	dir = 9;
+	icon_state = "greenwhite"
 	},
 /area/station/medical/cdc)
 "agH" = (
@@ -3098,8 +3098,8 @@
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/greenwhite{
-	icon_state = "greenwhite";
-	dir = 1
+	dir = 1;
+	icon_state = "greenwhite"
 	},
 /area/station/medical/cdc)
 "agI" = (
@@ -3115,8 +3115,8 @@
 	pixel_x = -1
 	},
 /turf/simulated/floor/greenwhite{
-	icon_state = "greenwhite";
-	dir = 1
+	dir = 1;
+	icon_state = "greenwhite"
 	},
 /area/station/medical/cdc)
 "agJ" = (
@@ -3126,8 +3126,8 @@
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/greenwhite{
-	icon_state = "greenwhite";
-	dir = 1
+	dir = 1;
+	icon_state = "greenwhite"
 	},
 /area/station/medical/cdc)
 "agK" = (
@@ -3140,8 +3140,8 @@
 	network = "SS13"
 	},
 /turf/simulated/floor/greenwhite{
-	icon_state = "greenwhite";
-	dir = 1
+	dir = 1;
+	icon_state = "greenwhite"
 	},
 /area/station/medical/cdc)
 "agL" = (
@@ -3151,8 +3151,8 @@
 /obj/item/reagent_containers/food/snacks/agar_block,
 /obj/item/reagent_containers/food/snacks/yuck,
 /turf/simulated/floor/greenwhite{
-	icon_state = "greenwhite";
-	dir = 1
+	dir = 1;
+	icon_state = "greenwhite"
 	},
 /area/station/medical/cdc)
 "agM" = (
@@ -3161,8 +3161,8 @@
 	pixel_x = -1
 	},
 /turf/simulated/floor/greenwhite{
-	icon_state = "greenwhite";
-	dir = 5
+	dir = 5;
+	icon_state = "greenwhite"
 	},
 /area/station/medical/cdc)
 "agN" = (
@@ -3178,33 +3178,33 @@
 "agP" = (
 /obj/grille/steel,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced/west,
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
 "agQ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/greenwhite{
-	icon_state = "greenwhite";
-	dir = 8
+	dir = 8;
+	icon_state = "greenwhite"
 	},
 /area/station/medical/cdc)
 "agR" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
@@ -3214,9 +3214,9 @@
 	icon_state = "office_chair"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
@@ -3225,8 +3225,8 @@
 /area/station/medical/cdc)
 "agU" = (
 /turf/simulated/floor/greenwhite{
-	icon_state = "greenwhite";
-	dir = 4
+	dir = 4;
+	icon_state = "greenwhite"
 	},
 /area/station/medical/cdc)
 "agV" = (
@@ -3239,38 +3239,38 @@
 "agW" = (
 /obj/grille/steel,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced/west,
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
 "agX" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/medical/cdc)
 "agY" = (
 /obj/stool/chair/office{
-	icon_state = "office_chair";
-	dir = 8
+	dir = 8;
+	icon_state = "office_chair"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "agZ" = (
 /obj/machinery/centrifuge,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
@@ -3289,9 +3289,9 @@
 /obj/item/clothing/gloves/latex,
 /obj/item/clothing/mask/surgical,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
@@ -3309,8 +3309,8 @@
 /obj/table/auto,
 /obj/machinery/microscope,
 /turf/simulated/floor/greenwhite{
-	icon_state = "greenwhite";
-	dir = 8
+	dir = 8;
+	icon_state = "greenwhite"
 	},
 /area/station/medical/cdc)
 "ahh" = (
@@ -3338,9 +3338,9 @@
 /obj/item/reagent_containers/dropper/mechanical,
 /obj/item/reagent_containers/emergency_injector/spaceacillin,
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
@@ -3360,15 +3360,15 @@
 "ahn" = (
 /obj/grille/steel,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced/west,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
@@ -3386,20 +3386,20 @@
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/greenwhite{
-	icon_state = "greenwhite";
-	dir = 8
+	dir = 8;
+	icon_state = "greenwhite"
 	},
 /area/station/medical/cdc)
 "ahq" = (
 /obj/table/auto,
 /obj/item/bloodslide,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/greenwhite{
-	icon_state = "greenwhite";
-	dir = 8
+	dir = 8;
+	icon_state = "greenwhite"
 	},
 /area/station/medical/cdc)
 "ahr" = (
@@ -3408,8 +3408,8 @@
 "ahs" = (
 /obj/grille/steel,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 1;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /obj/window/reinforced/west,
@@ -3419,8 +3419,8 @@
 "aht" = (
 /obj/grille/steel,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 1;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /obj/window/reinforced/south,
@@ -3429,13 +3429,13 @@
 "ahu" = (
 /obj/grille/steel,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 1;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	invisibility = 0;
 	reinf = 1
 	},
@@ -3451,8 +3451,8 @@
 	name = "monkeyspawn_normal"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/medical/cdc)
@@ -3462,21 +3462,21 @@
 	dir = 4
 	},
 /turf/simulated/floor/greenwhite{
-	icon_state = "greenwhite";
-	dir = 10
+	dir = 10;
+	icon_state = "greenwhite"
 	},
 /area/station/medical/cdc)
 "ahy" = (
 /obj/disposalpipe/segment{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/greenwhite,
 /area/station/medical/cdc)
 "ahz" = (
 /obj/disposalpipe/segment{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/machinery/sleeper,
 /obj/cable{
@@ -3490,8 +3490,8 @@
 /area/station/medical/cdc)
 "ahA" = (
 /obj/disposalpipe/segment{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/machinery/sleep_console,
 /obj/cable{
@@ -3510,16 +3510,16 @@
 /area/station/security/main)
 "ahC" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
 "ahD" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	icon_state = "chair"
 	},
 /obj/landmark/start{
 	name = "Security Officer"
@@ -3531,13 +3531,13 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/greenwhite,
 /area/station/medical/cdc)
@@ -3554,20 +3554,20 @@
 /area/station/security/main)
 "ahH" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
 "ahI" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	icon_state = "chair"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/landmark/start{
 	name = "Security Officer"
@@ -3579,18 +3579,18 @@
 /area/station/medical/cdc)
 "ahK" = (
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /turf/space,
 /area)
 "ahL" = (
 /obj/grille/steel,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced/west,
 /turf/simulated/floor/plating,
@@ -3598,48 +3598,48 @@
 "ahM" = (
 /obj/grille/steel,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
 "ahN" = (
 /obj/grille/steel,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced/west,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
 "ahO" = (
 /obj/grille/steel,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
@@ -3651,8 +3651,8 @@
 /obj/lattice,
 /obj/window/reinforced/south,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	invisibility = 0;
 	reinf = 1
 	},
@@ -3674,9 +3674,9 @@
 /obj/grille/steel,
 /obj/window/reinforced/north,
 /obj/window/reinforced/north{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/bridge)
@@ -3689,22 +3689,22 @@
 "ahV" = (
 /obj/grille/steel,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 1;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	invisibility = 0;
 	reinf = 1
 	},
 /obj/window/reinforced/west,
 /obj/securearea{
-	tag = "icon-space";
-	name = "VACUUM AREA";
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space"
+	icon_state = "space";
+	name = "VACUUM AREA";
+	tag = "icon-space"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
@@ -3721,9 +3721,9 @@
 	req_access_txt = "1"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
@@ -3731,9 +3731,9 @@
 /obj/grille/steel,
 /obj/window/reinforced/west,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
@@ -3742,8 +3742,8 @@
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/machinery/light,
 /turf/simulated/floor/greenwhite{
-	icon_state = "greenwhite";
-	dir = 6
+	dir = 6;
+	icon_state = "greenwhite"
 	},
 /area/station/medical/cdc)
 "aia" = (
@@ -3787,8 +3787,8 @@
 "aie" = (
 /obj/lattice,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	invisibility = 0;
 	reinf = 1
 	},
@@ -3804,8 +3804,8 @@
 /obj/grille/steel,
 /obj/window/reinforced/south,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	invisibility = 0;
 	reinf = 1
 	},
@@ -3824,8 +3824,8 @@
 /area/station/bridge)
 "aij" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/camera{
 	c_tag = "Bridge";
@@ -3834,8 +3834,8 @@
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer3/generic/communications,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -3861,8 +3861,8 @@
 /obj/grille/steel,
 /obj/window/reinforced/north,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	invisibility = 0;
 	reinf = 1
 	},
@@ -3876,8 +3876,8 @@
 "aip" = (
 /obj/grille/steel,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	invisibility = 0;
 	reinf = 1
 	},
@@ -3887,14 +3887,14 @@
 "aiq" = (
 /obj/grille/steel,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 1;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /obj/window/reinforced/west,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	invisibility = 0;
 	reinf = 1
 	},
@@ -3910,9 +3910,9 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/industrial,
@@ -3930,8 +3930,8 @@
 "aiu" = (
 /obj/machinery/communications_dish,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/plating/airless,
@@ -3939,8 +3939,8 @@
 "aiv" = (
 /obj/machinery/power/tracker,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating/airless,
 /area)
@@ -3948,8 +3948,8 @@
 /obj/grille/steel,
 /obj/window/reinforced/west,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	invisibility = 0;
 	reinf = 1
 	},
@@ -3972,12 +3972,12 @@
 /obj/machinery/computer3/generic/secure_data,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/darkblue/checker,
 /area/station/bridge)
@@ -3993,9 +3993,9 @@
 	dir = 1
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
 /area/station/bridge)
@@ -4006,8 +4006,8 @@
 /obj/machinery/computer3/terminal/network,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/darkblue/checker,
 /area/station/bridge)
@@ -4023,8 +4023,8 @@
 /obj/grille/steel,
 /obj/window/reinforced/west,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	invisibility = 0;
 	reinf = 1
 	},
@@ -4034,8 +4034,8 @@
 /obj/grille/steel,
 /obj/window/reinforced/west,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	invisibility = 0;
 	reinf = 1
 	},
@@ -4054,18 +4054,18 @@
 /area/station/medical/cdc)
 "aiK" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/airless,
 /area)
 "aiL" = (
 /obj/lattice,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/space,
 /area)
@@ -4080,8 +4080,8 @@
 /obj/window/reinforced/west,
 /obj/window/reinforced/south,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	invisibility = 0;
 	reinf = 1
 	},
@@ -4097,8 +4097,8 @@
 /obj/window/reinforced/west,
 /obj/window/reinforced/south,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	invisibility = 0;
 	reinf = 1
 	},
@@ -4112,8 +4112,8 @@
 "aiS" = (
 /obj/grille/steel,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	invisibility = 0;
 	reinf = 1
 	},
@@ -4133,9 +4133,9 @@
 	dir = 1
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/darkblue/checker,
 /area/station/bridge)
@@ -4147,9 +4147,9 @@
 /area/station/bridge)
 "aiY" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/blue/fancy,
 /area/station/bridge)
@@ -4190,8 +4190,8 @@
 /obj/window/reinforced/south,
 /obj/window/reinforced/west,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
@@ -4200,8 +4200,8 @@
 /obj/window/reinforced/north,
 /obj/window/reinforced/south,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
@@ -4211,16 +4211,16 @@
 /obj/window/reinforced/north,
 /obj/window/reinforced/south,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "aji" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
@@ -4228,8 +4228,8 @@
 /obj/grille/steel,
 /obj/window/reinforced/west,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	invisibility = 0;
 	reinf = 1
 	},
@@ -4240,28 +4240,28 @@
 /obj/grille/steel,
 /obj/window/reinforced/west,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
 "ajl" = (
 /obj/grille/steel,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
@@ -4272,28 +4272,28 @@
 /obj/grille/steel,
 /obj/window/reinforced/west,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
 "ajo" = (
 /obj/grille/steel,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
@@ -4301,37 +4301,37 @@
 /obj/grille/steel,
 /obj/window/reinforced/west,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/research)
 "ajq" = (
 /obj/grille/steel,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/research)
 "ajr" = (
 /obj/grille/steel,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/research)
@@ -4343,17 +4343,17 @@
 /area)
 "ajt" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area)
 "aju" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "1-4"
@@ -4362,9 +4362,9 @@
 /area)
 "ajv" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/r_wall,
 /area/station/bridge)
@@ -4374,9 +4374,9 @@
 "ajx" = (
 /obj/table/auto,
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /obj/item/device/multitool,
 /turf/simulated/floor/darkblue,
@@ -4387,18 +4387,18 @@
 /area/station/bridge)
 "ajz" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/darkblue/checker,
 /area/station/bridge)
 "ajA" = (
 /obj/item/device/radio/beacon,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/blue/fancy,
 /area/station/bridge)
@@ -4410,22 +4410,22 @@
 /obj/table/auto,
 /obj/item/storage/toolbox/emergency,
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/darkblue,
 /area/station/bridge)
 "ajD" = (
 /obj/machinery/computer/security,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/darkblue,
 /area/station/bridge)
@@ -4434,36 +4434,34 @@
 	dir = 8
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/darkblue,
 /area/station/bridge)
 "ajF" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/darkblue,
 /area/station/bridge)
 "ajG" = (
-/obj/item/device/radio/intercom{
-	
-	},
+/obj/item/device/radio/intercom,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/darkblue,
 /area/station/bridge)
 "ajH" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "1-4"
@@ -4475,9 +4473,9 @@
 	pixel_y = -22
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/carpet/blue/fancy/edge/west,
@@ -4496,27 +4494,27 @@
 	},
 /obj/disposalpipe/trunk,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/blue/fancy,
 /area/station/bridge)
 "ajK" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/blue/fancy,
 /area/station/bridge)
@@ -4540,19 +4538,19 @@
 /area/station/security/main)
 "ajO" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
@@ -4578,19 +4576,19 @@
 /area/station/security/main)
 "ajR" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
@@ -4598,14 +4596,14 @@
 /obj/grille/steel,
 /obj/window/reinforced/west,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
@@ -4613,9 +4611,9 @@
 /obj/grille/steel,
 /obj/window/reinforced/west,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/research)
@@ -4646,9 +4644,9 @@
 "ajZ" = (
 /obj/machinery/door/airlock/glass,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/bridge)
@@ -4657,9 +4655,9 @@
 	dir = 1
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/command{
 	name = "Head Office";
@@ -4702,9 +4700,9 @@
 /area/station/security/main)
 "akh" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -4788,9 +4786,9 @@
 /area/station/bridge)
 "akr" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -4799,8 +4797,8 @@
 /area/station/bridge)
 "aks" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 4
+	dir = 4;
+	icon_state = "chair"
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -4838,9 +4836,9 @@
 /area/station/crew_quarters/captain)
 "akx" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -4853,30 +4851,30 @@
 /area/station/crew_quarters/captain)
 "aky" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
 "akz" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
 "akA" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -4907,8 +4905,8 @@
 /obj/grille/steel,
 /obj/window/reinforced/west,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	invisibility = 0;
 	reinf = 1
 	},
@@ -4923,8 +4921,8 @@
 /area/station/maintenance/north)
 "akF" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
@@ -4935,16 +4933,16 @@
 /obj/window/reinforced/south,
 /obj/window/reinforced/east,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "akH" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/floorflusher{
 	id = "cell5";
@@ -4968,12 +4966,12 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
@@ -4984,16 +4982,16 @@
 /obj/window/reinforced/west,
 /obj/window/reinforced/south,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "akK" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/floorflusher{
 	id = "cell6";
@@ -5013,8 +5011,8 @@
 /obj/window/reinforced/west,
 /obj/window/reinforced/south,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
@@ -5031,9 +5029,9 @@
 	req_access_txt = "1"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
@@ -5043,8 +5041,8 @@
 /obj/item/implanter,
 /obj/item/clothing/glasses/thermal,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
@@ -5068,14 +5066,14 @@
 "akT" = (
 /obj/grille/steel,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/research)
@@ -5090,23 +5088,23 @@
 /obj/grille/steel,
 /obj/window/reinforced/west,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/research)
 "akW" = (
 /obj/grille/steel,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/research)
@@ -5119,8 +5117,8 @@
 /obj/window/reinforced/north,
 /obj/window/reinforced/west,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	invisibility = 0;
 	reinf = 1
 	},
@@ -5128,14 +5126,14 @@
 /area/station/crew_quarters/captain)
 "akZ" = (
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-c";
+	dir = 2;
 	icon_state = "pipe-c";
-	dir = 2
+	tag = "icon-pipe-c"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/darkblue/checker,
 /area/station/bridge)
@@ -5177,9 +5175,9 @@
 /area/station/crew_quarters/heads)
 "alf" = (
 /obj/machinery/computer/ATM{
-	tag = "icon-atm (WEST)";
+	dir = 8;
 	icon_state = "atm";
-	dir = 8
+	tag = "icon-atm (WEST)"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -5198,9 +5196,9 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
@@ -5226,8 +5224,8 @@
 /area/station/maintenance/north)
 "alm" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb1"
 	},
 /obj/stool/bed,
 /turf/simulated/floor,
@@ -5239,8 +5237,8 @@
 /obj/window/reinforced/south,
 /obj/window/reinforced/west,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
@@ -5249,9 +5247,9 @@
 	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
 	icon_state = "1-4"
@@ -5265,32 +5263,32 @@
 /area/station/security/main)
 "alp" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "1-4"
 	},
 /obj/disposalpipe/switch_junction{
-	tag = "icon-pipe-sj1 (WEST)";
+	dir = 8;
 	icon_state = "pipe-sj1";
-	dir = 8
+	tag = "icon-pipe-sj1 (WEST)"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
 "alq" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "1-8"
 	},
 /obj/disposalpipe/segment{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
@@ -5299,13 +5297,13 @@
 	dir = 1
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
@@ -5329,16 +5327,16 @@
 	pixel_y = 0
 	},
 /obj/disposalpipe/segment{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
 "alt" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 2;
@@ -5348,14 +5346,14 @@
 /area/station/security/main)
 "alu" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
@@ -5372,7 +5370,10 @@
 "alw" = (
 /obj/table/auto,
 /obj/item/secbot_assembly,
-/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 6
+	},
+/obj/item/kitchen/food_box/donut_box,
 /turf/simulated/floor,
 /area/station/security/main)
 "alx" = (
@@ -5408,14 +5409,14 @@
 /obj/grille/steel,
 /obj/window/reinforced/west,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/research)
@@ -5443,21 +5444,21 @@
 /obj/window/reinforced/west,
 /obj/machinery/computer/genetics,
 /turf/simulated/floor/greenblack{
-	icon_state = "greenblack";
-	dir = 9
+	dir = 9;
+	icon_state = "greenblack"
 	},
 /area/station/medical/research)
 "alK" = (
 /obj/machinery/genetics_scanner,
 /turf/simulated/floor/greenblack{
-	icon_state = "greenblack";
-	dir = 1
+	dir = 1;
+	icon_state = "greenblack"
 	},
 /area/station/medical/research)
 "alL" = (
 /turf/simulated/floor/greenblack{
-	icon_state = "greenblack";
-	dir = 1
+	dir = 1;
+	icon_state = "greenblack"
 	},
 /area/station/medical/research)
 "alM" = (
@@ -5479,26 +5480,26 @@
 /area/station/crew_quarters/captain)
 "alQ" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/darkblue/checker,
 /area/station/bridge)
 "alR" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/darkblue/checker,
 /area/station/bridge)
 "alS" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/darkblue/checker,
 /area/station/bridge)
@@ -5518,8 +5519,8 @@
 /area/station/crew_quarters/heads)
 "alW" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	icon_state = "chair"
 	},
 /obj/landmark/start{
 	name = "Head of Personnel"
@@ -5528,8 +5529,8 @@
 /area/station/crew_quarters/heads)
 "alX" = (
 /obj/machinery/computer/bank_data{
-	icon_state = "databank";
-	dir = 8
+	dir = 8;
+	icon_state = "databank"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/east,
 /area/station/crew_quarters/heads)
@@ -5582,9 +5583,9 @@
 /area/station/security/main)
 "ame" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/switch_junction{
 	mail_tag = "hydroponics"
@@ -5623,8 +5624,8 @@
 "amk" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
@@ -5635,28 +5636,28 @@
 /obj/grille/steel,
 /obj/window/reinforced/west,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
 "amn" = (
 /obj/grille/steel,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /obj/window/reinforced/west,
 /turf/simulated/floor/plating,
@@ -5665,47 +5666,47 @@
 /obj/grille/steel,
 /obj/window/reinforced/west,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "amp" = (
 /obj/grille/steel,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "amq" = (
 /obj/grille/steel,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
@@ -5715,23 +5716,23 @@
 "ams" = (
 /obj/machinery/clone_scanner,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/greenblack{
-	icon_state = "greenblack";
-	dir = 1
+	dir = 1;
+	icon_state = "greenblack"
 	},
 /area/station/medical/research)
 "amt" = (
 /obj/machinery/computer/cloning,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -5742,8 +5743,8 @@
 	pixel_x = -1
 	},
 /turf/simulated/floor/greenblack{
-	icon_state = "greenblack";
-	dir = 1
+	dir = 1;
+	icon_state = "greenblack"
 	},
 /area/station/medical/research)
 "amu" = (
@@ -5757,20 +5758,20 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/greenblack{
-	icon_state = "greenblack";
-	dir = 5
+	dir = 5;
+	icon_state = "greenblack"
 	},
 /area/station/medical/research)
 "amv" = (
 /obj/table/auto,
 /obj/item/storage/firstaid/brain,
 /obj/machinery/camera{
-	dir = 4;
-	c_tag = "Genetics Research West"
+	c_tag = "Genetics Research West";
+	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/bluegreen,
 /area/station/medical/research)
@@ -5797,8 +5798,8 @@
 	charge = 5e+006
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor,
 /area/station/turret_protected/ai)
@@ -5815,9 +5816,9 @@
 /area/station/turret_protected/ai)
 "amB" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/turret_protected/ai)
@@ -5828,9 +5829,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/grille/steel,
 /obj/window/reinforced/north,
@@ -5848,8 +5849,8 @@
 /obj/grille/steel,
 /obj/window/reinforced/north,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	invisibility = 0;
 	reinf = 1
 	},
@@ -5908,14 +5909,14 @@
 /area/station/security/main)
 "amO" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
@@ -5972,14 +5973,14 @@
 /area/station/security/main)
 "amW" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
@@ -6009,9 +6010,7 @@
 /turf/simulated/floor,
 /area/station/security/main)
 "ana" = (
-/obj/table/auto,
-/obj/item/kitchen/food_box/donut_box,
-/obj/machinery/recharger,
+/obj/submachine/weapon_vendor/security,
 /turf/simulated/floor,
 /area/station/security/main)
 "anb" = (
@@ -6030,8 +6029,8 @@
 /area/station/maintenance/NEmaint)
 "and" = (
 /obj/disposalpipe/segment{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
@@ -6040,8 +6039,8 @@
 	req_access_txt = "12"
 	},
 /obj/disposalpipe/segment{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
@@ -6084,15 +6083,15 @@
 	name = "Geneticist"
 	},
 /turf/simulated/floor/greenblack{
-	icon_state = "greenblack";
-	dir = 8
+	dir = 8;
+	icon_state = "greenblack"
 	},
 /area/station/medical/research)
 "anl" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/research)
@@ -6101,17 +6100,17 @@
 /area/station/turret_protected/ai)
 "ann" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall,
 /area/station/turret_protected/ai)
 "ano" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/turret_protected/ai)
@@ -6152,21 +6151,21 @@
 /area/station/crew_quarters/courtroom)
 "ant" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /obj/machinery/camera{
-	name = "autoname  - SS13";
-	icon_state = "camera";
+	c_tag = "autotag";
 	dir = 5;
-	network = "SS13";
-	c_tag = "autotag"
+	icon_state = "camera";
+	name = "autoname  - SS13";
+	network = "SS13"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
@@ -6259,9 +6258,9 @@
 /area/station/medical/research)
 "anF" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/medical/research)
@@ -6273,9 +6272,9 @@
 	name = "Geneticist"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
 	icon_state = "1-8"
@@ -6284,22 +6283,22 @@
 /area/station/medical/research)
 "anH" = (
 /turf/simulated/floor/greenblack{
-	icon_state = "greenblack";
-	dir = 4
+	dir = 4;
+	icon_state = "greenblack"
 	},
 /area/station/medical/research)
 "anI" = (
 /obj/machinery/door/window/westright,
 /turf/simulated/floor/greenblack{
-	icon_state = "greenblack";
-	dir = 8
+	dir = 8;
+	icon_state = "greenblack"
 	},
 /area/station/medical/research)
 "anJ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
 /area/station/medical/research)
@@ -6332,8 +6331,8 @@
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor,
@@ -6367,8 +6366,8 @@
 "anU" = (
 /obj/stool/bed,
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
@@ -6379,8 +6378,8 @@
 /obj/window/reinforced/north,
 /obj/window/reinforced/east,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
@@ -6457,11 +6456,11 @@
 /area/station/security/main)
 "aoe" = (
 /obj/machinery/camera{
-	name = "autoname  - SS13";
-	icon_state = "camera";
+	c_tag = "autotag";
 	dir = 5;
-	network = "SS13";
-	c_tag = "autotag"
+	icon_state = "camera";
+	name = "autoname  - SS13";
+	network = "SS13"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
@@ -6474,9 +6473,9 @@
 /area/station/medical/research)
 "aoh" = (
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/stool/chair,
 /turf/simulated/floor/white,
@@ -6490,9 +6489,9 @@
 /area/station/medical/research)
 "aoj" = (
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/research)
@@ -6506,9 +6505,9 @@
 	name = "Station Intercom"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/research)
@@ -6583,19 +6582,19 @@
 /area/station/turret_protected/ai)
 "aot" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
@@ -6717,8 +6716,8 @@
 /obj/window/reinforced/north,
 /obj/window/reinforced/east,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
@@ -6758,54 +6757,54 @@
 /obj/grille/steel,
 /obj/window/reinforced/west,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbay)
 "aoS" = (
 /obj/grille/steel,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbay)
 "aoT" = (
 /obj/grille/steel,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbay)
 "aoU" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/research)
@@ -6847,30 +6846,30 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "apd" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 8
+	dir = 8;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "ape" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "apf" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
@@ -6882,8 +6881,8 @@
 /area/station/crew_quarters/juryroom)
 "aph" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 4
+	dir = 4;
+	icon_state = "chair"
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/juryroom)
@@ -6931,8 +6930,8 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/wood/six,
 /area/station/crew_quarters/courtroom)
@@ -6958,8 +6957,8 @@
 /area/station/crew_quarters/courtroom)
 "aps" = (
 /obj/machinery/camera{
-	dir = 4;
-	c_tag = "Bridge South"
+	c_tag = "Bridge South";
+	dir = 4
 	},
 /turf/simulated/floor/darkblue/checker,
 /area/station/bridge)
@@ -7001,9 +7000,9 @@
 	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
@@ -7016,9 +7015,9 @@
 /area/station/maintenance/north)
 "apA" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
@@ -7052,9 +7051,9 @@
 /area/station/security/main)
 "apE" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/switch_junction{
 	dir = 4;
@@ -7066,9 +7065,9 @@
 /area/station/security/main)
 "apF" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "2-4"
@@ -7086,9 +7085,9 @@
 "apG" = (
 /obj/machinery/light,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -7099,9 +7098,9 @@
 /area/station/security/main)
 "apH" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "2-4"
@@ -7115,9 +7114,9 @@
 /area/station/security/main)
 "apI" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/switch_junction{
 	mail_tag = "hydroponics"
@@ -7126,9 +7125,9 @@
 /area/station/security/main)
 "apJ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	icon_state = "1-8"
@@ -7143,30 +7142,30 @@
 	dir = 1
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
 "apL" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
 "apM" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
@@ -7182,22 +7181,22 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
 "apO" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "1-8"
@@ -7207,25 +7206,25 @@
 /area/station/security/main)
 "apP" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall,
 /area/station/security/main)
 "apQ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "apR" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
@@ -7282,8 +7281,8 @@
 "apZ" = (
 /obj/machinery/atmospherics/portables_connector/west,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -7291,19 +7290,19 @@
 /obj/grille/steel,
 /obj/window/reinforced/west,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/research)
@@ -7318,8 +7317,8 @@
 	pixel_y = -24
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/research)
@@ -7353,9 +7352,9 @@
 /area/station/maintenance/east)
 "aqh" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -7394,8 +7393,8 @@
 "aqn" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
@@ -7405,31 +7404,31 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/item/circuitboard/teleporter,
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "aqp" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "aqq" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/r_wall,
 /area/station/turret_protected/ai)
@@ -7470,9 +7469,9 @@
 "aqy" = (
 /obj/stool/chair,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood/six,
 /area/station/crew_quarters/courtroom)
@@ -7504,9 +7503,9 @@
 /obj/machinery/door/airlock/glass,
 /obj/disposalpipe/segment,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
@@ -7537,9 +7536,9 @@
 	req_access_txt = "18"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage/eva)
@@ -7599,9 +7598,9 @@
 	req_access_txt = "1"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
@@ -7624,9 +7623,9 @@
 /area/station/security/main)
 "aqS" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
@@ -7673,9 +7672,9 @@
 /area/station/medical/robotics)
 "arb" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -7744,9 +7743,9 @@
 /area/station/storage/tech)
 "arm" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/wall,
 /area/station/storage/tech)
@@ -7755,8 +7754,8 @@
 	tag = "ZETA_MAINFRAME"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/circuit,
@@ -7767,21 +7766,21 @@
 	},
 /obj/machinery/networked/radio,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
 "arp" = (
 /obj/machinery/camera{
-	network = "SS13";
-	c_tag = "Genetic Research East"
+	c_tag = "Genetic Research East";
+	network = "SS13"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/computer/aiupload,
 /turf/simulated/floor/circuit,
@@ -7798,8 +7797,8 @@
 	setup_drive_type = /obj/item/disk/data/tape/master
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/circuit,
@@ -7807,8 +7806,8 @@
 "arr" = (
 /obj/machinery/computer/cloning,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/circuit,
@@ -7820,8 +7819,8 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /mob/living/silicon/hivebot/eyebot,
 /turf/simulated/floor/plating,
@@ -7862,9 +7861,9 @@
 "arA" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -7876,9 +7875,9 @@
 "arB" = (
 /obj/item/storage/secure/sbriefcase,
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
@@ -7908,9 +7907,9 @@
 /area/station/ai_monitored/storage/eva)
 "arG" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/darkpurple,
 /area/station/ai_monitored/storage/eva)
@@ -7957,8 +7956,8 @@
 /obj/window/reinforced/west,
 /obj/storage/secure/closet/medical,
 /turf/simulated/floor/greenblack{
-	icon_state = "greenblack";
-	dir = 10
+	dir = 10;
+	icon_state = "greenblack"
 	},
 /area/station/medical/research)
 "arP" = (
@@ -7979,9 +7978,9 @@
 /area/station/medical/medbay)
 "arS" = (
 /obj/machinery/camera{
+	c_tag = "Medical";
 	dir = 1;
-	layer = 4;
-	c_tag = "Medical"
+	layer = 4
 	},
 /obj/machinery/vending/port_a_nanomed,
 /turf/simulated/floor/white,
@@ -8008,8 +8007,8 @@
 /area/station/medical/medbay)
 "arW" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -8028,8 +8027,8 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor,
 /area/station/medical/robotics)
@@ -8046,9 +8045,9 @@
 /area/station/medical/robotics)
 "asa" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk,
@@ -8163,19 +8162,19 @@
 /area/station/turret_protected/ai_upload)
 "ass" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/turret_protected/ai_upload)
@@ -8205,9 +8204,9 @@
 /area/station/turret_protected/ai_upload)
 "asw" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/table/reinforced/bar/auto,
 /turf/simulated/floor/wood/six,
@@ -8223,16 +8222,16 @@
 /area/station/crew_quarters/juryroom)
 "asz" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/courtroom)
 "asA" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -8255,9 +8254,9 @@
 /obj/stool/chair,
 /obj/disposalpipe/segment,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -8273,8 +8272,8 @@
 "asE" = (
 /obj/table/auto,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/item/device/light/flashlight,
 /obj/item/device/gps,
@@ -8342,8 +8341,8 @@
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/head/helmet/space,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/darkpurple,
 /area/station/ai_monitored/storage/eva)
@@ -8378,9 +8377,9 @@
 /area/station/security/main)
 "asR" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -8439,9 +8438,9 @@
 /area/station/maintenance/NEmaint)
 "asY" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall,
 /area/station/maintenance/NEmaint)
@@ -8450,34 +8449,34 @@
 	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "ata" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall,
 /area/station/medical/medbay)
 "atb" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/greenblack,
 /area/station/medical/research)
 "atc" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -8487,22 +8486,22 @@
 /obj/window/reinforced/west,
 /obj/window/reinforced/south,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbay)
 "ate" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -8529,8 +8528,8 @@
 /area/station/medical/robotics)
 "atj" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 4
+	dir = 4;
+	icon_state = "chair"
 	},
 /obj/landmark/start{
 	name = "Staff Assistant"
@@ -8542,9 +8541,9 @@
 /area/station/medical/robotics)
 "atl" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
@@ -8559,14 +8558,14 @@
 /obj/grille/steel,
 /obj/window/reinforced/west,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
@@ -8613,9 +8612,9 @@
 /area/station/turret_protected/ai_upload)
 "atx" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/turret_protected/ai_upload)
@@ -8626,8 +8625,8 @@
 /area/station/crew_quarters/courtroom)
 "atz" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/courtroom)
@@ -8640,9 +8639,9 @@
 /obj/table/reinforced/auto,
 /obj/disposalpipe/segment,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
@@ -8707,8 +8706,8 @@
 /obj/window/reinforced/south,
 /obj/window/reinforced/north,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
@@ -8724,18 +8723,18 @@
 /obj/window/reinforced/south,
 /obj/window/reinforced/north,
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
@@ -8769,18 +8768,18 @@
 /obj/window/reinforced/south,
 /obj/window/reinforced/north,
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
@@ -8810,9 +8809,9 @@
 	name = "Security"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
 	icon_state = "1-4"
@@ -8822,9 +8821,9 @@
 /area/station/security/main)
 "atQ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/r_wall,
 /area/station/security/main)
@@ -8839,9 +8838,9 @@
 	dir = 8
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -8901,8 +8900,8 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/table/auto,
 /obj/item/gun/reagent/syringe,
@@ -8928,9 +8927,9 @@
 /area/station/medical/robotics)
 "aue" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	icon_state = "2-4"
@@ -8940,9 +8939,9 @@
 /area/station/medical/robotics)
 "auf" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/table/auto,
 /obj/item/device/flash,
@@ -8952,27 +8951,27 @@
 /obj/grille/steel,
 /obj/window/reinforced/west,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "auh" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "1-8"
@@ -8981,22 +8980,21 @@
 /area/station/maintenance/east)
 "aui" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "auj" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Crematorium Maintenance";
-	req_access_txt = "12;27";
 	req_access_txt = "12;27"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/chapel/main)
@@ -9011,9 +9009,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/main)
@@ -9025,8 +9023,8 @@
 /area/station/chapel/main)
 "aun" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -9035,9 +9033,9 @@
 /area/station/chapel/main)
 "auo" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -9062,8 +9060,8 @@
 /area/station/maintenance/west)
 "aus" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -9084,30 +9082,30 @@
 /area/station/maintenance/west)
 "auv" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "auw" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aux" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -9134,8 +9132,8 @@
 /area/station/turret_protected/ai_upload)
 "auB" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/juryroom)
@@ -9147,9 +9145,9 @@
 /area/station/crew_quarters/courtroom)
 "auE" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/stairs/wide/middle,
 /area/station/crew_quarters/courtroom)
@@ -9169,9 +9167,9 @@
 "auI" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -9211,9 +9209,9 @@
 /area/station/hallway/primary/north)
 "auN" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -9242,9 +9240,9 @@
 /area/station/hallway/primary/north)
 "auQ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/red/side{
@@ -9256,9 +9254,9 @@
 /area/station/hallway/primary/north)
 "auS" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -9279,15 +9277,15 @@
 /area/station/medical/medbay)
 "auV" = (
 /turf/simulated/floor/greenblack{
-	icon_state = "greenblack";
-	dir = 6
+	dir = 6;
+	icon_state = "greenblack"
 	},
 /area/station/medical/research)
 "auW" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -9297,24 +9295,24 @@
 /area/station/medical/medbay)
 "auY" = (
 /obj/machinery/camera{
-	dir = 8;
-	c_tag = "Medical East"
+	c_tag = "Medical East";
+	dir = 8
 	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "auZ" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor,
 /area/station/medical/robotics)
@@ -9337,9 +9335,9 @@
 /area/station/chapel/main)
 "avd" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /obj/machinery/conveyor_switch{
 	id = "chapel"
@@ -9381,17 +9379,17 @@
 	req_access_txt = "12"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "avj" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -9412,26 +9410,26 @@
 /area/station/turret_protected/ai_upload)
 "avn" = (
 /obj/machinery/camera{
-	name = "autoname  - SS13";
-	icon_state = "camera";
+	c_tag = "autotag";
 	dir = 5;
-	network = "SS13";
-	c_tag = "autotag"
+	icon_state = "camera";
+	name = "autoname  - SS13";
+	network = "SS13"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/juryroom)
 "avo" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/juryroom)
 "avp" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood/six,
 /area/station/crew_quarters/courtroom)
@@ -9445,31 +9443,31 @@
 	name = "Courtroom"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "avs" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "avt" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -9486,8 +9484,8 @@
 "avv" = (
 /obj/table/auto,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/cell_charger,
 /obj/item/cell{
@@ -9539,9 +9537,9 @@
 /area/station/hallway/primary/north)
 "avB" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -9550,9 +9548,9 @@
 /area/station/hallway/primary/north)
 "avC" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -9566,9 +9564,9 @@
 /area/station/hallway/primary/north)
 "avD" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -9580,9 +9578,9 @@
 	name = "Head of Personnel"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -9591,14 +9589,14 @@
 /area/station/hallway/primary/north)
 "avF" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/switch_junction{
 	mail_tag = "hydroponics"
@@ -9610,8 +9608,8 @@
 /area/station/medical/medbay)
 "avH" = (
 /obj/machinery/camera{
-	dir = 4;
-	c_tag = "Medical West"
+	c_tag = "Medical West";
+	dir = 4
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -9623,9 +9621,9 @@
 /area/station/medical/medbay)
 "avJ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/critter/bat/doctor,
 /turf/simulated/floor/white,
@@ -9642,9 +9640,9 @@
 /obj/grille/steel,
 /obj/window/reinforced/west,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /obj/window/reinforced/east,
 /obj/window/reinforced/north,
@@ -9722,9 +9720,9 @@
 /area/station/hallway/secondary/entry)
 "awa" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
@@ -9768,26 +9766,26 @@
 /obj/window/reinforced/west,
 /obj/window/reinforced/north,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/courtroom)
 "awi" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "awj" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -9863,9 +9861,9 @@
 /area/station/hallway/primary/north)
 "aws" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
@@ -9902,9 +9900,9 @@
 /area/station/maintenance/NEmaint)
 "awz" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "2-4"
@@ -9913,9 +9911,9 @@
 /area/station/medical/medbay)
 "awA" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -9925,9 +9923,9 @@
 /area/station/medical/medbay)
 "awB" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -9936,16 +9934,14 @@
 /area/station/medical/medbay)
 "awC" = (
 /obj/machinery/light,
-/obj/item/device/radio/intercom{
-	
-	},
+/obj/item/device/radio/intercom,
 /obj/cable{
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -9954,27 +9950,27 @@
 /area/station/medical/medbay)
 "awD" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/switch_junction{
-	tag = "icon-pipe-sj1 (WEST)";
+	dir = 8;
 	icon_state = "pipe-sj1";
-	dir = 8
+	tag = "icon-pipe-sj1 (WEST)"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "awE" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/switch_junction{
-	tag = "icon-pipe-sj2 (WEST)";
+	dir = 8;
 	icon_state = "pipe-sj2";
-	dir = 8
+	tag = "icon-pipe-sj2 (WEST)"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -9985,9 +9981,9 @@
 	req_access_txt = "29"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -9996,9 +9992,9 @@
 /area/station/medical/robotics)
 "awG" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -10010,9 +10006,9 @@
 	name = "Roboticist"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -10090,8 +10086,8 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/grimycarpet,
 /area/station/chapel/office)
@@ -10118,25 +10114,25 @@
 /area/station/hallway/secondary/entry)
 "awW" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "awX" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "awY" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/command{
@@ -10201,13 +10197,13 @@
 "axh" = (
 /obj/storage/closet/emergency,
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 8
+	dir = 8;
+	icon_state = "greyblack"
 	},
 /area/station/hallway/primary/central)
 "axi" = (
@@ -10219,9 +10215,9 @@
 /area/station/hallway/primary/north)
 "axj" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/arrival{
 	dir = 9
@@ -10229,22 +10225,22 @@
 /area/station/hallway/secondary/entry)
 "axk" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/wall,
 /area/station/maintenance/NEmaint)
 "axl" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
@@ -10252,8 +10248,8 @@
 /obj/machinery/computer3/generic/med_data,
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/white,
@@ -10303,8 +10299,8 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -10358,9 +10354,9 @@
 /area/station/chapel/main)
 "axB" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/grimycarpet,
 /area/station/chapel/office)
@@ -10425,13 +10421,13 @@
 /area/station/hallway/secondary/entry)
 "axN" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -10448,9 +10444,9 @@
 /area/station/turret_protected/ai_upload)
 "axP" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 1
@@ -10485,16 +10481,16 @@
 /area/station/maintenance/NWmaint)
 "axU" = (
 /obj/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "axV" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/courtroom)
@@ -10518,32 +10514,32 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "aya" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "ayb" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 1;
@@ -10553,9 +10549,9 @@
 /area/station/hallway/primary/north)
 "ayc" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -10568,9 +10564,9 @@
 	dir = 1
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -10580,19 +10576,19 @@
 /area/station/hallway/primary/north)
 "aye" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/disposalpipe/switch_junction{
-	tag = "icon-pipe-sj1 (EAST)";
+	dir = 4;
 	icon_state = "pipe-sj1";
-	dir = 4
+	tag = "icon-pipe-sj1 (EAST)"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -10625,8 +10621,8 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -10635,9 +10631,9 @@
 	dir = 1
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 1;
@@ -10650,23 +10646,23 @@
 	dir = 1
 	},
 /obj/disposalpipe/segment{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "ayk" = (
 /obj/disposalpipe/segment{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/wall,
 /area/station/hallway/primary/north)
 "ayl" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
+	dir = 8;
 	icon_state = "bulb1";
-	dir = 8
+	tag = "icon-bulb1 (WEST)"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -10681,8 +10677,8 @@
 /area/station/maintenance/NEmaint)
 "ayn" = (
 /obj/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
@@ -10735,11 +10731,11 @@
 /area/station/medical/medbay)
 "ayu" = (
 /obj/securearea{
-	tag = "icon-nosmoking";
-	name = "Sign";
 	desc = "No smoking";
 	icon_state = "nosmoking";
-	pixel_y = 30
+	name = "Sign";
+	pixel_y = 30;
+	tag = "icon-nosmoking"
 	},
 /turf/simulated/wall,
 /area/station/medical/medbay)
@@ -10752,9 +10748,9 @@
 /obj/item/paper_bin,
 /obj/item/cigpacket,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/window/reinforced/south,
 /turf/simulated/floor/white,
@@ -10845,9 +10841,9 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /obj/landmark/start{
 	name = "Security Officer"
@@ -10884,8 +10880,8 @@
 "ayP" = (
 /obj/storage/closet/coffin,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/wood/six,
 /area/station/chapel/office)
@@ -11008,9 +11004,9 @@
 	dir = 1
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -11023,9 +11019,9 @@
 /area/station/maintenance/NEmaint)
 "azo" = (
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-c";
+	dir = 2;
 	icon_state = "pipe-c";
-	dir = 2
+	tag = "icon-pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
@@ -11034,17 +11030,17 @@
 	req_access_txt = "12"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "azq" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "1-8"
@@ -11057,13 +11053,13 @@
 /area/station/maintenance/NEmaint)
 "azr" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
@@ -11072,22 +11068,22 @@
 	icon_state = "1-8"
 	},
 /obj/disposalpipe/segment{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "azt" = (
 /obj/disposalpipe/segment{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/wall,
 /area/station/medical/medbay)
 "azu" = (
 /obj/disposalpipe/segment{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -11095,8 +11091,8 @@
 /obj/storage/crate,
 /obj/item/storage/firstaid/oxygen,
 /obj/disposalpipe/segment{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -11106,8 +11102,8 @@
 /obj/window/reinforced/east,
 /obj/window/reinforced/north,
 /obj/disposalpipe/segment{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbay)
@@ -11119,20 +11115,20 @@
 	dir = 1
 	},
 /obj/disposalpipe/segment{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "azy" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -11208,8 +11204,8 @@
 	dir = 1
 	},
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 4
+	dir = 4;
+	icon_state = "chair"
 	},
 /turf/simulated/grimycarpet,
 /area/station/chapel/office)
@@ -11227,9 +11223,9 @@
 /area/station/hallway/secondary/exit)
 "azO" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/escape{
 	dir = 4
@@ -11280,14 +11276,14 @@
 /area/station/hallway/secondary/entry)
 "azV" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
@@ -11399,9 +11395,9 @@
 /area/station/crew_quarters/barber_shop)
 "aAg" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /obj/table/auto,
 /obj/item/scissors,
@@ -11415,9 +11411,9 @@
 "aAi" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
@@ -11427,9 +11423,9 @@
 /area/station/maintenance/maintcentral)
 "aAk" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only{
@@ -11437,9 +11433,9 @@
 	},
 /obj/machinery/door/airlock/maintenance,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -11456,9 +11452,9 @@
 	},
 /obj/machinery/door/airlock,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
@@ -11489,9 +11485,9 @@
 /area/station/hallway/primary/central)
 "aAs" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -11504,9 +11500,9 @@
 /area/station/maintenance/NEmaint)
 "aAu" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall,
 /area/station/maintenance/NEmaint)
@@ -11531,9 +11527,9 @@
 /area/station/medical/medbay)
 "aAy" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/red,
 /area/station/medical/medbay)
@@ -11590,9 +11586,9 @@
 /area/station/hallway/secondary/exit)
 "aAI" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall,
 /area/station/chapel/office)
@@ -11637,9 +11633,9 @@
 /area/station/hallway/primary/north)
 "aAQ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 1
@@ -11693,23 +11689,23 @@
 /area/station/crew_quarters/barber_shop)
 "aAZ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/barber_shop)
 "aBa" = (
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced/south,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced/north,
 /obj/barber_pole,
@@ -11729,8 +11725,8 @@
 /area/station/hallway/primary/north)
 "aBc" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -11746,25 +11742,25 @@
 /area/station/maintenance/maintcentral)
 "aBe" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
 "aBf" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
@@ -11777,9 +11773,9 @@
 /area/station/crew_quarters/bar)
 "aBh" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 8;
@@ -11825,8 +11821,8 @@
 /area/station/crew_quarters/bar)
 "aBp" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -11837,9 +11833,9 @@
 /obj/window/reinforced/east,
 /obj/window/reinforced/west,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
@@ -11852,8 +11848,8 @@
 /area/station/medical/medbay)
 "aBs" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -11882,8 +11878,8 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -11904,34 +11900,34 @@
 "aBy" = (
 /obj/morgue,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/medical/morgue)
 "aBz" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/medical/morgue)
 "aBA" = (
 /obj/morgue,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/medical/medbay)
 "aBB" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall,
 /area/station/medical/morgue)
@@ -12000,9 +11996,9 @@
 	pixel_x = -1
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -12038,17 +12034,17 @@
 /area/station/hallway/secondary/entry)
 "aBN" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "aBO" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
@@ -12057,9 +12053,9 @@
 /area/station/hallway/primary/west)
 "aBQ" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
@@ -12071,9 +12067,9 @@
 /area/station/storage/tools)
 "aBT" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/barber_shop)
@@ -12087,9 +12083,9 @@
 /area/station/crew_quarters/barber_shop)
 "aBV" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/barber_shop)
@@ -12099,38 +12095,38 @@
 	req_access_txt = "0"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/barber_shop)
 "aBX" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "aBY" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 8
+	dir = 8;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
 "aBZ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -12149,8 +12145,8 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/bar)
@@ -12175,15 +12171,14 @@
 "aCg" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Bar Maintenance";
-	req_access_txt = "12;25";
 	req_access_txt = "14;25"
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/bar)
 "aCh" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -12191,15 +12186,15 @@
 /obj/grille/steel,
 /obj/window/reinforced/east,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /obj/window/reinforced/west,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
@@ -12208,9 +12203,9 @@
 /obj/window/reinforced/east,
 /obj/window/reinforced/west,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbay)
@@ -12218,9 +12213,9 @@
 /obj/grille/steel,
 /obj/window/reinforced/west,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /obj/window/reinforced/east,
 /obj/window/reinforced/north,
@@ -12248,9 +12243,9 @@
 "aCo" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -12267,9 +12262,9 @@
 /obj/grille/steel,
 /obj/window/reinforced/west,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /obj/window/reinforced/east,
 /obj/window/reinforced/north,
@@ -12282,13 +12277,13 @@
 /area/station/medical/medbay)
 "aCt" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
 /area/station/medical/morgue)
@@ -12439,9 +12434,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 1
@@ -12449,9 +12444,9 @@
 /area/station/chapel/main)
 "aCK" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
@@ -12464,8 +12459,8 @@
 /area/station/chapel/main)
 "aCM" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
@@ -12494,16 +12489,16 @@
 /area/station/storage/tools)
 "aCR" = (
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced/north,
 /obj/barber_pole,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced/south,
 /obj/window{
@@ -12518,8 +12513,8 @@
 "aCT" = (
 /obj/table/auto,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/bar)
@@ -12545,9 +12540,9 @@
 /area/station/hallway/primary/east)
 "aCZ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
@@ -12577,8 +12572,8 @@
 /obj/item/storage/box/lglo_kit,
 /obj/item/crowbar,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/black,
 /area/station/medical/morgue)
@@ -12652,41 +12647,41 @@
 /area/station/chapel/main)
 "aDp" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "aDq" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "aDr" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "aDs" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "aDt" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "1-4"
@@ -12733,9 +12728,9 @@
 /area/station/crew_quarters/barber_shop)
 "aDB" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/barber_shop)
@@ -12773,8 +12768,8 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
@@ -12800,9 +12795,9 @@
 /area/station/security/detectives_office)
 "aDL" = (
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 1
@@ -12814,9 +12809,9 @@
 	},
 /obj/machinery/genetics_booth,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 1
@@ -12831,8 +12826,8 @@
 /area/station/crew_quarters/courtroom)
 "aDO" = (
 /obj/machinery/camera{
-	dir = 8;
-	c_tag = "East Hallway North"
+	c_tag = "East Hallway North";
+	dir = 8
 	},
 /turf/simulated/floor/blue/side{
 	dir = 5
@@ -12855,17 +12850,17 @@
 /area/station/hallway/primary/central)
 "aDS" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "aDT" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -12896,8 +12891,8 @@
 	network = "SS13"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -12917,9 +12912,9 @@
 /area/station/hallway/primary/east)
 "aDZ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -12928,14 +12923,14 @@
 /area/station/hallway/primary/east)
 "aEa" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
 	icon_state = "1-8"
@@ -12947,39 +12942,39 @@
 /area/station/hallway/primary/east)
 "aEb" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/switch_junction{
-	tag = "icon-pipe-sj1 (WEST)";
+	dir = 8;
 	icon_state = "pipe-sj1";
-	dir = 8
+	tag = "icon-pipe-sj1 (WEST)"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aEc" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/switch_junction{
-	tag = "icon-pipe-sj2 (WEST)";
+	dir = 8;
 	icon_state = "pipe-sj2";
-	dir = 8
+	tag = "icon-pipe-sj2 (WEST)"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aEd" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
@@ -12990,18 +12985,18 @@
 "aEf" = (
 /obj/disposalpipe/segment,
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
+	dir = 8;
 	icon_state = "bulb1";
-	dir = 8
+	tag = "icon-bulb1 (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "aEg" = (
 /obj/storage/crate,
 /obj/machinery/camera{
+	c_tag = "Security Checkpoint";
 	dir = 4;
-	network = "Prison";
-	c_tag = "Security Checkpoint"
+	network = "Prison"
 	},
 /turf/simulated/floor,
 /area/station/storage/auxillary)
@@ -13027,8 +13022,8 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor,
 /area/station/storage/auxillary)
@@ -13101,15 +13096,15 @@
 "aEx" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced/north,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced/south,
 /turf/simulated/floor/plating,
@@ -13123,37 +13118,37 @@
 /area/station/crew_quarters/barber_shop)
 "aEz" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "aEA" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "aEB" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -13166,17 +13161,17 @@
 	req_access_txt = "4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/security/detectives_office)
 "aED" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
@@ -13229,17 +13224,17 @@
 "aEJ" = (
 /obj/item/cigbutt,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
 "aEK" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
@@ -13275,8 +13270,8 @@
 /area/station/crew_quarters/bar)
 "aEQ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/chem_dispenser/soda,
 /turf/simulated/floor/specialroom/bar,
@@ -13293,8 +13288,8 @@
 /obj/item/clothing/mask/surgical_shield,
 /obj/item/surgical_spoon,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -13314,24 +13309,24 @@
 /area/station/hallway/primary/east)
 "aEX" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purple/side,
 /area/station/hallway/primary/east)
 "aEY" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/purple/corner{
-	icon_state = "purplecorner";
-	dir = 4
+	dir = 4;
+	icon_state = "purplecorner"
 	},
 /area/station/hallway/primary/east)
 "aEZ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
@@ -13392,9 +13387,9 @@
 /area/station/hallway/secondary/exit)
 "aFl" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
@@ -13471,15 +13466,15 @@
 /obj/grille/steel,
 /obj/window/reinforced/north,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced/south,
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
@@ -13521,8 +13516,8 @@
 /area/station/crew_quarters/bar)
 "aFE" = (
 /obj/decal/tile_edge/line/yellow{
-	icon_state = "noedge-tile1";
-	dir = 9
+	dir = 9;
+	icon_state = "noedge-tile1"
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
@@ -13545,8 +13540,8 @@
 /area/station/storage/autolathe)
 "aFJ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -13556,9 +13551,9 @@
 /area/station/hallway/primary/east)
 "aFL" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall,
 /area/station/hallway/primary/east)
@@ -13576,9 +13571,9 @@
 "aFO" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
@@ -13593,9 +13588,9 @@
 /area/station/science)
 "aFR" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/medical{
 	name = "science Research";
@@ -13632,9 +13627,9 @@
 "aFW" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
@@ -13644,16 +13639,16 @@
 /area/station/hallway/secondary/exit)
 "aFY" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aFZ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -13682,17 +13677,17 @@
 	name = "Central Access"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "aGd" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
@@ -13703,30 +13698,30 @@
 	name = "Central Access"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "aGf" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "aGg" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -13755,9 +13750,9 @@
 "aGk" = (
 /obj/machinery/computer/secure_data/detective_computer,
 /obj/machinery/camera{
-	dir = 4;
 	c_tag = "Forensics Office";
-	c_tag_order = 999
+	c_tag_order = 999;
+	dir = 4
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
@@ -13783,8 +13778,8 @@
 /area/station/security/detectives_office)
 "aGo" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 4
+	dir = 4;
+	icon_state = "chair"
 	},
 /obj/landmark/start{
 	name = "Staff Assistant"
@@ -13847,9 +13842,9 @@
 /area/station/science)
 "aGx" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purple,
 /area/station/science)
@@ -13945,9 +13940,9 @@
 /area/station/hallway/primary/west)
 "aGM" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -13963,13 +13958,13 @@
 /area/station/hallway/primary/north)
 "aGO" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /obj/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -14003,17 +13998,17 @@
 /area/station/maintenance/maintcentral)
 "aGT" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
 "aGU" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall,
 /area/station/storage/autolathe)
@@ -14022,22 +14017,22 @@
 	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
+	dir = 8;
 	icon_state = "bulb1";
-	dir = 8
+	tag = "icon-bulb1 (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/autolathe)
 "aGW" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/autolathe)
@@ -14046,25 +14041,25 @@
 	req_access_txt = "12"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/autolathe)
 "aGY" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -14076,9 +14071,9 @@
 	name = "Med-Sci Wing Access"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -14087,9 +14082,9 @@
 	dir = 1
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 1;
@@ -14099,9 +14094,9 @@
 /area/station/hallway/primary/east)
 "aHb" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "1-4"
@@ -14117,9 +14112,9 @@
 	name = "Central Access"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -14128,9 +14123,9 @@
 /area/station/hallway/primary/east)
 "aHd" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/switch_junction{
 	mail_tag = "hydroponics"
@@ -14139,9 +14134,9 @@
 /area/station/hallway/primary/east)
 "aHe" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	icon_state = "1-8"
@@ -14164,9 +14159,9 @@
 "aHh" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -14175,9 +14170,9 @@
 /area/station/hallway/primary/east)
 "aHi" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -14186,9 +14181,9 @@
 /area/station/hallway/secondary/exit)
 "aHj" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 8;
@@ -14198,17 +14193,17 @@
 /area/station/hallway/secondary/exit)
 "aHk" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/chapel/main)
 "aHl" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "1-8"
@@ -14217,55 +14212,55 @@
 /area/station/hallway/secondary/exit)
 "aHm" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aHn" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "aHo" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "aHp" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "aHq" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "aHr" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/grille/steel,
 /obj/window/reinforced/west,
@@ -14309,9 +14304,9 @@
 /area/station/hallway/secondary/entry)
 "aHx" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -14339,9 +14334,9 @@
 /area/station/hallway/primary/west)
 "aHB" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/arrival{
 	dir = 4
@@ -14400,8 +14395,8 @@
 "aHL" = (
 /obj/table/auto,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/bar)
@@ -14411,24 +14406,24 @@
 /area/station/crew_quarters/bar)
 "aHN" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
 "aHO" = (
 /obj/machinery/camera{
-	name = "autoname  - SS13";
-	icon_state = "camera";
+	c_tag = "autotag";
 	dir = 5;
-	network = "SS13";
-	c_tag = "autotag"
+	icon_state = "camera";
+	name = "autoname  - SS13";
+	network = "SS13"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/autolathe)
@@ -14444,9 +14439,9 @@
 /area/station/storage/autolathe)
 "aHR" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 1
@@ -14497,9 +14492,9 @@
 /obj/window/reinforced/south,
 /obj/window/reinforced/north,
 /obj/window/reinforced/north{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/science)
@@ -14543,9 +14538,9 @@
 /area/station/hallway/secondary/exit)
 "aIg" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/escape,
 /area/station/hallway/secondary/exit)
@@ -14556,9 +14551,9 @@
 /area/station/hallway/secondary/exit)
 "aIi" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
@@ -14617,9 +14612,9 @@
 /area/station/hallway/primary/west)
 "aIs" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 4
@@ -14627,9 +14622,9 @@
 /area/station/hallway/secondary/entry)
 "aIt" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 8
@@ -14746,9 +14741,9 @@
 /obj/grille/steel,
 /obj/window/reinforced/west,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /obj/window/reinforced/east,
 /turf/simulated/floor/plating,
@@ -14784,9 +14779,9 @@
 "aIQ" = (
 /obj/storage/closet/emergency,
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 4
@@ -14794,8 +14789,8 @@
 /area/station/hallway/primary/east)
 "aIR" = (
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 9
+	dir = 9;
+	icon_state = "purpleblack"
 	},
 /area/station/science)
 "aIS" = (
@@ -14810,9 +14805,9 @@
 /area/station/science/research_director)
 "aIV" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/medical{
 	name = "Research Director's Office";
@@ -14832,9 +14827,9 @@
 /area/station/science/artifact)
 "aIY" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -14843,9 +14838,9 @@
 /area/station/maintenance/south)
 "aIZ" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/escape{
 	dir = 8
@@ -14853,9 +14848,9 @@
 /area/station/hallway/secondary/exit)
 "aJa" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -14867,10 +14862,10 @@
 /obj/window/reinforced/south,
 /obj/window/reinforced/west,
 /obj/securearea{
-	tag = "icon-space";
-	name = "VACUUM AREA";
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space"
+	icon_state = "space";
+	name = "VACUUM AREA";
+	tag = "icon-space"
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
@@ -14895,64 +14890,64 @@
 /area/station/hallway/secondary/entry)
 "aJf" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "aJg" = (
 /obj/machinery/camera{
-	network = "SS13";
-	c_tag = "Arrival Shuttle Hallway West"
+	c_tag = "Arrival Shuttle Hallway West";
+	network = "SS13"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "aJh" = (
 /turf/simulated/floor{
-	tag = "icon-L1";
-	icon_state = "L1"
+	icon_state = "L1";
+	tag = "icon-L1"
 	},
 /area/station/hallway/secondary/entry)
 "aJi" = (
 /turf/simulated/floor{
-	tag = "icon-L3";
-	icon_state = "L3"
+	icon_state = "L3";
+	tag = "icon-L3"
 	},
 /area/station/hallway/secondary/entry)
 "aJj" = (
 /turf/simulated/floor{
-	tag = "icon-L5";
-	icon_state = "L5"
+	icon_state = "L5";
+	tag = "icon-L5"
 	},
 /area/station/hallway/secondary/entry)
 "aJk" = (
 /turf/simulated/floor{
-	tag = "icon-L7";
-	icon_state = "L7"
+	icon_state = "L7";
+	tag = "icon-L7"
 	},
 /area/station/hallway/secondary/entry)
 "aJl" = (
 /turf/simulated/floor{
-	tag = "icon-L9";
-	icon_state = "L9"
+	icon_state = "L9";
+	tag = "icon-L9"
 	},
 /area/station/hallway/secondary/entry)
 "aJm" = (
 /turf/simulated/floor{
-	tag = "icon-L11";
-	icon_state = "L11"
+	icon_state = "L11";
+	tag = "icon-L11"
 	},
 /area/station/hallway/secondary/entry)
 "aJn" = (
 /turf/simulated/floor{
-	tag = "icon-L13";
-	icon_state = "L13"
+	icon_state = "L13";
+	tag = "icon-L13"
 	},
 /area/station/hallway/secondary/entry)
 "aJo" = (
 /turf/simulated/floor{
-	tag = "icon-L15";
-	icon_state = "L15"
+	icon_state = "L15";
+	tag = "icon-L15"
 	},
 /area/station/hallway/secondary/entry)
 "aJp" = (
@@ -14960,9 +14955,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
@@ -15032,9 +15027,9 @@
 /area/station/quartermaster/office)
 "aJB" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
@@ -15049,8 +15044,8 @@
 /area/station/maintenance/SWmaint)
 "aJE" = (
 /obj/machinery/camera{
-	network = "SS13";
-	c_tag = "North Maint Hallway East"
+	c_tag = "North Maint Hallway East";
+	network = "SS13"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
@@ -15185,8 +15180,8 @@
 /area/station/storage/autolathe)
 "aJW" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -15195,9 +15190,9 @@
 /area/station/hallway/primary/central)
 "aJX" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -15237,8 +15232,8 @@
 /area/station/storage/primary)
 "aKc" = (
 /obj/machinery/camera{
-	network = "SS13";
-	c_tag = "Secure Storage"
+	c_tag = "Secure Storage";
+	network = "SS13"
 	},
 /obj/table/auto,
 /obj/item/storage/belt/utility,
@@ -15265,17 +15260,17 @@
 /area/station/storage/primary)
 "aKg" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purple/corner,
 /area/station/hallway/primary/east)
 "aKh" = (
 /obj/storage/closet/emergency,
 /turf/simulated/floor/purple/side{
-	icon_state = "purple";
-	dir = 6
+	dir = 6;
+	icon_state = "purple"
 	},
 /area/station/hallway/primary/east)
 "aKi" = (
@@ -15283,8 +15278,8 @@
 	dir = 1
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/disposalpipe/segment,
 /obj/machinery/networked/storage/tape_drive{
@@ -15302,8 +15297,8 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/white,
 /area/station/science/construction)
@@ -15314,8 +15309,8 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/white,
 /area/station/science/construction)
@@ -15342,23 +15337,23 @@
 /area/station/science/construction)
 "aKn" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 1
+	dir = 1;
+	icon_state = "purpleblack"
 	},
 /area/station/science)
 "aKo" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 5
+	dir = 5;
+	icon_state = "purpleblack"
 	},
 /area/station/science)
 "aKp" = (
@@ -15385,8 +15380,8 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/wood/two,
 /area/station/science/research_director)
@@ -15395,22 +15390,22 @@
 	dir = 1
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/wood/two,
 /area/station/science/research_director)
 "aKu" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/alarm{
 	id = "rd_lam";
@@ -15421,44 +15416,44 @@
 /area/station/science/research_director)
 "aKv" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/false_wall/reinforced,
 /area/station/science/artifact)
 "aKw" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /obj/lrteleporter,
 /turf/simulated/floor/white,
 /area/station/science/artifact)
 "aKx" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/white,
 /area/station/science/artifact)
 "aKy" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/camera{
 	c_tag = "Artifact Lab";
@@ -15470,14 +15465,14 @@
 /area/station/science/artifact)
 "aKz" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/table/auto,
 /obj/item/storage/toolbox/mechanical,
@@ -15488,9 +15483,9 @@
 /area/station/science/artifact)
 "aKA" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/r_wall,
 /area/station/science/artifact)
@@ -15505,9 +15500,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
@@ -15518,8 +15513,8 @@
 /area/station/hallway/secondary/exit)
 "aKE" = (
 /obj/machinery/camera{
-	dir = 8;
-	c_tag = "Escape Shuttle Hallway Northeast"
+	c_tag = "Escape Shuttle Hallway Northeast";
+	dir = 8
 	},
 /turf/simulated/floor/escape{
 	dir = 4
@@ -15527,71 +15522,71 @@
 /area/station/hallway/secondary/exit)
 "aKF" = (
 /turf/simulated/floor/escape/corner{
-	icon_state = "escapecorner";
-	dir = 4
+	dir = 4;
+	icon_state = "escapecorner"
 	},
 /area/station/hallway/secondary/exit)
 "aKG" = (
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/escape{
-	icon_state = "escape";
-	dir = 1
+	dir = 1;
+	icon_state = "escape"
 	},
 /area/station/hallway/secondary/exit)
 "aKH" = (
 /obj/machinery/light,
 /turf/simulated/floor{
-	tag = "icon-L2";
-	icon_state = "L2"
+	icon_state = "L2";
+	tag = "icon-L2"
 	},
 /area/station/hallway/secondary/entry)
 "aKI" = (
 /turf/simulated/floor{
-	tag = "icon-L4";
-	icon_state = "L4"
+	icon_state = "L4";
+	tag = "icon-L4"
 	},
 /area/station/hallway/secondary/entry)
 "aKJ" = (
 /turf/simulated/floor{
-	tag = "icon-L6";
-	icon_state = "L6"
+	icon_state = "L6";
+	tag = "icon-L6"
 	},
 /area/station/hallway/secondary/entry)
 "aKK" = (
 /turf/simulated/floor{
-	tag = "icon-L8";
-	icon_state = "L8"
+	icon_state = "L8";
+	tag = "icon-L8"
 	},
 /area/station/hallway/secondary/entry)
 "aKL" = (
 /turf/simulated/floor{
-	tag = "icon-L10";
-	icon_state = "L10"
+	icon_state = "L10";
+	tag = "icon-L10"
 	},
 /area/station/hallway/secondary/entry)
 "aKM" = (
 /turf/simulated/floor{
-	tag = "icon-L12";
-	icon_state = "L12"
+	icon_state = "L12";
+	tag = "icon-L12"
 	},
 /area/station/hallway/secondary/entry)
 "aKN" = (
 /turf/simulated/floor{
-	tag = "icon-L14";
-	icon_state = "L14"
+	icon_state = "L14";
+	tag = "icon-L14"
 	},
 /area/station/hallway/secondary/entry)
 "aKO" = (
 /obj/machinery/light,
 /turf/simulated/floor{
-	tag = "icon-L16";
-	icon_state = "L16"
+	icon_state = "L16";
+	tag = "icon-L16"
 	},
 /area/station/hallway/secondary/entry)
 "aKP" = (
 /obj/machinery/camera{
-	dir = 4;
-	c_tag = "West Hallway South"
+	c_tag = "West Hallway South";
+	dir = 4
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 10
@@ -15599,9 +15594,9 @@
 /area/station/hallway/secondary/entry)
 "aKQ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellow/side,
 /area/station/hallway/primary/west)
@@ -15725,9 +15720,9 @@
 /area/station/storage/primary)
 "aLn" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 4
@@ -15735,12 +15730,12 @@
 /area/station/hallway/primary/east)
 "aLo" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
@@ -15751,17 +15746,17 @@
 /area/station/science/research_director)
 "aLp" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/storage/crate/medical,
 /turf/simulated/floor/wood/two,
 /area/station/science/research_director)
 "aLq" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -15770,15 +15765,15 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 8
+	dir = 8;
+	icon_state = "purpleblack"
 	},
 /area/station/science)
 "aLr" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /obj/cable{
@@ -15788,9 +15783,9 @@
 /area/station/science/construction)
 "aLs" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "1-8"
@@ -15802,25 +15797,25 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
 /area/station/science/construction)
 "aLu" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/white,
 /area/station/science/construction)
@@ -15835,14 +15830,14 @@
 /area/station/science/construction)
 "aLw" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/black,
 /area/station/science)
@@ -15853,8 +15848,8 @@
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 4
+	dir = 4;
+	icon_state = "purpleblack"
 	},
 /area/station/science)
 "aLy" = (
@@ -15895,17 +15890,17 @@
 	name = "Scientist"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/science/artifact)
 "aLF" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/science/artifact)
@@ -15921,16 +15916,16 @@
 /area/station/maintenance/south)
 "aLI" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
 "aLJ" = (
 /turf/simulated/floor/escape{
-	icon_state = "escape";
-	dir = 1
+	dir = 1;
+	icon_state = "escape"
 	},
 /area/station/hallway/secondary/exit)
 "aLK" = (
@@ -15957,10 +15952,10 @@
 /obj/window/reinforced/north,
 /obj/window/reinforced/west,
 /obj/securearea{
-	tag = "icon-space";
-	name = "VACUUM AREA";
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space"
+	icon_state = "space";
+	name = "VACUUM AREA";
+	tag = "icon-space"
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
@@ -15993,17 +15988,17 @@
 /area/station/hallway/secondary/entry)
 "aLS" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/wall,
 /area/station/hallway/secondary/entry)
 "aLT" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall,
 /area/station/hallway/secondary/entry)
@@ -16075,9 +16070,9 @@
 /area/station/quartermaster/office)
 "aMf" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -16100,13 +16095,13 @@
 /obj/grille/steel,
 /obj/window/reinforced/south,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 1;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 8;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /turf/simulated/floor/plating,
@@ -16115,14 +16110,14 @@
 /obj/grille/steel,
 /obj/window/reinforced/south,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	invisibility = 0;
 	reinf = 1
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 1;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /turf/simulated/floor/plating,
@@ -16139,18 +16134,18 @@
 "aMn" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/window/northleft{
-	tag = "icon-left";
+	dir = 2;
 	icon_state = "left";
-	dir = 2
+	tag = "icon-left"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/cafeteria)
 "aMo" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/window/northright{
-	tag = "icon-right";
+	dir = 2;
 	icon_state = "right";
-	dir = 2
+	tag = "icon-right"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/cafeteria)
@@ -16220,9 +16215,9 @@
 	name = "Staff Assistant"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/storage/primary)
@@ -16231,9 +16226,9 @@
 	name = "Staff Assistant"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/storage/primary)
@@ -16249,8 +16244,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/blue/side{
-	icon_state = "blue";
-	dir = 8
+	dir = 8;
+	icon_state = "blue"
 	},
 /area/station/hallway/primary/east)
 "aMD" = (
@@ -16265,9 +16260,9 @@
 /area/station/science/research_director)
 "aME" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/critter/domestic_bee/heisenbee,
 /turf/simulated/floor/wood/two,
@@ -16279,20 +16274,20 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 9
+	dir = 9;
+	icon_state = "purpleblack"
 	},
 /area/station/science)
 "aMG" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -16300,15 +16295,15 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/purpleblack/corner{
-	icon_state = "purpleblackcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "purpleblackcorner"
 	},
 /area/station/science)
 "aMH" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/r_wall,
 /area/station/science/construction)
@@ -16320,9 +16315,9 @@
 	},
 /obj/disposalpipe/segment,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/table/auto,
 /obj/item/disk/data/tape{
@@ -16333,18 +16328,18 @@
 /area/station/science/construction)
 "aMJ" = (
 /obj/stool/chair/office{
-	icon_state = "office_chair";
-	dir = 4
+	dir = 4;
+	icon_state = "office_chair"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/white,
 /area/station/science/construction)
@@ -16362,9 +16357,9 @@
 /area/station/science/construction)
 "aML" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -16409,9 +16404,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/science)
@@ -16426,14 +16421,14 @@
 /area/station/science/storage)
 "aMS" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/storage/closet/office,
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 4
+	dir = 4;
+	icon_state = "purpleblack"
 	},
 /area/station/science)
 "aMT" = (
@@ -16449,16 +16444,16 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/wood/two,
 /area/station/science/research_director)
 "aMV" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/white,
@@ -16472,13 +16467,13 @@
 "aMX" = (
 /obj/cable,
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /obj/machinery/networked/teleconsole{
-	icon_state = "s_teleport";
-	dir = 8
+	dir = 8;
+	icon_state = "s_teleport"
 	},
 /obj/machinery/door_control{
 	id = "scienceteleporter";
@@ -16495,8 +16490,8 @@
 	pixel_x = -1
 	},
 /turf/simulated/floor/escape{
-	icon_state = "escape";
-	dir = 1
+	dir = 1;
+	icon_state = "escape"
 	},
 /area/station/hallway/secondary/exit)
 "aMZ" = (
@@ -16540,8 +16535,8 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/red/side{
 	dir = 5
@@ -16549,9 +16544,9 @@
 /area/station/security/checkpoint/arrivals)
 "aNg" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall,
 /area/station/security/checkpoint/arrivals)
@@ -16631,8 +16626,8 @@
 "aNt" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/purple/side{
-	icon_state = "purple";
-	dir = 10
+	dir = 10;
+	icon_state = "purple"
 	},
 /area/station/hallway/primary/east)
 "aNu" = (
@@ -16651,9 +16646,9 @@
 /area/station/hallway/primary/north)
 "aNw" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -16686,15 +16681,13 @@
 /turf/simulated/floor/white,
 /area/station/crew_quarters/cafeteria)
 "aNB" = (
-/obj/item/device/radio/intercom{
-	
-	},
+/obj/item/device/radio/intercom,
 /turf/simulated/floor/white,
 /area/station/crew_quarters/cafeteria)
 "aNC" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -16739,18 +16732,18 @@
 /area/station/maintenance/maintcentral)
 "aNI" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "aNJ" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -16762,13 +16755,13 @@
 "aNL" = (
 /obj/item/extinguisher,
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -16776,8 +16769,8 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor,
 /area/station/storage/primary)
@@ -16794,9 +16787,9 @@
 /area/station/storage/primary)
 "aNN" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /obj/item/rods{
 	amount = 50
@@ -16805,16 +16798,16 @@
 /area/station/storage/primary)
 "aNO" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	icon_state = "1-8"
 	},
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	icon_state = "chair"
 	},
 /turf/simulated/floor/wood/two,
 /area/station/science/research_director)
@@ -16858,19 +16851,19 @@
 "aNU" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 8
+	dir = 8;
+	icon_state = "purpleblack"
 	},
 /area/station/science)
 "aNV" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/storage/closet/port_a_sci,
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 4
+	dir = 4;
+	icon_state = "purpleblack"
 	},
 /area/station/science)
 "aNW" = (
@@ -16909,9 +16902,9 @@
 /obj/grille/steel,
 /obj/window/reinforced/north,
 /obj/window/reinforced/north{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced/south,
 /obj/window/reinforced/west,
@@ -16938,9 +16931,9 @@
 	p_open = 1
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -16956,9 +16949,9 @@
 /obj/grille/steel,
 /obj/window/reinforced/north,
 /obj/window/reinforced/north{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced/south,
 /obj/window/reinforced/west,
@@ -16978,9 +16971,9 @@
 /area/station/science/artifact)
 "aOg" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Chapel";
@@ -17009,22 +17002,22 @@
 	dir = 1
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/security/checkpoint/arrivals)
 "aOl" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/security/checkpoint/arrivals)
@@ -17035,9 +17028,9 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -17067,9 +17060,9 @@
 /area/station/hallway/secondary/entry)
 "aOq" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/arrival{
 	dir = 1
@@ -17086,30 +17079,30 @@
 /obj/window/reinforced/west,
 /obj/window/reinforced/south,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster)
 "aOt" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "aOu" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
@@ -17155,9 +17148,9 @@
 /area/station/hallway/primary/north)
 "aOB" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/neutral/side,
 /area/station/hallway/primary/north)
@@ -17173,19 +17166,19 @@
 "aOD" = (
 /obj/grille/steel,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 1;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	invisibility = 0;
 	reinf = 1
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 8;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /turf/simulated/floor/plating,
@@ -17193,19 +17186,19 @@
 "aOE" = (
 /obj/grille/steel,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 8;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	invisibility = 0;
 	reinf = 1
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 1;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /turf/simulated/floor/plating,
@@ -17229,9 +17222,9 @@
 "aOI" = (
 /obj/table/auto,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/cafeteria)
@@ -17264,9 +17257,9 @@
 	dir = 1
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -17287,9 +17280,9 @@
 "aOQ" = (
 /obj/reagent_dispensers/fueltank,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/storage/primary)
@@ -17362,9 +17355,7 @@
 /obj/item/sheet/glass{
 	amount = 50
 	},
-/obj/item/device/radio/intercom{
-	
-	},
+/obj/item/device/radio/intercom,
 /turf/simulated/floor,
 /area/station/storage/primary)
 "aPa" = (
@@ -17384,9 +17375,9 @@
 	dir = 1
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -17404,9 +17395,9 @@
 /area/station/science)
 "aPe" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood/two,
 /area/station/science/research_director)
@@ -17451,15 +17442,15 @@
 	name = "mail chute-'science'"
 	},
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 4
+	dir = 4;
+	icon_state = "purpleblack"
 	},
 /area/station/science)
 "aPm" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/camera{
-	dir = 4;
-	c_tag = "science Storage"
+	c_tag = "science Storage";
+	dir = 4
 	},
 /turf/simulated/floor/grime,
 /area/station/science/gen_storage)
@@ -17477,9 +17468,9 @@
 /area/station/science/artifact)
 "aPp" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine{
 	allows_vehicles = 0
@@ -17497,40 +17488,40 @@
 /area/station/hallway/secondary/exit)
 "aPs" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/machinery/light,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/escape,
 /area/station/hallway/secondary/exit)
 "aPt" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/escape,
 /area/station/hallway/secondary/exit)
 "aPu" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/escape,
 /area/station/hallway/secondary/exit)
 "aPv" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/item/device/radio/beacon,
 /turf/simulated/floor,
@@ -17548,9 +17539,9 @@
 /area/station/hallway/secondary/exit)
 "aPx" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/escape/corner{
 	dir = 8
@@ -17599,9 +17590,7 @@
 "aPE" = (
 /obj/item/crowbar,
 /obj/machinery/light,
-/obj/item/device/radio/intercom{
-	
-	},
+/obj/item/device/radio/intercom,
 /obj/item/device/flash,
 /turf/simulated/floor/red/side{
 	dir = 6
@@ -17616,8 +17605,8 @@
 /area/station/maintenance/west)
 "aPG" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/arrival{
 	dir = 4
@@ -17631,9 +17620,9 @@
 /area/station/hallway/primary/west)
 "aPI" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -17656,14 +17645,14 @@
 /area/station/quartermaster/office)
 "aPL" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/camera{
 	c_tag = "Quartermaster Reception Desk";
@@ -17683,9 +17672,9 @@
 /area/station/hydroponics)
 "aPO" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall,
 /area/station/hallway/primary/central)
@@ -17698,14 +17687,14 @@
 "aPQ" = (
 /obj/grille/steel,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	invisibility = 0;
 	reinf = 1
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 8;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /turf/simulated/floor/plating,
@@ -17713,13 +17702,13 @@
 "aPR" = (
 /obj/grille/steel,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 8;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	invisibility = 0;
 	reinf = 1
 	},
@@ -17758,9 +17747,9 @@
 /obj/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -17769,9 +17758,9 @@
 /area/station/maintenance/SEmaint)
 "aPY" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall,
 /area/station/storage/primary)
@@ -17783,14 +17772,14 @@
 /area/station/storage/primary)
 "aQa" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 4
@@ -17835,9 +17824,9 @@
 /area/station/science/construction)
 "aQg" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/window/reinforced/south,
 /turf/simulated/floor/wood/two,
@@ -17845,9 +17834,9 @@
 "aQh" = (
 /obj/window/reinforced/south,
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/wood/two,
 /area/station/science/research_director)
@@ -17857,8 +17846,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 8
+	dir = 8;
+	icon_state = "purpleblack"
 	},
 /area/station/science)
 "aQj" = (
@@ -17875,9 +17864,9 @@
 /area/station/science/research_director)
 "aQk" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/blob{
 	name = "Berry The Blob"
@@ -17886,9 +17875,9 @@
 /area/station/science/research_director)
 "aQl" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/engine{
 	allows_vehicles = 0
@@ -17897,8 +17886,8 @@
 "aQm" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/telepad,
@@ -17926,17 +17915,17 @@
 /area/station/maintenance/south)
 "aQq" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall,
 /area/station/maintenance/south)
 "aQr" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall,
 /area/station/hallway/secondary/exit)
@@ -17953,13 +17942,13 @@
 	reinf = 1
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 1;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 8;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /turf/simulated/floor/plating,
@@ -17971,8 +17960,8 @@
 	reinf = 1
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 1;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /turf/simulated/floor/plating,
@@ -17984,13 +17973,13 @@
 	reinf = 1
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 1;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	invisibility = 0;
 	reinf = 1
 	},
@@ -18025,9 +18014,9 @@
 /area/station/quartermaster/office)
 "aQA" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/item/device/radio/intercom{
 	dir = 8
@@ -18056,8 +18045,8 @@
 	dir = 1
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -18101,19 +18090,19 @@
 "aQJ" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /turf/simulated/floor,
 /area/station/hydroponics)
@@ -18152,9 +18141,9 @@
 /area/station/hydroponics)
 "aQN" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/neutral/side{
@@ -18163,22 +18152,22 @@
 /area/station/hallway/primary/north)
 "aQO" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "aQP" = (
 /obj/grille/steel,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 8;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /obj/window/reinforced/south,
@@ -18187,13 +18176,13 @@
 "aQQ" = (
 /obj/grille/steel,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 8;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	invisibility = 0;
 	reinf = 1
 	},
@@ -18203,9 +18192,9 @@
 "aQR" = (
 /obj/table/auto,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/item/reagent_containers/food/drinks/drinkingglass,
 /turf/simulated/floor/white,
@@ -18213,8 +18202,8 @@
 "aQS" = (
 /obj/table/auto,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 8;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /obj/item/kitchen/food_box/donut_box,
@@ -18238,16 +18227,14 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "aQW" = (
-/obj/item/device/radio/intercom{
-	
-	},
+/obj/item/device/radio/intercom,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "aQX" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
@@ -18272,9 +18259,9 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 4
@@ -18296,8 +18283,8 @@
 "aRd" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -18306,25 +18293,25 @@
 	pixel_y = 0
 	},
 /obj/window{
-	tag = "icon-window";
-	icon_state = "window";
 	dir = 2;
-	reinf = 1
+	icon_state = "window";
+	reinf = 1;
+	tag = "icon-window"
 	},
 /turf/simulated/floor/grime,
 /area/station/science/gen_storage)
 "aRe" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/window{
-	tag = "icon-window";
-	icon_state = "window";
 	dir = 2;
-	reinf = 1
+	icon_state = "window";
+	reinf = 1;
+	tag = "icon-window"
 	},
 /turf/simulated/floor,
 /area/station/science/gen_storage)
@@ -18339,29 +18326,29 @@
 /area/station/science/gen_storage)
 "aRh" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/industrial,
 /area/station/science/gen_storage)
 "aRi" = (
 /obj/storage/secure/closet/research,
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 8
+	dir = 8;
+	icon_state = "purpleblack"
 	},
 /area/station/science)
 "aRj" = (
 /turf/simulated/floor/purpleblack/corner{
-	icon_state = "purpleblackcorner";
-	dir = 8
+	dir = 8;
+	icon_state = "purpleblackcorner"
 	},
 /area/station/science)
 "aRk" = (
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 1
+	dir = 1;
+	icon_state = "purpleblack"
 	},
 /area/station/science)
 "aRl" = (
@@ -18373,9 +18360,9 @@
 /area/station/science/research_director)
 "aRm" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/grille/steel,
 /obj/window/reinforced/east,
@@ -18416,9 +18403,9 @@
 /obj/window/reinforced/north,
 /obj/window/reinforced/south,
 /obj/window/reinforced/north{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/cable{
 	d2 = 8;
@@ -18495,9 +18482,9 @@
 /area/station/quartermaster/storage)
 "aRz" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellow,
 /area/station/quartermaster)
@@ -18538,9 +18525,9 @@
 /area/station/quartermaster/office)
 "aRF" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/delivery,
 /area/station/quartermaster/office)
@@ -18559,23 +18546,23 @@
 /area/station/hydroponics)
 "aRI" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/green,
 /area/station/hydroponics)
 "aRJ" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /turf/simulated/floor,
 /area/station/hydroponics)
@@ -18634,17 +18621,17 @@
 /area/station/crew_quarters/cafeteria)
 "aRQ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/cafeteria)
 "aRR" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/landmark{
 	name = "peststart"
@@ -18654,9 +18641,9 @@
 "aRS" = (
 /obj/table/auto,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -18666,9 +18653,9 @@
 /area/station/crew_quarters/kitchen)
 "aRT" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
@@ -18681,8 +18668,8 @@
 /area/station/crew_quarters/kitchen)
 "aRV" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -18696,9 +18683,9 @@
 /area/station/crew_quarters/kitchen)
 "aRX" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -18707,22 +18694,22 @@
 /area/station/hallway/primary/central)
 "aRY" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "aRZ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
 /obj/cable{
@@ -18732,43 +18719,43 @@
 /area/station/hallway/primary/central)
 "aSa" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "aSb" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall,
 /area/station/hallway/primary/central)
 "aSc" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "aSd" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
@@ -18779,9 +18766,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
@@ -18796,8 +18783,8 @@
 "aSg" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 1
+	dir = 1;
+	icon_state = "purpleblack"
 	},
 /area/station/science)
 "aSh" = (
@@ -18806,13 +18793,13 @@
 	pltanks = 15
 	},
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 5
+	dir = 5;
+	icon_state = "purpleblack"
 	},
 /area/station/science)
 "aSi" = (
@@ -18832,9 +18819,9 @@
 /area/station/science/gen_storage)
 "aSk" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/item/device/analyzer/atmospheric,
 /obj/decal/tile_edge/stripe/extra_big,
@@ -18842,9 +18829,9 @@
 /area/station/science/gen_storage)
 "aSl" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/space,
 /area)
@@ -18881,9 +18868,9 @@
 /area/station/maintenance/south)
 "aSr" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/table/reinforced/auto,
 /turf/simulated/floor{
@@ -18952,9 +18939,9 @@
 /area/station/quartermaster/storage)
 "aSD" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
@@ -18977,23 +18964,23 @@
 "aSG" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced/south,
 /turf/simulated/floor,
 /area/station/hydroponics)
 "aSH" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/decal/tile_edge/line/green{
 	dir = 1;
@@ -19032,13 +19019,13 @@
 "aSL" = (
 /obj/grille/steel,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 1;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 8;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /obj/window/reinforced/south,
@@ -19047,13 +19034,13 @@
 "aSM" = (
 /obj/grille/steel,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 1;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /obj/window/reinforced/south,
@@ -19114,8 +19101,8 @@
 "aSU" = (
 /obj/table/auto,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 1;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /obj/window/reinforced/west,
@@ -19143,22 +19130,22 @@
 	name = "Chef"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "aSX" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -19169,17 +19156,17 @@
 /area/station/crew_quarters/kitchen)
 "aSY" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "aSZ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -19211,9 +19198,9 @@
 /area/station/maintenance/SEmaint)
 "aTd" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -19223,8 +19210,8 @@
 "aTe" = (
 /obj/item/cigbutt,
 /obj/decal/tile_edge/stripe/extra_big{
-	icon_state = "xtra_bigstripe-edge";
-	dir = 6
+	dir = 6;
+	icon_state = "xtra_bigstripe-edge"
 	},
 /turf/simulated/floor,
 /area/station/science/gen_storage)
@@ -19238,8 +19225,8 @@
 "aTg" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 8
+	dir = 8;
+	icon_state = "purpleblack"
 	},
 /area/station/science)
 "aTh" = (
@@ -19256,17 +19243,17 @@
 "aTj" = (
 /obj/storage/closet/biohazard,
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 4
+	dir = 4;
+	icon_state = "purpleblack"
 	},
 /area/station/science)
 "aTk" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/window{
-	tag = "icon-window";
-	icon_state = "window";
 	dir = 2;
-	reinf = 1
+	icon_state = "window";
+	reinf = 1;
+	tag = "icon-window"
 	},
 /turf/simulated/floor/grime,
 /area/station/science/gen_storage)
@@ -19280,9 +19267,9 @@
 /area/station/science/gen_storage)
 "aTm" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/r_wall,
 /area/station/science/lab)
@@ -19301,9 +19288,9 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/black,
 /area/station/maintenance/south)
@@ -19330,9 +19317,9 @@
 /area/station/maintenance/south)
 "aTt" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/table/reinforced/auto,
 /turf/simulated/floor{
@@ -19341,9 +19328,9 @@
 /area/station/maintenance/south)
 "aTu" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/black,
 /area/station/maintenance/south)
@@ -19363,10 +19350,10 @@
 /obj/window/reinforced/east,
 /obj/window/reinforced/south,
 /obj/securearea{
-	tag = "icon-space";
-	name = "VACUUM AREA";
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space"
+	icon_state = "space";
+	name = "VACUUM AREA";
+	tag = "icon-space"
 	},
 /turf/simulated/floor/plating,
 /area/station/quartermaster/storage)
@@ -19384,8 +19371,8 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk,
@@ -19393,8 +19380,8 @@
 /area/station/quartermaster/storage)
 "aTA" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer/supplycomp,
@@ -19432,16 +19419,14 @@
 /area/station/quartermaster/storage)
 "aTG" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/manufacturer/general,
 /turf/simulated/floor,
 /area/station/quartermaster/storage)
 "aTH" = (
-/obj/item/device/radio/intercom{
-	
-	},
+/obj/item/device/radio/intercom,
 /obj/machinery/light_switch{
 	pixel_x = 25
 	},
@@ -19456,14 +19441,14 @@
 /area/station/quartermaster/office)
 "aTJ" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
@@ -19491,8 +19476,8 @@
 /obj/disposalpipe/trunk,
 /obj/machinery/disposal,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
@@ -19516,9 +19501,9 @@
 "aTP" = (
 /obj/disposalpipe/segment,
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 8
@@ -19526,13 +19511,13 @@
 /area/station/hallway/primary/north)
 "aTQ" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 4
+	dir = 4;
+	icon_state = "greyblack"
 	},
 /area/station/hallway/primary/central)
 "aTR" = (
@@ -19549,9 +19534,9 @@
 /area/station/crew_quarters/kitchen)
 "aTT" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/critter/mouse/remy,
 /turf/simulated/floor/specialroom/cafeteria,
@@ -19580,26 +19565,26 @@
 "aTX" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/blue/side{
-	icon_state = "blue";
-	dir = 8
+	dir = 8;
+	icon_state = "blue"
 	},
 /area/station/hallway/primary/east)
 "aTY" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/disposalpipe/segment,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/blue/side{
-	icon_state = "blue";
-	dir = 8
+	dir = 8;
+	icon_state = "blue"
 	},
 /area/station/hallway/primary/east)
 "aTZ" = (
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 9
+	dir = 9;
+	icon_state = "greyblack"
 	},
 /area/station/hallway/primary/central)
 "aUa" = (
@@ -19608,9 +19593,9 @@
 	pixel_x = 24
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 4
@@ -19619,20 +19604,20 @@
 "aUb" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/window{
-	tag = "icon-window";
-	icon_state = "window";
 	dir = 2;
-	reinf = 1
+	icon_state = "window";
+	reinf = 1;
+	tag = "icon-window"
 	},
 /turf/simulated/floor,
 /area/station/science/gen_storage)
 "aUc" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/window{
-	tag = "icon-window";
-	icon_state = "window";
 	dir = 2;
-	reinf = 1
+	icon_state = "window";
+	reinf = 1;
+	tag = "icon-window"
 	},
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
@@ -19641,9 +19626,9 @@
 /area/station/science/gen_storage)
 "aUd" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/industrial,
 /area/station/science/gen_storage)
@@ -19656,13 +19641,13 @@
 "aUf" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 8
+	dir = 8;
+	icon_state = "purpleblack"
 	},
 /area/station/science)
 "aUg" = (
@@ -19690,9 +19675,9 @@
 "aUj" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/grime,
 /area/station/science/gen_storage)
@@ -19737,12 +19722,12 @@
 "aUq" = (
 /obj/table/reinforced/bar/auto,
 /obj/decal/tile_edge/line/grey{
-	icon_state = "noedge-tile1";
-	dir = 5
+	dir = 5;
+	icon_state = "noedge-tile1"
 	},
 /obj/decal/tile_edge/line/yellow{
-	icon_state = "tile1";
-	dir = 6
+	dir = 6;
+	icon_state = "tile1"
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/bar)
@@ -19761,8 +19746,8 @@
 	dir = 4
 	},
 /obj/machinery/computer/stockexchange{
-	icon_state = "QMreq";
-	dir = 4
+	dir = 4;
+	icon_state = "QMreq"
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/bar)
@@ -19772,14 +19757,14 @@
 /area/station/hallway/secondary/exit)
 "aUu" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/grille/steel,
 /obj/window/reinforced/west,
@@ -19859,9 +19844,9 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 2;
@@ -19874,25 +19859,25 @@
 	name = "Quartermaster"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/storage)
 "aUE" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/storage)
 "aUF" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -19903,9 +19888,9 @@
 /area/station/quartermaster/storage)
 "aUG" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -19919,17 +19904,17 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "aUI" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/landmark/start{
 	name = "Botanist"
@@ -19946,8 +19931,8 @@
 /area/station/hydroponics)
 "aUK" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
@@ -19969,9 +19954,9 @@
 /area/station/hydroponics)
 "aUM" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -19986,14 +19971,14 @@
 /area/station/hydroponics)
 "aUN" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Quartermasters";
@@ -20025,13 +20010,13 @@
 "aUR" = (
 /obj/table/auto,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 8;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 1;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /obj/disposalpipe/segment{
@@ -20094,37 +20079,37 @@
 "aUW" = (
 /obj/grille/steel,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 1;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	invisibility = 0;
 	reinf = 1
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 8;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "aUX" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "aUY" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/landmark{
 	name = "blobstart";
@@ -20146,16 +20131,16 @@
 /area/station/maintenance/SEmaint)
 "aVb" = (
 /obj/machinery/camera{
-	dir = 4;
-	c_tag = "East Hallway South"
+	c_tag = "East Hallway South";
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aVc" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
@@ -20164,36 +20149,36 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aVe" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aVf" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 4
@@ -20201,16 +20186,16 @@
 /area/station/hallway/primary/east)
 "aVg" = (
 /obj/decal/tile_edge/stripe/extra_big{
-	icon_state = "xtra_bigstripe-edge";
-	dir = 9
+	dir = 9;
+	icon_state = "xtra_bigstripe-edge"
 	},
 /turf/simulated/floor,
 /area/station/science/gen_storage)
 "aVh" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/decal/tile_edge/stripe/extra_big{
-	icon_state = "xtra_bigstripe-edge";
-	dir = 1
+	dir = 1;
+	icon_state = "xtra_bigstripe-edge"
 	},
 /turf/simulated/floor,
 /area/station/science/gen_storage)
@@ -20226,12 +20211,12 @@
 "aVj" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/decal/tile_edge/stripe/extra_big{
-	icon_state = "xtra_bigstripe-corner2";
-	dir = 9
+	dir = 9;
+	icon_state = "xtra_bigstripe-corner2"
 	},
 /turf/simulated/floor/grime,
 /area/station/science/gen_storage)
@@ -20260,25 +20245,25 @@
 /area/station/science/gen_storage)
 "aVm" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall,
 /area/station/science/gen_storage)
 "aVn" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/r_wall,
 /area/station/science/gen_storage)
 "aVo" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/r_wall,
 /area/station/science/lab)
@@ -20321,8 +20306,8 @@
 /obj/window/reinforced/south,
 /obj/window/reinforced/north,
 /obj/window/reinforced/west{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/hangar/main)
@@ -20363,9 +20348,9 @@
 /area/station/quartermaster/storage)
 "aVB" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /obj/machinery/conveyor{
 	dir = 1;
@@ -20430,9 +20415,9 @@
 /area/station/quartermaster/office)
 "aVK" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/portable_reclaimer,
 /turf/simulated/floor,
@@ -20458,14 +20443,14 @@
 /area/station/hydroponics)
 "aVO" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -20474,17 +20459,17 @@
 	dir = 1
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "aVQ" = (
 /obj/grille/steel,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 1;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /obj/window/reinforced/south,
@@ -20493,41 +20478,41 @@
 "aVR" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/window/northleft{
-	tag = "icon-left";
+	dir = 2;
 	icon_state = "left";
-	dir = 2
+	tag = "icon-left"
 	},
 /turf/simulated/floor/white,
 /area/station/hallway/primary/central)
 "aVS" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/window/northright{
-	tag = "icon-right";
+	dir = 2;
 	icon_state = "right";
-	dir = 2
+	tag = "icon-right"
 	},
 /turf/simulated/floor/white,
 /area/station/hallway/primary/central)
 "aVT" = (
 /obj/grille/steel,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	invisibility = 0;
 	reinf = 1
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 8;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "aVU" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -20588,29 +20573,27 @@
 "aWa" = (
 /obj/storage/secure/closet/research/uniform,
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 4
+	dir = 4;
+	icon_state = "purpleblack"
 	},
 /area/station/science)
 "aWb" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/item/device/radio/intercom{
-	
-	},
+/obj/item/device/radio/intercom,
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 1
+	dir = 1;
+	icon_state = "purpleblack"
 	},
 /area/station/science)
 "aWc" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/alarm{
 	id = "tox_lam";
@@ -20618,24 +20601,24 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 1
+	dir = 1;
+	icon_state = "purpleblack"
 	},
 /area/station/science)
 "aWd" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 1
+	dir = 1;
+	icon_state = "purpleblack"
 	},
 /area/station/science)
 "aWe" = (
@@ -20644,13 +20627,13 @@
 	dir = 3
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 1
+	dir = 1;
+	icon_state = "purpleblack"
 	},
 /area/station/science)
 "aWf" = (
@@ -20660,13 +20643,13 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 1
+	dir = 1;
+	icon_state = "purpleblack"
 	},
 /area/station/science)
 "aWg" = (
@@ -20689,27 +20672,27 @@
 /area/station/science/gen_storage)
 "aWj" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/industrial,
 /area/station/science/gen_storage)
 "aWk" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
@@ -20718,9 +20701,9 @@
 /area/station/science/gen_storage)
 "aWl" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/simulated/floor/grime,
@@ -20822,17 +20805,17 @@
 /area/station/quartermaster/storage)
 "aWD" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall,
 /area/station/quartermaster/office)
 "aWE" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
@@ -20840,9 +20823,9 @@
 /area/station/hydroponics)
 "aWF" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -20863,9 +20846,9 @@
 /area/station/hallway/primary/north)
 "aWH" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -20877,17 +20860,17 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "aWJ" = (
 /obj/storage/closet/emergency,
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 8
+	dir = 8;
+	icon_state = "greyblack"
 	},
 /area/station/hallway/primary/central)
 "aWK" = (
@@ -20902,53 +20885,53 @@
 "aWM" = (
 /obj/grille/steel,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	invisibility = 0;
 	reinf = 1
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 8;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central)
 "aWN" = (
 /obj/grille/steel,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	invisibility = 0;
 	reinf = 1
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 8;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "aWO" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
@@ -20983,9 +20966,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -21000,9 +20983,9 @@
 	req_access_txt = "7"
 	},
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/delivery,
 /area/station/science)
@@ -21032,30 +21015,30 @@
 /area/station/science)
 "aWY" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/light{
 	dir = 1;
 	pixel_x = -1
 	},
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 1
+	dir = 1;
+	icon_state = "purpleblack"
 	},
 /area/station/science)
 "aWZ" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 5
+	dir = 5;
+	icon_state = "purpleblack"
 	},
 /area/station/science)
 "aXa" = (
 /turf/simulated/floor/purpleblack/corner{
-	icon_state = "purpleblackcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "purpleblackcorner"
 	},
 /area/station/science)
 "aXb" = (
@@ -21069,9 +21052,9 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/red/side{
 	dir = 8
@@ -21079,9 +21062,9 @@
 /area/station/science)
 "aXd" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/medical{
 	name = "science Research";
@@ -21091,9 +21074,9 @@
 /area/station/science/lab)
 "aXe" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/medical{
@@ -21104,8 +21087,8 @@
 /area/station/science/gen_storage)
 "aXf" = (
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 10
+	dir = 10;
+	icon_state = "purpleblack"
 	},
 /area/station/science)
 "aXg" = (
@@ -21121,13 +21104,13 @@
 /area/station/science)
 "aXh" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/purpleblack/corner{
-	icon_state = "purpleblackcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "purpleblackcorner"
 	},
 /area/station/science)
 "aXi" = (
@@ -21140,9 +21123,9 @@
 /area/station/science/lab)
 "aXj" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/airlock_sensor{
 	id_tag = "tox_airlock_sensor";
@@ -21153,9 +21136,9 @@
 /area/station/science/lab)
 "aXk" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -21218,9 +21201,9 @@
 /area/station/hangar/main)
 "aXr" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hangar/main)
@@ -21299,9 +21282,9 @@
 /area/station/quartermaster/storage)
 "aXD" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -21317,9 +21300,9 @@
 /area/station/maintenance/SWmaint)
 "aXF" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/green,
 /area/station/hydroponics)
@@ -21364,9 +21347,9 @@
 /area/station/hallway/primary/south)
 "aXL" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -21381,9 +21364,9 @@
 /area/station/hallway/primary/south)
 "aXN" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -21409,14 +21392,14 @@
 /area/station/hallway/primary/central)
 "aXQ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -21425,9 +21408,9 @@
 /area/station/hallway/primary/central)
 "aXR" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -21436,9 +21419,9 @@
 /area/station/hallway/primary/central)
 "aXS" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Locker Room Hallway";
@@ -21451,9 +21434,9 @@
 /area/station/hallway/primary/central)
 "aXT" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/disposalpipe/segment{
@@ -21463,9 +21446,9 @@
 /area/station/hallway/primary/central)
 "aXU" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/disposalpipe/junction,
@@ -21481,14 +21464,14 @@
 /area/station/hallway/primary/central)
 "aXW" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -21498,17 +21481,17 @@
 	req_access_txt = "12"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/east)
 "aXY" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -21526,13 +21509,13 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
@@ -21555,14 +21538,14 @@
 /area/station/hallway/primary/east)
 "aYc" = (
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 5
+	dir = 5;
+	icon_state = "greyblack"
 	},
 /area/station/hallway/primary/east)
 "aYd" = (
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 8
+	dir = 8;
+	icon_state = "greyblack"
 	},
 /area/station/hallway/primary/central)
 "aYe" = (
@@ -21570,19 +21553,19 @@
 /area/station/chemistry)
 "aYf" = (
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 4
+	dir = 4;
+	icon_state = "greyblack"
 	},
 /area/station/hallway/primary/east)
 "aYg" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 4
+	dir = 4;
+	icon_state = "greyblack"
 	},
 /area/station/hallway/primary/east)
 "aYh" = (
@@ -21594,9 +21577,9 @@
 /area/station/chemistry)
 "aYi" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 2;
@@ -21628,9 +21611,9 @@
 /area/station/science)
 "aYm" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/science)
@@ -21658,14 +21641,14 @@
 /area/station/science)
 "aYq" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/black,
 /area/station/science)
@@ -21690,22 +21673,22 @@
 /area/station/science)
 "aYt" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/black,
 /area/station/science)
 "aYu" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/purpleblack/corner{
-	icon_state = "purpleblackcorner";
-	dir = 8
+	dir = 8;
+	icon_state = "purpleblackcorner"
 	},
 /area/station/science)
 "aYv" = (
@@ -21772,16 +21755,16 @@
 	pixel_y = 0
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/storage)
 "aYC" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall,
 /area/station/maintenance/SWmaint)
@@ -21793,9 +21776,9 @@
 /area/station/hallway/primary/south)
 "aYE" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -21804,8 +21787,8 @@
 /area/station/hallway/primary/south)
 "aYG" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 1
+	dir = 1;
+	icon_state = "shrub"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -21833,8 +21816,8 @@
 	pixel_y = -24
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -21850,9 +21833,9 @@
 /area/station/hallway/primary/central)
 "aYM" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -21862,13 +21845,13 @@
 /area/station/maintenance/SEmaint)
 "aYN" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 8
+	dir = 8;
+	icon_state = "greyblack"
 	},
 /area/station/hallway/primary/central)
 "aYO" = (
@@ -21876,8 +21859,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 4
+	dir = 4;
+	icon_state = "greyblack"
 	},
 /area/station/hallway/primary/east)
 "aYP" = (
@@ -21918,22 +21901,22 @@
 /area/station/maintenance/south)
 "aYV" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/south)
 "aYW" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "science Delivery";
@@ -21943,9 +21926,9 @@
 /area/station/maintenance/south)
 "aYX" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall,
 /area/station/science)
@@ -21954,15 +21937,13 @@
 /turf/simulated/floor/black,
 /area/station/science/lab)
 "aYZ" = (
-/obj/item/device/radio/intercom{
-	
-	},
+/obj/item/device/radio/intercom,
 /turf/simulated/floor/black,
 /area/station/science/lab)
 "aZa" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -21986,19 +21967,19 @@
 /area/station/science)
 "aZd" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 4
+	dir = 4;
+	icon_state = "purpleblack"
 	},
 /area/station/science)
 "aZe" = (
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 8
+	dir = 8;
+	icon_state = "purpleblack"
 	},
 /area/station/science)
 "aZf" = (
@@ -22006,9 +21987,9 @@
 /area/station/science)
 "aZg" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
 /area/station/science)
@@ -22041,8 +22022,8 @@
 "aZk" = (
 /obj/storage/secure/closet/research,
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 10
+	dir = 10;
+	icon_state = "purpleblack"
 	},
 /area/station/science)
 "aZl" = (
@@ -22055,9 +22036,9 @@
 /area/station/science/lab)
 "aZm" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	frequency = 1449;
@@ -22096,8 +22077,8 @@
 /area/station/hangar/main)
 "aZr" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/space_heater,
 /obj/machinery/camera{
@@ -22188,9 +22169,9 @@
 /area/station/maintenance/SWmaint)
 "aZC" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
@@ -22204,8 +22185,8 @@
 /obj/disposalpipe/segment,
 /obj/machinery/plantpot,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
@@ -22223,8 +22204,8 @@
 /area/station/hydroponics)
 "aZH" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/decal/tile_edge/stripe/extra_big,
 /turf/simulated/floor/green,
@@ -22242,8 +22223,8 @@
 "aZJ" = (
 /obj/disposalpipe/segment,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 8
@@ -22257,9 +22238,9 @@
 /area/station/janitor)
 "aZM" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock{
 	name = "Custodial Closet";
@@ -22269,9 +22250,9 @@
 /area/station/janitor)
 "aZN" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -22291,15 +22272,15 @@
 /area/station/teleporter)
 "aZQ" = (
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 6
+	dir = 6;
+	icon_state = "greyblack"
 	},
 /area/station/hallway/primary/east)
 "aZR" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/r_wall,
 /area/station/teleporter)
@@ -22311,23 +22292,23 @@
 /area/station/hallway/primary/east)
 "aZT" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/wall/r_wall,
 /area/station/chemistry)
 "aZU" = (
 /obj/grille/steel,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	invisibility = 0;
 	reinf = 1
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 8;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /obj/window{
@@ -22335,22 +22316,22 @@
 	reinf = 1
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 10;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /turf/simulated/floor/white,
@@ -22361,25 +22342,25 @@
 /area/station/hallway/primary/east)
 "aZW" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/purple/side{
-	icon_state = "purple";
-	dir = 6
+	dir = 6;
+	icon_state = "purple"
 	},
 /area/station/hallway/primary/east)
 "aZX" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/medical{
@@ -22399,14 +22380,14 @@
 "aZZ" = (
 /obj/grille/steel,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	invisibility = 0;
 	reinf = 1
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 8;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /obj/window{
@@ -22418,13 +22399,13 @@
 	icon_state = "0-8"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 10;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /turf/simulated/floor/white,
@@ -22438,9 +22419,9 @@
 /area/station/maintenance/south)
 "bab" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -22464,9 +22445,9 @@
 /area/station/science)
 "baf" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purpleblack,
 /area/station/science)
@@ -22477,8 +22458,8 @@
 /area/station/science)
 "bah" = (
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 4
+	dir = 4;
+	icon_state = "purpleblack"
 	},
 /area/station/science)
 "bai" = (
@@ -22486,9 +22467,9 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/darkblue,
 /area/station/science/lab)
@@ -22501,24 +22482,24 @@
 "bak" = (
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 8
+	dir = 8;
+	icon_state = "purpleblack"
 	},
 /area/station/science)
 "bal" = (
 /obj/item/storage/toolbox/mechanical,
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/black,
 /area/station/science)
 "bam" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -22541,9 +22522,9 @@
 /area/station/science)
 "bap" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/science/lab)
@@ -22554,9 +22535,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
 /area/station/science/lab)
@@ -22592,10 +22573,10 @@
 /obj/window/reinforced/east,
 /obj/window/reinforced/north,
 /obj/securearea{
-	tag = "icon-space";
-	name = "VACUUM AREA";
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space"
+	icon_state = "space";
+	name = "VACUUM AREA";
+	tag = "icon-space"
 	},
 /turf/simulated/floor/plating,
 /area/station/quartermaster/storage)
@@ -22636,9 +22617,9 @@
 /area/station/hydroponics)
 "baD" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/purple/side,
 /area/station/hallway/primary/central)
@@ -22666,9 +22647,9 @@
 /area/station/janitor)
 "baH" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purple/checker{
 	dir = 4
@@ -22698,22 +22679,22 @@
 	dir = 1
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "baM" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
@@ -22732,23 +22713,23 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/landmark{
 	name = "kudzustart"
 	},
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor/purple/side{
-	icon_state = "purple";
-	dir = 9
+	dir = 9;
+	icon_state = "purple"
 	},
 /area/station/chemistry)
 "baQ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/camera{
 	c_tag = "Artifact Lab";
@@ -22768,9 +22749,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 1
@@ -22782,8 +22763,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/wall/r_wall,
 /area/station/teleporter)
@@ -22804,8 +22785,8 @@
 "baV" = (
 /obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/purple/side{
-	icon_state = "purple";
-	dir = 5
+	dir = 5;
+	icon_state = "purple"
 	},
 /area/station/chemistry)
 "baW" = (
@@ -22853,7 +22834,6 @@
 "bbd" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Chemical Lab Maintenance";
-	req_access_txt = "12;7";
 	req_access_txt = "12;7"
 	},
 /turf/simulated,
@@ -22864,9 +22844,9 @@
 	req_access_txt = "7"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/science/lab)
@@ -22878,17 +22858,17 @@
 	pixel_y = -10
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/floor/black,
 /area/station/science/lab)
 "bbg" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/window/southleft{
 	name = "science Monkey Pen";
@@ -23012,8 +22992,8 @@
 "bbA" = (
 /obj/item/mop,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -23026,9 +23006,9 @@
 /area/station/janitor)
 "bbB" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/landmark/start{
 	name = "Janitor"
@@ -23065,9 +23045,9 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
@@ -23084,9 +23064,9 @@
 /area/station/maintenance/SEmaint)
 "bbH" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -23095,9 +23075,9 @@
 /area/station/maintenance/SEmaint)
 "bbI" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -23109,9 +23089,9 @@
 /area/station/maintenance/SEmaint)
 "bbJ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -23125,9 +23105,9 @@
 /area/station/maintenance/SEmaint)
 "bbK" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -23140,19 +23120,19 @@
 /area/station/maintenance/SEmaint)
 "bbL" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -23161,9 +23141,9 @@
 /area/station/maintenance/SEmaint)
 "bbM" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/junction{
 	dir = 4;
@@ -23179,24 +23159,24 @@
 	},
 /obj/disposalpipe/junction,
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "bbO" = (
 /obj/machinery/camera{
-	network = "SS13";
-	c_tag = "Southeast External Airlock"
+	c_tag = "Southeast External Airlock";
+	network = "SS13"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "bbP" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/darkpurple/side,
 /area/station/hallway/primary/east)
@@ -23206,8 +23186,8 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/purple/side{
-	icon_state = "purple";
-	dir = 6
+	dir = 6;
+	icon_state = "purple"
 	},
 /area/station/hallway/primary/east)
 "bbR" = (
@@ -23314,9 +23294,9 @@
 /area/station/maintenance/SWmaint)
 "bcj" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/vending/paint/broken,
 /turf/simulated/floor/plating,
@@ -23329,9 +23309,9 @@
 /area/station/maintenance/SWmaint)
 "bcl" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -23381,9 +23361,9 @@
 	req_access_txt = "12"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
@@ -23420,9 +23400,9 @@
 "bcy" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
@@ -23452,56 +23432,56 @@
 "bcA" = (
 /obj/grille/steel,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced/west,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/white,
 /area/station/chemistry)
 "bcB" = (
 /obj/grille/steel,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/white,
 /area/station/chemistry)
 "bcC" = (
 /obj/grille/steel,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -23509,9 +23489,9 @@
 	icon_state = "1-4"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/cable{
 	d1 = 1;
@@ -23523,19 +23503,19 @@
 "bcD" = (
 /obj/grille/steel,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d2 = 8;
@@ -23547,19 +23527,19 @@
 /obj/grille/steel,
 /obj/window/reinforced/east,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d2 = 8;
@@ -23570,14 +23550,14 @@
 "bcF" = (
 /obj/grille/steel,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	invisibility = 0;
 	reinf = 1
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 8;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /obj/window{
@@ -23585,22 +23565,22 @@
 	reinf = 1
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 10;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /turf/simulated/floor,
@@ -23611,14 +23591,14 @@
 /area/station/chemistry)
 "bcH" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/switch_junction{
-	tag = "icon-pipe-sj1 (EAST)";
+	dir = 4;
 	icon_state = "pipe-sj1";
-	dir = 4
+	tag = "icon-pipe-sj1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
@@ -23684,8 +23664,8 @@
 /area/station/hangar/main)
 "bcS" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
@@ -23712,9 +23692,9 @@
 	dir = 8
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
@@ -23744,9 +23724,9 @@
 /area/station/hallway/primary/south)
 "bdc" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -23826,9 +23806,9 @@
 /area/station/chemistry)
 "bdl" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/forcefield{
@@ -23840,14 +23820,14 @@
 "bdm" = (
 /obj/grille/steel,
 /obj/window{
-	icon_state = "rwindow";
 	dir = 4;
+	icon_state = "rwindow";
 	invisibility = 0;
 	reinf = 1
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 8;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /obj/window{
@@ -23855,31 +23835,31 @@
 	reinf = 1
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window{
-	icon_state = "rwindow";
 	dir = 10;
+	icon_state = "rwindow";
 	reinf = 1
 	},
 /turf/simulated/floor,
 /area/station/chemistry)
 "bdn" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/darkpurple,
 /area/station/teleporter)
@@ -23888,21 +23868,21 @@
 /obj/window/reinforced/east,
 /obj/window/reinforced/west,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/chemistry)
 "bdp" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -23922,16 +23902,16 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/darkpurple,
 /area/station/teleporter)
 "bdr" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door_control{
 	id = "chemd";
@@ -23944,9 +23924,9 @@
 /area/station/chemistry)
 "bds" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/industrial,
 /area/station/chemistry)
@@ -23957,9 +23937,9 @@
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/window/westright{
 	req_access_txt = "7"
@@ -23968,9 +23948,9 @@
 /area/station/chemistry)
 "bdu" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 1;
@@ -24020,9 +24000,9 @@
 /obj/grille/steel,
 /obj/window/reinforced/west,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /obj/window/reinforced/east,
 /turf/simulated/floor/plating,
@@ -24092,9 +24072,9 @@
 /area/station/hallway/primary/south)
 "bdO" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor,
@@ -24110,38 +24090,38 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/teleporter)
 "bdR" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/teleporter)
 "bdS" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/teleporter)
 "bdT" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/r_wall,
 /area/station/teleporter)
@@ -24158,9 +24138,9 @@
 /area/station/chemistry)
 "bdW" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/darkpurple,
 /area/station/teleporter)
@@ -24169,9 +24149,9 @@
 /area/station/teleporter)
 "bdY" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /obj/machinery/dispenser{
 	o2tanks = 10;
@@ -24181,9 +24161,9 @@
 /area/station/chemistry)
 "bdZ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -24251,34 +24231,34 @@
 /area/station/maintenance/south)
 "bei" = (
 /obj/machinery/door/poddoor/blast{
-	tag = "icon-bdoorright1 (WEST)";
-	name = "Mechanic's Bay";
-	icon_state = "bdoorright1";
-	dir = 8;
 	autoclose = 1;
-	id = "hangar_main"
+	dir = 8;
+	icon_state = "bdoorright1";
+	id = "hangar_main";
+	name = "Mechanic's Bay";
+	tag = "icon-bdoorright1 (WEST)"
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
 "bej" = (
 /obj/machinery/door/poddoor/blast{
-	tag = "icon-bdoormid1 (WEST)";
-	name = "Mechanic's Bay";
-	icon_state = "bdoormid1";
-	dir = 8;
 	autoclose = 1;
-	id = "hangar_main"
+	dir = 8;
+	icon_state = "bdoormid1";
+	id = "hangar_main";
+	name = "Mechanic's Bay";
+	tag = "icon-bdoormid1 (WEST)"
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
 "bek" = (
 /obj/machinery/door/poddoor/blast{
-	tag = "icon-bdoorleft1 (WEST)";
-	name = "Mechanic's Bay";
-	icon_state = "bdoorleft1";
-	dir = 8;
 	autoclose = 1;
-	id = "hangar_main"
+	dir = 8;
+	icon_state = "bdoorleft1";
+	id = "hangar_main";
+	name = "Mechanic's Bay";
+	tag = "icon-bdoorleft1 (WEST)"
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
@@ -24291,14 +24271,14 @@
 /area/station/hangar/main)
 "bem" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
@@ -24319,8 +24299,8 @@
 /area/station/maintenance/SWmaint)
 "beq" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -24356,8 +24336,8 @@
 "bey" = (
 /obj/storage/secure/closet/research,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 4
@@ -24389,8 +24369,8 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/item/device/radio/beacon,
@@ -24400,9 +24380,9 @@
 /area/station/teleporter)
 "beC" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -24425,9 +24405,9 @@
 /obj/window/reinforced/north,
 /obj/window/reinforced/south,
 /obj/window/reinforced/north{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
@@ -24456,9 +24436,9 @@
 /area/station/maintenance/disposal)
 "beJ" = (
 /obj/decal/boxingrope{
-	tag = "icon-ringrope (NORTHWEST)";
+	dir = 9;
 	icon_state = "ringrope";
-	dir = 9
+	tag = "icon-ringrope (NORTHWEST)"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -24473,17 +24453,17 @@
 /area/station/crew_quarters/fitness)
 "beL" = (
 /obj/decal/boxingrope{
-	tag = "icon-ringrope (NORTHWEST)";
+	dir = 9;
 	icon_state = "ringrope";
-	dir = 9
+	tag = "icon-ringrope (NORTHWEST)"
 	},
 /turf/simulated/floor/wood/three,
 /area/station/crew_quarters/fitness)
 "beM" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -24556,9 +24536,9 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/r_wall,
 /area/station/teleporter)
@@ -24570,17 +24550,17 @@
 /area/station/teleporter)
 "beZ" = (
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-c";
+	dir = 2;
 	icon_state = "pipe-c";
-	dir = 2
+	tag = "icon-pipe-c"
 	},
 /turf/simulated/wall/r_wall,
 /area/station/teleporter)
 "bfa" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/chemistry)
@@ -24589,14 +24569,14 @@
 /obj/window/reinforced/east,
 /obj/window/reinforced/west,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable,
 /turf/simulated/floor/white,
@@ -24686,22 +24666,22 @@
 /area/station/crew_quarters/fitness)
 "bfo" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/decal/boxingrope{
-	tag = "icon-ringrope (SOUTHEAST)";
+	dir = 6;
 	icon_state = "ringrope";
-	dir = 6
+	tag = "icon-ringrope (SOUTHEAST)"
 	},
 /turf/simulated/floor/wood/three,
 /area/station/crew_quarters/fitness)
 "bfp" = (
 /obj/decal/boxingrope{
-	tag = "icon-ringrope (WEST)";
+	dir = 8;
 	icon_state = "ringrope";
-	dir = 8
+	tag = "icon-ringrope (WEST)"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -24710,16 +24690,16 @@
 /area/station/crew_quarters/fitness)
 "bfr" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/stool,
 /obj/decal/boxingropeenter{
-	tag = "icon-ringrope (EAST)";
-	icon_state = "ringrope";
 	dir = 4;
-	pixel_x = -1
+	icon_state = "ringrope";
+	pixel_x = -1;
+	tag = "icon-ringrope (EAST)"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -24738,23 +24718,23 @@
 /area/station/engine/elect)
 "bfv" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "bfw" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
@@ -24763,17 +24743,17 @@
 	req_access_txt = "12"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "bfy" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo Storage";
@@ -24783,9 +24763,9 @@
 /area/station/maintenance/SEmaint)
 "bfz" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/SEmaint)
@@ -24795,9 +24775,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
@@ -24806,9 +24786,9 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
@@ -24834,9 +24814,9 @@
 /area/station/maintenance/south)
 "bfE" = (
 /obj/disposalpipe/segment{
-	tag = "icon-pipe-c";
+	dir = 2;
 	icon_state = "pipe-c";
-	dir = 2
+	tag = "icon-pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
@@ -24852,9 +24832,9 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/r_wall,
 /area/station/chemistry)
@@ -24873,9 +24853,9 @@
 /area/station/chemistry)
 "bfJ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
@@ -24886,8 +24866,8 @@
 /obj/window/reinforced/west,
 /obj/window/reinforced/south,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -24897,9 +24877,9 @@
 /area/station/maintenance/disposal)
 "bfL" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/grime,
 /area/station/maintenance/disposal)
@@ -24945,17 +24925,17 @@
 /area/station/maintenance/SWmaint)
 "bfQ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
 "bfR" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
@@ -24967,14 +24947,14 @@
 /area/station/crew_quarters/fitness)
 "bfT" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/decal/boxingrope{
-	tag = "icon-ringrope (EAST)";
+	dir = 4;
 	icon_state = "ringrope";
-	dir = 4
+	tag = "icon-ringrope (EAST)"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -24984,9 +24964,9 @@
 /area/station/hallway/primary/south)
 "bfV" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/camera{
 	c_tag = "South Hall North";
@@ -24994,9 +24974,9 @@
 	network = "SS13"
 	},
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -25032,9 +25012,9 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
@@ -25043,9 +25023,9 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo Storage";
@@ -25055,9 +25035,9 @@
 /area/station/maintenance/south)
 "bgb" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -25066,14 +25046,14 @@
 /area/station/maintenance/south)
 "bgc" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -25113,19 +25093,19 @@
 /area/station/maintenance/disposal)
 "bgh" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/wood/three,
 /area/station/crew_quarters/fitness)
 "bgi" = (
 /obj/stool,
 /obj/decal/boxingropeenter{
-	tag = "icon-ringrope (WEST)";
-	icon_state = "ringrope";
 	dir = 8;
-	pixel_x = -1
+	icon_state = "ringrope";
+	pixel_x = -1;
+	tag = "icon-ringrope (WEST)"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -25136,9 +25116,9 @@
 	icon_state = "1-4"
 	},
 /obj/decal/boxingrope{
-	tag = "icon-ringrope (EAST)";
+	dir = 4;
 	icon_state = "ringrope";
-	dir = 4
+	tag = "icon-ringrope (EAST)"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -25162,25 +25142,25 @@
 /area/station/crew_quarters/fitness)
 "bgm" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/window/westleft,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bgn" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bgo" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -25210,19 +25190,19 @@
 "bgs" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
@@ -25244,9 +25224,9 @@
 /obj/grille/steel,
 /obj/window/reinforced/south,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced/west,
 /turf/simulated/floor/plating,
@@ -25255,9 +25235,9 @@
 /obj/grille/steel,
 /obj/window/reinforced/south,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
@@ -25265,13 +25245,13 @@
 /obj/grille/steel,
 /obj/window/reinforced/south,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
@@ -25280,14 +25260,14 @@
 /obj/grille/steel,
 /obj/window/reinforced/south,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
@@ -25299,9 +25279,9 @@
 /area/station/maintenance/disposal)
 "bgA" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
@@ -25311,11 +25291,11 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
 	dir = 10;
+	icon_state = "intact";
 	layer = 3;
-	level = 2
+	level = 2;
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
@@ -25352,26 +25332,26 @@
 /area)
 "bgH" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/table/reinforced/auto,
 /turf/simulated/floor/wood/three,
 /area/station/crew_quarters/fitness)
 "bgI" = (
 /obj/decal/boxingrope{
-	tag = "icon-ringrope (SOUTHEAST)";
+	dir = 6;
 	icon_state = "ringrope";
-	dir = 6
+	tag = "icon-ringrope (SOUTHEAST)"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "bgJ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood/three,
 /area/station/crew_quarters/fitness)
@@ -25385,36 +25365,36 @@
 /area/station/hallway/primary/south)
 "bgL" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bgM" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bgN" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/r_wall,
 /area/station/engine/elect)
@@ -25443,31 +25423,31 @@
 "bgR" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced/south,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "bgS" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area)
 "bgT" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
@@ -25502,13 +25482,13 @@
 /area/station/maintenance/SWmaint)
 "bgY" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/camera{
-	dir = 4;
-	c_tag = "science Storage"
+	c_tag = "science Storage";
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
@@ -25520,18 +25500,18 @@
 /area/station/crew_quarters/fitness)
 "bha" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/wood/three,
 /area/station/crew_quarters/fitness)
 "bhb" = (
 /obj/table/reinforced/auto,
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
+	dir = 8;
 	icon_state = "bulb1";
-	dir = 8
+	tag = "icon-bulb1 (WEST)"
 	},
 /obj/item/electronics/resistor,
 /obj/item/electronics/screen,
@@ -25575,9 +25555,9 @@
 /area/station/maintenance/disposal)
 "bhi" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/atmospherics/binary/pump{
 	dir = 0;
@@ -25618,9 +25598,9 @@
 /obj/window/reinforced/west,
 /obj/window/reinforced/south,
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/plating,
@@ -25764,9 +25744,9 @@
 	req_access_txt = "12"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
@@ -25890,8 +25870,8 @@
 /area/station/crew_quarters/quarters)
 "bhZ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/computer/arcade,
 /turf/simulated/floor/carpet/arcade,
@@ -25966,8 +25946,8 @@
 /area/station/crew_quarters/quarters)
 "bik" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/submachine/claw_machine,
 /turf/simulated/floor/carpet/arcade,
@@ -26041,9 +26021,9 @@
 /obj/window/reinforced/west,
 /obj/window/reinforced/south,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/window/reinforced/north,
 /turf/simulated/floor/plating,
@@ -26057,9 +26037,9 @@
 /area/station/crew_quarters/quarters)
 "bix" = (
 /obj/machinery/door/window/northleft{
-	tag = "icon-left";
+	dir = 2;
 	icon_state = "left";
-	dir = 2
+	tag = "icon-left"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/quarters)
@@ -26072,9 +26052,9 @@
 /area/station/crew_quarters/showers)
 "biA" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/door/airlock/glass{
 	name = "Engineering Wing Access"
@@ -26083,36 +26063,34 @@
 /area/station/hallway/primary/south)
 "biB" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "biC" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "biD" = (
-/obj/item/device/radio/intercom{
-	
-	},
+/obj/item/device/radio/intercom,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "biE" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -26134,9 +26112,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -26145,17 +26123,17 @@
 "biG" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/r_wall,
 /area/station/atmos)
 "biH" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/atmos)
@@ -26166,9 +26144,9 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/atmos)
@@ -26177,17 +26155,17 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/atmos)
 "biK" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/r_wall,
 /area/station/atmos)
@@ -26196,17 +26174,17 @@
 	name = "Atmospheric Technician"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/atmos)
 "biM" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/atmos)
@@ -26216,15 +26194,15 @@
 /area/station/atmos)
 "biO" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/atmos)
 "biP" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/escape{
 	dir = 4
@@ -26232,9 +26210,9 @@
 /area/station/atmos)
 "biQ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/landmark{
 	name = "NASSA spawn"
@@ -26280,7 +26258,6 @@
 "biX" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Bar Maintenance";
-	req_access_txt = "12;25";
 	req_access_txt = "14;25"
 	},
 /obj/access_spawn/bar,
@@ -26288,9 +26265,9 @@
 /area/station/crew_quarters/bar)
 "biY" = (
 /obj/machinery/shower{
-	tag = "icon-showerhead (WEST)";
+	dir = 8;
 	icon_state = "showerhead";
-	dir = 8
+	tag = "icon-showerhead (WEST)"
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
@@ -26312,13 +26289,13 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/shrub{
-	tag = "icon-shrub (EAST)";
+	dir = 4;
 	icon_state = "shrub";
-	dir = 4
+	tag = "icon-shrub (EAST)"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/quarters)
@@ -26353,17 +26330,17 @@
 	pixel_y = 24
 	},
 /obj/shrub{
-	tag = "icon-shrub (WEST)";
+	dir = 8;
 	icon_state = "shrub";
-	dir = 8
+	tag = "icon-shrub (WEST)"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/quarters)
 "bjg" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment{
 	dir = 1;
@@ -26373,9 +26350,9 @@
 /area/station/hallway/primary/south)
 "bjh" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -26385,9 +26362,9 @@
 /area/station/hallway/primary/south)
 "bji" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -26405,9 +26382,9 @@
 /area/station/hallway/primary/south)
 "bjj" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light,
 /obj/disposalpipe/segment{
@@ -26418,9 +26395,9 @@
 /area/station/hallway/primary/south)
 "bjk" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -26435,9 +26412,9 @@
 /area/station/hallway/primary/south)
 "bjl" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/switch_junction{
 	dir = 4;
@@ -26446,9 +26423,9 @@
 	tag = "icon-pipe-sj1 (EAST)"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -26461,9 +26438,9 @@
 /area/station/hallway/primary/south)
 "bjn" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance{
 	frequency = 1449;
@@ -26492,9 +26469,9 @@
 /area/station/atmos)
 "bjp" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/atmos)
@@ -26562,8 +26539,8 @@
 "bjy" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/computer/telescope,
 /turf/simulated/floor/black,
@@ -26577,9 +26554,9 @@
 /area/station/crew_quarters/quarters)
 "bjA" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/quarters)
@@ -26592,9 +26569,9 @@
 /area/station/hallway/primary/south)
 "bjD" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor,
@@ -26605,9 +26582,9 @@
 /area/station/hallway/primary/south)
 "bjF" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -26629,8 +26606,8 @@
 /area/station/hallway/primary/south)
 "bjI" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 1
+	dir = 1;
+	icon_state = "shrub"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 2
@@ -26649,8 +26626,8 @@
 /obj/window/reinforced/north,
 /obj/window/reinforced/south,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/atmos)
@@ -26750,16 +26727,16 @@
 /area)
 "bjR" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/observatory)
 "bjS" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
@@ -26770,9 +26747,9 @@
 	icon_state = "1-4"
 	},
 /obj/pool{
-	tag = "icon-pool (NORTHWEST)";
+	dir = 9;
 	icon_state = "pool";
-	dir = 9
+	tag = "icon-pool (NORTHWEST)"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/quarters)
@@ -26783,43 +26760,43 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/pool{
-	tag = "icon-pool (NORTH)";
+	dir = 1;
 	icon_state = "pool";
-	dir = 1
+	tag = "icon-pool (NORTH)"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/quarters)
 "bjV" = (
 /obj/pool{
-	tag = "icon-pool (NORTH)";
+	dir = 1;
 	icon_state = "pool";
-	dir = 1
+	tag = "icon-pool (NORTH)"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/quarters)
 "bjW" = (
 /obj/pool{
-	tag = "icon-pool (NORTHEAST)";
+	dir = 5;
 	icon_state = "pool";
-	dir = 5
+	tag = "icon-pool (NORTHEAST)"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/quarters)
@@ -26839,9 +26816,9 @@
 /area/station/crew_quarters/quarters)
 "bka" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/locker)
@@ -26852,9 +26829,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/locker)
@@ -26880,21 +26857,21 @@
 /area/station/crew_quarters/locker)
 "bkg" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bkh" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
@@ -26970,16 +26947,16 @@
 /area/station/atmos)
 "bkp" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/quarters)
 "bkq" = (
 /obj/pool{
-	tag = "icon-pool (WEST)";
+	dir = 8;
 	icon_state = "pool";
-	dir = 8
+	tag = "icon-pool (WEST)"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/quarters)
@@ -26989,14 +26966,14 @@
 /area/station/crew_quarters/quarters)
 "bks" = (
 /obj/pool{
-	tag = "icon-pool (EAST)";
+	dir = 4;
 	icon_state = "pool";
-	dir = 4
+	tag = "icon-pool (EAST)"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/quarters)
@@ -27015,21 +26992,21 @@
 /area/station/crew_quarters/quarters)
 "bkv" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/locker)
 "bkw" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/locker)
@@ -27039,8 +27016,8 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/storage/closet/wardrobe/pink,
 /turf/simulated/floor,
@@ -27052,9 +27029,9 @@
 /area/station/hallway/primary/south)
 "bkz" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
@@ -27081,8 +27058,8 @@
 /area/station/atmos)
 "bkE" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -27096,9 +27073,9 @@
 /area/station/crew_quarters/observatory)
 "bkG" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/landmark{
 	name = "monkeyspawn_horse"
@@ -27118,14 +27095,14 @@
 /area/station/crew_quarters/observatory)
 "bkJ" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/pool{
-	tag = "icon-pool (EAST)";
+	dir = 4;
 	icon_state = "pool";
-	dir = 4
+	tag = "icon-pool (EAST)"
 	},
 /obj/cable{
 	d1 = 1;
@@ -27137,17 +27114,17 @@
 /area/station/crew_quarters/quarters)
 "bkK" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/quarters)
 "bkL" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/window/reinforced/west,
 /obj/window/reinforced/west,
@@ -27155,9 +27132,9 @@
 /area/station/crew_quarters/quarters)
 "bkM" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -27166,9 +27143,9 @@
 /area/station/crew_quarters/quarters)
 "bkN" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor,
@@ -27192,8 +27169,8 @@
 /area/station/hallway/primary/south)
 "bkR" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 4
@@ -27256,9 +27233,9 @@
 /area/station/atmos)
 "bla" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/observatory)
@@ -27283,21 +27260,21 @@
 /area/station/crew_quarters/quarters)
 "bld" = (
 /obj/machinery/camera{
-	dir = 4;
-	c_tag = "science Storage"
+	c_tag = "science Storage";
+	dir = 4
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/quarters)
 "ble" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/pool{
-	tag = "icon-pool (EAST)";
+	dir = 4;
 	icon_state = "pool";
-	dir = 4
+	tag = "icon-pool (EAST)"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/quarters)
@@ -27338,9 +27315,9 @@
 "bll" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTHEAST)";
+	dir = 5;
 	icon_state = "rwindow";
-	dir = 5
+	tag = "icon-rwindow (NORTHEAST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/atmos)
@@ -27405,25 +27382,25 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/observatory)
 "bls" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/observatory)
 "blt" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall,
 /area/station/crew_quarters/quarters)
@@ -27435,47 +27412,47 @@
 /area/station/crew_quarters/quarters)
 "blv" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 10
+	dir = 10;
+	icon_state = "shrub"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/quarters)
 "blw" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/pool{
-	tag = "icon-pool (SOUTHWEST)";
+	dir = 10;
 	icon_state = "pool";
-	dir = 10
+	tag = "icon-pool (SOUTHWEST)"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/quarters)
 "blx" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/pool,
 /turf/simulated/floor/white,
 /area/station/crew_quarters/quarters)
 "bly" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/pool{
 	density = 0
@@ -27491,19 +27468,19 @@
 /area/station/crew_quarters/quarters)
 "blz" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/pool{
-	tag = "icon-pool (SOUTHEAST)";
+	dir = 6;
 	icon_state = "pool";
-	dir = 6
+	tag = "icon-pool (SOUTHEAST)"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/quarters)
@@ -27532,9 +27509,9 @@
 /area/station/crew_quarters/locker)
 "blE" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/landmark{
 	name = "peststart"
@@ -27622,10 +27599,10 @@
 /obj/window/reinforced/west,
 /obj/window/reinforced/south,
 /obj/securearea{
-	tag = "icon-space";
-	name = "VACUUM AREA";
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space"
+	icon_state = "space";
+	name = "VACUUM AREA";
+	tag = "icon-space"
 	},
 /turf/simulated/floor/plating,
 /area/station/science/storage)
@@ -27659,9 +27636,9 @@
 /area/station/crew_quarters/quarters)
 "blT" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/wall,
 /area/station/crew_quarters/toilets)
@@ -27671,8 +27648,8 @@
 /area/station/crew_quarters/quarters)
 "blV" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/locker)
@@ -27682,8 +27659,8 @@
 	},
 /obj/storage/secure/closet/personal,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/locker)
@@ -27693,8 +27670,8 @@
 	pixel_x = -24
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 8
@@ -27759,9 +27736,9 @@
 /area/station/crew_quarters/quarters)
 "bmi" = (
 /obj/machinery/door/window/northleft{
-	tag = "icon-left";
+	dir = 2;
 	icon_state = "left";
-	dir = 2
+	tag = "icon-left"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quarters)
@@ -27777,25 +27754,25 @@
 "bmk" = (
 /obj/machinery/door/window/northleft,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quarters)
 "bml" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/locker)
 "bmm" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 1;
@@ -27903,14 +27880,14 @@
 "bmC" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/station/atmos)
@@ -27975,9 +27952,7 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/locker)
 "bmN" = (
-/obj/item/device/radio/intercom{
-	
-	},
+/obj/item/device/radio/intercom,
 /turf/simulated/floor,
 /area/station/crew_quarters/locker)
 "bmO" = (
@@ -28010,9 +27985,9 @@
 /obj/grille/steel,
 /obj/window/reinforced/south,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/atmos)
@@ -28027,9 +28002,9 @@
 /area/station/science/storage)
 "bmV" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/table/auto,
 /obj/item/paper_bin,
@@ -28045,9 +28020,9 @@
 "bmX" = (
 /obj/machinery/light,
 /obj/shrub{
-	tag = "icon-shrub (NORTHWEST)";
+	dir = 9;
 	icon_state = "shrub";
-	dir = 9
+	tag = "icon-shrub (NORTHWEST)"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/quarters)
@@ -28060,9 +28035,9 @@
 "bmZ" = (
 /obj/machinery/light,
 /obj/shrub{
-	tag = "icon-shrub (SOUTHWEST)";
+	dir = 10;
 	icon_state = "shrub";
-	dir = 10
+	tag = "icon-shrub (SOUTHWEST)"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/quarters)
@@ -28081,48 +28056,48 @@
 /area/station/janitor)
 "bnd" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall,
 /area/station/engine/power)
 "bne" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/wall,
 /area/station/engine/power)
 "bnf" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/wall,
 /area/station/engine/power)
 "bng" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/wall,
@@ -28130,24 +28105,24 @@
 "bnh" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /obj/window/reinforced/west,
 /turf/simulated/floor/plating,
@@ -28173,14 +28148,14 @@
 	req_access_txt = "34"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/disposalpipe/segment,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/bot,
 /area/station/engine/engineering)
@@ -28233,9 +28208,7 @@
 /area/station/crew_quarters/toilets)
 "bnq" = (
 /obj/stool,
-/obj/item/device/radio/intercom{
-	
-	},
+/obj/item/device/radio/intercom,
 /obj/item/chem_grenade/cleaner,
 /obj/item/chem_grenade/cleaner,
 /obj/item/chem_grenade/cleaner,
@@ -28246,9 +28219,9 @@
 /area/station/janitor)
 "bnr" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall,
 /area/station/engine/power)
@@ -28277,23 +28250,23 @@
 "bnv" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -28308,14 +28281,14 @@
 	req_access_txt = "40"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/delivery,
@@ -28323,19 +28296,19 @@
 "bny" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/storage)
@@ -28395,57 +28368,57 @@
 /area/station/chapel/main)
 "bnI" = (
 /obj/machinery/power/terminal{
-	tag = "icon-term (NORTH)";
+	dir = 1;
 	icon_state = "term";
-	dir = 1
+	tag = "icon-term (NORTH)"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor,
 /area/station/engine/power)
 "bnJ" = (
 /obj/machinery/power/terminal{
-	tag = "icon-term (NORTH)";
+	dir = 1;
 	icon_state = "term";
-	dir = 1
+	tag = "icon-term (NORTH)"
 	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor,
 /area/station/engine/power)
 "bnK" = (
 /obj/machinery/power/terminal{
-	tag = "icon-term (NORTH)";
+	dir = 1;
 	icon_state = "term";
-	dir = 1
+	tag = "icon-term (NORTH)"
 	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor,
 /area/station/engine/power)
 "bnL" = (
 /obj/machinery/power/terminal{
-	tag = "icon-term (NORTH)";
+	dir = 1;
 	icon_state = "term";
-	dir = 1
+	tag = "icon-term (NORTH)"
 	},
 /obj/cable{
 	d2 = 8;
@@ -28456,14 +28429,14 @@
 "bnM" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -28475,14 +28448,14 @@
 "bnO" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/storage)
@@ -28612,8 +28585,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor,
 /area/station/engine/power)
@@ -28622,8 +28595,8 @@
 	dir = 8
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /turf/simulated/floor,
@@ -28634,14 +28607,14 @@
 "bod" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
 	dir = 2;
@@ -28652,14 +28625,14 @@
 "boe" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
 	dir = 2;
@@ -28717,17 +28690,17 @@
 /area/station/atmos)
 "bom" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor,
 /area/station/science/storage)
 "bon" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor,
 /area/station/science/storage)
@@ -28737,34 +28710,34 @@
 "bop" = (
 /obj/machinery/power/monitor,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/engine/power)
 "boq" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/engine/power)
 "bor" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/power)
@@ -28794,9 +28767,9 @@
 	opacity = 1
 	},
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
@@ -28828,8 +28801,8 @@
 	pixel_y = -24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/light,
 /turf/simulated/floor,
@@ -28890,9 +28863,9 @@
 /area/station/engine/storage)
 "boF" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/r_wall,
 /area/station/engine/eva)
@@ -28917,14 +28890,14 @@
 "boJ" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
 	dir = 2;
@@ -28935,27 +28908,27 @@
 "boK" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
 	dir = 2;
 	icon_state = "rwindow"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/power)
 "boL" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
 	dir = 2;
@@ -28966,14 +28939,14 @@
 "boM" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
 	dir = 2;
@@ -29003,26 +28976,26 @@
 "boP" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
 	dir = 2;
 	icon_state = "rwindow"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/storage)
 "boQ" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
 	dir = 2;
@@ -29033,14 +29006,14 @@
 "boR" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
 	dir = 2;
@@ -29065,8 +29038,8 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor,
 /area/station/engine/eva)
@@ -29085,9 +29058,9 @@
 /area/station/engine/engineering)
 "boX" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
@@ -29138,16 +29111,16 @@
 /area/station/engine/eva)
 "bpe" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/engine/eva)
 "bpf" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/engine/eva)
@@ -29181,28 +29154,28 @@
 /obj/grille/steel,
 /obj/window/reinforced,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/storage)
 "bpm" = (
 /obj/securearea{
-	tag = "icon-space";
-	name = "VACUUM AREA";
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space"
+	icon_state = "space";
+	name = "VACUUM AREA";
+	tag = "icon-space"
 	},
 /turf/simulated/wall/r_wall,
 /area/station/engine/storage)
@@ -29211,9 +29184,9 @@
 /area/station/engine/storage)
 "bpo" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Power Room";
@@ -29231,13 +29204,12 @@
 "bpp" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering EVA";
-	req_access_txt = "40;50";
 	req_access_txt = "41,50"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/engine/eva)
@@ -29246,9 +29218,9 @@
 /area/station/engine/eva)
 "bpr" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	icon_state = "2-4"
@@ -29279,9 +29251,9 @@
 /area/station/hangar/engine)
 "bpv" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/caution/east,
 /area/station/hangar/engine)
@@ -29316,23 +29288,23 @@
 /area/station/engine/engineering)
 "bpB" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "bpC" = (
 /obj/grille/steel,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced/west,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -29340,19 +29312,19 @@
 "bpD" = (
 /obj/grille/steel,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
@@ -29366,30 +29338,30 @@
 "bpF" = (
 /obj/grille/steel,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced/west,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
 "bpG" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "bpH" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/r_wall,
 /area/station/engine/engineering)
@@ -29444,54 +29416,54 @@
 "bpP" = (
 /obj/machinery/power/furnace,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "bpQ" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "bpR" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "bpS" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "bpT" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -29503,14 +29475,14 @@
 "bpU" = (
 /obj/grille/steel,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced/west,
 /turf/simulated/floor/plating,
@@ -29529,8 +29501,8 @@
 /area/station/engine/engineering)
 "bpX" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer3/generic/engine,
@@ -29539,51 +29511,51 @@
 "bpY" = (
 /obj/storage/secure/closet/engineering/mining,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "bpZ" = (
 /obj/grille/steel,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced/west,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
 "bqa" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "bqb" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -29600,8 +29572,8 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
@@ -29637,8 +29609,8 @@
 "bqg" = (
 /obj/machinery/power/furnace,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
@@ -29649,9 +29621,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
@@ -29661,9 +29633,9 @@
 "bqj" = (
 /obj/grille/steel,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced/west,
 /turf/simulated/floor/plating,
@@ -29708,9 +29680,9 @@
 /area/station/engine/engineering)
 "bqp" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
@@ -29736,24 +29708,24 @@
 "bqt" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/storage)
@@ -29771,9 +29743,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/caution/east,
 /area/station/engine/engineering)
@@ -29786,34 +29758,34 @@
 "bqx" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
 "bqy" = (
 /obj/grille/steel,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced/west,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
@@ -29849,19 +29821,19 @@
 "bqD" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
@@ -29870,9 +29842,9 @@
 	dir = 8
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/landmark/start{
 	name = "Engineer"
@@ -29946,38 +29918,38 @@
 "bqP" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/storage)
 "bqQ" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/storage)
@@ -29987,23 +29959,23 @@
 "bqS" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
 "bqT" = (
 /obj/storage/crate,
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
@@ -30012,9 +29984,9 @@
 /obj/window/reinforced/west,
 /obj/window/reinforced/north,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -30024,9 +29996,9 @@
 /obj/window/reinforced/east,
 /obj/window/reinforced/north,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
@@ -30035,9 +30007,9 @@
 	dir = 1
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/stairs{
 	dir = 1
@@ -30048,32 +30020,32 @@
 /obj/window/reinforced/west,
 /obj/window/reinforced/north,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
 "bqY" = (
 /obj/storage/crate,
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
 "bqZ" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
@@ -30086,9 +30058,9 @@
 	dir = 8
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
@@ -30107,19 +30079,19 @@
 "bre" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
@@ -30128,8 +30100,8 @@
 /obj/window/reinforced/west,
 /obj/window/reinforced/north,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
@@ -30166,8 +30138,8 @@
 /obj/window/reinforced/east,
 /obj/window/reinforced/north,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
@@ -30188,38 +30160,38 @@
 "bro" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
 "brp" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
@@ -30234,9 +30206,9 @@
 /area/station/engine/engineering)
 "brr" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
@@ -30244,13 +30216,13 @@
 /obj/grille/steel,
 /obj/window/reinforced/west,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
@@ -30278,17 +30250,17 @@
 /obj/grille/steel,
 /obj/window/reinforced/east,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
 "brx" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -30298,51 +30270,51 @@
 "bry" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
 "brz" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
@@ -30360,17 +30332,17 @@
 /area/station/engine/engineering)
 "brC" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "brD" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -30410,9 +30382,9 @@
 /obj/table/reinforced/auto,
 /obj/window/reinforced/south,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
@@ -30439,8 +30411,8 @@
 /obj/grille/steel,
 /obj/window/reinforced/east,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
@@ -30448,17 +30420,17 @@
 "brL" = (
 /obj/reagent_dispensers/fueltank,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "brM" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -30478,22 +30450,22 @@
 	name = "West Solar Array"
 	},
 /turf/simulated/floor/airless{
-	tag = "icon-solarpanel";
-	icon_state = "solarpanel"
+	icon_state = "solarpanel";
+	tag = "icon-solarpanel"
 	},
 /area/station/solar/west)
 "brP" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/solar/west)
@@ -30503,57 +30475,57 @@
 "brR" = (
 /obj/grille/steel,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /obj/window/reinforced/west,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engine/engineering)
 "brS" = (
 /obj/grille/steel,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engine/engineering)
 "brT" = (
 /obj/grille/steel,
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engine/engineering)
 "brU" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engine/engineering)
@@ -30567,9 +30539,9 @@
 /area/station/engine/engineering)
 "brW" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
@@ -30582,51 +30554,51 @@
 	name = "East Solar Array"
 	},
 /turf/simulated/floor/airless{
-	tag = "icon-solarpanel";
-	icon_state = "solarpanel"
+	icon_state = "solarpanel";
+	tag = "icon-solarpanel"
 	},
 /area/station/solar/east)
 "brZ" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/solar/east)
 "bsa" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/solar/west)
 "bsb" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
@@ -30637,33 +30609,33 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "bsd" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engine/engineering)
@@ -30685,24 +30657,24 @@
 "bsi" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engine/engineering)
@@ -30713,37 +30685,37 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "bsk" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "bsl" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/solar/east)
@@ -30760,45 +30732,45 @@
 "bso" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engine/engineering)
 "bsp" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engine/proto)
 "bsq" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engine/engineering)
@@ -30819,53 +30791,53 @@
 "bsu" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
 "bsv" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
 "bsw" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engine/engineering)
 "bsx" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engine/proto)
@@ -30873,8 +30845,8 @@
 /obj/machinery/power/data_terminal,
 /obj/machinery/field_generator,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
@@ -30889,8 +30861,8 @@
 /obj/machinery/power/data_terminal,
 /obj/machinery/field_generator,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /turf/simulated/floor/plating/airless,
@@ -30901,8 +30873,8 @@
 "bsC" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/emitter{
@@ -30912,35 +30884,35 @@
 /area/station/engine/engineering)
 "bsD" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/solar/west)
 "bsE" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
 "bsF" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -30961,9 +30933,9 @@
 "bsH" = (
 /obj/stool,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/landmark/start{
 	name = "Engineer"
@@ -30972,9 +30944,9 @@
 /area/station/engine/engineering)
 "bsI" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/circuit,
 /area/station/engine/proto)
@@ -30994,79 +30966,79 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/eastsolar)
 "bsL" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/eastsolar)
 "bsM" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/solar/east)
 "bsN" = (
 /obj/machinery/power/tracker,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area)
 "bsO" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area)
 "bsP" = (
 /obj/grille/steel,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/solar/west)
 "bsQ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/solar/west)
 "bsR" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/cable{
@@ -31078,19 +31050,19 @@
 "bsS" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
@@ -31105,8 +31077,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
@@ -31128,8 +31100,8 @@
 "bsV" = (
 /obj/machinery/power/smes,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -31138,18 +31110,18 @@
 /area/station/maintenance/westsolar)
 "bsW" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/r_wall,
 /area/station/engine/engineering)
 "bsX" = (
 /obj/machinery/emitter,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -31157,28 +31129,28 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "bsY" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engine/engineering)
@@ -31190,9 +31162,9 @@
 /area/station/engine/engineering)
 "bta" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -31200,17 +31172,17 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "btb" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/landmark{
 	name = "monkeyspawn_mrsmuggles"
@@ -31233,8 +31205,8 @@
 	dir = 8
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d1 = 1;
@@ -31254,46 +31226,46 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/eastsolar)
 "btf" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/eastsolar)
 "btg" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/solar/east)
 "bth" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/cable{
@@ -31304,8 +31276,8 @@
 /area/station/solar/east)
 "bti" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/cable{
@@ -31313,17 +31285,17 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/solar/east)
 "btj" = (
 /obj/grille/steel,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/solar/east)
@@ -31338,19 +31310,19 @@
 "btl" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
@@ -31384,19 +31356,19 @@
 "btq" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/eastsolar)
@@ -31409,79 +31381,79 @@
 "bts" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engine/engineering)
 "btt" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engine/engineering)
 "btu" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
 "btv" = (
 /obj/item/storage/toolbox/mechanical,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/circuit,
 /area/station/engine/proto)
 "btw" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/emitter{
@@ -31500,40 +31472,40 @@
 /obj/machinery/field_generator,
 /obj/cable,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engine/proto)
 "btz" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engine/engineering)
 "btA" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/emitter{
@@ -31552,8 +31524,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/solar/west)
@@ -31564,148 +31536,148 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/solar/east)
 "btD" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "btE" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
 "btF" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engine/engineering)
 "btG" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "btH" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engine/engineering)
 "btI" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engine/engineering)
 "btJ" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced/west{
-	tag = "icon-rwindow";
+	dir = 2;
 	icon_state = "rwindow";
-	dir = 2
+	tag = "icon-rwindow"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engine/engineering)
@@ -31720,8 +31692,8 @@
 "btL" = (
 /obj/machinery/power/collector_array,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -31732,8 +31704,8 @@
 "btM" = (
 /obj/machinery/power/collector_control,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -31744,16 +31716,16 @@
 "btN" = (
 /obj/machinery/power/collector_control,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -31768,8 +31740,8 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
@@ -31839,23 +31811,23 @@
 "bub" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating/scorched,
 /area/station/security/prison)
@@ -31876,8 +31848,8 @@
 /area)
 "buf" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /obj/item/clothing/under/misc/syndicate,
 /obj/item/clothing/under/misc/syndicate,
@@ -31887,8 +31859,8 @@
 /area/listeningpost)
 "bug" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/table/wood/auto,
 /obj/machinery/recharger,
@@ -31898,9 +31870,9 @@
 /area/listeningpost)
 "buh" = (
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /mob/living/silicon/robot{
 	name = "Fire Range Robot"
@@ -31929,14 +31901,14 @@
 "bun" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -31948,17 +31920,17 @@
 	p_open = 1
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/space,
 /area/station/security/prison)
 "buo" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -31970,22 +31942,22 @@
 	p_open = 1
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/space,
 /area/station/security/prison)
 "bup" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -31997,8 +31969,8 @@
 	p_open = 1
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/space,
 /area/station/security/prison)
@@ -32020,8 +31992,8 @@
 /area)
 "but" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/door/airlock/security{
 	aiControlDisabled = 1;
@@ -32032,22 +32004,22 @@
 /area/station/security/armory)
 "buu" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/security/armory)
 "buv" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/security/armory)
@@ -32096,9 +32068,9 @@
 	dir = 1
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/security/armory)
@@ -32113,9 +32085,9 @@
 	p_open = 1
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/security{
 	aiControlDisabled = 1;
@@ -32126,17 +32098,17 @@
 /area/station/security/armory)
 "buB" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
 "buC" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
@@ -32167,8 +32139,8 @@
 /area/station/security/prison)
 "buF" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/vending/security,
 /turf/simulated/floor/specialroom/chapel{
@@ -32179,8 +32151,8 @@
 /obj/table/auto,
 /obj/machinery/recharger,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
@@ -32204,8 +32176,8 @@
 /area/station/security/prison)
 "buJ" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/computer/security,
 /turf/simulated/floor/specialroom/chapel{
@@ -32215,36 +32187,36 @@
 "buK" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area)
 "buL" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area)
@@ -32262,8 +32234,8 @@
 /area)
 "buO" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/grey/side{
 	dir = 8
@@ -32326,9 +32298,9 @@
 /area/station/security/armory)
 "buW" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -32347,9 +32319,9 @@
 	p_open = 1
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -32364,14 +32336,14 @@
 /area/station/security/armory)
 "buY" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 2;
@@ -32416,26 +32388,26 @@
 /area/station/security/prison)
 "bvd" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/security/prison)
 "bve" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 8
@@ -32443,9 +32415,9 @@
 /area/station/security/prison)
 "bvf" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/security/prison)
@@ -32460,9 +32432,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 8
@@ -32475,9 +32447,9 @@
 	req_access_txt = "39"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
@@ -32516,9 +32488,9 @@
 /area/listeningpost)
 "bvn" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
@@ -32555,14 +32527,14 @@
 /area/station/hallway/primary/north)
 "bvs" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 1
@@ -32570,9 +32542,9 @@
 /area/station/security/prison)
 "bvt" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
@@ -32581,9 +32553,9 @@
 "bvu" = (
 /obj/table/auto,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/item/clothing/glasses/vr{
 	desc = "A pair of VR goggles running a simulation of the Prison network. Perfect for interrogating suspects who are in the Vbrig.";
@@ -32641,17 +32613,17 @@
 	network = "prison"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "bvD" = (
 /obj/item/reagent_containers/food/snacks/plant/banana,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/item/clothing/glasses/eyepatch{
 	desc = "You gotta be a tough dude to wear this. There are handbooks and everything.";
@@ -32661,17 +32633,17 @@
 /area/station/security/prison)
 "bvE" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "bvF" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/command{
 	name = "Mainframe Access";
@@ -32681,9 +32653,9 @@
 /area/station/security/prison)
 "bvG" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d2 = 8;
@@ -32710,17 +32682,17 @@
 /area/station/security/prison)
 "bvK" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/security/prison)
 "bvL" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 8
@@ -32768,13 +32740,13 @@
 "bvT" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/brig/prison)
@@ -32798,19 +32770,19 @@
 "bvX" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
@@ -32825,9 +32797,9 @@
 /area/station/security/prison)
 "bwa" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/glass{
 	name = "Security Office";
@@ -32865,14 +32837,14 @@
 "bwf" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/brig/prison)
@@ -32891,14 +32863,14 @@
 "bwi" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prison)
@@ -32910,9 +32882,9 @@
 /area/station/security/prison)
 "bwk" = (
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prison)
@@ -32922,13 +32894,13 @@
 /area/station/security/prison)
 "bwm" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/disposalpipe/junction{
 	icon_state = "pipe-j2"
@@ -32937,9 +32909,9 @@
 /area/station/security/prison)
 "bwn" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -32962,8 +32934,8 @@
 	p_open = 1
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -32977,9 +32949,9 @@
 /area/station/security/prison)
 "bwp" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 8;
@@ -32994,22 +32966,22 @@
 	rigged = 0
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
 "bwr" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
@@ -33020,9 +32992,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -33030,9 +33002,9 @@
 /area/station/security/prison)
 "bwt" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -33050,9 +33022,9 @@
 	rigged = 0
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
@@ -33082,8 +33054,8 @@
 	credit = 12
 	},
 /turf/simulated/floor{
-	icon_state = "carpetN";
-	dir = 4
+	dir = 4;
+	icon_state = "carpetN"
 	},
 /area/listeningpost)
 "bwA" = (
@@ -33094,8 +33066,8 @@
 /area/listeningpost)
 "bwB" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -33138,30 +33110,30 @@
 "bwG" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
 "bwH" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
@@ -33181,8 +33153,8 @@
 	p_open = 1
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/door/airlock/security{
 	name = "Secure Transport";
@@ -33192,9 +33164,9 @@
 /area/station/security/prison)
 "bwJ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d2 = 8;
@@ -33204,9 +33176,9 @@
 /area/station/security/prison)
 "bwK" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/red/side,
 /area/station/security/prison)
@@ -33230,12 +33202,12 @@
 	},
 /obj/decal/glow{
 	brightness = 3;
-	invisibility = 101;
-	luminosity = 0;
-	name = "glow - WHITE";
 	color_b = 0.35;
 	color_g = 0.35;
-	color_r = 0.35
+	color_r = 0.35;
+	invisibility = 101;
+	luminosity = 0;
+	name = "glow - WHITE"
 	},
 /turf/simulated/floor/red,
 /area/listeningpost)
@@ -33246,14 +33218,14 @@
 /area/listeningpost)
 "bwO" = (
 /turf/simulated/floor{
-	icon_state = "carpet2";
-	dir = 4
+	dir = 4;
+	icon_state = "carpet2"
 	},
 /area/listeningpost)
 "bwP" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor{
 	icon_state = "carpetE"
@@ -33266,8 +33238,8 @@
 /area/listeningpost)
 "bwR" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor4"
@@ -33361,9 +33333,9 @@
 	name = "'Waste' Disposal"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
@@ -33395,8 +33367,8 @@
 /obj/item/plate,
 /obj/item/reagent_containers/food/snacks/snack_cake/golden,
 /turf/simulated/floor{
-	icon_state = "carpetS";
-	dir = 4
+	dir = 4;
+	icon_state = "carpetS"
 	},
 /area/listeningpost)
 "bxi" = (
@@ -33449,14 +33421,14 @@
 "bxq" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -33468,17 +33440,17 @@
 	p_open = 1
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "bxr" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -33490,22 +33462,22 @@
 	p_open = 1
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "bxs" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -33517,8 +33489,8 @@
 	p_open = 1
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prison)
@@ -33533,9 +33505,9 @@
 	p_open = 1
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/security{
 	name = "Secure Transport";
@@ -33545,9 +33517,9 @@
 /area/station/security/prison)
 "bxu" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 1;
@@ -33557,9 +33529,9 @@
 /area/station/security/prison)
 "bxv" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /obj/disposalpipe/segment{
 	dir = 2;
@@ -33600,8 +33572,8 @@
 	name = "loose chair"
 	},
 /obj/decal/cleanable/blood/gibs/body{
-	tag = "icon-helmetblood2";
-	icon_state = "helmetblood2"
+	icon_state = "helmetblood2";
+	tag = "icon-helmetblood2"
 	},
 /obj/decal/cleanable/cobweb,
 /turf/simulated/floor,
@@ -33611,8 +33583,8 @@
 	name = "Quiet Room"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prison)
@@ -33623,8 +33595,8 @@
 	icon_state = "1-8"
 	},
 /obj/decal/cleanable/blood/splatter{
-	tag = "icon-gibbl2";
-	icon_state = "gibbl2"
+	icon_state = "gibbl2";
+	tag = "icon-gibbl2"
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
@@ -33673,9 +33645,9 @@
 /area/station/security/prison)
 "bxM" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
@@ -33709,8 +33681,8 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -33720,14 +33692,14 @@
 /area/station/security/prison)
 "bxR" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
@@ -33742,9 +33714,9 @@
 	p_open = 1
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass{
 	name = "Security Office";
@@ -33779,15 +33751,15 @@
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/vent{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/decal/cleanable/blood/splatter,
 /obj/decal/cleanable/blood/tracks{
-	tag = "icon-tracks (NORTH)";
+	dir = 1;
 	icon_state = "tracks";
-	dir = 1
+	tag = "icon-tracks (NORTH)"
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
@@ -33800,19 +33772,19 @@
 	},
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
 	dir = 2;
@@ -33825,10 +33797,10 @@
 	dir = 4
 	},
 /obj/machinery/door_control{
+	id = "ntexecution";
 	name = "Waste Vent Control";
 	pixel_x = 0;
-	pixel_y = -23;
-	id = "ntexecution"
+	pixel_y = -23
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
@@ -33906,9 +33878,9 @@
 /area/station/security/prison)
 "byn" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/junction{
 	dir = 4
@@ -33964,13 +33936,12 @@
 	},
 /obj/machinery/door/airlock/glass{
 	name = "Commander's Office";
-	req_access_txt = "1";
 	req_access_txt = "37"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/stairs{
 	dir = 1
@@ -33982,13 +33953,12 @@
 	icon_state = "door_closed";
 	locked = 0;
 	name = "Prison Engineering";
-	req_access_txt = "1";
 	req_access_txt = "1"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
@@ -34034,8 +34004,8 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/black{
 	name = "floor"
@@ -34115,12 +34085,12 @@
 	charge = 5e+006
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -34130,9 +34100,9 @@
 /area/station/security/prison)
 "byY" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -34203,9 +34173,9 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prison)
@@ -34226,9 +34196,9 @@
 /area)
 "bzA" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/black{
 	name = "floor"
@@ -34258,14 +34228,14 @@
 /area/station/security/hos)
 "bzE" = (
 /obj/machinery/door_control{
+	id = "commander";
 	name = "Lockdown";
-	pixel_x = 24;
-	id = "commander"
+	pixel_x = 24
 	},
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/black{
 	name = "floor"
@@ -34365,14 +34335,14 @@
 "bAk" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -34384,17 +34354,17 @@
 	p_open = 1
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/hos)
 "bAl" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -34406,22 +34376,22 @@
 	p_open = 1
 	},
 /obj/window/reinforced{
-	icon_state = "rwindow";
-	dir = 2
+	dir = 2;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/hos)
 "bAm" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -34515,9 +34485,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/green,
 /area/station/medical/medbay)
@@ -34552,9 +34522,9 @@
 "bAI" = (
 /obj/stool/bed,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/sanitary,
 /area/station/medical/medbay)
@@ -34564,17 +34534,17 @@
 	c_tag = "Medical Holding Cells"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/sanitary,
 /area/station/medical/medbay)
 "bAK" = (
 /obj/storage/secure/closet/medical,
 /turf/simulated/floor/greenwhite{
-	icon_state = "greenwhite";
-	dir = 9
+	dir = 9;
+	icon_state = "greenwhite"
 	},
 /area/station/medical/medbay)
 "bAL" = (
@@ -34582,14 +34552,14 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/greenwhite{
-	icon_state = "greenwhite";
-	dir = 1
+	dir = 1;
+	icon_state = "greenwhite"
 	},
 /area/station/medical/medbay)
 "bAM" = (
 /turf/simulated/floor/greenwhite{
-	icon_state = "greenwhite";
-	dir = 1
+	dir = 1;
+	icon_state = "greenwhite"
 	},
 /area/station/medical/medbay)
 "bAN" = (
@@ -34597,34 +34567,34 @@
 	dir = 8
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/sanitary,
 /area/station/medical/medbay)
 "bAO" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/sanitary,
 /area/station/medical/medbay)
 "bAP" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/greenwhite{
-	icon_state = "greenwhite";
-	dir = 8
+	dir = 8;
+	icon_state = "greenwhite"
 	},
 /area/station/medical/medbay)
 "bAQ" = (
@@ -34632,9 +34602,9 @@
 /area/station/medical/medbay)
 "bAR" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/stool/chair,
 /obj/machinery/light{
@@ -34647,8 +34617,8 @@
 /area/station/maintenance/south)
 "bAS" = (
 /turf/simulated/floor/greenwhite{
-	icon_state = "greenwhite";
-	dir = 8
+	dir = 8;
+	icon_state = "greenwhite"
 	},
 /area/station/medical/medbay)
 "bAT" = (
@@ -34663,8 +34633,8 @@
 /obj/item/reagent_containers/syringe/haloperidol,
 /obj/item/clothing/glasses/blindfold,
 /turf/simulated/floor/greenwhite{
-	icon_state = "greenwhite";
-	dir = 8
+	dir = 8;
+	icon_state = "greenwhite"
 	},
 /area/station/medical/medbay)
 "bAV" = (
@@ -34672,17 +34642,17 @@
 	dir = 1
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/red,
 /area/station/science)
 "bAW" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -34701,8 +34671,8 @@
 /obj/item/wrench,
 /obj/machinery/light,
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 10
+	dir = 10;
+	icon_state = "purpleblack"
 	},
 /area/station/science)
 "bAZ" = (
@@ -34712,9 +34682,9 @@
 	},
 /obj/item/screwdriver,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purpleblack,
 /area/station/science)
@@ -34722,9 +34692,9 @@
 /obj/table/auto,
 /obj/item/weldingtool,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purpleblack,
 /area/station/science)
@@ -34748,9 +34718,9 @@
 	pixel_y = -5
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purpleblack,
 /area/station/science)
@@ -34774,19 +34744,19 @@
 /area/station/science)
 "bBe" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 6
+	dir = 6;
+	icon_state = "purpleblack"
 	},
 /area/station/science)
 "bBf" = (
 /obj/machinery/camera{
-	dir = 4;
-	c_tag = "Atomospherics Gas Processing East"
+	c_tag = "Atomospherics Gas Processing East";
+	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/science/lab)
@@ -34799,17 +34769,17 @@
 /area/station/science/lab)
 "bBh" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/black,
 /area/station/science/lab)
 "bBi" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/science)
@@ -34820,9 +34790,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/landmark{
 	name = "monkeyspawn_normal"
@@ -34838,25 +34808,25 @@
 /area/station/science)
 "bBm" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/black,
 /area/station/science/lab)
 "bBn" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/black,
 /area/station/science/lab)
 "bBo" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/meter,
 /obj/machinery/ignition_switch{
@@ -34869,17 +34839,17 @@
 /area/station/science/lab)
 "bBp" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/science)
 "bBq" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/science)
@@ -34891,9 +34861,9 @@
 /area/station/science)
 "bBs" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/black,
 /area/station/science/lab)
@@ -34903,9 +34873,9 @@
 	pixel_y = -24
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/science/lab)
@@ -34916,9 +34886,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
 /area/station/science/lab)
@@ -34931,9 +34901,9 @@
 /area/station/science/lab)
 "bBw" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/landmark{
 	name = "monkeyspawn_normal"
@@ -34955,30 +34925,30 @@
 /area/station/science/lab)
 "bBz" = (
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 4
+	dir = 4;
+	icon_state = "greyblack"
 	},
 /area/station/hallway/primary/central)
 "bBA" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 8
+	dir = 8;
+	icon_state = "greyblack"
 	},
 /area/station/hallway/primary/central)
 "bBB" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 10
+	dir = 10;
+	icon_state = "greyblack"
 	},
 /area/station/hallway/primary/central)
 "bBC" = (
@@ -35040,8 +35010,8 @@
 /area/station/hallway/primary/central)
 "bBM" = (
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 6
+	dir = 6;
+	icon_state = "greyblack"
 	},
 /area/station/hallway/primary/central)
 "bBN" = (
@@ -35059,9 +35029,9 @@
 /area/station/chemistry)
 "bBP" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/chemistry)
@@ -35073,9 +35043,9 @@
 /area/station/chemistry)
 "bBR" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -35113,8 +35083,8 @@
 "bBU" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/computer/teleporter,
 /turf/simulated/floor/darkpurple/side,
@@ -35130,14 +35100,14 @@
 /area/station/teleporter)
 "bBX" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/landmark{
 	name = "monkeyspawn_normal"
@@ -35146,9 +35116,9 @@
 /area/station/chemistry)
 "bBY" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -35178,9 +35148,9 @@
 /area/station/chemistry)
 "bCc" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/chemistry)
@@ -35222,9 +35192,7 @@
 /obj/item/screwdriver{
 	pixel_y = 10
 	},
-/obj/item/device/radio/intercom{
-	
-	},
+/obj/item/device/radio/intercom,
 /obj/item/extinguisher,
 /turf/simulated/floor/purple/side,
 /area/station/chemistry)
@@ -35258,8 +35226,8 @@
 /obj/item/chem_grenade,
 /obj/machinery/light,
 /turf/simulated/floor/purple/side{
-	icon_state = "purple";
-	dir = 6
+	dir = 6;
+	icon_state = "purple"
 	},
 /area/station/chemistry)
 "bCk" = (
@@ -35298,9 +35266,7 @@
 	},
 /area/station/hydroponics)
 "bCo" = (
-/obj/item/device/radio/intercom{
-	
-	},
+/obj/item/device/radio/intercom,
 /turf/simulated/floor/grass{
 	name = "astroturf"
 	},
@@ -35328,9 +35294,7 @@
 	},
 /area/station/hydroponics)
 "bCs" = (
-/obj/item/device/radio/intercom{
-	
-	},
+/obj/item/device/radio/intercom,
 /turf/simulated/floor/wood/three,
 /area/station/crew_quarters/fitness)
 "bCt" = (
@@ -35343,14 +35307,14 @@
 /area/station/crew_quarters/fitness)
 "bCv" = (
 /turf/simulated/floor/stairs/dark{
-	icon_state = "dark_stairs";
-	dir = 8
+	dir = 8;
+	icon_state = "dark_stairs"
 	},
 /area/station/crew_quarters/fitness)
 "bCw" = (
 /turf/simulated/floor/stairs/dark{
-	icon_state = "dark_stairs";
-	dir = 4
+	dir = 4;
+	icon_state = "dark_stairs"
 	},
 /area/station/crew_quarters/fitness)
 "bCx" = (
@@ -35394,9 +35358,9 @@
 	opacity = 0
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/darkblue/checker,
 /area/station/bridge)
@@ -35407,9 +35371,9 @@
 	req_access_txt = "19"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -35424,31 +35388,31 @@
 "bCD" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/darkblue,
 /area/station/bridge)
 "bCE" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/darkblue,
 /area/station/bridge)
 "bCF" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/darkblue,
 /area/station/bridge)
@@ -35463,9 +35427,9 @@
 /area/station/hallway/secondary/exit)
 "bCI" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -35475,25 +35439,25 @@
 /area/station/maintenance/south)
 "bCJ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/toilets)
 "bCK" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
+	dir = 4;
 	icon_state = "tube1";
-	dir = 4
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/toilets)
 "bCL" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/stool/chair,
 /obj/landmark/start{
@@ -35627,9 +35591,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/stool/chair,
 /obj/landmark/start{
@@ -35940,19 +35904,19 @@
 "bDU" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
+	dir = 1;
 	icon_state = "rwindow";
-	dir = 1
+	tag = "icon-rwindow (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/elect)
@@ -35965,14 +35929,14 @@
 "bDW" = (
 /obj/grille/steel,
 /obj/window/reinforced{
-	tag = "icon-rwindow (EAST)";
+	dir = 4;
 	icon_state = "rwindow";
-	dir = 4
+	tag = "icon-rwindow (EAST)"
 	},
 /obj/window/reinforced{
-	tag = "icon-rwindow (WEST)";
+	dir = 8;
 	icon_state = "rwindow";
-	dir = 8
+	tag = "icon-rwindow (WEST)"
 	},
 /obj/window/reinforced/south,
 /turf/simulated/floor/plating,
@@ -36011,9 +35975,9 @@
 /area/station/crew_quarters/showers)
 "bEb" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/stool/chair,
 /obj/landmark/start{
@@ -36050,9 +36014,9 @@
 /area/station/crew_quarters/quarters)
 "bEf" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/landmark/start{
 	name = "Staff Assistant"
@@ -36094,9 +36058,9 @@
 /area/station/engine/storage)
 "bEl" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/simulated/floor/yellow,
 /area/station/quartermaster)
@@ -36106,9 +36070,9 @@
 /area/station/quartermaster)
 "bEn" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/window/northright,
 /turf/simulated/floor/yellow,
@@ -36144,17 +36108,17 @@
 /area/station/quartermaster)
 "bEr" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow,
 /area/station/quartermaster)
 "bEs" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
+	dir = 8;
 	icon_state = "tube1";
-	dir = 8
+	tag = "icon-tube1 (WEST)"
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo Waiting Area";
@@ -36189,9 +36153,7 @@
 /turf/simulated/floor/yellow,
 /area/station/quartermaster)
 "bEx" = (
-/obj/item/device/radio/intercom{
-	
-	},
+/obj/item/device/radio/intercom,
 /turf/simulated/floor/yellow,
 /area/station/quartermaster)
 "bEy" = (
@@ -36318,12 +36280,10 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "bEV" = (
-/obj/item/device/radio/intercom{
-	
-	},
+/obj/item/device/radio/intercom,
 /obj/decal/tile_edge/line/yellow{
-	icon_state = "noedge-tile1";
-	dir = 9
+	dir = 9;
+	icon_state = "noedge-tile1"
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
@@ -36384,14 +36344,14 @@
 /obj/table/auto,
 /obj/machinery/recharger,
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
 	d1 = 1;
@@ -36431,9 +36391,9 @@
 /area/station/security/armory)
 "bFj" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/red/side{
 	dir = 1
@@ -36460,9 +36420,9 @@
 "bFp" = (
 /obj/rack,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/security/armory)
@@ -36477,22 +36437,22 @@
 /area/station/security/armory)
 "bFs" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/security/armory)
 "bFt" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/red/side{
 	dir = 8
@@ -36500,13 +36460,13 @@
 /area/station/security/armory)
 "bFu" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	icon_state = "1-8"
@@ -36515,9 +36475,9 @@
 /area/station/security/armory)
 "bFv" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -36560,9 +36520,9 @@
 /area/station/security/armory)
 "bFB" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -36582,12 +36542,12 @@
 /area/station/crew_quarters/bar)
 "bFD" = (
 /obj/decal/tile_edge/line/grey{
-	icon_state = "noedge-tile1";
-	dir = 5
+	dir = 5;
+	icon_state = "noedge-tile1"
 	},
 /obj/decal/tile_edge/line/yellow{
-	icon_state = "tile1";
-	dir = 6
+	dir = 6;
+	icon_state = "tile1"
 	},
 /obj/machinery/door/airlock{
 	name = "Kitchen";
@@ -36615,12 +36575,12 @@
 	},
 /obj/table/reinforced/bar/auto,
 /obj/decal/tile_edge/line/grey{
-	icon_state = "noedge-tile1";
-	dir = 5
+	dir = 5;
+	icon_state = "noedge-tile1"
 	},
 /obj/decal/tile_edge/line/yellow{
-	icon_state = "tile1";
-	dir = 6
+	dir = 6;
+	icon_state = "tile1"
 	},
 /obj/machinery/glass_recycler,
 /turf/simulated/floor/wood/two,
@@ -36643,9 +36603,9 @@
 /area/station/crew_quarters/bar)
 "bFK" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable,
 /obj/window/reinforced/west,
@@ -36662,9 +36622,9 @@
 /area/station/hydroponics)
 "bFM" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/submachine/poster_creator{
 	dir = 4
@@ -36673,6 +36633,12 @@
 	dir = 4
 	},
 /area/station/security/prison)
+"jul" = (
+/obj/machinery/recharger/wall/sticky{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/security/main)
 
 (1,1,1) = {"
 aaa
@@ -63087,7 +63053,7 @@ akO
 alw
 ami
 amY
-ahG
+jul
 aob
 ahG
 apL


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- exchanges the taser rack for the /empty variant on all in use maps but Horizon, Donut3, Kondaru, Chiron, Icarus, Kondaru, and Fleet

- adds the new security vendor to security dept. and major checkpoints on all in use maps but Horizon, Donut3, Kondaru, Chiron, Icarus, Kondaru, and Fleet


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

- MBC coded it, I'm mapping it

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

Changelog will be written after Jeni and Kubius' stuff is also merged