### PR TITLE
modified health scanners to show pathogen stages (and reorganized)

### DIFF
--- a/code/procs/scanprocs.dm
+++ b/code/procs/scanprocs.dm
@@ -112,23 +112,11 @@
 
 		if (H.pathogens.len)
 			pathogen_data = "<span class='alert'>Scans indicate the presence of [H.pathogens.len > 1 ? "[H.pathogens.len] " : null]pathogenic bodies.</span>"
-			var/list/therapy = list()
-			var/remissive = 0
 			for (var/uid in H.pathogens)
 				var/datum/pathogen/P = H.pathogens[uid]
+				pathogen_data += "<br>&emsp;<span class='alert'>Strain [P.name] seems to be in stage [P.stage]. Suggested suppressant: [P.suppressant.therapy].</span>."
 				if (P.in_remission)
-					remissive ++
-				if (!(P.suppressant.therapy in therapy))
-					therapy += P.suppressant.therapy
-			var/count_part
-			if (!remissive)
-				count_part = "None of them appear"
-			else if (remissive == 1)
-				count_part = "One pathogen appears"
-			else
-				count_part = "[remissive] of them appear"
-			pathogen_data += "<br>&emsp;<span class='alert'>[count_part] to be in a remissive state.</span>"
-			pathogen_data += "<br><span style='font-weight:bold'>Suggested pathogen suppression therapies: [jointext(therapy, ", ")]."
+					pathogen_data += "<br>&emsp;&emsp;<span class='alert'>It appears to be in remission.</span>."
 
 		if (H.get_organ("brain"))
 			if (H.get_brain_damage() >= 100)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[enhancement]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
![image](https://user-images.githubusercontent.com/35579460/86523293-9bec8000-be6a-11ea-89df-ac8f2215817d.png)
Changes the health scanner output regarding pathogens a little bit.
It now also shows the stage of the pathogen and also it shows which suppressant goes with which pathogen.
It's now like a situation with more than one pathogen happens more often than once a year or something, I mainly wanted it to show pathogen stage.

I intend to expand on the scanner output in relation to pathogens some more in a future patch, but I thought I should probably put this in first, to atomize it a little, since the next one will be bigger.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It tells doctors how serious a patients condition is and also makes it easier for people to know which suppressant they need in case there are ever multiple pathogens.