### PR TITLE
voltron through phone line

### DIFF
--- a/code/obj/item/device/voltron.dm
+++ b/code/obj/item/device/voltron.dm
@@ -254,7 +254,7 @@
 
 			activating = 1
 
-			playsound(src, "sound/effects/singsuck.ogg", 40, 1)
+			playsound(get_turf(src), 'sound/effects/singsuck.ogg', 40, 1)
 			var/obj/overlay/O = new/obj/overlay(get_turf(usr))
 			O.name = "Energy"
 			O.anchored = 1
@@ -281,8 +281,35 @@
 			boutput(target, "<span class='notice'>You deactivate the [src].</span>")
 			deactivate()
 		else
-			boutput(user, "<span class='notice'>You activate the [src].</span>")
-			activate()
+			if(istype(user.l_hand,/obj/item/phone_handset) || istype(user.r_hand,/obj/item/phone_handset)) // travel through space line
+				var/obj/item/phone_handset/PH = null
+				var/obj/item/phone_handset/EXIT = null
+				var/target_loc = null
+				if(istype(user.l_hand,/obj/item/phone_handset))
+					PH = user.l_hand
+				else
+					PH = user.r_hand
+				if(PH.parent.linked && PH.parent.linked.handset)
+					if(isturf(PH.parent.linked.handset.loc))
+						target_loc = PH.parent.linked.handset.loc
+					else if(ismob(PH.parent.linked.handset.loc))
+						target_loc = PH.parent.linked.handset.loc.loc
+					else
+						boutput(user, "You can't seem to enter the phone for some reason!")
+						return
+				else
+					boutput(user, "You can't seem to enter the phone for some reason!")
+					return
+				EXIT = PH.parent.linked.handset
+				user.visible_message("[user] enters the phone line using their [src].", "You enter the phone line using your [src].", "You hear a strange sucking noise.")
+				playsound(user.loc, 'sound/effects/singsuck.ogg', 40, 1)
+				user.drop_item(PH)
+				user.set_loc(target_loc)
+				playsound(user.loc, 'sound/effects/singsuck.ogg', 40, 1)
+				user.visible_message("[user] suddenly emerges from the [EXIT]. [pick("","What the fuck?")]", "You emerge from the [EXIT].", "You hear a strange sucking noise.")
+			else
+				boutput(user, "<span class='notice'>You activate the [src].</span>")
+				activate()
 			power -= 5
 			handle_overlay()
 		return

--- a/code/obj/item/device/voltron.dm
+++ b/code/obj/item/device/voltron.dm
@@ -284,7 +284,7 @@
 			if(istype(user.l_hand,/obj/item/phone_handset) || istype(user.r_hand,/obj/item/phone_handset)) // travel through space line
 				var/obj/item/phone_handset/PH = null
 				var/obj/item/phone_handset/EXIT = null
-				var/target_loc = null
+				var/turf/target_loc = null
 				if(istype(user.l_hand,/obj/item/phone_handset))
 					PH = user.l_hand
 				else
@@ -298,6 +298,9 @@
 						boutput(user, "You can't seem to enter the phone for some reason!")
 						return
 				else
+					boutput(user, "You can't seem to enter the phone for some reason!")
+					return
+				if(isrestrictedz(user.loc.z) || isrestrictedz(target_loc.z))
 					boutput(user, "You can't seem to enter the phone for some reason!")
 					return
 				EXIT = PH.parent.linked.handset

--- a/code/obj/item/device/voltron.dm
+++ b/code/obj/item/device/voltron.dm
@@ -254,7 +254,7 @@
 
 			activating = 1
 
-			playsound(get_turf(src), 'sound/effects/singsuck.ogg', 40, 1)
+			playsound(get_turf(src), "sound/effects/singsuck.ogg", 40, 1)
 			var/obj/overlay/O = new/obj/overlay(get_turf(usr))
 			O.name = "Energy"
 			O.anchored = 1
@@ -305,10 +305,10 @@
 					return
 				EXIT = PH.parent.linked.handset
 				user.visible_message("[user] enters the phone line using their [src].", "You enter the phone line using your [src].", "You hear a strange sucking noise.")
-				playsound(user.loc, 'sound/effects/singsuck.ogg', 40, 1)
+				playsound(user.loc, "sound/effects/singsuck.ogg", 40, 1)
 				user.drop_item(PH)
 				user.set_loc(target_loc)
-				playsound(user.loc, 'sound/effects/singsuck.ogg', 40, 1)
+				playsound(user.loc, "sound/effects/singsuck.ogg", 40, 1)
 				user.visible_message("[user] suddenly emerges from the [EXIT]. [pick("","What the fuck?")]", "You emerge from the [EXIT].", "You hear a strange sucking noise.")
 			else
 				boutput(user, "<span class='notice'>You activate the [src].</span>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This lets you use a Voltron to travel to a phone line to the other end of the connection.
It only works if the other phone has picked up, so I think it shouldn't be a balance issue, since the other person needs to pick up, or you need to travel to both locations in the first place to start the call.

I also fixed an issue where the zoop noise wouldn't properly play when activating a Voltron.
[Video](https://streamable.com/7h3cg7)
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It can be used for funny gimmicks, like calling a department and then appearing through the phone to prank them
Also, it makes more sense than vaping through the phone.
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)zjdtmkhzt:
(+)You can now use a Voltron to travel through active phone calls. Just use it while holding the phone handset in your other hand!
```
