### PR TITLE
fix for targeted involuntary emotes (i.e. pure love)

### DIFF
--- a/code/mob/living/carbon/human/machoman.dm
+++ b/code/mob/living/carbon/human/machoman.dm
@@ -1237,7 +1237,7 @@ var/list/snd_macho_idle = list('sound/voice/macho/macho_alert16.ogg', 'sound/voi
 							R.updateicon()
 				src.verbs += /mob/living/carbon/human/machoman/verb/macho_meteor
 */
-	emote(var/act)
+	emote(var/act, var/emoteTarget = null)
 		switch(act)
 			if ("scream")
 				if (src.mind && src.mind.special_role && src.mind.special_role == "faustian macho man")

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -2,7 +2,7 @@
 
 
 
-/mob/living/carbon/human/emote(var/act, var/voluntary = 0) //mbc : if voluntary is 2, it's a hotkeyed emote and that means that we can skip the findtext check. I am sorry, cleanup later
+/mob/living/carbon/human/emote(var/act, var/voluntary = 0, var/emoteTarget = null) //mbc : if voluntary is 2, it's a hotkeyed emote and that means that we can skip the findtext check. I am sorry, cleanup later
 	var/param = null
 
 	if (!bioHolder) bioHolder = new/datum/bioHolder( src )
@@ -11,7 +11,9 @@
 		src.visible_message("<span class='alert'>[src] makes [pick("a rude", "an eldritch", "a", "an eerie", "an otherworldly", "a netherly", "a spooky")] gesture!</span>", group = "revenant_emote")
 		return
 
-	if (voluntary == 1)
+	if (emoteTarget)
+		param = emoteTarget
+	else if (voluntary == 1)
 		if (findtext(act, " ", 1, null))
 			var/t1 = findtext(act, " ", 1, null)
 			param = copytext(act, t1 + 1, length(act) + 1)

--- a/code/mob/living/carbon/human/virtual.dm
+++ b/code/mob/living/carbon/human/virtual.dm
@@ -78,7 +78,7 @@
 
 		. = src.say_dead(message, 1)
 
-	emote(var/act, var/voluntary = 0)
+	emote(var/act, var/voluntary = 0, var/emoteTarget = null)
 		if(isghost)
 			if (findtext(act, " ", 1, null))
 				var/t1 = findtext(act, " ", 1, null)

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -1699,12 +1699,13 @@ datum
 
 					boutput(M, "<span class='notice'>You feel [.].</span>")
 
-				else if (prob(50) && !M.restrained())//(prob(16))
-					for (var/mob/living/hugTarget in orange(1,M))
-						if (hugTarget == M)
+				else if (prob(50) && !M.restrained() && istype(M, /mob/living/carbon/human)) // only humans hug, I think?
+					var/mob/living/carbon/human/H = M
+					for (var/mob/living/carbon/human/hugTarget in orange(1,H))
+						if (hugTarget == H)
 							continue
 						if (!hugTarget.stat)
-							M.emote(prob(5)?"sidehug":"hug", emoteTarget="[hugTarget]")
+							H.emote(prob(5)?"sidehug":"hug", emoteTarget="[hugTarget]")
 							break
 
 				..()

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -1699,12 +1699,12 @@ datum
 
 					boutput(M, "<span class='notice'>You feel [.].</span>")
 
-				else if (prob(100) && !M.restrained())//(prob(16))
+				else if (prob(50) && !M.restrained())//(prob(16))
 					for (var/mob/living/hugTarget in orange(1,M))
 						if (hugTarget == M)
 							continue
 						if (!hugTarget.stat)
-							M.emote(prob(5)?"sidehug [hugTarget]":"hug [hugTarget]")
+							M.emote(prob(5)?"sidehug":"hug", emoteTarget="[hugTarget]")
 							break
 
 				..()

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -1699,7 +1699,7 @@ datum
 
 					boutput(M, "<span class='notice'>You feel [.].</span>")
 
-				else if (prob(50) && !M.restrained() && istype(M, /mob/living/carbon/human)) // only humans hug, I think?
+				else if (prob(50) && !M.restrained() && ishuman(M)) // only humans hug, I think?
 					var/mob/living/carbon/human/H = M
 					for (var/mob/living/carbon/human/hugTarget in orange(1,H))
 						if (hugTarget == H)

--- a/code/procs/mobprocs/chatprocs.dm
+++ b/code/procs/mobprocs/chatprocs.dm
@@ -454,7 +454,7 @@
 	else
 		return "[speechverb], \"[font_accent ? "<font face='[font_accent]'[style]>" : null][text][font_accent ? "</font>" : null]\""
 
-/mob/proc/emote(var/act, var/voluntary = 0, var/emoteTarget = null)
+/mob/proc/emote(var/act, var/voluntary = 0)
 	return
 
 /mob/proc/emote_check(var/voluntary = 1, var/time = 10, var/admin_bypass = 1, var/dead_check = 1)

--- a/code/procs/mobprocs/chatprocs.dm
+++ b/code/procs/mobprocs/chatprocs.dm
@@ -454,7 +454,7 @@
 	else
 		return "[speechverb], \"[font_accent ? "<font face='[font_accent]'[style]>" : null][text][font_accent ? "</font>" : null]\""
 
-/mob/proc/emote(var/act, var/voluntary = 0)
+/mob/proc/emote(var/act, var/voluntary = 0, var/emoteTarget = null)
 	return
 
 /mob/proc/emote_check(var/voluntary = 1, var/time = 10, var/admin_bypass = 1, var/dead_check = 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Pure Love was broken in an emote performance change a few days ago, seeing as it is the only thing that is both involuntary and targeted it was overlooked.
In this PR I introduce a new variable for the emote proc that contains the target string, in case the emote is being involuntarily and you wanna pass a target, the target won't need to be searched for in the string, which should hopefully keep the performance boost of the original change.
Another option for this would have been to just pass the target as a mob in the first place, without going mob->string->mob, but I felt like that might have complicated the code in emote() too much, idk.
Please weigh in if you have opinions and stuff.

I also cut the chance for Pure Love to proc the hug in half, because honestly, it seemed kinda high and spammy.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
feature not work, not good