### PR TITLE
PNetComp Address & Settings in Description

### DIFF
--- a/code/WorkInProgress/MechanicsNetworkCon.dm
+++ b/code/WorkInProgress/MechanicsNetworkCon.dm
@@ -24,6 +24,11 @@
 
 	var/ready = 1
 
+	get_desc()
+		. += {"<br><span class='notice'>[self_only ? "Only receiving signals addressed to [net_id]":"Receiving all signals regardless of address_1."]<br>
+		[register ? "Registering with mainframes.":"Not registering with mainframes."]<br>
+		Current NetID: [net_id]</span>"}
+
 	New()
 		. = ..()
 		src.net_id = generate_net_id(src)
@@ -54,9 +59,11 @@
 				if("Toggle Self-Only Messages")
 					self_only = !self_only
 					boutput(usr, "[self_only ? "Now only processing messages adressed at us.":"Now processing all messages recieved."]")
+					tooltip_rebuild = 1
 				if("Toggle Mainframe Registration")
 					register = !register
 					boutput(usr, "[register ? "Now registering with mainframes.":"Now no longer registering with mainframes."]")
+					tooltip_rebuild = 1
 
 	proc/spacket(var/datum/mechanicsMessage/input)
 		if(!ready) return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The address, and the other settings, are now visible in the description.
![image](https://user-images.githubusercontent.com/9563541/86521941-9f9cea00-be0b-11ea-9bf9-70c07985c613.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Trying to find the address is a needless chore. Mimics the Wifi Comp's address being visible in the description.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)MarkNstein:
(+)PNetComp now displays it's address and settings when observed.
```
