### PR TITLE
Removed extra mailchute from Cog2 medbay

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -66547,7 +66547,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/disposal/mail/small,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "cPq" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the extra mail chute from Cog2 Medbay, Which is in the middle of a hallway and is not connected to anything.

![test](https://user-images.githubusercontent.com/22815407/90264745-e105c800-de94-11ea-946d-c442cd31c0d6.png)
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The mail chute starts in the middle of a hallway. and is unusable.
