### PR TITLE
DeconDevice is now Smaller (fits in belt, etc)

### DIFF
--- a/code/WorkInProgress/Electronics.dm
+++ b/code/WorkInProgress/Electronics.dm
@@ -676,7 +676,7 @@
 	throwforce = 4
 	hitsound = 'sound/machines/chainsaw_green.ogg'
 	hit_type = DAMAGE_CUT
-	w_class = 2.0
+	w_class = 3.0
 	var/datum/effects/system/spark_spread/spark_system
 	module_research = list("electronics" = 3, "engineering" = 1)
 

--- a/code/WorkInProgress/Electronics.dm
+++ b/code/WorkInProgress/Electronics.dm
@@ -676,7 +676,7 @@
 	throwforce = 4
 	hitsound = 'sound/machines/chainsaw_green.ogg'
 	hit_type = DAMAGE_CUT
-	w_class = 3.0
+	w_class = 2.0
 	var/datum/effects/system/spark_spread/spark_system
 	module_research = list("electronics" = 3, "engineering" = 1)
 

--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -182,6 +182,9 @@
 	desc = "Can hold various small objects."
 	icon_state = "utilitybelt"
 	item_state = "utility"
+	can_hold = list(
+	/obj/item/deconstructor
+	)
 
 /obj/item/storage/belt/utility/prepared/ceshielded
 	name = "aurora MKII utility belt"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The decon device is now w_class = 2.0 (was 3.0)
Fits in belts, boxes, etc. 
Fixes #1317

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It spawn's in the CE's belt, but can't be added back in. Also, it's a tool, seems appropriate.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)MarkNstein:
(+)Decon' Devices now fit in belts, boxes, pockets, etc.
```
