### PR TITLE
Fixes double bump when throwing items and bump fixes for the crusher

### DIFF
--- a/code/WorkInProgress/recycling/crusher.dm
+++ b/code/WorkInProgress/recycling/crusher.dm
@@ -25,9 +25,6 @@
 	if(istype(AM,/obj/item/scrap))
 		return
 
-	if(world.timeofday - AM.last_bumped <= 60)
-		return
-
 	if(ismob(AM))
 		var/mob/M = AM
 		M.set_loc(src.loc)

--- a/code/atom/throwing.dm
+++ b/code/atom/throwing.dm
@@ -206,9 +206,8 @@
 /obj/item/Bump(mob/M as mob)
 	if (src.throwing)
 		var/lt = src.throwing
-		SPAWN_DBG( 0 ) //responsible for race conditions in throw code that this ugly fix exists for! i'm very afraid to remove this!!!
-			src.throwing = lt //throw_at has long since set throwing back to 0 at the end, so lets do this so that our parent can use throwing pproperly ugh
-			..()
+		src.throwing = lt //throw_at has long since set throwing back to 0 at the end, so lets do this so that our parent can use throwing pproperly ugh
+	..()
 	return
 
 /atom/movable/proc/throw_at(atom/target, range, speed, list/params, turf/thrown_from, throw_type = 1, allow_anchored = 0)

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -1224,12 +1224,12 @@
 		playsound(T, "sound/impact_sounds/Glass_Shatter_[rand(1,3)].ogg", 100, 1)
 		for (var/i=src.shard_amt, i > 0, i--)
 			var/obj/item/raw_material/shard/glass/G = unpool(/obj/item/raw_material/shard/glass)
-			G.set_loc(T)
+			G.set_loc(src.loc)
 		if (src.in_glass)
-			src.in_glass.set_loc(T)
+			src.in_glass.set_loc(src.loc)
 			src.in_glass = null
 		if (src.wedge)
-			src.wedge.set_loc(T)
+			src.wedge.set_loc(src.loc)
 			src.wedge = null
 		qdel(src)
 
@@ -1520,7 +1520,7 @@
 		playsound(T, "sound/impact_sounds/Glass_Shatter_[rand(1,3)].ogg", 100, 1)
 		for (var/i=src.shard_amt, i > 0, i--)
 			var/obj/item/raw_material/shard/glass/G = unpool(/obj/item/raw_material/shard/glass)
-			G.set_loc(T)
+			G.set_loc(src.loc)
 		qdel(src)
 
 	throw_impact(var/atom/A)

--- a/code/modules/chemistry/tools/vendor_items.dm
+++ b/code/modules/chemistry/tools/vendor_items.dm
@@ -52,7 +52,7 @@
 		T.visible_message("<span class='alert'>[src] shatters!</span>")
 		playsound(T, pick('sound/impact_sounds/Glass_Shatter_1.ogg','sound/impact_sounds/Glass_Shatter_2.ogg','sound/impact_sounds/Glass_Shatter_3.ogg'), 100, 1)
 		var/obj/item/raw_material/shard/glass/G = unpool(/obj/item/raw_material/shard/glass)
-		G.set_loc(T)
+		G.set_loc(src.loc)
 
 		qdel(src)
 

--- a/code/modules/medical/surgery_tools.dm
+++ b/code/modules/medical/surgery_tools.dm
@@ -1564,7 +1564,8 @@ keeping this here because I want to make something else with it eventually
 		src.attached_objs.Add(I) // attach the item to the table
 		I.glide_size = 0 // required for smooth movement with the tray
 		// register for pickup, register for being pulled off the table, register for item deletion while attached to table
-		RegisterSignal(I, list(COMSIG_ITEM_PICKUP, COMSIG_MOVABLE_MOVED, COMSIG_PARENT_PRE_DISPOSING), .proc/detach)
+		SPAWN_DBG(0)
+			RegisterSignal(I, list(COMSIG_ITEM_PICKUP, COMSIG_MOVABLE_MOVED, COMSIG_PARENT_PRE_DISPOSING), .proc/detach)
 
 	proc/detach(obj/item/I as obj) //remove from the attached items list and deregister signals
 		src.attached_objs.Remove(I)

--- a/code/turf/turf.dm
+++ b/code/turf/turf.dm
@@ -294,7 +294,7 @@ var/global/client/ff_debugger = null
 						if (!mover.throwing)
 							mover.Bump(obstacle, 1)
 						return 0
-				else //cheaper, skip proc call lol lold
+				else //cheaper, skip proc call lol lol
 					if (obstacle.density)
 						if (!mover.throwing)
 							mover.Bump(obstacle,1)

--- a/code/turf/turf.dm
+++ b/code/turf/turf.dm
@@ -291,11 +291,13 @@ var/global/client/ff_debugger = null
 			if ((forget != obstacle))
 				if(obstacle.event_handler_flags & USE_CANPASS)
 					if(!obstacle.CanPass(mover, cturf, 1, 0))
-						mover.Bump(obstacle, 1)
+						if (!mover.throwing)
+							mover.Bump(obstacle, 1)
 						return 0
-				else //cheaper, skip proc call lol lol
+				else //cheaper, skip proc call lol lold
 					if (obstacle.density)
-						mover.Bump(obstacle,1)
+						if (!mover.throwing)
+							mover.Bump(obstacle,1)
 						return 0
 	return 1 //Nothing found to block so return success!
 

--- a/code/turf/turf.dm
+++ b/code/turf/turf.dm
@@ -291,13 +291,13 @@ var/global/client/ff_debugger = null
 			if ((forget != obstacle))
 				if(obstacle.event_handler_flags & USE_CANPASS)
 					if(!obstacle.CanPass(mover, cturf, 1, 0))
-						if (!mover.throwing)
-							mover.Bump(obstacle, 1)
+
+						mover.Bump(obstacle, 1)
 						return 0
 				else //cheaper, skip proc call lol lol
 					if (obstacle.density)
-						if (!mover.throwing)
-							mover.Bump(obstacle,1)
+
+						mover.Bump(obstacle,1)
 						return 0
 	return 1 //Nothing found to block so return success!
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][MAJOR][RUNTIME] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds checks to see if a mover has been thrown before calling bump on it. Even if the check fails the item will still have bumped called on it by BYOND's own internal proc calls. It just won't have it called a second time by `turf/Enter()`



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
After the following BYOND bugfix bump has been getting called twice when objects are thrown.
http://www.byond.com/forum/post/2385885


This has caused several issues, such as the crusher not working correctly, and also breaking surgery tables / kitchen islands causing them to runtime as shown below.
```
[10:37:44] _component.dm,580: itm_pickup overridden. Use override = TRUE to suppress this warning
proc name: stack trace (/proc/stack_trace)
  source file: _component.dm,580
  usr: (src)
  src: null
  call stack:
stack trace("itm_pickup overridden. Use ove...")
the tray (/obj/surgery_tray): RegisterSignal(the human\'s right eye (/obj/item/organ/eye/right), /list (/list), /obj/surgery_tray/proc/detach (/obj/surgery_tray/proc/detach), 0)
the tray (/obj/surgery_tray): attach(the human\'s right eye (/obj/item/organ/eye/right))
the tray (/obj/surgery_tray): hitby(the human\'s right eye (/obj/item/organ/eye/right))
the human\'s right eye (/obj/item/organ/eye/right): throw impact(the tray (/obj/surgery_tray), null)
the human\'s right eye (/obj/item/organ/eye/right): throw impact(the tray (/obj/surgery_tray))
the human\'s right eye (/obj/item/organ/eye/right): Bump(the tray (/obj/surgery_tray))
```

closes #1615
closes #1670

There is some question my mind if this SPAWN_DBG(0) call is the root of the issue, but comments have made me afraid to alter it
```
/atom/movable/Bump(atom/O)
	if(src.throwing)
		src.throw_impact(O)
		src.throwing = 0
	..()

/obj/item/Bump(mob/M as mob)
	if (src.throwing)
		var/lt = src.throwing
		SPAWN_DBG( 0 ) //responsible for race conditions in throw code that this ugly fix exists for! i'm very afraid to remove this!!!
			src.throwing = lt //throw_at has long since set throwing back to 0 at the end, so lets do this so that our parent can use throwing pproperly ugh
			..()
	return
```