### PR TITLE
Manta Fix - Bridge Intercoms & Enginge Speakers

### DIFF
--- a/code/obj/item/device/radio.dm
+++ b/code/obj/item/device/radio.dm
@@ -1081,6 +1081,22 @@ obj/item/device/radio/signaler/attackby(obj/item/W as obj, mob/user as mob)
 	density = 0
 	desc = "A Loudspeaker."
 
+	New()
+		//..()
+		pixel_place()
+
+	pixel_place()
+		if(src.pixel_x == 0 && src.pixel_y == 0)
+			switch(src.dir)
+				if(NORTH)
+					pixel_y = -14
+				if(SOUTH)
+					pixel_y = 32
+				if(EAST)
+					pixel_x = -21
+				if(WEST)
+					pixel_x = 21
+
 	north
 		dir = NORTH
 	south

--- a/code/obj/item/device/radio.dm
+++ b/code/obj/item/device/radio.dm
@@ -1083,9 +1083,6 @@ obj/item/device/radio/signaler/attackby(obj/item/W as obj, mob/user as mob)
 
 	New()
 		//..()
-		pixel_place()
-
-	pixel_place()
 		if(src.pixel_x == 0 && src.pixel_y == 0)
 			switch(src.dir)
 				if(NORTH)

--- a/code/obj/item/device/radios/intercoms.dm
+++ b/code/obj/item/device/radios/intercoms.dm
@@ -20,19 +20,16 @@
 				screen_image.color = new_color
 		screen_image.alpha = 180
 		src.UpdateOverlays(screen_image, "screen")
-		pixel_place()
-
-/obj/item/device/radio/intercom/proc/pixel_place()
-	if(src.pixel_x == 0 && src.pixel_y == 0)
-		switch(src.dir)
-			if(NORTH)
-				pixel_y = -21
-			if(SOUTH)
-				pixel_y = 24
-			if(EAST)
-				pixel_x = -21
-			if(WEST)
-				pixel_x = 21
+		if(src.pixel_x == 0 && src.pixel_y == 0)
+			switch(src.dir)
+				if(NORTH)
+					pixel_y = -21
+				if(SOUTH)
+					pixel_y = 24
+				if(EAST)
+					pixel_x = -21
+				if(WEST)
+					pixel_x = 21
 
 /obj/item/device/radio/intercom/attack_ai(mob/user as mob)
 	src.add_fingerprint(user)

--- a/code/obj/item/device/radios/intercoms.dm
+++ b/code/obj/item/device/radios/intercoms.dm
@@ -20,16 +20,19 @@
 				screen_image.color = new_color
 		screen_image.alpha = 180
 		src.UpdateOverlays(screen_image, "screen")
-		if(src.pixel_x == 0 && src.pixel_y == 0)
-			switch(src.dir)
-				if(NORTH)
-					pixel_y = -21
-				if(SOUTH)
-					pixel_y = 24
-				if(EAST)
-					pixel_x = -21
-				if(WEST)
-					pixel_x = 21
+		pixel_place()
+
+/obj/item/device/radio/intercom/proc/pixel_place()
+	if(src.pixel_x == 0 && src.pixel_y == 0)
+		switch(src.dir)
+			if(NORTH)
+				pixel_y = -21
+			if(SOUTH)
+				pixel_y = 24
+			if(EAST)
+				pixel_x = -21
+			if(WEST)
+				pixel_x = 21
 
 /obj/item/device/radio/intercom/attack_ai(mob/user as mob)
 	src.add_fingerprint(user)

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -638,8 +638,11 @@
 /turf/simulated/floor/black,
 /area/station/bridge)
 "abf" = (
-/obj/item/device/radio/intercom/AI,
-/turf/simulated/floor/darkblue,
+/obj/decal/stage_edge/alt,
+/obj/item/device/radio/intercom/AI{
+	pixel_y = 7
+	},
+/turf/simulated/floor/black,
 /area/station/bridge)
 "abg" = (
 /obj/table/reinforced/auto,
@@ -689,8 +692,11 @@
 /turf/simulated/floor,
 /area/station/hallway/starboardupperhallway)
 "abo" = (
-/obj/item/device/radio/intercom/brig,
-/turf/simulated/floor/darkblue,
+/obj/decal/stage_edge/alt,
+/obj/item/device/radio/intercom/brig{
+	pixel_y = 7
+	},
+/turf/simulated/floor/black,
 /area/station/bridge)
 "abp" = (
 /obj/machinery/drainage/big,
@@ -716,20 +722,32 @@
 /turf/simulated/floor/black,
 /area/station/bridge)
 "abs" = (
-/obj/item/device/radio/intercom/security,
-/turf/simulated/floor/darkblue,
+/obj/decal/stage_edge/alt,
+/obj/item/device/radio/intercom/security{
+	pixel_y = 7
+	},
+/turf/simulated/floor/black,
 /area/station/bridge)
 "abt" = (
-/obj/item/device/radio/intercom/medical,
-/turf/simulated/floor/darkblue,
+/obj/decal/stage_edge/alt,
+/obj/item/device/radio/intercom/medical{
+	pixel_y = 7
+	},
+/turf/simulated/floor/black,
 /area/station/bridge)
 "abu" = (
-/obj/item/device/radio/intercom/engineering,
-/turf/simulated/floor/darkblue,
+/obj/decal/stage_edge/alt,
+/obj/item/device/radio/intercom/engineering{
+	pixel_y = 7
+	},
+/turf/simulated/floor/black,
 /area/station/bridge)
 "abv" = (
-/obj/item/device/radio/intercom/science,
-/turf/simulated/floor/darkblue,
+/obj/decal/stage_edge/alt,
+/obj/item/device/radio/intercom/science{
+	pixel_y = 7
+	},
+/turf/simulated/floor/black,
 /area/station/bridge)
 "abw" = (
 /obj/displaycase{
@@ -3099,8 +3117,11 @@
 /turf/simulated/floor,
 /area/station/hallway/starboardupperhallway)
 "ail" = (
-/obj/item/device/radio/intercom/cargo,
-/turf/simulated/floor/darkblue,
+/obj/decal/stage_edge/alt,
+/obj/item/device/radio/intercom/cargo{
+	pixel_y = 7
+	},
+/turf/simulated/floor/black,
 /area/station/bridge)
 "aim" = (
 /obj/machinery/camera{
@@ -4288,8 +4309,11 @@
 	},
 /area/listeningpost/syndicateassaultvessel)
 "alv" = (
-/obj/item/device/radio/intercom/catering,
-/turf/simulated/floor/darkblue,
+/obj/decal/stage_edge/alt,
+/obj/item/device/radio/intercom/catering{
+	pixel_y = 7
+	},
+/turf/simulated/floor/black,
 /area/station/bridge)
 "alw" = (
 /obj/cable{
@@ -88809,8 +88833,8 @@ aah
 aal
 aaw
 aaI
-aaR
 abf
+abd
 aag
 aag
 aBz
@@ -89111,8 +89135,8 @@ aah
 aam
 aax
 aaI
-aaR
 abo
+abd
 abI
 aky
 aBz
@@ -89413,8 +89437,8 @@ aah
 aan
 aan
 aaJ
-aaR
 abs
+abd
 abe
 ahu
 aBB
@@ -89715,8 +89739,8 @@ aah
 aao
 aay
 aaI
-aaR
 abt
+abd
 abe
 ahx
 aBD
@@ -90319,8 +90343,8 @@ aaj
 aar
 aaC
 aaI
-aaR
 abu
+abd
 abe
 aoR
 aBF
@@ -90621,8 +90645,8 @@ aaj
 aan
 aan
 aaJ
-aaR
 abv
+abd
 abe
 aBq
 aBG
@@ -90923,8 +90947,8 @@ aaj
 aas
 aaD
 aaI
-aaR
 ail
+abd
 abP
 akA
 aBz
@@ -91225,8 +91249,8 @@ aaj
 aat
 aaw
 aaI
-aaR
 alv
+abd
 aag
 aag
 aBz


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moved the intercoms on Manta's bridge to be a bit more visually pleasing.
Added auto pixel shifting to the speakers (engine rooms),
Minor refactor of pixel-placement of intercoms - I was initially pursuing a different method of fixing speakers, but didn't like it. So the `pixel_place()` is a left-over; I can remove it and return it to being in `New()`.
![image](https://user-images.githubusercontent.com/9563541/87233885-653dca80-c380-11ea-8289-e925fb70c4c4.png)
![image](https://user-images.githubusercontent.com/9563541/87233886-6969e800-c380-11ea-832a-d8be0ecd0b3e.png)
![image](https://user-images.githubusercontent.com/9563541/87233890-74247d00-c380-11ea-8759-6bb8d50a3276.png)
Notably, this patch goes with the offset of the red intercom (the one above the character). Others are shown incase "we" want something else.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #927 