### PR TITLE
RockBox™ Sale Notifications for Miners

### DIFF
--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -739,9 +739,10 @@
 								leftovers = subtotal%accounts.len
 								var/divisible_amount = subtotal - leftovers
 								if(divisible_amount)
+									var/amount_per_account = divisible_amount/length(accounts)
 									for(var/datum/data/record/t in accounts)
-										t.fields["current_money"] += divisible_amount/accounts.len
-								minerSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="ROCKBOX&trade;-MAILBOT",  "group"="mining", "sender"=src.net_id, "message"="Notification: [divisible_amount] credits earned from Rockbox&trade; sale, deposited to your account.")
+										t.fields["current_money"] += amount_per_account
+									minerSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="ROCKBOX&trade;-MAILBOT",  "group"="mining", "sender"=src.net_id, "message"="Notification: [amount_per_account] credits earned from Rockbox&trade; sale, deposited to your account.")
 							else
 								leftovers = subtotal
 								minerSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="ROCKBOX&trade;-MAILBOT",  "group"="mining", "sender"=src.net_id, "message"="Notification: [leftovers + sum_taxes] credits earned from Rockbox&trade; sale, deposited to the shipping budget.")

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -725,6 +725,7 @@
 
 							var/datum/radio_frequency/transmit_connection = radio_controller.return_frequency("1149")
 							var/datum/signal/minerSignal = get_free_signal()
+							minerSignal.source = src
 							minerSignal.transmission_method = TRANSMISSION_RADIO
 							//any non-divisible amounts go to the shipping budget
 							var/leftovers = 0

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -744,7 +744,7 @@
 								minerSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="ROCKBOX™-MAILBOT",  "group"="mining", "sender"=src.net_id, "message"="Notification: [divisible_amount] credits earned from Rockbox™ sale, deposited to your account.")
 							else
 								leftovers = subtotal
-								minerSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="ROCKBOX™-MAILBOT",  "group"="mining", "sender"=src.net_id, "message"="Notification: [leftovers + sum_taxes] credits earned from Rockbox™ sale, deposited to the shipping budget.")
+								minerSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="ROCKBOX&trade;-MAILBOT",  "group"="mining", "sender"=src.net_id, "message"="Notification: [leftovers + sum_taxes] credits earned from Rockbox&trade; sale, deposited to the shipping budget.")
 							wagesystem.shipping_budget += (leftovers + sum_taxes)
 							transmit_connection.post_signal(src, minerSignal)
 

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -741,7 +741,7 @@
 								if(divisible_amount)
 									for(var/datum/data/record/t in accounts)
 										t.fields["current_money"] += divisible_amount/accounts.len
-								minerSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="ROCKBOX™-MAILBOT",  "group"="mining", "sender"="00000000", "message"="Notification: [divisible_amount] credits earned from Rockbox™ sale, deposited to your account.")
+								minerSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="ROCKBOX™-MAILBOT",  "group"="mining", "sender"=src.net_id, "message"="Notification: [divisible_amount] credits earned from Rockbox™ sale, deposited to your account.")
 							else
 								leftovers = subtotal
 								minerSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="ROCKBOX™-MAILBOT",  "group"="mining", "sender"=src.net_id, "message"="Notification: [leftovers + sum_taxes] credits earned from Rockbox™ sale, deposited to the shipping budget.")

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -737,7 +737,7 @@
 								minerSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="ROCKBOX™-MAILBOT",  "group"="mining", "sender"="00000000", "message"="Notification: [divisible_amount] credits earned from Rockbox™ sale, deposited to your account.")
 							else
 								leftovers = subtotal
-								minerSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="ROCKBOX™-MAILBOT",  "group"="mining", "sender"="00000000", "message"="Notification: [leftovers] credits earned from Rockbox™ sale, deposited to the shipping budget.")
+								minerSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="ROCKBOX™-MAILBOT",  "group"="mining", "sender"="00000000", "message"="Notification: [leftovers + sum_taxes] credits earned from Rockbox™ sale, deposited to the shipping budget.")
 							wagesystem.shipping_budget += (leftovers + sum_taxes)
 							transmit_connection.post_signal(src, minerSignal)
 

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -723,6 +723,9 @@
 									accounts += t
 
 
+							var/datum/radio_frequency/transmit_connection = radio_controller.return_frequency("1149")
+							var/datum/signal/minerSignal = get_free_signal()
+							minerSignal.transmission_method = TRANSMISSION_RADIO
 							//any non-divisible amounts go to the shipping budget
 							var/leftovers = 0
 							if(accounts.len)
@@ -731,9 +734,12 @@
 								if(divisible_amount)
 									for(var/datum/data/record/t in accounts)
 										t.fields["current_money"] += divisible_amount/accounts.len
+								minerSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="ROCKBOX™-MAILBOT",  "group"="mining", "sender"="00000000", "message"="Notification: [divisible_amount] credits earned from Rockbox™ sale, deposited to your account.")
 							else
 								leftovers = subtotal
+								minerSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="ROCKBOX™-MAILBOT",  "group"="mining", "sender"="00000000", "message"="Notification: [leftovers] credits earned from Rockbox™ sale, deposited to the shipping budget.")
 							wagesystem.shipping_budget += (leftovers + sum_taxes)
+							transmit_connection.post_signal(src, minerSignal)
 
 							src.temp = {"Enjoy your purchase!<BR>"}
 						else

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -730,7 +730,6 @@
 									accounts += t
 
 
-							var/datum/radio_frequency/transmit_connection = radio_controller.return_frequency("1149")
 							var/datum/signal/minerSignal = get_free_signal()
 							minerSignal.source = src
 							minerSignal.transmission_method = TRANSMISSION_RADIO

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -741,7 +741,7 @@
 								if(divisible_amount)
 									for(var/datum/data/record/t in accounts)
 										t.fields["current_money"] += divisible_amount/accounts.len
-								minerSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="ROCKBOX™-MAILBOT",  "group"="mining", "sender"=src.net_id, "message"="Notification: [divisible_amount] credits earned from Rockbox™ sale, deposited to your account.")
+								minerSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="ROCKBOX&trade;-MAILBOT",  "group"="mining", "sender"=src.net_id, "message"="Notification: [divisible_amount] credits earned from Rockbox&trade; sale, deposited to your account.")
 							else
 								leftovers = subtotal
 								minerSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="ROCKBOX&trade;-MAILBOT",  "group"="mining", "sender"=src.net_id, "message"="Notification: [leftovers + sum_taxes] credits earned from Rockbox&trade; sale, deposited to the shipping budget.")

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -64,6 +64,9 @@
 	var/list/text_bad_output_adjective = list("janky","crooked","warped","shoddy","shabby","lousy","crappy","shitty")
 	var/obj/item/card/id/scan = null
 	var/temp = null
+	var/frequency = 1149
+	var/datum/radio_frequency/transmit_connection = null
+	var/net_id = null
 
 #define WIRE_EXTEND 1
 #define WIRE_POWER 2
@@ -74,6 +77,8 @@
 		START_TRACKING
 		..()
 		src.area_name = src.loc.loc.name
+		src.transmit_connection = radio_controller.add_object(src,"[frequency]")
+		src.net_id = generate_net_id(src)
 
 		if (istype(manuf_controls,/datum/manufacturing_controller))
 			src.set_up_schematics()
@@ -116,6 +121,8 @@
 		src.sound_beginwork = null
 		src.sound_damaged = null
 		src.sound_destroyed = null
+		radio_controller.remove_object(src,"[frequency]")
+		src.transmit_connection = null
 
 		for (var/obj/O in src.contents)
 			O.loc = src.loc

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -744,7 +744,7 @@
 								minerSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="ROCKBOX™-MAILBOT",  "group"="mining", "sender"="00000000", "message"="Notification: [divisible_amount] credits earned from Rockbox™ sale, deposited to your account.")
 							else
 								leftovers = subtotal
-								minerSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="ROCKBOX™-MAILBOT",  "group"="mining", "sender"="00000000", "message"="Notification: [leftovers + sum_taxes] credits earned from Rockbox™ sale, deposited to the shipping budget.")
+								minerSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="ROCKBOX™-MAILBOT",  "group"="mining", "sender"=src.net_id, "message"="Notification: [leftovers + sum_taxes] credits earned from Rockbox™ sale, deposited to the shipping budget.")
 							wagesystem.shipping_budget += (leftovers + sum_taxes)
 							transmit_connection.post_signal(src, minerSignal)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
They say a picture is worth a thousand words, so have two!
![image](https://user-images.githubusercontent.com/9563541/87137936-856f6b80-c252-11ea-82b2-bded12cac21b.png)
Image of the funds being split.

![image](https://user-images.githubusercontent.com/9563541/87136344-3fb1a380-c250-11ea-9016-3290911b7184.png)
This is the message when the amount earned cannot be split among the accounts (such as, there being no miners and no C.E.).

I intentionally did not create a PDA notification for Cargo, as suspect the tax-earning plus leftovers will be too insignificant per-sale to be worth messaging them.

Note: The ™ Does not render well on the PDA messages screen, but that's a ~~sacrifice~~ bug I am willing to make.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Cargo and MedResearch has sale notifications, now Mining does too.
Also @Adharainspace (and indirectly, @UrsulaMejor ) asked me to.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)MarkNstein:
(+)Miners now get PDA notifications of RockBox™ sales.
```
