### PR TITLE
Fix VR sabers, prevent rainbow sabers glowstick modification

### DIFF
--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -77,43 +77,33 @@
 		switch(src.bladecolor)
 			if("R")
 				r = 255
-				if (use_glowstick)
-					src.loaded_glowstick = new /obj/item/device/light/glowstick/red(src)
+				src.loaded_glowstick = new /obj/item/device/light/glowstick/red(src)
 			if("O")
 				r = 255; g = 127
-				if (use_glowstick)
-					src.loaded_glowstick = new /obj/item/device/light/glowstick/orange(src)
+				src.loaded_glowstick = new /obj/item/device/light/glowstick/orange(src)
 			if("Y")
 				r = 255; g = 255
-				if (use_glowstick)
-					src.loaded_glowstick = new /obj/item/device/light/glowstick/yellow(src)
+				src.loaded_glowstick = new /obj/item/device/light/glowstick/yellow(src)
 			if("G")
 				g = 255
-				if (use_glowstick)
-					src.loaded_glowstick = new /obj/item/device/light/glowstick(src)
+				src.loaded_glowstick = new /obj/item/device/light/glowstick(src)
 			if("C")
 				b = 255; g = 200
-				if (use_glowstick)
-					src.loaded_glowstick = new /obj/item/device/light/glowstick/cyan(src)
+				src.loaded_glowstick = new /obj/item/device/light/glowstick/cyan(src)
 			if("B")
 				b = 255
-				if (use_glowstick)
-					src.loaded_glowstick = new /obj/item/device/light/glowstick/blue(src)
+				src.loaded_glowstick = new /obj/item/device/light/glowstick/blue(src)
 			if("P")
 				r = 153; b = 255
-				if (use_glowstick)
-					src.loaded_glowstick = new /obj/item/device/light/glowstick/purple(src)
+				src.loaded_glowstick = new /obj/item/device/light/glowstick/purple(src)
 			if("Pi")
 				r = 255; g = 121; b = 255
-				if (use_glowstick)
-					src.loaded_glowstick = new /obj/item/device/light/glowstick/pink(src)
+				src.loaded_glowstick = new /obj/item/device/light/glowstick/pink(src)
 			if("W")
 				r = 255; g = 255; b = 255
-				if (use_glowstick)
-					src.loaded_glowstick = new /obj/item/device/light/glowstick/white(src)
-
-		if (!src.loaded_glowstick && use_glowstick) //the glowstick needs to be on!
-			src.loaded_glowstick = new /obj/item/device/light/glowstick/white(src) // rainbow is basicall diffracted white light
+				src.loaded_glowstick = new /obj/item/device/light/glowstick/white(src)
+			else
+				src.loaded_glowstick = new /obj/item/device/light/glowstick/white(src)
 		src.loaded_glowstick.turnon()
 
 		light_c = src.AddComponent(/datum/component/holdertargeting/simple_light, r, g, b, 150)
@@ -296,6 +286,10 @@
 			return
 
 		if (!src.open)
+			if (!src.bladecolor) //rainbow
+				boutput(user, "<span class='alert'>This sword cannot be modified.</span>")
+				return
+
 			user.visible_message("<b>[user]</b> unscrews and opens [src].")
 			playsound(get_turf(src), "sound/items/Screwdriver.ogg", 100, 1)
 			src.open = 1
@@ -357,7 +351,7 @@
 
 /obj/item/sword/attack_hand(mob/user as mob)
 	if (src.open && src.loc == user)
-		if (src.loaded_glowstick)
+		if (src.loaded_glowstick && src.use_glowstick)
 			user.put_in_hand(loaded_glowstick)
 			src.loaded_glowstick = null
 			src.bladecolor = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][MINOR][RUNTIME] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Remove all of the `if (use_glowstick)` checks from the sword new proc. Every sword gets a glowstick now, even the ones that can't have it swapped. The the sword's light object is being stored in `loaded_glowstick` and gives every saber its glow. Additionally not having a light causes several different runtimes when the swords are created, go to update it, and go to remove it.

Prevent using a screwdriver on rainbow sabers. Doing so set them to a non-existent icon state, and even if you did remove the glowstick all you've done is destroy the rainbow saber as there is no such thing as a rainbow glowstick. Being rainbow is based on it having a null blade color

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's a bug