### PR TITLE
Special bee egg grammar fixes

### DIFF
--- a/code/obj/critter/bee.dm
+++ b/code/obj/critter/bee.dm
@@ -1672,7 +1672,7 @@
 
 	moon
 		name = "moon egg"
-		desc = "DAMU AK SIN"
+		desc = "DUMU NANNA AK"
 		icon_state = "moonbee_egg"
 		bee_name = "moon larva"
 
@@ -1681,7 +1681,7 @@
 			SPAWN_DBG (20)
 				if (derelict_mode)
 					name = "sun egg"
-					desc = "DAMU AK UTU"
+					desc = "DUMU UTU AK"
 					icon_state = "sunbee_egg"
 					bee_name = "sun larva"
 


### PR DESCRIPTION
## About the PR
Correcting a little pet peeve by fixing the grammar on the descriptions of a couple of bee egg types.
To avoid spoiling anything or stopping people from being able to translate the descriptions for themselves, I'm not going to talk about the exact details here. Anybody who has access to the verified channel in the Solarium Discord can see the details and my thought processes starting from this message: [https://discordapp.com/channels/398929650002296832/398929732424433674/731534886501875752](https://discordapp.com/channels/398929650002296832/398929732424433674/731534886501875752
)
If you're not in there and still want to know about it, feel free to get in touch however's convenient for you.

## Why's this needed?
I think having interesting languages in the game is neat, even more so when they really show off the interesting facts of grammar of that language.