### PR TITLE
Fix runtime for clients missing a player datum when mentorhelps happen

### DIFF
--- a/code/client.dm
+++ b/code/client.dm
@@ -678,7 +678,7 @@
 	return player.mentor
 
 /client/proc/can_see_mentor_pms()
-	return (player.mentor || src.holder) && player.see_mentor_pms
+	return (src.player?.mentor || src.holder) && src.player?.see_mentor_pms
 
 var/global/curr_year = null
 var/global/curr_month = null


### PR DESCRIPTION
[BUG - MINOR]

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

If they don't have a player they don't need to see them, so this should be fine.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Causing a bunch of runtimes (over a random 2 hour round, ~60 instances) when mentorhelps are happening.