### PR TITLE
some changes to emotes and the way the hug pathology symptom spreads

### DIFF
--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -264,7 +264,7 @@
 			if ("salute","bow","hug","wave", "blowkiss","sidehug")
 				// visible targeted emotes
 				if (!src.restrained())
-					var/M = null
+					var/mob/M = null
 					if (param)
 						var/range = 8
 						if (act == "hug" || act == "sidehug")

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -5,11 +5,6 @@
 /mob/living/carbon/human/emote(var/act, var/voluntary = 0)
 	var/param = null
 
-	for (var/uid in src.pathogens)
-		var/datum/pathogen/P = src.pathogens[uid]
-		if (P.onemote(act, voluntary))
-			return
-
 	if (!bioHolder) bioHolder = new/datum/bioHolder( src )
 
 	if (src.bioHolder.HasEffect("revenant"))
@@ -20,6 +15,11 @@
 		var/t1 = findtext(act, " ", 1, null)
 		param = copytext(act, t1 + 1, length(act) + 1)
 		act = copytext(act, 1, t1)
+
+	for (var/uid in src.pathogens)
+		var/datum/pathogen/P = src.pathogens[uid]
+		if (P.onemote(act, voluntary, param))
+			return
 
 	var/muzzled = istype(src.wear_mask, /obj/item/clothing/mask/muzzle)
 	var/m_type = 1 //1 is visible, 2 is audible
@@ -261,12 +261,15 @@
 					G.throw_at(target,5,1)
 					src.visible_message("<b>[src]</B> farts out a...glowstick?")
 
-			if ("salute","bow","hug","wave", "blowkiss")
+			if ("salute","bow","hug","wave", "blowkiss","sidehug")
 				// visible targeted emotes
 				if (!src.restrained())
 					var/M = null
 					if (param)
-						for (var/mob/A in view(null, null))
+						var/range = 8
+						if (act == "hug" || act == "sidehug")
+							range = 1
+						for (var/mob/A in view(range, src))
 							if (ckey(param) == ckey(A.name))
 								M = A
 								break
@@ -278,6 +281,8 @@
 						switch(act)
 							if ("bow","wave")
 								message = "<B>[src]</B> [act]s to [param]."
+							if ("sidehug")
+								message = "<B>[src]</B> awkwardly side-hugs [param]."
 							if ("blowkiss")
 								message = "<B>[src]</B> blows a kiss to [param]."
 								//var/atom/U = get_turf(param)
@@ -286,7 +291,7 @@
 								message = "<B>[src]</B> [act]s [param]."
 					else
 						switch(act)
-							if ("hug")
+							if ("hug", "sidehug")
 								message = "<B>[src]</b> [act]s [himself_or_herself(src)]."
 							if ("blowkiss")
 								message = "<B>[src]</b> blows a kiss to... [himself_or_herself(src)]?"

--- a/code/modules/chemistry/Reagents-Diseases.dm
+++ b/code/modules/chemistry/Reagents-Diseases.dm
@@ -496,7 +496,7 @@ datum
 						var/mob/living/carbon/human/H = M
 						if(prob(100-H.get_disease_protection()))
 							if(H.infected(P))
-								H.show_message("Ew, some of that disgusting green stuff touched you!")
+								H.show_message("<span class='alert'>Ew, some of that disgusting green stuff touched you!</span>")
 				return
 
 			on_plant_life(var/obj/machinery/plantpot/P)

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -1704,9 +1704,7 @@ datum
 						if (hugTarget == M)
 							continue
 						if (!hugTarget.stat)
-
-							M.visible_message("<span class='alert'>[M] [prob(5) ? "awkwardly side-" : ""]hugs [hugTarget]!</span>")
-
+							M.emote(prob(5)?"sidehug [hugTarget]":"hug [hugTarget]")
 							break
 
 				..()

--- a/code/modules/medical/pathology/pathogen.dm
+++ b/code/modules/medical/pathology/pathogen.dm
@@ -1427,10 +1427,10 @@ datum/pathogen
 		return message
 
 	// Act on emoting. Vetoing available by returning 0.
-	proc/onemote(act, voluntary)
-		suppressant.onemote(infected, act, voluntary, src)
+	proc/onemote(act, voluntary, param)
+		suppressant.onemote(infected, act, voluntary, param, src)
 		for (var/effect in src.effects)
-			. *= effect:onemote(infected, act, voluntary, src)
+			. *= effect:onemote(infected, act, voluntary, param, src)
 
 	// Act when dying. Returns nothing.
 	proc/ondeath()

--- a/code/modules/medical/pathology/pathogen_benevolent.dm
+++ b/code/modules/medical/pathology/pathogen_benevolent.dm
@@ -301,11 +301,24 @@ datum/pathogeneffects/benevolent/brewery
 datum/pathogeneffects/benevolent/oxytocinproduction
 	name = "Oxytocin Production"
 	desc = "The pathogen produces Pure Love within the infected."
-	infect_type = INFECT_TOUCH // TODO: make also spread via hugs, will require reworking pure love and part of the emote call, so I'll do it in another patch
+	infect_type = INFECT_TOUCH
 	rarity = RARITY_COMMON
 	spread = SPREAD_BODY | SPREAD_HANDS
 	infect_message = "<span style=\"color:pink\">You can't help but feel loved.</span>"
 	infect_attempt_message = "Their touch is suspiciously soft..."
+
+	onemote(mob/M as mob, act, voluntary, param, datum/pathogen/origin)
+		if (!origin.symptomatic)
+			return
+		if (act != "hug" && act != "sidehug")  // not a hug
+			return
+		if (param == null) // weirdo is just hugging themselves
+			return
+		for (var/mob/living/carbon/human/H in view(1, M))
+			if (ckey(param) == ckey(H.name))
+				SPAWN_DBG(0.5)
+					infect_direct(H, origin, "hug")
+				return
 
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)

--- a/code/modules/medical/pathology/pathogen_suppressants.dm
+++ b/code/modules/medical/pathology/pathogen_suppressants.dm
@@ -34,7 +34,7 @@
 	proc/onshocked(var/datum/shockparam/param, var/datum/pathogen/P)
 	proc/onsay(message, var/datum/pathogen/P)
 	proc/onadd(var/datum/pathogen/P)
-	proc/onemote(var/mob/M as mob, message, voluntary, var/datum/pathogen/P)
+	proc/onemote(var/mob/M as mob, message, voluntary, param, var/datum/pathogen/P)
 	proc/ondeath(var/datum/pathogen/P)
 	proc/oncured(var/datum/pathogen/P)
 

--- a/code/modules/medical/pathology/pathogen_symptoms.dm
+++ b/code/modules/medical/pathology/pathogen_symptoms.dm
@@ -84,7 +84,7 @@ datum/pathogeneffects
 	// OVERRIDE: Generally, you do not need to override this.
 	proc/infect_direct(var/mob/target as mob, var/datum/pathogen/origin, contact_type = "touch")
 		if (infect_attempt_message)
-			target.show_message(infect_attempt_message)
+			target.show_message("<span class='alert'><B>[infect_attempt_message]</B></span>")
 		if(istype(target, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = target
 			if(prob(100-H.get_disease_protection()))

--- a/code/modules/medical/pathology/pathogen_symptoms.dm
+++ b/code/modules/medical/pathology/pathogen_symptoms.dm
@@ -138,9 +138,9 @@ datum/pathogeneffects
 	proc/onsay(var/mob/M as mob, message, var/datum/pathogen/origin)
 		return message
 
-	// onemote(mob, string, number, datum/pathogen) : string
+	// onemote(mob, string, number, string, datum/pathogen) : string
 	// OVERRIDE: Overriding this is situational.
-	proc/onemote(var/mob/M as mob, act, voluntary, var/datum/pathogen/P)
+	proc/onemote(var/mob/M as mob, act, voluntary, param, var/datum/pathogen/P)
 		return 1
 
 	// ondeath(mob, datum/pathogen) : void
@@ -1708,7 +1708,7 @@ datum/pathogeneffects/malevolent/farts
 		if(voluntary)
 			origin.symptom_data[name] = TIME
 
-	onemote(mob/M as mob, act, voluntary, datum/pathogen/P)
+	onemote(mob/M as mob, act, voluntary, param, datum/pathogen/P)
 		// involuntary farts are free, but the others use the cooldown
 		if(voluntary && TIME-P.symptom_data[name] < cooldown)
 			return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[balance] [enhancement]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This makes it so the Pure Love chem actually makes you hug people rather than just displaying a message for it.
For this it also adds a new "sidehug" emote.
I also changed the way targets are picked for targeted emotes for hugs and hug-adjacent emotes, this has the side effect of making it so hugs are actually limited to people in touch range, rather than being able to hug anyone on screen.

Also changes the hug symptom to infect people when an afflicted person hugs them.
For this I changed the onemote event around a bit to also pass the param of the emote.

In addition, I also changed the messages when a pathogen infects you and the messages when the pathogen chem infects you to be more visible, see middle message here.
![image](https://user-images.githubusercontent.com/35579460/86534684-78611e00-beda-11ea-990a-ecb16a584f80.png)
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
- Pure Love not actually making you hug people is a tragedy.
- It makes more sense for the pathogen to spread this way.
- Makes it more visible when you get infected.