### PR TITLE
Artifact Tweak

### DIFF
--- a/code/obj/artifacts/artifact_items/energy_gun.dm
+++ b/code/obj/artifacts/artifact_items/energy_gun.dm
@@ -95,8 +95,14 @@
 		..()
 		bullet = new/datum/projectile/artifact
 		bullet.randomise()
+		// artifact tweak buff, people said guns were useless compared to their cells
+		// the next 3 lines override the randomize(). Doing this instead of editting randomize to avoid changing prismatic spray.
+		bullet.power = rand(15,35) // randomise puts it between 2 and 50, let's make it less variable
+		src.dissipation_rate = rand(1,power)
+		src.cost = rand(35,100) // randomise puts it at 50-150
+
 		integrity = rand(50, 100)
-		integrity_loss = rand(1, 7)
+		integrity_loss = rand(1, 3) // was rand(1,7)
 		react_xray[3] = integrity
 
 	proc/ReduceHealth(var/obj/item/gun/energy/artifact/O)

--- a/code/obj/artifacts/artifact_items/energy_gun.dm
+++ b/code/obj/artifacts/artifact_items/energy_gun.dm
@@ -98,8 +98,8 @@
 		// artifact tweak buff, people said guns were useless compared to their cells
 		// the next 3 lines override the randomize(). Doing this instead of editting randomize to avoid changing prismatic spray.
 		bullet.power = rand(15,35) // randomise puts it between 2 and 50, let's make it less variable
-		src.dissipation_rate = rand(1,power)
-		src.cost = rand(35,100) // randomise puts it at 50-150
+		bullet.dissipation_rate = rand(1,bullet.power)
+		bullet.cost = rand(35,100) // randomise puts it at 50-150
 
 		integrity = rand(50, 100)
 		integrity_loss = rand(1, 3) // was rand(1,7)

--- a/code/obj/artifacts/artifact_items/mining_tool.dm
+++ b/code/obj/artifacts/artifact_items/mining_tool.dm
@@ -10,9 +10,9 @@
 
 	New(var/loc, var/forceartitype)
 		..()
-		src.dig_power = rand(1,5)
+		src.dig_power = rand(3,5) // It was 1-5, changed to 3-5 because what's the point of a mining artifact if it's crappier than stuff you can print roundstart?!
 		if (prob(33))
-			src.extrahit = rand(0,4)
+			src.extrahit = rand(0,4) // extrahit isn't used anywhere. Victim of some ancient mining rework?
 		src.dig_sound = pick('sound/effects/exlow.ogg','sound/effects/mag_magmisimpact.ogg','sound/impact_sounds/Energy_Hit_1.ogg')
 
 	examine()

--- a/code/obj/artifacts/artifact_items/power_cell.dm
+++ b/code/obj/artifacts/artifact_items/power_cell.dm
@@ -40,7 +40,7 @@
 
 /datum/artifact/powercell
 	associated_object = /obj/item/cell/artifact
-	rarity_class = 1
+	rarity_class = 2 // modified from 1 as part of art tweak
 	validtypes = list("ancient","martian","wizard","precursor")
 	automatic_activation = 1
 	react_elec = list("equal",0,10)

--- a/code/obj/artifacts/artifact_items/watering_can.dm
+++ b/code/obj/artifacts/artifact_items/watering_can.dm
@@ -163,7 +163,7 @@
 
 /datum/artifact/watercan
 	associated_object = /obj/item/reagent_containers/glass/wateringcan/artifact
-	rarity_class = 1
+	rarity_class = 2 // modified from 1 as part of art tweak
 	validtypes = list("martian","wizard","precursor")
 	min_triggers = 0
 	max_triggers = 0

--- a/code/obj/artifacts/artifact_machines/grav_well.dm
+++ b/code/obj/artifacts/artifact_machines/grav_well.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/gravity_well_generator
 	associated_object = /obj/machinery/artifact/gravity_well_generator
-	rarity_class = 2
+	rarity_class = 1 // modified from 2 as part of art tweak
 	validtypes = list("wizard","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch)

--- a/code/obj/artifacts/artifact_machines/heater.dm
+++ b/code/obj/artifacts/artifact_machines/heater.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/heater
 	associated_object = /obj/machinery/artifact/heater
-	rarity_class = 2
+	rarity_class = 1 // modified from 2 as part of art tweak
 	validtypes = list("ancient","martian","eldritch","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/cold)

--- a/code/obj/artifacts/artifact_objects/healer.dm
+++ b/code/obj/artifacts/artifact_objects/healer.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/healer_bio
 	associated_object = /obj/artifact/healer_bio
-	rarity_class = 1
+	rarity_class = 2 // modified from 1 as part of art tweak
 	validtypes = list("martian","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch)

--- a/code/obj/artifacts/artifact_objects/power_gen.dm
+++ b/code/obj/artifacts/artifact_objects/power_gen.dm
@@ -30,8 +30,9 @@
 
 	New()
 		..()
+		// Previously generated a super lame amount of power from 5 KW to 5 MW. Let's make things... INTERESTING? Maybe 500 KW to 500 MW will be more interesting.
 		gen_level = rand(1,10) // levels from 1-10
-		gen_rate = 5000 * 1.0715 ** ((gen_level-1)*10 + rand(0,10)) // max 4.99MW
+		gen_rate = 500000 * 1.0715 ** ((gen_level-1)*10 + rand(0,10))
 
 	effect_touch(var/obj/O,var/mob/living/user)
 		if (..())

--- a/code/obj/artifacts/artifact_objects/recaller.dm
+++ b/code/obj/artifacts/artifact_objects/recaller.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/recaller
 	associated_object = /obj/artifact/teleport_recaller
-	rarity_class = 2
+	rarity_class = 1 // modified from 2 as part of art tweak
 	validtypes = list("wizard","eldritch","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch)

--- a/code/obj/artifacts/artifactdatums.dm
+++ b/code/obj/artifacts/artifactdatums.dm
@@ -4,6 +4,8 @@
 	var/associated_object = null
 	var/rarity_class = 0
 	//Bigger rarity means its less likely to show up. Thanks for documenting this, guys. - Azungar
+	// Also note that rarity 0 means the artifact does not randomly spawn.
+	// Tweaked rarity 1 to contain all the uninteresting garbage artifacts. Explosion artifacts still appear at 3/4 because explodey is not boring - Phyvo
 
 	var/datum/artifact_origin/artitype = null
 	var/list/validtypes = list("ancient","martian","wizard","eldritch","precursor",/*"reliquary"*/)

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -30,19 +30,16 @@
 
 	var/rarityroll = 1
 
+// artifact tweak. rarity 1 now contains garbage artifacts so that it's easier to control how much garbage science sees.
 	switch(rand(1,100))
-		if (63 to 88)
+		if (36 to 80) 		// 45%. 4% chance for a particular level 2 art.
 			rarityroll = 2
-			// 1 in 25
-		if (89 to 99)
+		if (81 to 95) 		// 15%. With current art list this means 2% chance of a certain level 3 art
 			rarityroll = 3
-			// 1 in 10
-		if (100)
+		if (96 to 100) 		// 5%. With current art list this means 1% chance of a certain level 4 art. 2 of the 5 are bombs...
 			rarityroll = 4
-			// 1 in 100
-		else
+		else 							// 35%. 4% chance for a particular garbage level 1 art.
 			rarityroll = 1
-			// 1 in 62
 
 	var/list/selection_pool = list()
 


### PR DESCRIPTION
Rebalancing artifact probabilities and a few artifacts (gun artifacts, generator arts, mining tool arts) to make them more interesting.

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR does a few thnigs. First and most importantly it rebalances the random distribution of artifacts.  I shuffled some artifacts to dedicate rarity 1 as the garbage, mostly uninteresting artifact tier. To do this I moved 3 rarity 2 artifacts to rarity 1 (recallers, gravity wells, and heaters) and three from number 1 to 2 (artbeakers, power cells, and healers). This allows better control over how much garbage artifact research finds. The higher numbered rarities all have boosted probabilities while rarity 1 is now only the second most common tier. The precise percentages I propose are fairly easy to read in the commit code below.

Secondly, I made some tweaks to particular artifacts. Mining tool artifacts now are guaranteed to spawn with dig strength 3 or above, giving them a better chance of not being utterly useless compared to tools that miners can print at round start. I was told that gun artifacts were pretty useless compared to their power cells so I significantly upped their usage before breaking, made bullets cost a bit less energy, and made the bullet power less random. Shooting a 2 power gun isn't very fun and getting shot by a 50 power gun isn't particularly fun either. Finally, I buffed generator artifacts because a super rare artifact that at best generates 5 MW and at worst generates 5 KW seems lame and boring. (disclaimer: I am not an engie nerd)

Set to DNM while me and Lurkey do some initial tests.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
In Chemistry, Telescience, and Toxins there is little randomness involved and a player can always explore the science or reach a target goal as they wish. Though chemistry is the obvious favorite these branches all can have a pretty big impact on the station. Meanwhile artifacts are generally regulated to empowering chemnerds at best and literally deafening noisemakers at worst because of their randomness and the difficulty of getting anything interesting. The most common rarity category, the one that covers 62% of all artifacts, currently consists mostly of useless junk. Rebalancing some of this randomness to make artifacts more productive is an easy way to improving player interest and make artifacts play a larger role in rounds compared to chemnerds' seventy flavors of lethal injections or more mail order TTVs.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Phyvo:
(*) Rebalanced artifact probabilities to make better artifacts more common.
(+) Buffed these artifact types: mining tools, energy guns, power generators.
```