### PR TITLE
Fixes: Code-Typos in MechComp Refactor

### DIFF
--- a/code/WorkInProgress/MechanicMadness.dm
+++ b/code/WorkInProgress/MechanicMadness.dm
@@ -1810,7 +1810,7 @@ var/list/mechanics_telepads = new/list()
 		return 1
 
 	proc/setidmsg(var/datum/mechanicsMessage/input)
-		if(level == 2 && input.signal)
+		if(level == 1 && input.signal)
 			teleID = input.signal
 			tooltip_rebuild = 1
 			componentSay("ID Changed to : [input.signal]")

--- a/code/WorkInProgress/MechanicsNetworkCon.dm
+++ b/code/WorkInProgress/MechanicsNetworkCon.dm
@@ -118,7 +118,7 @@
 		var/dataStr = ""//list2params(S.data)  Using list2params() will result in weird glitches if the data already contains a set of params, like in terminal comms
 		for(var/i in S.data)
 			dataStr += "[i][isnull(S.data[i]) ? ";" : "=[S.data[i]];"]"
-		SEND_SIGNAL(src,COMSIG_MECHCOMP_TRANSMIT_MSG,dataStr, S.data_file?.copy_file())
+		SEND_SIGNAL(src,COMSIG_MECHCOMP_TRANSMIT_SIGNAL, dataStr, S.data_file?.copy_file())
 		animate_flash_color_fill(src,"#00AA00",1, 1)
 		return
 

--- a/code/datums/components/mechComp_signals.dm
+++ b/code/datums/components/mechComp_signals.dm
@@ -289,7 +289,9 @@
 					return COMSIGBIT_ATTACKBY_COMPLETE
 				if(DC_ALL)
 					WipeConnections()
-					boutput(user, "<span class='notice'>You disconnect [src].</span>")
+					if(istype(parent, /atom))
+						var/atom/AP = parent
+						boutput(user, "<span class='notice'>You disconnect [AP.name].</span>")
 					return COMSIGBIT_ATTACKBY_COMPLETE
 				else
 					//must be a custom config specific to the device, so let the device handle it


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MAJOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes my typo in the PNetComp - it wasn't forwarding *any* messages on from PNet to MechComp.
When using "Disconnect All" on a MechComp device, it was saying that it was disconnecting the component datum, instead of the device name. Purely visual typo, behavior was otherwise proper.
Fixes the teleporter component not accepting new ID's through MechComp messages

Both changes tested.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
PNetcomp and Telecomp are major bugs (per label definition)
Disconnect was trivial.