### PR TITLE
Make Slow atmos processing on water maps more extreme

### DIFF
--- a/code/modules/admin/lag_hacks.dm
+++ b/code/modules/admin/lag_hacks.dm
@@ -10,19 +10,19 @@ client/proc/show_admin_lag_hacks()
 /datum/admins/proc/show_laghacks(mob/user)
 
 
-	var/HTML = "<html><head><title>Admin Lag Reductions</title></head><body>"
-	HTML += "<b><a href='?src=\ref[src];action=lightweight_doors'>Remove Light+Cam processing when doors open or close</a></b> (May jank up lights slightly)<br><br>"
-	HTML += "<b><a href='?src=\ref[src];action=lightweight_mobs'>Slow Life() Processing</a></b> (Extremely safe - Life() compensates for the change automatically)<br><br>"
-	HTML += "<b><a href='?src=\ref[src];action=slow_atmos'>Slow atmos processing</a></b> (May jank up the TEG/Hellburns)<br><br>"
-	HTML += "<b><a href='?src=\ref[src];action=slow_fluids'>Slow fluid processing</a></b> (Safe, just feels weird)<br><br>"
-	HTML += "<b><a href='?src=\ref[src];action=special_sea_fullbright'>Stop Sea Light processing on Z1</a></b> (Safe, makes the Z1 ocean a little ugly)<br><br>"
-	HTML += "<b><a href='?src=\ref[src];action=slow_ticklag'>Adjust ticklag bounds</a></b> (Manually adjust ticklag dilation upper and lower bounds! Compensate for lag, or go super smooth at lowpop!)<br><br>"
-	HTML += "<b><a href='?src=\ref[src];action=disable_deletions'>Disable Deletion Queue</a></b> (Garbage Collection will still run, but this stops hard deletions from happening.)<br><br>"
-	HTML += "<b><a href='?src=\ref[src];action=disable_ingame_logs'>Disable Ingame Logs</a></b> (Reduce the shitty logthething() lag! Make the admins angry! You can still access logs fine using the web version etc)<br><br>"
-
-	HTML += "</body></html>"
-
-	user.Browse(HTML,"window=alaghacks")
+	var/HTML = {"
+	<html><head><title>Admin Lag Reductions</title></head><body>
+	<b><a href='?src=\ref[src];action=lightweight_doors'>Remove Light+Cam processing when doors open or close</a></b> (May jank up lights slightly)<br><br>
+	<b><a href='?src=\ref[src];action=lightweight_mobs'>Slow Life() Processing</a></b> (Extremely safe - Life() compensates for the change automatically)<br><br>
+	<b><a href='?src=\ref[src];action=slow_atmos'>Slow atmos processing</a></b> (May jank up the TEG/Hellburns)<br><br>
+	<b><a href='?src=\ref[src];action=slow_fluids'>Slow fluid processing</a></b> (Safe, just feels weird)<br><br>
+	<b><a href='?src=\ref[src];action=special_sea_fullbright'>Stop Sea Light processing on Z1</a></b> (Safe, makes the Z1 ocean a little ugly)<br><br>
+	<b><a href='?src=\ref[src];action=slow_ticklag'>Adjust ticklag bounds</a></b> (Manually adjust ticklag dilation upper and lower bounds! Compensate for lag, or go super smooth at lowpop!)<br><br>
+	<b><a href='?src=\ref[src];action=disable_deletions'>Disable Deletion Queue</a></b> (Garbage Collection will still run, but this stops hard deletions from happening.)<br><br>
+	<b><a href='?src=\ref[src];action=disable_ingame_logs'>Disable Ingame Logs</a></b> (Reduce the shitty logthething() lag! Make the admins angry! You can still access logs fine using the web version etc)
+	</body></html>
+	"}
+	user.Browse(HTML,"window=alaghacks;size=400x390")
 
 
 //fluid_commands.dm
@@ -83,7 +83,11 @@ client/proc/slow_atmos()
 
 	if (processScheduler.hasProcess("Atmos"))
 		var/datum/controller/process/P = processScheduler.nameToProcessMap["Atmos"]
+#ifdef UNDERWATER_MAP
+		P.schedule_interval = 120
+#else
 		P.schedule_interval = 50
+#endif
 
 	message_admins("[key_name(src)] slowed the schedule interval of Atmos with Lag Reduction panel.")
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][FEATURE][QOL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the Slow atmos processing button to set the `schedule_interval` to `120` instead of `50` on underwater maps.

120 was chosen as that's the value mbc always use and has told me is safe on those maps. These maps don't have a TEG and hull breaches like space maps do. Currently you need to do this by editing the var by hand.

also removed a bunch of string ops from the lag panel build, and made it a little longer so it doesn't have an ugly scroll bar


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Lag reduction