### PR TITLE
make nitro explode in humans from moving/being hit

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1638,13 +1638,14 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 	var/oldbloss = get_brute_damage()
 	var/oldfloss = get_burn_damage()
 	..()
-	var/newbloss = get_brute_damage()
-	var/damage = ((newbloss - oldbloss) + (get_burn_damage() - oldfloss))
-	if (reagents)
-		reagents.physical_shock((newbloss - oldbloss) * 0.15)
+	SPAWN_DBG(0.1 SECONDS) //fix race condition
+		var/newbloss = get_brute_damage()
+		var/damage = ((newbloss - oldbloss) + (get_burn_damage() - oldfloss))
+		if (reagents)
+			reagents.physical_shock((newbloss - oldbloss) * 0.15)
 
-	if ((damage > 0) || W.force)
-		src.was_harmed(M, W)
+		if ((damage > 0) || W.force)
+			src.was_harmed(M, W)
 
 
 /mob/living/shock(var/atom/origin, var/wattage, var/zone = "chest", var/stun_multiplier = 1, var/ignore_gloves = 0)

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -1125,6 +1125,8 @@
 	for (var/obj/O in contents)
 		if (O.move_triggered)
 			O.move_trigger(src, ev)
+	if(reagents)
+		reagents.move_trigger(src, ev)
 	for (var/atom in statusEffects)
 		var/datum/statusEffect/S = atom
 		if (S && S.move_triggered)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE] [FIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
make nitro explode in humans from moving/being hit


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It seemed odd that nitro was more stable inside a human than when inside a glass, and the not detonating when being attacked was an outright bug


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Tarmunora:
(+)Nitro inside humans is no longer stable.
```
