### PR TITLE
Change dark mode colors for Admin Help and ADMIN LOG

### DIFF
--- a/browserassets/css/browserOutput.css
+++ b/browserassets/css/browserOutput.css
@@ -342,7 +342,7 @@ h1.alert, h2.alert {color: #000000;}
 body.theme-dark { background-color: #23272a; color: #dfdfcf; }
 body.theme-dark .regular { color: #dfdfcf; }
 body.theme-dark .mhelp {color: #e75ae0;}
-body.theme-dark .ahelp {color:  #de7d0b;}
+body.theme-dark .ahelp {color:  #ffa135;}
 body.theme-dark .notice { color: #7996ff; }
 body.theme-dark .hint { color: #7996ff; }
 body.theme-dark .internal { color: #92b4ff; }

--- a/browserassets/css/browserOutput.css
+++ b/browserassets/css/browserOutput.css
@@ -265,6 +265,7 @@ a.popt {text-decoration: none;}
 .regular { color: #000000; }
 .internal { color: #002fff; }
 .mhelp {color: #CC0066;}
+.ahelp {color: #0000ff;}
 .success {color: green;}
 .hint {color: #0000ff;}
 .notice {color: #0000ff;}

--- a/browserassets/css/browserOutput.css
+++ b/browserassets/css/browserOutput.css
@@ -341,6 +341,7 @@ h1.alert, h2.alert {color: #000000;}
 body.theme-dark { background-color: #23272a; color: #dfdfcf; }
 body.theme-dark .regular { color: #dfdfcf; }
 body.theme-dark .mhelp {color: #e75ae0;}
+body.theme-dark .ahelp {color:  #de7d0b;}
 body.theme-dark .notice { color: #7996ff; }
 body.theme-dark .hint { color: #7996ff; }
 body.theme-dark .internal { color: #92b4ff; }
@@ -392,7 +393,7 @@ body.theme-dark  {
 	scrollbar-arrow-color: #808080;
 }
 
-body.theme-dark .admin {color: #6e93ff;}
+body.theme-dark .admin {color: #ecc300;}
 body.theme-dark .adminMsgWrap {color: #cb79d4;}
 body.theme-dark .gfartooc {color: #60c4e6;}
 body.theme-dark .gfartlooc {color: #92cbdf;}

--- a/code/client.dm
+++ b/code/client.dm
@@ -845,7 +845,7 @@ var/global/curr_day = null
 				t = strip_html(t,500)
 			if (!( t ))
 				return
-			boutput(src.mob, "<span class='notice' class=\"bigPM\">Admin PM to-<b>[target] (Discord)</b>: [t]</span>")
+			boutput(src.mob, "<span class='ahelp' class=\"bigPM\">Admin PM to-<b>[target] (Discord)</b>: [t]</span>")
 			logTheThing("admin_help", src, null, "<b>PM'd [target]</b>: [t]")
 			logTheThing("diary", src, null, "PM'd [target]: [t]", "ahelp")
 

--- a/code/modules/admin/adminhelp.dm
+++ b/code/modules/admin/adminhelp.dm
@@ -39,13 +39,13 @@
 			if (C.player_mode && !C.player_mode_ahelp)
 				continue
 			else
-				boutput(C, "<span class='notice'><font size='3'><b><span class='alert'>HELP: </span>[key_name(client.mob,0,0)][(client.mob.real_name ? "/"+client.mob.real_name : "")] <A HREF='?src=\ref[C.holder];action=adminplayeropts;targetckey=[client.ckey]' class='popt'><i class='icon-info-sign'></i></A></b>: [msg]</font></span>")
+				boutput(C, "<span class='ahelp'><font size='3'><b><span class='alert'>HELP: </span>[key_name(client.mob,0,0)][(client.mob.real_name ? "/"+client.mob.real_name : "")] <A HREF='?src=\ref[C.holder];action=adminplayeropts;targetckey=[client.ckey]' class='popt'><i class='icon-info-sign'></i></A></b>: [msg]</font></span>")
 
 #ifdef DATALOGGER
 	game_stats.Increment("adminhelps")
 	game_stats.ScanText(msg)
 #endif
-	boutput(client.mob, "<span class='notice'><font size='3'><b><span class='alert'>HELP: </span> You</b>: [msg]</font></span>")
+	boutput(client.mob, "<span class='ahelp'><font size='3'><b><span class='alert'>HELP: </span> You</b>: [msg]</font></span>")
 	logTheThing("admin_help", client.mob, null, "HELP: [msg]")
 	logTheThing("diary", client.mob, null, "HELP: [msg]", "ahelp")
 	var/ircmsg[] = new()
@@ -207,17 +207,17 @@
 				</div>
 				"})
 			M << sound('sound/misc/adminhelp.ogg', volume=100, wait=0)
-			boutput(user, "<span class='notice' class=\"bigPM\">Admin PM to-<b>[key_name(M, 0, 0)][(M.real_name ? "/"+M.real_name : "")] <A HREF='?src=\ref[user.client.holder];action=adminplayeropts;targetckey=[M.ckey]' class='popt'><i class='icon-info-sign'></i></A></b>: [t]</span>")
+			boutput(user, "<span class='ahelp' class=\"bigPM\">Admin PM to-<b>[key_name(M, 0, 0)][(M.real_name ? "/"+M.real_name : "")] <A HREF='?src=\ref[user.client.holder];action=adminplayeropts;targetckey=[M.ckey]' class='popt'><i class='icon-info-sign'></i></A></b>: [t]</span>")
 		else
 			// Sender is not admin
 			if (M.client && M.client.holder)
 				// But recipient is
-				boutput(M, "<span class='notice' class=\"bigPM\">Reply PM from-<b>[key_name(user, 0, 0)][(user.real_name ? "/"+user.real_name : "")] <A HREF='?src=\ref[M.client.holder];action=adminplayeropts;targetckey=[user.ckey]' class='popt'><i class='icon-info-sign'></i></A></b>: [t]</span>")
+				boutput(M, "<span class='ahelp' class=\"bigPM\">Reply PM from-<b>[key_name(user, 0, 0)][(user.real_name ? "/"+user.real_name : "")] <A HREF='?src=\ref[M.client.holder];action=adminplayeropts;targetckey=[user.ckey]' class='popt'><i class='icon-info-sign'></i></A></b>: [t]</span>")
 				M << sound('sound/misc/adminhelp.ogg', volume=100, wait=0)
 			else
 				boutput(M, "<span class='alert' class=\"bigPM\">Reply PM from-<b>[key_name(user, 0, 0)]</b>: [t]</span>")
 				M << sound('sound/misc/adminhelp.ogg', volume=100, wait=0)
-			boutput(user, "<span class='notice' class=\"bigPM\">Reply PM to-<b>[key_name(M, 0, 0)]</b>: [t]</span>")
+			boutput(user, "<span class='ahelp' class=\"bigPM\">Reply PM to-<b>[key_name(M, 0, 0)]</b>: [t]</span>")
 
 		logTheThing("admin_help", user, M, "<b>PM'd [constructTarget(M,"admin_help")]</b>: [t]")
 		logTheThing("diary", user, M, "PM'd [constructTarget(M,"diary")]: [t]", "ahelp")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][FEATURE][QOL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Makes admin log space bee yellow 
- Makes admin help admin orange
- Adds a new `ahelp` css class and changes admin help to use the `ahelp` class instead of the `notice` class
![image](https://user-images.githubusercontent.com/33204415/90042251-6ff9c100-dc98-11ea-8985-6f945c57ac85.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
- QOL
- Reduce eye strain
- Accessibility
- Dark blue on black bad