### PR TITLE
fix trading herb substypes

### DIFF
--- a/code/datums/commodity.dm
+++ b/code/datums/commodity.dm
@@ -617,7 +617,7 @@
 
 /datum/commodity/drugs/cannabis
 	comname = "Cannabis"
-	comtype = /obj/item/plant/herb/cannabis/spawnable
+	comtype = /obj/item/plant/herb/cannabis
 	price = 150
 	baseprice = 150
 	upperfluc = 100
@@ -625,7 +625,7 @@
 
 /datum/commodity/drugs/cannabis_mega
 	comname = "Rainbow Cannabis"
-	comtype = /obj/item/plant/herb/cannabis/mega/spawnable
+	comtype = /obj/item/plant/herb/cannabis/mega
 	price = 700
 	baseprice = 700
 	upperfluc = 500
@@ -633,7 +633,7 @@
 
 /datum/commodity/drugs/cannabis_white
 	comname = "White Cannabis"
-	comtype = /obj/item/plant/herb/cannabis/white/spawnable
+	comtype = /obj/item/plant/herb/cannabis/white
 	price = 450
 	baseprice = 450
 	upperfluc = 200
@@ -641,7 +641,7 @@
 
 /datum/commodity/drugs/cannabis_omega
 	comname = "Omega Cannabis"
-	comtype = /obj/item/plant/herb/cannabis/omega/spawnable
+	comtype = /obj/item/plant/herb/cannabis/omega
 	price = 2500
 	baseprice = 2500
 	upperfluc = 2000

--- a/code/modules/economy/trader.dm
+++ b/code/modules/economy/trader.dm
@@ -283,27 +283,31 @@
 				sellitem = /obj/item/electronics
 			if(ispath(sellitem, /obj/item/parts/robot_parts))
 				sellitem = /obj/item/parts/robot_parts
+			var/goods_buy_types[0]
 			for(var/datum/commodity/N in goods_buy)
-				if(N.comtype == src.sellitem.type)
-					var/datum/data/record/account = null
-					account = FindBankAccountByName(src.scan.registered)
-					if (!account)
-						src.temp = {" [src] looks slightly agitated when he realizes there is no bank account associated with the ID card.<BR>
-									<BR><A href='?src=\ref[src];sell=1'>OK</A>"}
-						src.add_fingerprint(usr)
-						src.updateUsrDialog()
-						return
-					else
-						doing_a_thing = 1
-						src.temp = pick(src.successful_sale_dialogue) + "<BR>"
-						src.temp += "<BR><A href='?src=\ref[src];sell=1'>OK</A>"
-						qdel (src.sellitem)
-						src.sellitem = null
-						account.fields["current_money"] += N.price
-						src.add_fingerprint(usr)
-						src.updateUsrDialog()
-						doing_a_thing = 0
-						return
+				if (ispath(src.sellitem.type, N.comtype))
+					goods_buy_types[N.comtype] = N.price
+			if (goods_buy_types.len >= 1)
+				var/goods_type = maximal_subtype(goods_buy_types)
+				var/datum/data/record/account = null
+				account = FindBankAccountByName(src.scan.registered)
+				if (!account)
+					src.temp = {" [src] looks slightly agitated when he realizes there is no bank account associated with the ID card.<BR>
+								<BR><A href='?src=\ref[src];sell=1'>OK</A>"}
+					src.add_fingerprint(usr)
+					src.updateUsrDialog()
+					return
+				else
+					doing_a_thing = 1
+					src.temp = pick(src.successful_sale_dialogue) + "<BR>"
+					src.temp += "<BR><A href='?src=\ref[src];sell=1'>OK</A>"
+					qdel (src.sellitem)
+					src.sellitem = null
+					account.fields["current_money"] += goods_buy_types[goods_type]
+					src.add_fingerprint(usr)
+					src.updateUsrDialog()
+					doing_a_thing = 0
+					return
 			src.temp = {"[pick(failed_sale_dialogue)]<BR>
 						<BR><A href='?src=\ref[src];sell=1'>OK</A>"}
 

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -2581,4 +2581,40 @@ proc/client_has_cap_grace(var/client/C)
 	if (C.ckey in player_cap_grace)
 		.= (player_cap_grace[C.ckey] > TIME)
 
+proc/issubtype(var/T1, var/T2)
+	.= ispath(T1, T2) || ispath(T2, T1)
+/*
+this proc only finds the maximal subtype (i.e. the most subby) in a list if
+for all list elements T1 and T2, issubtype(T1, T2) is true
 
+*/
+proc/maximal_subtype(var/list/L)
+	.= null
+	if (L.len >= 1 && ispath(L[1]))
+		.= L[1]
+	// Looking for the type which is a child of all other types
+	if (L.len > 1)
+		var/i = 1
+		while (i <= L.len)
+			var/ispaths[L.len]
+			var/j = 1
+			var/x1
+			var/x2
+			while (j <= L.len)
+				x1 = L[i]
+				x2 = L[j]
+				ispaths[j] = ispath(x1, x2)
+				j += 1
+			if (all(ispaths))
+				.= x1
+				i = L.len+1
+			else
+				i += 1
+
+proc/all(var/list/L)
+	.= TRUE
+	if (L.len > 1)
+		var/i = 1
+		while((i <= L.len) && . )
+			.= . && L[i]
+			i += 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[BUGFIX]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

You can now trade both crate and grown weed with the sketchy trader! Wow!


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes issue #887

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Jawns:
(+)Fixed Sketchy D-5 not accepting both grown and crate weed
```
