### PR TITLE
remove sec chairflip immunity

### DIFF
--- a/code/datums/abilities/generic.dm
+++ b/code/datums/abilities/generic.dm
@@ -132,12 +132,6 @@
 					random_brute_damage(M, 20 * effect_mult)
 					M.changeStatus("weakened", 7 SECONDS * effect_mult)
 					M.force_laydown_standup()
-			else if (M.traitHolder.hasTrait("training_security")) //consider rremoving this, prrobably not necessarry any more
-				M.visible_message("<span class='alert'><B>[src]</B></span> does a flying flip into <span class='alert'>[M]</span>, but <span class='alert'>[M]</span> skillfully slings them away!")
-				src.changeStatus("weakened", 6 SECONDS)
-				var/atom/target = get_edge_target_turf(M, M.dir)
-				src.throw_at(target, 3, 10)
-				src.force_laydown_standup()
 			else
 				random_brute_damage(M, 10 * effect_mult)
 				if (!M.hasStatus("weakened"))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[balance] [removal]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
![image](https://user-images.githubusercontent.com/35579460/87583090-b977e000-c6db-11ea-9d97-72f519867cb9.png)
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's probably not needed, chairflips are a valid way of fighting back against your corrupt oppressors.
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)zjdtmkhzt:
(+) Security Officers are no longer immune to being chairflipped.
```
