### PR TITLE
Fixes nukies getting set nuke targets that don't exist on donut3

### DIFF
--- a/code/map.dm
+++ b/code/map.dm
@@ -158,6 +158,17 @@ var/global/list/mapNames = list(
 	merchant_right_centcom = /area/shuttle/merchant_shuttle/right_centcom/destiny
 	merchant_right_station = /area/shuttle/merchant_shuttle/right_station/destiny
 
+	valid_nuke_targets = list("the cargo bay (QM)" = list(/area/station/quartermaster/office),
+		"inner engineering (surrounding the singularity, not in it)" = list(/area/station/engine/inner),
+		"the station's cafeteria" = list(/area/station/crew_quarters/cafeteria),
+		"the inner hall of the medbay" = list(/area/station/medical/medbay),
+		"the main hallway in research" = list(/area/station/science),
+		"the chapel" = list(/area/station/chapel/main),
+		"the escape hallway" = list(/area/station/hallway/secondary/exit),
+		"the Research Director's office" = list(/area/station/crew_quarters/hor),
+		"the Chief Engineer's office" = list(/area/station/engine/engineering/ce),
+		"the kitchen" = list(/area/station/crew_quarters/kitchen))
+
 /datum/map_settings/cogmap_old
 	name = "COGMAP_OLD"
 	escape_centcom = /area/shuttle/escape/centcom/cogmap


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FIX]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes a bug where nuke targets were being overridden with a default nuke list being defined elsewhere, making a situation where nukies literally couldn't plant the nuke because the target was in a location that don't exist in Donut3


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's an awful bug that ruins nuke rounds completely.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Ryumi:
(*)Fixed a major bug where nukies would be given a Donut3 nuke target that doesn't exist... w h a t
```
