### PR TITLE
Manta: remove errant space tile in the ghost-drone ship

### DIFF
--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -3320,7 +3320,7 @@
 /area/ghostdrone_factory)
 "aiS" = (
 /obj/machinery/door/airlock/pyro/external,
-/turf/space,
+/turf/simulated/floor/grime,
 /area/ghostdrone_factory)
 "aiT" = (
 /obj/machinery/camera{


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG][MAPPING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces a space tile under a door in the ghostdrone factory with a regular tile.
Fixes #1436 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug.