### PR TITLE
Added quantum telescopes to research on the cogmaps and destiny

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -42745,6 +42745,11 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/orangeblack/side/white{
 	dir = 4
 	},
@@ -43511,6 +43516,9 @@
 /turf/simulated/floor/white,
 /area/station/science/teleporter)
 "bMY" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/orangeblack/side/white{
 	dir = 4
 	},
@@ -44172,13 +44180,29 @@
 /turf/simulated/floor/plating,
 /area/station/science/teleporter)
 "bOs" = (
-/obj/machinery/space_heater,
+/obj/reagent_dispensers/foamtank,
+/obj/item/extinguisher,
+/obj/item/extinguisher{
+	pixel_x = 8
+	},
 /turf/simulated/floor/bot,
 /area/station/science/teleporter)
 "bOt" = (
-/obj/reagent_dispensers/foamtank,
-/obj/item/extinguisher,
-/obj/item/extinguisher,
+/obj/table/auto,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/paper_bin{
+	pixel_x = -5
+	},
+/obj/item/device/radio/headset/multifreq{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/obj/item/pen{
+	pixel_x = 4
+	},
 /turf/simulated/floor,
 /area/station/science/teleporter)
 "bOu" = (
@@ -44269,14 +44293,14 @@
 /turf/simulated/floor/white,
 /area/station/science/teleporter)
 "bOC" = (
-/obj/table/auto,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/device/radio/headset/multifreq,
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/storage/firstaid/regular,
+/obj/machinery/computer/telescope{
+	dir = 8
+	},
+/obj/cable,
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/orangeblack/side/white{
 	dir = 4
 	},
@@ -63799,6 +63823,10 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/inner)
+"naz" = (
+/obj/machinery/space_heater,
+/turf/simulated/floor,
+/area/station/science/teleporter)
 "niO" = (
 /turf/simulated/wall/auto/shuttle{
 	icon_state = "3"
@@ -95551,7 +95579,7 @@ aaq
 bIP
 bKc
 bLq
-bLr
+naz
 bOs
 bIP
 bQY

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -52300,6 +52300,8 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
+/obj/machinery/disposal/mail/small/autoname/research/telescience/east,
+/obj/disposalpipe/trunk/mail/south,
 /turf/simulated/floor/caution/corner/nw,
 /area/station/science/teleporter)
 "cjy" = (
@@ -52982,6 +52984,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
+/obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/caution/west,
 /area/station/science/teleporter)
 "ckX" = (
@@ -54734,8 +54737,7 @@
 /area/station/science/teleporter)
 "cot" = (
 /obj/stool/bench/auto,
-/obj/disposalpipe/trunk/mail/south,
-/obj/machinery/disposal/mail/small/autoname/research/telescience/east,
+/obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/caution/west,
 /area/station/science/teleporter)
 "cou" = (
@@ -78774,6 +78776,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/caution/west,
 /area/station/science/teleporter)
 "nKf" = (

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -52300,8 +52300,6 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
-/obj/disposalpipe/trunk/mail/south,
-/obj/machinery/disposal/mail/small/autoname/research/telescience/east,
 /turf/simulated/floor/caution/corner/nw,
 /area/station/science/teleporter)
 "cjy" = (
@@ -52976,7 +52974,14 @@
 /turf/simulated/floor/circuit/green,
 /area/station/science/teleporter)
 "ckW" = (
-/obj/disposalpipe/segment/mail/vertical,
+/obj/machinery/computer/telescope{
+	dir = 4
+	},
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/caution/west,
 /area/station/science/teleporter)
 "ckX" = (
@@ -53802,6 +53807,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/caution/east{
 	dir = 8
@@ -54726,7 +54734,8 @@
 /area/station/science/teleporter)
 "cot" = (
 /obj/stool/bench/auto,
-/obj/disposalpipe/segment/mail/vertical,
+/obj/disposalpipe/trunk/mail/south,
+/obj/machinery/disposal/mail/small/autoname/research/telescience/east,
 /turf/simulated/floor/caution/west,
 /area/station/science/teleporter)
 "cou" = (
@@ -78748,9 +78757,25 @@
 /obj/machinery/ore_cloud_storage_container,
 /turf/simulated/floor/plating,
 /area/station/mining)
+"dOs" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/science/teleporter)
 "hRi" = (
 /turf/space,
 /area/shuttle/arrival/station)
+"iFq" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/caution/west,
+/area/station/science/teleporter)
 "nKf" = (
 /obj/machinery/incubator,
 /turf/simulated/floor/white,
@@ -109758,7 +109783,7 @@ chf
 cik
 cjx
 ckW
-ckW
+iFq
 cot
 cqh
 crU
@@ -110060,7 +110085,7 @@ chf
 cil
 cjy
 ckX
-cmJ
+dOs
 cmJ
 cqi
 crV

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -26356,6 +26356,9 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/machinery/computer/telescope{
+	dir = 4
+	},
 /turf/simulated/floor/orangeblack/side/white{
 	dir = 10
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]


## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Adds quantum telescopes to the cogmaps and destiny


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
- Years of gameplay has shown that separating the teleporter and telescope between science and mining just makes the long range teleporter see little to no use whatsoever. Also basically every other map gives research a quantum telescope computer anyway :heart: 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)AwkwardDryad:
(*)Cogmap 1, Cogmap 2, and Destiny research now have a quantum telescope computer!
```
