### PR TITLE
Allow setting transmission range on wifi comp & sets a maximum range

### DIFF
--- a/code/WorkInProgress/MechanicMadness.dm
+++ b/code/WorkInProgress/MechanicMadness.dm
@@ -1679,7 +1679,8 @@ var/list/mechanics_telepads = new/list()
 
 	var/net_id = null //What is our ID on the network?
 	var/last_ping = 0
-	var/range = 0
+	var/range = 64
+	var/maxrange = 64
 
 	var/noise_enabled = true
 	var/frequency = 1419
@@ -1689,7 +1690,7 @@ var/list/mechanics_telepads = new/list()
 		. += {"<br><span class='notice'>[forward_all ? "Sending full unprocessed Signals.":"Sending only processed sendmsg and pda Message Signals."]<br>
 		[only_directed ? "Only reacting to Messages directed at this Component.":"Reacting to ALL Messages received."]<br>
 		Current Frequency: [frequency]<br>
-		Current Transmission Range: [range ? range : "MAX"]<br>
+		Current Transmission Range: [range]<br>
 		Current NetID: [net_id]</span>"}
 
 	New()
@@ -1730,11 +1731,11 @@ var/list/mechanics_telepads = new/list()
 		return 1
 
 	proc/setRange(obj/item/W as obj, mob/user as mob)
-		var/inp = input(user, "Set transmission range (use 0 for max range):", "Range setting", range) as num
+		var/inp = input(user, "Set transmission range:", "Range setting", range) as num
 		if (!in_range(src, user) || user.stat)
 			return 0
 		if (!isnull(inp))
-			range = inp
+			range = max(1, min(inp, maxrange))
 			boutput(user, "Range set to [range]")
 			tooltip_rebuild = 1
 			return 1

--- a/code/WorkInProgress/MechanicMadness.dm
+++ b/code/WorkInProgress/MechanicMadness.dm
@@ -1689,6 +1689,7 @@ var/list/mechanics_telepads = new/list()
 		. += {"<br><span class='notice'>[forward_all ? "Sending full unprocessed Signals.":"Sending only processed sendmsg and pda Message Signals."]<br>
 		[only_directed ? "Only reacting to Messages directed at this Component.":"Reacting to ALL Messages received."]<br>
 		Current Frequency: [frequency]<br>
+		Current Transmission Range: [range ? range : "MAX"]<br>
 		Current NetID: [net_id]</span>"}
 
 	New()
@@ -1698,6 +1699,7 @@ var/list/mechanics_telepads = new/list()
 		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_CONFIG,"Set Frequency","setFreqManually")
 		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_CONFIG,"Toggle NetID Filtering","toggleAddressFiltering")
 		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_CONFIG,"Toggle Forward All","toggleForwardAll")
+		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_CONFIG,"Set Transmission Range","setRange")
 
 		if(radio_controller)
 			set_frequency(frequency)
@@ -1726,6 +1728,17 @@ var/list/mechanics_telepads = new/list()
 		boutput(user, "[forward_all ? "Now forwarding all Radio Messages as they are.":"Now processing only sendmsg and normal PDA messages."]")
 		tooltip_rebuild = 1
 		return 1
+
+	proc/setRange(obj/item/W as obj, mob/user as mob)
+		var/inp = input(user, "Set transmission range (use 0 for max range):", "Range setting", range) as num
+		if (!in_range(src, user) || user.stat)
+			return 0
+		if (!isnull(inp))
+			range = inp
+			boutput(user, "Range set to [range]")
+			tooltip_rebuild = 1
+			return 1
+		return 0
 
 	proc/setfreq(var/datum/mechanicsMessage/input)
 		if(level == 2) return

--- a/code/WorkInProgress/MechanicMadness.dm
+++ b/code/WorkInProgress/MechanicMadness.dm
@@ -1680,7 +1680,7 @@ var/list/mechanics_telepads = new/list()
 	var/net_id = null //What is our ID on the network?
 	var/last_ping = 0
 	var/range = 64
-	var/maxrange = 64
+	var/const/maxrange = 64
 
 	var/noise_enabled = true
 	var/frequency = 1419


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows for setting the transmission range on a wifi component. They were infinite range before - this lets you change it from anywhere under the max limit of 64


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Now that portable mechcomp is a thing, being able to limit the range on a wifi comp is very useful.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)glassofmilk:
(+)Changed wifi component to allow setting a max transmission range.
```
