### PR TITLE
Clarify Mechanics "two teleporters" Objective

### DIFF
--- a/code/datums/crew_objective.dm
+++ b/code/datums/crew_objective.dm
@@ -316,7 +316,7 @@ ABSTRACT_TYPE(/datum/objective/crew/mechanic)
 			if(mechanic_controls.scanned_items.len > 9) return 1
 			else return 0
 	teleporter
-		explanation_text = "Ensure that there are at least two teleporters on the station level at the end of the round, excluding the science teleporter."
+		explanation_text = "Ensure that there are at least two functioning command teleporter consoles, complete with portal generators and portal rings, on the station level at the end of the round."
 		medal_name = "It's not 'Door to Heaven'"
 		check_completion()
 			var/telecount = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Clarifies a confusing objective explanation for mechanics

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I consistently see newer mechanics confuse this objective to be talking about the mechanics teleporter components.

old text:

`explanation_text = "Ensure that there are at least two teleporters on the station level at the end of the round, excluding the science teleporter."`

new text:

`explanation_text = "Ensure that there are at least two functioning command teleporter consoles, complete with portal generators and portal rings, on the station level at the end of the round."    `
