### PR TITLE
make phase shift and dimensional shift lock position properly

### DIFF
--- a/code/datums/abilities/wizard/phaseshift.dm
+++ b/code/datums/abilities/wizard/phaseshift.dm
@@ -83,6 +83,7 @@
 		steam.start()
 		H.canmove = 0
 		H.restrain_time = TIME + 40
+		holder.canmove = 0
 		sleep(2 SECONDS)
 		flick("reappear",animation)
 		sleep(0.5 SECONDS)
@@ -100,12 +101,14 @@
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "nothing"
 	invisibility = 101
-	var/canmove = 1
+	var/canmove = 1 // can be used to completely stop movement
+	var/movecd = 0 // used in relaymove, so people don't move too quickly
 	density = 0
 	anchored = 1
 
 /obj/dummy/spell_invis/relaymove(var/mob/user, direction, delay)
-	if (!src.canmove) return
+	if (!src.canmove || src.movecd)
+		return
 	switch(direction)
 		if(NORTH)
 			src.y++
@@ -127,8 +130,8 @@
 		if(SOUTHWEST)
 			src.y--
 			src.x--
-	src.canmove = 0
-	SPAWN_DBG(0.2 SECONDS) src.canmove = 1
+	src.movecd = 1
+	SPAWN_DBG(0.2 SECONDS) src.movecd = 0
 
 /obj/dummy/spell_invis/ex_act(blah)
 	return

--- a/code/modules/medical/genetics/bioEffects/powers.dm
+++ b/code/modules/medical/genetics/bioEffects/powers.dm
@@ -1364,11 +1364,15 @@
 		if (!P.active)
 			P.active = 1
 			P.last_loc = owner.loc
+			owner.canmove = 0
+			owner.restrain_time = TIME + 0.7 SECONDS
 			owner.visible_message("<span class='alert'><b>[owner] vanishes in a burst of blue light!</b></span>")
 			playsound(owner.loc, "sound/effects/ghost2.ogg", 50, 0)
 			animate(owner, color = "#0000FF", time = 5, easing = LINEAR_EASING)
 			animate(alpha = 0, time = 5, easing = LINEAR_EASING)
 			SPAWN_DBG(0.7 SECONDS)
+				owner.canmove = 1
+				owner.restrain_time = 0
 				var/obj/dummy/spell_invis/invis_object = new /obj/dummy/spell_invis(get_turf(owner))
 				invis_object.canmove = 0
 				owner.set_loc(invis_object)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fixes #1397 
After using Phase Shift or the similar genetics power Biomass Manipulation, you could keep moving during the rematerialization. 
However, you would be teleported back to the position where the rematerialization started once the effect was done animating, so it was mainly confusing and annoying.
I believe this bug occured because the canmove variable was set back to 1 after 0.2 seconds due to the way that spell_invis/relaymove was implemented. Thus I introduced a new variable movecd to keep track of this cooldown, reserving canmove for cases where you want to shut down movement for a longer period of time (for instance the Dimensional Shift genetics power, which disables it the whole time).

The Dimensional Shift genetics power had another, unrelated bug where you could keep moving for 0.7 seconds while shifting into the dimension, but upon exiting the dimension you would be moved back to the place where you initiated the shift.
I fixed this by locking the user in the same way that Phase Shift already did.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's kind of annoying and disruptive to get teleported back, rather than having the spell accurately reflect that you are locked during the rematerialization period.
Similarly, Dimensional Shift might make you think that you will exit the dimension at a different location than you actually will, which was confusing and seemed clunky.