### PR TITLE
Transport Chutes can no longer be interacted with at any distance

### DIFF
--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -679,7 +679,8 @@
 
 	MouseDrop_T(mob/target, mob/user)
 		if (!istype(target) || target.buckled || get_dist(user, src) > 1 || get_dist(user, target) > 1 || user.stat || user.hasStatus(list("weakened", "paralysis", "stunned")) || isAI(user) || isAI(target) || isghostcritter(user))
-			return ..()
+			return 
+		..()
 		flush = 1
 
 		if (!is_processing)

--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -678,7 +678,8 @@
 		return
 
 	MouseDrop_T(mob/target, mob/user)
-		..()
+		if (!istype(target) || target.buckled || get_dist(user, src) > 1 || get_dist(user, target) > 1 || user.stat || user.hasStatus(list("weakened", "paralysis", "stunned")) || isAI(user) || isAI(target) || isghostcritter(user))
+			return ..()
 		flush = 1
 
 		if (!is_processing)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Transport Chutes can no longer be interacted with at any distance. Not that you could enter it at any distance, but you could trigger them.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #1285 