### PR TITLE
fix cryoxadone heating

### DIFF
--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -1285,7 +1285,7 @@ datum
 					if (M.get_brain_damage())
 						M.take_brain_damage(-2 * mult)
 					M.HealDamage("All", 12 * mult, 12 * mult)
-
+					M.updatehealth() //I hate this, but we actually need the health on time here.
 					if(M.health > health_before)
 						var/increase = min((M.health - health_before)/37*25,25) //12+12+3+10 = 37 health healed possible, 25 max temp increase possible
 						M.bodytemperature = min(M.bodytemperature+increase,M.base_body_temp)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Cryoxadone now directly updates health when before checking to determine temp change
(gets a changelog entry because it'll affect cryopill mixes a fair bit)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Cryoxadone is supposed to heat you up based on damage healed, but health queuing broke that. This fixes it


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Tarmunora:
(+)Cryoxadone will now properly heat the patient based on damage healed.
```
