### PR TITLE
Vending machines no longer erroneously take from machine credit instead of account

### DIFF
--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -1784,7 +1784,7 @@
 						playsound(src.loc, S, 50, 0)
 
 				if (src.pay)
-					if (src.acceptcard && src.scan && account)
+					if (src.acceptcard && account)
 						account.fields["current_money"] -= R.product_cost
 					else
 						src.credit -= R.product_cost


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUGFIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Vending machines now appropriately take from the bank account instead of machine credit when scanning an ID after selecting a product.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #1754 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Jawns:
(+)Vending machines no longer erroneously take from machine credit instead of account
```
