### PR TITLE
Prevent shuttle from instantly warping to centcom

### DIFF
--- a/code/modules/transport/shuttle/shuttle_controller.dm
+++ b/code/modules/transport/shuttle/shuttle_controller.dm
@@ -264,23 +264,21 @@ datum/shuttle_controller
 						if (particle_spawn)
 							particle_spawn.start_particles()
 
-						SPAWN_DBG(0)
-							var/shuttle_dir = map_settings ? map_settings.escape_dir : EAST // default to cog2 direction because EH
-							for (var/obj/landmark/L in escape_pod_success)
-								if (L.dir != shuttle_dir)
-									escape_pod_success -= L //leave behind only landmarks that match our dir
+						var/shuttle_dir = map_settings ? map_settings.escape_dir : EAST // default to cog2 direction because EH
+						for (var/obj/landmark/L in escape_pod_success)
+							if (L.dir != shuttle_dir)
+								escape_pod_success -= L //leave behind only landmarks that match our dir
 
-
-							DEBUG_MESSAGE("Now moving shuttle!")
-							start_location.move_contents_to(end_location, map_turf)
-							for (var/turf/O in end_location)
-								if (istype(O, map_turf))
-									O.ReplaceWith(transit_turf, force=1)
-							DEBUG_MESSAGE("Done moving shuttle!")
-							settimeleft(SHUTTLETRANSITTIME)
-							boutput(world, "<B>The Emergency Shuttle has left for CentCom! It will arrive in [timeleft()/60] minute[s_es(timeleft()/60)]!</B>")
-							world << csound("sound/misc/shuttle_enroute.ogg")
-							//online = 0
+						DEBUG_MESSAGE("Now moving shuttle!")
+						start_location.move_contents_to(end_location, map_turf)
+						for (var/turf/O in end_location)
+							if (istype(O, map_turf))
+								O.ReplaceWith(transit_turf, force=1)
+						DEBUG_MESSAGE("Done moving shuttle!")
+						settimeleft(SHUTTLETRANSITTIME)
+						boutput(world, "<B>The Emergency Shuttle has left for CentCom! It will arrive in [timeleft()/60] minute[s_es(timeleft()/60)]!</B>")
+						world << csound("sound/misc/shuttle_enroute.ogg")
+						//online = 0
 
 						return 1
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the `SPAWN_DBG(0)` from the shuttles departure from the station. Prevents shuttle from instantly warping to centcom


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently the way the shuttle leaving station works is that it first sets it's location flag to `SHUTTLE_LOC_TRANSIT`. It then hits the `SPAWN_DBG(0)` which moves all the shuttle turfs, and then finally sets the timer.

If there is sufficient lag when attempting to leave the station it is possible that a second tick of the `process` proc will occur. This new proc will see that the location flag is set to `SHUTTLE_LOC_TRANSIT` but the prior proc is still busy moving the shuttle turfs and hasn't yet set the new timer. As such the timer appears to be below zero, warping the shuttle to centcom instantly.

I chose to eliminate the `SPAWN_DBG(0)` entirely rather than moving the timer being set out of it based on the behavior of the other shuttle location moves, none of which use `SPAWN_DBG` as well as my conversation with Zamujasa.