### PR TITLE
Change Pathology UI a bit

### DIFF
--- a/browserassets/css/pathoui.css
+++ b/browserassets/css/pathoui.css
@@ -1,5 +1,5 @@
 *{
-	font-family:'Comic Sans MS',Consolas,monospace;
+	font-family:Consolas,monospace;
 }
 
 li {

--- a/browserassets/css/pathoui.css
+++ b/browserassets/css/pathoui.css
@@ -1,5 +1,5 @@
-* {
-	font-family:Consolas,monospace;
+*{
+	font-family:'Comic Sans MS',Consolas,monospace;
 	color: rgb(25, 201, 133);
 }
 
@@ -261,12 +261,12 @@ div {
 	cursor:default;
 }
 
-.transGood {
+#transTypesGood {
 	background-color: #090;
 	color: black;
 }
 
-.transBad {
+#transTypesBad {
 	background-color: #E00;
 	color: black;
 }
@@ -305,11 +305,11 @@ div {
 
 
 .a-green {
-	color:#050;
-	background-color:#010;
+	color:rgb(0, 0, 0);
+	background-color:rgb(185, 197, 185);
 }
 .a-green-on {
-	color:#090;
+	color:rgb(0, 0, 0);
 	background-color:#0E0;
 }
 
@@ -340,6 +340,7 @@ div {
 }
 
 /*buttons*/
+/* this is the fucking fuck zone that is not vertically aligned */
 .button {
 	display:inline-block;
 	text-align:center;

--- a/browserassets/css/pathoui.css
+++ b/browserassets/css/pathoui.css
@@ -1,8 +1,15 @@
 * {
 	font-family:Consolas,monospace;
+	color: rgb(25, 201, 133);
 }
+
+li {
+	margin-right: 15px
+}
+
 body {
 	background-color:#222;
+	overflow:hidden;
 }
 
 div {
@@ -35,7 +42,7 @@ div {
 /*DNA Load-Save components*/
 .dna-slot {
 	display:inline-block;
-	width:650px;
+	width:580px;
 	height:110px;
 	padding-left:5px;
 	background-color:#444;
@@ -49,12 +56,50 @@ div {
 }
 
 /*Manipulator components*/
+
 #manipHolder {
 	display:block;
-	width:650px;
-	height:80%;
+	width:375px;
+	height:50%;
 	margin:auto;
+	float:left;
 	border:none;
+}
+
+#manipStats {
+	width:50px;
+	display:inline;
+	height:50%;
+	border:none;
+}
+
+#manipHelp
+{
+	display:block;
+	margin:auto;
+	margin-right: 50px;
+	padding: 2px;
+	height: 107px;
+	width: 630px;
+	float: left;
+	background-color: rgb(20, 75, 78);
+}
+
+#analyzerHelp {
+	display:block;
+	margin-right: 155px;
+	padding: 2px;
+	height: 92px;
+	width: 310px;
+	float: right;
+	background-color: rgb(20, 75, 78);
+}
+
+#analyzerButtons {
+	display: inline;
+	height: 80px;
+	width: 50%;
+	padding-bottom: 2px;
 }
 
 /*Analyzer components*/
@@ -76,8 +121,8 @@ div {
 	background-color:#AAA;
 }
 #analyzeComponents {
-	height:150px;
-	width:350px;
+	height:200px;
+	width:300px;
 	overflow:auto;
 	display:inline-block;
 	vertical-align:top;
@@ -85,7 +130,7 @@ div {
 }
 #analyzeResults {
 	padding-top:2px;
-	width:400px;
+	width:300px;
 	height:170px;
 	display:inline-block;
 }
@@ -110,7 +155,7 @@ div {
 .splice-selection {
 	vertical-align:top;
 	height:350px;
-	width:800px;
+	width:600px;
 }
 
 	/* Part 2 */
@@ -165,7 +210,7 @@ div {
 #spliceFinalButtons {
 	height:338px;
 	width:150px;
-	float:right;
+	display:block;
 }
 
 /********************
@@ -180,12 +225,12 @@ div {
 	padding-left:20px;
 	width:200px;
 	vertical-align:middle;
-	background-color:#111;
-	color:#0D0;
+	background-color:rgb(17, 17, 17);
+	color:rgb(165, 190, 161);
 }
 
 .tf-c-red {
-		color:#e00;
+	color:#e00;
 }
 
 .tf-long {
@@ -216,6 +261,16 @@ div {
 	cursor:default;
 }
 
+.transGood {
+	background-color: #090;
+	color: black;
+}
+
+.transBad {
+	background-color: #E00;
+	color: black;
+}
+
 .tf-med {
 	width:100px;
 }
@@ -244,6 +299,7 @@ div {
 	height:25px;
 	font-weight:bold;
 	cursor:default;
+	border-radius: 10px;
 }
 
 
@@ -293,7 +349,7 @@ div {
 	width:100px;
 	height:50px;
 	font-weight:bold;
-	background-color:#DDD;
+	background-color:rgb(25, 201, 133);
 	color:#111;
 
 	font-family: sans-serif;
@@ -312,6 +368,9 @@ div {
 .btn-long {
 	width:150px;
 }
+.btn-xlong {
+	width:225px;
+}
 .btn-med {
 	height:25px;
 }
@@ -320,7 +379,7 @@ div {
 	width:70px;
 }
 .btn-tinyish {
-	height:25px;
+	height:22px;
 	width:35px;
 	margin:1px;
 }
@@ -359,8 +418,12 @@ div {
 	width:150px;
 }
 
+.lb-medl {
+	width:170px;
+}
+
 .lb-long {
-	width:200px;
+	width:220px;
 }
 
 .lb-elong {
@@ -381,9 +444,9 @@ div {
 Content containers
 ***************************/
 .mainContent {
-	background-color:#DDD;
-	width:850px;
-	height:auto;
+	background-color:rgb(27,103,107);
+	width:680px;
+	height:650;
 	margin:auto;
 	vertical-align:middle;
 	border-top: 4px solid #555;
@@ -395,17 +458,17 @@ Content containers
 #loadedPathogen {
 	width:auto;
 	display:block;
-	height:155px;
+	height:100px;
 	padding-left:20px;
 	padding-top:10px;
-	background-color:#BBB;
+	background-color:rgb(22, 72, 75);
 }
 
 
 .dataDisplay {
 	width:auto;
 	display:block;
-	height:500px;
+	height:450px;
 	overflow:hidden;
 }
 
@@ -416,11 +479,16 @@ Content containers
 	border:none;
 	padding-left:25px;
 }
+
+.bigfont{
+	font-size: large;
+}
+
 #mainMenu {
 	width:auto;
 	display:block;
 	height:75px;
 	bottom:0px;
 	padding:10px;
-	background-color:#BBB;
+	background-color:#1b676b;
 }

--- a/browserassets/css/pathoui.css
+++ b/browserassets/css/pathoui.css
@@ -1,6 +1,5 @@
 *{
 	font-family:'Comic Sans MS',Consolas,monospace;
-	color: rgb(25, 201, 133);
 }
 
 li {
@@ -10,6 +9,7 @@ li {
 body {
 	background-color:#222;
 	overflow:hidden;
+	color: rgb(25, 201, 133);
 }
 
 div {
@@ -263,12 +263,10 @@ div {
 
 #transTypesGood {
 	background-color: #090;
-	color: black;
 }
 
 #transTypesBad {
 	background-color: #E00;
-	color: black;
 }
 
 .tf-med {
@@ -314,22 +312,22 @@ div {
 }
 
 .a-red {
-	color:#500;
+	color:rgb(0, 0, 0);
 	background-color:#100;
 }
 .a-red-on{
-	color:#900;
+	color:rgb(0, 0, 0);
 	background-color:#E00;
 }
 
 .a-yellow {
 	background-color:#252205;
-	color:151203;
+	color:rgb(0, 0, 0);
 }
 
 .a-yellow-on {
 	background-color:#FAF320;
-	color:#737012;
+	color:rgb(0, 0, 0);
 }
 
 #annSynch {
@@ -370,7 +368,7 @@ div {
 	width:150px;
 }
 .btn-xlong {
-	width:225px;
+	width:220px;
 }
 .btn-med {
 	height:25px;

--- a/browserassets/html/pathoComp.html
+++ b/browserassets/html/pathoComp.html
@@ -8,171 +8,29 @@
 		<!--<script src="./json2.min.js" type="text/javascript"></script>-->
 		<script src="{{resource("js/pathology_display.js")}}" type="text/javascript"></script>
 		<script src="{{resource("js/pathoui-script.js")}}" type="text/javascript"></script>
-		<link href="{{resource("css/pathoui.css")}}" rel="stylesheet" type="text/css"></link>
+		<link href="pathoui.css" rel="stylesheet" type="text/css"></link>
 	</head>
 
-	<body>
+	<body onselectstart="return false;">
 		<div class="mainContent">
 			<!--Displays information about the currently loaded pathogen-->
 			<div id="loadedPathogen">
 				<div class="noborder">
-					<span class="label">DNA Load Status: </span>
-					<div class="annunciator a-green" id="annDNALoad">
-						LOAD
-					</div>
-					<div class="annunciator a-red" id="annDNANoLoad">
-						NO LOAD
-					</div>
-					<div class="annunciator a-yellow" id="annDNASplice">
-						SPLICE
-					</div>
-					<span class="label">Pathogen: </span>
+					<span class="lb-med">Current Pathogen: </span>
 					<div class="text-field tf-med" id="txtPName">G68P68</div>
 					<div class="text-field tf-med" id="txtPType">(fungus)</div>
-
 				</div>
 				<div class="noborder">
-					<span class="label">Slot: </span>
-					<div class="text-field tf-narrow" id="txtExpSlot">1</div>
-					<div class="annunciator a-yellow" id="annSlotExp">EXPOSED</div>
-					<div class="annunciator a-green" id="annSlotSample">SAMPLE</div>
-					<div class="button btn-small" id="btnCloseSlot">Close</div>
-					<div class="button btn-small" id="btnEjectSample">Eject</div>
-				</div>
-				<div class="noborder">
-					<span class="label">DNA Seq: </span><br>
 					<div class="text-field tf-long" id="txtPSeq">
 					</div>
 				</div>
 			</div>
 			<!--Displays the currently selected page-->
 			<div class="dataDisplay">
-				<div class="dataPage" id="dpManip">
-					<h1>DNA Manipulator</h1>
-					<div id="manipHolder">
-						<div class="narrow-border extrapad">
-							<span class="label lb-long">Status:</span>
-							<div class="annunciator a-green" id="aMutRdy">READY</div>
-							<div class="annunciator a-yellow"  id="aMutIrr">RAD</div>
-							<div class="annunciator a-green" id="aMutAck">PASS</div>
-							<span class="label lb-long"></span>
-							<div class="annunciator a-red" id="aMutOpen">EXPOSED</div>
-							<div class="annunciator a-red" id="aMutSample">SAMPLE</div>
-							<div class="annunciator a-red" id="aMutNack">FAIL</div>
-						</div>
-
-						<table>
-							<tr>
-								<td><span class="label lb-long">Mutativeness:</span></td>
-								<td><div class="button btn-tiny" data-tsk="mut=-1">-</div></td>
-								<td><div class="text-field tf-narrow" id="txtMut"></div></td>
-								<td><div class="button btn-tiny" data-tsk="mut=1">+</div></td>
-							</tr>
-							<tr>
-								<td><span class="label lb-long">Mutation Speed:</span></td>
-								<td><div class="button btn-tiny" data-tsk="mts=-1">-</div></td>
-								<td><div class="text-field tf-narrow"  id="txtMts"></div></td>
-								<td><div class="button btn-tiny" data-tsk="mts=1">+</div></td>
-							</tr>
-							<tr>
-								<td><span class="label lb-long">Advance Speed:</span></td>
-								<td><div class="button btn-tiny" data-tsk="adv=-1">-</div></td>
-								<td><div class="text-field tf-narrow"  id="txtAdv"></div></td>
-								<td><div class="button btn-tiny" data-tsk="adv=1">+</div></td>
-							</tr>
-							<tr>
-								<td><span class="label lb-long">Maliciousness:</span></td>
-								<td><div class="button btn-tiny" data-tsk="mal=-1">-</div></td>
-								<td><div class="text-field tf-narrow"  id="txtMal"></div></td>
-								<td><div class="button btn-tiny" data-tsk="mal=1">+</div></td>
-							</tr>
-							<tr>
-								<td><span class="label lb-long">Suppression Threshold:</span></td>
-								<td><div class="button btn-tiny" data-tsk="sth=-1">-</div></td>
-								<td><div class="text-field tf-narrow"  id="txtSth"></div></td>
-								<td><div class="button btn-tiny" data-tsk="sth=1">+</div></td>
-							</tr>
-
-						</table>
-					</div>
-				</div>
-
-				<div class="dataPage" id="dpSplice1">
-					<h1>Select splice target</h1>
-					<span class='label lb-slong'>The loaded DNA will be modified during this session.</span>
-					<div class='noborder splice-selection'>
-						<div class='noborder slot-holder' id='spliceSlots'>
-
-						</div>
-						<div class='narrow-border button-holder' id='spliceButtons'>
-							<div class='annunciator a-red' id='annSpliceStatExp'>EXPOSED</div>
-							<div class='annunciator a-green' id="annSpliceStatSource">SOURCE</div>
-							<div class='annunciator a-green' id="annSpliceStatTarget">TARGET</div>
-							<hr>
-							<div class='button' id='btnSpliceBegin'>Begin<BR>Splice</div>
-							<div class='button' id='btnSpliceCancel'>Cancel<BR>Splice</div>
-						</div>
-					</div>
-				</div>
-
-				<div class="dataPage" id="dpSplice2">
-					<h1>Splicing Session</h1>
-					<div class="noborder splice-selection">
-						<!--DATA HOLDER-->
-						<div class="noborder" id="spliceData">
-							<div class="extrapad button-holder prediction-holder">
-								<span class="label lb-long">Predictive Effectiveness:</span>
-								<div class="text-field tf-med txtPredEffect"></div>
-								<div class="button btn-med display-known">Sequences</div>
-							</div>
-							<div class='extrapad splice-sequence' id='spliceTargetField'>
-								<span class="label lb-long">Target sequence:</span>
-								<div class='text-field tf-long' id='txtSpliceTarget'></div>
-								<div class='button btn-small btn-seq-off' dir=-1>-</div>
-								<div class='button btn-small btn-seq-off' dir=1>+</div>
-								<span class="label">Status:</span>
-								<div class="annunciator a-red" id='annSpliceTargetEmpty'>EMPTY</div>
-							</div>
-							<div class='button-holder extrapad splice-controls' id='spliceActions'>
-								<span class="label lb-elong">Splice actions:</span>
-								<div class="button btn-small" dir=-1>Before</div>
-								<div class="button btn-small" dir=1>After</div>
-								<div class="button btn-small" dir=0>Remove</div>
-
-							</div>
-							<div class='extrapad splice-sequence' id='spliceSourceField'>
-								<span class="label lb-long">Source sequence:</span>
-								<div class='text-field tf-long' id='txtSpliceSource'></div>
-								<div class='button btn-small btn-seq-off' dir=-1>-</div>
-								<div class='button btn-small btn-seq-off' dir=1>+</div>
-								<span class='label'>Status:</span>
-								<div class="annunciator a-red" id='annSpliceSourceEmpty'>EMPTY</div>
-							</div>
-						</div>
-						<!--FINALIZING BUTTONS-->
-						<div class="button-holder extrapad" id="spliceFinalButtons">
-							<span class="label lb-med">Splice status:</span>
-							<div class='annunciator a-green' id='annSpliceSuccess'>SUCCESS</div>
-							<div class='annunciator a-red' id='annSpliceFail'>FAIL</div>
-							<span class="label">Prediction:</span>
-							<div class='annunciator a-green' id='annPredSuccess'>SUCCESS</div>
-							<div class='annunciator a-yellow' id='annPredUnk'>UNKNOWN</div>
-							<div class='annunciator a-red' id='annPredFail'>FAIL</div>
-							<hr>
-							<div class="button" id='btnSpliceFinish'>Finish Splicing</div>
-						</div>
-					</div>
-				</div>
 
 				<div class="dataPage" id="dpTester">
 					<h1>DNA Stability Analyzer</h1>
 					<div class= "noborder" id="analyzerHolder">
-						<!--SHOWING PREDICTIVE EFFECTIVENESS-->
-						<div class="narrow-border extrapad button-holder" id="predictionHolder">
-							<span class="label lb-long">Predictive Effectiveness:</span>
-							<div class="text-field tf-med txtPredEffect"></div>
-							<div class="button btn-med display-known">Sequences</div>
-						</div>
 						<!--HOLDING BOTH ANALYSIS BUFFERS (current / previous) -->
 						<div class="noborder extramargin">
 							<div class="narrow-border analysis-buffer extrapad" id="currAnalysis">
@@ -182,7 +40,7 @@
 								<div class="text-field tf-enarrow" id="currAnalysis2"></div>
 								<div class="text-field tf-enarrow" id="currAnalysis3"></div>
 								<div class="text-field tf-enarrow" id="currAnalysis4"></div>
-								<div class="button btn-tinyish" id="btnClrAnalysisCurr">CLR</div>
+								<div class="button btn-tinyish helpTextItem" id="btnClrAnalysisCurr">CLR</div>
 							</div>
 							<div class="narrow-border analysis-buffer extrapad" id="prevAnalysis">
 								<span class="label lb-long block">Previous analysis:</span>
@@ -196,52 +54,152 @@
 
 						<div class="noborder extramargin">
 
-							<div class="extrapad button-holder" id="analyzeComponents">
+							<div class="extrapad button-holder helpTextItem" id="analyzeComponents">
 							</div>
 
 							<div class="narrow-border extrapad" id="analyzeResults">
-								<span class="label">Stable:</span>
-								<div class="annunciator a-green" id="annStableYes">YES</div>
-								<div class="annunciator a-red" id="annStableNo">NO</div>
-								<div class="text-field tf-med-long" id="stableType"></div>
-								<span class="label">Transient:</span>
-								<div class="annunciator a-green" id="annTransYes">YES</div>
-								<div class="annunciator a-red" id="annTransNo">NO</div>
-								<div class="text-field tf-med-narrow" id="transTypesGood"></div>
-								<div class="text-field tf-med-narrow" id="transTypesBad"></div>
+								<span class="label helpTextItem" id="annStableLb">Stable:</span>
+								<div class="annunciator a-green helpTextItem" id="annStableYes">YES</div>
+								<div class="annunciator a-red helpTextItem" id="annStableNo">NO</div>
 								<hr>
-								<span class="label">Error:</span>
-								<div class="annunciator a-red" id="annErrBuffer">BUFFER</div>
-								<div class="annunciator a-red" id="annErrNack">NACK</div>
-								<br/>
-								<span class="label"></span>
-								<div class="annunciator a-yellow" id="annErrSample">SAMPLE</div>
-								<div class="annunciator a-yellow" id="annErrData">T. DATA</div>
+								<span class="label helpTextItem" id="annTransLb">Transient:</span>
+								<div class="annunciator a-green helpTextItem" id="annTransYes">YES</div>
+								<div class="annunciator a-red helpTextItem" id="annTransNo">NO</div>
+								<hr>
+								<span class="label helpTextItem">Types:</span>
+								<div class="text-field tf-med-narrow transGood helpTextItem" id="transTypesGood"></div>
+								<div class="text-field tf-med-narrow transBad helpTextItem" id="transTypesBad"></div>
+								<div class="text-field tf-med-long helpTextItem" id="stableType"></div>
 							</div>
 						</div>
+						<div id="analyzerHelp">Hover over elemements to receive helpful information about their behaviour.</div>
+						<div id="analyzerButtons" class="noborder">
+							<div class="button btn-med helpTextItem" id="btnAnalysisLoad">Split DNA</div>
+							<div class="button btn-med helpTextItem" id="btnAnalysisDoTest">Test DNA</div>
+							<br/>
+							<div class="button btn-med btn-xlong display-known helpTextItem" id="knownAnalyzer">Known Sequences</div>
+						</div>
+					</div>
+				</div>
+				<div class="dataPage" id="dpSplice1">
+					<h1>Select splice target</h1>
+					<div class='noborder splice-selection'>
+						<div class='noborder slot-holder' id='spliceSlots'>
+						</div>
+					</div>
+				</div>
+				<div class="dataPage" id="dpManip">
+					<h1>DNA Manipulator</h1>
+					<div id="manipMain" class="noborder">
+						<div id="manipHolder">
+							<table>
+								<tr id="helpMutativeness" class="helpTextItem">
+									<td><span class="label lb-long bigfont">Mutativeness</span></td>
+									<td><div class="button btn-tiny" data-tsk="mut=-1">-</div></td>
+									<td><div class="text-field tf-narrow" id="txtMut"></div></td>
+									<td><div class="button btn-tiny" data-tsk="mut=1">+</div></td>
+								</tr>
+								<tr id="helpMutSpeed" class="helpTextItem">
+									<td><span class="label lb-long bigfont">Mutation Speed</span></td>
+									<td><div class="button btn-tiny" data-tsk="mts=-1">-</div></td>
+									<td><div class="text-field tf-narrow"  id="txtMts"></div></td>
+									<td><div class="button btn-tiny" data-tsk="mts=1">+</div></td>
+								</tr>
+								<tr id="helpAdvSpeed" class="helpTextItem">
+									<td><span class="label lb-long bigfont">Advance Speed</span></td>
+									<td><div class="button btn-tiny" data-tsk="adv=-1">-</div></td>
+									<td><div class="text-field tf-narrow"  id="txtAdv"></div></td>
+									<td><div class="button btn-tiny" data-tsk="adv=1">+</div></td>
+								</tr>
+								<tr id="helpMaliciousness" class="helpTextItem">
+									<td><span class="label lb-long bigfont">Maliciousness</span></td>
+									<td><div class="button btn-tiny" data-tsk="mal=-1">-</div></td>
+									<td><div class="text-field tf-narrow"  id="txtMal"></div></td>
+									<td><div class="button btn-tiny" data-tsk="mal=1">+</div></td>
+								</tr>
+								<tr id="helpSupThreshold" class="helpTextItem">
+									<td><span class="label lb-long bigfont">Suppression Threshold</span></td>
+									<td><div class="button btn-tiny" data-tsk="sth=-1">-</div></td>
+									<td><div class="text-field tf-narrow"  id="txtSth"></div></td>
+									<td><div class="button btn-tiny" data-tsk="sth=1">+</div></td>
+								</tr>
+							</table>
+						</div>
+						<div id="manipStats">
+							<table>
+								<tr id="helpStages" class="helpTextItem">
+									<td><span class="label lb-medl bigfont">Stages</span></td>
+									<td><div class="text-field tf-narrow" id="txtStag"></div></td>
+								</tr>
+								<tr id="helpSymptomaticity" class="helpTextItem">
+									<td><span class="label lb-medl bigfont">Symptomaticity</span></td>
+									<td><div class="text-field tf-narrow"  id="txtSymp"></div></td>
+								</tr>
+								<tr id="helpSupCode" class="helpTextItem">
+									<td><span class="label lb-medl bigfont">Suppressant Code</span></td>
+									<td><div class="text-field tf-narrow"  id="txtSupCode"></div></td>
+								</tr>
+								<tr id="helpCapacity" class="helpTextItem">
+									<td><span class="label lb-medl bigfont">Capacity</span></td>
+									<td><div class="text-field tf-narrow"  id="txtCap"></div></td>
+								</tr>
+							</table>
+						</div>
+					</div>
+					<div id="manipHelp">
+						<span>
+							Hello, I am helpful text intended to explain the different fucking stupid pathology stats. </br></br>
+							Just mouse over them and I will tell you dumb shit.
+						</span>
+					</div>
+				</div>
 
-						<div class="button btn-long" id="btnAnalysisLoad">Load Sample &amp; Clear Buffer</div>
-						<div class="button btn-long" id="btnAnalysisDoTest">Test DNA</div>
+
+				<div class="dataPage" id="dpSplice2">
+					<h1>Splicing Session</h1>
+					<div class="noborder splice-selection">
+						<!--DATA HOLDER-->
+						<div class="noborder" id="spliceData">
+							<div class='extrapad splice-sequence' id='spliceTargetField'>
+								<span class="label lb-long">Target sequence:</span>
+								<div class='text-field tf-long' id='txtSpliceTarget'></div>
+								<div class='button btn-small btn-seq-off' dir=-1>-</div>
+								<div class='button btn-small btn-seq-off' dir=1>+</div>
+							</div>
+							<div class='button-holder extrapad splice-controls' id='spliceActions'>
+								<span class="label lb-elong">Splice actions:</span>
+								<div class="button btn-small" dir=-1>Before</div>
+								<div class="button btn-small" dir=1>After</div>
+								<div class="button btn-small" dir=0>Remove</div>
+
+							</div>
+							<div class='extrapad splice-sequence' id='spliceSourceField'>
+								<span class="label lb-long">Source sequence:</span>
+								<div class='text-field tf-long' id='txtSpliceSource'></div>
+								<div class='button btn-small btn-seq-off' dir=-1>-</div>
+								<div class='button btn-small btn-seq-off' dir=1>+</div>
+							</div>
+						</div>
+						<div class="button btn-med btn-long" id='btnSpliceFinish'>Finish Splice</div>
+						<div class="button btn-med btn-long display-known">Known Sequences</div>
 					</div>
 				</div>
 
 				<div class="dataPage" id="dpLoadSave">
-					<h1>Load / Save DNA</h1>
+					<h1>Samples</h1>
 					<div class="noborder slot-holder" id="dnaSlotHolder">
-
 					</div>
 				</div>
 
 				<div class="dataPage" id="dpWelcome">
 					<h1>Welcome to the Path-o-matic 2000</h1>
-					<span>The leading market solution for pathology research.</span>
-					<span>This device is capable of the following:</span>
-					<ul>
-						<li>DNA Sequence Verification</li>
-						<li>DNA Sequence Splicing</li>
-						<li>DNA Trait Segment Manipulation</li>
-						<li>Predictive Stability Analysis</li>
-						<li>Pathogen Sample Identification</li>
+					<span class="bigfont">The leading market solution for pathology research.</br>
+					This device is capable of the following:</span>
+					<ul class="bigfont">
+						<li><b>Manipulate</b><br/> Adjust the stats of the current pathogen</li>
+						<li><b>Splice</b><br/> Splice additional segments onto the current pathogen from another pathogen in order to add more symptoms - or remove them</li>
+						<li><b>Analyze</b><br/> Analyze sequences of DNA segments to discover symptoms of a higher tier</li>
+						<li><b>Samples</b><br/> Change which pathogen sample is currently selected or eject your samples</li>
 					</ul>
 				</div>
 
@@ -252,10 +210,8 @@
 				<div class="button" id="btnRetMain">Main Screen</div>
 				<div class="button" id="btnManip">Manipulate</div>
 				<div class="button" id="btnSplice">Splice</div>
-				<div class="button" id="btnTester">DNA Analyzer</div>
-				<div class="button" id="btnLoadSave">Load / Save DNA</div>
-
-				<div class="annunciator a-yellow" id="annSynch">SYNCH</div>
+				<div class="button" id="btnTester">Analyze</div>
+				<div class="button" id="btnLoadSave">Samples</div>
 			</div>
 
 		</div>

--- a/browserassets/html/pathoComp.html
+++ b/browserassets/html/pathoComp.html
@@ -67,8 +67,8 @@
 								<div class="annunciator a-red helpTextItem" id="annTransNo">NO</div>
 								<hr>
 								<span class="label helpTextItem">Types:</span>
-								<div class="text-field tf-med-narrow transGood helpTextItem" id="transTypesGood"></div>
-								<div class="text-field tf-med-narrow transBad helpTextItem" id="transTypesBad"></div>
+								<div class="text-field tf-med-narrow helpTextItem" id="transTypesGood"></div>
+								<div class="text-field tf-med-narrow helpTextItem" id="transTypesBad"></div>
 								<div class="text-field tf-med-long helpTextItem" id="stableType"></div>
 							</div>
 						</div>
@@ -78,13 +78,6 @@
 							<div class="button btn-med helpTextItem" id="btnAnalysisDoTest">Test DNA</div>
 							<br/>
 							<div class="button btn-med btn-xlong display-known helpTextItem" id="knownAnalyzer">Known Sequences</div>
-						</div>
-					</div>
-				</div>
-				<div class="dataPage" id="dpSplice1">
-					<h1>Select splice target</h1>
-					<div class='noborder splice-selection'>
-						<div class='noborder slot-holder' id='spliceSlots'>
 						</div>
 					</div>
 				</div>
@@ -197,9 +190,8 @@
 					This device is capable of the following:</span>
 					<ul class="bigfont">
 						<li><b>Manipulate</b><br/> Adjust the stats of the current pathogen</li>
-						<li><b>Splice</b><br/> Splice additional segments onto the current pathogen from another pathogen in order to add more symptoms - or remove them</li>
 						<li><b>Analyze</b><br/> Analyze sequences of DNA segments to discover symptoms of a higher tier</li>
-						<li><b>Samples</b><br/> Change which pathogen sample is currently selected or eject your samples</li>
+						<li><b>Samples</b><br/> Change which pathogen sample is currently selected or eject your samples.<br/>You can also splice new segments onto a pathogen or remove them to add or remove symptoms.</li>
 					</ul>
 				</div>
 
@@ -209,7 +201,6 @@
 			<div id="mainMenu">
 				<div class="button" id="btnRetMain">Main Screen</div>
 				<div class="button" id="btnManip">Manipulate</div>
-				<div class="button" id="btnSplice">Splice</div>
 				<div class="button" id="btnTester">Analyze</div>
 				<div class="button" id="btnLoadSave">Samples</div>
 			</div>

--- a/browserassets/js/pathoui-script.js
+++ b/browserassets/js/pathoui-script.js
@@ -689,6 +689,21 @@
 				doExposeSlot(0);
 	}
 
+	function loadHelp(slot) {
+		var dna = dnaDetails[slot -1].seq;
+			if(loadedDna && dna) {
+				doExchangeDna(slot);
+			}
+			else if(loadedDna)
+			{
+				doSaveDna(slot);
+			}
+			else if(dna)
+			{
+				doLoadDna(slot);
+			}
+	}
+
 	function doClearDna(slot) {
 		xmit({remove:slot});
 		dnaDetails[slot-1] = new dnaSlotInfo();
@@ -803,20 +818,11 @@
 
 		var detClick = id.slice(0, id.length - slot.toString().length);
 		switch(detClick) {
-			case "btnDnaLoad":
-				doLoadDna(slot);
-				break;
-			case "btnDnaSave":
-				doSaveDna(slot);
-				break;
 			case "btnDnaXchg":
-				doExchangeDna(slot);
+				loadHelp(slot);
 				break;
 			case "btnDnaClear":
 				doClearDna(slot);
-				break;
-			case "btnDnaSlotExpose":
-				doExposeSlot(slot);
 				break;
 			case "btnDnaEject":
 				doExposeSlot(slot);
@@ -878,19 +884,7 @@
 			setButtonEnabled("#btnDnaClear" + slot, true);
 		}
 
-		if(loadedDna || dna.seq === null) {
-			setButtonEnabled("#btnDnaLoad" + slot, false);
-		} else {
-			setButtonEnabled("#btnDnaLoad" + slot, true);
-		}
-
-		if(loadedDna && dna.seq === null && !loadedDna.isSplicing){
-			setButtonEnabled("#btnDnaSave" + slot, true);
-		} else {
-			setButtonEnabled("#btnDnaSave" + slot, false);
-		}
-
-		if( loadedDna && dna.seq !== null && !loadedDna.isSplicing) {
+		if( dna.seq !== null || (loadedDna && !loadedDna.isSplicing)) {
 			setButtonEnabled("#btnDnaXchg" + slot, true);
 		} else {
 			setButtonEnabled("#btnDnaXchg" + slot, false);

--- a/browserassets/js/pathoui-script.js
+++ b/browserassets/js/pathoui-script.js
@@ -83,6 +83,11 @@
 		$("#spliceActions .button").click(function() {handlePushButtonClick(this, handleSpliceActionClick);});
 		$("#btnSpliceFinish").click(function() {handlePushButtonClick(this, handleSpliceFinishClick);});
 
+		$("#btnSpliceFinish").click(function() {handlePushButtonClick(this, handleSpliceFinishClick);});
+
+		$(".helpTextItem").mouseenter(function() {displayHelpText(this);});
+		$(".helpTextItem").mouseleave(function() {clearHelpText();});
+
 
 		/* INITIALIZATION STUFF*/
 		setActivePage(0);
@@ -96,6 +101,76 @@
 		//debug_createDNAbuttons();
 	}
 
+	function clearHelpText()
+	{
+		$("#manipHelp").html("");
+		$("#analyzerHelp").html("");
+	}
+
+	function displayHelpText(element)
+	{
+		switch(element.id)
+		{
+			case "helpMutativeness":
+				$("#manipHelp").html("Mutativeness determines the probability that your pathogen will mutate. The rolls for this happen when the pathogens stats are manipulated, or every time it infects a new person. Suggested range: 0-100");
+				break;
+			case "helpMutSpeed":
+				$("#manipHelp").html("Mutation Speed determines how many different mutations your pathogen will undergo whenever it mutates. This scales very diminishingly the higher you go. Suggested range: 0-50");
+				break;
+			case "helpAdvSpeed":
+				$("#manipHelp").html("Advance Speed determines how quickly your pathogen will advance through its stages. Beware, this also makes it go down more quickly when suppressed or remissive. It is capped at 4 when advancing, but uncapped when receding. Suggested range: 0-10");
+				break;
+			case "helpMaliciousness":
+				$("#manipHelp").html("Maliciousness determines what kind of mutations will occur. Higher values will lead to things like gaining symptoms or even stages while negative ones will lead to things like losing symptoms or stages. High values on this will make the manipulator take longer to adjust stats! Suggested range: 0-40");
+				break;
+			case "helpSupThreshold":
+				$("#manipHelp").html("Suppression Threshold determines how hard your pathogen is to suppress. Higher values will require more of the suppressant chem or higher external suppression factors. This is capped at 50 for most purposes. Suggested range: 0-50");
+				break;
+			case "helpStages":
+				$("#manipHelp").html("This determines how many stages your pathogen can go through. This largely depends on the microbody, though rarely a pathogen can mutate to have less or more stages. This ranges from 1-5. At higher stages a pathogen's symptoms will generally have stronger effects. Different microbody types also trigger their symptoms at different rates depending on the stage.");
+				break;
+			case "helpSymptomaticity":
+				$("#manipHelp").html("If this is 0 your pathogen will not trigger its symptoms. Pathogens start out with this as 1, but it can sometimes mutate to become 0. If this happens, you may be able to get it back to 1 by making your pathogen mutate some more.");
+				break;
+			case "helpSupCode":
+				$("#manipHelp").html("This code determines what the pathogen is supressed by. If you see two pathogens with the same code, you know that they will have the same suppressant.");
+				break;
+			case "helpCapacity":
+				$("#manipHelp").html("This determines how many symptom segments you can splice onto a pathogen without it collapsing. For instance, a tier 5 symptom would cost 5 capacity, since it is made of 5 segments.");
+				break;
+			case "btnClrAnalysisCurr":
+				$("#analyzerHelp").html("Clear the currently assembled sequence of segments in Current Analysis");
+				break;
+			case "annStableLb":
+			case "annStableYes":
+			case "annStableNo":
+				$("#analyzerHelp").html("Shows if the last tested sequence of segments is stable. If it is stable, that means that it is a valid symptom that you can use in a pathogen!");
+				break;
+			case "annTransLb":
+			case "annTransYes":
+			case "annTransNo":
+				$("#analyzerHelp").html("Shows if the last tested sequence of segments is transient. If it is transient, that means that there is at least one valid symptom that starts with this sequence, but you will need to add more segments at the end to find it!");
+				break;
+			case "transTypesGood":
+				$("#analyzerHelp").html("If the last analyzed sequence of segments was transient, this shows you how many of the symptoms that start with it are considered beneficial to humans.");
+				break;
+			case "transTypesBad":
+				$("#analyzerHelp").html("If the last analyzed sequence of segments was transient, this shows you how many of the symptoms that start with it are considered harmful to humans.");
+				break;
+			case "stableType":
+				$("#analyzerHelp").html("If the last analyzed sequence of segments was stable, this shows you if it was a symptom that is considered beneficial or harmful to humans.");
+				break;
+			case "btnAnalysisLoad":
+				$("#analyzerHelp").html("This will destroy your currently loaded pathogen and give you its symptom segments to use for building sequences and analyzing them. Probably do not do this if you do not have a backup of your pathogen!");
+				break;
+			case "btnAnalysisDoTest":
+				$("#analyzerHelp").html("Test the currently assembled sequence of segments to find out if it is stable and/or transient. If it turns out to be stable, you will keep it and can experiment further, but if not those segments will be lost.");
+				break;
+			case "knownAnalyzer":
+				$("#analyzerHelp").html("Shows a list of sequences of segments you have already tried and whether or not they were stable and/or transient.");
+				break;
+		}
+	}
 
 	function setActivePage(page) {
 		$(".dataPage").hide();
@@ -582,6 +657,7 @@
 			dnaDetails[index] = new dnaSlotInfo();
 			updateLoadedDependents();
 		}
+		doExposeSlot(0);
 	}
 
 	function doSaveDna(slot) {
@@ -610,6 +686,7 @@
 				}
 				updateLoadedDependents(true);
 				updateDnaSlot(slot);
+				doExposeSlot(0);
 	}
 
 	function doClearDna(slot) {
@@ -659,44 +736,22 @@
 			tempObj = $("<div></div>", {
 									'class':'noborder'
 									}).appendTo(finalObj);
-			//Slot counter
-			$("<div>", {
-				'class':"text-field tf-narrow"
-			}).appendTo(tempObj).text(i.toString());
-			//Annunciators
-			$("<div>", {
-				id: 'annDnaEmp' + i,
-				'class':'annunciator a-red'
-			}).appendTo(tempObj).text("EMPTY");
-			$("<div>", {
-				id: 'annDnaExp' + i,
-				'class':'annunciator a-yellow'
-			}).appendTo(tempObj).text("EXPOSED");
-			$("<div>", {
-				id: 'btnDnaLoad' + i,
-				'class':'button btn-small',
-			}).appendTo(tempObj).text("LOAD");
-			$("<div>", {
-				id: 'btnDnaSave' + i,
-				'class':'button btn-small',
-			}).appendTo(tempObj).text("SAVE");
 			$("<div>", {
 				id: 'btnDnaXchg' + i,
 				'class':'button btn-small',
-			}).appendTo(tempObj).text("XCHG");
+			}).appendTo(tempObj).text("LOAD");
 			$("<div>", {
 				id: 'btnDnaClear' + i,
 				'class':'button btn-small',
-			}).appendTo(tempObj).text("CLEAR");
+			}).appendTo(tempObj).text("DISCARD");
 			$("<div>", {
-				id: 'btnDnaSlotExpose' + i,
+				id: 'btnDnaEject' + i,
 				'class':'button btn-small',
-			}).appendTo(tempObj).text("EXPOSE");
+			}).appendTo(tempObj).text("EJECT");
 			//new tempObj for the next row
 			tempObj = $("<div></div>", {
 									'class':'noborder'
 									}).appendTo(finalObj);
-			$("<span>", {'class':'label'}).appendTo(tempObj).text("Seq:");
 			$("<div>", {id: 'dnaSequence' + i, 'class':"text-field tf-long"}).appendTo(tempObj);
 
 			//Append finalObj to the holder
@@ -755,9 +810,18 @@
 			case "btnDnaClear":
 				doClearDna(slot);
 				break;
-
 			case "btnDnaSlotExpose":
 				doExposeSlot(slot);
+				break;
+			case "btnDnaEject":
+				doExposeSlot(slot);
+				doEjectSample();
+				doExposeSlot(0);
+				break;
+			case "btnSpliceSource":
+				setSpliceSource(slot);
+				doExposeSlot(0);
+				beginSplice();
 				break;
 		}
 	}
@@ -769,10 +833,18 @@
 			$("#txtPName").text(loadedDna.pathogenName);
 			$("#txtPType").text(loadedDna.pathogenType);
 			$("#txtPSeq").text(loadedDna.seq);
+			$("#txtStag").text(loadedDna.pathogenStages);
+			$("#txtSymp").text(loadedDna.pathogenSymptomaticity);
+			$("#txtSupCode").text(loadedDna.pathogenSupCode);
+			$("#txtCap").text(loadedDna.pathogenCap==-1?"∞":loadedDna.pathogenCap);
 		} else {
 			$("#txtPName").text("");
 			$("#txtPType").text("");
 			$("#txtPSeq").text("");
+			$("#txtStag").text("");
+			$("#txtSymp").text("");
+			$("#txtSupCode").text("");
+			$("#txtCap").text("");
 		}
 		annunciatorHolder.setLoadAnn(loadedDna);
 		if(!cancGlobalUpdate) {
@@ -984,47 +1056,23 @@
 
 			//ROW OF ANNUNCIATORS + BUTTONS
 
+			//SEQUENCE LISTING
 			var tempObj = $("<div></div>", {
 				'class':'noborder'
 			}).appendTo(finalObj);
-			//Slot field
-			$("<div></div>", {
-				'class':'text-field tf-narrow'
-				}).appendTo(tempObj).text(i);
-			/*
-			//Target annunciator
-			$("<div></div>", {
-				id:'annSpliceTarget' + i,
-				'class':'annunciator a-green'
-			}).appendTo(tempObj).text("TARGET");
-			*/
-			//Source annunciator
-			$("<div></div>", {
-				id:'annSpliceSource' + i,
-				'class':'annunciator a-green'
-			}).appendTo(tempObj).text("SOURCE");
-
-			//Load button
-			$("<div></div>", {
-				id:'btnSpliceLoad' + i,
-				'class':'button btn-small'
-			}).appendTo(tempObj).text("LOAD");
-			//Splice button
-			$("<div></div>", {
-				id:'btnSpliceSource' + i,
-				'class':'button btn-small'
-			}).appendTo(tempObj).text("SOURCE");
-
-			//SEQUENCE LISTING
-			tempObj = $("<div></div>", {
-				'class':'noborder'
-			}).appendTo(finalObj);
-			$("<span></span>", {
-				'class':'label'}).appendTo(tempObj).text("Seq:");
 			$("<div></div>", {
 				id:'txtSpliceSeq' +i,
 				'class':'text-field tf-long'
 				}).appendTo(tempObj);
+			tempObj = $("<div></div>", {
+				'class':'noborder'
+			}).appendTo(finalObj);
+			//Splice button
+			$("<div></div>", {
+				id:'btnSpliceSource' + i,
+				'class':'button btn-small'
+			}).appendTo(tempObj).text("SPLICE");
+
 		}
 		//Bind listeners
 		$("#spliceSlots .button").click(function() {handlePushButtonClick(this, handleSpliceSelectionClick);});
@@ -1171,15 +1219,10 @@
 		if (slot == null) return;
 		var id = clicked.id.slice(0, clicked.id.length - slot.toString().length);
 		switch(id)  {
-			case "btnSpliceLoad":
-				if (loadedDna) {
-					doExchangeDna(slot);
-				} else {
-					doLoadDna(slot);
-				}
-				break;
 			case "btnSpliceSource":
 				setSpliceSource(slot);
+				doExposeSlot(0);
+				beginSplice();
 				break;
 		}
 	}
@@ -1498,7 +1541,6 @@
 					break;
 				case "btnSplice":
 					setActivePage(3);
-
 					break;
 				case "btnTester":
 					setActivePage(5);
@@ -1518,7 +1560,9 @@
 				doExposeSlot(0);
 				break;
 			case "btnEjectSample":
+				doExposeSlot(0);
 				doEjectSample();
+				doExposeSlot(0);
 				break;
 		}
 	}

--- a/browserassets/js/pathoui-script.js
+++ b/browserassets/js/pathoui-script.js
@@ -748,6 +748,11 @@
 				id: 'btnDnaEject' + i,
 				'class':'button btn-small',
 			}).appendTo(tempObj).text("EJECT");
+
+			$("<div>", {
+				id: 'btnSpliceSource' + i,
+				'class':'button btn-small',
+			}).appendTo(tempObj).text("SPLICE");
 			//new tempObj for the next row
 			tempObj = $("<div></div>", {
 									'class':'noborder'
@@ -1068,11 +1073,12 @@
 				'class':'noborder'
 			}).appendTo(finalObj);
 			//Splice button
+			/*
 			$("<div></div>", {
 				id:'btnSpliceSource' + i,
 				'class':'button btn-small'
 			}).appendTo(tempObj).text("SPLICE");
-
+			*/
 		}
 		//Bind listeners
 		$("#spliceSlots .button").click(function() {handlePushButtonClick(this, handleSpliceSelectionClick);});
@@ -1305,7 +1311,7 @@
 		//Clear source slot
 		dnaDetails[selectedSpliceSource - 1] = new dnaSlotInfo();
 		selectedSpliceSource = 0;
-		setActivePage(3); //Go back to splice selection page when finished
+		setActivePage(1); //Go back to splice selection page when finished
 		updateLoadedDependents();
 		updateMainMenuButtons();
 
@@ -1442,7 +1448,6 @@
 
 		if (data.hasOwnProperty("analysis")) {
 			var a = data.analysis;
-			// { "curr":"ABCDEF..." "prev":{analysisCallback(see below)}, "buttons":'ABCDEF'}
 			if(a.hasOwnProperty("curr")) {
 				clearAnalysisBuffer(true);
 				for(var i = 0; i < a.curr.length && i < 15; i+=3) {
@@ -1455,13 +1460,6 @@
 			if(a.hasOwnProperty("buttons"))
 				updateAnalysisButtonsFromString(a.buttons);
 			if(a.hasOwnProperty("prev")) {
-				/*
-				{valid:true/false,
-					stable:1,0,-1,
-					trans,1,0,-1,
-					seqs:["123", "456" ...]
-					conf:[25, 100 ...]}
-				*/
 				a.prev.noclear = true;
 				handleAnalysisTestCallback(a.prev);
 
@@ -1476,29 +1474,19 @@
 		if(bSuppressXmit || !typeof(data) == 'object' ) {
 			return;
 		}
-		/*
-		if(callbackHandler) {
-			data.callbackHandler = callbackHandler;
-			setTimeout(function () {receiveData(callbackHandler, debug_getCallbackDummyData(callbackHandler)) }, Math.random() * 4000);
-			setAnnunciator("#annSynch", true);
-		}
-		*/
 		var params = [];
 		for(var k in data) {
 			params.push(encodeURI(k) + "=" + encodeURI(data[k]));
 		}
 
 		var target = "?src=" + src + ";" + params.join(";");
-		//console.log(target);
 		window.location = target;
-		//alert(target);
 	}
 
 	/* DATA RECEIPT */
 
 	function receiveData(handler, data) {
 		setAnnunciator("#annSynch", false);
-		//alert("Received data: " + data + "\nProcessing with: " + handler);
 		if(remoteHandlers[handler]) {
 				data = JSON.parse(data);
 				remoteHandlers[handler](data);
@@ -1531,10 +1519,6 @@
 		if($("#" + id).hasClass("button-disabled")) {return;}
 
 		if(!isSplicing()) {	//Not splicing, everything's fine + dandy with the world.
-		/*
-			$("#mainMenu > .button").removeClass("button-selected");
-			$("#" + id).addClass("button-selected");
-			*/
 			switch(id) {
 				case "btnManip":
 					setActivePage(2);
@@ -1695,17 +1679,6 @@
 			}
 		};
 		setUIState(dataObject);
-		//new (seq, pathogenName, pathogenType, exposed, isSplicing)
-		/*
-		dnaDetails.push(new dnaSlotInfo("00020006FFFDFFF60000FFF53142E||FCB055|6A86A8|0F4CC6CC6", "ABC1", "virus", false));
-		dnaDetails.push(new dnaSlotInfo("00020006000500000000FFFB3142E||055", "ABC2", "bacteria", false));
-		dnaDetails.push(new dnaSlotInfo("00040003FFED0005FFF3FFEF51B8E||FCB", "ABC3", "parasite", false));
-		updateLoadedSection();
-		for(var i = 1; i <= 3; i++){
-			updateDnaSlot(i);
-		}
-		doExposeSlot(0);
-		*/
 	}
 
 	function debug_createDNAbuttons() {

--- a/code/modules/medical/pathology/pathogen.dm
+++ b/code/modules/medical/pathology/pathogen.dm
@@ -176,7 +176,7 @@ datum/controller/pathogen
 							var/datum/suppressant/S = src.path_to_suppressant[spath]
 							types += S.name
 							types[S.name] = S
-						var/chosen = input("Which suppresant?", "Suppressant", types[1]) in types
+						var/chosen = input("Which suppressant?", "Suppressant", types[1]) in types
 						P.suppressant = types[chosen]
 						P.desc = "[P.suppressant.color] dodecahedrical [P.body_type.plural]"
 

--- a/code/modules/medical/pathology/pathogen_machines.dm
+++ b/code/modules/medical/pathology/pathogen_machines.dm
@@ -870,7 +870,7 @@
 			sendSpliceInfo(1)
 
 		if (href_list["beginsplice"])
-			if (src.manip.machine_state == PATHOGEN_MANIPULATOR_STATE_SPLICE && src.manip.loaded && src.manip.splicesource && src.manip.slots[src.manip.splicesource])
+			if (src.manip.machine_state == PATHOGEN_MANIPULATOR_STATE_LOADER && src.manip.loaded && src.manip.splicesource && src.manip.slots[src.manip.splicesource])
 				src.manip.cache_target = src.manip.loaded.explode()
 				var/datum/pathogendna/P = src.manip.slots[src.manip.splicesource]
 				src.manip.cache_source = P.explode()

--- a/code/modules/medical/pathology/pathogen_machines.dm
+++ b/code/modules/medical/pathology/pathogen_machines.dm
@@ -413,7 +413,7 @@
 	var/manipulating = false //are we currently irradiating the pathogen?
 	New()
 		..()
-		gui = new("html/pathoComp.html", "pathology", "size=900x800", src)
+		gui = new("html/pathoComp.html", "pathology", "size=715x685", src)
 		gui.validate_user = 1
 		SPAWN_DBG(5 SECONDS)
 			rescan()
@@ -452,7 +452,13 @@
 		if(!PDNA)
 			return "null"
 		var/splicing = (PDNA == src.manip.loaded && (!PDNA.valid || src.manip.machine_state == PATHOGEN_MANIPULATOR_STATE_SPLICING_SESSION))
-		return {"{"seq":"[PDNA.seqnumeric + PDNA.seqsplice]","pathogenName":"[PDNA.reference.name]","pathogenType":"[PDNA.reference.body_type.singular]","isSplicing":[splicing]}"}
+		return {"{"seq":"[PDNA.seqnumeric + PDNA.seqsplice]",
+		"pathogenName":"[PDNA.reference.name]",
+		"pathogenStages":"[PDNA.reference.stages]",
+		"pathogenSymptomaticity":"[PDNA.reference.symptomatic]",
+		"pathogenSupCode":"[pathogen_controller.suppressant_to_UID[PDNA.reference.suppressant.type]]",
+		"pathogenCap":"[PDNA.reference.body_type.seqMax]",
+		"pathogenType":"[PDNA.reference.body_type.singular]","isSplicing":[splicing]}"}
 
 	proc/slots2json()
 		if(!src.manip) return "\[null,null,null]"
@@ -766,6 +772,7 @@
 						out= {"{"success":0}"}
 					else if (act == -1)
 						src.manip.visible_message("<span class='alert'>The structure of the DNA appears to fundamentally change.</span>")
+						SEND_SLOT_LOAD_INFO
 					if(!out) out = {"{"newseq":"[src.manip.loaded.seqnumeric + src.manip.loaded.seqsplice]","success":1}"}
 					gui.sendToSubscribers(out, "handleManipCallback")
 					manipulating = false
@@ -1069,11 +1076,16 @@
 		flags |= NOSPLASH
 
 	attackby(var/obj/item/O as obj, var/mob/user as mob)
-		if (!exposed)
-			user.show_message("<span class='alert'>The manipulator has no exposed slots.</span>")
-			return
-		if (slots[exposed])
-			user.show_message("<span class='alert'>The currently exposed slot on the manipulator is occupied.</span>")
+		var/firstFreeSlot = -1 // -1 means no free slot, -2 means the active slot is free
+		if(!loaded)
+			firstFreeSlot = -2
+		else
+			for(var/i in 1 to length(slots))
+				if(isnull(slots[i]))
+					firstFreeSlot = i
+					break
+		if (firstFreeSlot == -1)
+			user.show_message("<span class='alert'>The manipulator has no free slots.</span>")
 			return
 		if (!istype(O, /obj/item/reagent_containers/glass/vial))
 			user.show_message("<span class='alert'>The slots on the manipulator are designed so that only vials will fit.</span>")
@@ -1100,7 +1112,10 @@
 		if (!PT.dnasample)
 			PT.dnasample = new(PT) // damage control
 			logTheThing("pathology", usr, null, "Pathogen [PT.name] (\ref[PT]) had no DNA. (this is a bug)")
-		slots[exposed] = PT.dnasample.clone()
+		if(firstFreeSlot == -2)
+			loaded = PT.dnasample.clone()
+		else
+			slots[firstFreeSlot] = PT.dnasample.clone()
 		O.reagents.del_reagent("pathogen")
 		user.u_equip(O)
 		qdel(O)
@@ -1557,30 +1572,34 @@
 				boutput(usr, "<span class='notice'>[added] units of anti-agent added to the beaker.</span>")
 			else if (href_list["buymats"])
 				#ifdef CREATE_PATHOGENS //PATHOLOGY REMOVAL
-				var/confirm = alert("Are you sure you want to spend [synthesize_pathogen_cost] credits to manufacture a new pathogen culture? This will take about five seconds.", "Confirm Purchase", "Yes", "No")
-				if (confirm == "Yes" && machine_state == 0 && (usr in range(1)))
+				var/confirm = alert("How many pathogen samples do you wish to synthesize? ([synthesize_pathogen_cost] credits per sample)", "Confirm Purchase", "1", "5", "Cancel")
+				if (confirm != "Cancel" && machine_state == 0 && (usr in range(1)))
 					if (synthesize_pathogen_cost > wagesystem.research_budget)
 						boutput(usr, "<span class='alert'>Insufficient research budget to make that transaction.</span>")
 					else
+						var/count = text2num(confirm)
 						boutput(usr, "<span class='notice'>Transaction successful.</span>")
-						wagesystem.research_budget -= synthesize_pathogen_cost
+						wagesystem.research_budget -= synthesize_pathogen_cost*count
 						machine_state = 1
 						icon_state = "synth2"
 						src.visible_message("The [src.name] bubbles and begins synthesis.", "You hear a bubbling noise.")
-						SPAWN_DBG (5 SECONDS)
+						SPAWN_DBG (0 SECONDS)
+							while(count > 0)
+								count--
+								sleep(5 SECONDS)
+								for (var/mob/C in viewers(src))
+									C.show_message("The [src.name] ejects a new pathogen sample.", 3)
+								switch(href_list["microbody"])
+									if("virus")
+										new /obj/item/reagent_containers/glass/vial/prepared/virus(src.loc)
+									if("parasite")
+										new /obj/item/reagent_containers/glass/vial/prepared/parasite(src.loc)
+									if("bacterium")
+										new /obj/item/reagent_containers/glass/vial/prepared/bacterium(src.loc)
+									if("fungus")
+										new /obj/item/reagent_containers/glass/vial/prepared/fungus(src.loc)
 							machine_state = 0
 							icon_state = "synth1"
-							for (var/mob/C in viewers(src))
-								C.show_message("The [src.name] shuts down and ejects a new pathogen sample.", 3)
-							switch(href_list["microbody"])
-								if("virus")
-									new /obj/item/reagent_containers/glass/vial/prepared/virus(src.loc)
-								if("parasite")
-									new /obj/item/reagent_containers/glass/vial/prepared/parasite(src.loc)
-								if("bacterium")
-									new /obj/item/reagent_containers/glass/vial/prepared/bacterium(src.loc)
-								if("fungus")
-									new /obj/item/reagent_containers/glass/vial/prepared/fungus(src.loc)
 				#else
 				boutput(usr, "<span class='alert'>[src] unable to complete task. Please contact your network administrator.</span>")
 				#endif


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[enhancement] [WIP]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Mainly changes Pathogen Manipulator UI:
- It's a bit smaller, so it doesn't take up the entire screen.
- Some people said it was too bright, so I stole the genetics color scheme.
- I removed all the useless things that gave useless information that made people think it was more complicated than it was.
- I added explanatory texts for most control elements on the manipulator and analyzer, so people know what the heck they do.
- I did away with the annoying "expose" system. There is just one button to switch slots for pathogens now, it saves when the lower is empty, loads when there is no active pathogen, exchanges when both are full.
- This gives us enough space to just put the splice button on that page too, saving us a page.
- Also, it's in Comic Sans now for readability or something and also because patho is a joke.

- When inserting new samples into the manipulator, instead of trying to go into the exposed slot, it now just picks the first open slot, or the active slot if there is no active sample.

- Also, the Synth-o-matic now lets you synthesize 5 samples of a type. It still takes the same amount of time and money per sample, you just don't need to stand there and press the button every 2 seconds. Shouldn't be a problem with draining the budget, since samples used to cost ten times as much as they do now and budget wasn't a problem then.

Here's a video and stuff, please tell me which parts are still shit.
[Hello, I am a hyperlink.](https://streamable.com/lqcjj8)
## Why's this needed? <!-- Describe why you think this should be added to the game. -->

- Old patho ui was confusing and scary for people
- Lots of elements were just useless clutter information
- People don't really know what the stats or some of the annunciators do, so might as well put that info into the UI since there was dead space.

- Putting a bunch of new samples in was an exercise in clicking lots of buttons really fast, now you just click all of them onto the manipulator to save my clicking fingers.

- Standing there and needing to press the button every 2 seconds when you need new samples is super annoying, especially seeing as the Synth-o-matic UI doesn't update when it's done, because it's garbage. It was fine when it took like 30 seconds and 2000 credits, but no more.
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)zjdtmkhzt:
(*) Changed pathogen manipulator UI bigly, pathology is still disabled, but you can look at it and be sad.
```
