### PR TITLE
Prevent `Anchored` Objects from Sliding Tile-to-Tile

### DIFF
--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -598,7 +598,7 @@
 		//		user.give_to(over_object)
 	else
 
-		if (isturf(over_object))
+		if (isturf(over_object) && !src.anchored)
 			if (on_turf && in_range(over_object,src)) //drag from floor to floor == slide
 				if (istype(over_object,/turf/simulated/floor) || istype(over_object,/turf/unsimulated/floor))
 					step_to(src,over_object)

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -598,8 +598,8 @@
 		//		user.give_to(over_object)
 	else
 
-		if (isturf(over_object) && !src.anchored)
-			if (on_turf && in_range(over_object,src)) //drag from floor to floor == slide
+		if (isturf(over_object))
+			if (on_turf && in_range(over_object,src) && !src.anchored) //drag from floor to floor == slide
 				if (istype(over_object,/turf/simulated/floor) || istype(over_object,/turf/unsimulated/floor))
 					step_to(src,over_object)
 					//this would be cool ha ha h


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This will prevent anchored objects from being able to slide tile-to-tile by click-dragging them.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
MechComp devices can be moved around while they are on the floor, so long as you have a multi-tool in-hand. This seems un-intended. If it is intended, I think it's a bad idea.

This has been possible for a long time, but was not used much. I don't think it needs a changelog.