### PR TITLE
guns now show a targeting cursor when held

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -51,7 +51,7 @@
 	var/stat = 0.0
 	var/next_click = 0
 	var/transforming = null
-	var/hand = 0
+	var/hand = 0 //1 means left hand is active, 0 means right hand is active. fucking hell why was this undocumented for so long
 	var/eye_blind = null
 	var/eye_blurry = null
 	var/eye_damage = null
@@ -759,9 +759,9 @@
 	if (src.client)
 		src.client.mouse_pointer_icon = cursor
 
-/mob/proc/update_cursor()
+/mob/proc/update_cursor(var/aim_override = 0)
 	if (client)
-		if (src.targeting_ability)
+		if (src.targeting_ability || aim_override)
 			src.set_cursor(cursors_selection[client.preferences.target_cursor])
 			return
 		if (src.client.admin_intent)

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2202,6 +2202,10 @@
 	hud.update_hands()
 	if(src.equipped() && (src.equipped().item_function_flags & USE_INTENT_SWITCH_TRIGGER) && !src.equipped().two_handed)
 		src.equipped().intent_switch_trigger(src)
+	if(src.find_type_in_active_hand(/obj/item/gun)) //if they have a gun in that hand, do the target stuff
+		src.update_cursor(1)
+	else
+		src.update_cursor()
 
 /mob/living/carbon/human/emp_act()
 	boutput(src, "<span class='alert'><B>Your equipment malfunctions.</B></span>")

--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -482,3 +482,16 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 		user.visible_message("<span class='alert'><b>[user] accidentally shoots [him_or_her(user)]self with [src]!</b></span>")
 		src.shoot_point_blank(user, user)
 		JOB_XP(user, "Clown", 3)
+
+/obj/item/gun/attack_hand(var/mob/user)
+	..()
+	if (user.find_in_active_hand(src)) //safety check
+		user.update_cursor(1)
+
+/obj/item/gun/dropped(var/mob/user)
+	..()
+	user.update_cursor()
+
+/obj/item/gun/equipped(var/mob/user)
+	..()
+	user.update_cursor()

--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -485,7 +485,7 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 
 /obj/item/gun/attack_hand(var/mob/user)
 	..()
-	if (user.find_in_active_hand(src)) //safety check
+	if (user.find_in_active_hand(src) && ishuman(user)) //safety check, also it wont work properly if nonhuman
 		user.update_cursor(1)
 
 /obj/item/gun/dropped(var/mob/user)

--- a/code/procs/mob_procs.dm
+++ b/code/procs/mob_procs.dm
@@ -52,6 +52,34 @@
 	else
 		return 0 // vOv
 
+/mob/proc/find_in_active_hand(var/obj/item/I) //for when you want to find a SPECIFIC THING in the mobs active hand
+	if (!I)
+		return 0
+	if (!src.r_hand && !src.l_hand)
+		return 0
+
+	if (src.hand) //left hand first
+		if (src.l_hand && src.l_hand == I)
+			return src.l_hand
+	else //then right hand
+		if (src.r_hand && src.r_hand == I)
+			return src.r_hand
+	return 0 //active hand had no item
+
+/mob/proc/find_type_in_active_hand(var/obj/item/I) //for finding a thing of a type but not an instance in the mobs active hand
+	if (!I)
+		return 0
+	if (!src.r_hand && !src.l_hand)
+		return 0
+
+	if (src.hand) //left hand first
+		if (src.l_hand && istype(src.l_hand, I))
+			return src.l_hand
+	else //then right hand
+		if (src.r_hand && istype(src.r_hand, I))
+			return src.r_hand
+	return 0 //active hand had no item
+
 /**
  * @param {int} tool_flag See _setup.dm for valid TOOL_X values
  * @param {string} [hand] If set, checks only in specific hand, else checks all hands


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[ENHANCEMENT] [CLEANLINESS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
shows a targeting reticle (the one from ur prefs) when you hold a gun.
also adds 2 helper procs that i use for finding items by type / instance in the mobs active hand. 
also adds a comment to a confusing var :skull:
right now this only works for humans, mainly because adding for critters and stuff would be hard work with minimal payoff (id have to design procs to work for any number of hands and stuff :skull:)

example: https://streamable.com/02x67f

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
better visual feedback, might be easier for new players too


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)adharainspace:
(*)A targeting cursor now shows up when you're holding a gun.
```
