### PR TITLE
Kondaru reactor computer fix

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -12309,6 +12309,9 @@
 	dir = 8;
 	level = 2
 	},
+/obj/cable{
+	icon_state = "6-10"
+	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "aBY" = (
@@ -12753,21 +12756,28 @@
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 10
 	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "aDd" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "2-5"
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "aDe" = (
-/obj/cable{
-	icon_state = "6-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold,
 /obj/machinery/power/stats_meter{
 	name = "Cold Loop Inlet Meter";
@@ -12778,6 +12788,11 @@
 	pixel_x = 9;
 	pixel_y = -8
 	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "aDf" = (
@@ -13247,11 +13262,22 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "aEh" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 10
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -13272,10 +13298,10 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "aEl" = (
-/obj/cable{
-	icon_state = "4-9"
-	},
 /obj/machinery/atmospherics/valve,
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "aEm" = (
@@ -13638,10 +13664,22 @@
 	name = "Hot Loop Outlet Meter";
 	tag = "Hot Loop Outlet Meter"
 	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "aFh" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "aFi" = (
@@ -13651,6 +13689,14 @@
 /obj/machinery/power/stats_meter{
 	name = "Cold Loop Outlet Meter";
 	tag = "Cold Loop Outlet Meter"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -54139,6 +54185,17 @@
 /obj/machinery/portable_reclaimer,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
+"dTh" = (
+/obj/machinery/atmospherics/valve{
+	dir = 4
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "dVP" = (
 /obj/decal/poster/wallsign/security,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -54355,6 +54412,17 @@
 	dir = 8
 	},
 /area/station/hallway/primary/east)
+"foi" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 6
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-9"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "fqj" = (
 /obj/machinery/recharge_station,
 /obj/machinery/light/small{
@@ -54461,6 +54529,13 @@
 	},
 /turf/space,
 /area/station/ai_monitored/armory)
+"fWk" = (
+/obj/machinery/atmospherics/valve,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/core)
 "fYL" = (
 /obj/grille/catwalk{
 	dir = 4
@@ -54543,6 +54618,8 @@
 	name = "Hot Loop Combustion Chamber Meter";
 	tag = "Hot Loop Combustion Chamber Meter"
 	},
+/obj/machinery/power/data_terminal,
+/obj/cable,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "gNp" = (
@@ -55189,6 +55266,16 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/hydroponics)
+"kTo" = (
+/obj/machinery/atmospherics/pipe/manifold{
+	level = 2
+	},
+/obj/machinery/meter,
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "kTp" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -55287,6 +55374,16 @@
 /obj/machinery/light,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
+"lrq" = (
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 1;
+	level = 2
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "lvb" = (
 /obj/grille/steel,
 /obj/disposalpipe/segment/transport,
@@ -56684,6 +56781,9 @@
 	on = 1;
 	pixel_y = 1;
 	target_pressure = 1e+031
+	},
+/obj/cable{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -100796,7 +100896,7 @@ auL
 aAX
 aBV
 aDf
-aDf
+dTh
 aBY
 aGp
 auL
@@ -101099,7 +101199,7 @@ aAY
 aBV
 uMJ
 aEh
-aGr
+kTo
 aDb
 aHu
 aIt
@@ -102006,8 +102106,8 @@ aBX
 aDe
 aEk
 aFi
-aDb
-aHu
+lrq
+fWk
 gMO
 aJt
 aKB
@@ -102305,7 +102405,7 @@ ayY
 azW
 aBb
 aBY
-aBa
+foi
 aEl
 aGr
 cIl


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes a lack of data terminals and cabling connecting the Kondaru reactor statistics computer's meters to the network. For some reason, I was under the impression they were wireless, but a powernet overlay inspection indicated otherwise, so they're now hardwired. Tested and it functions locally.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

See about section.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Kubius:
(+)Kondaru's reactor computer works properly now.
```
