### PR TITLE
Borgs pull corpses slightly slower than fullspeed

### DIFF
--- a/code/datums/movement_modifier/movement_modifiers.dm
+++ b/code/datums/movement_modifier/movement_modifiers.dm
@@ -80,7 +80,7 @@
 // robot modifiers
 /datum/movement_modifier/robot_base
 	health_deficiency_adjustment = -INFINITY
-	mob_pull_multiplier = 0.2
+	mob_pull_multiplier = 0.2 //make borgs pull mobs slightly slower than full speed (roundstart light borg will pull a corpse at ~1.3 delay, as opposed to ~1 when unencumbered)
 
 /datum/movement_modifier/robot_oil
 	additive_slowdown = -0.5

--- a/code/datums/movement_modifier/movement_modifiers.dm
+++ b/code/datums/movement_modifier/movement_modifiers.dm
@@ -13,6 +13,7 @@
 	var/pushpull_multiplier = 1 // multiplier for pushing/pulling speed
 	var/space_movement = 0
 	var/aquatic_movement = 0
+	var/mob_pull_multiplier = 1
 	var/ask_proc = 0
 
 /datum/movement_modifier/proc/modifiers(mob/user, turf/move_target, running)
@@ -79,6 +80,7 @@
 // robot modifiers
 /datum/movement_modifier/robot_base
 	health_deficiency_adjustment = -INFINITY
+	mob_pull_multiplier = 0.2
 
 /datum/movement_modifier/robot_oil
 	additive_slowdown = -0.5

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1455,6 +1455,7 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 	var/pushpull_multiplier = 1
 	var/aquatic_movement = 0
 	var/space_movement = 0
+	var/mob_pull_multiplier = 1
 
 	var/datum/movement_modifier/modifier
 	for(var/type_or_instance in src.movement_modifiers)
@@ -1475,6 +1476,7 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 		pushpull_multiplier *= modifier.pushpull_multiplier
 		aquatic_movement += modifier.aquatic_movement
 		space_movement += modifier.space_movement
+		mob_pull_multiplier *= modifier.mob_pull_multiplier
 
 		if (modifier.maximum_slowdown < maximum_slowdown)
 			maximum_slowdown = modifier.maximum_slowdown
@@ -1502,10 +1504,33 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 
 	if (pushpull_multiplier != 0) // if we're not completely ignoring pushing/pulling
 		if (src.pulling)
-			. *= (pull_speed_modifier(move_target) * pushpull_multiplier)
+			if (istype(src.pulling, /atom/movable) && !(src.is_hulk() || (src.bioHolder && src.bioHolder.HasEffect("strong"))))
+				var/atom/movable/A = src.pulling
+				// hi grayshift sorry grayshift
+				if (get_dist(src,A) > 0 && get_dist(move_target,A) > 0) //i think this is mbc dist stuff for if we're actually stepping away and pulling the thing or not?
+					if(pull_slowing)
+						. *= max(A.p_class, 1)
+					else
+						if(istype(A,/obj/machinery/nuclearbomb)) //can't speed off super fast with the nuke, it's heavy
+							. *= max(A.p_class, 1)
+						// else, ignore p_class*/
+						else if(ismob(A))
+							var/mob/M = A
+							//if they're lying, pull em slower, unless you have anext_move gang and they are in your gang.
+							if(M.lying)
+								if (src.mind?.gang && (src.mind.gang == M.mind?.gang))
+									. *= 1		//do nothing
+								else
+									. *= lerp(1, max(A.p_class, 1), mob_pull_multiplier) 
+						else if(istype(A, /obj/storage))
+							// if the storage object contains mobs, use its p_class (updated within storage to reflect containing mobs or not)
+							if (locate(/mob) in A.contents)
+								. *= lerp(1, max(A.p_class, 1), mob_pull_multiplier)
+			. = lerp(1, . , pushpull_multiplier)
+
 
 		if (src.pushing && (src.pulling != src.pushing))
-			. *= (max(src.pushing.p_class, 1) * pushpull_multiplier)
+			. *= lerp(1, max(src.pushing.p_class, 1), pushpull_multiplier)
 
 		for (var/obj/item/grab/G in list(src.r_hand, src.l_hand))
 			var/mob/M = G.affecting
@@ -1515,9 +1540,9 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 			if (G.state == 0)
 				if (get_dist(src,M) > 0 && get_dist(move_target,M) > 0) //pasted into living.dm pull slow as well (consider merge somehow)
 					if(ismob(M) && M.lying)
-						. *= (max(M.p_class, 1) * pushpull_multiplier)
+						. *= lerp(1, max(M.p_class, 1), pushpull_multiplier)
 			else
-				. *= (max(M.p_class, 1) * pushpull_multiplier)
+				. *= lerp(1, max(M.p_class, 1), pushpull_multiplier)
 
 	. *= multiplier
 
@@ -1583,32 +1608,6 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 				if (src.loc != last || force_puff) //ugly check to prevent stationary sprint weirds
 					sprint_particle(src, last)
 					playsound(src.loc,"sound/effects/sprint_puff.ogg", 25, 1)
-
-/mob/living/proc/pull_speed_modifier(var/atom/move_target = 0)
-	. = 1
-	if (istype(src.pulling, /atom/movable) && !(src.is_hulk() || (src.bioHolder && src.bioHolder.HasEffect("strong"))))
-		var/atom/movable/A = src.pulling
-		// hi grayshift sorry grayshift
-		if (get_dist(src,A) > 0 && get_dist(move_target,A) > 0) //i think this is mbc dist stuff for if we're actually stepping away and pulling the thing or not?
-			if(pull_slowing)
-				. *= max(A.p_class, 1)
-			else
-				if(istype(A,/obj/machinery/nuclearbomb)) //can't speed off super fast with the nuke, it's heavy
-					. *= max(A.p_class, 1)
-				// else, ignore p_class*/
-				if(ismob(A))
-					var/mob/M = A
-					//if they're lying, pull em slower, unless you have anext_move gang and they are in your gang.
-					if(M.lying)
-						if (src.mind?.gang && (src.mind.gang == M.mind?.gang))
-							. *= 1		//do nothing
-						else
-							. *= max(A.p_class, 1)
-				else if(istype(A, /obj/storage))
-					// if the storage object contains mobs, use its p_class (updated within storage to reflect containing mobs or not)
-					if (locate(/mob) in A.contents)
-						. *= max(A.p_class,1)
-
 
 // cogwerks - fix for soulguard and revive
 /mob/living/proc/remove_ailments()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE] [FIX] [CLEANLINESS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Make borgs pull corpses slightly slower than fullspeed (about 20% of standard movement penalty for mob-pulling)


Merge pull_speed_modifier proc into the exactly one place it was used - change pullspeed multipliers to be a linear interpolation b/w 1 and the higher value instead of a direct multiplier
Add a mob_pull_multiplier for movement modifiers that affects pullspeed for pulling mobs seperately from general pullspeed


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #1126
Supersedes #1143 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Tarmunora:
(*)Borgs will now pull mobs at slightly less than full speed
```
