### PR TITLE
UM-042 - Remove .38 Stunners from Hacked General Fabricator

### DIFF
--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -1830,7 +1830,6 @@
 		/datum/manufacture/vuvuzela,
 		/datum/manufacture/harmonica,
 		/datum/manufacture/bikehorn,
-		/datum/manufacture/stunrounds,
 		/datum/manufacture/bullet_22,
 		/datum/manufacture/bullet_smoke,
 #if ASS_JAM


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Title

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Blocks #1337 

I've never run out of ammo as Detective, as there's plenty of ammo available in the SecTechs around the station.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)UrsulaMajor:
(+)Removed 0.38 Stun Rounds from the General Manufacturer
```
