### PR TITLE
make tshotgun singlefire weaker but spammier

### DIFF
--- a/code/modules/projectiles/energy_bolt.dm
+++ b/code/modules/projectiles/energy_bolt.dm
@@ -114,10 +114,8 @@ toxic - poisons
 			L.emote("twitch_v")
 		return
 
-/datum/projectile/energy_bolt/tasershotgunsingle // old taser projectile cost for shotgun
-	cost = 15
-
 /datum/projectile/energy_bolt/tasershotgun //Projectile for Azungar's taser shotgun.
+	cost = 10
 	power = 15
 	dissipation_delay = 4
 	dissipation_rate = 5

--- a/code/modules/projectiles/energy_bolt.dm
+++ b/code/modules/projectiles/energy_bolt.dm
@@ -117,8 +117,8 @@ toxic - poisons
 /datum/projectile/energy_bolt/tasershotgun //Projectile for Azungar's taser shotgun.
 	cost = 10
 	power = 15
-	dissipation_delay = 4
-	dissipation_rate = 5
+	dissipation_delay = 1
+	dissipation_rate = 2
 	icon_state = "spark"
 
 //////////// VUVUZELA

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -402,7 +402,7 @@
 
 	New()
 		current_projectile = new/datum/projectile/special/spreader/tasershotgunspread
-		projectiles = list(current_projectile,new/datum/projectile/energy_bolt/tasershotgunsingle)
+		projectiles = list(current_projectile,new/datum/projectile/energy_bolt/tasershotgun)
 		..()
 
 	update_icon()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Change taser shotgun single-fire mode to shoot the same projectiles as spread, at 10pu/shot
Change taser shotgun falloff to be smoother

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Make tshotgun singlefire not just 'taser with more shots'

## Changelog
```
(u)Tarmunroa:
(+)Tweaked taser shotgun singlefire + falloff
```