### PR TITLE
Prevent  bots from exploding multiple times / drop duplication

### DIFF
--- a/code/modules/robotics/bot/bot_parent.dm
+++ b/code/modules/robotics/bot/bot_parent.dm
@@ -11,6 +11,7 @@
 	var/locked = null
 	var/on = 1
 	var/health = 25
+	var/exploding = 0 //So we don't die like five times at once.
 	var/muted = 0 // shut up omg shut up.
 	var/no_camera = 0
 	var/setup_camera_network = "Robots"

--- a/code/modules/robotics/bot/buttbot.dm
+++ b/code/modules/robotics/bot/buttbot.dm
@@ -99,6 +99,8 @@
 	return src.explode()
 
 /obj/machinery/bot/buttbot/explode()
+	if(src.exploding) return
+	src.exploding = 1
 	src.on = 0
 	src.visible_message("<span class='alert'><B>[src] blows apart!</B></span>")
 	var/datum/effects/system/spark_spread/s = unpool(/datum/effects/system/spark_spread)

--- a/code/modules/robotics/bot/cambot.dm
+++ b/code/modules/robotics/bot/cambot.dm
@@ -103,6 +103,8 @@
 	if (!src)
 		return
 
+	if(src.exploding) return
+	src.exploding = 1
 	src.on = 0
 	src.visible_message("<span class='alert'><B>[src] blows apart!</B></span>", 1)
 

--- a/code/modules/robotics/bot/chefbot.dm
+++ b/code/modules/robotics/bot/chefbot.dm
@@ -185,6 +185,8 @@
 	return src.explode()
 
 /obj/machinery/bot/chefbot/explode()
+	if(src.exploding) return
+	src.exploding = 1
 	src.on = 0
 	for(var/mob/O in hearers(src, null))
 		O.show_message("<span class='alert'><B>[src] blows apart!</B></span>", 1)

--- a/code/modules/robotics/bot/cleanbot.dm
+++ b/code/modules/robotics/bot/cleanbot.dm
@@ -421,6 +421,8 @@
 		if (!src)
 			return
 
+		if(src.exploding) return
+		src.exploding = 1
 		src.on = 0
 		for(var/mob/O in hearers(src, null))
 			O.show_message("<span class='alert'><B>[src] blows apart!</B></span>", 1)

--- a/code/modules/robotics/bot/duckbot.dm
+++ b/code/modules/robotics/bot/duckbot.dm
@@ -101,6 +101,8 @@
 	return src.explode()
 
 /obj/machinery/bot/duckbot/explode()
+	if(src.exploding) return
+	src.exploding = 1
 	src.on = 0
 	for(var/mob/O in hearers(src, null))
 		O.show_message("<span class='alert'><B>[src] blows apart!</B></span>", 1)

--- a/code/modules/robotics/bot/firebot.dm
+++ b/code/modules/robotics/bot/firebot.dm
@@ -353,6 +353,8 @@
 	return src.explode()
 
 /obj/machinery/bot/firebot/explode()
+	if(src.exploding) return
+	src.exploding = 1
 	src.on = 0
 	for(var/mob/O in hearers(src, null))
 		O.show_message("<span class='alert'><B>[src] blows apart!</B></span>", 1)

--- a/code/modules/robotics/bot/floorbot.dm
+++ b/code/modules/robotics/bot/floorbot.dm
@@ -500,6 +500,8 @@ text("<A href='?src=\ref[src];operation=make'>[src.maketiles ? "Yes" : "No"]</A>
 	qdel(src)
 
 /obj/machinery/bot/floorbot/explode()
+	if(src.exploding) return
+	src.exploding = 1
 	src.on = 0
 	for (var/mob/O in hearers(src, null))
 		O.show_message("<span class='alert'><B>[src] blows apart!</B></span>", 1)

--- a/code/modules/robotics/bot/goosebot.dm
+++ b/code/modules/robotics/bot/goosebot.dm
@@ -69,6 +69,8 @@
 	return src.explode()
 
 /obj/machinery/bot/goosebot/explode()
+	if(src.exploding) return
+	src.exploding = 1
 	src.on = 0
 	for(var/mob/O in hearers(src, null))
 		O.show_message("<span class='combat'><B>[src] blows apart!</B></span>", 1)

--- a/code/modules/robotics/bot/guardbot.dm
+++ b/code/modules/robotics/bot/guardbot.dm
@@ -145,7 +145,6 @@
 	var/net_id = null
 	var/last_comm = 0 //World time of last transmission
 	var/reply_wait = 0
-	var/exploding = 0 //So we don't die like five times at once.
 
 	var/botcard_access = "Captain" //Job access for doors.
 									//It's not like they can be pushed into airlocks anymore

--- a/code/modules/robotics/bot/medbot.dm
+++ b/code/modules/robotics/bot/medbot.dm
@@ -661,6 +661,8 @@
 	return src.explode()
 
 /obj/machinery/bot/medbot/explode()
+	if(src.exploding) return
+	src.exploding = 1
 	src.on = 0
 	for(var/mob/O in hearers(src, null))
 		O.show_message("<span class='alert'><B>[src] blows apart!</B></span>", 1)

--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -1045,6 +1045,8 @@ Report Arrests: <A href='?src=\ref[src];operation=report'>[report_arrests ? "On"
 		return
 
 	explode()
+		if(src.exploding) return
+		src.exploding = 1
 		walk_to(src,0)
 		for(var/mob/O in hearers(src, null))
 			O.show_message("<span class='alert'><B>[src] blows apart!</B></span>", 1)
@@ -1184,7 +1186,7 @@ Report Arrests: <A href='?src=\ref[src];operation=report'>[report_arrests ? "On"
 		src.overlays += image('icons/obj/bots/aibots.dmi', "hs_arm")
 		user.u_equip(W)
 		qdel(W)
-		
+
 	else if (istype(W, /obj/item/rods) && src.build_step == 3)
 		if (W.amount < 1)
 			boutput(user, "You need a non-zero amount of rods. How did you even do that?")

--- a/code/modules/robotics/bot/skullbot.dm
+++ b/code/modules/robotics/bot/skullbot.dm
@@ -74,6 +74,8 @@
 		return src.explode()
 
 	explode()
+		if(src.exploding) return
+		src.exploding = 1
 		src.on = 0
 		src.visible_message("<span class='combat'><B>[src] blows apart!</B></span>")
 		var/datum/effects/system/spark_spread/s = unpool(/datum/effects/system/spark_spread)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- moves `var/exploding` from `obj/machinery/bot/guardbot` to `obj/machinery/bot`
- adds `if(src.exploding)` checks to all bot subtypes that have an `explode()` proc (every bot but the MULE)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
- Prevent stun baton and other drop duping
- closes #1413 