### PR TITLE
Adds a DIY holy water kit to the Chaplains locker

### DIFF
--- a/code/modules/chemistry/tools/bottles.dm
+++ b/code/modules/chemistry/tools/bottles.dm
@@ -151,7 +151,7 @@
 	bottle_style = "4"
 	amount_per_transfer_from_this = 5
 	initial_reagents = "sulfonal"
-	
+
 /obj/item/reagent_containers/glass/bottle/synaptizine
 	name = "synaptizine bottle"
 	desc = "A small bottle."
@@ -222,6 +222,14 @@
 	initial_volume = 50
 	amount_per_transfer_from_this = 5
 	initial_reagents = "ethanol"
+
+/obj/item/reagent_containers/glass/bottle/mercury
+	name = "mercury bottle"
+	desc = "A small bottle with a 'Do Not Drink' label on it."
+	bottle_style = "1"
+	initial_volume = 50
+	amount_per_transfer_from_this = 5
+	initial_reagents = "mercury"
 
 /* ========================================================= */
 /* -------------------- Chem Precursors -------------------- */

--- a/code/obj/item/storage/misc.dm
+++ b/code/obj/item/storage/misc.dm
@@ -78,3 +78,10 @@
 	desc = "Conveniently, once this box runs out of hazardous waste bags, you can throw it away in one of your new hazardous waste bags!! (Please be sure to bleed on it first, though, otherwise it's a bit of a waste of a bag.)"
 	icon_state = "biohazard"
 	spawn_contents = list(/obj/item/clothing/under/trash_bag/biohazard = 7)
+
+/obj/item/storage/box/holywaterkit
+	name = "do-it-yourself holy water kit"
+	desc = "Just combine the ingredients with water! Free container with sample provided."
+	spawn_contents = list(/obj/item/reagent_containers/glass/bottle/mercury = 3,
+	/obj/item/reagent_containers/food/drinks/bottle/wine = 3,
+	/obj/item/reagent_containers/glass/bottle/holywater)

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -620,7 +620,7 @@
 	/obj/item/clothing/head/turban,\
 	/obj/item/clothing/shoes/sandal,\
 	/obj/item/clothing/suit/flockcultist,\
-	/obj/item/reagent_containers/glass/bottle/holywater)
+	/obj/item/storage/box/holywaterkit)
 
 /* =================== */
 /* ----- Fridges ----- */


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a box to the chaplains locker that contains 3 bottles of wine, 3 bottles of mercury and a holy water bottle

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Relying on the Barman to get you holy water is a bit eh. Getting a refill seems more fitting

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Carbadox:
(+)Added DIY Holy Water kit to Chaplains locker. Contains 3 bottles of wine and 3 bottles of mercury alongside a holy water container
```
