### PR TITLE
Vampire Blood Steal Ability Loss after Cloning Fix

### DIFF
--- a/code/datums/abilities/vampire.dm
+++ b/code/datums/abilities/vampire.dm
@@ -312,7 +312,6 @@
 		return
 
 	remove_unlocks()
-		src.removeAbility(/datum/targetable/vampire/blood_steal)
 		src.removeAbility(/datum/targetable/vampire/phaseshift_vampire)
 		src.removeAbility(/datum/targetable/vampire/phaseshift_vampire/mk2)
 		src.removeAbility(/datum/targetable/vampire/mark_coffin)


### PR DESCRIPTION
[BUG]

## About the PR
Vampires would lose their ranged blood stealing ability once cloned, because the remove_unlocks() proc of the vampire's ability holder removed it after their cloning had been started:
https://github.com/goonstation/goonstation/blob/c574c8bc4def262ae193df378b6b661e1d03ab49/code/obj/machinery/clonepod.dm#L181

https://github.com/goonstation/goonstation/blob/a205493479d1386ec469689ba0de4e2099740177/code/datums/abilities/vampire.dm#L314-L315

The issue is not only that it does remove it, but also that the ability isn't specifically an unlock for a vampire, since the only way for them to even get this ability in the first place is them being made into a non-infernal vampire in the make_vampire() proc:
https://github.com/goonstation/goonstation/blob/a205493479d1386ec469689ba0de4e2099740177/code/datums/abilities/vampire.dm#L19

So, I presumed the fix here would be to simply just not let it be removed in the remove_unlocks() proc as it currently seems to be an ability every non-infernal vampire is expected to have without any particular requirements or otherwise needing to unlock it first. Fixes #222.

## Why's this needed?
This should stop vampires from losing this ability by just being cloned.

## Changelog

```
(u)Somethings:
(+)Cloned non-infernal vampires will now keep their Blood Steal ability.
```
