### PR TITLE
Fix TTV-VR: no longer hangs after first simulation.

### DIFF
--- a/code/obj/item/device/transfer_valve.dm
+++ b/code/obj/item/device/transfer_valve.dm
@@ -372,6 +372,7 @@
 		processing_items.Remove(src)
 		if(tester)
 			tester.update_bomb_log("VR Bomb deleted.", 1)
+			tester.vrbomb = null;
 		if(ismob(src.loc))
 			boutput(src.loc, "<span class='alert'>[src] fades away!</span>")
 		else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Clears the tester's reference to vrbomb, allowing the simulation to reset.

Tested.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #1303