### PR TITLE
change synthflesh/siversulf to use standard healing procs

### DIFF
--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -375,13 +375,7 @@ datum
 				if(!volume_passed)
 					return
 				if(method == TOUCH)
-					for(var/A in M.organs)
-						var/obj/item/affecting = null
-						if(!M.organs[A])    continue
-						affecting = M.organs[A]
-						if(!isitem(affecting))
-							continue
-						affecting.heal_damage(volume_passed*1.5, volume_passed*1.5)
+					M.HealDamage("All", volume_passed * 1.5, volume_passed * 1.5)
 					if (isliving(M))
 						var/mob/living/H = M
 						if (H.bleeding)
@@ -994,13 +988,7 @@ datum
 					return
 
 				if (method == TOUCH)
-					for(var/A in M.organs)
-						var/obj/item/affecting = null
-						if(!M.organs[A])    continue
-						affecting = M.organs[A]
-						if (!isitem(affecting))
-							continue
-						affecting.heal_damage(0, volume_passed)
+					M.HealDamage("All", 0, volume_passed)
 
 					var/silent = 0
 					if (paramslist && paramslist.len)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FIX]
## About the PR 
changes synthflesh/siversulf to use standard healing procs
notably this does make them worse at healing broad-targeted damage (if you have multiple damaged limbs), but now it'll heal for only the amount it's supposed to 🤷‍♂️ 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #1596 