### PR TITLE
shoot_reflected_bounce / Meowitzer bugfixes, additions, and improvements

### DIFF
--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -1061,6 +1061,11 @@ datum/projectile/snowball
 
 	//spawns the new projectile in the same location as the existing one, not inside the hit thing
 	var/obj/projectile/Q = initialize_projectile(get_turf(P), P.proj_data, rx, ry, reflector)
+	if (!Q)
+		return
+	Q.reflectcount = P.reflectcount + 1
+	if (ismob(P.shooter))
+		Q.mob_shooter = P.shooter
 
 	//fix for duplicating projectiles when hitting nondense objects like secbots that don't kill projectiles
 	if (isobj(reflector) && reflector.density == 0)
@@ -1068,14 +1073,11 @@ datum/projectile/snowball
 			P.die()
 		else
 			Q.die()
+			if (P)
+				return P
+			else
+				return
 
-	if (!Q && !P)
-		return
-	else if (!Q && P) // P existed but we deleted Q
-		return P
-	Q.reflectcount = P.reflectcount + 1
-	if (ismob(P.shooter))
-		Q.mob_shooter = P.shooter
 	Q.name = "reflected [Q.name]"
 	Q.launch()
 	return Q

--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -1018,11 +1018,21 @@ datum/projectile/snowball
  * So I made my own proc, but left the old one in place just in case -- Sovexe
  * var/reflect_on_nondense_hits - flag for handling hitting objects that let bullets pass through like secbots, rather than duplicating projectiles
  */
-/proc/shoot_reflected_bounce(var/obj/projectile/P, var/obj/reflector, var/max_reflects = 3, var/reflect_on_nondense_hits = 0)
+/proc/shoot_reflected_bounce(var/obj/projectile/P, var/obj/reflector, var/max_reflects = 3, var/allow_headon_bounce = 0, var/reflect_on_nondense_hits = 0)
 	if(P.reflectcount >= max_reflects)
 		return
-	if (abs(P.shooter.x - reflector.x) < 1 || abs(P.shooter.y - reflector.y) < 1)
-		return //stop breaking the world you fuck!
+
+	if (allow_headon_bounce)
+		//stop breaking the world you fuck!
+		if (abs(P.shooter.x - reflector.x) == 1 && abs(P.shooter.y - reflector.y) == 1)
+			return
+		else if (abs(P.shooter.x - reflector.x) == 0 && abs(P.shooter.y - reflector.y) == 2)
+			return
+		else if (abs(P.shooter.x - reflector.x) == 2 && abs(P.shooter.y - reflector.y) == 0)
+			return
+	else
+		if(abs(P.shooter.x - reflector.x) == 0 || abs(P.shooter.y - reflector.y) == 0)
+			return //no
 
 	/*
 		* We have to calculate our incidence each time
@@ -1042,6 +1052,14 @@ datum/projectile/snowball
 		P.incidence = SOUTH
 	else if (x_diff == 0 && y_diff < 0)
 		P.incidence = NORTH
+	else if (x_diff < 0 && y_diff < 0)
+		P.incidence = pick(NORTH, EAST)
+	else if (x_diff < 0 && y_diff > 0)
+		P.incidence = pick(NORTH, WEST)
+	else if (x_diff > 0 && y_diff < 0)
+		P.incidence = pick(SOUTH, EAST)
+	else if (x_diff > 0 && y_diff > 0)
+		P.incidence = pick(SOUTH, WEST)
 	else
 		return //please no runtimes
 

--- a/code/modules/projectiles/special.dm
+++ b/code/modules/projectiles/special.dm
@@ -399,9 +399,10 @@ ABSTRACT_TYPE(/datum/projectile/special)
 	var/explosion_power = 30
 	var/hit_sound = 'sound/voice/animal/cat.ogg'
 	var/max_bounce_count = 50
+	var/allow_headon_bounce = 1
 
 	on_hit(atom/A, direction, projectile)
-		shoot_reflected_bounce(projectile, A, max_bounce_count)
+		shoot_reflected_bounce(projectile, A, max_bounce_count, allow_headon_bounce)
 		var/turf/T = get_turf(A)
 		playsound(A, hit_sound, 60, 1)
 

--- a/code/modules/projectiles/special.dm
+++ b/code/modules/projectiles/special.dm
@@ -411,7 +411,7 @@ ABSTRACT_TYPE(/datum/projectile/special)
 					shake_camera(M, 2, 1)
 
 			SPAWN_DBG(0)
-				explosion_new(null, T, explosion_power, 1)
+				explosion_new(projectile, T, explosion_power, 1)
 			if(prob(50))
 				playsound(A, hit_sound, 60, 1)
 		return

--- a/code/modules/projectiles/special.dm
+++ b/code/modules/projectiles/special.dm
@@ -384,7 +384,7 @@ ABSTRACT_TYPE(/datum/projectile/special)
 			world << sound('sound/effects/creaking_metal1.ogg', volume = 60)
 
 // A weapon by Sovexe
-datum/projectile/special/meowitzer //what have I done
+/datum/projectile/special/meowitzer //what have I done
 	shot_sound = 'sound/misc/boing/6.ogg'
 	name  = "meowitzer"
 	sname  = "meowitzer"
@@ -393,7 +393,9 @@ datum/projectile/special/meowitzer //what have I done
 	dissipation_delay = 75
 	dissipation_rate = 300
 	projectile_speed = 20
+	cost = 1
 
+	var/explosive_hits = 1
 	var/explosion_power = 30
 	var/hit_sound = 'sound/voice/animal/cat.ogg'
 	var/max_bounce_count = 50
@@ -402,15 +404,20 @@ datum/projectile/special/meowitzer //what have I done
 		shoot_reflected_bounce(projectile, A, max_bounce_count)
 		var/turf/T = get_turf(A)
 		playsound(A, hit_sound, 60, 1)
-		SPAWN_DBG(1 DECI SECOND)
-			for(var/mob/living/M in mobs)
-				shake_camera(M, 2, 1)
 
-		SPAWN_DBG(0)
-			explosion_new(null, T, explosion_power, 1)
-		if(prob(50))
-			playsound(A, hit_sound, 60, 1)
+		if (explosive_hits)
+			SPAWN_DBG(1 DECI SECOND)
+				for(var/mob/living/M in mobs)
+					shake_camera(M, 2, 1)
+
+			SPAWN_DBG(0)
+				explosion_new(null, T, explosion_power, 1)
+			if(prob(50))
+				playsound(A, hit_sound, 60, 1)
 		return
+
+/datum/projectile/special/meowitzer/inert
+	explosive_hits = 0
 
 /datum/projectile/special/spewer
 	name = "volatile bolt"

--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -1133,3 +1133,24 @@
 	ammo_type = new /datum/projectile/special/spawner/gun
 	caliber = 3 //idk what caliber to actually make it but apparently its diameter of the tube so i figure it should be 3 inches????
 	delete_on_reload = 1
+
+/obj/item/ammo/bullets/meowitzer
+	sname = "meowitzer"
+	name = "meowitzer"
+	desc = "A box containg a single meowitzer. It's shaking violently and feels warm to the touch. You probably don't want to be anywhere near this when it goes off. Wait is that a cat?"
+	icon_state = "lmg_ammo"
+	icon_empty = "lmg_ammo-0"
+	amount_left = 1
+	max_amount = 1
+	ammo_type = new/datum/projectile/special/meowitzer
+	caliber = 20
+	w_class = 3
+
+
+/obj/item/ammo/bullets/meowitzer/inert
+	sname = "inert meowitzer"
+	name = "inert meowitzer"
+	desc = "A box containg a single inert meowitzer. It appears to be softly purring. Wait is that a cat?"
+	ammo_type = new/datum/projectile/special/meowitzer/inert
+
+

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -1322,7 +1322,7 @@
 
 /obj/item/gun/kinetic/meowitzer
 	name = "\improper Meowitzer"
-	desc = "It purrs gently in your hand."
+	desc = "It purrs gently in your hands."
 	icon = 'icons/obj/items/mining.dmi'
 	icon_state = "blaster"
 
@@ -1336,12 +1336,12 @@
 	can_dual_wield = 0
 	slowdown = 0
 	slowdown_time = 0
-	two_handed = 0
+	two_handed = 1
 	w_class = 4
 
 	New()
-		ammo = new/obj/item/ammo/bullets/meowitzer/inert
-		current_projectile = new/datum/projectile/special/meowitzer/inert
+		ammo = new/obj/item/ammo/bullets/meowitzer
+		current_projectile = new/datum/projectile/special/meowitzer
 		..()
 
 	afterattack(atom/A, mob/user as mob)
@@ -1353,3 +1353,9 @@
 			return
 		else
 			..()
+
+/obj/item/gun/kinetic/meowitzer/inert
+	New()
+		..()
+		ammo = new/obj/item/ammo/bullets/meowitzer/inert
+		current_projectile = new/datum/projectile/special/meowitzer/inert

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -1319,3 +1319,37 @@
 		ammo.amount_left = 6 //spawn full please
 		current_projectile = new /datum/projectile/special/spawner/gun
 		..()
+
+/obj/item/gun/kinetic/meowitzer
+	name = "\improper Meowitzer"
+	desc = "It purrs gently in your hand."
+	icon = 'icons/obj/items/mining.dmi'
+	icon_state = "blaster"
+
+	color = "#ff7b00"
+	force = 5
+	caliber = 20
+	max_ammo_capacity = 1
+	auto_eject = 0
+	flags =  FPRINT | TABLEPASS | CONDUCT | USEDELAY | EXTRADELAY
+	spread_angle = 0
+	can_dual_wield = 0
+	slowdown = 0
+	slowdown_time = 0
+	two_handed = 0
+	w_class = 4
+
+	New()
+		ammo = new/obj/item/ammo/bullets/meowitzer/inert
+		current_projectile = new/datum/projectile/special/meowitzer/inert
+		..()
+
+	afterattack(atom/A, mob/user as mob)
+		if(src.ammo.amount_left < max_ammo_capacity && istype(A, /obj/critter/cat))
+			src.ammo.amount_left += 1
+			user.visible_message("<span class='alert'>[user] loads \the [A] into \the [src].</span>", "<span class='alert'>You load \the [A] into \the [src].</span>")
+			src.current_projectile.icon_state = A.icon_state //match the cat sprite that we load
+			qdel(A)
+			return
+		else
+			..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][FEATURE][BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Adds an inert version of the meowitzer that does not cause explosions
- Adds a meowitzer gun that can come preloaded with either live or inert ammo, and can be reloaded by hitting it on an actual cat
- Adds meowitzer and meowitzer inert ammo
- Fixes a bug that caused `\obj\`'s with a `density` of 0 to spawn a reflected projectile and still keep the initial projectile, duplicating it when hit
- The type of cat launched now matches the type of cat loaded, by default it's just jones
- Handles the rare occurrence of a projectile hitting perfectly on a corner by randomly choosing one of the two possible directions to bounce at random
- Adds `allow_headon_bounce` to `/proc/shoot_reflected_bounce` which as you might expect allows headon bouncing. However it also allows very tight bouncing in small halls, making for some bouncy chaos

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fixes and improvements
https://streamable.com/qfu0o5

follow up to #1591