### PR TITLE
Fix: Printers Missing Cables

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -2351,12 +2351,18 @@
 /turf/simulated/floor/bot,
 /area/station/security/main)
 "gg" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/yellow/corner,
 /area/station/quartermaster)
 "gh" = (
 /turf/simulated/floor/yellow/side,
 /area/station/quartermaster)
 "gi" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/yellow/corner{
 	dir = 8
 	},
@@ -2559,6 +2565,11 @@
 /turf/simulated/floor/delivery,
 /area/station/quartermaster)
 "gQ" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
@@ -3125,6 +3136,9 @@
 	},
 /area/station/quartermaster)
 "iu" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 6
 	},
@@ -3136,6 +3150,15 @@
 	pixel_x = 25
 	},
 /obj/table/auto,
+/obj/machinery/networked/printer{
+	name = "Printer - Escape Checkpoint";
+	pixel_y = 5;
+	print_id = "EscapeCheckpoint"
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/yellow,
 /area/station/quartermaster)
 "iw" = (
@@ -7847,6 +7870,11 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/carpet{
 	dir = 8;
 	icon_state = "fblue2"
@@ -8159,6 +8187,14 @@
 	dir = 10;
 	name = "autoname - SS13";
 	tag = ""
+	},
+/obj/table/wood/auto,
+/obj/cable,
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/printer{
+	name = "Printer - Escape Checkpoint";
+	pixel_y = 5;
+	print_id = "EscapeCheckpoint"
 	},
 /turf/simulated/floor/carpet{
 	dir = 10;
@@ -15818,6 +15854,16 @@
 /turf/simulated/floor/purplewhite,
 /area/station/science/teleporter)
 "Pe" = (
+/obj/table/auto,
+/obj/machinery/networked/printer{
+	name = "Printer - Escape Checkpoint";
+	pixel_y = 5;
+	print_id = "EscapeCheckpoint"
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/purplewhite,
 /area/station/science/teleporter)
 "Pf" = (
@@ -16025,6 +16071,11 @@
 "PF" = (
 /obj/cable{
 	icon_state = "1-4"
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/purplewhite,
 /area/station/science/teleporter)
@@ -16278,6 +16329,13 @@
 	dir = 4
 	},
 /area/station/hangar/science)
+"Qn" = (
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/quartermaster)
 "Qo" = (
 /obj/table/auto,
 /obj/item/storage/toolbox/mechanical,
@@ -16326,6 +16384,12 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
+"Qy" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/yellow/side,
+/area/station/quartermaster)
 "Qz" = (
 /obj/access_spawn/forensics,
 /obj/firedoor_spawn,
@@ -16797,6 +16861,20 @@
 	},
 /turf/simulated/floor/sanitary,
 /area/station/medical/medbay/surgery)
+"Tp" = (
+/obj/storage/secure/closet/engineering/cargo,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
+/area/station/quartermaster)
 "Ts" = (
 /obj/cable{
 	d1 = 1;
@@ -61274,7 +61352,7 @@ dz
 ea
 bH
 fu
-gh
+Qy
 EN
 gR
 iv
@@ -61576,7 +61654,7 @@ dA
 eb
 eM
 dx
-gh
+Qy
 bH
 bH
 bH
@@ -62180,7 +62258,7 @@ dC
 dY
 eO
 fv
-gj
+Qn
 gj
 hw
 ix
@@ -62482,7 +62560,7 @@ dD
 ec
 eP
 fw
-gk
+Tp
 gk
 hx
 iy

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -6325,6 +6325,11 @@
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/treatment)
 "bBc" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/carpet/red/fancy/edge{
 	dir = 9
 	},
@@ -8734,6 +8739,10 @@
 /obj/machinery/networked/printer{
 	pixel_y = 9;
 	print_id = "Research Sector"
+	},
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/carpet/purple/standard/edge{
 	dir = 1
@@ -29026,6 +29035,12 @@
 	},
 /turf/simulated/floor/black/grime,
 /area/station/medical/asylum/maintenance)
+"ixs" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/station/science)
 "ixI" = (
 /obj/machinery/light/incandescent/warm,
 /obj/machinery/firealarm{
@@ -39551,6 +39566,9 @@
 	dir = 4;
 	icon_state = "line1"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/purpleblack{
 	dir = 4
 	},
@@ -42526,6 +42544,10 @@
 	},
 /obj/machinery/light/incandescent/netural,
 /obj/disposalpipe/segment/food,
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/black,
 /area/station/chapel/main)
 "mJx" = (
@@ -43406,6 +43428,11 @@
 "mXi" = (
 /obj/disposalpipe/segment/morgue{
 	name = "crematorium pipe"
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/red/fancy/edge{
 	dir = 1
@@ -47570,6 +47597,9 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/black,
 /area/station/science)
@@ -52957,6 +52987,14 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
+"pPk" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/station/chapel/main)
 "pPD" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/mail,
@@ -55084,6 +55122,15 @@
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/carpet/arcade,
 /area/station/medical/asylum/rec)
+"qsm" = (
+/obj/stool,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/station/chapel/main)
 "qsz" = (
 /obj/table/wood/round/auto,
 /obj/critter/owl{
@@ -57566,6 +57613,11 @@
 	},
 /area/station/crew_quarters/kitchen)
 "rcr" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/carpet/purple/standard,
 /area/station/science)
 "rcs" = (
@@ -64987,6 +65039,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet/red/fancy/edge{
 	dir = 1
@@ -72602,6 +72657,9 @@
 /turf/simulated/floor/black,
 /area/station/quartermaster/refinery)
 "vEx" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/carpet/purple/standard/edge{
 	dir = 10
 	},
@@ -79788,6 +79846,12 @@
 	dir = 4
 	},
 /area/station/hallway/primary/west)
+"xKP" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/carpet/purple/standard/edge,
+/area/station/science)
 "xKX" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -117436,7 +117500,7 @@ gRP
 dhe
 gRP
 gDq
-bHI
+qsm
 mpU
 tJK
 tJK
@@ -117738,7 +117802,7 @@ tph
 vNJ
 tph
 aaz
-vRz
+pPk
 bHI
 mpU
 otv
@@ -122971,7 +123035,7 @@ gYK
 nUB
 aFv
 eWy
-hAg
+ixs
 hAg
 hAg
 hAg
@@ -123877,7 +123941,7 @@ pdV
 dRf
 clm
 rcr
-omL
+xKP
 lKW
 hAg
 ciS

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -5381,6 +5381,11 @@
 /obj/machinery/phone/wall{
 	pixel_y = 32
 	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/red/side{
 	dir = 9
 	},
@@ -5390,6 +5395,11 @@
 	pixel_y = 24
 	},
 /obj/storage/secure/closet/brig,
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
@@ -5844,6 +5854,9 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/security/checkpoint/podbay)

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -29242,6 +29242,10 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "bmg" = (
@@ -29256,6 +29260,10 @@
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -1713,17 +1713,15 @@
 /area/station/bridge)
 "ady" = (
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/teleporter)
+/turf/simulated/floor/bot,
+/area/station/crew_quarters/market)
 "adz" = (
 /obj/cable{
 	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-8"
 	},
 /turf/simulated/floor/black,
 /area/station/teleporter)
@@ -1731,17 +1729,6 @@
 /obj/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/black,
-/area/station/teleporter)
-"adB" = (
-/obj/cable{
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/black,
@@ -6603,6 +6590,10 @@
 	print_id = "Lounge"
 	},
 /obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/quartersA)
 "aot" = (
@@ -6614,6 +6605,10 @@
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/quartersA)
@@ -32257,6 +32252,11 @@
 /obj/landmark/start{
 	name = "Medical Director"
 	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/carpet/blue/fancy/innercorner/west,
 /area/station/bridge)
 "bxU" = (
@@ -32267,6 +32267,10 @@
 /obj/item/device/infra,
 /obj/machinery/light/incandescent/warm,
 /obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/carpet{
 	dir = 4;
 	icon_state = "blue2"
@@ -32572,6 +32576,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/carpet/blue/fancy/innercorner/nw,
 /area/station/bridge)
 "byM" = (
@@ -32584,6 +32593,10 @@
 	dir = 4;
 	pixel_x = 26;
 	pixel_y = 1
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/carpet{
 	dir = 4;
@@ -33039,6 +33052,7 @@
 	print_id = "Information"
 	},
 /obj/machinery/power/data_terminal,
+/obj/cable,
 /turf/simulated/floor/darkblue{
 	dir = 10
 	},
@@ -91399,9 +91413,9 @@ bwN
 byE
 bzB
 bzB
-ady
+bzB
 bAK
-ady
+bzB
 bzB
 bzB
 bHo
@@ -91703,7 +91717,7 @@ bzC
 bAX
 adz
 adA
-adB
+bDy
 bFz
 bGq
 bHb
@@ -94717,8 +94731,8 @@ bvc
 bvI
 bwo
 bwW
-bwo
-bvE
+bwW
+bvI
 bzE
 bBa
 bCq
@@ -95019,8 +95033,8 @@ bvd
 bvJ
 bvE
 bvI
-bvE
-bvE
+bvI
+bvI
 bzE
 btK
 bCr
@@ -102569,8 +102583,8 @@ btM
 bvO
 bwu
 bxh
-byb
-byR
+byd
+ady
 bzU
 cfw
 bBq

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -5834,6 +5834,7 @@
 	name = "AI Core Shield";
 	pixel_x = 28
 	},
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "amB" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MAPPING] [BUG] [FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I went through the maps in rotation, and searched for each printer in the map. If I didn't see a cable below the printer, I added a data-port (if missing) and cabling to hook it into the PNet.
I also added printers to Atlas.
Also Oshan didn't have a data-terminal under the AI - fixed.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bunch of unwired printers. 
@Nexusuxen asked me to.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)MarkNstein:
(+)All printers on all maps are now properly hooked-up to the PNet grid.
(+)Atlas now has printers.
```
