### PR TITLE
Access spawner change: null default access on doors

### DIFF
--- a/code/obj/access_spawn.dm
+++ b/code/obj/access_spawn.dm
@@ -22,6 +22,9 @@
 
 	proc/setup()
 		for (var/obj/machinery/M in src.loc)
+			if (istype(M,/obj/machinery/door/airlock) && M.modBySpawner == 0) //access spawn mapper QoL upgrade: no more accidental extra access
+				M.req_access = null
+				M.modBySpawner = 1
 			if (!M.req_access)
 				M.req_access = src.req_access
 			else

--- a/code/obj/access_spawn.dm
+++ b/code/obj/access_spawn.dm
@@ -22,9 +22,11 @@
 
 	proc/setup()
 		for (var/obj/machinery/M in src.loc)
-			if (istype(M,/obj/machinery/door/airlock) && M:modBySpawner == 0) //access spawn mapper QoL upgrade: no more accidental extra access
-				M.req_access = null
-				M:modBySpawner = 1
+			if (istype(M, /obj/machinery/door/airlock)) //access spawn mapper QoL upgrade: no more accidental extra access
+				var/obj/machinery/door/airlock/A = M
+				if (!A.modded_by_spawner)
+					A.req_access = null
+					A.modded_by_spawner = 1
 			if (!M.req_access)
 				M.req_access = src.req_access
 			else

--- a/code/obj/access_spawn.dm
+++ b/code/obj/access_spawn.dm
@@ -22,9 +22,9 @@
 
 	proc/setup()
 		for (var/obj/machinery/M in src.loc)
-			if (istype(M,/obj/machinery/door/airlock) && M.modBySpawner == 0) //access spawn mapper QoL upgrade: no more accidental extra access
+			if (istype(M,/obj/machinery/door/airlock) && M:modBySpawner == 0) //access spawn mapper QoL upgrade: no more accidental extra access
 				M.req_access = null
-				M.modBySpawner = 1
+				M:modBySpawner = 1
 			if (!M.req_access)
 				M.req_access = src.req_access
 			else

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -103,7 +103,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	var/no_access = 0
 
 	//for access spawn mapper QoL upgrade
-	var/modBySpawner = 0
+	var/modded_by_spawner = 0 //has this airlock had its access changed by a spawner? 0 if no, 1 if yes
 
 	autoclose = 1
 	power_usage = 50

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -102,6 +102,9 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 
 	var/no_access = 0
 
+	//for access spawn mapper QoL upgrade
+	var/modBySpawner = 0
+
 	autoclose = 1
 	power_usage = 50
 	operation_time = 6


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL][REWORK]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Modifies access spawners and airlocks to make access spawners behave more "predictably". Airlocks are given a "mod_by_spawner" flag that starts as 0 - when an access spawner procs, it will now check for this flag if it's modifying an airlock, and null the existing access before adding its own access and setting the flag to 1. This permits airlocks to retain default access in their base type while also making it so said default access doesn't accidentally "ride along" unless explicitly disabled with var-editing.

I've tagged this as a rework because it alters the existing functionality, and may disrupt maps if they've been configured relying on the old behavior.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Access spawners not nulling existing access continually causes issues with incorrect permissions. After this change, the access a mapper sees in the spawners will be precisely what they get.