### PR TITLE
fix the corner hit direction choices in shoot_reflected_bounce

### DIFF
--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -1030,9 +1030,8 @@ datum/projectile/snowball
 			return
 		else if (abs(P.shooter.x - reflector.x) == 2 && abs(P.shooter.y - reflector.y) == 0)
 			return
-	else
-		if(abs(P.shooter.x - reflector.x) == 0 || abs(P.shooter.y - reflector.y) == 0)
-			return //no
+	else if (abs(P.shooter.x - reflector.x) == 0 || abs(P.shooter.y - reflector.y) == 0)
+		return //no headon bounces
 
 	/*
 		* We have to calculate our incidence each time

--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -1053,13 +1053,13 @@ datum/projectile/snowball
 	else if (x_diff == 0 && y_diff < 0)
 		P.incidence = NORTH
 	else if (x_diff < 0 && y_diff < 0)
-		P.incidence = pick(NORTH, EAST)
+		P.incidence = pick(EAST, NORTH)
 	else if (x_diff < 0 && y_diff > 0)
-		P.incidence = pick(NORTH, WEST)
+		P.incidence = pick(EAST, SOUTH)
 	else if (x_diff > 0 && y_diff < 0)
-		P.incidence = pick(SOUTH, EAST)
+		P.incidence = pick(WEST, NORTH)
 	else if (x_diff > 0 && y_diff > 0)
-		P.incidence = pick(SOUTH, WEST)
+		P.incidence = pick(WEST, SOUTH)
 	else
 		return //please no runtimes
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I mixed up the X and Y axis on these corner hits


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
it's a bug
follow up to #1603