### PR TITLE
Playable non-traitor pests are now ghost critters

### DIFF
--- a/_std/code/_macros.dm
+++ b/_std/code/_macros.dm
@@ -47,7 +47,7 @@ var/list/detailed_spawn_dbg = list()
 #define isvirtual(x) istype(x, /mob/living/carbon/human/virtual)
 #define isVRghost(x) (istype(x, /mob/living/carbon/human/virtual) && x:isghost)
 #define issmallanimal(x) istype(x, /mob/living/critter/small_animal)
-#define isghostcritter(x) (istype(x, /mob/living/critter/small_animal) && x:ghost_spawned)
+#define isghostcritter(x) (istype(x, /mob/living/critter) && x:ghost_spawned)
 #define ishelpermouse(x) (istype(x, /mob/living/critter/small_animal/mouse/weak/mentor))//mentor and admin mice
 
 // I'm grump that we don't already have these so I'm adding them.  will we use all of them? probably not.  but we have them. - Haine

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -645,12 +645,6 @@
 			boutput(usr,"<span class='alert'><b>[src] is too heavy for you pull in your half-spectral state!</b></span>")
 			return
 
-	if (issmallanimal(usr))
-		var/mob/living/critter/small_animal/C = usr
-		if (!C.can_pull(src))
-			boutput(usr,"<span class='alert'><b>[src] is too heavy for you pull!</b></span>")
-			return
-
 	if (iscarbon(usr) || issilicon(usr))
 		add_fingerprint(usr)
 

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -639,10 +639,16 @@
 	else if (isghostdrone(usr) && ismob(src) && !isghostdrone(src))
 		return
 
-	if (issmallanimal(usr))
+	if (isghostcritter(usr))
 		var/mob/living/critter/small_animal/C = usr
 		if (!C.can_pull(src))
 			boutput(usr,"<span class='alert'><b>[src] is too heavy for you pull in your half-spectral state!</b></span>")
+			return
+
+	if (issmallanimal(usr))
+		var/mob/living/critter/small_animal/C = usr
+		if (!C.can_pull(src))
+			boutput(usr,"<span class='alert'><b>[src] is too heavy for you pull!</b></span>")
 			return
 
 	if (iscarbon(usr) || issilicon(usr))

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -640,7 +640,7 @@
 		return
 
 	if (isghostcritter(usr))
-		var/mob/living/critter/small_animal/C = usr
+		var/mob/living/critter/C = usr
 		if (!C.can_pull(src))
 			boutput(usr,"<span class='alert'><b>[src] is too heavy for you pull in your half-spectral state!</b></span>")
 			return

--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -73,6 +73,7 @@
 	var/last_life_process = 0
 	var/use_stunned_icon = 1
 
+	var/pull_w_class = 2
 
 	blood_id = "blood"
 
@@ -391,6 +392,19 @@
 			I.throw_at(target, I.throw_range, I.throw_speed, params)
 
 			playsound(src.loc, 'sound/effects/throw.ogg', 50, 1, 0.1)
+
+	proc/can_pull(atom/A)
+		if (!src.ghost_spawned) //if its an admin or wizard made critter, just let them pull everythang
+			return 1
+		if (ismob(A))
+			return (src.pull_w_class >= 3)
+		else if (isobj(A))
+			if (istype(A,/obj/item))
+				var/obj/item/I = A
+				return (pull_w_class >= I.w_class)
+			else
+				return (src.pull_w_class >= 4)
+		return 0
 
 	click(atom/target, list/params)
 		if (((src.client && src.client.check_key(KEY_THROW)) || src.in_throw_mode) && src.can_throw)

--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -59,7 +59,6 @@ todo: add more small animals!
 	var/health_brute_vuln = 1
 	var/health_burn = 20
 	var/health_burn_vuln = 1
-	var/pull_w_class = 2
 
 	var/fur_color = 0
 	var/eye_color = 0
@@ -95,20 +94,6 @@ todo: add more small animals!
 			return prob(50)
 		else
 			return ..()
-
-	proc/can_pull(atom/A)
-		if (!src.ghost_spawned) //if its an admin or wizard made critter, just let them pull everythang
-			return 1
-		if (ismob(A))
-			return (src.pull_w_class >= 3)
-		else if (isobj(A))
-			if (istype(A,/obj/item))
-				var/obj/item/I = A
-				return (pull_w_class >= I.w_class)
-			else
-				return (src.pull_w_class >= 4)
-		return 0
-
 
 	death(var/gibbed)
 		if (!gibbed)

--- a/code/modules/events/playable_pests.dm
+++ b/code/modules/events/playable_pests.dm
@@ -74,11 +74,11 @@
 
 			var/atom/pestlandmark = pick(EV)
 
-			var/list/select = null
+			var/list/select = list()
 			if (src.pest_type) //customized
-				select = src.pest_type
+				select += src.pest_type
 			else
-				select = pick(src.pest_invasion_critter_types)
+				select += pick(src.pest_invasion_critter_types)
 
 			if (src.num_pests) //customized
 				src.num_pests = min(src.num_pests, candidates.len)
@@ -91,7 +91,7 @@
 
 				var/datum/mind/M = pick(candidates)
 				if (M.current)
-					M.current.make_critter(pick(select), pestlandmark)
+					M.current.make_ghost_critter(pestlandmark,select)
 				candidates -= M
 
 			pestlandmark.visible_message("A group of pests emerge from their hidey-hole!")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG][REWORK][FEATURE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Pests spawned by the pests playable event are now considered ghost critters.

- refactor of isghostcritter. Now capable of treating any `mob/living/critter` as a ghost critter instead of just small animal
- move `can_pull()` along with `var/pull_w_class` to the main critter object. These are used over in `/atom/movable/proc/pull()` to determine if a mob can pull something
- Introduces a number of new restrictions onto playable pests as ghost critters (illiterate, speak animal, can't pull the things especially not the nuke, can't use some computers, etc)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Playable pests have been getting abused and can even unscrew and pull around the nuke. This should bring them in line. Additionally mbc said that pests not being treated as ghost critters is in fact a bug.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Sovexe:
(*)Playable pests are now treated as ghost critters and as such are subject to a number of additional restrictions.
```
