### PR TITLE
fix some projectile range stuff and runtime on laserguns

### DIFF
--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -362,8 +362,8 @@
 				ys = -1
 				y32 = -y32
 		var/max_t
-		if (proj_data.dissipation_rate && proj_data.max_range == 500) //500 is default maximum range
-			proj_data.max_range = proj_data.dissipation_delay + round(proj_data.power / proj_data.dissipation_rate)
+		if (proj_data.dissipation_rate > 0) //500 is default maximum range
+			proj_data.max_range = min(proj_data.max_range, proj_data.dissipation_delay + round(proj_data.power / proj_data.dissipation_rate))
 		max_t = proj_data.max_range // why not
 		var/next_x = x32 / 2
 		var/next_y = y32 / 2

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -199,7 +199,7 @@
 	name = "laser gun"
 	icon_state = "laser"
 	uses_multiple_icon_states = 1
-	cell_type = new/obj/item/ammo/power_cell/med_plus_power
+	cell_type = /obj/item/ammo/power_cell/med_plus_power
 	force = 7.0
 	desc = "A gun that produces a harmful laser, causing substantial damage."
 	module_research = list("weapons" = 4, "energy" = 4)


### PR DESCRIPTION
fix runtime on laser guns
[FIX]
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fix some projectile range stuff and runtime on laserguns


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Some projectiles were going further than intended (e.g.: taser shotgun projectiles)
laser guns were runtiming on creation