### PR TITLE
Replace Component Cabinets in Mechanic's lockers with frames

### DIFF
--- a/code/WorkInProgress/MechanicMadness.dm
+++ b/code/WorkInProgress/MechanicMadness.dm
@@ -1829,10 +1829,6 @@ var/list/mechanics_telepads = new/list()
 		icon_state = "[under_floor ? "u":""]comp_radiosig"
 		return
 
-/obj/item/mechanics/wificomp/super
-	range = 999
-	maxrange = 999
-
 #undef WIFI_NOISE_COOLDOWN
 #undef WIFI_NOISE_VOLUME
 /obj/item/mechanics/selectcomp

--- a/code/WorkInProgress/MechanicMadness.dm
+++ b/code/WorkInProgress/MechanicMadness.dm
@@ -326,7 +326,13 @@
 		icon_state = icon_up
 		return
 
-
+// Put these into Mechanic
+/obj/item/electronics/frame/mech_cabinet
+	name = "Component Cabinet frame"
+	store_type = /obj/item/storage/mechanics/housing_large
+	viewstat = 2
+	secured = 2
+	icon_state = "dbox"
 
 
 //Global list of telepads so we don't have to loop through the entire world aaaahhh.
@@ -1822,6 +1828,10 @@ var/list/mechanics_telepads = new/list()
 	updateIcon()
 		icon_state = "[under_floor ? "u":""]comp_radiosig"
 		return
+
+/obj/item/mechanics/wificomp/super
+	range = 999
+	maxrange = 999
 
 #undef WIFI_NOISE_COOLDOWN
 #undef WIFI_NOISE_VOLUME

--- a/code/WorkInProgress/MechanicMadness.dm
+++ b/code/WorkInProgress/MechanicMadness.dm
@@ -326,7 +326,7 @@
 		icon_state = icon_up
 		return
 
-// Put these into Mechanic
+// Put these into Mechanic's locker
 /obj/item/electronics/frame/mech_cabinet
 	name = "Component Cabinet frame"
 	store_type = /obj/item/storage/mechanics/housing_large

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -505,7 +505,7 @@
 	/obj/item/clothing/glasses/meson,
 	/obj/item/electronics/soldering,
 	/obj/item/deconstructor,
-	/obj/item/storage/mechanics/housing_large=2,
+	/obj/item/electronics/frame/mech_cabinet=2,
 	/obj/item/storage/mechanics/housing_handheld=1)
 
 /obj/storage/secure/closet/engineering/atmos


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces the Component Cabinets in the Mechanic's lockers with Component Cabinet frames.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It sure would be nice to be able to close a Mechanic's locker after you open it.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)glassofmilk:
(+)Replace Component Cabinets in Mechanic's lockers with frames to save space
```
