### PR TITLE
Cog1&2: Add Reagent Heater and Glass Recycler for Medical

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -61084,11 +61084,11 @@
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "cxK" = (
-/obj/storage/closet/biohazard,
 /obj/machinery/light{
 	dir = 1;
 	pixel_y = 21
 	},
+/obj/machinery/chem_heater,
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "cxL" = (
@@ -63838,6 +63838,11 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/hotloop)
+"nsR" = (
+/obj/table/auto,
+/obj/machinery/glass_recycler,
+/turf/simulated/floor/white,
+/area/station/medical/cdc)
 "ntO" = (
 /obj/machinery/atmospherics/mixer{
 	dir = 1;
@@ -99843,7 +99848,7 @@ aaw
 cxe
 cxK
 cxp
-cyf
+nsR
 cxp
 cyD
 cyK

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -63369,11 +63369,26 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/storage/closet/office,
 /obj/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/chem_master{
+	dir = 4
+	},
+/obj/item/device/reagentscanner{
+	pixel_x = -8;
+	pixel_y = -2
+	},
+/obj/item/clothing/glasses/spectro{
+	pixel_x = -7;
+	pixel_y = 10
 	},
 /turf/simulated/floor/black,
 /area/station/medical/medbay/pharmacy)
@@ -63382,13 +63397,16 @@
 	name = "Medical Doctor"
 	},
 /obj/stool/chair/office{
-	dir = 4
+	dir = 8
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/medical/medbay/pharmacy)
 "cIf" = (
-/obj/machinery/vending/medical,
-/obj/item/device/radio/intercom/medical,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 6;
@@ -63396,6 +63414,32 @@
 	pixel_y = 20;
 	tag = ""
 	},
+/obj/machinery/phone{
+	pixel_y = 5
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/table/reinforced/chemistry/auto,
+/obj/item/storage/box/patchbox{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/obj/item/storage/box/patchbox{
+	pixel_x = 8;
+	pixel_y = -8
+	},
+/obj/item/storage/box/patchbox{
+	pixel_x = 8;
+	pixel_y = -10
+	},
+/obj/item/paper/book/medical_guide{
+	pixel_x = -8;
+	pixel_y = -9
+	},
+/obj/item/device/radio/intercom/medical,
 /turf/simulated/floor/black,
 /area/station/medical/medbay/pharmacy)
 "cIg" = (
@@ -63909,11 +63953,6 @@
 /turf/simulated/floor/delivery,
 /area/station/security/checkpoint/cargo)
 "cJm" = (
-/obj/machinery/chem_master{
-	dir = 4
-	},
-/obj/item/device/reagentscanner,
-/obj/item/clothing/glasses/spectro,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "W APC";
@@ -63926,6 +63965,7 @@
 /obj/machinery/light_switch/west{
 	pixel_y = 11
 	},
+/obj/machinery/vending/medical,
 /turf/simulated/floor/black,
 /area/station/medical/medbay/pharmacy)
 "cJn" = (
@@ -63942,7 +63982,6 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/disposalpipe/segment/mail/bent/east,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -63951,7 +63990,6 @@
 /turf/simulated/floor/black,
 /area/station/medical/medbay/pharmacy)
 "cJp" = (
-/obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/black,
 /area/station/medical/medbay/pharmacy)
 "cJq" = (
@@ -63960,8 +63998,12 @@
 	pixel_x = 26;
 	pixel_y = 1
 	},
-/obj/disposalpipe/trunk/mail/west,
-/obj/machinery/disposal/mail/autoname/medbay,
+/obj/table/reinforced/chemistry/auto,
+/obj/machinery/glass_recycler,
+/obj/item/storage/box/beakerbox{
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/black,
 /area/station/medical/medbay/pharmacy)
 "cJr" = (
@@ -64593,49 +64635,38 @@
 "cKV" = (
 /obj/table/auto,
 /obj/item/clipboard,
-/obj/item/paper/book/medical_guide,
-/obj/item/storage/box/patchbox,
-/obj/item/storage/box/patchbox,
-/obj/item/storage/box/patchbox,
-/obj/item/paper/book/medical_guide,
-/obj/item/reagent_containers/dropper/mechanical,
+/obj/item/reagent_containers/dropper/mechanical{
+	pixel_x = 11
+	},
+/obj/item/storage/box/stma_kit{
+	pixel_x = -8
+	},
 /turf/simulated/floor/black,
 /area/station/medical/medbay/pharmacy)
 "cKW" = (
+/obj/decal/mule/beacon,
+/obj/machinery/navbeacon/mule/medbay_north/south,
 /turf/simulated/floor/black,
 /area/station/medical/medbay/pharmacy)
 "cKX" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/black,
 /area/station/medical/medbay/pharmacy)
 "cKY" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/stool/chair/office{
+	dir = 4
 	},
-/obj/machinery/navbeacon/mule/medbay_north/south,
-/obj/decal/mule/beacon,
 /turf/simulated/floor/black,
 /area/station/medical/medbay/pharmacy)
 "cKZ" = (
-/obj/machinery/power/data_terminal,
-/obj/table/auto,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/chem_dispenser,
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_x = -7
 	},
-/obj/machinery/phone,
 /turf/simulated/floor/black,
 /area/station/medical/medbay/pharmacy)
 "cLa" = (
@@ -65209,11 +65240,21 @@
 "cMx" = (
 /obj/table/auto,
 /obj/item/paper_bin,
-/obj/item/stamp,
-/obj/item/hand_labeler,
-/obj/item/storage/box/health_upgrade_kit,
-/obj/machinery/light/emergency,
-/obj/item/storage/box/stma_kit,
+/obj/item/stamp{
+	pixel_x = 5;
+	pixel_y = 12
+	},
+/obj/item/hand_labeler{
+	pixel_x = 7;
+	pixel_y = -7
+	},
+/obj/item/storage/box/health_upgrade_kit{
+	pixel_x = -8;
+	pixel_y = 11
+	},
+/obj/machinery/light/emergency{
+	pixel_x = 16
+	},
 /turf/simulated/floor/black,
 /area/station/medical/medbay/pharmacy)
 "cMy" = (
@@ -65232,15 +65273,20 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail/vertical,
+/obj/disposalpipe/segment/mail/bent/east,
 /turf/simulated/floor/black,
 /area/station/medical/medbay/pharmacy)
 "cMA" = (
-/obj/machinery/disposal,
-/obj/machinery/light/emergency,
+/obj/machinery/light/emergency{
+	pixel_x = -16
+	},
 /obj/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/machinery/chem_heater{
+	pixel_y = 5
+	},
+/obj/machinery/disposal/small,
 /turf/simulated/floor/black,
 /area/station/medical/medbay/pharmacy)
 "cMB" = (
@@ -66486,6 +66532,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/disposal/mail/small,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "cPq" = (
@@ -78822,6 +78869,16 @@
 	dir = 4
 	},
 /area/shuttle/arrival/station)
+"yfA" = (
+/obj/machinery/disposal/mail/small{
+	mail_tag = "medbay";
+	mailgroup = "medbay";
+	mailgroup2 = "medresearch";
+	name = "Medbay"
+	},
+/obj/disposalpipe/trunk/mail/west,
+/turf/simulated/floor/black,
+/area/station/medical/medbay/pharmacy)
 
 (1,1,1) = {"
 aaa
@@ -113147,7 +113204,7 @@ cGM
 cIe
 cJp
 cKY
-cKW
+yfA
 cGJ
 cPl
 cQI


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MAPPING][QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add a proper reagent heater and glass recycler to Cog1 patho'. Removes a third biohazard closet and a chair.
Renovates Cog2 reception desk to be a pharmacy. Fun-fact: It's area was already named "pharmacy"!

(There is an incubator in patho that shares the same sprite as reagent heaters, but they are not the same!)
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
 Many maps have a pharmacy. Sometimes it is a part of Patho'. Pharmacies require reagent heaters.

Adding it as a major changelog note, since many medical-staff break-into (white-tide?) chemistry for reagent heating.
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)MarkNstein:
(*)Cog1: Pathology now has proper pharmacy equipment: Reagent heater and glass recycler.
(*)Cog2: Medical reception desk is now also a pharmacy.
```
