### PR TITLE
Fix random mode picking.

### DIFF
--- a/code/datums/configuration.dm
+++ b/code/datums/configuration.dm
@@ -380,16 +380,19 @@
 /datum/configuration/proc/pick_random_mode()
 	var/total = 0
 	var/list/accum = list()
+	var/list/avail_modes = list()
 
 	for(var/M in src.modes)
-		total += src.probabilities[M]
-		accum[M] = total
+		if (src.probabilities[M] && getSpecialModeCase(M))
+			total += src.probabilities[M]
+			avail_modes += M
+			accum[M] = total
 
 	var/r = total - (rand() * total)
 
 	var/mode_name = null
-	for (var/M in modes)
-		if (src.probabilities[M] > 0 && accum[M] >= r && getSpecialModeCase(M))
+	for (var/M in avail_modes)
+		if (accum[M] >= r)
 			mode_name = M
 			break
 


### PR DESCRIPTION
## About the PR

Fix random mode picking so it only considers modes that are available.

## Why's this needed?

This fixes a situation where the end of the modes list having unavailable modes could result in a failure to pick a mode if the random roll was ~~high~~ low enough.