### PR TITLE
Add ishuman check to checkbioeffect_add

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1284,13 +1284,16 @@ var/global/noir = 0
 		if ("checkbioeffect_add")
 			if(src.level >= LEVEL_SA)
 				var/mob/M = locate(href_list["target"])
+				if (!ishuman(M))
+					alert("You may only use this secret on human mobs.")
+					return
 				var/input = input(usr, "Enter a /datum/bioEffect path or partial name.", "Add a Bioeffect", null) as null|text
 				input = get_one_match(input, "/datum/bioEffect")
-				var/datum/bioEffect/be_to_add = text2path("[input]")
-				if (be_to_add)
-					M.bioHolder.AddEffect(initial(be_to_add.id))
+				var/datum/bioEffect/BE = text2path("[input]")
+				if (BE)
+					M.bioHolder.AddEffect(initial(BE.id))
 					usr.client.cmd_admin_checkbioeffect(M)
-					message_admins("[key_name(usr)] added the [initial(be_to_add.id)] bio-effect to [key_name(M)].")
+					message_admins("[key_name(usr)] added the [initial(BE.id)] bio-effect to [key_name(M)].")
 			else
 				alert("You need to be at least a Secondary Administrator to add bioeffects to a player.")
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][TRIVIAL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I forgot to add an `ishuman` check to `checkbioeffect_add` which means you can add them to anything with a bioHolder (e.g. critters)

While critters can have bioeffects most of them don't actually work. Likewise the option to add or remove them isn't normally in the player options.

Also I renamed a var to be consistent with my other var names

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
it's a bug