### PR TITLE
More fleet fixes

### DIFF
--- a/maps/fleet.dmm
+++ b/maps/fleet.dmm
@@ -15690,9 +15690,7 @@
 	name = "Demeter Primary Zone"
 	})
 "Eb" = (
-/obj/tree1{
-	desc = "It's a tree. You see the phrase 'Haine <3 SpyGuy' carved into it."
-	},
+/obj/tree1,
 /turf/simulated/floor/grass,
 /area/station/aviary{
 	name = "Demeter Primary Zone"
@@ -16954,16 +16952,9 @@
 	name = "Demeter Primary Zone"
 	})
 "Gs" = (
-/obj/tree1{
-	desc = "It's a tree. You see the phrase 'Haine <3 SpyGuy' carved into it."
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/grass,
-/area/station/aviary{
-	name = "Demeter Primary Zone"
-	})
+/obj/tree1,
+/turf/simulated/floor/grass/leafy,
+/area/station/owlery)
 "Gt" = (
 /obj/stool/bench/blue/auto,
 /obj/landmark/start{
@@ -56822,7 +56813,7 @@ EZ
 Fq
 Fq
 Fq
-Gs
+Fq
 GJ
 Fq
 Hf
@@ -102851,7 +102842,7 @@ aF
 aF
 eY
 gN
-og
+Gs
 gN
 gN
 qQ
@@ -104362,7 +104353,7 @@ aF
 aF
 gN
 gN
-og
+Gs
 eY
 aF
 aF

--- a/maps/fleet.dmm
+++ b/maps/fleet.dmm
@@ -1193,6 +1193,7 @@
 "cy" = (
 /obj/machinery/manufacturer/uniform,
 /obj/machinery/light/small,
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/lounge_starboard{
 	name = "Tenebrae Crew Quarters"
@@ -1542,6 +1543,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
+/obj/machinery/light_switch/east,
 /turf/simulated/floor/greenblack{
 	dir = 1
 	},
@@ -2522,6 +2524,7 @@
 	},
 /area/station/owlery)
 "eZ" = (
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/purplewhite,
 /area/station/science{
 	name = "Tenebrae Primary Zone"
@@ -2935,6 +2938,7 @@
 	})
 "fM" = (
 /obj/machinery/manufacturer/general,
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/plating,
 /area/station/science/construction{
 	name = "Tenebrae Maintenance"
@@ -3465,6 +3469,7 @@
 	dir = 8;
 	pixel_x = 32
 	},
+/obj/machinery/light_switch/north,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/lounge_port{
 	name = "Maru Crew Quarters"
@@ -3850,6 +3855,7 @@
 /obj/item/clothing/head/helmet/space/engineer,
 /obj/item/device/gps,
 /obj/item/storage/belt/mining,
+/obj/machinery/light_switch/north,
 /turf/simulated/floor/orangeblack,
 /area/station/mining)
 "hK" = (
@@ -3982,6 +3988,7 @@
 /obj/machinery/conveyor{
 	id = "qmout"
 	},
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/orangeblack,
 /area/station/quartermaster/office)
 "hX" = (
@@ -4153,6 +4160,7 @@
 /obj/item/fuel_pellet/cerenkite,
 /obj/item/fuel_pellet/cerenkite,
 /obj/item/fuel_pellet/cerenkite,
+/obj/machinery/light_switch/east,
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
@@ -4441,6 +4449,7 @@
 	})
 "iT" = (
 /obj/machinery/rkit,
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
@@ -5167,6 +5176,7 @@
 "kt" = (
 /obj/machinery/manufacturer/uniform,
 /obj/machinery/light/small,
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/locker{
 	name = "Hammer Crew Quarters"
@@ -5405,6 +5415,7 @@
 	name = "Maru Primary Zone"
 	})
 "kO" = (
+/obj/machinery/light_switch/north,
 /turf/simulated/floor/orangeblack/side{
 	dir = 5
 	},
@@ -5478,6 +5489,9 @@
 /obj/item/storage/belt/utility,
 /obj/machinery/power/apc/autoname_west,
 /obj/cable,
+/obj/machinery/light_switch/west{
+	pixel_y = -10
+	},
 /turf/simulated/floor/grey,
 /area/station/engine/storage{
 	name = "Maru Equipment"
@@ -5764,6 +5778,7 @@
 /obj/table/reinforced/auto,
 /obj/item/paper/Port_A_Brig,
 /obj/item/remote/porter/port_a_brig,
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/redblack{
 	dir = 9
 	},
@@ -5992,8 +6007,8 @@
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
-/area/station/security/hos{
-	name = "Hammer Command"
+/area/station/turret_protected/AIbaseoutside{
+	name = "Hammer Defense Zone"
 	})
 "lY" = (
 /obj/machinery/light{
@@ -6212,6 +6227,7 @@
 	})
 "mx" = (
 /obj/machinery/manufacturer/general,
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage{
 	name = "Maru Power Room"
@@ -6451,6 +6467,7 @@
 "mT" = (
 /obj/machinery/computer/secure_data/detective_computer,
 /obj/blind_switch/area/west,
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "mU" = (
@@ -6480,6 +6497,7 @@
 /obj/item/shipcomponent/secondary_system/tractor_beam,
 /obj/item/shipcomponent/secondary_system/tractor_beam,
 /obj/item/storage/toolbox/mechanical,
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/red/side{
 	dir = 8
 	},
@@ -7266,6 +7284,7 @@
 	name = "Hammer Command"
 	})
 "ou" = (
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/black,
 /area/station/security/main{
 	name = "Hammer Primary Concourse"
@@ -9010,6 +9029,7 @@
 "rK" = (
 /obj/machinery/manufacturer/uniform,
 /obj/machinery/light/small,
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/grey,
 /area/station/medical/staff{
 	name = "Asclepius Quarters"
@@ -9544,6 +9564,7 @@
 	})
 "sM" = (
 /obj/machinery/manufacturer/uniform,
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/utility{
 	name = "Dionysus Cryocore"
@@ -9607,6 +9628,7 @@
 /obj/item/stamp,
 /obj/item/decoration/ashtray,
 /obj/item/reagent_containers/food/drinks/tea,
+/obj/machinery/light_switch/east,
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
@@ -9933,6 +9955,7 @@
 /obj/item/clothing/suit/bio_suit/paramedic,
 /obj/item/storage/belt/medical,
 /obj/item/storage/belt/medical,
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/white,
 /area/station/medical/medbay{
 	name = "Asclepius Primary Zone"
@@ -10397,6 +10420,7 @@
 /area/station/hydroponics)
 "ut" = (
 /obj/machinery/plantpot,
+/obj/machinery/light_switch/east,
 /turf/simulated/floor/grass,
 /area/station/hydroponics)
 "uu" = (
@@ -10562,6 +10586,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/machinery/light_switch/north,
 /turf/simulated/floor/blue/checker,
 /area/station/medical/research{
 	name = "Genetic Research"
@@ -10692,6 +10717,9 @@
 /obj/machinery/phone/wall{
 	pixel_y = 32
 	},
+/obj/machinery/light_switch/north{
+	pixel_x = -12
+	},
 /turf/simulated/floor/wood/two,
 /area/station/bridge/hos)
 "uR" = (
@@ -10715,6 +10743,7 @@
 	d2 = 8;
 	icon_state = "0-4"
 	},
+/obj/machinery/light_switch/north,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/bar)
 "uS" = (
@@ -11959,6 +11988,7 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
+/obj/machinery/light_switch/north,
 /turf/simulated/floor/carpet/red/fancy/edge/ne,
 /area/station/crew_quarters/cafeteria{
 	name = "Dionysus Primary Zone"
@@ -12107,6 +12137,7 @@
 	})
 "xt" = (
 /obj/machinery/manufacturer/general,
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/plating,
 /area/station/medical/maintenance{
 	name = "Asclepius Equipment Room"
@@ -12881,8 +12912,8 @@
 /obj/machinery/door/poddoor/pyro{
 	autoclose = 1;
 	dir = 4;
-	id = "hm17_crusher";
-	name = "HM-17 Crusher Door"
+	id = "asc_crusher";
+	name = "Asclepius Crusher Door"
 	},
 /obj/machinery/conveyor{
 	dir = 4;
@@ -13115,6 +13146,9 @@
 	id = "ham_brace";
 	name = "Hammer Combat Shield";
 	pixel_x = 24
+	},
+/obj/machinery/light_switch/east{
+	pixel_y = -9
 	},
 /turf/simulated/floor/redblack{
 	dir = 1
@@ -14168,6 +14202,7 @@
 "Bk" = (
 /obj/table/auto,
 /obj/item/card_box/suit,
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/captain{
 	name = "Meridian Primary Zone"
@@ -14521,6 +14556,7 @@
 /obj/item/peripheral/drive/cart_reader,
 /obj/item/peripheral/drive,
 /obj/item/peripheral/network/radio/locked,
+/obj/machinery/light_switch/north,
 /turf/simulated/floor/grey/blackgrime/other,
 /area/station/storage/tech)
 "BZ" = (
@@ -15338,6 +15374,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/machinery/light_switch/east,
 /turf/simulated/floor/grey,
 /area/station/turret_protected/ai)
 "Dv" = (
@@ -15583,6 +15620,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/machinery/light_switch/east,
 /turf/simulated/floor/grey,
 /area/station/bridge/captain{
 	name = "Meridian Command"
@@ -16005,6 +16043,7 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/neutral/corner{
 	dir = 8
 	},
@@ -16696,6 +16735,7 @@
 	})
 "FY" = (
 /obj/machinery/portable_reclaimer,
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west{
 	name = "Meridian Maintenance"
@@ -17363,6 +17403,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/stairs,
 /area/station/maintenance/south{
 	name = "Demeter Operations Room"
@@ -17609,6 +17650,7 @@
 	pixel_y = 20;
 	tag = ""
 	},
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner{
 	name = "Hammer Maintenance"
@@ -17974,6 +18016,9 @@
 	id = "scienceteleporter";
 	name = "Pad Shutters";
 	pixel_x = -24
+	},
+/obj/machinery/light_switch/west{
+	pixel_y = -8
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 8
@@ -20164,9 +20209,6 @@
 	name = "Erebus Plasmitics Zone"
 	})
 "MR" = (
-/obj/machinery/computer3/generic/engine{
-	dir = 4
-	},
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -20175,6 +20217,10 @@
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
+	},
+/obj/machinery/computer/atmosphere/mixercontrol{
+	dir = 4;
+	frequency = 1225
 	},
 /turf/simulated/floor/grey,
 /area/station/engine/power{
@@ -20254,7 +20300,11 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
 	},
-/obj/machinery/atmospherics/unary/vent_pump/toxlab_chamber_to_tank/south,
+/obj/machinery/atmospherics/unary/vent_pump/toxlab_chamber_to_tank/south{
+	frequency = 1225;
+	id = "Toxin Chamber Siphon";
+	on = 0
+	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
@@ -20349,11 +20399,6 @@
 /obj/machinery/computer3/terminal/zeta{
 	dir = 4;
 	setup_os_string = "ZETA_MAINFRAME"
-	},
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
 	},
 /turf/simulated/floor/grey,
 /area/station/engine/power{
@@ -20605,6 +20650,11 @@
 /obj/item/storage/wall/fire{
 	pixel_y = 32
 	},
+/obj/machinery/light_switch/north{
+	pixel_x = -11
+	},
+/obj/disposalpipe/trunk/south,
+/obj/machinery/disposal/small/west,
 /turf/simulated/floor/orange/corner{
 	dir = 4
 	},
@@ -20794,10 +20844,10 @@
 	name = "Erebus Plasmitics Zone"
 	})
 "NS" = (
+/obj/machinery/atmospherics/pipe/simple/insulated,
 /obj/machinery/atmospherics/valve{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/insulated,
 /obj/cable{
 	d1 = 2;
 	d2 = 4;
@@ -20858,6 +20908,7 @@
 	layer = 9.1;
 	pixel_x = 10
 	},
+/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/blue/side{
 	dir = 4
 	},
@@ -21092,6 +21143,7 @@
 	pixel_y = 20;
 	tag = ""
 	},
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria{
 	name = "Dionysus Primary Zone"
@@ -21399,6 +21451,7 @@
 	name = "autoname - SS13";
 	pixel_y = 20
 	},
+/obj/machinery/light_switch/north,
 /turf/simulated/floor/caution/south,
 /area/station/medical/robotics)
 "OG" = (
@@ -21520,6 +21573,7 @@
 	pixel_x = -10;
 	tag = ""
 	},
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "OQ" = (
@@ -21722,6 +21776,7 @@
 	pixel_x = 10;
 	tag = ""
 	},
+/obj/machinery/light_switch/east,
 /turf/simulated/floor/black,
 /area/station/bridge/captain{
 	name = "Meridian Command"
@@ -23441,6 +23496,7 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
+/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
@@ -23522,6 +23578,11 @@
 /area/station/maintenance/SWmaint{
 	name = "Erebus Maintenance Room"
 	})
+"Sj" = (
+/obj/machinery/chem_heater,
+/obj/machinery/light_switch/north,
+/turf/simulated/floor/specialroom/arcade,
+/area/station/chemistry)
 "Sl" = (
 /obj/machinery/portable_reclaimer,
 /obj/machinery/door_control{
@@ -23676,6 +23737,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/plating,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
@@ -23742,6 +23804,7 @@
 	d2 = 4;
 	icon_state = "5-8"
 	},
+/obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/engine,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
@@ -23826,6 +23889,15 @@
 /turf/simulated/floor/grey,
 /area/station/maintenance/SWmaint{
 	name = "Erebus Maintenance Room"
+	})
+"Th" = (
+/obj/shrub{
+	dir = 8
+	},
+/obj/machinery/light_switch/east,
+/turf/simulated/floor/grass,
+/area/station/aviary{
+	name = "Demeter Primary Zone"
 	})
 "Tj" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
@@ -23984,6 +24056,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/engine,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
@@ -23997,6 +24070,8 @@
 	on = 1;
 	target_pressure = 1000
 	},
+/obj/machinery/disposal/small/east,
+/obj/disposalpipe/trunk/east,
 /turf/simulated/floor/engine/caution/south,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
@@ -24036,6 +24111,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/orange/corner{
 	dir = 4
 	},
@@ -24075,6 +24151,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/engine,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
@@ -24103,6 +24180,15 @@
 "Ud" = (
 /obj/machinery/atmospherics/binary/circulatorTemp/right,
 /turf/simulated/floor/darkpurple,
+/area/station/engine/core{
+	name = "Erebus Plasmitics Zone"
+	})
+"Uf" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 6
+	},
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/engine,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
 	})
@@ -24251,6 +24337,7 @@
 	on = 1;
 	target_pressure = 1000
 	},
+/obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/engine/caution/south,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
@@ -24438,6 +24525,7 @@
 	dir = 4;
 	pixel_x = 12
 	},
+/obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/engine,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
@@ -24553,6 +24641,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/engine,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
@@ -24800,6 +24889,10 @@
 /area/station/solar/small_backup1{
 	name = "Erebus Solar Array"
 	})
+"Wo" = (
+/obj/machinery/light_switch/west,
+/turf/simulated/floor/black,
+/area/station/chapel/main)
 "Wp" = (
 /obj/disposalpipe/segment/transport,
 /obj/disposalpipe/segment/transport{
@@ -24959,6 +25052,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/caution/west,
 /area/station/hallway/primary/east{
 	name = "Erebus Primary Zone"
@@ -24982,6 +25076,7 @@
 /obj/machinery/atmospherics/pipe/tank{
 	dir = 4
 	},
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/engine,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
@@ -25004,6 +25099,7 @@
 /obj/cable{
 	icon_state = "4-9"
 	},
+/obj/disposalpipe/segment/bent/east,
 /turf/simulated/floor/engine,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
@@ -25153,6 +25249,7 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
+/obj/disposalpipe/junction/left/south,
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
@@ -25324,6 +25421,15 @@
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
 	})
+"XQ" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light_switch/north,
+/turf/simulated/floor/black,
+/area/station/security/main{
+	name = "Hammer Primary Concourse"
+	})
 "XT" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -25403,6 +25509,12 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
+	})
+"Yh" = (
+/obj/machinery/light_switch/north,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/cafeteria{
+	name = "Dionysus Primary Zone"
 	})
 "Yj" = (
 /obj/cable{
@@ -25498,6 +25610,7 @@
 	})
 "Yx" = (
 /obj/machinery/manufacturer/general,
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint{
 	name = "Erebus Maintenance Room"
@@ -25575,6 +25688,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/engine,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
@@ -25604,6 +25718,7 @@
 	master_id = "engine_combust_control";
 	name = "Gas Mixer (Combustion Chamber)"
 	},
+/obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/engine,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
@@ -25629,6 +25744,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/engine,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
@@ -25788,6 +25904,7 @@
 	pixel_x = 17;
 	pixel_y = 12
 	},
+/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/blue/side{
 	dir = 4
 	},
@@ -25835,6 +25952,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/engine,
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
@@ -25929,6 +26047,7 @@
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 5
 	},
+/obj/disposalpipe/segment/bent/west,
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 10
 	},
@@ -57305,7 +57424,7 @@ Dh
 EE
 Pm
 Dh
-Ey
+Th
 Dh
 Dh
 Dh
@@ -59371,7 +59490,7 @@ mo
 mV
 ny
 kT
-nS
+XQ
 pd
 pt
 pN
@@ -62153,7 +62272,7 @@ bY
 cl
 cy
 bV
-cg
+Sj
 dv
 dN
 ek
@@ -63019,7 +63138,7 @@ Op
 ut
 wM
 tL
-xe
+Yh
 yu
 yI
 hf
@@ -65146,7 +65265,7 @@ Ae
 Az
 AJ
 AT
-Bi
+Wo
 BA
 BT
 Pd
@@ -76330,7 +76449,7 @@ Yf
 Yf
 Vl
 WW
-Zb
+Uf
 ZP
 VH
 UN


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Another Fleet fix set bringing the map vaguely closer to being a real map.

- Removed an errant light tube on the Erebus.
- Installed a mistakenly absent pump control computer on the Erebus (prevents engine from functioning without major janky workarounds).
- Installed disposal chutes on the Erebus.
- More light switches!
- Asclepius crusher door now operates as intended.
- Refreshed tree instances.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes a good share of the problems with Fleet that aren't intentional.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Kubius:
(+)More Fleet fixes to make the map slightly closer to bearable.
```
