### PR TITLE
make portable flasher not destroy some things that block them from view

### DIFF
--- a/code/obj/machinery/flasher.dm
+++ b/code/obj/machinery/flasher.dm
@@ -218,17 +218,6 @@
 	src.last_flash = world.time
 	use_power(1000)
 
-	for (var/obj/O in get_turf(src))
-		if (istype(O, /obj/overlay/tile_effect) || istype(O, /obj/machinery/camera))
-			continue
-		if (O.layer > layer)
-			SPAWN_DBG(0)
-				O.overlays += image('icons/effects/fire.dmi', "2old")
-				sleep(1 SECOND)
-				if (O)
-					O.visible_message("<span class='alert'>[src]'s flashbulb burns [O] to a crisp.</span>")
-					qdel(O)
-
 	for (var/mob/O in viewers(src, null))
 		if (get_dist(src, O) > src.range)
 			continue


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[removal] [balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Right now portable flashers have a feature that makes them destroy any obj on their tile that has a higher layer than them.
(Excluding effects and AI cameras.)
Rather than fixing this to include things like light fixtures, I think it would be best to remove this.
There are many objects that probably should not be destroyed by this, including things like beepsky, morty, the sun, etc...
Thus I feel like adding an exhaustive list of items that should be blacklisted would be silly.
Also, it does not even fulfill its intended purpose of making hiding impossible completely, seeing as it still allows things like photographs of trees to hide flashers.
If people hiding portable flashers becomes a problem, I am sure we can find another solution to this.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Stops portable flashers from destroying objects in a questionable manner. 
(Mainly light fixtures, potentially more if people find out, I can see this having abuse cases that I did not think of.)
fixes #1511 
![image](https://user-images.githubusercontent.com/35579460/87924678-7f159680-ca7f-11ea-9c7e-7f97fe12d32c.png)
![image](https://user-images.githubusercontent.com/35579460/87924687-82108700-ca7f-11ea-944a-3d21902e61c9.png)
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)zjdtmkhzt:
(+)Portable flashers will no longer destroy some objects on their tile when triggering.
```
