### PR TITLE
Feature/pop extended jobs

### DIFF
--- a/code/datums/controllers/job_controls.dm
+++ b/code/datums/controllers/job_controls.dm
@@ -27,7 +27,7 @@ var/datum/job_controller/job_controls
 			new /datum/job/civilian/barman (),
 			new /datum/job/civilian/chaplain ())
 
-		else //possible future optimisation - childrentypesof/concretetypesof instead of manually purging null name jobs? dont wanna deal with that rn tho
+		else
 			for (var/A in childrentypesof(/datum/job/command)) src.staple_jobs += new A(src)
 			for (var/A in childrentypesof(/datum/job/security)) src.staple_jobs += new A(src)
 			for (var/A in childrentypesof(/datum/job/research)) src.staple_jobs += new A(src)
@@ -36,7 +36,7 @@ var/datum/job_controller/job_controls
 			for (var/A in childrentypesof(/datum/job/special)) src.special_jobs += new A(src)
 		src.job_creator = new /datum/job/created(src)
 		for (var/datum/job/J in src.staple_jobs)
-			// even though it seems like the above code would mean we wouldnt need the lines manually removing null jobs, ui looks bad without it. because of course it does. fuck
+			// we also need to get rid of jobs that have null names, because it messes with the ui otherwise.
 			if (!J.name)
 				src.staple_jobs -= J
 		for (var/datum/job/J in src.special_jobs)
@@ -60,7 +60,7 @@ var/datum/job_controller/job_controls
 				//lets get rid of the daily job too, we have our own logic for that
 				if (istype(job, /datum/job/daily))
 					job.limit = 0
-					src.staple_jobs -= job //cant qdel that in this proc, so we just have an instantiated job datum floating around, oops
+					src.staple_jobs -= job //cant qdel that in this proc, so we just have an instantiated job datum floating around
 				//now we want to start increasing job thresholds
 				switch(job.type)
 					if (/datum/job/security/security_officer)
@@ -112,7 +112,6 @@ var/datum/job_controller/job_controls
 				else
 					var/datum/job/job = shuffled_rand_jobs[i]
 					job.limit = 1
-//				shuffled_rand_jobs -= shuffled_rand_jobs[i]
 
 	proc/job_config()
 		var/dat = "<html><body><title>Job Controller</title>"

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -103,7 +103,7 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 	#endif
 
 	handle_mapvote()
-	global.job_controls.handle_roundstart_job_counts(total_clients()) //this should be a fine place for this
+	global.job_controls.handle_roundstart_job_counts(total_clients())
 
 	while(current_state <= GAME_STATE_PREGAME)
 		sleep(1 SECOND)

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -103,6 +103,7 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 	#endif
 
 	handle_mapvote()
+	global.job_controls.handle_roundstart_job_counts(total_clients()) //this should be a fine place for this
 
 	while(current_state <= GAME_STATE_PREGAME)
 		sleep(1 SECOND)

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1304,8 +1304,8 @@
 
 	New()
 		..()
-		if (prob(15))
-			limit = 1
+/*		if (prob(15)) //moved to job_controls.dm
+			limit = 1*/
 		if (src.alt_names.len)
 			name = pick(src.alt_names)
 

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -597,7 +597,7 @@
 	limit = 5
 	wages = 200
 	slot_back = /obj/item/storage/backpack/medic
-	slot_belt = /obj/item/device/pda2/medical
+	slot_belt = /obj/item/storage/belt/medical
 	slot_jump = /obj/item/clothing/under/rank/medical
 	slot_suit = /obj/item/clothing/suit/labcoat
 	slot_foot = /obj/item/clothing/shoes/red
@@ -605,6 +605,7 @@
 	slot_ears = /obj/item/device/radio/headset/medical
 	slot_eyes = /obj/item/clothing/glasses/healthgoggles
 	slot_poc1 = /obj/item/paper/book/pocketguide/medical
+	slot_poc2 = /obj/item/device/pda2/medical
 	items_in_backpack = list(/obj/item/crowbar, /obj/item/robodefibrillator) // cogwerks: giving medics a guaranteed air tank, stealing it from roboticists (those fucks)
 	// 2018: guaranteed air tanks now spawn in boxes (depending on backpack type) to save room
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[ENHANCEMENT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
this makes it so that if theres more than the set amount players (65 as of right now but u can change it) in the lobby pregame, it enables a bunch more jobs
also theres a toggle to make it "fuzzy", so it can trigger between 60 - 65 (or 5 - the number)
heres a count of the standard job counts with this pr: 

- secoff = 7 (vs 5 previously)
- roboticist = 4 (vs 3 previously)
- scientist = 7 (vs 5 previously)
- med doc = 8 (vs 5 previously)
- con worker = 2 (vs 1 previously)
- qm = 5 (vs 3 previously)
- eng = 7 (vs 5 previously)
- chef = 3 (vs 1 previously)
- botanist = 6 (vs 5 previously)
- chaplain = 2 (vs 1 previously)
- clown = 2 (vs 1 previously)
total base jobs (- staffies) = 69 (vs 53 previously)

also, i add all the jobs that have a random chance to be in and all the jobs that show up only on certain days of the week to 
a pool, then pick random jobs from that pool for a total of 19 gimmick jobs also being available (which is 24 * 0.8 rounded)

final results:
![image](https://user-images.githubusercontent.com/37386904/88217017-8a092c00-cc23-11ea-986b-431d44928211.png)


also all these nums are easily adjustable, and please yell at me for bad code, and all that standard stuff

also i did a tiny refactor of the random jobs and just made them do that stuff in the job controller instead of on the jobs individually

also i made medical doctors spawn with medical belts, over concerns that there wouldnt be enough of those to go around.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
 to try to cut down on the whole "theres 36 staff assistants oh god" problem that we've been seeing a lot with highpop. 
also it gives people more to do, so hopefully they can get the jobs they want with some extra slots and more gimmick jobs. 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)adharainspace:
(*)if there's 65 or more people in the pregame lobby, a bunch of additional job slots will be unlocked.
```
