### PR TITLE
Stops ghost drones getting law reset notifications.

### DIFF
--- a/code/obj/item/ai_modules.dm
+++ b/code/obj/item/ai_modules.dm
@@ -250,6 +250,8 @@ AI MODULES
 		ticker.centralized_ai_laws.set_zeroth_law("")
 		ticker.centralized_ai_laws.clear_supplied_laws()
 		for (var/mob/living/silicon/S in mobs)
+			if (isghostdrone(S))
+				return
 			LAGCHECK(LAG_LOW)
 			if (isAI(S) && isdead(S))
 				setalive(S)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds a ghostdrone check on the AI reset module, so that they don't get "your laws have been reset" messages in chat anymore.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Ghost drones don't follow AI laws, so the reset messages were irrelevant to them and possibly confusing to newer drones.
