### PR TITLE
fix attaching undroppables to other's arms

### DIFF
--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -1252,7 +1252,7 @@
 /obj/item/proc/attach(var/mob/living/carbon/human/attachee,var/mob/attacher)
 	//if (!src.arm_icon) return //ANYTHING GOES!~!
 
-	if (src.object_flags & NO_ARM_ATTACH || src.temp_flags & IS_LIMB_ITEM)
+	if (src.object_flags & NO_ARM_ATTACH || src.cant_drop)
 		boutput(attacher, "<span class='alert'>You try to attach [src] to [attachee]'s stump, but it politely declines!</span>")
 		return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
prevent any undroppable items from being attached as item arms.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #1375 

