### PR TITLE
Shockfixes

### DIFF
--- a/code/mob/living/silicon.dm
+++ b/code/mob/living/silicon.dm
@@ -689,3 +689,6 @@ var/global/list/module_editors = list()
 
 /mob/living/silicon/shock(var/atom/origin, var/wattage, var/zone, var/stun_multiplier = 1, var/ignore_gloves = 0)
 	return 0
+
+/mob/living/silicon/electric_expose(var/power = 1)
+	return 0

--- a/code/mob/living/silicon.dm
+++ b/code/mob/living/silicon.dm
@@ -686,3 +686,6 @@ var/global/list/module_editors = list()
 
 /mob/living/silicon/is_cold_resistant()
 	.= 1
+
+/mob/living/silicon/shock(var/atom/origin, var/wattage, var/zone, var/stun_multiplier = 1, var/ignore_gloves = 0)
+	return 0

--- a/code/procs/elecflash.dm
+++ b/code/procs/elecflash.dm
@@ -106,5 +106,8 @@ var/global/mutable_appearance/elecflash_ma = null
 
 /mob/living/electric_expose(var/power = 1)
 	if (power > 1) // pretty light damage and stam damage :)
+		if (src.bioHolder.HasEffect("resist_electric"))
+			boutput(src, "<span class='notice'>You feel electricity spark across you harmlessly!</span>")
+			return 0
 		src.do_disorient(stamina_damage = 15 + power * 7, weakened = 1 SECONDS + (power * (0.1 SECONDS)), stunned = 0, paralysis = 0, disorient = 1 SECONDS + (power * (0.2 SECONDS)), remove_stamina_below_zero = 0, target_type = DISORIENT_BODY)
 		src.TakeDamage("chest", 0, rand(0,1.00) * power * 0.1, damage_type=DAMAGE_BURN)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE] [FIX]?
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Make silicons immune to shocks again

Make silicons immune to elecflashes

Make SMES human grant immunity to elecflashes


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #1438 

Doesn't make much sense for elecflashes to work on mobs that are immune to electricity

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Tarmunora:
(+)Fix elecflashes shocking electricity-immune mobs
```
