### PR TITLE
Manta: Fix Armory Access

### DIFF
--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -2446,6 +2446,7 @@
 	dir = 8;
 	icon_base = "sec";
 	icon_state = "sec_closed";
+	lockdownbyai = 1;
 	name = "Explosives Storage"
 	},
 /obj/firedoor_spawn,
@@ -8221,6 +8222,7 @@
 /obj/machinery/door/airlock/pyro{
 	icon_base = "sec";
 	icon_state = "sec_closed";
+	lockdownbyai = 1;
 	name = "Armory"
 	},
 /obj/firedoor_spawn,

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -2442,11 +2442,11 @@
 /turf/space/fluid/manta,
 /area/abandonedmedicalship/robot_trader)
 "agq" = (
-/obj/machinery/door/airlock/pyro/security{
-	dir = 4;
-	lockdownbyai = 1;
-	name = "Explosives Storage";
-	req_access_txt = "37"
+/obj/machinery/door/airlock/pyro{
+	dir = 8;
+	icon_base = "sec";
+	icon_state = "sec_closed";
+	name = "Explosives Storage"
 	},
 /obj/firedoor_spawn,
 /obj/access_spawn/hos,
@@ -8218,7 +8218,9 @@
 /turf/space/fluid/manta/nospawn,
 /area/mantaSpace)
 "atV" = (
-/obj/machinery/door/airlock/pyro/security{
+/obj/machinery/door/airlock/pyro{
+	icon_base = "sec";
+	icon_state = "sec_closed";
 	name = "Armory"
 	},
 /obj/firedoor_spawn,
@@ -19197,12 +19199,13 @@
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/communications)
 "aRG" = (
-/obj/machinery/door/airlock/pyro/security{
-	name = "Head of Security's Personal Quarters";
-	req_access_txt = "37"
-	},
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/pyro{
+	icon_base = "sec";
+	icon_state = "sec_closed";
+	name = "HoS'ffice"
 	},
 /obj/firedoor_spawn,
 /obj/access_spawn/hos,
@@ -45499,18 +45502,19 @@
 /turf/simulated/floor/black,
 /area/station/chemistry)
 "kfj" = (
-/obj/machinery/door/airlock/pyro/security{
-	name = "Head of Security's Office";
-	req_access_txt = "37"
-	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro{
+	icon_base = "sec";
+	icon_state = "sec_closed";
+	name = "HoS'ffice"
+	},
 /obj/firedoor_spawn,
-/obj/access_spawn/hos,
 /obj/disposalpipe/segment,
+/obj/access_spawn/hos,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG][MAPPING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the doors of Manta Armory from 
`/obj/machinery/door/airlock/pyro/security`
to
`/obj/machinery/door/airlock/pyro`
Access spawners were already in place.

Tested.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug. Prevents anyone with security access walking into the armory.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)MarkNstein:
(+)Manta: Armory access fixed, requirements match other maps.
```
