### PR TITLE
fix chemmaster patch making

### DIFF
--- a/code/modules/chemistry/Chemistry-Machinery.dm
+++ b/code/modules/chemistry/Chemistry-Machinery.dm
@@ -531,7 +531,7 @@
 			if (use_box)
 				// create a patchbox
 				var/obj/item/item_box/medical_patches/B = new /obj/item/item_box/medical_patches(src.output_target)
-				B.name = "box of [patchname] [patchvol <= 20 ? "mini-" : null]patches"
+				B.name = "box of [patchname] [patchvol <= 15 ? "mini-" : null]patches"
 				patchloc = B
 				if (!med) // dangerrr
 					B.icon_state = "patchbox" // change icon
@@ -544,7 +544,7 @@
 			if (patchloc)
 				for (var/i=patchcount, i>0, i--)
 					var/obj/item/reagent_containers/patch/P
-					if (patchvol <= 20)
+					if (patchvol <= 15)
 						P = new /obj/item/reagent_containers/patch/mini(patchloc)
 						P.name = "[patchname] mini-patch"
 					else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[major]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fixes #1499 

Apparently at some point since 2016, mini-patches were nerfed to only have a reagent limit of 15 instead of 20, but the chemmaster was not informed of this.
This patch should remedy this.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Good if machine does what it says and does not send my chems into the ether.
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)zjdtmkhzt:
(+) Fixed bug where chemmaster would sometimes lose reagents when making patches between 15 and 20 units in size.
```
