### PR TITLE
Tiny Kondaru fixes: forcefield dirs, button for QM export door

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -38846,6 +38846,7 @@
 /obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/research_horizontal/vertical,
 /obj/forcefield/energyshield/perma/doorlink{
 	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
@@ -48359,6 +48360,13 @@
 /obj/machinery/door_control{
 	id = "qm_dock";
 	name = "Import Hatch Override";
+	pixel_x = -2;
+	pixel_y = 28
+	},
+/obj/machinery/door_control{
+	id = "manualshipping";
+	name = "Export Hatch Override";
+	pixel_x = 9;
 	pixel_y = 28
 	},
 /turf/simulated/floor/caution/northsouth,
@@ -48391,6 +48399,7 @@
 /obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/medbay_horizontal/vertical,
 /obj/forcefield/energyshield/perma/doorlink{
 	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
@@ -49946,6 +49955,7 @@
 	},
 /obj/forcefield/energyshield/perma/doorlink{
 	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
@@ -49972,6 +49982,7 @@
 	},
 /obj/forcefield/energyshield/perma/doorlink{
 	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
@@ -105270,7 +105281,7 @@ bXk
 cer
 coj
 cnW
-acO
+aaa
 aaa
 aaa
 aaa
@@ -105572,7 +105583,7 @@ cdt
 ces
 cfl
 cfY
-acO
+aaa
 aaa
 aaa
 aaa


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Small change to add a button for QM's export door and realign some force fields to better visually match their doors.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bonus button in QM should hopefully help when dealing with high export volumes.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Kubius:
(+)Kondaru's export driver door now has an override button.
```
