### PR TITLE
Correct jobban-panel access level requirement

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -616,7 +616,7 @@ var/global/noir = 0
 			usr.client.cmd_boot(M)
 
 		if ("removejobban")
-			if (src.level >= LEVEL_CODER)
+			if (src.level >= LEVEL_SA)
 				var/t = href_list["target"]
 				if(t)
 					logTheThing("admin", usr, null, "removed [t]")
@@ -624,7 +624,7 @@ var/global/noir = 0
 					message_admins("<span class='internal'>[key_name(usr)] removed [t]</span>")
 					jobban_remove(t)
 			else
-				alert("You need to be at least a Coder to remove job bans.")
+				alert("You need to be at least a Secondary Administrator to remove job bans.")
 
 		if ("mute")
 			if (src.level >= LEVEL_MOD)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the permission level check in the `removejobban` href switch from `LEVEL_CODER` to `LEVEL_SA`


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
SA's and above all have access to the `jobban-panel` verb but only coders can actually delete the bans. Originally staff as low as SA had access to the panel verb but couldn't access it at all. This was recently changed by ZeWaka after a discussion in discord chat, but this additional access check is still preventing non-coder level staff from utilizing the panel.