### PR TITLE
small instrument fixes

### DIFF
--- a/code/modules/medical/pathology/pathogen_symptoms.dm
+++ b/code/modules/medical/pathology/pathogen_symptoms.dm
@@ -2108,10 +2108,10 @@ datum/pathogeneffects/malevolent/snaps/jazz
 		..()
 		if (ishuman(M))
 			var/mob/living/carbon/human/H = M
-			if (H.find_type_in_hand(/obj/item/instrument/saxophone)) //bonus saxophone playing capability that doesn't count toward sax cooldown
+			if (H.find_type_in_hand(/obj/item/instrument/saxophone))
 				var/obj/item/instrument/saxophone/sax = H.find_type_in_hand(/obj/item/instrument/saxophone)
-				var/list/aud = sax.sounds_instrument
-				playsound(get_turf(H), pick(aud), 50, 1)
+				sax.play_note(rand(1,sax.sounds_instrument.len), user = H)
+
 
 	disease_act(var/mob/M, var/datum/pathogen/origin)
 		if (!origin.symptomatic)

--- a/code/obj/item/assembly/misc_assemblies.dm
+++ b/code/obj/item/assembly/misc_assemblies.dm
@@ -727,15 +727,12 @@ Contains:
 	return
 
 obj/item/assembly/radio_horn/attack_self(mob/user as mob)
-
 	src.part1.attack_self(user)
 	src.add_fingerprint(user)
 	return
 
 obj/item/assembly/radio_horn/receive_signal()
-	if (part2.next_play >= TIME)
-		part2.next_play = TIME + part2.note_time
-		part2.play_note(rand(1,part2.sounds_instrument.len), user = null)
+	part2.play_note(rand(1,part2.sounds_instrument.len), user = null)
 	return
 
 /////////////////////////////////////////////////////// Remote signaller/timer /////////////////////////////////////


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[improvement] [minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes horn/signaller assemblies, since they seemed to be broken. 
I think the cooldown check for the instrument was broken, and it was unnecessary/harmful in the first place, since play_note already checks the cooldown, I believe.

Also made the Jazz Snapping pathogen symptom actually play the instrument instead of just playing the sound.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's good if features that are in the game actually work.

If it says it plays the instrument, it should actually play the instrument. No more lies!