### PR TITLE
Fix path for objective to steal CE's belt on Manta

### DIFF
--- a/code/datums/objective.dm
+++ b/code/datums/objective.dm
@@ -161,7 +161,7 @@ proc/create_fluff(var/datum/mind/target)
 			if("yellow cake")
 				steal_target = /obj/item/reagent_containers/food/snacks/yellow_cake_uranium_cake
 			if("aurora MKII utility belt")
-				steal_target = /obj/item/storage/belt/utility/ceshielded
+				steal_target = /obj/item/storage/belt/utility/prepared/ceshielded
 			if("Head of Security\'s war medal")
 				steal_target = /obj/item/hosmedal
 			if("Research Director\'s Diploma")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes the path to the CE's belt when deriving "steal" objectives on Manta.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Manta fails to build.