### PR TITLE
/proc/shoot_reflected_bounce improvements and Meowitzer sound / screen shake tweaks

### DIFF
--- a/_std/_setup.dm
+++ b/_std/_setup.dm
@@ -709,6 +709,11 @@ proc/default_frequency_color(freq)
 #define D_TOXIC 48
 #define D_SPECIAL 128
 
+//Projectile reflection defines
+#define PROJ_NO_HEADON_BOUNCE 1
+#define PROJ_HEADON_BOUNCE 2
+#define PROJ_RAPID_HEADON_BOUNCE 3
+
 //Missing limb flags
 #define LIMB_LEFT_ARM 1
 #define LIMB_RIGHT_ARM 2

--- a/code/modules/projectiles/energy_bolt.dm
+++ b/code/modules/projectiles/energy_bolt.dm
@@ -61,12 +61,11 @@ toxic - poisons
 /datum/projectile/energy_bolt/bouncy
 	name = "ricochet energy bolt"
 	var/max_bounce_count = 1
-	var/allow_headon_bounce = 0
 	var/reflect_on_nondense_hits = 0
 
 	on_hit(atom/hit, direction, obj/projectile/P)
 		if (!ismob(hit))
-			if (shoot_reflected_bounce(P, hit, max_bounce_count, allow_headon_bounce, reflect_on_nondense_hits))
+			if (shoot_reflected_bounce(P, hit, max_bounce_count, PROJ_NO_HEADON_BOUNCE, reflect_on_nondense_hits))
 				elecflash(get_turf(P),radius=0, power=2, exclude_center = 0)
 		..()
 

--- a/code/modules/projectiles/energy_bolt.dm
+++ b/code/modules/projectiles/energy_bolt.dm
@@ -61,7 +61,7 @@ toxic - poisons
 /datum/projectile/energy_bolt/bouncy
 	name = "ricochet energy bolt"
 	var/max_bounce_count = 1
-	var/reflect_on_nondense_hits = 0
+	var/reflect_on_nondense_hits = FALSE
 
 	on_hit(atom/hit, direction, obj/projectile/P)
 		if (!ismob(hit))

--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -1033,15 +1033,15 @@ datum/projectile/snowball
 			if ((P.shooter.x == reflector.x) || (P.shooter.y == reflector.y))
 				return
 		if (PROJ_HEADON_BOUNCE) // no rapid head-on bounce
-			if (abs(P.shooter.x - reflector.x) == 0 && abs(P.shooter.y - reflector.y) == 2)
+			if ((P.shooter.x == reflector.x) && abs(P.shooter.y - reflector.y) == 2)
 				return
-			else if (abs(P.shooter.x - reflector.x) == 2 && abs(P.shooter.y - reflector.y) == 0)
+			else if (abs(P.shooter.x - reflector.x) == 2 && (P.shooter.y == reflector.y))
 				return
 		if (PROJ_RAPID_HEADON_BOUNCE)
 			if (P.proj_data.shot_sound)
-				if (abs(P.shooter.x - reflector.x) == 0 && abs(P.shooter.y - reflector.y) == 2)
+				if ((P.shooter.x == reflector.x) && abs(P.shooter.y - reflector.y) == 2)
 					play_shot_sound = FALSE //anti-ear destruction
-				else if (abs(P.shooter.x - reflector.x) == 2 && abs(P.shooter.y - reflector.y) == 0)
+				else if (abs(P.shooter.x - reflector.x) == 2 && (P.shooter.y == reflector.y))
 					play_shot_sound = FALSE //anti-ear destruction
 
 	/*

--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -924,7 +924,7 @@ datum/projectile/snowball
 		P.rotateDirection(prob(50) ? spread : -spread)
 	return P
 
-/proc/initialize_projectile(var/turf/S, var/datum/projectile/DATA, var/xo, var/yo, var/shooter = null, var/turf/remote_sound_source)
+/proc/initialize_projectile(var/turf/S, var/datum/projectile/DATA, var/xo, var/yo, var/shooter = null, var/turf/remote_sound_source, var/play_shot_sound = TRUE)
 	if (!S)
 		return
 	var/obj/projectile/P = unpool(/obj/projectile)
@@ -946,13 +946,14 @@ datum/projectile/snowball
 	if(remote_sound_source)
 		shooter = remote_sound_source
 
-	if (narrator_mode)
-		playsound(S, 'sound/vox/shoot.ogg', 50, 1)
-	else if(DATA.shot_sound && DATA.shot_volume && shooter)
-		playsound(S, DATA.shot_sound, DATA.shot_volume, 1,DATA.shot_sound_extrarange)
-		if (isobj(shooter))
-			for (var/mob/M in shooter)
-				M << sound(DATA.shot_sound, volume=DATA.shot_volume)
+	if (play_shot_sound)
+		if (narrator_mode)
+			playsound(S, 'sound/vox/shoot.ogg', 50, 1)
+		else if(DATA.shot_sound && DATA.shot_volume && shooter)
+			playsound(S, DATA.shot_sound, DATA.shot_volume, 1,DATA.shot_sound_extrarange)
+			if (isobj(shooter))
+				for (var/mob/M in shooter)
+					M << sound(DATA.shot_sound, volume=DATA.shot_volume)
 
 #ifdef DATALOGGER
 	if (game_stats && istype(game_stats))
@@ -1018,18 +1019,30 @@ datum/projectile/snowball
  * So I made my own proc, but left the old one in place just in case -- Sovexe
  * var/reflect_on_nondense_hits - flag for handling hitting objects that let bullets pass through like secbots, rather than duplicating projectiles
  */
-/proc/shoot_reflected_bounce(var/obj/projectile/P, var/obj/reflector, var/max_reflects = 3, var/allow_headon_bounce = 0, var/reflect_on_nondense_hits = 0)
+/proc/shoot_reflected_bounce(var/obj/projectile/P, var/obj/reflector, var/max_reflects = 3, var/mode = PROJ_RAPID_HEADON_BOUNCE, var/reflect_on_nondense_hits = 0)
+	if (!P || !reflector)
+		return
+
 	if(P.reflectcount >= max_reflects)
 		return
 
-	if (allow_headon_bounce)
-		//stop breaking the world you fuck!
-		if (abs(P.shooter.x - reflector.x) == 0 && abs(P.shooter.y - reflector.y) == 2)
-			return
-		else if (abs(P.shooter.x - reflector.x) == 2 && abs(P.shooter.y - reflector.y) == 0)
-			return
-	else if (abs(P.shooter.x - reflector.x) == 0 || abs(P.shooter.y - reflector.y) == 0)
-		return //no headon bounces
+	var/play_shot_sound = TRUE
+
+	switch (mode)
+		if (PROJ_NO_HEADON_BOUNCE) //no head-on bounce
+			if ((P.shooter.x == reflector.x) || (P.shooter.y == reflector.y))
+				return
+		if (PROJ_HEADON_BOUNCE) // no rapid head-on bounce
+			if (abs(P.shooter.x - reflector.x) == 0 && abs(P.shooter.y - reflector.y) == 2)
+				return
+			else if (abs(P.shooter.x - reflector.x) == 2 && abs(P.shooter.y - reflector.y) == 0)
+				return
+		if (PROJ_RAPID_HEADON_BOUNCE)
+			if (P.proj_data.shot_sound)
+				if (abs(P.shooter.x - reflector.x) == 0 && abs(P.shooter.y - reflector.y) == 2)
+					play_shot_sound = FALSE //anti-ear destruction
+				else if (abs(P.shooter.x - reflector.x) == 2 && abs(P.shooter.y - reflector.y) == 0)
+					play_shot_sound = FALSE //anti-ear destruction
 
 	/*
 		* We have to calculate our incidence each time
@@ -1075,7 +1088,7 @@ datum/projectile/snowball
 		return // unknown error
 
 	//spawns the new projectile in the same location as the existing one, not inside the hit thing
-	var/obj/projectile/Q = initialize_projectile(get_turf(P), P.proj_data, rx, ry, reflector)
+	var/obj/projectile/Q = initialize_projectile(get_turf(P), P.proj_data, rx, ry, reflector, play_shot_sound = play_shot_sound)
 	if (!Q)
 		return
 	Q.reflectcount = P.reflectcount + 1

--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -1043,6 +1043,8 @@ datum/projectile/snowball
 					play_shot_sound = FALSE //anti-ear destruction
 				else if (abs(P.shooter.x - reflector.x) == 2 && (P.shooter.y == reflector.y))
 					play_shot_sound = FALSE //anti-ear destruction
+		else
+			return
 
 	/*
 		* We have to calculate our incidence each time

--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -1019,7 +1019,7 @@ datum/projectile/snowball
  * So I made my own proc, but left the old one in place just in case -- Sovexe
  * var/reflect_on_nondense_hits - flag for handling hitting objects that let bullets pass through like secbots, rather than duplicating projectiles
  */
-/proc/shoot_reflected_bounce(var/obj/projectile/P, var/obj/reflector, var/max_reflects = 3, var/mode = PROJ_RAPID_HEADON_BOUNCE, var/reflect_on_nondense_hits = 0)
+/proc/shoot_reflected_bounce(var/obj/projectile/P, var/obj/reflector, var/max_reflects = 3, var/mode = PROJ_RAPID_HEADON_BOUNCE, var/reflect_on_nondense_hits = FALSE)
 	if (!P || !reflector)
 		return
 

--- a/code/modules/projectiles/special.dm
+++ b/code/modules/projectiles/special.dm
@@ -402,7 +402,7 @@ ABSTRACT_TYPE(/datum/projectile/special)
 	var/max_bounce_count = 50
 
 	on_hit(atom/A, direction, projectile)
-		shoot_reflected_bounce(projectile, A, max_bounce_count)
+		shoot_reflected_bounce(projectile, A, max_bounce_count, PROJ_RAPID_HEADON_BOUNCE)
 		var/turf/T = get_turf(A)
 
 		//prevent playing all 50 sounds at once on rapid bounce

--- a/code/modules/projectiles/special.dm
+++ b/code/modules/projectiles/special.dm
@@ -398,23 +398,21 @@ ABSTRACT_TYPE(/datum/projectile/special)
 	var/explosive_hits = 1
 	var/explosion_power = 30
 	var/hit_sound = 'sound/voice/animal/cat.ogg'
+	var/last_sound_time = 0 // anti-ear destruction
 	var/max_bounce_count = 50
-	var/allow_headon_bounce = 1
 
 	on_hit(atom/A, direction, projectile)
-		shoot_reflected_bounce(projectile, A, max_bounce_count, allow_headon_bounce)
+		shoot_reflected_bounce(projectile, A, max_bounce_count)
 		var/turf/T = get_turf(A)
-		playsound(A, hit_sound, 60, 1)
+
+		//prevent playing all 50 sounds at once on rapid bounce
+		if(world.time >= last_sound_time + 1 DECI SECOND)
+			last_sound_time = world.time
+			playsound(A, hit_sound, 60, 1)
 
 		if (explosive_hits)
-			SPAWN_DBG(1 DECI SECOND)
-				for(var/mob/living/M in mobs)
-					shake_camera(M, 2, 1)
-
 			SPAWN_DBG(0)
 				explosion_new(projectile, T, explosion_power, 1)
-			if(prob(50))
-				playsound(A, hit_sound, 60, 1)
 		return
 
 /datum/projectile/special/meowitzer/inert


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][FEATURE][REWORK]-->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Takes advantage of the changes in #1602 that now makes rapid head on bouncing possible without the world run timing from infinite loops
- Adds a new `play_shot_sound` flag to `initialize_projectile`
- Removes meowitzer global mob screen shake call.
- Adds a time check to the meowitzer meow noise of 1 decisecond
- Adds three new defines for controlling how bouncy projectiles are


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
- Prevents playing of all bounce shot sounds at the same time / destruction of ears and speakers
- Likewise prevents the meowtizer meows from doing the same thing
- Meowtizer explosions already shake the screen, no need to shake them even more, or from an entirely different Z level
- New defines allow for simpler customization of bouncy projectiles