### PR TITLE
makes explosions more consistently delete objects

### DIFF
--- a/code/obj.dm
+++ b/code/obj.dm
@@ -43,22 +43,20 @@
 		updateHealth(prevHealth)
 		return
 	proc/updateHealth(var/prevHealth)
-		/*
+
 		if(_health <= 0)
 			onDestroy()
-		else
+/*		else
 			if((_health > 75) && !(prevHealth > 75))
-				UpdateOverlays(null, "damage")
+				//UpdateOverlays(null, "damage")
 			else if((_health <= 75 && _health > 50) && !(prevHealth <= 75 && prevHealth > 50))
-				setTexture("damage1", BLEND_MULTIPLY, "damage")
+				//setTexture("damage1", BLEND_MULTIPLY, "damage")
 			else if((_health <= 50 && _health > 25) && !(prevHealth <= 50 && prevHealth > 25))
-				setTexture("damage2", BLEND_MULTIPLY, "damage")
+				//setTexture("damage2", BLEND_MULTIPLY, "damage")
 			else if((_health <= 25) && !(prevHealth <= 25))
-				setTexture("damage3", BLEND_MULTIPLY, "damage")
-		*/
-		return
+				//setTexture("damage3", BLEND_MULTIPLY, "damage")
+		return*/
 	proc/onDestroy()
-		src.visible_message("<span class='alert'><b>[src] is destroyed.</b></span>")
 		qdel(src)
 		return
 
@@ -71,7 +69,7 @@
 			src.material.triggerExp(src, severity)
 		switch(severity)
 			if(1.0)
-				changeHealth(-95)
+				changeHealth(-100)
 				return
 			if(2.0)
 				changeHealth(-70)


### PR DESCRIPTION
[ENHANCEMENT]
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
originally i was gonna write this code myself, but it seems like this was tended to be used (but commented out). i enabled / modified some of it so that more stuff should die to explosions. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
stuff like blowing the whole bar up but the sink stays there. i want to see how this change feels in game before giving it more effort. right now it should work pretty plainly, but for everything.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)adharainspace:
(+)explosions should more consistently blow up stuff like kitchen equipment.
```
