### PR TITLE
Mailgroups can be Muted

### DIFF
--- a/code/obj/item/device/pda2/base_os.dm
+++ b/code/obj/item/device/pda2/base_os.dm
@@ -201,9 +201,12 @@
 
 						for (var/mailgroup in src.master.mailgroups)
 							if (mailgroup in src.master.reserved_mailgroups)
-								myReservedGroups += "<a href='byond://?src=\ref[src];input=message;target=[mailgroup];department=1'>[mailgroup]</a><br>"
+								myReservedGroups += {"<a href='byond://?src=\ref[src];input=message;target=[mailgroup];department=1'>[mailgroup]</a>
+								 (<a href='byond://?src=\ref[src];message_func=mute_group;groupname=[mailgroup]'>*[(mailgroup in src.master.muted_mailgroups) ? "Unmute" : "Mute"]*</a>)<br>"}
 							else
-								myCustomGroups += "<a href='byond://?src=\ref[src];input=message;target=[mailgroup];department=1'>[mailgroup]</a> (<a href='byond://?src=\ref[src];message_func=leave_group;groupname=[mailgroup]'>*Leave Group*</a>)<br>"
+								myCustomGroups += {"<a href='byond://?src=\ref[src];input=message;target=[mailgroup];department=1'>[mailgroup]</a>
+								 (<a href='byond://?src=\ref[src];message_func=leave_group;groupname=[mailgroup]'>*Leave Group*</a>)
+								 (<a href='byond://?src=\ref[src];message_func=mute_group;groupname=[mailgroup]'>*[(mailgroup in src.master.muted_mailgroups) ? "Unmute" : "Mute"]*</a>)<br>"}
 
 						. += myReservedGroups
 						. += myCustomGroups
@@ -516,6 +519,12 @@
 						var/groupname = href_list["groupname"]
 						if (groupname)
 							src.master.mailgroups -= groupname
+					if("mute_group")
+						var/groupname = href_list["groupname"]
+						if (groupname in src.master.muted_mailgroups)
+							src.master.muted_mailgroups -= groupname
+						else
+							src.master.muted_mailgroups += groupname
 
 
 			else if(href_list["note_func"]) //Note program specific topic junk
@@ -658,7 +667,7 @@
 
 					var/groupAddress = signal.data["group"]
 					if(groupAddress) //Check to see if we have this ~mailgroup~
-						if(!(groupAddress in src.master.mailgroups) && groupAddress != "ai")
+						if((!(groupAddress in src.master.mailgroups) && groupAddress != "ai") || (groupAddress in src.master.muted_mailgroups))
 							return
 
 					var/sender = signal.data["sender_name"]

--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -48,6 +48,7 @@
 	var/setup_scanner_on = 1 //Do we search the cart for a scanprog to start loaded?
 	var/setup_default_module = /obj/item/device/pda_module/flashlight //Module to have installed on spawn.
 	var/mailgroups = list("staff","Party Line") //What default mail groups the PDA is part of.
+	var/muted_mailgroups = list() //What mail groups should the PDA ignore?
 	var/reserved_mailgroups = list("command","security","science","ai","sillicon","medresearch","medbay","cargo","janitor","chaplain","engineer","mining","kitchen","mechanic","botany") //Job-specific mailgroups that cannot be joined or left
 	var/bombproof = 0 // can't be destroyed with detomatix
 	var/exploding = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows mailgroups to be muted. Each mailgroup can be individually muted or unmuted at the Groups page.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Mute spam on Party Line or Cargo without muting all incoming messages.
Previously, to mute a group would require leaving it, but restricted groups cannot be left (cargo, for one).
Requested by @moonlol 

![image](https://user-images.githubusercontent.com/9563541/86549568-dac71800-bef4-11ea-9332-34e45e18860d.png)
![image](https://user-images.githubusercontent.com/9563541/86549734-3beeeb80-bef5-11ea-83fc-ed31a3eacf71.png)


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)MarkNstein:
(+)PDA mail groups can be individually muted in the Groups page.
```
