### PR TITLE
Make hand tele UI less intrusive

### DIFF
--- a/code/obj/item/teleportation.dm
+++ b/code/obj/item/teleportation.dm
@@ -133,10 +133,15 @@ Frequency:
 	var/obj/item/our_target = null
 	var/turf/our_random_target = null
 	var/list/portals = list()
+	var/list/users = list() // List of people who've clicked on the hand tele and haven't resolved its UI yet
 
 	// Port of the telegun improvements (Convair880).
 	attack_self(mob/user as mob)
 		src.add_fingerprint(user)
+
+		// If they've already got the UI open, don't try and open a new one
+		if (user in users)
+			return
 
 		// Make sure you're holding the hand tele, or it's implanted, before you can use it.
 		var/obj/item/I = user.equipped()
@@ -203,7 +208,10 @@ Frequency:
 			user.show_text("Error: couldn't find valid coordinates or working teleporters.", "red")
 			return
 
+		users += user // We're about to show the UI
 		var/t1 = input(user, "Please select a teleporter to lock in on.", "Target Selection") in L
+		users -= user // We're done showing the UI
+
 		if (user.stat || user.restrained())
 			return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a check to hand teles so they won't try to open their UI if you already have it open.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently, implanting a hand tele into your chest comes with the non-diegetic disadvantage of getting healed being really fucking annoying, especially from auto-menders. Every single time someone clicks on you in any way, it queues up another copy of the UI to show up as soon as you get rid of the last one. This change fixes it so none get queued up if the hand tele's already waiting for a choice - you can park the one that does show up out of your way and cancel or use it at your leisure.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Dabir:
(+)Fixed implanted hand teles queueing up way too many copies of their input UI if you got clicked on a bunch, like if you were being healed. You will now only be asked to select a teleporter once at a time.
```
