### PR TITLE
Add a check for null turf in Pali's map loader

### DIFF
--- a/code/modules/admin/buildmodes/load_map.dm
+++ b/code/modules/admin/buildmodes/load_map.dm
@@ -17,11 +17,11 @@ Right Mouse Button on the mode         = Cycle loading modes<br>
 	selected()
 		. = ..()
 		update_mode()
-	
+
 	click_mode_right(var/ctrl, var/alt, var/shift)
 		mode_number = (mode_number + 1) % mode_names.len
 		update_mode()
-	
+
 	proc/update_mode()
 		update_button_text(mode_names[mode_number + 1])
 
@@ -29,6 +29,7 @@ Right Mouse Button on the mode         = Cycle loading modes<br>
 		if(!dmm_suite)
 			dmm_suite = new
 		var/turf/A = get_turf(object)
+		if (!A) return
 		blink(A)
 		if(loading)
 			boutput(usr, "<span class='alert'>Already loading a map!</span>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG][RUNTIME] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a check for null turf in Pali's map loader


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Attempting to load a map by clicking an object with a null turf (like your HUD) runtimes and breaks the map loader. Subsequent attempts to load maps will all be met with the message `Already loading a map!` preventing you (and maybe even everyone else too?) from using the tool for the remainder of the round.


File | load_map.dm
-- | --
Line | 51
Error | Cannot read null.x

```
proc name: click left (/datum/buildmode/load_map/click_left)
  source file: load_map.dm,51
  usr: Osborne Baxter (/mob/dead/observer)
  src: Load Area (/datum/buildmode/load_map)
  usr.loc: space (228,193,1) (/turf/space)
  call stack:
Load Area (/datum/buildmode/load_map): click left(Toggle Lighting (/obj/screen/ability/topBar), 0, 0, 0)
/datum/buildmode_holder (/datum/buildmode_holder): build click(Toggle Lighting (/obj/screen/ability/topBar), null, "mapwindow.map", /list (/list))
Sovexe (/client): Click(Toggle Lighting (/obj/screen/ability/topBar), null, "mapwindow.map", "icon-x=14;icon-y=13;left=1;scr...")
```