### PR TITLE
Cogmap 1 Modernisation & Access Updates

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -923,18 +923,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "acx" = (
-/obj/machinery/power/apc{
-	areastring = "Observatory";
-	dir = 1;
-	name = "Observatory APC";
-	pixel_y = 24
-	},
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/plating,
-/area/station/maintenance/NWmaint)
+/area/station/crew_quarters/observatory)
 "acz" = (
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters)
@@ -1177,10 +1172,6 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/quarters)
 "add" = (
-/obj/machinery/power/apc{
-	name = "S APC";
-	pixel_y = -24
-	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -1192,6 +1183,7 @@
 /obj/disposalpipe/segment/food{
 	dir = 4
 	},
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters)
 "ade" = (
@@ -1506,14 +1498,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "adK" = (
-/obj/machinery/power/apc{
-	areastring = "Crew Quarters A";
-	name = "Crew Quarters A APC";
-	pixel_y = -24
-	},
 /obj/cable,
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor/plating,
-/area/station/maintenance/NWmaint)
+/area/station/crew_quarters/quartersA)
 "adL" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/secondary/construction2)
@@ -1531,15 +1519,11 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters)
 "adO" = (
-/obj/machinery/power/apc{
-	areastring = "Crew Quarters B";
-	name = "Crew Quarters B APC";
-	pixel_y = -24
-	},
 /obj/cable,
 /obj/machinery/space_heater,
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor/plating,
-/area/station/maintenance/NWmaint)
+/area/station/crew_quarters/quartersB)
 "adP" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
@@ -2155,16 +2139,12 @@
 /area/station/crew_quarters/clown)
 "afm" = (
 /obj/decal/cleanable/dirt,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "E APC";
-	pixel_x = 24
-	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/marker/supplymarker,
+/obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/plating/damaged1,
 /area/station/crew_quarters/clown)
 "afn" = (
@@ -2223,32 +2203,24 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/construction2)
 "aft" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "N APC";
-	pixel_y = 24
-	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/shieldgenerator/meteorshield,
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/construction2)
 "afu" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/secondary/entry)
 "afv" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "W APC";
-	pixel_x = -24
-	},
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/light,
+/obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "afw" = (
@@ -2294,16 +2266,12 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/secondary/construction)
 "afB" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "N APC";
-	pixel_y = 24
-	},
 /obj/item/tile/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/construction)
 "afC" = (
@@ -2821,11 +2789,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "W APC";
-	pixel_x = -24
-	},
+/obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "agH" = (
@@ -3004,16 +2968,12 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/SWmaint)
 "ahi" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "E APC";
-	pixel_x = 24
-	},
 /obj/cable,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northsolar)
 "ahj" = (
@@ -3288,11 +3248,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "N APC";
-	pixel_y = 24
-	},
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "ahM" = (
@@ -3481,15 +3437,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northsolar)
 "aid" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "N APC";
-	pixel_y = 24
-	},
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "aie" = (
@@ -3730,11 +3682,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "aiH" = (
-/obj/machinery/power/apc{
-	areastring = "Shower Room";
-	name = "Shower Room APC";
-	pixel_y = -24
-	},
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -3746,8 +3693,9 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor/plating,
-/area/station/maintenance/NWmaint)
+/area/station/crew_quarters/showers)
 "aiI" = (
 /obj/cable{
 	d1 = 4;
@@ -3779,11 +3727,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "aiK" = (
-/obj/machinery/power/apc{
-	areastring = "Fitness Room";
-	name = "Fitness Room APC";
-	pixel_y = -24
-	},
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -3795,8 +3738,9 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor/plating,
-/area/station/maintenance/NWmaint)
+/area/station/crew_quarters/fitness)
 "aiL" = (
 /obj/cable{
 	d1 = 4;
@@ -3994,15 +3938,11 @@
 	name = "Catering Hangar"
 	})
 "ajh" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "N APC";
-	pixel_y = 24
-	},
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/caution/corner/ne,
 /area/station/hangar/catering{
 	name = "Catering Hangar"
@@ -5075,11 +5015,8 @@
 /turf/simulated/floor,
 /area/station/routingdepot/security)
 "alC" = (
-/obj/machinery/power/apc{
-	name = "S APC";
-	pixel_y = -24
-	},
 /obj/cable,
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor,
 /area/station/routingdepot/security)
 "alD" = (
@@ -6237,15 +6174,11 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/item/stamp,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "E APC";
-	pixel_x = 24
-	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/red/side{
 	dir = 6
 	},
@@ -6388,16 +6321,12 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc{
-	areastring = "Kitchen";
-	name = "Kitchen APC";
-	pixel_y = -24
-	},
 /obj/landmark{
 	name = "blobstart"
 	},
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor/plating,
-/area/station/maintenance/NEmaint)
+/area/station/crew_quarters/kitchen)
 "aoD" = (
 /obj/cable{
 	d1 = 1;
@@ -6555,12 +6484,8 @@
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "E APC";
-	pixel_x = 24
-	},
 /obj/cable,
+/obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "aoX" = (
@@ -7220,15 +7145,10 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/power/apc{
-	areastring = "Bathroom";
-	dir = 8;
-	name = "Bathroom APC";
-	pixel_x = -24
-	},
 /obj/cable,
+/obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/plating,
-/area/station/maintenance/NWmaint)
+/area/station/crew_quarters/bathroom)
 "aqD" = (
 /obj/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple{
@@ -7243,17 +7163,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "aqF" = (
-/obj/machinery/power/apc{
-	areastring = "Arcade";
-	name = "Arcade APC";
-	pixel_y = -24
-	},
 /obj/cable,
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 9
 	},
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor/plating,
-/area/station/maintenance/NWmaint)
+/area/station/crew_quarters/arcade)
 "aqG" = (
 /obj/table/reinforced/auto,
 /obj/item/clothing/gloves/boxing,
@@ -8111,16 +8027,12 @@
 /turf/simulated/floor/grime,
 /area/station/hydroponics/lobby)
 "asJ" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "E APC";
-	pixel_x = 24
-	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/storage/secure/closet/civilian/hydro,
+/obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/grime,
 /area/station/hydroponics/lobby)
 "asK" = (
@@ -8970,11 +8882,7 @@
 /area/station/crew_quarters/fitness)
 "auK" = (
 /obj/cable,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "W APC";
-	pixel_x = -24
-	},
+/obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "auL" = (
@@ -9062,13 +8970,8 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc{
-	areastring = "Bar";
-	dir = 8;
-	name = "Bar APC";
-	pixel_x = -24
-	},
 /obj/cable,
+/obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "auV" = (
@@ -9227,11 +9130,8 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
 "avn" = (
-/obj/machinery/power/apc{
-	name = "S APC";
-	pixel_y = -24
-	},
 /obj/cable,
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
 "avo" = (
@@ -10055,12 +9955,6 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc{
-	areastring = "Barber Shop";
-	dir = 4;
-	name = "Barber Shop APC";
-	pixel_x = 24
-	},
 /obj/item/cigbutt,
 /obj/decal/cleanable/dirt,
 /obj/decal/cleanable/ash,
@@ -10068,6 +9962,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "awZ" = (
@@ -10156,14 +10051,9 @@
 /area/station/crew_quarters/locker)
 "axi" = (
 /obj/cable,
-/obj/machinery/power/apc{
-	areastring = "Locker Room";
-	dir = 8;
-	name = "Locker Room APC";
-	pixel_x = -24
-	},
+/obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/plating,
-/area/station/maintenance/NWmaint)
+/area/station/crew_quarters/locker)
 "axj" = (
 /obj/machinery/sim/vr_bed{
 	dir = 4;
@@ -10329,11 +10219,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "N APC";
-	pixel_y = 24
-	},
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/catering)
 "axB" = (
@@ -11736,15 +11622,11 @@
 /area/station/storage/emergency)
 "aAz" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "N APC";
-	pixel_y = 24
-	},
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/bot,
 /area/station/storage/emergency)
 "aAA" = (
@@ -11949,12 +11831,9 @@
 /turf/simulated/floor/green/side,
 /area/station/hydroponics)
 "aAX" = (
-/obj/machinery/power/apc{
-	name = "S APC";
-	pixel_y = -24
-	},
 /obj/cable,
 /obj/storage/crate,
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor/green/side,
 /area/station/hydroponics)
 "aAY" = (
@@ -12053,17 +11932,13 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "N APC";
-	pixel_y = 24
-	},
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
 "aBl" = (
@@ -13895,20 +13770,15 @@
 	dir = 9
 	},
 /obj/cable,
-/obj/machinery/power/apc{
-	areastring = "Security";
-	dir = 4;
-	name = "Security APC";
-	pixel_x = 24
-	},
 /obj/rack,
 /obj/machinery/shieldgenerator/meteorshield,
 /obj/machinery/shieldgenerator/meteorshield,
 /obj/item/device/radio,
 /obj/item/wrench,
 /obj/item/device/light/glowstick,
+/obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/plating,
-/area/station/maintenance/westsolar)
+/area/station/security/main)
 "aER" = (
 /obj/reagent_dispensers/watertank/fountain,
 /turf/simulated/floor/bot,
@@ -15349,15 +15219,11 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "N APC";
-	pixel_y = 24
-	},
 /obj/machinery/disposal{
 	name = "ejection chute"
 	},
 /obj/disposalpipe/trunk/ejection,
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
@@ -16861,15 +16727,11 @@
 /area/station/medical/medbooth)
 "aKW" = (
 /obj/storage/closet/emergency,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "W APC";
-	pixel_x = -24
-	},
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/delivery,
 /area/station/hallway/primary/east)
 "aKX" = (
@@ -17402,13 +17264,9 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 9
 	},
-/obj/machinery/power/apc{
-	areastring = "Bridge";
-	name = "Bridge APC";
-	pixel_y = -24
-	},
 /obj/cable,
 /obj/disposalpipe/segment/mail,
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
 "aMi" = (
@@ -18089,10 +17947,6 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc{
-	name = "S APC";
-	pixel_y = -24
-	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 5;
@@ -18100,6 +17954,7 @@
 	network = "Mining";
 	tag = ""
 	},
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor/yellow/side{
 	dir = 10
 	},
@@ -18298,11 +18153,6 @@
 /area/station/security/hos)
 "aNQ" = (
 /obj/table/reinforced/auto,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "N APC";
-	pixel_y = 24
-	},
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -18314,6 +18164,7 @@
 /obj/item/stamp/hos,
 /obj/item/implantcase/antirev,
 /obj/item/device/prisoner_scanner,
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/hos)
 "aNR" = (
@@ -18558,14 +18409,9 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc{
-	areastring = "Pool Room";
-	dir = 4;
-	name = "Pool Room APC";
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/plating,
-/area/station/maintenance/maintcentral)
+/area/station/crew_quarters/pool)
 "aOo" = (
 /obj/fluid_spawner{
 	amount = 2700
@@ -18606,13 +18452,9 @@
 	dir = 8
 	},
 /obj/storage/crate,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "E APC";
-	pixel_x = 24
-	},
 /obj/cable,
 /obj/item/storage/box,
+/obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/caution/west,
 /area/station/routingdepot/catering)
 "aOu" = (
@@ -18688,15 +18530,11 @@
 /area/station/medical/medbooth)
 "aOB" = (
 /obj/storage/closet/emergency,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "W APC";
-	pixel_x = -24
-	},
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/delivery,
 /area/station/medical/medbooth)
 "aOC" = (
@@ -18994,12 +18832,9 @@
 /area/station/security/beepsky)
 "aPe" = (
 /obj/item/cigbutt,
-/obj/machinery/power/apc{
-	name = "S APC";
-	pixel_y = -24
-	},
 /obj/cable,
 /obj/machinery/bot/secbot/beepsky,
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor/plating,
 /area/station/security/beepsky)
 "aPf" = (
@@ -19951,14 +19786,9 @@
 /area/station/maintenance/west)
 "aRi" = (
 /obj/cable,
-/obj/machinery/power/apc{
-	areastring = "Central Primary Hallway";
-	dir = 4;
-	name = "Central Primary Hallway APC";
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/plating,
-/area/station/maintenance/west)
+/area/station/hallway/primary/central)
 "aRj" = (
 /obj/cable{
 	d1 = 1;
@@ -20175,15 +20005,11 @@
 /obj/stool/chair{
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "W APC";
-	pixel_x = -24
-	},
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/main)
 "aRG" = (
@@ -20816,12 +20642,8 @@
 /area/station/crew_quarters/courtroom)
 "aTe" = (
 /obj/storage/closet/law,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "E APC";
-	pixel_x = 24
-	},
 /obj/cable,
+/obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/juryroom)
 "aTf" = (
@@ -21077,15 +20899,11 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "E APC";
-	pixel_x = 24
-	},
 /obj/machinery/light{
 	dir = 1;
 	pixel_y = 21
 	},
+/obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/black,
 /area/station/chapel/office)
 "aTM" = (
@@ -23581,18 +23399,15 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/east)
 "aYR" = (
-/obj/machinery/power/apc{
-	areastring = "Detective's Office";
-	dir = 1;
-	name = "Detective's Office APC";
-	pixel_y = 24
-	},
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/autoname_north{
+	areastring = null
+	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/security/detectives_office)
 "aYS" = (
 /turf/simulated/wall/false_wall,
 /area/station/chapel/main)
@@ -23834,14 +23649,11 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/jazz)
 "aZu" = (
-/obj/machinery/power/apc{
-	name = "S APC";
-	pixel_y = -24
-	},
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/jazz)
 "aZv" = (
@@ -24177,11 +23989,6 @@
 /turf/simulated/floor/black,
 /area/station/teleporter)
 "bal" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "E APC";
-	pixel_x = 24
-	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -24190,6 +23997,7 @@
 	pixel_y = 24;
 	text = "NF"
 	},
+/obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/black,
 /area/station/teleporter)
 "bam" = (
@@ -24269,18 +24077,15 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc{
-	areastring = "Crematorium";
-	dir = 1;
-	name = "Crematorium APC";
-	pixel_y = 24
-	},
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
 	name = "crematorium pipe"
 	},
+/obj/machinery/power/apc/autoname_north{
+	areastring = null
+	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/medical/crematorium)
 "baw" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
@@ -24754,15 +24559,11 @@
 /area/station/engine/substation/pylon)
 "bbv" = (
 /obj/disposalpipe/segment,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "N APC";
-	pixel_y = 24
-	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/plating,
 /area/station/engine/substation/pylon)
 "bbw" = (
@@ -24942,15 +24743,11 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/captain)
 "bbR" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "W APC";
-	pixel_x = -24
-	},
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/carpet{
 	dir = 9;
 	icon_state = "fgreen2"
@@ -25120,14 +24917,9 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc{
-	areastring = "Courtroom";
-	dir = 1;
-	name = "Courtroom APC";
-	pixel_y = 24
-	},
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/plating,
-/area/station/maintenance/west)
+/area/station/crew_quarters/courtroom)
 "bcj" = (
 /obj/machinery/drone_recharger,
 /turf/simulated/floor/plating,
@@ -25625,10 +25417,6 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/power/apc{
-	name = "S APC";
-	pixel_y = -24
-	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -25637,6 +25425,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor/black,
 /area/station/security/checkpoint)
 "bdg" = (
@@ -25751,11 +25540,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "E APC";
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "bdo" = (
@@ -26635,15 +26420,11 @@
 /area/station/maintenance/west)
 "beZ" = (
 /obj/disposalpipe/segment,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "W APC";
-	pixel_x = -24
-	},
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
 "bfa" = (
@@ -27137,18 +26918,13 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/east)
 "bgd" = (
-/obj/machinery/power/apc{
-	areastring = "Public Market";
-	dir = 8;
-	name = "Public Market APC";
-	pixel_x = -24
-	},
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/plating,
-/area/station/maintenance/west)
+/area/station/crew_quarters/market)
 "bge" = (
 /obj/securearea{
 	desc = "A warning sign which reads 'COLLISION HAZARD'";
@@ -27286,15 +27062,11 @@
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
 "bgp" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "W APC";
-	pixel_x = -24
-	},
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bgq" = (
@@ -27587,10 +27359,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc{
-	name = "S APC";
-	pixel_y = -24
-	},
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bha" = (
@@ -27714,11 +27483,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "E APC";
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/captain)
 "bhs" = (
@@ -29252,11 +29017,7 @@
 	},
 /obj/storage/crate,
 /obj/cable,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "E APC";
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/caution/east,
 /area/station/routingdepot/eva)
 "bkC" = (
@@ -29289,15 +29050,11 @@
 /turf/simulated/floor/grime,
 /area/station/routingdepot)
 "bkG" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "E APC";
-	pixel_x = 24
-	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/grime,
 /area/station/routingdepot)
 "bkH" = (
@@ -29968,15 +29725,11 @@
 	},
 /area/station/crew_quarters/stockex)
 "bmm" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "N APC";
-	pixel_y = 24
-	},
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/stairs{
 	dir = 4
 	},
@@ -31667,15 +31420,11 @@
 /area/station/ai_monitored/storage/eva)
 "bpC" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "E APC";
-	pixel_x = 24
-	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/orangeblack,
 /area/station/ai_monitored/storage/eva)
 "bpD" = (
@@ -31749,11 +31498,8 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc{
-	name = "S APC";
-	pixel_y = -24
-	},
 /obj/cable,
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/AIbaseoutside)
 "bpH" = (
@@ -33563,11 +33309,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "N APC";
-	pixel_y = 24
-	},
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor,
 /area/station/crew_quarters/info)
 "btj" = (
@@ -34796,14 +34538,11 @@
 /turf/simulated/floor/grime,
 /area/station/storage/warehouse)
 "bvQ" = (
-/obj/machinery/power/apc{
-	name = "S APC";
-	pixel_y = -24
-	},
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor/blue/side{
 	dir = 8
 	},
@@ -36793,14 +36532,11 @@
 /turf/simulated/floor/black,
 /area/station/engine/coldloop)
 "bzU" = (
-/obj/machinery/power/apc{
-	name = "S APC";
-	pixel_y = -24
-	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor/grime,
 /area/station/quartermaster/refinery)
 "bzV" = (
@@ -36976,11 +36712,8 @@
 	dir = 4
 	},
 /obj/item/device/light/flashlight,
-/obj/machinery/power/apc{
-	name = "S APC";
-	pixel_y = -24
-	},
 /obj/cable,
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor/yellow/side,
 /area/station/hangar/main)
 "bAo" = (
@@ -37045,15 +36778,12 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/market)
 "bAu" = (
-/obj/machinery/power/apc{
-	name = "S APC";
-	pixel_y = -24
-	},
 /obj/cable,
 /obj/machinery/light{
 	dir = 8;
 	tag = ""
 	},
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor/caution/south,
 /area/station/turret_protected/ai_upload_foyer)
 "bAv" = (
@@ -38396,11 +38126,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "N APC";
-	pixel_y = 24
-	},
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor,
 /area/station/turret_protected/Zeta)
 "bDj" = (
@@ -39424,20 +39150,8 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/qm)
 "bFs" = (
-/obj/machinery/disposal,
-/obj/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 10
-	},
-/area/station/mining)
+/turf/simulated/wall/auto/supernorn,
+/area/station/science)
 "bFt" = (
 /obj/cable,
 /obj/cable{
@@ -40235,11 +39949,6 @@
 /turf/simulated/floor/plating,
 /area/station/storage/warehouse)
 "bGS" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "W APC";
-	pixel_x = -24
-	},
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -40248,6 +39957,7 @@
 	id = "enginesupply"
 	},
 /obj/disposalpipe/segment/mail,
+/obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bGT" = (
@@ -41629,15 +41339,11 @@
 /obj/item/furniture_parts/table,
 /obj/item/device/light/flashlight,
 /obj/item/device/light/flashlight,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "N APC";
-	pixel_y = 24
-	},
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/grime,
 /area/station/storage/warehouse)
 "bJG" = (
@@ -43898,15 +43604,11 @@
 /obj/item/device/audio_log,
 /obj/item/remote/porter/port_a_sci,
 /obj/item/stamp/rd,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "W APC";
-	pixel_x = -24
-	},
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/hor)
 "bOm" = (
@@ -44043,16 +43745,12 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc{
-	locked = 0;
-	name = "S Test APC";
-	pixel_y = -24
-	},
 /obj/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor,
 /area/station/science/teleporter)
 "bOx" = (
@@ -44131,15 +43829,11 @@
 /turf/simulated/floor/plating,
 /area/station/routingdepot/airbridge)
 "bOG" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "N APC";
-	pixel_y = 24
-	},
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor,
 /area/station/routingdepot/airbridge)
 "bOH" = (
@@ -46668,14 +46362,11 @@
 /turf/simulated/floor,
 /area/station/hangar/qm)
 "bTF" = (
-/obj/machinery/power/apc{
-	name = "S APC";
-	pixel_y = -24
-	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor,
 /area/station/hangar/qm)
 "bTG" = (
@@ -48037,15 +47728,11 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/science/bot_storage)
 "bWE" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "W APC";
-	pixel_x = -24
-	},
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor,
 /area/station/science/bot_storage)
 "bWF" = (
@@ -48440,11 +48127,6 @@
 /area/station/science/lab)
 "bXz" = (
 /obj/storage/closet/biohazard,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "N APC";
-	pixel_y = 24
-	},
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -48452,6 +48134,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/white,
 /area/station/science/lab)
 "bXA" = (
@@ -49085,15 +48768,11 @@
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "bYV" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "N APC";
-	pixel_y = 24
-	},
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "bYW" = (
@@ -49352,15 +49031,11 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "E APC";
-	pixel_x = 24
-	},
 /obj/machinery/light_switch{
 	name = "N light switch";
 	pixel_y = 24
 	},
+/obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/toilets)
 "bZz" = (
@@ -49939,12 +49614,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
 "caO" = (
-/obj/machinery/power/apc{
-	areastring = "East Primary Hallway";
-	dir = 1;
-	name = "East Primary Hallway APC";
-	pixel_y = 24
-	},
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -49953,8 +49622,9 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/plating,
-/area/station/maintenance/SWmaint)
+/area/station/hallway/primary/south)
 "caP" = (
 /obj/cable{
 	d1 = 4;
@@ -50011,23 +49681,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
 "caW" = (
-/obj/machinery/power/apc{
-	areastring = "Medbay Lobby";
-	name = "Medbay Lobby APC";
-	pixel_y = -24
-	},
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor/plating,
-/area/station/maintenance/SWmaint)
+/area/station/medical/medbay/lobby)
 "caX" = (
-/obj/machinery/power/apc{
-	areastring = "Medbay";
-	name = "Medbay APC";
-	pixel_y = -24
-	},
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -50036,8 +49697,9 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor/plating,
-/area/station/maintenance/SWmaint)
+/area/station/medical/medbay)
 "caY" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/toilets)
@@ -50432,11 +50094,6 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/medbay/lobby)
 "cbV" = (
-/obj/machinery/power/apc{
-	areastring = "Medbay Operating Theater";
-	name = "Medbay Operating Theater APC";
-	pixel_y = -24
-	},
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -50445,8 +50102,9 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor/plating,
-/area/station/maintenance/SWmaint)
+/area/station/medical/medbay/surgery)
 "cbW" = (
 /obj/cable{
 	d1 = 1;
@@ -50826,15 +50484,11 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "N APC";
-	pixel_y = 24
-	},
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor,
 /area/station/science/artifact)
 "ccW" = (
@@ -50974,18 +50628,13 @@
 	},
 /area/station/medical/medbay/lobby)
 "cdj" = (
-/obj/machinery/power/apc{
-	areastring = "Robotics";
-	dir = 4;
-	name = "Robotics APC";
-	pixel_x = 24
-	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/plating,
-/area/station/maintenance/SWmaint)
+/area/station/medical/robotics)
 "cdk" = (
 /obj/window/reinforced{
 	dir = 8
@@ -51114,12 +50763,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "cdz" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "W APC";
-	noalerts = 1;
-	pixel_x = -24
-	},
 /obj/machinery/atmospherics/pipe/simple{
 	level = 2
 	},
@@ -51128,6 +50771,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/portable_atmospherics/canister/air/large,
+/obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/plating,
 /area/station/atmos/hookups/east)
 "cdA" = (
@@ -51225,16 +50869,12 @@
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "cdL" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "N APC";
-	pixel_y = 24
-	},
 /obj/disposalpipe/segment/ejection,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "cdM" = (
@@ -51253,13 +50893,9 @@
 /turf/simulated/floor/plating,
 /area/station/mining)
 "cdO" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "E APC";
-	pixel_x = 24
-	},
 /obj/storage/secure/closet/security/equipment,
 /obj/cable,
+/obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/cargo)
 "cdP" = (
@@ -51493,15 +51129,11 @@
 	},
 /area/station/medical/medbay/lobby)
 "cez" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "W APC";
-	pixel_x = -24
-	},
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
 "ceA" = (
@@ -52219,18 +51851,15 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	areastring = "Supply Lobby";
-	dir = 1;
-	name = "Supply Lobby APC";
-	pixel_y = 24
-	},
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/plating,
-/area/station/maintenance/SEmaint)
+/area/station/crew_quarters/market{
+	name = "Supply Lobby"
+	})
 "cgn" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -52794,12 +52423,8 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "W APC";
-	pixel_x = -24
-	},
 /obj/machinery/nanofab/mining,
+/obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/yellow/side{
 	dir = 9
 	},
@@ -53269,11 +52894,6 @@
 	},
 /area/station/hallway/secondary/exit)
 "ciD" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "E APC";
-	pixel_x = 24
-	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -53306,6 +52926,7 @@
 	desc = "A human heart, grody. How long has it been in that freezer?";
 	name = "funky ol' heart"
 	},
+/obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "ciE" = (
@@ -53551,11 +53172,6 @@
 /turf/simulated/floor/plating,
 /area/station/science/gen_storage)
 "cjh" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Research Sector APC";
-	pixel_y = 24
-	},
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -53564,8 +53180,9 @@
 	name = "E light switch";
 	pixel_x = 24
 	},
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/plating,
-/area/station/science/gen_storage)
+/area/station/science)
 "cji" = (
 /obj/cable{
 	d1 = 1;
@@ -53688,11 +53305,6 @@
 /area/station/medical/head)
 "cjv" = (
 /obj/table/auto,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "N APC";
-	pixel_y = 24
-	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -53703,6 +53315,7 @@
 /obj/item/remote/porter/port_a_nanomed,
 /obj/item/device/analyzer/healthanalyzer/borg,
 /obj/item/clothing/glasses/healthgoggles,
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/head)
 "cjw" = (
@@ -54240,16 +53853,12 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "W APC";
-	pixel_x = -24
-	},
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/disposalpipe/segment/transport,
+/obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/plating,
 /area/station/science/gen_storage)
 "ckA" = (
@@ -54936,15 +54545,11 @@
 /turf/simulated/floor/plating,
 /area/station/science/gen_storage)
 "clY" = (
-/obj/machinery/power/apc{
-	areastring = "Chemistry";
-	name = "Chemistry APC";
-	pixel_y = -24
-	},
 /obj/cable,
 /obj/machinery/fluid_canister,
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor/plating,
-/area/station/science/gen_storage)
+/area/station/chemistry)
 "clZ" = (
 /obj/machinery/light{
 	dir = 8;
@@ -55263,14 +54868,11 @@
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "cmM" = (
-/obj/machinery/power/apc{
-	name = "S APC";
-	pixel_y = -24
-	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "cmN" = (
@@ -55354,11 +54956,8 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/science)
 "cmV" = (
-/obj/machinery/power/apc{
-	name = "S APC";
-	pixel_y = -24
-	},
 /obj/cable,
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor/caution/west,
 /area/station/hangar/science)
 "cmW" = (
@@ -55523,12 +55122,9 @@
 /area/station/medical/medbay)
 "cno" = (
 /obj/cable,
-/obj/machinery/power/apc{
-	name = "S APC";
-	pixel_y = -24
-	},
 /obj/table/glass/auto,
 /obj/random_item_spawner/desk_stuff,
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor/escape,
 /area/station/hallway/secondary/exit)
 "cnp" = (
@@ -57936,15 +57532,11 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "N APC";
-	pixel_y = 24
-	},
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southsolar)
 "crZ" = (
@@ -58580,11 +58172,6 @@
 /turf/simulated/floor/delivery/white,
 /area/station/chemistry)
 "ctj" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "N APC";
-	pixel_y = 24
-	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -58594,6 +58181,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/delivery/white,
 /area/station/routingdepot/medsci)
 "ctk" = (
@@ -58896,15 +58484,11 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "E APC";
-	pixel_x = 24
-	},
 /obj/disposalpipe/segment/transport{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/plating,
 /area/station/testchamber)
 "ctV" = (
@@ -59096,18 +58680,13 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc{
-	areastring = "Medical Research";
-	dir = 8;
-	name = "Medical Research APC";
-	pixel_x = -24
-	},
 /obj/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/plating,
-/area/station/maintenance/SWmaint)
+/area/station/medical/research)
 "cuw" = (
 /obj/cable{
 	d1 = 4;
@@ -60076,11 +59655,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "N APC";
-	pixel_y = 24
-	},
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/purple/side{
 	dir = 9
 	},
@@ -61051,17 +60626,13 @@
 /area/station/janitor/supply)
 "cyu" = (
 /obj/cable,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "E APC";
-	pixel_x = 24
-	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 9;
 	name = "autoname - SS13";
 	tag = ""
 	},
+/obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "cyv" = (
@@ -62010,13 +61581,8 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "W APC";
-	noalerts = 1;
-	pixel_x = -24
-	},
 /obj/marker/supplymarker,
+/obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/grey/side{
 	dir = 4
 	},
@@ -63197,16 +62763,12 @@
 /turf/simulated/shuttle/wall/corner,
 /area/shuttle/arrival/station)
 "gjs" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "N APC";
-	pixel_y = 24
-	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/vending/janitor,
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/purple/side{
 	dir = 1
 	},
@@ -63476,6 +63038,21 @@
 	icon_state = "3"
 	},
 /area/shuttle/arrival/station)
+"nlN" = (
+/obj/machinery/disposal,
+/obj/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 10
+	},
+/area/station/mining)
 "nqb" = (
 /obj/machinery/atmospherics/valve{
 	desc = "furnace bypass valve";
@@ -95229,7 +94806,7 @@ aag
 bVv
 cfx
 cgP
-chS
+bFs
 cjh
 ckB
 clY
@@ -97584,12 +97161,12 @@ aUk
 aUk
 aUk
 baf
-aQF
+bag
 bci
 bcO
 aQF
 aQF
-aQF
+bfS
 aQF
 aQF
 biC
@@ -97886,7 +97463,7 @@ aUk
 aUk
 aZi
 bag
-aQF
+bag
 bcj
 bcN
 aQF
@@ -106112,8 +105689,8 @@ cqT
 cnC
 cpQ
 cmz
-aif
-aif
+cng
+cng
 cng
 cwq
 cuY
@@ -121810,7 +121387,7 @@ cke
 clE
 cmO
 cnU
-bFs
+nlN
 bLE
 bMf
 bMf

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -48399,13 +48399,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 1
-	},
 /obj/machinery/door/airlock/pyro{
 	name = "Toilets";
-	req_access_txt = "0"
+	req_access_txt = null
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/crew_quarters/toilets)
 "bYg" = (
@@ -50763,8 +50761,8 @@
 /turf/simulated/floor/grime,
 /area/station/medical/robotics)
 "cdt" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/toilets)
 "cdu" = (
@@ -51721,14 +51719,14 @@
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "cfN" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
 	name = "Robotics Storage";
-	req_access_txt = "12;29"
+	req_access = null;
+	req_access_txt = null
 	},
+/obj/access_spawn/robotics,
+/obj/firedoor_spawn,
 /turf/simulated/floor/grime,
 /area/station/medical/robotics)
 "cfO" = (
@@ -52832,14 +52830,14 @@
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "cio" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
 	name = "Robotics Maintenance";
-	req_access_txt = "12;29"
+	req_access = null;
+	req_access_txt = null
 	},
+/obj/access_spawn/robotics,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "cip" = (
@@ -52996,14 +52994,14 @@
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "ciE" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro/medical{
 	dir = 4;
 	name = "Morgue";
-	req_access_txt = "29"
+	req_access = null;
+	req_access_txt = null
 	},
+/obj/access_spawn/robotics,
+/obj/firedoor_spawn,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "ciF" = (
@@ -53309,7 +53307,7 @@
 /obj/machinery/door/window/westright{
 	dir = 1;
 	name = "Pharmacy";
-	req_access_txt = "5"
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 4;
@@ -53325,6 +53323,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/access_spawn/medical,
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay)
 "cjp" = (
@@ -54313,17 +54312,17 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro/medical{
 	dir = 4;
 	name = "Morgue";
-	req_access_txt = "5"
+	req_access = null;
+	req_access_txt = null
 	},
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
+/obj/access_spawn/medical,
+/obj/firedoor_spawn,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "clo" = (
@@ -54662,9 +54661,10 @@
 /obj/table/reinforced/auto,
 /obj/machinery/door/window/eastright{
 	name = "Pharmacy";
-	req_access_txt = "5"
+	req_access_txt = null
 	},
 /obj/machinery/phone,
+/obj/access_spawn/medical,
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay)
 "cmg" = (
@@ -54852,11 +54852,13 @@
 /obj/machinery/door/airlock/pyro/medical{
 	dir = 4;
 	name = "Morgue";
-	req_access_txt = "5"
+	req_access = null;
+	req_access_txt = null
 	},
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
+/obj/access_spawn/medical,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "cmC" = (
@@ -55240,11 +55242,12 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Medical Director";
-	req_access_txt = "53"
+	req_access_txt = null
 	},
+/obj/access_spawn/medical_director,
+/obj/firedoor_spawn,
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/head)
 "cnt" = (
@@ -55321,16 +55324,17 @@
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "cnz" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Robotics";
-	req_access_txt = "29"
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/access_spawn/robotics,
+/obj/firedoor_spawn,
 /turf/simulated/floor/blue,
 /area/station/medical/robotics)
 "cnA" = (
@@ -55851,11 +55855,10 @@
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Pharmacy";
-	req_access_txt = "5"
+	req_access_txt = null
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/access_spawn/medical,
+/obj/firedoor_spawn,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "coC" = (
@@ -56371,11 +56374,10 @@
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Pharmacy";
-	req_access_txt = "5"
+	req_access_txt = null
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/access_spawn/medical,
+/obj/firedoor_spawn,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "cpD" = (
@@ -56533,14 +56535,14 @@
 	},
 /area/station/medical/medbay)
 "cpQ" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro/medical{
 	dir = 4;
 	name = "Morgue";
-	req_access_txt = "5"
+	req_access = null;
+	req_access_txt = null
 	},
+/obj/access_spawn/medical,
+/obj/firedoor_spawn,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "cpR" = (
@@ -57124,7 +57126,8 @@
 "cqV" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance{
-	req_access_txt = "5"
+	req_access = null;
+	req_access_txt = null
 	},
 /obj/disposalpipe/segment/mail,
 /obj/cable{
@@ -57132,6 +57135,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/access_spawn/medical,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
 "cqW" = (
@@ -57929,8 +57933,9 @@
 	},
 /obj/machinery/door/window/westright{
 	name = "Operating Room";
-	req_access_txt = "5"
+	req_access_txt = null
 	},
+/obj/access_spawn/medical,
 /turf/simulated/floor,
 /area/station/medical/medbay)
 "csG" = (
@@ -58372,12 +58377,13 @@
 /turf/simulated/floor/plating,
 /area/station/medical/research)
 "ctE" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Med-Sci";
-	req_access_txt = "9"
+	req_access_txt = null
 	},
 /obj/disposalpipe/segment,
+/obj/access_spawn/medlab,
+/obj/firedoor_spawn,
 /turf/simulated/floor/bluewhite{
 	dir = 5
 	},
@@ -58657,8 +58663,9 @@
 "cuh" = (
 /obj/machinery/door/window/westright{
 	name = "Operating Room";
-	req_access_txt = "5"
+	req_access_txt = null
 	},
+/obj/access_spawn/medical,
 /turf/simulated/floor/redwhite{
 	dir = 8
 	},
@@ -58669,8 +58676,9 @@
 "cuj" = (
 /obj/machinery/door/window/eastleft{
 	name = "Operating Room";
-	req_access_txt = "5"
+	req_access_txt = null
 	},
+/obj/access_spawn/medical,
 /turf/simulated/floor/redwhite{
 	dir = 4
 	},
@@ -59100,8 +59108,9 @@
 /obj/machinery/door/window/westleft{
 	desc = "5";
 	name = "Operating Room";
-	req_access_txt = "5"
+	req_access_txt = null
 	},
+/obj/access_spawn/medical,
 /turf/simulated/floor/redwhite{
 	dir = 8
 	},
@@ -59123,8 +59132,9 @@
 "cve" = (
 /obj/machinery/door/window/eastright{
 	name = "Operating Room";
-	req_access_txt = "5"
+	req_access_txt = null
 	},
+/obj/access_spawn/medical,
 /turf/simulated/floor/redwhite{
 	dir = 4
 	},
@@ -59182,11 +59192,10 @@
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Med-Sci";
-	req_access_txt = "9"
+	req_access_txt = null
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/access_spawn/medlab,
+/obj/firedoor_spawn,
 /turf/simulated/floor/bluewhite{
 	dir = 10
 	},
@@ -59219,15 +59228,16 @@
 /area/station/maintenance/SWmaint)
 "cvn" = (
 /obj/disposalpipe/segment,
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass{
 	id = "medbay_front";
 	name = "Medical Bay";
-	req_access_txt = "5"
+	req_access_txt = null
 	},
 /obj/machinery/secscanner{
 	pixel_y = 10
 	},
+/obj/access_spawn/medical,
+/obj/firedoor_spawn,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "cvo" = (
@@ -59333,14 +59343,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Break Room";
-	req_access_txt = "5"
+	req_access_txt = null
 	},
+/obj/access_spawn/medical,
+/obj/firedoor_spawn,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "cvA" = (
@@ -59440,12 +59449,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
 /obj/disposalpipe/segment,
 /obj/machinery/door/airlock/pyro{
 	name = "Custodial Closet";
-	req_access_txt = "26"
+	req_access_txt = null
 	},
+/obj/access_spawn/janitor,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/janitor/supply)
 "cvM" = (
@@ -59697,23 +59707,23 @@
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Med-Sci";
-	req_access_txt = "9"
+	req_access_txt = null
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/access_spawn/medlab,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/medical/research)
 "cwr" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass{
 	id = "medbay_front";
 	name = "Medical Bay";
-	req_access_txt = "5"
+	req_access_txt = null
 	},
 /obj/machinery/secscanner{
 	pixel_y = 10
 	},
+/obj/access_spawn/medical,
+/obj/firedoor_spawn,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "cws" = (
@@ -60082,7 +60092,6 @@
 /area/station/janitor/supply)
 "cxc" = (
 /obj/disposalpipe/segment,
-/obj/machinery/door/firedoor/pyro,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -60090,8 +60099,10 @@
 	},
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Pathology Lab";
-	req_access_txt = "5"
+	req_access_txt = null
 	},
+/obj/access_spawn/medical,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery/white,
 /area/station/medical/cdc)
 "cxd" = (
@@ -60115,11 +60126,12 @@
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
 "cxg" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Monkey Pen";
-	req_access_txt = "5"
+	req_access_txt = null
 	},
+/obj/access_spawn/medical,
+/obj/firedoor_spawn,
 /turf/simulated/floor/blue,
 /area/station/medical/research)
 "cxh" = (
@@ -60310,11 +60322,12 @@
 /area/station/medical/cdc)
 "cxD" = (
 /obj/disposalpipe/segment,
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Pathology Lab";
-	req_access_txt = "5"
+	req_access_txt = null
 	},
+/obj/access_spawn/medical,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery/white,
 /area/station/medical/cdc)
 "cxE" = (
@@ -60577,14 +60590,13 @@
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "cyg" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Quarantine 1";
-	req_access_txt = "5"
+	req_access_txt = null
 	},
+/obj/access_spawn/medical,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery/white,
 /area/station/medical/cdc)
 "cyh" = (
@@ -60640,14 +60652,13 @@
 /turf/simulated/floor/plating,
 /area/station/medical/research)
 "cyo" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Pathology Lab";
-	req_access_txt = "5"
+	req_access_txt = null
 	},
+/obj/access_spawn/medical,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery/white,
 /area/station/medical/cdc)
 "cyp" = (
@@ -60659,8 +60670,9 @@
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Monkey Pen";
-	req_access_txt = "5"
+	req_access_txt = null
 	},
+/obj/access_spawn/medical,
 /turf/simulated/floor/delivery,
 /area/station/medical/cdc)
 "cyr" = (
@@ -60808,16 +60820,15 @@
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Quarantine 2";
-	req_access_txt = "5"
-	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/access_spawn/medical,
+/obj/firedoor_spawn,
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "cyF" = (

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -5319,7 +5319,6 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "ami" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -5327,8 +5326,11 @@
 	},
 /obj/machinery/door/airlock/pyro{
 	name = "Catering Storage";
-	req_access_txt = "25|28"
+	req_access_txt = null
 	},
+/obj/access_spawn/bar,
+/obj/access_spawn/kitchen,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/catering)
 "amj" = (
@@ -6832,14 +6834,14 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "apM" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
 	name = "Catering Storage";
-	req_access_txt = "25|28"
+	req_access_txt = null
 	},
+/obj/access_spawn/bar,
+/obj/access_spawn/kitchen,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/crew_quarters/catering)
 "apN" = (
@@ -7293,11 +7295,12 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/cafeteria)
 "aqS" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro{
 	name = "Kitchen";
-	req_access_txt = "28"
+	req_access_txt = null
 	},
+/obj/access_spawn/kitchen,
+/obj/firedoor_spawn,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/cafeteria)
 "aqT" = (
@@ -7309,14 +7312,13 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "aqU" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
 	name = "Kitchen";
-	req_access_txt = "28"
+	req_access_txt = null
 	},
+/obj/access_spawn/kitchen,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/kitchen)
 "aqV" = (
@@ -8026,14 +8028,13 @@
 	name = "Tool Storage"
 	})
 "asE" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
 	name = "Hydroponics";
-	req_access_txt = "35"
+	req_access_txt = null
 	},
+/obj/access_spawn/hydro,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/hallway/primary/east)
 "asF" = (
@@ -8445,8 +8446,10 @@
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
 	name = "Bar";
-	req_access_txt = "25|28"
+	req_access_txt = null
 	},
+/obj/access_spawn/bar,
+/obj/access_spawn/kitchen,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
 "atC" = (
@@ -8490,8 +8493,9 @@
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Meat Locker";
-	req_access_txt = "28"
+	req_access_txt = null
 	},
+/obj/access_spawn/kitchen,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/catering)
 "atH" = (
@@ -9125,15 +9129,16 @@
 	},
 /area/station/crew_quarters/pool)
 "avf" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro{
 	name = "Hydroponics Storage";
-	req_access_txt = "35"
+	req_access_txt = null
 	},
 /obj/disposalpipe/segment/produce,
+/obj/access_spawn/hydro,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hydroponics/lobby)
 "avg" = (
@@ -9519,14 +9524,13 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
 "awc" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
 	name = "Bar";
-	req_access_txt = "25"
+	req_access_txt = null
 	},
+/obj/access_spawn/bar,
+/obj/firedoor_spawn,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/cafeteria)
 "awd" = (
@@ -9549,14 +9553,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
 	name = "Bar";
-	req_access_txt = "25"
+	req_access_txt = null
 	},
+/obj/access_spawn/bar,
+/obj/firedoor_spawn,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/bar)
 "awg" = (
@@ -10398,17 +10401,16 @@
 /turf/simulated/floor,
 /area/station/hydroponics/lobby)
 "axP" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/disposalpipe/segment/produce{
 	dir = 4
 	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Biodome";
-	req_access_txt = "35"
+	req_access_txt = null
 	},
+/obj/access_spawn/hydro,
+/obj/firedoor_spawn,
 /turf/simulated/floor/green,
 /area/station/hydroponics)
 "axQ" = (
@@ -10933,7 +10935,6 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/storage/emergency)
 "ayV" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/disposalpipe/segment,
 /obj/cable{
 	d1 = 1;
@@ -10942,8 +10943,11 @@
 	},
 /obj/machinery/door/airlock/pyro{
 	name = "Catering Storage";
-	req_access_txt = "25|28"
+	req_access_txt = null
 	},
+/obj/access_spawn/bar,
+/obj/access_spawn/kitchen,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/storage/emergency)
 "ayW" = (
@@ -11078,17 +11082,16 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Biodome";
-	req_access_txt = "35"
+	req_access_txt = null
 	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/access_spawn/hydro,
+/obj/firedoor_spawn,
 /turf/simulated/floor/green,
 /area/station/hydroponics)
 "azk" = (
@@ -12424,7 +12427,6 @@
 	name = "Tool Storage"
 	})
 "aCg" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -12434,6 +12436,7 @@
 	name = "Tool Storage";
 	req_access_txt = null
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/yellow,
 /area/station/storage/auxillary{
 	name = "Tool Storage"
@@ -12492,7 +12495,6 @@
 /turf/simulated/floor/green,
 /area/station/hydroponics/lobby)
 "aCl" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -12500,8 +12502,10 @@
 	},
 /obj/machinery/door/airlock/pyro{
 	name = "Hydroponics";
-	req_access_txt = "35"
+	req_access_txt = null
 	},
+/obj/access_spawn/hydro,
+/obj/firedoor_spawn,
 /turf/simulated/floor/green,
 /area/station/hydroponics/lobby)
 "aCm" = (
@@ -13740,8 +13744,10 @@
 "aED" = (
 /obj/machinery/door/airlock/pyro{
 	name = "Bar";
-	req_access_txt = "25|28"
+	req_access_txt = null
 	},
+/obj/access_spawn/bar,
+/obj/access_spawn/kitchen,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
 "aEE" = (
@@ -25877,11 +25883,12 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/disposal)
 "bdJ" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/classic{
 	name = "Recycling Room";
-	req_access_txt = "12"
+	req_access_txt = null
 	},
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /turf/simulated/floor/grime,
 /area/station/maintenance/disposal)
 "bdK" = (
@@ -26304,13 +26311,14 @@
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
 	name = "Custodial Closet";
-	req_access_txt = "26"
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/access_spawn/janitor,
 /turf/simulated/floor/grime,
 /area/station/janitor)
 "beD" = (
@@ -26762,13 +26770,14 @@
 /area/station/maintenance/disposal)
 "bfu" = (
 /obj/machinery/door/airlock/pyro/classic{
-	req_access_txt = "12"
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor,
 /area/station/maintenance/disposal)
 "bfv" = (
@@ -27309,17 +27318,16 @@
 	},
 /area/station/janitor)
 "bgz" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro/classic{
 	dir = 4;
 	name = "Recycling Room";
-	req_access_txt = "26"
+	req_access_txt = null
 	},
 /obj/disposalpipe/segment/ejection{
 	dir = 4
 	},
+/obj/access_spawn/janitor,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/janitor)
 "bgA" = (
@@ -28045,8 +28053,9 @@
 "bif" = (
 /obj/machinery/door/airlock/pyro/classic{
 	dir = 4;
-	req_access_txt = "12"
+	req_access_txt = null
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor,
 /area/station/maintenance/disposal)
 "big" = (
@@ -28980,7 +28989,7 @@
 /area/station/maintenance/disposal)
 "bkg" = (
 /obj/machinery/door/airlock/pyro/classic{
-	req_access_txt = "12"
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 1;
@@ -28988,6 +28997,7 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/morgue,
+/obj/access_spawn/maint,
 /turf/simulated/floor,
 /area/station/maintenance/disposal)
 "bkh" = (
@@ -31195,7 +31205,7 @@
 "boR" = (
 /obj/machinery/door/airlock/pyro/classic{
 	name = "Emergency Airbridge Access";
-	req_access_txt = "12"
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 1;
@@ -31203,6 +31213,7 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/morgue,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "boS" = (

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -12432,7 +12432,7 @@
 	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	name = "Tool Storage";
-	req_access_txt = "12"
+	req_access_txt = null
 	},
 /turf/simulated/floor/yellow,
 /area/station/storage/auxillary{
@@ -13754,7 +13754,6 @@
 /turf/simulated/floor/plating,
 /area/station/storage/emergency)
 "aEG" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Emergency Storage"
 	},
@@ -13763,13 +13762,14 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/storage/emergency)
 "aEH" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Emergency Storage"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/storage/emergency)
 "aEI" = (
@@ -16214,11 +16214,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Medical Booth";
-	req_access_txt = "5"
+	req_access_txt = null
 	},
+/obj/access_spawn/medical,
+/obj/firedoor_spawn,
 /turf/simulated/floor/blue/side,
 /area/station/medical/medbooth)
 "aJN" = (
@@ -16306,8 +16307,9 @@
 	},
 /obj/machinery/door/window/westleft{
 	name = "Chapel Mass Driver";
-	req_access_txt = "22"
+	req_access_txt = null
 	},
+/obj/access_spawn/chapel_office,
 /turf/simulated/floor/plating,
 /area/station/chapel/main)
 "aJY" = (
@@ -20446,6 +20448,9 @@
 /area/station/crew_quarters/jazz)
 "aSs" = (
 /obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/right{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
 "aSt" = (
@@ -20541,20 +20546,22 @@
 "aSE" = (
 /obj/machinery/door/window/northleft{
 	name = "Chaplain's Office";
-	req_access_txt = "22"
+	req_access_txt = null
 	},
+/obj/access_spawn/chapel_office,
 /turf/simulated/floor/black,
 /area/station/chapel/office)
 "aSF" = (
 /obj/machinery/door/window/northright{
 	name = "Chaplain's Office";
-	req_access_txt = "22"
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/access_spawn/chapel_office,
 /turf/simulated/floor/black,
 /area/station/chapel/office)
 "aSG" = (
@@ -21580,7 +21587,7 @@
 	autoclose = 0;
 	dir = 4;
 	name = "Confession Booth (Chaplain)";
-	req_access_txt = "22"
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 4;
@@ -21590,6 +21597,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/access_spawn/chapel_office,
 /turf/simulated/floor/black,
 /area/station/chapel/office)
 "aUX" = (
@@ -22149,17 +22157,17 @@
 /obj/machinery/door/airlock/pyro/security{
 	dir = 4;
 	name = "Detective";
-	req_access_txt = "4"
+	req_access = null;
+	req_access_txt = null
 	},
 /obj/decal/cleanable/ash,
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/access_spawn/forensics,
+/obj/firedoor_spawn,
 /turf/simulated/floor/grime,
 /area/station/security/detectives_office)
 "aWi" = (
@@ -22206,14 +22214,13 @@
 /turf/simulated/floor/black,
 /area/station/medical/crematorium)
 "aWo" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
 	name = "Crematorium";
-	req_access_txt = "22"
+	req_access_txt = null
 	},
+/obj/access_spawn/chapel_office,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/medical/crematorium)
 "aWp" = (
@@ -22875,11 +22882,11 @@
 /obj/machinery/door/airlock/pyro/security{
 	dir = 4;
 	name = "Detective";
-	req_access_txt = "4"
+	req_access = null;
+	req_access_txt = null
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/access_spawn/forensics,
+/obj/firedoor_spawn,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aXy" = (
@@ -23837,11 +23844,12 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/security/detectives_office)
 "aZB" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro{
 	name = "Crematorium";
-	req_access_txt = "27"
+	req_access_txt = null
 	},
+/obj/access_spawn/crematorium,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/medical/crematorium)
 "aZC" = (

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -63015,6 +63015,16 @@
 	},
 /turf/simulated/floor/bot,
 /area/station/engine/gas)
+"mjO" = (
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
+	},
+/obj/machinery/light/small/floor,
+/turf/simulated/floor/carpet{
+	dir = 8;
+	icon_state = "fred1"
+	},
+/area/station/chapel/main)
 "msz" = (
 /obj/lattice,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -63076,6 +63086,13 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/hotloop)
+"nuk" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "qmin"
+	},
+/turf/space,
+/area)
 "nvq" = (
 /turf/simulated/wall/auto/shuttle{
 	icon_state = "7"
@@ -120402,7 +120419,7 @@ aIO
 aJT
 aLf
 aMo
-aNv
+mjO
 aMo
 aLf
 aJT
@@ -123776,9 +123793,9 @@ aaa
 aaa
 aah
 aaa
-aaj
-aaa
-aaj
+aah
+nuk
+aah
 cxB
 bLc
 bLc
@@ -124078,9 +124095,9 @@ aaa
 aaa
 aah
 aaa
-aaa
-aaa
-aaa
+aag
+bHU
+aaG
 bJU
 bLc
 bLc
@@ -124380,9 +124397,9 @@ aaa
 aaa
 aah
 aaa
+aaj
 aaa
-aaa
-aaa
+aaj
 bJU
 bFr
 bMF

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -1681,8 +1681,9 @@
 	},
 /obj/machinery/door/airlock/pyro/external{
 	name = "External Access";
-	req_access_txt = "13;40"
+	req_access_txt = null
 	},
+/obj/access_spawn/engineering,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northsolar)
 "aeo" = (
@@ -2703,9 +2704,10 @@
 	},
 /obj/machinery/door/airlock/pyro/external{
 	name = "External Access";
-	req_access_txt = "13;40"
+	req_access_txt = null
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/access_spawn/engineering,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northsolar)
 "agy" = (
@@ -12166,20 +12168,19 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/secwing)
 "aBB" = (
-/obj/machinery/disposal,
-/obj/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
+/obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
-	name = "autoname - SS13";
-	tag = ""
+	name = "Electrical Substation"
 	},
-/turf/simulated/floor/yellow/side{
-	dir = 10
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/area/station/mining)
+/obj/access_spawn/engineering_power,
+/obj/firedoor_spawn,
+/turf/simulated/floor/plating,
+/area/station/turret_protected/ai_upload_foyer)
 "aBC" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/cable{
@@ -25766,6 +25767,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/access_spawn/engineering_power,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/engine/substation/pylon)
 "bdw" = (
@@ -31952,8 +31955,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/external{
-	req_access_txt = "44"
+	req_access_txt = null
 	},
+/obj/access_spawn/engineering_storage,
 /turf/simulated/floor/plating,
 /area/station/hangar/engine)
 "bqs" = (
@@ -32240,8 +32244,9 @@
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
 	name = "Engineering Hangar";
-	req_access_txt = "44"
+	req_access_txt = null
 	},
+/obj/access_spawn/engineering_storage,
 /turf/simulated/floor/plating,
 /area/station/hangar/engine)
 "bqW" = (
@@ -32841,10 +32846,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/engineering{
-	req_access_txt = "44"
+	req_access_txt = null
 	},
+/obj/access_spawn/engineering_engine,
 /turf/simulated/floor/plating,
 /area/station/hangar/engine)
 "bsi" = (
@@ -33154,24 +33159,26 @@
 /turf/simulated/floor,
 /area/station/maintenance/east)
 "bsL" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/external{
 	name = "Engine Supply Dock";
-	req_access_txt = "40"
+	req_access_txt = null
 	},
+/obj/access_spawn/engineering_engine,
+/obj/firedoor_spawn,
 /turf/simulated/floor/caution/south,
 /area/station/routingdepot/engine)
 "bsM" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/external{
 	name = "Engine Supply Dock";
-	req_access_txt = "40"
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/access_spawn/engineering_engine,
+/obj/firedoor_spawn,
 /turf/simulated/floor/caution/south,
 /area/station/routingdepot/engine)
 "bsN" = (
@@ -33529,12 +33536,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
-"btA" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/inner)
 "btB" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /turf/simulated/floor/delivery,
@@ -33544,9 +33545,7 @@
 /turf/simulated/floor/delivery,
 /area/station/engine/inner)
 "btD" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
 "btE" = (
@@ -33804,8 +33803,9 @@
 	name = "crematorium pipe"
 	},
 /obj/machinery/door/window/northleft{
-	req_access_txt = "19"
+	req_access_txt = null
 	},
+/obj/access_spawn/ai_upload,
 /turf/simulated/floor/blue/side{
 	dir = 1
 	},
@@ -33901,9 +33901,7 @@
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
 "but" = (
@@ -33926,12 +33924,10 @@
 /turf/simulated/floor/delivery,
 /area/station/engine/inner)
 "buv" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
 "buw" = (
@@ -34264,11 +34260,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/engineering{
-	name = "Generator Core";
-	req_access_txt = "44"
+	name = "Generator Core"
 	},
+/obj/access_spawn/engineering_engine,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/engine/core)
 "bvh" = (
@@ -34300,9 +34296,8 @@
 	dir = 4;
 	name = "Gas Storage"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/access_spawn/engineering_engine,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/engine/gas)
 "bvk" = (
@@ -34346,13 +34341,14 @@
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
 	name = "Power Transmission Laser";
-	req_access_txt = "44"
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/access_spawn/engineering_engine,
 /turf/simulated/floor,
 /area/station/engine/gas)
 "bvo" = (
@@ -34996,12 +34992,13 @@
 /area/station/turret_protected/AIbaseoutside)
 "bwG" = (
 /obj/machinery/door/window/northleft{
-	req_access_txt = "19"
+	req_access_txt = null
 	},
 /obj/machinery/light_switch{
 	name = "S light switch";
 	pixel_y = -24
 	},
+/obj/access_spawn/ai_upload,
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai_upload)
 "bwH" = (
@@ -35024,8 +35021,9 @@
 	},
 /obj/machinery/turretid{
 	pixel_x = 24;
-	req_access_txt = "19"
+	req_access_txt = null
 	},
+/obj/access_spawn/ai_upload,
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai_upload)
 "bwJ" = (
@@ -35368,11 +35366,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/command{
 	name = "AI Upload";
-	req_access_txt = "19"
+	req_access = null
 	},
+/obj/access_spawn/ai_upload,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/turret_protected/ai_upload_foyer)
 "bxA" = (
@@ -36043,7 +36042,6 @@
 /turf/simulated/floor/plating,
 /area/station/engine/gas)
 "byQ" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -36051,8 +36049,10 @@
 	},
 /obj/machinery/door/airlock/pyro/glass/engineering{
 	name = "Gas Storage";
-	req_access_txt = "40"
+	req_access_txt = null
 	},
+/obj/access_spawn/engineering_engine,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/engine/gas)
 "byR" = (
@@ -36322,8 +36322,9 @@
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4;
 	name = "AI and Computer Core";
-	req_access_txt = "19"
+	req_access_txt = null
 	},
+/obj/access_spawn/heads,
 /turf/simulated/floor/delivery,
 /area/station/crew_quarters/market)
 "bzw" = (
@@ -36334,8 +36335,9 @@
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4;
 	name = "AI and Computer Core";
-	req_access_txt = "19"
+	req_access_txt = null
 	},
+/obj/access_spawn/heads,
 /turf/simulated/floor/delivery,
 /area/station/turret_protected/ai_upload_foyer)
 "bzy" = (
@@ -36401,18 +36403,18 @@
 	},
 /area/station/turret_protected/ai_upload_foyer)
 "bzD" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
-/obj/machinery/door/airlock/pyro/engineering{
-	dir = 4;
-	name = "Electrical Substation"
-	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/command{
+	dir = 4;
+	name = "Electrical Substation";
+	req_access = null
+	},
+/obj/access_spawn/heads,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/turret_protected/ai_upload_foyer)
 "bzE" = (
@@ -37297,13 +37299,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 1
-	},
 /obj/machinery/door/airlock/pyro/command{
 	name = "Computer Core Access";
-	req_access_txt = "19"
+	req_access = null;
+	req_access_txt = null
 	},
+/obj/access_spawn/heads,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/turret_protected/ai_upload_foyer)
 "bBt" = (
@@ -37666,11 +37668,12 @@
 "bCi" = (
 /obj/machinery/turretid{
 	pixel_x = -24;
-	req_access_txt = "19"
+	req_access_txt = null
 	},
 /obj/window/reinforced{
 	dir = 2
 	},
+/obj/access_spawn/heads,
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
 "bCj" = (
@@ -37689,12 +37692,13 @@
 /area/station/turret_protected/Zeta)
 "bCk" = (
 /obj/machinery/door/window/southleft{
-	req_access_txt = "19"
+	req_access_txt = null
 	},
 /obj/machinery/light_switch{
 	name = "N light switch";
 	pixel_y = 24
 	},
+/obj/access_spawn/heads,
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
 "bCl" = (
@@ -38273,17 +38277,15 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
-	name = "Hot Loop Equipment Room";
-	req_access_txt = "44"
+	name = "Hot Loop Equipment Room"
 	},
+/obj/access_spawn/engineering_engine,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/engine/hotloop)
 "bDv" = (
@@ -38320,14 +38322,14 @@
 /turf/simulated/floor/plating,
 /area/station/engine/core)
 "bDy" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0
 	},
 /obj/machinery/door/airlock/pyro/glass/engineering{
-	name = "Core Access";
-	req_access_txt = "44"
+	name = "Core Access"
 	},
+/obj/access_spawn/engineering_engine,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/engine/core)
 "bDz" = (
@@ -38335,7 +38337,6 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "bDA" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	can_rupture = 0
 	},
@@ -38343,9 +38344,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/glass/engineering{
-	name = "Core Access";
-	req_access_txt = "44"
+	name = "Core Access"
 	},
+/obj/access_spawn/engineering_engine,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/engine/core)
 "bDB" = (
@@ -38371,19 +38373,18 @@
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
 "bDD" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
 	name = "Cold Loop Equipment Room";
-	req_access_txt = "44"
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/access_spawn/engineering_engine,
+/obj/firedoor_spawn,
 /turf/simulated/floor/grime,
 /area/station/engine/coldloop)
 "bDE" = (
@@ -38701,15 +38702,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
-"bEp" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/inner)
 "bEq" = (
 /obj/submachine/cargopad{
 	name = "Mineral Magnet Pad"
@@ -38736,9 +38728,7 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
 "bEu" = (
@@ -39198,6 +39188,21 @@
 "bFr" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/qm)
+"bFs" = (
+/obj/machinery/disposal,
+/obj/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 10
+	},
+/area/station/mining)
 "bFt" = (
 /obj/cable,
 /obj/cable{
@@ -39375,22 +39380,24 @@
 /turf/simulated/floor/delivery,
 /area/station/engine/hotloop)
 "bFJ" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass/engineering{
 	name = "Core Access";
-	req_access_txt = "44"
+	req_access_txt = null
 	},
+/obj/access_spawn/engineering_control,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/engine/inner)
 "bFK" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/glass/engineering{
 	name = "Core Access";
-	req_access_txt = "44"
+	req_access_txt = null
 	},
+/obj/access_spawn/engineering_control,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/engine/inner)
 "bFL" = (
@@ -39471,17 +39478,16 @@
 /turf/simulated/floor/grime,
 /area/station/engine/coldloop)
 "bFT" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
 	name = "Ore Processing";
-	req_access_txt = "44"
+	req_access_txt = null
 	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/access_spawn/engineering_engine,
+/obj/firedoor_spawn,
 /turf/simulated/floor/grime,
 /area/station/storage/warehouse)
 "bFU" = (
@@ -39762,11 +39768,11 @@
 /turf/simulated/floor/plating,
 /area/station/engine/power)
 "bGy" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/engineering{
-	name = "Power Room";
-	req_access_txt = "44"
+	name = "Power Room"
 	},
+/obj/access_spawn/engineering_engine,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/engine/power)
 "bGz" = (
@@ -40654,14 +40660,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/glass/engineering{
 	dir = 4;
 	name = "Power Room";
-	req_access_txt = "40"
+	req_access_txt = null
 	},
+/obj/access_spawn/engineering_power,
+/obj/firedoor_spawn,
 /turf/simulated/floor/grime,
 /area/station/engine/power)
 "bIm" = (
@@ -40842,9 +40847,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
 	name = "Cold Loop Equipment Room"
@@ -40852,6 +40854,8 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/access_spawn/engineering_engine,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/engine/coldloop)
 "bIz" = (
@@ -41766,16 +41770,17 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/science)
 "bKr" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/engineering{
 	name = "Power Room";
-	req_access_txt = "45"
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/access_spawn/engineering_mechanic,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/engine/power)
 "bKs" = (
@@ -41879,19 +41884,18 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
 	name = "Engineering Storage";
-	req_access_txt = "44"
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/access_spawn/engineering_storage,
+/obj/firedoor_spawn,
 /turf/simulated/floor/yellow,
 /area/station/storage/primary)
 "bKG" = (
@@ -42528,15 +42532,15 @@
 	},
 /area/station/engine/elect)
 "bLX" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/engineering{
-	req_access_txt = "44"
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/engine/engineering)
 "bLY" = (
@@ -42544,11 +42548,11 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/south)
 "bLZ" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/engineering{
-	req_access_txt = "44"
+	req_access_txt = null
 	},
 /obj/disposalpipe/segment/mail,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/engine/engineering)
 "bMa" = (
@@ -42557,7 +42561,6 @@
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
 "bMb" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -42565,8 +42568,11 @@
 	},
 /obj/machinery/door/airlock/pyro/command{
 	name = "Chief Engineer";
-	req_access_txt = "49"
+	req_access = null;
+	req_access_txt = null
 	},
+/obj/access_spawn/engineering_chief,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "bMc" = (
@@ -44675,19 +44681,18 @@
 	},
 /area/station/storage/primary)
 "bQt" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
 	name = "Engineering Storage";
-	req_access_txt = "44"
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/access_spawn/engineering_storage,
+/obj/firedoor_spawn,
 /turf/simulated/floor/grime,
 /area/station/storage/primary)
 "bQu" = (
@@ -46141,7 +46146,6 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/engine/elect)
 "bTh" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/engineering{
 	name = "Electronics Lab";
 	req_access_txt = "45"
@@ -46150,6 +46154,8 @@
 	can_rupture = 0;
 	dir = 4
 	},
+/obj/access_spawn/engineering_mechanic,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/engine/elect)
 "bTi" = (
@@ -46161,13 +46167,13 @@
 /turf/simulated/floor/white,
 /area/station/science/teleporter)
 "bTj" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass/engineering,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/engine/engineering)
 "bTk" = (
@@ -46175,9 +46181,9 @@
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
 "bTl" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass/engineering,
 /obj/disposalpipe/segment/mail,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/engine/engineering)
 "bTm" = (
@@ -62955,13 +62961,14 @@
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/external{
 	name = "Combustion Chamber Access";
-	req_access_txt = "40"
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/access_spawn/engineering_engine,
 /turf/simulated/floor/delivery,
 /area/station/engine/hotloop)
 "iQv" = (
@@ -63208,13 +63215,11 @@
 /turf/simulated/floor/black,
 /area/station/engine/hotloop)
 "oqx" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	can_rupture = 0;
 	dir = 10
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
 "osp" = (
@@ -63272,7 +63277,7 @@
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4;
 	name = "Combustion Chamber Access";
-	req_access_txt = "40"
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 4;
@@ -63282,6 +63287,7 @@
 /obj/machinery/door/firedoor/pyro{
 	dir = 4
 	},
+/obj/access_spawn/engineering_engine,
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/hotloop)
 "pSb" = (
@@ -63572,13 +63578,11 @@
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
 "yfg" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0;
 	dir = 6
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
 "yhD" = (
@@ -106338,7 +106342,7 @@ bvO
 bwF
 bxx
 bxx
-bzD
+aBB
 bAz
 bxx
 bCh
@@ -110861,7 +110865,7 @@ bqp
 bqp
 bqp
 bsN
-btA
+btD
 bus
 bvf
 txq
@@ -110873,7 +110877,7 @@ bwd
 bwT
 bCu
 bvf
-bEp
+bEt
 yfg
 tAM
 bMn
@@ -121473,7 +121477,7 @@ cke
 clE
 cmO
 cnU
-aBB
+bFs
 bLE
 bMf
 bMf

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -113,7 +113,9 @@
 /obj/grille/catwalk{
 	dir = 9
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
 	icon_state = "catwalk_cross"
@@ -382,7 +384,9 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -396,7 +400,9 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -417,7 +423,10 @@
 /obj/grille/catwalk{
 	dir = 10
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 1;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 1;
 	icon_state = "catwalk_cross"
@@ -436,7 +445,10 @@
 /obj/grille/catwalk{
 	dir = 5
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -464,7 +476,9 @@
 	icon_state = "1-2"
 	},
 /obj/grille/catwalk,
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 1
+	},
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/west)
 "abn" = (
@@ -636,7 +650,10 @@
 /obj/grille/catwalk/cross{
 	dir = 1
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -649,7 +666,9 @@
 	icon_state = "1-2"
 	},
 /obj/grille/catwalk,
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 1
+	},
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/north)
 "abQ" = (
@@ -1917,7 +1936,10 @@
 /obj/grille/catwalk{
 	dir = 9
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -1944,7 +1966,9 @@
 	dir = 5;
 	tag = "icon-catwalk_cross (NORTHEAST)"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5
 	},
@@ -1994,7 +2018,9 @@
 /obj/grille/catwalk{
 	dir = 6
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	icon_state = "catwalk_cross"
 	},
@@ -2068,7 +2094,10 @@
 /obj/grille/catwalk{
 	dir = 5
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -3520,7 +3549,10 @@
 /obj/grille/catwalk{
 	dir = 9
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
 	icon_state = "catwalk_cross"
@@ -9158,7 +9190,9 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -9625,7 +9659,9 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/solar/west)
 "awr" = (
 /obj/cable{
@@ -9636,7 +9672,9 @@
 /obj/grille/catwalk/cross{
 	dir = 5
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5
+	},
 /area/station/solar/west)
 "aws" = (
 /obj/item/storage/toilet{
@@ -10446,7 +10484,9 @@
 	icon_state = "1-2"
 	},
 /obj/grille/catwalk,
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 1
+	},
 /area/station/solar/west)
 "ayd" = (
 /obj/cable{
@@ -11973,7 +12013,9 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -13885,7 +13927,9 @@
 /obj/grille/catwalk/cross{
 	dir = 6
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 6
+	},
 /area/station/solar/west)
 "aFd" = (
 /obj/machinery/atmospherics/pipe/manifold{
@@ -14995,7 +15039,10 @@
 /obj/grille/catwalk{
 	dir = 5
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -15113,7 +15160,10 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
 	icon_state = "catwalk_cross"
@@ -27296,7 +27346,9 @@
 /obj/grille/catwalk{
 	dir = 6
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -27623,7 +27675,9 @@
 	dir = 5;
 	tag = "icon-catwalk_cross (NORTHEAST)"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5
 	},
@@ -28137,7 +28191,9 @@
 	dir = 9;
 	tag = "icon-catwalk_cross (NORTHWEST)"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 9
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 9
 	},
@@ -28614,7 +28670,10 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -28941,7 +29000,9 @@
 	dir = 5;
 	tag = "icon-catwalk_cross (NORTHEAST)"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5
 	},
@@ -29254,7 +29315,9 @@
 	dir = 10;
 	tag = "icon-catwalk_cross (SOUTHWEST)"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 10
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10
 	},
@@ -29419,7 +29482,9 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -29518,7 +29583,10 @@
 /obj/grille/catwalk{
 	dir = 5
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -30287,7 +30355,10 @@
 /obj/grille/catwalk{
 	dir = 9
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -30298,7 +30369,10 @@
 /obj/grille/catwalk{
 	dir = 5
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -30797,7 +30871,10 @@
 	},
 /obj/disposalpipe/segment,
 /obj/grille/catwalk,
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -30813,7 +30890,9 @@
 	dir = 10;
 	tag = "icon-catwalk_cross (SOUTHWEST)"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 10
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10
 	},
@@ -30848,7 +30927,10 @@
 /obj/grille/catwalk{
 	dir = 10
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -30865,7 +30947,9 @@
 	dir = 6;
 	tag = "icon-catwalk_cross (SOUTHEAST)"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 6
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6
 	},
@@ -30886,7 +30970,9 @@
 	dir = 10;
 	tag = "icon-catwalk_cross (SOUTHWEST)"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 10
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10
 	},
@@ -31021,7 +31107,10 @@
 /obj/grille/catwalk{
 	dir = 10
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 1;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -31049,7 +31138,9 @@
 	dir = 6;
 	tag = "icon-catwalk_cross (SOUTHEAST)"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 6
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6
 	},
@@ -31062,7 +31153,9 @@
 	},
 /obj/disposalpipe/segment,
 /obj/grille/catwalk,
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 1
+	},
 /turf/simulated/floor/airless/plating/catwalk,
 /area)
 "boM" = (
@@ -31376,7 +31469,9 @@
 	dir = 9;
 	tag = "icon-catwalk_cross (NORTHWEST)"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 9
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 9
 	},
@@ -31934,7 +32029,9 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -32507,7 +32604,9 @@
 	dir = 10;
 	tag = "icon-catwalk_cross (SOUTHWEST)"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 10
+	},
 /area)
 "brJ" = (
 /obj/cable{
@@ -32593,7 +32692,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -32642,7 +32743,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -33526,7 +33630,9 @@
 	icon_state = "1-2"
 	},
 /obj/grille/catwalk,
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 1
+	},
 /turf/simulated/floor/airless/plating/catwalk,
 /area)
 "btI" = (
@@ -33540,7 +33646,9 @@
 /obj/grille/catwalk/cross{
 	dir = 5
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
 	icon_state = "catwalk_cross"
@@ -33703,7 +33811,9 @@
 	dir = 9;
 	tag = "icon-catwalk_cross (NORTHWEST)"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 9
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 9
 	},
@@ -33720,7 +33830,9 @@
 /obj/grille/catwalk{
 	dir = 6
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -33811,7 +33923,9 @@
 	dir = 5;
 	tag = "icon-catwalk_cross (NORTHEAST)"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5
 	},
@@ -33940,7 +34054,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -34176,7 +34293,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -34234,7 +34353,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 1;
 	icon_state = "catwalk_cross"
@@ -34281,7 +34402,9 @@
 	dir = 5;
 	tag = "icon-catwalk_cross (NORTHEAST)"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5
 	},
@@ -34608,7 +34731,9 @@
 	dir = 9;
 	tag = "icon-catwalk_cross (NORTHWEST)"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 9
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 9
 	},
@@ -34621,7 +34746,10 @@
 /obj/grille/catwalk{
 	dir = 5
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -34674,7 +34802,10 @@
 /obj/grille/catwalk{
 	dir = 9
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -34695,7 +34826,9 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -34709,7 +34842,9 @@
 	dir = 5;
 	tag = "icon-catwalk_cross (NORTHEAST)"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -34732,7 +34867,9 @@
 	dir = 6;
 	tag = "icon-catwalk_cross (SOUTHEAST)"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 6
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -34779,7 +34916,9 @@
 	dir = 10;
 	tag = "icon-catwalk_cross (SOUTHWEST)"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 10
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10
 	},
@@ -35016,7 +35155,9 @@
 	dir = 6;
 	tag = "icon-catwalk_cross (SOUTHEAST)"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 6
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6
 	},
@@ -35030,7 +35171,10 @@
 /obj/grille/catwalk{
 	dir = 10
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 1;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -35069,7 +35213,9 @@
 	dir = 6;
 	tag = "icon-catwalk_cross (SOUTHEAST)"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 6
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6
 	},
@@ -35140,7 +35286,9 @@
 	dir = 10;
 	tag = "icon-catwalk_cross (SOUTHWEST)"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 10
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -35171,7 +35319,9 @@
 	dir = 5;
 	tag = "icon-catwalk_cross (NORTHEAST)"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -35377,7 +35527,9 @@
 "bxE" = (
 /obj/disposalpipe/segment,
 /obj/grille/catwalk,
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 1
+	},
 /turf/simulated/floor/airless/plating/catwalk,
 /area)
 "bxF" = (
@@ -35403,7 +35555,9 @@
 	dir = 10;
 	tag = "icon-catwalk_cross (SOUTHWEST)"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 10
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10
 	},
@@ -35413,7 +35567,9 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment/mail,
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -35434,7 +35590,10 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/morgue,
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -35455,7 +35614,9 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/morgue,
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 1
+	},
 /turf/simulated/floor/airless/plating/catwalk,
 /area)
 "bxN" = (
@@ -36468,7 +36629,10 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 1;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 9
 	},
@@ -36877,7 +37041,9 @@
 	dir = 5;
 	tag = "icon-catwalk_cross (NORTHEAST)"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5
 	},
@@ -36917,7 +37083,9 @@
 	dir = 9;
 	tag = "icon-catwalk_cross (NORTHWEST)"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 9
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 9
 	},
@@ -36926,7 +37094,10 @@
 /obj/grille/catwalk{
 	dir = 10
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 1;
 	icon_state = "catwalk_cross"
@@ -36951,7 +37122,10 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -36960,7 +37134,10 @@
 /obj/grille/catwalk/cross{
 	dir = 1
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -36975,7 +37152,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -37005,7 +37185,10 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -37019,7 +37202,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/quartermaster/refinery)
 "bAS" = (
@@ -37451,7 +37637,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -37748,7 +37936,10 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -37796,7 +37987,9 @@
 	dir = 10;
 	tag = "icon-catwalk_cross (SOUTHWEST)"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10
 	},
@@ -37838,7 +38031,9 @@
 	dir = 6;
 	tag = "icon-catwalk_cross (SOUTHEAST)"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 6
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6
 	},
@@ -37847,7 +38042,9 @@
 /obj/grille/catwalk{
 	dir = 6
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -38353,7 +38550,9 @@
 	dir = 10;
 	tag = "icon-catwalk_cross (SOUTHWEST)"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 10
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10
 	},
@@ -38926,7 +39125,10 @@
 /obj/grille/catwalk/cross{
 	dir = 1
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -38979,7 +39181,9 @@
 	dir = 6;
 	tag = "icon-catwalk_cross (SOUTHEAST)"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 6
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6
 	},
@@ -38997,7 +39201,10 @@
 /obj/grille/catwalk{
 	dir = 9
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
 	icon_state = "catwalk_cross"
@@ -39029,7 +39236,9 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -39043,7 +39252,9 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -39143,7 +39354,10 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/south)
 "bFr" = (
@@ -39318,7 +39532,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 1
+	},
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/south)
 "bFI" = (
@@ -39370,7 +39586,10 @@
 	dir = 10
 	},
 /obj/cable,
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 1;
 	icon_state = "catwalk_cross"
@@ -39413,7 +39632,9 @@
 	icon_state = "1-2"
 	},
 /obj/grille/catwalk,
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 1
+	},
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/south)
 "bFS" = (
@@ -39568,7 +39789,10 @@
 /obj/grille/catwalk/cross{
 	dir = 1
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -39749,7 +39973,9 @@
 /obj/grille/catwalk{
 	dir = 6
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	icon_state = "catwalk_cross"
 	},
@@ -39767,7 +39993,10 @@
 /obj/grille/catwalk{
 	dir = 5
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -48692,7 +48921,9 @@
 	icon_state = "magwarning2";
 	name = "ACTIVE MAGNET AREA"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 9
+	},
 /area/mining/magnet)
 "bYN" = (
 /obj/grille/catwalk{
@@ -48705,7 +48936,9 @@
 	icon_state = "magwarning";
 	name = "Magnet Area Boundary"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/mining/magnet)
 "bYO" = (
 /obj/grille/catwalk/cross{
@@ -48734,7 +48967,9 @@
 	icon_state = "magwarning2";
 	name = "ACTIVE MAGNET AREA"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5
+	},
 /area/mining/magnet)
 "bYP" = (
 /obj/decal/cleanable/cobweb,
@@ -49288,7 +49523,9 @@
 	icon_state = "magwarning";
 	name = "Magnet Area Boundary"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 1
+	},
 /area/mining/magnet)
 "cad" = (
 /turf/space,
@@ -49301,7 +49538,9 @@
 	icon_state = "magwarning";
 	name = "Magnet Area Boundary"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 1
+	},
 /area/mining/magnet)
 "caf" = (
 /obj/machinery/atmospherics/pipe/tank{
@@ -51972,7 +52211,8 @@
 	tag = ""
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 4
+	dir = 8;
+	icon_state = "catwalk_cross"
 	},
 /area/station/quartermaster/refinery)
 "cgA" = (
@@ -51986,7 +52226,10 @@
 	icon_state = "magwarning";
 	name = "Magnet Area Boundary"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	icon_state = "catwalk_cross"
+	},
 /area/mining/magnet)
 "cgB" = (
 /obj/machinery/atmospherics/pipe/vent{
@@ -52526,10 +52769,6 @@
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "chJ" = (
-/obj/lattice{
-	dir = 1;
-	icon_state = "lattice-dir"
-	},
 /obj/grille/catwalk{
 	dir = 4
 	},
@@ -52540,7 +52779,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 4
+	dir = 8;
+	icon_state = "catwalk_cross"
 	},
 /area/station/quartermaster/refinery)
 "chK" = (
@@ -53715,7 +53955,9 @@
 	dir = 4;
 	id = "mining"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area)
 "ckm" = (
 /obj/table/auto,
@@ -56623,7 +56865,9 @@
 	icon_state = "magwarning2";
 	name = "ACTIVE MAGNET AREA"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 10
+	},
 /area/mining/magnet)
 "cqh" = (
 /obj/grille/catwalk{
@@ -56636,7 +56880,9 @@
 	icon_state = "magwarning";
 	name = "Magnet Area Boundary"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/mining/magnet)
 "cqi" = (
 /obj/grille/catwalk/cross{
@@ -56665,7 +56911,9 @@
 	icon_state = "magwarning2";
 	name = "ACTIVE MAGNET AREA"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 6
+	},
 /area/mining/magnet)
 "cqj" = (
 /obj/table/auto,
@@ -62603,6 +62851,13 @@
 	},
 /turf/simulated/floor/bot,
 /area/station/engine/gas)
+"dJk" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "qmin"
+	},
+/turf/space,
+/area)
 "dLz" = (
 /obj/storage/crate/furnacefuel,
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
@@ -62762,6 +63017,24 @@
 	},
 /turf/simulated/shuttle/wall/corner,
 /area/shuttle/arrival/station)
+"geM" = (
+/obj/grille/catwalk{
+	dir = 4
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
+/area/station/quartermaster/refinery)
+"gfz" = (
+/obj/grille/catwalk,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 1
+	},
+/turf/simulated/floor/airless/plating/catwalk,
+/area)
 "gjs" = (
 /obj/cable{
 	d2 = 8;
@@ -62818,6 +63091,30 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
+"gtK" = (
+/obj/grille/catwalk/cross{
+	dir = 10;
+	tag = "icon-catwalk_cross (SOUTHWEST)"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 10
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 10
+	},
+/area/station/quartermaster/refinery)
+"gDG" = (
+/obj/grille/catwalk{
+	dir = 4
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 1;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
+/area/station/quartermaster/refinery)
 "gVk" = (
 /obj/cable{
 	d1 = 2;
@@ -62838,6 +63135,20 @@
 	dir = 5
 	},
 /area/station/storage/warehouse)
+"hmN" = (
+/obj/grille/catwalk,
+/obj/landmark/magnet_shield,
+/obj/securearea{
+	desc = "A warning that demarcates where the magnetic area begins.";
+	dir = 1;
+	icon_state = "magwarning";
+	name = "Magnet Area Boundary"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	icon_state = "catwalk_cross"
+	},
+/area/mining/magnet)
 "hqI" = (
 /obj/cable{
 	d1 = 2;
@@ -62852,6 +63163,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/hotloop)
+"hqQ" = (
+/obj/grille/catwalk{
+	dir = 4
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
+/area/station/quartermaster/refinery)
 "iix" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/external{
@@ -63015,16 +63343,6 @@
 	},
 /turf/simulated/floor/bot,
 /area/station/engine/gas)
-"mjO" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4
-	},
-/obj/machinery/light/small/floor,
-/turf/simulated/floor/carpet{
-	dir = 8;
-	icon_state = "fred1"
-	},
-/area/station/chapel/main)
 "msz" = (
 /obj/lattice,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -63086,13 +63404,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/hotloop)
-"nuk" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "qmin"
-	},
-/turf/space,
-/area)
 "nvq" = (
 /turf/simulated/wall/auto/shuttle{
 	icon_state = "7"
@@ -63236,6 +63547,16 @@
 	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
+"qTU" = (
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
+	},
+/obj/machinery/light/small/floor,
+/turf/simulated/floor/carpet{
+	dir = 8;
+	icon_state = "fred1"
+	},
+/area/station/chapel/main)
 "rwR" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 9
@@ -63357,6 +63678,17 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/hotloop)
+"uxY" = (
+/obj/grille/catwalk{
+	dir = 4
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 6
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
+/area/station/quartermaster/refinery)
 "uKI" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -63499,6 +63831,17 @@
 /obj/reagent_dispensers/foamtank,
 /turf/simulated/floor/black,
 /area/station/engine/coldloop)
+"xOs" = (
+/obj/grille/catwalk{
+	dir = 4
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
+/area/station/quartermaster/refinery)
 "xXP" = (
 /obj/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/insulated/cold,
@@ -106236,12 +106579,12 @@ aIe
 aVO
 aXi
 aYs
-aVA
-aVA
-aVA
-aVA
-aVA
-aVA
+gfz
+gfz
+gfz
+gfz
+gfz
+gfz
 bld
 aaG
 aaa
@@ -120419,7 +120762,7 @@ aIO
 aJT
 aLf
 aMo
-mjO
+qTU
 aMo
 aLf
 aJT
@@ -123794,7 +124137,7 @@ aaa
 aah
 aaa
 aah
-nuk
+dJk
 aah
 cxB
 bLc
@@ -124417,7 +124760,7 @@ aaa
 aaa
 aam
 aap
-bAM
+gDG
 bBL
 aap
 ckl
@@ -124719,7 +125062,7 @@ aaa
 aaa
 aaa
 aag
-bAM
+gDG
 bBL
 aap
 ckl
@@ -125021,7 +125364,7 @@ aaa
 aaa
 aaa
 aag
-bAM
+gDG
 bBL
 aap
 ckl
@@ -125323,7 +125666,7 @@ aaa
 aaa
 aaa
 aag
-bAM
+gDG
 bBL
 aap
 ckl
@@ -125625,7 +125968,7 @@ aaa
 aaa
 aaa
 aag
-bAM
+gDG
 bBL
 aap
 ckl
@@ -125927,7 +126270,7 @@ aaa
 aaa
 aaa
 aag
-bAM
+gDG
 bBL
 aap
 ckl
@@ -126229,7 +126572,7 @@ aaa
 aaa
 aaa
 aag
-bAM
+gDG
 bBL
 aap
 ckl
@@ -126531,7 +126874,7 @@ aaa
 aaa
 aaa
 aag
-bAM
+gDG
 bBL
 aap
 ckl
@@ -126833,7 +127176,7 @@ aaa
 aaa
 aaa
 aag
-bAM
+gDG
 bBL
 aap
 ckl
@@ -127135,7 +127478,7 @@ aaa
 aaa
 aaa
 aag
-bAM
+gDG
 bBL
 aap
 ckl
@@ -127437,7 +127780,7 @@ aaa
 aaa
 aaa
 aag
-bAM
+gDG
 bBL
 aap
 ckl
@@ -127740,7 +128083,7 @@ bWn
 bWn
 bWm
 bAM
-bBL
+hqQ
 ciU
 ckl
 clH
@@ -128042,7 +128385,7 @@ ccF
 cdT
 bWm
 bAM
-bBL
+hqQ
 cea
 cea
 clI
@@ -130155,8 +130498,8 @@ aah
 aaa
 aah
 aag
-bAM
-bAM
+gDG
+xOs
 aaG
 aah
 aaa
@@ -130459,7 +130802,7 @@ cdZ
 bAJ
 bAN
 bAN
-bCy
+gtK
 aap
 aay
 aap
@@ -131063,7 +131406,7 @@ cea
 bAM
 bWm
 bWm
-bAM
+xOs
 aaq
 aai
 aaq
@@ -131362,10 +131705,10 @@ aaa
 aaa
 aah
 aaa
-bAM
+geM
 cgz
 chJ
-bAM
+uxY
 aaa
 aah
 aaa
@@ -131664,10 +132007,10 @@ cac
 cac
 cac
 cac
-cac
+hmN
 cgA
 cgA
-cac
+hmN
 cac
 cac
 cac

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -12165,6 +12165,21 @@
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/secwing)
+"aBB" = (
+/obj/machinery/disposal,
+/obj/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 10
+	},
+/area/station/mining)
 "aBC" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/cable{
@@ -38476,9 +38491,8 @@
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "bDR" = (
+/obj/wingrille_spawn/auto,
 /obj/securearea,
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "bDS" = (
@@ -39554,14 +39568,14 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
 	name = "Cargo Office";
-	req_access_txt = "31"
+	req_access = null;
+	req_access_txt = null
 	},
+/obj/access_spawn/cargo,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bGe" = (
@@ -44167,13 +44181,10 @@
 /turf/simulated/floor/caution/north,
 /area/station/quartermaster/office)
 "bPs" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4;
 	name = "External Access";
-	req_access_txt = "31"
+	req_access_txt = null
 	},
 /obj/cable{
 	icon_state = "1-4"
@@ -44183,6 +44194,8 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/access_spawn/cargo,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hangar/qm)
 "bPt" = (
@@ -44750,7 +44763,7 @@
 "bQB" = (
 /obj/machinery/door/window/northleft{
 	name = "Cargo Office";
-	req_access_txt = "31"
+	req_access_txt = null
 	},
 /obj/disposalpipe/segment,
 /obj/cable{
@@ -44758,6 +44771,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/access_spawn/cargo,
 /turf/simulated/floor/delivery,
 /area/station/crew_quarters/market{
 	name = "Supply Lobby"
@@ -45539,9 +45553,10 @@
 /obj/machinery/door/window/northleft{
 	dir = 2;
 	name = "Cargo Office";
-	req_access_txt = "31"
+	req_access_txt = null
 	},
 /obj/machinery/cashreg,
+/obj/access_spawn/cargo,
 /turf/simulated/floor/delivery,
 /area/station/crew_quarters/market{
 	name = "Supply Lobby"
@@ -47555,11 +47570,13 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/engineering{
 	name = "Mining";
-	req_access_txt = "50"
+	req_access = null;
+	req_access_txt = null
 	},
+/obj/access_spawn/mining,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/mining)
 "bWl" = (
@@ -48619,19 +48636,19 @@
 	name = "Supply Lobby"
 	})
 "bYG" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
 	name = "Mining";
-	req_access_txt = "50"
+	req_access = null;
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/access_spawn/mining,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/mining)
 "bYH" = (
@@ -49917,13 +49934,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/mining)
 "cbv" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/yellow/side{
+/turf/simulated/floor/yellow/corner{
 	dir = 8
 	},
 /area/station/mining)
@@ -50645,7 +50656,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/access_spawn/security,
 /obj/firedoor_spawn,
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/cargo)
@@ -51402,14 +51412,16 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/external{
-	req_access_txt = "50"
+	req_access_txt = null
 	},
+/obj/access_spawn/mining,
 /turf/simulated/floor/plating/airless,
 /area/station/quartermaster/refinery)
 "cfh" = (
 /obj/machinery/door/airlock/pyro/external{
-	req_access_txt = "50"
+	req_access_txt = null
 	},
+/obj/access_spawn/mining,
 /turf/simulated/floor/plating/airless,
 /area/station/quartermaster/refinery)
 "cfi" = (
@@ -51960,9 +51972,8 @@
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/access_spawn/mining,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/mining)
 "cgu" = (
@@ -52533,9 +52544,8 @@
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/access_spawn/mining,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/mining)
 "chD" = (
@@ -53035,11 +53045,13 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance{
 	name = "Tech Storage";
-	req_access_txt = "23"
+	req_access = null;
+	req_access_txt = null
 	},
+/obj/access_spawn/tech_storage,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "ciK" = (
@@ -54470,25 +54482,27 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/mining)
 "clF" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/disposalpipe/segment,
 /obj/machinery/door/airlock/pyro/external{
-	req_access_txt = "50"
+	req_access_txt = null
 	},
+/obj/access_spawn/mining,
+/obj/firedoor_spawn,
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
 /area/station/mining)
 "clG" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/external{
-	req_access_txt = "50"
+	req_access_txt = null
 	},
+/obj/access_spawn/mining,
+/obj/firedoor_spawn,
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
@@ -55511,11 +55525,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment{
-	dir = 4
+/obj/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/yellow/side{
-	dir = 10
+	dir = 8
 	},
 /area/station/mining)
 "cnV" = (
@@ -55528,9 +55543,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/yellow/corner{
-	dir = 8
-	},
+/turf/simulated/floor,
 /area/station/mining)
 "cnW" = (
 /obj/cable{
@@ -57189,10 +57202,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/engineering{
-	name = "Solar Substation"
+	name = "Solar Substation";
+	req_access = null
 	},
+/obj/access_spawn/engineering,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southsolar)
 "cri" = (
@@ -57335,11 +57350,10 @@
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4;
 	name = "External Access";
-	req_access_txt = "13;40"
+	req_access_txt = null
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/access_spawn/engineering,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southsolar)
 "crz" = (
@@ -57624,8 +57638,9 @@
 	},
 /obj/machinery/door/airlock/pyro/external{
 	name = "External Access";
-	req_access_txt = "13;40"
+	req_access_txt = null
 	},
+/obj/access_spawn/engineering,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southsolar)
 "csd" = (
@@ -121157,8 +121172,8 @@ ccy
 ccy
 cnT
 bUZ
+bUZ
 aaG
-aaa
 aaa
 aaa
 aaa
@@ -121458,7 +121473,7 @@ cke
 clE
 cmO
 cnU
-bUZ
+aBB
 bLE
 bMf
 bMf

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -37578,11 +37578,17 @@
 	dir = 8;
 	level = 2
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "bBF" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "5-8"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -63539,6 +63545,16 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/coldloop)
+"qIA" = (
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 4;
+	level = 2
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "qOp" = (
 /obj/machinery/light{
 	dir = 8;
@@ -63725,6 +63741,17 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
+"vli" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "vlS" = (
 /obj/decal/tile_edge/stripe/big{
 	dir = 1;
@@ -63766,6 +63793,15 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/engine/gas)
+"vBu" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-9"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "vEb" = (
 /obj/machinery/atmospherics/unary/furnace_connector{
 	dir = 8
@@ -63817,6 +63853,15 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
+"wSv" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-10"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "wTq" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold{
@@ -63824,6 +63869,15 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/coldloop)
+"wVz" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-6"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "xKG" = (
 /obj/machinery/light{
 	dir = 8
@@ -110841,7 +110895,7 @@ bxY
 bwk
 bwk
 bwk
-bwk
+wVz
 bBC
 byE
 bvf
@@ -111144,7 +111198,7 @@ bxN
 ezG
 bxN
 bwd
-bwT
+vBu
 bCu
 bvf
 bEt
@@ -111446,7 +111500,7 @@ bxO
 byI
 bzM
 bHb
-bBD
+qIA
 bBD
 bDy
 luH
@@ -111748,7 +111802,7 @@ bCn
 byJ
 bzN
 bAI
-bwf
+vli
 bCv
 bDz
 bEr
@@ -112653,7 +112707,7 @@ bBG
 bxS
 bCB
 bwk
-bwk
+wSv
 cbd
 byH
 bvf

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -12207,11 +12207,6 @@
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/secwing)
-"aBB" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/central)
 "aBC" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass,
@@ -17303,8 +17298,7 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "aLO" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
 "aLP" = (
@@ -21335,7 +21329,6 @@
 	},
 /area/station/bridge)
 "aUf" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -21348,7 +21341,7 @@
 	name = "Bridge Lockdown Doors";
 	opacity = 0
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "aUg" = (
@@ -23292,7 +23285,6 @@
 /turf/simulated/floor/grey/side,
 /area/station/bridge)
 "aYd" = (
-/obj/grille/steel,
 /obj/cable,
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
@@ -23302,7 +23294,7 @@
 	name = "Bridge Lockdown Doors";
 	opacity = 0
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "aYe" = (
@@ -39368,11 +39360,6 @@
 "bFr" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/qm)
-"bFs" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/hangar/qm)
 "bFt" = (
 /obj/cable,
 /obj/cable{
@@ -45141,12 +45128,11 @@
 /turf/simulated/floor/caution/south,
 /area/station/science/lab)
 "bQT" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/crystal/reinforced,
+/obj/wingrille_spawn/auto/crystal,
 /obj/window_blinds/cog2{
 	dir = 4
 	},
@@ -48105,12 +48091,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
-"bWW" = (
-/obj/grille/steel,
-/obj/disposalpipe/segment/transport,
-/obj/window/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/south)
 "bWX" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor/bot,
@@ -48570,10 +48550,9 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bXZ" = (
-/obj/grille/steel,
 /obj/disposalpipe/segment/transport,
-/obj/window/auto/reinforced,
-/turf/simulated/floor/black,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
 /area/station/hallway/primary/south)
 "bYa" = (
 /obj/machinery/vending/cola/red,
@@ -49409,8 +49388,7 @@
 	name = "Supply Lobby"
 	})
 "bZQ" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/market{
 	name = "Supply Lobby"
@@ -99623,7 +99601,7 @@ bRk
 bSP
 bUj
 bVw
-bWW
+bXZ
 bXZ
 bZE
 ceJ
@@ -101680,7 +101658,7 @@ aaa
 aaa
 aaa
 aah
-aBB
+bUk
 aWV
 aYj
 aZo
@@ -101982,7 +101960,7 @@ aaa
 aaa
 aaa
 aah
-aBB
+bUk
 aWW
 aYk
 aZp
@@ -102284,7 +102262,7 @@ aaa
 aaa
 aaa
 aah
-aBB
+bUk
 aWV
 aYj
 aZo
@@ -121356,7 +121334,7 @@ bFr
 bGj
 bGX
 bHP
-bFs
+ceH
 bJN
 bKX
 bMA

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -4050,25 +4050,28 @@
 /turf/simulated/floor,
 /area/station/security/brig)
 "ajp" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/security{
 	aiControlDisabled = 1;
 	name = "Armory";
-	req_access_txt = "37"
+	req_access = null
 	},
+/obj/access_spawn/hos,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/security/armory)
 "ajq" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/security{
 	aiControlDisabled = 1;
 	name = "Armory";
-	req_access_txt = "37"
+	req_access = null;
+	req_access_txt = null
 	},
 /obj/disposalpipe/segment/ejection,
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/access_spawn/hos,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/security/armory)
 "ajr" = (
@@ -4323,16 +4326,16 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/security/checkpoint/arrivals)
 "ajY" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/security{
 	name = "Arrivals Desk";
-	req_access_txt = "1"
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/arrivals)
 "ajZ" = (
@@ -4460,7 +4463,7 @@
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Sollitary Cell";
-	req_access_txt = "1"
+	req_access_txt = null
 	},
 /obj/disposalpipe/segment/ejection{
 	dir = 4
@@ -4470,6 +4473,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/access_spawn/security,
 /turf/simulated/floor/delivery,
 /area/station/security/brig)
 "ako" = (
@@ -4515,13 +4519,10 @@
 /turf/simulated/floor,
 /area/station/security/brig)
 "aks" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Brig Dock";
-	req_access_txt = "1"
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 4;
@@ -4538,6 +4539,8 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/access_spawn/security,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/routingdepot/security)
 "akt" = (
@@ -7557,19 +7560,18 @@
 	},
 /area/station/hangar/sec)
 "arB" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4;
 	name = "Secure Dock";
-	req_access_txt = "1"
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/access_spawn/security,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hangar/sec)
 "arC" = (
@@ -7621,17 +7623,16 @@
 /turf/simulated/floor/bot,
 /area/station/security/brig)
 "arH" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Brig";
-	req_access_txt = "1"
+	req_access_txt = null
 	},
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 10
 	},
+/obj/access_spawn/security,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/security/brig)
 "arI" = (
@@ -9956,16 +9957,16 @@
 "awU" = (
 /obj/machinery/door/airlock/pyro/security{
 	name = "Brig Visitation Area";
-	req_access_txt = "1"
+	req_access_txt = null
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/door/firedoor/pyro,
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/security/secwing)
 "awV" = (
@@ -10478,10 +10479,10 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "axZ" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/security{
 	name = "Defendant Stand"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/security/main)
 "aya" = (
@@ -10588,15 +10589,13 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro/security{
 	dir = 4;
 	name = "Interrogation Room";
-	req_access_txt = "1"
+	req_access_txt = null
 	},
 /obj/disposalpipe/segment/transport,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/security/main)
 "aym" = (
@@ -10668,11 +10667,10 @@
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Brig";
-	req_access_txt = "1"
+	req_access_txt = null
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/access_spawn/security,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/security/brig)
 "ayr" = (
@@ -11261,11 +11259,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
 "azG" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/security{
 	name = "Interrogation Room";
-	req_access_txt = "1"
+	req_access_txt = null
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/security/main)
 "azH" = (
@@ -12065,8 +12063,9 @@
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4;
 	name = "External Access";
-	req_access_txt = "12"
+	req_access_txt = null
 	},
+/obj/access_spawn/engineering,
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
 "aBq" = (
@@ -12526,11 +12525,10 @@
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4;
 	name = "External Access";
-	req_access_txt = "12"
+	req_access_txt = null
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/access_spawn/engineering,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
 "aCq" = (
@@ -12605,19 +12603,17 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro/security{
 	dir = 4;
 	name = "Interrogation Room";
-	req_access_txt = "1"
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/security/main)
 "aCA" = (
@@ -13963,7 +13959,6 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/westsolar)
 "aFe" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -13976,30 +13971,23 @@
 	name = "Interrogation Room";
 	opacity = 0
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
-/area/station/security/main)
-"aFf" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/obj/securearea{
-	pixel_y = -4
-	},
-/turf/simulated/floor,
 /area/station/security/main)
 "aFg" = (
 /obj/disposalpipe/segment,
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Brig";
-	req_access_txt = "1"
+	req_access_txt = null
 	},
+/obj/access_spawn/security,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/security/main)
 "aFh" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Brig";
-	req_access_txt = "1"
+	req_access_txt = null
 	},
 /obj/disposalpipe/segment/mail,
 /obj/cable{
@@ -14007,15 +13995,16 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/access_spawn/security,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/security/main)
 "aFi" = (
-/obj/grille/steel,
+/obj/wingrille_spawn/auto,
 /obj/securearea{
 	pixel_y = -4
 	},
-/obj/window/auto/reinforced,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/security/main)
 "aFj" = (
 /obj/table/reinforced/auto,
@@ -14762,11 +14751,11 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/security/secwing)
 "aGL" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/security{
 	name = "Brig Visitation Area";
-	req_access_txt = "1"
+	req_access_txt = null
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/security/secwing)
 "aGM" = (
@@ -15112,8 +15101,10 @@
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Locker Room";
-	req_access_txt = "1"
+	req_access_txt = null
 	},
+/obj/access_spawn/security,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/security/main)
 "aHE" = (
@@ -16361,11 +16352,13 @@
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Locker Room";
-	req_access_txt = "1"
+	req_access_txt = null
 	},
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/access_spawn/security,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/security/main)
 "aKg" = (
@@ -17549,11 +17542,11 @@
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
 	name = "Bridge Maintenance";
-	req_access_txt = "19"
+	req_access = null;
+	req_access_txt = null
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/access_spawn/heads,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/bridge)
 "aMC" = (
@@ -17666,19 +17659,19 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/security/main)
 "aMN" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/plasticflaps{
 	layer = 3
 	},
 /obj/machinery/door/airlock/pyro/security{
 	name = "Secure Transport";
-	req_access_txt = "1"
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/security/secwing)
 "aMO" = (
@@ -18348,17 +18341,15 @@
 /obj/plasticflaps{
 	layer = 3
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/security{
 	dir = 4;
 	name = "Secure Transport";
-	req_access_txt = "1"
+	req_access_txt = null
 	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/bot,
 /area/station/security/main)
 "aOa" = (
@@ -18719,7 +18710,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
 	icon_state = "pdoor0";
@@ -18730,6 +18720,8 @@
 /obj/machinery/door/airlock/pyro/command{
 	name = "Radio Room"
 	},
+/obj/access_spawn/heads,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/bridge)
 "aOM" = (
@@ -19354,9 +19346,6 @@
 /turf/simulated/floor,
 /area/station/bridge)
 "aPU" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
 	dir = 4;
@@ -19368,8 +19357,10 @@
 /obj/machinery/door/airlock/pyro/security{
 	dir = 4;
 	name = "Head of Security";
-	req_access_txt = "37"
+	req_access = null
 	},
+/obj/access_spawn/hos,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/security/hos)
 "aPV" = (
@@ -19386,14 +19377,13 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/security{
 	dir = 4;
 	name = "Head of Security";
-	req_access_txt = "37"
+	req_access = null
 	},
+/obj/access_spawn/hos,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/security/hos)
 "aPY" = (
@@ -19508,13 +19498,10 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/central)
 "aQm" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Security Office";
-	req_access_txt = "1"
+	req_access_txt = null
 	},
 /obj/disposalpipe/segment/ejection{
 	dir = 4
@@ -19523,6 +19510,8 @@
 	dir = 4;
 	pixel_x = -20
 	},
+/obj/access_spawn/security,
+/obj/firedoor_spawn,
 /turf/simulated/floor/red,
 /area/station/security/secwing)
 "aQn" = (
@@ -21821,6 +21810,7 @@
 	dir = 4;
 	name = "Bridge"
 	},
+/obj/access_spawn/heads,
 /turf/simulated/floor,
 /area/station/bridge)
 "aVu" = (
@@ -21844,9 +21834,6 @@
 	name = "Bridge Lockdown Doors";
 	opacity = 0
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/glass/command{
 	dir = 4;
 	name = "Bridge"
@@ -21864,6 +21851,8 @@
 	dir = 4;
 	pixel_x = -20
 	},
+/obj/access_spawn/heads,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/bridge)
 "aVw" = (
@@ -22370,12 +22359,10 @@
 	dir = 4;
 	name = "Bridge"
 	},
+/obj/access_spawn/heads,
 /turf/simulated/floor,
 /area/station/bridge)
 "aWI" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -22397,6 +22384,8 @@
 	dir = 4;
 	pixel_x = -20
 	},
+/obj/access_spawn/heads,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/bridge)
 "aWJ" = (
@@ -23718,11 +23707,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/command{
 	name = "Teleport Access";
-	req_access_txt = "17"
+	req_access_txt = null
 	},
+/obj/access_spawn/teleporter,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/teleporter)
 "aZq" = (
@@ -24440,9 +24430,6 @@
 /turf/simulated/floor,
 /area/station/bridge)
 "baY" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
 	dir = 4;
@@ -24454,7 +24441,8 @@
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
 	name = "Head of Personnel";
-	req_access_txt = "55"
+	req_access = null;
+	req_access_txt = null
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -24464,6 +24452,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/access_spawn/head_of_personnel,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/crew_quarters/heads)
 "baZ" = (
@@ -24851,7 +24841,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
 	icon_state = "pdoor0";
@@ -24861,8 +24850,11 @@
 	},
 /obj/machinery/door/airlock/pyro/command{
 	name = "Captain's Quarters";
-	req_access_txt = "20"
+	req_access = null;
+	req_access_txt = null
 	},
+/obj/access_spawn/captain,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/captain)
 "bbR" = (
@@ -25529,9 +25521,6 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/heads)
 "bde" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -25540,8 +25529,11 @@
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
 	name = "Head of Personnel";
-	req_access_txt = "55"
+	req_access = null;
+	req_access_txt = null
 	},
+/obj/access_spawn/head_of_personnel,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/heads)
 "bdf" = (
@@ -25642,17 +25634,15 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro/security{
 	dir = 4;
 	name = "Customs";
-	req_access_txt = "1"
+	req_access_txt = null
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint)
 "bdm" = (
@@ -27368,13 +27358,14 @@
 /area/station/crew_quarters/captain)
 "bgI" = (
 /obj/machinery/door/window/southleft{
-	req_access_txt = "20"
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/access_spawn/captain,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
 "bgJ" = (
@@ -29554,14 +29545,14 @@
 /turf/simulated/floor/caution/east,
 /area/station/crew_quarters/market)
 "blI" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
 	name = "E.V.A.";
-	req_access_txt = "18"
+	req_access = null;
+	req_access_txt = null
 	},
+/obj/access_spawn/eva,
+/obj/firedoor_spawn,
 /turf/simulated/floor/bot,
 /area/station/ai_monitored/storage/eva)
 "blJ" = (
@@ -30654,13 +30645,11 @@
 /turf/simulated/floor/orangeblack,
 /area/station/ai_monitored/storage/eva)
 "bnV" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
 	name = "E.V.A.";
-	req_access_txt = "18"
+	req_access = null;
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 4;
@@ -30670,6 +30659,8 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 9
 	},
+/obj/access_spawn/eva,
+/obj/firedoor_spawn,
 /turf/simulated/floor/bot,
 /area/station/maintenance/maintcentral)
 "bnW" = (
@@ -30694,9 +30685,7 @@
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
 "bnY" = (
@@ -49896,13 +49885,13 @@
 /area/station/hallway/primary/south)
 "cbs" = (
 /obj/table/reinforced/auto,
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/cashreg{
 	name = "bail payment device"
 	},
 /obj/disposalpipe/segment/ejection{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/cargo)
 "cbt" = (
@@ -50641,10 +50630,9 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/south)
 "cdh" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/security{
 	name = "Security Checkpoint";
-	req_access_txt = "1"
+	req_access_txt = null
 	},
 /obj/disposalpipe/segment/ejection{
 	dir = 4
@@ -50657,6 +50645,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/access_spawn/security,
+/obj/firedoor_spawn,
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/cargo)
 "cdi" = (
@@ -52476,11 +52466,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "chx" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Mini-Brig";
-	req_access_txt = "1"
+	req_access_txt = null
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/security/checkpoint/cargo)
 "chy" = (
@@ -93887,7 +93877,7 @@ awK
 awK
 awK
 aDW
-aFf
+aFi
 aGD
 avd
 aJf

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -42852,12 +42852,12 @@
 	id_tag = "tox_airlock_exterior";
 	locked = 1;
 	name = "Toxins Research Access";
-	req_access_txt = "7"
+	req_access_txt = null
 	},
+/obj/access_spawn/tox,
 /turf/simulated/floor/plating,
 /area/station/science/lab)
 "bMH" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass{
 	autoclose = 0;
 	frequency = 1449;
@@ -42865,8 +42865,10 @@
 	id_tag = "tox_airlock_exterior";
 	locked = 1;
 	name = "Toxins Research Access";
-	req_access_txt = "7"
+	req_access_txt = null
 	},
+/obj/access_spawn/tox,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/science/lab)
 "bMI" = (
@@ -42886,7 +42888,6 @@
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "bMK" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0;
 	dir = 1
@@ -43035,9 +43036,6 @@
 	},
 /area/station/science/teleporter)
 "bMZ" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/poddoor/pyro{
 	dir = 4;
 	id = "scienceteleporter";
@@ -43047,8 +43045,10 @@
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Teleporter Pad";
-	req_access_txt = "8"
+	req_access_txt = null
 	},
+/obj/access_spawn/tox,
+/obj/firedoor_spawn,
 /turf/simulated/floor/engine,
 /area/station/science/teleporter)
 "bNa" = (
@@ -43083,9 +43083,6 @@
 	},
 /area/station/science/teleporter)
 "bNd" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/poddoor/pyro{
 	dir = 4;
 	id = "scienceteleporter2";
@@ -43095,9 +43092,10 @@
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Teleporter Pad";
-	req_access_txt = "0"
+	req_access_txt = null
 	},
 /obj/disposalpipe/segment/transport,
+/obj/firedoor_spawn,
 /turf/simulated/floor/engine,
 /area/station/science/teleporter)
 "bNe" = (
@@ -44353,14 +44351,16 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/medical{
 	name = "Teleporter Control Room";
-	req_access_txt = "8"
+	req_access = null;
+	req_access_txt = null
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/access_spawn/tox,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/science/teleporter)
 "bPN" = (
@@ -45784,19 +45784,19 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/hor)
 "bSC" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
 	name = "Research Director's Office";
-	req_access_txt = "19"
+	req_access = null;
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/access_spawn/research_director,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/hor)
 "bSD" = (
@@ -45923,11 +45923,12 @@
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Research Sector";
-	req_access_txt = "24"
+	req_access_txt = null
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/access_spawn/research,
 /turf/simulated/floor/purple,
 /area/station/science)
 "bSN" = (
@@ -45969,8 +45970,9 @@
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Research Sector";
-	req_access_txt = "24"
+	req_access_txt = null
 	},
+/obj/access_spawn/research,
 /turf/simulated/floor/purple,
 /area/station/science)
 "bSQ" = (
@@ -47062,18 +47064,18 @@
 /turf/simulated/floor/caution/northsouth,
 /area/station/science)
 "bVu" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 1
-	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	name = "Guardbot Depot";
-	req_access_txt = "8"
+	req_access = null;
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/access_spawn/research,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/science)
 "bVv" = (
@@ -48775,19 +48777,19 @@
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "bYW" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
 	name = "Gas Storage";
-	req_access_txt = "8"
+	req_access = null;
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/access_spawn/tox_storage,
+/obj/firedoor_spawn,
 /turf/simulated/floor/white,
 /area/station/science/storage)
 "bYX" = (
@@ -48819,19 +48821,19 @@
 /turf/simulated/floor/white,
 /area/station/science/lab)
 "bZb" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/medical{
 	dir = 4;
 	name = "Mixing Room";
-	req_access_txt = "8"
+	req_access = null;
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/access_spawn/tox,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/science/lab)
 "bZc" = (
@@ -48848,19 +48850,19 @@
 /turf/simulated/floor/white,
 /area/station/science/lab)
 "bZd" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/medical{
 	dir = 4;
 	name = "Mixing Room";
-	req_access_txt = "8"
+	req_access = null;
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/access_spawn/tox,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/science)
 "bZe" = (
@@ -51512,13 +51514,11 @@
 /turf/simulated/floor,
 /area/station/engine/ptl)
 "cfs" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/medical{
 	dir = 4;
 	name = "Artifact Lab";
-	req_access_txt = "8"
+	req_access = null;
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 4;
@@ -51530,6 +51530,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/access_spawn/tox_storage,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/science/artifact)
 "cft" = (
@@ -53964,7 +53966,7 @@
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
 	name = "Emergency Storage";
-	req_access_txt = "0"
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 4;
@@ -54537,11 +54539,11 @@
 /obj/machinery/door/airlock/pyro/medical{
 	dir = 4;
 	name = "Science Hangar";
-	req_access_txt = "8"
+	req_access = null;
+	req_access_txt = null
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/access_spawn/tox_storage,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/hangar/science)
 "clP" = (
@@ -55063,7 +55065,8 @@
 "cna" = (
 /obj/machinery/door/airlock/pyro/medical{
 	name = "Test Chamber Access";
-	req_access_txt = "33"
+	req_access = null;
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 1;
@@ -55071,6 +55074,7 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
+/obj/access_spawn/chemistry,
 /turf/simulated/floor/plating,
 /area/station/science)
 "cnb" = (
@@ -55088,10 +55092,10 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/chemistry)
 "cnf" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/medical{
 	name = "Chemistry Department Access";
-	req_access_txt = "33"
+	req_access = null;
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 1;
@@ -55099,6 +55103,8 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
+/obj/access_spawn/chemistry,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/chemistry)
 "cng" = (
@@ -55582,9 +55588,11 @@
 "coc" = (
 /obj/machinery/door/airlock/pyro/medical{
 	name = "Science Hangar";
-	req_access_txt = "8"
+	req_access = null;
+	req_access_txt = null
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/access_spawn/tox_storage,
+/obj/firedoor_spawn,
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/science)
 "cod" = (
@@ -56840,9 +56848,7 @@
 	},
 /obj/item/storage/box/beakerbox,
 /obj/item/reagent_containers/glass/beaker/large,
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/chemistry)
 "cqA" = (
@@ -58150,14 +58156,14 @@
 	},
 /area/station/testchamber)
 "ctc" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/medical{
 	dir = 4;
 	name = "Test Chamber Access";
-	req_access_txt = "33"
+	req_access = null;
+	req_access_txt = null
 	},
+/obj/access_spawn/chemistry,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/chemistry)
 "ctd" = (
@@ -58209,19 +58215,19 @@
 	},
 /area/station/chemistry)
 "cti" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro/medical{
 	dir = 4;
 	name = "Loading Dock";
-	req_access_txt = "33"
+	req_access = null;
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/access_spawn/chemistry,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery/white,
 /area/station/chemistry)
 "ctj" = (
@@ -58252,14 +58258,13 @@
 /turf/simulated/floor/delivery/white,
 /area/station/routingdepot/medsci)
 "ctm" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Loading Dock";
-	req_access_txt = "5"
+	req_access_txt = null
 	},
+/obj/access_spawn/medical,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery/white,
 /area/station/medical/medbay)
 "ctn" = (
@@ -58499,9 +58504,6 @@
 	},
 /area/station/testchamber)
 "ctS" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
 	dir = 4;
@@ -58516,8 +58518,10 @@
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Test Chamber";
-	req_access_txt = "7"
+	req_access_txt = null
 	},
+/obj/access_spawn/tox,
+/obj/firedoor_spawn,
 /turf/simulated/floor/shuttlebay{
 	name = "test chamber plating"
 	},
@@ -58908,9 +58912,6 @@
 	},
 /area/station/testchamber)
 "cuL" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
 	dir = 4;
@@ -58922,7 +58923,7 @@
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Test Chamber";
-	req_access_txt = "7"
+	req_access_txt = null
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -58932,6 +58933,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/access_spawn/tox,
+/obj/firedoor_spawn,
 /turf/simulated/floor/shuttlebay{
 	name = "test chamber plating"
 	},

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -2728,6 +2728,11 @@
 	id = "cateringdock_in";
 	name = "Cargo Routing Door"
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/plating,
 /area/station/hangar/catering{
 	name = "Catering Hangar"
@@ -2751,6 +2756,11 @@
 /obj/machinery/door/poddoor/pyro{
 	id = "cateringdock_out";
 	name = "Cargo Routing Door"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/hangar/catering{
@@ -3094,6 +3104,11 @@
 	id = "sec_in";
 	name = "Cargo Routing Door"
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/plating,
 /area/station/routingdepot/security)
 "ahu" = (
@@ -3112,6 +3127,11 @@
 /obj/machinery/door/poddoor/pyro{
 	id = "sec_out";
 	name = "Cargo Routing Door"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/routingdepot/security)
@@ -4031,6 +4051,12 @@
 	icon_state = "bdoormid1";
 	id = "hangar_north";
 	name = "Catering Hangar"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/catering{
@@ -5858,6 +5884,12 @@
 	id = "hangar_bridge";
 	name = "Command Hangar"
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
 "anv" = (
@@ -6389,6 +6421,12 @@
 	icon_state = "bdoormid1";
 	id = "hangar_bridge";
 	name = "Command Hangar"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
@@ -6957,6 +6995,12 @@
 	icon_state = "bdoorright1";
 	id = "hangar_bridge";
 	name = "Command Hangar"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
@@ -19611,6 +19655,11 @@
 	id = "catering_in";
 	name = "Cargo Routing Door"
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/plating,
 /area/station/routingdepot/catering)
 "aQw" = (
@@ -19620,6 +19669,11 @@
 /obj/machinery/door/poddoor/pyro{
 	id = "catering_out";
 	name = "Cargo Routing Door"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/routingdepot/catering)
@@ -27113,6 +27167,11 @@
 	id = "catering_in";
 	name = "Cargo Routing Door"
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/plating,
 /area/station/routingdepot)
 "bgg" = (
@@ -27123,6 +27182,11 @@
 /obj/machinery/door/poddoor/pyro{
 	id = "catering_out";
 	name = "Cargo Routing Door"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/routingdepot)
@@ -28146,6 +28210,12 @@
 	id = "disp-vent";
 	name = "Disposal Vents"
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "biu" = (
@@ -28344,6 +28414,12 @@
 	id = "eva_out";
 	name = "Cargo Routing Door"
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/caution/northsouth,
 /area/station/routingdepot/eva)
 "biP" = (
@@ -28356,6 +28432,12 @@
 	dir = 4;
 	id = "eva_out";
 	name = "Cargo Routing Door"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/routingdepot)
@@ -28855,6 +28937,12 @@
 	id = "eva_in";
 	name = "Cargo Routing Door"
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/plating,
 /area/station/routingdepot/eva)
 "bjR" = (
@@ -28867,6 +28955,12 @@
 	dir = 4;
 	id = "eva_in";
 	name = "Cargo Routing Door"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/caution/northsouth,
 /area/station/routingdepot)
@@ -29233,6 +29327,12 @@
 	id = "cargo_out";
 	name = "Cargo Routing Door"
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/caution/northsouth,
 /area/station/routingdepot)
 "bkL" = (
@@ -29309,6 +29409,12 @@
 	dir = 4;
 	id = "cargo_out";
 	name = "Cargo Routing Door"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -29690,6 +29796,12 @@
 	id = "cargo_in";
 	name = "Cargo Routing Door"
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/plating,
 /area/station/routingdepot)
 "blV" = (
@@ -29744,6 +29856,12 @@
 	dir = 4;
 	id = "cargo_in";
 	name = "Cargo Routing Door"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/caution/northsouth,
 /area/station/maintenance/east)
@@ -30073,6 +30191,12 @@
 	id = "outer_out";
 	name = "Cargo Routing Door"
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bmN" = (
@@ -30326,6 +30450,11 @@
 	id = "medsci_out";
 	name = "Cargo Routing Door"
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/plating,
 /area/station/routingdepot)
 "bnn" = (
@@ -30335,6 +30464,11 @@
 /obj/machinery/door/poddoor/pyro{
 	id = "medsci_in";
 	name = "Cargo Routing Door"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/routingdepot)
@@ -30822,6 +30956,11 @@
 	id = "engine_out";
 	name = "Cargo Routing Door"
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/plating,
 /area/station/routingdepot)
 "boh" = (
@@ -30832,6 +30971,11 @@
 /obj/machinery/door/poddoor/pyro{
 	id = "engine_in";
 	name = "Cargo Routing Door"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/routingdepot)
@@ -30873,6 +31017,12 @@
 	dir = 4;
 	id = "outer_in";
 	name = "Cargo Routing Door"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -31247,6 +31397,11 @@
 /obj/machinery/door/poddoor/pyro{
 	id = "qm_in";
 	name = "Cargo Routing Door"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -31721,6 +31876,11 @@
 	id = "engine_out";
 	name = "Cargo Routing Door"
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/plating,
 /area/station/routingdepot/engine)
 "bpP" = (
@@ -31731,6 +31891,11 @@
 /obj/machinery/door/poddoor/pyro{
 	id = "engine_in";
 	name = "Cargo Routing Door"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/routingdepot/engine)
@@ -32295,6 +32460,12 @@
 	id = "hangar_engine";
 	name = "Engineering Hangar"
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/engine)
 "bra" = (
@@ -32569,6 +32740,12 @@
 	id = "hangar_engine";
 	name = "Engineering Hangar"
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/engine)
 "brG" = (
@@ -32804,6 +32981,11 @@
 	id = "qm_out";
 	name = "Cargo Routing Door"
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bsc" = (
@@ -32924,6 +33106,12 @@
 	icon_state = "bdoorright1";
 	id = "hangar_engine";
 	name = "Engineering Hangar"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/engine)
@@ -34441,6 +34629,12 @@
 	id = "hangar_main";
 	name = "Mechanic's Bay"
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
 "bvx" = (
@@ -34869,6 +35063,12 @@
 	icon_state = "bdoormid1";
 	id = "hangar_main";
 	name = "Mechanic's Bay"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
@@ -35719,6 +35919,12 @@
 	icon_state = "bdoorright1";
 	id = "hangar_main";
 	name = "Mechanic's Bay"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
@@ -36643,6 +36849,11 @@
 	id = "qm_out";
 	name = "Cargo Routing Door"
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "bAa" = (
@@ -36661,6 +36872,11 @@
 /obj/machinery/door/poddoor/pyro{
 	id = "qm_in";
 	name = "Cargo Routing Door"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
@@ -39699,6 +39915,12 @@
 	icon_state = "bdoormid1";
 	id = "qm_dock_out"
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/plating,
 /area/station/hangar/qm)
 "bGo" = (
@@ -40502,6 +40724,12 @@
 	dir = 4;
 	icon_state = "bdoormid1";
 	id = "qm_dock"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/hangar/qm)
@@ -42444,6 +42672,11 @@
 	id = "medsci_out";
 	name = "Cargo Routing Door"
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
 "bLL" = (
@@ -42454,6 +42687,11 @@
 /obj/machinery/door/poddoor/pyro{
 	id = "medsci_in";
 	name = "Cargo Routing Door"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
@@ -42880,6 +43118,12 @@
 	icon_state = "bdoorleft1";
 	id = "hangar_cargo";
 	name = "Cargo Hangar"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/qm)
@@ -43540,6 +43784,12 @@
 	icon_state = "bdoormid1";
 	id = "hangar_cargo";
 	name = "Cargo Hangar"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/qm)
@@ -44241,6 +44491,12 @@
 	id = "hangar_cargo";
 	name = "Cargo Hangar"
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/qm)
 "bPv" = (
@@ -44519,6 +44775,12 @@
 	id = "medsci1_out";
 	name = "Cargo Routing Door"
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/caution/northsouth,
 /area/station/routingdepot/airbridge)
 "bQb" = (
@@ -44545,6 +44807,12 @@
 	dir = 4;
 	id = "medsci1_out";
 	name = "Cargo Routing Door"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
@@ -45271,6 +45539,12 @@
 	id = "medsci1_in";
 	name = "Cargo Routing Door"
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/plating,
 /area/station/routingdepot/airbridge)
 "bRw" = (
@@ -45283,6 +45557,12 @@
 	dir = 4;
 	id = "medsci1_in";
 	name = "Cargo Routing Door"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/caution/northsouth,
 /area/station/maintenance/inner)
@@ -53841,6 +54121,12 @@
 	id = "hangar_artlab";
 	name = "Science Hangar"
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/science)
 "cko" = (
@@ -54558,6 +54844,12 @@
 	id = "hangar_artlab";
 	name = "Science Hangar"
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/science)
 "clM" = (
@@ -55039,6 +55331,12 @@
 	icon_state = "bdoorright1";
 	id = "hangar_artlab";
 	name = "Science Hangar"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/science)
@@ -56188,6 +56486,12 @@
 	dir = 4;
 	id = "artlabgun";
 	name = "Emergency Mass Driver"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/science)
@@ -59821,6 +60125,11 @@
 	id = "chemdock_out";
 	name = "Cargo Routing Door"
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/plating,
 /area/station/routingdepot/medsci)
 "cwx" = (
@@ -59840,6 +60149,11 @@
 /obj/machinery/door/poddoor/pyro{
 	id = "chemdock_in";
 	name = "Cargo Routing Door"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/routingdepot/medsci)

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -303,8 +303,7 @@
 	},
 /area/shuttle/arrival/station)
 "aaW" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "aaX" = (
@@ -330,8 +329,6 @@
 /turf/space,
 /area/station/solar/north)
 "aba" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -340,6 +337,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northsolar)
 "abb" = (
@@ -445,18 +443,12 @@
 	},
 /area/station/solar/north)
 "abi" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/observatory)
 "abj" = (
 /turf/simulated/floor,
 /area/station/routingdepot/security)
-"abk" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
 "abl" = (
 /obj/cable,
 /obj/machinery/power/solar/west,
@@ -1025,8 +1017,7 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/secondary/construction2)
 "acK" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/construction2)
 "acL" = (
@@ -1070,8 +1061,7 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "acS" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/construction)
 "acT" = (
@@ -1711,12 +1701,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northsolar)
 "aeo" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
 "aep" = (
@@ -1965,12 +1954,11 @@
 	},
 /area/station/solar/north)
 "aeQ" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northsolar)
 "aeR" = (
@@ -2957,8 +2945,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "agW" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -2967,6 +2953,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
 "agX" = (
@@ -3603,9 +3590,8 @@
 /turf/simulated/floor/plating,
 /area/station/routingdepot/security)
 "air" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/turf/simulated/floor/plating/airless,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "ais" = (
 /obj/rack,
@@ -3965,14 +3951,12 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "aiX" = (
-/obj/grille/steel,
 /obj/disposalpipe/segment/food,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/kitchen)
 "aiY" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/kitchen)
 "aiZ" = (
@@ -4146,12 +4130,11 @@
 	},
 /area/station/security/brig)
 "aju" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/routingdepot/security)
 "ajv" = (
@@ -4350,9 +4333,8 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/fitness)
 "ajU" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/turf/simulated/floor/black,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "ajV" = (
 /obj/cable{
@@ -4361,12 +4343,11 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/secwing)
 "ajW" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/arrivals)
 "ajX" = (
@@ -4467,12 +4448,11 @@
 	name = "Catering Hangar"
 	})
 "akk" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/crystal/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "akl" = (
@@ -4854,13 +4834,12 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "alb" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/arrivals)
 "alc" = (
@@ -5074,9 +5053,8 @@
 /turf/simulated/floor/red/side,
 /area/station/security/brig)
 "alz" = (
-/obj/grille/steel,
 /obj/cable,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/routingdepot/security)
 "alA" = (
@@ -5454,13 +5432,12 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/sec)
 "ams" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable,
-/obj/window/auto/crystal/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "amt" = (
@@ -5488,13 +5465,12 @@
 	},
 /area/station/security/brig)
 "amw" = (
-/obj/grille/steel,
-/obj/window/auto/crystal/reinforced,
 /obj/cable,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/routingdepot/security)
 "amx" = (
@@ -5979,8 +5955,7 @@
 	},
 /area/station/security/brig)
 "anC" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "anD" = (
@@ -6010,19 +5985,6 @@
 /turf/simulated/floor/red/side{
 	dir = 4
 	},
-/area/station/security/brig)
-"anG" = (
-/obj/grille/steel,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/window/auto/crystal/reinforced,
-/turf/simulated/floor/plating,
 /area/station/security/brig)
 "anH" = (
 /obj/machinery/computer/arcade{
@@ -6244,10 +6206,8 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "aom" = (
-/obj/grille/steel,
 /obj/cable,
-/obj/item/reagent_containers/food/drinks/tea,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/arrivals)
 "aon" = (
@@ -6337,7 +6297,6 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "aou" = (
-/obj/grille/steel,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -6346,7 +6305,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/kitchen)
 "aov" = (
@@ -6450,21 +6409,9 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hydroponics/lobby)
 "aoF" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hydroponics/lobby)
-"aoG" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/hydroponics)
-"aoH" = (
-/obj/grille/steel,
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/hydroponics)
 "aoI" = (
 /obj/machinery/door/poddoor/blast/pyro{
 	autoclose = 1;
@@ -6492,12 +6439,11 @@
 /turf/simulated/floor/caution/west,
 /area/station/hangar/sec)
 "aoL" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hangar/sec)
 "aoM" = (
@@ -6554,7 +6500,6 @@
 	},
 /area/station/security/brig)
 "aoR" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -6563,7 +6508,7 @@
 /obj/disposalpipe/segment/ejection{
 	dir = 4
 	},
-/obj/window/auto/crystal/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "aoS" = (
@@ -7142,9 +7087,8 @@
 /turf/simulated/floor,
 /area/station/security/brig)
 "aqm" = (
-/obj/grille/steel,
 /obj/cable,
-/obj/window/auto/crystal/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "aqn" = (
@@ -8298,7 +8242,6 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/brig)
 "asY" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -8306,7 +8249,7 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
-/obj/window/auto/crystal/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "asZ" = (
@@ -8802,9 +8745,8 @@
 /turf/simulated/floor/delivery,
 /area/station/security/brig)
 "aui" = (
-/obj/grille/steel,
 /obj/disposalpipe/segment/transport,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "auj" = (
@@ -8829,7 +8771,6 @@
 	},
 /area/station/security/brig)
 "aul" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -8839,7 +8780,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/crystal/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "aum" = (
@@ -9249,9 +9190,8 @@
 	},
 /area/station/hydroponics)
 "avj" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/turf/simulated/floor/black,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
 /area/station/hydroponics)
 "avk" = (
 /obj/shrub,
@@ -9337,12 +9277,11 @@
 /turf/simulated/floor/delivery,
 /area/station/security/brig)
 "avt" = (
-/obj/grille/steel,
 /obj/cable,
 /obj/disposalpipe/segment/brig{
 	dir = 4
 	},
-/obj/window/auto/crystal/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "avu" = (
@@ -10163,14 +10102,13 @@
 	},
 /area/station/crew_quarters/barber_shop)
 "axd" = (
-/obj/grille/steel,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/wingrille_spawn/auto,
 /obj/decal/poster/wallsign/barber{
 	pixel_y = -16
 	},
-/obj/window/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/barber_shop)
 "axe" = (
@@ -10596,8 +10534,6 @@
 	},
 /area/station/medical/medbooth)
 "ayb" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -10606,6 +10542,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southsolar)
 "ayc" = (
@@ -10873,8 +10810,7 @@
 	},
 /area/station/crew_quarters/barber_shop)
 "ayA" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/barber_shop)
 "ayB" = (
@@ -11335,7 +11271,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southsolar)
 "azC" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -11344,20 +11279,19 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
 "azD" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
 "azE" = (
@@ -12062,12 +11996,12 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "aBf" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
 "aBg" = (
@@ -12694,9 +12628,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southsolar)
 "aCw" = (
-/obj/grille/steel,
 /obj/cable,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
 "aCx" = (
@@ -14233,12 +14166,11 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/secwing)
 "aFs" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/secwing)
 "aFt" = (
@@ -14770,12 +14702,11 @@
 /turf/simulated/floor/bot,
 /area/station/security/main)
 "aGz" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "aGA" = (
@@ -14865,8 +14796,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/grille/steel,
-/obj/window/auto/crystal/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "aGI" = (
@@ -14875,12 +14805,11 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/crystal/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "aGJ" = (
@@ -14892,8 +14821,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/grille/steel,
-/obj/window/auto/crystal/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "aGK" = (
@@ -14912,20 +14840,18 @@
 /turf/simulated/floor,
 /area/station/security/secwing)
 "aGM" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/secwing)
 "aGN" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -14938,17 +14864,16 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/secwing)
 "aGO" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/decal/poster/wallsign/security,
 /turf/simulated/floor/plating,
 /area/station/security/secwing)
@@ -15417,7 +15342,6 @@
 	},
 /area/station/security/main)
 "aHQ" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -15426,15 +15350,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/disposalpipe/segment/mail{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/secwing)
 "aHR" = (
@@ -15523,9 +15439,8 @@
 	},
 /area/station/security/secwing)
 "aHX" = (
-/obj/grille/steel,
 /obj/cable,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/secwing)
 "aHY" = (
@@ -16055,13 +15970,12 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aJb" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "aJc" = (
@@ -16322,12 +16236,11 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/cafeteria)
 "aJJ" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/blue/side,
 /area/station/medical/medbooth)
 "aJK" = (
@@ -16611,7 +16524,6 @@
 /turf/simulated/floor,
 /area/station/security/main)
 "aKp" = (
-/obj/grille/steel,
 /obj/cable,
 /obj/cable{
 	d2 = 4;
@@ -16620,7 +16532,7 @@
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/secwing)
 "aKq" = (
@@ -17174,9 +17086,8 @@
 /turf/simulated/floor/delivery,
 /area/station/security/main)
 "aLr" = (
-/obj/grille/steel,
 /obj/cable,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "aLs" = (
@@ -17455,8 +17366,7 @@
 /turf/simulated/floor/bot,
 /area/station/routingdepot/catering)
 "aLZ" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/cafeteria)
 "aMa" = (
@@ -17620,11 +17530,6 @@
 	icon_state = "fred2"
 	},
 /area/station/chapel/main)
-"aMt" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/chapel/main)
 "aMu" = (
 /obj/cable{
 	d2 = 4;
@@ -17645,7 +17550,6 @@
 /turf/simulated/floor/plating/airless,
 /area/station/com_dish/comdish)
 "aMw" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -17654,7 +17558,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "aMx" = (
@@ -17978,11 +17882,6 @@
 	},
 /turf/simulated/floor,
 /area/station/routingdepot/catering)
-"aNc" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/jazz)
 "aNd" = (
 /obj/cable{
 	d1 = 1;
@@ -17991,11 +17890,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/jazz)
-"aNe" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/medical/medbooth)
 "aNf" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -18753,9 +18647,8 @@
 	},
 /area/station/crew_quarters/jazz)
 "aOv" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/turf/simulated/floor/black,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
 /area/station/medical/medbooth)
 "aOw" = (
 /obj/cable{
@@ -18879,13 +18772,7 @@
 	icon_state = "blue1"
 	},
 /area/station/bridge)
-"aOI" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/turf/simulated/floor/black,
-/area/station/chapel/main)
 "aOJ" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -18898,7 +18785,7 @@
 	name = "Bridge Lockdown Doors";
 	opacity = 0
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "aOK" = (
@@ -18983,7 +18870,6 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/hos)
 "aOT" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -18992,7 +18878,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2{
 	dir = 8
 	},
@@ -19391,7 +19277,6 @@
 	},
 /area/station/chapel/main)
 "aPI" = (
-/obj/grille/steel,
 /obj/cable{
 	icon_state = "0-2"
 	},
@@ -19399,7 +19284,6 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
 	dir = 9;
@@ -19408,10 +19292,10 @@
 	name = "Bridge Lockdown Doors";
 	opacity = 0
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "aPJ" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -19427,17 +19311,15 @@
 	name = "Bridge Lockdown Doors";
 	opacity = 0
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "aPK" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable,
-/obj/window/auto/reinforced,
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
 	dir = 6;
@@ -19446,6 +19328,7 @@
 	name = "Bridge Lockdown Doors";
 	opacity = 0
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "aPL" = (
@@ -19822,17 +19705,15 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/detectives_office)
 "aQz" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/left,
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
 "aQA" = (
-/obj/grille/steel,
 /obj/disposalpipe/segment/mail,
 /obj/cable{
 	d2 = 2;
@@ -19842,7 +19723,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/right,
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
@@ -19894,23 +19775,6 @@
 	dir = 1
 	},
 /area/station/chapel/main)
-"aQJ" = (
-/obj/grille/steel,
-/obj/cable,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/window/auto/reinforced,
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "lockdown";
-	name = "Bridge Lockdown Doors";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/station/bridge)
 "aQK" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -20027,39 +19891,36 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/hos)
 "aQY" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "aQZ" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "aRa" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "aRb" = (
@@ -20401,7 +20262,6 @@
 	},
 /area/station/chapel/main)
 "aRP" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -20410,7 +20270,6 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
 	dir = 9;
@@ -20419,10 +20278,10 @@
 	name = "Bridge Lockdown Doors";
 	opacity = 0
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "aRQ" = (
-/obj/grille/steel,
 /obj/cable,
 /obj/cable{
 	d2 = 8;
@@ -20440,7 +20299,7 @@
 	name = "Bridge Lockdown Doors";
 	opacity = 0
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "aRR" = (
@@ -20560,8 +20419,7 @@
 /turf/simulated/floor,
 /area/station/security/main)
 "aSe" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/courtroom)
 "aSf" = (
@@ -20665,11 +20523,7 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/jazz)
 "aSs" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/obj/window_blinds/cog2/right{
-	dir = 4
-	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
 "aSt" = (
@@ -20723,7 +20577,6 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aSy" = (
-/obj/grille/steel,
 /obj/disposalpipe/segment{
 	dir = 4
 	},
@@ -20735,7 +20588,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/left{
 	dir = 8
 	},
@@ -20813,24 +20666,6 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/main)
-"aSK" = (
-/obj/grille/steel,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable,
-/obj/window/auto/reinforced,
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "lockdown";
-	name = "Bridge Lockdown Doors";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/station/bridge)
 "aSL" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -20959,7 +20794,6 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/hos)
 "aTa" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -20968,17 +20802,16 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "aTb" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "aTc" = (
@@ -21160,8 +20993,7 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/jazz)
 "aTx" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/left{
 	dir = 4
 	},
@@ -21192,13 +21024,12 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aTB" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/right{
 	dir = 8
 	},
@@ -21599,9 +21430,8 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "aUp" = (
-/obj/grille/steel,
+/obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment,
-/obj/window/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/courtroom)
 "aUq" = (
@@ -21967,25 +21797,6 @@
 	icon_state = "fred2"
 	},
 /area/station/chapel/main)
-"aVh" = (
-/obj/grille/steel,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable,
-/obj/machinery/door/poddoor/pyro,
-/obj/window/auto/reinforced,
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "lockdown";
-	name = "Bridge Lockdown Doors";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/station/bridge)
 "aVi" = (
 /obj/stool/chair{
 	dir = 8
@@ -22402,9 +22213,8 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/jazz)
 "aWc" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/turf/simulated/floor/plating,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/black,
 /area/station/crew_quarters/jazz)
 "aWd" = (
 /obj/item/device/radio/intercom{
@@ -23280,8 +23090,7 @@
 /turf/simulated/floor/black,
 /area/station/medical/crematorium)
 "aXJ" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/crematorium)
 "aXK" = (
@@ -23334,13 +23143,10 @@
 /turf/simulated/floor/carpet,
 /area/station/chapel/main)
 "aXQ" = (
-/obj/grille/steel,
-/obj/item/pen,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/chapel/main)
 "aXR" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -23354,7 +23160,7 @@
 	name = "Bridge Lockdown Doors";
 	opacity = 0
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "aXS" = (
@@ -24203,7 +24009,6 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/chapel/main)
 "aZK" = (
-/obj/grille/steel,
 /obj/cable,
 /obj/cable{
 	d2 = 4;
@@ -24217,11 +24022,10 @@
 	name = "Bridge Lockdown Doors";
 	opacity = 0
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "aZL" = (
-/obj/grille/steel,
 /obj/cable{
 	icon_state = "0-2"
 	},
@@ -24237,7 +24041,7 @@
 	name = "Bridge Lockdown Doors";
 	opacity = 0
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "aZM" = (
@@ -24642,7 +24446,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "baN" = (
-/obj/grille/steel,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-2"
@@ -24655,7 +24458,7 @@
 	name = "Bridge Lockdown Doors";
 	opacity = 0
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "baO" = (
@@ -25164,7 +24967,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "bbO" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -25176,7 +24978,7 @@
 	name = "Bridge Lockdown Doors";
 	opacity = 0
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "bbP" = (
@@ -25709,12 +25511,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "bcQ" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/right{
 	dir = 4
 	},
@@ -25767,19 +25568,17 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
 "bcW" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/left{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/captain)
 "bcX" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -25788,7 +25587,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/right{
 	dir = 4
 	},
@@ -25937,17 +25736,14 @@
 /turf/simulated/floor/black,
 /area/station/security/checkpoint)
 "bdi" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
 "bdj" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable,
 /obj/cable{
 	d2 = 2;
@@ -25957,6 +25753,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
 "bdk" = (
@@ -26237,13 +26034,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "bdP" = (
-/obj/grille/steel,
 /obj/cable,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/left{
 	dir = 4
 	},
@@ -26320,26 +26116,24 @@
 	},
 /area/station/crew_quarters/captain)
 "bdV" = (
-/obj/grille/steel,
 /obj/cable,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/right{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/captain)
 "bdW" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/left{
 	dir = 4
 	},
@@ -26797,17 +26591,15 @@
 	},
 /area/station/crew_quarters/captain)
 "beP" = (
-/obj/grille/steel,
 /obj/cable,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/heads)
 "beQ" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -26816,7 +26608,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/left{
 	layer = 2.9;
 	pixel_y = 13
@@ -26824,7 +26616,6 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/heads)
 "beR" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -26833,7 +26624,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/middle{
 	layer = 2.9;
 	pixel_y = 13
@@ -26841,12 +26632,11 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/heads)
 "beS" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/right{
 	layer = 2.9;
 	pixel_y = 13
@@ -27189,17 +26979,15 @@
 /turf/simulated/floor/plating/damaged2,
 /area/station/maintenance/disposal)
 "bfF" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/turf/simulated/floor/black,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bfG" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2{
 	dir = 4
 	},
@@ -27282,20 +27070,18 @@
 	},
 /area/station/crew_quarters/captain)
 "bfM" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/captain)
 "bfN" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/market)
 "bfO" = (
@@ -27696,12 +27482,11 @@
 /turf/simulated/floor/caution/south,
 /area/station/maintenance/disposal)
 "bgE" = (
-/obj/grille/steel,
 /obj/disposalpipe/segment/ejection{
 	dir = 4
 	},
-/obj/window/auto/reinforced,
-/turf/simulated/floor/black,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bgF" = (
 /obj/disposaloutlet{
@@ -28206,13 +27991,12 @@
 /turf/simulated/floor/grime,
 /area/station/routingdepot)
 "bhO" = (
-/obj/grille/steel,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/routingdepot)
 "bhP" = (
@@ -28486,12 +28270,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "biu" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2{
 	dir = 4
 	},
@@ -28532,7 +28315,6 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/captain)
 "biy" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -28541,7 +28323,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2{
 	dir = 8
 	},
@@ -28752,8 +28534,7 @@
 /turf/simulated/floor/grime,
 /area/station/routingdepot)
 "biW" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/routingdepot)
 "biX" = (
@@ -28864,8 +28645,7 @@
 /turf/simulated/floor/sand,
 /area/station/chapel/main)
 "bjh" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/storage/emergency)
 "bji" = (
@@ -29000,17 +28780,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bjy" = (
-/obj/grille/steel,
 /obj/cable,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/captain)
 "bjz" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -29019,7 +28797,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/left{
 	layer = 2.9;
 	pixel_y = 13
@@ -29027,7 +28805,6 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/captain)
 "bjA" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -29036,7 +28813,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/middle{
 	layer = 2.9;
 	pixel_y = 13
@@ -29044,7 +28821,6 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/captain)
 "bjB" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -29053,7 +28829,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/right{
 	layer = 2.9;
 	pixel_y = 13
@@ -29061,13 +28837,12 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/captain)
 "bjC" = (
-/obj/grille/steel,
 /obj/cable,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/captain)
 "bjD" = (
@@ -29613,7 +29388,6 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/east)
 "bkO" = (
-/obj/grille/steel,
 /obj/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -29623,16 +29397,15 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bkP" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bkQ" = (
@@ -29890,8 +29663,7 @@
 /turf/space,
 /area/shuttle/merchant_shuttle/right_station/cogmap)
 "blz" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/stockex)
 "blA" = (
@@ -30585,7 +30357,6 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "bnc" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -30598,7 +30369,7 @@
 	name = "E.V.A.";
 	opacity = 0
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage/eva)
 "bnd" = (
@@ -30959,7 +30730,6 @@
 /turf/simulated/floor/caution/east,
 /area/station/crew_quarters/market)
 "bnP" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -30980,7 +30750,7 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage/eva)
 "bnQ" = (
@@ -31411,7 +31181,6 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "boD" = (
-/obj/grille/steel,
 /obj/cable,
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
@@ -31421,7 +31190,7 @@
 	name = "E.V.A.";
 	opacity = 0
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage/eva)
 "boE" = (
@@ -32703,8 +32472,7 @@
 /turf/simulated/floor/yellow/side,
 /area/station/engine/engineering)
 "brg" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/info)
 "brh" = (
@@ -32751,10 +32519,9 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "brl" = (
-/obj/grille/steel,
 /obj/cable,
-/obj/window/auto/reinforced,
-/turf/simulated/floor,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
 /area/station/ai_monitored/storage/eva)
 "brm" = (
 /obj/grille/steel,
@@ -32783,8 +32550,7 @@
 	name = "AI Core Shield";
 	opacity = 0
 	},
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "brp" = (
@@ -32806,8 +32572,7 @@
 /obj/disposalpipe/segment/morgue{
 	name = "crematorium pipe"
 	},
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "brq" = (
@@ -32827,8 +32592,7 @@
 	name = "AI Core Shield";
 	opacity = 0
 	},
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "brr" = (
@@ -33114,14 +32878,6 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "brW" = (
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "ai_core";
-	name = "AI Core Shield";
-	opacity = 0
-	},
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -33169,12 +32925,7 @@
 	icon_state = "0-2"
 	},
 /obj/cable,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "bsa" = (
@@ -33501,8 +33252,7 @@
 	icon_state = "0-4"
 	},
 /obj/cable,
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "bsH" = (
@@ -33525,8 +33275,7 @@
 	icon_state = "0-8"
 	},
 /obj/cable,
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "bsI" = (
@@ -33547,17 +33296,15 @@
 	icon_state = "0-8"
 	},
 /obj/cable,
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "bsJ" = (
-/obj/grille/steel,
 /obj/disposalpipe/segment/mail{
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bsK" = (
@@ -33846,9 +33593,8 @@
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "btp" = (
-/obj/grille/steel,
 /obj/disposalpipe/segment/mail,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "btq" = (
@@ -33939,8 +33685,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/turret_protected/Zeta)
 "btz" = (
@@ -34507,16 +34252,14 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/main)
 "buN" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hangar/main)
 "buO" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -34525,20 +34268,19 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hangar/main)
 "buP" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hangar/main)
 "buQ" = (
@@ -34918,8 +34660,7 @@
 /turf/simulated/floor/delivery,
 /area/station/hangar/main)
 "bvF" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hangar/main)
 "bvG" = (
@@ -35270,9 +35011,8 @@
 /turf/simulated/wall/auto/supernorn,
 /area/ghostdrone_factory)
 "bwq" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/turf/simulated/floor/plating/random,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
 /area/ghostdrone_factory)
 "bwr" = (
 /obj/machinery/door/poddoor/blast/pyro{
@@ -35750,13 +35490,12 @@
 	},
 /area/station/crew_quarters/market)
 "bxt" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hangar/main)
 "bxu" = (
@@ -35985,9 +35724,6 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "bxT" = (
-/obj/window/crystal/reinforced/south,
-/obj/window/crystal/reinforced/north,
-/obj/window/crystal/reinforced/west,
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
 	icon_state = "pdoor0";
@@ -35998,7 +35734,7 @@
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 5
 	},
-/obj/wingrille_spawn/auto,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/hotloop)
 "bxU" = (
@@ -37495,9 +37231,8 @@
 	},
 /area/station/storage/warehouse)
 "bAT" = (
-/obj/grille/steel,
 /obj/disposalpipe/segment/mail,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/storage/warehouse)
 "bAU" = (
@@ -37511,8 +37246,7 @@
 /turf/simulated/floor,
 /area/station/storage/warehouse)
 "bAV" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/storage/warehouse)
 "bAW" = (
@@ -38082,9 +37816,8 @@
 /area/station/crew_quarters/market)
 "bCf" = (
 /obj/cable,
-/obj/grille/steel,
+/obj/wingrille_spawn/auto,
 /obj/decal/poster/wallsign/space,
-/obj/window/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/market)
 "bCg" = (
@@ -39660,12 +39393,11 @@
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
 "bFu" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/turret_protected/Zeta)
 "bFv" = (
@@ -39705,12 +39437,11 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/turret_protected/Zeta)
 "bFz" = (
@@ -40569,7 +40300,6 @@
 /turf/simulated/floor/circuit/green,
 /area/station/turret_protected/Zeta)
 "bHg" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -40578,7 +40308,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/turret_protected/Zeta)
 "bHh" = (
@@ -40971,9 +40701,8 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/grille/steel,
+/obj/wingrille_spawn/auto,
 /obj/decal/poster/wallsign/space,
-/obj/window/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/south)
 "bIb" = (
@@ -41064,8 +40793,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/Zeta)
 "bIj" = (
@@ -41407,12 +41135,11 @@
 /turf/simulated/floor/bot,
 /area/station/quartermaster/office)
 "bIL" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hangar/qm)
 "bIM" = (
@@ -41434,16 +41161,14 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/science/teleporter)
 "bIR" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/science/teleporter)
 "bIS" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -41452,11 +41177,10 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/science/teleporter)
 "bIT" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -41465,16 +41189,15 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/science/teleporter)
 "bIU" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/science/teleporter)
 "bIV" = (
@@ -41926,7 +41649,6 @@
 /turf/simulated/floor/delivery,
 /area/station/quartermaster/office)
 "bJP" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -41936,7 +41658,7 @@
 	icon_state = "0-4"
 	},
 /obj/cable,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hangar/qm)
 "bJQ" = (
@@ -41956,7 +41678,6 @@
 /turf/simulated/floor/plating,
 /area/station/hangar/qm)
 "bJS" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -41965,11 +41686,10 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hangar/qm)
 "bJT" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -41978,7 +41698,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hangar/qm)
 "bJU" = (
@@ -42022,17 +41742,15 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/hor)
 "bJZ" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/left,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/hor)
 "bKa" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -42045,17 +41763,16 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/middle,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/hor)
 "bKb" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/right,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/hor)
@@ -42520,13 +42237,12 @@
 /turf/simulated/floor/delivery,
 /area/station/quartermaster/office)
 "bKZ" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hangar/qm)
 "bLa" = (
@@ -42763,7 +42479,6 @@
 	},
 /area/station/science/teleporter)
 "bLy" = (
-/obj/grille/steel,
 /obj/machinery/door/poddoor/pyro{
 	dir = 4;
 	id = "scienceteleporter";
@@ -42778,7 +42493,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/engine,
 /area/station/science/teleporter)
 "bLz" = (
@@ -42820,7 +42535,6 @@
 	},
 /area/station/science/teleporter)
 "bLC" = (
-/obj/grille/steel,
 /obj/machinery/door/poddoor/pyro{
 	dir = 4;
 	id = "scienceteleporter2";
@@ -42831,17 +42545,17 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/securearea{
-	desc = "Careless use of experimental teleportation technology may be hazardous to your health.";
-	name = "Molecular Integrity Hazard";
-	pixel_y = -4
-	},
 /obj/disposalpipe/segment/transport,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
+/obj/securearea{
+	desc = "Careless use of experimental teleportation technology may be hazardous to your health.";
+	name = "Molecular Integrity Hazard";
+	pixel_y = -4
+	},
 /turf/simulated/floor/engine,
 /area/station/science/teleporter)
 "bLD" = (
@@ -42851,12 +42565,11 @@
 	},
 /area/station/hallway/primary/south)
 "bLE" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/mining)
 "bLF" = (
@@ -43056,13 +42769,12 @@
 	name = "Supply Lobby"
 	})
 "bMf" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/mining)
 "bMg" = (
@@ -43349,41 +43061,28 @@
 /turf/simulated/floor/plating,
 /area/station/science/lab)
 "bMI" = (
-/obj/grille/steel,
-/obj/window/crystal/reinforced/south,
-/obj/window/crystal/reinforced/north,
-/obj/window/crystal/reinforced/west,
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0;
 	dir = 5
 	},
-/obj/window/auto/crystal/reinforced,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "bMJ" = (
-/obj/grille/steel,
-/obj/window/crystal/reinforced/south,
-/obj/window/crystal/reinforced/north,
-/obj/window/crystal/reinforced/east,
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 4;
 	level = 2
 	},
-/obj/window/auto/crystal/reinforced,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "bMK" = (
-/obj/grille/steel,
-/obj/window/crystal/reinforced/west,
-/obj/window/crystal/reinforced/north,
-/obj/window/crystal/reinforced/east,
-/obj/window/crystal/reinforced/south,
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0;
 	dir = 1
 	},
-/obj/window/auto/crystal/reinforced,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "bML" = (
@@ -43461,7 +43160,6 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/hor)
 "bMS" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -43470,7 +43168,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/left{
 	dir = 8
 	},
@@ -43888,8 +43586,7 @@
 /turf/simulated/floor/yellow,
 /area/station/storage/primary)
 "bNL" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/neutral/side{
 	dir = 8
 	},
@@ -44182,9 +43879,8 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/hor)
 "bOr" = (
-/obj/grille/steel,
 /obj/cable,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/right{
 	dir = 8
 	},
@@ -44335,11 +44031,7 @@
 /turf/simulated/floor/caution/west,
 /area/station/hallway/primary/south)
 "bOF" = (
-/obj/grille/steel,
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/routingdepot/airbridge)
 "bOG" = (
@@ -44620,12 +44312,11 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bPl" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "bPm" = (
@@ -44727,11 +44418,6 @@
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "bPx" = (
-/obj/grille/steel,
-/obj/window/crystal/reinforced/west,
-/obj/window/crystal/reinforced/north,
-/obj/window/crystal/reinforced/east,
-/obj/window/crystal/reinforced/south,
 /obj/machinery/door/firedoor/pyro{
 	dir = 4
 	},
@@ -44740,7 +44426,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/window/auto/crystal/reinforced,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "bPy" = (
@@ -45244,13 +44930,12 @@
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "bQA" = (
-/obj/grille/steel,
 /obj/cable,
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "bQB" = (
@@ -45269,22 +44954,20 @@
 	name = "Supply Lobby"
 	})
 "bQC" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/market{
 	name = "Supply Lobby"
 	})
 "bQD" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -45293,12 +44976,12 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
 /area/station/crew_quarters/market{
 	name = "Supply Lobby"
 	})
@@ -46035,10 +45718,9 @@
 	name = "Supply Lobby"
 	})
 "bSe" = (
-/obj/grille/steel,
 /obj/cable,
-/obj/window/auto/reinforced,
-/turf/simulated/floor,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
 /area/station/crew_quarters/market{
 	name = "Supply Lobby"
 	})
@@ -46571,8 +46253,7 @@
 /turf/simulated/floor/plating,
 /area/station/routingdepot/airbridge)
 "bSY" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/east)
 "bSZ" = (
@@ -46586,8 +46267,7 @@
 /turf/simulated/floor/bot,
 /area/station/hallway/primary/south)
 "bTa" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
 "bTb" = (
@@ -46833,8 +46513,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hangar/qm)
 "bTE" = (
@@ -46985,13 +46664,12 @@
 /turf/simulated/floor/white,
 /area/station/science/lab)
 "bTU" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/left{
 	layer = 2.9;
 	pixel_y = 13
@@ -46999,12 +46677,11 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/hor)
 "bTV" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/right{
 	layer = 2.9;
 	pixel_y = 13
@@ -47139,12 +46816,10 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science)
 "bUk" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/hallway/primary/south)
+/area/station/hallway/primary/central)
 "bUl" = (
-/obj/grille/steel,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -47153,7 +46828,7 @@
 /obj/disposalpipe/segment/morgue{
 	name = "crematorium pipe"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/south)
 "bUm" = (
@@ -47281,11 +46956,14 @@
 /turf/simulated/floor/delivery,
 /area/station/hallway/primary/south)
 "bUF" = (
-/obj/grille/steel,
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/obj/window/auto/reinforced,
+/obj/cable,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/hallway/primary/south)
+/area/station/security/main)
 "bUG" = (
 /obj/noticeboard{
 	pixel_y = 28
@@ -47334,13 +47012,12 @@
 /turf/simulated/floor/bot,
 /area/station/hallway/primary/south)
 "bUM" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/mining)
 "bUN" = (
@@ -47368,12 +47045,11 @@
 /turf/simulated/floor/grime,
 /area/station/storage/warehouse)
 "bUR" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "bUU" = (
@@ -47420,8 +47096,7 @@
 	},
 /area/station/hangar/qm)
 "bVb" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/mining)
 "bVc" = (
@@ -47598,8 +47273,7 @@
 /turf/simulated/floor/delivery,
 /area/station/science)
 "bVv" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/science)
 "bVw" = (
@@ -47607,11 +47281,9 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science)
 "bVx" = (
-/obj/grille/steel,
-/obj/machinery/atmospherics/pipe/simple/insulated/cold,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/hallway/primary/south)
+/area/station/maintenance/east)
 "bVy" = (
 /obj/machinery/light/emergency{
 	dir = 8
@@ -48026,13 +47698,12 @@
 	name = "Supply Lobby"
 	})
 "bWf" = (
-/obj/grille/steel,
 /obj/disposalpipe/segment{
 	dir = 4
 	},
 /obj/cable,
 /obj/disposalpipe/segment/mail,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/market{
 	name = "Supply Lobby"
@@ -48097,8 +47768,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/quartermaster/refinery)
 "bWn" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/quartermaster/refinery)
 "bWo" = (
@@ -48392,13 +48062,12 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bWR" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "bWS" = (
@@ -48917,8 +48586,6 @@
 	},
 /area/station/hallway/primary/south)
 "bYc" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -48927,6 +48594,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "bYd" = (
@@ -49015,11 +48683,10 @@
 	},
 /area/station/hallway/primary/south)
 "bYo" = (
-/obj/grille/steel,
 /obj/disposalpipe/segment/morgue{
 	name = "crematorium pipe"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/south)
 "bYp" = (
@@ -49451,8 +49118,7 @@
 /turf/simulated/floor/purple,
 /area/station/science)
 "bZh" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/science/bot_storage)
 "bZi" = (
@@ -49963,11 +49629,10 @@
 	},
 /area/station/science)
 "cat" = (
-/obj/grille/steel,
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/science)
 "cau" = (
@@ -50009,11 +49674,10 @@
 /turf/simulated/floor/purple,
 /area/station/science)
 "cay" = (
-/obj/grille/steel,
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/science/bot_storage)
 "caz" = (
@@ -50113,9 +49777,8 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/south)
 "caI" = (
-/obj/grille/steel,
 /obj/disposalpipe/segment/mail,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/south)
 "caJ" = (
@@ -50201,12 +49864,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
 "caQ" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "caR" = (
@@ -50232,13 +49894,12 @@
 	},
 /area/station/mining)
 "caU" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/mining)
 "caV" = (
@@ -50456,7 +50117,6 @@
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/cargo)
 "cbt" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -50468,7 +50128,7 @@
 /obj/disposalpipe/segment/ejection{
 	dir = 4
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/cargo)
 "cbu" = (
@@ -50734,19 +50394,17 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/robotics)
 "ccb" = (
-/obj/grille/steel,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "ccc" = (
-/obj/grille/steel,
 /obj/disposalpipe/segment/mail,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "ccd" = (
@@ -51329,8 +50987,7 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/toilets)
 "cdu" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "cdv" = (
@@ -51494,12 +51151,11 @@
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/cargo)
 "cdN" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/mining)
 "cdO" = (
@@ -51598,8 +51254,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/storage)
 "ced" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/securearea{
 	pixel_y = -4
 	},
@@ -51652,8 +51307,7 @@
 /turf/simulated/floor,
 /area/station/science)
 "cel" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/lobby)
 "cem" = (
@@ -51787,10 +51441,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
 "ceH" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/SWmaint)
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/hangar/qm)
 "ceJ" = (
 /obj/disposalpipe/segment/transport{
 	dir = 8;
@@ -51813,8 +51466,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/secondary/exit)
 "ceO" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "ceP" = (
@@ -51905,8 +51557,6 @@
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/cargo)
 "cfa" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -51915,6 +51565,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/mining)
 "cfb" = (
@@ -52681,8 +52332,7 @@
 /turf/simulated/floor/white,
 /area/station/science/artifact)
 "cgJ" = (
-/obj/grille/steel,
-/obj/window/auto,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/science/artifact)
 "cgK" = (
@@ -53314,7 +52964,6 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "cie" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -53323,11 +52972,10 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/head)
 "cif" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -53336,17 +52984,16 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/left,
 /turf/simulated/floor/plating,
 /area/station/medical/head)
 "cig" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/right,
 /turf/simulated/floor/plating,
 /area/station/medical/head)
@@ -53433,24 +53080,21 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
 "cir" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
 "cis" = (
-/obj/grille/steel,
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 9
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/south)
 "cit" = (
-/obj/grille/steel,
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 5
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/south)
 "ciu" = (
@@ -53848,15 +53492,6 @@
 "cjk" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/medbay)
-"cjl" = (
-/obj/grille/steel,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/window/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/medical/medbay)
 "cjm" = (
 /obj/cable{
 	d1 = 4;
@@ -53915,12 +53550,11 @@
 /area/station/medical/medbay)
 "cjp" = (
 /obj/disposalpipe/segment/mail,
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/medbay)
 "cjq" = (
@@ -53934,13 +53568,12 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "cjs" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/right{
 	dir = 4
 	},
@@ -54427,7 +54060,6 @@
 	},
 /area/station/hangar/science)
 "ckr" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -54436,7 +54068,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hangar/science)
 "cks" = (
@@ -54609,8 +54241,7 @@
 	},
 /area/station/science)
 "ckG" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/medbay)
 "ckH" = (
@@ -54627,9 +54258,8 @@
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay)
 "ckJ" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/mining)
 "ckK" = (
@@ -54672,13 +54302,12 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "ckO" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/left{
 	dir = 4
 	},
@@ -54816,13 +54445,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
 "cle" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southsolar)
 "clf" = (
@@ -54962,12 +54590,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "clt" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southsolar)
 "clu" = (
@@ -55147,13 +54774,12 @@
 /turf/simulated/floor/delivery,
 /area/station/hangar/science)
 "clP" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/mining)
 "clQ" = (
@@ -55635,16 +55261,14 @@
 	},
 /area/station/hangar/science)
 "cmX" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/science/artifact)
 "cmY" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -55654,16 +55278,15 @@
 	icon_state = "0-4"
 	},
 /obj/cable,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/science/artifact)
 "cmZ" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/science/artifact)
 "cna" = (
@@ -55719,8 +55342,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/medbay)
 "cnj" = (
@@ -55768,21 +55390,19 @@
 	},
 /area/station/medical/medbay)
 "cnm" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/medbay)
 "cnn" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/medbay)
 "cno" = (
@@ -55807,13 +55427,12 @@
 /turf/simulated/floor/escape,
 /area/station/hallway/secondary/exit)
 "cnq" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/disposalpipe/segment/morgue,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/medbay)
 "cnr" = (
@@ -55821,8 +55440,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2{
 	layer = 2.9;
 	pixel_y = 13
@@ -55857,8 +55475,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2{
 	layer = 2.9;
 	pixel_y = 13
@@ -55884,16 +55501,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
 "cnv" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "cnw" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -55902,21 +55517,19 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "cnx" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "cny" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -55927,7 +55540,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "cnz" = (
@@ -55944,12 +55557,11 @@
 /turf/simulated/floor/blue,
 /area/station/medical/robotics)
 "cnA" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "cnB" = (
@@ -55957,8 +55569,7 @@
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "cnC" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/morgue)
 "cnD" = (
@@ -56018,8 +55629,7 @@
 /turf/simulated/floor/caution/south,
 /area/station/hallway/secondary/exit)
 "cnL" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "cnM" = (
@@ -56274,7 +55884,6 @@
 /turf/simulated/floor/plating,
 /area/station/testchamber)
 "cok" = (
-/obj/grille/steel,
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
 	dir = 4;
@@ -56288,7 +55897,7 @@
 	icon_state = "0-2"
 	},
 /obj/disposalpipe/segment/transport,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/chemistry)
 "col" = (
@@ -56830,7 +56439,6 @@
 /turf/simulated/floor/plating,
 /area/station/testchamber)
 "cpn" = (
-/obj/grille/steel,
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
 	dir = 4;
@@ -56848,7 +56456,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/chemistry)
 "cpo" = (
@@ -56908,23 +56516,6 @@
 /turf/simulated/floor/purplewhite{
 	dir = 4
 	},
-/area/station/chemistry)
-"cpw" = (
-/obj/grille/steel,
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "chemistry";
-	name = "Chemistry Privacy Shutters";
-	opacity = 0
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/window/auto/reinforced,
-/turf/simulated/floor/plating,
 /area/station/chemistry)
 "cpx" = (
 /obj/storage/secure/closet/medical/medicine,
@@ -57519,8 +57110,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/medbay)
 "cqE" = (
@@ -57851,35 +57441,6 @@
 	name = "very reinforced wall"
 	},
 /area/station/testchamber)
-"crk" = (
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "test_chamber2";
-	name = "Test Chamber Shield";
-	opacity = 0
-	},
-/obj/grille/steel,
-/obj/window/crystal/reinforced/west,
-/obj/window/crystal/reinforced/north,
-/obj/window/crystal/reinforced/south,
-/obj/window/auto/crystal/reinforced,
-/turf/simulated/floor/engine/vacuum,
-/area/station/testchamber)
-"crl" = (
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "test_chamber2";
-	name = "Test Chamber Shield";
-	opacity = 0
-	},
-/obj/grille/steel,
-/obj/window/crystal/reinforced/north,
-/obj/window/crystal/reinforced/south,
-/obj/window/auto/crystal/reinforced,
-/turf/simulated/floor/engine/vacuum,
-/area/station/testchamber)
 "crm" = (
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
@@ -57888,11 +57449,7 @@
 	name = "Test Chamber Shield";
 	opacity = 0
 	},
-/obj/grille/steel,
-/obj/window/crystal/reinforced/north,
-/obj/window/crystal/reinforced/east,
-/obj/window/crystal/reinforced/south,
-/obj/window/auto/crystal/reinforced,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/engine/vacuum,
 /area/station/testchamber)
 "crn" = (
@@ -58023,12 +57580,11 @@
 	name = "Chemistry Privacy Shutters";
 	opacity = 0
 	},
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/chemistry)
 "crA" = (
@@ -58058,8 +57614,7 @@
 	icon_state = "0-2"
 	},
 /obj/cable,
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/medbay)
 "crD" = (
@@ -58455,7 +58010,6 @@
 	},
 /area/station/chemistry)
 "csr" = (
-/obj/grille/steel,
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
 	icon_state = "pdoor0";
@@ -58463,7 +58017,7 @@
 	name = "Chemistry Privacy Shutters";
 	opacity = 0
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/chemistry)
 "css" = (
@@ -58974,8 +58528,7 @@
 /area/station/medical/medbay)
 "cts" = (
 /obj/cable,
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/medbay)
 "ctt" = (
@@ -59049,8 +58602,7 @@
 /turf/simulated/floor/caution/east,
 /area/station/medical/medbay/surgery)
 "ctD" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/research)
 "ctE" = (
@@ -59292,7 +58844,6 @@
 /turf/simulated/floor/delivery,
 /area/station/chemistry)
 "cub" = (
-/obj/grille/steel,
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
 	dir = 4;
@@ -59301,7 +58852,7 @@
 	name = "Chemistry Privacy Shutters";
 	opacity = 0
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/chemistry)
 "cuc" = (
@@ -59647,7 +59198,6 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/grille/steel,
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
 	icon_state = "pdoor0";
@@ -59655,7 +59205,7 @@
 	name = "Chemistry Privacy Shutters";
 	opacity = 0
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/chemistry)
 "cuO" = (
@@ -59667,7 +59217,6 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/grille/steel,
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
 	icon_state = "pdoor0";
@@ -59675,7 +59224,7 @@
 	name = "Chemistry Privacy Shutters";
 	opacity = 0
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/chemistry)
 "cuP" = (
@@ -59683,7 +59232,6 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/grille/steel,
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
 	icon_state = "pdoor0";
@@ -59691,7 +59239,7 @@
 	name = "Chemistry Privacy Shutters";
 	opacity = 0
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/chemistry)
 "cuQ" = (
@@ -59767,16 +59315,13 @@
 	},
 /area/station/medical/medbay)
 "cuY" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/research)
 "cuZ" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
@@ -59784,19 +59329,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/plating,
-/area/station/medical/research)
-"cva" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/research)
 "cvb" = (
@@ -60341,11 +59874,10 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "cwi" = (
-/obj/grille/steel,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/research)
 "cwj" = (
@@ -60774,8 +60306,6 @@
 	},
 /area/station/janitor/supply)
 "cxa" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -60783,17 +60313,9 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/janitor/supply)
-"cxb" = (
-/obj/grille/steel,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/window/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/medical/cdc)
 "cxc" = (
 /obj/disposalpipe/segment,
 /obj/machinery/door/firedoor/pyro,
@@ -60809,7 +60331,6 @@
 /turf/simulated/floor/delivery/white,
 /area/station/medical/cdc)
 "cxd" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -60819,15 +60340,14 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
 "cxe" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/cdc)
 "cxf" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
 "cxg" = (
@@ -60899,16 +60419,15 @@
 /turf/simulated/floor/caution/west,
 /area/station/medical/cdc)
 "cxn" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
 "cxo" = (
@@ -60932,12 +60451,11 @@
 	},
 /area/station/medical/research)
 "cxs" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/research)
 "cxt" = (
@@ -60961,9 +60479,8 @@
 /turf/simulated/floor/caution/west,
 /area/station/medical/cdc)
 "cxv" = (
-/obj/grille/steel,
 /obj/cable,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
 "cxw" = (
@@ -61149,12 +60666,11 @@
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "cxP" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
 "cxQ" = (
@@ -61267,20 +60783,18 @@
 	},
 /area/station/medical/research)
 "cyc" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/research)
 "cyd" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -61289,17 +60803,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/medical/research)
-"cye" = (
-/obj/grille/steel,
-/obj/cable,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/research)
 "cyf" = (
@@ -61363,13 +60867,12 @@
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "cyn" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/research)
 "cyo" = (
@@ -61402,20 +60905,18 @@
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "cys" = (
-/obj/grille/steel,
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
 "cyt" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/janitor/supply)
 "cyu" = (
@@ -61434,16 +60935,14 @@
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "cyv" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/janitor/supply)
 "cyw" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -61452,7 +60951,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
 "cyx" = (
@@ -61505,13 +61004,12 @@
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "cyB" = (
-/obj/grille/steel,
 /obj/cable,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
 "cyC" = (
@@ -61559,13 +61057,12 @@
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "cyF" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/janitor/supply)
 "cyG" = (
@@ -61573,16 +61070,15 @@
 /turf/simulated/floor/bot/white,
 /area/station/medical/cdc)
 "cyH" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
 "cyI" = (
@@ -61648,17 +61144,15 @@
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "cyR" = (
-/obj/grille/steel,
 /obj/cable,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
 "cyT" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -61667,17 +61161,16 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
 "cyU" = (
-/obj/grille/steel,
 /obj/cable,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
 "cyV" = (
@@ -62980,7 +62473,6 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/routingdepot/airbridge)
 "cCj" = (
-/obj/grille/steel,
 /obj/cable,
 /obj/cable{
 	d2 = 8;
@@ -62991,7 +62483,11 @@
 	icon_state = "0-4"
 	},
 /obj/disposalpipe/segment/mail,
-/obj/window/auto/reinforced,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/wingrille_spawn/auto,
 /obj/decal/poster/wallsign/stencil/left/c{
 	pixel_x = -7
 	},
@@ -63001,19 +62497,14 @@
 /obj/decal/poster/wallsign/stencil/right/r{
 	pixel_x = 17
 	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "cCk" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/decal/poster/wallsign/stencil/left/g,
 /obj/decal/poster/wallsign/stencil/right/o{
 	pixel_x = 9
@@ -63545,8 +63036,6 @@
 /turf/simulated/floor/black,
 /area/station/engine/coldloop)
 "fQQ" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -63556,6 +63045,7 @@
 	icon_state = "0-4"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
 "fVA" = (
@@ -63788,12 +63278,11 @@
 /turf/simulated/floor/delivery,
 /area/station/engine/inner)
 "lwT" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
 "lNm" = (
@@ -63899,9 +63388,6 @@
 /turf/simulated/floor/bot,
 /area/station/engine/gas)
 "nPX" = (
-/obj/window/crystal/reinforced/south,
-/obj/window/crystal/reinforced/north,
-/obj/window/crystal/reinforced/east,
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
 	icon_state = "pdoor0";
@@ -63913,7 +63399,7 @@
 	dir = 4;
 	level = 2
 	},
-/obj/wingrille_spawn/auto,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/hotloop)
 "opf" = (
@@ -64266,15 +63752,14 @@
 /turf/simulated/floor/grime,
 /area/station/engine/coldloop)
 "wKE" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
 "wTq" = (
@@ -87999,10 +87484,10 @@ aal
 aaa
 aaf
 aRP
-aSK
-aSK
-aVh
-aSK
+aXR
+aXR
+aXR
+aXR
 aXR
 aXR
 aZK
@@ -88299,7 +87784,7 @@ aMv
 aNE
 aag
 aPI
-aQJ
+baN
 aRQ
 aSL
 aTS
@@ -92303,7 +91788,7 @@ cmX
 cod
 cph
 cqk
-crk
+crm
 csl
 csm
 csm
@@ -92605,7 +92090,7 @@ cmY
 cod
 cph
 cqk
-crl
+crm
 csm
 csY
 ctP
@@ -95826,7 +95311,7 @@ ajs
 akr
 alw
 aho
-anG
+aGJ
 aoR
 aqm
 arI
@@ -96152,7 +95637,7 @@ aNZ
 awM
 awK
 aGz
-aJb
+bUF
 aTb
 aUk
 aUk
@@ -98341,7 +97826,7 @@ ckG
 ckG
 cne
 cne
-cpw
+crz
 cqz
 crz
 cne
@@ -98638,7 +98123,7 @@ cem
 cfA
 cgS
 chY
-cjl
+cni
 ckH
 cmc
 cni
@@ -99175,10 +98660,10 @@ aPb
 aRh
 aSg
 aBI
-aBB
+bUk
 aWR
 aWR
-aBB
+bUk
 aQl
 aQF
 aQF
@@ -99481,7 +98966,7 @@ aVF
 aEh
 aEh
 aZl
-aBB
+bUk
 aaa
 aaa
 aaa
@@ -99783,7 +99268,7 @@ bbJ
 aEh
 aEh
 aZm
-aBB
+bUk
 aaw
 aaw
 aaw
@@ -100086,12 +99571,12 @@ aEh
 aEh
 aZn
 aQl
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
+bUk
+bUk
+bUk
+bUk
+bUk
+bUk
 aQF
 bhY
 bjf
@@ -100465,7 +99950,7 @@ crD
 cvA
 cvW
 cwE
-cxb
+lwT
 cxk
 cxt
 cxC
@@ -100668,7 +100153,7 @@ avE
 axa
 ayz
 azZ
-aBB
+bUk
 aCO
 aEh
 aFu
@@ -100970,7 +100455,7 @@ avF
 axb
 avF
 aAa
-aBB
+bUk
 aCP
 aEi
 aFu
@@ -101272,7 +100757,7 @@ avF
 axc
 avF
 aAb
-aBB
+bUk
 aCQ
 aEj
 aFv
@@ -101574,21 +101059,21 @@ avF
 axb
 avF
 aAc
-aBB
+bUk
 aCR
 aEh
 aFw
 aGR
 aIb
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
-aBB
+bUk
+bUk
+bUk
+bUk
+bUk
+bUk
+bUk
+bUk
+bUk
 aBI
 aUv
 aBI
@@ -101599,9 +101084,9 @@ aUv
 aBI
 bcp
 aBI
-aBB
-aBB
-aBB
+bUk
+bUk
+bUk
 aGT
 bhB
 biI
@@ -101876,13 +101361,13 @@ avF
 axc
 avF
 aAd
-aBB
+bUk
 aCR
 aEh
 aFx
 aGS
-aBB
-aBB
+bUk
+bUk
 aap
 aaq
 aaq
@@ -102182,8 +101667,8 @@ ath
 aCS
 aEh
 aFy
-aBB
-aBB
+bUk
+bUk
 aap
 acW
 aaa
@@ -102484,7 +101969,7 @@ aBF
 aCR
 aEh
 aFy
-aBB
+bUk
 aap
 acW
 aaa
@@ -102786,7 +102271,7 @@ aBC
 akl
 aEk
 aFy
-aBB
+bUk
 aaG
 aaa
 aaa
@@ -103088,7 +102573,7 @@ aBF
 aCT
 aWT
 aFy
-aBB
+bUk
 aaG
 aaa
 aaa
@@ -103390,7 +102875,7 @@ aBE
 aCU
 aEl
 aFy
-aBB
+bUk
 aaG
 aaa
 aaa
@@ -103692,7 +103177,7 @@ aBF
 aCR
 aEm
 aFz
-aBB
+bUk
 aaG
 aaa
 aaa
@@ -103994,7 +103479,7 @@ aAg
 aCR
 aEm
 aFy
-aBB
+bUk
 aaG
 aaa
 aaa
@@ -104296,7 +103781,7 @@ bas
 aCR
 aEm
 aFy
-aBB
+bUk
 aaG
 aaa
 aaa
@@ -104399,7 +103884,7 @@ cxq
 cyc
 cxs
 cxs
-cye
+cyn
 aaG
 aaa
 aaa
@@ -104670,7 +104155,7 @@ bUt
 bVO
 bWU
 bYj
-bUk
+jPb
 caP
 cca
 cwI
@@ -104972,7 +104457,7 @@ bUu
 bVO
 bWU
 bYm
-bUk
+jPb
 ceA
 ccb
 cdn
@@ -105269,7 +104754,7 @@ bCh
 bCh
 bQb
 bQb
-bUk
+jPb
 bUv
 bVP
 bXa
@@ -105302,7 +104787,7 @@ cxs
 cxs
 cxs
 cxs
-cye
+cyn
 aaG
 aaa
 aaa
@@ -105599,7 +105084,7 @@ cCf
 cvj
 cwm
 cwU
-cva
+cyd
 aap
 aar
 aar
@@ -105873,12 +105358,12 @@ bCh
 bCh
 bQb
 bQb
-bUk
+jPb
 bUw
 bVO
 bWU
 bYp
-bUk
+jPb
 cjG
 cca
 cca
@@ -105901,7 +105386,7 @@ cuo
 cuo
 cwn
 cwS
-cva
+cyd
 aah
 aaa
 aaa
@@ -106180,7 +105665,7 @@ bUB
 bVO
 bWU
 bYq
-bUk
+jPb
 cjG
 cca
 cdq
@@ -106203,7 +105688,7 @@ cDj
 cuo
 cus
 cwR
-cva
+cyd
 aah
 aaa
 aaa
@@ -108902,8 +108387,8 @@ caY
 bYe
 caY
 caY
-ceH
-ceH
+aif
+aif
 cir
 ahh
 cnO
@@ -109094,13 +108579,13 @@ aaa
 aaa
 aaa
 aag
-abk
-abk
-abk
-abk
-abk
-abk
-abk
+ajU
+ajU
+ajU
+ajU
+ajU
+ajU
+ajU
 acL
 adz
 aeb
@@ -109396,7 +108881,7 @@ aar
 aar
 aar
 aap
-abk
+ajU
 abp
 aby
 aby
@@ -109698,7 +109183,7 @@ aaa
 aaa
 aaa
 aag
-abk
+ajU
 abq
 abz
 abz
@@ -110000,13 +109485,13 @@ aaP
 gcg
 aak
 aaq
-abk
+ajU
 abr
-abk
-abk
-abk
-abk
-abk
+ajU
+ajU
+ajU
+ajU
+ajU
 acO
 acN
 adp
@@ -110308,8 +109793,8 @@ niO
 gcg
 aaa
 aam
-abk
-abk
+ajU
+ajU
 adq
 adp
 adp
@@ -110611,7 +110096,7 @@ abG
 aaT
 aaJ
 aaa
-abk
+ajU
 adr
 aec
 acN
@@ -110951,13 +110436,13 @@ aaa
 aaa
 aaa
 aaa
-aNc
-aNc
+aWc
+aWc
 aSq
 aVQ
 aSq
-aNc
-aNc
+aWc
+aWc
 bbr
 bbq
 aaa
@@ -111252,15 +110737,15 @@ aaa
 aaa
 aaa
 aaa
-aNc
-aNc
+aWc
+aWc
 aUD
 aYK
 aXq
 aYv
 aZt
-aNc
-aNc
+aWc
+aWc
 bbr
 baq
 bep
@@ -111554,7 +111039,7 @@ aaw
 aaw
 aaw
 aaw
-aNc
+aWc
 aTs
 aUE
 aVX
@@ -111617,7 +111102,7 @@ bWL
 bWU
 bZm
 cbb
-bUF
+iQv
 cis
 cdu
 ceN
@@ -111819,7 +111304,7 @@ abH
 aaV
 aaJ
 aaa
-abk
+ajU
 adv
 aeg
 acQ
@@ -111851,11 +111336,11 @@ aIq
 aJF
 aKM
 apC
-aNc
-aNc
-aNc
-aNc
-aNc
+aWc
+aWc
+aWc
+aWc
+aWc
 aSq
 aTt
 aUF
@@ -112120,8 +111605,8 @@ niO
 fhL
 aaa
 aaf
-abk
-abk
+ajU
+ajU
 adq
 adp
 abu
@@ -112416,13 +111901,13 @@ aaP
 fhL
 aak
 aaw
-abk
+ajU
 abr
-abk
-abk
-abk
-abk
-abk
+ajU
+ajU
+ajU
+ajU
+ajU
 acP
 acQ
 adp
@@ -112455,11 +111940,11 @@ aIq
 aJH
 aKO
 aMb
-aNc
-aNc
-aNc
-aNc
-aNc
+aWc
+aWc
+aWc
+aWc
+aWc
 aSq
 aTv
 aUH
@@ -112718,7 +112203,7 @@ aaa
 aaa
 aaa
 aag
-abk
+ajU
 abu
 aby
 aby
@@ -112762,7 +112247,7 @@ aaq
 aaq
 aaq
 aaq
-aNc
+aWc
 aTw
 aUE
 aUH
@@ -112825,7 +112310,7 @@ bWL
 bWU
 bZm
 ccf
-bVx
+kvk
 cit
 cdu
 ceN
@@ -113020,7 +112505,7 @@ aar
 aar
 aar
 aap
-abk
+ajU
 abv
 abz
 abz
@@ -113064,15 +112549,15 @@ aaa
 aaa
 aaa
 aaa
-aNc
-aNc
+aWc
+aWc
 aUI
 aWb
 aXw
 aWb
 aZz
-aNc
-aNc
+aWc
+aWc
 aaa
 aaa
 aaa
@@ -113322,13 +112807,13 @@ aaa
 aaa
 aaa
 aag
-abk
-abk
-abk
-abk
-abk
-abk
-abk
+ajU
+ajU
+ajU
+ajU
+ajU
+ajU
+ajU
 acL
 adz
 aeh
@@ -113361,19 +112846,19 @@ aIv
 aJC
 aKP
 aKR
-aNe
 aOv
-aNe
+aOv
+aOv
 aKR
 aaa
 aaa
-aNc
-aNc
+aWc
+aWc
 aWc
 aXw
 aWc
-aNc
-aNc
+aWc
+aWc
 aaa
 aaa
 aaa
@@ -113666,7 +113151,7 @@ aKR
 aNf
 aOw
 aPt
-aNe
+aOv
 aaa
 aaa
 aaa
@@ -114885,7 +114370,7 @@ aQy
 aQy
 bdN
 bdN
-bbK
+bVx
 bdN
 bdN
 bfW
@@ -116987,7 +116472,7 @@ aGo
 aMj
 aNn
 aOD
-aMt
+aXQ
 bia
 bkM
 aSB
@@ -117289,7 +116774,7 @@ aGo
 bnt
 aLa
 aOE
-aMt
+aXQ
 bib
 blu
 aSB
@@ -117591,7 +117076,7 @@ aKY
 aMl
 aNo
 aHr
-aMt
+aXQ
 bjg
 bib
 aSB
@@ -117893,7 +117378,7 @@ aKZ
 aMm
 aNp
 aHs
-aMt
+aXQ
 bia
 bnp
 aSB
@@ -118195,8 +117680,8 @@ aLa
 aHs
 aNq
 aMm
-aMt
-aMt
+aXQ
+aXQ
 aGo
 aSC
 aSB
@@ -119130,9 +118615,9 @@ bny
 boT
 bpS
 brK
-bbK
-bbK
-bbK
+bVx
+bVx
+bVx
 aaq
 aap
 aaq
@@ -122471,7 +121956,7 @@ aaa
 aaa
 aaa
 aag
-bFs
+ceH
 bGj
 bGY
 bHP
@@ -122734,7 +122219,7 @@ aVg
 aVg
 aVg
 aYW
-aOI
+aXQ
 aaq
 aaq
 aaq
@@ -122773,7 +122258,7 @@ aaa
 aaa
 aaa
 aag
-bFs
+ceH
 bGj
 bGY
 bHP
@@ -123029,14 +122514,14 @@ aNC
 aMI
 aPG
 baL
-aMt
-aMt
-aMt
-aMt
-aMt
 aXQ
-aMt
-aOI
+aXQ
+aXQ
+aXQ
+aXQ
+aXQ
+aXQ
+aXQ
 aaa
 aaa
 aaa
@@ -123075,7 +122560,7 @@ aaa
 aaa
 aaa
 aag
-bFs
+ceH
 bGl
 bGZ
 bHP
@@ -123330,7 +122815,7 @@ aMs
 aND
 aJW
 aPH
-aOI
+aXQ
 aaq
 aaq
 aaq
@@ -123377,7 +122862,7 @@ aaa
 aaa
 aaa
 aag
-bFs
+ceH
 bGm
 bHa
 bHR
@@ -123628,11 +123113,11 @@ aag
 baL
 aKa
 baL
-aMt
+aXQ
 baL
-aOI
-aOI
-aOI
+aXQ
+aXQ
+aXQ
 aaa
 aaa
 aaa
@@ -123683,7 +123168,7 @@ bFr
 bGn
 bFr
 bHS
-bFs
+ceH
 bJS
 bLd
 bLc
@@ -124215,9 +123700,9 @@ aaa
 aaa
 aaa
 aag
-aoG
-aoG
-aoG
+avj
+avj
+avj
 atV
 atV
 awC
@@ -124226,9 +123711,9 @@ azl
 aAX
 atV
 atV
-aoG
-aoG
-aoG
+avj
+avj
+avj
 aaG
 aaa
 aaj
@@ -124517,7 +124002,7 @@ aaa
 aaa
 aaa
 aag
-aoG
+avj
 arl
 asK
 atW
@@ -124530,7 +124015,7 @@ avg
 atW
 asK
 arl
-aoG
+avj
 aaG
 aaa
 aaa
@@ -124818,22 +124303,22 @@ aaa
 aaa
 aaa
 aaa
-aoG
-aoG
+avj
+avj
 arm
 arn
 atX
-aoG
+avj
 awE
 axS
 azn
 aAZ
-aoG
+avj
 aDF
 arn
 arm
-aoG
-aoG
+avj
+avj
 aaa
 aaa
 aaa
@@ -125120,7 +124605,7 @@ aaa
 aaa
 aaa
 aaa
-aoG
+avj
 apY
 arn
 arn
@@ -125135,7 +124620,7 @@ aBc
 arn
 arn
 aHv
-aoG
+avj
 aaa
 aaa
 aaa
@@ -125422,7 +124907,7 @@ aaa
 aaa
 aaa
 aaa
-aoG
+avj
 apZ
 arn
 arn
@@ -125437,7 +124922,7 @@ aDG
 arn
 arn
 aHw
-aoG
+avj
 aaa
 aaa
 aaa
@@ -125724,7 +125209,7 @@ aaa
 aaa
 aaa
 aaa
-aoG
+avj
 apZ
 arn
 arn
@@ -125739,7 +125224,7 @@ aDH
 arn
 arn
 aHw
-aoG
+avj
 aaa
 aaa
 aaa
@@ -126026,7 +125511,7 @@ aaa
 aaa
 aaa
 aaa
-aoG
+avj
 apZ
 arn
 arn
@@ -126041,7 +125526,7 @@ aub
 arn
 arn
 aHw
-aoG
+avj
 aaa
 aaa
 aaa
@@ -126328,7 +125813,7 @@ aaa
 aaa
 aaa
 aaa
-aoG
+avj
 apZ
 arn
 arn
@@ -126343,7 +125828,7 @@ arn
 arn
 arn
 aHw
-aoG
+avj
 aaa
 aaa
 aaa
@@ -126630,7 +126115,7 @@ aaa
 aaa
 aaa
 aaa
-aoG
+avj
 aqa
 arn
 arn
@@ -126645,7 +126130,7 @@ arn
 aEX
 arn
 aqa
-aoG
+avj
 aaa
 aaa
 aaa
@@ -126932,8 +126417,8 @@ aaa
 aaa
 aaa
 aaa
-aoH
-aoG
+avj
+avj
 arn
 arn
 arn
@@ -126946,8 +126431,8 @@ avl
 arn
 arn
 arn
-aoG
-aoG
+avj
+avj
 aaa
 aaa
 aaa
@@ -127235,7 +126720,7 @@ aaa
 aaa
 aaa
 aag
-aoG
+avj
 aro
 asL
 arn
@@ -127248,7 +126733,7 @@ arn
 arn
 asL
 aGq
-aoG
+avj
 aaG
 aaa
 aaa
@@ -127537,9 +127022,9 @@ aaa
 aaa
 aaa
 aag
-aoH
-aoG
-aoG
+avj
+avj
+avj
 aud
 avl
 awJ
@@ -127548,9 +127033,9 @@ azs
 aBd
 avl
 aDI
-aoG
-aoG
-aoG
+avj
+avj
+avj
 aaG
 aaa
 aaa
@@ -127841,16 +127326,16 @@ aaa
 aam
 aaq
 aap
-aoG
-aoG
+avj
+avj
 atV
 atV
-aoG
-aoG
+avj
+avj
 atV
 atV
-aoG
-aoG
+avj
+avj
 aap
 aaq
 acW

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -709,10 +709,10 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/NWmaint)
 "abZ" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro{
 	name = "Observatory"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/crew_quarters/observatory)
 "aca" = (
@@ -935,25 +935,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
-"acy" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/quarters)
 "acz" = (
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters)
 "acA" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/quarters)
 "acB" = (
@@ -1537,8 +1526,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters)
 "adO" = (
@@ -1621,12 +1610,10 @@
 /turf/simulated/floor/grime,
 /area/station/hallway/secondary/construction2)
 "aeb" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "aec" = (
@@ -1657,12 +1644,10 @@
 	},
 /area/station/hallway/secondary/entry)
 "aeh" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/grime,
 /area/station/hallway/secondary/entry)
 "aei" = (
@@ -2673,13 +2658,13 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/secondary/construction)
 "ags" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/grime,
 /area/station/hallway/secondary/construction)
 "agt" = (
@@ -2844,21 +2829,17 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "agI" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/quartersA)
 "agJ" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/purple,
 /area/station/crew_quarters/quarters)
 "agK" = (
@@ -2905,13 +2886,13 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/clown)
 "agR" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/classic,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/clown)
 "agS" = (
@@ -2931,13 +2912,13 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/secondary/construction2)
 "agU" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/grime,
 /area/station/hallway/secondary/construction2)
 "agV" = (
@@ -3344,15 +3325,13 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/disposalpipe/segment/food{
 	dir = 4
 	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "ahR" = (
@@ -3410,15 +3389,13 @@
 	},
 /area/station/hallway/secondary/entry)
 "ahW" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/disposalpipe/segment/food{
 	dir = 4
 	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "ahX" = (
@@ -3665,12 +3642,10 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/blue,
 /area/station/crew_quarters/quarters)
 "aiC" = (
@@ -3686,12 +3661,10 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/quartersB)
 "aiE" = (
@@ -3829,9 +3802,6 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
@@ -3840,6 +3810,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "aiO" = (
@@ -3923,12 +3894,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "aiU" = (
@@ -4319,8 +4288,8 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/fitness)
 "ajR" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance,
+/obj/firedoor_spawn,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "ajS" = (
@@ -5220,13 +5189,11 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
 "alT" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
 	name = "Showers"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
 "alU" = (
@@ -5262,9 +5229,6 @@
 /area/station/hallway/secondary/entry)
 "ama" = (
 /obj/table/reinforced/auto,
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/light/lamp,
 /obj/cable{
 	d1 = 1;
@@ -5279,6 +5243,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/arrivals)
 "amb" = (
@@ -5496,19 +5461,19 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/wreckage)
 "amB" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass,
 /obj/disposalpipe/segment/mail,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters)
 "amC" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters)
 "amD" = (
@@ -5637,9 +5602,6 @@
 /area/station/hallway/secondary/entry)
 "amU" = (
 /obj/table/reinforced/auto,
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/cashreg,
 /obj/item/postit_stack,
 /obj/cable{
@@ -5647,6 +5609,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/arrivals)
 "amV" = (
@@ -6583,12 +6546,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/wreckage)
 "apc" = (
@@ -6600,12 +6561,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "apd" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/barber_shop)
 "ape" = (
@@ -6745,7 +6704,6 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/cafeteria)
 "apx" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -6754,6 +6712,7 @@
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Cafeteria"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/crew_quarters/cafeteria)
 "apy" = (
@@ -6763,11 +6722,11 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/cafeteria)
 "apz" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Cafeteria"
 	},
 /obj/disposalpipe/segment/mail,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/crew_quarters/cafeteria)
 "apA" = (
@@ -6964,7 +6923,6 @@
 	},
 /area/station/hydroponics)
 "aqb" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/external,
 /obj/cable{
 	d1 = 1;
@@ -6974,14 +6932,15 @@
 /obj/machinery/secscanner{
 	pixel_y = 10
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/east)
 "aqc" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/external,
 /obj/machinery/secscanner{
 	pixel_y = 10
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/east)
 "aqd" = (
@@ -8914,10 +8873,10 @@
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
 "auE" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro{
 	name = "Bathroom"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/bathroom)
 "auF" = (
@@ -11220,7 +11179,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
@@ -11230,7 +11189,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /turf/simulated/floor/green/side{
 	dir = 4
 	},
@@ -12208,13 +12167,13 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/secwing)
 "aBC" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/crew_quarters/locker)
 "aBD" = (
@@ -12229,9 +12188,9 @@
 	},
 /area/station/crew_quarters/locker)
 "aBE" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass,
 /obj/disposalpipe/segment/mail,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/crew_quarters/locker)
 "aBF" = (
@@ -12263,15 +12222,15 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/primary/central)
 "aBJ" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "aBK" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "aBL" = (
@@ -12280,13 +12239,13 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/arcade)
 "aBM" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "aBN" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "aBO" = (
@@ -12875,20 +12834,16 @@
 	},
 /area/station/hallway/primary/central)
 "aCY" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/light/emergency{
 	dir = 1
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/neutral/side{
 	dir = 1
 	},
 /area/station/hallway/primary/central)
 "aCZ" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/neutral/side{
 	dir = 1
 	},
@@ -13625,24 +13580,7 @@
 /obj/machinery/atmospherics/pipe/simple,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
-"aEo" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
 "aEp" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -13651,6 +13589,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "aEq" = (
@@ -14269,25 +14208,21 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
 /obj/machinery/light/emergency,
+/obj/firedoor_spawn,
 /turf/simulated/floor/neutral/side,
 /area/station/hallway/primary/central)
 "aFE" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/neutral/side,
 /area/station/hallway/primary/central)
 "aFF" = (
@@ -14900,13 +14835,13 @@
 /area/station/maintenance/maintcentral)
 "aGU" = (
 /obj/disposalpipe/segment,
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
 "aGV" = (
 /obj/machinery/door/airlock/pyro/maintenance,
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
 "aGW" = (
@@ -14929,10 +14864,10 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/pool)
 "aHb" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Pool"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/blue/side{
 	dir = 0
 	},
@@ -14962,13 +14897,11 @@
 	},
 /area/station/hallway/primary/central)
 "aHg" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Cafeteria"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/crew_quarters/cafeteria)
 "aHh" = (
@@ -15568,9 +15501,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
@@ -15578,6 +15508,7 @@
 	dir = 4;
 	name = "Cafeteria"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/crew_quarters/cafeteria)
 "aIq" = (
@@ -16092,9 +16023,6 @@
 	},
 /area/station/security/secwing)
 "aJp" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Brig Visitation Area"
@@ -16103,6 +16031,7 @@
 	dir = 4;
 	pixel_x = -20
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/security/secwing)
 "aJq" = (
@@ -16313,29 +16242,29 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
 /obj/disposalpipe/segment,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aJQ" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aJR" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/specialroom/chapel{
 	dir = 1
 	},
 /area/station/chapel/main)
 "aJS" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
 	},
@@ -16709,7 +16638,6 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/routingdepot/catering)
 "aKG" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/external{
 	name = "Supply Dock Airlock"
 	},
@@ -16718,13 +16646,14 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/routingdepot/catering)
 "aKH" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/external{
 	name = "Supply Dock Airlock"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/routingdepot/catering)
 "aKI" = (
@@ -17364,13 +17293,13 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/cafeteria)
 "aMa" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/crew_quarters/cafeteria)
 "aMb" = (
@@ -18285,12 +18214,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/maintenance/west)
 "aNO" = (
@@ -19048,13 +18975,13 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/maintcentral)
 "aPi" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
 "aPj" = (
@@ -19064,12 +18991,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
 "aPk" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery/white,
 /area/station/crew_quarters/pool)
 "aPl" = (
@@ -19574,9 +19499,9 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/juryroom)
 "aQk" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/plasticflaps,
 /obj/disposalpipe/segment,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/security/beepsky)
 "aQl" = (
@@ -19990,12 +19915,10 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central)
 "aRm" = (
@@ -20099,8 +20022,8 @@
 	},
 /area/station/crew_quarters/pool)
 "aRu" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery/white,
 /area/station/maintenance/maintcentral)
 "aRv" = (
@@ -20507,13 +20430,13 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/jazz)
 "aSr" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/jazz)
 "aSs" = (
@@ -20874,32 +20797,6 @@
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/east)
-"aTj" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 1
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/grey/side{
-	dir = 8
-	},
-/area/station/hallway/primary/central)
-"aTk" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 1
-	},
-/obj/disposalpipe/segment/transport,
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
-"aTl" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
 "aTm" = (
 /turf/simulated/wall{
 	desc = "Upon closer inspection, you see that this is a cleverly painted wall.";
@@ -21428,8 +21325,8 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/courtroom)
 "aUq" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "aUr" = (
@@ -21448,23 +21345,23 @@
 	},
 /area/station/chapel/main)
 "aUs" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/grey/side{
 	dir = 8
 	},
 /area/station/hallway/primary/central)
 "aUt" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/disposalpipe/segment/transport,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "aUu" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "aUv" = (
@@ -22063,11 +21960,11 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "aVJ" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
 "aVK" = (
@@ -22097,7 +21994,7 @@
 /area/station/owlery)
 "aVO" = (
 /obj/machinery/door/airlock/pyro/external,
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
 "aVP" = (
@@ -22588,12 +22485,10 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "aWR" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "aWS" = (
@@ -22619,9 +22514,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/hallway/primary/central)
 "aWV" = (
@@ -23324,9 +23217,7 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "aYi" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/hallway/primary/central)
 "aYj" = (
@@ -24361,12 +24252,10 @@
 /turf/simulated/floor/grime,
 /area/station/maintenance/east)
 "baD" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "baE" = (
@@ -24414,13 +24303,13 @@
 /area/station/maintenance/east)
 "baI" = (
 /obj/disposalpipe/segment,
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "baJ" = (
@@ -24650,9 +24539,6 @@
 /area/station/security/checkpoint)
 "bbe" = (
 /obj/table/reinforced/auto,
-/obj/machinery/door/firedoor/pyro{
-	dir = 1
-	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 4;
@@ -24660,22 +24546,7 @@
 	tag = ""
 	},
 /obj/item/pen/marker/blue,
-/turf/simulated/floor/black,
-/area/station/security/checkpoint)
-"bbf" = (
-/obj/table/reinforced/auto,
-/obj/machinery/door/firedoor/pyro{
-	dir = 1
-	},
-/obj/machinery/cashreg,
-/turf/simulated/floor/black,
-/area/station/security/checkpoint)
-"bbg" = (
-/obj/table/reinforced/auto,
-/obj/machinery/door/firedoor/pyro{
-	dir = 1
-	},
-/obj/machinery/light/lamp,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/security/checkpoint)
 "bbh" = (
@@ -25208,12 +25079,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/east)
 "bcn" = (
@@ -25334,12 +25203,10 @@
 	icon_state = "bdoor_pyro";
 	name = "rusted airlock"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/grime,
 /area/station/hallway/primary/east)
 "bcA" = (
@@ -26637,7 +26504,6 @@
 /area/station/crew_quarters/heads)
 "beT" = (
 /obj/table/reinforced/auto,
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 4;
@@ -26646,18 +26512,19 @@
 	},
 /obj/item/stamp,
 /obj/item/postit_stack,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/security/checkpoint)
 "beU" = (
 /obj/table/reinforced/auto,
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/cashreg,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/security/checkpoint)
 "beV" = (
 /obj/table/reinforced/auto,
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/light/lamp,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/security/checkpoint)
 "beW" = (
@@ -27589,8 +27456,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/external,
+/obj/firedoor_spawn,
 /turf/simulated/floor/caution/south,
 /area/station/routingdepot)
 "bgV" = (
@@ -27778,12 +27645,10 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "bhu" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "bhv" = (
@@ -27844,9 +27709,7 @@
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
 "bhC" = (
@@ -28099,9 +27962,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "bhZ" = (
@@ -28344,9 +28205,6 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
 	},
@@ -28355,6 +28213,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "biE" = (
@@ -28395,9 +28254,7 @@
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
 "biJ" = (
@@ -28405,9 +28262,7 @@
 	dir = 4;
 	name = "Supply Dock Airlock"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/routingdepot/eva)
 "biK" = (
@@ -28566,14 +28421,12 @@
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/routingdepot)
 "bjc" = (
@@ -28625,9 +28478,7 @@
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "bjg" = (
@@ -28839,7 +28690,7 @@
 /area/station/crew_quarters/captain)
 "bjD" = (
 /obj/machinery/door/airlock/pyro/external,
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "bjE" = (
@@ -28918,9 +28769,7 @@
 	dir = 4;
 	name = "Supply Dock Airlock"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/routingdepot/eva)
 "bjM" = (
@@ -29233,22 +29082,18 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/market)
 "bkv" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 1
-	},
 /obj/machinery/door/airlock/pyro/glass,
 /obj/disposalpipe/segment/transport,
+/obj/firedoor_spawn,
 /turf/simulated/floor/bot,
 /area/station/crew_quarters/market)
 "bkw" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 1
-	},
 /obj/machinery/door/airlock/pyro/glass,
 /obj/disposalpipe/segment,
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/bot,
 /area/station/crew_quarters/market)
 "bkx" = (
@@ -30001,9 +29846,7 @@
 	dir = 4;
 	name = "Stock Exchange"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/crew_quarters/stockex)
 "bmo" = (
@@ -30170,8 +30013,8 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/external,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating/airless,
 /area/station/routingdepot)
 "bmI" = (
@@ -31430,9 +31273,7 @@
 	dir = 4;
 	name = "Stock Exchange"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/crew_quarters/stockex)
 "bpd" = (
@@ -31498,13 +31339,13 @@
 /turf/simulated/floor/plating/airless,
 /area)
 "bpl" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/external,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/hangar/main)
 "bpm" = (
@@ -32239,16 +32080,15 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/market)
 "bqE" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /obj/disposalpipe/segment/transport,
+/obj/firedoor_spawn,
 /turf/simulated/floor/bot,
 /area/station/crew_quarters/market)
 "bqF" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass,
 /obj/disposalpipe/segment,
 /obj/disposalpipe/segment/mail{
@@ -32257,6 +32097,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/bot,
 /area/station/crew_quarters/market)
 "bqG" = (
@@ -32468,7 +32309,6 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/info)
 "brh" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -32477,6 +32317,7 @@
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Information Office"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/crew_quarters/info)
 "bri" = (
@@ -32761,14 +32602,12 @@
 	dir = 4;
 	name = "Information Office"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/crew_quarters/info)
 "brP" = (
@@ -33307,7 +33146,7 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/morgue,
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/maintenance/east)
 "bsL" = (
@@ -33489,8 +33328,8 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/main)
 "btg" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/external,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/hangar/main)
 "bth" = (
@@ -33830,14 +33669,12 @@
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/hangar/main)
 "btT" = (
@@ -35921,14 +35758,12 @@
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/hangar/main)
 "byr" = (
@@ -37802,8 +37637,8 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/market)
 "bCe" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/external,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/crew_quarters/market)
 "bCf" = (
@@ -38100,7 +37935,7 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/morgue,
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/storage/warehouse)
 "bCK" = (
@@ -40504,10 +40339,8 @@
 /turf/simulated/floor/caution/northsouth,
 /area/station/engine/coldloop)
 "bHD" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 1
-	},
 /obj/machinery/door/airlock/pyro/external,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/hallway/primary/south)
 "bHE" = (
@@ -41655,13 +41488,13 @@
 /turf/simulated/floor/airless/plating/damaged2,
 /area/abandonedship)
 "bJR" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/external,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/hangar/qm)
 "bJS" = (
@@ -45326,9 +45159,6 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bRo" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Medsci Cargo Dock"
@@ -45338,6 +45168,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/routingdepot/airbridge)
 "bRp" = (
@@ -46210,13 +46041,11 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bSU" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Medsci Cargo Dock"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/routingdepot/airbridge)
 "bSV" = (
@@ -47020,14 +46849,14 @@
 	},
 /area/station/hallway/primary/south)
 "bUP" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass,
 /obj/disposalpipe/segment/morgue,
+/obj/firedoor_spawn,
 /turf/simulated/floor/grime,
 /area/station/storage/warehouse)
 "bUQ" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
 /turf/simulated/floor/grime,
 /area/station/storage/warehouse)
 "bUR" = (
@@ -47523,9 +47352,7 @@
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bVR" = (
@@ -47583,12 +47410,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/hallway/primary/south)
 "bVX" = (
@@ -48010,12 +47835,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	can_rupture = 0
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/hallway/primary/south)
 "bWO" = (
@@ -48129,15 +47952,13 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bXc" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/crew_quarters/market{
 	name = "Supply Lobby"
@@ -48175,10 +47996,8 @@
 	name = "Supply Lobby"
 	})
 "bXh" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/disposalpipe/segment/mail,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/crew_quarters/market{
 	name = "Supply Lobby"
@@ -48453,9 +48272,7 @@
 /obj/disposalpipe/segment/morgue{
 	name = "crematorium pipe"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bXO" = (
@@ -48480,12 +48297,10 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/hallway/primary/south)
 "bXR" = (
@@ -48509,12 +48324,10 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	can_rupture = 0
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/hallway/primary/south)
 "bXV" = (
@@ -48793,13 +48606,11 @@
 	name = "Supply Lobby"
 	})
 "bYD" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/disposalpipe/segment/mail{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/crew_quarters/market{
 	name = "Supply Lobby"
@@ -49167,8 +48978,8 @@
 /turf/simulated/floor/yellow/side,
 /area/station/hallway/primary/south)
 "bZq" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/east)
 "bZr" = (
@@ -49328,13 +49139,13 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/south)
 "bZJ" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/south)
 "bZK" = (
@@ -49343,10 +49154,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/machinery/atmospherics/pipe/simple,
 /obj/disposalpipe/segment/morgue,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "bZL" = (
@@ -50301,14 +50112,14 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/medbay/lobby)
 "cbS" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/disposalpipe/segment/mail,
 /obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/lobby)
 "cbT" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/lobby)
 "cbU" = (
@@ -51430,14 +51241,14 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/south)
 "ceL" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass,
 /obj/disposalpipe/segment,
+/obj/firedoor_spawn,
 /turf/simulated/floor/bot,
 /area/station/hallway/secondary/exit)
 "ceM" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
 /turf/simulated/floor/bot,
 /area/station/hallway/secondary/exit)
 "ceN" = (
@@ -51464,7 +51275,6 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/atmos/hookups/east)
 "ceR" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance{
 	name = "Air Hookups"
 	},
@@ -51473,6 +51283,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/atmos/hookups/east)
 "ceS" = (
@@ -51493,8 +51304,8 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/SEmaint)
 "ceV" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "ceW" = (
@@ -51877,9 +51688,6 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "cfI" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
@@ -51888,6 +51696,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/lobby)
 "cfJ" = (
@@ -53729,9 +53538,6 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "cjN" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
@@ -53746,6 +53552,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "cjO" = (
@@ -54556,15 +54363,13 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "cls" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "clt" = (
@@ -54654,12 +54459,10 @@
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "clB" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "clC" = (
@@ -55562,12 +55365,10 @@
 /turf/simulated/floor/caution/south,
 /area/station/hallway/secondary/exit)
 "cnG" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "cnH" = (
@@ -55594,12 +55395,10 @@
 /turf/simulated/floor/escape,
 /area/station/hallway/secondary/exit)
 "cnJ" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "cnK" = (
@@ -55703,9 +55502,7 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "cnU" = (
@@ -56088,9 +55885,6 @@
 	},
 /area/station/medical/medbay)
 "coD" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
@@ -56105,6 +55899,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
 "coE" = (
@@ -56801,12 +56596,10 @@
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "cpV" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
 "cpW" = (
@@ -58244,8 +58037,8 @@
 	},
 /area/station/crew_quarters/info)
 "csS" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/external,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "csT" = (
@@ -95019,7 +94812,7 @@ aWN
 aYf
 aUk
 aZY
-bbf
+beU
 bcc
 bdg
 bed
@@ -95321,7 +95114,7 @@ aWM
 bes
 aUk
 aZY
-bbg
+beV
 bec
 bdg
 bec
@@ -99844,7 +99637,7 @@ aGP
 aGP
 aRm
 aSj
-aTj
+aUs
 aUs
 aHe
 aEk
@@ -100146,7 +99939,7 @@ aLN
 aLN
 aLN
 aLN
-aTk
+aUt
 aUt
 aLN
 aWS
@@ -100448,7 +100241,7 @@ aEh
 aEh
 aEh
 aEh
-aTl
+aUu
 aUu
 aVI
 aWT
@@ -101618,7 +101411,7 @@ abC
 abn
 abR
 abE
-acy
+acA
 adc
 adM
 aev
@@ -104965,7 +104758,7 @@ arY
 arY
 arY
 aCY
-aEo
+aEp
 aFD
 aGW
 aGZ


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MAPPPING] [QOL] 

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Big PR that changes many things on Cogmap1, most of which are unnoticeable in standard play

- Access has been swapped over to obj/access_spawn rather than being variables in the doors
- All windows, bar Armoury & AI Defences have been swapped to using `obj/wingrille_spawn/auto`, However, due to the lack of a wingrille spawner for unreinforced windows, unreinforced windows have been left as-is.
- Swapped APCs over to use `obj/autoname_[dir]`, fixed one hallway having two APCs while another has none
- Updated Firedoors to use `obj/firedoor_spawn`
- Removed several instances of windows or firedoors in walls
- Catwalks somehow lost their `simulated/floor/airless/plating/catwalk` turf, added it back like other modern maps.
- Extended the QM Intake belt by 2 tiles, slight QOL Change for big orders

Revamped Engineering Access:
- Engineers no longer have direct access to the AI Upload Foyer, now having a Heads-Level Door between them and the Foyer.
- Engineering Storage and Engineering Dock moved to `engineering_storage`
- Burnchamber, both Loops, Gas Storage, TEG Chamber, PTL & Gas Storage still use `engineering_engine`
- Engineering Power Room & both substations now use `engineering_power`
- The entrance to engineering is now `engineering` rather than `engineering_engine`

- Mining is no longer public via space, added a new disposal chute to the mining shuttle dock so those who are spaced and catch themselves on the mineral magnet can still get inside quickly
- Belt Hell, Cargo Routers & Hanger Bays now have Door-Linked Atmospheric Forcefields

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Cleanliness & Modernity. Brings Cogmap 1 up to using modern standards. Plus some QOL Changes too.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Comradef191:
(*) Added Atmospherics Forcefields to Cogmap 1, located at the hanger bays and Cargo Routers.
(+) Revamped Engineering Access on Cogmap 1; Engineers no longer have direct access to the AI Upload Foyer, Engineering Storage and Engineering Dock moved to 'Engineering Storage' Access rather than 'Engineering Engine', Engineering Power Room & both substations now use 'Engineering Power' Access rather than 'Engineering Engine' & the entrance to Engineering no longer requires Engineering Engine access
(+) Mining is no longer publicly accessible via space! Use the disposals chute in the Mining Shuttle Dock if needed!
(+) QM Cargo Intake extended by two tiles
```