### PR TITLE
fix cloaked panellus icon

### DIFF
--- a/code/modules/hydroponics/plant_mutations.dm
+++ b/code/modules/hydroponics/plant_mutations.dm
@@ -449,7 +449,7 @@
 
 /datum/plantmutation/fungus/cloak
 	name = "Cloaked Panellus"
-	iconmod = "Cloak"
+	iconmod = "FungusCloak"
 	crop = /obj/item/reagent_containers/food/snacks/mushroom/cloak
 	PTrange = list(null,10) //low potency
 	CZrange = list(25,null) // high crop size


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The Cloaked Panellus fungus mutation had the wrong iconmod set, so it just appeared as FIXTHISSHIT in game.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Mushroom is prettier.