### PR TITLE
Fixed inconsistent chaplain immunities

### DIFF
--- a/code/datums/abilities/wizard/bullcharge.dm
+++ b/code/datums/abilities/wizard/bullcharge.dm
@@ -38,12 +38,14 @@
 			for (var/atom/movable/M in T)
 				if (M.anchored || affected.Find(M) || M == holder.owner)
 					continue
-				affected += M
-				SPAWN_DBG(0) M.throw_at(get_edge_cheap(T, B.dir), 30, 1)
 				if (ismob(M))
 					var/mob/some_idiot = M
+					if(some_idiot?.traitHolder?.hasTrait("training_chaplain"))
+						continue
 					some_idiot.changeStatus("weakened", 3 SECONDS)
 					some_idiot.TakeDamage("chest", 33, 0, 0, DAMAGE_BLUNT)//it's magic. no armor 4 u
+				affected += M
+				SPAWN_DBG(0) M.throw_at(get_edge_cheap(T, B.dir), 30, 1)
 			sleep(0.1 SECONDS)
 
 		qdel(B)

--- a/code/datums/abilities/wizard/fireball.dm
+++ b/code/datums/abilities/wizard/fireball.dm
@@ -4,6 +4,8 @@
 	icon = 'icons/obj/wizard.dmi'
 	shot_sound = 'sound/effects/mag_fireballlaunch.ogg'
 
+	is_magical = 1
+
 	on_hit(atom/hit, direction, var/obj/projectile/projectile)
 		var/turf/T = get_turf(hit)
 		if (projectile.mob_shooter && projectile.mob_shooter:wizard_spellpower())

--- a/code/datums/abilities/wizard/prismatic_spray.dm
+++ b/code/datums/abilities/wizard/prismatic_spray.dm
@@ -30,6 +30,7 @@
 		..()
 		for (var/X in filtered_concrete_typesof(/datum/projectile, .proc/filter_projectile))
 			var/datum/projectile/A = new X
+			A.is_magical = 1
 			proj_types += A
 
 	proc/filter_projectile(proj_type)

--- a/code/mob/living/carbon/human/procs/damage.dm
+++ b/code/mob/living/carbon/human/procs/damage.dm
@@ -32,8 +32,9 @@
 		return
 
 	if (P?.proj_data?.is_magical  && src?.traitHolder?.hasTrait("training_chaplain"))
+		src.visible_message("<span class='alert'>A divine light absorbs the magical projectile!</span>")
+		playsound(src.loc, "sound/impact_sounds/Energy_Hit_1.ogg", 40, 1)
 		P.die()
-		src.visible_message("<span class='alert'>A divine shield absorbs the magical projectile!</span>")
 		return
 
 	if(src.material) src.material.triggerOnBullet(src, src, P)

--- a/code/mob/living/carbon/human/procs/damage.dm
+++ b/code/mob/living/carbon/human/procs/damage.dm
@@ -36,7 +36,6 @@
 		src.visible_message("<span class='alert'>A divine shield absorbs the magical projectile!</span>")
 		return
 
-
 	if(src.material) src.material.triggerOnBullet(src, src, P)
 	for (var/atom/A in src)
 		if (A.material)

--- a/code/mob/living/carbon/human/procs/damage.dm
+++ b/code/mob/living/carbon/human/procs/damage.dm
@@ -31,6 +31,11 @@
 		playsound(src.loc, 'sound/impact_sounds/Energy_Hit_1.ogg',80, 0.1, 0, 3)
 		return
 
+	if (P?.proj_data?.is_magical  && src?.traitHolder?.hasTrait("training_chaplain"))
+		P.die()
+		src.visible_message("<span class='alert'>A divine shield absorbs the magical projectile!</span>")
+		return
+
 
 	if(src.material) src.material.triggerOnBullet(src, src, P)
 	for (var/atom/A in src)

--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -607,6 +607,7 @@ datum/projectile
 	var/goes_through_mobs = 0
 	var/pierces = 0
 	var/ticks_between_mob_hits = 0
+	var/is_magical = 0              //magical projectiles, i.e. the chaplain is immune to these
 	// var/type = "K"					//3 types, K = Kinetic, E = Energy, T = Taser
 
 

--- a/code/modules/projectiles/special.dm
+++ b/code/modules/projectiles/special.dm
@@ -700,17 +700,9 @@ ABSTRACT_TYPE(/datum/projectile/special)
 				pass_proj.die()
 			return
 
+		hit.damage_cold(temp_reduc / 10)
 		if (isliving(hit))
 			var/mob/living/L = hit
-
-			if (L?.traitHolder?.hasTrait("training_chaplain"))
-				var/obj/itemspecialeffect/glare/E = unpool(/obj/itemspecialeffect/glare)
-				E.color = "#FFFFFF"
-				E.setup(L.loc)
-				playsound(L.loc,"sound/effects/glare.ogg", 50, 1, pitch = 1, extrarange = -4)
-				L.visible_message("<span class='alert'>A divine light shields [hit] from the frost bat!</span>")
-				return
-
 			L.bodytemperature -= temp_reduc
 			L.TakeDamage("All", 3, 1, 0, 0)//magic
 
@@ -725,8 +717,6 @@ ABSTRACT_TYPE(/datum/projectile/special)
 				L.changeStatus("weakened", 2 SECONDS)
 				L.force_laydown_standup()
 				L.throw_at(targetTurf, rand(5,7), rand(1,2), throw_type = THROW_GUNIMPACT)
-
-		hit.damage_cold(temp_reduc / 10)
 
 	on_canpass(var/obj/projectile/P, atom/movable/passing_thing)
 		if (P != passing_thing)

--- a/code/modules/projectiles/special.dm
+++ b/code/modules/projectiles/special.dm
@@ -676,6 +676,7 @@ ABSTRACT_TYPE(/datum/projectile/special)
 	rotate_proj = 0
 	face_desired_dir = 1
 	goes_through_walls = 1
+	is_magical = 1
 
 	shot_sound = 0
 	hit_mob_sound = 'sound/effects/mag_iceburstimpact_high.ogg'
@@ -699,9 +700,17 @@ ABSTRACT_TYPE(/datum/projectile/special)
 				pass_proj.die()
 			return
 
-		hit.damage_cold(temp_reduc / 10)
 		if (isliving(hit))
 			var/mob/living/L = hit
+
+			if (L?.traitHolder?.hasTrait("training_chaplain"))
+				var/obj/itemspecialeffect/glare/E = unpool(/obj/itemspecialeffect/glare)
+				E.color = "#FFFFFF"
+				E.setup(L.loc)
+				playsound(L.loc,"sound/effects/glare.ogg", 50, 1, pitch = 1, extrarange = -4)
+				L.visible_message("<span class='alert'>A divine light shields [hit] from the frost bat!</span>")
+				return
+
 			L.bodytemperature -= temp_reduc
 			L.TakeDamage("All", 3, 1, 0, 0)//magic
 
@@ -716,6 +725,8 @@ ABSTRACT_TYPE(/datum/projectile/special)
 				L.changeStatus("weakened", 2 SECONDS)
 				L.force_laydown_standup()
 				L.throw_at(targetTurf, rand(5,7), rand(1,2), throw_type = THROW_GUNIMPACT)
+
+		hit.damage_cold(temp_reduc / 10)
 
 	on_canpass(var/obj/projectile/P, atom/movable/passing_thing)
 		if (P != passing_thing)
@@ -811,14 +822,14 @@ ABSTRACT_TYPE(/datum/projectile/special)
 		if(ismob(hit) && typetospawn)
 			hasspawned = 1
 			. = new typetospawn(get_turf(hit))
-		return 
+		return
 
 
 	on_end(obj/projectile/O)
 		if(!hasspawned && typetospawn)
 			. = new typetospawn(get_turf(O))
 		hasspawned = null
-		return 
+		return
 
 /datum/projectile/special/spawner/gun //shoot guns
 	name = "gun"
@@ -861,7 +872,7 @@ ABSTRACT_TYPE(/datum/projectile/special)
 		var/obj/item/reagent_containers/food/snacks/ingredient/egg/critter/wasp/angry/W = ..()
 		if(istype(W))
 			W.throw_impact(get_turf(O))
-		
+
 
 
 

--- a/code/obj/artifacts/artifactdatums.dm
+++ b/code/obj/artifacts/artifactdatums.dm
@@ -187,11 +187,3 @@
 	New()
 		..()
 		src.randomise()
-
-	on_hit(atom/hit, angle, var/obj/projectile/O)
-		var/mob/M = hit
-		if (istype(M) && M?.traitHolder?.hasTrait("training_chaplain"))
-			M.visible_message("<span class='alert'>A divine light shields [hit]!</span>")
-			return
-
-		..()

--- a/code/obj/artifacts/artifactdatums.dm
+++ b/code/obj/artifacts/artifactdatums.dm
@@ -182,7 +182,16 @@
 
 // for use with the wizard spell prismatic_spray
 /datum/projectile/artifact/prismatic_projectile
+	is_magical = 1
 
 	New()
 		..()
 		src.randomise()
+
+	on_hit(atom/hit, angle, var/obj/projectile/O)
+		var/mob/M = hit
+		if (istype(M) && M?.traitHolder?.hasTrait("training_chaplain"))
+			M.visible_message("<span class='alert'>A divine light shields [hit]!</span>")
+			return
+
+		..()

--- a/code/obj/item/misc_wizard_stuff.dm
+++ b/code/obj/item/misc_wizard_stuff.dm
@@ -88,7 +88,7 @@
 
 	// Part of the parent for convenience.
 	proc/do_brainmelt(var/mob/affected_mob, var/severity = 2)
-		if (!src || !istype(src) || !affected_mob || !ismob(affected_mob) || check_target_immunity(affected_mob) || affected_mob?.traitHolder?.hasTrait("training_chaplain"))
+		if (!src || !istype(src) || !affected_mob || !ismob(affected_mob) || check_target_immunity(affected_mob))
 			return
 
 		switch (severity)

--- a/code/obj/item/misc_wizard_stuff.dm
+++ b/code/obj/item/misc_wizard_stuff.dm
@@ -165,9 +165,8 @@
 	desc = "A dark staff infused with eldritch power. Trying to steal this is probably a bad idea."
 	icon_state = "staffcthulhu"
 	item_state = "staffcthulhu"
-	force = 0
+	force = 14
 	hitsound = 'sound/effects/ghost2.ogg'
-	var/magic_damage = 14
 
 	New()
 		. = ..()
@@ -196,7 +195,6 @@
 				playsound(M, "sound/impact_sounds/Energy_Hit_1.ogg", 40, 1)
 				return
 
-			M.TakeDamage("All", magic_damage, 0)
 			if (prob(20))
 				src.do_brainmelt(M, 1)
 			else if (prob(35))

--- a/code/obj/item/misc_wizard_stuff.dm
+++ b/code/obj/item/misc_wizard_stuff.dm
@@ -88,7 +88,7 @@
 
 	// Part of the parent for convenience.
 	proc/do_brainmelt(var/mob/affected_mob, var/severity = 2)
-		if (!src || !istype(src) || !affected_mob || !ismob(affected_mob) || check_target_immunity(affected_mob))
+		if (!src || !istype(src) || !affected_mob || !ismob(affected_mob) || check_target_immunity(affected_mob) || affected_mob?.traitHolder?.hasTrait("training_chaplain"))
 			return
 
 		switch (severity)
@@ -165,8 +165,9 @@
 	desc = "A dark staff infused with eldritch power. Trying to steal this is probably a bad idea."
 	icon_state = "staffcthulhu"
 	item_state = "staffcthulhu"
-	force = 14
+	force = 0
 	hitsound = 'sound/effects/ghost2.ogg'
+	var/magic_damage = 14
 
 	New()
 		. = ..()
@@ -190,6 +191,12 @@
 
 	attack(mob/M as mob, mob/user as mob)
 		if (iswizard(user) && !iswizard(M) && !isdead(M) && !check_target_immunity(M))
+			if (M?.traitHolder?.hasTrait("training_chaplain"))
+				M.visible_message("<spab class='alert'>A divine light shields [M] from harm!</span>")
+				playsound(M, "sound/impact_sounds/Energy_Hit_1.ogg", 40, 1)
+				return
+
+			M.TakeDamage("All", magic_damage, 0)
 			if (prob(20))
 				src.do_brainmelt(M, 1)
 			else if (prob(35))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
There were some spells and abilities from both vampires and wizards that still worked on the chaplain, despite the chaplain being regarded as the only person immune to supernatural and magical abilities. This PR makes it so the chaplain - in addition to existing immunities - is also protected from:

- Staff of Cthulu direct attacks (trying to pick it up will still result in damage)
- Bull's charge
- Prismatic Spray
- Fireball (yes, the chaplain was in fact not immune to these)
- Frost bats

Do note that Fireball can still do splash damage.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The chaplain was the only person on the station immune to supernatural and magical abilities, and the previously mentioned inconsistent protection from these abilities was unintuitive; players would have no idea which abilities worked and which abilities didn't outside trial and error.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)RichardGere:
(+)Fixed chaplain immunity inconsistencies. For a full list of covered abilities, please see the PR.
```
