### PR TITLE
change resurrection symptom and some minor other related things

### DIFF
--- a/code/mob/living/life/Life.dm
+++ b/code/mob/living/life/Life.dm
@@ -609,8 +609,6 @@
 				for (var/uid in src.pathogens)
 					var/datum/pathogen/P = src.pathogens[uid]
 					P.disease_act_dead()
-					if (prob(5))
-						src.cured(P)
 			return
 		for (var/uid in src.pathogens)
 			var/datum/pathogen/P = src.pathogens[uid]

--- a/code/modules/medical/pathology/pathogen.dm
+++ b/code/modules/medical/pathology/pathogen.dm
@@ -1247,25 +1247,8 @@ datum/pathogen
 			rad_mutate_cooldown = 0
 		*/
 
-	// This is the real thing, wrapped by process().
-	proc/disease_act()
-		var/list/acted = list()
-		var/order = pick(0,1)
-		if (order)
-			for (var/datum/effect in src.effects)
-				if (effect.type in acted)
-					continue
-				acted += effect.type
-				if (prob(body_type.activity[stage]))
-					effect:disease_act(infected, src)
-		else
-			for (var/i = src.effects.len, i > 0, i--)
-				var/datum/effect = src.effects[i]
-				if (effect.type in acted)
-					continue
-				acted += effect.type
-				if (prob(body_type.activity[stage]))
-					effect:disease_act(infected, src)
+	// handles pathogen advancing or receding in stage and also being cured
+	proc/progress_pathogen()
 		if (!cooldown)
 			if (in_remission)
 				if (prob(abs(advance_speed)))
@@ -1298,6 +1281,27 @@ datum/pathogen
 		else
 			cooldown--
 
+	// This is the real thing, wrapped by process().
+	proc/disease_act()
+		var/list/acted = list()
+		var/order = pick(0,1)
+		if (order)
+			for (var/datum/effect in src.effects)
+				if (effect.type in acted)
+					continue
+				acted += effect.type
+				if (prob(body_type.activity[stage]))
+					effect:disease_act(infected, src)
+		else
+			for (var/i = src.effects.len, i > 0, i--)
+				var/datum/effect = src.effects[i]
+				if (effect.type in acted)
+					continue
+				acted += effect.type
+				if (prob(body_type.activity[stage]))
+					effect:disease_act(infected, src)
+		progress_pathogen()
+
 	// it's like disease_act, but for dead people!
 	proc/disease_act_dead()
 		var/list/acted = list()
@@ -1317,7 +1321,7 @@ datum/pathogen
 				acted += effect.type
 				if (prob(body_type.activity[stage]))
 					effect:disease_act_dead(infected, src)
-		// let's not bother doing all the suppression and curing type stuff for dead people, most symptoms won't do anything anyway
+		progress_pathogen()
 
 	// A safe method for advancing the pathogen's stage.
 	proc/advance()

--- a/code/modules/medical/pathology/pathogen_benevolent.dm
+++ b/code/modules/medical/pathology/pathogen_benevolent.dm
@@ -208,25 +208,25 @@ datum/pathogeneffects/benevolent/resurrection
 	name = "Necrotic Resurrection"
 	desc = "The pathogen will resurrect you if it procs while you are dead."
 	rarity = RARITY_VERY_RARE
+	var/cooldown = 20 MINUTES
 
 	may_react_to()
 		return "Some of the pathogen's dead cells seem to remain active."
 
-	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
-		if (!origin.symptomatic)
-			return
-		if (origin.stage < 5)
-			return
-		if(prob(5))
-			M.show_message("<span class='alert'>You feel a sudden craving for ... brains??</span>")
-
 	disease_act_dead(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
 			return
-		if (origin.stage < 5)
+		if (origin.stage < 3)
+			return
+		if(!origin.symptom_data["resurrect_cd"]) // if not yet set, initialize it so that it is off cooldown
+			origin.symptom_data["resurrect_cd"] = -cooldown
+		if(TIME-origin.symptom_data["resurrect_cd"] < cooldown)
 			return
 		// Shamelessly stolen from Strange Reagent
 		if (isdead(M) || istype(get_area(M),/area/afterlife/bar))
+			origin.symptom_data["resurrect_cd"] = TIME
+			// range from 65 to 45. This is applied to both brute and burn, so the total max damage after resurrection is 130 to 90.
+			var/cap =	95 - origin.stage*10
 			var/brute = M.get_brute_damage()>45?45:M.get_brute_damage()
 			var/burn = M.get_burn_damage()>45?45:M.get_burn_damage()
 
@@ -238,8 +238,9 @@ datum/pathogeneffects/benevolent/resurrection
 				H.blood_volume = 500 					// let's not have people immediately suffocate from being exsanguinated
 				H.take_toxin_damage(-INFINITY)
 				H.take_oxygen_deprivation(-INFINITY)
+				H.take_brain_damage(-INFINITY)
 
-			M.TakeDamage("chest", brute, burn)			// this makes it so our burn and brute are between 0-45, so at worst we will have 10% hp
+			M.TakeDamage("chest", brute, burn)
 			M.take_brain_damage(70)						// and a lot of brain damage
 			setalive(M)
 			M.changeStatus("paralysis", 150) 			// paralyze the person for a while, because coming back to life is hard work
@@ -252,8 +253,6 @@ datum/pathogeneffects/benevolent/resurrection
 			if (ishuman(M))
 				var/mob/living/carbon/human/H = M
 				H.contract_disease(/datum/ailment/disease/tissue_necrosis, null, null, 1) // this disease will make the person more and more rotten even while alive
-				H.remission(origin)			// set the pathogen into remission, so it will be gone soon. Unlikely for a person to revive twice like this!
-				H.immunity(origin)
 				H.visible_message("<span class='alert'>[H] suddenly starts moving again!</span>","<span class='alert'>You feel the pathogen weakening as you rise from the dead.</span>")
 
 	react_to(var/R, var/zoom)

--- a/code/modules/medical/pathology/pathogen_benevolent.dm
+++ b/code/modules/medical/pathology/pathogen_benevolent.dm
@@ -226,9 +226,9 @@ datum/pathogeneffects/benevolent/resurrection
 		if (isdead(M) || istype(get_area(M),/area/afterlife/bar))
 			origin.symptom_data["resurrect_cd"] = TIME
 			// range from 65 to 45. This is applied to both brute and burn, so the total max damage after resurrection is 130 to 90.
-			var/cap =	95 - origin.stage*10
-			var/brute = M.get_brute_damage()>cap?cap:M.get_brute_damage()
-			var/burn = M.get_burn_damage()>cap?cap:M.get_burn_damage()
+			var/cap =	95 - origin.stage * 10
+			var/brute = min(cap, M.get_brute_damage())
+			var/burn = min(cap, M.get_burn_damage())
 
 			// let's heal them before we put some of the damage back
 			// but they don't get back organs/limbs/whatever, so I don't use full_heal

--- a/code/modules/medical/pathology/pathogen_benevolent.dm
+++ b/code/modules/medical/pathology/pathogen_benevolent.dm
@@ -227,8 +227,8 @@ datum/pathogeneffects/benevolent/resurrection
 			origin.symptom_data["resurrect_cd"] = TIME
 			// range from 65 to 45. This is applied to both brute and burn, so the total max damage after resurrection is 130 to 90.
 			var/cap =	95 - origin.stage*10
-			var/brute = M.get_brute_damage()>45?45:M.get_brute_damage()
-			var/burn = M.get_burn_damage()>45?45:M.get_burn_damage()
+			var/brute = M.get_brute_damage()>cap?cap:M.get_brute_damage()
+			var/burn = M.get_burn_damage()>cap?cap:M.get_burn_damage()
 
 			// let's heal them before we put some of the damage back
 			// but they don't get back organs/limbs/whatever, so I don't use full_heal


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[balance] [enhancement]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the resurrection pathology symptom.

Before, it would only function when at stage 5. Upon triggering, it would cause the pathogen to go into remission, slowly going down through the stages and eventually curing itself. This meant that if a person was killed several times in quick succession, they could be repeatedly revived.

After this PR, it will instead revive at stages 3-5. It will then enter a cooldown period of 20 minutes, during which it will not be able to revive a person again. Scaling has been added so that reviving at a stage lower than 5 will mean that the resurrected person will retain more of the damage that their corpse had.

I have also removed pathogens curing themselves on dead people. They are now also able to continue advancing in stage while a person is dead. This should really only affect the resurrection symptom, making it so that people that die with it, that are not yet at stage 3 will resurrect a few minutes later when the pathogen has sufficiently advanced.

The only other thing that I think of that this could possibly affect is that you might catch a pathogen from punching an infected dead person (which was already possible but is now more likely).
If this is a problem for you, I suggest you stop beating dead staff assistants.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It was possible for the pathogen to be cured by random chance because dead people randomly cure themselves of diseases with a 5% chance. In addition, you may have the pathogen temporarily regress down to stage 4 or 3 due to short exposure to a suppressant (for instance, walking by a breach or being shocked). These kinds of things made it so sometimes you would not be revived when you really expected it, being very unsatisfying.
In addition, repeatedly being revived until the pathogen left stage 5 seems very unfair if someone is trying to murder you, this will also be stopped by this PR, due to the 20 minute cooldown.
Lastly, I feel like the downside of having the entire pathogen be cured because of one symptom was too harsh, thus the rest of the pathogen now remains intact after the revival triggers.