### PR TITLE
Fix admin verb tab names

### DIFF
--- a/_std/defines/_admin.dm
+++ b/_std/defines/_admin.dm
@@ -11,7 +11,7 @@
 #define ADMIN_CAT_UNUSED "You Should Never See This" // note that the verb might still be used as a proc, don't delete those
 #define ADMIN_CAT_NONE null // not in the tabs
 
-#define SET_ADMIN_CAT(CAT) set category = CAT ? "Lummox broke verb categories" + ADMIN_CAT_PREFIX + CAT : null
+#define SET_ADMIN_CAT(CAT) set category = CAT ? ADMIN_CAT_PREFIX + CAT : null
 
 var/global/list/toggleable_admin_verb_categories = list(
 	ADMIN_CAT_PLAYERS,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes the admin verb tab names by removing Pali's work around
![image](https://user-images.githubusercontent.com/33204415/87080395-99d14b00-c1f5-11ea-8029-c7a6657bfb02.png)

This workaround is no longer needed as the concatenation of string objects in defines has been fixed
http://www.byond.com/forum/post/2581688

![image](https://user-images.githubusercontent.com/33204415/87080357-87efa800-c1f5-11ea-943f-dd74ae62451b.png)



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
![image](https://user-images.githubusercontent.com/33204415/87080344-80c89a00-c1f5-11ea-8e0c-2cca11ac1d6a.png)