### PR TITLE
small brain damage fixes

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -655,15 +655,15 @@
 			var/mob/living/carbon/human/H = owner
 			H.max_health = 150
 			H.health = 150
-			H.brainloss = 60
+			H.take_brain_damage(60)
 		return
 
 	onLife(var/mob/owner) //Just to be safe.
 		if(ishuman(owner))
 			var/mob/living/carbon/human/H = owner
 			H.max_health = 150
-			if(H.brainloss < 60)
-				H.brainloss = 60
+			if(H.get_brain_damage() < 60)
+				H.take_brain_damage(60)
 		return
 
 /obj/trait/athletic

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -661,7 +661,6 @@
 	onLife(var/mob/owner) //Just to be safe.
 		if(ishuman(owner))
 			var/mob/living/carbon/human/H = owner
-			H.max_health = 150
 			if(H.get_brain_damage() < 60)
 				H.take_brain_damage(60)
 		return

--- a/code/modules/antagonists/changeling/abilities/regeneration.dm
+++ b/code/modules/antagonists/changeling/abilities/regeneration.dm
@@ -45,7 +45,7 @@
 				changeling_super_heal_step(C, 100, 100) //get those limbs back i didn't lay here for 45 seconds to be hopping around on one leg dang it
 				if (C && !isdead(C))
 					C.HealDamage("All", 1000, 1000)
-					C.brainloss = 0
+					C.take_brain_damage(-INFINITY)
 					C.take_toxin_damage(-INFINITY)
 					C.take_oxygen_deprivation(-INFINITY)
 					C.delStatus("paralysis")

--- a/code/obj/item/football.dm
+++ b/code/obj/item/football.dm
@@ -103,7 +103,7 @@
 
 	if (!src.head || !istype(src.head,/obj/item/clothing/head/helmet/football))
 		boutput(src, __red("Ouch! Feels like a properly designed helmet would come in handy."))
-		src.brainloss += 1 + power * 0.1
+		src.take_brain_damage(1 + power * 0.1)
 
 	for (var/mob/C in viewers(src))
 		shake_camera(C, 6, 1)

--- a/code/obj/machinery/door/door_parent.dm
+++ b/code/obj/machinery/door/door_parent.dm
@@ -91,7 +91,7 @@
 		var/mob/living/carbon/human/C = user
 		if (isdead(C)) //No need to call for dead people!
 			return 0
-		if (C.brainloss >= 60)
+		if (C.get_brain_damage() >= 60)
 			// No text spam, please. Bumped() is called more than once by some doors, though.
 			// If we just return 0, they will be able to bump-open the door and get past regardless
 			// because mob paralysis doesn't take effect until the next tick.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I believe some things were left out when human brain damage was changed to be based on their brain's health rather than on their brainloss var.
- The meathead perk actually just gave you 150% hp for one point and did not cause permanent brain damage.
- The football charge did not do brain damage when not wearing a helmet.
- The check for stumbling into airlocks never actually succeeded.
- Changeling regenerative stasis did not actually heal brain damage (but I do not think lings are really affected by brain damage).
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's good if features that are in the game actually work.