### PR TITLE
Donut3: Moves critter spawns, More foam/welder tanks, more pipe dispensers!!! MORE TRASH!

### DIFF
--- a/code/map.dm
+++ b/code/map.dm
@@ -127,7 +127,7 @@ var/global/list/mapNames = list(
 
 /datum/map_settings/donut3
 	name = "DONUT3"
-	goonhub_map = "https://cdn.discordapp.com/attachments/469379618168897538/727936626147459192/donut3-30-FINAL2-lol.png"
+	goonhub_map = "https://cdn.discordapp.com/attachments/469379618168897538/729407450737934376/donut3-30-FINAL3-it-never-ends.png"
 	airlock_style = "pyro"
 	walls = /turf/simulated/wall/auto/jen
 	rwalls = /turf/simulated/wall/auto/reinforced/jen

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -2721,6 +2721,15 @@
 	icon_state = "12"
 	},
 /area/station/mining)
+"auz" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/hallway/secondary/construction2)
 "auB" = (
 /obj/plasticflaps{
 	layer = 3
@@ -5977,6 +5986,8 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/reagent_dispensers/fueltank,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/north)
 "bwC" = (
@@ -8099,20 +8110,6 @@
 	dir = 8
 	},
 /area/listeningpost)
-"cdX" = (
-/obj/table/reinforced/auto,
-/obj/machinery/door/airlock/pyro/glass/windoor{
-	dir = 8
-	},
-/obj/access_spawn/engineering,
-/obj/firedoor_spawn,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/storage/primary)
 "cdY" = (
 /obj/table/auto,
 /obj/item/storage/toolbox/mechanical{
@@ -10143,16 +10140,6 @@
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating,
 /area/station/janitor)
-"cNK" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "4-9"
-	},
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating/jen,
-/area/station/maintenance/inner/sw)
 "cNV" = (
 /obj/lattice{
 	icon_state = "lattice-dir"
@@ -19622,10 +19609,6 @@
 /obj/decal/poster/wallsign/space,
 /turf/simulated/wall/auto/reinforced/jen,
 /area/station/hallway/secondary/exit)
-"fKw" = (
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating/jen,
-/area/station/maintenance/inner/sw)
 "fKO" = (
 /obj/cable{
 	d1 = 4;
@@ -22991,18 +22974,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
-"gPX" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 4
-	},
-/area/station/storage/auxillary{
-	name = "Tool Storage"
-	})
 "gQc" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -24188,6 +24159,16 @@
 	dir = 4
 	},
 /area/station/engine/engineering)
+"hiA" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/yellowblack{
+	dir = 8
+	},
+/area/station/storage/primary)
 "hiB" = (
 /obj/grille/catwalk{
 	dir = 6
@@ -24614,11 +24595,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/nw)
-"hpU" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating/jen,
-/area/station/maintenance/outer/sw)
 "hpV" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/grille/catwalk/jen,
@@ -27098,6 +27074,12 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
+"idv" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
+/turf/simulated/floor/black/grime,
+/area/station/maintenance/outer/sw)
 "idw" = (
 /obj/stool/chair/office{
 	dir = 4
@@ -30817,6 +30799,14 @@
 /obj/random_item_spawner/tools/two,
 /turf/simulated/floor/yellowblack,
 /area/station/engine/inner)
+"jsb" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/hallway/secondary/construction2)
 "jsg" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/wood/five,
@@ -31329,15 +31319,6 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/courtroom)
-"jAX" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/grimycarpet,
-/area/station/hallway/secondary/construction2)
 "jAZ" = (
 /obj/machinery/door/unpowered/wood/pyro{
 	dir = 4;
@@ -32695,6 +32676,15 @@
 "jXA" = (
 /turf/simulated/floor/carpet/red/fancy,
 /area/station/crew_quarters/stockex)
+"jXL" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/grimycarpet,
+/area/station/hallway/secondary/construction2)
 "jXP" = (
 /obj/machinery/light/incandescent/warm,
 /obj/machinery/recharger,
@@ -33184,6 +33174,10 @@
 	},
 /turf/simulated/floor/redblack,
 /area/station/security/brig/south_side)
+"khM" = (
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/inner/sw)
 "khT" = (
 /obj/disposalpipe/segment,
 /obj/machinery/atmospherics/unary/vent_pump/security/east,
@@ -35893,6 +35887,16 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
+/area/station/maintenance/inner/sw)
+"lcG" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "4-9"
+	},
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/sw)
 "lcP" = (
 /obj/wingrille_spawn/auto,
@@ -39295,6 +39299,13 @@
 	icon_state = "floor4"
 	},
 /area/listeningpost)
+"mcl" = (
+/obj/random_item_spawner/junk/one_or_zero,
+/obj/decal/cleanable/dirt/jen,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
+/obj/reagent_dispensers/foamtank,
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/outer/se)
 "mcL" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 8;
@@ -39661,6 +39672,13 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quartersB)
+"miE" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/reagent_dispensers/fueltank,
+/obj/decal/cleanable/rust/jen,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/inner/sw)
 "miG" = (
 /obj/storage/closet/emergency,
 /turf/simulated/floor/white,
@@ -41490,14 +41508,6 @@
 /obj/machinery/light/emergency,
 /turf/simulated/floor/green/side,
 /area/station/hallway/primary/west)
-"mOU" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/hallway/secondary/construction2)
 "mPa" = (
 /obj/decal/mule/dropoff,
 /obj/machinery/door/airlock/pyro/glass,
@@ -42859,13 +42869,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
-"nkE" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/reagent_dispensers/fueltank,
-/obj/decal/cleanable/rust/jen,
-/obj/decal/mule/beacon/no_auto_dropoff_spawn,
-/turf/simulated/floor/plating/jen,
-/area/station/maintenance/inner/sw)
 "nkG" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/grille/catwalk/jen/side{
@@ -43521,6 +43524,7 @@
 "nuv" = (
 /obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /obj/decal/cleanable/dirt/jen,
+/obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
 "nuw" = (
@@ -43916,11 +43920,12 @@
 /turf/simulated/floor/white/checker,
 /area/station/medical/asylum)
 "nBy" = (
-/obj/random_item_spawner/junk/one_or_zero,
+/obj/reagent_dispensers/foamtank,
 /obj/decal/cleanable/dirt/jen,
 /obj/machinery/light/small/sticky{
 	dir = 1
 	},
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
 "nBz" = (
@@ -44843,6 +44848,15 @@
 	},
 /turf/simulated/floor/black,
 /area/station/medical/medbay/cloner)
+"nRF" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/hallway/secondary/construction)
 "nRR" = (
 /obj/machinery/power/apc/autoname_west,
 /obj/cable,
@@ -49637,11 +49651,6 @@
 	},
 /turf/simulated/floor/green/side,
 /area/station/hydroponics)
-"ppH" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/black/grime,
-/area/station/maintenance/outer/sw)
 "ppI" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/blue/side{
@@ -50862,15 +50871,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/hallway/secondary/exit)
-"pGK" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/hallway/secondary/construction)
 "pGS" = (
 /obj/cable{
 	d1 = 1;
@@ -54968,14 +54968,6 @@
 	dir = 9
 	},
 /area/station/medical/head)
-"qRb" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/hallway/secondary/construction2)
 "qRe" = (
 /obj/table/auto,
 /obj/item/decoration/ashtray{
@@ -56008,16 +56000,6 @@
 /area/station/medical/research{
 	name = "Genetic Research"
 	})
-"rfJ" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/yellowblack{
-	dir = 8
-	},
-/area/station/storage/primary)
 "rgh" = (
 /obj/decal/mule/dropoff,
 /obj/machinery/door/airlock/pyro/glass,
@@ -57590,13 +57572,6 @@
 /obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
-"rCZ" = (
-/obj/random_item_spawner/junk/one_or_zero,
-/obj/decal/cleanable/dirt/jen,
-/obj/decal/mule/beacon/no_auto_dropoff_spawn,
-/obj/reagent_dispensers/foamtank,
-/turf/simulated/floor/plating/jen,
-/area/station/maintenance/outer/se)
 "rDq" = (
 /obj/machinery/conveyor_switch{
 	id = "disposals"
@@ -59886,6 +59861,18 @@
 	},
 /turf/simulated/floor/purple/side,
 /area/station/hallway/primary/south)
+"spA" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
+/area/station/storage/auxillary{
+	name = "Tool Storage"
+	})
 "spC" = (
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
@@ -60540,6 +60527,11 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/hallway/primary/south)
+"sBn" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/outer/sw)
 "sBt" = (
 /turf/simulated/wall/auto/reinforced/jen/blue,
 /area/station/bridge/customs)
@@ -61257,18 +61249,6 @@
 "sOd" = (
 /turf/simulated/floor/specialroom/freezer,
 /area/station/medical/morgue)
-"sOo" = (
-/obj/decal/mule/dropoff,
-/obj/machinery/door/airlock/pyro/glass,
-/obj/firedoor_spawn,
-/obj/access_spawn,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/hallway/secondary/construction2)
 "sOs" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/decal/mule/dropoff,
@@ -61373,15 +61353,6 @@
 	},
 /turf/simulated/floor/black/grime,
 /area/station/security/brig/north_side)
-"sQU" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/hallway/secondary/construction2)
 "sQZ" = (
 /obj/cable{
 	d1 = 4;
@@ -64185,6 +64156,20 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
+"tKr" = (
+/obj/table/reinforced/auto,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 8
+	},
+/obj/access_spawn/engineering,
+/obj/firedoor_spawn,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/storage/primary)
 "tKu" = (
 /obj/disposalpipe/segment/food{
 	icon_state = "pipe-c"
@@ -66276,6 +66261,11 @@
 	},
 /turf/simulated/wall/auto/reinforced/jen,
 /area/station/maintenance/outer/ne)
+"uuU" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/black/grime,
+/area/station/maintenance/outer/sw)
 "uuV" = (
 /obj/stool/chair/wooden{
 	dir = 4
@@ -69293,11 +69283,12 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/sw)
 "voi" = (
-/obj/random_item_spawner/junk/one_or_zero,
 /obj/decal/cleanable/dirt/jen,
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/reagent_dispensers/foamtank,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/north)
 "voj" = (
@@ -71545,12 +71536,6 @@
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor)
-"vYy" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/decal/mule/beacon/no_auto_dropoff_spawn,
-/turf/simulated/floor/black/grime,
-/area/station/maintenance/outer/sw)
 "vYM" = (
 /obj/cable{
 	d2 = 8;
@@ -76569,6 +76554,14 @@
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/bar)
+"xAw" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/hallway/secondary/construction2)
 "xAB" = (
 /obj/decal/tile_edge/line/purple{
 	dir = 6;
@@ -78637,6 +78630,18 @@
 /obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /turf/simulated/floor/plating/jen,
 /area/station/science/gen_storage)
+"yfd" = (
+/obj/decal/mule/dropoff,
+/obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
+/obj/access_spawn,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/hallway/secondary/construction2)
 "yff" = (
 /obj/storage/closet/wardrobe/pride,
 /turf/unsimulated/floor/shuttle,
@@ -105296,7 +105301,7 @@ qgG
 qgG
 jKY
 jDb
-ppH
+uuU
 eQS
 pFp
 ltH
@@ -105599,7 +105604,7 @@ wZJ
 hcW
 hsj
 bUO
-vYy
+idv
 pFp
 kif
 pFp
@@ -105901,7 +105906,7 @@ gBM
 hcW
 hsj
 bUO
-hpU
+sBn
 uOO
 uOO
 cWf
@@ -111928,7 +111933,7 @@ rAR
 qab
 bFY
 wXY
-cNK
+lcG
 uwa
 pJj
 sqY
@@ -113746,8 +113751,8 @@ tlF
 fha
 tsm
 aak
-fKw
-fKw
+khM
+khM
 pjy
 suS
 eaO
@@ -113768,7 +113773,7 @@ tuV
 pyL
 mZl
 kze
-nkE
+miE
 uXW
 quO
 cma
@@ -132162,10 +132167,10 @@ wnv
 oLR
 rRw
 wjJ
-pGK
-sOo
-sQU
-mOU
+nRF
+yfd
+auz
+jsb
 uQW
 oiX
 tWs
@@ -132467,7 +132472,7 @@ vLR
 kyC
 qtZ
 uQW
-qRb
+xAw
 xBW
 ged
 qtZ
@@ -132769,7 +132774,7 @@ oxI
 iOH
 orh
 gIe
-jAX
+jXL
 jwX
 bhG
 qtZ
@@ -136087,7 +136092,7 @@ oxG
 oHf
 khD
 wPR
-gPX
+spA
 bww
 elM
 vwi
@@ -136389,7 +136394,7 @@ vqi
 ohh
 ohh
 jWD
-cdX
+tKr
 byA
 lVy
 lVy
@@ -136691,7 +136696,7 @@ oAy
 ohh
 uSB
 dae
-rfJ
+hiA
 xCC
 jab
 lVy
@@ -143641,7 +143646,7 @@ lwP
 ncJ
 kGg
 mQN
-rCZ
+mcl
 eZn
 wPF
 vje

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -161,14 +161,12 @@
 	},
 /area/mining/magnet)
 "aak" = (
-/obj/machinery/disposal_pipedispenser/mobile{
-	dir = 8
-	},
-/obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /obj/decal/cleanable/dirt/jen,
 /obj/railing/orange{
 	dir = 1
 	},
+/obj/reagent_dispensers/foamtank,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/sw)
 "aal" = (
@@ -1898,9 +1896,9 @@
 /turf/simulated/floor/black,
 /area/station/science/bot_storage)
 "agU" = (
-/obj/machinery/fluid_canister,
 /obj/decal/cleanable/dirt/jen,
 /obj/decal/mule/beacon/no_auto_dropoff_spawn,
+/obj/reagent_dispensers/foamtank,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/east)
 "ahg" = (
@@ -1970,13 +1968,14 @@
 /turf/simulated/wall/auto/jen/blue,
 /area/station/crew_quarters/courtroom)
 "ahI" = (
-/obj/decal/cleanable/dirt/jen,
 /obj/landmark{
 	icon_state = "x3";
 	name = "peststart"
 	},
-/turf/simulated/floor/plating/jen,
-/area/station/maintenance/inner/east)
+/turf/unsimulated/floor/carpet/green/standard/edge{
+	dir = 8
+	},
+/area/station/crew_quarters/quartersC)
 "ahL" = (
 /obj/machinery/light/incandescent/warm{
 	dir = 1
@@ -4257,15 +4256,18 @@
 /turf/simulated/wall/auto/reinforced/jen,
 /area/station/maintenance/outer/ne)
 "aUn" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/random_item_spawner/junk/one_or_zero,
-/obj/decal/cleanable/rust/jen,
+/obj/stool/chair/comfy/blue{
+	dir = 8
+	},
 /obj/landmark{
 	icon_state = "x3";
 	name = "peststart"
 	},
-/turf/simulated/floor/plating/jen,
-/area/station/maintenance/inner/nw)
+/turf/simulated/floor/carpet{
+	dir = 4;
+	icon_state = "fred2"
+	},
+/area/station/hallway/secondary/exit)
 "aUo" = (
 /turf/simulated/floor/carpet/green/standard/edge{
 	dir = 5
@@ -5519,6 +5521,10 @@
 /area/station/security/checkpoint/west)
 "bqK" = (
 /obj/stool/chair/moveable,
+/obj/landmark{
+	icon_state = "x3";
+	name = "peststart"
+	},
 /turf/simulated/floor/red/side{
 	dir = 8
 	},
@@ -7239,8 +7245,14 @@
 "bPa" = (
 /obj/decal/boxingrope,
 /obj/table/wood/round/auto,
-/obj/item/clothing/under/shorts/blue,
-/obj/item/clothing/under/shorts/blue,
+/obj/item/clothing/under/shorts/blue{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/item/clothing/under/shorts/blue{
+	pixel_x = -7;
+	pixel_y = 4
+	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "bPg" = (
@@ -7783,11 +7795,11 @@
 /turf/simulated/floor/darkblue/checker,
 /area/station/ai_monitored/storage/eva)
 "bXp" = (
-/obj/storage/closet,
 /obj/decal/cleanable/dirt/jen,
-/obj/decal/cleanable/rust/jen,
+/obj/reagent_dispensers/foamtank,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /turf/simulated/floor/plating/jen,
-/area/station/maintenance/inner/nw)
+/area/station/maintenance/outer/nw)
 "bXq" = (
 /obj/cable,
 /obj/cable{
@@ -8087,6 +8099,20 @@
 	dir = 8
 	},
 /area/listeningpost)
+"cdX" = (
+/obj/table/reinforced/auto,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 8
+	},
+/obj/access_spawn/engineering,
+/obj/firedoor_spawn,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/storage/primary)
 "cdY" = (
 /obj/table/auto,
 /obj/item/storage/toolbox/mechanical{
@@ -9523,6 +9549,10 @@
 /obj/railing/orange,
 /obj/decal/cleanable/dirt/jen,
 /obj/decal/cleanable/rust/jen,
+/obj/machinery/disposal_pipedispenser/mobile{
+	dir = 8
+	},
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/sw)
 "cCl" = (
@@ -9786,6 +9816,10 @@
 	dir = 4
 	},
 /obj/machinery/light/incandescent/netural,
+/obj/landmark{
+	icon_state = "x3";
+	name = "peststart"
+	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/courtroom)
 "cHV" = (
@@ -10109,6 +10143,16 @@
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating,
 /area/station/janitor)
+"cNK" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "4-9"
+	},
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/inner/sw)
 "cNV" = (
 /obj/lattice{
 	icon_state = "lattice-dir"
@@ -11051,14 +11095,12 @@
 /turf/simulated/floor/specialroom/freezer,
 /area/station/security/brig/north_side)
 "dbt" = (
-/obj/grille/catwalk/jen,
 /obj/landmark{
 	icon_state = "x3";
 	name = "peststart"
 	},
-/obj/decal/cleanable/dirt/jen,
-/turf/simulated/floor/plating/jen,
-/area/station/maintenance/outer/se)
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/locker)
 "dbP" = (
 /turf/simulated/wall/auto/reinforced/supernorn/yellow,
 /area/station/engine/inner)
@@ -12033,16 +12075,12 @@
 /turf/simulated/wall/auto/jen/blue,
 /area/station/crew_quarters/clown)
 "dqP" = (
-/obj/grille/catwalk/jen/side{
-	dir = 1
-	},
 /obj/decal/cleanable/dirt/jen,
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
-	},
+/obj/decal/cleanable/rust/jen,
+/obj/reagent_dispensers/foamtank,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /turf/simulated/floor/plating/jen,
-/area/station/maintenance/outer/ne)
+/area/station/maintenance/inner/nw)
 "dqQ" = (
 /obj/machinery/light/incandescent{
 	dir = 1
@@ -12417,19 +12455,9 @@
 /turf/simulated/floor,
 /area/station/hallway)
 "dwM" = (
-/obj/grille/catwalk/jen/side{
-	dir = 1
-	},
-/obj/decal/cleanable/dirt/jen,
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
-	},
+/obj/storage/closet/emergency,
 /turf/simulated/floor/plating/jen,
-/area/station/maintenance/outer/north)
+/area/station/maintenance/inner/north)
 "dwU" = (
 /obj/decal/floatingtiles{
 	dir = 8;
@@ -12723,16 +12751,11 @@
 	},
 /area/station/hallway/primary/west)
 "dDW" = (
-/obj/grille/catwalk/jen/side{
-	dir = 4
-	},
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
-	},
+/obj/machinery/fluid_canister,
 /obj/decal/cleanable/dirt/jen,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /turf/simulated/floor/plating/jen,
-/area/station/maintenance/outer/se)
+/area/station/maintenance/outer/east)
 "dEo" = (
 /obj/storage/closet/coffin,
 /obj/disposalpipe/segment/transport{
@@ -13471,6 +13494,7 @@
 "dPY" = (
 /obj/table/auto,
 /obj/item/storage/toolbox/emergency{
+	pixel_x = 5;
 	pixel_y = 8
 	},
 /obj/machinery/light/incandescent/cool{
@@ -13483,10 +13507,20 @@
 	pixel_x = 10;
 	tag = ""
 	},
-/obj/item/robodefibrillator,
+/obj/item/robodefibrillator{
+	pixel_x = 8
+	},
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
 	name = "crematorium pipe"
+	},
+/obj/item/reagent_containers/hypospray{
+	pixel_x = -6;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/hypospray{
+	pixel_x = -9;
+	pixel_y = 4
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/surgery/storage)
@@ -13621,7 +13655,8 @@
 "dSq" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/decal/cleanable/rust/jen,
-/obj/random_item_spawner/junk/maybe_few,
+/obj/reagent_dispensers/fueltank,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/nw)
 "dSy" = (
@@ -15803,13 +15838,11 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/quarters)
 "eDr" = (
-/obj/decal/cleanable/rust/jen,
-/obj/railing/orange{
-	dir = 1
-	},
+/obj/reagent_dispensers/fueltank,
 /obj/decal/cleanable/dirt/jen,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /turf/simulated/floor/plating/jen,
-/area/station/maintenance/inner/sw)
+/area/station/maintenance/outer/east)
 "eDT" = (
 /obj/decal/tile_edge/line/black{
 	dir = 1;
@@ -16420,6 +16453,7 @@
 /obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /obj/decal/cleanable/dirt/jen,
 /obj/decal/cleanable/rust/jen,
+/obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/west)
 "eML" = (
@@ -16806,6 +16840,7 @@
 "eRI" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/decal/cleanable/rust/jen,
+/obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/sw)
 "eRY" = (
@@ -17474,16 +17509,17 @@
 /turf/simulated/floor/orangeblack,
 /area/station/engine/elect)
 "fcl" = (
-/obj/grille/catwalk/jen/side{
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/yellow/side{
 	dir = 1
 	},
-/obj/decal/cleanable/dirt/jen,
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/maintenance/outer/east)
+/area/station/storage/auxillary{
+	name = "Tool Storage"
+	})
 "fcp" = (
 /obj/item/clothing/suit/bedsheet,
 /obj/stool/bed,
@@ -17813,6 +17849,7 @@
 	dir = 4
 	},
 /obj/decal/cleanable/dirt/jen,
+/obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/sw)
 "fiN" = (
@@ -19585,6 +19622,10 @@
 /obj/decal/poster/wallsign/space,
 /turf/simulated/wall/auto/reinforced/jen,
 /area/station/hallway/secondary/exit)
+"fKw" = (
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/inner/sw)
 "fKO" = (
 /obj/cable{
 	d1 = 4;
@@ -19915,10 +19956,6 @@
 "fPj" = (
 /obj/grille/catwalk/jen/side,
 /obj/decal/cleanable/dirt/jen,
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
-	},
 /obj/cable{
 	d1 = 2;
 	d2 = 4;
@@ -22046,6 +22083,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/sw)
 "gzx" = (
@@ -22953,6 +22991,18 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
+"gPX" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
+/area/station/storage/auxillary{
+	name = "Tool Storage"
+	})
 "gQc" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -24534,6 +24584,10 @@
 /obj/landmark{
 	name = "shitty_bill_respawn"
 	},
+/obj/landmark{
+	icon_state = "x3";
+	name = "peststart"
+	},
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/bathroom)
 "hpH" = (
@@ -24560,6 +24614,11 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/nw)
+"hpU" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/outer/sw)
 "hpV" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/grille/catwalk/jen,
@@ -24962,6 +25021,7 @@
 /obj/disposalpipe/segment,
 /obj/decal/cleanable/dirt/jen,
 /obj/decal/cleanable/rust/jen,
+/obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/sw)
 "hvM" = (
@@ -26306,6 +26366,9 @@
 /obj/cable{
 	icon_state = "4-10"
 	},
+/obj/item/storage/wall/fire{
+	pixel_y = 32
+	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/north)
 "hQi" = (
@@ -27633,10 +27696,22 @@
 "ine" = (
 /obj/decal/boxingrope,
 /obj/table/wood/round/auto,
-/obj/item/basketball,
-/obj/item/basketball,
-/obj/item/basketball,
-/obj/item/basketball,
+/obj/item/basketball{
+	pixel_x = 4;
+	pixel_y = 7
+	},
+/obj/item/basketball{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/basketball{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/basketball{
+	pixel_x = 13;
+	pixel_y = 1
+	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "inf" = (
@@ -30424,6 +30499,10 @@
 	pixel_y = 20;
 	tag = ""
 	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/grimycarpet,
 /area/station/hallway/secondary/construction2)
 "jmX" = (
@@ -31250,6 +31329,15 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/courtroom)
+"jAX" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/grimycarpet,
+/area/station/hallway/secondary/construction2)
 "jAZ" = (
 /obj/machinery/door/unpowered/wood/pyro{
 	dir = 4;
@@ -31316,8 +31404,14 @@
 "jCe" = (
 /obj/decal/boxingrope,
 /obj/table/wood/round/auto,
-/obj/item/clothing/under/shorts/black,
-/obj/item/clothing/under/shorts/black,
+/obj/item/clothing/under/shorts/black{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/item/clothing/under/shorts/black{
+	pixel_x = -6;
+	pixel_y = 4
+	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "jCk" = (
@@ -31406,6 +31500,7 @@
 	dir = 4
 	},
 /obj/decal/cleanable/dirt/jen,
+/obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/sw)
 "jEt" = (
@@ -33061,6 +33156,8 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/reagent_dispensers/foamtank,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/west)
 "khz" = (
@@ -33141,13 +33238,6 @@
 	},
 /turf/simulated/floor/dojo/sand/vertical,
 /area/station/crew_quarters/captain)
-"kiF" = (
-/obj/machinery/drone_recharger,
-/obj/decal/cleanable/dirt/jen,
-/obj/decal/mule/beacon/no_auto_dropoff_spawn,
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/plating/jen,
-/area/station/maintenance/inner/west)
 "kiP" = (
 /obj/machinery/computer/announcement{
 	name = "Security Announcement Computer";
@@ -33750,6 +33840,10 @@
 /obj/machinery/light/small,
 /obj/disposalpipe/segment/transport{
 	dir = 4
+	},
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
+/obj/machinery/disposal_pipedispenser/mobile{
+	dir = 8
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/west)
@@ -36517,10 +36611,6 @@
 /area/station/crew_quarters/heads)
 "log" = (
 /obj/disposalpipe/segment/food,
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
-	},
 /turf/simulated/floor/carpet{
 	dir = 9;
 	icon_state = "red2"
@@ -39050,7 +39140,8 @@
 /area/station/science)
 "mae" = (
 /obj/decal/cleanable/dirt/jen,
-/obj/storage/closet/emergency,
+/obj/reagent_dispensers/fueltank,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/north)
 "mai" = (
@@ -40810,10 +40901,6 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
-	},
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
@@ -41403,6 +41490,14 @@
 /obj/machinery/light/emergency,
 /turf/simulated/floor/green/side,
 /area/station/hallway/primary/west)
+"mOU" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/hallway/secondary/construction2)
 "mPa" = (
 /obj/decal/mule/dropoff,
 /obj/machinery/door/airlock/pyro/glass,
@@ -42764,6 +42859,13 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
+"nkE" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/reagent_dispensers/fueltank,
+/obj/decal/cleanable/rust/jen,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/inner/sw)
 "nkG" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/grille/catwalk/jen/side{
@@ -43176,6 +43278,9 @@
 	},
 /area/mining/magnet)
 "npT" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/storage/auxillary{
 	name = "Tool Storage"
@@ -43414,9 +43519,6 @@
 /turf/simulated/floor/black/grime,
 /area/station/security/brig/north_side)
 "nuv" = (
-/obj/machinery/disposal_pipedispenser/mobile{
-	dir = 8
-	},
 /obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
@@ -43744,6 +43846,7 @@
 "nzJ" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/disposalpipe/segment/mail,
+/obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/west)
 "nzQ" = (
@@ -44353,6 +44456,9 @@
 /area/station/security/brig/south_side)
 "nLv" = (
 /obj/landmark/gps_waypoint,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/storage/auxillary{
 	name = "Tool Storage"
@@ -44493,22 +44599,14 @@
 /turf/simulated/floor/yellow,
 /area/station/engine/inner)
 "nOi" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/grille/catwalk/jen/side,
+/obj/railing/orange,
 /obj/decal/cleanable/dirt/jen,
-/obj/disposalpipe/segment{
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
-	},
+/obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating/jen,
-/area/station/maintenance/outer/ne)
+/area/station/maintenance/inner/sw)
 "nOq" = (
 /obj/grille,
 /obj/structure/woodwall,
@@ -45938,9 +46036,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4;
-	req_access = null
+/obj/machinery/door/airlock/pyro/alt{
+	dir = 4
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/hallway/secondary/construction)
@@ -49540,6 +49637,11 @@
 	},
 /turf/simulated/floor/green/side,
 /area/station/hydroponics)
+"ppH" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/black/grime,
+/area/station/maintenance/outer/sw)
 "ppI" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/blue/side{
@@ -50760,6 +50862,15 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/hallway/secondary/exit)
+"pGK" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/hallway/secondary/construction)
 "pGS" = (
 /obj/cable{
 	d1 = 1;
@@ -50877,10 +50988,11 @@
 /area/station/crew_quarters/courtroom)
 "pJo" = (
 /obj/decal/cleanable/dirt/jen,
-/obj/storage/closet/fire,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /obj/machinery/light/small/sticky{
 	dir = 1
 	},
+/obj/reagent_dispensers/foamtank,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/north)
 "pJr" = (
@@ -50982,6 +51094,8 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/reagent_dispensers/foamtank,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/west)
 "pLm" = (
@@ -51464,9 +51578,9 @@
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "pTp" = (
-/obj/machinery/portable_atmospherics/scrubber,
 /obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /obj/decal/cleanable/dirt/jen,
+/obj/reagent_dispensers/foamtank,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/sw)
 "pTE" = (
@@ -53481,11 +53595,12 @@
 /area/station/hallway/primary/west)
 "quM" = (
 /obj/decal/cleanable/dirt/jen,
-/obj/random_item_spawner/junk/one_or_zero,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /obj/disposalpipe/segment/mail{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/west)
 "quO" = (
@@ -53555,8 +53670,13 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/west)
 "qvK" = (
-/obj/table/auto,
-/obj/random_item_spawner/tools/some,
+/obj/machinery/light/incandescent/cool{
+	dir = 1;
+	pixel_x = 10;
+	pixel_y = 24
+	},
+/obj/reagent_dispensers/fueltank,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /turf/simulated/floor/darkblue/checker,
 /area/station/ai_monitored/storage/eva)
 "qvR" = (
@@ -54361,10 +54481,8 @@
 /area/station/crew_quarters/courtroom)
 "qJe" = (
 /obj/disposalpipe/segment,
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
-	},
+/obj/reagent_dispensers/fueltank,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/west)
 "qJf" = (
@@ -54850,6 +54968,14 @@
 	dir = 9
 	},
 /area/station/medical/head)
+"qRb" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/hallway/secondary/construction2)
 "qRe" = (
 /obj/table/auto,
 /obj/item/decoration/ashtray{
@@ -55479,6 +55605,9 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/storage/auxillary{
 	name = "Tool Storage"
@@ -55492,6 +55621,10 @@
 	},
 /obj/disposalpipe/segment/transport{
 	dir = 4
+	},
+/obj/landmark{
+	icon_state = "x3";
+	name = "peststart"
 	},
 /turf/simulated/grass,
 /area/station/hallway/primary/west)
@@ -55875,6 +56008,16 @@
 /area/station/medical/research{
 	name = "Genetic Research"
 	})
+"rfJ" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/yellowblack{
+	dir = 8
+	},
+/area/station/storage/primary)
 "rgh" = (
 /obj/decal/mule/dropoff,
 /obj/machinery/door/airlock/pyro/glass,
@@ -57302,12 +57445,12 @@
 /area/station/crew_quarters/heads)
 "rAR" = (
 /obj/decal/cleanable/dirt/jen,
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
+/obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating/jen,
-/area/station/maintenance/inner/se)
+/area/station/maintenance/inner/sw)
 "rAW" = (
 /obj/lattice{
 	dir = 5;
@@ -57447,6 +57590,13 @@
 /obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
+"rCZ" = (
+/obj/random_item_spawner/junk/one_or_zero,
+/obj/decal/cleanable/dirt/jen,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
+/obj/reagent_dispensers/foamtank,
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/outer/se)
 "rDq" = (
 /obj/machinery/conveyor_switch{
 	id = "disposals"
@@ -58174,10 +58324,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
-	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/north)
 "rPw" = (
@@ -58729,9 +58875,9 @@
 	name = "Funeral Parlor"
 	})
 "rZw" = (
-/obj/rack,
-/obj/random_item_spawner/tools/one,
+/obj/reagent_dispensers/foamtank,
 /obj/decal/cleanable/dirt/jen,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/sw)
 "rZR" = (
@@ -59388,6 +59534,10 @@
 	name = "autoname - SS13";
 	pixel_y = 20;
 	tag = ""
+	},
+/obj/landmark{
+	icon_state = "x3";
+	name = "peststart"
 	},
 /turf/simulated/floor/carpet/blue/standard/edge{
 	dir = 5
@@ -61107,6 +61257,18 @@
 "sOd" = (
 /turf/simulated/floor/specialroom/freezer,
 /area/station/medical/morgue)
+"sOo" = (
+/obj/decal/mule/dropoff,
+/obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
+/obj/access_spawn,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/hallway/secondary/construction2)
 "sOs" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/decal/mule/dropoff,
@@ -61211,6 +61373,15 @@
 	},
 /turf/simulated/floor/black/grime,
 /area/station/security/brig/north_side)
+"sQU" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/hallway/secondary/construction2)
 "sQZ" = (
 /obj/cable{
 	d1 = 4;
@@ -61751,8 +61922,9 @@
 /obj/machinery/light/small/sticky{
 	dir = 1
 	},
-/obj/random_item_spawner/junk/one_or_zero,
+/obj/reagent_dispensers/fueltank,
 /obj/decal/cleanable/dirt/jen,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /turf/simulated/floor/plating/jen,
 /area/station/storage/auxillary{
 	name = "Tool Storage"
@@ -63129,6 +63301,10 @@
 /obj/machinery/light/incandescent/netural{
 	dir = 1
 	},
+/obj/machinery/disposal_pipedispenser/mobile{
+	dir = 8
+	},
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /turf/simulated/floor/plating/jen,
 /area/station/hallway/secondary/exit)
 "twO" = (
@@ -63650,13 +63826,19 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/south)
 "tEG" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
 /obj/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable,
 /turf/simulated/floor/black,
 /area/station/storage/primary)
 "tEP" = (
@@ -63766,6 +63948,10 @@
 	dir = 8
 	},
 /obj/disposalpipe/segment,
+/obj/landmark{
+	icon_state = "x3";
+	name = "peststart"
+	},
 /turf/simulated/floor/wood/six,
 /area/station/library)
 "tGm" = (
@@ -66595,6 +66781,10 @@
 /obj/disposalpipe/segment/brig{
 	dir = 4
 	},
+/obj/landmark{
+	icon_state = "x3";
+	name = "peststart"
+	},
 /turf/simulated/floor/wood/two,
 /area/station/hallway/primary/south)
 "uCu" = (
@@ -66993,10 +67183,6 @@
 	},
 /obj/decoration/toiletholder{
 	pixel_y = 32
-	},
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
 	},
 /turf/simulated/floor/sanitary/blue,
 /area/station/crew_quarters/captain)
@@ -69899,6 +70085,10 @@
 	pixel_x = 6;
 	pixel_y = 1
 	},
+/obj/landmark{
+	icon_state = "x3";
+	name = "peststart"
+	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/bathroom)
 "vBp" = (
@@ -70503,10 +70693,6 @@
 	dir = 4
 	},
 /obj/decal/cleanable/dirt/jen,
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
-	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/sw)
 "vKW" = (
@@ -70954,9 +71140,6 @@
 	pixel_x = -3;
 	pixel_y = 4
 	},
-/obj/machinery/light/incandescent/warm{
-	dir = 1
-	},
 /obj/item/storage/belt/utility,
 /obj/item/extinguisher{
 	pixel_x = 6;
@@ -71296,6 +71479,10 @@
 	dir = 4;
 	icon_state = "line1"
 	},
+/obj/landmark{
+	icon_state = "x3";
+	name = "peststart"
+	},
 /turf/simulated/floor/white/checker{
 	dir = 6
 	},
@@ -71358,6 +71545,12 @@
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor)
+"vYy" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
+/turf/simulated/floor/black/grime,
+/area/station/maintenance/outer/sw)
 "vYM" = (
 /obj/cable{
 	d2 = 8;
@@ -71403,17 +71596,13 @@
 /turf/simulated/floor/white/checker,
 /area/station/hallway/primary/south)
 "vZE" = (
-/obj/access_spawn/maint,
-/obj/decal/mule/dropoff,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro/maintenance{
-	req_access = null
-	},
 /obj/disposalpipe/segment/mail,
+/obj/grille/catwalk/jen/twosides,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/sw)
 "vZI" = (
@@ -72052,16 +72241,11 @@
 /turf/simulated/floor/black,
 /area/station/science/bot_storage)
 "wje" = (
-/obj/grille/catwalk/jen/side{
-	dir = 1
-	},
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
-	},
+/obj/reagent_dispensers/fueltank,
 /obj/decal/cleanable/dirt/jen,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /turf/simulated/floor/plating/jen,
-/area/station/maintenance/outer/sw)
+/area/station/maintenance/inner/sw)
 "wjh" = (
 /obj/grille/catwalk/jen,
 /turf/simulated/floor/plating/jen,
@@ -72095,12 +72279,18 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/sw)
 "wjJ" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/railing/orange{
-	dir = 4
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating/jen,
-/area/station/maintenance/inner/south)
+/area/station/hallway/secondary/construction)
 "wjM" = (
 /obj/rack,
 /obj/item/clothing/shoes/magnetic,
@@ -74182,6 +74372,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/west)
 "wPZ" = (
@@ -74901,6 +75092,7 @@
 "wZJ" = (
 /obj/railing/orange,
 /obj/decal/cleanable/dirt/jen,
+/obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/sw)
 "wZR" = (
@@ -74997,6 +75189,7 @@
 	dir = 1
 	},
 /obj/decal/cleanable/dirt/jen,
+/obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/sw)
 "xbC" = (
@@ -75280,16 +75473,15 @@
 /turf/simulated/floor/sand,
 /area/station/engine/engineering/ce)
 "xgv" = (
-/obj/grille/catwalk/jen/side{
-	dir = 8
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/disposalpipe/segment,
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/maintenance/inner/south)
+/turf/simulated/floor,
+/area/station/storage/auxillary{
+	name = "Tool Storage"
+	})
 "xgx" = (
 /obj/machinery/door/airlock/pyro/command/alt{
 	dir = 8
@@ -76326,6 +76518,10 @@
 "xzw" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/decal/cleanable/rust/jen,
+/obj/landmark{
+	icon_state = "x3";
+	name = "peststart"
+	},
 /turf/simulated/floor/plating/jen,
 /area/station/hallway/secondary/construction)
 "xzH" = (
@@ -78741,9 +78937,6 @@
 /obj/item/storage/belt/utility{
 	pixel_x = -3;
 	pixel_y = -1
-	},
-/obj/machinery/light/incandescent/cool{
-	dir = 1
 	},
 /turf/simulated/floor/darkblue/checker,
 /area/station/ai_monitored/storage/eva)
@@ -105103,7 +105296,7 @@ qgG
 qgG
 jKY
 jDb
-uOO
+ppH
 eQS
 pFp
 ltH
@@ -105406,7 +105599,7 @@ wZJ
 hcW
 hsj
 bUO
-uOO
+vYy
 pFp
 kif
 pFp
@@ -105705,10 +105898,10 @@ mLB
 bUO
 mQf
 gBM
-wje
+hcW
 hsj
 bUO
-bUO
+hpU
 uOO
 uOO
 cWf
@@ -106823,7 +107016,7 @@ dZz
 acs
 kmE
 kmE
-kmE
+ahI
 kll
 dZz
 rdj
@@ -108702,7 +108895,7 @@ mSD
 mJS
 cQT
 sTC
-kiF
+nzJ
 nzJ
 tHl
 sPu
@@ -109256,7 +109449,7 @@ waP
 nFW
 cXT
 gcK
-cXT
+dbt
 kVR
 gKJ
 rdj
@@ -110825,7 +111018,7 @@ dVe
 dVe
 rdj
 jpQ
-esE
+nOi
 tsm
 kXA
 wAD
@@ -111731,11 +111924,11 @@ etN
 vwD
 rdj
 ogJ
-fha
+rAR
 qab
 bFY
 wXY
-wyf
+cNK
 uwa
 pJj
 sqY
@@ -112035,7 +112228,7 @@ rdj
 jpQ
 vnN
 qab
-eDr
+wfe
 lxV
 gLe
 uwa
@@ -112292,7 +112485,7 @@ ifh
 umn
 dGE
 tJK
-aIK
+dqP
 aIK
 wVG
 nKw
@@ -112872,7 +113065,7 @@ tOR
 gdE
 bxe
 mpU
-uPc
+bXp
 fOn
 fiz
 ovQ
@@ -113553,8 +113746,8 @@ tlF
 fha
 tsm
 aak
-nVa
-nVa
+fKw
+fKw
 pjy
 suS
 eaO
@@ -113575,7 +113768,7 @@ tuV
 pyL
 mZl
 kze
-jIL
+nkE
 uXW
 quO
 cma
@@ -115057,7 +115250,7 @@ rBC
 mAu
 hzf
 hzf
-hzf
+tDz
 kGK
 ksg
 wrs
@@ -115662,7 +115855,7 @@ mAu
 qrt
 dSk
 iyl
-hzf
+tDz
 ksg
 ory
 wYh
@@ -116266,7 +116459,7 @@ bhf
 mCx
 hzf
 hzf
-mCx
+jIL
 ksg
 hNB
 aOn
@@ -116566,7 +116759,7 @@ jpQ
 jpQ
 jpQ
 bgm
-ydA
+wje
 ydA
 xjY
 ksg
@@ -116883,10 +117076,10 @@ rTs
 tDz
 lcP
 oos
-wjJ
 oos
 oos
-wjJ
+oos
+oos
 oos
 oos
 eOq
@@ -117120,13 +117313,13 @@ bWP
 szx
 dSq
 suy
-bXp
+rMd
 obo
 fDt
 fDt
 oQP
 gcd
-aUn
+uum
 vNE
 rdj
 rdj
@@ -117187,7 +117380,7 @@ xFi
 qUC
 xNM
 tku
-xgv
+rcS
 rcS
 rcS
 rcS
@@ -119502,7 +119695,7 @@ jvj
 jvj
 cqD
 ewH
-dwM
+dHo
 xSt
 kKA
 oxn
@@ -126186,7 +126379,7 @@ nlB
 uYt
 pYb
 nbB
-jnB
+dwM
 nlB
 rdj
 rdj
@@ -129475,7 +129668,7 @@ aUm
 aUm
 aUm
 bzi
-nOi
+cMy
 hYv
 dvR
 wqJ
@@ -130161,7 +130354,7 @@ nsc
 bCH
 uOK
 xfq
-rAR
+fes
 ueF
 rtD
 vxr
@@ -130447,7 +130640,7 @@ eXv
 qWg
 cLK
 jnN
-ahI
+aeN
 iMh
 mBl
 hna
@@ -131968,11 +132161,11 @@ wnv
 wnv
 oLR
 rRw
-txw
-oxI
-oEK
-uQW
-xBW
+wjJ
+pGK
+sOo
+sQU
+mOU
 uQW
 oiX
 tWs
@@ -132186,7 +132379,7 @@ ofw
 kyD
 aRI
 mkU
-dqP
+bzi
 btN
 vpz
 vpz
@@ -132274,7 +132467,7 @@ vLR
 kyC
 qtZ
 uQW
-xBW
+qRb
 xBW
 ged
 qtZ
@@ -132576,7 +132769,7 @@ oxI
 iOH
 orh
 gIe
-iYL
+jAX
 jwX
 bhG
 qtZ
@@ -134916,7 +135109,7 @@ etV
 uyp
 mxH
 oxl
-hAc
+aUn
 hAc
 ahj
 nrl
@@ -135586,13 +135779,13 @@ vqi
 vqi
 vqi
 vqi
-uQw
+fcl
 npT
 nLv
 qZS
 qZS
 npT
-npT
+xgv
 bvC
 elM
 sZI
@@ -135894,7 +136087,7 @@ oxG
 oHf
 khD
 wPR
-wPR
+gPX
 bww
 elM
 vwi
@@ -135907,7 +136100,7 @@ fnX
 uvJ
 rhm
 rhm
-dDW
+uvJ
 uvJ
 fvF
 fhT
@@ -136196,7 +136389,7 @@ vqi
 ohh
 ohh
 jWD
-jWD
+cdX
 byA
 lVy
 lVy
@@ -136498,7 +136691,7 @@ oAy
 ohh
 uSB
 dae
-dae
+rfJ
 xCC
 jab
 lVy
@@ -138269,7 +138462,7 @@ cus
 hbA
 tSd
 stM
-fcl
+aVk
 plW
 tat
 qDA
@@ -140691,7 +140884,7 @@ oXU
 oXU
 eAg
 fuB
-jaL
+dDW
 aVk
 gJu
 kxV
@@ -140993,7 +141186,7 @@ sdN
 eUt
 rJD
 fuB
-jaL
+eDr
 aVk
 kPG
 dbP
@@ -141598,7 +141791,7 @@ pmt
 rJD
 fuB
 sfD
-fcl
+aVk
 kPG
 dbP
 ohe
@@ -141944,7 +142137,7 @@ ndW
 imD
 vco
 jSF
-dbt
+rhm
 vfx
 gQk
 rdj
@@ -143448,7 +143641,7 @@ lwP
 ncJ
 kGg
 mQN
-rJj
+rCZ
 eZn
 wPF
 vje
@@ -144955,7 +145148,7 @@ bNa
 pPi
 jTc
 wPF
-dbt
+rhm
 sFw
 ugn
 uvJ

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -2721,15 +2721,6 @@
 	icon_state = "12"
 	},
 /area/station/mining)
-"auz" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/hallway/secondary/construction2)
 "auB" = (
 /obj/plasticflaps{
 	layer = 3
@@ -4206,6 +4197,14 @@
 /obj/disposalpipe/segment/food,
 /turf/simulated/floor/sanitary,
 /area/station/chapel/main)
+"aTw" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/hallway/secondary/construction2)
 "aTA" = (
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
@@ -8020,6 +8019,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/ptl)
+"cbS" = (
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/inner/sw)
 "cbY" = (
 /obj/machinery/door/airlock/pyro/security/alt{
 	dir = 4
@@ -9443,6 +9446,15 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/engine/engineering)
+"cAJ" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/hallway/secondary/construction2)
 "cAQ" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 9;
@@ -11854,10 +11866,14 @@
 	},
 /obj/item/device/radio{
 	pixel_x = -7;
-	pixel_y = 7
+	pixel_y = 4
 	},
 /obj/decal/tile_edge/line/purple{
 	icon_state = "line1"
+	},
+/obj/item/chem_grenade/cleaner{
+	pixel_x = -1;
+	pixel_y = 12
 	},
 /turf/simulated/floor/black,
 /area/station/janitor)
@@ -24159,16 +24175,6 @@
 	dir = 4
 	},
 /area/station/engine/engineering)
-"hiA" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/yellowblack{
-	dir = 8
-	},
-/area/station/storage/primary)
 "hiB" = (
 /obj/grille/catwalk{
 	dir = 6
@@ -26429,6 +26435,13 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
+"hSZ" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/reagent_dispensers/fueltank,
+/obj/decal/cleanable/rust/jen,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/inner/sw)
 "hTp" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/mail,
@@ -27074,12 +27087,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
-"idv" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/decal/mule/beacon/no_auto_dropoff_spawn,
-/turf/simulated/floor/black/grime,
-/area/station/maintenance/outer/sw)
 "idw" = (
 /obj/stool/chair/office{
 	dir = 4
@@ -30487,6 +30494,16 @@
 	},
 /turf/simulated/grimycarpet,
 /area/station/hallway/secondary/construction2)
+"jmS" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/yellowblack{
+	dir = 8
+	},
+/area/station/storage/primary)
 "jmX" = (
 /obj/stool/chair/comfy/barber_chair{
 	desc = "A traditional barbershop chair, obviously a very old one at that.  What it is doing on a space station you haven't the foggiest.";
@@ -30799,14 +30816,6 @@
 /obj/random_item_spawner/tools/two,
 /turf/simulated/floor/yellowblack,
 /area/station/engine/inner)
-"jsb" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/hallway/secondary/construction2)
 "jsg" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/wood/five,
@@ -31850,6 +31859,18 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/sw)
+"jJC" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
+/area/station/storage/auxillary{
+	name = "Tool Storage"
+	})
 "jJM" = (
 /obj/marker/supplymarker,
 /turf/simulated/floor/black,
@@ -32676,15 +32697,6 @@
 "jXA" = (
 /turf/simulated/floor/carpet/red/fancy,
 /area/station/crew_quarters/stockex)
-"jXL" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/grimycarpet,
-/area/station/hallway/secondary/construction2)
 "jXP" = (
 /obj/machinery/light/incandescent/warm,
 /obj/machinery/recharger,
@@ -32974,6 +32986,16 @@
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
+"kdO" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "4-9"
+	},
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/inner/sw)
 "kee" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/cable{
@@ -33174,10 +33196,6 @@
 	},
 /turf/simulated/floor/redblack,
 /area/station/security/brig/south_side)
-"khM" = (
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating/jen,
-/area/station/maintenance/inner/sw)
 "khT" = (
 /obj/disposalpipe/segment,
 /obj/machinery/atmospherics/unary/vent_pump/security/east,
@@ -35887,16 +35905,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/sw)
-"lcG" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "4-9"
-	},
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/sw)
 "lcP" = (
 /obj/wingrille_spawn/auto,
@@ -39299,13 +39307,14 @@
 	icon_state = "floor4"
 	},
 /area/listeningpost)
-"mcl" = (
-/obj/random_item_spawner/junk/one_or_zero,
-/obj/decal/cleanable/dirt/jen,
-/obj/decal/mule/beacon/no_auto_dropoff_spawn,
-/obj/reagent_dispensers/foamtank,
+"mcF" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating/jen,
-/area/station/maintenance/outer/se)
+/area/station/hallway/secondary/construction2)
 "mcL" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 8;
@@ -39672,13 +39681,6 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quartersB)
-"miE" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/reagent_dispensers/fueltank,
-/obj/decal/cleanable/rust/jen,
-/obj/decal/mule/beacon/no_auto_dropoff_spawn,
-/turf/simulated/floor/plating/jen,
-/area/station/maintenance/inner/sw)
 "miG" = (
 /obj/storage/closet/emergency,
 /turf/simulated/floor/white,
@@ -42605,6 +42607,18 @@
 	dir = 8
 	},
 /area/station/security/quarters)
+"nfV" = (
+/obj/decal/mule/dropoff,
+/obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
+/obj/access_spawn,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/hallway/secondary/construction2)
 "nfZ" = (
 /obj/machinery/light/small/sticky/harsh{
 	dir = 8
@@ -44659,6 +44673,15 @@
 	name = "test chamber plating"
 	},
 /area/station/testchamber)
+"nOY" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/grimycarpet,
+/area/station/hallway/secondary/construction2)
 "nPk" = (
 /turf/simulated/wall/auto/reinforced/jen,
 /area/station/crew_quarters/arcade/dungeon)
@@ -44848,15 +44871,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/medical/medbay/cloner)
-"nRF" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/hallway/secondary/construction)
 "nRR" = (
 /obj/machinery/power/apc/autoname_west,
 /obj/cable,
@@ -51906,6 +51920,11 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
+"pYX" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/outer/sw)
 "pZc" = (
 /obj/cable{
 	d1 = 1;
@@ -54739,6 +54758,13 @@
 /area/station/chapel/main{
 	name = "Funeral Parlor"
 	})
+"qNt" = (
+/obj/random_item_spawner/junk/one_or_zero,
+/obj/decal/cleanable/dirt/jen,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
+/obj/reagent_dispensers/foamtank,
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/outer/se)
 "qNv" = (
 /obj/decal/tile_edge/line/black{
 	dir = 4;
@@ -57182,6 +57208,20 @@
 	dir = 6
 	},
 /area/station/engine/ptl)
+"rxI" = (
+/obj/table/reinforced/auto,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 8
+	},
+/obj/access_spawn/engineering,
+/obj/firedoor_spawn,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/storage/primary)
 "rxL" = (
 /obj/machinery/light/incandescent/warm{
 	dir = 8
@@ -59861,18 +59901,6 @@
 	},
 /turf/simulated/floor/purple/side,
 /area/station/hallway/primary/south)
-"spA" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 4
-	},
-/area/station/storage/auxillary{
-	name = "Tool Storage"
-	})
 "spC" = (
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
@@ -60527,11 +60555,6 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/hallway/primary/south)
-"sBn" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating/jen,
-/area/station/maintenance/outer/sw)
 "sBt" = (
 /turf/simulated/wall/auto/reinforced/jen/blue,
 /area/station/bridge/customs)
@@ -61492,6 +61515,10 @@
 /obj/item/device/radio/intercom/loudspeaker/speaker/south{
 	pixel_y = 24
 	},
+/obj/machinery/disposal_pipedispenser/mobile{
+	dir = 8
+	},
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /turf/simulated/floor/yellowblack{
 	dir = 5
 	},
@@ -64156,20 +64183,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
-"tKr" = (
-/obj/table/reinforced/auto,
-/obj/machinery/door/airlock/pyro/glass/windoor{
-	dir = 8
-	},
-/obj/access_spawn/engineering,
-/obj/firedoor_spawn,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/storage/primary)
 "tKu" = (
 /obj/disposalpipe/segment/food{
 	icon_state = "pipe-c"
@@ -65620,6 +65633,11 @@
 	},
 /turf/simulated/floor/purpleblack/corner,
 /area/station/chemistry)
+"ukJ" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/black/grime,
+/area/station/maintenance/outer/sw)
 "ukM" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 1
@@ -66261,11 +66279,6 @@
 	},
 /turf/simulated/wall/auto/reinforced/jen,
 /area/station/maintenance/outer/ne)
-"uuU" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/black/grime,
-/area/station/maintenance/outer/sw)
 "uuV" = (
 /obj/stool/chair/wooden{
 	dir = 4
@@ -68982,6 +68995,15 @@
 /obj/cable,
 /turf/simulated/floor/redblack,
 /area/station/security/main)
+"vkm" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/hallway/secondary/construction)
 "vkr" = (
 /obj/decal/cleanable/cobweb2,
 /obj/rack,
@@ -70205,6 +70227,12 @@
 "vDo" = (
 /turf/simulated/floor/black,
 /area/station/medical/medbay)
+"vDw" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
+/turf/simulated/floor/black/grime,
+/area/station/maintenance/outer/sw)
 "vDz" = (
 /turf/simulated/floor/black/grime,
 /area/station/science/storage)
@@ -75712,11 +75740,11 @@
 "xlw" = (
 /obj/rack,
 /obj/item/reagent_containers/glass/bucket{
-	pixel_x = -5;
+	pixel_x = -7;
 	pixel_y = 5
 	},
 /obj/item/reagent_containers/glass/bucket{
-	pixel_x = -2;
+	pixel_x = -4;
 	pixel_y = 1
 	},
 /obj/item/mop{
@@ -75732,6 +75760,17 @@
 	icon_state = "line1"
 	},
 /obj/disposalpipe/segment/transport,
+/obj/item/chem_grenade/cleaner{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/item/chem_grenade/cleaner{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/obj/item/chem_grenade/cleaner{
+	pixel_x = 9
+	},
 /turf/simulated/floor/black,
 /area/station/janitor)
 "xlx" = (
@@ -76554,14 +76593,6 @@
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/bar)
-"xAw" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/hallway/secondary/construction2)
 "xAB" = (
 /obj/decal/tile_edge/line/purple{
 	dir = 6;
@@ -77258,10 +77289,22 @@
 /obj/table/auto,
 /obj/item/spraybottle/cleaner{
 	pixel_x = 9;
-	pixel_y = 6
+	pixel_y = 8
 	},
 /obj/item/sponge{
-	pixel_x = -3
+	pixel_x = 4
+	},
+/obj/item/chem_grenade/cleaner{
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/obj/item/chem_grenade/cleaner{
+	pixel_x = -2;
+	pixel_y = 10
+	},
+/obj/item/chem_grenade/cleaner{
+	pixel_x = -7;
+	pixel_y = 5
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/supply)
@@ -78630,18 +78673,6 @@
 /obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /turf/simulated/floor/plating/jen,
 /area/station/science/gen_storage)
-"yfd" = (
-/obj/decal/mule/dropoff,
-/obj/machinery/door/airlock/pyro/glass,
-/obj/firedoor_spawn,
-/obj/access_spawn,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/hallway/secondary/construction2)
 "yff" = (
 /obj/storage/closet/wardrobe/pride,
 /turf/unsimulated/floor/shuttle,
@@ -105301,7 +105332,7 @@ qgG
 qgG
 jKY
 jDb
-uuU
+ukJ
 eQS
 pFp
 ltH
@@ -105604,7 +105635,7 @@ wZJ
 hcW
 hsj
 bUO
-idv
+vDw
 pFp
 kif
 pFp
@@ -105906,7 +105937,7 @@ gBM
 hcW
 hsj
 bUO
-sBn
+pYX
 uOO
 uOO
 cWf
@@ -111933,7 +111964,7 @@ rAR
 qab
 bFY
 wXY
-lcG
+kdO
 uwa
 pJj
 sqY
@@ -113751,8 +113782,8 @@ tlF
 fha
 tsm
 aak
-khM
-khM
+cbS
+cbS
 pjy
 suS
 eaO
@@ -113773,7 +113804,7 @@ tuV
 pyL
 mZl
 kze
-miE
+hSZ
 uXW
 quO
 cma
@@ -132167,10 +132198,10 @@ wnv
 oLR
 rRw
 wjJ
-nRF
-yfd
-auz
-jsb
+vkm
+nfV
+cAJ
+aTw
 uQW
 oiX
 tWs
@@ -132472,7 +132503,7 @@ vLR
 kyC
 qtZ
 uQW
-xAw
+mcF
 xBW
 ged
 qtZ
@@ -132774,7 +132805,7 @@ oxI
 iOH
 orh
 gIe
-jXL
+nOY
 jwX
 bhG
 qtZ
@@ -136092,7 +136123,7 @@ oxG
 oHf
 khD
 wPR
-spA
+jJC
 bww
 elM
 vwi
@@ -136394,7 +136425,7 @@ vqi
 ohh
 ohh
 jWD
-tKr
+rxI
 byA
 lVy
 lVy
@@ -136696,7 +136727,7 @@ oAy
 ohh
 uSB
 dae
-hiA
+jmS
 xCC
 jab
 lVy
@@ -143646,7 +143677,7 @@ lwP
 ncJ
 kGg
 mQN
-mcl
+qNt
 eZn
 wPF
 vje

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -4197,14 +4197,6 @@
 /obj/disposalpipe/segment/food,
 /turf/simulated/floor/sanitary,
 /area/station/chapel/main)
-"aTw" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/hallway/secondary/construction2)
 "aTA" = (
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
@@ -6121,6 +6113,7 @@
 /obj/disposalpipe/segment/transport,
 /obj/item/storage/box/mousetraps,
 /obj/item/storage/box/biohazard_bags,
+/obj/item/chem_grenade/cleaner,
 /turf/simulated/floor/black,
 /area/station/janitor)
 "byA" = (
@@ -8019,10 +8012,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/ptl)
-"cbS" = (
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating/jen,
-/area/station/maintenance/inner/sw)
 "cbY" = (
 /obj/machinery/door/airlock/pyro/security/alt{
 	dir = 4
@@ -9256,6 +9245,16 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/black,
 /area/station/medical/medbay/lobby)
+"cxb" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/yellowblack{
+	dir = 8
+	},
+/area/station/storage/primary)
 "cxc" = (
 /turf/simulated/wall/auto/jen/yellow,
 /area/station/mining)
@@ -9446,15 +9445,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/engine/engineering)
-"cAJ" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/hallway/secondary/construction2)
 "cAQ" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 9;
@@ -16931,6 +16921,12 @@
 	},
 /turf/simulated/floor/wood/five,
 /area/station/medical/asylum)
+"eST" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
+/turf/simulated/floor/black/grime,
+/area/station/maintenance/outer/sw)
 "eTk" = (
 /obj/machinery/manufacturer/uniform,
 /obj/machinery/light/emergency,
@@ -18319,6 +18315,13 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/carpet/purple/decal/outercross,
 /area/station/chapel/main)
+"fpl" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/reagent_dispensers/fueltank,
+/obj/decal/cleanable/rust/jen,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/inner/sw)
 "fpq" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/grille/catwalk/jen/side{
@@ -18482,6 +18485,20 @@
 	dir = 10
 	},
 /area/station/crew_quarters/kitchen)
+"fso" = (
+/obj/table/reinforced/auto,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 8
+	},
+/obj/access_spawn/engineering,
+/obj/firedoor_spawn,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/storage/primary)
 "fss" = (
 /obj/cable{
 	d1 = 4;
@@ -25989,6 +26006,14 @@
 	dir = 10
 	},
 /area/station/crew_quarters/stockex)
+"hKO" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/hallway/secondary/construction2)
 "hKS" = (
 /turf/simulated/floor/stairs/wide{
 	dir = 4
@@ -26435,13 +26460,6 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
-"hSZ" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/reagent_dispensers/fueltank,
-/obj/decal/cleanable/rust/jen,
-/obj/decal/mule/beacon/no_auto_dropoff_spawn,
-/turf/simulated/floor/plating/jen,
-/area/station/maintenance/inner/sw)
 "hTp" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/mail,
@@ -27771,6 +27789,16 @@
 /obj/railing/cyan,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/cafeteria)
+"ipb" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "4-9"
+	},
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/inner/sw)
 "ipi" = (
 /obj/disposalpipe/segment/morgue{
 	name = "crematorium pipe"
@@ -29388,6 +29416,11 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/black/grime,
 /area/station/security/brig/north_side)
+"iSC" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/black/grime,
+/area/station/maintenance/outer/sw)
 "iSF" = (
 /turf/simulated/wall/auto/reinforced/jen/yellow,
 /area/station/maintenance/outer/se)
@@ -30494,16 +30527,6 @@
 	},
 /turf/simulated/grimycarpet,
 /area/station/hallway/secondary/construction2)
-"jmS" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/yellowblack{
-	dir = 8
-	},
-/area/station/storage/primary)
 "jmX" = (
 /obj/stool/chair/comfy/barber_chair{
 	desc = "A traditional barbershop chair, obviously a very old one at that.  What it is doing on a space station you haven't the foggiest.";
@@ -31859,18 +31882,6 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/sw)
-"jJC" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 4
-	},
-/area/station/storage/auxillary{
-	name = "Tool Storage"
-	})
 "jJM" = (
 /obj/marker/supplymarker,
 /turf/simulated/floor/black,
@@ -32782,6 +32793,18 @@
 /obj/machinery/vending/cola/red,
 /turf/simulated/grimycarpet,
 /area/station/hallway)
+"kaf" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
+/area/station/storage/auxillary{
+	name = "Tool Storage"
+	})
 "kag" = (
 /turf/simulated/floor/carpet/purple/standard/edge{
 	dir = 8
@@ -32986,16 +33009,6 @@
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
-"kdO" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "4-9"
-	},
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating/jen,
-/area/station/maintenance/inner/sw)
 "kee" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/cable{
@@ -33837,6 +33850,9 @@
 /obj/item/storage/box/biohazard_bags,
 /obj/item/storage/box/biohazard_bags,
 /obj/item/storage/box/trash_bags,
+/obj/item/chem_grenade/cleaner,
+/obj/item/chem_grenade/cleaner,
+/obj/item/chem_grenade/cleaner,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/supply)
 "kth" = (
@@ -34850,6 +34866,11 @@
 /obj/access_spawn/cargo,
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
+"kKk" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/outer/sw)
 "kKq" = (
 /obj/decal/cleanable/dirt,
 /obj/decal/cleanable/rust/jen,
@@ -39307,14 +39328,6 @@
 	icon_state = "floor4"
 	},
 /area/listeningpost)
-"mcF" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/hallway/secondary/construction2)
 "mcL" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 8;
@@ -42607,18 +42620,6 @@
 	dir = 8
 	},
 /area/station/security/quarters)
-"nfV" = (
-/obj/decal/mule/dropoff,
-/obj/machinery/door/airlock/pyro/glass,
-/obj/firedoor_spawn,
-/obj/access_spawn,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/hallway/secondary/construction2)
 "nfZ" = (
 /obj/machinery/light/small/sticky/harsh{
 	dir = 8
@@ -43535,6 +43536,18 @@
 /obj/machinery/light/incandescent/warm,
 /turf/simulated/floor/black/grime,
 /area/station/security/brig/north_side)
+"nuh" = (
+/obj/decal/mule/dropoff,
+/obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
+/obj/access_spawn,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/hallway/secondary/construction2)
 "nuv" = (
 /obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /obj/decal/cleanable/dirt/jen,
@@ -44673,15 +44686,6 @@
 	name = "test chamber plating"
 	},
 /area/station/testchamber)
-"nOY" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/grimycarpet,
-/area/station/hallway/secondary/construction2)
 "nPk" = (
 /turf/simulated/wall/auto/reinforced/jen,
 /area/station/crew_quarters/arcade/dungeon)
@@ -51920,11 +51924,6 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
-"pYX" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating/jen,
-/area/station/maintenance/outer/sw)
 "pZc" = (
 /obj/cable{
 	d1 = 1;
@@ -54758,13 +54757,6 @@
 /area/station/chapel/main{
 	name = "Funeral Parlor"
 	})
-"qNt" = (
-/obj/random_item_spawner/junk/one_or_zero,
-/obj/decal/cleanable/dirt/jen,
-/obj/decal/mule/beacon/no_auto_dropoff_spawn,
-/obj/reagent_dispensers/foamtank,
-/turf/simulated/floor/plating/jen,
-/area/station/maintenance/outer/se)
 "qNv" = (
 /obj/decal/tile_edge/line/black{
 	dir = 4;
@@ -57208,20 +57200,6 @@
 	dir = 6
 	},
 /area/station/engine/ptl)
-"rxI" = (
-/obj/table/reinforced/auto,
-/obj/machinery/door/airlock/pyro/glass/windoor{
-	dir = 8
-	},
-/obj/access_spawn/engineering,
-/obj/firedoor_spawn,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/storage/primary)
 "rxL" = (
 /obj/machinery/light/incandescent/warm{
 	dir = 8
@@ -58729,6 +58707,15 @@
 	},
 /turf/simulated/floor/stairs/wide/other,
 /area/station/crew_quarters/market)
+"rWq" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/hallway/secondary/construction2)
 "rWw" = (
 /obj/table/wood/round/auto,
 /obj/random_item_spawner/snacks/two,
@@ -65283,6 +65270,15 @@
 	},
 /turf/simulated/floor/wood/five,
 /area/station/hydroponics)
+"ucK" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/grimycarpet,
+/area/station/hallway/secondary/construction2)
 "ucZ" = (
 /obj/decal/tile_edge/line/yellow{
 	icon_state = "line1"
@@ -65633,11 +65629,6 @@
 	},
 /turf/simulated/floor/purpleblack/corner,
 /area/station/chemistry)
-"ukJ" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/black/grime,
-/area/station/maintenance/outer/sw)
 "ukM" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 1
@@ -68430,6 +68421,13 @@
 	icon_state = "wooden"
 	},
 /area/station/crew_quarters/sauna)
+"uZu" = (
+/obj/random_item_spawner/junk/one_or_zero,
+/obj/decal/cleanable/dirt/jen,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
+/obj/reagent_dispensers/foamtank,
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/outer/se)
 "uZz" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -68609,6 +68607,14 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
+"vdq" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/hallway/secondary/construction2)
 "vdA" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -68995,15 +69001,6 @@
 /obj/cable,
 /turf/simulated/floor/redblack,
 /area/station/security/main)
-"vkm" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/hallway/secondary/construction)
 "vkr" = (
 /obj/decal/cleanable/cobweb2,
 /obj/rack,
@@ -70227,12 +70224,6 @@
 "vDo" = (
 /turf/simulated/floor/black,
 /area/station/medical/medbay)
-"vDw" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/decal/mule/beacon/no_auto_dropoff_spawn,
-/turf/simulated/floor/black/grime,
-/area/station/maintenance/outer/sw)
 "vDz" = (
 /turf/simulated/floor/black/grime,
 /area/station/science/storage)
@@ -73456,6 +73447,15 @@
 /obj/disposalpipe/junction/left/south,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quarters)
+"wBM" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/hallway/secondary/construction)
 "wBN" = (
 /obj/table/glass/reinforced/auto,
 /obj/item/plate,
@@ -74503,6 +74503,10 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/bathroom)
+"wSk" = (
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/inner/sw)
 "wSo" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -105332,7 +105336,7 @@ qgG
 qgG
 jKY
 jDb
-ukJ
+iSC
 eQS
 pFp
 ltH
@@ -105635,7 +105639,7 @@ wZJ
 hcW
 hsj
 bUO
-vDw
+eST
 pFp
 kif
 pFp
@@ -105937,7 +105941,7 @@ gBM
 hcW
 hsj
 bUO
-pYX
+kKk
 uOO
 uOO
 cWf
@@ -111964,7 +111968,7 @@ rAR
 qab
 bFY
 wXY
-kdO
+ipb
 uwa
 pJj
 sqY
@@ -113782,8 +113786,8 @@ tlF
 fha
 tsm
 aak
-cbS
-cbS
+wSk
+wSk
 pjy
 suS
 eaO
@@ -113804,7 +113808,7 @@ tuV
 pyL
 mZl
 kze
-hSZ
+fpl
 uXW
 quO
 cma
@@ -132198,10 +132202,10 @@ wnv
 oLR
 rRw
 wjJ
-vkm
-nfV
-cAJ
-aTw
+wBM
+nuh
+rWq
+hKO
 uQW
 oiX
 tWs
@@ -132503,7 +132507,7 @@ vLR
 kyC
 qtZ
 uQW
-mcF
+vdq
 xBW
 ged
 qtZ
@@ -132805,7 +132809,7 @@ oxI
 iOH
 orh
 gIe
-nOY
+ucK
 jwX
 bhG
 qtZ
@@ -136123,7 +136127,7 @@ oxG
 oHf
 khD
 wPR
-jJC
+kaf
 bww
 elM
 vwi
@@ -136425,7 +136429,7 @@ vqi
 ohh
 ohh
 jWD
-rxI
+fso
 byA
 lVy
 lVy
@@ -136727,7 +136731,7 @@ oAy
 ohh
 uSB
 dae
-jmS
+cxb
 xCC
 jab
 lVy
@@ -143677,7 +143681,7 @@ lwP
 ncJ
 kGg
 mQN
-qNt
+uZu
 eZn
 wPF
 vje


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->


1. Adds several more tanks of welding fuel and foam tanks to maintenance tunnels, lots more fuel tanks! There is now at least one fuel tank in each maint area. 
2. moved a pipe cart next to both the crusher and the loafer.
3. More trash! MORE TRASH!
4. Moved pest spawners out of maintenance and into publicly accessible areas.
5. Added chem grenades to janitor closets

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

1. Complaints of not having enough fuel or foam, players had to do a lot of running around to find welding fuel. Also because welderbombs are !FUN!
2. Pipecarts weren't near enough to places where they're mainly used.
3. Trash is GOOD
4. Player critters who couldn't move through doors spawned in maint... where they couldn't escape. Oops.
5. I forgot about the cleaner grenades, o o p s

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Ryumi:
(+)Donut3: Added more tanks of welder fuel and firefighting foam. There should be one weldtank in each maintenance area. 
(+)Donut3: Moved player critter spawns into public maint halls.
(+)Donut3: Even MORE trash spawners in maint! You'll only notice a little bit more junk though.
(+)Donut3: Moved a pipe cart next to the loafer, and added another next to the crusher. You know what to do.
(+)Donut3: Added cleaner grenades to the janitor closets. Oops.
```
