### PR TITLE
Stop the cocktail shaker from getting reclaimed in the glass recycler

### DIFF
--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -433,6 +433,7 @@
 	var/gulp_size = 5 //This is now officially broken ... need to think of a nice way to fix it.
 	var/splash_all_contents = 1
 	doants = 0
+	var/can_recycle = 1
 
 	New()
 		..()
@@ -1611,6 +1612,7 @@
 	icon = 'icons/obj/foodNdrink/bottle.dmi'
 	icon_state = "GannetsCocktailer"
 	initial_volume = 120
+	can_recycle = 0
 
 	New()
 		..()

--- a/code/obj/machinery/glass_recycler.dm
+++ b/code/obj/machinery/glass_recycler.dm
@@ -36,7 +36,11 @@
 			qdel(W)
 			return 1
 		else if (istype(W, /obj/item/raw_material/shard) || istype(W, /obj/item/reagent_containers/glass) || istype(W, /obj/item/reagent_containers/food/drinks))
-			if (istype(W,/obj/item/reagent_containers/food/drinks/bottle))
+			if (istype(W,/obj/item/reagent_containers/food/drinks))
+				var/obj/item/reagent_containers/food/drinks/bottle/D = W
+				if (!D.can_recycle)
+					boutput(user, "<span class='alert'>[src] only accepts glass shards or glassware!</span>")
+					return
 				var/obj/item/reagent_containers/food/drinks/bottle/B = W
 				if (!B.broken) glass_amt += 1
 			else

--- a/code/obj/machinery/glass_recycler.dm
+++ b/code/obj/machinery/glass_recycler.dm
@@ -37,12 +37,13 @@
 			return 1
 		else if (istype(W, /obj/item/raw_material/shard) || istype(W, /obj/item/reagent_containers/glass) || istype(W, /obj/item/reagent_containers/food/drinks))
 			if (istype(W,/obj/item/reagent_containers/food/drinks))
-				var/obj/item/reagent_containers/food/drinks/bottle/D = W
+				var/obj/item/reagent_containers/food/drinks/D = W
 				if (!D.can_recycle)
 					boutput(user, "<span class='alert'>[src] only accepts glass shards or glassware!</span>")
 					return
-				var/obj/item/reagent_containers/food/drinks/bottle/B = W
-				if (!B.broken) glass_amt += 1
+				if (istype(W,/obj/item/reagent_containers/food/drinks/bottle))
+					var/obj/item/reagent_containers/food/drinks/bottle/B = W
+					if (!B.broken) glass_amt += 1
 			else
 				glass_amt += 1
 			user.visible_message("<span class='notice'>[user] inserts [W] into [src].</span>")


### PR DESCRIPTION
##About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Prevents the players from being able to reclaim the cocktail shaker in a glass recycler


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #1441