### PR TITLE
Stops frog jumpsuit + obesity from recursively looping.

### DIFF
--- a/code/obj/item/clothing/gimmick.dm
+++ b/code/obj/item/clothing/gimmick.dm
@@ -1315,7 +1315,8 @@
 	desc = "A jumpsuit with a cute frog pattern on it. Get it? <i>Jump</i>suit? Ribbit!"
 	icon_state = "frogsuit"
 	item_state = "lightgreen"
-
+	c_flags = ONESIZEFITSALL // Fix to stop frog suit + obese infinite looping. RemoveEffect would loop through the obesity code back to unequipped over 5 procs total.
+													 //	(The loop goes unequipped->RemoveEffect->UpdateMob->update_clothing->u_equip->unequipped if you're courageous enough to fix it properly. I think that's not be the only way it could loop either.) -BatElite
 	equipped(var/mob/user, var/slot)
 		if (slot == SLOT_W_UNIFORM && user.bioHolder)
 			user.bioHolder.AddEffect("jumpy_suit", 0, 0, 0, 1) // id, variant, time left, do stability, magical


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR gives the frog jumpsuit the flag that lets it be worn by mobs with obesity. Previously the code responsible for removing the jumpsuit's genetic power would loop back recursively to the jumpsuit's unequip code.

I decided against resolving the loop itself  because it involves several widely-used procs, and I wasn't confident I could find a way that doesn't break stuff. I'm not aware of any other item of clothing having the same issue (tried with the empower wizard ring and titanium ring) so it's not like it'd be much of a gain. I did leave a big comment with the names of the procs that loop into one another though, should someone else feel braver than me.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Frogs are cool but infinite loops aren't.
closes  #1772 