### PR TITLE
fix interdimensional monkey attacks, fix monkey throwing itemarms

### DIFF
--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -935,7 +935,7 @@
 /mob/living/carbon/human/proc/throw_item(atom/target, list/params)
 	var/turf/thrown_from = get_turf(src)
 	src.throw_mode_off()
-	if (usr.stat)
+	if (src.stat)
 		return
 #if ASS_JAM //no throwing while in timestop
 	if (paused)
@@ -947,6 +947,8 @@
 	//	return
 
 	var/obj/item/I = src.equipped()
+	if("npc_throw" in params)
+		I = src.r_hand
 
 	if (!I || !isitem(I) || I.cant_drop) return
 

--- a/code/mob/living/carbon/human/npc.dm
+++ b/code/mob/living/carbon/human/npc.dm
@@ -423,8 +423,6 @@
 
 /mob/living/carbon/human/proc/ai_pickupweapon()
 
-	if(src.r_hand?.cant_drop)
-		return
 
 	if(istype(src.r_hand,/obj/item/gun) && src.r_hand:canshoot())
 		return
@@ -441,19 +439,12 @@
 				BB.dropped(src)
 				BB.layer = initial(BB.layer)
 			return
-		if(!GN:canshoot())
-			src.drop_item()
-			if(src.w_uniform && !src.belt)
-				GN:set_loc(src)
-				src.belt = GN
-				GN:layer = HUD_LAYER
-			else if(src.back && istype(src.back,/obj/item/storage/backpack))
-				var/obj/item/storage/backpack/B = src.back
-				if(B.contents.len < 7)
-					B.attackby(GN,src)
 
-	if(istype(src.r_hand, /obj/item/gun/energy) && !src.r_hand:canshoot())
-		var/obj/item/gun/energy/GN = src.r_hand
+	if(src.r_hand?.cant_drop)
+		return
+
+	if(istype(src.r_hand, /obj/item/gun) && !src.r_hand:canshoot())
+		var/obj/item/gun/GN = src.r_hand
 		src.drop_item()
 		if(src.w_uniform && !src.belt)
 			GN:set_loc(src)

--- a/code/mob/living/carbon/human/npc.dm
+++ b/code/mob/living/carbon/human/npc.dm
@@ -293,7 +293,7 @@
 
 			src.a_intent = INTENT_HARM
 
-			if(!ai_target || ai_target == src && !ai_suicidal)
+			if(!ai_target || ai_target == src && !ai_suicidal || ai_target.z != src.z)
 				ai_frustration = 0
 				ai_target = null
 				ai_state = AI_PASSIVE
@@ -358,11 +358,7 @@
 				if((prob(33) || ai_throw) && distance > 1 && ai_validpath() && src.r_hand && !(istype(src.r_hand,/obj/item/gun) && src.r_hand:canshoot()))
 					//I can attack someone! =D
 					ai_target_old.Cut()
-					var/obj/item/temp = src.r_hand
-					temp.set_loc(src.loc)
-					src.u_equip(temp)
-					src.visible_message("<span class='alert'>[src] throws [temp].</span>")
-					temp.throw_at(carbon_target, 7, 1)
+					src.throw_item(ai_target, list("npc_throw"))
 
 			if(distance <= 1 && (world.timeofday - ai_attacked) > 100 && !ai_incapacitated() && ai_meleecheck())
 				//I can attack someone! =D
@@ -426,6 +422,9 @@
 				step_towards(src, ai_target) //Take a step and hit the shite (but only if you won't push them out of the way by doing so)
 
 /mob/living/carbon/human/proc/ai_pickupweapon()
+
+	if(src.r_hand?.cant_drop)
+		return
 
 	if(istype(src.r_hand,/obj/item/gun) && src.r_hand:canshoot())
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Make monkeys use standard throw proc for throwing weapons at targets
Prevent monkeys from picking up weapons if their (right) arm is stapled (monkeys are very right-handed, OK?)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #1323 
Fixes issue where monkeys could attack cross-z-level

## Changelog

```
(u)Tarmunora:
(+)Fix monkeys incorrectly astral projecting melee attacks.
```