### PR TITLE
Add create all wizard rings verb for PA and higher

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -231,6 +231,7 @@ var/list/admin_verbs = list(
 		/client/proc/cmd_makeshittyweapon,
 		/client/proc/rspawn_panel,
 		/client/proc/cmd_admin_manageabils,
+		/client/proc/create_all_wizard_rings,
 
 		// moved up from admin
 		//client/proc/cmd_admin_delete,

--- a/code/modules/admin/gimmick/wizard_rings.dm
+++ b/code/modules/admin/gimmick/wizard_rings.dm
@@ -64,7 +64,7 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves/ring/wizard)
 				show_message = 1
 			if (user?.bioHolder.HasEffect("hulk"))
 				user.bioHolder.RemoveEffect("hulk")
-				show_message = 1 
+				show_message = 1
 			if (show_message)
 				boutput(user, "<span class='alert'><b>Removing [src] removes its powers with it!</b></span>")
 	staff
@@ -76,7 +76,7 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves/ring/wizard)
 
 		equipped(var/mob/user, var/slot)
 			..()
-			
+
 			//can only make one staff per ring. Anyone who equips the ring claims the staff
 			if (!created_staff)
 				var/obj/item/staff/cthulhu/staff = new /obj/item/staff/cthulhu(get_turf(user))
@@ -252,11 +252,11 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves/ring/wizard)
 			var/path = pick(L)
 			new path(loc)
 			qdel(src)
-
+8
 /client/proc/create_all_wizard_rings()
 	set name = "Create All Wizard Rings"
 	set desc = "Spawn all of the magical wizard rings."
-	SET_ADMIN_CAT(ADMIN_CAT_SELF)
+	SET_ADMIN_CAT(ADMIN_CAT_FUN)
 	set popup_menu = 0
 	admin_only
 

--- a/code/modules/admin/gimmick/wizard_rings.dm
+++ b/code/modules/admin/gimmick/wizard_rings.dm
@@ -252,7 +252,7 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves/ring/wizard)
 			var/path = pick(L)
 			new path(loc)
 			qdel(src)
-8
+
 /client/proc/create_all_wizard_rings()
 	set name = "Create All Wizard Rings"
 	set desc = "Spawn all of the magical wizard rings."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][FEATURE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Assigns `create_all_wizard_rings` to primary administrator rank in `admin_verbs.dm`

Adjusts the category of `/client/proc/create_all_wizard_rings()` to `ADMIN_CAT_FUN` from `ADMIN_CAT_SELF`


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This proc is currently only accessible to coders who know that the proc exists, and that call it manually against client. Kyle setup the groundwork to have a corresponding verb, but he didn't add it to `admin_verbs.dm` which is required since this is actually a proc. I believe adding a verb was his intention as otherwise several of the lines in `/client/proc/create_all_wizard_rings()` have no function.

The move from Self to Fun was made as I felt it better fits in with verbs existing in the fun category.