### PR TITLE
Add composite holder compatibility to remove ability and minor improvements

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1532,11 +1532,32 @@ var/global/noir = 0
 				if (!M.abilityHolder)
 					alert("No ability holder detected.")
 					return
-				var/ab_to_rem = input("Which ability?", "Ability", null) as anything in M.abilityHolder.abilities
+				var/datum/targetable/ab_to_rem = null
+				if (istype(M.abilityHolder, /datum/abilityHolder/composite))
+					var/datum/abilityHolder/composite/CH = M.abilityHolder
+					if (CH.holders.len)
+						var/list/abils = list()
+						var/datum/abilityHolder/AH = null
+						for (AH in CH.holders)
+							abils += AH.abilities //get a lit of all the different abilities in the holders
+						if(!abils.len)
+							boutput(usr, "<b><span class='alert'>[M] doesn't have any abilities!</span></b>")
+							return //nothing to remove
+						ab_to_rem = input("Which ability?", "Ability", null) as null|anything in abils
+						if (!ab_to_rem) return //user cancelled
+						AH = ab_to_rem.holder
+						AH.removeAbilityInstance(ab_to_rem)
+						M.abilityHolder.updateButtons()
+					else
+						boutput(usr, "<b><span class='alert'>[M]'s composite holder lacks any ability holders to remove from!</span></b>")
+						return //no ability holders in composite holder
+				else
+					ab_to_rem = input("Which ability?", "Ability", null) as null|anything in M.abilityHolder.abilities
+					if (!ab_to_rem) return //no abilities or user cancelled
+					M.abilityHolder.removeAbilityInstance(ab_to_rem)
+					M.abilityHolder.updateButtons()
 				message_admins("[key_name(usr)] removed ability [ab_to_rem] from [key_name(M)].")
 				logTheThing("admin", usr, M, "removed ability [ab_to_rem] from [constructTarget(M,"admin")].")
-				M.abilityHolder.removeAbilityInstance(ab_to_rem)
-				M.abilityHolder.updateButtons()
 			else
 				alert("You must be at least a Primary Administrator to do this!")
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1532,30 +1532,30 @@ var/global/noir = 0
 				if (!M.abilityHolder)
 					alert("No ability holder detected.")
 					return
+
 				var/datum/targetable/ab_to_rem = null
+				var/list/abils = list()
 				if (istype(M.abilityHolder, /datum/abilityHolder/composite))
 					var/datum/abilityHolder/composite/CH = M.abilityHolder
 					if (CH.holders.len)
-						var/list/abils = list()
 						for (var/datum/abilityHolder/AH in CH.holders)
 							abils += AH.abilities //get a list of all the different abilities in each holder
-						if(!abils.len)
-							boutput(usr, "<b><span class='alert'>[M] doesn't have any abilities!</span></b>")
-							return //nothing to remove
-						ab_to_rem = input("Which ability?", "Ability", null) as null|anything in abils
-						if (!ab_to_rem) return //user cancelled
-						ab_to_rem.holder.removeAbilityInstance(ab_to_rem)
-						M.abilityHolder.updateButtons()
 					else
 						boutput(usr, "<b><span class='alert'>[M]'s composite holder lacks any ability holders to remove from!</span></b>")
 						return //no ability holders in composite holder
 				else
-					ab_to_rem = input("Which ability?", "Ability", null) as null|anything in M.abilityHolder.abilities
-					if (!ab_to_rem) return //no abilities or user cancelled
-					M.abilityHolder.removeAbilityInstance(ab_to_rem)
-					M.abilityHolder.updateButtons()
+					abils += M.abilityHolder.abilities
+
+				if(!abils.len)
+					boutput(usr, "<b><span class='alert'>[M] doesn't have any abilities!</span></b>")
+					return //nothing to remove
+
+				ab_to_rem = input("Remove which ability?", "Ability", null) as null|anything in abils
+				if (!ab_to_rem) return //user cancelled
 				message_admins("[key_name(usr)] removed ability [ab_to_rem] from [key_name(M)].")
 				logTheThing("admin", usr, M, "removed ability [ab_to_rem] from [constructTarget(M,"admin")].")
+				M.abilityHolder.removeAbilityInstance(ab_to_rem)
+				M.abilityHolder.updateButtons()
 			else
 				alert("You must be at least a Primary Administrator to do this!")
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1539,7 +1539,7 @@ var/global/noir = 0
 						var/list/abils = list()
 						var/datum/abilityHolder/AH = null
 						for (AH in CH.holders)
-							abils += AH.abilities //get a lit of all the different abilities in the holders
+							abils += AH.abilities //get a list of all the different abilities in each holder
 						if(!abils.len)
 							boutput(usr, "<b><span class='alert'>[M] doesn't have any abilities!</span></b>")
 							return //nothing to remove

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1537,16 +1537,14 @@ var/global/noir = 0
 					var/datum/abilityHolder/composite/CH = M.abilityHolder
 					if (CH.holders.len)
 						var/list/abils = list()
-						var/datum/abilityHolder/AH = null
-						for (AH in CH.holders)
+						for (var/datum/abilityHolder/AH in CH.holders)
 							abils += AH.abilities //get a list of all the different abilities in each holder
 						if(!abils.len)
 							boutput(usr, "<b><span class='alert'>[M] doesn't have any abilities!</span></b>")
 							return //nothing to remove
 						ab_to_rem = input("Which ability?", "Ability", null) as null|anything in abils
 						if (!ab_to_rem) return //user cancelled
-						AH = ab_to_rem.holder
-						AH.removeAbilityInstance(ab_to_rem)
+						ab_to_rem.holder.removeAbilityInstance(ab_to_rem)
 						M.abilityHolder.updateButtons()
 					else
 						boutput(usr, "<b><span class='alert'>[M]'s composite holder lacks any ability holders to remove from!</span></b>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG][FEATURE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The remove ability button now checks for a composite holder, and if present loops through it's holders to enumerate all of the abilities owned by the mob. After the user makes their selection it then removes the ability from that ability's particular ability holder.

Also lets users press cancel on the remove ability prompt. You know, in case you changed your mind or something.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently the remove ability button in player options does not work with mobs that have composite ability holders. This is because the list that it presents to the user is populated to check the composite holder itself for abilities, as well to remove abilities from the composite holder - which should never actually have abilities added to it directly.