### PR TITLE
UM-041 - Adjust Zip Gun Failure Chances

### DIFF
--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -607,7 +607,7 @@
 
 	shoot()
 		if(ammo && ammo.amount_left && current_projectile && current_projectile.caliber && current_projectile.power)
-			failure_chance = max(10,min(33,round(current_projectile.caliber * (current_projectile.power/2))))
+			failure_chance = max(0,min(33,round(current_projectile.power/2 - 9)))
 		if(canshoot() && prob(failure_chance)) // Empty zip guns had a chance of blowing up. Stupid (Convair880).
 			var/turf/T = get_turf(src)
 			explosion(src, T,-1,-1,1,2)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Changes zip gun failure chances to progress linearly by power instead of confusingly using caliber
- 2% with .22 bullets, capped at 33% chance for most high powered rounds

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

- Not everything needs to explode all the fricken' time
- Using Caliber in the formula is a bad idea, since that's a flavor/aesthetic choice and not mathematically consistent
- Part of a wider effort to help crew weaponry not suck so bad

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)UrsulaMajor:
(*)Significantly lowered zip gun failure chances for low caliber rounds
```
