### PR TITLE
fix zippobombs

### DIFF
--- a/code/obj/item/cigarette.dm
+++ b/code/obj/item/cigarette.dm
@@ -1177,6 +1177,11 @@
 				return
 			//sleep(1 SECOND)
 
+	temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+		if (exposed_temperature > 1000)
+			return ..()
+		return
+
 	custom_suicide = 1
 	suicide(var/mob/user as mob)
 		if (!src.user_can_suicide(user))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fix issue where zippo lighters would blow themselves up (uses same logic as weldingtools)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Lighters being bombs was uh. Not great.

