### PR TITLE
Improves Cogmap1 Burnchamber Radiator Pipe coverage

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -110052,7 +110052,7 @@ bqm
 bru
 bsc
 bqm
-bxJ
+bqk
 bxJ
 uKI
 uKI

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -35469,12 +35469,6 @@
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/combustion_chamber)
-"bwK" = (
-/obj/machinery/atmospherics/pipe/simple/junction{
-	dir = 1
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/station/engine/combustion_chamber)
 "bwL" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
@@ -35584,12 +35578,12 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "bwW" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 4
-	},
 /obj/machinery/atmospherics/unary/outlet_injector{
 	icon_state = "on";
 	on = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 4
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/combustion_chamber)
@@ -35848,8 +35842,8 @@
 	name = "Mounted Igniter";
 	pixel_x = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/junction{
+	dir = 8
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/combustion_chamber)
@@ -108247,8 +108241,8 @@ aag
 buk
 bum
 buZ
-bwK
-bwU
+buZ
+bwL
 bqk
 byB
 ntO
@@ -110058,7 +110052,7 @@ bqm
 bru
 bsc
 bqm
-bqk
+bxJ
 bxJ
 uKI
 uKI

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -34590,14 +34590,11 @@
 /area/station/engine/combustion_chamber)
 "buZ" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 1
+	dir = 4
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/combustion_chamber)
 "bva" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 1
-	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/test_apparatus/gas_sensor{
 	setup_tag = "ENGINE"
@@ -34605,6 +34602,9 @@
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/combustion_chamber)
@@ -35032,13 +35032,13 @@
 /turf/simulated/floor,
 /area/station/turret_protected/ai_upload)
 "bvS" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 1
-	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 6
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/combustion_chamber)
@@ -35459,13 +35459,13 @@
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai_upload)
 "bwJ" = (
-/obj/machinery/atmospherics/pipe/simple/junction{
-	dir = 1
-	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 9
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/combustion_chamber)
@@ -35560,8 +35560,8 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "bwU" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/junction{
+	dir = 8
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/combustion_chamber)
@@ -108240,8 +108240,8 @@ bqQ
 aag
 buk
 bum
-buZ
-buZ
+bwL
+bum
 bwL
 bqk
 byB
@@ -108541,9 +108541,9 @@ aaa
 bqQ
 aag
 buk
-buY
+buZ
 bva
-bwL
+bwM
 bwW
 bxT
 bzI
@@ -108843,9 +108843,9 @@ aaa
 bqQ
 aag
 buk
-bum
+buZ
 bvS
-bwM
+bwL
 bwW
 nPX
 bAH


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a few more Radiator Pipes to the Enginering Burnchamber of Cogmap1.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Small QoL change that makes running the engine on cog1 just that slightly less painful

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Comradef191:
(+)Slightly Improved Radiator Coverage in the Cogmap1 Engineering Burnchamber
```
