### PR TITLE
Cyborgs can't cook (also dirty microwave text)

### DIFF
--- a/code/obj/machinery/deep_fryer.dm
+++ b/code/obj/machinery/deep_fryer.dm
@@ -27,7 +27,7 @@
 		if (isghostdrone(user) || isAI(user))
 			boutput(usr, "<span class='alert'>The [src] refuses to interface with you, as you are not a properly trained chef!</span>")
 			return
-		if (issilicon(user) && W.loc == user) //For borg held items
+		if (W.cant_drop) //For borg held items
 			user.show_text("You can't put that in [src] when it's attached to you!", "red")
 			return
 		if (src.fryitem)

--- a/code/obj/machinery/deep_fryer.dm
+++ b/code/obj/machinery/deep_fryer.dm
@@ -27,6 +27,9 @@
 		if (isghostdrone(user) || isAI(user))
 			boutput(usr, "<span class='alert'>The [src] refuses to interface with you, as you are not a properly trained chef!</span>")
 			return
+		if (issilicon(user) && W.loc == user) //For borg held items
+			user.show_text("You can't put that in [src] when it's attached to you!", "red")
+			return
 		if (src.fryitem)
 			boutput(user, "<span class='alert'>There is already something in the fryer!</span>")
 			return

--- a/code/obj/machinery/microwave.dm
+++ b/code/obj/machinery/microwave.dm
@@ -92,7 +92,7 @@ obj/machinery/microwave/attackby(var/obj/item/O as obj, var/mob/user as mob)
 		else //Otherwise bad luck!!
 			boutput(user, "It's dirty!")
 			return
-	else if (issilicon(user) && O.loc == user) //For borg held items, if the microwave is clean and functioning
+	else if (O.cant_drop) //For borg held items, if the microwave is clean and functioning
 		user.show_text("You can't put that in [src] when it's attached to you!", "red")
 	else if(istype(O,/obj/item/dice))
 		var/obj/item/dice/die = O

--- a/code/obj/machinery/microwave.dm
+++ b/code/obj/machinery/microwave.dm
@@ -81,6 +81,7 @@ obj/machinery/microwave/attackby(var/obj/item/O as obj, var/mob/user as mob)
 			src.broken = 0 // Fix it!
 		else
 			boutput(user, "It's broken!")
+			return
 	else if(src.dirty) // The microwave is all dirty so can't be used!
 		if(istype(O, /obj/item/spraybottle)) // If they're trying to clean it then let them
 			src.visible_message("<span class='notice'>[user] starts to clean the microwave.</span>")
@@ -89,7 +90,10 @@ obj/machinery/microwave/attackby(var/obj/item/O as obj, var/mob/user as mob)
 			src.dirty = 0 // It's cleaned!
 			src.icon_state = "mw"
 		else //Otherwise bad luck!!
+			boutput(user, "It's dirty!")
 			return
+	else if (issilicon(user) && O.loc == user) //For borg held items, if the microwave is clean and functioning
+		user.show_text("You can't put that in [src] when it's attached to you!", "red")
 	else if(istype(O,/obj/item/dice))
 		var/obj/item/dice/die = O
 		if(die.dicePals.len)

--- a/code/obj/submachine/cooking.dm
+++ b/code/obj/submachine/cooking.dm
@@ -714,7 +714,7 @@ table#cooktime a#start {
 		if (isghostdrone(user))
 			boutput(usr, "<span class='alert'>\The [src] refuses to interface with you, as you are not a properly trained chef!</span>")
 			return
-		if (issilicon(user) && W.loc == user) //For borg held items
+		if (W.cant_drop) //For borg held items
 			user.show_text("You can't put that in [src] when it's attached to you!", "red")
 			return
 		if (src.working)

--- a/code/obj/submachine/cooking.dm
+++ b/code/obj/submachine/cooking.dm
@@ -714,6 +714,9 @@ table#cooktime a#start {
 		if (isghostdrone(user))
 			boutput(usr, "<span class='alert'>\The [src] refuses to interface with you, as you are not a properly trained chef!</span>")
 			return
+		if (issilicon(user) && W.loc == user) //For borg held items
+			user.show_text("You can't put that in [src] when it's attached to you!", "red")
+			return
 		if (src.working)
 			boutput(usr, "<span class='alert'>It's already on! Putting a new thing in could result in a collapse of the cooking waveform into a really lousy eigenstate, like a vending machine chili dog.</span>")
 			return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUGFIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Cyborgs used to be able to put their tools into microwaves, ovens, and deep fryers. Now they can't! They can still repair and clean microwaves, and the microwave now gives a response if you try to put something in it when it's dirty.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This makes ovens, microwaves, and fryers consistent with disposal chutes. As a side effect, it fixes #1737 . The microwave text fix gives the user feedback if they are trying to cook their food in a dirty microwave, where before there was none. Cyborgs can still scan things with a device analyzer and repair/clean the microwave. 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Jawns:
(+)Cyborg cooking privileges revoked (for their own tools).
```