### PR TITLE
Fix 0 stacks of floor tiles

### DIFF
--- a/code/obj.dm
+++ b/code/obj.dm
@@ -319,16 +319,16 @@
 	attackby(obj/item/C as obj, mob/user as mob)
 
 		if (istype(C, /obj/item/tile))
+			var/obj/item/tile/T = C
+			if (T.amount >= 1)
+				T.build(get_turf(src))
+				playsound(src.loc, "sound/impact_sounds/Generic_Stab_1.ogg", 50, 1)
+				T.add_fingerprint(user)
+				qdel(src)
 
-			C:build(get_turf(src))
-			C:amount--
-			playsound(src.loc, "sound/impact_sounds/Generic_Stab_1.ogg", 50, 1)
-			C.add_fingerprint(user)
-
-			if (C:amount < 1)
-				user.u_equip(C)
-				qdel(C)
-			qdel(src)
+			if (T.amount < 1 && !issilicon(user))
+				user.u_equip(T)
+				qdel(T)
 			return
 		if (isweldingtool(C) && C:try_weld(user,0))
 			boutput(user, "<span class='notice'>Slicing lattice joints ...</span>")

--- a/code/obj/flock/furniture.dm
+++ b/code/obj/flock/furniture.dm
@@ -229,15 +229,16 @@
 
 /obj/lattice/flock/attackby(obj/item/C as obj, mob/user as mob)
 	if (istype(C, /obj/item/tile))
-		C:build(get_turf(src))
-		C:amount--
-		playsound(src.loc, "sound/impact_sounds/Generic_Stab_1.ogg", 50, 1)
-		C.add_fingerprint(user)
+		var/obj/item/tile/T = C
+		if (T.amount >= 1)
+			T.build(get_turf(src))
+			playsound(src.loc, "sound/impact_sounds/Generic_Stab_1.ogg", 50, 1)
+			T.add_fingerprint(user)
+			qdel(src)
 
-		if (C:amount < 1)
-			user.u_equip(C)
-			qdel(C)
-		qdel(src)
+		if (T.amount < 1  && !issilicon(user))
+			user.u_equip(T)
+			qdel(T)
 	if (isweldingtool(C) && C:try_weld(user,0,-1,0,0))
 		boutput(user, "<span class='notice'>The fibres burn away in the same way glass doesn't. Huh.</span>")
 		qdel(src)

--- a/code/obj/item/building_materials.dm
+++ b/code/obj/item/building_materials.dm
@@ -1014,12 +1014,11 @@ MATERIAL
 				return
 			else
 				src.build(S)
-				src.amount--
 				tooltip_rebuild = 1
 		if (src.amount < 1)
-			user.u_equip(src)
-			//SN src = null
-			qdel(src)
+			if (!issilicon(user))
+				user.u_equip(src)
+				qdel(src)
 			return
 		src.add_fingerprint(user)
 		return
@@ -1054,6 +1053,8 @@ MATERIAL
 		boutput(user, "<span class='notice'>You finish stacking tiles.</span>")
 
 	proc/build(turf/S as turf)
+		if (src.amount < 1)
+			return
 		var/turf/simulated/floor/W = S.ReplaceWithFloor()
 		if (W) //Wire: Fix for: Cannot read null.icon_old
 			W.inherit_area()
@@ -1063,7 +1064,7 @@ MATERIAL
 
 		if(ismob(usr) && !istype(src.material, /datum/material/metal/steel))
 			logTheThing("station", usr, null, "constructs a floor (<b>Material:</b>: [src.material && src.material.name ? "[src.material.name]" : "*UNKNOWN*"]) at [log_loc(S)].")
-
+		src.amount--
 		return
 
 /obj/item/tile/steel

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -1129,13 +1129,15 @@
 	if(!C || !user)
 		return 0
 	if (istype(C, /obj/item/tile))
-		playsound(src, "sound/impact_sounds/Generic_Stab_1.ogg", 50, 1)
-		C:build(src)
-		C:amount--
-		if(C.material) src.setMaterial(C.material)
-		if (C:amount < 1)
-			user.u_equip(C)
-			qdel(C)
+		var/obj/item/tile/T = C
+		if (T.amount >= 1)
+			playsound(src, "sound/impact_sounds/Generic_Stab_1.ogg", 50, 1)
+			T.build(src)
+			if(T.material) src.setMaterial(T.material)
+
+		if (T.amount < 1 && !issilicon(user))
+			user.u_equip(T)
+			qdel(T)
 			return
 		return
 
@@ -1442,6 +1444,11 @@
 
 	if(istype(C, /obj/item/tile))
 		var/obj/item/tile/T = C
+		if (T.amount < 1)
+			if(!issilicon(user))
+				user.u_equip(T)
+				qdel(T)
+			return
 		if (!intact)
 			restore_tile()
 			src.plate_mat = src.material

--- a/code/turf/turf.dm
+++ b/code/turf/turf.dm
@@ -967,7 +967,8 @@ var/global/client/ff_debugger = null
 			playsound(src, "sound/impact_sounds/Generic_Stab_1.ogg", 50, 1)
 			T.build(src)
 			if(T.material) src.setMaterial(T.material)
-		else if (!issilicon(user))
+
+		if (T.amount < 1 && !issilicon(user))
 			user.u_equip(T)
 			qdel(T)
 			return

--- a/code/turf/turf.dm
+++ b/code/turf/turf.dm
@@ -960,15 +960,16 @@ var/global/client/ff_debugger = null
 
 	if (istype(C, /obj/item/tile))
 		//var/obj/lattice/L = locate(/obj/lattice, src)
-		for(var/obj/lattice/L in src)
-			qdel(L)
-		playsound(src, "sound/impact_sounds/Generic_Stab_1.ogg", 50, 1)
-		C:build(src)
-		C:amount--
-		if(C.material) src.setMaterial(C.material)
-		if (C:amount < 1)
-			user.u_equip(C)
-			qdel(C)
+		var/obj/item/tile/T = C
+		if (T.amount >= 1)
+			for(var/obj/lattice/L in src)
+				qdel(L)
+			playsound(src, "sound/impact_sounds/Generic_Stab_1.ogg", 50, 1)
+			T.build(src)
+			if(T.material) src.setMaterial(T.material)
+		else if (!issilicon(user))
+			user.u_equip(T)
+			qdel(T)
 			return
 		return
 	return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Refactors how floor tiles are handled a little. Subtracting from the stack is now handled in the tiles `build()` proc. The various tile interactions will also now qdel any stacks of 0 tiles a player attempts to use on them, unless they are a robot in which they can keep the 0 stack as part of their module.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #1390
Emily told me I had to fix it