### PR TITLE
Adds bible healing as way to earn chaplain job xp

### DIFF
--- a/code/obj/item/storage/bible.dm
+++ b/code/obj/item/storage/bible.dm
@@ -29,13 +29,14 @@ var/global/list/bible_contents = list()
 		..()
 		STOP_TRACKING
 
-	proc/bless(mob/M as mob)
+	proc/bless(mob/M as mob, var/mob/user)
 		if (isvampire(M) || iswraith(M) || M.bioHolder.HasEffect("revenant"))
 			M.visible_message("<span class='alert'><B>[M] burns!</span>", 1)
 			var/zone = "chest"
 			if (usr.zone_sel)
 				zone = usr.zone_sel.selecting
 			M.TakeDamage(zone, 0, heal_amt)
+			JOB_XP(user, "Chaplain", 2)
 		else
 			var/mob/living/H = M
 			if( istype(H) )
@@ -45,6 +46,7 @@ var/global/list/bible_contents = list()
 				if( prob(25) )
 					H.cure_disease_by_path(/datum/ailment/disability/clumsy/cluwne)
 			M.HealDamage("All", heal_amt, heal_amt)
+			JOB_XP(user, "Chaplain", 2)
 
 	attackby(var/obj/item/W, var/mob/user)
 		if (istype(W, /obj/item/storage/bible))
@@ -72,7 +74,7 @@ var/global/list/bible_contents = list()
 
 		if (iswraith(M) || (M.bioHolder && M.bioHolder.HasEffect("revenant")))
 			M.visible_message("<span class='alert'><B>[user] smites [M] with the [src]!</B></span>")
-			bless(M)
+			bless(M, user)
 			boutput(M, "<span_class='alert'><B>IT BURNS!</B></span>")
 			if (narrator_mode)
 				playsound(src.loc, 'sound/vox/hit.ogg', 25, 1, -1)
@@ -84,7 +86,7 @@ var/global/list/bible_contents = list()
 			var/mob/H = M
 			// ******* Check
 			if ((ishuman(H) && prob(60)))
-				bless(M)
+				bless(M, user)
 				M.visible_message("<span class='alert'><B>[user] heals [M] with the power of Christ!</B></span>")
 				boutput(M, "<span class='alert'>May the power of Christ compel you to be healed!</span>")
 				if (narrator_mode)


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Bible healing / smiting as a chaplain will now add 1 XP to your bar. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Giving the chaplain a way to earn XP opens the path to implementing more ways of earning it as well as job rewards.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Carbadox:
(+)Chaplain can now earn Job XP by Bible Healing/Smiting
```
