### PR TITLE
Kinda fix fluid draining on reagent change

### DIFF
--- a/code/modules/fluids/fluid_core.dm
+++ b/code/modules/fluids/fluid_core.dm
@@ -784,7 +784,7 @@ var/mutable_appearance/fluid_ma
 
 	//Possibility to consume reagents. (Each reagent should return 0 in its reaction_[type]() proc if reagents should be removed from fluid)
 	if (do_reagent_reaction && F.group.reagents && F.group.reagents.reagent_list)
-		F.group.last_reacted = src
+		F.group.last_reacted = F
 		var/react_volume = F.amt > 10 ? (F.amt / 2) : (F.amt)
 		react_volume = min(react_volume,100) //capping the react amt
 		var/list/reacted_ids = F.group.reagents.reaction(src, TOUCH, react_volume,1,F.group.members.len, entered_group)

--- a/code/modules/fluids/fluid_groups.dm
+++ b/code/modules/fluids/fluid_groups.dm
@@ -51,7 +51,7 @@
 						my_group.evaporate()
 						return
 				skip_next_update = 1
-				my_group.drain(remove_source, fluids_to_remove)
+				my_group.drain(remove_source, fluids_to_remove, remove_reagent = 0)
 
 	get_reagents_fullness()
 		.= "empty"
@@ -632,7 +632,7 @@
 				break
 			src.waitforit = 0
 
-	proc/drain(var/obj/fluid/drain_source, var/fluids_to_remove, var/atom/transfer_to = 0) //basically a reverse spread with drain_source as the center
+	proc/drain(var/obj/fluid/drain_source, var/fluids_to_remove, var/atom/transfer_to = 0, var/remove_reagent = 1) //basically a reverse spread with drain_source as the center
 		if (!drain_source || drain_source.group != src) return
 
 		//Don't delete tiles if we can just drain existing deep fluid
@@ -678,7 +678,7 @@
 			src.reagents.skip_next_update = 1
 			src.reagents.trans_to_direct(transfer_to.reagents,src.amt_per_tile * removed_len)
 			src.contained_amt = src.reagents.total_volume
-		else if (src.reagents)
+		else if (src.reagents && remove_reagent)
 			src.reagents.skip_next_update = 1
 			src.reagents.remove_any(src.amt_per_tile * removed_len)
 			src.contained_amt = src.reagents.total_volume


### PR DESCRIPTION
[FIX]

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
first pass on properly draining fluid puddles when reagents are removed (e.g.: water boiling off)
Worked on puddles in testing but not on fireflooding oshan. Idk

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
So we don't leave behind a 200-tile size puddle of 10u ash after lighting a big puddle on fire