### PR TITLE
fix eaten bioeffect not displaying correctly

### DIFF
--- a/code/modules/medical/genetics/bioEffects/non_genetic.dm
+++ b/code/modules/medical/genetics/bioEffects/non_genetic.dm
@@ -66,7 +66,7 @@
 
 	OnMobDraw()
 		if (ishuman(owner) && !owner:decomp_stage)
-			owner:body_standing:overlays += image('icons/mob/human.dmi', "decomp1")
+			owner:body_standing:overlays += image('icons/mob/human_decomp.dmi', "decomp1")
 		return
 
 	OnAdd()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
"eaten" bioeffect didn't correctly display on a person, since it tried to get the decomp1 sprite from human.dmi rather than human_decomp.dmi.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's good if features that are in the game work.