### PR TITLE
Adds the bouncy taser

### DIFF
--- a/code/modules/projectiles/energy_bolt.dm
+++ b/code/modules/projectiles/energy_bolt.dm
@@ -58,6 +58,18 @@ toxic - poisons
 				H.changeStatus("stunned", power)
 		return*/
 
+/datum/projectile/energy_bolt/bouncy
+	name = "richochet energy bolt"
+	var/max_bounce_count = 1
+	var/allow_headon_bounce = 0
+	var/reflect_on_nondense_hits = 0
+
+	on_hit(atom/hit, direction, obj/projectile/P)
+		if (!ismob(hit))
+			if (shoot_reflected_bounce(P, hit, max_bounce_count, allow_headon_bounce, reflect_on_nondense_hits))
+				elecflash(get_turf(P),radius=0, power=2, exclude_center = 0)
+		..()
+
 /datum/projectile/heavyion
 	name = "ion bolt"
 	icon = 'icons/obj/projectiles.dmi'

--- a/code/modules/projectiles/energy_bolt.dm
+++ b/code/modules/projectiles/energy_bolt.dm
@@ -59,7 +59,7 @@ toxic - poisons
 		return*/
 
 /datum/projectile/energy_bolt/bouncy
-	name = "richochet energy bolt"
+	name = "ricochet energy bolt"
 	var/max_bounce_count = 1
 	var/allow_headon_bounce = 0
 	var/reflect_on_nondense_hits = 0

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -194,6 +194,22 @@
 			cell.charge = 100
 			..()
 
+/obj/item/gun/energy/taser_gun/bouncy
+	name = "richochet taser gun"
+	desc = "A weapon that produces an cohesive electrical charge that stuns its target. This one appears to be capable of firing richochet charges."
+
+	New()
+		..()
+		current_projectile = new/datum/projectile/energy_bolt/bouncy
+		projectiles = list(current_projectile)
+
+	update_icon()
+		if(cell)
+			var/ratio = min(1, src.cell.charge / src.cell.max_charge)
+			ratio = round(ratio, 0.25) * 100
+			if(current_projectile.type == /datum/projectile/energy_bolt/bouncy)
+				src.icon_state = "taser[ratio]"
+
 /////////////////////////////////////LASERGUN
 /obj/item/gun/energy/laser_gun
 	name = "laser gun"

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -196,7 +196,7 @@
 
 /obj/item/gun/energy/taser_gun/bouncy
 	name = "richochet taser gun"
-	desc = "A weapon that produces an cohesive electrical charge that stuns its target. This one appears to be capable of firing richochet charges."
+	desc = "A weapon that produces an cohesive electrical charge that stuns its target. This one appears to be capable of firing ricochet charges."
 
 	New()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][FEATURE][BALANCE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Adds a new bouncy taser projectile to the game and creates a modified taser gun to go with it
- bounces off of up to 1 non-mob
- When bouncing makes a small elecflash (radius 0),
- Does not bounce head on, can be changed
- named ricochet energy bolt (until someone has something cooler)
- not obtainable outside of admin spawn currently

https://streamable.com/6ut1qo

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Requested by @mybluecorners 