### PR TITLE
Action(bar)s Don't Restart on Successive Attempts

### DIFF
--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -32,8 +32,8 @@ o+`        `-` ``..-:yooos-..----------..`
 
 //////////// OPTIONS TO GO FAST
 
-#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // Skip setup for atmos, Z5, don't show changelogs, skip pregame lobby
-#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the map Atlas, no other zlevels. Boots way faster
+//#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // Skip setup for atmos, Z5, don't show changelogs, skip pregame lobby
+//#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the map Atlas, no other zlevels. Boots way faster
 //#define Z_LOG_ENABLE 1  // Enable additional world.log logging
 
 

--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -32,8 +32,8 @@ o+`        `-` ``..-:yooos-..----------..`
 
 //////////// OPTIONS TO GO FAST
 
-//#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // Skip setup for atmos, Z5, don't show changelogs, skip pregame lobby
-//#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the map Atlas, no other zlevels. Boots way faster
+#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // Skip setup for atmos, Z5, don't show changelogs, skip pregame lobby
+#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the map Atlas, no other zlevels. Boots way faster
 //#define Z_LOG_ENABLE 1  // Enable additional world.log logging
 
 

--- a/code/WorkInProgress/GerhazoStuff.dm
+++ b/code/WorkInProgress/GerhazoStuff.dm
@@ -355,31 +355,25 @@
 		lightning_targets = potentiallightningtargets
 		..()
 
+	proc/checkNulls()
+		if(M == null || lightningability == null)
+			interrupt(INTERRUPT_ALWAYS)
+			return
 
 	onUpdate()
 		..()
-		if(M == null || lightningability == null)
-			interrupt(INTERRUPT_ALWAYS)
-			return
-
+		checkNulls()
 
 	onStart()
 		..()
-		if(M == null || lightningability == null)
-			interrupt(INTERRUPT_ALWAYS)
-			return
+		src.loopStart()
 
-		/*
-		if (!H.can_bite(HH, is_pointblank = 1))
-			interrupt(INTERRUPT_ALWAYS)
-			return
-		*/
+	loopStart()
+		..()
+		checkNulls()
 
 	onEnd()
-		..()
-		if(M == null || lightningability == null)
-			interrupt(INTERRUPT_ALWAYS)
-			return
+		checkNulls()
 
 		var/targetcounter = rand(4,7)
 		var/i
@@ -394,11 +388,12 @@
 				arcFlashTurf(M, shock_target, 20000)
 		H.points -= targetcounter
 		if(H.points <= 0)
+			..()
 			H.points = 0
 			interrupt(INTERRUPT_ALWAYS)
 			return
-		src.interrupt_flags &= ~INTERRUPT_ACTION
-		actions.start(new/datum/action/bar/icon/force_lightning_action(M,H,HH,lightningability,lightning_targets), M)
+		//src.interrupt_flags &= ~INTERRUPT_ACTION
+		src.onRestart()
 
 	onInterrupt()
 		..()
@@ -470,25 +465,25 @@
 		original_pixel_y = origpixely
 		..()
 
+	proc/checkNulls()
+		if(M == null || chokeability == null)
+			interrupt(INTERRUPT_ALWAYS)
+			return
 
 	onUpdate()
 		..()
-		if(M == null || chokeability == null)
-			interrupt(INTERRUPT_ALWAYS)
-			return
-
+		checkNulls()
 
 	onStart()
 		..()
-		if(M == null || chokeability == null)
-			interrupt(INTERRUPT_ALWAYS)
-			return
+		src.loopStart()
+
+	loopStart()
+		..()
+		checkNulls()
 
 	onEnd()
-		..()
-		if(M == null || chokeability == null)
-			interrupt(INTERRUPT_ALWAYS)
-			return
+		checkNulls()
 
 		if(HH.losebreath < 8)
 			HH.losebreath += 5
@@ -498,11 +493,12 @@
 		H.points -= 5
 
 		if(H.points <= 0)
+			..()
 			H.points = 0
 			interrupt(INTERRUPT_ALWAYS)
 			return
-		src.interrupt_flags &= ~INTERRUPT_ACTION // this action is already finished, this prevents it from getting interrupted by starting a new one
-		actions.start(new/datum/action/bar/icon/force_choke_action(M,H,HH,chokeability,original_pixel_y), M)
+		//src.interrupt_flags &= ~INTERRUPT_ACTION // this action is already finished, this prevents it from getting interrupted by starting a new one
+		src.onRestart()
 
 	onInterrupt()
 		..()
@@ -546,25 +542,25 @@
 		healability = healabil
 		..()
 
+	proc/checkNulls()
+		if(M == null || healability == null)
+			interrupt(INTERRUPT_ALWAYS)
+			return
 
 	onUpdate()
 		..()
-		if(M == null || healability == null)
-			interrupt(INTERRUPT_ALWAYS)
-			return
-
+		checkNulls()
 
 	onStart()
 		..()
-		if(M == null || healability == null)
-			interrupt(INTERRUPT_ALWAYS)
-			return
+		src.loopStart()
+	
+	loopStart()
+		..()
+		checkNulls()
 
 	onEnd()
-		..()
-		if(M == null || healability == null)
-			interrupt(INTERRUPT_ALWAYS)
-			return
+		checkNulls()
 
 		if (M.get_burn_damage() > 0 || M.get_toxin_damage() > 0 || M.get_brute_damage() > 0 || M.get_oxygen_deprivation() > 0 || M.losebreath > 0)
 			M.HealDamage("All", 15, 15)
@@ -574,6 +570,7 @@
 			M.visible_message("<span class='alert'>Some of [M]'s wounds slowly fade away!</span>", "<span class='alert'>Your wounds begin to fade away.</span>")
 			playsound(get_turf(M), 'sound/items/mender.ogg', 50, 1)
 		else
+			..()
 			boutput(M, "<span class='alert'>You don't have any lingering wounds to heal.</span>")
 			interrupt(INTERRUPT_ALWAYS)
 			return
@@ -581,11 +578,12 @@
 		H.points -= 15
 
 		if(H.points <= 0)
+			..()
 			H.points = 0
 			interrupt(INTERRUPT_ALWAYS)
 			return
-		src.interrupt_flags &= ~INTERRUPT_ACTION // this action is already finished, this prevents it from getting interrupted by starting a new one
-		actions.start(new/datum/action/bar/icon/force_heal_action(M,H,healability), M)
+		//src.interrupt_flags &= ~INTERRUPT_ACTION // this action is already finished, this prevents it from getting interrupted by starting a new one
+		src.onRestart()
 
 	onInterrupt()
 		..()

--- a/code/WorkInProgress/GerhazoStuff.dm
+++ b/code/WorkInProgress/GerhazoStuff.dm
@@ -358,7 +358,8 @@
 	proc/checkNulls()
 		if(M == null || lightningability == null)
 			interrupt(INTERRUPT_ALWAYS)
-			return
+			return 0
+		return 1
 
 	onUpdate()
 		..()
@@ -373,7 +374,9 @@
 		checkNulls()
 
 	onEnd()
-		checkNulls()
+		if(!checkNulls())
+			..()
+			return
 
 		var/targetcounter = rand(4,7)
 		var/i
@@ -467,7 +470,8 @@
 	proc/checkNulls()
 		if(M == null || chokeability == null)
 			interrupt(INTERRUPT_ALWAYS)
-			return
+			return 0
+		return 1
 
 	onUpdate()
 		..()
@@ -482,7 +486,9 @@
 		checkNulls()
 
 	onEnd()
-		checkNulls()
+		if(!checkNulls())
+			..()
+			return
 
 		if(HH.losebreath < 8)
 			HH.losebreath += 5
@@ -543,7 +549,8 @@
 	proc/checkNulls()
 		if(M == null || healability == null)
 			interrupt(INTERRUPT_ALWAYS)
-			return
+			return 0
+		return 1
 
 	onUpdate()
 		..()
@@ -558,7 +565,9 @@
 		checkNulls()
 
 	onEnd()
-		checkNulls()
+		if(!checkNulls())
+			..()
+			return
 
 		if (M.get_burn_damage() > 0 || M.get_toxin_damage() > 0 || M.get_brute_damage() > 0 || M.get_oxygen_deprivation() > 0 || M.losebreath > 0)
 			M.HealDamage("All", 15, 15)

--- a/code/WorkInProgress/GerhazoStuff.dm
+++ b/code/WorkInProgress/GerhazoStuff.dm
@@ -392,7 +392,6 @@
 			H.points = 0
 			interrupt(INTERRUPT_ALWAYS)
 			return
-		//src.interrupt_flags &= ~INTERRUPT_ACTION
 		src.onRestart()
 
 	onInterrupt()
@@ -497,7 +496,6 @@
 			H.points = 0
 			interrupt(INTERRUPT_ALWAYS)
 			return
-		//src.interrupt_flags &= ~INTERRUPT_ACTION // this action is already finished, this prevents it from getting interrupted by starting a new one
 		src.onRestart()
 
 	onInterrupt()
@@ -582,7 +580,6 @@
 			H.points = 0
 			interrupt(INTERRUPT_ALWAYS)
 			return
-		//src.interrupt_flags &= ~INTERRUPT_ACTION // this action is already finished, this prevents it from getting interrupted by starting a new one
 		src.onRestart()
 
 	onInterrupt()

--- a/code/datums/abilities/vampire/vampire_bite.dm
+++ b/code/datums/abilities/vampire/vampire_bite.dm
@@ -531,9 +531,9 @@
 			H.vamp_isbiting = HH
 		HH.vamp_beingbitten = 1
 
-		src.onLoopStart()
+		src.loopStart()
 
-	onLoopStart()
+	loopStart()
 		..()
 		logTheThing("combat", M, HH, "bites [constructTarget(HH,"combat")]'s neck at [log_loc(M)].")
 		return

--- a/code/datums/abilities/vampire/vampire_bite.dm
+++ b/code/datums/abilities/vampire/vampire_bite.dm
@@ -389,6 +389,9 @@
 			H.vamp_isbiting = HH
 		HH.vamp_beingbitten = 1
 
+		src.loopStart()
+	
+	loopStart()
 		var/obj/projectile/proj = initialize_projectile_ST(HH, new/datum/projectile/special/homing/vamp_blood, M)
 		var/tries = 10
 		while (tries > 0 && (!proj || proj.disposed))
@@ -407,13 +410,13 @@
 		logTheThing("combat", M, HH, "steals blood from [constructTarget(HH,"combat")] at [log_loc(M)].")
 
 	onEnd()
-		..()
 		if(get_dist(M, HH) > 7 || M == null || HH == null)
+			..()
 			interrupt(INTERRUPT_ALWAYS)
+			src.end()
 			return
 
-		src.end()
-		actions.start(new/datum/action/bar/private/icon/vamp_ranged_blood_suc(M,H,HH), M)
+		src.onRestart()
 
 	onInterrupt() //Called when the action fails / is interrupted.
 		if (state == ACTIONSTATE_RUNNING)

--- a/code/datums/abilities/vampire/vampire_bite.dm
+++ b/code/datums/abilities/vampire/vampire_bite.dm
@@ -530,17 +530,19 @@
 		HH.vamp_beingbitten = 1
 
 	onEnd()
-		..()
 		if(get_dist(M, HH) > 1 || M == null || HH == null || B == null)
+			..()
 			interrupt(INTERRUPT_ALWAYS)
+			src.end()
 			return
 
 		if (!H.do_bite(HH,mult = 1.5, thrall = B.thrall))
+			..()
 			interrupt(INTERRUPT_ALWAYS)
+			src.end()
 			return
 
-		src.end()
-		actions.start(new/datum/action/bar/icon/vamp_blood_suc(M,H,HH,B), M)
+		src.onRestart()
 
 	onInterrupt() //Called when the action fails / is interrupted.
 		if (state == ACTIONSTATE_RUNNING)

--- a/code/datums/abilities/vampire/vampire_bite.dm
+++ b/code/datums/abilities/vampire/vampire_bite.dm
@@ -392,6 +392,7 @@
 		src.loopStart()
 	
 	loopStart()
+		..()
 		var/obj/projectile/proj = initialize_projectile_ST(HH, new/datum/projectile/special/homing/vamp_blood, M)
 		var/tries = 10
 		while (tries > 0 && (!proj || proj.disposed))
@@ -533,6 +534,7 @@
 		src.onLoopStart()
 
 	onLoopStart()
+		..()
 		logTheThing("combat", M, HH, "bites [constructTarget(HH,"combat")]'s neck at [log_loc(M)].")
 		return
 

--- a/code/datums/abilities/vampire/vampire_bite.dm
+++ b/code/datums/abilities/vampire/vampire_bite.dm
@@ -526,11 +526,15 @@
 			interrupt(INTERRUPT_ALWAYS)
 			return
 
-		logTheThing("combat", M, HH, "bites [constructTarget(HH,"combat")]'s neck at [log_loc(M)].")
-
 		if (istype(H))
 			H.vamp_isbiting = HH
 		HH.vamp_beingbitten = 1
+
+		src.onLoopStart()
+
+	onLoopStart()
+		logTheThing("combat", M, HH, "bites [constructTarget(HH,"combat")]'s neck at [log_loc(M)].")
+		return
 
 	onEnd()
 		if(get_dist(M, HH) > 1 || M == null || HH == null || B == null)

--- a/code/datums/controllers/action_controls.dm
+++ b/code/datums/controllers/action_controls.dm
@@ -40,6 +40,7 @@ var/datum/action_controller/actions
 		else
 			interrupt(owner, INTERRUPT_ACTION)
 			for(var/datum/action/OA in running[owner])
+				//Meant to catch users starting the same action twice, and saving the first-attempt from deletion
 				if(OA.id == A.id && OA.state == ACTIONSTATE_DELETE) 
 					OA.onResume()
 					qdel(A)
@@ -101,6 +102,16 @@ var/datum/action_controller/actions
 		state = ACTIONSTATE_RUNNING
 		return
 
+	proc/onRestart()			   //Called when the action restarts (for example: automenders)
+		sleep(1)
+		started = world.time
+		state = ACTIONSTATE_RUNNING
+		loopStart()
+		return
+
+	proc/loopStart()				//Called after restarting. Meant to cotain code from -and be called from- onStart()
+		return
+
 	proc/onResume()				   //Called when the action resumes - likely from almost ending
 		state = ACTIONSTATE_RUNNING
 		return
@@ -137,6 +148,11 @@ var/datum/action_controller/actions
 			// this will absolutely obviously cause no problems.
 			bar.color = "#4444FF"
 			updateBar()
+
+	onRestart()
+		//Start the bar back at 0
+		bar.transform = matrix(0, 0, -15, 0, 1, 0)
+		..()
 
 	onDelete()
 		..()
@@ -207,6 +223,7 @@ var/datum/action_controller/actions
 			animate( bar, transform = matrix(1, 0, 0, 0, 1, 0), time = remain )
 		else
 			animate( bar, flags = ANIMATION_END_NOW )
+		return
 
 /datum/action/bar/blob_health // WOW HACK
 	onUpdate()

--- a/code/datums/controllers/action_controls.dm
+++ b/code/datums/controllers/action_controls.dm
@@ -47,16 +47,16 @@ var/datum/action_controller/actions
 			A.started = world.time
 		else
 			interrupt(owner, INTERRUPT_ACTION)
-			A.owner = owner
-			A.started = world.time
-			running[owner] += A
 			//If there is a a prexisting action of the same kind, let's replace it.
 			var/list/owner_actions = running[owner]
 			for(var/datum/action/OA in owner_actions)
 				if(OA.id == A.id && OA.state == ACTIONSTATE_DELETE) 
-					A.owner = OA.owner
-					A.started = OA.started
-					break
+					OA.onResume()
+					qdel(A)
+					return OA
+			A.owner = owner
+			A.started = world.time
+			running[owner] += A
 		A.onStart()
 		return A // cirr here, I added action ref to the return because I need it for AI stuff, thank you
 
@@ -108,6 +108,10 @@ var/datum/action_controller/actions
 		return
 
 	proc/onStart()				   //Called when the action begins
+		state = ACTIONSTATE_RUNNING
+		return
+
+	proc/onResume()				   //Called when the action resumes - likely from almost ending
 		state = ACTIONSTATE_RUNNING
 		return
 
@@ -188,6 +192,12 @@ var/datum/action_controller/actions
 				updateBar(0)
 				bar.color = "#FFFFFF"
 				animate( bar, color = "#CC0000", time = 2.5 )
+		..()
+
+	onResume()
+		if (bar)
+			updateBar()
+			bar.color = "#4444FF"
 		..()
 
 	onUpdate()

--- a/code/datums/controllers/action_controls.dm
+++ b/code/datums/controllers/action_controls.dm
@@ -34,29 +34,20 @@ var/datum/action_controller/actions
 		return
 
 	proc/start(var/datum/action/A, var/atom/owner) //Starts a new action.
-	//if the owner isn't being tracked:
-		//add the ownder to racking
-		//add the action to the tracking.ownser
-		// proprtyify the action
-	//else (owner is already tracked)
-		//
 		if(!(owner in running))
 			running.Add(owner)
 			running[owner] = list(A)
-			A.owner = owner
-			A.started = world.time
 		else
 			interrupt(owner, INTERRUPT_ACTION)
-			//If there is a a prexisting action of the same kind, let's replace it.
 			var/list/owner_actions = running[owner]
 			for(var/datum/action/OA in owner_actions)
 				if(OA.id == A.id && OA.state == ACTIONSTATE_DELETE) 
 					OA.onResume()
 					qdel(A)
 					return OA
-			A.owner = owner
-			A.started = world.time
 			running[owner] += A
+		A.owner = owner
+		A.started = world.time
 		A.onStart()
 		return A // cirr here, I added action ref to the return because I need it for AI stuff, thank you
 

--- a/code/datums/controllers/action_controls.dm
+++ b/code/datums/controllers/action_controls.dm
@@ -39,8 +39,7 @@ var/datum/action_controller/actions
 			running[owner] = list(A)
 		else
 			interrupt(owner, INTERRUPT_ACTION)
-			var/list/owner_actions = running[owner]
-			for(var/datum/action/OA in owner_actions)
+			for(var/datum/action/OA in running[owner])
 				if(OA.id == A.id && OA.state == ACTIONSTATE_DELETE) 
 					OA.onResume()
 					qdel(A)

--- a/code/datums/controllers/action_controls.dm
+++ b/code/datums/controllers/action_controls.dm
@@ -6,7 +6,7 @@ var/datum/action_controller/actions
 	var/list/running = list() //Associative list of running actions, format: owner=list of action datums
 
 	proc/hasAction(var/atom/owner, var/id) //has this mob an action of a given type running?
-		if(owner in running)
+		if(running.Find(owner))
 			var/list/actions = running[owner]
 			for(var/datum/action/A in actions)
 				if(A.id == id) return 1
@@ -34,29 +34,15 @@ var/datum/action_controller/actions
 		return
 
 	proc/start(var/datum/action/A, var/atom/owner) //Starts a new action.
-	//if the owner isn't being tracked:
-		//add the ownder to racking
-		//add the action to the tracking.ownser
-		// proprtyify the action
-	//else (owner is already tracked)
-		//
-		if(!(owner in running))
+		if(!running.Find(owner))
 			running.Add(owner)
 			running[owner] = list(A)
-			A.owner = owner
-			A.started = world.time
 		else
 			interrupt(owner, INTERRUPT_ACTION)
-			A.owner = owner
-			A.started = world.time
 			running[owner] += A
-			//If there is a a prexisting action of the same kind, let's replace it.
-			var/list/owner_actions = running[owner]
-			for(var/datum/action/OA in owner_actions)
-				if(OA.id == A.id && OA.state == ACTIONSTATE_DELETE) 
-					A.owner = OA.owner
-					A.started = OA.started
-					break
+
+		A.owner = owner
+		A.started = world.time
 		A.onStart()
 		return A // cirr here, I added action ref to the return because I need it for AI stuff, thank you
 

--- a/code/datums/controllers/action_controls.dm
+++ b/code/datums/controllers/action_controls.dm
@@ -6,7 +6,7 @@ var/datum/action_controller/actions
 	var/list/running = list() //Associative list of running actions, format: owner=list of action datums
 
 	proc/hasAction(var/atom/owner, var/id) //has this mob an action of a given type running?
-		if(running.Find(owner))
+		if(owner in running)
 			var/list/actions = running[owner]
 			for(var/datum/action/A in actions)
 				if(A.id == id) return 1
@@ -34,15 +34,29 @@ var/datum/action_controller/actions
 		return
 
 	proc/start(var/datum/action/A, var/atom/owner) //Starts a new action.
-		if(!running.Find(owner))
+	//if the owner isn't being tracked:
+		//add the ownder to racking
+		//add the action to the tracking.ownser
+		// proprtyify the action
+	//else (owner is already tracked)
+		//
+		if(!(owner in running))
 			running.Add(owner)
 			running[owner] = list(A)
+			A.owner = owner
+			A.started = world.time
 		else
 			interrupt(owner, INTERRUPT_ACTION)
+			A.owner = owner
+			A.started = world.time
 			running[owner] += A
-
-		A.owner = owner
-		A.started = world.time
+			//If there is a a prexisting action of the same kind, let's replace it.
+			var/list/owner_actions = running[owner]
+			for(var/datum/action/OA in owner_actions)
+				if(OA.id == A.id && OA.state == ACTIONSTATE_DELETE) 
+					A.owner = OA.owner
+					A.started = OA.started
+					break
 		A.onStart()
 		return A // cirr here, I added action ref to the return because I need it for AI stuff, thank you
 

--- a/code/modules/chemistry/tools/patches.dm
+++ b/code/modules/chemistry/tools/patches.dm
@@ -611,7 +611,11 @@
 		if(get_dist(user, target) > 1 || user == null || target == null)
 			interrupt(INTERRUPT_ALWAYS)
 			return
+		src.loopStart()
+		return
 
+	loopStart()
+		..()
 		if (!M.reagents || M.reagents.total_volume <= 0)
 			user.show_text("[M] is empty.", "red")
 			interrupt(INTERRUPT_ALWAYS)
@@ -627,8 +631,8 @@
 		M.apply_to(target,user, multiply, silent = (looped >= 1))
 
 	onEnd()
-		..()
 		if(get_dist(user, target) > 1 || user == null || target == null)
+			..()
 			interrupt(INTERRUPT_ALWAYS)
 			return
 
@@ -636,7 +640,9 @@
 		if (!M.tampered)
 			target.updatehealth() //I hate this, but we actually need the health on time here.
 			if (health_temp == target.health)
+				..()
 				user.show_text("[M] is finished healing and powers down automatically.", "blue")
 				return
-
-		actions.start(new/datum/action/bar/icon/automender_apply(user, M, target, looped + 1), user)
+		
+		looped++
+		src.onRestart()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[REWORK] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add a new check when a (new) action starts:
If there is an existing action of the same ID that has it's state set to END: resume the existing action, do not use (destroy) the attempted new action.

![BBfi3ui184](https://user-images.githubusercontent.com/9563541/87871231-88a9dc00-c963-11ea-8f0b-b44424d92a9a.gif)
I'm rapid-fire clicking the table in the above GIF. Cosmetic bug: my interruptions are "pulling" the color towards red, but it springs back to blue when I stop.
(I know it springs back to green instead of blue in the gif, it's been fixed)
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
In my opinion, actions restarting because you triggered their start-condition twice, is bad user experience.
When I click the table with a wrench, and I'm 3/4 done, accidentally clicking it again should not "reset" my progress.

Furthermore, many noobs spam-resist cuffs. Maybe they think it will help? (like spamming resist to roll out a fire does.) However, users don't even get any visual feedback that spamming isn't working, since cuffs take so long that the colored bar doesn't even render.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)MarkNstein:
(*)Action(bar)s will no longer reset upon successive attempts.
```
