### PR TITLE
Lets players put contents of small storage items into disposals chutes.

### DIFF
--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -87,7 +87,7 @@
 				return
 		if (istype(I,/obj/item/storage/))
 			var/action = input(user, "What do you want to do with [I]?") as null|anything in list("Empty it into the chute","Place it in the Chute")
-			if (get_dist(src,user) > 1)
+			if (!in_range(src, user))
 				boutput(user, "<span class='alert'>You need to be closer to the chute to do that.</span>")
 				return
 			if (action == "Empty it into the chute")

--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -85,6 +85,19 @@
 				S.satchel_updateicon()
 				user.visible_message("<b>[user.name]</b> dumps out [S] into [src].")
 				return
+		if (istype(I,/obj/item/storage/))
+			var/action = input(user, "What do you want to do with [I]?") as null|anything in list("Empty it into the chute","Place it in the Chute")
+			if (get_dist(src,user) > 1)
+				boutput(user, "<span class='alert'>You need to be closer to the chute to do that.</span>")
+				return
+			if (action == "Empty it into the chute")
+				var/obj/item/storage/S = I
+				for(var/obj/item/O in S)
+					O.set_loc(src)
+					S.hud.remove_object(O)
+				user.visible_message("<b>[user.name]</b> dumps out [S] into [src].")
+				return
+			if (isnull(action)) return
 		var/obj/item/magtractor/mag
 		if (istype(I.loc, /obj/item/magtractor))
 			mag = I.loc


### PR DESCRIPTION
## About the PR
Lets players dump the contents of holdable storage items (i.e. backpacks, boxes) into disposals chutes.

## Why's this needed?
It adds a more convenient way for players to move large amounts of items into the disposals system.  Right now it's mostly janitors who have notable or convenient interactions with disposals.  Which makes sense, but doesn't mean other roles should be totally out of luck.  Janitors will still have garbage bags and the trash cart to themselves, this just gives anyone with a box or a backpack on hand a more convenient option.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->
+ Made storage items able to be emptied into disposals chutes via a new dialog.