### PR TITLE
Yacht dice score sheets

### DIFF
--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -1277,6 +1277,7 @@
 	create_products()
 		..()
 		product_list += new/datum/data/vending_product(/obj/item/paper/card_manual, 10, cost=1)
+		product_list += new/datum/data/vending_product(/obj/item/paper/yachtdice, 20, cost=2)
 		product_list += new/datum/data/vending_product(/obj/item/card_box/trading, 5, cost=60)
 		product_list += new/datum/data/vending_product(/obj/item/card_box/booster, 20, cost=20)
 		product_list += new/datum/data/vending_product(/obj/item/card_box/suit, 10, cost=15)

--- a/code/obj/item/yacht_dice_sheet.dm
+++ b/code/obj/item/yacht_dice_sheet.dm
@@ -1,0 +1,27 @@
+obj/item/paper/yachtdice
+	name = "yacht dice sheet"
+	info = {"Aces (Sum of Match): __
+	<BR>Twos (Sum of Match): __
+	<BR>Threes (Sum of Match): __
+	<BR>Fours (Sum of Match): __
+	<BR>Fives (Sum of Match): __
+	<BR>Sixes (Sum of Match): __
+	<BR>Over 63 (35): __
+	<BR>Upper Total: ___
+	<BR>
+	<BR>3 of a Kind (Sum of All): __
+	<BR>4 of a Kind (Sum of All): __
+	<BR>Full House (25): __
+	<BR>4 in a Row (30): __
+	<BR>5 in a Row (35): __
+	<BR>Yacht (50): __
+	<BR>Chance (Sum of All): __
+	<BR>Lower Total: ___
+	<BR>
+	<BR>Grand Total: ____"}
+
+	New()
+		..()
+		build_formpoints()
+
+

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -1271,6 +1271,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\obj\item\toys.dm"
 #include "code\obj\item\uplinks.dm"
 #include "code\obj\item\vending_restock.dm"
+#include "code\obj\item\yacht_dice_sheet.dm"
 #include "code\obj\item\zoldorfmisc.dm"
 #include "code\obj\item\assembly\detonator.dm"
 #include "code\obj\item\assembly\dynassemblies.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEAT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Introduces generic yacht dice sheets with writable score fields, and adds them to the card vendor. I had originally developed these for use in an upcoming map that has several yacht dice tables, but decided there was no particular reason they needed to wait for the map.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

More fun stuff to do with dice.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Kubius:
(*)You can now buy yacht dice score sheets at card vendors. Dice sold separately.
```
