### PR TITLE
Add Spawn-Supplydrop and supplydrop build mode cinematic

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -4639,6 +4639,28 @@ var/global/noir = 0
 		alert("You cannot perform this action. You must be of a higher administrative rank!", null, null, null, null, null)
 		return
 
+/datum/admins/proc/supplydrop_spawn_obj(var/obj/object as text)
+	SET_ADMIN_CAT(ADMIN_CAT_NONE)
+	set desc="(object path) Spawn an object. But all fancy-like"
+	set name="Spawn-Supplydrop"
+	if(!object)
+		return
+	if (usr.client.holder.level >= LEVEL_PA)
+		var/chosen = get_one_match(object)
+		var/preDropTime = 3 SECONDS
+
+		if (chosen)
+			//var/obj/A = new chosen()
+			//A.set_loc(usr.loc)
+			//heavenly_spawn(A)
+			new/obj/effect/supplymarker/safe(usr.loc, preDropTime, chosen)
+			logTheThing("admin", usr, null, "spawned [chosen] at ([showCoords(usr.x, usr.y, usr.z)])")
+			logTheThing("diary", usr, null, "spawned [chosen] at ([showCoords(usr.x, usr.y, usr.z, 1)])", "admin")
+
+	else
+		alert("You cannot perform this action. You must be of a higher administrative rank!", null, null, null, null, null)
+		return
+
 /datum/admins/proc/show_chatbans(var/client/C)//do not use this as an example of how to write DM please.
 	if( !C.cloud_available() )
 		alert( "Failed to communicate to Goonhub." )

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -4650,12 +4650,10 @@ var/global/noir = 0
 		var/preDropTime = 3 SECONDS
 
 		if (chosen)
-			//var/obj/A = new chosen()
-			//A.set_loc(usr.loc)
-			//heavenly_spawn(A)
-			new/obj/effect/supplymarker/safe(usr.loc, preDropTime, chosen)
-			logTheThing("admin", usr, null, "spawned [chosen] at ([showCoords(usr.x, usr.y, usr.z)])")
-			logTheThing("diary", usr, null, "spawned [chosen] at ([showCoords(usr.x, usr.y, usr.z, 1)])", "admin")
+			var/turf/T = get_turf(usr)
+			new/obj/effect/supplymarker/safe(T, preDropTime, chosen)
+			logTheThing("admin", usr, null, "spawned [chosen] at ([showCoords(T.x, T.y, T.z)])")
+			logTheThing("diary", usr, null, "spawned [chosen] at ([showCoords(T.x, T.y, T.z, 1)])", "admin")
 
 	else
 		alert("You cannot perform this action. You must be of a higher administrative rank!", null, null, null, null, null)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -4623,6 +4623,7 @@ var/global/noir = 0
 	SET_ADMIN_CAT(ADMIN_CAT_NONE)
 	set desc="(object path) Spawn an object. But all fancy-like"
 	set name="Spawn-Heavenly"
+	admin_only
 	if(!object)
 		return
 	if (usr.client.holder.level >= LEVEL_PA)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -4623,7 +4623,6 @@ var/global/noir = 0
 	SET_ADMIN_CAT(ADMIN_CAT_NONE)
 	set desc="(object path) Spawn an object. But all fancy-like"
 	set name="Spawn-Heavenly"
-	admin_only
 	if(!object)
 		return
 	if (usr.client.holder.level >= LEVEL_PA)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -260,6 +260,7 @@ var/list/admin_verbs = list(
 		/client/proc/show_admin_lag_hacks,
 		/datum/admins/proc/spawn_atom,
 		/datum/admins/proc/heavenly_spawn_obj,
+		/datum/admins/proc/supplydrop_spawn_obj,
 
 		// moved down from coder. shows artists, atmos etc
 		/client/proc/SetInfoOverlay,

--- a/code/modules/admin/buildmodes/spawn_single.dm
+++ b/code/modules/admin/buildmodes/spawn_single.dm
@@ -16,7 +16,7 @@ change the direction of created objects.<br>
 	var/matrix/mtx = matrix()
 	click_mode_right(var/ctrl, var/alt, var/shift)
 		if(ctrl)
-			cinematic = (input("Cinematic spawn mode") as null|anything in list("Telepad", "Blink", "Supplydrop", "None")) || cinematic
+			cinematic = (input("Cinematic spawn mode") as null|anything in list("Telepad", "Blink", "Supplydrop", "Supplydrop (no lootbox)", "None")) || cinematic
 			return
 		objpath = get_one_match(input("Type path", "Type path", "/obj/closet"), /atom)
 		update_button_text(objpath)
@@ -76,6 +76,9 @@ change the direction of created objects.<br>
 				if("Supplydrop")
 					if (ispath(objpath, /atom/movable))
 						new/obj/effect/supplymarker/safe(T, 3 SECONDS, objpath)
+				if("Supplydrop (no lootbox)")
+					if (ispath(objpath, /atom/movable))
+						new/obj/effect/supplymarker/safe(T, 3 SECONDS, objpath, TRUE)
 				else
 					var/atom/A = 0
 					if(ispath(objpath, /turf))

--- a/code/modules/admin/buildmodes/spawn_single.dm
+++ b/code/modules/admin/buildmodes/spawn_single.dm
@@ -16,7 +16,7 @@ change the direction of created objects.<br>
 	var/matrix/mtx = matrix()
 	click_mode_right(var/ctrl, var/alt, var/shift)
 		if(ctrl)
-			cinematic = (input("Cinematic spawn mode") as null|anything in list("Telepad", "Blink", "None")) || cinematic
+			cinematic = (input("Cinematic spawn mode") as null|anything in list("Telepad", "Blink", "Supplydrop", "None")) || cinematic
 			return
 		objpath = get_one_match(input("Type path", "Type path", "/obj/closet"), /atom)
 		update_button_text(objpath)
@@ -73,6 +73,9 @@ change the direction of created objects.<br>
 						A.dir = holder.dir
 						A.onVarChanged("dir", SOUTH, A.dir)
 						blink(T)
+				if("Supplydrop")
+					if (ispath(objpath, /atom/movable))
+						new/obj/effect/supplymarker/safe(T, 3 SECONDS, objpath)
 				else
 					var/atom/A = 0
 					if(ispath(objpath, /turf))

--- a/code/modules/admin/buildmodes/spawn_wide.dm
+++ b/code/modules/admin/buildmodes/spawn_wide.dm
@@ -23,7 +23,7 @@ change the direction of created objects.<br>
 
 	click_mode_right(var/ctrl, var/alt, var/shift)
 		if(ctrl)
-			cinematic = (input("Cinematic spawn mode") as null|anything in list("Telepad", "Blink", "None", "Fancy and Inefficient yet Laggy Telepad", "Supplydrop")) || cinematic
+			cinematic = (input("Cinematic spawn mode") as null|anything in list("Telepad", "Blink", "None", "Fancy and Inefficient yet Laggy Telepad", "Supplydrop", "Supplydrop (no lootbox)")) || cinematic
 			return
 		if(alt)
 			delete_area = !delete_area
@@ -140,6 +140,10 @@ change the direction of created objects.<br>
 						SPAWN_DBG(rand(0, min(area_of_block*5, 200)))
 							if (ispath(objpath, /atom/movable))
 								new/obj/effect/supplymarker/safe(Q, 3 SECONDS, objpath)
+					if("Supplydrop (no lootbox)")
+						SPAWN_DBG(rand(0, min(area_of_block*5, 200)))
+							if (ispath(objpath, /atom/movable))
+								new/obj/effect/supplymarker/safe(Q, 3 SECONDS, objpath, TRUE)
 					else
 						var/atom/A = 0
 						if(ispath(objpath, /turf))

--- a/code/modules/admin/buildmodes/spawn_wide.dm
+++ b/code/modules/admin/buildmodes/spawn_wide.dm
@@ -23,7 +23,7 @@ change the direction of created objects.<br>
 
 	click_mode_right(var/ctrl, var/alt, var/shift)
 		if(ctrl)
-			cinematic = (input("Cinematic spawn mode") as null|anything in list("Telepad", "Blink", "None", "Fancy and Inefficient yet Laggy Telepad")) || cinematic
+			cinematic = (input("Cinematic spawn mode") as null|anything in list("Telepad", "Blink", "None", "Fancy and Inefficient yet Laggy Telepad", "Supplydrop")) || cinematic
 			return
 		if(alt)
 			delete_area = !delete_area
@@ -50,6 +50,7 @@ change the direction of created objects.<br>
 				return
 			update_button_text("Spawning...")
 			var/cnt = 0
+			var/area_of_block = (abs(A.x - B.x) * abs(A.y - B.y))
 			for (var/turf/Q in block(A,B))
 				//var/atom/sp = new objpath(Q)
 				//if (isobj(sp) || ismob(sp) || isturf(sp))
@@ -135,6 +136,10 @@ change the direction of created objects.<br>
 							A.dir = holder.dir
 							A.onVarChanged("dir", SOUTH, A.dir)
 							blink(Q)
+					if("Supplydrop")
+						SPAWN_DBG(rand(0, min(area_of_block*5, 200)))
+							if (ispath(objpath, /atom/movable))
+								new/obj/effect/supplymarker/safe(Q, 3 SECONDS, objpath)
 					else
 						var/atom/A = 0
 						if(ispath(objpath, /turf))

--- a/code/modules/events/supply_drop.dm
+++ b/code/modules/events/supply_drop.dm
@@ -71,8 +71,7 @@
 			if (obj_path && no_lootbox)
 				new obj_path(src.loc)
 			else if (no_lootbox)
-				var/atom/movable/AM = makeRandomLootTrash()
-				AM.set_loc(src.loc)
+				makeRandomLootTrash().set_loc(src.loc)
 			else
 				new/obj/lootbox(src.loc, obj_path)
 			qdel(src)
@@ -127,6 +126,7 @@
 	return
 
 /proc/makeRandomLootTrash()
+	RETURN_TYPE(/atom/movable)
 	var/obj/item/I = null
 	var/list/permittedItemPaths = list(/obj/item/clothing)
 	var/pickedClothingPath = pick(typesof(pick(permittedItemPaths)))

--- a/code/modules/events/supply_drop.dm
+++ b/code/modules/events/supply_drop.dm
@@ -71,7 +71,8 @@
 			if (obj_path && no_lootbox)
 				new obj_path(src.loc)
 			else if (no_lootbox)
-				makeRandomLootTrash().set_loc(src.loc)
+				var/atom/movable/AM = makeRandomLootTrash()
+				AM.set_loc(src.loc)
 			else
 				new/obj/lootbox(src.loc, obj_path)
 			qdel(src)
@@ -280,25 +281,25 @@
 
 			SPAWN_DBG(2 SECONDS)
 				var/mob/living/carbon/human/H = usr
-				var/obj/item/I = null
+				var/atom/movable/AM = null
 				if (obj_path)
-					I = new obj_path()
+					AM = new obj_path()
 				else
-					I = makeRandomLootTrash()
+					AM = makeRandomLootTrash()
 				if(istype(H))
 					var/obj/screen/lootcrateicon/background/B = new/obj/screen/lootcrateicon/background(src)
 					var/obj/screen/lootcrateicon/sparks/S = new/obj/screen/lootcrateicon/sparks(src)
 					var/obj/screen/lootcratepreview/P = new/obj/screen/lootcratepreview(src)
-					P.icon = I.icon
-					P.icon_state = I.icon_state
-					P.color = I.color
+					P.icon = AM.icon
+					P.icon_state = AM.icon_state
+					P.color = AM.color
 					H.hud.add_screen(B)
 					H.hud.add_screen(S)
 					H.hud.add_screen(P)
 
-					if (ishuman(usr) && I)
+					if (ishuman(usr) && AM)
 						var/mob/living/carbon/human/dude = usr
-						dude.put_in_hand_or_drop(I)
+						dude.put_in_hand_or_drop(AM)
 
 					SPAWN_DBG(2.5 SECONDS)
 						del(B)

--- a/code/modules/events/supply_drop.dm
+++ b/code/modules/events/supply_drop.dm
@@ -33,13 +33,13 @@
 	pixel_y = -16
 	var/gib_mobs = TRUE
 
-	New(var/atom/location, var/preDropTime = 100, var/obj_path)
+	New(var/atom/location, var/preDropTime = 100, var/obj_path, var/no_lootbox)
 		src.loc = location
 		SPAWN_DBG(preDropTime)
 			if (gib_mobs)
-				new/obj/effect/supplydrop(src.loc, obj_path)
+				new/obj/effect/supplydrop(src.loc, obj_path, no_lootbox)
 			else
-				new/obj/effect/supplydrop/safe(src.loc, obj_path)
+				new/obj/effect/supplydrop/safe(src.loc, obj_path, no_lootbox)
 			qdel(src)
 		..()
 
@@ -56,7 +56,7 @@
 	var/dropTime = 30
 	var/gib_mobs = TRUE
 
-	New(atom/loc, var/obj_path)
+	New(atom/loc, var/obj_path, var/no_lootbox)
 		pixel_y = 480
 		animate(src, pixel_y = 0, time = dropTime)
 		playsound(src.loc, 'sound/effects/flameswoosh.ogg', 100, 0)
@@ -68,7 +68,12 @@
 				if(gib_mobs && M.loc == src.loc)
 					M.gib(1, 1)
 			sleep(0.5 SECONDS)
-			new/obj/lootbox(src.loc, obj_path)
+			if (obj_path && no_lootbox)
+				new obj_path(src.loc)
+			else if (no_lootbox)
+				makeRandomLootTrash().set_loc(src.loc)
+			else
+				new/obj/lootbox(src.loc, obj_path)
 			qdel(src)
 		..()
 

--- a/strings/admin_changelog.txt
+++ b/strings/admin_changelog.txt
@@ -1,3 +1,6 @@
+(t)wed aug 05 20
+(u)Sovexe
+(*)Added new command Spawn-Supplydrop along with a Supplydrop cinematic effect for build mode spawning.
 (t)tue aug 04 20
 (u)Zamujasa
 (*)Player notes now show multiline data properly. Maybe. I didn't test this. vOv


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][FEATURE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Adds new admin verb `Spawn-Supplydrop` that allows you to spawn a supplydrop in with any item of your choosing
- Adds a supply drop cinematic to buildmode.
- Adds a supply drop without lootbox cinematic to buildmode. This plays the drop animation but then just spawns the item rather than spawning the crate

These do **not** gib on landing. I could change that if people want them to though.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
![ezgif-7-44503bd13b0e](https://user-images.githubusercontent.com/33204415/89476519-e35f7800-d758-11ea-99b0-67cd567fe0ad.gif)
