### PR TITLE
Limit Cog1 to require at least 14 players on RP server

### DIFF
--- a/code/map.dm
+++ b/code/map.dm
@@ -12,7 +12,11 @@ var/global/datum/map_settings/map_settings = null
 //playerPickable defines whether the map can be chosen by players when voting on a new map. Setting to ASS_JAM should allow it on the 13th only, and not on RP.
 var/global/list/mapNames = list(
 	"Clarion" = 		list("id" = "CLARION", 		"settings" = "destiny/clarion", "playerPickable" = 1),
+#ifdef RP_MODE
+	"Cogmap 1" = 		list("id" = "COGMAP", 		"settings" = "cogmap", 			"playerPickable" = 1, 	"MinPlayersAllowed" = 20),
+#else
 	"Cogmap 1" = 		list("id" = "COGMAP", 		"settings" = "cogmap", 			"playerPickable" = 1),
+#endif
 	//"Construction" = list("id" = "CONSTRUCTION", "settings" = "construction"),
 	"Cogmap 1 (Old)" = 	list("id" = "COGMAP_OLD", 	"settings" = "cogmap_old"),
 	"Cogmap 2" = 		list("id" = "COGMAP2", 		"settings" = "cogmap2", 		"playerPickable" = 1, 	"MinPlayersAllowed" = 40),

--- a/code/map.dm
+++ b/code/map.dm
@@ -13,7 +13,7 @@ var/global/datum/map_settings/map_settings = null
 var/global/list/mapNames = list(
 	"Clarion" = 		list("id" = "CLARION", 		"settings" = "destiny/clarion", "playerPickable" = 1),
 #ifdef RP_MODE
-	"Cogmap 1" = 		list("id" = "COGMAP", 		"settings" = "cogmap", 			"playerPickable" = 1, 	"MinPlayersAllowed" = 20),
+	"Cogmap 1" = 		list("id" = "COGMAP", 		"settings" = "cogmap", 			"playerPickable" = 1, 	"MinPlayersAllowed" = 14),
 #else
 	"Cogmap 1" = 		list("id" = "COGMAP", 		"settings" = "cogmap", 			"playerPickable" = 1),
 #endif


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[REWORK][FEEDBACK]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
On the RP server: ~~20~~ 14 players must be connected to be able to vote for Cog1.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Cog1 may be comfortable, but it does not help create RP situations.

- Some departments have little/no hallway-facing rooms. Notably Science, and to a lesser extent Botany (An empty reception desk doesn't count i.m.o)
- There are massive stretches of hallway that are (on low pop) just walking space. 
  - From Science to Security, there's nothing worth stopping for.
  - From medbay to cargo, the only notable "stop" is mechanics.

Maps like Clarion and Manta strike a good balance of exposing departments without needing too much hallway space.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)MarkNstein:
(+)On the RP server: Cogmap 1 can only be voted for when at least 14 players are connected.
```
