### PR TITLE
(RP) Gang Mode - Min 20 Readied Players - Max 2 Teams, Max Tot' 4 Each

### DIFF
--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -19,12 +19,18 @@
 	var/list/under_list = list()
 	var/list/headwear_list = list()
 
+#ifdef RP_MODE
+	var/const/setup_min_teams = 1
+	var/const/setup_max_teams = 2 //Maybe make this one?
+	var/current_max_gang_members = 3 //maximum number of gang members, not including the leader
+#else
 	var/const/setup_min_teams = 3
 	var/const/setup_max_teams = 5
+	var/current_max_gang_members = 5 //maximum number of gang members, not including the leader
+#endif
+
 	var/const/waittime_l = 600 //lower bound on time before intercept arrives (in tenths of seconds)
 	var/const/waittime_h = 1800 //upper bound on time before intercept arrives (in tenths of seconds)
-
-	var/current_max_gang_members = 5 //maximum number of gang members, not including the leader
 	//var/const/absolute_max_gang_members = 9
 
 	var/list/potential_hot_zones = null
@@ -55,7 +61,13 @@
 		if (!istype(player)) continue
 		if(player.ready) num_players++
 
-	var/num_teams = max(setup_min_teams, min(round((num_players) / 9), setup_max_teams)) //1 gang per 9 players
+#ifdef RP_MODE
+	//Using ternary since we're just choosing between 1 and 2 teams
+	var/num_teams = (num_players > 35) ? setup_max_teams : setup_min_teams
+	//var/num_teams = clamp(round((num_players-6) / 9), setup_min_teams, setup_max_teams) //third team at 29 pop
+#else
+	var/num_teams = clamp(round(num_players / 9), setup_min_teams, setup_max_teams) //1 gang per 9 players
+#endif
 
 	var/list/leaders_possible = get_possible_leaders(num_teams)
 	if (num_teams > leaders_possible.len)

--- a/code/datums/gamemodes/mixed_rp.dm
+++ b/code/datums/gamemodes/mixed_rp.dm
@@ -2,8 +2,8 @@
 	name = "mixed (mild)"
 	config_tag = "mixed_rp"
 	latejoin_antag_compatible = 1
-	latejoin_antag_roles = list("traitor", "changeling", "vampire", "wrestler")
-	traitor_types = list("traitor","changeling","vampire", "spy_thief")
+	latejoin_antag_roles = list("traitor", "vampire", "wrestler")
+	traitor_types = list("traitor","vampire", "spy_thief")
 
 
 	has_wizards = 0

--- a/code/datums/gamemodes/mixed_rp.dm
+++ b/code/datums/gamemodes/mixed_rp.dm
@@ -2,8 +2,8 @@
 	name = "mixed (mild)"
 	config_tag = "mixed_rp"
 	latejoin_antag_compatible = 1
-	latejoin_antag_roles = list("traitor", "vampire", "wrestler")
-	traitor_types = list("traitor","vampire", "spy_thief")
+	latejoin_antag_roles = list("traitor", "changeling", "vampire", "wrestler")
+	traitor_types = list("traitor","changeling","vampire", "spy_thief")
 
 
 	has_wizards = 0

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -103,7 +103,7 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 	switch(master_mode)
 		if("random","secret") src.mode = config.pick_random_mode()
 		if("action") src.mode = config.pick_mode(pick("nuclear","wizard","blob"))
-		if("intrigue") src.mode = config.pick_mode(pick("mixed_rp", "traitor","changeling","vampire","conspiracy","spy_theft", prob(50); "extended"))
+		if("intrigue") src.mode = config.pick_mode(pick("mixed_rp", "traitor","changeling","vampire","conspiracy","spy_theft","gang", prob(50); "extended"))
 		else src.mode = config.pick_mode(master_mode)
 
 	if(hide_mode)

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -103,7 +103,18 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 	switch(master_mode)
 		if("random","secret") src.mode = config.pick_random_mode()
 		if("action") src.mode = config.pick_mode(pick("nuclear","wizard","blob"))
-		if("intrigue") src.mode = config.pick_mode(pick("mixed_rp", "traitor","changeling","vampire","conspiracy","spy_theft","gang", prob(50); "extended"))
+		if("intrigue") 
+			var/ready_count = 0
+			for (var/mob/new_player/P in mobs)
+				if(P.ready)
+					ready_count++
+					if(ready_count >= 20)
+						break //for now, we don't care about higher numbers
+			//weighted pick() cannot use lists, so this is the best solution that I can think of.
+			if(ready_count >= 20)
+				src.mode = config.pick_mode(pick("mixed_rp", "traitor","changeling","vampire","conspiracy","spy_theft","gang", prob(50); "extended"))
+			else
+				src.mode = config.pick_mode(pick("mixed_rp", "traitor","changeling","vampire","conspiracy","spy_theft", prob(50); "extended"))
 		else src.mode = config.pick_mode(master_mode)
 
 	if(hide_mode)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEEDBACK][FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds potential for Gang to the Intrigue picklist. 
**The numbers below are just me slapping numbers around, please share thoughts in the PR comments.**
For gang to be pick-able on intrigue, 20 clients must be _readied at round-start_.
When the server is in `RP_MODE`:
- There is a single gang, unless there are 35 players _readied at round-start_, then there is the maximum of 2
- There is a maximum of 3 gang members per team (plus the gang boss per team)

Successor of #1229
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Gang seems like it has the potential to be a good game mode for the RP server, but it's population-scaling is not suitable for Goon1 without some adjustment.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)MarkNstein:
(*)RP server: Gang is added to the Intrigue gamemode picklist if >=20 players are ready at round-start.
```
