### PR TITLE
Fix Double Drop - remove turf/Entered call from mob/proc/drop_item

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -1166,8 +1166,6 @@
 			if (W)
 				W.layer = initial(W.layer)
 
-			var/turf/T = get_turf(src.loc)
-			T.Entered(W)
 			u_equip(W)
 			.= 1
 		else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG][RUNTIME] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
removes `turf/Entered` call from `mob/proc/drop_item`

This direct call to `turf/Entered` isn't needed as `set_loc` already calls `turf/Entered` if the set location is a turf. In the event the the location isn't a turf `drop_item` calling `turf/Entered` is still inappropriate as it can result in bugs such as a player dropping an object inside of a locker and the item interacting with the turf. This can be further complicated if there is fluid on the tile as `turf/Entered` will also call the `obj/fluid/HasEntered` proc which can be exploited in a few ways by players

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #1713

`mob/drop_item` can call `turf/Entered` twice. 

Once from a `set_loc` call on line 1165
```
else
	W.set_loc(src.loc)
```
and then again on lin 1170
```
var/turf/T = get_turf(src.loc)
T.Entered(W)
```

This also means procs like `obj/fluid/HasEntered` get called twice, which can cause runtimes such as this


File | sponge_capsule.dm
-- | --
Line | 58
Error | Cannot execute null.visible message().

```
proc name: add water (/obj/item/toy/sponge_capsule/proc/add_water)
  source file: sponge_capsule.dm,58
  usr: Sov Extant (/mob/living/carbon/human)
  src: the space opossum capsule (/obj/item/toy/sponge_capsule)
  usr.loc: the steel floor (155,171,1) (/turf/simulated/floor)
  src.loc: null
  call stack:
the space opossum capsule (/obj/item/toy/sponge_capsule): add water()
the space opossum capsule (/obj/item/toy/sponge_capsule): EnteredFluid(the water (/obj/fluid), null)
the water (/obj/fluid): HasEntered(the space opossum capsule (/obj/item/toy/sponge_capsule), null)
the steel floor (155,171,1) (/turf/simulated/floor): Entered(the space opossum capsule (/obj/item/toy/sponge_capsule), null)
Sov Extant (/mob/living/carbon/human): drop item(the space opossum capsule (/obj/item/toy/sponge_capsule))
Sov Extant (/mob/living/carbon/human): hotkey("drop")
Sovexe (/client): .keydown("Q")
```
