### PR TITLE
Station payroll status change rate limit

### DIFF
--- a/code/datums/banking.dm
+++ b/code/datums/banking.dm
@@ -571,9 +571,9 @@
 						boutput(usr, "<span class='notice'>$[t1] added to [R.fields["name"]]'s account from station budget.</span>")
 					else boutput(usr, "<span class='alert'>Error selecting withdraw/deposit mode.</span>")
 				else if(href_list["payroll"])
-					if(world.time >= src.payroll_rate_limit_time) //slow the fuck down cowboy
+					if(world.time >= src.payroll_rate_limit_time)
 						src.payroll_rate_limit_time = world.time + (10 SECONDS)
-					else
+					else //slow the fuck down cowboy
 						boutput(usr, "<span class='alert'>Nanotrasen policy forbids the modification station payroll status more than once every ten seconds!</span>")
 						return
 					if (wagesystem.pay_active)

--- a/code/datums/banking.dm
+++ b/code/datums/banking.dm
@@ -425,6 +425,7 @@
 	var/temp = null
 	var/printing = null
 	var/can_change_id = 0
+	var/payroll_rate_limit_time = 0 //for preventing coammand message spam
 
 	attack_ai(mob/user as mob)
 		return src.attack_hand(user)
@@ -570,6 +571,11 @@
 						boutput(usr, "<span class='notice'>$[t1] added to [R.fields["name"]]'s account from station budget.</span>")
 					else boutput(usr, "<span class='alert'>Error selecting withdraw/deposit mode.</span>")
 				else if(href_list["payroll"])
+					if(world.time >= src.payroll_rate_limit_time) //slow the fuck down cowboy
+						src.payroll_rate_limit_time = world.time + (10 SECONDS)
+					else
+						boutput(usr, "<span class='alert'>Nanotrasen policy forbids the modification station payroll status more than once every ten seconds!</span>")
+						return
 					if (wagesystem.pay_active)
 						wagesystem.pay_active = 0
 						command_alert("The payroll has been suspended until further notice. No further wages will be paid until the payroll is resumed.","Payroll Announcement")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][FEATURE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a 10 second rate limiter to changing payroll status. Attempting to change payroll before 10 seconds have passed will display the message `Nanotrasen policy forbids the modification station payroll status more than once every ten seconds!`


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
- There is no limit on changing payroll status
- payroll status changes issue command messages
- command message spam can crash players on slower machines
- @UrsulaMejor told me to


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Sovexe:
(+)There is now a 10 second rate limit on changing the station payroll status.
```
