### PR TITLE
adds blob life loop multiplier

### DIFF
--- a/code/mob/living/intangible/blob_overmind.dm
+++ b/code/mob/living/intangible/blob_overmind.dm
@@ -16,7 +16,7 @@
 	var/attack_power = 1
 	var/bio_points = 0
 	var/bio_points_max = 1
-	var/bio_points_max_bonus = 5
+	var/bio_points_max_bonus = 7 //starting bio point cap should be 10-12 now, i think. a bit more wiggle room for starter blobs.
 	var/base_gen_rate = 3
 	var/gen_rate_bonus = 0
 	var/gen_rate_used = 0
@@ -60,6 +60,9 @@
 	var/extra_tries_max = 2
 	var/extra_try_period = 3000 //3000 = 5 minutes
 	var/extra_try_timestamp = 0
+
+	var/last_blob_life_tick = 0 //needed for mult to properly work for blob abilities
+	var/last_blob_life_mult = 0 //in a perfect world i wouldnt need this, but i gotta make the stat panel reflect reality
 
 	proc/start_tutorial()
 		if (tutorial)
@@ -134,7 +137,7 @@
 			src.bio_points_max = BlobPointsBezierApproximation(round(blobs.len / 5)) + bio_points_max_bonus
 
 		var/newBioPoints
-
+		var/mult = (max(tick_spacing, TIME - last_blob_life_tick) / tick_spacing)
 		//debuff active
 		if (src.debuff_timestamp)
 			var/genBonus = gen_rate_bonus
@@ -143,10 +146,10 @@
 
 			//maybe other debuffs here in the future
 
-			newBioPoints = max(0,min(src.bio_points + (base_gen_rate + genBonus - gen_rate_used),src.bio_points_max))
+			newBioPoints = clamp((src.bio_points + (base_gen_rate + genBonus - gen_rate_used) * mult), 0, src.bio_points_max) //these are rounded in point displays
 
 		else
-			newBioPoints = max(0,min(src.bio_points + (base_gen_rate + gen_rate_bonus - gen_rate_used),src.bio_points_max))
+			newBioPoints = clamp((src.bio_points + (base_gen_rate + gen_rate_bonus - gen_rate_used) * mult), 0, src.bio_points_max) //ditto above
 
 		src.bio_points = newBioPoints
 
@@ -180,6 +183,9 @@
 				else
 					N.UpdateOverlays(null, "reflectivity")
 
+		src.last_blob_life_tick = TIME
+		src.last_blob_life_mult = mult
+
 	death()
 		//death was called but the player isnt playing this blob anymore
 		//OR they're in the process of transforming (e.g. gibbing)
@@ -207,8 +213,7 @@
 		..()
 		stat(null, " ")
 		stat("--Blob--", " ")
-		stat("Bio Points:", "[bio_points]/[bio_points_max]")
-
+		stat("Bio Points:", "[round(bio_points)]/[bio_points_max]")
 		//debuff active
 		if (src.debuff_timestamp && gen_rate_bonus > 0)
 			var/genBonus = round(gen_rate_bonus / 2)

--- a/code/mob/living/intangible/blob_overmind.dm
+++ b/code/mob/living/intangible/blob_overmind.dm
@@ -62,7 +62,6 @@
 	var/extra_try_timestamp = 0
 
 	var/last_blob_life_tick = 0 //needed for mult to properly work for blob abilities
-	var/last_blob_life_mult = 0 //in a perfect world i wouldnt need this, but i gotta make the stat panel reflect reality
 
 	proc/start_tutorial()
 		if (tutorial)
@@ -184,7 +183,6 @@
 					N.UpdateOverlays(null, "reflectivity")
 
 		src.last_blob_life_tick = TIME
-		src.last_blob_life_mult = mult
 
 	death()
 		//death was called but the player isnt playing this blob anymore


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[CLEANLINESS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
this fixes an issue where blob life loops were never made to account for the changes to use a multiplier for the life loop. so blobs were generating a lot less points than they shouldve been. i also added a small increase to starting blob point caps that lyra said was a good idea. so now starting blobs have a bit more wiggle room, and also blobs as a whole now generate biopoints faster (but kinda at the intended rate)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
this happened because nobody thought to update blob life loops to use mult. it happens sometimes! this fixes it, and makes blobs a lot less weak with regards to how quickly they can do stuff. 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)adharainspace:
(*)fixed an oversight that made it so blobs generated biopoints slower than intended.
(+)blobs now have a small starting biopoint cap increase
```
