### PR TITLE
AntiSingulo Can Always be Ordered

### DIFF
--- a/code/datums/supply_packs.dm
+++ b/code/datums/supply_packs.dm
@@ -1174,8 +1174,6 @@
 	containertype = /obj/storage/crate
 	containername = "Telecrystal Resupply Pack"
 
-
-#ifdef MAP_OVERRIDE_MANTA
 /datum/supply_packs/antisingularity
 	name = "Anti-Singularity  Pack"
 	desc = "Everything that the crew needs to take down a rogue singularity."
@@ -1184,7 +1182,6 @@
 	cost = 10000
 	containertype = /obj/storage/crate/classcrate/qm
 	containername = "Anti-Singularity Supply Pack"
-#endif
 
 /* ================================================= */
 /* -------------------- Complex -------------------- */


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[REWORK]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the Manta-only `#ifdef` restricting the Singulo Buster.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Singulo-Setup kits are always available to order regardless of the map, but the buster is not?
I understand this was a map-feature at the time, and I have no qualms against ensuring that only Manta continues to have a buster in the CE's office at round-start, but this seems relevant to all maps.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)MarkNstein:
(+)The "Anti-Singularity  Pack" can be ordered by QM's on any map (no longer restricted to Manta).
```
