### PR TITLE
Adds a safe version of Supply Drop

### DIFF
--- a/code/modules/events/supply_drop.dm
+++ b/code/modules/events/supply_drop.dm
@@ -47,6 +47,7 @@
 	anchored = 1
 	plane = PLANE_FLOCKVISION
 	var/dropTime = 30
+	var/gib_mobs = TRUE
 
 	New()
 		pixel_y = 480
@@ -57,12 +58,15 @@
 			playsound(src.loc, 'sound/effects/ExplosionFirey.ogg', 100, 1)
 			for(var/mob/M in view(7, src.loc))
 				shake_camera(M, 20, 1)
-				if(M.loc == src.loc)
+				if(gib_mobs && M.loc == src.loc)
 					M.gib(1, 1)
 			sleep(0.5 SECONDS)
 			new/obj/lootbox(src.loc)
 			qdel(src)
 		..()
+
+/obj/effect/supplydrop/safe
+	gib_mobs = FALSE
 
 /obj/effect/supplyexplosion
 	name = ""


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][FEATURE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a safe version of the supply drop that doesn't gib players if it lands on them


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
So that giving all the players a supply drop doesn't gib half the server and all 6 nuke ops