### PR TITLE
Debug overlay tool tip correction

### DIFF
--- a/code/modules/admin/diagnostics.dm
+++ b/code/modules/admin/diagnostics.dm
@@ -757,8 +757,8 @@ proc/debug_color_of(var/thing)
 			var/list/lparams = params2list(params)
 			var/offs = splittext(lparams["screen-loc"], ",")
 
-			var/x = text2num(splittext(offs[1], ":")[1])+1
-			var/y = text2num(splittext(offs[2], ":")[1])+1
+			var/x = text2num(splittext(offs[1], ":")[1])
+			var/y = text2num(splittext(offs[2], ":")[1])
 			var/image/im = usr.client.infoOverlayImages["[x]-[y]"]
 			if(im && im.desc)
 				usr.client.tooltipHolder.transient.show(src, list(


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes two incidents of `+1` from the debug overlay `/turf/MouseEntered` proc


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Debug overlay tooltips currently show the information for the tile North East of the tile your mouse is over. Now they will show you the information for the tile your mouse is actually on top of