### PR TITLE
Change wifi comp delay to match pnet comp

### DIFF
--- a/code/WorkInProgress/MechanicMadness.dm
+++ b/code/WorkInProgress/MechanicMadness.dm
@@ -1558,7 +1558,7 @@ var/list/mechanics_telepads = new/list()
 		if(!converted.len || !ready) return
 
 		ready = 0
-		SPAWN_DBG(3 SECONDS) ready = 1
+		SPAWN_DBG(0.4 SECONDS) ready = 1
 
 		var/datum/signal/sendsig = get_free_signal()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This changes the cooldown on the wifi comp sending from 3 seconds to 0.4 seconds to match the delay on the PNET comp.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It seems weird that the wifi comp would have a much longer cooldown on sending a packet than the PNET comp. Now a control unit ROM calibrated for use with the wired network can also work with the wireless network.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)glassofmilk:
(+)Reduced the cooldown on the wifi component to be in line with the cooldown on the PNET component.
```
