### PR TITLE
Fix Multitool Dropping with MechComp

### DIFF
--- a/code/WorkInProgress/MechanicMadness.dm
+++ b/code/WorkInProgress/MechanicMadness.dm
@@ -331,6 +331,10 @@ var/list/mechanics_telepads = new/list()
 			return 1
 		return 0
 
+	pick_up_by(var/mob/M)
+		if(level != 1) return ..()
+		//If it's anchored, it can't be picked up!
+
 	pickup()
 		if(level == 1) return
 		mechanics.wipeIncoming()
@@ -356,10 +360,10 @@ var/list/mechanics_telepads = new/list()
 
 		if (!usr.find_tool_in_hand(TOOL_PULSING))
 			boutput(usr, "<span class='alert'>[MECHFAILSTRING]</span>")
-			return
+			return ..()
 
 		mechanics.dropConnect(O, null, src_location, control_orig, control_new, params)
-		return ..()
+		return
 
 	proc/componentSay(var/string)
 		string = trim(sanitize(html_encode(string)), 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
b99b3d5 is causing MechComp connection-forming to create an action bar, and force-drop the user's multitool.
Moving the ..() is the main fix. The `pick_up_by(var/mob/M)` override will cover any other edge cases.
Both changes, and the combined change, were tested with MechComp.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Very annoying, but work-around-able bug.