### PR TITLE
implements portable processor suicide

### DIFF
--- a/code/mob/transform_procs.dm
+++ b/code/mob/transform_procs.dm
@@ -494,7 +494,10 @@
 
 /mob/proc/make_cube(var/CT, var/life, var/turf/T)
 	if (!CT)
-		CT = /mob/living/carbon/cube/meat
+		if(issilicon(CT))
+			CT = /mob/living/carbon/cube/metal
+		else
+			CT = /mob/living/carbon/cube/meat
 	var/mob/living/carbon/cube/W = new CT()
 	if (!T || !isturf(T))
 		T = get_turf(src)

--- a/code/modules/materials/Mat_Processing.dm
+++ b/code/modules/materials/Mat_Processing.dm
@@ -255,7 +255,15 @@
 	anchored = 0
 	density = 1
 
+	custom_suicide = 1
+	suicide(var/mob/user)
+		if (!src.user_can_suicide(user))
+			return 0
 
+		user.visible_message("<span class='alert'><b>[user] hops right into [src]! Jesus!</b></span>")
+		user.unequip_all()
+		user.set_loc(src)
+		user.make_cube(/mob/living/carbon/cube/meat, INFINITY, src.loc)
 /obj/machinery/neosmelter
 	name = "Nano-crucible"
 	desc = "A huge furnace-like machine used to combine materials."

--- a/code/modules/materials/Mat_Processing.dm
+++ b/code/modules/materials/Mat_Processing.dm
@@ -263,7 +263,7 @@
 		user.visible_message("<span class='alert'><b>[user] hops right into [src]! Jesus!</b></span>")
 		user.unequip_all()
 		user.set_loc(src)
-		user.make_cube(life = INFINITY, T = src.loc)
+		user.make_cube(life = 5 MINUTES, T = src.loc)
 /obj/machinery/neosmelter
 	name = "Nano-crucible"
 	desc = "A huge furnace-like machine used to combine materials."

--- a/code/modules/materials/Mat_Processing.dm
+++ b/code/modules/materials/Mat_Processing.dm
@@ -263,7 +263,7 @@
 		user.visible_message("<span class='alert'><b>[user] hops right into [src]! Jesus!</b></span>")
 		user.unequip_all()
 		user.set_loc(src)
-		user.make_cube(/mob/living/carbon/cube/meat, INFINITY, src.loc)
+		user.make_cube(life = INFINITY, T = src.loc)
 /obj/machinery/neosmelter
 	name = "Nano-crucible"
 	desc = "A huge furnace-like machine used to combine materials."


### PR DESCRIPTION
[FEATURE]

## About the PR 
Implements a suicide for the Portable Reclaimer, which transforms the one that suicides into a meatcube.



## Why's this needed? 
This is a way to become a meatcube, and as it is a suicide, it isn't possible to weaponize it.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Chickenish:
(+)Added a suicide for the Portable Reclaimer, it's quite cubular.
```
