### PR TITLE
Add documentation for a possible fix for a build error. 

### DIFF
--- a/.github/DEV_GUIDE.md
+++ b/.github/DEV_GUIDE.md
@@ -134,7 +134,11 @@ If you are on a version of BYOND different from the one specified in buildByond.
 
 Alternative solution is to press `ctrl+shift+B` and then select the build task by hitting enter. This one does not automatically make you an administrator in-game so you will need to edit the config/admins.txt file by adding a `yourckey - Host` line there. Just make sure you don't commit this file later!
 
-<!--- TODO: Troubleshooting for non-existing task? --->
+:::info
+If an error popup with an error message of "Could not find the task 'dm: build - goonstation.dme'." shows up, one possible cause is that a VS Code Workspace is confusing things. If this is the case, close your current workspace (`File` -> `Close Workspace`) then use the `Open Folder` option to select the `goonstation` folder and try to build again.
+
+You can use a VS Code Workspace, but should do via Open Folder to select the `goonstation` folder then `File` -> `Save Workspace As...` rather than `Add Folder to Workspace`.
+:::
 
 ![](https://i.imgur.com/mXSjfC2.png)
 


### PR DESCRIPTION
[DOCUMENTATION]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

After encountering the "Could not find the task 'dm: build - goonstation.dme'." popup, I found that one possible cause is that I had the repo as part of a larger workspace. Opening the `goonstation` folder directly in VS Code (or using a top-level workspace created from that) fixed the problem.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

As I've had this issue in the past and workspaces could definitely have been a cause then (as I use them a bunch), and I verified that removing the workspace or using as described above solves the issue this time, this seems like something work documenting.