### PR TITLE
Assjam: Fleet and Icarus additions

### DIFF
--- a/maps/fleet.dmm
+++ b/maps/fleet.dmm
@@ -20848,7 +20848,6 @@
 	frequency = 1225;
 	icon_state = "intact_on";
 	id = "Toxin Chamber Outlet";
-	on = 1;
 	target_pressure = 1000
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -24095,38 +24094,12 @@
 /area/station/maintenance/SWmaint{
 	name = "Erebus Maintenance Room"
 	})
-"Sm" = (
-/obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	dir = 5
-	},
-/obj/machinery/meter,
-/obj/machinery/light,
-/obj/decal/tile_edge/line/purple{
-	icon_state = "line1"
-	},
-/obj/cable{
-	icon_state = "5-9"
-	},
-/turf/simulated/floor/engine,
-/area/station/engine/core{
-	name = "Erebus Plasmitics Zone"
-	})
 "So" = (
 /obj/machinery/atmospherics/binary/volume_pump{
 	on = 1;
 	transfer_rate = 1000
 	},
 /turf/simulated/floor/engine,
-/area/station/engine/core{
-	name = "Erebus Plasmitics Zone"
-	})
-"Sp" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
 	})
@@ -24257,6 +24230,21 @@
 	},
 /turf/space,
 /area)
+"SN" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0;
+	dir = 4
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
 "SO" = (
 /obj/machinery/atmospherics/binary/circulatorTemp,
 /turf/simulated/floor/darkpurple,
@@ -24940,6 +24928,18 @@
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
 	})
+"UZ" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 9
+	},
+/obj/decal/tile_edge/line/yellow{
+	dir = 4;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
 "Vc" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0;
@@ -25088,6 +25088,22 @@
 /obj/decal/tile_edge/line/purple{
 	dir = 5;
 	icon_state = "line1"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Vo" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 5
+	},
+/obj/machinery/meter,
+/obj/machinery/light,
+/obj/decal/tile_edge/line/purple{
+	icon_state = "line1"
+	},
+/obj/cable{
+	icon_state = "5-9"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core{
@@ -25333,6 +25349,16 @@
 /area/station/maintenance/SWmaint{
 	name = "Erebus Maintenance Room"
 	})
+"Wh" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
 "Wn" = (
 /obj/grille/catwalk{
 	dir = 10;
@@ -25445,18 +25471,6 @@
 /turf/simulated/floor/darkpurple,
 /area/station/hallway/primary/east{
 	name = "Erebus Primary Zone"
-	})
-"WD" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 9
-	},
-/obj/decal/tile_edge/line/yellow{
-	dir = 4;
-	icon_state = "line1"
-	},
-/turf/simulated/floor/engine,
-/area/station/engine/core{
-	name = "Erebus Plasmitics Zone"
 	})
 "WE" = (
 /obj/cable{
@@ -26067,21 +26081,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint{
 	name = "Erebus Maintenance Room"
-	})
-"Yz" = (
-/obj/wingrille_spawn/auto,
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	can_rupture = 0;
-	dir = 4
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/core{
-	name = "Erebus Plasmitics Zone"
 	})
 "YB" = (
 /obj/machinery/door/airlock/pyro/engineering{
@@ -77216,7 +77215,7 @@ YR
 Yf
 VQ
 Vp
-WD
+UZ
 Vn
 Zf
 Yf
@@ -78124,7 +78123,7 @@ Xz
 YQ
 Ud
 VS
-Sm
+Vo
 Yf
 SP
 Sd
@@ -78722,7 +78721,7 @@ Yf
 MP
 Ne
 Np
-Sp
+Wh
 Yf
 Xg
 TG
@@ -79933,7 +79932,7 @@ Xi
 UN
 NU
 Yr
-Yz
+SN
 SF
 RX
 Uc

--- a/maps/fleet.dmm
+++ b/maps/fleet.dmm
@@ -552,32 +552,16 @@
 	name = "Tenebrae Solar Array"
 	})
 "bk" = (
-/obj/lattice{
-	dir = 4;
-	icon_state = "lattice-dir"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "8-10"
-	},
-/turf/space,
+/obj/item/seed/alien,
+/turf/simulated/floor/plating/airless/asteroid,
 /area)
 "bl" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/machinery/chem_master{
+	dir = 8
 	},
-/obj/machinery/door/airlock/pyro/engineering{
-	name = "Auxiliary Component Bay"
-	},
-/obj/forcefield/energyshield/perma/doorlink{
-	desc = "A door-linked force field that prevents gasses from passing through it.";
-	name = "Door-linked Atmospheric Forcefield";
-	powerlevel = 1
-	},
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/lounge_port{
-	name = "Maru Crew Quarters"
+/turf/simulated/floor/engine/vacuum,
+/area/research_outpost{
+	name = "Indigo Rye"
 	})
 "bm" = (
 /obj/machinery/light/small{
@@ -681,11 +665,11 @@
 /area/station/owlery)
 "bx" = (
 /obj/item/raw_material/shard/glass,
-/turf/simulated/floor/plating{
-	icon_state = "platingdmg1"
-	},
 /turf/simulated/floor/airless/plating{
 	icon_state = "platingdmg2"
+	},
+/turf/simulated/floor/plating{
+	icon_state = "platingdmg1"
 	},
 /area/research_outpost{
 	name = "Indigo Rye"
@@ -1041,10 +1025,10 @@
 	name = "Tenebrae Crew Quarters"
 	})
 "cf" = (
-/obj/decal/cleanable/oil,
-/turf/simulated/floor/plating,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/item/clothing/glasses/blindfold,
+/turf/simulated/floor/engine/vacuum,
+/area/research_outpost{
+	name = "Indigo Rye"
 	})
 "cg" = (
 /obj/machinery/chem_heater,
@@ -1142,16 +1126,17 @@
 	name = "Meridian Primary Zone"
 	})
 "cq" = (
-/obj/storage/cart,
-/obj/machinery/light/small/warm{
-	dir = 1;
-	pixel_y = 21
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/item/reagent_containers/ampoule/smelling_salts,
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/machinery/atmospherics/pipe/simple{
+	level = 2
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/research_outpost{
+	name = "Indigo Rye"
 	})
 "cr" = (
 /obj/machinery/shuttle/engine/heater{
@@ -1177,10 +1162,12 @@
 	},
 /area/station/science/teleporter)
 "ct" = (
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/caution/east,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/reagent_dispensers/foamtank,
+/turf/simulated/floor/caution/corner/misc{
+	dir = 6
+	},
+/area/research_outpost{
+	name = "Indigo Rye"
 	})
 "cu" = (
 /obj/submachine/chem_extractor{
@@ -1747,6 +1734,10 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/transport{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/darkblue/checker,
 /area/station/science/artifact)
 "dA" = (
@@ -1761,6 +1752,10 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment/transport{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
 /turf/simulated/floor/darkblue/checker,
 /area/station/science/artifact)
 "dB" = (
@@ -1772,16 +1767,28 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/disposalpipe/segment/transport{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
 /turf/simulated/floor/caution/westeast,
 /area/station/science/artifact)
 "dC" = (
 /obj/reagent_dispensers/fueltank,
+/obj/disposalpipe/segment/transport{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
 /turf/simulated/floor,
 /area/station/science{
 	name = "Tenebrae Primary Zone"
 	})
 "dD" = (
 /obj/machinery/vehicle/pod_smooth/light,
+/obj/disposalpipe/segment/transport{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/shuttlebay,
 /area/station/science{
 	name = "Tenebrae Primary Zone"
@@ -1950,15 +1957,15 @@
 	name = "Tenebrae Primary Zone"
 	})
 "dS" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "meribelt";
-	name = "Meridian disposal belt";
-	operating = 1
+/obj/machinery/light_switch/east,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
 	},
-/turf/simulated/floor/grey,
-/area/station/maintenance/west{
-	name = "Meridian Maintenance"
+/turf/simulated/floor/purplewhite{
+	dir = 1
+	},
+/area/research_outpost{
+	name = "Indigo Rye"
 	})
 "dT" = (
 /obj/machinery/networked/test_apparatus/xraymachine,
@@ -1979,6 +1986,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/darkblue/checker,
 /area/station/science/artifact)
 "dV" = (
@@ -1995,35 +2003,46 @@
 /turf/simulated/floor/caution/westeast,
 /area/station/science/artifact)
 "dX" = (
-/obj/machinery/light/small/warm{
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "pink";
+	icon_state = "bedsheet-pink"
+	},
+/obj/machinery/light/small{
 	dir = 8;
 	pixel_x = -12
 	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/item/storage/wall{
+	pixel_y = 32
+	},
+/turf/simulated/floor/black,
+/area/research_outpost{
+	name = "Indigo Rye"
 	})
 "dY" = (
-/obj/machinery/door/airlock/pyro/classic{
-	dir = 4
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-R"
 	},
-/obj/decal/cleanable/oil,
-/turf/simulated/floor/plating,
-/area/station/wreckage{
-	name = "Calamarain"
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/lounge_port{
+	name = "Maru Crew Quarters"
 	})
 "dZ" = (
-/obj/machinery/conveyor{
-	dir = 2;
-	id = "meribelt";
-	name = "Meridian disposal belt";
-	operating = 1
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 4;
+	icon_state = "alt_propulsion"
 	},
-/turf/simulated/floor/grey,
-/area/station/maintenance/west{
-	name = "Meridian Maintenance"
-	})
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir"
+	},
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area)
 "ea" = (
 /turf/simulated/floor/black,
 /area/station/science/research_director{
@@ -2186,6 +2205,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/darkblue/checker,
 /area/station/science/artifact)
 "ep" = (
@@ -2513,6 +2533,7 @@
 	icon_state = "1-2"
 	},
 /obj/access_spawn/research,
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor,
 /area/station/science/artifact)
 "eV" = (
@@ -2615,6 +2636,10 @@
 "fg" = (
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/white,
 /area/station/science{
@@ -3637,15 +3662,11 @@
 	name = "Tenebrae Primary Zone"
 	})
 "gZ" = (
-/obj/machinery/shuttle/engine/propulsion{
+/obj/machinery/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "alt_propulsion"
+	icon_state = "alt_heater-L"
 	},
-/obj/lattice{
-	dir = 4;
-	icon_state = "lattice-dir"
-	},
-/turf/space,
+/turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/storage{
 	name = "Maru Power Room"
 	})
@@ -3657,13 +3678,17 @@
 /turf/simulated/floor/orangeblack,
 /area/station/mining)
 "hb" = (
+/obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage{
 	name = "Maru Power Room"
 	})
 "hc" = (
-/obj/machinery/vending/medical_public,
-/turf/simulated/floor/orangeblack/side,
+/obj/machinery/disposal/transport{
+	name = "Erebus transportation unit"
+	},
+/obj/disposalpipe/trunk/south,
+/turf/simulated/floor/delivery/caution,
 /area/station/engine/engineering{
 	name = "Maru Primary Zone"
 	})
@@ -3689,26 +3714,6 @@
 /obj/disposalpipe/segment/transport,
 /turf/space,
 /area)
-"hg" = (
-/obj/storage/crate,
-/obj/item/electronics/frame/collector_control,
-/obj/item/electronics/frame/collector_control,
-/obj/item/electronics/frame/collector_control,
-/obj/item/electronics/frame/collector_array,
-/obj/item/electronics/frame/collector_array,
-/obj/item/electronics/frame/collector_array,
-/obj/item/electronics/frame/collector_array,
-/obj/item/electronics/frame/collector_array,
-/obj/item/electronics/frame/collector_array,
-/obj/item/electronics/soldering,
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/shuttlebay,
-/area/station/crew_quarters/lounge_port{
-	name = "Maru Crew Quarters"
-	})
 "hh" = (
 /obj/shrub{
 	dir = 8;
@@ -3809,32 +3814,16 @@
 	})
 "ht" = (
 /obj/machinery/light/small,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/stool/bed,
-/obj/landmark/start{
-	name = "Engineer"
-	},
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "yellow";
-	icon_state = "bedsheet-yellow"
-	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/lounge_port{
 	name = "Maru Crew Quarters"
 	})
 "hu" = (
-/obj/machinery/power/terminal{
-	dir = 8
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-L"
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/lounge_port{
 	name = "Maru Crew Quarters"
 	})
@@ -4652,15 +4641,16 @@
 /turf/simulated/floor/orangeblack,
 /area/station/mining)
 "ji" = (
-/obj/machinery/light/small/warm{
-	dir = 1;
-	pixel_y = 21
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 4;
+	icon_state = "alt_propulsion"
 	},
-/obj/machinery/manufacturer/gas,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
-	})
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area)
 "jj" = (
 /obj/submachine/cargopad/magnet,
 /turf/simulated/floor/plating/airless,
@@ -5766,7 +5756,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/storage/closet/welding_supply,
+/obj/machinery/portable_atmospherics/canister/air/large,
 /turf/simulated/floor/orangeblack/side,
 /area/station/engine/engineering{
 	name = "Maru Primary Zone"
@@ -5775,7 +5765,7 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/portable_atmospherics/canister/air/large,
+/obj/machinery/vending/medical_public,
 /turf/simulated/floor/orangeblack/side,
 /area/station/engine/engineering{
 	name = "Maru Primary Zone"
@@ -5786,7 +5776,9 @@
 	pixel_x = 32
 	},
 /obj/disposalpipe/trunk/south,
-/obj/machinery/disposal/transport,
+/obj/machinery/disposal/transport{
+	name = "Meridian transportation unit"
+	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 6
 	},
@@ -6077,8 +6069,8 @@
 "lU" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/maintenance/storage{
-	name = "Maru Power Room"
+/area/station/engine/engineering{
+	name = "Maru Primary Zone"
 	})
 "lV" = (
 /obj/lattice{
@@ -6368,7 +6360,6 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage{
 	name = "Maru Power Room"
@@ -6424,24 +6415,27 @@
 	name = "Maru Power Room"
 	})
 "mD" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/lattice{
+	dir = 6;
+	icon_state = "lattice-dir-b"
 	},
-/obj/machinery/portable_atmospherics/canister/toxins,
-/turf/simulated/floor/shuttlebay,
-/area/station/crew_quarters/lounge_port{
-	name = "Maru Crew Quarters"
-	})
+/obj/disposalpipe/segment/transport{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/space,
+/area)
 "mE" = (
-/obj/machinery/emitter{
-	dir = 8
+/obj/disposalpipe/segment/transport{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/shuttlebay,
-/area/station/maintenance/storage{
-	name = "Maru Power Room"
-	})
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 4;
+	icon_state = "alt_propulsion"
+	},
+/turf/space,
+/area)
 "mF" = (
 /obj/lattice{
 	dir = 2;
@@ -6704,11 +6698,16 @@
 	name = "Maru Power Room"
 	})
 "nf" = (
-/obj/machinery/field_generator,
-/turf/simulated/floor/shuttlebay,
-/area/station/crew_quarters/lounge_port{
-	name = "Maru Crew Quarters"
-	})
+/obj/lattice{
+	dir = 5;
+	icon_state = "lattice-dir-b"
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
+/turf/space,
+/area)
 "ng" = (
 /obj/machinery/communications_dish,
 /obj/machinery/power/data_terminal,
@@ -6983,23 +6982,14 @@
 	name = "Maru Power Room"
 	})
 "nG" = (
-/obj/machinery/field_generator,
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
+/obj/lattice{
+	dir = 8;
+	icon_state = "lattice-dir"
 	},
-/turf/simulated/floor/shuttlebay,
-/area/station/crew_quarters/lounge_port{
-	name = "Maru Crew Quarters"
-	})
-"nH" = (
-/obj/machinery/shuttle/engine/heater{
-	dir = 4;
-	icon_state = "alt_heater-M"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/storage{
-	name = "Maru Power Room"
+/obj/disposalpipe/segment/transport,
+/turf/space,
+/area/station/solar/small_backup1{
+	name = "Erebus Solar Array"
 	})
 "nI" = (
 /obj/lattice{
@@ -8469,11 +8459,11 @@
 	name = "Indigo Rye"
 	})
 "qu" = (
-/turf/simulated/floor/plating{
-	icon_state = "platingdmg1"
-	},
 /turf/simulated/floor/airless/plating{
 	icon_state = "platingdmg2"
+	},
+/turf/simulated/floor/plating{
+	icon_state = "platingdmg1"
 	},
 /area/research_outpost{
 	name = "Indigo Rye"
@@ -8647,6 +8637,7 @@
 	pixel_x = 10;
 	status = "LIGHT_BROKEN"
 	},
+/obj/item/reagent_containers/dropper,
 /turf/simulated/floor/engine/vacuum,
 /area/research_outpost{
 	name = "Indigo Rye"
@@ -8956,6 +8947,7 @@
 	name = "Dionysus Solar Array"
 	})
 "rm" = (
+/obj/machinery/chem_heater,
 /turf/simulated/floor/engine/vacuum,
 /area/research_outpost{
 	name = "Indigo Rye"
@@ -9103,6 +9095,11 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/outlet_injector{
+	icon_state = "on";
+	level = 2;
+	on = 1
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/research_outpost{
@@ -9707,13 +9704,21 @@
 	name = "Hammer Primary Concourse"
 	})
 "sL" = (
-/obj/machinery/shuttle/engine/propulsion{
-	dir = 4;
-	icon_state = "alt_propulsion"
+/obj/grille/catwalk{
+	dir = 9;
+	icon_state = "catwalk_cross"
 	},
-/turf/space,
-/area/station/maintenance/storage{
-	name = "Maru Power Room"
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 9;
+	layer = 2
+	},
+/area/station/solar/small_backup1{
+	name = "Erebus Solar Array"
 	})
 "sM" = (
 /obj/machinery/manufacturer/uniform,
@@ -13809,6 +13814,9 @@
 	icon_state = "1-2"
 	},
 /obj/decal/tile_edge/stripe/extra_big,
+/obj/machinery/atmospherics/pipe/simple{
+	level = 2
+	},
 /turf/simulated/floor/engine/vacuum,
 /area/research_outpost{
 	name = "Indigo Rye"
@@ -13981,7 +13989,9 @@
 /obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{
 	id = "ppap"
 	},
-/turf/simulated/floor/engine,
+/turf/simulated/floor/shuttlebay{
+	icon_state = "engine_caution_north"
+	},
 /area/research_outpost{
 	name = "Indigo Rye"
 	})
@@ -14897,17 +14907,17 @@
 	name = "Dionysus Solar Array"
 	})
 "Ch" = (
-/obj/reagent_dispensers/fueltank,
+/obj/storage/crate/furnacefuel,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
 /turf/simulated/floor/caution/south,
 /area/research_outpost{
 	name = "Indigo Rye"
 	})
 "Ci" = (
-/obj/reagent_dispensers/foamtank,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
+/obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/caution/south,
 /area/research_outpost{
 	name = "Indigo Rye"
@@ -14915,11 +14925,8 @@
 "Cj" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/machinery/door/poddoor/pyro{
-	density = 1;
-	icon_state = "pdoor1";
 	id = "test_chamber2";
-	name = "Test Chamber Shield";
-	opacity = 1
+	name = "Test Chamber Shield"
 	},
 /turf/simulated/floor/plating,
 /area/research_outpost{
@@ -15176,13 +15183,15 @@
 "CG" = (
 /obj/machinery/door/airlock/pyro/medical/alt{
 	icon_state = "research2_locked";
-	locked = 1;
-	req_access = null
+	locked = 1
 	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple{
+	level = 2
 	},
 /turf/simulated/floor/engine{
 	icon_state = "engine_caution_ns"
@@ -16415,6 +16424,7 @@
 	pixel_x = 0;
 	tag = ""
 	},
+/obj/storage/closet/welding_supply,
 /turf/simulated/floor/orangeblack/side,
 /area/station/engine/engineering{
 	name = "Maru Primary Zone"
@@ -16433,24 +16443,6 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/crew_quarters/captain{
 	name = "Meridian Primary Zone"
-	})
-"ET" = (
-/obj/machinery/computer3/generic/engine{
-	dir = 4
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/shuttlebay,
-/area/station/crew_quarters/lounge_port{
-	name = "Maru Crew Quarters"
 	})
 "EU" = (
 /turf/simulated/floor{
@@ -16783,7 +16775,7 @@
 	})
 "Fy" = (
 /obj/machinery/manufacturer/general,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/caution/south,
 /area/station/maintenance/west{
 	name = "Meridian Maintenance"
 	})
@@ -16801,7 +16793,7 @@
 	pixel_y = 21
 	},
 /obj/item/extinguisher,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/caution/south,
 /area/station/maintenance/west{
 	name = "Meridian Maintenance"
 	})
@@ -16810,7 +16802,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/caution/south,
 /area/station/maintenance/west{
 	name = "Meridian Maintenance"
 	})
@@ -16839,7 +16831,7 @@
 	})
 "FC" = (
 /obj/machinery/portable_atmospherics/canister/air/large,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/caution/south,
 /area/station/maintenance/west{
 	name = "Meridian Maintenance"
 	})
@@ -17042,11 +17034,6 @@
 	})
 "FY" = (
 /obj/machinery/portable_reclaimer,
-/obj/machinery/door_control{
-	id = "meri_crusher";
-	name = "Meridian Crusher Door";
-	pixel_x = -24
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west{
 	name = "Meridian Maintenance"
@@ -17338,7 +17325,7 @@
 	name = "Meridian Solar Array"
 	})
 "Gy" = (
-/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/portable_atmospherics/canister/air/large,
 /turf/simulated/floor/engine,
 /area/research_outpost{
 	name = "Indigo Rye"
@@ -17355,63 +17342,63 @@
 /area/station/maintenance/west{
 	name = "Meridian Maintenance"
 	})
-"GB" = (
-/obj/machinery/light/small,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "meribelt";
-	name = "Meridian disposal belt";
-	operating = 1
-	},
-/turf/simulated/floor/grey,
-/area/station/maintenance/west{
-	name = "Meridian Maintenance"
-	})
 "GC" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "meribelt";
-	name = "Meridian disposal belt";
-	operating = 1
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/door/poddoor/pyro{
-	autoclose = 1;
-	dir = 4;
-	id = "meri_crusher";
-	name = "Meridian Crusher Door"
+/obj/grille/catwalk{
+	dir = 4
 	},
-/turf/simulated/floor/grey,
-/area/station/maintenance/west{
-	name = "Meridian Maintenance"
+/obj/disposalpipe/segment/transport,
+/turf/space,
+/area/station/solar/small_backup1{
+	name = "Erebus Solar Array"
 	})
 "GD" = (
-/obj/machinery/crusher,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "meribelt";
-	name = "Meridian disposal belt";
-	operating = 1
+/obj/grille/catwalk{
+	dir = 4
 	},
-/turf/simulated/floor/grey,
-/area/station/maintenance/west{
-	name = "Meridian Maintenance"
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/cable,
+/turf/space,
+/area/station/solar/small_backup1{
+	name = "Erebus Solar Array"
 	})
 "GE" = (
 /obj/machinery/light/small,
-/obj/machinery/launcher_loader/east,
-/turf/simulated/floor/grey,
+/obj/machinery/vending/paint/broken,
+/turf/simulated/floor/plating,
 /area/station/maintenance/west{
 	name = "Meridian Maintenance"
 	})
 "GF" = (
-/obj/machinery/mass_driver{
-	dir = 4;
-	id = "meri_trash";
-	name = "Meridian Waste Driver"
+/obj/grille/catwalk{
+	dir = 4
 	},
-/turf/simulated/floor/grey,
-/area/station/maintenance/west{
-	name = "Meridian Maintenance"
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/space,
+/area/station/solar/small_backup1{
+	name = "Erebus Solar Array"
 	})
 "GG" = (
 /obj/grille/catwalk{
@@ -17490,10 +17477,6 @@
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
-	},
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
 	},
 /obj/machinery/power/furnace,
 /turf/simulated/floor/caution/east,
@@ -17622,6 +17605,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
 /turf/space,
 /area/station/solar/west{
 	name = "Meridian Solar Array"
@@ -17695,13 +17681,21 @@
 	name = "Demeter Primary Zone"
 	})
 "Hk" = (
-/obj/lattice{
-	dir = 10;
-	icon_state = "lattice-dir"
+/obj/cable,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/space,
-/area/station/solar/west{
-	name = "Meridian Solar Array"
+/obj/grille/catwalk{
+	dir = 5
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	icon_state = "catwalk_cross";
+	layer = 2
+	},
+/area/station/solar/small_backup1{
+	name = "Erebus Solar Array"
 	})
 "Hl" = (
 /obj/machinery/light/small{
@@ -17983,8 +17977,7 @@
 	})
 "HN" = (
 /obj/stool/chair/office{
-	dir = 1;
-	icon_state = "office_chair"
+	dir = 1
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 1
@@ -18009,6 +18002,10 @@
 	icon_state = "1-2"
 	},
 /obj/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 5;
+	level = 2
+	},
 /turf/simulated/floor/purplewhite{
 	dir = 1
 	},
@@ -18016,6 +18013,9 @@
 	name = "Indigo Rye"
 	})
 "HQ" = (
+/obj/machinery/atmospherics/valve{
+	dir = 4
+	},
 /turf/simulated/floor/purplewhite{
 	dir = 1
 	},
@@ -18048,11 +18048,11 @@
 /turf/space,
 /area)
 "HU" = (
-/obj/rack,
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_x = -12
 	},
+/obj/submachine/cargopad/researchoutpost,
 /turf/simulated/floor/engine{
 	allows_vehicles = 0;
 	icon_state = "engine_caution_south"
@@ -18071,7 +18071,6 @@
 "HW" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
 	layer = 9.1;
 	pixel_x = -10
 	},
@@ -18082,7 +18081,6 @@
 "HX" = (
 /obj/machinery/light{
 	dir = 4;
-	icon_state = "tube1";
 	layer = 9.1;
 	pixel_x = 10
 	},
@@ -18170,10 +18168,11 @@
 	},
 /obj/cable{
 	d2 = 8;
-	icon_state = "0-4";
-	pixel_y = 0
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/autoname_west/nopoweralert{
+	req_access = null;
+	req_access_txt = "24";
 	start_charge = 0
 	},
 /turf/simulated/floor/caution/east,
@@ -18368,6 +18367,10 @@
 /obj/grille/catwalk{
 	dir = 5
 	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
@@ -18415,14 +18418,18 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/storage/secure/closet/research/uniform,
 /turf/simulated/floor/purplewhite,
 /area/station/science{
 	name = "Tenebrae Primary Zone"
 	})
 "Iy" = (
-/obj/storage/secure/closet/research/uniform,
 /obj/machinery/light,
-/turf/simulated/floor/purplewhite,
+/obj/machinery/disposal/transport{
+	name = "Erebus transportation unit"
+	},
+/obj/disposalpipe/trunk/north,
+/turf/simulated/floor/delivery/caution,
 /area/station/science{
 	name = "Tenebrae Primary Zone"
 	})
@@ -18432,7 +18439,9 @@
 	pixel_x = 32
 	},
 /obj/disposalpipe/trunk/north,
-/obj/machinery/disposal/transport,
+/obj/machinery/disposal/transport{
+	name = "Meridian transportation unit"
+	},
 /turf/simulated/floor/purplewhite,
 /area/station/science{
 	name = "Tenebrae Primary Zone"
@@ -18488,16 +18497,12 @@
 	})
 "IF" = (
 /obj/machinery/door/airlock/pyro/medical/alt{
-	dir = 4;
-	req_access = null
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/purpleblack{
-	dir = 4;
-	icon_state = "purpleblack"
-	},
+/turf/simulated/floor/caution/westeast,
 /area/research_outpost{
 	name = "Indigo Rye"
 	})
@@ -18523,6 +18528,7 @@
 	name = "Indigo Rye"
 	})
 "II" = (
+/obj/item/cigbutt,
 /turf/simulated/floor/white,
 /area/research_outpost{
 	name = "Indigo Rye"
@@ -18532,11 +18538,16 @@
 /turf/space,
 /area)
 "IK" = (
-/obj/wingrille_spawn/auto/tuff,
-/turf/simulated/floor/plating,
-/area/station/wreckage{
-	name = "Calamarain"
-	})
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 6
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/space,
+/area)
 "IL" = (
 /obj/lattice{
 	dir = 1;
@@ -18553,13 +18564,32 @@
 /turf/simulated/wall/asteroid,
 /area)
 "IO" = (
-/obj/machinery/shuttle/engine/heater{
-	dir = 4;
-	icon_state = "alt_heater-R"
+/obj/cable,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/grille/catwalk{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 4
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8;
+	icon_state = "catwalk_cross";
+	layer = 2
+	},
+/area/station/solar/small_backup1{
+	name = "Erebus Solar Array"
 	})
 "IP" = (
 /obj/cable{
@@ -19455,8 +19485,7 @@
 	})
 "KS" = (
 /obj/machinery/door/airlock/pyro/medical/alt{
-	dir = 4;
-	req_access = null
+	dir = 4
 	},
 /turf/simulated/floor/caution/westeast,
 /area/research_outpost{
@@ -19513,7 +19542,6 @@
 "KZ" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
 	layer = 9.1;
 	pixel_x = -10
 	},
@@ -19530,7 +19558,6 @@
 /obj/machinery/door_control{
 	id = "test_chamber2";
 	name = "Test Chamber Shutter Control";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/item/storage/firstaid/fire,
@@ -19556,6 +19583,11 @@
 	})
 "Ld" = (
 /obj/machinery/vending/cigarette,
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
 /turf/simulated/floor/purplewhite,
 /area/research_outpost{
 	name = "Indigo Rye"
@@ -19572,25 +19604,20 @@
 	name = "Indigo Rye"
 	})
 "Lf" = (
-/obj/machinery/door/airlock/pyro/medical/alt{
-	req_access = null
-	},
+/obj/machinery/door/airlock/pyro/medical/alt,
 /turf/simulated/floor/plating,
 /area/research_outpost{
 	name = "Indigo Rye"
 	})
 "Lg" = (
-/obj/machinery/door/airlock/pyro/medical/alt{
-	req_access = null
-	},
+/obj/machinery/door/airlock/pyro/medical/alt,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/purpleblack{
-	dir = 1;
-	icon_state = "purpleblack"
+	dir = 1
 	},
 /area/research_outpost{
 	name = "Indigo Rye"
@@ -19615,7 +19642,6 @@
 "Lj" = (
 /obj/machinery/shower{
 	dir = 1;
-	icon_state = "showerhead";
 	pixel_y = 20
 	},
 /turf/simulated/floor/sanitary,
@@ -19656,13 +19682,11 @@
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
 	},
-/obj/item/storage/wall{
-	pixel_y = 32
-	},
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_x = -12
 	},
+/obj/item/storage/wall/random,
 /turf/simulated/floor/black,
 /area/research_outpost{
 	name = "Indigo Rye"
@@ -19693,8 +19717,7 @@
 	})
 "Ls" = (
 /obj/stool/chair/office{
-	dir = 4;
-	icon_state = "office_chair"
+	dir = 4
 	},
 /turf/simulated/floor/purpleblack,
 /area/research_outpost{
@@ -19704,11 +19727,22 @@
 /obj/table/round/auto,
 /obj/item/decoration/ashtray{
 	butts = 5;
-	icon_state = "ashtray";
 	name = "grubby old ashtray"
 	},
-/obj/item/cigpacket,
-/obj/item/matchbook,
+/obj/item/cigpacket{
+	pixel_x = -4;
+	pixel_y = 2;
+	rand_pos = 0
+	},
+/obj/item/matchbook{
+	pixel_x = 3;
+	pixel_y = 6;
+	rand_pos = 0
+	},
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_x = 12;
+	pixel_y = 4
+	},
 /turf/simulated/floor/purpleblack,
 /area/research_outpost{
 	name = "Indigo Rye"
@@ -19739,8 +19773,7 @@
 "Lw" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor/purpleblack/corner{
-	dir = 4;
-	icon_state = "purpleblackcorner"
+	dir = 4
 	},
 /area/research_outpost{
 	name = "Indigo Rye"
@@ -19756,8 +19789,7 @@
 	})
 "Ly" = (
 /obj/machinery/door/airlock/pyro/medical/alt{
-	dir = 4;
-	req_access = null
+	dir = 4
 	},
 /turf/simulated/floor/sanitary,
 /area/research_outpost{
@@ -19773,7 +19805,6 @@
 "LA" = (
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "showerhead";
 	pixel_x = 8;
 	pixel_y = 8
 	},
@@ -19788,8 +19819,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/purpleblack{
-	dir = 4;
-	icon_state = "purpleblack"
+	dir = 4
 	},
 /area/research_outpost{
 	name = "Indigo Rye"
@@ -19809,14 +19839,16 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/landmark{
+	name = "monkeyspawn_horse"
+	},
 /turf/simulated/floor/specialroom/arcade,
 /area/research_outpost{
 	name = "Indigo Rye"
 	})
 "LE" = (
 /obj/stool/chair/office{
-	dir = 1;
-	icon_state = "office_chair"
+	dir = 1
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -19827,8 +19859,7 @@
 	})
 "LF" = (
 /obj/stool/chair/office{
-	dir = 1;
-	icon_state = "office_chair"
+	dir = 1
 	},
 /obj/cable{
 	icon_state = "1-8"
@@ -19856,12 +19887,10 @@
 	})
 "LI" = (
 /obj/machinery/door/airlock/pyro/medical/alt{
-	dir = 4;
-	req_access = null
+	dir = 4
 	},
 /turf/simulated/floor/blackwhite{
-	dir = 8;
-	icon_state = "darkwhite"
+	dir = 8
 	},
 /area/research_outpost{
 	name = "Indigo Rye"
@@ -19875,6 +19904,12 @@
 "LK" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 1
+	},
+/obj/item/storage/wall{
+	dir = 8;
+	name = "bath cabinet";
+	pixel_x = 32;
+	spawn_contents = list(/obj/item/clothing/under/towel,/obj/item/clothing/under/towel)
 	},
 /turf/simulated/floor/sanitary,
 /area/research_outpost{
@@ -19893,8 +19928,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/purpleblack/corner{
-	dir = 8;
-	icon_state = "purpleblackcorner"
+	dir = 8
 	},
 /area/research_outpost{
 	name = "Indigo Rye"
@@ -19904,8 +19938,7 @@
 	anchored = 1
 	},
 /turf/simulated/floor/purpleblack{
-	dir = 1;
-	icon_state = "purpleblack"
+	dir = 1
 	},
 /area/research_outpost{
 	name = "Indigo Rye"
@@ -19913,8 +19946,7 @@
 "LO" = (
 /obj/machinery/light,
 /turf/simulated/floor/purpleblack{
-	dir = 1;
-	icon_state = "purpleblack"
+	dir = 1
 	},
 /area/research_outpost{
 	name = "Indigo Rye"
@@ -19922,8 +19954,7 @@
 "LP" = (
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/purpleblack{
-	dir = 1;
-	icon_state = "purpleblack"
+	dir = 1
 	},
 /area/research_outpost{
 	name = "Indigo Rye"
@@ -19933,16 +19964,14 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/purpleblack{
-	dir = 1;
-	icon_state = "purpleblack"
+	dir = 1
 	},
 /area/research_outpost{
 	name = "Indigo Rye"
 	})
 "LR" = (
 /turf/simulated/floor/purpleblack{
-	dir = 1;
-	icon_state = "purpleblack"
+	dir = 1
 	},
 /area/research_outpost{
 	name = "Indigo Rye"
@@ -19950,8 +19979,7 @@
 "LS" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/purpleblack/corner{
-	dir = 1;
-	icon_state = "purpleblackcorner"
+	dir = 1
 	},
 /area/research_outpost{
 	name = "Indigo Rye"
@@ -19993,10 +20021,6 @@
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
 	},
-/obj/item/storage/wall{
-	dir = 8;
-	pixel_x = 32
-	},
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_x = -12
@@ -20005,6 +20029,11 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/item/storage/wall/random{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = 0
 	},
 /turf/simulated/floor/black,
 /area/research_outpost{
@@ -20019,12 +20048,10 @@
 	},
 /obj/decal/fakeobjects{
 	anchored = 1;
-	density = 0;
 	desc = "There's a ring of dots blinking on and off intermittently. You're not sure what this represents, but it looks cool.";
 	dir = 1;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "mars_status_comp";
-	layer = 3;
 	name = "mysterious computer";
 	pixel_y = 30
 	},
@@ -20056,6 +20083,7 @@
 	pixel_x = 12
 	},
 /obj/item/device/multitool,
+/obj/machinery/light_switch/north,
 /turf/simulated/floor/carpet/purple/fancy/edge/ne,
 /area/research_outpost{
 	name = "Indigo Rye"
@@ -20111,12 +20139,10 @@
 	})
 "Mg" = (
 /obj/shrub{
-	dir = 2;
 	icon = 'icons/obj/stationobjs.dmi';
 	icon_state = "plant";
 	level = 1.9
 	},
-/obj/item/item_box/medical_patches/mini_synthflesh,
 /turf/simulated/floor/carpet/purple/fancy/edge/sw,
 /area/research_outpost{
 	name = "Indigo Rye"
@@ -20193,128 +20219,215 @@
 	name = "Indigo Rye"
 	})
 "Mp" = (
-/obj/machinery/shuttle/engine/propulsion{
-	dir = 4;
-	icon_state = "alt_propulsion"
+/obj/cable,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/turf/space,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/grille/catwalk{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 4
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	intact = 0
+	},
+/area/station/solar/small_backup1{
+	name = "Erebus Solar Array"
 	})
 "Mq" = (
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/grille/catwalk{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 4
+	},
+/turf/space,
+/area/station/solar/small_backup1{
+	name = "Erebus Solar Array"
 	})
 "Mr" = (
-/obj/machinery/shuttle/engine/heater{
-	dir = 4;
-	icon_state = "alt_heater-M"
+/obj/cable,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/grille/catwalk{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 4
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	icon_state = "catwalk_cross";
+	layer = 2
+	},
+/area/station/solar/small_backup1{
+	name = "Erebus Solar Array"
 	})
 "Ms" = (
-/obj/machinery/shuttle/engine/heater{
-	dir = 4;
-	icon_state = "alt_heater-L"
+/obj/lattice,
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 10
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/disposalpipe/segment/transport,
+/turf/space,
+/area/station/solar/small_backup1{
+	name = "Erebus Solar Array"
 	})
 "Mt" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/power{
+	name = "Erebus Power Room"
 	})
 "Mu" = (
-/obj/machinery/door/airlock/pyro/classic,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/engine/power{
+	name = "Erebus Power Room"
 	})
 "Mv" = (
-/turf/simulated/floor/plating,
-/area/station/wreckage{
-	name = "Calamarain"
-	})
+/obj/machinery/atmospherics/pipe/simple/junction,
+/turf/space,
+/area)
 "Mw" = (
-/obj/machinery/door/airlock/pyro/classic{
-	dir = 4
+/obj/cable,
+/obj/machinery/power/solar{
+	id = "erebus";
+	name = "Erebus solar panel"
 	},
-/turf/simulated/floor/plating,
-/area/station/wreckage{
-	name = "Calamarain"
+/turf/simulated/floor/airless{
+	icon_state = "solarbase";
+	name = "solar paneling"
+	},
+/area/station/solar/small_backup1{
+	name = "Erebus Solar Array"
 	})
 "Mx" = (
-/obj/machinery/door/airlock/pyro/external,
-/turf/simulated/floor/grey,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/grille/catwalk,
+/turf/simulated/floor/airless/plating/catwalk,
+/area/station/solar/small_backup1{
+	name = "Erebus Solar Array"
 	})
 "My" = (
-/obj/machinery/door/airlock/pyro/external{
+/obj/lattice,
+/obj/machinery/atmospherics/pipe/simple/insulated/cold,
+/obj/disposalpipe/segment/transport{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/space,
+/area/station/solar/small_backup1{
+	name = "Erebus Solar Array"
+	})
+"Mz" = (
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/power{
+	name = "Erebus Power Room"
+	})
+"MA" = (
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/autoname_north,
+/obj/machinery/the_singularitygen,
+/obj/disposalpipe/segment/transport{
 	dir = 4
 	},
 /turf/simulated/floor/grey,
-/area/station/wreckage{
-	name = "Calamarain"
+/area/station/engine/power{
+	name = "Erebus Power Room"
 	})
-"Mz" = (
-/turf/simulated/floor/grey,
-/area/station/wreckage{
-	name = "Calamarain"
-	})
-"MA" = (
-/obj/machinery/light/small/warm{
+"MB" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/light/small{
 	dir = 1;
 	pixel_y = 21
 	},
-/turf/simulated/floor/plating,
-/area/station/wreckage{
-	name = "Calamarain"
-	})
-"MB" = (
-/obj/machinery/door_control/podbay{
-	id = "calamarain";
-	pixel_y = 24
+/obj/machinery/field_generator,
+/obj/disposalpipe/segment/transport{
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/turf/simulated/floor/grey,
+/area/station/engine/power{
+	name = "Erebus Power Room"
 	})
 "MC" = (
-/turf/simulated/floor/caution/east,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/machinery/field_generator,
+/turf/simulated/floor/grey,
+/area/station/engine/power{
+	name = "Erebus Power Room"
 	})
 "MD" = (
-/turf/simulated/floor/shuttlebay,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/machinery/emitter{
+	dir = 8
+	},
+/turf/simulated/floor/grey,
+/area/station/engine/power{
+	name = "Erebus Power Room"
 	})
 "ME" = (
-/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{
-	dir = 4;
-	id = "calamarain"
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
 	},
-/turf/simulated/floor/shuttlebay,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/item/storage/wall/emergency{
+	dir = 8;
+	pixel_x = 32
+	},
+/obj/machinery/emitter{
+	dir = 8
+	},
+/turf/simulated/floor/grey,
+/area/station/engine/power{
+	name = "Erebus Power Room"
 	})
 "MF" = (
-/obj/machinery/door/airlock/pyro/glass,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
-	})
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 1
+	},
+/turf/space,
+/area)
 "MG" = (
-/obj/table/reinforced/bar/auto,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	can_rupture = 0
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
 	})
 "MH" = (
 /obj/grille/catwalk{
@@ -20340,181 +20453,248 @@
 	name = "Dionysus Solar Array"
 	})
 "MI" = (
-/obj/machinery/light/small/warm{
-	dir = 1;
-	pixel_y = 21
-	},
-/obj/machinery/disposal_pipedispenser,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
-	})
-"MJ" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4
-	},
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
-	})
-"MK" = (
-/obj/machinery/door/unpowered/wood/pyro{
-	dir = 8
-	},
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
-	})
-"ML" = (
-/obj/machinery/door/unpowered/wood/pyro{
-	dir = 4
-	},
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
-	})
-"MM" = (
-/obj/machinery/light/small/warm{
-	dir = 1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
-	})
-"MN" = (
-/obj/item/furniture_parts/table,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
-	})
-"MO" = (
-/obj/rack,
-/obj/item/clothing/suit/space/emerg,
-/obj/item/clothing/head/emerg,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/air,
-/obj/item/storage/belt/utility,
-/obj/machinery/light/small/warm,
-/turf/simulated/floor/grey,
-/area/station/wreckage{
-	name = "Calamarain"
-	})
-"MP" = (
-/obj/decal/cleanable/paper,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
-	})
-"MQ" = (
-/obj/item/storage/wall/random,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
-	})
-"MR" = (
-/obj/machinery/light/small/warm{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
-	})
-"MS" = (
-/obj/machinery/light/small/warm{
-	dir = 1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/shuttlebay,
-/area/station/wreckage{
-	name = "Calamarain"
-	})
-"MT" = (
-/obj/machinery/light/small/warm{
-	dir = 8;
-	pixel_x = -12
-	},
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
-	})
-"MU" = (
 /obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/autoname_east/noaicontrol{
-	start_charge = 0
-	},
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
-	})
-"MV" = (
-/obj/item/c_tube,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
-	})
-"MW" = (
-/obj/computer3frame{
-	anchored = 1;
-	dir = 4;
-	state = 1
+	d2 = 4;
+	icon_state = "0-4";
+	pixel_y = 0
 	},
 /obj/machinery/power/data_terminal,
+/obj/machinery/computer/atmosphere/pumpcontrol{
+	dir = 4
+	},
+/turf/simulated/floor/grey,
+/area/station/engine/power{
+	name = "Erebus Power Room"
+	})
+"MJ" = (
+/obj/machinery/power/reactor_stats,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4";
+	pixel_y = 0
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/grey,
+/area/station/engine/power{
+	name = "Erebus Power Room"
+	})
+"MK" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/field_generator,
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/disposalpipe/segment/transport,
+/turf/simulated/floor/grey,
+/area/station/engine/power{
+	name = "Erebus Power Room"
+	})
+"ML" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-R"
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/engine/power{
+	name = "Erebus Power Room"
+	})
+"MM" = (
+/obj/machinery/door/poddoor/pyro{
+	dir = 4;
+	id = "tox_vent";
+	layer = 8;
+	name = "Chamber Exhaust"
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"MN" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 6
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"MO" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
+	},
+/obj/machinery/networked/test_apparatus/gas_sensor{
+	setup_tag = "TOXCHMB"
+	},
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
 	})
-"MX" = (
-/obj/cable{
-	icon_state = "2-8"
+"MP" = (
+/obj/machinery/door/airlock/pyro/engineering{
+	dir = 4;
+	name = "Core Access";
+	req_access = null
 	},
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
-	})
-"MY" = (
+/obj/access_spawn/engineering_engine,
+/obj/access_spawn/research,
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
 	})
-"MZ" = (
-/obj/reagent_dispensers/fueltank,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+"MQ" = (
+/obj/machinery/atmospherics/binary/passive_gate{
+	on = 1;
+	target_pressure = 1e+031
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
 	})
-"Na" = (
-/obj/item/tile/steel,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+"MR" = (
+/obj/machinery/computer3/generic/engine{
+	dir = 4
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/grey,
+/area/station/engine/power{
+	name = "Erebus Power Room"
 	})
-"Nb" = (
+"MS" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "4-6"
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/plating,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/stool/chair/office{
+	dir = 8;
+	icon_state = "office_chair"
+	},
+/turf/simulated/floor/grey,
+/area/station/engine/power{
+	name = "Erebus Power Room"
+	})
+"MT" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/disposalpipe/segment/transport,
+/turf/simulated/floor/grey,
+/area/station/engine/power{
+	name = "Erebus Power Room"
+	})
+"MU" = (
+/turf/simulated/floor/grey,
+/area/station/engine/power{
+	name = "Erebus Power Room"
+	})
+"MV" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-M"
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/engine/power{
+	name = "Erebus Power Room"
+	})
+"MW" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 6
+	},
+/turf/space,
+/area)
+"MX" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 4
+	},
+/turf/space,
+/area)
+"MY" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 9
+	},
+/turf/space,
+/area)
+"MZ" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Na" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 5
+	},
+/obj/machinery/atmospherics/unary/vent_pump/toxlab_chamber_to_tank/south,
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Nb" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 9
+	},
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 4;
+	icon_state = "on";
+	level = 2;
+	on = 1
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
 	})
 "Nc" = (
-/obj/decal/cleanable/cobweb2,
-/obj/reagent_dispensers/foamtank,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0;
+	dir = 4
+	},
+/obj/machinery/sparker{
+	id = "eng_ignition";
+	layer = 7;
+	name = "Mounted Igniter";
+	pixel_x = 24;
+	pixel_y = 8
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
 	})
 "Nd" = (
 /obj/cable,
@@ -20544,369 +20724,547 @@
 	name = "Dionysus Solar Array"
 	})
 "Ne" = (
-/obj/computer3frame{
-	anchored = 1;
-	dir = 4;
-	state = 1
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0;
+	dir = 10
 	},
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/wreckage{
-	name = "Calamarain"
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
 	})
 "Nf" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	can_rupture = 0
 	},
-/obj/cable{
-	icon_state = "1-4"
+/obj/machinery/meter,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	layer = 9.1;
+	pixel_x = 10
 	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
 	})
 "Ng" = (
+/obj/machinery/light/small,
+/obj/machinery/power/data_terminal,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d2 = 4;
+	icon_state = "0-4";
+	pixel_y = 0
 	},
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/machinery/computer3/terminal/zeta{
+	dir = 4;
+	setup_os_string = "ZETA_MAINFRAME"
+	},
+/turf/simulated/floor/grey,
+/area/station/engine/power{
+	name = "Erebus Power Room"
 	})
 "Nh" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/submachine/chef_sink/chem_sink{
+	dir = 1;
+	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "1-4"
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/turf/simulated/floor/grey,
+/area/station/engine/power{
+	name = "Erebus Power Room"
 	})
 "Ni" = (
-/obj/machinery/door/airlock/pyro/classic{
-	dir = 4
-	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/disposalpipe/segment/transport,
+/turf/simulated/floor/stairs{
+	dir = 1
+	},
+/area/station/engine/power{
+	name = "Erebus Power Room"
 	})
 "Nj" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "8-9"
-	},
-/turf/simulated/floor/plating,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/storage/crate,
+/obj/item/electronics/frame/collector_control,
+/obj/item/electronics/frame/collector_control,
+/obj/item/electronics/frame/collector_control,
+/obj/item/electronics/frame/collector_array,
+/obj/item/electronics/frame/collector_array,
+/obj/item/electronics/frame/collector_array,
+/obj/item/electronics/frame/collector_array,
+/obj/item/electronics/frame/collector_array,
+/obj/item/electronics/frame/collector_array,
+/obj/item/electronics/soldering,
+/turf/simulated/floor/grey,
+/area/station/engine/power{
+	name = "Erebus Power Room"
 	})
 "Nk" = (
-/obj/item/crowbar,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/machinery/light/small,
+/obj/machinery/emitter{
+	dir = 8
+	},
+/turf/simulated/floor/grey,
+/area/station/engine/power{
+	name = "Erebus Power Room"
 	})
 "Nl" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-L"
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/engine/power{
+	name = "Erebus Power Room"
+	})
+"Nm" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
-	})
-"Nm" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/communications_dish{
+	tag = "MAIN_DISH_SS13"
 	},
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
-	})
+/turf/simulated/floor/plating/airless,
+/area)
 "Nn" = (
-/obj/machinery/light/small/warm,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/machinery/atmospherics/pipe/simple/junction{
+	dir = 1
+	},
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8;
+	frequency = 1225;
+	icon_state = "intact_on";
+	id = "Toxin Chamber Outlet";
+	on = 1;
+	target_pressure = 1000
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
 	})
 "No" = (
-/obj/item/tile/steel,
-/obj/machinery/light/small/warm,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0;
+	dir = 9
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
 	})
 "Np" = (
-/obj/item/storage/box/cablesbox,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0;
+	dir = 5
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
 	})
 "Nq" = (
-/obj/item/wrench,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	can_rupture = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0;
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
 	})
 "Nr" = (
-/obj/machinery/portable_reclaimer,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/pyro/engineering{
+	name = "Bicameral Chamber";
+	req_access = null
+	},
+/obj/access_spawn/engineering_engine,
+/obj/access_spawn/research,
+/obj/disposalpipe/segment/transport,
+/turf/simulated/floor,
+/area/station/engine/power{
+	name = "Erebus Power Room"
 	})
 "Ns" = (
-/obj/machinery/portable_atmospherics/canister/air/large,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/machinery/atmospherics/valve,
+/turf/simulated/floor/darkpurple,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
 	})
 "Nt" = (
-/obj/machinery/light/small/warm,
-/turf/simulated/floor/shuttlebay,
-/area/station/wreckage{
-	name = "Calamarain"
-	})
-"Nu" = (
-/obj/item/storage/toolbox/electrical,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
-	})
-"Nv" = (
-/obj/item/storage/wall/fire{
-	dir = 4;
-	pixel_x = -32
-	},
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
-	})
-"Nw" = (
-/obj/machinery/light/small/warm,
-/turf/simulated/floor/plating,
-/area/station/wreckage{
-	name = "Calamarain"
-	})
-"Nx" = (
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/wreckage{
-	name = "Calamarain"
-	})
-"Ny" = (
-/obj/decal/cleanable/dirt,
-/obj/machinery/light/small/warm,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
-	})
-"Nz" = (
-/obj/item/storage/wall/office,
-/obj/item/chair/folded,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
-	})
-"NA" = (
-/obj/decal/cleanable/cobweb2,
-/turf/simulated/floor/plating,
-/area/station/wreckage{
-	name = "Calamarain"
-	})
-"NB" = (
-/obj/rack,
-/obj/item/clothing/suit/space/emerg,
-/obj/item/clothing/head/emerg,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/air,
-/obj/item/storage/belt/utility,
-/obj/machinery/light/small/warm{
+/obj/machinery/light{
 	dir = 1;
+	icon_state = "tube1";
+	layer = 9.1;
 	pixel_y = 21
 	},
-/turf/simulated/floor/grey,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/machinery/atmospherics/valve,
+/turf/simulated/floor/darkpurple,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Nu" = (
+/obj/lattice,
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/turf/space,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Nv" = (
+/obj/lattice,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 6
+	},
+/turf/space,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Nw" = (
+/obj/lattice,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
+	},
+/turf/space,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Nx" = (
+/obj/machinery/power/stats_meter{
+	name = "Hot Loop Combustion Chamber Meter";
+	tag = "Hot Loop Combustion Chamber Meter"
+	},
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 9
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Ny" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	can_rupture = 0
+	},
+/obj/machinery/door/airlock/pyro/engineering{
+	name = "Core Access";
+	req_access = null
+	},
+/obj/access_spawn/engineering_engine,
+/obj/access_spawn/research,
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Nz" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0;
+	dir = 1
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"NA" = (
+/obj/machinery/portable_atmospherics/pump,
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"NB" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/transport,
+/turf/simulated/floor/caution/west,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
 	})
 "NC" = (
-/obj/decal/cleanable/paper,
-/turf/simulated/floor/plating,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/item/storage/wall/fire{
+	pixel_y = 32
+	},
+/turf/simulated/floor/orange/corner{
+	dir = 4
+	},
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
 	})
 "ND" = (
-/obj/decal/poster/wallsign/stencil/right/a,
-/obj/decal/poster/wallsign/stencil/left/c,
-/turf/simulated/wall/auto/supernorn,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/table/reinforced/auto,
+/obj/item/clothing/suit/fire/heavy,
+/obj/item/clothing/suit/fire/heavy,
+/obj/item/clothing/head/helmet/welding,
+/obj/item/clothing/head/helmet/welding,
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/darkpurple,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
 	})
 "NE" = (
-/obj/decal/poster/wallsign/stencil/right/a,
-/obj/decal/poster/wallsign/stencil/left/l,
-/turf/simulated/wall/auto/supernorn,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/table/reinforced/auto,
+/obj/item/device/transfer_valve,
+/obj/item/device/transfer_valve,
+/obj/item/device/transfer_valve,
+/obj/item/device/transfer_valve,
+/obj/item/device/transfer_valve,
+/obj/machinery/phone/wall{
+	pixel_y = 32
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/darkpurple,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
 	})
 "NF" = (
-/obj/decal/poster/wallsign/stencil/right/a,
-/obj/decal/poster/wallsign/stencil/left/m,
-/turf/simulated/wall/auto/supernorn,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/table/reinforced/auto,
+/obj/item/device/analyzer/atmospheric,
+/obj/item/device/analyzer/atmospheric,
+/obj/item/device/analyzer/atmospheric,
+/obj/item/device/igniter,
+/obj/item/device/igniter,
+/obj/item/device/igniter,
+/obj/item/device/timer,
+/obj/item/device/timer,
+/obj/item/device/timer,
+/obj/item/device/analyzer/atmosanalyzer_upgrade,
+/obj/item/device/analyzer/atmosanalyzer_upgrade,
+/obj/item/device/analyzer/atmosanalyzer_upgrade,
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1";
+	layer = 9.1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/darkpurple,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
 	})
 "NG" = (
-/obj/decal/poster/wallsign/stencil/right/a{
-	pixel_x = 7
+/obj/table/reinforced/auto,
+/obj/item/extinguisher,
+/obj/item/extinguisher,
+/obj/item/device/prox_sensor{
+	pixel_x = 2;
+	pixel_y = -8
 	},
-/obj/decal/poster/wallsign/stencil/left/r{
-	pixel_x = -6
+/obj/item/device/prox_sensor{
+	pixel_x = 2;
+	pixel_y = -8
 	},
-/obj/decal/poster/wallsign/stencil/right/i{
-	pixel_x = 18
+/obj/item/device/prox_sensor{
+	pixel_x = 2;
+	pixel_y = -8
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/item/clothing/glasses/vr{
+	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
+	network = "bombtest";
+	pixel_x = 2;
+	pixel_y = 5
+	},
+/obj/item/clothing/glasses/vr{
+	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
+	network = "bombtest";
+	pixel_x = 2;
+	pixel_y = 5
+	},
+/turf/simulated/floor/darkpurple,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
 	})
 "NH" = (
-/obj/decal/poster/wallsign/stencil/left/n,
-/turf/simulated/wall/auto/supernorn,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/table/auto,
+/obj/item/sheet/steel{
+	amount = 50
+	},
+/obj/item/sheet/glass/reinforced{
+	amount = 50
+	},
+/obj/item/storage/toolbox/electrical,
+/obj/item/wrench,
+/turf/simulated/floor/orangeblack/side{
+	dir = 8
+	},
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
 	})
 "NI" = (
-/obj/item/storage/wall/emergency{
-	dir = 8;
-	pixel_x = 32
-	},
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/turf/simulated/floor/caution/east,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
 	})
 "NJ" = (
-/obj/item/storage/backpack,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/turf/simulated/floor/shuttlebay,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
 	})
 "NK" = (
-/obj/item/storage/wall{
-	pixel_y = 32
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1";
+	layer = 9.1;
+	pixel_y = 21
 	},
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/turf/simulated/floor/shuttlebay,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
 	})
 "NL" = (
-/obj/machinery/space_heater,
-/obj/item/storage/wall/emergency{
-	dir = 8;
-	pixel_x = 32
-	},
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
 	})
 "NM" = (
-/obj/item/furniture_parts/table/round,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1";
+	layer = 9.1;
+	pixel_y = 21
+	},
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
 	})
 "NN" = (
-/obj/machinery/r_door_control/podbay{
-	id = "calamarain"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
 	})
 "NO" = (
-/obj/item/horseshoe,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/decal/tile_edge/line/red,
+/turf/simulated/floor/darkpurple,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
 	})
 "NP" = (
-/obj/item/furniture_parts/table,
-/obj/item/chair/folded,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/machinery/atmospherics/binary/passive_gate{
+	on = 1;
+	pixel_y = 1;
+	target_pressure = 1e+031
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
 	})
 "NQ" = (
-/obj/item/reagent_containers/food/drinks/bottle/beer,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/shuttlebay,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
 	})
 "NR" = (
-/obj/item/chair/folded,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 8;
+	level = 2
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
 	})
 "NS" = (
-/obj/item/furniture_parts/stool/bar,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/machinery/atmospherics/valve{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
 	})
 "NT" = (
-/obj/table/reinforced/bar/auto,
-/obj/item/reagent_containers/food/drinks/drinkingglass/oldf,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	layer = 9.1;
+	pixel_x = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 1;
+	level = 2
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
 	})
 "NU" = (
-/obj/bedsheetbin,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/wingrille_spawn/auto,
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8;
+	frequency = 1225;
+	icon_state = "intact_on";
+	id = "Cold Loop Gas Supply 1";
+	on = 1;
+	target_pressure = 1000
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
 	})
 "NV" = (
-/obj/item/furniture_parts/bed,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/valve{
+	dir = 4
+	},
+/obj/disposalpipe/segment/transport,
+/turf/simulated/floor/caution/west,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
 	})
 "NW" = (
-/obj/item/furniture_parts/comfy_chair/blue,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/decal/poster/wallsign/stencil/right/one{
+	layer = 2;
+	pixel_x = 15;
+	pixel_y = 12
+	},
+/turf/simulated/floor/blue/side{
+	dir = 4
+	},
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
 	})
 "NX" = (
-/obj/item/storage/wall{
-	pixel_y = 32
+/obj/table/reinforced/auto,
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 4
 	},
-/obj/item/furniture_parts/bed,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/item/storage/firstaid/fire{
+	pixel_x = -4
+	},
+/turf/simulated/floor/darkpurple,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
 	})
 "NY" = (
 /obj/grille/steel,
@@ -20931,27 +21289,29 @@
 /turf/simulated/floor/airless/plating,
 /area/listeningpost)
 "Ob" = (
-/obj/item/furniture_parts/rack,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/bot/darkpurple,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
 	})
 "Oc" = (
-/obj/machinery/light/small/warm,
-/obj/item/furniture_parts/bed,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/turf/simulated/floor/bot/darkpurple,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
 	})
 "Od" = (
-/obj/storage/crate,
-/obj/item/furniture_parts/bench/blue,
-/obj/item/furniture_parts/bench/blue,
-/obj/item/furniture_parts/bench/blue,
-/obj/item/furniture_parts/bench/blue,
-/turf/simulated/floor/grime,
-/area/station/wreckage{
-	name = "Calamarain"
+/obj/table/reinforced/auto,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/wrench,
+/obj/item/wrench,
+/obj/item/chem_grenade/firefighting,
+/obj/item/chem_grenade/firefighting,
+/turf/simulated/floor/darkpurple,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
 	})
 "Oe" = (
 /obj/cable{
@@ -21843,17 +22203,18 @@
 /turf/simulated/floor/grey/blackgrime/other,
 /area/station/storage/tech)
 "Pf" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
 /obj/cable{
-	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
-/obj/cable{
-	icon_state = "2-4"
+/turf/simulated/floor/orangeblack/side{
+	dir = 8
 	},
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/lounge_port{
-	name = "Maru Crew Quarters"
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
 	})
 "Pg" = (
 /obj/machinery/camera{
@@ -22052,12 +22413,8 @@
 	name = "autoname - SS13";
 	pixel_y = 20
 	},
-/obj/machinery/macrofab{
-	createdObject = /obj/item/tank/emergency_oxygen;
-	desc = "A sophisticated machine that fabricates and pressurizes oxygen tanks.";
-	name = "Tank Fabricator"
-	},
-/turf/simulated/floor/plating,
+/obj/storage/closet/office,
+/turf/simulated/floor/caution/south,
 /area/station/maintenance/west{
 	name = "Meridian Maintenance"
 	})
@@ -22390,6 +22747,10 @@
 	pixel_x = -10;
 	tag = ""
 	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/greenblack{
 	dir = 8;
 	icon_state = "greenblack"
@@ -22530,6 +22891,9 @@
 /obj/grille/catwalk{
 	dir = 5
 	},
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
@@ -22667,24 +23031,15 @@
 	name = "Demeter Primary Zone"
 	})
 "Qg" = (
-/obj/machinery/mass_driver{
-	dir = 4;
-	id = "meri_trash";
-	name = "Meridian Waste Driver"
-	},
+/obj/window/auto/reinforced,
 /obj/machinery/door/poddoor/pyro{
 	dir = 4;
-	id = "meri_trash";
-	name = "Meridian Waste Door"
+	id = "PTLDOOR";
+	name = "Laser Confinement Door"
 	},
-/obj/forcefield/energyshield/perma/doorlink{
-	desc = "A door-linked force field that prevents gasses from passing through it.";
-	name = "Door-linked Atmospheric Forcefield";
-	powerlevel = 1
-	},
-/turf/simulated/floor/grey,
-/area/station/maintenance/west{
-	name = "Meridian Maintenance"
+/turf/simulated/floor/engine,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
 	})
 "Qh" = (
 /obj/machinery/recharge_station,
@@ -23211,11 +23566,11 @@
 	name = "Tenebrae Solar Array"
 	})
 "QK" = (
-/obj/machinery/door/airlock/pyro/engineering{
+/obj/machinery/shuttle/engine/heater{
 	dir = 4;
-	name = "Auxiliary Component Bay"
+	icon_state = "alt_heater-M"
 	},
-/turf/simulated/floor/shuttlebay,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/lounge_port{
 	name = "Maru Crew Quarters"
 	})
@@ -23414,6 +23769,12 @@
 /area/station/science/construction{
 	name = "Tenebrae Maintenance"
 	})
+"Ro" = (
+/obj/machinery/dispenser,
+/turf/simulated/floor/darkpurple,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
 "Rp" = (
 /obj/decal/fakeobjects/pipe/heat{
 	dir = 5;
@@ -23430,10 +23791,13 @@
 /turf/simulated/floor/plating,
 /area/ghostdrone_factory)
 "Rs" = (
-/obj/machinery/power/smes,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/stool/bed,
+/obj/landmark/start{
+	name = "Engineer"
+	},
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "yellow";
+	icon_state = "bedsheet-yellow"
 	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/lounge_port{
@@ -23570,45 +23934,693 @@
 	},
 /turf/space,
 /area/ghostdrone_factory)
-"SJ" = (
+"RL" = (
 /obj/machinery/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "alt_heater-L"
+	icon_state = "alt_heater-R"
 	},
 /turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/lounge_port{
-	name = "Maru Crew Quarters"
+/area/station/maintenance/SWmaint{
+	name = "Erebus Maintenance Room"
 	})
-"Tc" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	dir = 4;
-	name = "Auxiliary Component Bay"
-	},
-/turf/simulated/floor/shuttlebay,
-/area/station/maintenance/storage{
-	name = "Maru Power Room"
-	})
-"Tu" = (
-/obj/machinery/shuttle/engine/heater{
-	dir = 4;
-	icon_state = "alt_heater-L"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/storage{
-	name = "Maru Power Room"
-	})
-"TU" = (
+"RR" = (
 /obj/machinery/shuttle/engine/propulsion{
 	dir = 4;
 	icon_state = "alt_propulsion"
 	},
-/obj/lattice{
+/turf/space,
+/area/station/maintenance/SWmaint{
+	name = "Erebus Maintenance Room"
+	})
+"RU" = (
+/obj/machinery/computer3/terminal/zeta{
 	dir = 4;
-	icon_state = "lattice-dir"
+	setup_os_string = "ZETA_MAINFRAME"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/darkpurple,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
+"RV" = (
+/obj/decal/poster/wallsign/stencil/right/two{
+	layer = 2;
+	pixel_x = 17;
+	pixel_y = 12
+	},
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/turf/simulated/floor/orangeblack/side{
+	dir = 4
+	},
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
+"RX" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/obj/access_spawn/engineering_engine,
+/obj/access_spawn/research,
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Sd" = (
+/obj/machinery/shower{
+	dir = 4;
+	icon_state = "showerhead";
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/sanitary/white,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Se" = (
+/obj/machinery/crusher,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "erebusbelt";
+	name = "Erebus disposal belt";
+	operating = 1
+	},
+/turf/simulated/floor/grey,
+/area/station/maintenance/SWmaint{
+	name = "Erebus Maintenance Room"
+	})
+"Sf" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0;
+	dir = 6
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Sh" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Si" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-M"
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/maintenance/SWmaint{
+	name = "Erebus Maintenance Room"
+	})
+"Sl" = (
+/obj/machinery/portable_reclaimer,
+/obj/machinery/door_control{
+	id = "erebus_crusher";
+	name = "Erebus Crusher Door";
+	pixel_x = -24
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SWmaint{
+	name = "Erebus Maintenance Room"
+	})
+"So" = (
+/obj/machinery/atmospherics/binary/volume_pump{
+	on = 1;
+	transfer_rate = 1000
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Sq" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "4-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"St" = (
+/obj/lattice{
+	dir = 9;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
-/area/station/crew_quarters/lounge_port{
-	name = "Maru Crew Quarters"
+/area/station/solar/small_backup1{
+	name = "Erebus Solar Array"
+	})
+"Su" = (
+/obj/lattice,
+/turf/space,
+/area/station/solar/small_backup1{
+	name = "Erebus Solar Array"
+	})
+"Sv" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/junction{
+	dir = 1
+	},
+/turf/space,
+/area)
+"Sw" = (
+/turf/simulated/floor/sanitary/white,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Sy" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 6
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"SA" = (
+/obj/machinery/mass_driver{
+	dir = 4;
+	id = "erebus_trash";
+	name = "Erebus Waste Driver"
+	},
+/turf/simulated/floor/grey,
+/area/station/maintenance/SWmaint{
+	name = "Erebus Maintenance Room"
+	})
+"SB" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0;
+	dir = 10
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/power{
+	name = "Erebus Power Room"
+	})
+"SF" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0;
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"SH" = (
+/turf/simulated/wall/auto/supernorn,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
+"SI" = (
+/obj/wingrille_spawn/auto,
+/obj/disposalpipe/segment/transport{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
+/turf/simulated/floor/plating,
+/area/station/science/artifact)
+"SJ" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"SK" = (
+/obj/grille/catwalk{
+	dir = 2;
+	icon_state = "catwalk_cross"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-4";
+	pixel_y = 0
+	},
+/obj/machinery/power/tracker{
+	id = "erebus";
+	name = "Erebus solar tracker"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross";
+	layer = 2
+	},
+/area/station/solar/small_backup1{
+	name = "Erebus Solar Array"
+	})
+"SM" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-9"
+	},
+/turf/space,
+/area)
+"SO" = (
+/obj/machinery/atmospherics/binary/circulatorTemp,
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"SP" = (
+/obj/submachine/chef_sink/chem_sink{
+	pixel_y = 16
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
+/turf/simulated/floor/sanitary/white,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"SQ" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
+"SS" = (
+/obj/machinery/atmospherics/binary/passive_gate{
+	dir = 4;
+	on = 1;
+	pixel_y = 1;
+	target_pressure = 1e+031
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "6-8"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"ST" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 9
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "5-8"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"SV" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"SX" = (
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/obj/reagent_dispensers/fueltank,
+/turf/simulated/floor/plating,
+/area/station/maintenance/SWmaint{
+	name = "Erebus Maintenance Room"
+	})
+"Tc" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-M"
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/maintenance/storage{
+	name = "Maru Power Room"
+	})
+"Td" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
+	},
+/obj/machinery/atmospherics/binary/volume_pump{
+	dir = 1;
+	on = 1;
+	transfer_rate = 1000
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Te" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/empty,
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Tf" = (
+/obj/disposaloutlet/east,
+/obj/disposalpipe/trunk/east,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "erebusbelt";
+	name = "Erebus disposal belt";
+	operating = 1
+	},
+/turf/simulated/floor/grey,
+/area/station/maintenance/SWmaint{
+	name = "Erebus Maintenance Room"
+	})
+"Tg" = (
+/obj/machinery/light/small,
+/obj/machinery/launcher_loader/east,
+/turf/simulated/floor/grey,
+/area/station/maintenance/SWmaint{
+	name = "Erebus Maintenance Room"
+	})
+"Tj" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 5
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Tm" = (
+/obj/machinery/portable_atmospherics/canister/air/large,
+/turf/simulated/floor/orangeblack/side{
+	dir = 8
+	},
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
+"Tn" = (
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"To" = (
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
+/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{
+	dir = 4;
+	id = "erebusbay";
+	name = "Erebus pod bay door"
+	},
+/turf/simulated/floor/shuttlebay,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
+"Tp" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 5
+	},
+/turf/space,
+/area)
+"Tq" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/grille/catwalk{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 5
+	},
+/turf/space,
+/area/station/solar/small_backup1{
+	name = "Erebus Solar Array"
+	})
+"Ts" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
+"Tt" = (
+/obj/disposalpipe/segment/transport{
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/purplewhite/corner{
+	dir = 8
+	},
+/area/station/science{
+	name = "Tenebrae Primary Zone"
+	})
+"Tu" = (
+/obj/machinery/power/apc/autoname_west,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4";
+	pixel_y = 0
+	},
+/turf/simulated/floor/engine/caution/north,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Tx" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 4;
+	level = 2
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Ty" = (
+/obj/lattice{
+	dir = 6;
+	icon_state = "lattice-dir-b"
+	},
+/turf/space,
+/area/station/solar/small_backup1{
+	name = "Erebus Solar Array"
+	})
+"Tz" = (
+/obj/table/auto,
+/obj/item/sheet/steel{
+	amount = 50
+	},
+/obj/item/sheet/glass{
+	amount = 50
+	},
+/obj/item/storage/box/cablesbox,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/obj/item/extinguisher,
+/turf/simulated/floor/plating,
+/area/station/maintenance/SWmaint{
+	name = "Erebus Maintenance Room"
+	})
+"TC" = (
+/obj/machinery/power/smes{
+	charge = 1e+006;
+	chargelevel = 15000;
+	output = 10000
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"TG" = (
+/obj/machinery/atmospherics/valve{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-9"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"TH" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 1;
+	frequency = 1225;
+	icon_state = "intact_on";
+	id = "Hot Loop Gas Supply 1";
+	on = 1;
+	target_pressure = 1000
+	},
+/turf/simulated/floor/engine/caution/south,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"TK" = (
+/obj/machinery/atmospherics/pipe/simple/junction{
+	dir = 1
+	},
+/turf/space,
+/area)
+"TL" = (
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/obj/machinery/meter,
+/obj/cable{
+	icon_state = "6-10"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"TS" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/orange/corner{
+	dir = 4
+	},
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
+"TT" = (
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SWmaint{
+	name = "Erebus Maintenance Room"
+	})
+"TU" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 6
+	},
+/obj/cable{
+	icon_state = "6-8"
+	},
+/turf/simulated/floor/engine/caution/north,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"TX" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 9
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"TZ" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Uc" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Ud" = (
+/obj/machinery/atmospherics/binary/circulatorTemp/right,
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Ug" = (
+/obj/rack,
+/obj/item/sheet/steel{
+	amount = 50
+	},
+/obj/item/sheet/steel{
+	amount = 50
+	},
+/obj/item/sheet/glass{
+	amount = 50
+	},
+/obj/item/sheet/glass{
+	amount = 50
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west{
+	name = "Meridian Maintenance"
+	})
+"Uh" = (
+/obj/disposalpipe/segment/transport{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
 	})
 "Uq" = (
 /obj/machinery/light/small{
@@ -23626,9 +24638,233 @@
 /area/station/aviary{
 	name = "Demeter Primary Zone"
 	})
+"Ur" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 4
+	},
+/obj/machinery/atmospherics/valve,
+/obj/cable{
+	icon_state = "5-9"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
 "Ut" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/bridge/hos)
+"Uu" = (
+/obj/cable,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/grille/catwalk{
+	dir = 1;
+	icon_state = "catwalk_cross"
+	},
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 4
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross";
+	layer = 2
+	},
+/area/station/solar/small_backup1{
+	name = "Erebus Solar Array"
+	})
+"Uv" = (
+/obj/machinery/manufacturer/gas,
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Uw" = (
+/obj/disposalpipe/segment/transport{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"UB" = (
+/obj/disposalpipe/segment/transport{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/caution/west,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
+"UC" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/maintenance/SWmaint{
+	name = "Erebus Maintenance Room"
+	})
+"UF" = (
+/obj/storage/crate/furnacefuel,
+/turf/simulated/floor/plating,
+/area/station/maintenance/west{
+	name = "Meridian Maintenance"
+	})
+"UG" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 1;
+	frequency = 1225;
+	icon_state = "intact_on";
+	id = "Hot Loop Gas Supply 2";
+	on = 1;
+	target_pressure = 1000
+	},
+/turf/simulated/floor/engine/caution/south,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"UH" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/stairs,
+/area/station/maintenance/SWmaint{
+	name = "Erebus Maintenance Room"
+	})
+"UI" = (
+/turf/simulated/floor/darkpurple,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
+"UJ" = (
+/obj/machinery/door/poddoor/pyro{
+	autoclose = 1;
+	dir = 4;
+	id = "erebus_crusher";
+	name = "Erebus Crusher Door"
+	},
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "erebusbelt";
+	name = "Erebus disposal belt";
+	operating = 1
+	},
+/turf/simulated/floor/grey,
+/area/station/maintenance/SWmaint{
+	name = "Erebus Maintenance Room"
+	})
+"UK" = (
+/turf/simulated/wall/auto/supernorn,
+/area/station/maintenance/SWmaint{
+	name = "Erebus Maintenance Room"
+	})
+"UN" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"UT" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/grille/catwalk{
+	dir = 4
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/space,
+/area/station/solar/west{
+	name = "Meridian Solar Array"
+	})
+"UU" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/binary/volume_pump{
+	on = 1;
+	transfer_rate = 1000
+	},
+/turf/simulated/floor/grey,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"UW" = (
+/obj/lattice,
+/obj/machinery/macrofab/emergency_pod,
+/turf/space,
+/area/station/solar/small_backup1{
+	name = "Erebus Solar Array"
+	})
+"UX" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 9
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"UY" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Vc" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0;
+	dir = 4
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Vd" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/bot/darkpurple,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
 "Ve" = (
 /obj/machinery/macrofab{
 	createdObject = /obj/item/tank/emergency_oxygen;
@@ -23640,6 +24876,46 @@
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/lounge_starboard{
 	name = "Tenebrae Crew Quarters"
+	})
+"Vf" = (
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 4;
+	level = 2
+	},
+/obj/machinery/power/stats_meter{
+	name = "Hot Loop Outlet Meter";
+	tag = "Hot Loop Outlet Meter"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Vh" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
+	},
+/obj/machinery/meter,
+/obj/cable{
+	icon_state = "4-9"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Vi" = (
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "4-10"
+	},
+/turf/simulated/floor/orange/corner{
+	dir = 4
+	},
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
 	})
 "Vj" = (
 /obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{
@@ -23656,14 +24932,78 @@
 /area/station/crew_quarters/utility{
 	name = "Dionysus Cryocore"
 	})
+"Vk" = (
+/obj/disposalpipe/loafer/horizontal,
+/obj/machinery/abcu,
+/turf/simulated/floor/plating,
+/area/station/maintenance/west{
+	name = "Meridian Maintenance"
+	})
 "Vl" = (
-/obj/machinery/shuttle/engine/propulsion{
-	dir = 4;
-	icon_state = "alt_propulsion"
+/obj/machinery/atmospherics/valve{
+	dir = 4
 	},
+/turf/simulated/floor/engine/caution/corner2{
+	dir = 9
+	},
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Vm" = (
+/obj/disposalpipe/segment/bent/west,
+/obj/machinery/conveyor{
+	id = "erebusbelt";
+	name = "Erebus disposal belt";
+	operating = 1
+	},
+/turf/simulated/floor/grey,
+/area/station/maintenance/SWmaint{
+	name = "Erebus Maintenance Room"
+	})
+"Vn" = (
+/obj/machinery/atmospherics/binary/passive_gate{
+	dir = 8;
+	on = 1;
+	pixel_y = 1;
+	target_pressure = 1e+031
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Vp" = (
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/obj/machinery/atmospherics/valve{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Vr" = (
+/obj/machinery/light,
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/simulated/floor,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
+"Vt" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/space,
-/area/station/crew_quarters/lounge_port{
-	name = "Maru Crew Quarters"
+/area)
+"Vx" = (
+/obj/machinery/disposal_pipedispenser,
+/turf/simulated/floor/plating,
+/area/station/maintenance/west{
+	name = "Meridian Maintenance"
 	})
 "Vy" = (
 /obj/decal/poster/wallsign/stencil/left/m,
@@ -23674,42 +25014,425 @@
 /area/station/maintenance/storage{
 	name = "Maru Power Room"
 	})
+"Vz" = (
+/obj/machinery/r_door_control/podbay{
+	id = "erebusbay";
+	name = "Erebus pod bay door control"
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
+"VA" = (
+/obj/machinery/atmospherics/portables_connector,
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"VB" = (
+/obj/cable,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/grille/catwalk{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 9
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	icon_state = "catwalk_cross";
+	layer = 2
+	},
+/area/station/solar/small_backup1{
+	name = "Erebus Solar Array"
+	})
+"VH" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/turf/simulated/floor/engine/caution/west,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
 "VI" = (
 /obj/machinery/oreaccumulator,
 /turf/simulated/floor/plating/airless,
 /area/station/mining)
+"VJ" = (
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
 "VK" = (
 /obj/disposalpipe/segment/transport,
-/obj/machinery/emitter{
-	dir = 8
+/obj/disposalpipe/segment/transport{
+	dir = 4;
+	icon_state = "pipe-s"
 	},
-/turf/simulated/floor/shuttlebay,
-/area/station/maintenance/storage{
-	name = "Maru Power Room"
+/turf/space,
+/area)
+"VM" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
 	})
 "VQ" = (
-/obj/machinery/shuttle/engine/heater{
-	dir = 4;
-	icon_state = "alt_heater-M"
+/obj/machinery/door_control{
+	id = "tox_vent";
+	name = "Chamber Exhaust";
+	pixel_x = -7;
+	pixel_y = 28
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/lounge_port{
-	name = "Maru Crew Quarters"
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 1;
+	level = 2
+	},
+/obj/machinery/ignition_switch{
+	id = "eng_ignition";
+	name = "Burn Chamber Ignition";
+	pixel_x = 7;
+	pixel_y = 28
+	},
+/obj/cable{
+	icon_state = "6-10"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"VS" = (
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 8;
+	level = 2
+	},
+/obj/machinery/power/stats_meter{
+	name = "Cold Loop Outlet Meter";
+	tag = "Cold Loop Outlet Meter"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "4-10"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"VX" = (
+/obj/grille/catwalk{
+	dir = 4
+	},
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/space,
+/area/station/solar/small_backup1{
+	name = "Erebus Solar Array"
 	})
 "VZ" = (
-/obj/disposalpipe/segment/transport,
-/obj/machinery/door/airlock/pyro/engineering{
-	name = "Auxiliary Component Bay"
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 9
 	},
-/obj/forcefield/energyshield/perma/doorlink{
-	desc = "A door-linked force field that prevents gasses from passing through it.";
-	name = "Door-linked Atmospheric Forcefield";
-	powerlevel = 1
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Wf" = (
+/obj/machinery/portable_atmospherics/canister/air/large,
+/turf/simulated/floor/plating,
+/area/station/maintenance/SWmaint{
+	name = "Erebus Maintenance Room"
+	})
+"Wg" = (
+/obj/machinery/power/solar_control{
+	dir = 8;
+	id = "erebus";
+	name = "HM-17 solar panel control"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Maru Power Room"
+/area/station/maintenance/SWmaint{
+	name = "Erebus Maintenance Room"
 	})
+"Wn" = (
+/obj/grille/catwalk{
+	dir = 10;
+	icon_state = "catwalk_cross"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 10;
+	layer = 2
+	},
+/area/station/solar/small_backup1{
+	name = "Erebus Solar Array"
+	})
+"Wp" = (
+/obj/disposalpipe/segment/transport,
+/obj/disposalpipe/segment/transport{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
+/turf/simulated/floor/caution/east,
+/area/station/science{
+	name = "Tenebrae Primary Zone"
+	})
+"Wq" = (
+/obj/machinery/door/airlock/pyro{
+	name = "Vessel Restroom"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Wt" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "6-10"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Wu" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/obj/disposalpipe/segment/transport,
+/turf/simulated/floor/caution/west,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
+"Ww" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/decal/poster/wallsign/stencil/right/two{
+	layer = 2;
+	pixel_x = 17;
+	pixel_y = 12
+	},
+/turf/simulated/floor/orangeblack,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Wx" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
+	},
+/turf/space,
+/area)
+"Wz" = (
+/obj/machinery/atmospherics/valve,
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"WA" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"WB" = (
+/obj/machinery/vending/standard,
+/turf/simulated/floor/darkpurple,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
+"WE" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/vertical,
+/obj/machinery/door/airlock/pyro{
+	name = "Vessel Power Room"
+	},
+/turf/simulated/floor,
+/area/station/maintenance/SWmaint{
+	name = "Erebus Maintenance Room"
+	})
+"WF" = (
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/orange/corner{
+	dir = 4
+	},
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
+"WH" = (
+/obj/machinery/power/pt_laser,
+/turf/simulated/floor/caution/east,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
+"WJ" = (
+/obj/machinery/macrofab/emergency_pod{
+	color = "#DDDDDD";
+	createdObject = /obj/machinery/vehicle/miniputt/armed;
+	desc = "A sophisticated machine that fabricates compact transit pods from a nearby reserve of supplies.";
+	dir = 1;
+	fabTime = 150;
+	name = "MiniPutt Fabricator";
+	override_dir = 4
+	},
+/turf/simulated/floor/shuttlebay,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
+"WK" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/valve{
+	dir = 4
+	},
+/obj/disposalpipe/segment/transport,
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/caution/west,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
+"WN" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0;
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"WO" = (
+/turf/simulated/wall/auto/supernorn,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"WP" = (
+/obj/machinery/atmospherics/pipe/tank{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"WS" = (
+/obj/machinery/door/airlock/pyro/engineering{
+	name = "Core Access";
+	req_access = null
+	},
+/obj/access_spawn/engineering_engine,
+/obj/access_spawn/research,
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"WW" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "5-9"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"WY" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/insulated/cold,
+/turf/simulated/floor/grey,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"WZ" = (
+/obj/machinery/light/small,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "erebusbelt";
+	name = "Erebus disposal belt";
+	operating = 1
+	},
+/turf/simulated/floor/grey,
+/area/station/maintenance/SWmaint{
+	name = "Erebus Maintenance Room"
+	})
+"Xa" = (
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/turf/space,
+/area)
 "Xb" = (
 /obj/rack,
 /obj/item/clothing/mask/breath,
@@ -23726,12 +25449,76 @@
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/mining)
+"Xd" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SWmaint{
+	name = "Erebus Maintenance Room"
+	})
+"Xf" = (
+/obj/item/storage/wall/emergency{
+	dir = 8;
+	pixel_x = 32
+	},
+/obj/disposalpipe/trunk/north,
+/obj/machinery/disposal/transport{
+	name = "Tenebrae transportation unit"
+	},
+/obj/decal/tile_edge/line/purple,
+/turf/simulated/floor/grey,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
+"Xg" = (
+/obj/machinery/atmospherics/pipe/tank{
+	dir = 8
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Xi" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/power{
+	name = "Erebus Power Room"
+	})
+"Xj" = (
+/obj/item/storage/toilet{
+	dir = 4;
+	icon_state = "toilet";
+	tag = ""
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
+/turf/simulated/floor/sanitary/white,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Xk" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/space,
+/area)
 "Xl" = (
 /obj/submachine/weapon_vendor/security,
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
 /area/station/security/secwing)
+"Xm" = (
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
 "Xn" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/grey,
@@ -23739,33 +25526,106 @@
 	name = "Dionysus Cryocore"
 	})
 "Xp" = (
-/obj/machinery/the_singularitygen,
+/obj/machinery/atmospherics/valve,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "6-10"
 	},
-/turf/simulated/floor/shuttlebay,
-/area/station/crew_quarters/lounge_port{
-	name = "Maru Crew Quarters"
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
 	})
-"Xy" = (
-/obj/machinery/emitter{
+"Xr" = (
+/obj/decal/poster/wallsign/stencil/right/one{
+	layer = 2;
+	pixel_x = 15;
+	pixel_y = 12
+	},
+/obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
-/obj/machinery/light/small,
-/turf/simulated/floor/shuttlebay,
-/area/station/maintenance/storage{
-	name = "Maru Power Room"
-	})
-"Xz" = (
-/obj/machinery/shuttle/engine/heater{
-	dir = 4;
-	icon_state = "alt_heater-R"
+/turf/simulated/floor/orangeblack/side{
+	dir = 4
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/lounge_port{
-	name = "Maru Crew Quarters"
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
+"Xs" = (
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 1
+	},
+/turf/space,
+/area)
+"Xu" = (
+/obj/disposalpipe/segment/transport,
+/turf/simulated/floor/shuttlebay,
+/area/station/science{
+	name = "Tenebrae Primary Zone"
+	})
+"Xx" = (
+/obj/lattice{
+	dir = 8;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/station/solar/small_backup1{
+	name = "Erebus Solar Array"
+	})
+"Xy" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 4;
+	icon_state = "alt_propulsion"
+	},
+/turf/space,
+/area)
+"Xz" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 6
+	},
+/obj/machinery/meter,
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1";
+	layer = 9.1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"XB" = (
+/obj/rack,
+/obj/item/clothing/suit/space/emerg,
+/obj/item/clothing/head/emerg,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/air,
+/obj/item/device/light/flashlight,
+/turf/simulated/floor/grey,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"XD" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "1-5"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"XE" = (
+/obj/storage/crate,
+/obj/item/device/light/glowstick,
+/obj/item/clothing/under/gimmick/chav,
+/obj/item/clothing/head/chav,
+/obj/item/storage/pill_bottle/cyberpunk,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/station/maintenance/west{
+	name = "Meridian Maintenance"
 	})
 "XF" = (
 /obj/machinery/r_door_control/podbay{
@@ -23779,21 +25639,274 @@
 /area/station/crew_quarters/utility{
 	name = "Dionysus Cryocore"
 	})
-"Yc" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "yellow";
-	icon_state = "bedsheet-yellow"
+"XH" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0;
+	dir = 4
 	},
-/obj/landmark/start{
-	name = "Engineer"
-	},
+/obj/machinery/meter,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"XI" = (
 /obj/cable{
-	icon_state = "4-8"
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/solar{
+	id = "erebus";
+	name = "Erebus solar panel"
+	},
+/turf/simulated/floor/airless{
+	icon_state = "solarbase";
+	name = "solar paneling"
+	},
+/area/station/solar/small_backup1{
+	name = "Erebus Solar Array"
+	})
+"XJ" = (
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"XK" = (
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 4;
+	level = 2
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"XL" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
+"XM" = (
+/obj/rack,
+/obj/item/clothing/suit/space/emerg,
+/obj/item/clothing/head/emerg,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/air,
+/obj/item/device/light/flashlight,
+/obj/item/storage/belt/utility,
+/obj/item/storage/toolbox/mechanical,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
 	},
 /turf/simulated/floor/grey,
-/area/station/crew_quarters/lounge_port{
-	name = "Maru Crew Quarters"
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"XT" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/science/research_director{
+	name = "Tenebrae Command Center"
+	})
+"XX" = (
+/obj/decal/poster/wallsign/stencil/right/e{
+	pixel_x = 13
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"XY" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/grille/catwalk{
+	dir = 4
+	},
+/turf/space,
+/area/station/solar/small_backup1{
+	name = "Erebus Solar Array"
+	})
+"XZ" = (
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/grille/catwalk{
+	dir = 5
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	icon_state = "catwalk_cross";
+	layer = 2
+	},
+/area/station/solar/small_backup1{
+	name = "Erebus Solar Array"
+	})
+"Yb" = (
+/obj/machinery/door/airlock/pyro/external,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/insulated/cold,
+/turf/simulated/floor/grey,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Yc" = (
+/obj/machinery/atmospherics/valve{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "6-10"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Yf" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Yg" = (
+/obj/machinery/atmospherics/valve{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Yj" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Yk" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/maintenance/SWmaint{
+	name = "Erebus Maintenance Room"
+	})
+"Yl" = (
+/obj/decal/poster/wallsign/stencil/left/r{
+	pixel_x = -6
+	},
+/obj/decal/poster/wallsign/stencil/right/e{
+	pixel_x = 6
+	},
+/obj/decal/poster/wallsign/stencil/right/b{
+	pixel_x = 18
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Ym" = (
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "5-8"
+	},
+/obj/machinery/vending/medical_public,
+/turf/simulated/floor,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
+"Yn" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/disposalpipe/segment/bent/west,
+/turf/simulated/floor/plating,
+/area/station/maintenance/SWmaint{
+	name = "Erebus Maintenance Room"
+	})
+"Yq" = (
+/obj/disposalpipe/trunk/west,
+/obj/machinery/disposal/transport{
+	name = "Maru transportation unit"
+	},
+/obj/decal/tile_edge/line/yellow,
+/turf/simulated/floor/grey,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
+"Yr" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8;
+	frequency = 1225;
+	icon_state = "intact_on";
+	id = "Cold Loop Gas Supply 2";
+	on = 1;
+	target_pressure = 1000
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Yw" = (
+/obj/machinery/light,
+/turf/simulated/floor/shuttlebay,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
+"Yx" = (
+/obj/machinery/manufacturer/general,
+/turf/simulated/floor/plating,
+/area/station/maintenance/SWmaint{
+	name = "Erebus Maintenance Room"
+	})
+"YB" = (
+/obj/machinery/door/airlock/pyro/engineering{
+	dir = 4;
+	name = "Engine Gas Storage";
+	req_access = null
+	},
+/obj/access_spawn/engineering_engine,
+/obj/access_spawn/research,
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
 	})
 "YC" = (
 /obj/decal/poster/wallsign/stencil/left/r{
@@ -23805,6 +25918,434 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/storage{
 	name = "Maru Power Room"
+	})
+"YE" = (
+/obj/disposalpipe/segment/transport{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "1-6"
+	},
+/turf/space,
+/area)
+"YG" = (
+/obj/machinery/drainage,
+/obj/disposalpipe/segment/transport{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
+/turf/simulated/floor/sanitary/white,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"YK" = (
+/obj/decal/tile_edge/line/blue,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/turf/simulated/floor/darkpurple,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"YM" = (
+/obj/machinery/power/stats_meter{
+	name = "Hot Loop Inlet Meter";
+	tag = "Hot Loop Inlet Meter"
+	},
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 1;
+	level = 2
+	},
+/obj/cable{
+	icon_state = "5-9"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"YN" = (
+/obj/reagent_dispensers/foamtank,
+/turf/simulated/floor/plating,
+/area/station/maintenance/SWmaint{
+	name = "Erebus Maintenance Room"
+	})
+"YO" = (
+/obj/machinery/door_control{
+	id = "PTLDOOR";
+	name = "Transmission Laser Confinement";
+	pixel_x = 24
+	},
+/obj/machinery/vehicle/miniputt/armed,
+/turf/simulated/floor/shuttlebay,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
+"YP" = (
+/obj/machinery/atmospherics/mixer{
+	dir = 1;
+	frequency = 1225;
+	id_tag = "engine_combust";
+	master_id = "engine_combust_control";
+	name = "Gas Mixer (Combustion Chamber)"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"YQ" = (
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 8;
+	level = 2
+	},
+/obj/machinery/power/stats_meter{
+	name = "Cold Loop Inlet Meter";
+	tag = "Cold Loop Inlet Meter"
+	},
+/obj/cable{
+	icon_state = "5-9"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"YR" = (
+/obj/lattice,
+/turf/space,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"YT" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/grille/catwalk,
+/obj/machinery/atmospherics/pipe/simple/insulated/cold,
+/turf/simulated/floor/airless/plating/catwalk,
+/area/station/solar/small_backup1{
+	name = "Erebus Solar Array"
+	})
+"YU" = (
+/turf/simulated/floor/plating,
+/area/station/maintenance/SWmaint{
+	name = "Erebus Maintenance Room"
+	})
+"YV" = (
+/obj/disposalpipe/segment/transport{
+	icon_state = "pipe-c"
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/orange/corner{
+	dir = 4
+	},
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
+"YX" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/darkpurple,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
+"YY" = (
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/station/solar/small_backup1{
+	name = "Erebus Solar Array"
+	})
+"YZ" = (
+/obj/rack,
+/obj/item/clothing/suit/fire,
+/obj/item/clothing/suit/fire,
+/obj/item/clothing/mask/gas/emergency,
+/obj/item/clothing/mask/gas/emergency,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/caution/north,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Zb" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 6
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Zf" = (
+/obj/machinery/atmospherics/valve{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Zg" = (
+/obj/decal/poster/wallsign/stencil/left/u{
+	pixel_x = -2
+	},
+/obj/decal/poster/wallsign/stencil/right/s,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Zi" = (
+/obj/disposalpipe/segment/bent/east,
+/turf/simulated/floor/plating,
+/area/station/maintenance/SWmaint{
+	name = "Erebus Maintenance Room"
+	})
+"Zj" = (
+/obj/machinery/atmospherics/pipe/simple/junction{
+	dir = 1
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Zl" = (
+/obj/machinery/door_control/podbay{
+	id = "erebusbay";
+	name = "Erebus pod bay door control";
+	pixel_x = -24
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/orangeblack/side{
+	dir = 8
+	},
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
+"Zs" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
+"Zt" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	layer = 9.1;
+	pixel_x = 10
+	},
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/decal/poster/wallsign/stencil/right/two{
+	layer = 2;
+	pixel_x = 17;
+	pixel_y = 12
+	},
+/turf/simulated/floor/blue/side{
+	dir = 4
+	},
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
+"Zu" = (
+/obj/machinery/door/airlock/pyro/external,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/transport,
+/obj/machinery/atmospherics/pipe/simple/insulated/cold,
+/obj/access_spawn/engineering_engine,
+/obj/access_spawn/research,
+/turf/simulated/floor/grey,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Zx" = (
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Hardware Chamber"
+	},
+/obj/access_spawn/engineering_engine,
+/obj/access_spawn/research,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/darkpurple,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
+"Zy" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Zz" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-L"
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/maintenance/SWmaint{
+	name = "Erebus Maintenance Room"
+	})
+"ZA" = (
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/orange/corner{
+	dir = 4
+	},
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
+"ZC" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/power{
+	name = "Erebus Power Room"
+	})
+"ZH" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 10
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"ZI" = (
+/obj/machinery/power/generatorTemp,
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"ZJ" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	can_rupture = 0;
+	dir = 5
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"ZM" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/disposalpipe/segment/horizontal,
+/turf/simulated/floor/plating,
+/area/station/maintenance/SWmaint{
+	name = "Erebus Maintenance Room"
+	})
+"ZO" = (
+/obj/machinery/networked/storage/bomb_tester{
+	bank_id = "Mixer"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/darkpurple,
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
+"ZP" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 5
+	},
+/turf/simulated/floor/engine/caution/corner2{
+	dir = 10
+	},
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"ZT" = (
+/obj/machinery/door/poddoor/pyro{
+	dir = 4;
+	id = "erebus_trash";
+	name = "Erebus Waste Door"
+	},
+/turf/simulated/floor/grey,
+/area/station/maintenance/SWmaint{
+	name = "Erebus Maintenance Room"
+	})
+"ZU" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/decal/poster/wallsign/stencil/right/one{
+	layer = 2;
+	pixel_x = 15;
+	pixel_y = 12
+	},
+/turf/simulated/floor/orangeblack,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"ZW" = (
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	layer = 9.1;
+	pixel_x = -10
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/orangeblack/side{
+	dir = 8
+	},
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
+	})
+"ZX" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/orangeblack/side{
+	dir = 8
+	},
+/area/station/hallway/primary/east{
+	name = "Erebus Primary Zone"
 	})
 
 (1,1,1) = {"
@@ -32603,17 +35144,17 @@ aa
 aa
 aa
 aa
-IK
-IK
-IK
-IK
-IK
-IK
-IK
-IK
-IK
-IK
-IK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -32904,19 +35445,19 @@ aa
 aa
 aa
 aa
-IK
-IK
-Mv
-Nx
-cf
-Mv
-dX
-Mv
-Mv
-Nx
-Mv
-IK
-IK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -33206,19 +35747,19 @@ aa
 aa
 aa
 aa
-IK
-MA
-Mv
-IK
-IK
-IK
-IK
-IK
-IK
-IK
-Mv
-Nw
-IK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -33508,19 +36049,19 @@ aa
 aa
 aa
 aa
-Mt
-Nx
-IK
-IK
-MT
-MW
-Ne
-Nl
-MT
-IK
-IK
-Nx
-Mt
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -33810,19 +36351,19 @@ aa
 aa
 aa
 aa
-Mt
-Mw
-Mt
-Mq
-Mq
-MX
-Nf
-Nm
-Mq
-Mq
-Mt
-Mw
-Mt
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -34112,19 +36653,19 @@ aa
 aa
 aa
 aa
-IK
-Mv
-Mt
-Mq
-Mq
-Mv
-Ng
-Mq
-Nq
-Nr
-Mt
-Mv
-IK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -34413,21 +36954,21 @@ aa
 aa
 aa
 aa
-IK
-IK
-Mv
-Mt
-MM
-MU
-MY
-Nh
-Mv
-NW
-Nn
-Mt
-Mv
-IK
-IK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -34714,23 +37255,23 @@ aa
 aa
 aa
 aa
-IK
-IK
-Nx
-Mv
-Mt
-Mt
-Mt
-Mt
-Ni
-Mt
-Mt
-Mt
-Mt
-Nx
-Mv
-IK
-IK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -35016,23 +37557,23 @@ aa
 aa
 aa
 aa
-IK
-Mv
-Mv
-Mv
-Mv
-Nx
-Mu
-Mq
-Ng
-Mq
-Mu
-Mv
-Mv
-Mv
-Mv
-NC
-IK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -35316,27 +37857,27 @@ aa
 aa
 aa
 aa
-IK
-IK
-Mt
-MA
-Mt
-Mt
-Mt
-Mt
-Mt
-Mq
-Ng
-Nn
-Mt
-Mt
-Mt
-Mt
-Mt
-Nw
-Mt
-IK
-IK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -35617,29 +38158,29 @@ aa
 aa
 aa
 aa
-IK
-IK
-Mq
-Mt
-cf
-Mt
-MI
-NM
-Mq
-IK
-MZ
-Ng
-Mq
-IK
-Mq
-Ob
-Ny
-Mt
-Mv
-Mt
-Mq
-IK
-IK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -35919,29 +38460,29 @@ aa
 aa
 aa
 aa
-IK
-Mq
-Mq
-Mu
-Mv
-Mu
-Mq
-NO
-Mq
-IK
-MM
-Ng
-Mq
-IK
-Mq
-Nu
-Mq
-Mu
-Mv
-Mu
-Mq
-Mq
-IK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -36221,29 +38762,29 @@ aa
 aa
 aa
 aa
-IK
-Mq
-Nn
-Mt
-Mv
-Mt
-Mq
-MP
-NR
-IK
-Mq
-Ng
-Mq
-IK
-Mq
-Mq
-Mq
-Mt
-Mv
-Mt
-MM
-Mq
-IK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -36523,29 +39064,29 @@ aa
 aa
 aa
 aa
-IK
-Mq
-Mq
-Mt
-Mv
-Mt
-MN
-Mq
-Mq
-MF
-Na
-Ng
-Mq
-MF
-Mq
-Mq
-NR
-Mt
-Mv
-Mt
-Mq
-Mq
-IK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -36825,29 +39366,29 @@ aa
 aa
 aa
 aa
-IO
-Mr
-Ms
-Mt
-Mv
-Mt
-Nz
-NJ
-Mq
-IK
-Nb
-Ng
-No
-IK
-MP
-Mq
-Od
-Mt
-Mv
-Mt
-IO
-Mr
-Ms
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -37127,29 +39668,29 @@ aa
 aa
 aa
 aa
-Mp
-Mp
-Mp
-Mt
-Mv
-Mt
-ji
-NP
-Mq
-IK
-Mv
-Nj
-Mq
-IK
-Mq
-NR
-Nn
-Mt
-Mv
-Mt
-Mp
-Mp
-Mp
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -37432,23 +39973,23 @@ aa
 aa
 aa
 aa
-Mt
-Mw
-Mt
-Mt
-Mt
-Mt
-Mt
-MM
-Mq
-Np
-Mt
-Mt
-Mt
-Mt
-Mt
-dY
-Mt
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -37734,23 +40275,23 @@ aa
 aa
 aa
 aa
-Mt
-Mv
-Mt
-MQ
-Nv
-Mq
-IK
-Mq
-Nk
-Mq
-Mt
-NX
-Mt
-NK
-Mt
-Mv
-ND
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -38036,23 +40577,23 @@ aa
 aa
 aa
 aa
-Mt
-Mv
-Mt
-MM
-Mq
-Mq
-MF
-Mq
-Mq
-Nn
-Mt
-MK
-Mt
-MK
-Mt
-Mv
-NE
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -38338,23 +40879,23 @@ aa
 aa
 aa
 aa
-Mt
-Nx
-Mt
-Nc
-NI
-Mq
-IK
-NU
-Na
-Mq
-MF
-Mq
-NV
-Nn
-Mt
-Nx
-NF
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -38640,23 +41181,23 @@ aa
 aa
 aa
 aa
-Mt
-Mv
-Mt
-Mt
-Mt
-Mt
-Mt
-Mt
-Mq
-NV
-Mt
-ML
-Mt
-ML
-Mt
-Mv
-NG
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -38942,23 +41483,23 @@ aa
 aa
 aa
 aa
-Mt
-Mv
-Mv
-Mt
-Mq
-Mq
-NS
-IK
-MM
-Mq
-Mt
-NK
-Mt
-NK
-Mt
-Mv
-NH
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -39244,23 +41785,23 @@ aa
 aa
 aa
 aa
-Mt
-Mv
-Mv
-Mt
-MM
-Mq
-MV
-MF
-Mq
-Mq
-Mt
-Mt
-Mt
-Mt
-Mt
-Mv
-Mt
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -39546,23 +42087,23 @@ aa
 aa
 aa
 aa
-Mt
-cq
-Mv
-Mt
-MQ
-Mq
-Mq
-IK
-Mq
-Mq
-Mq
-Mq
-Oc
-Mt
-Nx
-Nw
-Mt
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -39848,23 +42389,23 @@ aa
 aa
 aa
 aa
-Mt
-Mt
-Mv
-Mu
-Mq
-NS
-Mq
-NT
-Mq
-Mq
-Mq
-Mq
-Mq
-Mu
-Mv
-Mt
-Mt
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -40151,21 +42692,21 @@ aa
 aa
 aa
 aa
-Mt
-Mv
-Mt
-NQ
-MR
-NS
-MG
-Mq
-Mq
-Mq
-Mq
-NL
-Mt
-Mv
-Mt
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -40453,21 +42994,21 @@ aa
 aa
 aa
 aa
-Mt
-Mv
-Mt
-Mt
-Mt
-Mt
-Mt
-IK
-IK
-MJ
-IK
-Mt
-Mt
-Mv
-Mt
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -40755,21 +43296,21 @@ aa
 aa
 aa
 aa
-Mt
-Mv
-Nx
-Mt
-MB
-Mq
-MT
-Mq
-Mq
-Mq
-Ns
-Mt
-Mv
-Mv
-Mt
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -41057,21 +43598,21 @@ aa
 aa
 aa
 aa
-Mt
-Mv
-Mv
-Mu
-ct
-MC
-MC
-MC
-MC
-MC
-MC
-Mt
-NA
-Mv
-Mt
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -41359,21 +43900,21 @@ aa
 aa
 aa
 aa
-Mt
-My
-Mt
-Mt
-MS
-MD
-MD
-MD
-MD
-MD
-Nt
-Mt
-Mt
-My
-Mt
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -41661,21 +44202,21 @@ aa
 aa
 aa
 aa
-Mx
-Mz
-MO
-Mt
-MD
-MD
-MD
-MD
-MD
-MD
-MD
-Mt
-NB
-Mz
-Mx
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -41963,21 +44504,21 @@ aa
 aa
 aa
 aa
-IO
-Mr
-Ms
-Mt
-ME
-ME
-ME
-ME
-ME
-ME
-ME
-NN
-IO
-Mr
-Ms
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -42265,9 +44806,6 @@ aa
 aa
 aa
 aa
-Mp
-Mp
-Mp
 aa
 aa
 aa
@@ -42277,9 +44815,12 @@ aa
 aa
 aa
 aa
-Mp
-Mp
-Mp
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -44974,7 +47515,7 @@ aa
 aa
 aa
 aa
-qv
+aa
 aa
 aa
 aa
@@ -54845,7 +57386,7 @@ aa
 aa
 cN
 cN
-cN
+XT
 cN
 cN
 aa
@@ -58142,7 +60683,7 @@ aa
 aa
 aa
 aX
-fw
+Nm
 aT
 aa
 aa
@@ -62095,7 +64636,7 @@ dA
 dV
 et
 cZ
-fa
+Tt
 Iy
 ge
 fT
@@ -62695,7 +65236,7 @@ aa
 aa
 cK
 cZ
-cZ
+SI
 cZ
 cZ
 cK
@@ -63104,6 +65645,7 @@ aa
 aa
 aa
 aa
+ab
 aa
 aa
 aa
@@ -63111,8 +65653,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+db
 db
 db
 db
@@ -63299,7 +65840,7 @@ hf
 hf
 eG
 eH
-eH
+Wp
 eH
 eH
 eH
@@ -63415,7 +65956,7 @@ db
 db
 db
 db
-db
+iJ
 iJ
 iJ
 iJ
@@ -63588,19 +66129,19 @@ FX
 Aq
 Gz
 Ac
-Ae
-Hk
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-cM
-dg
+UT
+er
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+eG
+Xu
 dD
 dg
 eI
@@ -63718,7 +66259,7 @@ db
 db
 db
 iJ
-iJ
+ct
 GO
 Ie
 KW
@@ -64012,7 +66553,7 @@ aa
 aa
 aa
 aa
-ab
+aa
 aa
 aa
 qt
@@ -64189,7 +66730,7 @@ cp
 AW
 Fy
 FY
-dS
+Vx
 GA
 GA
 Hb
@@ -64491,8 +67032,8 @@ cm
 AW
 Fz
 dI
-dZ
-GB
+dI
+GE
 GA
 Hb
 Aw
@@ -64631,7 +67172,7 @@ HM
 HM
 Lo
 HM
-Lo
+dX
 LL
 db
 db
@@ -64793,8 +67334,8 @@ Pk
 AW
 FA
 dO
-Gi
-GC
+dI
+Ug
 GA
 Hb
 Aw
@@ -64924,7 +67465,7 @@ fJ
 fN
 fR
 rz
-rm
+cf
 zS
 Cj
 HN
@@ -65095,8 +67636,8 @@ EM
 cx
 cD
 dP
-Gi
-GD
+dI
+Vk
 Gi
 Hb
 Aw
@@ -65126,7 +67667,7 @@ aa
 aa
 aa
 aa
-gf
+aa
 gf
 aa
 aa
@@ -65398,7 +67939,7 @@ AW
 Pu
 FZ
 Gj
-GE
+XE
 Gi
 Hb
 Aw
@@ -65427,8 +67968,8 @@ aa
 aa
 aa
 aa
-gf
-gf
+aa
+aa
 aa
 aa
 aa
@@ -65528,7 +68069,7 @@ fJ
 fN
 qH
 rA
-rA
+cq
 zZ
 CG
 HP
@@ -65700,7 +68241,7 @@ AW
 FC
 Ga
 Gk
-GF
+UF
 GA
 PV
 Aw
@@ -65728,8 +68269,8 @@ aa
 aa
 aa
 aa
-gf
-gf
+aa
+aa
 aa
 aa
 aa
@@ -66002,9 +68543,9 @@ Aq
 FD
 Gb
 Gl
-Qg
 GA
-aa
+GA
+Xa
 aa
 Hs
 Hs
@@ -66029,8 +68570,8 @@ aa
 aa
 aa
 aa
-gf
-gf
+aa
+aa
 aa
 aa
 aa
@@ -66135,7 +68676,7 @@ yM
 zk
 Ad
 Cj
-HO
+dS
 KR
 Ld
 HM
@@ -66306,7 +68847,7 @@ FE
 FE
 aa
 aa
-aa
+Xa
 aa
 Hs
 Hs
@@ -66329,9 +68870,9 @@ aa
 aa
 aa
 aa
-gf
-gf
-gf
+aa
+aa
+aa
 aa
 aa
 aa
@@ -66433,7 +68974,7 @@ iH
 gp
 qA
 qK
-rm
+bl
 zv
 iJ
 iJ
@@ -66608,7 +69149,7 @@ aa
 aa
 aa
 aa
-aa
+Xa
 aa
 aa
 Hs
@@ -66631,7 +69172,7 @@ aa
 aa
 aa
 aa
-gf
+aa
 aa
 aa
 aa
@@ -66844,7 +69385,7 @@ gR
 aO
 bf
 eF
-Pf
+eF
 hE
 nV
 hj
@@ -66910,7 +69451,7 @@ aa
 aa
 aa
 aa
-aa
+Xa
 aa
 aa
 Hs
@@ -66932,8 +69473,8 @@ aa
 aa
 aa
 aa
-gf
-gf
+aa
+aa
 aa
 aa
 aa
@@ -67146,7 +69687,7 @@ gV
 aP
 aP
 aS
-Yc
+bi
 hF
 hH
 hH
@@ -67212,7 +69753,7 @@ aa
 aa
 aa
 aa
-aa
+Xa
 aa
 aa
 Hs
@@ -67233,8 +69774,8 @@ aa
 aa
 aa
 aa
-gf
-gf
+aa
+aa
 aa
 aa
 aa
@@ -67514,7 +70055,7 @@ aa
 aa
 aa
 aa
-aa
+Xa
 aa
 Ht
 Hs
@@ -67534,8 +70075,8 @@ aa
 aa
 aa
 aa
-gf
-gf
+aa
+aa
 aa
 aa
 aa
@@ -67816,7 +70357,7 @@ aa
 aa
 aa
 aa
-aa
+Xa
 aa
 aa
 Hs
@@ -67836,7 +70377,7 @@ aa
 aa
 aa
 aa
-gf
+aa
 aa
 aa
 aa
@@ -68050,7 +70591,7 @@ aa
 aa
 gI
 gI
-gI
+dY
 QK
 hu
 hG
@@ -68062,9 +70603,9 @@ kk
 kN
 ll
 lS
-nD
+gX
 Tc
-lS
+gZ
 sS
 lS
 aG
@@ -68118,7 +70659,7 @@ aa
 aa
 aa
 aa
-aa
+Xa
 aa
 aa
 Hs
@@ -68137,8 +70678,8 @@ aa
 aa
 aa
 aa
-gf
-gf
+aa
+aa
 aa
 aa
 aa
@@ -68352,9 +70893,9 @@ aa
 aa
 gO
 aa
-gI
-hg
-ET
+dZ
+Xy
+Xy
 hG
 ic
 iB
@@ -68363,10 +70904,10 @@ jI
 hH
 kM
 hc
-lS
+lU
 mE
 Xy
-lS
+ji
 aa
 gO
 aH
@@ -68420,7 +70961,7 @@ aa
 aa
 aa
 aa
-aa
+Xa
 aa
 aa
 Hs
@@ -68438,8 +70979,8 @@ aa
 aa
 aa
 aa
-gf
-gf
+aa
+aa
 aa
 aa
 aa
@@ -68653,10 +71194,10 @@ aa
 aa
 aa
 gO
-eC
-bl
-mD
-Xp
+aa
+gO
+aa
+aa
 hG
 id
 iB
@@ -68667,8 +71208,8 @@ kO
 lm
 lU
 VK
-VK
-VZ
+hf
+nI
 hf
 nI
 hf
@@ -68722,25 +71263,25 @@ aa
 aa
 aa
 aa
+Xa
+aa
+aa
+Hs
+Hs
+Hs
+Hs
+Hs
+Hs
+Hs
+Hs
+Hs
 aa
 aa
 aa
-Hs
-Hs
-Hs
-Hs
-Hs
-Hs
-Hs
-Hs
-Hs
 aa
 aa
 aa
 aa
-aa
-gf
-gf
 aa
 aa
 aa
@@ -68954,11 +71495,11 @@ aa
 aa
 aa
 aa
-bk
+gO
 aa
-gV
-nf
-nf
+gO
+aa
+aa
 hG
 hH
 iC
@@ -68968,9 +71509,9 @@ hF
 kP
 hF
 hG
-mE
-mE
-nD
+pO
+aa
+gO
 aa
 gO
 aa
@@ -69024,24 +71565,24 @@ aa
 aa
 aa
 aa
+Xa
+aa
+aa
+Hs
+Hs
+Hs
+Hs
+Hs
+Hs
+Hs
+Hs
+Hs
 aa
 aa
 aa
-Hs
-Hs
-Hs
-Hs
-Hs
-Hs
-Hs
-Hs
-Hs
 aa
 aa
 aa
-aa
-aa
-gf
 aa
 aa
 aa
@@ -69258,9 +71799,9 @@ aa
 aa
 gO
 aa
-gI
-nG
-nf
+gO
+aa
+aa
 hG
 ie
 iD
@@ -69270,9 +71811,9 @@ km
 iD
 ln
 hG
-mE
-Xy
-lS
+pO
+aa
+gO
 aa
 gO
 aa
@@ -69326,24 +71867,24 @@ aa
 aa
 aa
 aa
+Xa
+aa
+aa
+Hs
+Hs
+Hs
+Hs
+Hs
+Hs
+Hs
+Hs
+Hs
 aa
 aa
 aa
-Hs
-Hs
-Hs
-Hs
-Hs
-Hs
-Hs
-Hs
-Hs
 aa
 aa
 aa
-aa
-aa
-gf
 aa
 aa
 aa
@@ -69560,10 +72101,10 @@ aa
 aa
 gO
 aa
-Xz
-VQ
-SJ
-hG
+gO
+aa
+aa
+hH
 gU
 iE
 iE
@@ -69571,10 +72112,10 @@ iE
 iE
 iE
 iE
-hG
-gX
-nH
-Tu
+hH
+pO
+aa
+gO
 aa
 gO
 aa
@@ -69628,7 +72169,7 @@ aa
 aa
 aa
 aa
-aa
+Xa
 aa
 aa
 aa
@@ -69644,8 +72185,8 @@ aa
 aa
 aa
 aa
-gf
-gf
+aa
+aa
 aa
 aa
 aa
@@ -69862,9 +72403,9 @@ aa
 aa
 gO
 aa
-TU
-Vl
-Vl
+gO
+aa
+aa
 hH
 if
 iF
@@ -69874,9 +72415,9 @@ if
 if
 lo
 hH
-sL
-sL
-gZ
+pO
+aa
+gO
 aa
 gO
 aa
@@ -69930,7 +72471,7 @@ aa
 aa
 aa
 aa
-aa
+Xa
 aa
 aa
 aa
@@ -69945,8 +72486,8 @@ aa
 aa
 aa
 aa
-gf
-gf
+aa
+aa
 aa
 aa
 aa
@@ -70167,7 +72708,7 @@ aa
 gO
 aa
 aa
-hH
+hG
 ig
 if
 if
@@ -70175,8 +72716,8 @@ if
 if
 if
 lp
-hH
-aa
+hG
+pO
 aa
 gO
 aa
@@ -70232,7 +72773,7 @@ aa
 aa
 aa
 aa
-aa
+Xa
 aa
 aa
 aa
@@ -70247,7 +72788,7 @@ aa
 aa
 aa
 aa
-gf
+aa
 aa
 aa
 aa
@@ -70478,7 +73019,7 @@ lK
 lK
 lK
 hG
-aa
+pO
 aa
 gO
 aa
@@ -70534,7 +73075,7 @@ aa
 aa
 aa
 aa
-aa
+Xa
 aa
 aa
 aa
@@ -70549,7 +73090,7 @@ aa
 aa
 aa
 aa
-gf
+aa
 aa
 aa
 aa
@@ -70780,7 +73321,7 @@ aa
 kK
 aa
 gO
-aa
+pO
 aa
 gO
 aa
@@ -70836,7 +73377,7 @@ aa
 aa
 aa
 aa
-aa
+Xa
 aa
 aa
 aa
@@ -70850,8 +73391,8 @@ aa
 aa
 aa
 aa
-gf
-gf
+aa
+aa
 aa
 aa
 aa
@@ -71082,7 +73623,7 @@ hl
 kK
 aa
 gO
-aa
+pO
 aa
 gO
 aa
@@ -71138,6 +73679,7 @@ aa
 aa
 aa
 aa
+Xa
 aa
 aa
 aa
@@ -71151,8 +73693,7 @@ aa
 aa
 aa
 aa
-gf
-gf
+aa
 aa
 aa
 aa
@@ -71384,7 +73925,7 @@ kn
 kK
 ii
 lV
-aa
+pO
 aa
 gO
 aa
@@ -71431,6 +73972,16 @@ aa
 aa
 aa
 aa
+MW
+MF
+MF
+MF
+MF
+MF
+Tp
+aa
+aa
+Xa
 aa
 aa
 aa
@@ -71444,16 +73995,6 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-gf
-gf
 aa
 aa
 aa
@@ -71686,7 +74227,7 @@ ko
 kK
 aa
 gO
-aa
+pO
 aa
 gO
 aa
@@ -71718,12 +74259,9 @@ yb
 yD
 Ow
 yO
-aa
-aa
-pO
-aa
-aa
-aa
+aH
+Xk
+YE
 aa
 aa
 aa
@@ -71735,6 +74273,17 @@ aa
 aa
 aa
 aa
+MW
+MY
+Yf
+Yf
+Yf
+Yf
+Yf
+Wx
+Tp
+aa
+Xa
 aa
 aa
 aa
@@ -71747,14 +74296,6 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-gf
-gf
-gf
-gf
 aa
 aa
 aa
@@ -71988,10 +74529,10 @@ VI
 kK
 aa
 gO
-aa
-aa
-gO
-aX
+pP
+hf
+nI
+mD
 oo
 aa
 aa
@@ -72021,8 +74562,9 @@ xA
 aa
 aa
 aa
-aa
+Ii
 pO
+Ib
 aa
 aa
 aa
@@ -72033,6 +74575,17 @@ aa
 aa
 aa
 aa
+MX
+Yf
+Yf
+NL
+WA
+WA
+Yf
+Yf
+MX
+aa
+Xa
 aa
 aa
 aa
@@ -72042,18 +74595,6 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-gf
-gf
 aa
 aa
 aa
@@ -72293,7 +74834,7 @@ gv
 gv
 gv
 mB
-oo
+nf
 aa
 aa
 aa
@@ -72326,6 +74867,7 @@ hf
 hf
 zQ
 aa
+Ib
 aa
 aa
 aa
@@ -72335,6 +74877,17 @@ aa
 aa
 aa
 aa
+MX
+Yf
+NL
+NL
+NL
+WA
+WA
+Yf
+MX
+aa
+Xa
 aa
 aa
 aa
@@ -72343,18 +74896,6 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-gf
-gf
 aa
 aa
 aa
@@ -72464,7 +75005,7 @@ aa
 IN
 IN
 KP
-KP
+bk
 IN
 IN
 aa
@@ -72595,7 +75136,7 @@ hi
 hi
 hi
 od
-aa
+pO
 aa
 aa
 aa
@@ -72629,6 +75170,8 @@ aa
 aa
 aa
 aa
+SM
+aM
 aa
 aa
 aa
@@ -72636,6 +75179,17 @@ aa
 aa
 aa
 aa
+MX
+Yf
+NM
+SJ
+VA
+Wz
+Te
+Yf
+MX
+aa
+Xa
 aa
 aa
 aa
@@ -72643,19 +75197,6 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-gf
-gf
 aa
 aa
 aa
@@ -72897,7 +75438,7 @@ hi
 hi
 hi
 od
-aa
+pO
 aa
 aa
 aa
@@ -72933,30 +75474,30 @@ aa
 aa
 aa
 aa
+Ib
+aa
+aa
+MW
+Vt
+Tp
+MW
+MY
+Yf
+NN
+SJ
+Xm
+Xm
+Uv
+Yf
+Wx
+Tp
+Xa
 aa
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-gf
-gf
 aa
 aa
 aa
@@ -73199,7 +75740,7 @@ hi
 hi
 hi
 od
-aa
+pO
 aa
 aa
 aa
@@ -73236,28 +75777,28 @@ aa
 aa
 aa
 aa
+Ib
+aa
+MX
+aa
+Wx
+Sv
+ZJ
+Yf
+Yf
+Yf
+Yf
+YB
+Yf
+Yf
+Yf
+MX
+Xa
 aa
 aa
+SK
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-gf
-gf
-gf
 aa
 aa
 aa
@@ -73501,7 +76042,7 @@ hi
 hi
 hi
 od
-aa
+pO
 aa
 aa
 aa
@@ -73539,25 +76080,25 @@ aa
 aa
 aa
 aa
+Am
+Wx
+Vt
+Vt
+Sv
+Tx
+Ns
+YK
+Tu
+WP
+Zb
+TH
+ZU
+UN
+MX
+Xa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-gf
-gf
+XY
 aa
 aa
 aa
@@ -73803,7 +76344,7 @@ hi
 hi
 hi
 od
-aa
+pO
 aa
 aa
 aa
@@ -73841,25 +76382,25 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-gf
-gf
-aa
+IK
+Mv
+MF
+MF
+MY
+Sf
+Nt
+NO
+TU
+Td
+XK
+UG
+Ww
+UN
+Wx
+Xs
+MF
+TK
+Tq
 aa
 aa
 aa
@@ -74105,7 +76646,7 @@ hi
 hi
 hi
 od
-aa
+pO
 aa
 aa
 aa
@@ -74142,27 +76683,27 @@ aa
 aa
 aa
 aa
+XI
+IO
+Mw
 aa
 aa
 aa
+XH
+Yf
+Yf
+Vl
+WW
+Zb
+ZP
+VH
+UN
+pQ
+zQ
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-gf
-gf
-aa
-aa
-aa
+XI
+Uu
+Mw
 aa
 aa
 aa
@@ -74407,7 +76948,7 @@ hi
 hi
 hi
 od
-aa
+pO
 aa
 aa
 aa
@@ -74444,27 +76985,27 @@ aa
 aa
 aa
 aa
+XI
+Mp
+Mw
+Yf
+MM
+MM
+Vc
+YR
+Yf
+VQ
+Vp
+VZ
+Vn
+Zf
+Yf
+Uh
+Yf
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-gf
-gf
-aa
-aa
-aa
-aa
+XI
+Mp
+Mw
 aa
 aa
 aa
@@ -74709,6 +77250,7 @@ hi
 hi
 hi
 od
+pO
 aa
 aa
 aa
@@ -74745,28 +77287,27 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-gf
-gf
-gf
-aa
-aa
-aa
-aa
-aa
+XI
+Mp
+Mw
+Yf
+MN
+MZ
+Nn
+Nu
+Nz
+VZ
+YM
+SO
+Vf
+UX
+Yf
+Xj
+Yf
+Yf
+XI
+Mp
+Mw
 aa
 aa
 aa
@@ -75011,6 +77552,7 @@ hi
 hi
 hi
 od
+pO
 aa
 aa
 aa
@@ -75047,28 +77589,27 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-gf
-gf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+XI
+Mp
+Mw
+Tn
+MO
+Na
+No
+Nv
+NP
+Xp
+TX
+ZI
+SV
+XD
+Wq
+YG
+Sw
+XX
+XI
+Mp
+Mw
 aa
 aa
 aa
@@ -75313,6 +77854,7 @@ hi
 hi
 hi
 od
+pO
 aa
 aa
 aa
@@ -75349,28 +77891,27 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-gf
-gf
-gf
-gf
-gf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+XI
+Mp
+Mw
+Tn
+Sy
+Nb
+Tn
+Nw
+NQ
+Xz
+YQ
+Ud
+VS
+Tj
+Yf
+SP
+Sd
+Yl
+XI
+Mp
+Mw
 aa
 aa
 aa
@@ -75615,6 +78156,7 @@ hi
 hi
 hi
 od
+pO
 aa
 aa
 aa
@@ -75650,30 +78192,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-gf
-gf
-gf
-gf
-gf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Ty
+Su
+Mq
+Su
+WS
+UY
+Nc
+Zj
+Nx
+NQ
+Yc
+Zy
+XJ
+SS
+Yg
+Yf
+Uw
+WO
+Zg
+Su
+Mq
+Su
+St
 aa
 aa
 aa
@@ -75917,6 +78458,7 @@ hi
 hi
 hi
 od
+pO
 aa
 aa
 aa
@@ -75952,30 +78494,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-gf
-gf
-gf
-gf
-gf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Xx
+sL
+Mr
+Mx
+Yf
+MP
+Ne
+Np
+Yf
+Yf
+Xg
+TG
+TC
+ZH
+Ur
+Zu
+WY
+UU
+Yb
+YT
+VB
+Wn
+YY
 aa
 aa
 aa
@@ -76219,65 +78760,65 @@ hi
 hi
 hi
 od
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-gf
-gf
-gf
-gf
-gf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+pP
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+nG
+GC
+Ms
+My
+MG
+MQ
+Nf
+Nq
+Ny
+NR
+So
+ST
+TZ
+Wt
+Yj
+UN
+XB
+XM
+Yf
+UW
+Su
+XY
+YY
 aa
 aa
 aa
@@ -76552,34 +79093,34 @@ aa
 aa
 aa
 aa
-gf
-gf
-gf
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+XI
+GD
+Su
+Mz
+Xi
+ZC
+Xi
+SB
+Nz
+NS
+TL
+YP
+WN
+RX
+Sq
+Yk
+UK
+UK
+Yk
+Yk
+Su
+VX
+Mw
 aa
 aa
 aa
@@ -76851,10 +79392,6 @@ aa
 aa
 aa
 aa
-gf
-gf
-gf
-gf
 aa
 aa
 aa
@@ -76863,25 +79400,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+XI
+GD
+Xi
+Mz
+MI
+MR
+Ng
+Xi
+NA
+NT
+Tj
+Vh
+SF
+Sh
+YZ
+Yk
+Yx
+Sl
+Tf
+Yk
+Yk
+VX
+Mw
 aa
 aa
 aa
@@ -77152,8 +79693,6 @@ aa
 aa
 aa
 aa
-gf
-gf
 aa
 aa
 aa
@@ -77163,27 +79702,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+XI
+GD
+Xi
+MA
+MJ
+MS
+Nh
+Xi
+UN
+NU
+Yr
+SF
+SF
+RX
+Uc
+Yk
+Tz
+Zi
+Vm
+WZ
+Yk
+VX
+Mw
 aa
 aa
 aa
@@ -77453,8 +79994,6 @@ aa
 aa
 aa
 aa
-gf
-gf
 aa
 aa
 aa
@@ -77465,27 +80004,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+XI
+GF
+Mt
+MB
+MK
+MT
+Ni
+Nr
+NB
+NV
+NV
+WK
+NV
+Wu
+UB
+UK
+TT
+ZM
+UC
+UJ
+Yk
+VX
+Mw
 aa
 aa
 aa
@@ -77753,9 +80294,6 @@ aa
 aa
 aa
 aa
-gf
-gf
-gf
 aa
 aa
 aa
@@ -77768,26 +80306,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+XI
+GD
+Mu
+MC
+MC
+MU
+Nj
+Xi
+NC
+NW
+Zt
+Xr
+RV
+TS
+Ts
+WE
+UH
+Yn
+UC
+Se
+UC
+VX
+Mw
 aa
 aa
 aa
@@ -78053,9 +80594,6 @@ aa
 aa
 aa
 aa
-gf
-gf
-gf
 aa
 aa
 aa
@@ -78070,26 +80608,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+XI
+GD
+Mu
+MD
+MD
+MD
+Nk
+Xi
+XL
+XL
+XL
+XL
+XL
+WF
+VJ
+UK
+SX
+Xd
+YU
+Tg
+UC
+VX
+Mw
 aa
 aa
 aa
@@ -78352,10 +80893,6 @@ aa
 aa
 aa
 aa
-gf
-gf
-gf
-gf
 aa
 aa
 aa
@@ -78373,25 +80910,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+XI
+Hk
+Xi
+ME
+MD
+MD
+MD
+Xi
+ND
+NX
+ZO
+RU
+XL
+WF
+Vr
+UK
+YN
+Wg
+Wf
+SA
+Yk
+XZ
+Mw
 aa
 aa
 aa
@@ -78649,12 +81190,6 @@ aa
 aa
 aa
 aa
-gf
-gf
-gf
-gf
-gf
-gf
 aa
 aa
 aa
@@ -78679,19 +81214,25 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Xi
+Xi
+ML
+MV
+Nl
+Xi
+NE
+Ob
+Vd
+YX
+Zx
+ZA
+Ym
+Yk
+RL
+Si
+Zz
+ZT
+Yk
 aa
 aa
 aa
@@ -78950,8 +81491,6 @@ gf
 gf
 gf
 gf
-gf
-gf
 aa
 aa
 aa
@@ -78979,19 +81518,21 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Xy
+Xy
+Xy
+VM
+NF
+Oc
+Oc
+UI
+XL
+Vi
+Yq
+VM
+RR
+RR
+RR
 aa
 aa
 aa
@@ -79282,15 +81823,15 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+VM
+NG
+Od
+WB
+Ro
+XL
+YV
+Xf
+VM
 aa
 aa
 aa
@@ -79584,15 +82125,15 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+VM
+XL
+XL
+XL
+XL
+SH
+Zs
+SH
+VM
 aa
 aa
 aa
@@ -79886,15 +82427,15 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+XL
+NH
+Pf
+ZX
+ZW
+Zl
+SQ
+Tm
+XL
 aa
 aa
 aa
@@ -80188,15 +82729,15 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+XL
+NI
+NI
+WH
+NI
+NI
+NI
+NI
+XL
 aa
 aa
 aa
@@ -80490,15 +83031,15 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+XL
+NJ
+NJ
+NJ
+NJ
+NJ
+NJ
+WJ
+XL
 aa
 aa
 aa
@@ -80792,15 +83333,15 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+VM
+NK
+NJ
+NJ
+YO
+NJ
+NJ
+Yw
+VM
 aa
 aa
 aa
@@ -81094,15 +83635,15 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+VM
+VM
+Qg
+VM
+VM
+To
+To
+To
+Vz
 aa
 aa
 aa

--- a/maps/fleet.dmm
+++ b/maps/fleet.dmm
@@ -20759,6 +20759,12 @@
 	dir = 4;
 	setup_os_string = "ZETA_MAINFRAME"
 	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	layer = 9.1;
+	pixel_x = 10
+	},
 /turf/simulated/floor/grey,
 /area/station/engine/power{
 	name = "Erebus Power Room"
@@ -20899,17 +20905,17 @@
 	})
 "Ns" = (
 /obj/machinery/atmospherics/valve,
-/turf/simulated/floor/darkpurple,
-/area/station/engine/core{
-	name = "Erebus Plasmitics Zone"
-	})
-"Nt" = (
 /obj/machinery/light{
 	dir = 1;
 	icon_state = "tube1";
 	layer = 9.1;
 	pixel_y = 21
 	},
+/turf/simulated/floor/darkpurple,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Nt" = (
 /obj/machinery/atmospherics/valve,
 /turf/simulated/floor/darkpurple,
 /area/station/engine/core{
@@ -20926,6 +20932,10 @@
 /obj/lattice,
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 6
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
 	},
 /turf/space,
 /area/station/engine/core{
@@ -20948,6 +20958,11 @@
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 9
 	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/plating/airless,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
@@ -20956,12 +20971,15 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	can_rupture = 0
 	},
-/obj/machinery/door/airlock/pyro/engineering{
+/obj/machinery/door/airlock/pyro/glass/engineering{
 	name = "Core Access";
 	req_access = null
 	},
 /obj/access_spawn/engineering_engine,
 /obj/access_spawn/research,
+/obj/cable{
+	icon_state = "6-8"
+	},
 /turf/simulated/floor/engine,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
@@ -20977,6 +20995,10 @@
 	})
 "NA" = (
 /obj/machinery/portable_atmospherics/pump,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
 /turf/simulated/floor/engine,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
@@ -21192,17 +21214,16 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated,
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-9"
+	},
 /turf/simulated/floor/engine,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
 	})
 "NT" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	layer = 9.1;
-	pixel_x = 10
-	},
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 1;
 	level = 2
@@ -21247,6 +21268,12 @@
 	layer = 2;
 	pixel_x = 15;
 	pixel_y = 12
+	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	layer = 9.1;
+	pixel_x = 10
 	},
 /turf/simulated/floor/blue/side{
 	dir = 4
@@ -23990,8 +24017,10 @@
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
+/obj/machinery/door/airlock/pyro/glass/engineering{
+	dir = 4;
+	name = "Corelock";
+	req_access = null
 	},
 /obj/access_spawn/engineering_engine,
 /obj/access_spawn/research,
@@ -24066,12 +24095,38 @@
 /area/station/maintenance/SWmaint{
 	name = "Erebus Maintenance Room"
 	})
+"Sm" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 5
+	},
+/obj/machinery/meter,
+/obj/machinery/light,
+/obj/decal/tile_edge/line/purple{
+	icon_state = "line1"
+	},
+/obj/cable{
+	icon_state = "5-9"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
 "So" = (
 /obj/machinery/atmospherics/binary/volume_pump{
 	on = 1;
 	transfer_rate = 1000
 	},
 /turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Sp" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
 	})
@@ -24204,7 +24259,7 @@
 /area)
 "SO" = (
 /obj/machinery/atmospherics/binary/circulatorTemp,
-/turf/simulated/floor/engine,
+/turf/simulated/floor/darkpurple,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
 	})
@@ -24237,11 +24292,20 @@
 	pixel_y = 1;
 	target_pressure = 1e+031
 	},
-/obj/cable{
-	icon_state = "1-8"
+/obj/decal/tile_edge/line/purple{
+	dir = 9;
+	icon_state = "line1"
 	},
 /obj/cable{
-	icon_state = "6-8"
+	icon_state = "6-10"
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-10"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core{
@@ -24261,8 +24325,19 @@
 	name = "Erebus Plasmitics Zone"
 	})
 "SV" = (
+/obj/decal/tile_edge/line/yellow{
+	dir = 1;
+	icon_state = "line1"
+	},
 /obj/cable{
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "1-6"
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core{
@@ -24484,7 +24559,9 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-9"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core{
@@ -24514,6 +24591,11 @@
 /obj/machinery/meter,
 /obj/cable{
 	icon_state = "6-10"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "1-6"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core{
@@ -24564,6 +24646,14 @@
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 9
 	},
+/obj/decal/tile_edge/line/yellow{
+	icon_state = "line1"
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/engine,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
@@ -24591,7 +24681,7 @@
 	})
 "Ud" = (
 /obj/machinery/atmospherics/binary/circulatorTemp/right,
-/turf/simulated/floor/engine,
+/turf/simulated/floor/darkpurple,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
 	})
@@ -24652,6 +24742,10 @@
 /obj/machinery/atmospherics/valve,
 /obj/cable{
 	icon_state = "5-9"
+	},
+/obj/decal/tile_edge/line/purple{
+	dir = 10;
+	icon_state = "line1"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core{
@@ -24828,6 +24922,9 @@
 	dir = 9
 	},
 /obj/machinery/meter,
+/obj/decal/tile_edge/line/purple{
+	icon_state = "line1"
+	},
 /turf/simulated/floor/engine,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
@@ -24886,6 +24983,15 @@
 	name = "Hot Loop Outlet Meter";
 	tag = "Hot Loop Outlet Meter"
 	},
+/obj/decal/tile_edge/line/purple{
+	dir = 1;
+	icon_state = "line1"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/engine,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
@@ -24897,6 +25003,10 @@
 /obj/machinery/meter,
 /obj/cable{
 	icon_state = "4-9"
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core{
@@ -24943,6 +25053,14 @@
 /obj/machinery/atmospherics/valve{
 	dir = 4
 	},
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/obj/decal/tile_edge/line/purple{
+	dir = 5;
+	icon_state = "line1"
+	},
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 9
 	},
@@ -24967,6 +25085,10 @@
 	pixel_y = 1;
 	target_pressure = 1e+031
 	},
+/obj/decal/tile_edge/line/purple{
+	dir = 5;
+	icon_state = "line1"
+	},
 /turf/simulated/floor/engine,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
@@ -24975,6 +25097,15 @@
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /obj/machinery/atmospherics/valve{
 	dir = 4
+	},
+/obj/decal/tile_edge/line/purple{
+	dir = 6;
+	icon_state = "line1"
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core{
@@ -25057,7 +25188,15 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
-/turf/simulated/floor/engine/caution/west,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8;
+	icon_state = "xtra_bigstripe-edge"
+	},
+/obj/decal/tile_edge/line/purple{
+	dir = 6;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/engine,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
 	})
@@ -25108,8 +25247,9 @@
 	pixel_x = 7;
 	pixel_y = 28
 	},
-/obj/cable{
-	icon_state = "6-10"
+/obj/decal/tile_edge/line/yellow{
+	dir = 1;
+	icon_state = "line1"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core{
@@ -25124,11 +25264,19 @@
 	name = "Cold Loop Outlet Meter";
 	tag = "Cold Loop Outlet Meter"
 	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "4-10"
+/obj/decal/tile_edge/line/purple{
+	dir = 1;
+	icon_state = "line1"
 	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/engine,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
@@ -25157,6 +25305,10 @@
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 9
 	},
+/obj/decal/tile_edge/line/purple{
+	dir = 1;
+	icon_state = "line1"
+	},
 /turf/simulated/floor/engine,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
@@ -25171,7 +25323,7 @@
 /obj/machinery/power/solar_control{
 	dir = 8;
 	id = "erebus";
-	name = "HM-17 solar panel control"
+	name = "Erebus solar panel control"
 	},
 /obj/cable{
 	d2 = 8;
@@ -25227,6 +25379,11 @@
 	},
 /obj/cable{
 	icon_state = "6-10"
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core{
@@ -25288,6 +25445,18 @@
 /turf/simulated/floor/darkpurple,
 /area/station/hallway/primary/east{
 	name = "Erebus Primary Zone"
+	})
+"WD" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 9
+	},
+/obj/decal/tile_edge/line/yellow{
+	dir = 4;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
 	})
 "WE" = (
 /obj/cable{
@@ -25394,7 +25563,7 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "5-9"
+	icon_state = "4-9"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core{
@@ -25475,6 +25644,10 @@
 /obj/machinery/atmospherics/pipe/tank{
 	dir = 8
 	},
+/obj/decal/tile_edge/line/purple{
+	dir = 9;
+	icon_state = "line1"
+	},
 /turf/simulated/floor/engine,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
@@ -25527,8 +25700,9 @@
 	})
 "Xp" = (
 /obj/machinery/atmospherics/valve,
-/obj/cable{
-	icon_state = "6-10"
+/obj/decal/tile_edge/line/yellow{
+	dir = 1;
+	icon_state = "line1"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core{
@@ -25591,6 +25765,10 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
+/obj/decal/tile_edge/line/purple{
+	dir = 1;
+	icon_state = "line1"
+	},
 /turf/simulated/floor/engine,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
@@ -25607,10 +25785,8 @@
 	name = "Erebus Plasmitics Zone"
 	})
 "XD" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "1-5"
+/obj/decal/tile_edge/line/yellow{
+	icon_state = "line1"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core{
@@ -25672,6 +25848,10 @@
 	},
 /obj/machinery/power/terminal{
 	dir = 4
+	},
+/obj/decal/tile_edge/line/yellow{
+	dir = 8;
+	icon_state = "line1"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core{
@@ -25777,8 +25957,9 @@
 /obj/machinery/atmospherics/valve{
 	dir = 4
 	},
-/obj/cable{
-	icon_state = "6-10"
+/obj/decal/tile_edge/line/yellow{
+	dir = 1;
+	icon_state = "line1"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core{
@@ -25786,15 +25967,6 @@
 	})
 "Yf" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/core{
-	name = "Erebus Plasmitics Zone"
-	})
-"Yg" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4
-	},
-/obj/machinery/light,
-/turf/simulated/floor/engine,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
 	})
@@ -25896,6 +26068,21 @@
 /area/station/maintenance/SWmaint{
 	name = "Erebus Maintenance Room"
 	})
+"Yz" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0;
+	dir = 4
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
 "YB" = (
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
@@ -25959,8 +26146,17 @@
 	dir = 1;
 	level = 2
 	},
+/obj/decal/tile_edge/line/purple{
+	icon_state = "line1"
+	},
+/obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "5-9"
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core{
@@ -26004,8 +26200,17 @@
 	name = "Cold Loop Inlet Meter";
 	tag = "Cold Loop Inlet Meter"
 	},
+/obj/decal/tile_edge/line/purple{
+	icon_state = "line1"
+	},
+/obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "5-9"
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core{
@@ -26082,6 +26287,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/light,
 /turf/simulated/floor/caution/north,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
@@ -26097,6 +26303,9 @@
 "Zf" = (
 /obj/machinery/atmospherics/valve{
 	dir = 4
+	},
+/obj/decal/tile_edge/line/yellow{
+	icon_state = "line1"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core{
@@ -26154,12 +26363,6 @@
 	name = "Erebus Primary Zone"
 	})
 "Zt" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	layer = 9.1;
-	pixel_x = 10
-	},
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
@@ -26206,6 +26409,15 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 4
 	},
+/obj/decal/tile_edge/line/purple{
+	dir = 10;
+	icon_state = "line1"
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/engine,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
@@ -26246,13 +26458,21 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 10
 	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/engine,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
 	})
 "ZI" = (
 /obj/machinery/power/generatorTemp,
-/turf/simulated/floor/engine,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/darkpurple,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
 	})
@@ -67970,7 +68190,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -68272,7 +68492,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -68574,7 +68794,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -68876,7 +69096,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -69178,7 +69398,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -69480,7 +69700,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -69782,7 +70002,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -70084,7 +70304,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -70386,7 +70606,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -70687,8 +70907,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+gf
+gf
 aa
 aa
 aa
@@ -70989,7 +71209,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -71291,7 +71511,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -71592,8 +71812,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+gf
+gf
 aa
 aa
 aa
@@ -71894,7 +72114,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -72196,7 +72416,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -72498,7 +72718,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -72800,7 +73020,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -73101,8 +73321,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+gf
+gf
 aa
 aa
 aa
@@ -73403,7 +73623,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -73705,7 +73925,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -74007,7 +74227,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -74308,8 +74528,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+gf
+gf
 aa
 aa
 aa
@@ -74610,7 +74830,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -74912,7 +75132,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -75213,8 +75433,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+gf
+gf
 aa
 aa
 aa
@@ -75515,7 +75735,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -75817,7 +76037,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -76119,7 +76339,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -76420,8 +76640,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+gf
+gf
 aa
 aa
 aa
@@ -76722,7 +76942,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -76996,7 +77216,7 @@ YR
 Yf
 VQ
 Vp
-VZ
+WD
 Vn
 Zf
 Yf
@@ -77024,7 +77244,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -77325,8 +77545,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+gf
+gf
 aa
 aa
 aa
@@ -77627,7 +77847,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -77904,7 +78124,7 @@ Xz
 YQ
 Ud
 VS
-Tj
+Sm
 Yf
 SP
 Sd
@@ -77928,8 +78148,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+gf
+gf
 aa
 aa
 aa
@@ -78206,7 +78426,7 @@ Yc
 Zy
 XJ
 SS
-Yg
+Zf
 Yf
 Uw
 WO
@@ -78230,7 +78450,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -78502,7 +78722,7 @@ Yf
 MP
 Ne
 Np
-Yf
+Sp
 Yf
 Xg
 TG
@@ -78531,8 +78751,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+gf
+gf
 aa
 aa
 aa
@@ -78833,7 +79053,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -79135,7 +79355,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -79437,7 +79657,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -79713,7 +79933,7 @@ Xi
 UN
 NU
 Yr
-SF
+Yz
 SF
 RX
 Uc
@@ -79738,7 +79958,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -80040,7 +80260,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -80341,8 +80561,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+gf
+gf
 aa
 aa
 aa
@@ -80643,7 +80863,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -80944,8 +81164,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+gf
+gf
 aa
 aa
 aa
@@ -81246,7 +81466,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -81491,9 +81711,9 @@ gf
 gf
 gf
 gf
-aa
-aa
-aa
+gf
+gf
+gf
 aa
 aa
 aa
@@ -81548,7 +81768,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -81795,10 +82015,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+gf
+gf
+gf
+gf
 aa
 aa
 aa
@@ -81849,8 +82069,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+gf
+gf
 aa
 aa
 aa
@@ -82100,8 +82320,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+gf
+gf
 aa
 aa
 aa
@@ -82150,8 +82370,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+gf
+gf
 aa
 aa
 aa
@@ -82403,9 +82623,9 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+gf
+gf
+gf
 aa
 aa
 aa
@@ -82452,7 +82672,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -82707,9 +82927,9 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+gf
+gf
+gf
 aa
 aa
 aa
@@ -82753,8 +82973,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+gf
+gf
 aa
 aa
 aa
@@ -83011,8 +83231,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+gf
+gf
 aa
 aa
 aa
@@ -83055,7 +83275,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 aa
 aa
 aa
@@ -83314,8 +83534,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+gf
+gf
 aa
 aa
 aa
@@ -83356,8 +83576,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+gf
+gf
 aa
 aa
 aa
@@ -83617,9 +83837,9 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+gf
+gf
+gf
 aa
 aa
 aa
@@ -83657,8 +83877,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+gf
+gf
 aa
 aa
 aa
@@ -83921,6 +84141,8 @@ aa
 aa
 aa
 aa
+gf
+gf
 aa
 aa
 aa
@@ -83957,9 +84179,7 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+gf
 aa
 aa
 aa
@@ -84224,6 +84444,9 @@ aa
 aa
 aa
 aa
+gf
+gf
+gf
 aa
 aa
 aa
@@ -84256,11 +84479,8 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
+gf
+gf
 aa
 aa
 aa
@@ -84528,6 +84748,9 @@ aa
 aa
 aa
 aa
+gf
+gf
+gf
 aa
 aa
 aa
@@ -84556,12 +84779,9 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
+gf
+gf
+gf
 aa
 aa
 aa
@@ -84832,6 +85052,10 @@ aa
 aa
 aa
 aa
+gf
+gf
+gf
+gf
 aa
 aa
 aa
@@ -84854,14 +85078,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+gf
+gf
+gf
+gf
 aa
 aa
 aa
@@ -85137,6 +85357,9 @@ aa
 aa
 aa
 aa
+gf
+gf
+gf
 aa
 aa
 aa
@@ -85154,13 +85377,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+gf
+gf
+gf
+gf
 aa
 aa
 aa
@@ -85441,25 +85661,25 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+gf
+gf
+gf
+gf
+gf
+gf
+gf
+gf
+gf
+gf
+gf
+gf
+gf
+gf
+gf
+gf
+gf
+gf
+gf
 aa
 aa
 aa

--- a/maps/fleet.dmm
+++ b/maps/fleet.dmm
@@ -49,8 +49,8 @@
 "aj" = (
 /turf/simulated/floor/airless,
 /turf/simulated/shuttle/wall{
-	icon_state = "wall3";
-	dir = 6
+	dir = 6;
+	icon_state = "wall3"
 	},
 /area)
 "ak" = (
@@ -182,8 +182,8 @@
 "az" = (
 /turf/simulated/floor/airless,
 /turf/simulated/shuttle/wall{
-	icon_state = "diagonalWall3";
-	dir = 6
+	dir = 6;
+	icon_state = "diagonalWall3"
 	},
 /area)
 "aA" = (
@@ -296,8 +296,8 @@
 	})
 "aO" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	icon_state = "chair"
 	},
 /obj/cable{
 	d1 = 1;
@@ -478,8 +478,8 @@
 /area)
 "bf" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	icon_state = "chair"
 	},
 /obj/cable{
 	d1 = 1;
@@ -552,26 +552,27 @@
 	name = "Tenebrae Solar Array"
 	})
 "bk" = (
-/obj/machinery/shuttle/engine/heater{
-	dir = 4;
-	icon_state = "alt_heater-R"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/lounge_port{
-	name = "Maru Crew Quarters"
-	})
-"bl" = (
-/obj/machinery/shuttle/engine/propulsion{
-	dir = 4;
-	icon_state = "alt_propulsion"
-	},
 /obj/lattice{
 	dir = 4;
 	icon_state = "lattice-dir"
 	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "8-10"
+	},
 /turf/space,
-/area/station/crew_quarters/lounge_port{
-	name = "Maru Crew Quarters"
+/area)
+"bl" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/pyro/engineering{
+	name = "Auxiliary Component Bay"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/maintenance/storage{
+	name = "Maru Power Room"
 	})
 "bm" = (
 /obj/machinery/light/small{
@@ -699,8 +700,8 @@
 	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment/transport{
-	icon_state = "pipe-c";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/captain{
@@ -822,8 +823,8 @@
 	},
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/neutral/corner{
-	icon_state = "neutralcorner";
-	dir = 8
+	dir = 8;
+	icon_state = "neutralcorner"
 	},
 /area/station/crew_quarters/captain{
 	name = "Meridian Primary Zone"
@@ -848,8 +849,8 @@
 	})
 "bN" = (
 /obj/disposalpipe/segment/transport{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/cable{
 	d1 = 2;
@@ -860,8 +861,8 @@
 /area)
 "bO" = (
 /obj/disposalpipe/segment/transport{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/cable{
 	icon_state = "5-9"
@@ -890,8 +891,8 @@
 	})
 "bQ" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	icon_state = "chair"
 	},
 /obj/cable{
 	d1 = 1;
@@ -956,8 +957,8 @@
 	},
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/neutral/side{
-	icon_state = "neutral";
-	dir = 8
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/station/crew_quarters/captain{
 	name = "Meridian Primary Zone"
@@ -986,8 +987,8 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/transport{
-	icon_state = "pipe-c";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/neutral,
 /area/station/crew_quarters/captain{
@@ -1004,8 +1005,8 @@
 	})
 "cc" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	icon_state = "chair"
 	},
 /obj/cable{
 	d1 = 1;
@@ -1046,8 +1047,8 @@
 /area/station/chemistry)
 "ch" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 2
+	dir = 2;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area)
@@ -1074,8 +1075,8 @@
 	icon_state = "1-4"
 	},
 /obj/disposalpipe/segment/transport{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/neutral,
 /area/station/crew_quarters/captain{
@@ -1094,8 +1095,8 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/transport{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/neutral,
 /area/station/crew_quarters/captain{
@@ -1103,8 +1104,8 @@
 	})
 "cn" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 1
+	dir = 1;
+	icon_state = "chair"
 	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/lounge_starboard{
@@ -1128,8 +1129,8 @@
 	},
 /obj/machinery/light,
 /obj/disposalpipe/segment/transport{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/neutral,
 /area/station/crew_quarters/captain{
@@ -1196,8 +1197,8 @@
 	})
 "cw" = (
 /obj/stool/chair/office{
-	icon_state = "office_chair";
-	dir = 1
+	dir = 1;
+	icon_state = "office_chair"
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/chemistry)
@@ -1235,8 +1236,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/stairs/medical{
-	icon_state = "medstairs_alone";
-	dir = 1
+	dir = 1;
+	icon_state = "medstairs_alone"
 	},
 /area/station/crew_quarters/lounge_starboard{
 	name = "Tenebrae Crew Quarters"
@@ -1249,8 +1250,8 @@
 	})
 "cC" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 4
+	dir = 4;
+	icon_state = "chair"
 	},
 /obj/machinery/door_control/podbay{
 	id = "tenebay";
@@ -1423,8 +1424,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/purplewhite/corner{
-	icon_state = "purplewhitecorner";
-	dir = 4
+	dir = 4;
+	icon_state = "purplewhitecorner"
 	},
 /area/station/science{
 	name = "Tenebrae Primary Zone"
@@ -1537,8 +1538,8 @@
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/greenblack{
-	icon_state = "greenblack";
-	dir = 1
+	dir = 1;
+	icon_state = "greenblack"
 	},
 /area/station/science/research_director{
 	name = "Tenebrae Command Center"
@@ -1559,8 +1560,8 @@
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/greenblack{
-	icon_state = "greenblack";
-	dir = 1
+	dir = 1;
+	icon_state = "greenblack"
 	},
 /area/station/science/research_director{
 	name = "Tenebrae Command Center"
@@ -1579,8 +1580,8 @@
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/greenblack{
-	icon_state = "greenblack";
-	dir = 1
+	dir = 1;
+	icon_state = "greenblack"
 	},
 /area/station/science/research_director{
 	name = "Tenebrae Command Center"
@@ -1674,8 +1675,8 @@
 /area/station/chemistry)
 "du" = (
 /obj/stool/chair/office{
-	icon_state = "office_chair";
-	dir = 4
+	dir = 4;
+	icon_state = "office_chair"
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/chemistry)
@@ -1725,8 +1726,8 @@
 /area/station/science/artifact)
 "dz" = (
 /obj/stool/chair/office{
-	icon_state = "office_chair";
-	dir = 1
+	dir = 1;
+	icon_state = "office_chair"
 	},
 /obj/cable{
 	d1 = 2;
@@ -1791,8 +1792,8 @@
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/greenblack{
-	icon_state = "greenblack";
-	dir = 8
+	dir = 8;
+	icon_state = "greenblack"
 	},
 /area/station/science/research_director{
 	name = "Tenebrae Command Center"
@@ -1842,8 +1843,8 @@
 	})
 "dJ" = (
 /obj/stool/chair/office{
-	icon_state = "office_chair";
-	dir = 8
+	dir = 8;
+	icon_state = "office_chair"
 	},
 /obj/cable{
 	d1 = 1;
@@ -2334,8 +2335,8 @@
 	})
 "eE" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 1
+	dir = 1;
+	icon_state = "chair"
 	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/lounge_port{
@@ -2384,8 +2385,8 @@
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/greenblack{
-	icon_state = "greenblack";
-	dir = 8
+	dir = 8;
+	icon_state = "greenblack"
 	},
 /area/station/science/research_director{
 	name = "Tenebrae Command Center"
@@ -2443,8 +2444,8 @@
 	},
 /obj/access_spawn/research_director,
 /turf/simulated/floor/blackwhite{
-	icon_state = "darkwhite";
-	dir = 8
+	dir = 8;
+	icon_state = "darkwhite"
 	},
 /area/station/science/research_director{
 	name = "Tenebrae Command Center"
@@ -2483,8 +2484,8 @@
 /area/station/science/teleporter)
 "eS" = (
 /obj/disposalpipe/segment/transport{
-	icon_state = "pipe-c";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/purplewhite/corner{
 	dir = 1
@@ -2619,8 +2620,8 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment/transport{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 4
@@ -2630,8 +2631,8 @@
 	})
 "fi" = (
 /obj/disposalpipe/segment/transport{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor,
 /area/station/science{
@@ -2671,8 +2672,8 @@
 	},
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/purplewhite/corner{
-	icon_state = "purplewhitecorner";
-	dir = 4
+	dir = 4;
+	icon_state = "purplewhitecorner"
 	},
 /area/station/science{
 	name = "Tenebrae Primary Zone"
@@ -2763,8 +2764,8 @@
 	},
 /obj/disposalpipe/junction/right/east,
 /turf/simulated/floor/purplewhite/corner{
-	icon_state = "purplewhitecorner";
-	dir = 4
+	dir = 4;
+	icon_state = "purplewhitecorner"
 	},
 /area/station/science{
 	name = "Tenebrae Primary Zone"
@@ -2825,8 +2826,8 @@
 /area)
 "fx" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 1
+	dir = 1;
+	icon_state = "chair"
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 4
@@ -3617,11 +3618,11 @@
 "gX" = (
 /obj/machinery/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "alt_heater-M"
+	icon_state = "alt_heater-R"
 	},
 /turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/lounge_port{
-	name = "Maru Crew Quarters"
+/area/station/maintenance/storage{
+	name = "Maru Power Room"
 	})
 "gY" = (
 /obj/decal/poster/wallsign/stencil/right/e,
@@ -3631,14 +3632,18 @@
 	name = "Tenebrae Primary Zone"
 	})
 "gZ" = (
-/obj/decal/poster/wallsign/stencil/left/r{
-	pixel_x = -4
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 4;
+	icon_state = "alt_propulsion"
 	},
-/obj/decal/poster/wallsign/stencil/right/u{
-	pixel_x = 10
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir"
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/mining)
+/turf/space,
+/area/station/maintenance/storage{
+	name = "Maru Power Room"
+	})
 "ha" = (
 /obj/stool/chair/yellow,
 /obj/landmark/start{
@@ -3689,18 +3694,26 @@
 /turf/space,
 /area)
 "hg" = (
-/obj/machinery/shuttle/engine/propulsion{
-	dir = 4;
-	icon_state = "alt_propulsion"
+/obj/machinery/computer3/generic/engine{
+	dir = 4
 	},
-/turf/space,
-/area/station/crew_quarters/lounge_port{
-	name = "Maru Crew Quarters"
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/maintenance/storage{
+	name = "Maru Power Room"
 	})
 "hh" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 8
+	dir = 8;
+	icon_state = "shrub"
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/owlery)
@@ -3797,16 +3810,18 @@
 	})
 "ht" = (
 /obj/machinery/light/small,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/lounge_port{
 	name = "Maru Crew Quarters"
 	})
 "hu" = (
-/obj/machinery/shuttle/engine/heater{
-	dir = 4;
-	icon_state = "alt_heater-L"
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/wall/auto/supernorn,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/lounge_port{
 	name = "Maru Crew Quarters"
 	})
@@ -4141,8 +4156,8 @@
 /area/mining/magnet)
 "ii" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 2
+	dir = 2;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area)
@@ -4401,8 +4416,8 @@
 	})
 "iL" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	icon_state = "chair"
 	},
 /obj/cable{
 	d1 = 1;
@@ -4674,8 +4689,8 @@
 	})
 "jq" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	icon_state = "chair"
 	},
 /obj/cable{
 	d1 = 1;
@@ -4961,8 +4976,8 @@
 	})
 "jW" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 1
+	dir = 1;
+	icon_state = "chair"
 	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/locker{
@@ -5240,8 +5255,8 @@
 	pixel_x = 10
 	},
 /obj/stool/chair/red{
-	icon_state = "chair-r";
-	dir = 8
+	dir = 8;
+	icon_state = "chair-r"
 	},
 /obj/landmark/start{
 	name = "Security Officer"
@@ -5271,8 +5286,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/stairs/dark{
-	icon_state = "dark_stairs";
-	dir = 1
+	dir = 1;
+	icon_state = "dark_stairs"
 	},
 /area/station/crew_quarters/locker{
 	name = "Hammer Crew Quarters"
@@ -5322,6 +5337,13 @@
 	item_amount = 20
 	},
 /obj/item/cargotele,
+/obj/item/storage/wall{
+	desc = "It's a big box that comes in useful when the inevitable depressurization occurs.";
+	dir = 8;
+	name = "breach response cabinet";
+	pixel_x = 32;
+	spawn_contents = list(/obj/item/chem_grenade/metalfoam,/obj/item/chem_grenade/metalfoam,/obj/item/chem_grenade/metalfoam,/obj/item/tank/emergency_oxygen,/obj/item/tank/emergency_oxygen)
+	},
 /turf/simulated/floor/yellowblack,
 /area/station/engine/engineering/ce{
 	name = "Maru Bridge"
@@ -5688,8 +5710,8 @@
 	},
 /obj/machinery/light,
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	icon_state = "chair"
 	},
 /turf/simulated/floor/orangeblack/side,
 /area/station/engine/engineering{
@@ -5849,8 +5871,8 @@
 /obj/item/paper/Port_A_Brig,
 /obj/item/remote/porter/port_a_brig,
 /turf/simulated/floor/redblack{
-	icon_state = "redblack";
-	dir = 9
+	dir = 9;
+	icon_state = "redblack"
 	},
 /area/station/security/secwing)
 "lx" = (
@@ -5880,8 +5902,8 @@
 	},
 /obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/redblack{
-	icon_state = "redblack";
-	dir = 5
+	dir = 5;
+	icon_state = "redblack"
 	},
 /area/station/security/secwing)
 "lA" = (
@@ -5892,8 +5914,8 @@
 	},
 /obj/disposalpipe/segment/bent/east,
 /turf/simulated/floor/redblack/corner{
-	icon_state = "redblackcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "redblackcorner"
 	},
 /area/station/security/main{
 	name = "Hammer Primary Concourse"
@@ -6040,14 +6062,10 @@
 	name = "Maru Primary Zone"
 	})
 "lU" = (
-/obj/decal/poster/wallsign/stencil/left/m,
-/obj/decal/poster/wallsign/stencil/right/a{
-	pixel_x = 13
-	},
 /obj/disposalpipe/segment/transport,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/engineering{
-	name = "Maru Primary Zone"
+/area/station/maintenance/storage{
+	name = "Maru Power Room"
 	})
 "lV" = (
 /obj/lattice{
@@ -6212,8 +6230,8 @@
 /area/station/security/detectives_office)
 "mn" = (
 /obj/stool/chair/comfy{
-	icon_state = "chair_comfy";
-	dir = 4
+	dir = 4;
+	icon_state = "chair_comfy"
 	},
 /obj/landmark/start{
 	name = "Detective"
@@ -6392,27 +6410,43 @@
 	name = "Maru Power Room"
 	})
 "mD" = (
-/obj/machinery/shuttle/engine/heater{
-	dir = 4;
-	icon_state = "alt_heater-R"
+/obj/storage/crate,
+/obj/item/electronics/frame/collector_control,
+/obj/item/electronics/frame/collector_control,
+/obj/item/electronics/frame/collector_control,
+/obj/item/electronics/frame/collector_array,
+/obj/item/electronics/frame/collector_array,
+/obj/item/electronics/frame/collector_array,
+/obj/item/electronics/frame/collector_array,
+/obj/item/electronics/frame/collector_array,
+/obj/item/electronics/frame/collector_array,
+/obj/item/electronics/soldering,
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/turf/simulated/wall/auto/supernorn,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/airless,
 /area/station/maintenance/storage{
 	name = "Maru Power Room"
 	})
 "mE" = (
-/obj/machinery/shuttle/engine/propulsion{
-	dir = 4;
-	icon_state = "alt_propulsion"
+/obj/machinery/emitter{
+	dir = 8
 	},
-/turf/space,
+/turf/simulated/floor/plating/airless,
 /area/station/maintenance/storage{
 	name = "Maru Power Room"
 	})
 "mF" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 2
+	dir = 2;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area/station/turret_protected/AIbaseoutside{
@@ -6475,12 +6509,14 @@
 	name = "Hammer Command"
 	})
 "mL" = (
-/obj/machinery/door_control{
-	id = "ham_brace";
-	name = "Hammer Combat Shield";
-	pixel_x = 24
-	},
 /obj/storage/secure/crate/weapon/armory/pod_weapons,
+/obj/item/storage/wall{
+	desc = "It's a big box that comes in useful when the inevitable depressurization occurs.";
+	dir = 8;
+	name = "breach response cabinet";
+	pixel_x = 32;
+	spawn_contents = list(/obj/item/chem_grenade/metalfoam,/obj/item/chem_grenade/metalfoam,/obj/item/chem_grenade/metalfoam,/obj/item/tank/emergency_oxygen,/obj/item/tank/emergency_oxygen)
+	},
 /turf/simulated/floor/black,
 /area/station/security/hos{
 	name = "Hammer Command"
@@ -6514,9 +6550,9 @@
 /area/station/security/secwing)
 "mQ" = (
 /obj/stool/chair/office/red{
-	tag = "icon-office_chair_red (EAST)";
+	dir = 4;
 	icon_state = "office_chair_red";
-	dir = 4
+	tag = "icon-office_chair_red (EAST)"
 	},
 /turf/simulated/floor/black,
 /area/station/security/secwing)
@@ -6669,11 +6705,8 @@
 	name = "Maru Power Room"
 	})
 "nf" = (
-/obj/machinery/shuttle/engine/heater{
-	dir = 4;
-	icon_state = "alt_heater-M"
-	},
-/turf/simulated/wall/auto/supernorn,
+/obj/machinery/field_generator,
+/turf/simulated/floor/plating/airless,
 /area/station/maintenance/storage{
 	name = "Maru Power Room"
 	})
@@ -6741,8 +6774,8 @@
 	})
 "nk" = (
 /obj/stool/chair/comfy{
-	icon_state = "chair_comfy";
-	dir = 8
+	dir = 8;
+	icon_state = "chair_comfy"
 	},
 /obj/landmark/start{
 	name = "Head of Security"
@@ -6790,8 +6823,8 @@
 /obj/machinery/disposal/brig,
 /obj/disposalpipe/trunk/south,
 /turf/simulated/floor/redblack{
-	icon_state = "redblack";
-	dir = 10
+	dir = 10;
+	icon_state = "redblack"
 	},
 /area/station/security/secwing)
 "nq" = (
@@ -6822,14 +6855,14 @@
 /obj/machinery/recharger,
 /obj/item/instrument/whistle,
 /turf/simulated/floor/redblack{
-	icon_state = "redblack";
-	dir = 6
+	dir = 6;
+	icon_state = "redblack"
 	},
 /area/station/security/secwing)
 "nt" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 1
+	dir = 1;
+	icon_state = "chair"
 	},
 /turf/simulated/floor/redblack{
 	dir = 4
@@ -6852,8 +6885,8 @@
 /area/station/security/detectives_office)
 "nw" = (
 /obj/stool/chair/comfy{
-	icon_state = "chair_comfy";
-	dir = 8
+	dir = 8;
+	icon_state = "chair_comfy"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
@@ -6951,24 +6984,21 @@
 	name = "Maru Power Room"
 	})
 "nG" = (
-/obj/machinery/shuttle/engine/heater{
-	dir = 4;
-	icon_state = "alt_heater-L"
+/obj/machinery/field_generator,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
 	},
-/turf/simulated/wall/auto/supernorn,
+/turf/simulated/floor/plating/airless,
 /area/station/maintenance/storage{
 	name = "Maru Power Room"
 	})
 "nH" = (
-/obj/machinery/shuttle/engine/propulsion{
+/obj/machinery/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "alt_propulsion"
+	icon_state = "alt_heater-M"
 	},
-/obj/lattice{
-	dir = 4;
-	icon_state = "lattice-dir"
-	},
-/turf/space,
+/turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/storage{
 	name = "Maru Power Room"
 	})
@@ -7395,8 +7425,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/redblack/corner{
-	icon_state = "redblackcorner";
-	dir = 8
+	dir = 8;
+	icon_state = "redblackcorner"
 	},
 /area/station/security/main{
 	name = "Hammer Primary Concourse"
@@ -7584,8 +7614,8 @@
 /area/station/hangar/sec)
 "oK" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 4
+	dir = 4;
+	icon_state = "shrub"
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/owlery)
@@ -7837,8 +7867,8 @@
 	})
 "pj" = (
 /turf/simulated/floor/caution/corner/misc{
-	icon_state = "floor_hazard_corners";
-	dir = 9
+	dir = 9;
+	icon_state = "floor_hazard_corners"
 	},
 /area/station/owlery)
 "pk" = (
@@ -8115,8 +8145,8 @@
 /area)
 "pO" = (
 /obj/disposalpipe/segment/transport{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/space,
 /area)
@@ -8128,8 +8158,8 @@
 /area)
 "pQ" = (
 /obj/disposalpipe/segment/transport{
-	icon_state = "pipe-c";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/space,
 /area)
@@ -8412,8 +8442,8 @@
 	})
 "qs" = (
 /obj/grille/catwalk{
-	icon_state = "catwalk_cross";
-	dir = 2
+	dir = 2;
+	icon_state = "catwalk_cross"
 	},
 /obj/cable{
 	d2 = 8;
@@ -8540,8 +8570,8 @@
 	})
 "qE" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 1
+	dir = 1;
+	icon_state = "shrub"
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/owlery)
@@ -8672,8 +8702,8 @@
 	})
 "qQ" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 6
+	dir = 6;
+	icon_state = "shrub"
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/owlery)
@@ -8699,8 +8729,8 @@
 	})
 "qS" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	icon_state = "chair"
 	},
 /obj/cable{
 	d1 = 1;
@@ -8818,8 +8848,8 @@
 	})
 "rd" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	icon_state = "chair"
 	},
 /obj/cable{
 	d1 = 1;
@@ -8981,8 +9011,8 @@
 	},
 /obj/access_spawn/engineering_chief,
 /obj/grille/catwalk{
-	icon_state = "catwalk";
-	dir = 5
+	dir = 5;
+	icon_state = "catwalk"
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -8993,8 +9023,8 @@
 	powerlevel = 1
 	},
 /turf/simulated/floor/yellowblack{
-	icon_state = "yellowblack";
-	dir = 4
+	dir = 4;
+	icon_state = "yellowblack"
 	},
 /area/station/engine/engineering/ce{
 	name = "Maru Bridge"
@@ -9016,8 +9046,8 @@
 	})
 "ru" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 1
+	dir = 1;
+	icon_state = "chair"
 	},
 /obj/landmark/start{
 	name = "Medical Doctor"
@@ -9196,8 +9226,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/stairs/medical{
-	icon_state = "medstairs_alone";
-	dir = 1
+	dir = 1;
+	icon_state = "medstairs_alone"
 	},
 /area/station/medical/staff{
 	name = "Asclepius Quarters"
@@ -9237,6 +9267,10 @@
 	},
 /obj/machinery/power/apc/autoname_north,
 /obj/machinery/clothingbooth,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8;
+	icon_state = "xtra_bigstripe-edge"
+	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/utility{
 	name = "Dionysus Cryocore"
@@ -9382,7 +9416,14 @@
 	name = "Dionysus Primary Zone"
 	})
 "sj" = (
-/obj/machinery/air_vendor,
+/obj/machinery/door_control{
+	id = "gamernetwork";
+	name = "Emergency Exit Door Control";
+	pixel_x = -24
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/utility{
 	name = "Dionysus Cryocore"
@@ -9660,16 +9701,20 @@
 "sK" = (
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/redblack/corner{
-	icon_state = "redblackcorner";
-	dir = 8
+	dir = 8;
+	icon_state = "redblackcorner"
 	},
 /area/station/security/main{
 	name = "Hammer Primary Concourse"
 	})
 "sL" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/utility{
-	name = "Dionysus Cryocore"
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 4;
+	icon_state = "alt_propulsion"
+	},
+/turf/space,
+/area/station/maintenance/storage{
+	name = "Maru Power Room"
 	})
 "sM" = (
 /obj/machinery/manufacturer/uniform,
@@ -9724,8 +9769,8 @@
 	pixel_y = 21
 	},
 /turf/simulated/floor/blueblack{
-	icon_state = "blueblack";
-	dir = 1
+	dir = 1;
+	icon_state = "blueblack"
 	},
 /area/station/medical/head{
 	name = "Asclepius Command"
@@ -9739,8 +9784,8 @@
 /obj/item/decoration/ashtray,
 /obj/item/reagent_containers/food/drinks/tea,
 /turf/simulated/floor/blueblack{
-	icon_state = "blueblack";
-	dir = 1
+	dir = 1;
+	icon_state = "blueblack"
 	},
 /area/station/medical/head{
 	name = "Asclepius Command"
@@ -9878,8 +9923,8 @@
 	})
 "tf" = (
 /obj/machinery/atmospherics/pipe/manifold{
-	icon_state = "manifold";
 	dir = 4;
+	icon_state = "manifold";
 	level = 2
 	},
 /obj/table/auto,
@@ -9936,7 +9981,7 @@
 	})
 "tl" = (
 /obj/machinery/light/small,
-/obj/machinery/vending/coffee,
+/obj/machinery/air_vendor,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/utility{
 	name = "Dionysus Cryocore"
@@ -9959,8 +10004,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/stairs/wood2{
-	icon_state = "wood2_stairs";
-	dir = 1
+	dir = 1;
+	icon_state = "wood2_stairs"
 	},
 /area/station/crew_quarters/utility{
 	name = "Dionysus Cryocore"
@@ -10015,16 +10060,16 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/blueblack{
-	icon_state = "blueblack";
-	dir = 8
+	dir = 8;
+	icon_state = "blueblack"
 	},
 /area/station/medical/head{
 	name = "Asclepius Command"
 	})
 "ts" = (
 /obj/stool/chair/office/red{
-	icon_state = "office_chair_red";
-	dir = 8
+	dir = 8;
+	icon_state = "office_chair_red"
 	},
 /obj/landmark/start{
 	name = "Medical Director"
@@ -10176,8 +10221,8 @@
 	})
 "tJ" = (
 /obj/submachine/chef_sink/chem_sink{
-	icon_state = "sink";
-	dir = 1
+	dir = 1;
+	icon_state = "sink"
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/cafeteria{
@@ -10191,6 +10236,11 @@
 	},
 /obj/machinery/door/airlock/pyro{
 	name = "Vessel Quarters"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/utility{
@@ -10472,8 +10522,8 @@
 	})
 "un" = (
 /obj/grille/catwalk{
-	icon_state = "catwalk_cross";
-	dir = 2
+	dir = 2;
+	icon_state = "catwalk_cross"
 	},
 /obj/cable{
 	d2 = 8;
@@ -10617,8 +10667,8 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/blueblack{
-	icon_state = "blueblack";
-	dir = 8
+	dir = 8;
+	icon_state = "blueblack"
 	},
 /area/station/medical/head{
 	name = "Asclepius Command"
@@ -10781,8 +10831,8 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/blue/side{
-	icon_state = "blue";
-	dir = 8
+	dir = 8;
+	icon_state = "blue"
 	},
 /area/station/medical/medbay{
 	name = "Asclepius Primary Zone"
@@ -10799,16 +10849,8 @@
 	name = "Asclepius Primary Zone"
 	})
 "uO" = (
-/obj/table/wood/auto,
-/obj/item/clipboard,
-/obj/item/pen/fancy,
-/obj/item/item_box/gold_star{
-	item_amount = 20
-	},
-/obj/item/coin{
-	pixel_x = 4;
-	pixel_y = 11
-	},
+/obj/storage/secure/closet/command/hop,
+/obj/item/cargotele,
 /turf/simulated/floor/wood/two,
 /area/station/bridge/hos)
 "uP" = (
@@ -10831,12 +10873,26 @@
 /turf/simulated/floor/wood/two,
 /area/station/bridge/hos)
 "uQ" = (
-/obj/storage/secure/closet/command/hop,
-/obj/machinery/phone/wall{
-	pixel_x = 24;
-	pixel_y = 4
+/obj/table/wood/auto,
+/obj/item/clipboard,
+/obj/item/pen/fancy,
+/obj/item/item_box/gold_star{
+	item_amount = 20
 	},
-/obj/item/cargotele,
+/obj/item/coin{
+	pixel_x = 4;
+	pixel_y = 11
+	},
+/obj/item/storage/wall{
+	desc = "It's a big box that comes in useful when the inevitable depressurization occurs.";
+	dir = 8;
+	name = "breach response cabinet";
+	pixel_x = 32;
+	spawn_contents = list(/obj/item/chem_grenade/metalfoam,/obj/item/chem_grenade/metalfoam,/obj/item/chem_grenade/metalfoam,/obj/item/tank/emergency_oxygen,/obj/item/tank/emergency_oxygen)
+	},
+/obj/machinery/phone/wall{
+	pixel_y = 32
+	},
 /turf/simulated/floor/wood/two,
 /area/station/bridge/hos)
 "uR" = (
@@ -10865,9 +10921,9 @@
 /area/station/crew_quarters/bar)
 "uS" = (
 /obj/stool/chair{
-	tag = "icon-chair (EAST)";
+	dir = 4;
 	icon_state = "chair";
-	dir = 4
+	tag = "icon-chair (EAST)"
 	},
 /obj/cable{
 	d1 = 2;
@@ -10996,8 +11052,8 @@
 /area/station/hydroponics)
 "ve" = (
 /obj/stool/chair/green{
-	icon_state = "chair-g";
-	dir = 8
+	dir = 8;
+	icon_state = "chair-g"
 	},
 /turf/simulated/floor/green/side{
 	dir = 4
@@ -11048,6 +11104,13 @@
 "vm" = (
 /obj/storage/secure/closet/command/medical_director,
 /obj/item/cargotele,
+/obj/item/storage/wall{
+	desc = "It's a big box that comes in useful when the inevitable depressurization occurs.";
+	dir = 8;
+	name = "breach response cabinet";
+	pixel_x = 32;
+	spawn_contents = list(/obj/item/chem_grenade/metalfoam,/obj/item/chem_grenade/metalfoam,/obj/item/chem_grenade/metalfoam,/obj/item/tank/emergency_oxygen,/obj/item/tank/emergency_oxygen)
+	},
 /turf/simulated/floor/blueblack,
 /area/station/medical/head{
 	name = "Asclepius Command"
@@ -11218,8 +11281,8 @@
 	},
 /obj/disposalpipe/junction/right/east,
 /turf/simulated/floor/bluewhite/corner{
-	icon_state = "bluewhitecorner";
-	dir = 1
+	dir = 1;
+	icon_state = "bluewhitecorner"
 	},
 /area/station/medical/medbay{
 	name = "Asclepius Primary Zone"
@@ -11250,8 +11313,8 @@
 	})
 "vC" = (
 /obj/disposalpipe/segment/transport{
-	icon_state = "pipe-c";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 4
@@ -11264,8 +11327,8 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment/transport{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 4
@@ -11278,16 +11341,16 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/blue/side{
-	icon_state = "blue";
-	dir = 8
+	dir = 8;
+	icon_state = "blue"
 	},
 /area/station/medical/medbay{
 	name = "Asclepius Primary Zone"
 	})
 "vF" = (
 /turf/simulated/floor/caution/corner/misc{
-	icon_state = "floor_hazard_corners";
-	dir = 5
+	dir = 5;
+	icon_state = "floor_hazard_corners"
 	},
 /area/station/medical/medbay{
 	name = "Asclepius Primary Zone"
@@ -11372,8 +11435,8 @@
 /area/station/crew_quarters/bar)
 "vN" = (
 /obj/submachine/chef_sink/chem_sink{
-	icon_state = "sink";
-	dir = 1
+	dir = 1;
+	icon_state = "sink"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/bar)
@@ -11667,8 +11730,8 @@
 /obj/disposalpipe/trunk/north,
 /obj/machinery/disposal/transport,
 /turf/simulated/floor/bluewhite{
-	icon_state = "bluewhite";
-	dir = 6
+	dir = 6;
+	icon_state = "bluewhite"
 	},
 /area/station/medical/medbay{
 	name = "Asclepius Primary Zone"
@@ -11682,8 +11745,8 @@
 /obj/machinery/vending/medical,
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/blue/side{
-	icon_state = "blue";
-	dir = 8
+	dir = 8;
+	icon_state = "blue"
 	},
 /area/station/medical/medbay{
 	name = "Asclepius Primary Zone"
@@ -11752,8 +11815,8 @@
 /area/station/security/secwing)
 "ww" = (
 /obj/stool/chair/office/blue{
-	icon_state = "office_chair_blue";
-	dir = 8
+	dir = 8;
+	icon_state = "office_chair_blue"
 	},
 /obj/cable{
 	d1 = 2;
@@ -11797,8 +11860,8 @@
 /obj/table/reinforced/bar/auto,
 /obj/machinery/cashreg,
 /turf/simulated/floor/specialroom/bar/edge{
-	icon_state = "bar-edge";
-	dir = 8
+	dir = 8;
+	icon_state = "bar-edge"
 	},
 /area/station/crew_quarters/cafeteria{
 	name = "Dionysus Primary Zone"
@@ -11809,8 +11872,8 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/specialroom/bar/edge{
-	icon_state = "bar-edge";
-	dir = 8
+	dir = 8;
+	icon_state = "bar-edge"
 	},
 /area/station/crew_quarters/cafeteria{
 	name = "Dionysus Primary Zone"
@@ -11820,8 +11883,8 @@
 /obj/item/device/radio/beacon,
 /obj/item/clothing/head/cakehat,
 /turf/simulated/floor/specialroom/bar/edge{
-	icon_state = "bar-edge";
-	dir = 8
+	dir = 8;
+	icon_state = "bar-edge"
 	},
 /area/station/crew_quarters/cafeteria{
 	name = "Dionysus Primary Zone"
@@ -11833,8 +11896,8 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/specialroom/bar/edge{
-	icon_state = "bar-edge";
-	dir = 8
+	dir = 8;
+	icon_state = "bar-edge"
 	},
 /area/station/crew_quarters/cafeteria{
 	name = "Dionysus Primary Zone"
@@ -11844,8 +11907,8 @@
 /obj/item/reagent_containers/food/drinks/bowl,
 /obj/item/kitchen/utensil/spoon,
 /turf/simulated/floor/specialroom/bar/edge{
-	icon_state = "bar-edge";
-	dir = 8
+	dir = 8;
+	icon_state = "bar-edge"
 	},
 /area/station/crew_quarters/cafeteria{
 	name = "Dionysus Primary Zone"
@@ -11868,8 +11931,8 @@
 	pixel_x = 3
 	},
 /turf/simulated/floor/specialroom/bar/edge{
-	icon_state = "bar-edge";
-	dir = 8
+	dir = 8;
+	icon_state = "bar-edge"
 	},
 /area/station/crew_quarters/cafeteria{
 	name = "Dionysus Primary Zone"
@@ -11902,8 +11965,8 @@
 "wJ" = (
 /obj/reagent_dispensers/compostbin,
 /turf/simulated/floor/green/corner{
-	icon_state = "greencorner";
-	dir = 4
+	dir = 4;
+	icon_state = "greencorner"
 	},
 /area/station/hydroponics)
 "wK" = (
@@ -11913,8 +11976,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/green/side{
-	icon_state = "green";
-	dir = 1
+	dir = 1;
+	icon_state = "green"
 	},
 /area/station/hydroponics)
 "wL" = (
@@ -12071,8 +12134,8 @@
 	})
 "wY" = (
 /obj/machinery/computer/bank_data{
-	icon_state = "databank";
-	dir = 4
+	dir = 4;
+	icon_state = "databank"
 	},
 /obj/cable{
 	d2 = 8;
@@ -12418,8 +12481,8 @@
 /obj/table/reinforced/auto,
 /obj/machinery/cashreg,
 /obj/machinery/door/airlock/pyro/glass/windoor{
-	icon_state = "windoor_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "windoor_closed"
 	},
 /obj/access_spawn/security,
 /turf/simulated/floor/red,
@@ -12735,8 +12798,8 @@
 	},
 /obj/machinery/light,
 /obj/stool/chair/wooden{
-	icon_state = "chair_wooden";
-	dir = 8
+	dir = 8;
+	icon_state = "chair_wooden"
 	},
 /obj/landmark/start{
 	name = "Staff Assistant"
@@ -13303,6 +13366,11 @@
 	name = "autoname - SS13";
 	pixel_x = 10;
 	tag = ""
+	},
+/obj/machinery/door_control{
+	id = "ham_brace";
+	name = "Hammer Combat Shield";
+	pixel_x = 24
 	},
 /turf/simulated/floor/redblack{
 	dir = 1
@@ -13977,8 +14045,8 @@
 	name = "Meridian solar panel"
 	},
 /obj/disposalpipe/segment/transport{
-	icon_state = "pipe-c";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/airless{
 	icon_state = "solarbase";
@@ -13994,8 +14062,8 @@
 	name = "Meridian solar panel"
 	},
 /obj/disposalpipe/segment/transport{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/airless{
 	icon_state = "solarbase";
@@ -14007,8 +14075,8 @@
 "Az" = (
 /obj/lattice,
 /obj/disposalpipe/segment/transport{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/space,
 /area/station/solar/west{
@@ -14025,8 +14093,8 @@
 	})
 "AB" = (
 /obj/disposalpipe/segment/transport{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/captain{
@@ -14375,9 +14443,9 @@
 	})
 "Bm" = (
 /obj/stool/chair/office/red{
-	tag = "icon-office_chair_red (EAST)";
+	dir = 4;
 	icon_state = "office_chair_red";
-	dir = 4
+	tag = "icon-office_chair_red (EAST)"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -14483,8 +14551,8 @@
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/blueblack{
-	icon_state = "blueblack";
-	dir = 1
+	dir = 1;
+	icon_state = "blueblack"
 	},
 /area/station/turret_protected/ai)
 "Bz" = (
@@ -14500,8 +14568,8 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/blueblack{
-	icon_state = "blueblack";
-	dir = 1
+	dir = 1;
+	icon_state = "blueblack"
 	},
 /area/station/turret_protected/ai)
 "BA" = (
@@ -14711,8 +14779,8 @@
 	name = "Staff Assistant"
 	},
 /turf/simulated/floor/neutral/side{
-	icon_state = "neutral";
-	dir = 4
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/station/crew_quarters/captain{
 	name = "Meridian Primary Zone"
@@ -15016,8 +15084,8 @@
 /obj/table/auto,
 /obj/item/game_kit,
 /turf/simulated/floor/neutral/side{
-	icon_state = "neutral";
-	dir = 4
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/station/crew_quarters/captain{
 	name = "Meridian Primary Zone"
@@ -15135,8 +15203,8 @@
 	})
 "CI" = (
 /obj/pool{
-	icon_state = "pool";
-	dir = 4
+	dir = 4;
+	icon_state = "pool"
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -15150,8 +15218,8 @@
 	})
 "CJ" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 10
+	dir = 10;
+	icon_state = "shrub"
 	},
 /turf/simulated/floor/grass,
 /area/station/aviary{
@@ -15218,8 +15286,8 @@
 	})
 "CP" = (
 /obj/stool/chair/office/blue{
-	icon_state = "office_chair_blue";
-	dir = 8
+	dir = 8;
+	icon_state = "office_chair_blue"
 	},
 /obj/cable{
 	d1 = 2;
@@ -15309,8 +15377,8 @@
 	name = "Staff Assistant"
 	},
 /turf/simulated/floor/neutral/side{
-	icon_state = "neutral";
-	dir = 4
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/station/crew_quarters/captain{
 	name = "Meridian Primary Zone"
@@ -15360,8 +15428,8 @@
 	})
 "De" = (
 /obj/pool{
-	icon_state = "pool";
-	dir = 8
+	dir = 8;
+	icon_state = "pool"
 	},
 /turf/simulated/floor/grass,
 /area/station/aviary{
@@ -15385,8 +15453,8 @@
 /area/station/quartermaster/office)
 "Dg" = (
 /obj/pool{
-	icon_state = "pool";
-	dir = 4
+	dir = 4;
+	icon_state = "pool"
 	},
 /turf/simulated/floor/grass,
 /area/station/aviary{
@@ -15464,8 +15532,8 @@
 	})
 "Dn" = (
 /obj/stool/chair/comfy{
-	icon_state = "chair_comfy";
-	dir = 8
+	dir = 8;
+	icon_state = "chair_comfy"
 	},
 /obj/landmark/start{
 	name = "Captain"
@@ -15607,8 +15675,8 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/neutral/side{
-	icon_state = "neutral";
-	dir = 4
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/station/crew_quarters/captain{
 	name = "Meridian Primary Zone"
@@ -15692,8 +15760,8 @@
 	})
 "DJ" = (
 /obj/pool{
-	icon_state = "pool";
-	dir = 8
+	dir = 8;
+	icon_state = "pool"
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -15721,8 +15789,8 @@
 /area/station/mining)
 "DL" = (
 /obj/pool{
-	icon_state = "pool";
-	dir = 4
+	dir = 4;
+	icon_state = "pool"
 	},
 /obj/pool_springboard,
 /turf/simulated/floor/grass,
@@ -15841,8 +15909,8 @@
 /area/station/chapel/main)
 "DW" = (
 /turf/simulated/floor/neutral/side{
-	icon_state = "neutral";
-	dir = 4
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/station/crew_quarters/captain{
 	name = "Meridian Primary Zone"
@@ -15893,8 +15961,8 @@
 	})
 "Ec" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 10
+	dir = 10;
+	icon_state = "shrub"
 	},
 /obj/cable{
 	d1 = 2;
@@ -15977,6 +16045,13 @@
 /obj/item/reagent_containers/food/drinks/bottle/thegoodstuff,
 /obj/shrub/captainshrub,
 /obj/machinery/light,
+/obj/item/storage/wall{
+	desc = "It's a big box that comes in useful when the inevitable depressurization occurs.";
+	dir = 8;
+	name = "breach response cabinet";
+	pixel_x = 32;
+	spawn_contents = list(/obj/item/chem_grenade/metalfoam,/obj/item/chem_grenade/metalfoam,/obj/item/chem_grenade/metalfoam,/obj/item/tank/emergency_oxygen,/obj/item/tank/emergency_oxygen)
+	},
 /turf/simulated/floor/black,
 /area/station/bridge/captain{
 	name = "Meridian Command"
@@ -16000,8 +16075,8 @@
 	})
 "El" = (
 /obj/stool/chair/office/blue{
-	icon_state = "office_chair_blue";
-	dir = 8
+	dir = 8;
+	icon_state = "office_chair_blue"
 	},
 /turf/simulated/floor/grey,
 /area/station/bridge/captain{
@@ -16112,8 +16187,8 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/neutral/corner{
-	icon_state = "neutralcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
 /area/station/crew_quarters/captain{
 	name = "Meridian Primary Zone"
@@ -16133,8 +16208,8 @@
 	})
 "Ey" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 8
+	dir = 8;
+	icon_state = "shrub"
 	},
 /turf/simulated/floor/grass,
 /area/station/aviary{
@@ -16156,9 +16231,9 @@
 	})
 "EA" = (
 /obj/pool{
-	tag = "icon-pool (SOUTHWEST)";
+	dir = 10;
 	icon_state = "pool";
-	dir = 10
+	tag = "icon-pool (SOUTHWEST)"
 	},
 /turf/simulated/floor/grass,
 /area/station/aviary{
@@ -16195,9 +16270,9 @@
 	})
 "ED" = (
 /obj/pool{
-	tag = "icon-pool (SOUTHEAST)";
+	dir = 6;
 	icon_state = "pool";
-	dir = 6
+	tag = "icon-pool (SOUTHEAST)"
 	},
 /turf/simulated/floor/grass,
 /area/station/aviary{
@@ -16242,8 +16317,8 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/neutral/corner{
-	icon_state = "neutralcorner";
-	dir = 8
+	dir = 8;
+	icon_state = "neutralcorner"
 	},
 /area/station/crew_quarters/captain{
 	name = "Meridian Primary Zone"
@@ -16265,8 +16340,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/neutral/side{
-	icon_state = "neutral";
-	dir = 4
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/station/crew_quarters/captain{
 	name = "Meridian Primary Zone"
@@ -16360,6 +16435,16 @@
 /area/station/crew_quarters/captain{
 	name = "Meridian Primary Zone"
 	})
+"ET" = (
+/obj/machinery/power/smes,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/maintenance/storage{
+	name = "Maru Power Room"
+	})
 "EU" = (
 /turf/simulated/floor{
 	icon = 'icons/misc/worlds.dmi';
@@ -16409,8 +16494,8 @@
 	})
 "EZ" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 4
+	dir = 4;
+	icon_state = "shrub"
 	},
 /obj/cable{
 	d1 = 2;
@@ -16468,8 +16553,8 @@
 	})
 "Ff" = (
 /obj/grille/catwalk{
-	icon_state = "catwalk_cross";
-	dir = 2
+	dir = 2;
+	icon_state = "catwalk_cross"
 	},
 /obj/cable{
 	d2 = 8;
@@ -16566,8 +16651,8 @@
 	})
 "Fl" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 8
+	dir = 8;
+	icon_state = "shrub"
 	},
 /turf/simulated/floor{
 	icon = 'icons/misc/worlds.dmi';
@@ -16615,8 +16700,8 @@
 	})
 "Fp" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 6
+	dir = 6;
+	icon_state = "shrub"
 	},
 /turf/simulated/floor/grass,
 /area/station/aviary{
@@ -16772,8 +16857,8 @@
 /area)
 "FG" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 1
+	dir = 1;
+	icon_state = "shrub"
 	},
 /turf/simulated/floor{
 	icon = 'icons/misc/worlds.dmi';
@@ -17006,8 +17091,8 @@
 	})
 "Ge" = (
 /obj/stool/chair/wooden{
-	icon_state = "chair_wooden";
-	dir = 8
+	dir = 8;
+	icon_state = "chair_wooden"
 	},
 /obj/machinery/portableowl/attached{
 	desc = "A particularily large space owl.";
@@ -17119,8 +17204,8 @@
 	})
 "Gn" = (
 /obj/stool/chair/wooden{
-	icon_state = "chair_wooden";
-	dir = 1
+	dir = 1;
+	icon_state = "chair_wooden"
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/south,
 /area/station/aviary{
@@ -17158,8 +17243,8 @@
 	})
 "Gr" = (
 /obj/stool/chair/wooden{
-	icon_state = "chair_wooden";
-	dir = 8
+	dir = 8;
+	icon_state = "chair_wooden"
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -17211,8 +17296,8 @@
 	pixel_x = 10
 	},
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 10
+	dir = 10;
+	icon_state = "shrub"
 	},
 /turf/simulated/floor/grass,
 /area/station/aviary{
@@ -17338,8 +17423,8 @@
 	})
 "GI" = (
 /obj/stool/chair/wooden{
-	icon_state = "chair_wooden";
-	dir = 8
+	dir = 8;
+	icon_state = "chair_wooden"
 	},
 /obj/cable{
 	icon_state = "1-10"
@@ -17370,8 +17455,8 @@
 	})
 "GL" = (
 /turf/simulated/floor/caution/corner/misc{
-	icon_state = "floor_hazard_corners";
-	dir = 5
+	dir = 5;
+	icon_state = "floor_hazard_corners"
 	},
 /area/station/aviary{
 	name = "Demeter Primary Zone"
@@ -17438,8 +17523,8 @@
 	})
 "GT" = (
 /obj/stool/chair/wooden{
-	icon_state = "chair_wooden";
-	dir = 8
+	dir = 8;
+	icon_state = "chair_wooden"
 	},
 /obj/landmark/start{
 	name = "Staff Assistant"
@@ -17553,8 +17638,8 @@
 	name = "Vessel Power Room"
 	},
 /turf/simulated/floor/green/side{
-	icon_state = "green";
-	dir = 1
+	dir = 1;
+	icon_state = "green"
 	},
 /area/station/maintenance/south{
 	name = "Demeter Operations Room"
@@ -17677,8 +17762,8 @@
 /area)
 "Hu" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 8
+	dir = 8;
+	icon_state = "shrub"
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -17884,8 +17969,8 @@
 	})
 "HN" = (
 /obj/stool/chair/office{
-	icon_state = "office_chair";
-	dir = 1
+	dir = 1;
+	icon_state = "office_chair"
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 1
@@ -18281,6 +18366,13 @@
 "Iv" = (
 /obj/storage/secure/closet/command/research_director,
 /obj/item/cargotele,
+/obj/item/storage/wall{
+	desc = "It's a big box that comes in useful when the inevitable depressurization occurs.";
+	dir = 8;
+	name = "breach response cabinet";
+	pixel_x = 32;
+	spawn_contents = list(/obj/item/chem_grenade/metalfoam,/obj/item/chem_grenade/metalfoam,/obj/item/chem_grenade/metalfoam,/obj/item/tank/emergency_oxygen,/obj/item/tank/emergency_oxygen)
+	},
 /turf/simulated/floor/greenblack,
 /area/station/science/research_director{
 	name = "Tenebrae Command Center"
@@ -18297,8 +18389,8 @@
 /obj/disposalpipe/segment/horizontal,
 /obj/machinery/light,
 /turf/simulated/floor/purplewhite/corner{
-	icon_state = "purplewhitecorner";
-	dir = 4
+	dir = 4;
+	icon_state = "purplewhitecorner"
 	},
 /area/station/science{
 	name = "Tenebrae Primary Zone"
@@ -18389,8 +18481,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 4
+	dir = 4;
+	icon_state = "purpleblack"
 	},
 /area/research_outpost{
 	name = "Indigo Rye"
@@ -18499,8 +18591,8 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/caution/east{
 	dir = 8
@@ -18684,12 +18776,12 @@
 	},
 /obj/decal/glow{
 	brightness = 3;
-	invisibility = 101;
-	luminosity = 0;
-	name = "glow - WHITE";
 	color_b = 0.35;
 	color_g = 0.35;
-	color_r = 0.35
+	color_r = 0.35;
+	invisibility = 101;
+	luminosity = 0;
+	name = "glow - WHITE"
 	},
 /turf/simulated/floor/grey/side{
 	dir = 8
@@ -18706,8 +18798,8 @@
 /area/listeningpost)
 "Jp" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb1"
 	},
 /obj/machinery/bot/medbot/no_camera,
 /obj/noticeboard{
@@ -18735,8 +18827,8 @@
 /area/listeningpost)
 "Jt" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /obj/item/clothing/under/misc/syndicate,
 /obj/item/clothing/under/misc/syndicate,
@@ -18747,8 +18839,8 @@
 /area/listeningpost)
 "Ju" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 8
+	dir = 8;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/grey/side{
 	dir = 8
@@ -18760,8 +18852,8 @@
 /area/listeningpost)
 "Jw" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/grey/side{
@@ -18832,8 +18924,8 @@
 	icon_state = "1-2"
 	},
 /obj/stool/chair/comfy{
-	icon_state = "chair_comfy";
-	dir = 8
+	dir = 8;
+	icon_state = "chair_comfy"
 	},
 /turf/simulated/floor/orangeblack,
 /area/listeningpost)
@@ -18851,8 +18943,8 @@
 /area/listeningpost)
 "JK" = (
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 0;
+	dir = 8;
 	frequency = 1485;
 	name = "Security Intercom"
 	},
@@ -18889,8 +18981,8 @@
 	icon_state = "1-4"
 	},
 /obj/stool/chair/comfy{
-	icon_state = "chair_comfy";
-	dir = 8
+	dir = 8;
+	icon_state = "chair_comfy"
 	},
 /turf/simulated/floor/orangeblack,
 /area/listeningpost)
@@ -18923,8 +19015,8 @@
 /area/listeningpost)
 "JR" = (
 /obj/item/device/radio/intercom{
-	dir = 8;
 	broadcasting = 0;
+	dir = 8;
 	frequency = 1489;
 	name = "Brig Intercom"
 	},
@@ -18953,8 +19045,8 @@
 /area/listeningpost)
 "JU" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb1"
 	},
 /obj/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -18968,8 +19060,8 @@
 /area/listeningpost)
 "JV" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb1"
 	},
 /obj/machinery/light_switch{
 	name = "S light switch";
@@ -19012,8 +19104,8 @@
 /area/listeningpost)
 "Ka" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/grey/side{
 	dir = 4
@@ -19075,8 +19167,8 @@
 /area/listeningpost)
 "Ki" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/black,
 /area/listeningpost)
@@ -19089,8 +19181,8 @@
 "Kk" = (
 /obj/machinery/vending/snack,
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/nw,
 /area/listeningpost)
@@ -19099,8 +19191,8 @@
 /area/listeningpost)
 "Km" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/ne,
 /area/listeningpost)
@@ -19111,15 +19203,15 @@
 "Ko" = (
 /obj/machinery/drainage,
 /obj/submachine/chef_sink/chem_sink{
-	icon_state = "sink";
-	dir = 1
+	dir = 1;
+	icon_state = "sink"
 	},
 /turf/simulated/floor/sanitary,
 /area/listeningpost)
 "Kp" = (
 /obj/machinery/shower{
-	icon_state = "showerhead";
-	dir = 1
+	dir = 1;
+	icon_state = "showerhead"
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/sanitary,
@@ -19160,8 +19252,8 @@
 /obj/item/chem_grenade/metalfoam,
 /obj/item/chem_grenade/metalfoam,
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 8
+	dir = 8;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/caution/east{
 	dir = 8
@@ -19214,8 +19306,8 @@
 /area/listeningpost)
 "KD" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor4"
@@ -19483,8 +19575,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 1
+	dir = 1;
+	icon_state = "purpleblack"
 	},
 /area/research_outpost{
 	name = "Indigo Rye"
@@ -19587,8 +19679,8 @@
 	})
 "Ls" = (
 /obj/stool/chair/office{
-	icon_state = "office_chair";
-	dir = 4
+	dir = 4;
+	icon_state = "office_chair"
 	},
 /turf/simulated/floor/purpleblack,
 /area/research_outpost{
@@ -19633,8 +19725,8 @@
 "Lw" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor/purpleblack/corner{
-	icon_state = "purpleblackcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "purpleblackcorner"
 	},
 /area/research_outpost{
 	name = "Indigo Rye"
@@ -19682,8 +19774,8 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 4
+	dir = 4;
+	icon_state = "purpleblack"
 	},
 /area/research_outpost{
 	name = "Indigo Rye"
@@ -19709,8 +19801,8 @@
 	})
 "LE" = (
 /obj/stool/chair/office{
-	icon_state = "office_chair";
-	dir = 1
+	dir = 1;
+	icon_state = "office_chair"
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -19721,8 +19813,8 @@
 	})
 "LF" = (
 /obj/stool/chair/office{
-	icon_state = "office_chair";
-	dir = 1
+	dir = 1;
+	icon_state = "office_chair"
 	},
 /obj/cable{
 	icon_state = "1-8"
@@ -19754,8 +19846,8 @@
 	req_access = null
 	},
 /turf/simulated/floor/blackwhite{
-	icon_state = "darkwhite";
-	dir = 8
+	dir = 8;
+	icon_state = "darkwhite"
 	},
 /area/research_outpost{
 	name = "Indigo Rye"
@@ -19787,8 +19879,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/purpleblack/corner{
-	icon_state = "purpleblackcorner";
-	dir = 8
+	dir = 8;
+	icon_state = "purpleblackcorner"
 	},
 /area/research_outpost{
 	name = "Indigo Rye"
@@ -19798,8 +19890,8 @@
 	anchored = 1
 	},
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 1
+	dir = 1;
+	icon_state = "purpleblack"
 	},
 /area/research_outpost{
 	name = "Indigo Rye"
@@ -19807,8 +19899,8 @@
 "LO" = (
 /obj/machinery/light,
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 1
+	dir = 1;
+	icon_state = "purpleblack"
 	},
 /area/research_outpost{
 	name = "Indigo Rye"
@@ -19816,8 +19908,8 @@
 "LP" = (
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 1
+	dir = 1;
+	icon_state = "purpleblack"
 	},
 /area/research_outpost{
 	name = "Indigo Rye"
@@ -19827,16 +19919,16 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 1
+	dir = 1;
+	icon_state = "purpleblack"
 	},
 /area/research_outpost{
 	name = "Indigo Rye"
 	})
 "LR" = (
 /turf/simulated/floor/purpleblack{
-	icon_state = "purpleblack";
-	dir = 1
+	dir = 1;
+	icon_state = "purpleblack"
 	},
 /area/research_outpost{
 	name = "Indigo Rye"
@@ -19844,8 +19936,8 @@
 "LS" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/purpleblack/corner{
-	icon_state = "purpleblackcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "purpleblackcorner"
 	},
 /area/research_outpost{
 	name = "Indigo Rye"
@@ -20212,8 +20304,8 @@
 	})
 "MH" = (
 /obj/grille/catwalk{
-	icon_state = "catwalk_cross";
-	dir = 2
+	dir = 2;
+	icon_state = "catwalk_cross"
 	},
 /obj/cable{
 	d2 = 8;
@@ -21146,8 +21238,8 @@
 	})
 "Ov" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 4
+	dir = 4;
+	icon_state = "chair"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -21387,8 +21479,8 @@
 "OI" = (
 /obj/grille/catwalk,
 /obj/disposalpipe/segment/transport{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
@@ -21404,8 +21496,8 @@
 /area/station/hydroponics)
 "OK" = (
 /turf/simulated/floor/green/side{
-	icon_state = "green";
-	dir = 5
+	dir = 5;
+	icon_state = "green"
 	},
 /area/station/hydroponics)
 "OL" = (
@@ -21542,8 +21634,8 @@
 	tag = ""
 	},
 /turf/simulated/floor/blueblack{
-	icon_state = "blueblack";
-	dir = 8
+	dir = 8;
+	icon_state = "blueblack"
 	},
 /area/station/medical/head{
 	name = "Asclepius Command"
@@ -21660,8 +21752,8 @@
 	name = "autoname - SS13"
 	},
 /turf/simulated/floor/caution/corner/misc{
-	icon_state = "floor_hazard_corners";
-	dir = 5
+	dir = 5;
+	icon_state = "floor_hazard_corners"
 	},
 /area/station/medical/medbay{
 	name = "Asclepius Primary Zone"
@@ -21688,9 +21780,9 @@
 	pixel_y = 21
 	},
 /obj/machinery/bathtub{
-	icon_state = "bathtub";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "bathtub"
 	},
 /obj/item/rubberduck,
 /obj/machinery/camera{
@@ -21737,10 +21829,17 @@
 /turf/simulated/floor/grey/blackgrime/other,
 /area/station/storage/tech)
 "Pf" = (
-/obj/machinery/recharge_station,
-/turf/simulated/floor/plating/airless,
-/area/station/crew_quarters/cafeteria{
-	name = "Dionysus Primary Zone"
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/lounge_port{
+	name = "Maru Crew Quarters"
 	})
 "Pg" = (
 /obj/machinery/camera{
@@ -21795,8 +21894,8 @@
 	tag = ""
 	},
 /turf/simulated/floor/neutral/corner{
-	icon_state = "neutralcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
 /area/station/crew_quarters/captain{
 	name = "Meridian Primary Zone"
@@ -21825,8 +21924,8 @@
 	tag = ""
 	},
 /turf/simulated/floor/neutral/side{
-	icon_state = "neutral";
-	dir = 10
+	dir = 10;
+	icon_state = "neutral"
 	},
 /area/station/crew_quarters/captain{
 	name = "Meridian Primary Zone"
@@ -21896,8 +21995,8 @@
 	})
 "Ps" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 8
+	dir = 8;
+	icon_state = "shrub"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -21973,8 +22072,8 @@
 	pixel_x = 12
 	},
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 8
+	dir = 8;
+	icon_state = "shrub"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -22065,8 +22164,8 @@
 	})
 "PD" = (
 /obj/stool/chair/wooden{
-	icon_state = "chair_wooden";
-	dir = 8
+	dir = 8;
+	icon_state = "chair_wooden"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -22278,16 +22377,16 @@
 	tag = ""
 	},
 /turf/simulated/floor/greenblack{
-	icon_state = "greenblack";
-	dir = 8
+	dir = 8;
+	icon_state = "greenblack"
 	},
 /area/station/science/research_director{
 	name = "Tenebrae Command Center"
 	})
 "PQ" = (
 /obj/grille/catwalk{
-	icon_state = "catwalk_cross";
-	dir = 2
+	dir = 2;
+	icon_state = "catwalk_cross"
 	},
 /obj/cable{
 	d2 = 8;
@@ -22511,8 +22610,8 @@
 "Qc" = (
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/neutral/corner{
-	icon_state = "neutralcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
 /area/station/crew_quarters/captain{
 	name = "Meridian Primary Zone"
@@ -22545,8 +22644,8 @@
 	})
 "Qf" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 4
+	dir = 4;
+	icon_state = "shrub"
 	},
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/grass,
@@ -22588,8 +22687,8 @@
 	})
 "Qj" = (
 /obj/grille/catwalk{
-	icon_state = "catwalk_cross";
-	dir = 2
+	dir = 2;
+	icon_state = "catwalk_cross"
 	},
 /obj/cable{
 	d2 = 8;
@@ -22990,8 +23089,8 @@
 	})
 "QF" = (
 /obj/grille/catwalk{
-	icon_state = "catwalk_cross";
-	dir = 2
+	dir = 2;
+	icon_state = "catwalk_cross"
 	},
 /obj/cable{
 	d2 = 8;
@@ -23149,15 +23248,15 @@
 /area/ghostdrone_factory)
 "QS" = (
 /obj/decal/fakeobjects/pipe/heat{
-	icon_state = "intact";
-	dir = 9
+	dir = 9;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/plating,
 /area/ghostdrone_factory)
 "QT" = (
 /obj/machinery/door/airlock/pyro/classic{
-	icon_state = "old_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "old_closed"
 	},
 /turf/simulated/floor/plating,
 /area/ghostdrone_factory)
@@ -23209,8 +23308,8 @@
 /area/ghostdrone_factory)
 "Rb" = (
 /obj/decal/fakeobjects/pipe/heat{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/stool/chair{
 	dir = 4
@@ -23219,8 +23318,8 @@
 /area/ghostdrone_factory)
 "Rc" = (
 /obj/decal/fakeobjects/pipe/heat{
-	icon_state = "intact";
-	dir = 10
+	dir = 10;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/plating,
 /area/ghostdrone_factory)
@@ -23294,16 +23393,16 @@
 	})
 "Rp" = (
 /obj/decal/fakeobjects/pipe/heat{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/plating,
 /area/ghostdrone_factory)
 "Rq" = (
 /obj/machinery/drone_recharger/factory,
 /obj/decal/fakeobjects/pipe/heat{
-	icon_state = "intact";
-	dir = 10
+	dir = 10;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/plating,
 /area/ghostdrone_factory)
@@ -23323,8 +23422,8 @@
 "Rv" = (
 /obj/disposalpipe/segment/vertical,
 /obj/decal/fakeobjects/pipe/heat{
-	icon_state = "intact";
-	dir = 10
+	dir = 10;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/plating,
 /area/ghostdrone_factory)
@@ -23438,6 +23537,15 @@
 	},
 /turf/space,
 /area/ghostdrone_factory)
+"Tu" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-L"
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/maintenance/storage{
+	name = "Maru Power Room"
+	})
 "Uq" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -23454,6 +23562,9 @@
 /area/station/aviary{
 	name = "Demeter Primary Zone"
 	})
+"Ut" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/bridge/hos)
 "Ve" = (
 /obj/machinery/macrofab{
 	createdObject = /obj/item/tank/emergency_oxygen;
@@ -23466,10 +23577,52 @@
 /area/station/crew_quarters/lounge_starboard{
 	name = "Tenebrae Crew Quarters"
 	})
+"Vj" = (
+/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{
+	dir = 4;
+	id = "gamernetwork";
+	name = "Dionysus emergency exit door"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
+/turf/simulated/floor/shuttlebay,
+/area/station/crew_quarters/utility{
+	name = "Dionysus Cryocore"
+	})
+"Vy" = (
+/obj/decal/poster/wallsign/stencil/left/m,
+/obj/decal/poster/wallsign/stencil/right/a{
+	pixel_x = 13
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/maintenance/storage{
+	name = "Maru Power Room"
+	})
 "VI" = (
 /obj/machinery/oreaccumulator,
 /turf/simulated/floor/plating/airless,
 /area/station/mining)
+"VK" = (
+/obj/disposalpipe/segment/transport,
+/obj/machinery/emitter{
+	dir = 8
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/maintenance/storage{
+	name = "Maru Power Room"
+	})
+"VZ" = (
+/obj/disposalpipe/segment/transport,
+/obj/machinery/door/airlock/pyro/engineering{
+	name = "Auxiliary Component Bay"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/maintenance/storage{
+	name = "Maru Power Room"
+	})
 "Xb" = (
 /obj/rack,
 /obj/item/clothing/mask/breath,
@@ -23486,6 +23639,76 @@
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/mining)
+"Xl" = (
+/obj/submachine/weapon_vendor/security,
+/turf/simulated/floor/redblack{
+	dir = 1
+	},
+/area/station/security/secwing)
+"Xn" = (
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/utility{
+	name = "Dionysus Cryocore"
+	})
+"Xp" = (
+/obj/machinery/the_singularitygen,
+/obj/cable,
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/maintenance/storage{
+	name = "Maru Power Room"
+	})
+"Xy" = (
+/obj/machinery/emitter{
+	dir = 8
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/plating/airless,
+/area/station/maintenance/storage{
+	name = "Maru Power Room"
+	})
+"XF" = (
+/obj/machinery/r_door_control/podbay{
+	id = "gamernetwork";
+	pixel_y = 32
+	},
+/obj/machinery/macrofab/emergency_pod{
+	override_dir = 8
+	},
+/turf/simulated/floor/shuttlebay,
+/area/station/crew_quarters/utility{
+	name = "Dionysus Cryocore"
+	})
+"Yc" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "yellow";
+	icon_state = "bedsheet-yellow"
+	},
+/obj/landmark/start{
+	name = "Engineer"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/lounge_port{
+	name = "Maru Crew Quarters"
+	})
+"YC" = (
+/obj/decal/poster/wallsign/stencil/left/r{
+	pixel_x = -4
+	},
+/obj/decal/poster/wallsign/stencil/right/u{
+	pixel_x = 10
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/maintenance/storage{
+	name = "Maru Power Room"
+	})
 
 (1,1,1) = {"
 aa
@@ -53242,7 +53465,7 @@ hL
 hN
 hL
 jn
-jS
+Xl
 kr
 kQ
 lw
@@ -54175,13 +54398,13 @@ aa
 aa
 aa
 aa
-uf
+Ut
 uQ
 vK
 wy
 xb
 xE
-uf
+Ut
 aa
 aa
 aa
@@ -57457,7 +57680,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 gf
 aa
 aa
@@ -57492,7 +57715,7 @@ aa
 qX
 rj
 rh
-Pf
+rh
 sh
 Ol
 tk
@@ -57758,9 +57981,9 @@ aa
 aa
 aa
 aa
-aa
-aa
 gf
+gf
+aa
 aa
 aa
 aa
@@ -57793,12 +58016,12 @@ hf
 pN
 qY
 rk
-rh
+rB
+Vj
 rB
 rB
-sL
-sL
-sL
+rB
+rB
 um
 uX
 vQ
@@ -58060,9 +58283,9 @@ aa
 aa
 aa
 aa
-aa
-aa
 gf
+aa
+aa
 aa
 aa
 aa
@@ -58096,11 +58319,11 @@ pO
 qY
 rk
 rB
-rB
+XF
 sj
 sM
 tl
-sL
+rB
 Om
 va
 vR
@@ -58361,10 +58584,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 gf
+gf
+aa
+aa
 aa
 aa
 aa
@@ -58401,8 +58624,8 @@ rB
 rS
 rV
 rV
-rV
-sL
+Xn
+rB
 si
 si
 vS
@@ -58663,10 +58886,10 @@ aa
 aa
 aa
 aa
+gf
 aa
 aa
-gf
-gf
+aa
 aa
 aa
 aa
@@ -58964,10 +59187,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 gf
+gf
+aa
+aa
 aa
 aa
 aa
@@ -59006,7 +59229,7 @@ rU
 rV
 rV
 to
-tL
+tM
 tL
 vc
 vU
@@ -59266,10 +59489,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 gf
+aa
+aa
+aa
 aa
 aa
 aa
@@ -59308,7 +59531,7 @@ rV
 rV
 rV
 tp
-tL
+tM
 up
 vd
 vV
@@ -59567,11 +59790,11 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
 gf
+gf
+aa
+aa
+aa
 aa
 aa
 aa
@@ -59610,7 +59833,7 @@ Ok
 sm
 sN
 to
-tL
+tM
 uq
 ve
 vW
@@ -59869,11 +60092,11 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
 gf
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -60171,11 +60394,11 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
 gf
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -60473,11 +60696,11 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
 gf
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -60774,12 +60997,12 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
 gf
+gf
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -61076,12 +61299,12 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
 gf
-gf
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -61378,11 +61601,11 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
 gf
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -61680,11 +61903,11 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
 gf
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -61982,11 +62205,11 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
 gf
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -62284,11 +62507,11 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
 gf
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -62586,11 +62809,11 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
 gf
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -62888,11 +63111,11 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 gf
-gf
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -63190,10 +63413,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 gf
+aa
+aa
+aa
 aa
 aa
 aa
@@ -63492,10 +63715,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 gf
+aa
+aa
+aa
 aa
 aa
 aa
@@ -63794,10 +64017,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 gf
+aa
+aa
+aa
 aa
 aa
 aa
@@ -64096,10 +64319,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 gf
+aa
+aa
+aa
 aa
 aa
 aa
@@ -64398,10 +64621,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 gf
+aa
+aa
+aa
 aa
 aa
 aa
@@ -64700,10 +64923,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 gf
+aa
+aa
+aa
 aa
 aa
 gw
@@ -65002,10 +65225,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 gf
+aa
+aa
+aa
 aa
 aa
 gx
@@ -65304,10 +65527,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 gf
+aa
+aa
+aa
 aa
 aa
 gx
@@ -65606,10 +65829,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 gf
+aa
+aa
+aa
 aa
 aa
 gy
@@ -65908,10 +66131,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 gf
+aa
+aa
+aa
 aa
 aa
 gy
@@ -66210,10 +66433,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 gf
+aa
+aa
+aa
 aa
 aa
 gy
@@ -66236,7 +66459,7 @@ my
 nb
 nC
 oi
-lS
+Vy
 pi
 gS
 pO
@@ -66512,10 +66735,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 gf
+aa
+aa
+aa
 aa
 aa
 gy
@@ -66524,7 +66747,7 @@ gR
 aO
 bf
 eF
-eF
+Pf
 hE
 nV
 hj
@@ -66538,7 +66761,7 @@ mz
 nc
 nD
 oj
-lS
+YC
 pi
 gS
 pO
@@ -66814,10 +67037,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 gf
+aa
+aa
+aa
 aa
 aa
 gy
@@ -66826,7 +67049,7 @@ gV
 aP
 aP
 aS
-bi
+Yc
 hF
 hH
 hH
@@ -67116,10 +67339,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 gf
+aa
+aa
+aa
 aa
 aa
 gy
@@ -67418,10 +67641,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 gf
+aa
+aa
+aa
 aa
 aa
 gy
@@ -67430,7 +67653,7 @@ gI
 gK
 bi
 bi
-bi
+Yc
 hF
 hV
 ha
@@ -67720,18 +67943,18 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 gf
 aa
 aa
 aa
 aa
+aa
+aa
+aa
 gI
 gI
-bk
-gX
+gI
+gI
 hu
 hG
 oX
@@ -67742,9 +67965,9 @@ kk
 kN
 ll
 lS
-mD
-nf
-nG
+lS
+lS
+lS
 sS
 lS
 aG
@@ -68022,19 +68245,19 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 gf
+aa
+aa
+aa
 aa
 aa
 aa
 aa
 gO
 aa
-bl
+lS
 hg
-hg
+ET
 hG
 ic
 iB
@@ -68043,10 +68266,10 @@ jI
 hH
 kM
 hc
-lT
+lS
 mE
-mE
-nH
+Xy
+lS
 aa
 gO
 aH
@@ -68324,19 +68547,19 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 gf
 aa
 aa
 aa
 aa
-gO
+aa
+aa
 aa
 gO
-aa
-aa
+eC
+bl
+mD
+Xp
 hG
 id
 iB
@@ -68346,9 +68569,9 @@ hF
 kO
 lm
 lU
-hf
-hf
-nI
+VK
+VK
+VZ
 hf
 nI
 hf
@@ -68626,19 +68849,19 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 gf
 aa
 aa
 aa
 aa
-gO
-aa
-gO
 aa
 aa
+aa
+bk
+aa
+lS
+nf
+nf
 hG
 hH
 iC
@@ -68647,10 +68870,10 @@ hH
 hF
 kP
 hF
-gZ
-aa
-aa
-gO
+hG
+mE
+mE
+lS
 aa
 gO
 aa
@@ -68928,19 +69151,19 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 gf
 aa
 aa
 aa
 aa
-gO
+aa
+aa
 aa
 gO
 aa
-aa
+lS
+nG
+nf
 hG
 ie
 iD
@@ -68950,9 +69173,9 @@ km
 iD
 ln
 hG
-aa
-aa
-gO
+mE
+Xy
+lS
 aa
 gO
 aa
@@ -69230,20 +69453,20 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 gf
 aa
 aa
 aa
 aa
-gO
+aa
+aa
 aa
 gO
 aa
-aa
-hH
+gX
+nH
+Tu
+hG
 gU
 iE
 iE
@@ -69251,10 +69474,10 @@ iE
 iE
 iE
 iE
-hH
-aa
-aa
-gO
+hG
+gX
+nH
+Tu
 aa
 gO
 aa
@@ -69532,19 +69755,19 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 gf
 aa
 aa
 aa
 aa
-gO
+aa
+aa
 aa
 gO
 aa
-aa
+gZ
+sL
+sL
 hH
 if
 iF
@@ -69554,9 +69777,9 @@ if
 if
 lo
 hH
-aa
-aa
-gO
+sL
+sL
+gZ
 aa
 gO
 aa
@@ -69834,20 +70057,20 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 gf
 aa
 aa
 aa
 aa
-gO
+aa
+aa
 aa
 gO
 aa
+gO
 aa
-hG
+aa
+hH
 ig
 if
 if
@@ -69855,7 +70078,7 @@ if
 if
 if
 lp
-hG
+hH
 aa
 aa
 gO
@@ -70136,10 +70359,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 gf
+aa
+aa
+aa
 aa
 aa
 aa
@@ -70438,10 +70661,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 gf
+aa
+aa
+aa
 aa
 aa
 aa
@@ -70740,10 +70963,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 gf
+aa
+aa
+aa
 aa
 aa
 aa
@@ -71042,10 +71265,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 gf
+gf
+aa
+aa
 aa
 aa
 aa
@@ -71345,9 +71568,9 @@ aa
 aa
 aa
 aa
-aa
-aa
 gf
+aa
+aa
 aa
 aa
 aa
@@ -71647,9 +71870,9 @@ aa
 aa
 aa
 aa
-aa
-aa
 gf
+aa
+aa
 aa
 aa
 aa
@@ -71949,9 +72172,9 @@ aa
 aa
 aa
 aa
-aa
-aa
 gf
+aa
+aa
 aa
 aa
 aa
@@ -72251,9 +72474,9 @@ aa
 aa
 aa
 aa
-aa
-aa
 gf
+aa
+aa
 aa
 aa
 aa
@@ -72553,10 +72776,10 @@ aa
 aa
 aa
 aa
-aa
-aa
 gf
 gf
+aa
+aa
 aa
 aa
 aa
@@ -72856,9 +73079,9 @@ aa
 aa
 aa
 aa
-aa
-aa
 gf
+aa
+aa
 aa
 aa
 aa
@@ -73158,9 +73381,9 @@ aa
 aa
 aa
 aa
-aa
-aa
 gf
+aa
+aa
 aa
 aa
 aa
@@ -73460,9 +73683,9 @@ aa
 aa
 aa
 aa
-aa
-aa
 gf
+aa
+aa
 aa
 aa
 aa
@@ -73762,9 +73985,9 @@ aa
 aa
 aa
 aa
-aa
-aa
 gf
+gf
+aa
 aa
 aa
 aa
@@ -74065,9 +74288,9 @@ aa
 aa
 aa
 aa
+gf
 aa
-gf
-gf
+aa
 aa
 aa
 aa
@@ -74367,9 +74590,9 @@ aa
 aa
 aa
 aa
-aa
-aa
 gf
+aa
+aa
 aa
 aa
 aa
@@ -74669,9 +74892,9 @@ aa
 aa
 aa
 aa
-aa
-aa
 gf
+gf
+aa
 aa
 aa
 aa
@@ -74972,9 +75195,9 @@ aa
 aa
 aa
 aa
+gf
 aa
-gf
-gf
+aa
 aa
 aa
 aa
@@ -75274,9 +75497,9 @@ aa
 aa
 aa
 aa
-aa
-aa
 gf
+gf
+aa
 aa
 aa
 aa
@@ -75577,7 +75800,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 gf
 aa
 aa
@@ -75881,7 +76104,7 @@ aa
 aa
 aa
 gf
-gf
+aa
 aa
 aa
 fW
@@ -76182,8 +76405,8 @@ aa
 aa
 aa
 aa
-aa
 gf
+aa
 aa
 aa
 gi
@@ -76484,7 +76707,7 @@ aa
 aa
 aa
 aa
-aa
+gf
 gf
 aa
 aa

--- a/maps/fleet.dmm
+++ b/maps/fleet.dmm
@@ -570,9 +570,14 @@
 /obj/machinery/door/airlock/pyro/engineering{
 	name = "Auxiliary Component Bay"
 	},
-/turf/simulated/floor/plating/airless,
-/area/station/maintenance/storage{
-	name = "Maru Power Room"
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/lounge_port{
+	name = "Maru Crew Quarters"
 	})
 "bm" = (
 /obj/machinery/light/small{
@@ -3652,15 +3657,6 @@
 /turf/simulated/floor/orangeblack,
 /area/station/mining)
 "hb" = (
-/obj/machinery/power/solar_control{
-	dir = 8;
-	id = "maru";
-	name = "Maru solar panel control"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage{
 	name = "Maru Power Room"
@@ -3694,21 +3690,24 @@
 /turf/space,
 /area)
 "hg" = (
-/obj/machinery/computer3/generic/engine{
-	dir = 4
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/data_terminal,
+/obj/storage/crate,
+/obj/item/electronics/frame/collector_control,
+/obj/item/electronics/frame/collector_control,
+/obj/item/electronics/frame/collector_control,
+/obj/item/electronics/frame/collector_array,
+/obj/item/electronics/frame/collector_array,
+/obj/item/electronics/frame/collector_array,
+/obj/item/electronics/frame/collector_array,
+/obj/item/electronics/frame/collector_array,
+/obj/item/electronics/frame/collector_array,
+/obj/item/electronics/soldering,
 /obj/machinery/light/small{
 	dir = 1;
 	pixel_y = 21
 	},
-/turf/simulated/floor/plating/airless,
-/area/station/maintenance/storage{
-	name = "Maru Power Room"
+/turf/simulated/floor/shuttlebay,
+/area/station/crew_quarters/lounge_port{
+	name = "Maru Crew Quarters"
 	})
 "hh" = (
 /obj/shrub{
@@ -3813,15 +3812,29 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/stool/bed,
+/obj/landmark/start{
+	name = "Engineer"
+	},
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "yellow";
+	icon_state = "bedsheet-yellow"
+	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/lounge_port{
 	name = "Maru Crew Quarters"
 	})
 "hu" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/machinery/power/terminal{
+	dir = 8
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4";
+	pixel_y = 0
+	},
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
 /area/station/crew_quarters/lounge_port{
 	name = "Maru Crew Quarters"
 	})
@@ -6355,6 +6368,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage{
 	name = "Maru Power Room"
@@ -6410,36 +6424,21 @@
 	name = "Maru Power Room"
 	})
 "mD" = (
-/obj/storage/crate,
-/obj/item/electronics/frame/collector_control,
-/obj/item/electronics/frame/collector_control,
-/obj/item/electronics/frame/collector_control,
-/obj/item/electronics/frame/collector_array,
-/obj/item/electronics/frame/collector_array,
-/obj/item/electronics/frame/collector_array,
-/obj/item/electronics/frame/collector_array,
-/obj/item/electronics/frame/collector_array,
-/obj/item/electronics/frame/collector_array,
-/obj/item/electronics/soldering,
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating/airless,
-/area/station/maintenance/storage{
-	name = "Maru Power Room"
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/simulated/floor/shuttlebay,
+/area/station/crew_quarters/lounge_port{
+	name = "Maru Crew Quarters"
 	})
 "mE" = (
 /obj/machinery/emitter{
 	dir = 8
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/floor/shuttlebay,
 /area/station/maintenance/storage{
 	name = "Maru Power Room"
 	})
@@ -6698,7 +6697,7 @@
 	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage{
@@ -6706,9 +6705,9 @@
 	})
 "nf" = (
 /obj/machinery/field_generator,
-/turf/simulated/floor/plating/airless,
-/area/station/maintenance/storage{
-	name = "Maru Power Room"
+/turf/simulated/floor/shuttlebay,
+/area/station/crew_quarters/lounge_port{
+	name = "Maru Crew Quarters"
 	})
 "ng" = (
 /obj/machinery/communications_dish,
@@ -6989,9 +6988,9 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/turf/simulated/floor/plating/airless,
-/area/station/maintenance/storage{
-	name = "Maru Power Room"
+/turf/simulated/floor/shuttlebay,
+/area/station/crew_quarters/lounge_port{
+	name = "Maru Crew Quarters"
 	})
 "nH" = (
 /obj/machinery/shuttle/engine/heater{
@@ -16436,14 +16435,22 @@
 	name = "Meridian Primary Zone"
 	})
 "ET" = (
-/obj/machinery/power/smes,
+/obj/machinery/computer3/generic/engine{
+	dir = 4
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4";
+	pixel_y = 0
+	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/plating/airless,
-/area/station/maintenance/storage{
-	name = "Maru Power Room"
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/shuttlebay,
+/area/station/crew_quarters/lounge_port{
+	name = "Maru Crew Quarters"
 	})
 "EU" = (
 /turf/simulated/floor{
@@ -16812,12 +16819,19 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/reagent_dispensers/fueltank,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 0;
 	name = "autoname - SS13";
 	pixel_y = 20
+	},
+/obj/machinery/power/solar_control{
+	id = "maru";
+	name = "Maru solar panel control"
+	},
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage{
@@ -23196,6 +23210,15 @@
 /area/station/solar/small_backup3{
 	name = "Tenebrae Solar Array"
 	})
+"QK" = (
+/obj/machinery/door/airlock/pyro/engineering{
+	dir = 4;
+	name = "Auxiliary Component Bay"
+	},
+/turf/simulated/floor/shuttlebay,
+/area/station/crew_quarters/lounge_port{
+	name = "Maru Crew Quarters"
+	})
 "QL" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plating/airless,
@@ -23406,6 +23429,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/ghostdrone_factory)
+"Rs" = (
+/obj/machinery/power/smes,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/lounge_port{
+	name = "Maru Crew Quarters"
+	})
 "Rt" = (
 /obj/disposalpipe/segment/vertical,
 /obj/decal/fakeobjects/pipe/heat{
@@ -23537,6 +23570,24 @@
 	},
 /turf/space,
 /area/ghostdrone_factory)
+"SJ" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-L"
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/lounge_port{
+	name = "Maru Crew Quarters"
+	})
+"Tc" = (
+/obj/machinery/door/airlock/pyro/engineering{
+	dir = 4;
+	name = "Auxiliary Component Bay"
+	},
+/turf/simulated/floor/shuttlebay,
+/area/station/maintenance/storage{
+	name = "Maru Power Room"
+	})
 "Tu" = (
 /obj/machinery/shuttle/engine/heater{
 	dir = 4;
@@ -23545,6 +23596,19 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/storage{
 	name = "Maru Power Room"
+	})
+"TU" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 4;
+	icon_state = "alt_propulsion"
+	},
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/station/crew_quarters/lounge_port{
+	name = "Maru Crew Quarters"
 	})
 "Uq" = (
 /obj/machinery/light/small{
@@ -23592,6 +23656,15 @@
 /area/station/crew_quarters/utility{
 	name = "Dionysus Cryocore"
 	})
+"Vl" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 4;
+	icon_state = "alt_propulsion"
+	},
+/turf/space,
+/area/station/crew_quarters/lounge_port{
+	name = "Maru Crew Quarters"
+	})
 "Vy" = (
 /obj/decal/poster/wallsign/stencil/left/m,
 /obj/decal/poster/wallsign/stencil/right/a{
@@ -23610,16 +23683,30 @@
 /obj/machinery/emitter{
 	dir = 8
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/floor/shuttlebay,
 /area/station/maintenance/storage{
 	name = "Maru Power Room"
+	})
+"VQ" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-M"
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/lounge_port{
+	name = "Maru Crew Quarters"
 	})
 "VZ" = (
 /obj/disposalpipe/segment/transport,
 /obj/machinery/door/airlock/pyro/engineering{
 	name = "Auxiliary Component Bay"
 	},
-/turf/simulated/floor/plating/airless,
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
+/turf/simulated/floor/plating,
 /area/station/maintenance/storage{
 	name = "Maru Power Room"
 	})
@@ -23653,22 +23740,32 @@
 	})
 "Xp" = (
 /obj/machinery/the_singularitygen,
-/obj/cable,
-/obj/machinery/power/terminal{
-	dir = 8
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/plating/airless,
-/area/station/maintenance/storage{
-	name = "Maru Power Room"
+/turf/simulated/floor/shuttlebay,
+/area/station/crew_quarters/lounge_port{
+	name = "Maru Crew Quarters"
 	})
 "Xy" = (
 /obj/machinery/emitter{
 	dir = 8
 	},
 /obj/machinery/light/small,
-/turf/simulated/floor/plating/airless,
+/turf/simulated/floor/shuttlebay,
 /area/station/maintenance/storage{
 	name = "Maru Power Room"
+	})
+"Xz" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-R"
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/lounge_port{
+	name = "Maru Crew Quarters"
 	})
 "XF" = (
 /obj/machinery/r_door_control/podbay{
@@ -67653,7 +67750,7 @@ gI
 gK
 bi
 bi
-Yc
+Rs
 hF
 hV
 ha
@@ -67954,7 +68051,7 @@ aa
 gI
 gI
 gI
-gI
+QK
 hu
 hG
 oX
@@ -67965,8 +68062,8 @@ kk
 kN
 ll
 lS
-lS
-lS
+nD
+Tc
 lS
 sS
 lS
@@ -68255,7 +68352,7 @@ aa
 aa
 gO
 aa
-lS
+gI
 hg
 ET
 hG
@@ -68859,7 +68956,7 @@ aa
 aa
 bk
 aa
-lS
+gV
 nf
 nf
 hG
@@ -68873,7 +68970,7 @@ hF
 hG
 mE
 mE
-lS
+nD
 aa
 gO
 aa
@@ -69161,7 +69258,7 @@ aa
 aa
 gO
 aa
-lS
+gI
 nG
 nf
 hG
@@ -69463,9 +69560,9 @@ aa
 aa
 gO
 aa
-gX
-nH
-Tu
+Xz
+VQ
+SJ
 hG
 gU
 iE
@@ -69765,9 +69862,9 @@ aa
 aa
 gO
 aa
-gZ
-sL
-sL
+TU
+Vl
+Vl
 hH
 if
 iF

--- a/maps/icarus.dmm
+++ b/maps/icarus.dmm
@@ -187,9 +187,9 @@
 "aaB" = (
 /obj/item/raw_material/shard/glass,
 /obj/cable{
-	icon_state = "2-9";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-9"
 	},
 /turf/simulated/floor/plating{
 	icon_state = "platingdmg1"
@@ -236,9 +236,9 @@
 	})
 "aaH" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/unary/outlet_injector{
 	icon_state = "on";
@@ -266,8 +266,8 @@
 	name = "fore beacon"
 	},
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 2
+	dir = 2;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area/station/com_dish/comdish)
@@ -283,15 +283,15 @@
 /area/station/com_dish/comdish)
 "aaN" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 2
+	dir = 2;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area/station/com_dish/comdish)
 "aaO" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 8
+	dir = 8;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/station/com_dish/comdish)
@@ -301,8 +301,8 @@
 /area/station/com_dish/comdish)
 "aaQ" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/communications_dish{
@@ -312,15 +312,15 @@
 /area/station/com_dish/comdish)
 "aaR" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 1
+	dir = 1;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area/station/com_dish/comdish)
 "aaS" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 6
+	dir = 6;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area)
@@ -332,22 +332,22 @@
 /area/station/com_dish/comdish)
 "aaU" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 1
+	dir = 1;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area)
 "aaV" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 6
+	dir = 6;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area)
 "aaW" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 10
+	dir = 10;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area)
@@ -368,8 +368,8 @@
 	pixel_y = 21
 	},
 /obj/stool/chair/wooden{
-	icon_state = "chair_wooden";
-	dir = 1
+	dir = 1;
+	icon_state = "chair_wooden"
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -403,8 +403,8 @@
 /area/station/crew_quarters/observatory)
 "abe" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 1
+	dir = 1;
+	icon_state = "shrub"
 	},
 /turf/simulated/floor/grass,
 /area/station/crew_quarters/observatory)
@@ -417,8 +417,8 @@
 /area/station/crew_quarters/observatory)
 "abg" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 6
+	dir = 6;
+	icon_state = "shrub"
 	},
 /turf/simulated/floor/grass,
 /area/station/crew_quarters/observatory)
@@ -432,8 +432,8 @@
 /area/station/crew_quarters/observatory)
 "abi" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 10
+	dir = 10;
+	icon_state = "shrub"
 	},
 /turf/simulated/floor/grass,
 /area/station/crew_quarters/observatory)
@@ -464,8 +464,8 @@
 /area/station/crew_quarters/observatory)
 "abn" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 4
+	dir = 4;
+	icon_state = "shrub"
 	},
 /turf/simulated/floor/grass,
 /area/station/crew_quarters/observatory)
@@ -483,8 +483,8 @@
 /area/station/crew_quarters/observatory)
 "abq" = (
 /obj/stool/chair/wooden{
-	icon_state = "chair_wooden";
-	dir = 8
+	dir = 8;
+	icon_state = "chair_wooden"
 	},
 /turf/simulated/floor/grass,
 /area/station/crew_quarters/observatory)
@@ -518,9 +518,9 @@
 /area/station/crew_quarters/observatory)
 "abv" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -545,8 +545,8 @@
 	pixel_y = 21
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/carpet/purple/fancy/edge/nw,
@@ -592,8 +592,8 @@
 /obj/storage/secure/closet/personal,
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/ne,
 /area/station/crew_quarters/quartersB)
@@ -619,9 +619,9 @@
 /area/station/crew_quarters/quartersA)
 "abG" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/east,
 /area/station/crew_quarters/quartersA)
@@ -630,18 +630,18 @@
 	dir = 8
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/quartersA)
 "abI" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/north)
@@ -650,9 +650,9 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
 	icon_state = "2-4"
@@ -661,9 +661,9 @@
 /area/station/hallway/primary/north)
 "abK" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/darkblue,
 /area/station/hallway/primary/north)
@@ -673,18 +673,18 @@
 	name = "Luxury Suite"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
 /turf/simulated/floor/darkblue,
 /area/station/crew_quarters/quartersB)
 "abM" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/west,
 /area/station/crew_quarters/quartersB)
@@ -700,9 +700,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/east,
 /area/station/crew_quarters/quartersB)
@@ -720,8 +720,8 @@
 /area/station/crew_quarters/quartersA)
 "abQ" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	icon_state = "chair"
 	},
 /obj/machinery/phone/wall{
 	pixel_x = 24
@@ -795,8 +795,8 @@
 	icon_state = "bedsheet-pink"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/autoname_west,
 /obj/machinery/firealarm{
@@ -836,8 +836,8 @@
 "ace" = (
 /obj/cryotron,
 /obj/item/device/radio/intercom/medical{
-	pixel_x = -20;
-	dir = 4
+	dir = 4;
+	pixel_x = -20
 	},
 /turf/simulated/floor/white,
 /area/station/storage/emergency)
@@ -881,17 +881,17 @@
 /area/station/crew_quarters/quarters_north)
 "acj" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/purple/fancy,
 /area/station/crew_quarters/quarters_north)
 "ack" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/east,
 /area/station/crew_quarters/quarters_north)
@@ -900,9 +900,9 @@
 	dir = 8
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
 /turf/simulated/floor/grey,
@@ -912,9 +912,9 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/north)
@@ -958,8 +958,8 @@
 "acs" = (
 /obj/machinery/light/small,
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	icon_state = "chair"
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/south,
 /area/station/crew_quarters/quarters_north)
@@ -993,17 +993,17 @@
 	name = "Hibernation Nexus"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
 /area/station/storage/emergency)
 "acx" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light/emergency,
 /turf/simulated/floor/white,
@@ -1013,9 +1013,9 @@
 	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
 /area/station/storage/emergency)
@@ -1070,8 +1070,8 @@
 	icon_state = "bedsheet-pink"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/carpet/purple/fancy/edge/nw,
@@ -1089,8 +1089,8 @@
 /area/station/crew_quarters/quarters_west)
 "acI" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	icon_state = "chair"
 	},
 /obj/machinery/light/small{
 	dir = 1;
@@ -1167,9 +1167,9 @@
 /area/station/crew_quarters/quarters_south)
 "acQ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/purple/fancy,
 /area/station/crew_quarters/quarters_south)
@@ -1183,9 +1183,9 @@
 	})
 "acS" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/east,
 /area/station/crew_quarters/quarters_south)
@@ -1194,9 +1194,9 @@
 	dir = 8
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
 /turf/simulated/floor/grey,
@@ -1223,17 +1223,17 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/green/corner,
 /area/station/storage/emergency)
 "acX" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/green/corner{
 	dir = 1
@@ -1247,9 +1247,9 @@
 	pixel_x = 10
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/green/corner,
 /area/station/storage/emergency)
@@ -1268,8 +1268,8 @@
 /area/station/crew_quarters/quarters_west)
 "adb" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	icon_state = "chair"
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/carpet/purple/fancy/edge/south,
@@ -1371,8 +1371,8 @@
 /area/station/storage/emergency)
 "ado" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 2
+	dir = 2;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area)
@@ -1387,8 +1387,8 @@
 	pixel_y = 21
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/carpet/purple/fancy/edge/nw,
@@ -1421,8 +1421,8 @@
 /area/station/crew_quarters/quarters_south)
 "adt" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	icon_state = "chair"
 	},
 /obj/machinery/light_switch/east,
 /turf/simulated/floor/carpet/purple/fancy/edge/ne,
@@ -1485,9 +1485,9 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/darkblue,
@@ -1523,8 +1523,8 @@
 /area/station/crew_quarters/quarters_south)
 "adG" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 1
+	dir = 1;
+	icon_state = "chair"
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/south,
 /area/station/crew_quarters/quarters_south)
@@ -1553,18 +1553,18 @@
 	pixel_y = 21
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light/emergency,
 /turf/simulated/floor/darkblue,
 /area/station/hallway/primary/north)
 "adL" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -1573,9 +1573,9 @@
 /area/station/storage/emergency)
 "adM" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -1602,9 +1602,9 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/darkblue,
@@ -1716,31 +1716,31 @@
 /area/station/maintenance/NEmaint)
 "aed" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "aee" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "aef" = (
 /obj/decal/fakeobjects/pipe/heat{
-	icon_state = "intact";
-	dir = 9
+	dir = 9;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/plating,
 /area/ghostdrone_factory)
 "aeg" = (
 /obj/machinery/door/airlock/pyro/classic{
-	icon_state = "old_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "old_closed"
 	},
 /turf/simulated/floor/plating,
 /area/ghostdrone_factory)
@@ -1765,8 +1765,8 @@
 /area/ghostdrone_factory)
 "aem" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 8
+	dir = 8;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area)
@@ -1778,9 +1778,9 @@
 /area/station/maintenance/NWmaint)
 "aeo" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -1798,9 +1798,9 @@
 	pixel_y = 21
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light/emergency,
 /turf/simulated/floor/grey,
@@ -1846,8 +1846,8 @@
 	icon_state = "0-2"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/heads)
@@ -1990,8 +1990,8 @@
 /area/station/maintenance/NEmaint)
 "aeJ" = (
 /obj/decal/fakeobjects/pipe/heat{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/stool/chair{
 	dir = 4
@@ -2000,8 +2000,8 @@
 /area/ghostdrone_factory)
 "aeK" = (
 /obj/decal/fakeobjects/pipe/heat{
-	icon_state = "intact";
-	dir = 10
+	dir = 10;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/plating,
 /area/ghostdrone_factory)
@@ -2038,9 +2038,9 @@
 /area/station/hallway/primary/north)
 "aeQ" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -2050,9 +2050,9 @@
 "aeR" = (
 /obj/machinery/light/small,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/green/fancy/edge,
 /area/station/crew_quarters/heads)
@@ -2066,9 +2066,9 @@
 	name = "Head of Personnel"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/se,
 /area/station/crew_quarters/heads)
@@ -2180,8 +2180,8 @@
 	pixel_y = 21
 	},
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	icon_state = "chair"
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/north,
 /area/station/crew_quarters/quartersC)
@@ -2266,17 +2266,17 @@
 /area/station/crew_quarters/quartersC)
 "afv" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/purple/fancy,
 /area/station/crew_quarters/quartersC)
 "afw" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/east,
 /area/station/crew_quarters/quartersC)
@@ -2285,9 +2285,9 @@
 	dir = 8
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
 /turf/simulated/floor/grey,
@@ -2308,9 +2308,9 @@
 /area/station/hallway/primary/north)
 "afz" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -2327,17 +2327,17 @@
 	req_access_txt = "17"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/teleporter)
 "afB" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -2348,9 +2348,9 @@
 /area/station/teleporter)
 "afC" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/item/device/radio/beacon,
 /obj/cable{
@@ -2377,16 +2377,16 @@
 /area/station/maintenance/NEmaint)
 "afF" = (
 /obj/decal/fakeobjects/pipe/heat{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/plating,
 /area/ghostdrone_factory)
 "afG" = (
 /obj/machinery/drone_recharger/factory,
 /obj/decal/fakeobjects/pipe/heat{
-	icon_state = "intact";
-	dir = 10
+	dir = 10;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/plating,
 /area/ghostdrone_factory)
@@ -2398,9 +2398,9 @@
 /area/station/maintenance/NWmaint)
 "afI" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
@@ -2491,9 +2491,9 @@
 /area/station/teleporter)
 "afV" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -2521,8 +2521,8 @@
 "afY" = (
 /obj/disposalpipe/segment/vertical,
 /obj/decal/fakeobjects/pipe/heat{
-	icon_state = "intact";
-	dir = 10
+	dir = 10;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/plating,
 /area/ghostdrone_factory)
@@ -2594,8 +2594,8 @@
 "agj" = (
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
@@ -2721,8 +2721,8 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
 /obj/table/auto,
@@ -2783,8 +2783,8 @@
 "agz" = (
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
@@ -2871,8 +2871,8 @@
 	req_access_txt = "19"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/black,
@@ -2890,9 +2890,9 @@
 	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/nw,
 /area/station/bridge)
@@ -2981,8 +2981,8 @@
 	tag = ""
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/black,
@@ -3004,8 +3004,8 @@
 /obj/machinery/recharger,
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
@@ -3029,8 +3029,8 @@
 /area)
 "ahb" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 4
+	dir = 4;
+	icon_state = "chair"
 	},
 /obj/landmark/start{
 	name = "Staff Assistant"
@@ -3039,8 +3039,8 @@
 /area/station/crew_quarters/fitness)
 "ahc" = (
 /obj/stool/chair/boxingrope_corner{
-	icon_state = "ringrope";
-	dir = 10
+	dir = 10;
+	icon_state = "ringrope"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -3054,8 +3054,8 @@
 /area/station/crew_quarters/fitness)
 "ahf" = (
 /obj/stool/chair/boxingrope_corner{
-	icon_state = "ringrope";
-	dir = 6
+	dir = 6;
+	icon_state = "ringrope"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -3073,9 +3073,9 @@
 /area/station/bridge)
 "ahi" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
 	icon_state = "1-4"
@@ -3085,17 +3085,17 @@
 "ahj" = (
 /obj/machinery/light,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/se,
 /area/station/bridge)
 "ahk" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "1-4"
@@ -3109,9 +3109,9 @@
 	name = "Helm Control"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
 /turf/simulated/floor/black,
@@ -3121,9 +3121,9 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
@@ -3136,8 +3136,8 @@
 /area/shuttle/merchant_shuttle/right_station/destiny)
 "ahp" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 10
+	dir = 10;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area)
@@ -3163,8 +3163,8 @@
 /area/station/crew_quarters/fitness)
 "ahu" = (
 /obj/decal/boxingrope{
-	icon_state = "ringrope";
-	dir = 4
+	dir = 4;
+	icon_state = "ringrope"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -3217,9 +3217,9 @@
 /area/station/crew_quarters/fitness)
 "ahA" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
@@ -3234,8 +3234,8 @@
 /area/station/crew_quarters/fitness)
 "ahC" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 4
+	dir = 4;
+	icon_state = "chair"
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -3288,8 +3288,8 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/circuit,
 /area/station/bridge)
@@ -3360,8 +3360,8 @@
 /area/station/crew_quarters/fitness)
 "ahO" = (
 /obj/decal/boxingrope{
-	icon_state = "ringrope";
-	dir = 4
+	dir = 4;
+	icon_state = "ringrope"
 	},
 /obj/stool,
 /turf/simulated/floor/specialroom/gym,
@@ -3383,8 +3383,8 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/light/small{
 	dir = 8;
@@ -3394,8 +3394,8 @@
 /area/station/bridge)
 "ahS" = (
 /obj/stool/chair/office/blue{
-	icon_state = "office_chair_blue";
-	dir = 8
+	dir = 8;
+	icon_state = "office_chair_blue"
 	},
 /obj/cable{
 	d1 = 1;
@@ -3469,8 +3469,8 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/circuit,
 /area/station/bridge)
@@ -3648,8 +3648,8 @@
 "air" = (
 /obj/machinery/computer/secure_data/detective_computer,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/autoname_east,
 /obj/machinery/light_switch/north,
@@ -3837,9 +3837,9 @@
 	req_access_txt = "4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
@@ -3853,9 +3853,9 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
@@ -3893,8 +3893,8 @@
 /area/station/crew_quarters/showers)
 "aiX" = (
 /obj/item/storage/toilet/random{
-	icon_state = "toilet";
-	dir = 4
+	dir = 4;
+	icon_state = "toilet"
 	},
 /obj/machinery/light/small{
 	dir = 1;
@@ -3934,32 +3934,32 @@
 /area)
 "ajc" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 8
+	dir = 8;
+	icon_state = "lattice-dir"
 	},
 /obj/machinery/light/runway_light/delay4,
 /turf/space,
 /area)
 "ajd" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 4
+	dir = 4;
+	icon_state = "lattice-dir"
 	},
 /obj/machinery/light/runway_light/delay3,
 /turf/space,
 /area)
 "aje" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 4
+	dir = 4;
+	icon_state = "lattice-dir"
 	},
 /obj/machinery/light/runway_light/delay2,
 /turf/space,
 /area)
 "ajf" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 4
+	dir = 4;
+	icon_state = "lattice-dir"
 	},
 /obj/machinery/light/runway_light,
 /turf/space,
@@ -3971,8 +3971,8 @@
 /area)
 "ajh" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 5
+	dir = 5;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area)
@@ -4039,8 +4039,8 @@
 /area/station/hangar/sec)
 "ajs" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 1
+	dir = 1;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area)
@@ -4097,9 +4097,9 @@
 /area/station/crew_quarters/kitchen)
 "ajB" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/kitchen)
@@ -4111,9 +4111,9 @@
 	req_access_txt = "28"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
 /turf/simulated/floor,
@@ -4156,9 +4156,9 @@
 /area/station/hangar/sec)
 "ajF" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/hangar/sec)
@@ -4189,9 +4189,9 @@
 /area/station/maintenance/westsolar)
 "ajJ" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
@@ -4289,8 +4289,8 @@
 /area/station/hangar/sec)
 "ajS" = (
 /obj/grille/catwalk{
-	icon_state = "catwalk_cross";
-	dir = 2
+	dir = 2;
+	icon_state = "catwalk_cross"
 	},
 /obj/machinery/power/tracker/west,
 /obj/cable{
@@ -4407,9 +4407,9 @@
 /area/station/maintenance/NEmaint)
 "ake" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "2-4"
@@ -4421,18 +4421,18 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "akg" = (
 /obj/machinery/light/small,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "1-4"
@@ -4441,9 +4441,9 @@
 /area/station/maintenance/eastsolar)
 "akh" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -4460,8 +4460,8 @@
 /area/station/maintenance/eastsolar)
 "akj" = (
 /obj/grille/catwalk{
-	icon_state = "catwalk_cross";
-	dir = 2
+	dir = 2;
+	icon_state = "catwalk_cross"
 	},
 /obj/machinery/power/tracker/east,
 /obj/cable{
@@ -4480,9 +4480,9 @@
 /area/station/solar/east)
 "akk" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/grille/catwalk,
 /turf/simulated/floor/airless/plating/catwalk,
@@ -4565,9 +4565,9 @@
 	req_access_txt = "25"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
 /turf/simulated/floor/black,
@@ -4580,9 +4580,9 @@
 /area/station/maintenance/eastsolar)
 "akv" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/grille/catwalk,
 /turf/simulated/floor/airless/plating/catwalk,
@@ -4710,8 +4710,8 @@
 /obj/item/device/reagentscanner,
 /obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/autoname_north,
 /obj/item/reagent_containers/dropper/mechanical,
@@ -4764,9 +4764,9 @@
 	name = "Toilets"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
@@ -4844,9 +4844,9 @@
 /area/station/maintenance/eastsolar)
 "akX" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/eastsolar)
@@ -4856,8 +4856,8 @@
 /area/station/maintenance/eastsolar)
 "akZ" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/solar/west,
 /turf/simulated/floor/airless{
@@ -4867,16 +4867,16 @@
 /area/station/solar/west)
 "ala" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/grille/catwalk{
 	dir = 10
@@ -4905,8 +4905,8 @@
 "alc" = (
 /obj/grille/catwalk,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -4963,9 +4963,9 @@
 /area/station/crew_quarters/pool)
 "alh" = (
 /obj/shrub{
+	dir = 1;
 	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "plant";
-	dir = 1
+	icon_state = "plant"
 	},
 /obj/item/device/radio/intercom{
 	pixel_y = 24
@@ -5024,8 +5024,8 @@
 /area/station/crew_quarters/showers)
 "alo" = (
 /obj/submachine/chef_sink/chem_sink{
-	icon_state = "sink";
-	dir = 1
+	dir = 1;
+	icon_state = "sink"
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -5034,8 +5034,8 @@
 /area/station/crew_quarters/showers)
 "alp" = (
 /obj/submachine/chef_sink/chem_sink{
-	icon_state = "sink";
-	dir = 1
+	dir = 1;
+	icon_state = "sink"
 	},
 /obj/machinery/light_switch/east,
 /obj/cable{
@@ -5081,8 +5081,8 @@
 /area/station/crew_quarters/bar)
 "alt" = (
 /obj/submachine/chef_sink/chem_sink{
-	icon_state = "sink";
-	dir = 1
+	dir = 1;
+	icon_state = "sink"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/bar)
@@ -5108,8 +5108,8 @@
 /area/station/maintenance/eastsolar)
 "alw" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/solar/east,
 /turf/simulated/floor/airless{
@@ -5120,8 +5120,8 @@
 "alx" = (
 /obj/grille/catwalk,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
@@ -5148,16 +5148,16 @@
 /area/station/solar/east)
 "alz" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/grille/catwalk{
 	dir = 10
@@ -5196,8 +5196,8 @@
 /area/station/crew_quarters/pool)
 "alD" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 6
+	dir = 6;
+	icon_state = "shrub"
 	},
 /turf/simulated/floor/grass,
 /area/station/crew_quarters/pool)
@@ -5257,8 +5257,8 @@
 	pixel_y = -5
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/plating,
@@ -5268,9 +5268,9 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
 	icon_state = "2-4"
@@ -5288,8 +5288,8 @@
 /area/station/crew_quarters/pool)
 "alN" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 8
+	dir = 8;
+	icon_state = "shrub"
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -5309,8 +5309,8 @@
 /area/station/crew_quarters/pool)
 "alP" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 10
+	dir = 10;
+	icon_state = "shrub"
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -5339,8 +5339,8 @@
 "alT" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/nw,
 /area/station/crew_quarters/barber_shop)
@@ -5529,17 +5529,17 @@
 /area/station/crew_quarters/barber_shop)
 "ams" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/red/fancy/innercorner/omni,
 /area/station/crew_quarters/barber_shop)
 "amt" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/east,
 /area/station/crew_quarters/barber_shop)
@@ -5549,9 +5549,9 @@
 	name = "Barber Shop"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/barber_shop)
@@ -5817,8 +5817,8 @@
 /area/station/crew_quarters/cafeteria)
 "amZ" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 6
+	dir = 6;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/station/solar/west)
@@ -5828,8 +5828,8 @@
 /area/station/solar/west)
 "anb" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 8
+	dir = 8;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/station/solar/west)
@@ -5927,8 +5927,8 @@
 "ang" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/computer/arcade,
 /turf/simulated/floor/carpet/green/standard/narrow/eastwest,
@@ -6029,27 +6029,27 @@
 /area/station/solar/east)
 "anu" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 8
+	dir = 8;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/station/solar/east)
 "anv" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 1
+	dir = 1;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/station/solar/east)
 "anw" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/grille/catwalk{
 	dir = 9
@@ -6067,9 +6067,9 @@
 /area/station/solar/west)
 "anx" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/grille/catwalk{
 	dir = 4
@@ -6085,16 +6085,16 @@
 "any" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/grille/catwalk{
 	dir = 1;
@@ -6113,8 +6113,8 @@
 "anz" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -6131,8 +6131,8 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
+	dir = 1;
+	icon_state = "term"
 	},
 /obj/machinery/fluid_canister,
 /turf/simulated/floor/plating,
@@ -6152,9 +6152,9 @@
 /area/station/crew_quarters/arcade)
 "anD" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/north,
 /area/station/crew_quarters/arcade)
@@ -6197,16 +6197,16 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
+	dir = 1;
+	icon_state = "term"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/eastsolar)
 "anJ" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -6216,9 +6216,9 @@
 /area/station/maintenance/eastsolar)
 "anK" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/grille/catwalk{
 	dir = 4
@@ -6234,16 +6234,16 @@
 "anL" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/grille/catwalk{
 	dir = 1;
@@ -6262,8 +6262,8 @@
 "anM" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
@@ -6285,8 +6285,8 @@
 /area/station/solar/east)
 "anN" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 10
+	dir = 10;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/station/solar/west)
@@ -6324,8 +6324,8 @@
 /area/station/crew_quarters/pool)
 "anS" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 1
+	dir = 1;
+	icon_state = "shrub"
 	},
 /turf/simulated/floor/grass,
 /area/station/crew_quarters/pool)
@@ -6428,16 +6428,16 @@
 /area/station/maintenance/eastsolar)
 "aof" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 10
+	dir = 10;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/station/solar/east)
 "aog" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
@@ -6512,8 +6512,8 @@
 	name = "monkeyspawn_mrmuggles"
 	},
 /obj/item/device/radio/intercom{
-	pixel_y = -20;
-	dir = 1
+	dir = 1;
+	pixel_y = -20
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
@@ -6540,9 +6540,9 @@
 /area/station/maintenance/eastsolar)
 "aou" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/eastsolar)
@@ -6558,9 +6558,9 @@
 /area/station/maintenance/westsolar)
 "aow" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
@@ -6598,14 +6598,14 @@
 	pixel_y = 16
 	},
 /turf/simulated/floor/neutral/side{
-	icon_state = "neutral";
-	dir = 6
+	dir = 6;
+	icon_state = "neutral"
 	},
 /area/station/hallway/primary/central)
 "aoE" = (
 /obj/decal/tile_edge/line/blue{
-	icon_state = "line1";
-	dir = 8
+	dir = 8;
+	icon_state = "line1"
 	},
 /obj/cable{
 	d1 = 1;
@@ -6616,9 +6616,9 @@
 /area/station/hallway/primary/central)
 "aoF" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/central)
@@ -6630,9 +6630,9 @@
 	pixel_y = 21
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/central)
@@ -6685,8 +6685,8 @@
 /obj/table/auto,
 /obj/machinery/computer3/generic/personal,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/neutral/side,
@@ -6712,35 +6712,35 @@
 "aoR" = (
 /obj/machinery/clothingbooth,
 /turf/simulated/floor/neutral/side{
-	icon_state = "neutral";
-	dir = 6
+	dir = 6;
+	icon_state = "neutral"
 	},
 /area/station/hallway/primary/central)
 "aoS" = (
 /obj/decal/tile_edge/line/blue{
-	icon_state = "line1";
-	dir = 8
+	dir = 8;
+	icon_state = "line1"
 	},
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/central)
 "aoT" = (
 /obj/decal/tile_edge/line/blue{
-	icon_state = "line1";
-	dir = 5
+	dir = 5;
+	icon_state = "line1"
 	},
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/central)
 "aoU" = (
 /obj/decal/tile_edge/line/blue{
-	icon_state = "line1";
-	dir = 1
+	dir = 1;
+	icon_state = "line1"
 	},
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/central)
 "aoV" = (
 /obj/decal/tile_edge/line/blue{
-	icon_state = "line1";
-	dir = 9
+	dir = 9;
+	icon_state = "line1"
 	},
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/central)
@@ -6769,8 +6769,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 6
+	dir = 6;
+	icon_state = "greyblack"
 	},
 /area/station/crew_quarters/courtroom)
 "apb" = (
@@ -6823,9 +6823,9 @@
 /area/station/security/main)
 "apg" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/eastsolar)
@@ -6837,12 +6837,12 @@
 /area/station/hallway/primary/central)
 "api" = (
 /obj/decal/tile_edge/line/blue{
-	icon_state = "line1";
-	dir = 1
+	dir = 1;
+	icon_state = "line1"
 	},
 /obj/stool/chair/comfy{
-	icon_state = "chair_comfy";
-	dir = 1
+	dir = 1;
+	icon_state = "chair_comfy"
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -6854,24 +6854,24 @@
 /area/station/hallway/primary/central)
 "apj" = (
 /obj/decal/tile_edge/line/blue{
-	icon_state = "line1";
-	dir = 1
+	dir = 1;
+	icon_state = "line1"
 	},
 /obj/disposalpipe/segment/bent/east,
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/central)
 "apk" = (
 /obj/decal/tile_edge/line/blue{
-	icon_state = "line1";
-	dir = 1
+	dir = 1;
+	icon_state = "line1"
 	},
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/central)
 "apl" = (
 /obj/decal/tile_edge/line/blue{
-	icon_state = "line1";
-	dir = 9
+	dir = 9;
+	icon_state = "line1"
 	},
 /obj/disposalpipe/junction/right/west,
 /turf/simulated/floor/grey,
@@ -6908,8 +6908,8 @@
 /area/station/hallway/primary/central)
 "aps" = (
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 4
+	dir = 4;
+	icon_state = "greyblack"
 	},
 /area/station/crew_quarters/courtroom)
 "apt" = (
@@ -6922,8 +6922,8 @@
 	pixel_x = 10
 	},
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 1
+	dir = 1;
+	icon_state = "chair"
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -6943,8 +6943,8 @@
 /area/station/security/main)
 "apv" = (
 /obj/stool/chair/red{
-	icon_state = "chair-r";
-	dir = 8
+	dir = 8;
+	icon_state = "chair-r"
 	},
 /obj/landmark/start{
 	name = "Security Officer"
@@ -6956,8 +6956,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/red/corner{
-	icon_state = "redcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/station/security/main)
 "apx" = (
@@ -6994,9 +6994,9 @@
 	pixel_x = 12
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/eastsolar)
@@ -7013,9 +7013,9 @@
 /area/station/maintenance/westsolar)
 "apA" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	icon_state = "1-4"
@@ -7071,43 +7071,43 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/central)
 "apG" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/central)
 "apH" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/darkblue,
 /area/station/hallway/primary/central)
 "apI" = (
 /obj/machinery/light/small,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/darkblue,
 /area/station/hallway/primary/central)
 "apJ" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/darkblue,
@@ -7151,8 +7151,8 @@
 /area/station/hallway/primary/central)
 "apQ" = (
 /obj/stool/chair/wooden{
-	icon_state = "chair_wooden";
-	dir = 8
+	dir = 8;
+	icon_state = "chair_wooden"
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -7166,14 +7166,14 @@
 /area/station/hallway/primary/central)
 "apR" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/darkblue,
 /area/station/hallway/primary/central)
@@ -7182,63 +7182,63 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/darkblue,
 /area/station/hallway/primary/central)
 "apT" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light/emergency,
 /turf/simulated/floor/black/corner{
-	icon_state = "greyblackcorner";
-	dir = 8
+	dir = 8;
+	icon_state = "greyblackcorner"
 	},
 /area/station/crew_quarters/courtroom)
 "apU" = (
 /obj/machinery/light,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 1
+	dir = 1;
+	icon_state = "greyblack"
 	},
 /area/station/crew_quarters/courtroom)
 "apV" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 1
+	dir = 1;
+	icon_state = "greyblack"
 	},
 /area/station/crew_quarters/courtroom)
 "apW" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 5
+	dir = 5;
+	icon_state = "greyblack"
 	},
 /area/station/crew_quarters/courtroom)
 "apX" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
@@ -7265,7 +7265,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/storage/secure/closet/security/equipment,
+/obj/submachine/weapon_vendor/security,
 /turf/simulated/floor/red/side{
 	dir = 4
 	},
@@ -7360,8 +7360,8 @@
 /area/station/hallway/primary/central)
 "aqo" = (
 /obj/stool/chair/wooden{
-	icon_state = "chair_wooden";
-	dir = 8
+	dir = 8;
+	icon_state = "chair_wooden"
 	},
 /obj/machinery/power/apc/autoname_east,
 /obj/cable,
@@ -7380,8 +7380,8 @@
 "aqr" = (
 /obj/storage/crate/bin/lostandfound,
 /turf/simulated/floor/black/corner{
-	icon_state = "greyblackcorner";
-	dir = 8
+	dir = 8;
+	icon_state = "greyblackcorner"
 	},
 /area/station/crew_quarters/courtroom)
 "aqs" = (
@@ -7389,8 +7389,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 5
+	dir = 5;
+	icon_state = "greyblack"
 	},
 /area/station/crew_quarters/courtroom)
 "aqt" = (
@@ -7524,9 +7524,9 @@
 	pixel_y = 21
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
@@ -7546,8 +7546,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 4
+	dir = 4;
+	icon_state = "greyblack"
 	},
 /area/station/crew_quarters/courtroom)
 "aqK" = (
@@ -7581,9 +7581,9 @@
 "aqO" = (
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -7608,8 +7608,8 @@
 /obj/machinery/light_switch/north,
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor{
 	icon_state = "arcade"
@@ -7617,9 +7617,9 @@
 /area/station/janitor)
 "aqS" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor)
@@ -7716,11 +7716,11 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/storage/emergency)
 "are" = (
-/obj/machinery/weapon_stand/taser_rack/recharger,
 /obj/item/device/radio/intercom/security{
-	pixel_x = -20;
-	dir = 4
+	dir = 4;
+	pixel_x = -20
 	},
+/obj/machinery/weapon_stand/taser_rack/recharger/empty,
 /turf/simulated/floor/red/side{
 	dir = 10
 	},
@@ -7734,13 +7734,13 @@
 /area/station/security/main)
 "arg" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/red/corner{
-	icon_state = "redcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/station/security/main)
 "arh" = (
@@ -7775,9 +7775,9 @@
 	pixel_x = -12
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -7799,8 +7799,8 @@
 	amount = 50
 	},
 /turf/simulated/floor/escape{
-	icon_state = "escape";
-	dir = 1
+	dir = 1;
+	icon_state = "escape"
 	},
 /area/station/maintenance/west)
 "arm" = (
@@ -7810,8 +7810,8 @@
 	pixel_x = 12
 	},
 /turf/simulated/floor/escape{
-	icon_state = "escape";
-	dir = 1
+	dir = 1;
+	icon_state = "escape"
 	},
 /area/station/maintenance/west)
 "arn" = (
@@ -7866,8 +7866,8 @@
 "arv" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/brig)
@@ -7882,15 +7882,15 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/blue/side{
-	icon_state = "blue";
-	dir = 8
+	dir = 8;
+	icon_state = "blue"
 	},
 /area/station/turret_protected/ai)
 "arx" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 4
@@ -7906,9 +7906,9 @@
 	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -7919,17 +7919,17 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "arA" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -8003,8 +8003,8 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 4
+	dir = 4;
+	icon_state = "greyblack"
 	},
 /area/station/crew_quarters/courtroom)
 "arJ" = (
@@ -8087,9 +8087,9 @@
 /area/station/maintenance/eastsolar)
 "arQ" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -8100,15 +8100,15 @@
 	tag = ""
 	},
 /turf/simulated/floor/blue/side{
-	icon_state = "blue";
-	dir = 8
+	dir = 8;
+	icon_state = "blue"
 	},
 /area/station/turret_protected/ai)
 "arR" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -8155,8 +8155,8 @@
 /area/station/engine/engineering)
 "arX" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 4
+	dir = 4;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/station/engine/engineering)
@@ -8171,8 +8171,8 @@
 /obj/machinery/power/apc/autoname_west,
 /obj/cable,
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 4
+	dir = 4;
+	icon_state = "greyblack"
 	},
 /area/station/crew_quarters/courtroom)
 "asa" = (
@@ -8244,8 +8244,8 @@
 /area/station/security/brig)
 "asf" = (
 /obj/stool/chair/red{
-	icon_state = "chair-r";
-	dir = 8
+	dir = 8;
+	icon_state = "chair-r"
 	},
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
@@ -8271,15 +8271,15 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/blue/side{
-	icon_state = "blue";
-	dir = 8
+	dir = 8;
+	icon_state = "blue"
 	},
 /area/station/turret_protected/ai)
 "asj" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -8313,8 +8313,8 @@
 	pixel_x = 10
 	},
 /turf/simulated/floor/stairs/wood/wide{
-	icon_state = "wood_stairs2";
-	dir = 6
+	dir = 6;
+	icon_state = "wood_stairs2"
 	},
 /area/station/crew_quarters/jazz)
 "aso" = (
@@ -8347,8 +8347,8 @@
 "ass" = (
 /obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 4
+	dir = 4;
+	icon_state = "greyblack"
 	},
 /area/station/crew_quarters/courtroom)
 "ast" = (
@@ -8382,8 +8382,8 @@
 /area/station/security/brig)
 "asw" = (
 /obj/stool/chair/red{
-	icon_state = "chair-r";
-	dir = 8
+	dir = 8;
+	icon_state = "chair-r"
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -8418,12 +8418,12 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/blue/side{
-	icon_state = "blue";
-	dir = 8
+	dir = 8;
+	icon_state = "blue"
 	},
 /area/station/turret_protected/ai)
 "asz" = (
@@ -8431,9 +8431,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 4
@@ -8441,15 +8441,15 @@
 /area/station/turret_protected/ai)
 "asA" = (
 /obj/stool/chair/office/blue{
-	icon_state = "office_chair_blue";
-	dir = 8
+	dir = 8;
+	icon_state = "office_chair_blue"
 	},
 /turf/simulated/floor/blue,
 /area/station/turret_protected/ai)
 "asB" = (
 /obj/stool/chair/couch{
-	icon_state = "chair_couch-brown";
-	dir = 8
+	dir = 8;
+	icon_state = "chair_couch-brown"
 	},
 /obj/submachine/ATM{
 	pixel_x = -32;
@@ -8470,8 +8470,8 @@
 /area/station/crew_quarters/jazz)
 "asD" = (
 /obj/stool/chair/couch{
-	icon_state = "chair_couch-brown";
-	dir = 4
+	dir = 4;
+	icon_state = "chair_couch-brown"
 	},
 /obj/machinery/light/small{
 	dir = 1;
@@ -8510,13 +8510,13 @@
 /area/station/engine/engineering)
 "asH" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 4
+	dir = 4;
+	icon_state = "lattice-dir"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/space,
 /area/station/engine/engineering)
@@ -8550,8 +8550,8 @@
 /area/station/engine/engineering)
 "asL" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 4
+	dir = 4;
+	icon_state = "lattice-dir"
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -8581,8 +8581,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 4
+	dir = 4;
+	icon_state = "greyblack"
 	},
 /area/station/crew_quarters/courtroom)
 "asP" = (
@@ -8667,12 +8667,12 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/blue/side{
-	icon_state = "blue";
-	dir = 8
+	dir = 8;
+	icon_state = "blue"
 	},
 /area/station/turret_protected/ai)
 "asW" = (
@@ -8709,11 +8709,11 @@
 /obj/item/instrument/large/jukebox,
 /obj/decal/glow{
 	brightness = 3;
-	invisibility = 101;
-	name = "glow - YELLOW";
 	color_b = 0.2;
 	color_g = 0.45;
-	color_r = 0.5
+	color_r = 0.5;
+	invisibility = 101;
+	name = "glow - YELLOW"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/jazz)
@@ -8728,8 +8728,8 @@
 /area/station/engine/engineering)
 "ate" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 2
+	dir = 2;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/station/engine/engineering)
@@ -8750,8 +8750,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 6
+	dir = 6;
+	icon_state = "greyblack"
 	},
 /area/station/crew_quarters/courtroom)
 "ath" = (
@@ -8787,9 +8787,9 @@
 /area/station/security/brig)
 "atj" = (
 /obj/submachine/chef_sink/chem_sink{
-	tag = "icon-sink (NORTH)";
+	dir = 1;
 	icon_state = "sink";
-	dir = 1
+	tag = "icon-sink (NORTH)"
 	},
 /obj/machinery/light/small,
 /obj/machinery/floorflusher/solitary2,
@@ -8831,8 +8831,8 @@
 /obj/item/remote/porter/port_a_brig,
 /obj/machinery/light/emergency,
 /obj/item/device/radio/intercom/security{
-	pixel_x = 20;
-	dir = 8
+	dir = 8;
+	pixel_x = 20
 	},
 /turf/simulated/floor/red/side{
 	dir = 6
@@ -8840,9 +8840,9 @@
 /area/station/security/brig)
 "atn" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -8879,13 +8879,13 @@
 /area/station/turret_protected/ai)
 "ats" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/blue/side{
-	icon_state = "blue";
-	dir = 8
+	dir = 8;
+	icon_state = "blue"
 	},
 /area/station/turret_protected/ai)
 "att" = (
@@ -8902,13 +8902,13 @@
 /area/station/turret_protected/ai)
 "atv" = (
 /obj/stool/chair/comfy{
-	icon_state = "chair_comfy";
-	dir = 4
+	dir = 4;
+	icon_state = "chair_comfy"
 	},
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/jazz)
@@ -8920,14 +8920,14 @@
 /area/station/crew_quarters/jazz)
 "atx" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/carpet/red/fancy/innercorner/south,
 /area/station/crew_quarters/jazz)
@@ -8981,9 +8981,9 @@
 "atE" = (
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/east)
@@ -8993,8 +8993,8 @@
 "atG" = (
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/blue,
@@ -9004,8 +9004,8 @@
 /obj/item/aiModule/oneHuman,
 /obj/item/aiModule/makeCaptain,
 /turf/simulated/floor/blue/side{
-	icon_state = "blue";
-	dir = 8
+	dir = 8;
+	icon_state = "blue"
 	},
 /area/station/turret_protected/ai)
 "atI" = (
@@ -9112,8 +9112,8 @@
 /area/station/crew_quarters/courtroom)
 "atV" = (
 /turf/simulated/floor/red/corner{
-	icon_state = "redcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/station/crew_quarters/courtroom)
 "atW" = (
@@ -9182,14 +9182,14 @@
 /area/station/crew_quarters/courtroom)
 "auc" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/machinery/light/emergency{
 	dir = 8;
@@ -9246,9 +9246,9 @@
 	opacity = 0
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/blue,
 /area/station/turret_protected/ai)
@@ -9318,14 +9318,14 @@
 "auq" = (
 /obj/machinery/vending/cola/red,
 /turf/simulated/floor/neutral/side{
-	icon_state = "neutral";
-	dir = 5
+	dir = 5;
+	icon_state = "neutral"
 	},
 /area/station/crew_quarters/courtroom)
 "aur" = (
 /obj/decal/tile_edge/line/blue{
-	icon_state = "line1";
-	dir = 8
+	dir = 8;
+	icon_state = "line1"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
@@ -9341,8 +9341,8 @@
 /area/station/crew_quarters/courtroom)
 "aut" = (
 /obj/stool/chair/office/red{
-	icon_state = "office_chair_red";
-	dir = 8
+	dir = 8;
+	icon_state = "office_chair_red"
 	},
 /obj/landmark/start{
 	name = "Security Officer"
@@ -9380,9 +9380,9 @@
 	pixel_x = -10
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/red/side{
 	dir = 8
@@ -9412,9 +9412,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/grey,
 /area/station/turret_protected/ai)
@@ -9484,8 +9484,8 @@
 	},
 /obj/blind_switch/area/west,
 /turf/simulated/floor/neutral/side{
-	icon_state = "neutral";
-	dir = 4
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/station/crew_quarters/courtroom)
 "auJ" = (
@@ -9505,9 +9505,9 @@
 /area/station/crew_quarters/courtroom)
 "auL" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/red/side{
 	dir = 8
@@ -9559,9 +9559,9 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/grey,
 /area/station/turret_protected/ai)
@@ -9593,9 +9593,9 @@
 /area/station/maintenance/west)
 "auT" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -9617,8 +9617,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/stairs/wood/wide{
-	icon_state = "wood_stairs2";
-	dir = 10
+	dir = 10;
+	icon_state = "wood_stairs2"
 	},
 /area/station/crew_quarters/jazz)
 "auV" = (
@@ -9630,8 +9630,8 @@
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/stairs/wood/wide{
-	icon_state = "wood_stairs2";
-	dir = 1
+	dir = 1;
+	icon_state = "wood_stairs2"
 	},
 /area/station/crew_quarters/jazz)
 "auW" = (
@@ -9673,8 +9673,8 @@
 /area/station/hallway/primary/east)
 "ava" = (
 /turf/simulated/floor/red/corner{
-	icon_state = "redcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "redcorner"
 	},
 /area/station/hallway/primary/east)
 "avb" = (
@@ -9692,9 +9692,9 @@
 /area/station/hallway/primary/east)
 "avd" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/red/corner{
 	dir = 1
@@ -9826,12 +9826,12 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/caution/corner/misc{
-	icon_state = "floor_hazard_corners";
-	dir = 10
+	dir = 10;
+	icon_state = "floor_hazard_corners"
 	},
 /area/station/engine/engineering)
 "avp" = (
@@ -9848,8 +9848,8 @@
 /area/station/engine/engineering)
 "avq" = (
 /obj/window/cubicle{
-	icon_state = "cubicle";
-	dir = 8
+	dir = 8;
+	icon_state = "cubicle"
 	},
 /obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating/airless,
@@ -9858,8 +9858,8 @@
 /obj/item/storage/toilet,
 /obj/machinery/door/window/southleft,
 /obj/window/cubicle{
-	icon_state = "cubicle";
-	dir = 4
+	dir = 4;
+	icon_state = "cubicle"
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/hallway/primary/east)
@@ -9889,9 +9889,9 @@
 "avv" = (
 /obj/stool/bench/yellow/auto,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
@@ -9986,9 +9986,9 @@
 	req_access_txt = "45"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /obj/firedoor_spawn,
@@ -10005,14 +10005,14 @@
 /area/station/engine/engineering)
 "avI" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/black,
@@ -10079,8 +10079,8 @@
 	dir = 1
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -10103,9 +10103,9 @@
 /area/station/engine/engineering)
 "avQ" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engine/engineering)
@@ -10126,14 +10126,14 @@
 /area/station/hallway/primary/east)
 "avU" = (
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 9
+	dir = 9;
+	icon_state = "greyblack"
 	},
 /area/station/hallway/primary/east)
 "avV" = (
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 1
+	dir = 1;
+	icon_state = "greyblack"
 	},
 /area/station/hallway/primary/east)
 "avW" = (
@@ -10141,8 +10141,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 1
+	dir = 1;
+	icon_state = "greyblack"
 	},
 /area/station/hallway/primary/east)
 "avX" = (
@@ -10155,19 +10155,19 @@
 	tag = ""
 	},
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 1
+	dir = 1;
+	icon_state = "greyblack"
 	},
 /area/station/hallway/primary/east)
 "avY" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 5
+	dir = 5;
+	icon_state = "greyblack"
 	},
 /area/station/hallway/primary/east)
 "avZ" = (
@@ -10192,31 +10192,31 @@
 /area/station/hallway/primary/west)
 "awb" = (
 /obj/decal/tile_edge/line/yellow{
-	icon_state = "line1";
-	dir = 1
+	dir = 1;
+	icon_state = "line1"
 	},
 /obj/machinery/light_switch/west,
 /turf/simulated/floor/black,
 /area/station/engine/engineering)
 "awc" = (
 /obj/decal/tile_edge/line/yellow{
-	icon_state = "line1";
-	dir = 8
+	dir = 8;
+	icon_state = "line1"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/black,
 /area/station/engine/engineering)
@@ -10291,8 +10291,8 @@
 /area/station/hallway/primary/east)
 "awk" = (
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 8
+	dir = 8;
+	icon_state = "greyblack"
 	},
 /area/station/hallway/primary/east)
 "awl" = (
@@ -10309,13 +10309,13 @@
 "awn" = (
 /obj/stool/bench/yellow/auto,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 4
+	dir = 4;
+	icon_state = "greyblack"
 	},
 /area/station/hallway/primary/east)
 "awo" = (
@@ -10354,8 +10354,8 @@
 /obj/rack,
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/market)
@@ -10396,18 +10396,18 @@
 /area/station/engine/engineering)
 "awC" = (
 /obj/decal/tile_edge/line/yellow{
-	icon_state = "line1";
-	dir = 8
+	dir = 8;
+	icon_state = "line1"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/black,
 /area/station/engine/engineering)
@@ -10497,26 +10497,26 @@
 	pixel_x = -10
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 4
+	dir = 4;
+	icon_state = "greyblack"
 	},
 /area/station/hallway/primary/east)
 "awM" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 6
+	dir = 6;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area/station/hangar/main)
 "awN" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 8
+	dir = 8;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/station/hangar/main)
@@ -10538,8 +10538,8 @@
 	pixel_x = 10
 	},
 /turf/simulated/floor/caution/corner/misc{
-	icon_state = "floor_hazard_corners";
-	dir = 10
+	dir = 10;
+	icon_state = "floor_hazard_corners"
 	},
 /area/station/hangar/main)
 "awS" = (
@@ -10561,8 +10561,8 @@
 /area/station/crew_quarters/market)
 "awU" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 4
+	dir = 4;
+	icon_state = "chair"
 	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/market)
@@ -10598,8 +10598,8 @@
 /obj/machinery/shield_generator,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/light/emergency{
 	dir = 8;
@@ -10609,18 +10609,18 @@
 /area/station/engine/engineering)
 "awY" = (
 /obj/decal/tile_edge/line/yellow{
-	icon_state = "line1";
-	dir = 8
+	dir = 8;
+	icon_state = "line1"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
 /area/station/engine/engineering)
@@ -10708,17 +10708,17 @@
 	req_access_txt = "44"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/caution/westeast,
 /area/station/engine/engineering)
 "axi" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/item/device/radio/intercom/engineering{
 	pixel_y = 24
@@ -10768,39 +10768,39 @@
 	pixel_x = -10
 	},
 /turf/simulated/floor/black/corner{
-	icon_state = "greyblackcorner";
-	dir = 8
+	dir = 8;
+	icon_state = "greyblackcorner"
 	},
 /area/station/hallway/primary/east)
 "axq" = (
 /obj/stool/bench/yellow/auto,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 1
+	dir = 1;
+	icon_state = "greyblack"
 	},
 /area/station/hallway/primary/east)
 "axr" = (
 /obj/machinery/light,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 1
+	dir = 1;
+	icon_state = "greyblack"
 	},
 /area/station/hallway/primary/east)
 "axs" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -10811,15 +10811,15 @@
 	tag = ""
 	},
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 5
+	dir = 5;
+	icon_state = "greyblack"
 	},
 /area/station/hallway/primary/east)
 "axt" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/item/storage/wall/emergency{
 	dir = 8;
@@ -10829,15 +10829,15 @@
 /area/station/hallway/primary/east)
 "axu" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 6
+	dir = 6;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/station/hangar/main)
 "axv" = (
 /obj/decal/tile_edge/stripe/extra_big{
-	icon_state = "xtra_bigstripe-edge";
-	dir = 8
+	dir = 8;
+	icon_state = "xtra_bigstripe-edge"
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -10863,8 +10863,8 @@
 /area/station/hangar/main)
 "axx" = (
 /obj/decal/tile_edge/stripe/extra_big{
-	icon_state = "xtra_bigstripe-edge";
-	dir = 8
+	dir = 8;
+	icon_state = "xtra_bigstripe-edge"
 	},
 /turf/simulated/floor/engine,
 /area/station/hangar/main)
@@ -10889,15 +10889,15 @@
 /area/station/crew_quarters/market)
 "axC" = (
 /obj/decal/tile_edge/line/yellow{
-	icon_state = "line1";
-	dir = 1
+	dir = 1;
+	icon_state = "line1"
 	},
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/black,
@@ -10908,9 +10908,9 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	icon_state = "1-8"
@@ -10954,9 +10954,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
@@ -10967,9 +10967,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow/corner,
 /area/station/engine/engineering)
@@ -10980,9 +10980,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
@@ -11032,8 +11032,8 @@
 	pixel_x = 10
 	},
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 8
+	dir = 8;
+	icon_state = "greyblack"
 	},
 /area/station/hallway/primary/east)
 "axO" = (
@@ -11042,9 +11042,9 @@
 "axP" = (
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
@@ -11126,15 +11126,15 @@
 	},
 /obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor/caution/corner/misc{
-	icon_state = "floor_hazard_corners";
-	dir = 8
+	dir = 8;
+	icon_state = "floor_hazard_corners"
 	},
 /area/station/engine/engineering)
 "aya" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -11154,9 +11154,9 @@
 	req_access_txt = "44"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /obj/firedoor_spawn,
@@ -11166,9 +11166,9 @@
 /area/station/engine/engineering)
 "ayc" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor,
@@ -11212,9 +11212,9 @@
 /area/station/engine/engineering)
 "ayk" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
@@ -11225,9 +11225,9 @@
 	req_access_txt = "44"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
 /turf/simulated/floor/caution/westeast,
@@ -11284,8 +11284,8 @@
 	print_id = "Chapel"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/specialroom/chapel{
@@ -11312,16 +11312,16 @@
 	pixel_x = 12
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "ayw" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 4
+	dir = 4;
+	icon_state = "chair"
 	},
 /obj/landmark/start{
 	name = "Staff Assistant"
@@ -11346,33 +11346,33 @@
 /area/station/hallway/primary/west)
 "ayy" = (
 /turf/simulated/floor/neutral/corner{
-	icon_state = "neutralcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/west)
 "ayz" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
+	dir = 1;
+	icon_state = "term"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
 "ayA" = (
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
+	dir = 1;
+	icon_state = "term"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
@@ -11538,9 +11538,9 @@
 /area/station/chapel/main)
 "ayS" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/east,
 /area/station/chapel/main)
@@ -11549,8 +11549,8 @@
 /area/station/chapel/main)
 "ayU" = (
 /obj/stool/chair/comfy{
-	icon_state = "chair_comfy";
-	dir = 8
+	dir = 8;
+	icon_state = "chair_comfy"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 1
@@ -11558,9 +11558,9 @@
 /area/station/chapel/main)
 "ayV" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -11585,8 +11585,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/caution/corner/misc{
-	icon_state = "floor_hazard_corners";
-	dir = 4
+	dir = 4;
+	icon_state = "floor_hazard_corners"
 	},
 /area/station/hangar/main)
 "ayZ" = (
@@ -11603,8 +11603,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/caution/corner/misc{
-	icon_state = "floor_hazard_corners";
-	dir = 8
+	dir = 8;
+	icon_state = "floor_hazard_corners"
 	},
 /area/station/crew_quarters/market)
 "azc" = (
@@ -11658,8 +11658,8 @@
 "azj" = (
 /obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 8
+	dir = 8;
+	icon_state = "greyblack"
 	},
 /area/station/hallway/primary/east)
 "azk" = (
@@ -11714,16 +11714,16 @@
 /area/station/chapel/main)
 "azs" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "azt" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 6
+	dir = 6;
+	icon_state = "lattice-dir"
 	},
 /obj/machinery/r_door_control/podbay/mainpod1/new_walls/east,
 /turf/space,
@@ -11769,8 +11769,8 @@
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/yellow/corner{
-	icon_state = "yellowcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "yellowcorner"
 	},
 /area/station/hallway/primary/west)
 "azy" = (
@@ -11929,8 +11929,8 @@
 /obj/storage/secure/closet/engineering/engineer,
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -11956,8 +11956,8 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -11988,8 +11988,8 @@
 	pixel_y = 21
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -12006,8 +12006,8 @@
 	},
 /obj/item/dice/d1,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/yellowblack{
@@ -12034,9 +12034,9 @@
 /area/station/chapel/main)
 "azX" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/purple/fancy/innercorner/ne,
 /area/station/chapel/main)
@@ -12066,8 +12066,8 @@
 /area/station/hangar/main)
 "aAc" = (
 /obj/decal/tile_edge/stripe/extra_big{
-	icon_state = "xtra_bigstripe-edge";
-	dir = 8
+	dir = 8;
+	icon_state = "xtra_bigstripe-edge"
 	},
 /obj/machinery/vehicle/pod_smooth/light,
 /turf/simulated/floor/engine,
@@ -12086,8 +12086,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/caution/corner/misc{
-	icon_state = "floor_hazard_corners";
-	dir = 4
+	dir = 4;
+	icon_state = "floor_hazard_corners"
 	},
 /area/station/hangar/main)
 "aAf" = (
@@ -12115,8 +12115,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/caution/corner/misc{
-	icon_state = "floor_hazard_corners";
-	dir = 8
+	dir = 8;
+	icon_state = "floor_hazard_corners"
 	},
 /area/station/crew_quarters/market)
 "aAi" = (
@@ -12127,9 +12127,9 @@
 	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
@@ -12345,9 +12345,9 @@
 /area/station/chapel/main)
 "aAD" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -12375,9 +12375,9 @@
 /area/shuttle_sound_spawn)
 "aAG" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/caution/west,
 /area/station/hangar/main)
@@ -12505,8 +12505,8 @@
 	},
 /obj/firedoor_spawn,
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 8
+	dir = 8;
+	icon_state = "greyblack"
 	},
 /area/station/chapel/main)
 "aAX" = (
@@ -12526,9 +12526,9 @@
 /area/station/chapel/main)
 "aBb" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/se,
 /area/station/chapel/main)
@@ -12538,9 +12538,9 @@
 	},
 /obj/disposalpipe/segment/bent/east,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/main)
@@ -12549,9 +12549,9 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /obj/firedoor_spawn,
@@ -12562,18 +12562,18 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "aBf" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment/bent/south,
 /turf/simulated/floor/plating,
@@ -12816,17 +12816,17 @@
 /area/station/maintenance/east)
 "aBF" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "aBG" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 6
+	dir = 6;
+	icon_state = "lattice-dir"
 	},
 /obj/machinery/r_door_control/podbay/mainpod2/new_walls/east,
 /turf/space,
@@ -12904,8 +12904,8 @@
 	pixel_x = 10
 	},
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 8
+	dir = 8;
+	icon_state = "greyblack"
 	},
 /area/station/hallway/primary/east)
 "aBQ" = (
@@ -12933,8 +12933,8 @@
 /area/station/chapel/main)
 "aBT" = (
 /obj/stool/chair/comfy{
-	icon_state = "chair_comfy";
-	dir = 1
+	dir = 1;
+	icon_state = "chair_comfy"
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/south,
 /area/station/chapel/main)
@@ -12948,9 +12948,9 @@
 /area/station/medical/crematorium)
 "aBW" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /obj/machinery/camera{
@@ -12990,8 +12990,8 @@
 /area/station/crew_quarters/market)
 "aBZ" = (
 /turf/simulated/floor/yellow/corner{
-	icon_state = "yellowcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "yellowcorner"
 	},
 /area/station/hallway/primary/west)
 "aCa" = (
@@ -13077,14 +13077,14 @@
 /area/station/medical/crematorium)
 "aCl" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -13184,8 +13184,8 @@
 "aCA" = (
 /obj/machinery/light,
 /turf/simulated/floor/green/corner{
-	icon_state = "greencorner";
-	dir = 8
+	dir = 8;
+	icon_state = "greencorner"
 	},
 /area/station/hallway/primary/west)
 "aCB" = (
@@ -13217,8 +13217,8 @@
 /area/station/hallway/primary/east)
 "aCG" = (
 /turf/simulated/floor/blue/corner{
-	icon_state = "bluecorner";
-	dir = 8
+	dir = 8;
+	icon_state = "bluecorner"
 	},
 /area/station/hallway/primary/east)
 "aCH" = (
@@ -13232,8 +13232,8 @@
 "aCI" = (
 /obj/storage/closet/wardrobe/black/chaplain,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/black,
@@ -13351,8 +13351,8 @@
 "aDd" = (
 /obj/machinery/vending/book,
 /turf/simulated/floor/blue/side{
-	icon_state = "blue";
-	dir = 10
+	dir = 10;
+	icon_state = "blue"
 	},
 /area/station/hallway/primary/east)
 "aDe" = (
@@ -13379,17 +13379,17 @@
 "aDh" = (
 /obj/stool/chair/comfy,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/office)
 "aDi" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/office)
@@ -13401,26 +13401,26 @@
 	req_access = list(27)
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
 /turf/simulated/floor/sanitary,
 /area/station/medical/crematorium)
 "aDk" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/sanitary,
 /area/station/medical/crematorium)
 "aDl" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
 	icon_state = "2-4"
@@ -13538,8 +13538,8 @@
 /area/station/maintenance/maintcentral)
 "aDz" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 1
+	dir = 1;
+	icon_state = "shrub"
 	},
 /turf/simulated/floor/grass,
 /area/station/medical/dome)
@@ -13589,8 +13589,8 @@
 	slogan_list = list("Access to Public Mini-Meds is complementary! Disclaimer: charge per product remains.","We've gone green! Our packaging now uses 60% ramscoop-harvested space debris.","Address all complaints about Public MiniMed services to Icarus Cruise Lines for a swift response.","Now 80% sterilized!","There is a 500 credit fine for vomiting on this machine.","Are you or a loved one currently dying? Consider our onboard cremation solutions!","ERROR: Item \"Spaced Rum\" not found!","Please, be considerate! Use our sanitary washroom facilities when applying treatments.","Questions? Problems? Please hesitate to call Icarus Cruise Lines' service department.")
 	},
 /turf/simulated/floor/blue/side{
-	icon_state = "blue";
-	dir = 8
+	dir = 8;
+	icon_state = "blue"
 	},
 /area/station/hallway/primary/east)
 "aDF" = (
@@ -13741,8 +13741,8 @@
 /area/station/hangar/main)
 "aDV" = (
 /obj/decal/tile_edge/line/yellow{
-	icon_state = "line1";
-	dir = 8
+	dir = 8;
+	icon_state = "line1"
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/hangar/main)
@@ -13806,8 +13806,8 @@
 /area/station/medical/dome)
 "aEe" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 8
+	dir = 8;
+	icon_state = "shrub"
 	},
 /turf/simulated/floor/grass,
 /area/station/medical/dome)
@@ -13826,8 +13826,8 @@
 	slogan_list = list("Satisfy that crunchy munchy urge!","Luxury. Affordable. Discount Dan.","Grab a bite on the high seas of space!","Discount Dan's wishes you a tasty voyage!","Everything tastes better in space!")
 	},
 /turf/simulated/floor/blue/side{
-	icon_state = "blue";
-	dir = 8
+	dir = 8;
+	icon_state = "blue"
 	},
 /area/station/hallway/primary/east)
 "aEh" = (
@@ -13915,23 +13915,23 @@
 /area/station/hangar/main)
 "aEr" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment/bent/east,
 /turf/simulated/floor/orangeblack,
 /area/station/hangar/main)
 "aEs" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/orangeblack,
@@ -13942,22 +13942,22 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/orangeblack,
 /area/station/hangar/main)
 "aEu" = (
 /obj/decal/tile_edge/line/yellow{
-	icon_state = "line1";
-	dir = 1
+	dir = 1;
+	icon_state = "line1"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/orangeblack,
@@ -13968,18 +13968,18 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/orangeblack,
 /area/station/hangar/main)
 "aEw" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/junction/right/west,
 /turf/simulated/floor/orangeblack,
@@ -13989,9 +13989,9 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /obj/firedoor_spawn,
@@ -13999,9 +13999,9 @@
 /area/station/hangar/main)
 "aEy" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/yellow/side{
@@ -14010,9 +14010,9 @@
 /area/station/hallway/primary/west)
 "aEz" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor,
@@ -14031,8 +14031,8 @@
 /area/station/hallway/primary/west)
 "aEB" = (
 /obj/decal/tile_edge/line/green{
-	icon_state = "line1";
-	dir = 6
+	dir = 6;
+	icon_state = "line1"
 	},
 /turf/simulated/floor/grass,
 /area/station/hydroponics)
@@ -14073,24 +14073,24 @@
 /area/station/medical/dome)
 "aEG" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/grass,
 /area/station/medical/dome)
 "aEH" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 10
+	dir = 10;
+	icon_state = "shrub"
 	},
 /turf/simulated/floor/grass,
 /area/station/medical/dome)
 "aEI" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/blue/side{
-	icon_state = "blue";
-	dir = 10
+	dir = 10;
+	icon_state = "blue"
 	},
 /area/station/hallway/primary/east)
 "aEJ" = (
@@ -14227,14 +14227,14 @@
 /area/station/hangar/main)
 "aEX" = (
 /turf/simulated/floor/green/side{
-	icon_state = "green";
-	dir = 9
+	dir = 9;
+	icon_state = "green"
 	},
 /area/station/hydroponics)
 "aEY" = (
 /turf/simulated/floor/green/side{
-	icon_state = "green";
-	dir = 1
+	dir = 1;
+	icon_state = "green"
 	},
 /area/station/hydroponics)
 "aEZ" = (
@@ -14251,14 +14251,14 @@
 	tag = ""
 	},
 /turf/simulated/floor/green/side{
-	icon_state = "green";
-	dir = 1
+	dir = 1;
+	icon_state = "green"
 	},
 /area/station/hydroponics)
 "aFb" = (
 /turf/simulated/floor/green/side{
-	icon_state = "green";
-	dir = 5
+	dir = 5;
+	icon_state = "green"
 	},
 /area/station/hydroponics)
 "aFc" = (
@@ -14284,8 +14284,8 @@
 /area/station/medical/dome)
 "aFf" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 8
+	dir = 8;
+	icon_state = "shrub"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -14299,8 +14299,8 @@
 /area/station/medical/dome)
 "aFg" = (
 /obj/shrub{
-	icon_state = "shrub";
-	dir = 1
+	dir = 1;
+	icon_state = "shrub"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/grass,
@@ -14325,8 +14325,8 @@
 	})
 "aFj" = (
 /turf/simulated/floor/blue/side{
-	icon_state = "blue";
-	dir = 10
+	dir = 10;
+	icon_state = "blue"
 	},
 /area/station/hallway/primary/east)
 "aFk" = (
@@ -14350,23 +14350,23 @@
 /area/station/maintenance/east)
 "aFn" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/junction/middle/south,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "aFo" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/plating,
@@ -14474,9 +14474,9 @@
 /area/station/storage/eva)
 "aFx" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
 	icon_state = "2-4"
@@ -14558,8 +14558,8 @@
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/west,
 /turf/simulated/floor/green/side{
-	icon_state = "green";
-	dir = 1
+	dir = 1;
+	icon_state = "green"
 	},
 /area/station/hydroponics)
 "aFE" = (
@@ -14703,8 +14703,8 @@
 	pixel_x = 10
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
@@ -14736,8 +14736,8 @@
 /area/station/hangar/escape)
 "aFY" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 1
+	dir = 1;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/station/hangar/escape)
@@ -14757,8 +14757,8 @@
 "aGb" = (
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/disposalpipe/segment/bent/south,
 /obj/machinery/camera{
@@ -14928,8 +14928,8 @@
 	})
 "aGw" = (
 /obj/stool/chair/office{
-	icon_state = "office_chair";
-	dir = 8
+	dir = 8;
+	icon_state = "office_chair"
 	},
 /obj/landmark/start{
 	name = "Geneticist"
@@ -14945,9 +14945,9 @@
 /area/station/medical/medbay/lobby)
 "aGy" = (
 /obj/shrub{
+	dir = 1;
 	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "plant";
-	dir = 1
+	icon_state = "plant"
 	},
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/lobby)
@@ -14965,8 +14965,8 @@
 /area/station/medical/medbay/cloner)
 "aGB" = (
 /obj/stool/chair/office{
-	icon_state = "office_chair";
-	dir = 8
+	dir = 8;
+	icon_state = "office_chair"
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 1
@@ -14974,8 +14974,8 @@
 /area/station/medical/medbay/cloner)
 "aGC" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/machinery/power/apc/autoname_east,
@@ -15067,9 +15067,9 @@
 	name = "Disposal Plant"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/plating,
@@ -15080,14 +15080,14 @@
 	pixel_y = 21
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/disposalpipe/junction/right/west,
 /turf/simulated/floor/plating,
@@ -15131,9 +15131,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/storage/eva)
@@ -15148,9 +15148,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
@@ -15190,15 +15190,15 @@
 /area/station/hydroponics)
 "aGY" = (
 /obj/submachine/seed_manipulator{
-	icon_state = "geneman-on";
-	dir = 4
+	dir = 4;
+	icon_state = "geneman-on"
 	},
 /turf/simulated/floor,
 /area/station/hydroponics)
 "aGZ" = (
 /obj/stool/chair/office/green{
-	icon_state = "office_chair_green";
-	dir = 8
+	dir = 8;
+	icon_state = "office_chair_green"
 	},
 /obj/landmark/start{
 	name = "Botanist"
@@ -15357,8 +15357,8 @@
 /obj/machinery/clonepod,
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/camera{
@@ -15381,23 +15381,23 @@
 /area/station/medical/morgue)
 "aHs" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/sanitary,
 /area/station/medical/morgue)
 "aHt" = (
 /obj/morgue{
-	icon_state = "morgue1";
-	dir = 2
+	dir = 2;
+	icon_state = "morgue1"
 	},
 /turf/simulated/floor/sanitary,
 /area/station/medical/morgue)
 "aHu" = (
 /obj/morgue{
-	icon_state = "morgue1";
-	dir = 2
+	dir = 2;
+	icon_state = "morgue1"
 	},
 /obj/machinery/light/small{
 	dir = 4;
@@ -15558,9 +15558,9 @@
 /area/station/hydroponics)
 "aHK" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/hydroponics)
@@ -15644,8 +15644,8 @@
 	tag = ""
 	},
 /obj/item/device/radio/intercom/medical{
-	pixel_x = -20;
 	dir = 4;
+	pixel_x = -20;
 	pixel_y = -6
 	},
 /turf/simulated/floor/bluewhite,
@@ -15690,8 +15690,8 @@
 /area/station/medical/medbay/lobby)
 "aHZ" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 4
+	dir = 4;
+	icon_state = "chair"
 	},
 /turf/simulated/floor/bluewhite/corner,
 /area/station/medical/medbay/cloner)
@@ -15706,9 +15706,9 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/bluewhite/corner,
 /area/station/medical/medbay/cloner)
@@ -15721,26 +15721,26 @@
 	req_access_txt = null
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
 /turf/simulated/floor/sanitary,
 /area/station/medical/morgue)
 "aId" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/sanitary,
 /area/station/medical/morgue)
 "aIe" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -15751,9 +15751,9 @@
 /area/station/medical/morgue)
 "aIf" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -15777,8 +15777,8 @@
 /area/station/hangar/escape)
 "aIi" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 8
+	dir = 8;
+	icon_state = "lattice-dir"
 	},
 /obj/machinery/light/runway_light/delay4,
 /turf/space,
@@ -15850,13 +15850,13 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/green/corner{
-	icon_state = "greencorner";
-	dir = 4
+	dir = 4;
+	icon_state = "greencorner"
 	},
 /area/station/hallway/primary/west)
 "aIr" = (
@@ -15867,18 +15867,18 @@
 	req_access_txt = "35"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hydroponics)
 "aIs" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hydroponics)
@@ -15938,9 +15938,9 @@
 /area/station/medical/medbay/cloner)
 "aIC" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay/cloner)
@@ -15981,8 +15981,8 @@
 /area/station/hangar/escape)
 "aIK" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 1
+	dir = 1;
+	icon_state = "lattice-dir"
 	},
 /obj/machinery/r_door_control/podbay/medbay/new_walls/west,
 /turf/space,
@@ -16097,9 +16097,9 @@
 /area/station/quartermaster/office)
 "aIY" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/item/storage/wall/emergency{
 	dir = 8;
@@ -16130,8 +16130,8 @@
 	tag = ""
 	},
 /obj/item/device/radio/intercom/medical{
-	pixel_x = -20;
 	dir = 4;
+	pixel_x = -20;
 	pixel_y = -6
 	},
 /turf/simulated/floor/black,
@@ -16232,17 +16232,17 @@
 	req_access_txt = "5"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
 /turf/simulated/floor/redwhite,
 /area/station/medical/medbay/surgery)
 "aJp" = (
 /obj/stool/chair/office{
-	icon_state = "office_chair";
-	dir = 1
+	dir = 1;
+	icon_state = "office_chair"
 	},
 /obj/machinery/light/small{
 	dir = 4;
@@ -16252,9 +16252,9 @@
 /area/station/medical/morgue)
 "aJq" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -16265,17 +16265,17 @@
 	req_access_txt = "5"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/grey,
 /area/station/hangar/escape)
 "aJs" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/grey,
 /area/station/hangar/escape)
@@ -16381,13 +16381,13 @@
 /area/station/quartermaster/office)
 "aJD" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/neutral/side{
-	icon_state = "neutral";
-	dir = 4
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/station/hallway/primary/west)
 "aJE" = (
@@ -16424,8 +16424,8 @@
 /area/station/bridge/captain)
 "aJH" = (
 /obj/stool/chair/comfy{
-	icon_state = "chair_comfy";
-	dir = 8
+	dir = 8;
+	icon_state = "chair_comfy"
 	},
 /obj/machinery/phone/wall{
 	pixel_y = 32
@@ -16439,8 +16439,8 @@
 	},
 /obj/storage/secure/closet/command/hos,
 /obj/item/device/radio/intercom/security{
-	pixel_x = -20;
-	dir = 4
+	dir = 4;
+	pixel_x = -20
 	},
 /turf/simulated/floor/wood,
 /area/station/security/hos)
@@ -16473,8 +16473,8 @@
 /area/station/security/hos)
 "aJL" = (
 /obj/stool/chair/office{
-	icon_state = "office_chair";
-	dir = 4
+	dir = 4;
+	icon_state = "office_chair"
 	},
 /obj/cable{
 	d2 = 8;
@@ -16486,9 +16486,9 @@
 /area/station/medical/medbay/treatment1)
 "aJM" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/medical/medbay/treatment1)
@@ -16498,20 +16498,20 @@
 	name = "Treatment Room One"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/blueblack{
-	icon_state = "blueblack";
-	dir = 4
+	dir = 4;
+	icon_state = "blueblack"
 	},
 /area/station/medical/medbay/treatment1)
 "aJO" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
 	icon_state = "2-4"
@@ -16523,8 +16523,8 @@
 	icon_state = "1-8"
 	},
 /obj/stool/chair/office{
-	icon_state = "office_chair";
-	dir = 4
+	dir = 4;
+	icon_state = "office_chair"
 	},
 /obj/landmark/start{
 	name = "Medical Doctor"
@@ -16555,8 +16555,8 @@
 "aJS" = (
 /obj/reagent_dispensers/watertank/fountain,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/specialroom/medbay,
@@ -16578,9 +16578,9 @@
 /area/station/medical/medbay/surgery)
 "aJV" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/redwhite{
 	dir = 1
@@ -16737,8 +16737,8 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/neutral/side{
-	icon_state = "neutral";
-	dir = 4
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/station/hallway/primary/west)
 "aKo" = (
@@ -16748,31 +16748,31 @@
 	name = "Secure Quarters Zone"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
 /turf/simulated/floor/wood,
 /area/station/bridge/captain)
 "aKp" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
 /area/station/bridge/captain)
 "aKq" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/wood,
 /area/station/bridge/captain)
@@ -16783,18 +16783,18 @@
 	req_access_txt = "37"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
 /turf/simulated/floor/wood,
 /area/station/security/hos)
 "aKs" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/nw,
 /area/station/security/hos)
@@ -16803,13 +16803,13 @@
 	name = "Head of Security"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/stool/chair/comfy{
-	icon_state = "chair_comfy";
-	dir = 1
+	dir = 1;
+	icon_state = "chair_comfy"
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/ne,
 /area/station/security/hos)
@@ -16891,8 +16891,8 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/light_switch/west,
@@ -16907,9 +16907,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/bent/east,
 /turf/simulated/floor/white,
@@ -16940,9 +16940,9 @@
 	pixel_x = -12
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -17015,8 +17015,8 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
@@ -17036,8 +17036,8 @@
 /area/station/quartermaster/office)
 "aKT" = (
 /turf/simulated/floor/neutral/side{
-	icon_state = "neutral";
-	dir = 4
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/station/hallway/primary/west)
 "aKU" = (
@@ -17120,8 +17120,8 @@
 /area/station/medical/medbay/lobby)
 "aLd" = (
 /turf/simulated/floor/red/checker{
-	icon_state = "redchecker";
-	dir = 1
+	dir = 1;
+	icon_state = "redchecker"
 	},
 /area/station/medical/medbay/lobby)
 "aLe" = (
@@ -17153,9 +17153,9 @@
 	req_access_txt = "5"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /obj/firedoor_spawn,
@@ -17165,9 +17165,9 @@
 /area/station/medical/medbay/surgery)
 "aLj" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/redwhite{
@@ -17294,8 +17294,8 @@
 	pixel_y = 20
 	},
 /obj/item/device/radio/intercom/medical{
-	pixel_y = 24;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = 24
 	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
@@ -17388,8 +17388,8 @@
 	pixel_x = 10
 	},
 /turf/simulated/floor/neutral/side{
-	icon_state = "neutral";
-	dir = 4
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/station/hallway/primary/west)
 "aLC" = (
@@ -17455,8 +17455,8 @@
 	tag = ""
 	},
 /obj/item/device/radio/intercom/medical{
-	pixel_x = -20;
 	dir = 4;
+	pixel_x = -20;
 	pixel_y = -6
 	},
 /turf/simulated/floor/black,
@@ -17558,9 +17558,9 @@
 /area/station/medical/morgue)
 "aLT" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	icon_state = "2-4"
@@ -17576,9 +17576,9 @@
 	req_access_txt = "29"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /obj/firedoor_spawn,
@@ -17586,13 +17586,13 @@
 /area/station/medical/robotics)
 "aLV" = (
 /obj/decal/tile_edge/line/blue{
-	icon_state = "line1";
-	dir = 6
+	dir = 6;
+	icon_state = "line1"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/black,
@@ -17602,9 +17602,9 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/black,
@@ -17615,9 +17615,9 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -17626,8 +17626,8 @@
 	},
 /obj/disposalpipe/segment/horizontal,
 /obj/stool/chair/office{
-	icon_state = "office_chair";
-	dir = 1
+	dir = 1;
+	icon_state = "office_chair"
 	},
 /obj/landmark/start{
 	name = "Roboticist"
@@ -17636,22 +17636,22 @@
 /area/station/medical/robotics)
 "aLY" = (
 /obj/decal/tile_edge/stripe/big{
-	icon_state = "bigstripe-edge";
-	dir = 4
+	dir = 4;
+	icon_state = "bigstripe-edge"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/bent/west,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "aLZ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/robotics)
@@ -17678,9 +17678,9 @@
 /area/station/hangar/qm)
 "aMc" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/stool/chair/yellow{
 	dir = 8
@@ -17692,9 +17692,9 @@
 /area/station/hangar/qm)
 "aMd" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/caution/south,
 /area/station/hangar/qm)
@@ -17703,13 +17703,13 @@
 	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/caution/corner/misc{
-	icon_state = "floor_hazard_corners";
-	dir = 10
+	dir = 10;
+	icon_state = "floor_hazard_corners"
 	},
 /area/station/hangar/qm)
 "aMf" = (
@@ -17719,9 +17719,9 @@
 	req_access_txt = "31"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
 /turf/simulated/floor,
@@ -17748,9 +17748,9 @@
 	req_access_txt = "31"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /obj/firedoor_spawn,
@@ -17758,9 +17758,9 @@
 /area/station/quartermaster/office)
 "aMi" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor,
@@ -17771,14 +17771,14 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/yellow/corner{
@@ -17790,9 +17790,9 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/yellow/corner{
@@ -17806,9 +17806,9 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/bent/south,
 /turf/simulated/floor/yellow/corner{
@@ -17846,8 +17846,8 @@
 	pixel_x = 10
 	},
 /turf/simulated/floor/neutral/side{
-	icon_state = "neutral";
-	dir = 4
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/station/hallway/primary/west)
 "aMp" = (
@@ -17884,8 +17884,8 @@
 	name = "special bedsheet"
 	},
 /obj/item/device/radio/intercom/bridge{
-	pixel_x = 20;
-	dir = 8
+	dir = 8;
+	pixel_x = 20
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/east,
 /area/station/bridge/captain)
@@ -17917,8 +17917,8 @@
 /area/station/maintenance/maintcentral)
 "aMu" = (
 /obj/stool/chair/office{
-	icon_state = "office_chair";
-	dir = 4
+	dir = 4;
+	icon_state = "office_chair"
 	},
 /obj/cable{
 	d2 = 8;
@@ -17930,9 +17930,9 @@
 /area/station/medical/medbay/treatment2)
 "aMv" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/medical/medbay/treatment2)
@@ -17942,13 +17942,13 @@
 	name = "Treatment Room One"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/blueblack{
-	icon_state = "blueblack";
-	dir = 4
+	dir = 4;
+	icon_state = "blueblack"
 	},
 /area/station/medical/medbay/treatment2)
 "aMx" = (
@@ -17956,9 +17956,9 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay)
@@ -18011,8 +18011,8 @@
 /area/station/medical/medbay/surgery)
 "aME" = (
 /turf/simulated/floor/redwhite/corner{
-	icon_state = "redwhitecorner";
-	dir = 8
+	dir = 8;
+	icon_state = "redwhitecorner"
 	},
 /area/station/medical/medbay/surgery)
 "aMF" = (
@@ -18030,8 +18030,8 @@
 /obj/storage/secure/closet/fridge/blood,
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/redwhite{
 	dir = 1
@@ -18063,15 +18063,15 @@
 /area/station/medical/robotics)
 "aML" = (
 /obj/decal/tile_edge/line/blue{
-	icon_state = "line1";
-	dir = 8
+	dir = 8;
+	icon_state = "line1"
 	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "aMM" = (
 /obj/decal/tile_edge/stripe/big{
-	icon_state = "bigstripe-edge";
-	dir = 4
+	dir = 4;
+	icon_state = "bigstripe-edge"
 	},
 /obj/landmark/start{
 	name = "Roboticist"
@@ -18100,8 +18100,8 @@
 /area/station/medical/robotics)
 "aMP" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 2
+	dir = 2;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area/station/com_dish/auxdish)
@@ -18120,9 +18120,9 @@
 	pixel_x = 10
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/caution/west,
 /area/station/hangar/qm)
@@ -18150,9 +18150,9 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
@@ -18162,8 +18162,8 @@
 /area/station/quartermaster/office)
 "aMX" = (
 /obj/decal/tile_edge/line/yellow{
-	icon_state = "line1";
-	dir = 8
+	dir = 8;
+	icon_state = "line1"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
@@ -18208,8 +18208,8 @@
 	name = "Captain"
 	},
 /obj/stool/chair/office/blue{
-	icon_state = "office_chair_blue";
-	dir = 8
+	dir = 8;
+	icon_state = "office_chair_blue"
 	},
 /obj/cable{
 	d1 = 1;
@@ -18238,9 +18238,9 @@
 /area/station/bridge/captain)
 "aNe" = (
 /obj/machinery/bathtub{
-	icon_state = "bathtub";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "bathtub"
 	},
 /obj/machinery/light/small{
 	dir = 1;
@@ -18338,8 +18338,8 @@
 /obj/item/bandage,
 /obj/item/staple_gun,
 /obj/item/device/radio/intercom/medical{
-	pixel_x = -20;
-	dir = 4
+	dir = 4;
+	pixel_x = -20
 	},
 /turf/simulated/floor/redwhite{
 	dir = 8
@@ -18366,9 +18366,9 @@
 /area/station/medical/medbay/surgery)
 "aNu" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/redwhite{
@@ -18382,9 +18382,9 @@
 	req_access_txt = "5"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /obj/firedoor_spawn,
@@ -18394,14 +18394,14 @@
 /area/station/medical/medbay/surgery)
 "aNw" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/junction/left/south,
 /turf/simulated/floor/plating,
@@ -18412,15 +18412,15 @@
 /area/station/medical/robotics)
 "aNy" = (
 /obj/decal/tile_edge/line/blue{
-	icon_state = "line1";
-	dir = 5
+	dir = 5;
+	icon_state = "line1"
 	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "aNz" = (
 /obj/decal/tile_edge/line/blue{
-	icon_state = "line1";
-	dir = 1
+	dir = 1;
+	icon_state = "line1"
 	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
@@ -18430,8 +18430,8 @@
 /obj/item/storage/toolbox/emergency,
 /obj/item/reagent_containers/glass/oilcan,
 /obj/decal/tile_edge/line/blue{
-	icon_state = "line1";
-	dir = 9
+	dir = 9;
+	icon_state = "line1"
 	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
@@ -18533,16 +18533,16 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "aNN" = (
 /obj/decal/tile_edge/line/yellow{
-	icon_state = "line1";
-	dir = 1
+	dir = 1;
+	icon_state = "line1"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
@@ -18738,9 +18738,9 @@
 	pixel_x = -12
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /obj/machinery/camera{
@@ -18837,8 +18837,8 @@
 	pixel_x = 10
 	},
 /turf/simulated/floor/neutral/corner{
-	icon_state = "neutralcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/west)
 "aOy" = (
@@ -18855,8 +18855,8 @@
 	tag = ""
 	},
 /obj/item/device/radio/intercom/medical{
-	pixel_x = -20;
 	dir = 4;
+	pixel_x = -20;
 	pixel_y = -6
 	},
 /turf/simulated/floor/caution/south,
@@ -18981,9 +18981,9 @@
 "aOO" = (
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -19016,8 +19016,8 @@
 	pixel_y = 26
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor,
@@ -19061,8 +19061,8 @@
 /area/station/com_dish/auxdish)
 "aOV" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 8
+	dir = 8;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/station/com_dish/auxdish)
@@ -19183,9 +19183,9 @@
 	pixel_y = 16
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/darkblue,
 /area/station/medical/medbay/pharmacy)
@@ -19196,37 +19196,37 @@
 	req_access_txt = "5"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
 /turf/simulated/floor/bluewhite{
-	icon_state = "bluewhite";
-	dir = 8
+	dir = 8;
+	icon_state = "bluewhite"
 	},
 /area/station/medical/medbay/pharmacy)
 "aPm" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "aPn" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/bluewhite/corner,
 /area/station/medical/medbay)
 "aPo" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/bluewhite/corner,
 /area/station/medical/medbay)
@@ -19295,9 +19295,9 @@
 /area/station/medical/head)
 "aPw" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -19410,8 +19410,8 @@
 /area/station/com_dish/auxdish)
 "aPH" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 9
+	dir = 9;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area)
@@ -19577,18 +19577,18 @@
 /area/station/medical/medbay/pharmacy)
 "aPZ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/darkblue,
 /area/station/medical/medbay/pharmacy)
 "aQa" = (
 /obj/machinery/drainage,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/darkblue,
 /area/station/medical/medbay/pharmacy)
@@ -19686,8 +19686,8 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/north,
 /area/station/medical/head)
@@ -19714,8 +19714,8 @@
 /area/station/maintenance/SEmaint)
 "aQp" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	icon_state = "chair"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/maintenance/SEmaint)
@@ -19736,8 +19736,8 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/green/side{
-	icon_state = "green";
-	dir = 9
+	dir = 9;
+	icon_state = "green"
 	},
 /area/station/turret_protected/Zeta)
 "aQt" = (
@@ -19747,8 +19747,8 @@
 /obj/item/circuitboard/robotics,
 /obj/item/disk/data/floppy/read_only/communications,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/green,
@@ -19775,15 +19775,15 @@
 /area/station/turret_protected/Zeta)
 "aQy" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 10
+	dir = 10;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/station/com_dish/auxdish)
 "aQz" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 9
+	dir = 9;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area)
@@ -19799,8 +19799,8 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/purple/corner{
-	icon_state = "purplecorner";
-	dir = 4
+	dir = 4;
+	icon_state = "purplecorner"
 	},
 /area/station/hallway/primary/west)
 "aQD" = (
@@ -19862,8 +19862,8 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/blueblack{
-	icon_state = "blueblack";
-	dir = 1
+	dir = 1;
+	icon_state = "blueblack"
 	},
 /area/station/medical/medbay/pharmacy)
 "aQL" = (
@@ -19871,8 +19871,8 @@
 /obj/item/storage/box/beakerbox,
 /obj/item/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/blueblack{
-	icon_state = "blueblack";
-	dir = 1
+	dir = 1;
+	icon_state = "blueblack"
 	},
 /area/station/medical/medbay/pharmacy)
 "aQM" = (
@@ -19888,8 +19888,8 @@
 	tag = ""
 	},
 /turf/simulated/floor/blueblack{
-	icon_state = "blueblack";
-	dir = 1
+	dir = 1;
+	icon_state = "blueblack"
 	},
 /area/station/medical/medbay/pharmacy)
 "aQN" = (
@@ -19897,8 +19897,8 @@
 /obj/machinery/light,
 /obj/disposalpipe/trunk/south,
 /turf/simulated/floor/blueblack{
-	icon_state = "blueblack";
-	dir = 1
+	dir = 1;
+	icon_state = "blueblack"
 	},
 /area/station/medical/medbay/pharmacy)
 "aQO" = (
@@ -19912,21 +19912,21 @@
 	tag = ""
 	},
 /turf/simulated/floor/blueblack{
-	icon_state = "blueblack";
-	dir = 1
+	dir = 1;
+	icon_state = "blueblack"
 	},
 /area/station/medical/medbay/pharmacy)
 "aQP" = (
 /obj/storage/secure/closet/medical/medkit,
 /turf/simulated/floor/blueblack{
-	icon_state = "blueblack";
-	dir = 1
+	dir = 1;
+	icon_state = "blueblack"
 	},
 /area/station/medical/medbay/pharmacy)
 "aQQ" = (
 /obj/stool/chair/office{
-	icon_state = "office_chair";
-	dir = 1
+	dir = 1;
+	icon_state = "office_chair"
 	},
 /obj/landmark/start{
 	name = "Medical Doctor"
@@ -19935,9 +19935,9 @@
 /area/station/medical/medbay)
 "aQR" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -19958,8 +19958,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/blackwhite{
-	icon_state = "darkwhite";
-	dir = 4
+	dir = 4;
+	icon_state = "darkwhite"
 	},
 /area/station/medical/head)
 "aQU" = (
@@ -19976,8 +19976,8 @@
 /area/station/medical/head)
 "aQW" = (
 /obj/stool/chair/office/red{
-	icon_state = "office_chair_red";
-	dir = 4
+	dir = 4;
+	icon_state = "office_chair_red"
 	},
 /obj/landmark/start{
 	name = "Medical Director"
@@ -20022,9 +20022,9 @@
 	pixel_x = -12
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	icon_state = "2-4"
@@ -20067,8 +20067,8 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/green/side{
-	icon_state = "green";
-	dir = 1
+	dir = 1;
+	icon_state = "green"
 	},
 /area/station/turret_protected/Zeta)
 "aRe" = (
@@ -20093,8 +20093,8 @@
 /area/station/turret_protected/Zeta)
 "aRh" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 1
+	dir = 1;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area/station/com_dish/auxdish)
@@ -20113,8 +20113,8 @@
 	},
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/fitness/speedbag/captain,
 /turf/simulated/floor/plating,
@@ -20124,9 +20124,9 @@
 /area/station/crew_quarters/clown)
 "aRm" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment/bent/east,
 /turf/simulated/floor/plating,
@@ -20137,9 +20137,9 @@
 	pixel_y = 21
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /obj/machinery/camera{
@@ -20168,9 +20168,9 @@
 /area/station/maintenance/SWmaint)
 "aRp" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/plating,
@@ -20213,8 +20213,8 @@
 /obj/item/device/reagentscanner,
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 1
@@ -20269,8 +20269,8 @@
 /area/station/chemistry)
 "aRy" = (
 /turf/simulated/floor/purple/side{
-	icon_state = "purple";
-	dir = 8
+	dir = 8;
+	icon_state = "purple"
 	},
 /area/station/hallway/primary/west)
 "aRz" = (
@@ -20305,17 +20305,17 @@
 	pixel_x = -10
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/purple,
 /area/station/science/teleporter)
 "aRC" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/floorguide/science{
 	dir = 4
@@ -20332,18 +20332,18 @@
 	req_access_txt = "8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
 /turf/simulated/floor/purple,
 /area/station/science/teleporter)
 "aRE" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -20373,8 +20373,8 @@
 /obj/item/body_bag,
 /obj/storage/cart/medcart,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/bluewhite,
@@ -20392,17 +20392,17 @@
 /obj/item/storage/box/health_upgrade_kit,
 /obj/machinery/light,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
 "aRI" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -20421,9 +20421,9 @@
 /area/station/medical/medbay)
 "aRJ" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
 	icon_state = "2-4"
@@ -20432,9 +20432,9 @@
 /area/station/medical/medbay)
 "aRK" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
@@ -20471,9 +20471,9 @@
 /area/station/medical/head)
 "aRO" = (
 /obj/shrub{
+	dir = 1;
 	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "plant";
-	dir = 1
+	icon_state = "plant"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/carpet/purple/fancy/edge/south,
@@ -20547,9 +20547,9 @@
 /area/station/turret_protected/Zeta)
 "aRV" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -20558,9 +20558,9 @@
 /area/station/turret_protected/Zeta)
 "aRW" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/turret_protected/Zeta)
@@ -20608,9 +20608,9 @@
 /area/station/crew_quarters/clown)
 "aSc" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/classic{
 	desc = "Someone covered over the door's old label with... you can't even tell what that is. What the hell?";
@@ -20622,14 +20622,14 @@
 /area/station/crew_quarters/clown)
 "aSd" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -20669,16 +20669,16 @@
 /area/station/chemistry)
 "aSi" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/white,
 /area/station/chemistry)
 "aSj" = (
 /obj/stool/chair/office{
-	icon_state = "office_chair";
-	dir = 4
+	dir = 4;
+	icon_state = "office_chair"
 	},
 /obj/landmark/start{
 	name = "Scientist"
@@ -20726,8 +20726,8 @@
 /obj/machinery/power/apc/autoname_west,
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/purple,
 /area/station/science/teleporter)
@@ -20759,27 +20759,27 @@
 /area/station/maintenance/maintcentral)
 "aSr" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
 "aSs" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/junction/left/west,
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
 "aSt" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment/bent/south,
 /turf/simulated/floor/plating,
@@ -20803,8 +20803,8 @@
 	},
 /obj/firedoor_spawn,
 /turf/simulated/floor/blueblack{
-	icon_state = "blueblack";
-	dir = 1
+	dir = 1;
+	icon_state = "blueblack"
 	},
 /area/station/medical/medbay)
 "aSw" = (
@@ -20918,9 +20918,9 @@
 /area/station/crew_quarters/clown)
 "aSH" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -20945,8 +20945,8 @@
 "aSJ" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
@@ -20969,9 +20969,9 @@
 	pixel_y = 21
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/purplewhite/corner{
 	dir = 4
@@ -21005,9 +21005,9 @@
 /area/station/chemistry)
 "aSP" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purplewhite/corner{
 	dir = 8
@@ -21032,8 +21032,8 @@
 "aSS" = (
 /obj/machinery/light/emergency,
 /turf/simulated/floor/purple/side{
-	icon_state = "purple";
-	dir = 10
+	dir = 10;
+	icon_state = "purple"
 	},
 /area/station/hallway/primary/west)
 "aST" = (
@@ -21050,8 +21050,8 @@
 	pixel_x = 10
 	},
 /turf/simulated/floor/purple/side{
-	icon_state = "purple";
-	dir = 6
+	dir = 6;
+	icon_state = "purple"
 	},
 /area/station/hallway/primary/west)
 "aSV" = (
@@ -21084,14 +21084,14 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/firedoor_spawn,
 /turf/simulated/floor/purpleblack,
@@ -21147,40 +21147,40 @@
 "aTd" = (
 /obj/machinery/light/small,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
 "aTe" = (
 /obj/machinery/door/airlock/pyro/classic{
-	icon_state = "old_closed";
-	dir = 4
+	dir = 4;
+	icon_state = "old_closed"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
 "aTf" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "aTg" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "1-8"
@@ -21190,14 +21190,14 @@
 /area/station/maintenance/SEmaint)
 "aTh" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/plating,
@@ -21208,9 +21208,9 @@
 	pixel_y = 21
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /obj/machinery/camera{
@@ -21228,9 +21228,9 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/plating,
@@ -21241,9 +21241,9 @@
 	pixel_y = 21
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /obj/machinery/camera{
@@ -21256,23 +21256,23 @@
 /area/station/maintenance/SEmaint)
 "aTl" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/grime,
 /area/station/maintenance/SEmaint)
 "aTm" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /obj/machinery/light/emergency{
@@ -21283,13 +21283,13 @@
 /area/station/maintenance/SEmaint)
 "aTn" = (
 /obj/decal/tile_edge/stripe/extra_big{
-	icon_state = "xtra_bigstripe-edge";
-	dir = 8
+	dir = 8;
+	icon_state = "xtra_bigstripe-edge"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/plating,
@@ -21325,9 +21325,9 @@
 /area/station/hangar/science)
 "aTs" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /obj/machinery/door/airlock/pyro/classic,
@@ -21346,14 +21346,14 @@
 /area/station/science/artifact)
 "aTu" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/purplewhite/corner{
 	dir = 4
@@ -21361,9 +21361,9 @@
 /area/station/science/artifact)
 "aTv" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/purplewhite/corner{
 	dir = 8
@@ -21559,9 +21559,9 @@
 "aTN" = (
 /obj/machinery/door/airlock/pyro/external,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
@@ -21579,8 +21579,8 @@
 "aTR" = (
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable,
 /turf/simulated/floor/grime,
@@ -21606,8 +21606,8 @@
 	setup_os_string = "ZETA_MAINFRAME"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/firealarm{
@@ -21637,8 +21637,8 @@
 	frequency = 1229
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/camera{
@@ -21658,8 +21658,8 @@
 	bank_id = "Mixer"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/item/device/radio/intercom/science{
@@ -21740,23 +21740,23 @@
 /area/station/science/artifact)
 "aUe" = (
 /obj/stool/chair/office{
-	icon_state = "office_chair";
-	dir = 8
+	dir = 8;
+	icon_state = "office_chair"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/landmark/start{
 	name = "Scientist"
@@ -21767,9 +21767,9 @@
 /area/station/science/artifact)
 "aUf" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/purplewhite/corner{
 	dir = 4
@@ -21805,9 +21805,9 @@
 /area/station/chemistry)
 "aUk" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/bent/east,
 /turf/simulated/floor/purplewhite,
@@ -21887,13 +21887,13 @@
 /area/station/science/teleporter)
 "aUs" = (
 /obj/stool/chair/office{
-	icon_state = "office_chair";
-	dir = 1
+	dir = 1;
+	icon_state = "office_chair"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/landmark/start{
 	name = "Scientist"
@@ -21907,9 +21907,9 @@
 /area/station/science/teleporter)
 "aUt" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/purplewhite/corner{
 	dir = 4
@@ -21917,9 +21917,9 @@
 /area/station/science/teleporter)
 "aUu" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "1-8"
@@ -21928,14 +21928,14 @@
 /area/station/science/teleporter)
 "aUv" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 4
@@ -21948,9 +21948,9 @@
 	req_access_txt = "11"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
 /turf/simulated/floor/purpleblack{
@@ -21959,9 +21959,9 @@
 /area/station/crew_quarters/hor)
 "aUx" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/hor)
@@ -21970,9 +21970,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -22060,9 +22060,9 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/caution/west,
 /area/station/maintenance/SEmaint)
@@ -22122,9 +22122,9 @@
 	pixel_x = 12
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/decal/tile_edge/floorguide/science{
 	dir = 4
@@ -22220,9 +22220,9 @@
 	pixel_x = -12
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -22246,19 +22246,19 @@
 /area/station/science/artifact)
 "aUY" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/purplewhite/corner{
 	dir = 4
@@ -22292,9 +22292,9 @@
 	req_access_txt = null
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /obj/firedoor_spawn,
@@ -22306,26 +22306,26 @@
 	pixel_x = -12
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/white,
 /area/station/science)
 "aVd" = (
 /obj/machinery/drainage,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
 /area/station/science)
 "aVe" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
 /area/station/science)
@@ -22336,18 +22336,18 @@
 	req_access_txt = "8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
 /turf/simulated/floor/white,
 /area/station/science/teleporter)
 "aVg" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 8
@@ -22373,9 +22373,9 @@
 /area/station/science/teleporter)
 "aVk" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/stool/chair/office,
 /obj/landmark/start{
@@ -22434,8 +22434,8 @@
 /area/station/mining/refinery)
 "aVr" = (
 /turf/simulated/floor/airless/caution/corner/misc{
-	icon_state = "floor_hazard_corners";
-	dir = 6
+	dir = 6;
+	icon_state = "floor_hazard_corners"
 	},
 /area/station/mining/refinery)
 "aVs" = (
@@ -22461,9 +22461,9 @@
 /area/station/maintenance/SEmaint)
 "aVv" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -22533,9 +22533,9 @@
 /area/station/science/lab)
 "aVC" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/white,
 /area/station/science/lab)
@@ -22578,14 +22578,14 @@
 /area/station/science/artifact)
 "aVG" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/purplewhite/corner{
 	dir = 8
@@ -22622,9 +22622,9 @@
 /area/station/science)
 "aVL" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/machinery/light/emergency{
 	dir = 1;
@@ -22636,9 +22636,9 @@
 /area/station/science)
 "aVM" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "1-4"
@@ -22650,9 +22650,9 @@
 /area/station/science)
 "aVN" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 1
@@ -22660,14 +22660,14 @@
 /area/station/science)
 "aVO" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 5
@@ -22680,9 +22680,9 @@
 	req_access_txt = "24"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
 /turf/simulated/floor/purplewhite{
@@ -22811,8 +22811,8 @@
 /area/station/mining/refinery)
 "aWd" = (
 /turf/simulated/floor/airless/caution/corner/misc{
-	icon_state = "floor_hazard_corners";
-	dir = 9
+	dir = 9;
+	icon_state = "floor_hazard_corners"
 	},
 /area/station/mining/refinery)
 "aWe" = (
@@ -22845,9 +22845,9 @@
 /area/station/maintenance/SEmaint)
 "aWj" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/decal/tile_edge/floorguide/mining,
 /turf/simulated/floor/grime,
@@ -22905,9 +22905,9 @@
 	level = 2
 	},
 /obj/cable{
-	icon_state = "2-9";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-9"
 	},
 /turf/simulated/floor/white,
 /area/station/science/lab)
@@ -22921,8 +22921,8 @@
 /area/station/science/lab)
 "aWr" = (
 /obj/decal/tile_edge/line/blue{
-	icon_state = "line1";
-	dir = 6
+	dir = 6;
+	icon_state = "line1"
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -22954,17 +22954,17 @@
 "aWt" = (
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/engine,
 /area/station/hangar/science)
 "aWu" = (
 /obj/decal/tile_edge/stripe/extra_big,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -22979,9 +22979,9 @@
 /area/station/science/artifact)
 "aWw" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 4
@@ -22993,9 +22993,9 @@
 /area/station/science/artifact)
 "aWy" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment/bent/east,
 /turf/simulated/floor/purple,
@@ -23008,9 +23008,9 @@
 	req_access_txt = "24"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /obj/firedoor_spawn,
@@ -23018,9 +23018,9 @@
 /area/station/science/artifact)
 "aWA" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
@@ -23032,9 +23032,9 @@
 /area/station/science)
 "aWB" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/purplewhite/corner{
@@ -23111,9 +23111,9 @@
 	req_access_txt = null
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
 /turf/simulated/floor/grime,
@@ -23151,9 +23151,9 @@
 	name = "Burn Chamber Heat Shield"
 	},
 /obj/cable{
-	icon_state = "1-6";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "1-6"
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
@@ -23200,8 +23200,8 @@
 /area/station/hangar/science)
 "aWX" = (
 /obj/decal/tile_edge/stripe/extra_big{
-	icon_state = "xtra_bigstripe-edge";
-	dir = 9
+	dir = 9;
+	icon_state = "xtra_bigstripe-edge"
 	},
 /turf/simulated/floor/white/grime,
 /area/station/hangar/science)
@@ -23227,9 +23227,9 @@
 	req_access_txt = "0"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/access_spawn/research,
 /turf/simulated/floor/white/grime,
@@ -23244,9 +23244,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor/white/grime,
@@ -23259,9 +23259,9 @@
 	req_access_txt = "24"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /obj/firedoor_spawn,
@@ -23269,9 +23269,9 @@
 /area/station/science/artifact)
 "aXd" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/junction/left/west,
 /turf/simulated/floor/purplewhite{
@@ -23281,9 +23281,9 @@
 "aXe" = (
 /obj/machinery/light,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "1-4"
@@ -23296,9 +23296,9 @@
 "aXf" = (
 /obj/landmark/artifact,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/purple,
@@ -23367,9 +23367,9 @@
 /area/station/maintenance/south)
 "aXo" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
@@ -23379,17 +23379,17 @@
 	pixel_y = 21
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
 "aXq" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
@@ -23448,9 +23448,9 @@
 /area/station/mining)
 "aXx" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -23514,12 +23514,12 @@
 /area/station/science/lab)
 "aXE" = (
 /obj/decal/tile_edge/line/red{
-	icon_state = "line1";
-	dir = 6
+	dir = 6;
+	icon_state = "line1"
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/white,
 /area/station/science/lab)
@@ -23538,8 +23538,8 @@
 /area/station/science/lab)
 "aXG" = (
 /obj/machinery/atmospherics/pipe/simple/junction{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
@@ -23550,20 +23550,20 @@
 	on = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/cable{
-	icon_state = "2-9";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-9"
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "aXI" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	icon_state = "intact";
-	dir = 10
+	dir = 10;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
@@ -23614,9 +23614,9 @@
 	dir = 1
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
@@ -23700,9 +23700,9 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/mining)
@@ -23741,16 +23741,16 @@
 /area/station/science/lab)
 "aYg" = (
 /obj/machinery/atmospherics/pipe/manifold{
-	icon_state = "manifold";
 	dir = 8;
+	icon_state = "manifold";
 	level = 2
 	},
 /turf/simulated/floor/white,
 /area/station/science/lab)
 "aYh" = (
 /obj/machinery/atmospherics/pipe/manifold{
-	icon_state = "manifold";
 	dir = 4;
+	icon_state = "manifold";
 	level = 2
 	},
 /obj/machinery/meter,
@@ -23758,8 +23758,8 @@
 /area/station/science/lab)
 "aYi" = (
 /obj/decal/tile_edge/line/red{
-	icon_state = "line1";
-	dir = 4
+	dir = 4;
+	icon_state = "line1"
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 6
@@ -23792,8 +23792,8 @@
 /area/station/science/lab)
 "aYm" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	icon_state = "intact";
-	dir = 1
+	dir = 1;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
@@ -23828,9 +23828,9 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -23844,30 +23844,30 @@
 /area/station/maintenance/south)
 "aYr" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
 "aYs" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
 "aYt" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -23879,9 +23879,9 @@
 /area/station/maintenance/south)
 "aYu" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -23895,9 +23895,9 @@
 /area/station/maintenance/south)
 "aYv" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -23926,17 +23926,17 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
 "aYy" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/airless/engine,
 /area/station/mining/refinery)
@@ -23979,13 +23979,13 @@
 /area/station/mining)
 "aYG" = (
 /obj/decal/tile_edge/line/yellow{
-	icon_state = "line1";
-	dir = 8
+	dir = 8;
+	icon_state = "line1"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/mining)
@@ -24025,8 +24025,8 @@
 /area/station/science/lab)
 "aYL" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/white,
 /area/station/science/lab)
@@ -24037,8 +24037,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/white,
 /area/station/science/lab)
@@ -24052,8 +24052,8 @@
 /area/station/science/lab)
 "aYO" = (
 /obj/machinery/atmospherics/pipe/simple/junction{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/machinery/sparker{
 	dir = 8;
@@ -24066,15 +24066,15 @@
 /area/station/science/lab)
 "aYP" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "aYQ" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	icon_state = "intact";
-	dir = 9
+	dir = 9;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
@@ -24097,9 +24097,9 @@
 /area/station/maintenance/south)
 "aYU" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
@@ -24194,8 +24194,8 @@
 /area/station/mining)
 "aZh" = (
 /obj/decal/tile_edge/line/yellow{
-	icon_state = "line1";
-	dir = 1
+	dir = 1;
+	icon_state = "line1"
 	},
 /obj/item/device/radio/beacon,
 /turf/simulated/floor,
@@ -24211,9 +24211,9 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/mining)
@@ -24348,8 +24348,8 @@
 	},
 /obj/machinery/door/window/westleft,
 /obj/window/cubicle{
-	icon_state = "cubicle";
-	dir = 2
+	dir = 2;
+	icon_state = "cubicle"
 	},
 /obj/machinery/light/small{
 	dir = 1;
@@ -24403,9 +24403,9 @@
 /area/station/storage/tech)
 "aZC" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -24542,9 +24542,9 @@
 /area/station/mining)
 "aZL" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow/side,
 /area/station/mining)
@@ -24559,9 +24559,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellow/side,
 /area/station/mining)
@@ -24705,8 +24705,8 @@
 	},
 /obj/machinery/door/window/westleft,
 /obj/window/cubicle{
-	icon_state = "cubicle";
-	dir = 2
+	dir = 2;
+	icon_state = "cubicle"
 	},
 /turf/simulated/floor/white/grime,
 /area/station/crew_quarters/toilets)
@@ -24758,9 +24758,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/grey/blackgrime/other,
 /area/station/storage/tech)
@@ -24913,15 +24913,15 @@
 "baz" = (
 /obj/machinery/atmospherics/pipe/vent/north,
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 10
+	dir = 10;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area)
 "baA" = (
 /obj/lattice{
-	icon_state = "lattice-dir-b";
-	dir = 5
+	dir = 5;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area)
@@ -24960,8 +24960,8 @@
 /area/station/maintenance/south)
 "baG" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 8
+	dir = 8;
+	icon_state = "chair"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/maintenance/south)
@@ -24998,9 +24998,9 @@
 /area/station/storage/tech)
 "baK" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/grey/blackgrime/other,
 /area/station/storage/tech)
@@ -25015,9 +25015,9 @@
 /area/station/storage/tech)
 "baM" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/airless/engine,
 /area/station/mining/refinery)
@@ -25030,9 +25030,9 @@
 	req_access_txt = null
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
 /obj/forcefield/energyshield/perma/doorlink{
@@ -25045,17 +25045,17 @@
 "baO" = (
 /obj/machinery/light,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/mining)
 "baP" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/mining)
@@ -25068,9 +25068,9 @@
 	req_access_txt = null
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
 /turf/simulated/floor/yellow/side{
@@ -25277,15 +25277,15 @@
 /area/station/mining/refinery)
 "bbl" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 6
+	dir = 6;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/station/mining/refinery)
 "bbm" = (
 /obj/lattice{
-	icon_state = "lattice-dir";
-	dir = 1
+	dir = 1;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/station/mining/refinery)
@@ -25444,17 +25444,17 @@
 /area)
 "bbA" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/airless,
 /area/listeningpost)
 "bbB" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/shuttle/wall{
 	icon_state = "wall3"
@@ -25469,16 +25469,16 @@
 /obj/machinery/power/data_terminal,
 /obj/computer3frame,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/circuit,
 /area/listeningpost)
 "bbE" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/shuttle/wall{
 	icon_state = "wall3"
@@ -25486,16 +25486,16 @@
 /area/listeningpost)
 "bbF" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	icon_state = "1-8"
 	},
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/caution/east{
 	dir = 8
@@ -25514,8 +25514,8 @@
 "bbH" = (
 /obj/machinery/power/monitor,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/listeningpost)
@@ -25541,9 +25541,9 @@
 /area/listeningpost)
 "bbL" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/caution/east{
 	dir = 8
@@ -25554,9 +25554,9 @@
 /area/listeningpost)
 "bbN" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/listeningpost)
@@ -25590,9 +25590,9 @@
 /area/listeningpost)
 "bbS" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
 	icon_state = "1-4"
@@ -25619,9 +25619,9 @@
 "bbU" = (
 /obj/machinery/light/small,
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
@@ -25632,9 +25632,9 @@
 /area/listeningpost)
 "bbV" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/power/rtg,
 /obj/cable{
@@ -25656,9 +25656,9 @@
 /area/listeningpost)
 "bbX" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock,
 /turf/simulated/floor/black,
@@ -25679,12 +25679,12 @@
 	},
 /obj/decal/glow{
 	brightness = 3;
-	invisibility = 101;
-	luminosity = 0;
-	name = "glow - WHITE";
 	color_b = 0.35;
 	color_g = 0.35;
-	color_r = 0.35
+	color_r = 0.35;
+	invisibility = 101;
+	luminosity = 0;
+	name = "glow - WHITE"
 	},
 /turf/simulated/floor/grey/side{
 	dir = 8
@@ -25701,8 +25701,8 @@
 /area/listeningpost)
 "bcb" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb1"
 	},
 /obj/machinery/bot/medbot/no_camera,
 /obj/noticeboard{
@@ -25712,9 +25712,9 @@
 /area/listeningpost)
 "bcc" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/orangeblack,
 /area/listeningpost)
@@ -25730,8 +25730,8 @@
 /area/listeningpost)
 "bcf" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /obj/item/clothing/under/misc/syndicate,
 /obj/item/clothing/under/misc/syndicate,
@@ -25742,8 +25742,8 @@
 /area/listeningpost)
 "bcg" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 8
+	dir = 8;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/grey/side{
 	dir = 8
@@ -25755,8 +25755,8 @@
 /area/listeningpost)
 "bci" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/grey/side{
@@ -25822,13 +25822,13 @@
 /area/listeningpost)
 "bct" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/stool/chair/comfy{
-	icon_state = "chair_comfy";
-	dir = 8
+	dir = 8;
+	icon_state = "chair_comfy"
 	},
 /turf/simulated/floor/orangeblack,
 /area/listeningpost)
@@ -25875,9 +25875,9 @@
 /area/listeningpost)
 "bcz" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 1;
@@ -25885,16 +25885,16 @@
 	icon_state = "1-4"
 	},
 /obj/stool/chair/comfy{
-	icon_state = "chair_comfy";
-	dir = 8
+	dir = 8;
+	icon_state = "chair_comfy"
 	},
 /turf/simulated/floor/orangeblack,
 /area/listeningpost)
 "bcA" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/grey/side{
 	dir = 4
@@ -25902,18 +25902,18 @@
 /area/listeningpost)
 "bcB" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/black,
 /area/listeningpost)
 "bcC" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/listeningpost)
@@ -25938,8 +25938,8 @@
 /area/listeningpost)
 "bcE" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/plating/airless,
 /area/listeningpost)
@@ -25954,8 +25954,8 @@
 /area/listeningpost)
 "bcG" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb1"
 	},
 /obj/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -25969,8 +25969,8 @@
 /area/listeningpost)
 "bcH" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb1"
 	},
 /obj/machinery/light_switch{
 	name = "S light switch";
@@ -25980,9 +25980,9 @@
 /area/listeningpost)
 "bcI" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/grey/side{
 	dir = 8
@@ -25990,18 +25990,18 @@
 /area/listeningpost)
 "bcJ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/orangeblack,
 /area/listeningpost)
 "bcK" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/orangeblack,
 /area/listeningpost)
@@ -26013,8 +26013,8 @@
 /area/listeningpost)
 "bcM" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/grey/side{
 	dir = 4
@@ -26049,9 +26049,9 @@
 /area/listeningpost)
 "bcR" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock,
 /obj/cable{
@@ -26076,8 +26076,8 @@
 /area/listeningpost)
 "bcU" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/black,
 /area/listeningpost)
@@ -26090,8 +26090,8 @@
 "bcW" = (
 /obj/machinery/vending/snack,
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/nw,
 /area/listeningpost)
@@ -26100,8 +26100,8 @@
 /area/listeningpost)
 "bcY" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/ne,
 /area/listeningpost)
@@ -26112,15 +26112,15 @@
 "bda" = (
 /obj/machinery/drainage,
 /obj/submachine/chef_sink/chem_sink{
-	icon_state = "sink";
-	dir = 1
+	dir = 1;
+	icon_state = "sink"
 	},
 /turf/simulated/floor/sanitary,
 /area/listeningpost)
 "bdb" = (
 /obj/machinery/shower{
-	icon_state = "showerhead";
-	dir = 1
+	dir = 1;
+	icon_state = "showerhead"
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/sanitary,
@@ -26161,8 +26161,8 @@
 /obj/item/chem_grenade/metalfoam,
 /obj/item/chem_grenade/metalfoam,
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 8
+	dir = 8;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/caution/east{
 	dir = 8
@@ -26215,8 +26215,8 @@
 /area/listeningpost)
 "bdp" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor4"
@@ -26263,8 +26263,8 @@
 	name = "broken computer"
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
@@ -26359,9 +26359,9 @@
 	})
 "bty" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/south,
 /area/station/chapel/main)
@@ -26394,25 +26394,25 @@
 	})
 "bQW" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/purple,
 /area/station/chapel/main)
 "bWd" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/east,
 /area/station/crew_quarters/quarters_west)
 "bYf" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purpleblack,
 /area/research_outpost{
@@ -26429,9 +26429,9 @@
 /area/station/chapel/main)
 "cmI" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple{
 	level = 2
@@ -26449,8 +26449,8 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 4
+	dir = 4;
+	icon_state = "greyblack"
 	},
 /area/station/crew_quarters/courtroom)
 "cze" = (
@@ -26473,9 +26473,9 @@
 	})
 "cBn" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
 	icon_state = "1-8"
@@ -26487,9 +26487,9 @@
 "cSo" = (
 /obj/machinery/door/unpowered/wood/pyro,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
 /area/research_outpost{
@@ -26514,9 +26514,9 @@
 /area/station/hangar/sec)
 "dgN" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/airless/plating,
 /area/research_outpost{
@@ -26655,9 +26655,9 @@
 	})
 "eKF" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /obj/machinery/light/emergency{
@@ -26719,8 +26719,8 @@
 /area/station/crew_quarters/market)
 "fuS" = (
 /obj/stool/chair{
-	icon_state = "chair";
-	dir = 1
+	dir = 1;
+	icon_state = "chair"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
@@ -26768,18 +26768,18 @@
 	dir = 8
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/quarters_west)
 "gUO" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple{
@@ -26804,9 +26804,9 @@
 	})
 "heF" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/landmark{
 	name = "blobstart"
@@ -26870,8 +26870,8 @@
 	pixel_x = 10
 	},
 /turf/simulated/floor/black/side{
-	icon_state = "greyblack";
-	dir = 8
+	dir = 8;
+	icon_state = "greyblack"
 	},
 /area/station/hallway/primary/east)
 "hYd" = (
@@ -26958,14 +26958,14 @@
 /area/station/crew_quarters/quarters_west)
 "iIB" = (
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -26973,9 +26973,9 @@
 /area/station/crew_quarters/courtroom)
 "iJH" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/purpleblack{
 	dir = 4
@@ -27007,9 +27007,9 @@
 	})
 "jeV" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/east,
 /area/station/chapel/main)
@@ -27070,9 +27070,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/research_outpost{
@@ -27184,9 +27184,9 @@
 /area/station/crew_quarters/courtroom)
 "lff" = (
 /obj/cable{
-	icon_state = "2-4";
 	d1 = 2;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/research_outpost{
@@ -27200,9 +27200,9 @@
 /area/station/crew_quarters/kitchen)
 "llZ" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light/emergency,
 /turf/simulated/floor/darkblue,
@@ -27252,9 +27252,9 @@
 	})
 "lLt" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/research_outpost{
@@ -27262,14 +27262,14 @@
 	})
 "lWS" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-8";
 	d1 = 2;
-	d2 = 8
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/item/storage/wall{
 	name = "bath cabinet";
@@ -27299,9 +27299,9 @@
 /area/station/hallway/primary/west)
 "mgT" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/phone/wall{
 	pixel_y = 32
@@ -27380,8 +27380,8 @@
 "mAU" = (
 /obj/grille/catwalk,
 /obj/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/cable{
 	d2 = 8;
@@ -27421,9 +27421,9 @@
 "njr" = (
 /obj/creepy_sound_trigger,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/decal/tile_edge/stripe/extra_big,
 /obj/machinery/atmospherics/pipe/simple{
@@ -27495,9 +27495,9 @@
 	})
 "nII" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purpleblack/corner{
 	dir = 8
@@ -27570,9 +27570,9 @@
 /area/station/crew_quarters/pool)
 "oTX" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/light/emergency,
 /turf/simulated/floor/wood,
@@ -27714,9 +27714,9 @@
 /area/station/hallway/primary/central)
 "qLD" = (
 /obj/cable{
-	icon_state = "4-8";
 	d1 = 4;
-	d2 = 8
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/purple/fancy,
 /area/station/crew_quarters/quarters_west)
@@ -27734,8 +27734,8 @@
 	pixel_x = 10
 	},
 /turf/simulated/floor/neutral/side{
-	icon_state = "neutral";
-	dir = 4
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/station/hallway/primary/west)
 "qUs" = (
@@ -27804,9 +27804,9 @@
 "sdI" = (
 /obj/machinery/door/airlock/pyro/medical/alt,
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purpleblack{
 	dir = 1
@@ -27895,9 +27895,9 @@
 	locked = 1
 	},
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple{
 	level = 2
@@ -27910,8 +27910,8 @@
 	})
 "uxq" = (
 /obj/decal/tile_edge/line/blue{
-	icon_state = "line1";
-	dir = 8
+	dir = 8;
+	icon_state = "line1"
 	},
 /obj/machinery/light/emergency,
 /turf/simulated/floor,
@@ -27948,8 +27948,8 @@
 	setup_starting_program = null
 	},
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/purpleblack,
@@ -27958,9 +27958,9 @@
 	})
 "uVI" = (
 /obj/cable{
-	icon_state = "1-2";
 	d1 = 1;
-	d2 = 2
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purplewhite,
 /area/research_outpost{
@@ -28110,8 +28110,8 @@
 /obj/machinery/power/furnace,
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
 	d2 = 8;
@@ -28136,8 +28136,8 @@
 	})
 "wjh" = (
 /obj/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/furnace,
 /turf/simulated/floor/caution/east,
@@ -28151,8 +28151,8 @@
 	icon_state = "bedsheet-blue"
 	},
 /obj/item/device/radio/intercom/medical{
-	pixel_x = -20;
-	dir = 4
+	dir = 4;
+	pixel_x = -20
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/maintenance/SEmaint)
@@ -28175,8 +28175,8 @@
 	icon_state = "1-2"
 	},
 /obj/item/device/radio/intercom/medical{
-	pixel_x = -20;
-	dir = 4
+	dir = 4;
+	pixel_x = -20
 	},
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Set of changes to my assjam only maps. Icarus only received a Security Weapons Vendor, but Fleet's changes were more extensive:

- Aforementioned security vendor.
- New vessel: the Erebus. Located behind the Meridian, it contains a set of plasma experimentation hardware as well as the necessary components to create a singularity, and can be accessed by both Engineering and Research personnel.
- The Meridian has been modified to remove its disposal hardware (as it was unnecessary), and now contains an ABC-U, a paint vendor, and a loafer with associated disposal pipe dispenser.
- The Tenebrae and Maru have been slightly modified to permit the addition of new chute lines leading to the Erebus.
- Other stuff I can't remember

StrongDMM shuffled some stuff.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes some important issues, and gives fleet more options for Things 2 Do

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Kubius:
(*)The Bellerophon Fleet has a new vessel.
```
