### PR TITLE
Rajaijah buff

### DIFF
--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -1588,8 +1588,10 @@ datum
 			var/t4 = 26
 			var/t5 = 28
 			var/t6 = 30
-			var/t7 = 101
-			var/t8 = 103
+			var/t7 = 50
+			var/t8 = 51
+			var/t9 = 101
+			var/t10 = 103
 
 			pooled()
 				..()
@@ -1608,6 +1610,8 @@ datum
 				t6 = initial(t6)
 				t7 = initial(t7)
 				t8 = initial(t8)
+				t9 = initial(t9)
+				t10 = initial(t10)
 
 
 			//MBC : you may be wondering why this looks so weird
@@ -1655,7 +1659,6 @@ datum
 					t4 = 0
 					H.show_text("<font size=+2><B>IT HURTS!!</B></font>","red")
 					H.emote("scream")
-					H.drowsyness = max(H.drowsyness,30)
 					ai_was_active = H.ai_active
 					H.ai_init() //:getin:
 					H.ai_aggressive = 1 //Fak
@@ -1666,7 +1669,6 @@ datum
 				if (t6 && data >= t6)
 					t5 = 0
 					if (prob(33))
-						H.drowsyness = max(H.drowsyness,10)
 						H.make_jittery(600)
 						H.show_text("<B>[pick_string("chemistry_reagent_messages.txt", "madness3")]</B>", "red")
 
@@ -1679,31 +1681,33 @@ datum
 
 
 					//POWER UP!!
-
-					if (data > 50) //Oh dear
-						if (data == 51)
-							H.add_stam_mod_regen(src.id, 100) //Buff
-							H.show_text("You feel very buff!", "red")
-						if (prob(20)) //The AI is in control now.
-							H.change_misstep_chance(100 * mult)
-							H.show_text("You can't seem to control your legs!", "red")
-
-						if (prob(10)) //Stronk
-							H.show_text("You feel strong!", "red")
-							H.delStatus("weakened")
-							H.delStatus("stunned")
-							H.delStatus("paralysis")
-							H.delStatus("disorient")
-
 				if (t7 && data >= t7)
 					t6 = 0
+					H.add_stam_mod_regen(src.id, 100) //Buff
+					H.show_text("You feel very buff!", "red")
+
+				if (t8 && data >= t8)
+					t7 = 0
+
+					if (prob(20)) //The AI is in control now.
+						H.change_misstep_chance(100 * mult)
+						H.show_text("You can't seem to control your legs!", "red")
+
+					if (prob(10)) //Stronk
+						H.show_text("You feel strong!", "red")
+						H.delStatus("weakened")
+						H.delStatus("stunned")
+						H.delStatus("paralysis")
+						H.delStatus("disorient")
+
+				if (t9 && data >= t9)
+					t8 = 0
 					H.ai_suicidal = 1
 					H.show_text("Death... I can only stop this by dying...", "red")
 
-				if (t8 && data > t8)
-					t7 = 0
+				if (t10 && data > t10)
+					t9 = 0
 					if (prob(33))
-						H.drowsyness = max(H.drowsyness,10)
 						H.make_jittery(600)
 						H.show_text("<B>[pick_string("chemistry_reagent_messages.txt", "madness3")]</B>", "red")
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE] [FIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes drowsiness from late stages of raj, makes stamina buff apply properly


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Raj wasn't getting the stam regen buff b/c mult changes, I felt it was odd that one stage cleared drowsiness, only for future stages to add it right back. Drowsiness change means that someone hopped up on raj will no longer randomly pass out for 10 seconds at a time with no other chems


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Tarmunora:
(+)Changed rajaijah to properly make you buff again
```
