### PR TITLE
Reduced capacity of securitron dropped batons to 75PU, and removed the ability to swap their cells out.

### DIFF
--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -35,7 +35,7 @@
 	var/botcard_access = "Head of Security" //Job access for doors.
 	var/hat = null //Add an overlay from aibots.dmi with this state.  hats.
 	var/our_baton_type = /obj/item/baton/secbot
-	var/loot_baton_type = /obj/item/baton
+	var/loot_baton_type = /obj/item/baton/secbotdropped
 	var/stun_type = "stun"
 	var/mode = 0
 #define SECBOT_IDLE 		0		// idle
@@ -80,6 +80,7 @@
 /obj/machinery/bot/secbot/beepsky
 	name = "Officer Beepsky"
 	desc = "It's Officer Beepsky! He's a loose cannon but he gets the job done."
+	loot_baton_type = /obj/item/baton
 	idcheck = 1
 	auto_patrol = 1
 	report_arrests = 1

--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -927,6 +927,13 @@
 			else
 				return 0
 
+/obj/item/ammo/power_cell/minpower
+	name = "Power Cell - 75"
+	desc = "A power cell that holds a max of 75PU"
+	icon = 'icons/obj/items/ammo.dmi'
+	icon_state = "power_cell"
+	max_charge = 75.0
+
 /obj/item/ammo/power_cell/med_power
 	name = "Power Cell - 200"
 	desc = "A power cell that holds a max of 200PU"

--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -414,7 +414,7 @@
 	cell_type = /obj/item/ammo/power_cell
 
 /obj/item/baton/secbotdropped
-	desc = "A low capacity security baton for use by securitrons. Its battery is firmly stuck in place, and can't be removed."
+	desc = "A low capacity security baton for use by securitrons. Its battery is fixed firmly in place, and can't be removed."
 	cell_type= /obj/item/ammo/power_cell/minpower
 	can_swap_cell = 0
 

--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -413,6 +413,11 @@
 	icon_off = "stuncane"
 	cell_type = /obj/item/ammo/power_cell
 
+/obj/item/baton/secbotdropped
+	desc = "A low capacity security baton for use by securitrons. Its battery is firmly stuck in place, and can't be removed."
+	cell_type= /obj/item/ammo/power_cell/minpower
+	can_swap_cell = 0
+
 /obj/item/baton/classic
 	name = "police baton"
 	desc = "A wooden truncheon for beating criminal scum."


### PR DESCRIPTION
[BALANCE][INPUT WANTED]

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes regular securitrons drop batons with unremovable 75PU cells. Beepsky is exempt from this change.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Alternative to #1315 , should let crew and antags get bad alternatives to security gear, without completely removing their access to it.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)TrustworthyFella:
(*)Securitrons now drop batons with smaller cells that can't be replaced
```
