### PR TITLE
Removes unecessary cape=1 on children and fixes the block_vision on b…

### DIFF
--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -744,72 +744,62 @@
 	item_state = "bedcape"
 	cape = 1
 	over_back = 1
+	block_vision = 0
 
 /obj/item/clothing/suit/bedsheet/cape/red
 	icon_state = "bedcape-red"
 	item_state = "bedcape-red"
 	bcolor = "red"
-	cape = 1
 
 /obj/item/clothing/suit/bedsheet/cape/orange
 	icon_state = "bedcape-orange"
 	item_state = "bedcape-orange"
 	bcolor = "orange"
-	cape = 1
 
 /obj/item/clothing/suit/bedsheet/cape/yellow
 	icon_state = "bedcape-yellow"
 	item_state = "bedcape-yellow"
 	bcolor = "yellow"
-	cape = 1
 
 /obj/item/clothing/suit/bedsheet/cape/green
 	icon_state = "bedcape-green"
 	item_state = "bedcape-green"
 	bcolor = "green"
-	cape = 1
 
 /obj/item/clothing/suit/bedsheet/cape/blue
 	icon_state = "bedcape-blue"
 	item_state = "bedcape-blue"
 	bcolor = "blue"
-	cape = 1
 
 /obj/item/clothing/suit/bedsheet/cape/pink
 	icon_state = "bedcape-pink"
 	item_state = "bedcape-pink"
 	bcolor = "pink"
-	cape = 1
 
 /obj/item/clothing/suit/bedsheet/cape/black
 	icon_state = "bedcape-black"
 	item_state = "bedcape-black"
 	bcolor = "black"
-	cape = 1
 
 /obj/item/clothing/suit/bedsheet/cape/hop
 	icon_state = "bedcape-hop"
 	item_state = "bedcape-hop"
 	bcolor = "hop"
-	cape = 1
 
 /obj/item/clothing/suit/bedsheet/cape/captain
 	icon_state = "bedcape-captain"
 	item_state = "bedcape-captain"
 	bcolor = "captain"
-	cape = 1
 
 /obj/item/clothing/suit/bedsheet/cape/royal
 	icon_state = "bedcape-royal"
 	item_state = "bedcape-royal"
 	bcolor = "royal"
-	cape = 1
 
 /obj/item/clothing/suit/bedsheet/cape/psych
 	icon_state = "bedcape-psych"
 	item_state = "bedcape-psych"
 	bcolor = "psych"
-	cape = 1
 
 // FIRE SUITS
 


### PR DESCRIPTION
…edsheet/cape

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Hey! This is my first PR! :)
A minor bugfix. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
https://github.com/goonstation/goonstation/issues/1305
This was the issue which was posted.
Vampires could not use their glare and hypnosis ability due to admin spawned in bedsheet/cape items.


## Changelog
Admin spawned bedshee/cape items work now.
Uneccessary cape = 1 from child /obj/ of bedsheet/cape have been removed.
