### PR TITLE
Added ishuman check to rev-by-beating

### DIFF
--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -1041,7 +1041,7 @@
 									if (owner in viewers(7,M.current))
 										M.current.changeStatus("mutiny", 10 SECONDS)
 
-				if(target.client && target.health < 0) //Only do rev stuff if they have a client and are low health
+				if(target.client && target.health < 0 && ishuman(target)) //Only do rev stuff if they have a client and are low health
 					if ((owner.mind in R.revolutionaries) || (owner.mind in R.head_revolutionaries))
 						if (R.add_revolutionary(target.mind))
 							target.HealDamage("All", max(30 - target.health,0), 0)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUGFIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Previously, the check for whether a crew member could be beaten into revolutionary status did not check to see if the recipient of said beating was human. This allowed AI shells to be be revolutionized, by beating them below zero health. This PR fixes that bug by adding a check to see if the target of a beating is human.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #1520 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

