### PR TITLE
Cog2: Add Data Terminal beneath TTV-VR

### DIFF
--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -34,7 +34,7 @@ o+`        `-` ``..-:yooos-..----------..`
 
 //#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // Skip setup for atmos, Z5, don't show changelogs, skip pregame lobby
 //#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the map Atlas, no other zlevels. Boots way faster
-//#define Z_LOG_ENABLE 1  // Enable additional world.log logging
+#define Z_LOG_ENABLE 1  // Enable additional world.log logging
 
 
 //////////// PROFILING OPTIONS

--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -34,7 +34,7 @@ o+`        `-` ``..-:yooos-..----------..`
 
 //#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // Skip setup for atmos, Z5, don't show changelogs, skip pregame lobby
 //#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the map Atlas, no other zlevels. Boots way faster
-#define Z_LOG_ENABLE 1  // Enable additional world.log logging
+//#define Z_LOG_ENABLE 1  // Enable additional world.log logging
 
 
 //////////// PROFILING OPTIONS

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -65018,6 +65018,11 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/science/lab)
 "cMb" = (
@@ -65567,11 +65572,21 @@
 /turf/simulated/floor/red,
 /area/station/science/lab)
 "cNu" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/caution/east,
 /area/station/science/lab)
 "cNv" = (
 /obj/machinery/networked/storage/bomb_tester{
 	bank_id = "Mixer"
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/bot,
 /area/station/science/lab)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MAJOR][MAPPING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the necessary hardware to connect the TTV VR simulator to the mainframe.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's broken and shouldn't be broken.

The simulator in Cog2 hasn't been connected for a while. There's been MHelps about it "not working" but I assumed it was user-error or the mainframe being down.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)MarkNstein:
(+)Cog2: TTV VR now properly connected and functioning.
```
