### PR TITLE
Makes some auto-loading guns not act like revolvers

### DIFF
--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -445,6 +445,7 @@
 	force = 7.0
 	caliber = 0.355
 	max_ammo_capacity = 18
+	auto_eject = 1
 
 	New()
 		if (prob(30))
@@ -969,7 +970,7 @@
 	force = 5
 	caliber = 0.308
 	max_ammo_capacity = 100
-	auto_eject = 0
+	auto_eject = 1
 
 	flags =  FPRINT | TABLEPASS | CONDUCT | USEDELAY | EXTRADELAY | ONBACK
 	object_flags = NO_ARM_ATTACH


### PR DESCRIPTION
## About the PR 
Changes the Clock 188 and M90 LMG to eject brass as they fire like all other autoloading guns.  


## Why's this needed? 
Brass is important evidence for detectives.  Also the trail of destruction really isn't complete without 300 brass casings strewn in your wake.