### PR TITLE
Adds some new, cool-looking bottles to the Glass Recycler

### DIFF
--- a/code/modules/food_and_drink/alcohol.dm
+++ b/code/modules/food_and_drink/alcohol.dm
@@ -404,3 +404,68 @@
 		desc = "A stick of celery. Does not feature ants. Unless you leave it on the floor, but those would probably not be very tasty. I dunno, though, I've never eaten an ant. They might be delicious."
 		icon_state = "celery"
 		edible = 1
+
+// empty bottles
+
+/obj/item/reagent_containers/food/drinks/bottle/empty/long
+	name = "long bottle"
+	desc = "A bottle shaped like the ones used to hold beer or vermouth."
+	icon_state = "bottle-vermouthC"
+	item_state = "vermouth"
+	alt_filled_state = 1
+	heal_amt = 1
+	g_amt = 40
+	bottle_style = "vermouthC"
+	label = "label-none"
+	initial_volume = 50
+
+/obj/item/reagent_containers/food/drinks/bottle/empty/tall
+	name = "tall bottle"
+	desc = "A bottle shaped like the ones used to hold vodka."
+	icon_state = "bottle-tvodka"
+	bottle_style = "tvodka"
+	fluid_style = "tvodka"
+	label = "label-none"
+	alt_filled_state = 1
+	heal_amt = 1
+	g_amt = 60
+	initial_volume = 50
+
+/obj/item/reagent_containers/food/drinks/bottle/empty/rectangular
+	name = "rectangular bottle"
+	desc = "A bottle shaped like the ones used to hold gin."
+	icon_state = "bottle-gin"
+	bottle_style = "gin"
+	fluid_style = "gin"
+	label = "label-none"
+	alt_filled_state = 1
+	heal_amt = 1
+	g_amt = 60
+	initial_volume = 50
+
+/obj/item/reagent_containers/food/drinks/bottle/empty/square
+	name = "square bottle"
+	desc = "A bottle shaped like the ones used to hold rum."
+	icon_state = "bottle-spicedrum"
+	bottle_style = "spicedrum"
+	fluid_style = "spicedrum"
+	label = "label-none"
+	alt_filled_state = 1
+	heal_amt = 1
+	g_amt = 60
+	initial_volume = 50
+
+/obj/item/reagent_containers/food/drinks/bottle/empty/masculine
+	name = "masculine bottle"
+	desc = "A bottle shaped like the ones used to hold tequila."
+	icon_state = "bottle-tequila"
+	bottle_style = "tequila"
+	fluid_style = "tequila"
+	label = "label-none"
+	alt_filled_state = 1
+	heal_amt = 1
+	g_amt = 60
+	initial_volume = 50
+
+
+

--- a/code/modules/food_and_drink/alcohol.dm
+++ b/code/modules/food_and_drink/alcohol.dm
@@ -456,7 +456,7 @@
 	initial_volume = 50
 
 /obj/item/reagent_containers/food/drinks/bottle/empty/masculine
-	name = "masculine bottle"
+	name = "wide bottle"
 	desc = "A bottle shaped like the ones used to hold tequila."
 	icon_state = "bottle-tequila"
 	bottle_style = "tequila"

--- a/code/obj/machinery/glass_recycler.dm
+++ b/code/obj/machinery/glass_recycler.dm
@@ -74,6 +74,11 @@
 					<A href='?src=\ref[src];type=flute'>Champagne Flute</A><br>
 					<A href='?src=\ref[src];type=cocktail'>Cocktail Glass</A><br>
 					<A href='?src=\ref[src];type=drinkbottle'>Drink Bottle</A><br>
+					<A href='?src=\ref[src];type=tallbottle'>Tall Bottle</A><br>
+					<A href='?src=\ref[src];type=longbottle'>Long Bottle</A><br>
+					<A href='?src=\ref[src];type=rectangularbottle'>Rectangular Bottle</A><br>
+					<A href='?src=\ref[src];type=squarebottle'>Square Bottle</A><br>
+					<A href='?src=\ref[src];type=masculinebottle'>Masculine Bottle</A><br>
 					<A href='?src=\ref[src];type=drinking'>Drinking Glass</A><br>
 					<A href='?src=\ref[src];type=oldf'>Old Fashioned Glass</A><br>
 					<A href='?src=\ref[src];type=pitcher'>Pitcher</A><br>
@@ -132,6 +137,21 @@
 				src.glass_amt -= 1
 			if("drinkbottle")
 				G = new /obj/item/reagent_containers/food/drinks/bottle(get_turf(src))
+				src.glass_amt -= 1
+			if("longbottle")
+				G = new /obj/item/reagent_containers/food/drinks/bottle/empty/long(get_turf(src))
+				src.glass_amt -= 1
+			if("tallbottle")
+				G = new /obj/item/reagent_containers/food/drinks/bottle/empty/tall(get_turf(src))
+				src.glass_amt -= 1
+			if("rectangularbottle")
+				G = new /obj/item/reagent_containers/food/drinks/bottle/empty/rectangular(get_turf(src))
+				src.glass_amt -= 1
+			if("squarebottle")
+				G = new /obj/item/reagent_containers/food/drinks/bottle/empty/square(get_turf(src))
+				src.glass_amt -= 1
+			if("masculinebottle")
+				G = new /obj/item/reagent_containers/food/drinks/bottle/empty/masculine(get_turf(src))
 				src.glass_amt -= 1
 			if("plate")
 				G = new /obj/item/plate(get_turf(src))

--- a/code/obj/machinery/glass_recycler.dm
+++ b/code/obj/machinery/glass_recycler.dm
@@ -78,7 +78,7 @@
 					<A href='?src=\ref[src];type=longbottle'>Long Bottle</A><br>
 					<A href='?src=\ref[src];type=rectangularbottle'>Rectangular Bottle</A><br>
 					<A href='?src=\ref[src];type=squarebottle'>Square Bottle</A><br>
-					<A href='?src=\ref[src];type=masculinebottle'>Masculine Bottle</A><br>
+					<A href='?src=\ref[src];type=masculinebottle'>Wide Bottle</A><br>
 					<A href='?src=\ref[src];type=drinking'>Drinking Glass</A><br>
 					<A href='?src=\ref[src];type=oldf'>Old Fashioned Glass</A><br>
 					<A href='?src=\ref[src];type=pitcher'>Pitcher</A><br>


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR adds five new bottles, printable at a Glass Recycler. They are functionally identical to a drinking bottle, but with different sprites, names, and descriptions. They all cost 1 glass-point(?) to print, and all hold 50 units. This does not change or remove anything else that the Glass Recycler can make.

![image](https://user-images.githubusercontent.com/46986487/87125089-e8173600-c257-11ea-84b0-0f38c6cf2829.png)
From left to right; 'Long Bottle', 'Tall Bottle', 'Rectangular Bottle', 'Square Bottle', 'Wide Bottle'

**I DID NOT SPRITE THESE BOTTLES, AND TAKE ZERO CREDIT FOR THE SPRITES.** They're used as bases for various drinks you can get from vendors, but these all lack a label and start off empty. The sprites are already in the game files, hence why this PR does not add or change any .dmi files. (Woohoo, no icon conflicts!)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I like bottles. I really, really like bottles; in real life, I have a bottle collection. When new bottle sprites came to town, I was hyped; and for the most part, the new bottles looked great. Except for the one that the bartender could make, anyways - that one just looked like a crappy soda-bottle codersprite to me. Originally, this PR was going to just add the old bottle sprite back alongside the new bottle sprite as seperate items, but I saw that cool-ass blank bottle sprites and took my opportunity.

These bottles will let creative barmen spruce up their creations, and look great on shelves. They're also useful for organizing your drinks if you have a lot that look the same color. And they're pretty as hell, so that's a plus.

TL;DR: current soda bottle for barman bad, new sprites for barman bottle good

EDIT: learned to english
EDIT 2: 'Masculine Bottles' renamed to 'Wide Bottles'. Bottle fetishists worldwide howl in sorrow.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Genessee:
(+)Five new types of bottle can now be printed at a Glass Recycler.
```
