### PR TITLE
Wavegun tweaks

### DIFF
--- a/code/modules/projectiles/wavegun.dm
+++ b/code/modules/projectiles/wavegun.dm
@@ -7,7 +7,7 @@
 //How much ammo this costs
 	cost = 30
 //How fast the power goes away
-	dissipation_rate = -1 //gains power at the same rate that a taser loses power
+	dissipation_rate = -1 //gains power at the same rate that a taser loses power - equal at 6 tiles
 	max_range = 24 //Range/time limiter for non-standard dissipation - long range, but not infinite
 //How many tiles till it starts to lose power (gain, in this case)
 	dissipation_delay = 0
@@ -82,10 +82,3 @@ toxic - poisons
 		var/datum/effects/system/spark_spread/s = unpool(/datum/effects/system/spark_spread)
 		s.set_up(5, 0, T)
 		s.start()
-
-	on_pointblank(obj/projectile/P, mob/living/M)  //on pointblank, just EMP the mob. No AoE, don't EMP other things on the tile.
-		M.emp_act()
-		var/datum/effects/system/spark_spread/s = unpool(/datum/effects/system/spark_spread)
-		s.set_up(5, 0, M)
-		s.start()
-		P.die()

--- a/code/modules/projectiles/wavegun.dm
+++ b/code/modules/projectiles/wavegun.dm
@@ -1,16 +1,16 @@
 /datum/projectile/wavegun
 	name = "energy wave"
 	icon = 'icons/obj/projectiles.dmi'
-	icon_state = "wave"
+	icon_state = "wave-r"
 //How much of a punch this has, tends to be seconds/damage before any resist
 	power = 10
 //How much ammo this costs
-	cost = 50
+	cost = 30
 //How fast the power goes away
-	dissipation_rate = -2.5 //gets strong fast-ish
+	dissipation_rate = -1 //gains power at the same rate that a taser loses power
 	max_range = 24 //Range/time limiter for non-standard dissipation - long range, but not infinite
 //How many tiles till it starts to lose power (gain, in this case)
-	dissipation_delay = 4
+	dissipation_delay = 0
 //Kill/Stun ratio
 	ks_ratio = 0.0
 //name of the projectile setting, used when you change a guns setting
@@ -42,7 +42,7 @@ toxic - poisons
 	dissipation_delay = 3
 	dissipation_rate = -30
 	max_range = 5 //super short. about 4 tile max range
-	cost = 75
+	cost = 50
 	hit_ground_chance = 100 //no escape
 	pierces = -1 //no limits
 	goes_through_walls = 1
@@ -62,7 +62,7 @@ toxic - poisons
 	dissipation_delay = 0
 	dissipation_rate = -10 //only reliable past a few tiles
 	max_range = 18 //taser-and-a-half range
-	cost = 150 //two shots
+	cost = 100 //three shots
 	hit_ground_chance = 0
 	damage_type = D_SPECIAL
 	sname = "electromagnetic distruption wave"
@@ -71,15 +71,14 @@ toxic - poisons
 
 	on_hit(atom/H, angle, var/obj/projectile/P)
 		var/turf/T = get_turf(H)
-		if(P.power != 0) //avoid AoE on pointblank... but if you just shoot the guy beside you you're going to get EMPed
+		for(var/atom/movable/O in T.contents)
+			if(!istype(O, /obj/machinery/nuclearbomb) || prob(P.power * 0.5)) //Direct hit has a low chance to affect the nuke -
+				O.emp_act()
+		if(prob(P.power * 1.25)) //chance to EMP in an AoE - better odds the further it travels. Has a meaningful effect on borgs/pods/doors
 			for(var/turf/tile in range(1, T))
 				for(var/atom/movable/O in tile.contents)
 					if(!istype(O, /obj/machinery/nuclearbomb)) //AoE emp does not affect nuke
 						O.emp_act()
-		if(prob(P.power * 1.25)) //chance to EMP main target again - better odds the further it travels. Has a meaningful effect on borgs/pods/doors
-			for(var/atom/movable/O in T.contents)
-				if(!istype(O, /obj/machinery/nuclearbomb) || prob(P.power * 0.5)) //Direct hit has a low chance to affect the nuke -
-					O.emp_act()
 		var/datum/effects/system/spark_spread/s = unpool(/datum/effects/system/spark_spread)
 		s.set_up(5, 0, T)
 		s.start()
@@ -89,3 +88,4 @@ toxic - poisons
 		var/datum/effects/system/spark_spread/s = unpool(/datum/effects/system/spark_spread)
 		s.set_up(5, 0, M)
 		s.start()
+		P.die()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Reduces cost of wavegun modes - now gets 10 shots of inversion, 6 shots of transverse, 3 shots of EMP
Adjusted inversion wave anti-falloff to match taser falloff rate
Adjust EMP mode to do the AoE on long-range shots, instead of always AoE with a chance of doubling the direct hit on long-range shots


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Wavegun being in roundstart sec loadouts means it has to actually be a viable alternative, and the EMP was perhaps too easy to land with always being an AoE


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Tarmunora:
(+)Adjusted wavegun energy costs and effects - EMP AoE is now range-dependant
```
