### PR TITLE
PDAs Can Be Activated In-Slot By Simple Clicking

### DIFF
--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -297,6 +297,15 @@
 
 	..()
 
+/obj/item/device/pda2/attack_hand(mob/user as mob)
+	if(ishuman(user) || ismonkey(user))
+		var/mob/living/carbon/human/U = user
+		var/slot = U.get_slot_from_item(src)
+		if((slot == U.slot_wear_id) || (slot == U.slot_belt))
+			attack_self(user)
+			return
+	..()
+
 /obj/item/device/pda2/attack_self(mob/user as mob)
 	if(!user.literate)
 		boutput(user, "<span class='alert'>You don't know how to read, the screen is meaningless to you.</span>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Clicking the PDA in either the belt or ID slot will open the PDA. Works as human or monkey. Dragging from slot to hand removes it the item from the slot.

Tested on both mob types.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Quality of Life.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)MarkNstein:
(*)PDA's can be activated from the belt or ID slot by simple-clicking them.
```
