### PR TITLE
Fix ling blood not doing the sizzle message

### DIFF
--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -3075,9 +3075,7 @@ datum
 			minimum_reaction_temperature = T0C + 50
 
 			reaction_temperature(exposed_temperature, exposed_volume)
-				holder.del_reagent(id)
 				var/list/covered = holder.covered_turf()
-
 				if(length(covered) < 9 || prob(2)) // no spam pls
 					if (holder.my_atom)
 						for (var/mob/O in AIviewers(get_turf(holder.my_atom), null))
@@ -3086,6 +3084,8 @@ datum
 						for(var/turf/t in covered)
 							for (var/mob/O in AIviewers(t, null))
 								boutput(O, "<span class='alert'>The blood reacts, attempting to escape the heat before sizzling away!</span>")
+
+				holder.del_reagent(id)
 
 
 		vomit


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
closes #1330 
I tested this, and the blood did indeed not make the message, in addition to this, it caused a runtime.
This seemed to be because the bloodc reagent would be pooled when it was deleted, causing holder to become null. 
To rectify this, I have moved the part that makes the message over the part that deletes the reagent.
It works for me now and gives no runtime.

However, I must confess that I don't really understand pooling mechanics and why this used to work properly but it broken now, so if there may be a better way to fix this (or maybe this bug is also present in other things affected by pooling that I am not aware of.)
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's good if features work.