### PR TITLE
fixes unlimited fire burp and rangefinding glitches.

### DIFF
--- a/code/modules/status_system/statusFoodBuffs.dm
+++ b/code/modules/status_system/statusFoodBuffs.dm
@@ -302,8 +302,10 @@
 	proc/cast()
 
 		var/turf/T = get_step(owner,owner.dir)
-		while(get_dist(owner,T) < range)
+		var/whileexit = 1
+		while(get_dist(owner,T) < range && whileexit < 20)
 			T = get_step(T,owner.dir)
+			whileexit += 1
 		var/list/affected_turfs = getline(owner, T)
 
 		owner.visible_message("<span class='alert'><b>[owner] burps a stream of fire!</b></span>")

--- a/code/modules/status_system/statusFoodBuffs.dm
+++ b/code/modules/status_system/statusFoodBuffs.dm
@@ -302,10 +302,10 @@
 	proc/cast()
 
 		var/turf/T = get_step(owner,owner.dir)
-		var/whileexit = 1
-		while((get_dist(owner,T) < range) && (whileexit < 20))
+		var/range_breath = 1
+		while((get_dist(owner,T) < range) && (range_breath < 20))// range is used for the range the fireburp can reach from the caster.
 			T = get_step(T,owner.dir)
-			whileexit += 1
+			range_breath ++ //range_breath is used to make sure the loop doesn't stay active too long and lag the game if something messes up range.
 		var/list/affected_turfs = getline(owner, T)
 
 		owner.visible_message("<span class='alert'><b>[owner] burps a stream of fire!</b></span>")
@@ -328,7 +328,7 @@
 
 		//reduce duration
 		src.duration -= min(durationLoss,src.duration)
-		if(src.duration <= 0)
+		if(src.duration <= 0)//without this check, it will get stuck at 0 and never go away.
 			if(src.owner)
 				src.owner.delStatus(src)
 

--- a/code/modules/status_system/statusFoodBuffs.dm
+++ b/code/modules/status_system/statusFoodBuffs.dm
@@ -303,7 +303,7 @@
 
 		var/turf/T = get_step(owner,owner.dir)
 		var/whileexit = 1
-		while(get_dist(owner,T) < range && whileexit < 20)
+		while((get_dist(owner,T) < range) && (whileexit < 20))
 			T = get_step(T,owner.dir)
 			whileexit += 1
 		var/list/affected_turfs = getline(owner, T)

--- a/code/modules/status_system/statusFoodBuffs.dm
+++ b/code/modules/status_system/statusFoodBuffs.dm
@@ -302,7 +302,8 @@
 	proc/cast()
 
 		var/turf/T = get_step(owner,owner.dir)
-		T = get_step(T,owner.dir)
+		while(get_dist(owner,T) < range)
+			T = get_step(T,owner.dir)
 		var/list/affected_turfs = getline(owner, T)
 
 		owner.visible_message("<span class='alert'><b>[owner] burps a stream of fire!</b></span>")
@@ -325,6 +326,9 @@
 
 		//reduce duration
 		src.duration -= min(durationLoss,src.duration)
+		if(src.duration <= 0)
+			if(src.owner)
+				src.owner.delStatus(src)
 
 /datum/statusEffect/explosion_resist
 	id = "food_explosion_resist"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUGFIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This fixes the bug that makes it so that using fire burps while there is 50 seconds or less remaining on the timer allows unlimited fire burps, and also restores fire burps to their intended range.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Two bugs, fixed.


## Changelog

```
(u)Chickenish:
(+)Chili burps are now working closer to as intended.
```
