### PR TITLE
Mushroom Updates & Complete Re-Wire

### DIFF
--- a/maps/unused/mushroom_new_walls.dmm
+++ b/maps/unused/mushroom_new_walls.dmm
@@ -10167,7 +10167,10 @@
 /obj/grille/catwalk/cross{
 	dir = 9
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 9;
 	layer = 2
@@ -10318,7 +10321,10 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 1;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -10376,7 +10382,9 @@
 	dir = 5;
 	icon_state = "catwalk_cross-0"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	layer = 2
@@ -10586,7 +10594,10 @@
 /area/station/medical/medbay/lobby)
 "aBC" = (
 /obj/grille/catwalk,
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/mining/magnet)
 "aBD" = (
@@ -11230,7 +11241,10 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	layer = 2
@@ -11495,19 +11509,19 @@
 /turf/simulated/floor/plating/damaged2,
 /area/station/maintenance/west)
 "aDY" = (
+/turf/simulated/floor/plating,
+/area/station/maintenance/eastsolar)
+"aDZ" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
 /obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/west)
-"aDZ" = (
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/hallway/primary/central)
+/area/station/quartermaster/office)
 "aEa" = (
 /obj/machinery/camera{
 	c_tag = "Habitation Ring South Junction";
@@ -11680,7 +11694,10 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/mining/magnet)
 "aEA" = (
@@ -11871,25 +11888,23 @@
 /turf/space,
 /area)
 "aEX" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/cable{
 	icon_state = "4-6"
+	},
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aEY" = (
-/obj/disposalpipe/switch_junction{
-	dir = 4;
-	icon_state = "pipe-sj1";
-	mail_tag = "hydroponics";
-	tag = "icon-pipe-sj1 (EAST)"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aEZ" = (
@@ -11898,14 +11913,14 @@
 	name = "S APC";
 	pixel_y = -24
 	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "5-8"
 	},
 /obj/cable{
 	icon_state = "0-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -11916,12 +11931,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aFb" = (
-/obj/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
+/obj/disposalpipe/segment,
+/turf/simulated/wall/auto/supernorn,
+/area/station/medical/morgue)
 "aFc" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/south)
@@ -12131,28 +12143,26 @@
 	},
 /area/station/hydroponics)
 "aFG" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/disposalpipe/segment,
 /obj/cable{
 	icon_state = "8-9"
+	},
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aFH" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
+/obj/disposalpipe/segment,
 /turf/simulated/wall/auto/supernorn,
-/area/station/hydroponics/lobby)
+/area/station/maintenance/inner)
 "aFI" = (
 /obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+	dir = 4;
+	pixel_y = 0
 	},
 /turf/simulated/wall/auto/supernorn,
-/area/station/hydroponics/lobby)
+/area/station/maintenance/inner)
 "aFJ" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/hydroponics/lobby)
@@ -12258,7 +12268,10 @@
 /area/station/medical/medbay)
 "aFY" = (
 /obj/grille/catwalk/cross,
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross";
@@ -12406,11 +12419,11 @@
 /turf/simulated/floor/green,
 /area/station/hydroponics/lobby)
 "aGw" = (
-/obj/disposalpipe/segment,
 /obj/machinery/camera{
 	c_tag = "Hydroponics Foyer";
 	dir = 2
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/green,
 /area/station/hydroponics/lobby)
 "aGx" = (
@@ -12443,6 +12456,9 @@
 	},
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/hydroponics)
@@ -12636,12 +12652,6 @@
 	tag = "icon-grass1"
 	},
 /area/station/hydroponics)
-"aHa" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/storage/primary)
 "aHb" = (
 /turf/simulated/floor/stairs/wide/middle{
 	dir = 4
@@ -12711,7 +12721,10 @@
 	dir = 5;
 	icon_state = "catwalk"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross";
@@ -12741,10 +12754,6 @@
 /turf/simulated/floor,
 /area/station/hydroponics)
 "aHr" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
 /obj/cable{
 	icon_state = "2-8"
 	},
@@ -12753,19 +12762,11 @@
 	},
 /area/station/hydroponics)
 "aHs" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hydroponics/lobby)
+/turf/simulated/wall/auto/supernorn,
+/area/station/engine/inner)
 "aHt" = (
 /obj/rack,
 /obj/item/clothing/mask/gas/emergency,
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 9
 	},
@@ -12777,19 +12778,11 @@
 	pixel_y = 24;
 	req_access_txt = "19"
 	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 1
 	},
 /area/station/hydroponics/lobby)
 "aHv" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
 /obj/machinery/light/emergency{
 	dir = 1;
 	icon_state = "ebulb1"
@@ -12799,22 +12792,15 @@
 	},
 /area/station/hydroponics/lobby)
 "aHw" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/orangeblack/side{
 	dir = 5
 	},
 /area/station/hydroponics/lobby)
 "aHx" = (
-/obj/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/light{
 	dir = 1;
 	icon_state = "tube1";
@@ -13168,6 +13154,9 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
@@ -13184,6 +13173,9 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/hydroponics/lobby)
 "aID" = (
@@ -13196,6 +13188,10 @@
 /obj/cable,
 /obj/cable{
 	icon_state = "0-2"
+	},
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
@@ -13210,22 +13206,22 @@
 	},
 /area/station/hydroponics/lobby)
 "aIG" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
 /obj/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/green,
 /area/station/hydroponics/lobby)
 "aIH" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
 /obj/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
-	},
-/obj/cable{
-	icon_state = "2-8"
 	},
 /turf/simulated/floor/green,
 /area/station/hydroponics/lobby)
@@ -13233,7 +13229,10 @@
 /obj/grille/catwalk{
 	dir = 5
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross";
@@ -13265,7 +13264,9 @@
 /obj/grille/catwalk{
 	dir = 6
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 2;
 	icon_state = "catwalk_cross";
@@ -13741,7 +13742,9 @@
 /obj/grille/catwalk/cross{
 	dir = 6
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 6
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6;
 	layer = 2
@@ -16433,7 +16436,9 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 10
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10;
 	layer = 2
@@ -16482,7 +16487,9 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 2;
 	icon_state = "catwalk_cross";
@@ -16516,7 +16523,9 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -21120,6 +21129,15 @@
 	},
 /turf/space,
 /area)
+"bej" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/hydroponics)
 "bek" = (
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
@@ -22297,27 +22315,17 @@
 /turf/simulated/floor/black,
 /area/station/bridge)
 "bhJ" = (
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/black,
 /area/station/security/hos)
 "bhK" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/light/small,
 /turf/simulated/floor/black,
 /area/station/security/hos)
 "bhL" = (
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/storage/secure/closet/command/hos{
 	req_access_txt = "37"
 	},
@@ -22428,6 +22436,9 @@
 	name = "N light switch";
 	pixel_y = 24
 	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/carpet{
 	dir = 1;
 	icon_state = "blue2"
@@ -22472,7 +22483,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bif" = (
-/turf/simulated/wall/auto/supernorn,
+/turf/simulated/wall/auto/jen/dark3,
 /area/station/turret_protected/ai)
 "big" = (
 /obj/critter/cat/jones,
@@ -22488,10 +22499,10 @@
 	},
 /area/station/bridge)
 "bij" = (
-/obj/disposalpipe/trunk{
-	dir = 1
-	},
 /obj/machinery/disposal,
+/obj/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/simulated/floor/carpet{
 	dir = 1;
 	icon_state = "blue2"
@@ -23058,7 +23069,7 @@
 /area/station/turret_protected/ai)
 "bjD" = (
 /obj/machinery/turretid,
-/turf/simulated/wall/auto/supernorn,
+/turf/simulated/wall/auto/jen/dark3,
 /area/station/turret_protected/ai)
 "bjF" = (
 /obj/window/reinforced{
@@ -25507,14 +25518,15 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "brw" = (
-/obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment,
 /obj/machinery/door/airlock/pyro/security{
 	name = "Head of Security'"
 	},
 /obj/access_spawn/hos,
-/obj/cable{
-	icon_state = "1-2"
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/security/hos)
 "brz" = (
@@ -25757,7 +25769,10 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
 /area/station/mining/magnet)
 "bsk" = (
 /obj/grille/catwalk{
@@ -25766,7 +25781,10 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
 /area/station/mining/magnet)
 "bsl" = (
 /obj/table/auto,
@@ -25801,7 +25819,10 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
 /area/station/mining/magnet)
 "bsp" = (
 /obj/grille/catwalk{
@@ -25810,7 +25831,10 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
 /area/station/mining/magnet)
 "bsq" = (
 /obj/landmark/magnet_center,
@@ -25939,7 +25963,10 @@
 	network = "SS13";
 	tag = ""
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
 /area/station/mining/magnet)
 "bsH" = (
 /obj/landmark{
@@ -25974,7 +26001,10 @@
 /obj/machinery/mining_magnet{
 	dir = 8
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
 /area/station/mining/magnet)
 "bsK" = (
 /obj/lattice,
@@ -26083,6 +26113,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/machinery/light/small/floor/cool/very,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "bsW" = (
@@ -26125,6 +26156,10 @@
 	pixel_y = 9
 	},
 /turf/space,
+/area/station/turret_protected/ai)
+"btd" = (
+/obj/machinery/light/small/floor/cool,
+/turf/simulated/floor/engine,
 /area/station/turret_protected/ai)
 "bte" = (
 /obj/storage/secure/crate/plasma/armory/anti_biological,
@@ -26607,6 +26642,12 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/captain)
+"bRs" = (
+/obj/machinery/light/incandescent/cool{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/station/turret_protected/ai)
 "bRC" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -26654,6 +26695,17 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
+"cgH" = (
+/obj/grille/catwalk,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk,
+/area/station/mining/magnet)
 "cjc" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -26683,10 +26735,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"cnN" = (
-/obj/disposalpipe/segment,
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/SEmaint)
 "cnU" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -26803,9 +26851,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/ai)
-"cWq" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/storage/warehouse)
 "cXe" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -26843,6 +26888,9 @@
 	dir = 1
 	},
 /area/station/science)
+"dpx" = (
+/turf/simulated/wall/auto/supernorn,
+/area/station/storage/warehouse)
 "dqc" = (
 /obj/machinery/turret,
 /obj/cable{
@@ -26869,6 +26917,10 @@
 "duf" = (
 /obj/cable{
 	icon_state = "1-10"
+	},
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/carpet{
 	dir = 1;
@@ -27130,6 +27182,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
+"ept" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/storage/primary)
 "eqv" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -27151,6 +27209,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/captain)
+"eIL" = (
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/maintenance{
+	name = "Botany Maintenance";
+	req_access = null
+	},
+/obj/access_spawn/hydro,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "eKg" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -27498,6 +27569,16 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
+"fUr" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor,
+/area/station/hydroponics)
 "fVw" = (
 /obj/cable{
 	icon_state = "5-6"
@@ -27736,6 +27817,9 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/medical/research)
+"gZX" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/turret_protected/ai)
 "haT" = (
 /obj/wingrille_spawn/auto,
 /obj/cable,
@@ -27790,10 +27874,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"hkO" = (
-/obj/disposalpipe/segment,
-/turf/simulated/wall/auto/supernorn,
-/area/station/storage/emergency)
 "hoZ" = (
 /obj/cable{
 	icon_state = "4-9"
@@ -27869,6 +27949,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/light/small/floor/cool,
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai)
 "hBl" = (
@@ -27962,9 +28043,19 @@
 	tag = "icon-grass1"
 	},
 /area/station/hydroponics)
-"hTJ" = (
-/turf/simulated/floor/plating,
-/area/station/maintenance/eastsolar)
+"hVL" = (
+/obj/grille/catwalk/cross{
+	dir = 9
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 9;
+	layer = 2
+	},
+/area/station/mining/magnet)
 "hWg" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -28177,6 +28268,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
+"iPJ" = (
+/obj/grille/catwalk{
+	dir = 4
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	intact = 0
+	},
+/area/station/mining/magnet)
 "iQr" = (
 /obj/cable{
 	icon_state = "4-5"
@@ -28227,11 +28330,12 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "jgD" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "4-9"
+	},
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -28279,6 +28383,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/storage)
+"jvc" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hydroponics)
 "jvN" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -28289,6 +28399,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
+"jBD" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-9"
+	},
+/obj/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/station/hydroponics)
 "jBH" = (
 /obj/cable{
 	icon_state = "1-10"
@@ -28384,13 +28502,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/brig)
-"jTu" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/inner)
 "jXg" = (
 /obj/cable{
 	icon_state = "1-6"
@@ -28435,9 +28546,6 @@
 	},
 /area/station/bridge)
 "keX" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "5-8"
 	},
@@ -28668,6 +28776,9 @@
 	tag = "icon-grass1"
 	},
 /area/station/hydroponics)
+"loS" = (
+/turf/simulated/wall/auto/jen/dark4,
+/area/station/turret_protected/ai)
 "lwm" = (
 /obj/cable{
 	icon_state = "2-9"
@@ -28817,6 +28928,10 @@
 	dir = 2
 	},
 /area/station/owlery)
+"mcn" = (
+/obj/disposalpipe/segment,
+/turf/simulated/wall/auto/supernorn,
+/area/station/maintenance/SEmaint)
 "mcF" = (
 /obj/disposalpipe/segment,
 /obj/cable{
@@ -28894,6 +29009,13 @@
 	dir = 8
 	},
 /area/listeningpost)
+"mpq" = (
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor,
+/area/station/hydroponics)
 "mrE" = (
 /obj/disposalpipe/segment,
 /obj/cable{
@@ -28923,7 +29045,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/wall/auto/supernorn,
+/turf/simulated/wall/auto/reinforced/jen/dark4,
 /area/station/turret_protected/ai)
 "mAF" = (
 /obj/cable{
@@ -29282,6 +29404,10 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating/damaged1,
 /area/station/maintenance/west)
 "oQx" = (
@@ -29622,6 +29748,12 @@
 	dir = 2
 	},
 /area/station/owlery)
+"qko" = (
+/obj/machinery/light/incandescent/cool{
+	dir = 8
+	},
+/turf/simulated/floor/engine,
+/area/station/turret_protected/ai)
 "qlN" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -29750,6 +29882,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hydroponics)
+"qIi" = (
+/obj/grille/catwalk,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk,
+/area/station/mining/magnet)
+"qMC" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/auto/jen/dark4,
+/area/station/turret_protected/ai)
 "qNU" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -29863,6 +30009,13 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/ai)
+"rmD" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small/floor/cool,
+/turf/simulated/floor/engine,
+/area/station/turret_protected/ai)
 "roE" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -29940,6 +30093,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
+"rAl" = (
+/obj/machinery/camera,
+/obj/machinery/light/incandescent/cool{
+	dir = 1
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
 "rBQ" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -29989,8 +30149,8 @@
 /obj/cable{
 	icon_state = "1-5"
 	},
-/turf/simulated/floor/plating,
 /turf/simulated/floor/plating/damaged2,
+/turf/space,
 /area/station/maintenance/west)
 "rXC" = (
 /obj/cable{
@@ -30272,6 +30432,9 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/security/hos)
+"tsb" = (
+/turf/simulated/wall/auto/reinforced/jen/dark4,
+/area/station/turret_protected/ai)
 "tsB" = (
 /obj/disposalpipe/segment,
 /obj/cable{
@@ -30440,10 +30603,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/ai)
-"uhK" = (
-/obj/disposalpipe/segment,
-/turf/simulated/wall/auto/supernorn,
-/area/station/medical/morgue)
 "uiU" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -30454,6 +30613,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/research)
+"ukZ" = (
+/obj/disposalpipe/switch_junction{
+	dir = 1;
+	mail_tag = "hydroponics";
+	tag = "icon-pipe-sj1 (EAST)"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "umj" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -30502,23 +30669,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
-"uzM" = (
-/obj/disposalpipe/segment,
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/inner)
 "uCl" = (
 /obj/cable{
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
+"uCB" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/orangeblack/side{
+	dir = 8
+	},
+/area/station/hydroponics/lobby)
 "uFt" = (
 /obj/disposalpipe/segment,
-/obj/cable{
-	icon_state = "4-10"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
+/turf/simulated/wall/auto/supernorn,
+/area/station/storage/emergency)
 "uHv" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -30533,6 +30704,12 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/hydroponics)
+"uHC" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/auto/jen/dark3,
+/area/station/turret_protected/ai)
 "uHG" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -30551,6 +30728,13 @@
 	},
 /turf/simulated/floor/purple/side,
 /area/station/science)
+"uJa" = (
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "uJW" = (
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/engineering{
@@ -30598,6 +30782,12 @@
 	dir = 1
 	},
 /area/station/science)
+"uTa" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/auto/jen/dark4,
+/area/station/turret_protected/ai)
 "uTY" = (
 /obj/wingrille_spawn/auto,
 /obj/cable,
@@ -30689,6 +30879,7 @@
 /obj/cable{
 	icon_state = "0-9"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/hydroponics)
 "vnw" = (
@@ -30894,6 +31085,16 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
+"wpY" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/hydroponics)
+"wqZ" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/storage/primary)
 "wrJ" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -30939,9 +31140,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/research)
-"wyl" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/engine/inner)
 "wGn" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -30967,12 +31165,11 @@
 	},
 /area/station/hallway/primary/central)
 "wIj" = (
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/cable{
 	icon_state = "4-9"
+	},
+/obj/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -31004,10 +31201,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/ai)
-"wQZ" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/storage/primary)
 "wUv" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -31082,6 +31275,14 @@
 	icon_state = "blue2"
 	},
 /area/station/bridge)
+"xrH" = (
+/obj/grille/catwalk,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk,
+/area/station/mining/magnet)
 "xtT" = (
 /obj/wingrille_spawn/auto,
 /obj/cable,
@@ -31224,6 +31425,12 @@
 	tag = "icon-grass1"
 	},
 /area/station/hydroponics)
+"ydo" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/auto/jen/dark3,
+/area/station/turret_protected/ai)
 "ydz" = (
 /obj/stool/chair,
 /obj/cable{
@@ -31244,7 +31451,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/wall/auto/supernorn,
+/turf/simulated/wall/auto/reinforced/jen/dark4,
 /area/station/turret_protected/ai)
 
 (1,1,1) = {"
@@ -42695,7 +42902,7 @@ blm
 aAQ
 bsG
 bsJ
-aAQ
+iPJ
 aaa
 aaa
 bsu
@@ -42922,7 +43129,7 @@ bsK
 aAQ
 ayo
 ayo
-aAQ
+iPJ
 aaa
 aaa
 bsu
@@ -43369,10 +43576,10 @@ aaa
 aaa
 bsu
 aAQ
-aAu
-aBC
-aBC
-aBC
+hVL
+qIi
+qIi
+qIi
 aHl
 aII
 aII
@@ -45417,11 +45624,11 @@ aEz
 aEz
 aEz
 aEz
-aEz
-aEz
-aEz
-aEz
-aEz
+cgH
+cgH
+cgH
+cgH
+cgH
 aRJ
 ahT
 aaa
@@ -45639,16 +45846,16 @@ aaa
 aaa
 bsu
 aAY
-aBC
-aBC
-aBC
-aBC
-aBC
-aBC
-aBC
-aBC
-aBC
-aBC
+xrH
+xrH
+xrH
+xrH
+xrH
+xrH
+xrH
+xrH
+xrH
+xrH
 aRQ
 ahT
 aaa
@@ -46091,14 +46298,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
+ahe
 aaa
 amn
 aaa
+ahe
 aaa
 aaa
-aaa
-aaa
+ahe
 aaa
 aaa
 aaa
@@ -46322,10 +46529,10 @@ azW
 azW
 azW
 azW
+ahe
 aaa
 aaa
-aaa
-aaa
+ahe
 aaa
 aaa
 aaa
@@ -46552,7 +46759,7 @@ azW
 azW
 aaa
 aaa
-aaa
+ahe
 aaa
 aaa
 aaa
@@ -46779,7 +46986,7 @@ bpT
 azW
 azW
 aaa
-aaa
+ahe
 aaa
 aaa
 aaa
@@ -47006,7 +47213,7 @@ bpY
 aww
 azW
 aaa
-aaa
+ahe
 aaa
 aaa
 aaa
@@ -48163,7 +48370,7 @@ aFw
 aFw
 aLe
 vmu
-xeK
+jBD
 aNA
 aOo
 aPj
@@ -51089,7 +51296,7 @@ aBN
 aBV
 avt
 avW
-wyl
+aHs
 atZ
 atZ
 ayq
@@ -51108,7 +51315,7 @@ aCP
 aER
 aES
 aES
-aHp
+bej
 aES
 aJA
 aCP
@@ -51316,7 +51523,7 @@ auy
 auM
 avu
 avW
-wyl
+aHs
 axb
 aEu
 hBl
@@ -51335,8 +51542,8 @@ aCP
 aET
 aFD
 aES
-aHp
-aES
+fUr
+mpq
 aJB
 aCP
 aLk
@@ -51543,7 +51750,7 @@ avh
 aCb
 avv
 avW
-wyl
+aHs
 axc
 kkl
 pBt
@@ -51562,8 +51769,8 @@ aCP
 aEU
 aFE
 aGq
-aHp
-aES
+jvc
+wpY
 aJC
 boH
 aLl
@@ -51745,7 +51952,7 @@ akK
 aiF
 akK
 agQ
-akK
+aDZ
 bok
 ald
 alv
@@ -51764,13 +51971,13 @@ apE
 ase
 axh
 atd
-wyl
-wyl
-wyl
+aHs
+aHs
+aHs
 aBt
-wyl
-wyl
-wyl
+aHs
+aHs
+aHs
 pAK
 pfQ
 aEu
@@ -52016,7 +52223,7 @@ atZ
 aaa
 aaa
 aGs
-aHs
+aGs
 aGz
 aGs
 aGs
@@ -52244,7 +52451,7 @@ aaa
 aaa
 aGs
 aHt
-aIA
+uCB
 aJE
 aGs
 aPz
@@ -52923,7 +53130,7 @@ aEu
 bET
 fai
 oMV
-aQB
+eIL
 aHw
 aID
 aJH
@@ -53126,7 +53333,7 @@ amT
 ash
 apU
 mcF
-hkO
+uFt
 auA
 auA
 auW
@@ -53136,7 +53343,7 @@ awB
 boW
 axf
 axf
-hkO
+uFt
 azo
 apU
 ath
@@ -53146,12 +53353,12 @@ aBS
 aBS
 aBS
 aCY
-aDY
-aEu
+aBS
+ukZ
 aEX
 wIj
 aGs
-aHs
+aGs
 aGV
 aGs
 aGs
@@ -53373,11 +53580,11 @@ amT
 amT
 amT
 amT
-aAV
-aEu
+amT
+uJa
 aEY
 aFG
-aGu
+aFJ
 aHx
 aIA
 aJI
@@ -53600,10 +53807,10 @@ azq
 aCr
 any
 awG
-aAV
+amT
 aEv
 aEZ
-aFH
+aFJ
 aFJ
 aHy
 aIF
@@ -53827,10 +54034,10 @@ any
 any
 any
 any
-aAV
+amT
 pAK
 aFa
-aFH
+aFJ
 aGv
 aHz
 aIG
@@ -54054,10 +54261,10 @@ aBp
 aCs
 aCX
 any
-aAV
+amT
 rFx
 jgD
-aFI
+aGu
 aGw
 aHA
 aIH
@@ -54266,22 +54473,22 @@ atH
 atH
 atH
 atH
-cWq
-cWq
-cWq
-cWq
+dpx
+dpx
+dpx
+dpx
 aCD
 aCD
-cWq
-cWq
-cWq
-cWq
-cWq
-cWq
+dpx
+dpx
+dpx
+dpx
+dpx
+dpx
 aCe
 aCZ
 aCZ
-aAV
+amT
 aEu
 keX
 aFJ
@@ -54504,13 +54711,13 @@ axP
 aAt
 aAS
 avC
-cWq
+dpx
 aCe
 aCZ
 aCZ
-aDZ
-uFt
-aFb
+amT
+pAK
+aEu
 aFJ
 aFJ
 aHC
@@ -54707,11 +54914,11 @@ anC
 anZ
 aoy
 anZ
-uhK
+aFb
 apU
 apU
 aqX
-uzM
+aFH
 ask
 ask
 atl
@@ -54731,7 +54938,7 @@ auE
 auE
 auE
 aBq
-cWq
+dpx
 aCv
 any
 aDs
@@ -54958,7 +55165,7 @@ awF
 auE
 auE
 alO
-cWq
+dpx
 aCv
 any
 any
@@ -55669,11 +55876,11 @@ aOH
 aZx
 aYD
 aZx
-wQZ
-wQZ
-wQZ
-wQZ
-aHa
+wqZ
+wqZ
+wqZ
+wqZ
+ept
 aYD
 aZx
 bdB
@@ -55847,7 +56054,7 @@ apU
 apU
 apU
 arD
-uzM
+aFH
 asH
 ato
 atJ
@@ -56605,7 +56812,7 @@ bgW
 bhn
 bhz
 bhL
-bgL
+bgJ
 bij
 bjg
 bpG
@@ -56757,18 +56964,18 @@ any
 aqW
 avd
 avd
-jTu
+aFI
 atL
 avd
 avd
 avd
-cWq
-cWq
-cWq
-cWq
-cWq
-cWq
-cWq
+dpx
+dpx
+dpx
+dpx
+dpx
+dpx
+dpx
 atH
 aAa
 aRf
@@ -58313,7 +58520,7 @@ aaa
 aew
 aeN
 aqp
-hTJ
+aDY
 afL
 agg
 agE
@@ -58828,7 +59035,7 @@ aFQ
 aGE
 tvk
 aIR
-cnN
+mcn
 aKI
 aLJ
 aMy
@@ -70470,21 +70677,21 @@ bga
 bga
 bjO
 bjO
-bif
-bif
-bif
-bif
-bif
-bif
-bif
+tsb
+tsb
+tsb
+tsb
+tsb
+tsb
+tsb
 yfD
-bif
-bif
-bif
-bif
-bif
-bif
-bif
+tsb
+tsb
+tsb
+tsb
+tsb
+tsb
+tsb
 bjO
 bjO
 bga
@@ -70696,8 +70903,8 @@ bga
 bga
 bjO
 bjO
-bif
-bif
+tsb
+tsb
 bjS
 bjS
 bjS
@@ -70711,8 +70918,8 @@ bjS
 bjS
 bjS
 bjS
-bif
-bif
+tsb
+tsb
 bjO
 bjO
 bga
@@ -70922,25 +71129,25 @@ bga
 bga
 bjO
 bjO
-bif
-bif
+tsb
+tsb
 bjS
 bjS
-bif
-bif
-bif
-bif
-bif
-yfD
-bif
-bif
-bif
-bif
-bif
+loS
+loS
+loS
+loS
+loS
+uTa
+loS
+loS
+loS
+loS
+loS
 bjS
 bjS
-bif
-bif
+tsb
+tsb
 bjO
 bjO
 bga
@@ -71148,12 +71355,12 @@ bga
 bga
 bjO
 bjO
-bif
-bif
+tsb
+tsb
 bjS
 bjS
-bif
-bif
+loS
+loS
 bjS
 bjS
 bjS
@@ -71163,12 +71370,12 @@ bjS
 bjS
 bjS
 bjS
-bif
-bif
+loS
+loS
 bjS
 bjS
-bif
-bif
+tsb
+tsb
 bjO
 bga
 aVx
@@ -71374,28 +71581,28 @@ aVx
 bga
 bjO
 bjO
-bif
-bif
+tsb
+tsb
+bjS
+bjS
+loS
+loS
 bjS
 bjS
 bif
 bif
-bjS
-bjS
 bif
-bif
-bif
-yfD
+ydo
 bif
 bif
 bif
 bjS
 bjS
-bif
-bif
+loS
+loS
 bjS
 bjS
-bif
+tsb
 bjO
 bga
 aVx
@@ -71600,29 +71807,29 @@ aVy
 bgp
 bnQ
 bjO
-bif
-bif
+tsb
+tsb
 bjS
 bjS
-bif
-bif
+loS
+loS
 bjS
+btd
+bif
+bif
+bif
+bif
+ydo
+bif
+bif
+bif
+bif
+btd
 bjS
-bif
-bif
-bif
-bif
-yfD
-bif
-bif
-bif
-bif
+loS
+loS
 bjS
-bjS
-bif
-bif
-bjS
-bif
+tsb
 bjO
 bnQ
 bgp
@@ -71827,11 +72034,11 @@ bgb
 bgb
 bgb
 bjO
-bif
+tsb
 bjS
 bjS
-bif
-bif
+loS
+loS
 bjS
 bjS
 bif
@@ -71847,9 +72054,9 @@ bif
 bif
 bjS
 bjS
-bif
-bjS
-bif
+loS
+bRs
+tsb
 bjO
 bjO
 bjO
@@ -72054,10 +72261,10 @@ bga
 bga
 bga
 bjO
-bif
+tsb
 bjS
-bif
-bif
+loS
+loS
 bjS
 bjS
 bif
@@ -72074,14 +72281,14 @@ bif
 bif
 bif
 bjS
-bif
-bif
-bif
-bif
-bif
-bif
-bif
-bif
+tsb
+tsb
+tsb
+tsb
+tsb
+tsb
+tsb
+tsb
 bjO
 bga
 bga
@@ -72281,9 +72488,9 @@ bkl
 aXp
 bga
 bjO
-bif
+tsb
 bjS
-bif
+loS
 bjS
 bjS
 bif
@@ -72301,14 +72508,14 @@ bif
 bif
 bif
 bjS
-bif
+tsb
 bjS
 bjS
 bjS
 bjS
 bjS
 bjS
-bif
+tsb
 bjO
 bga
 aVy
@@ -72508,9 +72715,9 @@ eYg
 uHG
 bga
 bjO
-bif
+tsb
 bjS
-bif
+loS
 bjS
 bif
 bif
@@ -72528,14 +72735,14 @@ bjV
 bif
 bif
 bjS
-bif
+tsb
+bjS
+bRs
+bjS
+tsb
 bjS
 bjS
-bjS
-bif
-bjS
-bjS
-bif
+tsb
 bjO
 bga
 kJy
@@ -72735,9 +72942,9 @@ cvJ
 ugm
 bga
 bjO
-bif
+tsb
 bjS
-bif
+loS
 bjS
 bif
 bif
@@ -72747,22 +72954,22 @@ bjV
 dqc
 bjV
 bjV
-bif
-bif
+gZX
+gZX
 bjV
 oes
 bjV
 uby
-mzV
+uHC
 rvL
-bif
-bif
-bif
-bif
-bif
+tsb
+tsb
+tsb
+tsb
+tsb
 bjS
 bjS
-bif
+tsb
 bjO
 bga
 ugm
@@ -72962,9 +73169,9 @@ bga
 ugm
 bga
 bjO
-bif
+tsb
 bjS
-bif
+loS
 bjS
 bif
 bif
@@ -72975,21 +73182,21 @@ gdQ
 kZu
 rdl
 qyt
-bif
-bif
+gZX
+gZX
 oFX
 bjV
 vYk
 bif
 bAQ
-bif
+tsb
 bjS
 bjS
 bjS
 bjS
 bjS
 bjS
-bif
+tsb
 bjO
 bga
 ugm
@@ -73190,21 +73397,21 @@ eaS
 rlS
 mlv
 mzV
-dyi
-mzV
-dyi
-mzV
-mzV
+rmD
+qMC
+rmD
+uHC
+uHC
 bjW
 bkK
 wgs
 ssU
 bko
-bif
+gZX
 bsV
-bif
-bif
-beb
+gZX
+gZX
+rAl
 kUT
 xJQ
 btY
@@ -73212,7 +73419,7 @@ dYm
 btX
 dyi
 dyi
-dyi
+rmD
 dyi
 dyi
 dyi
@@ -73416,9 +73623,9 @@ bga
 ugm
 bga
 bjO
-bif
+tsb
 bjS
-bif
+loS
 bjS
 bif
 bif
@@ -73429,21 +73636,21 @@ oes
 mks
 rdl
 xJQ
-bif
-bif
+gZX
+gZX
 waK
 bjV
 bjV
 bif
 bjS
-bif
+tsb
 bjS
 bjS
 bjS
 bjS
 bjS
 bjS
-bif
+tsb
 bjO
 bga
 ugm
@@ -73643,9 +73850,9 @@ bkl
 ugm
 bga
 bjO
-bif
+tsb
 bjS
-bif
+loS
 bjS
 bif
 bif
@@ -73655,22 +73862,22 @@ bjV
 rqE
 bjV
 bjV
-bif
-bif
+gZX
+gZX
 bjV
 gdQ
 bjV
 bkL
 bif
 bkP
-bif
-bif
-bif
-bif
-bif
+tsb
+tsb
+tsb
+tsb
+tsb
 bqB
 bjS
-bif
+tsb
 bjO
 bga
 ugm
@@ -73870,9 +74077,9 @@ eYg
 mzE
 bga
 bjO
-bif
+tsb
 bjS
-bif
+loS
 bjS
 bif
 bif
@@ -73890,14 +74097,14 @@ bjV
 bif
 bif
 bjS
-bif
+tsb
+bjS
+qko
+bjS
+tsb
 bjS
 bjS
-bjS
-bif
-bjS
-bjS
-bif
+tsb
 bjO
 bga
 cTL
@@ -74097,9 +74304,9 @@ cvJ
 beq
 bga
 bjO
-bif
+tsb
 bjS
-bif
+loS
 bjS
 bjS
 bif
@@ -74117,14 +74324,14 @@ bif
 bif
 bif
 bjS
-bif
+tsb
 bjS
 bjS
 bjS
 bjS
 bjS
 bjS
-bif
+tsb
 bjO
 bga
 aVJ
@@ -74324,10 +74531,10 @@ bga
 bga
 bga
 bjO
-bif
+tsb
 bjS
-bif
-bif
+loS
+loS
 bjS
 bjS
 bif
@@ -74344,14 +74551,14 @@ bif
 bif
 bif
 bjS
-bif
-bif
-bif
-bif
-bif
-bif
-bif
-bif
+tsb
+tsb
+tsb
+tsb
+tsb
+tsb
+tsb
+tsb
 bjO
 bga
 bga
@@ -74551,11 +74758,11 @@ bgb
 bgb
 bgb
 bjO
-bif
+tsb
 bjS
 bjS
-bif
-bif
+loS
+loS
 bjS
 bjS
 bif
@@ -74571,9 +74778,9 @@ bif
 bif
 bjS
 bjS
-bif
-bjS
-bif
+loS
+qko
+tsb
 bjO
 bjO
 bjO
@@ -74778,29 +74985,29 @@ aVJ
 bgp
 boL
 bjO
-bif
-bif
+tsb
+tsb
 bjS
 bjS
-bif
-bif
+loS
+loS
 bjS
+btd
+bif
+bif
+bif
+bif
+ydo
+bif
+bif
+bif
+bif
+btd
 bjS
-bif
-bif
-bif
-bif
-yfD
-bif
-bif
-bif
-bif
+loS
+loS
 bjS
-bjS
-bif
-bif
-bjS
-bif
+tsb
 bjO
 boL
 bgp
@@ -75006,28 +75213,28 @@ aVx
 bga
 bjO
 bjO
-bif
-bif
+tsb
+tsb
+bjS
+bjS
+loS
+loS
 bjS
 bjS
 bif
 bif
-bjS
-bjS
 bif
-bif
-bif
-yfD
+ydo
 bif
 bif
 bif
 bjS
 bjS
-bif
-bif
+loS
+loS
 bjS
 bjS
-bif
+tsb
 bjO
 bga
 aVx
@@ -75234,12 +75441,12 @@ bga
 bga
 bjO
 bjO
-bif
-bif
+tsb
+tsb
 bjS
 bjS
-bif
-bif
+loS
+loS
 bjS
 bjS
 bjS
@@ -75249,12 +75456,12 @@ bjS
 bjS
 bjS
 bjS
-bif
-bif
+loS
+loS
 bjS
 bjS
-bif
-bif
+tsb
+tsb
 bjO
 bga
 aVx
@@ -75462,25 +75669,25 @@ bga
 bga
 bjO
 bjO
-bif
-bif
+tsb
+tsb
 bjS
 bjS
-bif
-bif
-bif
-bif
-bif
-yfD
-bif
-bif
-bif
-bif
-bif
+loS
+loS
+loS
+loS
+loS
+uTa
+loS
+loS
+loS
+loS
+loS
 bjS
 bjS
-bif
-bif
+tsb
+tsb
 bjO
 bjO
 bga
@@ -75690,8 +75897,8 @@ bga
 bga
 bjO
 bjO
-bif
-bif
+tsb
+tsb
 bjS
 bjS
 bjS
@@ -75705,8 +75912,8 @@ bjS
 bjS
 bjS
 bjS
-bif
-bif
+tsb
+tsb
 bjO
 bjO
 bga
@@ -75918,21 +76125,21 @@ bga
 bga
 bjO
 bjO
-bif
-bif
-bif
-bif
-bif
-bif
-bif
+tsb
+tsb
+tsb
+tsb
+tsb
+tsb
+tsb
 yfD
-bif
-bif
-bif
-bif
-bif
-bif
-bif
+tsb
+tsb
+tsb
+tsb
+tsb
+tsb
+tsb
 bjO
 bjO
 bga

--- a/maps/unused/mushroom_new_walls.dmm
+++ b/maps/unused/mushroom_new_walls.dmm
@@ -6,13 +6,12 @@
 /turf/space,
 /area/shuttle/escape/station/cogmap2)
 "aac" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/machinery/power/solar{
 	id = "westsolar";
 	name = "West Solar Array"
+	},
+/obj/cable{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/airless{
 	icon_state = "solarpanel";
@@ -21,27 +20,23 @@
 /area/station/solar/west)
 "aad" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/solar/west)
 "aae" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/power/solar{
 	id = "westsolar";
 	name = "West Solar Array"
+	},
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/airless{
 	icon_state = "solarpanel";
@@ -85,18 +80,15 @@
 /area/station/hallway/secondary/exit)
 "aal" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/cable,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/cable,
 /turf/simulated/floor/plating/airless,
 /area/station/solar/west)
 "aam" = (
@@ -171,15 +163,6 @@
 	icon_state = "13"
 	},
 /area/shuttle/arrival/station)
-"aaO" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable,
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/quartermaster/office)
 "aaP" = (
 /obj/machinery/light{
 	dir = 4;
@@ -213,8 +196,6 @@
 /area/shuttle/arrival/station)
 "aaW" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/airless,
@@ -239,11 +220,6 @@
 /turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "aba" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
@@ -251,6 +227,9 @@
 	name = "Solar Substation"
 	},
 /obj/access_spawn/engineering,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
 "abb" = (
@@ -262,26 +241,14 @@
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
-"abc" = (
-/obj/firedoor_spawn,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/pyro/command{
-	dir = 4;
-	icon_state = "com_closed";
-	name = "E.V.A."
-	},
-/obj/access_spawn/eva,
-/turf/simulated/floor/orangeblack,
-/area/station/ai_monitored/storage/eva)
 "abd" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/security/checkpoint)
 "abe" = (
 /obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint)
 "abf" = (
@@ -309,47 +276,30 @@
 	},
 /area/station/hallway/secondary/entry)
 "abi" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "N APC";
 	pixel_y = 24
 	},
 /obj/critter/domestic_bee/bubs,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor,
 /area/station/security/checkpoint)
 "abj" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/table/auto,
 /obj/item/device/flash,
 /turf/simulated/floor,
 /area/station/security/checkpoint)
 "abk" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/submachine/weapon_vendor/security,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/security/checkpoint)
 "abl" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/table/auto,
 /obj/machinery/recharger{
 	pixel_y = 3
@@ -399,36 +349,29 @@
 /turf/simulated/floor,
 /area/station/security/checkpoint)
 "abr" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/cryotron{
+	layer = 3.9
 	},
-/turf/simulated/floor,
-/area/station/security/checkpoint)
+/obj/machinery/light/incandescent/netural{
+	dir = 1
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
 "abs" = (
 /turf/simulated/floor,
 /area/station/security/checkpoint)
 "abt" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor,
-/area/station/security/checkpoint)
+/turf/space,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
 "abu" = (
 /obj/machinery/power/data_terminal,
+/obj/machinery/computer/security{
+	dir = 8
+	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/computer/security,
 /turf/simulated/floor,
 /area/station/security/checkpoint)
 "abv" = (
@@ -470,22 +413,21 @@
 /area/station/security/checkpoint)
 "abz" = (
 /obj/machinery/power/data_terminal,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/computer/card{
+	dir = 8
 	},
-/obj/machinery/computer/card,
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
+	},
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor,
 /area/station/security/checkpoint)
 "abA" = (
 /obj/firedoor_spawn,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -513,17 +455,15 @@
 	},
 /area/station/hallway/secondary/entry)
 "abF" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/table/reinforced{
 	icon_state = "reinf_tabledir";
 	tag = "icon-reinf_tabledir"
 	},
 /obj/firedoor_spawn,
 /obj/item/pen,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/security/checkpoint)
 "abG" = (
@@ -537,20 +477,19 @@
 	},
 /area/station/hallway/secondary/entry)
 "abI" = (
-/obj/cable,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "1"
 	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/security/checkpoint)
+/area/shuttle/arrival/station)
 "abJ" = (
 /obj/table/reinforced{
 	icon_state = "reinf_tabledir";
 	tag = "icon-reinf_tabledir"
 	},
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/security/checkpoint)
 "abK" = (
@@ -558,14 +497,9 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "abL" = (
-/obj/cable,
-/obj/cable{
-	icon_state = "0-2";
-	tag = "icon-0-2"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/security/checkpoint)
+/obj/machinery/computer/arcade,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
 "abM" = (
 /obj/machinery/light{
 	dir = 8;
@@ -573,17 +507,12 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/escape{
 	dir = 1
 	},
-/area/station/hallway/secondary/exit)
-"abN" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "abO" = (
 /obj/item/device/analyzer/atmospheric,
@@ -603,14 +532,12 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "abS" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/access_spawn/maint,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "abU" = (
@@ -623,27 +550,12 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "abW" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/noticeboard{
 	name = "Complaint Board";
 	pixel_y = 28
 	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
-"abX" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
@@ -670,11 +582,6 @@
 	},
 /area/station/hallway/secondary/exit)
 "acc" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor{
 	icon_state = "L5";
 	tag = "icon-L5"
@@ -720,17 +627,15 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "acj" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
 	icon_state = "maint_closed"
 	},
 /obj/access_spawn/maint,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
 "ack" = (
@@ -761,13 +666,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "acn" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/machinery/power/solar{
 	id = "eastsolar";
 	name = "East Solar Array"
+	},
+/obj/cable{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/airless{
 	icon_state = "solarpanel";
@@ -776,27 +680,23 @@
 /area/station/solar/east)
 "aco" = (
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/solar/east)
 "acp" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/power/solar{
 	id = "eastsolar";
 	name = "East Solar Array"
+	},
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/airless{
 	icon_state = "solarpanel";
@@ -828,11 +728,6 @@
 	},
 /area/station/hallway/secondary/exit)
 "acv" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor{
 	icon_state = "L6";
 	tag = "icon-L6"
@@ -873,157 +768,110 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "acC" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/NEmaint)
+/obj/table/reinforced/auto,
+/obj/item/storage/firstaid/regular,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
 "acD" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-9"
+	},
+/obj/cable{
+	icon_state = "1-9"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "acE" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/table/reinforced/auto,
+/obj/item/device/radio{
+	pixel_x = -3;
+	pixel_y = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/NEmaint)
+/obj/item/device/radio{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
 "acF" = (
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable,
-/obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
 /turf/simulated/floor/plating/airless,
 /area/station/solar/east)
 "acG" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
+/obj/cable,
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/solar/west)
 "acH" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/solar/west)
 "acI" = (
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/solar/west)
 "acJ" = (
-/obj/cryotron{
-	layer = 3.9
-	},
-/obj/machinery/light/incandescent/netural{
-	dir = 1
-	},
+/obj/storage/closet/emergency,
 /turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "acK" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "5-6"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
 "acL" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/landmark/start{
 	name = "predator"
+	},
+/obj/cable{
+	icon_state = "4-5"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
 "acM" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
-"acN" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/firedoor_spawn,
-/obj/machinery/door/airlock/pyro/glass,
-/turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
 "acO" = (
+/obj/machinery/light/emergency,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/light/emergency,
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "acP" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/light,
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
-"acQ" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "acR" = (
@@ -1039,13 +887,12 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "acS" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/storage/closet/emergency,
+/obj/machinery/light/incandescent/netural{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/NEmaint)
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
 "acT" = (
 /obj/grille/steel,
 /turf/simulated/floor/plating/airless,
@@ -1058,9 +905,7 @@
 /area/station/maintenance/westsolar)
 "acW" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "4-5"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
@@ -1073,11 +918,6 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/shuttle)
 "acZ" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
@@ -1085,23 +925,16 @@
 	name = "E.V.A."
 	},
 /obj/access_spawn/eva,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage/eva)
 "ada" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/ai_monitored/storage/eva)
-"adb" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating/airless,
-/area)
 "adc" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
@@ -1110,14 +943,6 @@
 /obj/lattice,
 /turf/space,
 /area/station/com_dish/auxdish)
-"ade" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/westsolar)
 "adf" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -1128,7 +953,6 @@
 	name = "Station Intercom (Engineering)"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -1140,6 +964,9 @@
 	online = 0;
 	output = 2500;
 	tag = ""
+	},
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
@@ -1177,28 +1004,16 @@
 /obj/storage/closet/office,
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
-"adm" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/market)
 "adn" = (
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
-"ado" = (
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
 "adp" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/indestructible/shuttle_corner{
+	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
+/turf/space,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
 "adq" = (
 /obj/machinery/vending/capsule,
 /turf/simulated/floor,
@@ -1266,13 +1081,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "adx" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/turf/simulated/shuttle/wall/corner{
+	dir = 1
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/NEmaint)
+/area/shuttle/arrival/station)
 "ady" = (
 /obj/lattice,
 /obj/machinery/camera{
@@ -1282,60 +1094,40 @@
 /area)
 "adz" = (
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable,
-/obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
 /turf/simulated/floor/plating/scorched,
 /area/station/solar/east)
 "adA" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4;
 	icon_state = "airlock_closed"
 	},
 /obj/access_spawn/engineering,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
 "adB" = (
+/obj/cable,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "0-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
 "adC" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
@@ -1347,14 +1139,10 @@
 /area/station/hallway/secondary/exit)
 "adE" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "6-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "2-5"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
@@ -1368,19 +1156,15 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "adH" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater-R"
 	},
-/turf/simulated/floor,
-/area/station/crew_quarters/market)
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
 "adI" = (
 /obj/firedoor_spawn,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
 	icon_state = "maint_closed"
@@ -1434,46 +1218,41 @@
 	pixel_x = 24;
 	pixel_y = 0
 	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/item/crowbar,
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
 /area/station/ai_monitored/storage/eva)
 "adO" = (
-/obj/cable{
-	icon_state = "0-2";
-	tag = "icon-0-2"
-	},
 /obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "adP" = (
-/obj/cable{
-	icon_state = "0-2";
-	tag = "icon-0-2"
-	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/camera{
 	c_tag = "Aux Comm Control";
 	dir = 2
 	},
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "adQ" = (
 /obj/machinery/recharge_station,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "adR" = (
 /obj/wingrille_spawn/auto,
-/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
 "adS" = (
-/obj/cable,
 /obj/machinery/power/solar_control{
 	id = "westsolar";
 	name = "West Solar Control";
@@ -1483,6 +1262,7 @@
 	c_tag = "West Solar Substation";
 	dir = 1
 	},
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
 "adT" = (
@@ -1512,66 +1292,43 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "adX" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/market)
+/area/shuttle/arrival/station)
 "adY" = (
 /turf/simulated/floor/orangeblack/corner{
 	dir = 2
 	},
 /area/station/hallway/primary/north)
 "adZ" = (
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 4;
+	icon_state = "0-2"
+	},
+/obj/cable{
 	icon_state = "0-4"
 	},
-/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage/eva)
 "aea" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/item/sheet/glass{
+	amount = 50
+	},
+/obj/item/sheet/glass{
+	amount = 50
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/item/sheet/glass{
-	amount = 50
-	},
-/obj/item/sheet/glass{
-	amount = 50
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
 /area/station/ai_monitored/storage/eva)
 "aeb" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/ai_monitored/storage/eva)
+/turf/simulated/wall/auto/supernorn,
+/area/station/hallway/secondary/exit)
 "aec" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/item/caution{
 	desc = "Caution! Construction Zone!";
 	name = "caution sign"
@@ -1589,23 +1346,16 @@
 	},
 /area/station/ai_monitored/storage/eva)
 "aed" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/NEmaint)
+/obj/decal/poster/wallsign/escape,
+/turf/simulated/wall/auto/supernorn,
+/area/station/hallway/secondary/exit)
 "aee" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/external,
+/turf/simulated/floor/escape{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/NEmaint)
+/area/station/hallway/secondary/exit)
 "aef" = (
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/command{
@@ -1618,70 +1368,56 @@
 /area/station/ai_monitored/storage/eva)
 "aeg" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "aeh" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "aei" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/light/small{
 	brightness = 2;
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "aej" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "4"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/NEmaint)
+/area/shuttle/arrival/station)
 "aek" = (
-/obj/cable,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "W APC";
 	pixel_x = -24;
 	pixel_y = 0
 	},
+/obj/cable{
+	icon_state = "1-6"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
 "ael" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "W APC";
@@ -1697,24 +1433,11 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "aem" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "8"
 	},
-/turf/simulated/floor,
-/area/station/crew_quarters/market)
+/area/shuttle/arrival/station)
 "aen" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
@@ -1727,16 +1450,6 @@
 	},
 /area/station/hallway/primary/north)
 "aep" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/item/weldingtool,
 /obj/item/device/light/flashlight,
 /obj/item/device/light/flashlight,
@@ -1779,27 +1492,25 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "aeu" = (
-/obj/cable,
 /obj/machinery/power/data_terminal,
 /obj/computer3frame{
 	anchored = 1;
 	state = 1
 	},
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "aev" = (
 /obj/item/luggable_computer,
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/maintenance/NEmaint)
+/area/station/maintenance/eastsolar)
 "aew" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/maintenance/NEmaint)
+/area/station/maintenance/eastsolar)
 "aex" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/airless,
@@ -1807,8 +1518,6 @@
 "aey" = (
 /obj/lattice,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/space,
@@ -1827,33 +1536,16 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "aeC" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/bot/guardbot/bootleg,
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/market)
 "aeD" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
+/obj/storage/closet/wardrobe/mixed,
+/obj/random_item_spawner/dressup/one_or_zero,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
 "aeE" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=arrivals";
 	location = "market"
@@ -1862,22 +1554,16 @@
 /area/station/hallway/primary/north)
 "aeF" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "aeG" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/landmark{
+	name = "Observer-Start"
 	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 4
-	},
-/area/station/hallway/primary/north)
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
 "aeH" = (
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/engineering{
@@ -1886,27 +1572,18 @@
 	name = "Solar Substation"
 	},
 /obj/access_spawn/engineering,
-/turf/simulated/floor/plating,
-/area/station/maintenance/NEmaint)
-"aeI" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/eastsolar)
+"aeI" = (
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
 /area/station/ai_monitored/storage/eva)
 "aeJ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/orangeblack/side{
@@ -1919,21 +1596,14 @@
 	name = "Custodial Closet"
 	},
 /obj/access_spawn/janitor,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/janitor)
 "aeL" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/NEmaint)
+/turf/simulated/shuttle/wall/cockpit,
+/area/shuttle/arrival/station)
 "aeM" = (
 /obj/machinery/power/smes{
 	chargelevel = 5000;
@@ -1942,115 +1612,98 @@
 	output = 2500;
 	tag = ""
 	},
-/turf/simulated/floor,
-/area/station/maintenance/NEmaint)
-"aeN" = (
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-2"
 	},
+/turf/simulated/floor,
+/area/station/maintenance/eastsolar)
+"aeN" = (
 /obj/machinery/power/terminal{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/NEmaint)
-"aeO" = (
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/eastsolar)
+"aeO" = (
 /obj/machinery/power/solar_control{
 	id = "eastsolar";
 	name = "East Solar Control";
 	track = 2
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/NEmaint)
-"aeP" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/eastsolar)
+"aeP" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
 	icon_state = "4-8"
 	},
-/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/maintenance/NEmaint)
+/area/station/maintenance/eastsolar)
 "aeQ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/solar/east)
 "aeR" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "0-4"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "0-2"
 	},
+/obj/cable,
 /turf/simulated/floor/plating/scorched,
 /area/station/solar/east)
 "aeS" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/scorched,
 /area/station/solar/east)
 "aeT" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "0-4"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "0-2"
 	},
+/obj/cable,
 /turf/simulated/floor/plating/airless,
 /area/station/solar/east)
 "aeU" = (
 /obj/lattice,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/space,
 /area)
 "aeV" = (
 /obj/machinery/power/tracker,
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating/airless,
 /area)
 "aeW" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable,
@@ -2064,14 +1717,6 @@
 /obj/machinery/mass_driver{
 	dir = 4;
 	id = "chapelgun"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
 	},
 /obj/machinery/door/window/westleft{
 	name = "Chapel Mass Driver"
@@ -2098,46 +1743,31 @@
 	},
 /area/station/ai_monitored/storage/eva)
 "afb" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light/emergency{
+	dir = 1;
+	icon_state = "ebulb1"
 	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/table/auto,
+/obj/machinery/shieldgenerator/meteorshield,
+/turf/simulated/floor/escape{
+	dir = 5
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/NEmaint)
+/area/station/hallway/secondary/exit)
 "afc" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/NEmaint)
-"afd" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/NEmaint)
+/area/station/hangar/main)
+"afd" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater-L"
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
 "afe" = (
 /obj/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
@@ -2145,18 +1775,16 @@
 	name = "Station Intercom (Engineering)"
 	},
 /turf/simulated/floor,
-/area/station/maintenance/NEmaint)
+/area/station/maintenance/eastsolar)
 "aff" = (
 /obj/disposalpipe/segment{
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/grime,
-/area/station/maintenance/NEmaint)
+/area/station/maintenance/eastsolar)
 "afg" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -2169,7 +1797,7 @@
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/maintenance/NEmaint)
+/area/station/maintenance/eastsolar)
 "afi" = (
 /obj/disposalpipe/trunk{
 	dir = 8
@@ -2192,51 +1820,35 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "afk" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/market)
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/hangar/main)
 "afl" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/market)
 "afm" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/storage/closet/welding_supply,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	layer = 9.1;
+	pixel_x = -10
 	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/turf/simulated/floor/orangeblack/side{
+	dir = 9
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
+/area/station/hangar/main)
 "afn" = (
+/obj/reagent_dispensers/fueltank,
+/obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "0-2"
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/turf/simulated/floor/orangeblack/side{
+	dir = 1
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
+/area/station/hangar/main)
 "afo" = (
 /obj/landmark{
 	name = "monkeyspawn_albert"
@@ -2340,7 +1952,12 @@
 	name = "S APC";
 	pixel_y = -24
 	},
-/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "afx" = (
@@ -2350,40 +1967,46 @@
 	req_access = null
 	},
 /obj/access_spawn/cargo,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "afy" = (
 /obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/NEmaint)
+/area/station/maintenance/eastsolar)
 "afz" = (
 /obj/machinery/camera{
 	c_tag = "East Solar Substation";
 	dir = 1
 	},
+/obj/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/NEmaint)
+/area/station/maintenance/eastsolar)
 "afA" = (
 /obj/machinery/light/small{
 	brightness = 2;
 	dir = 4
 	},
 /turf/simulated/floor/grime,
-/area/station/maintenance/NEmaint)
+/area/station/maintenance/eastsolar)
 "afB" = (
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable,
-/obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
 /turf/simulated/floor/airless/plating/damaged1,
 /area/station/solar/east)
 "afC" = (
@@ -2396,11 +2019,6 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/quartermaster/office)
 "afD" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
@@ -2437,12 +2055,12 @@
 "afK" = (
 /obj/disposalpipe/segment,
 /turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/disposal)
+/area/station/maintenance/eastsolar)
 "afL" = (
 /obj/machinery/door/airlock/pyro/external,
 /obj/access_spawn/engineering,
 /turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
+/area/station/maintenance/eastsolar)
 "afM" = (
 /obj/machinery/door_control{
 	id = "qm_dock";
@@ -2561,26 +2179,11 @@
 /area/station/janitor)
 "agc" = (
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
-"agd" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable,
-/obj/firedoor_spawn,
-/obj/machinery/door/airlock/pyro/glass,
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
 "age" = (
 /obj/item/device/radio/intercom,
 /obj/machinery/light/small{
@@ -2617,15 +2220,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
-"agj" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/quartermaster/office)
 "agk" = (
 /obj/machinery/mass_driver{
 	dir = 8;
@@ -2702,7 +2296,6 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "agr" = (
-/obj/cable,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "W APC";
@@ -2744,13 +2337,12 @@
 /obj/landmark/start{
 	name = "Janitor"
 	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor,
 /area/station/janitor)
 "agy" = (
-/obj/cable{
-	icon_state = "0-2";
-	tag = "icon-0-2"
-	},
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "E APC";
@@ -2761,14 +2353,12 @@
 /obj/item/spraybottle/cleaner,
 /obj/item/spraybottle/cleaner,
 /obj/table/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor,
 /area/station/janitor)
 "agz" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/camera{
 	c_tag = "FS Maintenance - Center";
 	dir = 4
@@ -2780,14 +2370,13 @@
 /turf/simulated/floor,
 /area/station/maintenance/disposal)
 "agB" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "N APC";
 	pixel_y = 24
+	},
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/grime,
 /area/station/maintenance/disposal)
@@ -2871,47 +2460,30 @@
 "agN" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/market)
-"agO" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/north)
 "agP" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "agQ" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/firedoor_spawn,
 /obj/machinery/door/window/westleft{
 	name = "Cargo Office"
 	},
 /obj/access_spawn/cargo,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/orangeblack,
 /area/station/quartermaster/office)
 "agR" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/north)
@@ -2927,16 +2499,6 @@
 /turf/simulated/floor,
 /area/station/janitor)
 "agV" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/light_switch{
 	name = "E light switch";
 	pixel_x = 24;
@@ -2949,45 +2511,44 @@
 /turf/simulated/floor,
 /area/station/janitor)
 "agW" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/manufacturer/hangar,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/janitor)
+/turf/simulated/floor/orangeblack/side{
+	dir = 1
+	},
+/area/station/hangar/main)
 "agX" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/table/reinforced/auto,
+/obj/item/storage/toolbox/electrical{
+	pixel_y = -3
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 7
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/NEmaint)
+/obj/random_item_spawner/tools,
+/obj/random_item_spawner/tools,
+/turf/simulated/floor/orangeblack/side{
+	dir = 1
+	},
+/area/station/hangar/main)
 "agY" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	layer = 9.1;
+	pixel_x = 10
 	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
+/turf/simulated/floor/orangeblack/side{
+	dir = 5
+	},
+/area/station/hangar/main)
 "agZ" = (
 /turf/simulated/floor/grime,
-/area/station/maintenance/disposal)
-"aha" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "ahb" = (
 /obj/wingrille_spawn/auto,
@@ -3039,36 +2600,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
-"ahh" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/quartermaster/office)
 "ahi" = (
 /obj/machinery/conveyor_switch{
 	id = "qmin"
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
 /area/station/quartermaster/office)
 "ahj" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater-M"
 	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 8
-	},
-/area/station/quartermaster)
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
 "ahk" = (
 /obj/machinery/manufacturer/medical,
 /turf/simulated/floor/orangeblack,
@@ -3088,27 +2638,12 @@
 /turf/simulated/floor/orangeblack,
 /area/station/quartermaster/office)
 "ahn" = (
-/turf/space,
+/obj/storage/closet/wardrobe/mixed,
+/obj/random_item_spawner/dressup/one_or_zero,
+/obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
-"aho" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/storage/autolathe)
 "ahp" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/storage/closet,
 /obj/machinery/light{
 	dir = 1;
@@ -3124,31 +2659,18 @@
 	name = "N APC";
 	pixel_y = 24
 	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/storage/closet,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor,
 /area/station/storage/autolathe)
 "ahr" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "2"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/storage/autolathe)
+/area/shuttle/arrival/station)
 "ahs" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/item/storage/box/mousetraps,
 /obj/item/storage/box/mousetraps,
 /obj/item/storage/box/mousetraps,
@@ -3157,37 +2679,24 @@
 /area/station/janitor)
 "aht" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/janitor)
 "ahu" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/reagent_dispensers/watertank,
 /obj/machinery/light,
 /turf/simulated/floor,
 /area/station/janitor)
 "ahv" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/janitor)
+/obj/storage/closet/emergency,
+/obj/machinery/light/incandescent/netural,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
 "ahw" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
+/obj/indestructible/shuttle_corner,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
 "ahx" = (
 /obj/machinery/camera{
 	c_tag = "Waste Disposal";
@@ -3271,14 +2780,7 @@
 /area/station/hallway/primary/north)
 "ahI" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/stairs{
 	dir = 8
@@ -3291,6 +2793,9 @@
 /obj/machinery/camera{
 	c_tag = "Autolathe";
 	dir = 8
+	},
+/obj/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor,
 /area/station/storage/autolathe)
@@ -3307,43 +2812,39 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "ahN" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/turf/simulated/shuttle/wall/corner{
+	dir = 4
 	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
+/area/shuttle/arrival/station)
 "ahO" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	layer = 9.1;
+	pixel_x = -10
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
+/turf/simulated/floor/escape{
+	dir = 9
+	},
+/area/station/hallway/secondary/exit)
 "ahP" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "ahQ" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/camera{
+	c_tag = "Escape Shuttle Dock"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
+/obj/machinery/light/emergency{
+	dir = 1;
+	icon_state = "ebulb1"
+	},
+/turf/simulated/floor/escape{
+	dir = 1
+	},
+/area/station/hallway/secondary/exit)
 "ahR" = (
 /obj/machinery/light_switch{
 	name = "E light switch";
@@ -3377,11 +2878,6 @@
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "ahV" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4;
 	name = "Supply Dock Airlock"
@@ -3393,7 +2889,6 @@
 /turf/simulated/floor/caution/west,
 /area/station/quartermaster/office)
 "ahX" = (
-/obj/cable,
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/storage/autolathe)
@@ -3406,6 +2901,9 @@
 	pixel_y = 24;
 	text = "NF"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "aia" = (
@@ -3415,6 +2913,9 @@
 	icon_state = "maint_closed"
 	},
 /obj/access_spawn/maint,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "aib" = (
@@ -3540,29 +3041,13 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "aiv" = (
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
+	icon_state = "0-4"
 	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/quartermaster/office)
-"aiw" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "aix" = (
@@ -3608,54 +3093,34 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "aiD" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "garbage";
-	operating = 1
+/obj/machinery/light{
+	dir = 1;
+	name = "light fixture";
+	pixel_y = 21;
+	rigged = 0
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/turf/simulated/floor/escape{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
+/area/station/hallway/secondary/exit)
 "aiE" = (
-/obj/cable,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/cable,
 /turf/simulated/floor/airless/plating/damaged3,
 /area/station/solar/east)
 "aiF" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/table/reinforced,
 /obj/machinery/cashreg,
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/orangeblack,
-/area/station/quartermaster/office)
-"aiG" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
-/obj/cable,
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "aiH" = (
 /obj/firedoor_spawn,
@@ -3670,6 +3135,9 @@
 /obj/landmark/start{
 	name = "Quartermaster"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
@@ -3682,15 +3150,17 @@
 	dir = 4
 	},
 /obj/machinery/light/emergency,
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "aiL" = (
+/obj/wingrille_spawn/auto,
 /obj/cable,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/quartermaster)
 "aiM" = (
@@ -3723,13 +3193,13 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/chapel/main)
 "aiS" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/camera{
+	c_tag = "Escape Shuttle Dock"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/chapel/main)
+/turf/simulated/floor/escape{
+	dir = 1
+	},
+/area/station/hallway/secondary/exit)
 "aiT" = (
 /obj/overlay{
 	anchored = 1;
@@ -3793,16 +3263,10 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "aja" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/turf/simulated/floor/escape{
+	dir = 5
 	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
+/area/station/hallway/secondary/exit)
 "ajb" = (
 /obj/machinery/light{
 	dir = 4;
@@ -3832,6 +3296,9 @@
 	mail_tag = null;
 	tag = "icon-pipe-sj1 (EAST)"
 	},
+/obj/cable{
+	icon_state = "4-10"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "aje" = (
@@ -3839,6 +3306,9 @@
 	dir = 4;
 	icon_state = "pipe-s";
 	tag = "icon-pipe-s (EAST)"
+	},
+/obj/cable{
+	icon_state = "5-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
@@ -3875,11 +3345,6 @@
 	},
 /area/station/chapel/main)
 "ajj" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/camera{
 	c_tag = "Chapel Launcher";
 	dir = 2
@@ -3926,34 +3391,10 @@
 	dir = 4
 	},
 /area/station/quartermaster/office)
-"ajo" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/orangeblack/side{
-	dir = 8
-	},
-/area/station/quartermaster)
 "ajp" = (
 /turf/simulated/floor/orangeblack/side{
 	dir = 9
 	},
-/area/station/quartermaster)
-"ajq" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
 /area/station/quartermaster)
 "ajr" = (
 /turf/simulated/wall/auto/supernorn,
@@ -3990,15 +3431,17 @@
 	},
 /area/station/chapel/main)
 "ajx" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	name = "Pod Bay"
 	},
-/turf/simulated/floor/specialroom/chapel{
-	dir = 4
+/obj/machinery/secscanner{
+	dir = 4;
+	icon_state = "scanner_on";
+	pixel_x = -20
 	},
-/area/station/chapel/main)
+/turf/simulated/floor,
+/area/station/hangar/main)
 "ajy" = (
 /obj/window/reinforced{
 	dir = 2;
@@ -4059,19 +3502,11 @@
 	},
 /area/station/quartermaster)
 "ajD" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/turf/simulated/floor/orangeblack/side{
+	dir = 9
 	},
-/turf/simulated/floor,
-/area/station/quartermaster)
+/area/station/hangar/main)
 "ajE" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=market";
 	location = "cargo"
@@ -4087,6 +3522,9 @@
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/access_spawn/maint,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "ajH" = (
@@ -4143,24 +3581,11 @@
 	},
 /area/station/chapel/main)
 "ajP" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/turf/simulated/floor/orangeblack/side{
+	dir = 1
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/specialroom/chapel,
-/area/station/chapel/main)
+/area/station/hangar/main)
 "ajQ" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/window/eastleft{
 	name = "Chapel Office"
 	},
@@ -4171,10 +3596,6 @@
 /obj/machinery/mass_driver{
 	dir = 4;
 	id = "chapelgun"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/chapel/main)
@@ -4192,16 +3613,14 @@
 	},
 /area/station/quartermaster/office)
 "ajU" = (
-/obj/cable,
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "ajV" = (
@@ -4215,22 +3634,6 @@
 	dir = 8
 	},
 /area/station/quartermaster/office)
-"ajW" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/orangeblack/side{
-	dir = 8
-	},
-/area/station/quartermaster)
 "ajX" = (
 /obj/disposalpipe/segment,
 /obj/machinery/light{
@@ -4242,29 +3645,16 @@
 	},
 /area/station/quartermaster)
 "ajY" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/firedoor_spawn,
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
 /area/station/quartermaster)
 "ajZ" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/turf/simulated/floor/orangeblack/corner{
+	dir = 1
 	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
+/area/station/hangar/main)
 "aka" = (
 /obj/storage/closet/coffin,
 /obj/machinery/camera{
@@ -4300,6 +3690,9 @@
 	pixel_y = 24;
 	text = "NF"
 	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
 	},
@@ -4329,33 +3722,23 @@
 /area/station/com_dish/auxdish)
 "akj" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/com_dish/auxdish)
 "akk" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/communications_dish{
 	name = "Auxiliary Communications dish"
 	},
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating/airless,
 /area/station/com_dish/auxdish)
 "akl" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/specialroom/chapel{
-	dir = 5
-	},
-/area/station/chapel/main)
+/turf/simulated/floor,
+/area/station/hangar/main)
 "akm" = (
 /obj/window/reinforced{
 	dir = 1;
@@ -4386,12 +3769,10 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "akp" = (
-/obj/cable,
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "akq" = (
@@ -4404,15 +3785,13 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "akr" = (
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "aks" = (
@@ -4422,20 +3801,15 @@
 /turf/simulated/floor,
 /area/station/quartermaster)
 "akt" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "S APC";
 	pixel_y = -24
 	},
 /obj/machinery/light,
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/orangeblack/side,
 /area/station/quartermaster)
 "aku" = (
@@ -4443,6 +3817,9 @@
 	name = "Chapel Office"
 	},
 /obj/access_spawn/chapel_office,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/black,
 /area/station/chapel/office)
 "akv" = (
@@ -4463,6 +3840,9 @@
 	icon_state = "maint_closed"
 	},
 /obj/access_spawn/maint,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "aky" = (
@@ -4535,11 +3915,6 @@
 	},
 /area/station/chapel/main)
 "akF" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/table/wood/auto,
 /obj/candle_light,
 /turf/simulated/floor/specialroom/chapel{
@@ -4554,29 +3929,25 @@
 	},
 /area/station/chapel/main)
 "akH" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
-/obj/cable,
 /obj/wingrille_spawn/auto,
+/obj/cable,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "akI" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-4"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
@@ -4584,55 +3955,33 @@
 /area/station/quartermaster/office)
 "akJ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "akK" = (
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable,
-/obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/wingrille_spawn/auto,
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "akL" = (
-/obj/cable,
 /obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /turf/simulated/floor/plating,
 /area/station/quartermaster)
 "akM" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment,
+/obj/submachine/cargopad/podbay,
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
-/area/station/quartermaster)
+/area/station/hangar/main)
 "akN" = (
 /obj/machinery/firealarm{
 	dir = 1;
 	layer = 3.5;
 	pixel_y = -24
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo Bay Lobby";
@@ -4646,10 +3995,6 @@
 	icon_state = "grey_target_prism";
 	tag = "icon-grey_target_prism (SOUTHEAST)"
 	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/light{
 	dir = 1;
 	icon_state = "tube1";
@@ -4659,16 +4004,6 @@
 /turf/simulated/floor/bot,
 /area/station/turret_protected/ai_upload_foyer)
 "akP" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /turf/simulated/floor/orangeblack/side,
 /area/station/quartermaster)
 "akQ" = (
@@ -4811,11 +4146,6 @@
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/main)
 "akZ" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/table/wood/auto,
 /obj/loudspeaker,
 /turf/simulated/floor/specialroom/chapel{
@@ -4841,11 +4171,6 @@
 /area/station/chapel/main)
 "alc" = (
 /obj/firedoor_spawn,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	req_access = null
 	},
@@ -4857,6 +4182,9 @@
 /area/station/quartermaster)
 "ale" = (
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "5-6"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "alf" = (
@@ -4864,14 +4192,13 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/quartermaster)
 "alg" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "N APC";
 	pixel_y = 24
+	},
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/office)
@@ -4952,11 +4279,6 @@
 	},
 /area/station/chapel/main)
 "alm" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/access_spawn/maint,
 /turf/simulated/floor/plating,
@@ -5001,16 +4323,15 @@
 	dir = 4;
 	icon_state = "pew"
 	},
+/obj/cable{
+	icon_state = "9-10";
+	tag = "icon-9-10"
+	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
 	},
 /area/station/chapel/main)
 "alp" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/table/wood/auto,
 /obj/item/storage/bible,
 /turf/simulated/floor/specialroom/chapel,
@@ -5041,13 +4362,9 @@
 /turf/simulated/floor/plating/damaged1,
 /area/station/maintenance/NWmaint)
 "alx" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/NWmaint)
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/shuttle,
+/area/shuttle/arrival/station)
 "aly" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -5076,17 +4393,13 @@
 /area/station/chapel/office)
 "alC" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/office)
 "alD" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/office)
@@ -5096,12 +4409,13 @@
 	name = "Crematorium"
 	},
 /obj/access_spawn/chapel_office,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/black,
 /area/station/medical/morgue)
 "alF" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/chapel{
@@ -5110,30 +4424,20 @@
 /area/station/chapel/main)
 "alG" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
 	},
 /area/station/chapel/main)
 "alH" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/indestructible/shuttle_corner{
+	dir = 8
 	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor/specialroom/chapel{
-	dir = 9
+/turf/simulated/shuttle/wall/corner{
+	dir = 4
 	},
-/area/station/chapel/main)
+/area/shuttle/arrival/station)
 "alI" = (
 /obj/cable{
 	d1 = 1;
@@ -5240,6 +4544,10 @@
 	icon_state = "2-5";
 	tag = "icon-2-5"
 	},
+/obj/cable{
+	icon_state = "5-6";
+	tag = "icon-5-6"
+	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 1
 	},
@@ -5255,10 +4563,12 @@
 /area/station/storage/warehouse)
 "alP" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "0-8"
 	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
 /turf/simulated/floor/specialroom/chapel{
 	dir = 5
 	},
@@ -5294,14 +4604,9 @@
 	frequency = 1441;
 	name = "Station Intercom (Engineering)"
 	},
-/obj/item/device/net_sniffer,
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "alU" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/firealarm{
 	pixel_y = 24;
@@ -5310,6 +4615,10 @@
 /obj/machinery/light/small{
 	dir = 4;
 	icon_state = "bulb1"
+	},
+/obj/item/device/net_sniffer,
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
@@ -5365,11 +4674,6 @@
 /area/station/chapel/office)
 "amb" = (
 /obj/firedoor_spawn,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
 	name = "Crematorium"
@@ -5379,16 +4683,12 @@
 /area/station/medical/morgue)
 "amc" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/main)
 "amd" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/chapel{
@@ -5396,15 +4696,16 @@
 	},
 /area/station/chapel/main)
 "ame" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=crewhall";
+	location = "escape"
+	},
+/obj/stool/bench/red/auto,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/specialroom/chapel{
-	dir = 8
-	},
-/area/station/chapel/main)
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "amf" = (
 /obj/cable{
 	d1 = 1;
@@ -5481,8 +4782,6 @@
 /area/station/chapel/main)
 "amj" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/chapel{
@@ -5501,8 +4800,6 @@
 	pixel_y = 21
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/chapel{
@@ -5510,11 +4807,19 @@
 	},
 /area/station/chapel/main)
 "aml" = (
-/obj/cable,
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "S APC";
 	pixel_y = -24
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "8-9"
+	},
+/obj/cable{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 6
@@ -5527,6 +4832,9 @@
 	},
 /obj/landmark{
 	name = "peststart"
+	},
+/obj/cable{
+	icon_state = "6-8"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 8
@@ -5565,22 +4873,25 @@
 /area/station/storage/tech)
 "amq" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "0-8"
 	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "amr" = (
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	icon_state = "0-2";
-	tag = "icon-0-2"
-	},
-/obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "ams" = (
@@ -5591,28 +4902,19 @@
 /obj/machinery/vending/floppy,
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
-"amu" = (
-/obj/firedoor_spawn,
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
 "amv" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/NWmaint)
+/turf/simulated/floor/orangeblack/side{
+	dir = 8
+	},
+/area/station/hangar/main)
 "amw" = (
 /obj/disposalpipe/segment,
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/NWmaint)
 "amx" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -5626,6 +4928,9 @@
 "amA" = (
 /obj/disposalpipe/segment{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
@@ -5725,6 +5030,9 @@
 	name = "Confession Booth (Chaplain)";
 	req_access_txt = "22"
 	},
+/obj/cable{
+	icon_state = "2-9"
+	},
 /turf/simulated/floor/black,
 /area/station/chapel/main)
 "amK" = (
@@ -5737,42 +5045,22 @@
 /turf/space,
 /area)
 "amM" = (
-/obj/cable{
-	icon_state = "0-2";
-	tag = "icon-0-2"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "amN" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/table/auto,
 /obj/item/storage/box/diskbox,
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "amO" = (
+/obj/machinery/power/data_terminal,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/plating,
-/area/station/storage/tech)
-"amP" = (
-/obj/cable,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "amQ" = (
@@ -5791,15 +5079,6 @@
 "amT" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/central)
-"amU" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
 "amV" = (
 /obj/submachine/slot_machine,
 /turf/simulated/floor/plating/damaged3,
@@ -5815,6 +5094,9 @@
 	req_access = null
 	},
 /obj/access_spawn/cargo,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "amY" = (
@@ -5834,15 +5116,15 @@
 	},
 /area/station/chapel/main)
 "amZ" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/door_control{
+	id = "hangar_arrivals";
+	name = "Pod Door Control";
+	pixel_x = 24
 	},
-/turf/simulated/floor/specialroom/chapel{
-	dir = 6
+/turf/simulated/floor/orangeblack/side{
+	dir = 4
 	},
-/area/station/chapel/main)
+/area/station/hangar/main)
 "ana" = (
 /turf/simulated/floor{
 	icon_state = "carpetW"
@@ -5893,6 +5175,9 @@
 /turf/simulated/floor/black,
 /area/station/chapel/main)
 "anh" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/black,
 /area/station/chapel/main)
 "ani" = (
@@ -5925,30 +5210,38 @@
 /turf/simulated/floor/purple,
 /area/station/turret_protected/ai_upload_foyer)
 "anm" = (
+/obj/wingrille_spawn/auto,
 /obj/cable,
 /obj/cable{
-	icon_state = "0-2";
-	tag = "icon-0-2"
+	icon_state = "0-2"
 	},
-/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "ann" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable,
 /obj/wingrille_spawn/auto,
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "ano" = (
 /obj/table/auto,
 /obj/item/aiModule/reset,
 /obj/item/clothing/glasses/meson,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "anp" = (
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
 /obj/landmark/start{
 	name = "Technical Assistant"
 	},
@@ -5966,49 +5259,30 @@
 /area/station/turret_protected/ai_upload_foyer)
 "anr" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "4-10"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "ans" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
 	icon_state = "maint_closed"
 	},
 /obj/access_spawn/maint,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "ant" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/landmark/start{
 	name = "Technical Assistant"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "anu" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/table/wood/auto,
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/camera{
 	c_tag = "FP Maintenance - Storage";
 	dir = 8
@@ -6018,50 +5292,42 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "anv" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	layer = 9.1;
+	pixel_x = 10
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/NWmaint)
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "anw" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/computer/mining_shuttle{
+	dir = 4
 	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/NWmaint)
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "anx" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light/emergency{
+	dir = 8;
+	icon_state = "ebulb1";
+	pixel_x = -16
 	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/decal/tile_edge/stripe/big{
+	dir = 1;
+	icon_state = "xtra_bigstripe-edge"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/NWmaint)
+/turf/simulated/floor/engine,
+/area/station/hangar/main)
 "any" = (
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "anz" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/decal/tile_edge/stripe/big{
+	dir = 1;
+	icon_state = "xtra_bigstripe-edge"
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
+/turf/simulated/floor/engine,
+/area/station/hangar/main)
 "anA" = (
 /obj/stool/chair,
 /turf/simulated/floor,
@@ -6086,9 +5352,6 @@
 	icon_state = "tube1";
 	tag = "icon-tube1 (NORTH)"
 	},
-/turf/simulated/floor/black,
-/area/station/medical/morgue)
-"anD" = (
 /turf/simulated/floor/black,
 /area/station/medical/morgue)
 "anE" = (
@@ -6120,17 +5383,17 @@
 /turf/simulated/floor/carpet,
 /area/station/chapel/main)
 "anH" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/light/emergency{
+	dir = 4;
+	icon_state = "ebulb1";
+	pixel_x = 16
 	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/decal/tile_edge/stripe/big{
+	dir = 1;
+	icon_state = "xtra_bigstripe-edge"
 	},
-/obj/wingrille_spawn/auto/crystal,
-/turf/simulated/floor/plating,
-/area/station/security/brig)
+/turf/simulated/floor/engine,
+/area/station/hangar/main)
 "anI" = (
 /obj/stool,
 /obj/disposalpipe/segment,
@@ -6158,16 +5421,22 @@
 /obj/stool/chair{
 	dir = 8
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/black,
 /area/station/chapel/main)
 "anM" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	layer = 9.1;
+	pixel_x = -10
 	},
-/turf/simulated/floor/circuit,
-/area/station/turret_protected/ai_upload_foyer)
+/turf/simulated/floor/arrival{
+	dir = 10
+	},
+/area/station/hallway/secondary/entry)
 "anN" = (
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload_foyer)
@@ -6179,11 +5448,6 @@
 /turf/simulated/floor,
 /area/station/storage/autolathe)
 "anQ" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/table/auto,
 /obj/item/device/flash,
 /obj/item/screwdriver,
@@ -6191,46 +5455,30 @@
 /area/station/storage/tech)
 "anR" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "anS" = (
 /obj/firedoor_spawn,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
 	icon_state = "maint_closed";
 	name = "Tech Storage"
 	},
 /obj/access_spawn/tech_storage,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "anT" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/light/small{
 	brightness = 2;
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "2-9"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
@@ -6248,7 +5496,6 @@
 /area/station/maintenance/NWmaint)
 "anW" = (
 /obj/machinery/power/data_terminal,
-/obj/cable,
 /obj/item/device/multitool,
 /obj/item/device/radio/intercom{
 	dir = 8
@@ -6276,9 +5523,7 @@
 /area/station/medical/morgue)
 "aoa" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
 /area/station/medical/morgue)
@@ -6293,18 +5538,10 @@
 	},
 /area/station/medical/morgue)
 "aoc" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/specialroom/chapel,
-/area/station/chapel/main)
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/external,
+/turf/simulated/floor/caution/northsouth,
+/area/station/hallway/secondary/exit)
 "aod" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/teleporter)
@@ -6313,14 +5550,16 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/teleporter)
 "aof" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/wall/false_wall,
 /area/station/chapel/main)
 "aog" = (
+/obj/machinery/power/monitor,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/monitor,
 /turf/simulated/floor/plating,
 /area/station/chapel/main)
 "aoh" = (
@@ -6334,19 +5573,13 @@
 /area/station/chapel/main)
 "aoi" = (
 /obj/machinery/power/data_terminal,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/computer/supplycomp,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "aoj" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/camera{
 	c_tag = "AI Module Storage";
 	dir = 4
@@ -6354,36 +5587,21 @@
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload_foyer)
 "aok" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/circuit,
-/area/station/turret_protected/ai_upload_foyer)
+/turf/simulated/floor/engine,
+/area/station/hangar/main)
 "aol" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/purple,
-/area/station/turret_protected/ai_upload_foyer)
+/obj/machinery/vehicle/pod_smooth/light,
+/turf/simulated/floor/engine,
+/area/station/hangar/main)
 "aom" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "E APC";
 	pixel_x = 24;
 	pixel_y = 0
+	},
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload_foyer)
@@ -6399,11 +5617,6 @@
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "aoo" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1";
@@ -6441,19 +5654,11 @@
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "aor" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/arrivals_horizontal{
+	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	layer = 9.1;
-	pixel_x = -10
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
+/turf/simulated/floor/engine,
+/area/station/hangar/main)
 "aos" = (
 /obj/landmark{
 	name = "kudzustart"
@@ -6464,14 +5669,12 @@
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/access_spawn/maint,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "aou" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
@@ -6519,13 +5722,13 @@
 /turf/simulated/floor/black,
 /area/station/medical/morgue)
 "aoz" = (
-/obj/cable,
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "E APC";
 	pixel_x = 24;
 	pixel_y = 0
 	},
+/obj/cable,
 /turf/simulated/floor/black,
 /area/station/medical/morgue)
 "aoA" = (
@@ -6537,17 +5740,9 @@
 /area/station/teleporter)
 "aoB" = (
 /obj/machinery/computer/teleporter,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /turf/simulated/floor/orangeblack,
 /area/station/teleporter)
 "aoC" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/camera{
 	c_tag = "Teleporter";
 	dir = 2
@@ -6556,24 +5751,19 @@
 /turf/simulated/floor/orangeblack,
 /area/station/teleporter)
 "aoD" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/teleport/portal_ring,
 /turf/simulated/floor/orangeblack,
 /area/station/teleporter)
 "aoE" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "N APC";
 	pixel_y = 24
 	},
 /obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
@@ -6587,6 +5777,9 @@
 /turf/simulated/floor/plating,
 /area/station/chapel/main)
 "aoH" = (
+/obj/cable{
+	icon_state = "1-6"
+	},
 /turf/simulated/floor/plating/damaged1,
 /area/station/chapel/main)
 "aoI" = (
@@ -6595,8 +5788,6 @@
 	},
 /obj/item/instrument/large/organ,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/chapel{
@@ -6604,13 +5795,15 @@
 	},
 /area/station/chapel/main)
 "aoJ" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/lattice{
+	dir = 5;
+	icon_state = "lattice-dir"
 	},
-/turf/simulated/floor/plating,
-/area/station/chapel/main)
+/obj/warp_beacon{
+	name = "Hangar Beacon"
+	},
+/turf/space,
+/area)
 "aoK" = (
 /turf/simulated/floor/plating,
 /area/station/chapel/main)
@@ -6621,13 +5814,9 @@
 /turf/simulated/floor/orangeblack,
 /area/station/medical/robotics)
 "aoN" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/purple,
-/area/station/turret_protected/ai_upload_foyer)
+/obj/machinery/vehicle/miniputt/armed,
+/turf/simulated/floor/engine,
+/area/station/hangar/main)
 "aoO" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/engineering)
@@ -6637,8 +5826,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/chapel{
@@ -6652,31 +5839,28 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "4-10"
+	},
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "aoR" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/camera{
 	c_tag = "FP Maintenance - Central";
 	dir = 2
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/NWmaint)
-"aoS" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "6-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
+"aoS" = (
+/turf/simulated/floor/arrival{
+	dir = 5
+	},
+/area/station/hallway/secondary/entry)
 "aoT" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor,
@@ -6709,43 +5893,19 @@
 	dir = 4
 	},
 /area/station/teleporter)
-"aoY" = (
+"aoZ" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 1
 	},
 /area/station/teleporter)
-"aoZ" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 1
-	},
-/area/station/teleporter)
 "apa" = (
+/obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/disposalpipe/segment,
 /turf/simulated/floor/orangeblack/corner{
 	dir = 1
 	},
@@ -6763,13 +5923,8 @@
 /turf/simulated/floor/plating,
 /area/station/chapel/main)
 "ape" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/damaged1,
-/area/station/chapel/main)
+/turf/simulated/wall/auto/supernorn,
+/area/station/hallway/secondary/entry)
 "apf" = (
 /obj/item/device/radio/intercom{
 	dir = 4
@@ -6796,13 +5951,11 @@
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload_foyer)
 "aph" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/door/window{
 	dir = 1
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purple,
 /area/station/turret_protected/ai_upload_foyer)
@@ -6845,14 +5998,14 @@
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "apo" = (
 /obj/machinery/camera{
 	c_tag = "Engineering North";
 	dir = 2
 	},
 /turf/simulated/floor,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "app" = (
 /turf/simulated/floor,
 /area/station/engine/engineering)
@@ -6863,19 +6016,17 @@
 	name = "Station Intercom (Engineering)"
 	},
 /turf/simulated/floor,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "apr" = (
 /obj/table/auto,
 /obj/random_item_spawner/tools,
 /obj/item/sheet/steel/reinforced/fullstack,
 /turf/simulated/floor,
-/area/station/engine/engineering)
-"aps" = (
-/obj/table/auto,
-/obj/random_item_spawner/tools,
-/turf/simulated/floor,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "apt" = (
+/obj/cable{
+	icon_state = "4-9"
+	},
 /turf/simulated/floor/plating,
 /turf/simulated/floor/plating/damaged2,
 /area/station/maintenance/NWmaint)
@@ -6886,28 +6037,24 @@
 "apw" = (
 /obj/firedoor_spawn,
 /obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "apx" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/command{
 	name = "AI Module Storage"
 	},
 /obj/access_spawn/ai_upload,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/purple,
 /area/station/turret_protected/ai_upload_foyer)
 "apy" = (
 /obj/firedoor_spawn,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/door/window/southleft,
 /turf/simulated/floor/grey/side{
 	dir = 1
@@ -6923,8 +6070,6 @@
 /area/station/teleporter)
 "apA" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -6956,33 +6101,26 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/chapel/main)
 "apG" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/machinery/power/data_terminal,
 /obj/computer3frame{
 	anchored = 1;
+	dir = 4;
 	state = 1
+	},
+/obj/cable{
+	icon_state = "0-5"
 	},
 /turf/simulated/floor/plating,
 /area/station/chapel/main)
 "apH" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plating,
 /area/station/chapel/main)
 "apI" = (
 /obj/decal/cleanable/vomit,
+/obj/cable{
+	icon_state = "2-9"
+	},
 /turf/simulated/floor/plating,
 /area/station/chapel/main)
 "apJ" = (
@@ -7001,10 +6139,6 @@
 /obj/machinery/turret{
 	dir = 8
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/machinery/light{
 	dir = 1;
 	pixel_x = -1
@@ -7012,60 +6146,45 @@
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
 "apM" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/purple,
-/area/station/turret_protected/ai_upload)
+/obj/machinery/light,
+/turf/simulated/floor/engine,
+/area/station/hangar/main)
 "apN" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer/robotics{
 	perma = 1
 	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /turf/simulated/floor/purple,
 /area/station/turret_protected/ai_upload)
 "apO" = (
 /obj/machinery/power/data_terminal,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/emitter{
 	dir = 1;
 	icon_state = "Emitter";
 	tag = "icon-Emitter (NORTH)"
 	},
-/turf/simulated/floor/yellow/side{
-	dir = 2
-	},
-/area/station/engine/engineering)
-"apP" = (
-/obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 2
 	},
-/area/station/engine/engineering)
+/area/station/engine/inner)
+"apP" = (
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 2
+	},
+/area/station/engine/inner)
 "apQ" = (
 /obj/table/auto,
 /obj/random_item_spawner/tools,
 /obj/item/sheet/steel/fullstack,
 /turf/simulated/floor,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "apR" = (
 /obj/disposalpipe/segment,
 /obj/machinery/light{
@@ -7099,9 +6218,8 @@
 	},
 /area/station/hallway/secondary/entry)
 "apW" = (
-/obj/disposalpipe/segment,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/primary/central)
+/turf/simulated/wall/auto/supernorn,
+/area/station/maintenance/eastsolar)
 "apX" = (
 /obj/machinery/vending/cola/blue,
 /turf/simulated/floor/purple,
@@ -7111,14 +6229,15 @@
 /turf/simulated/floor/purple,
 /area/station/hallway/primary/central)
 "apZ" = (
+/obj/machinery/r_door_control{
+	id = "hangar_arrivals"
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/hangar/main)
+"aqa" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/turret_protected/ai_upload_foyer)
-"aqa" = (
 /turf/simulated/wall/false_wall/reinforced,
 /area/station/turret_protected/ai_upload_foyer)
 "aqb" = (
@@ -7128,8 +6247,6 @@
 /area/station/turret_protected/ai_upload_foyer)
 "aqc" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/purple/side{
@@ -7146,44 +6263,36 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/turret_protected/ai_upload_foyer)
 "aqf" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	layer = 9.1;
+	pixel_x = 10
 	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/specialroom/chapel{
-	dir = 5
-	},
-/area/station/chapel/main)
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "aqg" = (
+/obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/purple,
-/area/station/turret_protected/ai_upload)
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/escape{
+	dir = 1
+	},
+/area/station/hallway/secondary/exit)
 "aqh" = (
 /obj/machinery/turret{
 	dir = 8
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
 "aqi" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/circuit,
-/area/station/turret_protected/ai_upload)
+/obj/shrub,
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "aqj" = (
 /obj/machinery/light{
 	dir = 1;
@@ -7200,21 +6309,14 @@
 "aql" = (
 /obj/machinery/emitter,
 /turf/simulated/floor,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "aqm" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "4-10"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/NWmaint)
+/area/station/maintenance/westsolar)
 "aqn" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/firealarm{
 	pixel_y = 24;
 	text = "NF"
@@ -7223,64 +6325,44 @@
 	c_tag = "FP Maintenance - Lower Entrance";
 	dir = 2
 	},
+/obj/cable{
+	icon_state = "2-6"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "aqo" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "8-10"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/NWmaint)
+/area/station/maintenance/westsolar)
 "aqp" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/disposalpipe/segment{
+	dir = 4
 	},
-/obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/station/maintenance/NWmaint)
+/area/station/maintenance/eastsolar)
 "aqq" = (
 /obj/firedoor_spawn,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/pyro/command{
 	name = "Teleporter Access"
 	},
 /obj/access_spawn/teleporter,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/teleporter)
 "aqr" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/station/hallway/primary/central)
+/area/station/hallway/secondary/entry)
 "aqs" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
+/obj/grille,
+/turf/simulated/floor/plating/airless,
+/area/station/com_dish/auxdish)
 "aqt" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=lowcrew";
@@ -7292,6 +6374,9 @@
 /obj/machinery/camera{
 	c_tag = "Teleporter Access";
 	dir = 2
+	},
+/obj/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -7323,13 +6408,11 @@
 	},
 /area/station/turret_protected/ai_upload_foyer)
 "aqz" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/landmark{
 	name = "kudzustart"
+	},
+/obj/cable{
+	icon_state = "4-6"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 1
@@ -7343,6 +6426,9 @@
 /obj/machinery/light/emergency{
 	dir = 1;
 	icon_state = "ebulb1"
+	},
+/obj/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 1
@@ -7369,36 +6455,29 @@
 	},
 /area/station/turret_protected/ai_upload_foyer)
 "aqD" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /turf/simulated/floor/purple/corner{
 	dir = 1
 	},
 /area/station/turret_protected/ai_upload_foyer)
 "aqE" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-4"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "0-8"
 	},
-/turf/simulated/floor,
-/area/station/turret_protected/ai_upload_foyer)
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/turf/simulated/floor/plating/airless,
+/area/station/solar/east)
 "aqF" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "2-9"
 	},
-/turf/simulated/floor,
-/area/station/turret_protected/ai_upload_foyer)
+/turf/simulated/floor/plating,
+/area/station/maintenance/westsolar)
 "aqG" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -7412,13 +6491,12 @@
 /turf/simulated/floor/purple,
 /area/station/turret_protected/ai_upload)
 "aqI" = (
+/obj/grille/steel,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/circuit,
-/area/station/turret_protected/ai_upload)
+/turf/simulated/floor/plating/airless,
+/area)
 "aqJ" = (
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
@@ -7430,87 +6508,65 @@
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "aqL" = (
 /obj/window/reinforced{
 	dir = 2;
 	icon_state = "rwindow"
 	},
 /turf/simulated/floor/yellow,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "aqM" = (
 /obj/securearea{
 	desc = "A warning sign telling of the dangers of gravitational singularities.  Apparently they are dangerous.";
 	name = "Molecular Integrity Hazard"
 	},
 /turf/simulated/wall/auto/supernorn,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "aqN" = (
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/engineering)
-"aqO" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/engine/engineering)
-"aqP" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
+/turf/simulated/floor/plating,
+/area/station/engine/inner)
+"aqP" = (
 /obj/machinery/door/airlock/pyro/external{
 	name = "Singularity Core"
 	},
 /obj/access_spawn/engineering,
-/turf/simulated/floor/caution/south,
-/area/station/engine/engineering)
-"aqQ" = (
 /obj/cable{
-	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/caution/south,
+/area/station/engine/inner)
+"aqQ" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/engine/engineering)
-"aqR" = (
-/turf/simulated/floor/yellow/side{
-	dir = 8
-	},
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "aqS" = (
 /turf/simulated/floor/plating/damaged3,
 /area/station/maintenance/NWmaint)
 "aqT" = (
 /obj/item/extinguisher,
+/obj/cable{
+	icon_state = "5-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "aqU" = (
@@ -7534,68 +6590,38 @@
 /area/station/hallway/primary/central)
 "aqZ" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "9-10"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
-"ara" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
-"arb" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/westsolar)
+"ara" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/maintenance/NEmaint)
+"arb" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
-/area/station/hallway/primary/central)
+/area/station/hangar/main)
 "arc" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
-/area/station/hallway/primary/central)
+/area/station/hallway/secondary/exit)
 "ard" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/purple/side{
-	dir = 4
-	},
-/area/station/hallway/primary/central)
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "are" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
@@ -7603,12 +6629,13 @@
 	name = "AI Upload"
 	},
 /obj/access_spawn/ai_upload,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/purple,
 /area/station/turret_protected/ai_upload)
 "arf" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/purple/side{
@@ -7617,16 +6644,16 @@
 /area/station/turret_protected/ai_upload_foyer)
 "arg" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-4"
 	},
-/turf/simulated/floor,
-/area/station/turret_protected/ai_upload_foyer)
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/turf/simulated/floor/plating/airless,
+/area/station/solar/west)
 "arh" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/purple/side{
@@ -7635,43 +6662,36 @@
 /area/station/turret_protected/ai_upload_foyer)
 "ari" = (
 /obj/firedoor_spawn,
+/obj/firedoor_spawn,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/firedoor_spawn,
 /turf/simulated/floor/purple,
 /area/station/turret_protected/ai_upload_foyer)
 "arj" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	name = "Pod Bay"
+	},
+/obj/machinery/secscanner{
+	dir = 4;
+	icon_state = "scanner_on";
+	pixel_x = -20
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/hangar/main)
 "ark" = (
 /turf/simulated/floor,
 /area/station/turret_protected/ai_upload_foyer)
 "arl" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/hangar/main)
 "arm" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -7680,74 +6700,58 @@
 /turf/simulated/floor/purple,
 /area/station/turret_protected/ai_upload)
 "arn" = (
-/obj/firedoor_spawn,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "6-8"
 	},
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4;
-	icon_state = "maint_closed"
-	},
-/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "aro" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
 	icon_state = "com_closed";
 	name = "AI Upload"
 	},
 /obj/access_spawn/ai_upload,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/purple,
 /area/station/turret_protected/ai_upload)
 "arp" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/purple,
-/area/station/turret_protected/ai_upload)
-"arq" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
+/turf/simulated/floor,
+/area/station/hangar/main)
+"arq" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/purple,
-/area/station/turret_protected/ai_upload)
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/turf/simulated/floor/plating/airless,
+/area/station/solar/west)
 "arr" = (
 /obj/machinery/power/data_terminal,
-/obj/machinery/computer/aiupload,
+/obj/machinery/computer/aiupload{
+	dir = 8
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/purple,
 /area/station/turret_protected/ai_upload)
 "ars" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "art" = (
 /obj/machinery/light{
 	dir = 4;
@@ -7756,38 +6760,36 @@
 	pixel_x = 10
 	},
 /turf/simulated/floor/yellow,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "aru" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/field_generator,
-/obj/cable,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1"
 	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable,
 /turf/simulated/floor/orangeblack,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "arv" = (
 /turf/simulated/floor/orangeblack,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "arw" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/field_generator,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable,
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
 	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
 /turf/simulated/floor/orangeblack,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "arx" = (
 /obj/machinery/light{
 	dir = 8;
@@ -7796,15 +6798,7 @@
 	pixel_x = -10
 	},
 /turf/simulated/floor/yellow,
-/area/station/engine/engineering)
-"ary" = (
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "arz" = (
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance{
@@ -7812,7 +6806,7 @@
 	},
 /obj/access_spawn/engineering,
 /turf/simulated/floor/plating,
-/area/station/maintenance/NWmaint)
+/area/station/engine/inner)
 "arA" = (
 /turf/simulated/floor/purple/side{
 	dir = 4
@@ -7826,12 +6820,13 @@
 /area/station/hallway/primary/central)
 "arC" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/purple/side,
-/area/station/hallway/primary/central)
+/obj/cable{
+	icon_state = "1-5"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/westsolar)
 "arD" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/purple/side,
@@ -7853,6 +6848,9 @@
 /turf/simulated/floor/purple/corner,
 /area/station/hallway/primary/central)
 "arH" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/purple/side{
 	dir = 6
 	},
@@ -7887,34 +6885,17 @@
 /turf/simulated/floor/white,
 /area/station/chemistry)
 "arN" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/purple/corner{
 	dir = 4
 	},
 /area/station/turret_protected/ai_upload_foyer)
 "arO" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/hallway/secondary/exit)
 "arP" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/purple/corner,
 /area/station/turret_protected/ai_upload_foyer)
 "arQ" = (
@@ -7961,36 +6942,33 @@
 	tag = "icon-rwindow (EAST)"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "arV" = (
-/obj/cable,
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/wingrille_spawn/auto,
+/obj/cable,
 /turf/simulated/floor/plating,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "arW" = (
 /turf/simulated/floor/orangeblack/side{
 	dir = 9
 	},
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "arX" = (
 /turf/simulated/floor/orangeblack/side{
 	dir = 1
 	},
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "arY" = (
 /turf/simulated/floor/orangeblack/side{
 	dir = 5
 	},
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "arZ" = (
 /obj/window/reinforced{
 	dir = 8;
@@ -7998,19 +6976,21 @@
 	tag = "icon-rwindow (WEST)"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "asa" = (
 /obj/machinery/firealarm{
 	pixel_y = 24;
 	text = "NF"
 	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/yellow/corner,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "asb" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -8018,17 +6998,12 @@
 /turf/simulated/floor/yellow/side{
 	dir = 9
 	},
-/area/station/engine/engineering)
-"asc" = (
-/turf/simulated/floor/yellow/side{
-	dir = 1
-	},
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "asd" = (
 /turf/simulated/floor/yellow/side{
 	dir = 5
 	},
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "ase" = (
 /obj/shrub,
 /turf/simulated/floor/yellow/side{
@@ -8074,14 +7049,19 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
 "asl" = (
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/checkpoint)
+"asm" = (
+/obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/hallway/primary/central)
-"asm" = (
 /turf/simulated/floor/purple/side{
 	dir = 8
 	},
@@ -8097,11 +7077,11 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "aso" = (
-/obj/firedoor_spawn,
-/obj/machinery/door/airlock/pyro/maintenance,
-/obj/access_spawn/maint,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor,
+/area/station/security/checkpoint)
 "asp" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -8124,10 +7104,6 @@
 /obj/machinery/turret{
 	dir = 8
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/machinery/camera/motion{
 	c_tag = "AI Upload";
 	dir = 1
@@ -8136,12 +7112,10 @@
 /area/station/turret_protected/ai_upload)
 "ass" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/circuit,
-/area/station/turret_protected/ai_upload)
+/turf/simulated/floor,
+/area/station/security/checkpoint)
 "ast" = (
 /obj/machinery/light,
 /mob/living/silicon/hivebot/eyebot,
@@ -8154,33 +7128,18 @@
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "asv" = (
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "asw" = (
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
-/area/station/engine/engineering)
-"asx" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 4
-	},
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "asy" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
@@ -8188,87 +7147,39 @@
 	},
 /obj/access_spawn/engineering,
 /turf/simulated/floor/yellow,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "asz" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
-/area/station/engine/engineering)
-"asA" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/engine/engineering)
-"asB" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 4
-	},
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "asC" = (
 /obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/specialroom/chapel{
-	dir = 5
-	},
-/area/station/chapel/main)
-"asD" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 8
-	},
-/area/station/hallway/primary/central)
-"asE" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
-"asF" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
-"asG" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "2-5"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner)
+/area/station/maintenance/westsolar)
+"asE" = (
+/obj/cable{
+	icon_state = "1-6"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/westsolar)
+"asF" = (
+/obj/landmark/start{
+	name = "predator"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/NEmaint)
+"asG" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/NEmaint)
 "asH" = (
 /obj/disposalpipe/junction{
 	dir = 1
@@ -8296,13 +7207,10 @@
 	},
 /area/station/hallway/primary/central)
 "asL" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/machinery/power/tracker,
+/obj/cable,
+/turf/simulated/floor/plating/airless,
+/area)
 "asM" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -8341,86 +7249,67 @@
 /obj/machinery/turret{
 	dir = 8
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/machinery/light,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
 "asT" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/turf/simulated/floor/orangeblack/side{
+	dir = 1
 	},
-/turf/simulated/floor/purple,
-/area/station/turret_protected/ai_upload)
+/area/station/quartermaster/office)
 "asU" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "E APC";
 	pixel_x = 24;
 	pixel_y = 0
 	},
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/purple,
 /area/station/turret_protected/ai_upload)
 "asV" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4;
 	icon_state = "airlock_closed";
 	name = "Singularity Core"
 	},
 /obj/access_spawn/engineering,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/caution/east,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "asW" = (
 /obj/machinery/the_singularitygen{
 	bhole = 0
 	},
 /turf/simulated/floor,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "asX" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4;
 	icon_state = "airlock_closed";
 	name = "Singularity Core"
 	},
 /obj/access_spawn/engineering,
-/turf/simulated/floor/caution/west,
-/area/station/engine/engineering)
-"asY" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
+/turf/simulated/floor/caution/west,
+/area/station/engine/inner)
+"asY" = (
 /obj/table/auto,
 /obj/random_item_spawner/tools_w_igloves,
 /obj/item/sheet/glass/fullstack,
 /turf/simulated/floor/yellow/corner{
 	dir = 4
 	},
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "asZ" = (
 /turf/simulated/floor/yellow/side{
 	dir = 10
@@ -8439,7 +7328,7 @@
 /turf/simulated/floor/yellow/side{
 	dir = 2
 	},
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "atc" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/yellow/side{
@@ -8454,14 +7343,10 @@
 /area/station/hallway/primary/central)
 "ate" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/yellow/side{
-	dir = 2
-	},
-/area/station/hallway/primary/central)
+/turf/simulated/floor,
+/area/station/quartermaster/office)
 "atf" = (
 /turf/simulated/floor/yellow/side{
 	dir = 2
@@ -8479,94 +7364,53 @@
 	dir = 2
 	},
 /area/station/hallway/primary/central)
-"ati" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/yellow/corner{
-	dir = 8
-	},
-/area/station/hallway/primary/central)
-"atj" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/firedoor_spawn,
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4;
-	icon_state = "maint_closed"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner)
 "atk" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner)
+/turf/simulated/floor,
+/area/station/quartermaster/office)
 "atl" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
 "atm" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner)
+/turf/simulated/floor,
+/area/station/janitor)
 "atn" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "qmout"
+	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner)
+/turf/simulated/floor/caution/northsouth,
+/area/station/quartermaster/office)
 "ato" = (
 /obj/disposalpipe/segment{
 	dir = 4;
 	pixel_y = 0
 	},
 /obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
 "atp" = (
@@ -8574,6 +7418,9 @@
 	dir = 4;
 	icon_state = "pipe-sj1";
 	tag = "icon-pipe-sj1 (EAST)"
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
@@ -8584,6 +7431,9 @@
 	},
 /obj/landmark{
 	name = "blobstart"
+	},
+/obj/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
@@ -8607,6 +7457,9 @@
 	dir = 4;
 	pixel_y = 0
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/purple/corner{
 	dir = 1
 	},
@@ -8629,21 +7482,18 @@
 	},
 /area/station/hallway/primary/central)
 "atw" = (
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor,
+/area/station/quartermaster/office)
 "atx" = (
 /obj/machinery/camera{
 	c_tag = "S Maintenance - North";
 	dir = 8
+	},
+/obj/cable{
+	icon_state = "1-10"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -8676,23 +7526,16 @@
 /turf/simulated/floor,
 /area/station/maintenance/east)
 "atC" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/table/auto,
 /obj/random_item_spawner/tools,
 /turf/simulated/floor,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "atD" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "atE" = (
@@ -8712,26 +7555,24 @@
 	},
 /area/station/turret_protected/ai_upload_foyer)
 "atG" = (
-/obj/cable,
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "S APC";
 	pixel_y = -24
 	},
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
 "atH" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/storage/warehouse)
 "atI" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/door/poddoor{
 	id = "emergencyinternals";
 	name = "Emergency Internals"
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/warehouse)
@@ -8754,6 +7595,9 @@
 	dir = 4;
 	icon_state = "maint_closed"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
 "atM" = (
@@ -8765,14 +7609,13 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "atN" = (
-/obj/disposalpipe/segment,
+/obj/wingrille_spawn/auto,
+/obj/cable,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/quartermaster/office)
 "atO" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -8797,26 +7640,21 @@
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "atS" = (
 /turf/simulated/floor/orangeblack/side{
 	dir = 10
 	},
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "atT" = (
 /turf/simulated/floor/orangeblack/side,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "atU" = (
 /turf/simulated/floor/orangeblack/side{
 	dir = 6
 	},
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "atV" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/light_switch{
 	name = "E light switch";
 	pixel_x = 24;
@@ -8825,8 +7663,11 @@
 /obj/table/auto,
 /obj/random_item_spawner/med_kit,
 /obj/item/sheet/glass/reinforced/fullstack,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "atW" = (
 /obj/storage/crate/furnacefuel,
 /obj/machinery/light/small{
@@ -8834,12 +7675,18 @@
 	icon_state = "bulb1";
 	tag = "icon-bulb1 (WEST)"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "atX" = (
 /obj/storage/crate/furnacefuel,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "atY" = (
 /obj/storage/crate/furnacefuel,
 /obj/machinery/light{
@@ -8849,26 +7696,22 @@
 	pixel_x = 10
 	},
 /turf/simulated/floor,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "atZ" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/west)
 "aua" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aub" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/table/wood/auto,
 /obj/candle_light,
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 5
 	},
@@ -8883,60 +7726,28 @@
 "aue" = (
 /turf/simulated/floor,
 /area/station/storage/emergency)
-"auf" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/disposalpipe/segment,
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/simulated/floor,
-/area/station/storage/emergency)
-"aug" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/storage/emergency)
-"auh" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 8
-	},
-/area/station/hallway/primary/central)
 "aui" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "N APC";
 	pixel_y = 24
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
 /obj/storage/closet/emergency,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/grime,
 /area/station/storage/warehouse)
 "auj" = (
+/obj/cable,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/grime,
-/area/station/storage/warehouse)
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor,
+/area/station/quartermaster/office)
 "auk" = (
 /obj/disposalpipe/segment,
 /obj/storage/closet/emergency,
@@ -8964,67 +7775,59 @@
 	name = "Engineer"
 	},
 /turf/simulated/floor,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "aup" = (
+/obj/wingrille_spawn/auto,
 /obj/cable,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "auq" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/field_generator,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1"
 	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/orangeblack,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "aur" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/field_generator,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
 	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/orangeblack,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "aus" = (
+/obj/wingrille_spawn/auto,
 /obj/cable,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "aut" = (
 /obj/window/reinforced{
 	dir = 4;
@@ -9032,53 +7835,36 @@
 	tag = "icon-rwindow (EAST)"
 	},
 /turf/simulated/floor/yellow,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "auu" = (
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/machinery/emitter{
 	dir = 8;
 	icon_state = "Emitter";
 	tag = "icon-Emitter (WEST)"
 	},
-/turf/simulated/floor/bot,
-/area/station/engine/engineering)
-"auv" = (
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
-/turf/simulated/floor,
-/area/station/engine/engineering)
-"auw" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/station/engine/engineering)
+/area/station/engine/inner)
+"auv" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor,
+/area/station/engine/inner)
+"auw" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/engine/inner)
 "aux" = (
 /obj/landmark/magnet_shield,
 /obj/securearea{
@@ -9115,12 +7901,10 @@
 /area/mining/magnet)
 "auy" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "auz" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/machinery/camera{
@@ -9130,16 +7914,6 @@
 /turf/simulated/floor,
 /area/station/storage/emergency)
 "auA" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment,
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor,
@@ -9159,13 +7933,10 @@
 /area/station/storage/warehouse)
 "auD" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/storage/closet/emergency,
-/turf/simulated/floor/grime,
-/area/station/storage/warehouse)
+/turf/simulated/floor,
+/area/station/storage/autolathe)
 "auE" = (
 /turf/simulated/floor/grime,
 /area/station/storage/warehouse)
@@ -9223,50 +7994,35 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "auM" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/power/smes{
+	name = "emitter auxiliary power storage unit"
 	},
-/turf/simulated/floor,
-/area/station/engine/engineering)
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/engine/inner)
 "auN" = (
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable,
-/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "auO" = (
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/engine/engineering)
-"auP" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-8"
 	},
+/turf/simulated/floor/plating,
+/area/station/engine/inner)
+"auP" = (
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "auQ" = (
 /obj/securearea{
 	desc = "";
@@ -9295,12 +8051,10 @@
 /area/mining/magnet)
 "auS" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/engine/power)
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "auT" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/power)
@@ -9341,16 +8095,6 @@
 	},
 /area/mining/magnet)
 "auW" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/disposalpipe/segment,
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/light{
@@ -9377,12 +8121,10 @@
 /area/station/storage/warehouse)
 "ava" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/grime,
-/area/station/storage/warehouse)
+/turf/simulated/floor/plating,
+/area/station/maintenance/NEmaint)
 "avb" = (
 /obj/disposalpipe/segment,
 /obj/machinery/light/small{
@@ -9420,12 +8162,8 @@
 	},
 /area/station/hallway/primary/south)
 "avh" = (
-/obj/cable{
-	icon_state = "1-4";
-	tag = "icon-1-4"
-	},
 /turf/simulated/floor,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "avi" = (
 /obj/window/reinforced{
 	dir = 8;
@@ -9433,45 +8171,33 @@
 	tag = "icon-rwindow (WEST)"
 	},
 /turf/simulated/floor/yellow,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "avj" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/window/reinforced{
 	dir = 8;
 	icon_state = "rwindow";
 	tag = "icon-rwindow (WEST)"
 	},
-/turf/simulated/floor/yellow,
-/area/station/engine/engineering)
-"avk" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellow,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "avl" = (
 /obj/machinery/power/collector_array,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/window/reinforced{
 	dir = 1;
 	icon_state = "rwindow";
 	tag = "icon-rwindow (NORTH)"
 	},
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/yellow,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "avm" = (
 /obj/window/reinforced{
 	dir = 1;
@@ -9480,63 +8206,35 @@
 	},
 /obj/machinery/power/collector_control,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/yellow,
-/area/station/engine/engineering)
-"avn" = (
-/obj/machinery/power/collector_array,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow";
-	tag = "icon-rwindow (NORTH)"
-	},
-/turf/simulated/floor/yellow,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "avo" = (
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/engine/power)
 "avp" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/engine/power)
 "avq" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/engine/power)
 "avr" = (
+/obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "0-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/engine/power)
 "avs" = (
 /obj/storage/secure/closet/engineering/electrical,
@@ -9550,88 +8248,68 @@
 /area/station/engine/power)
 "avt" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "0-4"
 	},
-/turf/simulated/floor,
-/area/station/engine/engineering)
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/engine/inner)
 "avu" = (
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
+	icon_state = "0-4"
 	},
-/obj/cable,
-/turf/simulated/floor,
-/area/station/engine/engineering)
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/inner)
 "avv" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1";
 	layer = 9.1;
 	pixel_x = 10
 	},
-/turf/simulated/floor,
-/area/station/engine/engineering)
-"avw" = (
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "2-8"
 	},
+/turf/simulated/floor/plating,
+/area/station/engine/inner)
+"avw" = (
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "W APC";
 	pixel_x = -24;
 	pixel_y = 0
 	},
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor,
 /area/station/storage/emergency)
 "avx" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment,
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/storage/emergency)
-"avy" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/camera{
-	c_tag = "Habitation Ring West";
-	dir = 4
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 8
-	},
-/area/station/hallway/primary/central)
 "avz" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-8"
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/storage/warehouse)
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
+/turf/simulated/floor,
+/area/station/security/checkpoint)
 "avA" = (
 /obj/machinery/door/poddoor{
 	id = "emergencyinternals";
@@ -9653,15 +8331,13 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "avE" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/firedoor_spawn,
 /obj/disposalpipe/segment{
 	dir = 4;
 	pixel_y = 0
+	},
+/obj/cable{
+	icon_state = "4-10"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -9672,16 +8348,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "avG" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "N APC";
 	pixel_y = 24
 	},
 /obj/machinery/space_heater,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "avH" = (
@@ -9700,23 +8375,12 @@
 /area/station/maintenance/east)
 "avJ" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	icon_state = "5-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/maintenance/disposal)
 "avK" = (
 /obj/firedoor_spawn,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/pyro{
 	dir = 4
 	},
@@ -9724,45 +8388,34 @@
 /area/station/storage/emergency)
 "avL" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-4"
 	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+/obj/cable{
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor,
+/area/station/security/checkpoint)
 "avM" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/quartermaster/office)
 "avN" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/disposalpipe/segment{
 	dir = 4;
-	pixel_y = 0
+	icon_state = "pipe-c"
+	},
+/obj/cable{
+	icon_state = "2-9"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/maintenance/NEmaint)
 "avO" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -9779,66 +8432,56 @@
 /area/station/maintenance/NEmaint)
 "avQ" = (
 /obj/machinery/power/collector_control,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/window/reinforced{
 	dir = 1;
 	icon_state = "rwindow";
 	tag = "icon-rwindow (NORTH)"
 	},
 /obj/cable{
-	d2 = 2;
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/yellow,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "avR" = (
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable,
-/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/engine/power)
 "avS" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable,
 /obj/machinery/power/terminal{
 	dir = 4
 	},
-/turf/simulated/floor,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
 /area/station/engine/power)
 "avT" = (
-/obj/machinery/power/smes{
-	chargelevel = 5000;
-	chargemode = 0;
-	online = 0;
-	output = 2500;
-	tag = ""
+/obj/machinery/power/smes,
+/obj/cable{
+	icon_state = "0-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/engine/power)
 "avU" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/cable,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor,
+/obj/cable,
+/turf/simulated/floor/plating,
 /area/station/engine/power)
 "avV" = (
 /obj/machinery/firealarm{
@@ -9853,57 +8496,26 @@
 "avW" = (
 /obj/machinery/power/furnace,
 /obj/cable,
-/turf/simulated/floor,
-/area/station/engine/engineering)
+/turf/simulated/floor/plating,
+/area/station/engine/inner)
 "avX" = (
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "0-4"
 	},
-/turf/simulated/floor,
-/area/station/storage/emergency)
+/turf/simulated/floor/plating,
+/area/station/quartermaster/office)
 "avY" = (
+/obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-10"
 	},
-/turf/simulated/floor,
-/area/station/storage/emergency)
+/turf/simulated/floor/plating,
+/area/station/maintenance/NEmaint)
 "avZ" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/storage/emergency)
-"awa" = (
-/obj/firedoor_spawn,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"awb" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 8
-	},
-/area/station/hallway/primary/central)
 "awc" = (
 /obj/rack,
 /obj/item/clipboard,
@@ -9913,6 +8525,10 @@
 /area/station/storage/warehouse)
 "awd" = (
 /obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "8-9";
+	tag = "icon-8-9"
+	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/main)
 "awe" = (
@@ -9933,11 +8549,6 @@
 /turf/simulated/floor/grime,
 /area/station/storage/warehouse)
 "awh" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/firedoor_spawn,
 /turf/simulated/floor/yellow/side{
 	dir = 8
@@ -9945,56 +8556,57 @@
 /area/station/hallway/primary/central)
 "awi" = (
 /obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "awj" = (
 /obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/maintenance/NEmaint)
 "awk" = (
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/quartermaster/office)
 "awl" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "2-5"
+	},
+/obj/cable{
+	icon_state = "5-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/NEmaint)
+"awm" = (
 /obj/cable,
 /obj/cable{
-	d2 = 8;
+	icon_state = "0-2"
+	},
+/obj/cable{
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"awm" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor,
+/area/station/quartermaster/office)
 "awn" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -10019,46 +8631,13 @@
 /area/station/maintenance/east)
 "awq" = (
 /obj/machinery/power/data_terminal,
-/obj/cable,
+/obj/cable{
+	icon_state = "0-9"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "awr" = (
 /turf/simulated/wall/auto/supernorn,
-/area/station/medical/robotics)
-"aws" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
-/obj/cable,
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/medical/robotics)
-"awt" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/medical/robotics)
-"awu" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "awv" = (
 /obj/storage/closet/emergency,
@@ -10071,13 +8650,13 @@
 	tag = "icon-Emitter (WEST)"
 	},
 /turf/simulated/floor,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "awx" = (
 /obj/machinery/light,
 /turf/simulated/floor/yellow/side{
 	dir = 2
 	},
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "awy" = (
 /obj/machinery/light_switch{
 	name = "E light switch";
@@ -10091,14 +8670,12 @@
 /turf/simulated/floor,
 /area/station/engine/power)
 "awz" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/camera{
 	c_tag = "Emergency Storage Maintenance";
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "5-10"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -10166,11 +8743,6 @@
 /area/station/maintenance/east)
 "awL" = (
 /obj/machinery/manufacturer/robotics,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
 /obj/machinery/camera{
 	c_tag = "Robotics Laboratory";
 	dir = 2
@@ -10181,28 +8753,10 @@
 /area/station/medical/robotics)
 "awM" = (
 /obj/machinery/manufacturer/robotics,
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
 /turf/simulated/floor/blueblack/corner,
 /area/station/medical/robotics)
 "awN" = (
 /obj/machinery/manufacturer/robotics,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /turf/simulated/floor/blueblack/corner{
 	dir = 1
 	},
@@ -10264,63 +8818,68 @@
 /area/station/medical/research)
 "awS" = (
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "2-8"
 	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/medical/research)
+/turf/simulated/floor/orangeblack/side{
+	dir = 8
+	},
+/area/station/quartermaster)
 "awT" = (
+/obj/disposalpipe/segment,
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/medical/research)
+/turf/simulated/floor/specialroom/chapel{
+	dir = 9
+	},
+/area/station/chapel/main)
 "awU" = (
-/turf/simulated/wall/auto/shuttle{
-	icon_state = "1"
+/obj/cable{
+	icon_state = "2-8"
 	},
-/area/shuttle/arrival/station)
+/turf/simulated/floor/specialroom/chapel{
+	dir = 9
+	},
+/area/station/chapel/main)
 "awV" = (
-/obj/machinery/computer/arcade,
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/specialroom/chapel,
+/area/station/chapel/main)
 "awW" = (
-/obj/cable,
 /obj/machinery/power/data_terminal,
-/obj/machinery/computer3/generic/engine,
+/obj/machinery/computer3/generic/engine{
+	dir = 4
+	},
+/obj/cable,
 /turf/simulated/floor,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "awX" = (
 /obj/stool/chair{
 	dir = 8;
 	name = "engineering chair"
 	},
 /turf/simulated/floor,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "awY" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1";
 	layer = 9.1;
 	pixel_x = -10
 	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor,
 /area/station/engine/power)
 "awZ" = (
-/obj/cable,
 /obj/machinery/power/terminal{
 	dir = 4
 	},
-/turf/simulated/floor,
+/obj/cable,
+/turf/simulated/floor/plating,
 /area/station/engine/power)
 "axa" = (
 /obj/item/device/radio/intercom{
@@ -10357,16 +8916,6 @@
 /turf/simulated/floor/plating,
 /area/station/mining/magnet)
 "axh" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
@@ -10440,26 +8989,30 @@
 	name = "N light switch";
 	pixel_y = 24
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/blueblack/corner{
 	dir = 1
 	},
 /area/station/medical/robotics)
 "axu" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/blueblack/corner,
-/area/station/medical/robotics)
+/turf/simulated/floor/specialroom/chapel{
+	dir = 10
+	},
+/area/station/chapel/main)
 "axv" = (
 /turf/simulated/floor/blueblack/corner,
 /area/station/medical/robotics)
 "axw" = (
-/obj/table/reinforced/auto,
-/obj/item/storage/firstaid/regular,
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/orangeblack/side,
+/area/station/quartermaster/office)
 "axx" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -10485,62 +9038,52 @@
 /area/station/medical/research)
 "axz" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/black,
-/area/station/medical/research)
+/turf/simulated/floor/specialroom/chapel{
+	dir = 5
+	},
+/area/station/chapel/main)
 "axA" = (
 /obj/storage/secure/closet/animal,
 /turf/simulated/floor/black,
 /area/station/medical/research)
 "axB" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/landmark/artifact{
 	name = "artifact spawner (10%)";
 	spawnchance = 10
 	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
 /turf/simulated/floor/plating/airless,
 /area/station/solar/west)
 "axC" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/storage/emergency)
 "axD" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/landmark/artifact{
 	name = "artifact spawner (10%)";
 	spawnchance = 10
 	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
 /turf/simulated/floor/plating/airless,
 /area/station/solar/east)
 "axE" = (
@@ -10551,11 +9094,6 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/engine/engineering)
 "axG" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/pyro/engineering,
 /obj/access_spawn/engineering,
 /turf/simulated/floor,
@@ -10572,70 +9110,57 @@
 /area/station/hydroponics)
 "axI" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/power)
 "axJ" = (
 /obj/cable{
-	d2 = 8;
+	icon_state = "0-4"
+	},
+/obj/cable{
 	icon_state = "0-8"
 	},
 /obj/cable,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /turf/simulated/floor,
 /area/station/engine/power)
 "axK" = (
+/obj/machinery/power/monitor{
+	dir = 8
+	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/monitor,
 /turf/simulated/floor,
 /area/station/engine/power)
 "axL" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
-"axM" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
-"axN" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
-"axO" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
+/turf/simulated/floor/specialroom/chapel{
+	dir = 1
+	},
+/area/station/chapel/main)
+"axM" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/specialroom/chapel{
+	dir = 6
+	},
+/area/station/chapel/main)
+"axN" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/specialroom/chapel{
+	dir = 8
+	},
+/area/station/chapel/main)
+"axO" = (
 /obj/machinery/camera{
 	c_tag = "Habitation Ring West";
 	dir = 4
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 8
@@ -10647,13 +9172,10 @@
 /area/station/storage/warehouse)
 "axQ" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/item/wirecutters,
-/turf/simulated/floor/grime,
-/area/station/storage/warehouse)
+/turf/simulated/floor/plating,
+/area/station/maintenance/NWmaint)
 "axR" = (
 /obj/item/cable_coil/cut,
 /obj/storage/crate,
@@ -10673,20 +9195,20 @@
 	pixel_x = -24;
 	pixel_y = 0
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
+/obj/cable,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "axT" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
+/obj/cable{
+	icon_state = "4-6"
+	},
+/turf/simulated/floor/specialroom/chapel{
+	dir = 9
+	},
+/area/station/chapel/main)
 "axU" = (
 /obj/disposalpipe/segment{
 	dir = 1;
@@ -10734,6 +9256,9 @@
 /obj/landmark/start{
 	name = "predator"
 	},
+/obj/cable{
+	icon_state = "1-6"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "aya" = (
@@ -10776,6 +9301,9 @@
 /area/station/medical/robotics)
 "ayg" = (
 /obj/machinery/light,
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 10
 	},
@@ -10784,6 +9312,9 @@
 /obj/machinery/camera{
 	c_tag = "Robotics Maintenance";
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "5-6"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -10794,35 +9325,23 @@
 /turf/simulated/floor/black,
 /area/station/medical/research)
 "ayk" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/critter/opossum/morty,
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/black,
 /area/station/medical/research)
 "ayl" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
 	icon_state = "eng_closed"
 	},
 /obj/access_spawn/engineering,
-/turf/simulated/floor,
-/area/station/engine/engineering)
-"aym" = (
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "4-8"
 	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/storage/warehouse)
+/turf/simulated/floor,
+/area/station/engine/inner)
 "ayn" = (
 /obj/storage/secure/closet/engineering/engineer,
 /turf/simulated/floor,
@@ -10835,11 +9354,6 @@
 	c_tag = "Engineering East";
 	dir = 8
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "ayq" = (
@@ -10849,19 +9363,6 @@
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
-"ays" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/storage/warehouse)
 "ayt" = (
 /obj/item/paper{
 	info = "Holy crap were you born in a barn? What the hell is wrong with you? Tidy this crap up. - W";
@@ -10893,11 +9394,6 @@
 	},
 /area/station/medical/robotics)
 "ayx" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "W APC";
@@ -10917,27 +9413,12 @@
 	},
 /area/station/medical/robotics)
 "ayz" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/landmark/start{
 	name = "Roboticist"
 	},
 /turf/simulated/floor/blueblack/corner,
 /area/station/medical/robotics)
 "ayA" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/landmark/start{
 	name = "Roboticist"
 	},
@@ -10946,24 +9427,10 @@
 	},
 /area/station/medical/robotics)
 "ayB" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/optable,
 /turf/simulated/floor/blueblack/corner,
 /area/station/medical/robotics)
 "ayC" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/submachine/cargopad{
 	name = "Robotics Pad"
 	},
@@ -10981,6 +9448,9 @@
 /obj/machinery/camera{
 	c_tag = "Genetics Research Morgue";
 	dir = 8
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
 /area/station/medical/research)
@@ -11022,17 +9492,10 @@
 /area/station/mining/magnet)
 "ayJ" = (
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "1-10"
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
-/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/medical/research)
+/area/station/maintenance/NWmaint)
 "ayK" = (
 /obj/item/weldingtool,
 /turf/simulated/floor/grime,
@@ -11043,20 +9506,22 @@
 /area/station/storage/warehouse)
 "ayM" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/grime,
-/area/station/storage/warehouse)
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/black,
+/area/station/chapel/office)
 "ayN" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/grime,
-/area/station/storage/warehouse)
+/turf/simulated/floor/specialroom/chapel{
+	dir = 8
+	},
+/area/station/chapel/main)
 "ayO" = (
 /obj/machinery/portable_reclaimer,
 /turf/simulated/floor/grime,
@@ -11072,11 +9537,6 @@
 	},
 /area/station/hallway/primary/central)
 "ayR" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/light,
 /turf/simulated/floor/neutral/side{
 	dir = 2
@@ -11089,12 +9549,13 @@
 /area/station/hallway/primary/central)
 "ayT" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "4-5";
+	tag = "icon-4-5"
 	},
-/turf/simulated/floor/blueblack/corner,
-/area/station/medical/robotics)
+/turf/simulated/floor/specialroom/chapel{
+	dir = 8
+	},
+/area/station/chapel/main)
 "ayU" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -11128,40 +9589,41 @@
 /area/station/maintenance/east)
 "ayX" = (
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/cable,
-/turf/simulated/floor/black,
-/area/station/medical/research)
-"ayY" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "0-2"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black,
-/area/station/medical/research)
-"ayZ" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/medical/research)
-"aza" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/medical/research)
+/area/station/storage/tech)
+"ayY" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/station/chapel/office)
+"ayZ" = (
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/storage/tech)
+"aza" = (
+/obj/cable{
+	icon_state = "1-10"
+	},
+/obj/cable{
+	icon_state = "1-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/NWmaint)
 "azb" = (
 /obj/storage/secure/closet/command/chief_engineer,
 /turf/simulated/floor,
@@ -11252,18 +9714,19 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
 /area/station/engine/engineering)
 "azm" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 5
@@ -11301,11 +9764,6 @@
 	},
 /area/station/hallway/primary/central)
 "azq" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/yellow/corner{
 	dir = 1
 	},
@@ -11329,54 +9787,44 @@
 /area/station/hallway/primary/central)
 "azu" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/storage/tech)
 "azv" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/east)
+/turf/simulated/floor/plating,
+/area/station/maintenance/NWmaint)
 "azw" = (
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/access_spawn/maint,
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/medical/medbay/lobby)
 "azx" = (
-/obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "5-8"
+	},
+/obj/cable{
+	icon_state = "5-6"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/maintenance/NWmaint)
 "azy" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/storage/tech)
 "azz" = (
 /obj/machinery/light_switch{
 	name = "S light switch";
@@ -11388,14 +9836,10 @@
 /area/station/medical/robotics)
 "azA" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/blueblack/corner{
-	dir = 1
-	},
-/area/station/medical/robotics)
+/turf/simulated/floor/plating,
+/area/station/storage/tech)
 "azB" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -11475,19 +9919,12 @@
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "azL" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/stool/chair/office/purple{
 	dir = 1;
 	icon_state = "office_chair_purple"
+	},
+/obj/cable{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/carpet{
 	dir = 2;
@@ -11503,9 +9940,7 @@
 	},
 /obj/machinery/genetics_booth,
 /turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "azN" = (
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
@@ -11513,8 +9948,6 @@
 /area/station/mining/magnet)
 "azO" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellow/corner{
@@ -11523,32 +9956,20 @@
 /area/station/engine/engineering)
 "azP" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-2"
 	},
+/obj/cable,
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "0-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "azQ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "5-8"
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 4
-	},
-/area/station/engine/engineering)
+/turf/simulated/floor/plating,
+/area/station/maintenance/NWmaint)
 "azR" = (
 /obj/disposalpipe/segment,
 /obj/machinery/bot/floorbot,
@@ -11556,17 +9977,10 @@
 /area/station/storage/warehouse)
 "azS" = (
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "2-9"
 	},
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
-/turf/simulated/floor/plating/airless,
-/area/station/maintenance/east)
+/turf/simulated/floor/plating,
+/area/station/maintenance/NWmaint)
 "azT" = (
 /obj/decal/cleanable/writing{
 	words = "Erik wuz here!! 2k16"
@@ -11574,11 +9988,6 @@
 /turf/simulated/floor/plating/airless,
 /area)
 "azU" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/item/sheet/glass{
 	amount = 50
 	},
@@ -11592,17 +10001,8 @@
 /turf/simulated/floor/plating,
 /area/station/storage/warehouse)
 "azW" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/inner)
 "azX" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -11623,6 +10023,9 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/cable{
+	icon_state = "2-5"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "aAa" = (
@@ -11631,15 +10034,6 @@
 	dir = 8
 	},
 /area/station/storage/warehouse)
-"aAc" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/medical/robotics)
 "aAd" = (
 /obj/disposalpipe/segment,
 /turf/simulated/wall/auto/supernorn,
@@ -11661,6 +10055,13 @@
 /turf/simulated/floor/blue/checker,
 /area/station/medical/research)
 "aAh" = (
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/greenwhite{
 	dir = 1
 	},
@@ -11676,6 +10077,9 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/greenwhite{
 	dir = 1
 	},
@@ -11685,16 +10089,14 @@
 	c_tag = "Genetics Research North";
 	dir = 2
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/greenwhite{
 	dir = 1
 	},
 /area/station/medical/research)
 "aAk" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/item/crowbar,
 /obj/machinery/light{
 	dir = 1;
@@ -11702,16 +10104,14 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/greenwhite{
 	dir = 5
 	},
 /area/station/medical/research)
 "aAl" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable,
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
@@ -11731,7 +10131,7 @@
 "aAo" = (
 /obj/machinery/light,
 /turf/simulated/floor,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "aAp" = (
 /turf/simulated/floor/yellow/side{
 	dir = 4
@@ -11745,20 +10145,13 @@
 /area/station/engine/engineering)
 "aAr" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 2
 	},
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "aAs" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/yellow/corner{
 	dir = 8
 	},
@@ -11782,12 +10175,10 @@
 /area/station/mining/magnet)
 "aAv" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "1-6"
 	},
-/turf/simulated/floor,
-/area/station/storage/warehouse)
+/turf/simulated/floor/plating,
+/area/station/maintenance/NWmaint)
 "aAw" = (
 /obj/machinery/door/window{
 	base_state = "right";
@@ -11803,155 +10194,99 @@
 /turf/simulated/floor/plating,
 /area/station/storage/warehouse)
 "aAy" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/reagent_dispensers/fueltank,
+/turf/simulated/floor,
+/area/station/engine/inner)
 "aAz" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/camera{
 	c_tag = "S Maintenance - Medical Junction";
 	dir = 1
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "aAA" = (
 /obj/firedoor_spawn,
 /turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aAB" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "1-9"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/maintenance/NWmaint)
 "aAC" = (
 /turf/simulated/wall/auto/supernorn,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aAD" = (
 /turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aAE" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/turf/simulated/floor/yellow/side{
+	dir = 10
 	},
-/turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/engine/inner)
 "aAF" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "0-8"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-4"
 	},
+/obj/cable,
 /turf/simulated/floor/purplewhite{
 	dir = 9
 	},
 /area/station/science/artifact)
 "aAG" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/turf/simulated/floor/yellow/side{
+	dir = 2
 	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/medical/research)
+/area/station/engine/inner)
 "aAH" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/clone_scanner,
 /obj/cable{
-	icon_state = "2-8"
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aAI" = (
 /turf/simulated/floor/blackwhite{
 	dir = 9
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aAJ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/turf/simulated/floor,
+/area/station/engine/inner)
 "aAK" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/light_switch{
 	name = "N light switch";
 	pixel_y = 24
 	},
 /obj/machinery/computer/cloning,
-/obj/cable{
-	icon_state = "2-8"
-	},
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture";
 	rigged = 0
 	},
-/turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
-"aAL" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/greenwhite{
-	dir = 1
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
+"aAL" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
 	},
-/area/station/medical/research)
+/turf/simulated/floor/plating,
+/area/station/engine/inner)
 "aAM" = (
 /obj/machinery/light{
 	dir = 1;
@@ -11962,17 +10297,11 @@
 /turf/simulated/floor/grass,
 /area/station/medical/research)
 "aAN" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/light/small,
+/turf/simulated/floor/yellow/side{
+	dir = 6
 	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/medical/research)
+/area/station/engine/inner)
 "aAO" = (
 /obj/lattice,
 /obj/window/reinforced{
@@ -11983,9 +10312,6 @@
 /area)
 "aAP" = (
 /obj/storage/secure/closet/engineering/welding,
-/obj/cable{
-	icon_state = "1-8"
-	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "aAQ" = (
@@ -12029,16 +10355,16 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/central)
 "aAW" = (
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
-/obj/disposalpipe/segment{
-	dir = 4
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/engine/inner)
 "aAX" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -12057,41 +10383,27 @@
 	},
 /area/station/mining/magnet)
 "aAZ" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/engineering{
 	name = "Power Room"
 	},
 /obj/access_spawn/engineering,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/engine/power)
 "aBa" = (
 /obj/firedoor_spawn,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor,
 /area/station/storage/warehouse)
 "aBb" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aBc" = (
 /obj/firedoor_spawn,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "aBd" = (
@@ -12105,42 +10417,36 @@
 	},
 /area/station/medical/research)
 "aBe" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/genetics_scanner,
 /turf/simulated/floor/greenwhite{
 	dir = 5
 	},
 /area/station/medical/research)
 "aBf" = (
-/obj/disposalpipe/segment,
+/obj/window/reinforced{
+	dir = 8;
+	icon_state = "rwindow";
+	tag = "icon-rwindow (WEST)"
+	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/greenwhite{
-	dir = 8
+/obj/cable{
+	icon_state = "0-8"
 	},
-/area/station/medical/research)
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/yellow,
+/area/station/engine/inner)
 "aBg" = (
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/cable{
-	icon_state = "2-8"
+/turf/simulated/floor/yellow/side{
+	dir = 8
 	},
-/turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/engine/inner)
 "aBh" = (
 /obj/item/storage/belt/utility,
 /obj/item/storage/belt/utility,
@@ -12212,20 +10518,17 @@
 	name = "Quartermaster"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-8"
 	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
 /area/station/quartermaster/office)
 "aBs" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/table/auto,
 /obj/item/device/light/flashlight,
 /obj/item/device/light/flashlight,
@@ -12238,7 +10541,7 @@
 	},
 /obj/access_spawn/engineering,
 /turf/simulated/floor/plating,
-/area/station/maintenance/west)
+/area/station/engine/inner)
 "aBu" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -12262,11 +10565,6 @@
 /turf/simulated/floor/grime,
 /area/station/storage/warehouse)
 "aBy" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	layer = 3.5;
@@ -12280,24 +10578,12 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/station/storage/warehouse)
-"aBA" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
 "aBB" = (
 /obj/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/wall/auto/supernorn,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aBC" = (
 /obj/grille/catwalk,
 /turf/space,
@@ -12305,25 +10591,20 @@
 /area/station/mining/magnet)
 "aBD" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-8"
 	},
-/obj/disposalpipe/segment{
-	dir = 4
+/obj/cable{
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/obj/cable,
+/turf/simulated/floor,
+/area/station/engine/inner)
 "aBE" = (
 /obj/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aBF" = (
 /obj/disposalpipe/segment{
 	dir = 2;
@@ -12331,9 +10612,7 @@
 	tag = "icon-pipe-c"
 	},
 /turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aBG" = (
 /turf/simulated/floor/bluewhite{
 	dir = 10
@@ -12345,72 +10624,59 @@
 	},
 /area/station/medical/research)
 "aBI" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
 	},
-/obj/machinery/computer/genetics,
+/obj/machinery/computer/genetics{
+	dir = 8
+	},
 /turf/simulated/floor/greenwhite{
 	dir = 4
 	},
 /area/station/medical/research)
 "aBJ" = (
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/green,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
-"aBK" = (
+/obj/cable{
+	icon_state = "0-4"
+	},
 /obj/cable,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/medical/research)
+/turf/simulated/floor/green,
+/area/station/medical/medbay/lobby)
+"aBK" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/inner)
 "aBL" = (
+/obj/storage/crate/furnacefuel,
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/grille/catwalk/cross{
-	dir = 9
-	},
-/turf/space,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 9;
-	layer = 2
-	},
-/area/station/mining/magnet)
-"aBM" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
-"aBN" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
+/turf/simulated/floor,
+/area/station/engine/inner)
+"aBM" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor,
+/area/station/engine/inner)
+"aBN" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor,
+/area/station/engine/inner)
 "aBO" = (
 /obj/table/auto,
 /obj/deskclutter,
@@ -12422,11 +10688,6 @@
 	pixel_x = -24;
 	pixel_y = 0
 	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aBP" = (
@@ -12435,11 +10696,6 @@
 /obj/stool/chair/syndicate,
 /obj/npc/trader/exclown{
 	trader_area = "/area/station/crew_quarters/clown"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -12453,8 +10709,7 @@
 	},
 /obj/marker/supplymarker,
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "0-10"
 	},
 /turf/simulated/floor/plating/damaged1,
 /area/station/maintenance/west)
@@ -12470,104 +10725,56 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aBT" = (
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/hallway/primary/central)
-"aBU" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/hallway/primary/central)
-"aBV" = (
-/obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/medical/research)
+/area/station/engine/inner)
+"aBU" = (
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	layer = 9.1;
+	pixel_x = -10
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/yellow,
+/area/station/engine/inner)
+"aBV" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/inner)
 "aBW" = (
 /obj/disposalpipe/segment{
 	dir = 4
 	},
 /obj/firedoor_spawn,
 /turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aBX" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
-"aBY" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/storage/warehouse)
-"aBZ" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/storage/warehouse)
 "aCa" = (
 /obj/disposalpipe/segment,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/storage/warehouse)
 "aCb" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/primary/central)
+/turf/simulated/floor/plating,
+/area/station/engine/inner)
 "aCc" = (
 /obj/machinery/vending/medical_public,
 /turf/simulated/floor/neutral/side{
 	dir = 8
 	},
-/area/station/hallway/primary/central)
+/area/station/storage/warehouse)
 "aCe" = (
 /obj/firedoor_spawn,
 /turf/simulated/floor/neutral/side{
@@ -12580,14 +10787,15 @@
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aCg" = (
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/classic{
 	aiControlDisabled = 0;
 	locked = 0
+	},
+/obj/cable{
+	icon_state = "1-10"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -12598,25 +10806,7 @@
 	tag = "icon-pipe-j1 (WEST)"
 	},
 /turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
-"aCi" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/storage/warehouse)
+/area/station/medical/medbay/lobby)
 "aCj" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/greenwhite{
@@ -12633,28 +10823,11 @@
 /area/station/security/brig)
 "aCm" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/blue/checker,
-/area/station/medical/research)
+/turf/simulated/floor/yellow,
+/area/station/engine/inner)
 "aCn" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/table/auto,
 /obj/item/clipboard,
 /obj/item/paper,
@@ -12670,17 +10843,15 @@
 /obj/item/storage/goodybag,
 /obj/item/peripheral/videocard,
 /obj/item/storage/pill_bottle/cyberpunk,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plating/scorched,
 /area/station/maintenance/west)
 "aCp" = (
 /obj/decal/cleanable/dirt,
 /obj/creepy_sound_trigger,
 /obj/item/bananapeel,
+/obj/cable{
+	icon_state = "2-5"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aCq" = (
@@ -12691,11 +10862,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aCr" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
@@ -12716,15 +10882,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/central)
-"aCt" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
 "aCv" = (
 /turf/simulated/floor/neutral/side{
 	dir = 1
@@ -12732,14 +10889,12 @@
 /area/station/hallway/primary/central)
 "aCw" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/neutral/side{
+/turf/simulated/floor/yellow/side{
 	dir = 1
 	},
-/area/station/hallway/primary/central)
+/area/station/engine/inner)
 "aCx" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/neutral/side{
@@ -12748,55 +10903,33 @@
 /area/station/hallway/primary/central)
 "aCy" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/neutral/side{
-	dir = 1
-	},
-/area/station/hallway/primary/central)
+/turf/simulated/floor/yellow,
+/area/station/engine/inner)
 "aCz" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/neutral/side{
-	dir = 1
-	},
-/area/station/hallway/primary/central)
-"aCA" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
+/turf/simulated/floor/yellow/side{
+	dir = 5
+	},
+/area/station/engine/inner)
+"aCA" = (
 /turf/simulated/floor/neutral/corner{
 	dir = 1
 	},
 /area/station/hallway/primary/central)
 "aCB" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "1-8"
 	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/turf/simulated/floor,
+/area/station/engine/inner)
 "aCC" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/trunk{
 	dir = 1
 	},
@@ -12805,68 +10938,45 @@
 	name = "mail chute-'Medbay'"
 	},
 /turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aCD" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/storage/warehouse)
 "aCE" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/segment,
 /obj/item/extinguisher,
 /turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aCF" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/storage/secure/closet/medical{
 	name = "locker"
 	},
 /turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aCG" = (
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/cable,
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/wingrille_spawn/auto,
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/medical/research)
 "aCH" = (
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/blue/checker,
-/area/station/medical/research)
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/power)
 "aCI" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/firealarm{
 	pixel_y = 24;
 	text = "NF"
@@ -12877,6 +10987,9 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/red,
 /area/station/security/brig)
 "aCJ" = (
@@ -12884,14 +10997,12 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "2-4"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/greenwhite/corner{
 	dir = 8
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aCK" = (
 /obj/machinery/firealarm{
 	pixel_y = 24;
@@ -12904,9 +11015,7 @@
 /turf/simulated/floor/blackwhite{
 	dir = 5
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aCL" = (
 /obj/table/auto,
 /obj/item/storage/toolbox/mechanical,
@@ -12931,64 +11040,41 @@
 /obj/machinery/light,
 /turf/simulated/floor/greenwhite,
 /area/station/medical/research)
-"aCO" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
 "aCP" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/hydroponics)
 "aCQ" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
 /obj/cable,
 /obj/cable{
-	d2 = 8;
+	icon_state = "0-2"
+	},
+/obj/cable{
 	icon_state = "0-8"
 	},
-/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/medical/research)
+/area/station/engine/power)
 "aCR" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/wingrille_spawn/auto,
+/obj/cable,
 /turf/simulated/floor/plating,
-/area/station/medical/research)
+/area/station/engine/power)
 "aCS" = (
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable,
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/medical/research)
-"aCT" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/west)
+/turf/simulated/floor,
+/area/station/engine/engineering)
+"aCT" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor,
+/area/station/engine/engineering)
 "aCU" = (
 /obj/firedoor_spawn,
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aCV" = (
@@ -12998,18 +11084,11 @@
 /area/station/maintenance/west)
 "aCW" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
-"aCX" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
+/turf/simulated/floor,
+/area/station/engine/engineering)
+"aCX" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=crew";
 	location = "lowcrew"
@@ -13027,23 +11106,13 @@
 /area/station/hallway/primary/central)
 "aDa" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
-"aDb" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
+/area/station/engine/engineering)
+"aDb" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=chapel";
 	location = "outerbar"
@@ -13052,12 +11121,18 @@
 /area/station/hallway/primary/central)
 "aDc" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "0-8"
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
+/area/station/engine/engineering)
 "aDd" = (
 /obj/landmark{
 	name = "kudzustart"
@@ -13070,21 +11145,18 @@
 	icon_state = "tube1"
 	},
 /turf/simulated/floor/bot/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aDf" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/chemistry)
 "aDg" = (
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/hydroponics)
+/turf/simulated/floor/yellow/side{
+	dir = 8
+	},
+/area/station/engine/engineering)
 "aDh" = (
 /obj/machinery/plantpot,
 /turf/simulated/floor/grass{
@@ -13099,11 +11171,6 @@
 	},
 /area/station/hydroponics)
 "aDj" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/plantpot,
 /obj/machinery/camera,
 /obj/machinery/light{
@@ -13112,65 +11179,55 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/grass{
 	name = "astroturf";
 	tag = "icon-grass1"
 	},
 /area/station/hydroponics)
 "aDk" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/engineering{
+	dir = 4;
+	icon_state = "eng_closed"
 	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/hydroponics)
+/obj/access_spawn/engineering,
+/obj/access_spawn/mining,
+/turf/simulated/floor/yellow,
+/area/station/engine/engineering)
 "aDl" = (
 /obj/machinery/camera{
 	c_tag = "S Maintenance - South";
 	dir = 2
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "4-9"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aDm" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/power/apc/autoname_south,
+/obj/cable,
+/turf/simulated/floor/yellow/side{
+	dir = 4
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
+/area/station/engine/engineering)
 "aDn" = (
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
+/turf/simulated/floor/yellow/side{
+	dir = 2
+	},
+/area/station/engine/engineering)
 "aDo" = (
 /obj/grille/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross-0"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/space,
@@ -13185,11 +11242,6 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "aDq" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment,
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass,
@@ -13205,21 +11257,10 @@
 /area/station/hallway/primary/central)
 "aDt" = (
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
+	icon_state = "1-8"
 	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/disposalpipe/segment,
 /turf/simulated/floor,
-/area/station/hallway/primary/central)
+/area/station/engine/engineering)
 "aDu" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -13237,29 +11278,25 @@
 /area/station/crew_quarters/cafeteria)
 "aDw" = (
 /obj/machinery/power/data_terminal,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
+	},
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/Zeta)
 "aDx" = (
 /turf/simulated/floor/delivery/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aDy" = (
+/obj/disposalpipe/segment,
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "2-8"
 	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/hydroponics)
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/cafeteria)
 "aDz" = (
 /obj/window/reinforced/west,
 /obj/machinery/atmospherics/unary/cold_sink/freezer/cryo/east,
@@ -13346,11 +11383,6 @@
 /turf/simulated/floor/white,
 /area/station/chemistry)
 "aDJ" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment,
 /obj/storage/secure/closet/personal,
 /turf/simulated/floor/neutral/side{
@@ -13408,17 +11440,10 @@
 /area/station/crew_quarters/cafeteria)
 "aDQ" = (
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
+	icon_state = "1-4"
 	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/hydroponics)
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/cafeteria)
 "aDR" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -13429,40 +11454,33 @@
 	},
 /area/station/hydroponics)
 "aDS" = (
+/obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/grass{
-	name = "astroturf";
-	tag = "icon-grass1"
+/obj/cable{
+	icon_state = "4-6"
 	},
-/area/station/hydroponics)
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/cafeteria)
 "aDT" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "1-6"
 	},
-/obj/machinery/plantpot,
-/turf/simulated/floor/grass{
-	name = "astroturf";
-	tag = "icon-grass1"
+/obj/cable{
+	icon_state = "1-10"
 	},
-/area/station/hydroponics)
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/cafeteria)
 "aDU" = (
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "8-10"
 	},
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "1-4"
 	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/hydroponics)
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/cafeteria)
 "aDV" = (
 /turf/simulated/wall/auto/supernorn,
 /area)
@@ -13500,28 +11518,21 @@
 /area/station/hallway/primary/central)
 "aEb" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "1-8"
 	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/cafeteria)
 "aEc" = (
 /obj/disposalpipe/trunk{
 	dir = 4
 	},
 /obj/machinery/disposal,
 /turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aEd" = (
 /obj/disposalpipe/junction,
 /turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aEe" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -13623,57 +11634,20 @@
 	},
 /area/station/chemistry)
 "aEq" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/computer/riotgear{
+	dir = 8;
+	pixel_x = 32
 	},
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/turf/simulated/floor/red/side{
+	dir = 4
 	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/hydroponics)
-"aEr" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/plantpot,
-/turf/simulated/floor/grass{
-	name = "astroturf";
-	tag = "icon-grass1"
-	},
-/area/station/hydroponics)
-"aEs" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/grass{
-	name = "astroturf";
-	tag = "icon-grass1"
-	},
-/area/station/hydroponics)
+/area/station/security/brig)
 "aEt" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/grass{
-	name = "astroturf";
-	tag = "icon-grass1"
-	},
-/area/station/hydroponics)
+/turf/simulated/floor,
+/area/station/turret_protected/ai_upload_foyer)
 "aEu" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -13696,13 +11670,14 @@
 	c_tag = "S Maintenance - South";
 	dir = 2
 	},
+/obj/cable{
+	icon_state = "4-10"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "aEz" = (
 /obj/grille/catwalk,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/space,
@@ -13725,19 +11700,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
-"aEC" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
-/obj/cable,
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/hydroponics)
+/area/station/medical/medbay/lobby)
 "aED" = (
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
@@ -13863,17 +11826,15 @@
 	},
 /area/station/hydroponics)
 "aEQ" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/plantpot,
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1";
 	layer = 9.1;
 	pixel_x = -10
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf";
@@ -13909,50 +11870,29 @@
 /obj/item/clothing/head/snake,
 /turf/space,
 /area)
-"aEW" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "aEX" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/cable{
+	icon_state = "4-6"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aEY" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/switch_junction{
 	dir = 4;
 	icon_state = "pipe-sj1";
 	mail_tag = "hydroponics";
 	tag = "icon-pipe-sj1 (EAST)"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aEZ" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "S APC";
@@ -13960,6 +11900,12 @@
 	},
 /obj/disposalpipe/segment{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "5-8"
+	},
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -13987,6 +11933,9 @@
 	req_access = null
 	},
 /obj/access_spawn/robotics,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/medical/robotics)
 "aFe" = (
@@ -14001,10 +11950,13 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/blue/side{
 	dir = 1
 	},
-/area/station/maintenance/east)
+/area/station/hallway/primary/south)
 "aFg" = (
 /obj/disposalpipe/segment,
 /obj/machinery/camera{
@@ -14019,9 +11971,7 @@
 	},
 /obj/stool/bench/blue/auto,
 /turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aFh" = (
 /obj/landmark/magnet_shield,
 /obj/securearea{
@@ -14079,31 +12029,8 @@
 	dir = 4
 	},
 /area/station/medical/medbay)
-"aFm" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/blue,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
 "aFn" = (
 /obj/storage/secure/closet/research/chemical,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/white,
-/area/station/chemistry)
-"aFo" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/white,
 /area/station/chemistry)
 "aFp" = (
@@ -14124,11 +12051,6 @@
 	name = "astroturf";
 	tag = "icon-grass1"
 	},
-/area/station/hydroponics)
-"aFr" = (
-/obj/cable,
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
 /area/station/hydroponics)
 "aFs" = (
 /turf/simulated/floor/stairs/wide/other{
@@ -14175,37 +12097,6 @@
 	tag = "icon-grass1"
 	},
 /area/station/hydroponics)
-"aFy" = (
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/blue,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
-"aFz" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "chemistry";
-	name = "Chemistry Privacy Shutters";
-	opacity = 0
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/chemistry)
 "aFA" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -14213,34 +12104,12 @@
 	pixel_x = -24;
 	pixel_y = 0
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/camera{
 	c_tag = "Hydroponics Shipping";
 	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/hydroponics)
-"aFB" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/hydroponics)
-"aFC" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "0-2"
 	},
 /turf/simulated/floor,
 /area/station/hydroponics)
@@ -14261,19 +12130,14 @@
 	dir = 1
 	},
 /area/station/hydroponics)
-"aFF" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/damaged1,
-/area/station/maintenance/west)
 "aFG" = (
 /obj/disposalpipe/segment{
 	dir = 4
 	},
 /obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "8-9"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aFH" = (
@@ -14293,10 +12157,16 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hydroponics/lobby)
 "aFK" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating/damaged3,
 /area/station/maintenance/west)
 "aFL" = (
 /obj/decal/cleanable/oil,
+/obj/cable{
+	icon_state = "4-9"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aFM" = (
@@ -14319,15 +12189,6 @@
 "aFN" = (
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
-"aFO" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
 "aFP" = (
 /obj/submachine/ATM{
 	pixel_x = 30
@@ -14341,9 +12202,7 @@
 /area/station/hallway/primary/south)
 "aFR" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aFS" = (
 /obj/disposalpipe/segment,
 /obj/machinery/firealarm{
@@ -14356,20 +12215,17 @@
 	icon_state = "tube1"
 	},
 /turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aFT" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hydroponics)
 "aFU" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer3/generic/med_data,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "aFV" = (
@@ -14423,23 +12279,13 @@
 	dir = 6
 	},
 /area/station/medical/medbay)
-"aGa" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/hydroponics)
 "aGb" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
 /area/station/chemistry)
@@ -14449,14 +12295,13 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/white,
 /area/station/chemistry)
@@ -14466,11 +12311,10 @@
 	name = "S APC";
 	pixel_y = -24
 	},
+/obj/machinery/light,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/light,
 /turf/simulated/floor/white,
 /area/station/chemistry)
 "aGe" = (
@@ -14499,19 +12343,6 @@
 	dir = 4
 	},
 /area/station/chemistry)
-"aGi" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/hydroponics)
 "aGj" = (
 /turf/simulated/floor/stairs/wide{
 	dir = 4
@@ -14542,14 +12373,6 @@
 	dir = 8
 	},
 /area/station/hydroponics)
-"aGp" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hydroponics)
 "aGq" = (
 /obj/table/wood/auto,
 /obj/item/paper_bin{
@@ -14567,16 +12390,12 @@
 /area/station/hydroponics/lobby)
 "aGt" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 8
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aGu" = (
 /obj/disposalpipe/segment,
 /turf/simulated/wall/auto/supernorn,
@@ -14610,11 +12429,6 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "aGz" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/external{
 	autoclose = 0;
@@ -14627,6 +12441,9 @@
 	name = "Grove Module Airlock";
 	opacity = 1
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/orangeblack,
 /area/station/hydroponics)
 "aGA" = (
@@ -14637,10 +12454,11 @@
 /area/station/hallway/primary/south)
 "aGC" = (
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/blue,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aGD" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -14672,14 +12490,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
-"aGF" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/carpet/grime,
-/area/station/security/detectives_office)
 "aGG" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -14688,17 +12498,6 @@
 /turf/simulated/floor/blue/side{
 	dir = 1
 	},
-/area/station/hallway/primary/south)
-"aGH" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
 /area/station/hallway/primary/south)
 "aGI" = (
 /obj/disposalpipe/segment{
@@ -14715,9 +12514,7 @@
 	pixel_y = 0
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aGK" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -14730,9 +12527,7 @@
 /turf/simulated/floor/blue/side{
 	dir = 9
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aGL" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -14747,9 +12542,7 @@
 /turf/simulated/floor/blue/side{
 	dir = 1
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aGM" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -14758,9 +12551,7 @@
 /turf/simulated/floor/blue/side{
 	dir = 5
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aGN" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -14769,39 +12560,17 @@
 /turf/simulated/floor/bluewhite/corner{
 	dir = 4
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aGO" = (
 /obj/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
-"aGP" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable,
-/turf/simulated/wall/auto/supernorn,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aGQ" = (
 /obj/landmark/start{
 	name = "Medical Doctor"
-	},
-/turf/simulated/floor/blue,
-/area/station/medical/medbay)
-"aGR" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
@@ -14836,11 +12605,6 @@
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "aGV" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/external{
 	autoclose = 0;
@@ -14853,46 +12617,19 @@
 	name = "Grove Module Airlock";
 	opacity = 1
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/orangeblack,
 /area/station/hydroponics/lobby)
 "aGW" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/artifact)
-"aGX" = (
-/obj/cable,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "chemistry";
-	name = "Chemistry Privacy Shutters";
-	opacity = 0
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/chemistry)
 "aGY" = (
 /obj/machinery/plantpot,
 /obj/machinery/light,
-/turf/simulated/floor/grass{
-	name = "astroturf";
-	tag = "icon-grass1"
-	},
-/area/station/hydroponics)
-"aGZ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf";
@@ -14900,46 +12637,23 @@
 	},
 /area/station/hydroponics)
 "aHa" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/disposalpipe/segment{
+	dir = 4
 	},
-/obj/landmark/start{
-	name = "Botanist"
-	},
-/turf/simulated/floor/grass{
-	name = "astroturf";
-	tag = "icon-grass1"
-	},
-/area/station/hydroponics)
+/turf/simulated/wall/auto/supernorn,
+/area/station/storage/primary)
 "aHb" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/stairs/wide/middle{
 	dir = 4
 	},
 /area/station/hydroponics)
 "aHc" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/stool,
 /obj/item/reagent_containers/glass/bottle/topcrop,
 /obj/item/reagent_containers/glass/bottle/topcrop,
 /turf/simulated/floor,
 /area/station/hydroponics)
 "aHd" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/table/wood/auto,
 /obj/item/plate,
 /obj/item/reagent_containers/food/snacks/sandwich/meat_s{
@@ -14953,53 +12667,17 @@
 /turf/simulated/floor,
 /area/station/hydroponics)
 "aHe" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/stool,
 /obj/item/reagent_containers/glass/bottle/powerplant,
 /obj/item/reagent_containers/glass/bottle/powerplant,
 /turf/simulated/floor,
 /area/station/hydroponics)
 "aHf" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/stairs/wide/middle{
 	dir = 8
 	},
 /area/station/hydroponics)
-"aHg" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/grass{
-	name = "astroturf";
-	tag = "icon-grass1"
-	},
-/area/station/hydroponics)
 "aHh" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/disposalpipe/segment,
 /obj/disposalpipe/switch_junction{
 	dir = 1;
@@ -15007,40 +12685,8 @@
 	mail_tag = "crew";
 	tag = "icon-pipe-sj1 (NORTH)"
 	},
-/turf/simulated/floor/grass{
-	name = "astroturf";
-	tag = "icon-grass1"
-	},
-/area/station/hydroponics)
-"aHi" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
-/turf/simulated/floor/grass{
-	name = "astroturf";
-	tag = "icon-grass1"
-	},
-/area/station/hydroponics)
-"aHj" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf";
@@ -15048,19 +12694,12 @@
 	},
 /area/station/hydroponics)
 "aHk" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/disposalpipe/segment{
 	dir = 4;
 	pixel_y = 0
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf";
@@ -15072,11 +12711,6 @@
 	dir = 5;
 	icon_state = "catwalk"
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
@@ -15085,59 +12719,24 @@
 	},
 /area/station/mining/magnet)
 "aHm" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/segment{
 	dir = 4;
 	pixel_y = 0
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/green/side{
 	dir = 8
 	},
-/area/station/hydroponics)
-"aHn" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
-/turf/simulated/floor,
-/area/station/hydroponics)
-"aHo" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
-/turf/simulated/floor,
 /area/station/hydroponics)
 "aHp" = (
 /obj/disposalpipe/segment{
 	dir = 4;
 	pixel_y = 0
 	},
-/turf/simulated/floor,
-/area/station/hydroponics)
-"aHq" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hydroponics)
@@ -15145,6 +12744,9 @@
 /obj/disposalpipe/segment{
 	dir = 4;
 	pixel_y = 0
+	},
+/obj/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
@@ -15197,14 +12799,12 @@
 	},
 /area/station/hydroponics/lobby)
 "aHw" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment{
 	dir = 4;
 	pixel_y = 0
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 5
@@ -15280,7 +12880,7 @@
 	pixel_y = 0
 	},
 /turf/simulated/wall/auto/supernorn,
-/area/station/hallway/primary/south)
+/area/station/hydroponics/lobby)
 "aHF" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -15307,28 +12907,13 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "aHH" = (
+/obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+	icon_state = "6-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "aHI" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/disposalpipe/junction{
 	dir = 8;
 	icon_state = "pipe-j2"
@@ -15340,22 +12925,6 @@
 /obj/machinery/cashreg,
 /turf/simulated/floor,
 /area/station/engine/elect)
-"aHK" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
 "aHM" = (
 /obj/disposalpipe/segment{
 	dir = 8;
@@ -15365,24 +12934,7 @@
 	dir = 0
 	},
 /area/station/hallway/primary/south)
-"aHN" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
 "aHO" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/junction{
 	dir = 8;
 	icon_state = "pipe-y";
@@ -15392,104 +12944,71 @@
 	codes_txt = "patrol;next_patrol=outerbar";
 	location = "crossway"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "aHQ" = (
-/obj/firedoor_spawn,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "2-5"
 	},
-/obj/machinery/door/airlock/pyro/maintenance{
-	name = "Engineering Maintenance";
-	req_access = null
-	},
-/obj/access_spawn/engineering,
 /turf/simulated/floor/plating,
-/area/station/maintenance/west)
-"aHR" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
-"aHS" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
+/area/station/maintenance/NWmaint)
 "aHT" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 4
 	},
 /area/station/hallway/primary/south)
 "aHU" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/access_spawn/maint,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aHV" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/blue/side{
 	dir = 8
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aHW" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aHX" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 4
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aHY" = (
+/obj/firedoor_spawn,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/firedoor_spawn,
 /turf/simulated/floor/bluewhite{
 	dir = 8
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aHZ" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
@@ -15497,21 +13016,16 @@
 	name = "Med-Sci"
 	},
 /obj/access_spawn/medlab,
+/obj/cable{
+	icon_state = "5-8"
+	},
+/obj/cable{
+	icon_state = "6-8"
+	},
 /turf/simulated/floor/blackwhite/side{
 	dir = 4
 	},
 /area/station/medical/research)
-"aIa" = (
-/obj/disposalpipe/segment,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
 "aIb" = (
 /obj/storage/secure/closet/medical/medicine,
 /obj/health_scanner/wall{
@@ -15522,29 +13036,6 @@
 	name = "lobby health status screen";
 	pixel_x = -22;
 	pixel_y = -2
-	},
-/turf/simulated/floor/blue,
-/area/station/medical/medbay)
-"aIc" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
-"aId" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
@@ -15580,20 +13071,17 @@
 	},
 /area/station/medical/medbay)
 "aIi" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/landmark{
 	name = "peststart"
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/light,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "aIj" = (
@@ -15615,15 +13103,6 @@
 /obj/item/guardbot_core,
 /turf/simulated/floor/purple,
 /area/station/science)
-"aIl" = (
-/obj/disposalpipe/segment,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/purple,
-/area/station/science)
 "aIm" = (
 /obj/machinery/camera{
 	c_tag = "Research Sector North";
@@ -15641,7 +13120,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor,
@@ -15653,7 +13131,6 @@
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/test_apparatus/impact_pad,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor,
@@ -15674,18 +13151,6 @@
 	dir = 8
 	},
 /area/station/hydroponics)
-"aIu" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor/grass{
-	name = "astroturf";
-	tag = "icon-grass1"
-	},
-/area/station/hydroponics)
 "aIv" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/grass{
@@ -15699,104 +13164,45 @@
 	dir = 8
 	},
 /area/station/hydroponics)
-"aIx" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor,
-/area/station/hydroponics)
 "aIy" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
 /area/station/hydroponics)
-"aIz" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/grille/catwalk/cross,
-/turf/space,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 5;
-	icon_state = "catwalk_cross";
-	layer = 2
-	},
-/area/station/mining/magnet)
 "aIA" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
 /area/station/hydroponics/lobby)
-"aIB" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/hydroponics/lobby)
 "aIC" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/hydroponics/lobby)
 "aID" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "0-4"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
 /area/station/hydroponics/lobby)
-"aIE" = (
-/obj/grille/catwalk{
-	dir = 5
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/space,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	icon_state = "catwalk_cross";
-	layer = 2
-	},
-/area/station/mining/magnet)
 "aIF" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/green/side{
@@ -15804,31 +13210,22 @@
 	},
 /area/station/hydroponics/lobby)
 "aIG" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/green,
 /area/station/hydroponics/lobby)
 "aIH" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
+	},
+/obj/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/green,
 /area/station/hydroponics/lobby)
@@ -15843,28 +13240,6 @@
 	layer = 2
 	},
 /area/station/mining/magnet)
-"aIJ" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
-"aIK" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
 "aIL" = (
 /turf/simulated/floor/blue/corner,
 /area/station/hallway/primary/south)
@@ -15904,6 +13279,9 @@
 	req_access = null
 	},
 /obj/access_spawn/medlab,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/medical/research)
 "aIQ" = (
@@ -15918,10 +13296,6 @@
 	},
 /area/station/hallway/primary/south)
 "aIS" = (
-/obj/cable{
-	icon_state = "1-2";
-	tag = "icon-1-2"
-	},
 /turf/simulated/floor/blue/side{
 	dir = 6
 	},
@@ -15932,29 +13306,21 @@
 /turf/simulated/floor/blue/side{
 	dir = 10
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aIU" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 0
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aIV" = (
 /obj/machinery/light/emergency,
 /turf/simulated/floor/blue/side{
 	dir = 6
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aIW" = (
 /obj/machinery/light{
 	dir = 4;
@@ -15963,9 +13329,7 @@
 /turf/simulated/floor/bluewhite/corner{
 	dir = 1
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aIX" = (
 /obj/disposalpipe/junction{
 	dir = 8;
@@ -15975,9 +13339,7 @@
 /turf/simulated/floor/bluewhite/corner{
 	dir = 4
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aIY" = (
 /obj/disposalpipe/segment{
 	dir = 1;
@@ -15985,63 +13347,19 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
-"aIZ" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aJa" = (
 /obj/machinery/vending/medical_public,
 /turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
-"aJb" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/hydroponics)
+/area/station/medical/medbay/lobby)
 "aJc" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable,
 /obj/table/auto/desk,
 /obj/machinery/cashreg,
 /obj/item/kitchen/food_box/lollipop,
 /obj/machinery/door/window/westleft,
 /obj/access_spawn/medical,
 /turf/simulated/floor/blue,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
-"aJd" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/blue,
-/area/station/medical/medbay)
+/area/station/medical/medbay/lobby)
 "aJe" = (
 /obj/disposalpipe/trunk,
 /obj/machinery/disposal,
@@ -16050,11 +13368,6 @@
 	icon_state = "tube1";
 	layer = 9.1;
 	pixel_x = -10
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
@@ -16066,14 +13379,12 @@
 /area/station/medical/medbay)
 "aJg" = (
 /obj/firedoor_spawn,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
 	icon_state = "maint_closed"
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -16093,38 +13404,21 @@
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "aJi" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "W APC";
 	pixel_x = -24;
 	pixel_y = 0
 	},
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/purple,
 /area/station/science)
 "aJj" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/purple,
-/area/station/science)
-"aJk" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purple,
 /area/station/science)
@@ -16139,30 +13433,16 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/caution/south,
 /area/station/science/artifact)
 "aJn" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/caution/south,
 /area/station/science/artifact)
 "aJo" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /turf/simulated/floor/orangeblack/corner{
 	dir = 8
@@ -16256,9 +13536,7 @@
 /area/station/hydroponics/lobby)
 "aJG" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/orangeblack/side,
 /area/station/hydroponics/lobby)
@@ -16266,6 +13544,9 @@
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
+	},
+/obj/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 6
@@ -16276,23 +13557,6 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
-/area/station/hydroponics/lobby)
-"aJJ" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor/green,
-/area/station/hydroponics/lobby)
-"aJK" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/green,
 /area/station/hydroponics/lobby)
 "aJL" = (
 /obj/storage/crate,
@@ -16305,20 +13569,15 @@
 /turf/simulated/floor/green,
 /area/station/hydroponics/lobby)
 "aJN" = (
-/obj/cable,
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "S APC";
 	pixel_y = -24
 	},
+/obj/cable,
 /turf/simulated/floor/green,
 /area/station/hydroponics/lobby)
 "aJO" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/green/side{
 	dir = 8
 	},
@@ -16336,26 +13595,13 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
-"aJR" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2 (NORTH)"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
 "aJS" = (
-/obj/cable,
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "S APC";
 	pixel_y = -24
 	},
+/obj/cable,
 /turf/simulated/floor/blue/side{
 	dir = 0
 	},
@@ -16370,13 +13616,6 @@
 	dir = 9
 	},
 /area/station/quartermaster)
-"aJU" = (
-/obj/cable{
-	icon_state = "1-2";
-	tag = "icon-1-2"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/hallway/primary/south)
 "aJV" = (
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass,
@@ -16384,66 +13623,21 @@
 	dir = 1
 	},
 /area/station/hallway/primary/west)
-"aJW" = (
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/hydroponics)
-"aJX" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
 "aJY" = (
 /obj/disposalpipe/segment/bent/south,
 /turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
-"aJZ" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/blue,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aKa" = (
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
 	},
 /obj/disposalpipe/segment/bent/north,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aKb" = (
 /obj/machinery/light/small,
 /obj/reagent_dispensers/fueltank,
@@ -16517,6 +13711,9 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/purple/corner{
 	dir = 1
 	},
@@ -16526,30 +13723,19 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/purple/corner{
 	dir = 1
 	},
-/area/station/science)
-"aKk" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/purple,
-/area/station/science)
-"aKl" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/purple,
 /area/station/science)
 "aKm" = (
 /obj/grille/catwalk/cross{
@@ -16563,29 +13749,24 @@
 /area/station/mining/magnet)
 "aKn" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 1
 	},
 /area/station/science/artifact)
-"aKo" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/white,
-/area/station/science/artifact)
 "aKp" = (
 /obj/machinery/networked/artifact_console,
+/obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/data_terminal,
 /turf/simulated/floor/purplewhite{
 	dir = 1
 	},
@@ -16595,43 +13776,15 @@
 	dir = 5
 	},
 /area/station/science/artifact)
-"aKr" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/caution/west,
-/area/station/science/artifact)
 "aKs" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/test_apparatus/electrobox,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor,
 /area/station/science/artifact)
-"aKt" = (
-/obj/cable,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/hydroponics)
 "aKu" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/grass{
 	name = "astroturf";
@@ -16663,6 +13816,9 @@
 /area/station/hydroponics)
 "aKx" = (
 /obj/item/reagent_containers/food/drinks/bowl,
+/obj/cable{
+	icon_state = "1-10"
+	},
 /turf/simulated/floor/grass{
 	name = "astroturf";
 	tag = "icon-grass1"
@@ -16745,30 +13901,7 @@
 /obj/storage/closet/emergency,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
-"aKJ" = (
-/obj/cable{
-	icon_state = "1-2";
-	tag = "icon-1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/SEmaint)
 "aKK" = (
-/turf/simulated/floor/plating,
-/area/station/maintenance/SEmaint)
-"aKL" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/SEmaint)
-"aKM" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "aKN" = (
@@ -16780,49 +13913,18 @@
 /turf/simulated/floor/purplewhite{
 	dir = 9
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aKP" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/random_item_spawner/desk_stuff,
 /obj/table/glass/auto,
 /turf/simulated/floor/purplewhite{
 	dir = 5
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aKQ" = (
 /obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /turf/simulated/floor/plating,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
-"aKR" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/blue,
-/area/station/medical/medbay)
+/area/station/medical/medbay/lobby)
 "aKS" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -16832,6 +13934,9 @@
 /area/station/medical/medbay)
 "aKT" = (
 /obj/disposalpipe/switch_junction/left/west,
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "aKU" = (
@@ -16846,58 +13951,28 @@
 "aKV" = (
 /turf/simulated/floor/purple,
 /area/station/science)
-"aKW" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/purple,
-/area/station/science)
 "aKX" = (
 /obj/storage/secure/closet/research/uniform,
 /turf/simulated/floor/purple,
 /area/station/science)
 "aKY" = (
-/obj/cable{
-	icon_state = "1-2";
-	tag = "icon-1-2"
-	},
 /obj/machinery/light_switch{
 	name = "W light switch";
 	pixel_x = -24;
 	pixel_y = 0
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/purplewhite{
 	dir = 8
 	},
 /area/station/science/artifact)
-"aKZ" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/white,
-/area/station/science/artifact)
 "aLa" = (
 /obj/machinery/power/data_terminal,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/computer3/terminal/zeta{
+	dir = 8;
 	setup_os_string = "ZETA_MAINFRAME"
+	},
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/white,
 /area/station/science/artifact)
@@ -16907,27 +13982,17 @@
 	dir = 4
 	},
 /area/station/science/artifact)
-"aLc" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/caution/west,
-/area/station/science/artifact)
 "aLd" = (
 /obj/item/wrench,
+/obj/cable{
+	icon_state = "5-10"
+	},
 /turf/simulated/floor/grass{
 	name = "astroturf";
 	tag = "icon-grass1"
 	},
 /area/station/hydroponics)
 "aLe" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/plantpot,
 /obj/disposalpipe/segment,
 /turf/simulated/floor/grass{
@@ -16968,15 +14033,14 @@
 	name = "N APC";
 	pixel_y = 24
 	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture";
 	pixel_y = 21;
 	rigged = 0
+	},
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor{
 	icon_state = "0,6";
@@ -17018,14 +14082,6 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/SWmaint)
 "aLo" = (
-/turf/simulated/floor/plating,
-/area/station/maintenance/SWmaint)
-"aLp" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
 "aLq" = (
@@ -17083,16 +14139,17 @@
 /area/station/crew_quarters/quarters)
 "aLz" = (
 /obj/wingrille_spawn/auto,
-/obj/cable{
-	icon_state = "0-2"
-	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/lobby)
 "aLA" = (
 /obj/machinery/vending/standard,
 /turf/simulated/floor/yellow/side{
@@ -17140,6 +14197,9 @@
 /obj/landmark/start{
 	name = "Mechanic"
 	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor,
 /area/station/engine/elect)
 "aLG" = (
@@ -17166,48 +14226,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
-"aLK" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/cable{
-	icon_state = "1-2";
-	tag = "icon-1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/SEmaint)
-"aLL" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/SEmaint)
-"aLM" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/SEmaint)
 "aLN" = (
 /obj/stool/bench/blue/auto,
 /turf/simulated/floor/purplewhite{
 	dir = 8
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aLO" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
@@ -17216,39 +14241,26 @@
 /turf/simulated/floor/purplewhite{
 	dir = 4
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aLP" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/guardbot_dock,
 /obj/machinery/bot/guardbot/gunner,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/orangeblack,
 /area/station/science)
 "aLQ" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/bot/guardbot/ranger,
 /obj/machinery/guardbot_dock,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/orangeblack,
 /area/station/science)
 "aLR" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/guardbot_dock,
 /obj/machinery/bot/guardbot/syringe,
@@ -17256,18 +14268,12 @@
 	c_tag = "Research Sector";
 	dir = 2
 	},
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/orangeblack,
 /area/station/science)
 "aLS" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/guardbot_dock,
 /obj/item/device/radio/intercom{
@@ -17275,19 +14281,21 @@
 	frequency = 1445;
 	name = "Station Intercom (Medical)"
 	},
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/orangeblack,
 /area/station/science)
 "aLT" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/guardbot_dock,
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture";
 	rigged = 0
+	},
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/science)
@@ -17316,27 +14324,30 @@
 	pixel_x = -24;
 	pixel_y = 0
 	},
-/obj/cable,
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1"
+	},
+/obj/cable{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 8
 	},
 /area/station/science/artifact)
 "aLY" = (
-/obj/cable{
-	icon_state = "1-2";
-	tag = "icon-1-2"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/landmark/start{
 	name = "Scientist"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/white,
 /area/station/science/artifact)
@@ -17344,8 +14355,7 @@
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/test_apparatus/heater,
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "0-8"
 	},
 /turf/simulated/floor,
 /area/station/science/artifact)
@@ -17369,55 +14379,20 @@
 	tag = "icon-grass1"
 	},
 /area/station/hydroponics)
-"aMc" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/grass{
-	name = "astroturf";
-	tag = "icon-grass1"
-	},
-/area/station/hydroponics)
-"aMd" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small,
-/turf/simulated/floor/grass{
-	name = "astroturf";
-	tag = "icon-grass1"
-	},
-/area/station/hydroponics)
-"aMe" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/plantpot,
-/turf/simulated/floor/grass{
-	name = "astroturf";
-	tag = "icon-grass1"
-	},
-/area/station/hydroponics)
 "aMf" = (
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/blue,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/lobby)
 "aMg" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -17435,7 +14410,6 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/grass{
@@ -17478,11 +14452,6 @@
 /obj/item/clothing/gloves/boxing,
 /obj/item/clothing/under/shorts/black,
 /obj/item/clothing/under/shorts/black,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/item/clothing/under/shorts/black,
 /obj/item/clothing/gloves/boxing,
 /obj/item/device/radio,
@@ -17527,19 +14496,6 @@
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
-"aMq" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable,
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/hydroponics)
 "aMr" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/light{
@@ -17583,30 +14539,18 @@
 	dir = 4;
 	pixel_x = 24
 	},
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor,
 /area/station/engine/elect)
 "aMy" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
-"aMz" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/SEmaint)
 "aMA" = (
 /obj/firedoor_spawn,
 /turf/simulated/floor/plating,
-/area/station/maintenance/SEmaint)
-"aMB" = (
-/obj/cable{
-	icon_state = "1-2";
-	tag = "icon-1-2"
-	},
-/turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/SEmaint)
 "aMC" = (
 /obj/machinery/sim/vr_bed{
@@ -17666,57 +14610,16 @@
 /area/station/science)
 "aMI" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 4
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
-"aMJ" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 1
-	},
-/area/station/science)
-"aMK" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 1
-	},
-/area/station/science)
-"aML" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 1
-	},
-/area/station/science)
+/area/station/medical/medbay/lobby)
 "aMM" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 1
 	},
@@ -17736,10 +14639,6 @@
 	},
 /area/station/science)
 "aMP" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/camera{
 	c_tag = "Robotics East";
 	dir = 8
@@ -17757,8 +14656,6 @@
 	name = "Station Intercom (Medical)"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/purplewhite{
@@ -17767,52 +14664,15 @@
 /area/station/science/artifact)
 "aMR" = (
 /obj/cable{
-	icon_state = "1-2";
-	tag = "icon-1-2"
+	icon_state = "0-2"
 	},
+/obj/cable,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/white,
 /area/station/science/artifact)
-"aMS" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/caution/west,
-/area/station/science/artifact)
-"aMT" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor,
-/area/station/science/artifact)
 "aMU" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/door/poddoor{
 	id = "deliverydoor";
 	name = "Delivery Door"
@@ -17854,12 +14714,10 @@
 	},
 /area/station/crew_quarters/pool)
 "aMZ" = (
+/obj/fitness/weightlifter,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/fitness/weightlifter,
 /turf/simulated/floor{
 	icon_state = "0,6";
 	tag = "icon-0,6"
@@ -17887,20 +14745,6 @@
 /obj/stool,
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
-"aNd" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable,
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/hydroponics)
 "aNe" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -17921,65 +14765,11 @@
 "aNg" = (
 /turf/simulated/floor/yellow/corner,
 /area/station/engine/elect)
-"aNh" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/yellow/corner{
-	dir = 1
-	},
-/area/station/engine/elect)
-"aNi" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/yellow/corner,
-/area/station/engine/elect)
-"aNj" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/firedoor_spawn,
-/obj/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/station/maintenance/SEmaint)
-"aNk" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/station/maintenance/SEmaint)
-"aNl" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/SEmaint)
 "aNm" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/landmark{
 	name = "kudzustart"
 	},
+/obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "aNn" = (
@@ -17992,33 +14782,13 @@
 /obj/access_spawn/engineering_chief,
 /turf/simulated/floor,
 /area/station/engine/engineering)
-"aNo" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/purple,
-/area/station/science)
 "aNp" = (
 /obj/shrub,
 /turf/simulated/floor/purplewhite{
 	dir = 10
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aNq" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
@@ -18042,11 +14812,11 @@
 /area/station/science/artifact)
 "aNs" = (
 /obj/machinery/power/data_terminal,
-/obj/cable,
 /obj/table/wood/auto,
 /obj/machinery/networked/printer{
 	print_id = "Artlab"
 	},
+/obj/cable,
 /turf/simulated/floor/purplewhite,
 /area/station/science/artifact)
 "aNt" = (
@@ -18077,40 +14847,14 @@
 "aNw" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/test_apparatus/xraymachine,
-/obj/cable,
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
 	},
+/obj/cable,
 /turf/simulated/floor,
 /area/station/science/artifact)
-"aNx" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable,
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/hydroponics)
-"aNy" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/maintenance/SWmaint)
 "aNz" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/door/poddoor{
 	id = "deliverydoor";
 	name = "Delivery Door"
@@ -18159,17 +14903,6 @@
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
-"aNG" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor{
-	icon_state = "0,6";
-	tag = "icon-0,6"
-	},
-/area/station/crew_quarters/fitness)
 "aNH" = (
 /obj/decal/boxingrope{
 	dir = 4;
@@ -18178,39 +14911,6 @@
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
-"aNI" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable,
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/maintenance/SWmaint)
-"aNJ" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/SWmaint)
-"aNK" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/landmark{
-	name = "blobstart"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/SWmaint)
 "aNL" = (
 /obj/reagent_dispensers/foamtank,
 /turf/simulated/floor/plating,
@@ -18239,11 +14939,6 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/quarters)
 "aNQ" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1";
@@ -18252,21 +14947,6 @@
 	},
 /turf/simulated/floor/yellow/corner,
 /area/station/engine/elect)
-"aNR" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/yellow/corner{
-	dir = 1
-	},
-/area/station/engine/elect)
 "aNS" = (
 /obj/disposalpipe/segment{
 	dir = 1;
@@ -18274,105 +14954,66 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
-"aNT" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/SEmaint)
 "aNU" = (
-/obj/cable,
-/obj/machinery/power/terminal{
-	dir = 4
-	},
+/obj/table/auto,
+/obj/machinery/cell_charger,
+/obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "aNV" = (
-/obj/machinery/power/smes{
-	charge = 1.5e+006;
-	chargemode = 1;
-	n_tag = "Research Sector SMES";
-	output = 15000
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/SEmaint)
-"aNW" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/light/small,
+/obj/decal/cleanable/dirt/jen,
+/obj/decal/cleanable/rust/jen,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "aNX" = (
 /obj/stool/bench/blue/auto,
 /turf/simulated/floor/purplewhite,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aNY" = (
 /obj/shrub,
 /obj/item/cigpacket,
 /turf/simulated/floor/purplewhite{
 	dir = 4
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aNZ" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/light{
 	dir = 1;
 	icon_state = "tube1";
 	layer = 9.1;
 	pixel_y = 21
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
 /area/station/security/brig)
 "aOa" = (
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/purple/side,
 /area/station/science)
 "aOb" = (
 /obj/machinery/power/data_terminal,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/camera{
 	c_tag = "Research Sector South";
 	dir = 8
+	},
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/purple,
 /area/station/science)
 "aOc" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
-"aOd" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/bar)
 "aOe" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/wood/two,
@@ -18397,31 +15038,20 @@
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
 "aOi" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/table/reinforced/bar/auto,
 /obj/item/reagent_containers/food/snacks/burger/cheeseburger,
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
 "aOj" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "N APC";
 	pixel_y = 24
 	},
 /obj/table/reinforced/bar/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
 "aOk" = (
@@ -18432,20 +15062,7 @@
 /obj/stool/bar,
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
-"aOm" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/pool)
 "aOn" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/table/wood/auto,
 /obj/item/clothing/under/shorts/blue{
 	desc = "In space?";
@@ -18473,11 +15090,6 @@
 	},
 /area/station/crew_quarters/pool)
 "aOo" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor{
 	icon = 'icons/misc/beach.dmi';
@@ -18486,11 +15098,6 @@
 	},
 /area/station/crew_quarters/pool)
 "aOp" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/overlay{
 	anchored = 1;
 	icon = 'icons/misc/beach2.dmi';
@@ -18510,24 +15117,7 @@
 	name = "sand"
 	},
 /area/station/crew_quarters/pool)
-"aOq" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor{
-	icon = 'icons/misc/beach.dmi';
-	icon_state = "sand";
-	name = "sand"
-	},
-/area/station/crew_quarters/pool)
 "aOr" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/item/beach_ball,
 /turf/simulated/floor{
 	icon = 'icons/misc/beach.dmi';
@@ -18536,11 +15126,6 @@
 	},
 /area/station/crew_quarters/pool)
 "aOs" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/critter/sealpup,
 /turf/simulated/floor{
 	icon = 'icons/misc/beach.dmi';
@@ -18548,59 +15133,10 @@
 	name = "sand"
 	},
 /area/station/crew_quarters/pool)
-"aOt" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor{
-	icon = 'icons/misc/beach.dmi';
-	icon_state = "sand";
-	name = "sand"
-	},
-/area/station/crew_quarters/pool)
 "aOu" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/window/westleft,
-/turf/simulated/floor{
-	icon_state = "0,6";
-	tag = "icon-0,6"
-	},
-/area/station/crew_quarters/fitness)
-"aOv" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
-	},
-/turf/simulated/floor{
-	icon_state = "0,6";
-	tag = "icon-0,6"
-	},
-/area/station/crew_quarters/fitness)
-"aOw" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/stool/chair{
-	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "0,6";
@@ -18627,56 +15163,8 @@
 	pixel_x = 0;
 	tag = "icon-ringrope (WEST)"
 	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
-"aOz" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/specialroom/gym,
-/area/station/crew_quarters/fitness)
-"aOA" = (
-/obj/decal/boxingrope{
-	dir = 4;
-	icon_state = "ringrope";
-	tag = "icon-ringrope (EAST)"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/specialroom/gym,
-/area/station/crew_quarters/fitness)
-"aOB" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/wingrille_spawn/auto,
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/bar)
-"aOC" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/SWmaint)
 "aOD" = (
 /obj/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -18697,16 +15185,7 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/quarters)
-"aOF" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/quarters)
@@ -18726,43 +15205,14 @@
 "aOH" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/west)
-"aOI" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable,
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/maintenance/SWmaint)
-"aOK" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
 "aOL" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Med-Sci"
 	},
 /obj/access_spawn/medlab,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/blackwhite/side,
 /area/station/medical/research)
 "aOM" = (
@@ -18795,26 +15245,22 @@
 	pixel_x = 24;
 	pixel_y = 0
 	},
-/obj/cable,
+/obj/disposalpipe/segment,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "aOP" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance{
 	name = "Engineering Maintenance";
 	req_access = null
 	},
 /obj/access_spawn/engineering,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aOQ" = (
@@ -18830,30 +15276,13 @@
 	},
 /turf/simulated/floor/purple,
 /area/station/science)
-"aOS" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/purple,
-/area/station/science)
 "aOT" = (
 /obj/machinery/power/data_terminal,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
-/obj/cable,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/table/auto,
 /obj/machinery/networked/printer{
 	print_id = "Office"
 	},
+/obj/cable,
 /turf/simulated/floor/purple,
 /area/station/science)
 "aOU" = (
@@ -18885,7 +15314,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/purplewhite{
@@ -18903,12 +15331,11 @@
 /area/station/science/lab)
 "aOY" = (
 /obj/machinery/power/data_terminal,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/networked/storage/bomb_tester{
 	bank_id = "Mixer"
+	},
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 1
@@ -18950,15 +15377,6 @@
 /obj/storage/closet/welding_supply,
 /turf/simulated/floor/grime,
 /area/station/storage/warehouse)
-"aPd" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable,
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/bar)
 "aPe" = (
 /obj/table/reinforced/bar/auto,
 /obj/machinery/light{
@@ -19032,18 +15450,6 @@
 	name = "sand"
 	},
 /area/station/crew_quarters/pool)
-"aPl" = (
-/obj/cable{
-	icon_state = "1-2";
-	tag = "icon-1-2"
-	},
-/obj/machinery/light,
-/turf/simulated/floor{
-	icon = 'icons/misc/beach.dmi';
-	icon_state = "sand";
-	name = "sand"
-	},
-/area/station/crew_quarters/pool)
 "aPm" = (
 /obj/machinery/light,
 /turf/simulated/floor{
@@ -19071,14 +15477,6 @@
 "aPp" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/mining/magnet)
-"aPq" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/quarters)
 "aPr" = (
 /obj/disposalpipe/segment,
 /obj/machinery/light,
@@ -19116,11 +15514,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/quarters)
-"aPt" = (
-/obj/cable,
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/maintenance/SWmaint)
 "aPu" = (
 /obj/shrub,
 /turf/simulated/floor/neutral/side{
@@ -19147,11 +15540,6 @@
 	},
 /area/station/hallway/primary/west)
 "aPy" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/junction{
 	dir = 1
 	},
@@ -19160,22 +15548,14 @@
 "aPz" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/fitness)
-"aPA" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor,
-/area/station/engine/elect)
 "aPB" = (
-/obj/cable,
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "E APC";
 	pixel_x = 24;
 	pixel_y = 0
 	},
+/obj/cable,
 /turf/simulated/floor/yellow/corner{
 	dir = 1
 	},
@@ -19250,14 +15630,13 @@
 	dir = 4
 	},
 /turf/simulated/wall/auto/supernorn,
-/area/station/hallway/primary/south)
+/area/station/engine/elect)
 "aPJ" = (
 /obj/machinery/computer/telescope{
 	dir = 4
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/purple/side{
@@ -19266,62 +15645,27 @@
 /area/station/science/teleporter)
 "aPK" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "0-8"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 1
 	},
 /area/station/science/teleporter)
 "aPL" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/lrteleporter,
 /turf/simulated/floor/purple,
 /area/station/science/teleporter)
-"aPM" = (
-/obj/firedoor_spawn,
-/obj/machinery/door/airlock/pyro/maintenance,
-/obj/access_spawn/maint,
-/turf/simulated/floor/plating,
-/area/station/maintenance/SWmaint)
-"aPN" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light,
-/turf/simulated/floor/purple,
-/area/station/science)
-"aPO" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/purple,
-/area/station/science)
 "aPP" = (
+/obj/item/extinguisher,
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/item/extinguisher,
 /turf/simulated/floor/purple,
 /area/station/science)
 "aPQ" = (
@@ -19337,12 +15681,10 @@
 /area/station/science/teleporter)
 "aPT" = (
 /obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters)
 "aPU" = (
@@ -19356,8 +15698,6 @@
 /area/station/science)
 "aPV" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/purple/side{
@@ -19370,36 +15710,6 @@
 	},
 /turf/simulated/floor/bot,
 /area/station/storage/warehouse)
-"aPX" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/purplewhite{
-	dir = 9
-	},
-/area/station/science/lab)
-"aPY" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/purplewhite{
-	dir = 1
-	},
-/area/station/science/lab)
 "aPZ" = (
 /turf/simulated/floor/purplewhite{
 	dir = 10
@@ -19407,10 +15717,15 @@
 /area/station/science/lab)
 "aQa" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "0-4"
 	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
 /turf/simulated/floor/purplewhite{
 	dir = 1
 	},
@@ -19460,6 +15775,9 @@
 	layer = 9.1;
 	pixel_x = 10
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
 "aQi" = (
@@ -19489,15 +15807,11 @@
 	icon_state = "maint_closed"
 	},
 /obj/access_spawn/maint,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
-"aQm" = (
-/obj/cable{
-	icon_state = "1-2";
-	tag = "icon-1-2"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/pool)
 "aQn" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -19507,44 +15821,28 @@
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Pool"
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/crew_quarters/pool)
 "aQp" = (
 /obj/firedoor_spawn,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
 	icon_state = "eng_closed"
 	},
 /obj/access_spawn/engineering,
 /obj/access_spawn/mining,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "aQq" = (
 /obj/storage/crate/abcumarker,
 /turf/simulated/floor/bot,
 /area/station/storage/warehouse)
-"aQr" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/SWmaint)
-"aQs" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable,
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/bar)
 "aQt" = (
 /obj/disposalpipe/trunk,
 /obj/machinery/disposal/mail{
@@ -19573,33 +15871,14 @@
 /obj/item/device/multitool,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
-"aQw" = (
+"aQx" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/station/maintenance/SEmaint)
-"aQx" = (
 /turf/simulated/floor/purplewhite/corner{
 	dir = 1
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
-"aQy" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/science/teleporter)
+/area/station/medical/medbay/lobby)
 "aQz" = (
 /obj/machinery/light_switch{
 	name = "E light switch";
@@ -19619,17 +15898,15 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/quarters)
 "aQB" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance{
 	name = "Botany Maintenance";
 	req_access = null
 	},
 /obj/access_spawn/hydro,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aQC" = (
@@ -19653,9 +15930,11 @@
 /area/station/turret_protected/Zeta)
 "aQF" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/turret_protected/Zeta)
@@ -19672,11 +15951,6 @@
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/Zeta)
 "aQH" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/camera{
 	c_tag = "Research Sector Lobby";
 	dir = 8
@@ -19685,9 +15959,7 @@
 /turf/simulated/floor/purplewhite{
 	dir = 4
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aQI" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -19696,9 +15968,7 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 10
@@ -19707,24 +15977,9 @@
 "aQJ" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/purple,
-/area/station/science/lab)
-"aQK" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/purplewhite,
 /area/station/science/lab)
 "aQL" = (
 /obj/table/auto,
@@ -19787,16 +16042,6 @@
 /area/station/crew_quarters/cafeteria)
 "aQS" = (
 /obj/firedoor_spawn,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Robotics"
 	},
@@ -19855,47 +16100,6 @@
 	icon_state = "tube1";
 	layer = 9.1;
 	pixel_y = 21
-	},
-/turf/simulated/floor/neutral/side{
-	dir = 1
-	},
-/area/station/hallway/primary/west)
-"aQY" = (
-/obj/cable{
-	icon_state = "1-2";
-	tag = "icon-1-2"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
-/turf/simulated/floor/neutral/side{
-	dir = 1
-	},
-/area/station/hallway/primary/west)
-"aQZ" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
-/turf/simulated/floor/neutral/side{
-	dir = 1
-	},
-/area/station/hallway/primary/west)
-"aRa" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 1
@@ -19976,8 +16180,12 @@
 /turf/simulated/floor/purple,
 /area/station/science/teleporter)
 "aRi" = (
+/obj/cable,
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor,
 /area/station/science/teleporter)
@@ -19987,6 +16195,13 @@
 /turf/simulated/floor/grime,
 /area/station/storage/warehouse)
 "aRk" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/purple/side{
 	dir = 1
 	},
@@ -19996,22 +16211,23 @@
 	pixel_y = 24;
 	text = "NF"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/purple/side{
 	dir = 1
 	},
 /area/station/crew_quarters/hor)
 "aRm" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/critter/domestic_bee{
 	name = "Heisenbee"
 	},
 /obj/item/paper_bin{
 	desc = "A little improvised bee bed of unusually-soft printer paper.";
 	name = "Bee Bin"
+	},
+/obj/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 1
@@ -20032,10 +16248,6 @@
 	},
 /area/station/crew_quarters/hor)
 "aRp" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/window/reinforced{
 	dir = 1;
 	icon_state = "rwindow";
@@ -20058,23 +16270,13 @@
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/Zeta)
 "aRr" = (
+/obj/machinery/door/window/northleft,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/window/northleft,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/turret_protected/Zeta)
 "aRs" = (
-/turf/simulated/floor/circuit,
-/area/station/turret_protected/Zeta)
-"aRt" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/Zeta)
 "aRu" = (
@@ -20150,6 +16352,9 @@
 	},
 /area/station/science/lab)
 "aRB" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/carpet{
 	dir = 9;
 	icon_state = "red2"
@@ -20220,23 +16425,12 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
-"aRI" = (
-/obj/cable{
-	icon_state = "1-2";
-	tag = "icon-1-2"
-	},
-/obj/firedoor_spawn,
-/obj/machinery/door/airlock/pyro/glass,
-/turf/simulated/floor,
-/area/station/hallway/primary/west)
 "aRJ" = (
 /obj/grille/catwalk{
 	dir = 10;
 	icon_state = "catwalk_cross"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/space,
@@ -20246,11 +16440,6 @@
 	},
 /area/station/mining/magnet)
 "aRK" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1";
@@ -20268,6 +16457,9 @@
 	icon_state = "pipe-s";
 	tag = "icon-pipe-s (EAST)"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/neutral/corner{
 	dir = 8
 	},
@@ -20282,69 +16474,12 @@
 	dir = 8
 	},
 /area/station/hallway/primary/west)
-"aRN" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s";
-	tag = "icon-pipe-s (EAST)"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/neutral/corner{
-	dir = 8
-	},
-/area/station/hallway/primary/west)
-"aRO" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s";
-	tag = "icon-pipe-s (EAST)"
-	},
-/turf/simulated/floor/neutral/corner{
-	dir = 8
-	},
-/area/station/hallway/primary/west)
-"aRP" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s";
-	tag = "icon-pipe-s (EAST)"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/neutral/corner{
-	dir = 8
-	},
-/area/station/hallway/primary/west)
 "aRQ" = (
 /obj/grille/catwalk{
 	dir = 6;
 	icon_state = "catwalk-0"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/space,
@@ -20360,57 +16495,25 @@
 	icon_state = "pipe-s";
 	tag = "icon-pipe-s (EAST)"
 	},
-/turf/simulated/floor/neutral/corner{
-	dir = 1
-	},
-/area/station/hallway/primary/west)
-"aRS" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s";
-	tag = "icon-pipe-s (EAST)"
-	},
 /turf/simulated/floor/neutral/corner{
 	dir = 1
 	},
 /area/station/hallway/primary/west)
-"aRT" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/purple,
-/area/station/science/teleporter)
 "aRU" = (
 /obj/machinery/door/poddoor/pyro{
 	id = "publicscienceteleporter";
 	name = "teleporter lockdown"
 	},
 /turf/simulated/floor/purple,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
-"aRV" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/purple,
-/area/station/science/teleporter)
+/area/station/medical/medbay/lobby)
 "aRW" = (
 /obj/grille/catwalk{
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/space,
@@ -20420,28 +16523,28 @@
 	},
 /area/station/mining/magnet)
 "aRX" = (
+/obj/machinery/light,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/light,
 /turf/simulated/floor/purple/side{
 	dir = 10
 	},
 /area/station/science/teleporter)
 "aRY" = (
+/obj/cable,
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/purple/side,
 /area/station/science/teleporter)
 "aRZ" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/carpet{
 	dir = 9;
 	icon_state = "red2"
@@ -20466,27 +16569,16 @@
 	pixel_x = -24;
 	pixel_y = 0
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
 /turf/simulated/floor/purple/side{
 	dir = 8
 	},
 /area/station/crew_quarters/hor)
 "aSd" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/data_terminal,
 /obj/machinery/turret{
 	dir = 1;
 	icon_state = "grey_target_prism";
 	tag = "icon-grey_target_prism (NORTH)"
 	},
-/obj/cable,
 /turf/simulated/floor/bot,
 /area/station/turret_protected/Zeta)
 "aSe" = (
@@ -20501,15 +16593,6 @@
 /turf/simulated/floor/purplewhite{
 	dir = 4
 	},
-/area/station/science/lab)
-"aSh" = (
-/obj/machinery/atmospherics/valve,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/purple,
 /area/station/science/lab)
 "aSi" = (
 /obj/machinery/atmospherics/pipe/manifold{
@@ -20593,6 +16676,13 @@
 	icon_state = "pipe-s";
 	tag = "icon-pipe-s (EAST)"
 	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
 "aSq" = (
@@ -20600,6 +16690,9 @@
 	dir = 4;
 	icon_state = "pipe-s";
 	tag = "icon-pipe-s (EAST)"
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
 	dir = 8;
@@ -20617,12 +16710,18 @@
 /area/station/crew_quarters/cafeteria)
 "aSs" = (
 /obj/stool/bar,
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor{
 	icon_state = "carpetSE"
 	},
 /area/station/crew_quarters/cafeteria)
 "aSt" = (
 /obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
 "aSu" = (
@@ -20635,6 +16734,9 @@
 	dir = 1;
 	icon_state = "chair_wooden"
 	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
 "aSv" = (
@@ -20643,17 +16745,15 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "aSw" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
 	name = "Mining";
 	req_access = null
 	},
 /obj/access_spawn/mining,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/mining/magnet)
 "aSx" = (
@@ -20686,33 +16786,6 @@
 	dir = 2
 	},
 /area/station/hallway/primary/west)
-"aSA" = (
-/obj/cable{
-	icon_state = "1-2";
-	tag = "icon-1-2"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
-/turf/simulated/floor/neutral/side{
-	dir = 2
-	},
-/area/station/hallway/primary/west)
-"aSB" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
-/turf/simulated/floor/neutral/side{
-	dir = 2
-	},
-/area/station/hallway/primary/west)
 "aSC" = (
 /obj/machinery/power/apc{
 	dir = 2;
@@ -20723,10 +16796,7 @@
 	dir = 4;
 	pixel_y = 0
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
+/obj/cable,
 /turf/simulated/floor/neutral/side{
 	dir = 2
 	},
@@ -20735,11 +16805,6 @@
 /obj/machinery/camera{
 	c_tag = "Crew Quarters - Maint";
 	dir = 1
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -20750,17 +16815,7 @@
 	},
 /area/station/hallway/primary/west)
 "aSE" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment,
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/disposalpipe/segment{
 	dir = 4;
 	pixel_y = 0
@@ -20825,22 +16880,7 @@
 /turf/simulated/floor/purplewhite/corner{
 	dir = 8
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
-"aSM" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/purple,
-/area/station/science/teleporter)
+/area/station/medical/medbay/lobby)
 "aSN" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -20857,9 +16897,6 @@
 /turf/simulated/floor/engine,
 /area/station/science/teleporter)
 "aSP" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/stool/chair,
 /turf/simulated/floor/carpet{
 	dir = 1;
@@ -20868,9 +16905,7 @@
 /area/station/crew_quarters/hor)
 "aSQ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet{
 	dir = 8;
@@ -20879,11 +16914,6 @@
 /area/station/crew_quarters/hor)
 "aSR" = (
 /obj/table/wood/auto,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/deskclutter,
 /obj/item/reagent_containers/food/drinks/rum_spaced,
 /turf/simulated/floor/carpet,
@@ -20902,57 +16932,19 @@
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/pool)
-"aST" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/circuit,
-/area/station/turret_protected/Zeta)
-"aSU" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/circuit,
-/area/station/turret_protected/Zeta)
 "aSV" = (
+/obj/stool,
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "0-4"
 	},
-/obj/cable,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
-/obj/stool,
+/obj/cable,
 /turf/simulated/floor/specialroom/arcade,
-/area/station/turret_protected/Zeta)
-"aSW" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/circuit,
 /area/station/turret_protected/Zeta)
 "aSX" = (
 /obj/machinery/camera{
@@ -21004,31 +16996,26 @@
 	tag = "icon-manifold (WEST)"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/purple,
 /area/station/science/lab)
 "aTb" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-4"
 	},
-/obj/firedoor_spawn,
-/obj/machinery/door/airlock/pyro/maintenance,
-/obj/access_spawn/maint,
-/turf/simulated/floor/plating,
-/area/station/maintenance/SWmaint)
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/turf/simulated/floor,
+/area/station/security/checkpoint)
 "aTc" = (
 /obj/firedoor_spawn,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "1-10"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "aTd" = (
@@ -21039,6 +17026,9 @@
 /obj/stool/chair/wooden{
 	dir = 1;
 	icon_state = "chair_wooden"
+	},
+/obj/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
@@ -21059,28 +17049,24 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/bar)
 "aTh" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
 	name = "Mining";
 	req_access = null
 	},
 /obj/access_spawn/mining,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "aTi" = (
 /obj/firedoor_spawn,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/access_spawn/research,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/white,
 /area/station/science/storage)
 "aTj" = (
@@ -21092,7 +17078,6 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/quarters)
 "aTl" = (
-/obj/cable,
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/hor)
@@ -21195,15 +17180,12 @@
 /turf/simulated/floor/purple,
 /area/station/science/teleporter)
 "aTA" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/purple,
 /area/station/science/teleporter)
 "aTB" = (
-/turf/simulated/floor/engine,
-/area/station/science/teleporter)
-"aTC" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/engine,
 /area/station/science/teleporter)
 "aTD" = (
@@ -21231,17 +17213,7 @@
 	},
 /area/station/crew_quarters/hor)
 "aTF" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/table/wood/auto,
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/carpet,
 /area/station/crew_quarters/hor)
 "aTG" = (
@@ -21254,11 +17226,6 @@
 /turf/simulated/floor/engine,
 /area/station/science/teleporter)
 "aTH" = (
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer3/terminal/zeta{
 	setup_os_string = "ZETA_MAINFRAME"
@@ -21266,6 +17233,10 @@
 /obj/window/reinforced{
 	dir = 2;
 	icon_state = "rwindow"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/turret_protected/Zeta)
@@ -21467,15 +17438,6 @@
 	dir = 2
 	},
 /area/station/owlery)
-"aUc" = (
-/obj/cable{
-	icon_state = "1-2";
-	tag = "icon-1-2"
-	},
-/turf/simulated/floor/grass/random{
-	dir = 2
-	},
-/area/station/owlery)
 "aUd" = (
 /obj/critter/parrot/random,
 /turf/simulated/floor/grass/random{
@@ -21496,15 +17458,6 @@
 	dir = 2
 	},
 /area/station/owlery)
-"aUg" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/turret_protected/Zeta)
 "aUh" = (
 /obj/stool/chair/comfy,
 /obj/machinery/light/small{
@@ -21517,10 +17470,6 @@
 	},
 /area/station/crew_quarters/barber_shop)
 "aUi" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "N APC";
@@ -21528,6 +17477,9 @@
 	},
 /obj/table/wood/auto,
 /obj/item/instrument/harmonica,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor{
 	icon_state = "carpetS"
 	},
@@ -21571,12 +17523,18 @@
 /obj/landmark/start{
 	name = "predator"
 	},
+/obj/cable{
+	icon_state = "1-6"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
 "aUo" = (
 /obj/machinery/camera{
 	c_tag = "Bar Maintenance";
 	dir = 2
+	},
+/obj/cable{
+	icon_state = "2-6"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
@@ -21596,6 +17554,9 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "2-9"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "aUs" = (
@@ -21614,18 +17575,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
-"aUu" = (
-/obj/table/reinforced/auto,
-/obj/item/device/radio{
-	pixel_x = -3;
-	pixel_y = 4
-	},
-/obj/item/device/radio{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
 "aUv" = (
 /obj/machinery/light{
 	dir = 8;
@@ -21662,15 +17611,14 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aUA" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "W APC";
 	pixel_x = -24;
 	pixel_y = 0
+	},
+/obj/cable{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 8
@@ -21686,17 +17634,12 @@
 /obj/item/device/radio/headset/multifreq,
 /obj/item/device/radio/headset/multifreq,
 /obj/storage/crate,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/purple,
 /area/station/science/teleporter)
 "aUC" = (
-/obj/cable,
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/telepad,
+/obj/cable,
 /turf/simulated/floor/engine,
 /area/station/science/teleporter)
 "aUD" = (
@@ -21708,18 +17651,12 @@
 /area/station/science/teleporter)
 "aUE" = (
 /obj/machinery/power/data_terminal,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
 /obj/computerframe{
 	anchored = 1;
 	state = 1
+	},
+/obj/cable{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 10
@@ -21730,52 +17667,34 @@
 /turf/simulated/floor,
 /area/station/bridge)
 "aUG" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/stool{
 	desc = "A soft little bed the general size and shape of a space bee.";
 	icon = 'icons/misc/critter.dmi';
 	icon_state = "beebed";
 	name = "heisenbed"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/purple/side,
 /area/station/crew_quarters/hor)
 "aUH" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/stool/bed,
 /obj/machinery/light,
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
 	},
-/turf/simulated/floor/purple/side,
-/area/station/crew_quarters/hor)
-"aUI" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "0-4"
 	},
+/obj/cable,
+/turf/simulated/floor/purple/side,
+/area/station/crew_quarters/hor)
+"aUI" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/storage/tape_drive{
 	bank_id = "Control";
@@ -21786,6 +17705,9 @@
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
+	},
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 6
@@ -21799,14 +17721,13 @@
 /turf/simulated/floor/caution/west,
 /area/station/turret_protected/Zeta)
 "aUK" = (
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/mainframe/zeta{
 	tag = "ZETA_MAINFRAME"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/delivery,
 /area/station/turret_protected/Zeta)
@@ -21820,44 +17741,17 @@
 	},
 /area/station/turret_protected/Zeta)
 "aUM" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/door_control{
 	id = "dwaine_core";
 	name = "DWAINE Core Shield";
 	pixel_x = 24;
 	pixel_y = 0
 	},
+/obj/cable{
+	icon_state = "1-10"
+	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/Zeta)
-"aUN" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/purple/corner{
-	dir = 1
-	},
-/area/station/science)
 "aUO" = (
 /obj/disposalpipe/segment{
 	dir = 8;
@@ -21869,8 +17763,6 @@
 /area/station/medical/research)
 "aUP" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/purplewhite{
@@ -21900,11 +17792,6 @@
 /turf/simulated/floor/purple,
 /area/station/science/lab)
 "aUU" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment,
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/west)
@@ -22039,109 +17926,32 @@
 "aVj" = (
 /turf/simulated/floor,
 /area/station/mining/magnet)
-"aVk" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/grass/random{
-	dir = 2
-	},
-/area/station/owlery)
-"aVl" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/grass/random{
-	dir = 2
-	},
-/area/station/owlery)
 "aVm" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/critter/owl,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/grass/random{
 	dir = 2
 	},
 /area/station/owlery)
-"aVn" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/unpowered/wood/pyro{
-	dir = 4;
-	name = "The Snip"
-	},
-/turf/simulated/floor/wood/two,
-/area/station/crew_quarters/barber_shop)
-"aVo" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/wood/two,
-/area/station/crew_quarters/barber_shop)
-"aVp" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/wood/two,
-/area/station/crew_quarters/barber_shop)
 "aVq" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/unpowered/wood/pyro{
 	dir = 4;
 	name = "The Snip"
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/barber_shop)
-"aVr" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/specialroom/cafeteria,
-/area/station/crew_quarters/barber_shop)
 "aVs" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/bar)
 "aVt" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -22193,26 +18003,19 @@
 	},
 /area/station/hallway/primary/south)
 "aVB" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/pyro/security{
 	dir = 4;
 	icon_state = "sec_closed";
 	name = "Detective's Office"
 	},
 /obj/access_spawn/forensics,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
 "aVC" = (
 /obj/table/wood/auto,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/item/hand_labeler,
 /obj/item/device/audio_log{
 	pixel_x = 3;
@@ -22223,11 +18026,6 @@
 	},
 /area/station/security/detectives_office)
 "aVD" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/stool/chair,
 /obj/landmark/start{
 	name = "Detective"
@@ -22256,6 +18054,9 @@
 /obj/stool/chair/office/purple{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/purple,
 /area/station/science/teleporter)
 "aVI" = (
@@ -22270,48 +18071,16 @@
 	},
 /turf/space,
 /area/station/turret_protected/ai)
-"aVK" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/light,
-/turf/simulated/floor/circuit,
-/area/station/turret_protected/Zeta)
 "aVL" = (
-/obj/cable,
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/radio,
+/obj/cable,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/turret_protected/Zeta)
 "aVM" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/light,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/Zeta)
-"aVN" = (
-/obj/firedoor_spawn,
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4;
-	icon_state = "maint_closed";
-	name = "Tech Storage"
-	},
-/obj/access_spawn/tech_storage,
-/turf/simulated/floor,
-/area/station/storage/primary)
-"aVO" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/SWmaint)
 "aVP" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/plating,
@@ -22407,10 +18176,6 @@
 /area/station/maintenance/SWmaint)
 "aWg" = (
 /obj/disposalpipe/segment,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "N APC";
@@ -22420,6 +18185,12 @@
 	dir = 1;
 	icon_state = "tube1";
 	tag = "icon-tube1 (NORTH)"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/black,
 /area/station/security/hos)
@@ -22448,21 +18219,12 @@
 /turf/simulated/floor/sanitary,
 /area/station/hallway/primary/west)
 "aWk" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-9"
+	},
 /turf/simulated/floor/plating,
 /area/station/turret_protected/Zeta)
-"aWl" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/carpet/grime,
-/area/station/security/detectives_office)
 "aWm" = (
 /turf/simulated/floor{
 	icon_state = "carpetSW"
@@ -22477,19 +18239,9 @@
 	},
 /area/station/security/detectives_office)
 "aWo" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/table/wood/auto,
 /obj/item/cigpacket,
 /obj/item/clothing/glasses/thermal,
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /turf/simulated/floor{
 	icon_state = "carpetS"
 	},
@@ -22501,11 +18253,6 @@
 	name = "detectives camera";
 	pictures_left = 30
 	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor{
 	icon_state = "carpetS"
 	},
@@ -22513,22 +18260,9 @@
 "aWq" = (
 /obj/table/wood/auto,
 /obj/item/storage/secure/sbriefcase,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor{
 	icon_state = "carpetSE"
 	},
-/area/station/security/detectives_office)
-"aWr" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aWs" = (
 /obj/firedoor_spawn,
@@ -22537,29 +18271,11 @@
 	icon_state = "sec_closed"
 	},
 /obj/access_spawn/security,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/security/main)
-"aWt" = (
-/obj/disposalpipe/segment,
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/SEmaint)
 "aWu" = (
 /obj/window/reinforced{
 	dir = 1;
@@ -22586,14 +18302,6 @@
 /obj/access_spawn/research,
 /turf/simulated/floor/plating,
 /area/station/science/storage)
-"aWz" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/science/storage)
 "aWA" = (
 /obj/machinery/atmospherics/pipe/simple{
 	icon_state = "intact";
@@ -22618,10 +18326,17 @@
 /area/station/science/storage)
 "aWD" = (
 /obj/machinery/chem_dispenser/soda,
+/obj/machinery/power/apc/autoname_west,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
 "aWE" = (
 /obj/machinery/light,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
 "aWF" = (
@@ -22634,6 +18349,9 @@
 	name = "VIP Door Control";
 	pixel_y = -35
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
 "aWG" = (
@@ -22641,19 +18359,12 @@
 	name = "S light switch";
 	pixel_y = -24
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
 "aWH" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
@@ -22661,6 +18372,16 @@
 	name = "Med-Sci"
 	},
 /obj/access_spawn/medlab,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/white,
 /area/station/medical/research)
 "aWI" = (
@@ -22779,29 +18500,17 @@
 	dir = 6
 	},
 /area/station/medical/research)
-"aWY" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/grime,
-/area/station/security/detectives_office)
 "aWZ" = (
-/obj/cable,
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "S APC";
 	pixel_y = -24
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
@@ -22810,33 +18519,25 @@
 	name = "S light switch";
 	pixel_y = -24
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aXb" = (
 /obj/machinery/light,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
-"aXc" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/SEmaint)
 "aXd" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
+	},
+/obj/cable{
+	icon_state = "9-10"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
@@ -22862,11 +18563,6 @@
 /area/station/science/storage)
 "aXh" = (
 /obj/firedoor_spawn,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
@@ -22876,15 +18572,18 @@
 	name = "Tech Storage"
 	},
 /obj/access_spawn/tech_storage,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/maintenance/SWmaint)
 "aXi" = (
-/obj/cable,
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "S APC";
 	pixel_y = -24
 	},
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "aXj" = (
@@ -22901,11 +18600,6 @@
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "aXk" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
@@ -22914,9 +18608,7 @@
 	name = "locker"
 	},
 /turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aXl" = (
 /obj/reagent_dispensers/foamtank,
 /turf/simulated/floor/plating,
@@ -22952,9 +18644,7 @@
 	icon_state = "tube1"
 	},
 /turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "aXs" = (
 /obj/landmark/magnet_shield,
 /obj/securearea{
@@ -23026,28 +18716,6 @@
 "aXz" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/kitchen)
-"aXA" = (
-/obj/cable,
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/bar)
-"aXB" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/SWmaint)
-"aXC" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/station/maintenance/SWmaint)
 "aXD" = (
 /obj/item/sheet/glass{
 	amount = 50
@@ -23084,11 +18752,6 @@
 /area/station/storage/primary)
 "aXI" = (
 /obj/firedoor_spawn,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
@@ -23184,12 +18847,11 @@
 	pixel_x = 24;
 	pixel_y = 0
 	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/stool/chair/comfy/wheelchair{
 	dir = 8
+	},
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
@@ -23232,6 +18894,9 @@
 /area/station/hallway/primary/west)
 "aXV" = (
 /obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/specialroom/cafeteria{
 	dir = 8
 	},
@@ -23242,11 +18907,10 @@
 	name = "N APC";
 	pixel_y = 24
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/storage/secure/closet/civilian/kitchen,
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/specialroom/cafeteria{
 	dir = 8
 	},
@@ -23254,11 +18918,6 @@
 "aXX" = (
 /obj/disposalpipe/trunk,
 /obj/machinery/disposal,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/specialroom/cafeteria{
 	dir = 8
 	},
@@ -23272,11 +18931,6 @@
 /turf/simulated/floor/sanitary,
 /area/station/hallway/primary/west)
 "aXZ" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -23286,26 +18940,7 @@
 	dir = 8
 	},
 /area/station/crew_quarters/kitchen)
-"aYa" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
-/turf/simulated/floor/specialroom/cafeteria{
-	dir = 8
-	},
-/area/station/crew_quarters/kitchen)
 "aYb" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/segment{
 	dir = 4;
 	pixel_y = 0
@@ -23320,11 +18955,6 @@
 	},
 /area/station/crew_quarters/kitchen)
 "aYc" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/disposal/mail{
 	mail_tag = "kitchen";
 	name = "mail chute-'Kitchen'"
@@ -23343,21 +18973,6 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/storage)
-"aYe" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/grass/random{
-	dir = 2
-	},
-/area/station/owlery)
 "aYf" = (
 /obj/machinery/computer/arcade{
 	icon_state = "arcadeb";
@@ -23371,16 +18986,14 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "aYh" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "N APC";
 	pixel_y = 24
 	},
-/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "aYi" = (
@@ -23422,15 +19035,6 @@
 	icon_state = "carpetNE"
 	},
 /area/station/crew_quarters/arcade)
-"aYl" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/station/maintenance/SWmaint)
 "aYm" = (
 /obj/machinery/light_switch{
 	name = "W light switch";
@@ -23483,27 +19087,16 @@
 	},
 /area/station/security/main)
 "aYr" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer3/generic/secure_data,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
 /area/station/security/main)
 "aYs" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
@@ -23553,15 +19146,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/detectives_office)
-"aYz" = (
-/obj/disposalpipe/segment,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/SEmaint)
 "aYA" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
@@ -23577,11 +19161,10 @@
 /turf/space,
 /area)
 "aYB" = (
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
 "aYC" = (
@@ -23590,11 +19173,6 @@
 /area/station/hallway/primary/west)
 "aYD" = (
 /obj/firedoor_spawn,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
 	icon_state = "maint_closed";
@@ -23652,22 +19230,7 @@
 	dir = 2
 	},
 /area/station/owlery)
-"aYK" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/grass/random{
-	dir = 2
-	},
-/area/station/owlery)
 "aYL" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/critter/owl{
 	desc = "His name is Carl.";
 	name = "space owl named Carl"
@@ -23676,35 +19239,6 @@
 	dir = 2
 	},
 /area/station/owlery)
-"aYN" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
-"aYO" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
-"aYP" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
 "aYQ" = (
 /obj/machinery/sim/vr_bed{
 	dir = 4;
@@ -23732,25 +19266,10 @@
 	},
 /area/station/crew_quarters/arcade)
 "aYT" = (
+/obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/plating,
-/area/station/maintenance/SWmaint)
-"aYU" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
 "aYV" = (
@@ -23793,11 +19312,6 @@
 /turf/simulated/floor,
 /area/station/security/main)
 "aZa" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/stool/chair,
 /obj/landmark/start{
 	name = "Security Officer"
@@ -23911,13 +19425,6 @@
 "aZn" = (
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
-"aZo" = (
-/obj/cable{
-	icon_state = "1-2";
-	tag = "icon-1-2"
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
 "aZp" = (
 /obj/machinery/sim/vr_bed{
 	dir = 4;
@@ -23943,14 +19450,6 @@
 /obj/item/storage/box/diskbox,
 /turf/simulated/floor/greenwhite,
 /area/station/medical/research)
-"aZs" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/kitchen)
 "aZt" = (
 /obj/table/auto,
 /obj/item/cable_coil,
@@ -24000,15 +19499,18 @@
 	name = "S APC";
 	pixel_y = -24
 	},
-/obj/cable,
 /obj/table/auto,
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/cable,
 /turf/simulated/floor/greenwhite,
 /area/station/medical/research)
 "aZz" = (
 /obj/disposalpipe/segment{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
@@ -24137,24 +19639,6 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
-"aZS" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
 "aZT" = (
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor,
@@ -24172,11 +19656,6 @@
 	},
 /area/station/storage/primary)
 "aZV" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment,
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=crossway";
@@ -24191,31 +19670,25 @@
 	pixel_x = -24;
 	pixel_y = 0
 	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/camera{
 	c_tag = "Security West";
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/red/side{
 	dir = 8
 	},
 /area/station/security/main)
-"aZX" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/table/auto,
-/obj/machinery/recharger,
-/turf/simulated/floor,
-/area/station/security/main)
 "aZY" = (
-/obj/machinery/computer/security,
+/obj/machinery/computer/security{
+	dir = 4
+	},
 /obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor,
 /area/station/security/main)
 "aZZ" = (
@@ -24226,6 +19699,9 @@
 	},
 /obj/landmark/start{
 	name = "Security Officer"
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
@@ -24245,20 +19721,7 @@
 	dir = 4
 	},
 /area/station/security/main)
-"bab" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black,
-/area/station/security/main)
 "bac" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/stool/chair{
 	dir = 1;
 	icon_state = "chair";
@@ -24273,23 +19736,6 @@
 	tag = "icon-pipe-s (EAST)"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/main)
-"bae" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/main)
-"baf" = (
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
 /area/station/security/main)
 "bag" = (
 /obj/item/satchel/hydro,
@@ -24342,16 +19788,6 @@
 /turf/simulated/floor,
 /area/station/security/main)
 "bap" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/segment,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/main)
@@ -24382,35 +19818,7 @@
 	dir = 8
 	},
 /area/station/hallway/primary/south)
-"bat" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/red/side{
-	dir = 4
-	},
-/area/station/hallway/primary/south)
-"bau" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/SWmaint)
 "bav" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/light_switch{
 	name = "W light switch";
 	pixel_x = -24;
@@ -24421,41 +19829,24 @@
 	},
 /area/station/security/main)
 "baw" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/stool/chair{
 	dir = 4
 	},
 /obj/landmark/start{
 	name = "Security Officer"
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/security/main)
 "bax" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/table/auto,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/recharger,
 /turf/simulated/floor,
 /area/station/security/main)
 "bay" = (
 /obj/table/auto,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/item/wrench,
 /obj/disposalpipe/segment,
 /obj/item/kitchen/food_box/donut_box{
@@ -24466,29 +19857,14 @@
 	},
 /turf/simulated/floor,
 /area/station/security/main)
-"baz" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/security/main)
-"baA" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/red/side{
-	dir = 4
-	},
-/area/station/security/main)
 "baB" = (
 /turf/simulated/floor/black,
 /area/station/security/main)
 "baC" = (
 /obj/machinery/light/small,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/black,
 /area/station/security/main)
 "baE" = (
@@ -24498,6 +19874,9 @@
 	icon_state = "tube1";
 	pixel_y = 15;
 	tag = "icon-tube1 (NORTH)"
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
@@ -24512,16 +19891,11 @@
 /area/station/maintenance/SWmaint)
 "baG" = (
 /obj/item/bananapeel,
+/obj/cable{
+	icon_state = "5-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
-"baH" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/arcade)
 "baI" = (
 /obj/lattice{
 	dir = 6;
@@ -24529,19 +19903,6 @@
 	},
 /turf/space,
 /area)
-"baJ" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/main)
 "baK" = (
 /obj/lattice{
 	dir = 10;
@@ -24679,38 +20040,7 @@
 	dir = 4
 	},
 /area/station/hallway/primary/south)
-"bbc" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/maintenance/SEmaint)
-"bbd" = (
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/arcade)
 "bbe" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
@@ -24719,16 +20049,20 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/cable{
+	icon_state = "4-5"
+	},
+/obj/cable{
+	icon_state = "2-5"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
 "bbf" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/segment{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
@@ -24736,23 +20070,7 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
-"bbh" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/storage/primary)
 "bbi" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
@@ -24762,11 +20080,17 @@
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/storage/primary)
 "bbj" = (
 /obj/disposalpipe/segment{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/storage/primary)
@@ -24791,37 +20115,12 @@
 	},
 /area/station/hallway/primary/south)
 "bbm" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment,
 /obj/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
-"bbn" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/door/airlock/pyro/security,
-/obj/access_spawn/security,
-/turf/simulated/floor,
-/area/station/security/brig)
 "bbo" = (
 /obj/disposalpipe/switch_junction{
 	dir = 8;
@@ -24837,16 +20136,21 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/security/main)
 "bbq" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment{
 	dir = 4
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -24873,15 +20177,6 @@
 	},
 /turf/simulated/floor,
 /area/station/security/main)
-"bbu" = (
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/maintenance/SEmaint)
 "bbv" = (
 /obj/machinery/conveyor/south{
 	id = "ghostdrone"
@@ -24922,30 +20217,11 @@
 /obj/machinery/ghost_catcher,
 /turf/simulated/floor/plating/random,
 /area/ghostdrone_factory)
-"bbB" = (
+"bbD" = (
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/arcade)
-"bbC" = (
-/obj/cable,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/arcade)
-"bbD" = (
-/obj/cable,
-/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "bbE" = (
@@ -24970,11 +20246,6 @@
 /turf/simulated/floor,
 /area/station/storage/primary)
 "bbF" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/table/auto,
 /obj/item/device/radio/signaler,
 /obj/item/device/radio/signaler{
@@ -24984,20 +20255,13 @@
 /turf/simulated/floor,
 /area/station/storage/primary)
 "bbG" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "S APC";
 	pixel_y = -24
 	},
 /obj/machinery/light/small,
+/obj/cable,
 /turf/simulated/floor,
 /area/station/storage/primary)
 "bbH" = (
@@ -25010,47 +20274,36 @@
 	},
 /area/station/storage/primary)
 "bbI" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/access_spawn/maint,
-/turf/simulated/floor,
-/area/station/maintenance/SWmaint)
-"bbJ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor/yellow/side{
-	dir = 8
-	},
-/area/station/hallway/primary/south)
-"bbK" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment,
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor,
-/area/station/hallway/primary/south)
+/area/station/maintenance/SWmaint)
+"bbK" = (
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/turf/simulated/floor,
+/area/station/turret_protected/ai_upload_foyer)
 "bbL" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/kitchen)
 "bbM" = (
 /obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/red/side{
 	dir = 8
 	},
@@ -25067,25 +20320,13 @@
 /area/station/security/main)
 "bbP" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
 	},
 /turf/simulated/floor/red/corner{
 	dir = 4
 	},
 /area/station/security/main)
 "bbQ" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/storage/secure/closet/security/equipment,
 /turf/simulated/floor/red/side{
 	dir = 5
@@ -25093,6 +20334,9 @@
 /area/station/security/main)
 "bbR" = (
 /obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/arcade)
 "bbS" = (
@@ -25158,7 +20402,9 @@
 /turf/simulated/floor/plating/random,
 /area/ghostdrone_factory)
 "bcb" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
 /turf/simulated/floor/plating/random,
 /area/ghostdrone_factory)
 "bcc" = (
@@ -25168,22 +20414,6 @@
 	},
 /turf/space,
 /area)
-"bcd" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/SWmaint)
-"bce" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/SWmaint)
 "bcf" = (
 /obj/machinery/camera{
 	c_tag = "Courtroom Maintenance";
@@ -25216,14 +20446,6 @@
 /obj/machinery/vending/security,
 /obj/machinery/light,
 /turf/simulated/floor/red/side,
-/area/station/security/main)
-"bck" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
 /area/station/security/main)
 "bcl" = (
 /obj/disposalpipe/trunk{
@@ -25346,17 +20568,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/south)
-"bcz" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/firedoor_spawn,
-/obj/disposalpipe/segment,
-/obj/machinery/door/airlock/pyro/glass,
-/turf/simulated/floor,
-/area/station/crew_quarters/courtroom)
 "bcA" = (
 /obj/table/auto,
 /obj/item/storage/firstaid/regular,
@@ -25424,34 +20635,7 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/ghostdrone_factory)
-"bcL" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/arcade)
 "bcM" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/firedoor_spawn,
 /obj/disposalpipe/segment,
 /obj/machinery/door/airlock/pyro/glass,
@@ -25461,16 +20645,14 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
-"bcO" = (
-/obj/cable,
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/security/main)
 "bcP" = (
 /obj/window/reinforced{
 	dir = 1;
 	icon_state = "rwindow";
 	tag = "icon-rwindow (NORTH)"
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/red,
 /area/station/security/brig)
@@ -25487,47 +20669,29 @@
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
-"bcR" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/red,
-/area/station/security/brig)
 "bcS" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/brig)
 "bcT" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/door/airlock/pyro/security,
 /obj/access_spawn/security,
-/turf/simulated/floor,
-/area/station/security/brig)
-"bcU" = (
 /obj/cable{
-	d2 = 8;
+	icon_state = "0-4"
+	},
+/obj/cable{
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/cable,
+/turf/simulated/floor,
+/area/station/security/brig)
+"bcU" = (
 /obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "bcV" = (
@@ -25538,6 +20702,9 @@
 	name = "Armoury"
 	},
 /obj/access_spawn/security,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/security/brig)
 "bcW" = (
@@ -25601,18 +20768,17 @@
 "bdf" = (
 /obj/firedoor_spawn,
 /obj/table/reinforced,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor,
 /area/station/bridge)
-"bdg" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 4
-	},
-/area/station/storage/primary)
 "bdh" = (
 /obj/machinery/door/poddoor/pyro{
 	dir = 4;
@@ -25621,44 +20787,10 @@
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
-"bdi" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/security/brig)
-"bdj" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/red,
-/area/station/security/brig)
 "bdk" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
-"bdl" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor,
-/area/station/security/brig)
 "bdm" = (
 /obj/machinery/door_timer{
 	id = "solitary1";
@@ -25666,67 +20798,29 @@
 	pixel_x = 0;
 	pixel_y = -24
 	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/access_spawn/brig,
 /turf/simulated/floor/red/side,
 /area/station/security/brig)
 "bdn" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/clonepod,
 /obj/cable,
 /turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
-"bdo" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/red,
-/area/station/security/brig)
+/area/station/medical/medbay/lobby)
 "bdp" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/ghostdrone_factory)
-"bdq" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/wingrille_spawn/auto/crystal,
-/turf/simulated/floor/plating,
-/area/station/security/brig)
 "bdr" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/camera{
 	c_tag = "Brig - Solitary 3";
 	dir = 2
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
-/area/station/security/brig)
-"bds" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
 /area/station/security/brig)
 "bdt" = (
 /obj/lattice,
@@ -25782,19 +20876,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/ghostdrone_factory)
-"bdz" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/SWmaint)
 "bdA" = (
 /obj/landmark{
 	name = "blobstart"
@@ -25820,21 +20901,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/red,
 /area/station/security/brig)
-"bdD" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/red/side{
-	dir = 4
-	},
-/area/station/security/main)
 "bdE" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -25848,48 +20914,18 @@
 	dir = 8
 	},
 /area/station/security/brig)
-"bdG" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s";
-	tag = "icon-pipe-s (EAST)"
-	},
-/turf/simulated/floor,
-/area/station/security/brig)
-"bdH" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/red/side{
-	dir = 1
-	},
-/area/station/security/brig)
 "bdI" = (
 /turf/simulated/floor/red/corner{
 	dir = 1
 	},
 /area/station/security/brig)
 "bdJ" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/storage/secure/closet/brig/automatic/solitary{
 	id = "solitary3";
 	name = "Automatic Locker (Cell #3)"
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/red/side{
 	dir = 1
@@ -25903,14 +20939,6 @@
 	id = "solitary3"
 	},
 /turf/simulated/floor,
-/area/station/security/brig)
-"bdL" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
 /area/station/security/brig)
 "bdM" = (
 /obj/machinery/light,
@@ -25965,6 +20993,9 @@
 	},
 /obj/machinery/door/window/brigdoor/solitary3/eastleft,
 /obj/access_spawn/brig,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/security/brig)
 "bdT" = (
@@ -25978,9 +21009,14 @@
 	},
 /obj/access_spawn/brig,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor,
 /area/station/security/brig)
@@ -25992,27 +21028,10 @@
 	},
 /obj/machinery/door/window/brigdoor/solitary2/westright,
 /obj/access_spawn/brig,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
-/area/station/security/brig)
-"bdV" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/wingrille_spawn/auto/crystal,
-/turf/simulated/floor/plating,
-/area/station/security/brig)
-"bdW" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/wingrille_spawn/auto/crystal,
-/turf/simulated/floor/plating,
 /area/station/security/brig)
 "bdX" = (
 /obj/disposalpipe/segment{
@@ -26039,6 +21058,9 @@
 	dir = 1;
 	icon_state = "pipe-j2";
 	tag = "icon-pipe-j2 (NORTH)"
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -26067,11 +21089,6 @@
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "bec" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/stool,
 /turf/simulated/floor/red/side,
 /area/station/security/brig)
@@ -26081,31 +21098,13 @@
 	c_tag = "Brig - Solitary 1";
 	dir = 4
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/red/side,
 /area/station/security/brig)
 "bee" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/stool/bed/brig,
 /obj/machinery/light/small,
 /turf/simulated/floor/red/side,
 /area/station/security/brig)
-"bef" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/south)
 "beg" = (
 /obj/window/reinforced{
 	dir = 8;
@@ -26121,27 +21120,10 @@
 	},
 /turf/space,
 /area)
-"bei" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/south)
-"bej" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/courtroom)
 "bek" = (
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "bel" = (
-/obj/cable,
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "N APC";
@@ -26150,6 +21132,12 @@
 /obj/machinery/camera{
 	c_tag = "Jury Booth";
 	dir = 2
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
@@ -26185,34 +21173,15 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
-"bes" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/crew_quarters/courtroom)
 "bet" = (
 /obj/storage/secure/closet/brig/automatic/solitary{
 	id = "solitary1"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
 	},
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
 /area/station/security/brig)
 "beu" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1";
@@ -26221,20 +21190,7 @@
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
-"bev" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/courtroom)
 "bew" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/firedoor_spawn,
 /obj/machinery/secscanner{
 	dir = 4;
@@ -26247,6 +21203,13 @@
 	name = "Medical Bay"
 	},
 /obj/access_spawn/medical,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "bex" = (
@@ -26258,44 +21221,20 @@
 	c_tag = "Courtroom";
 	dir = 2
 	},
-/turf/simulated/floor,
-/area/station/crew_quarters/courtroom)
-"bey" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/crew_quarters/courtroom)
-"bez" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/courtroom)
-"beA" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor,
-/area/station/security/brig)
+/area/station/crew_quarters/courtroom)
 "beB" = (
 /obj/machinery/floorflusher{
 	id = "solitary1"
 	},
 /obj/disposalpipe/trunk{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/security/brig)
@@ -26308,11 +21247,17 @@
 	name = "Bridge"
 	},
 /obj/access_spawn/heads,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/bridge)
 "beD" = (
 /obj/table/auto,
 /obj/machinery/recharger,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/red,
 /area/station/security/brig)
 "beE" = (
@@ -26323,27 +21268,17 @@
 "beF" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
+	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/cable,
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "beG" = (
-/obj/stool/chair,
-/turf/simulated/floor,
-/area/station/crew_quarters/courtroom)
-"beH" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/stool/chair,
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
@@ -26366,37 +21301,9 @@
 	},
 /area/station/crew_quarters/courtroom)
 "beK" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/stool,
 /obj/machinery/light/small,
 /turf/simulated/floor/red/side,
-/area/station/security/brig)
-"beL" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/security/brig)
-"beM" = (
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/wingrille_spawn/auto/crystal,
-/turf/simulated/floor/plating,
 /area/station/security/brig)
 "beN" = (
 /obj/disposalpipe/segment{
@@ -26408,27 +21315,16 @@
 /area/station/security/brig)
 "beO" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "0-4"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor,
-/area/station/security/brig)
-"beP" = (
-/obj/disposalpipe/segment,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/red/side{
-	dir = 4
-	},
 /area/station/security/brig)
 "beQ" = (
 /obj/wingrille_spawn/auto,
@@ -26444,16 +21340,6 @@
 /obj/machinery/vending/pizza,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/west)
-"beT" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/red/corner{
-	dir = 8
-	},
-/area/station/security/brig)
 "beU" = (
 /obj/storage/secure/crate/weapon/confiscated_items,
 /obj/item/instrument/vuvuzela,
@@ -26473,54 +21359,17 @@
 	dir = 4
 	},
 /area/station/security/brig)
-"beW" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/wingrille_spawn/auto/crystal,
-/turf/simulated/floor/plating,
-/area/station/security/brig)
 "beX" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/storage/secure/closet/brig/automatic/solitary{
 	id = "solitary2";
 	name = "Automatic Locker (Cell #2)"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
-/area/station/security/brig)
-"beY" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/courtroom)
-"beZ" = (
-/obj/cable,
-/obj/wingrille_spawn/auto/crystal,
-/turf/simulated/floor/plating,
 /area/station/security/brig)
 "bfa" = (
 /obj/machinery/navbeacon{
@@ -26553,16 +21402,6 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "bfe" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/disposalpipe/segment,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
@@ -26571,41 +21410,32 @@
 /turf/simulated/floor/bot,
 /area/station/crew_quarters/courtroom)
 "bff" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/light,
 /turf/simulated/floor/delivery,
 /area/station/crew_quarters/courtroom)
 "bfg" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
 /area/station/security/brig)
 "bfh" = (
+/obj/wingrille_spawn/auto/crystal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
+	icon_state = "0-4"
 	},
-/obj/wingrille_spawn/auto/crystal,
-/turf/simulated/floor/red/side{
-	dir = 1
+/obj/cable{
+	icon_state = "0-2"
 	},
+/turf/simulated/floor/plating,
 /area/station/security/brig)
 "bfi" = (
 /obj/machinery/light{
@@ -26621,15 +21451,6 @@
 	dir = 4
 	},
 /area/station/security/brig)
-"bfk" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable,
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/courtroom)
 "bfl" = (
 /obj/storage/crate{
 	desc = "A private crate that isn't yours.";
@@ -26664,41 +21485,11 @@
 	dir = 2
 	},
 /area/station/crew_quarters/courtroom)
-"bfo" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/courtroom)
-"bfp" = (
-/obj/cable,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/courtroom)
-"bfq" = (
-/obj/cable,
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/security/brig)
 "bfr" = (
 /obj/item/instrument/harmonica,
 /obj/machinery/camera{
 	c_tag = "Brig - Solitary 2";
 	dir = 4
-	},
-/obj/cable{
-	icon_state = "1-2";
-	tag = "icon-1-2"
 	},
 /turf/simulated/floor,
 /area/station/security/brig)
@@ -26718,12 +21509,10 @@
 	pixel_x = 0;
 	pixel_y = 24
 	},
+/obj/access_spawn/brig,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/access_spawn/brig,
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
@@ -26740,27 +21529,13 @@
 /obj/access_spawn/heads,
 /turf/simulated/floor,
 /area/station/bridge)
-"bfv" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
-/turf/simulated/floor,
-/area/station/security/brig)
 "bfw" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/firedoor_spawn,
 /obj/disposalpipe/segment,
 /obj/machinery/door/airlock/pyro/security,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/security/brig)
 "bfx" = (
@@ -26784,11 +21559,6 @@
 /turf/simulated/floor,
 /area/station/security/brig)
 "bfA" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/junction{
 	dir = 1;
 	icon_state = "pipe-y";
@@ -26798,6 +21568,9 @@
 	dir = 8;
 	icon_state = "chair";
 	tag = "icon-chair (WEST)"
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/security/brig)
@@ -26810,11 +21583,6 @@
 /area/station/security/brig)
 "bfC" = (
 /obj/stool/bed/brig,
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/red/side,
 /area/station/security/brig)
 "bfD" = (
@@ -26823,10 +21591,6 @@
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
-"bfE" = (
-/obj/storage/closet/emergency,
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
 "bfF" = (
 /obj/random_item_spawner/desk_stuff,
 /obj/table/glass/auto,
@@ -26856,21 +21620,11 @@
 	name = "S APC";
 	pixel_y = -24
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/clonegrinder,
-/obj/cable,
 /obj/machinery/light,
+/obj/cable,
 /turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "bfJ" = (
 /obj/disposalpipe/segment{
 	dir = 1;
@@ -26879,13 +21633,11 @@
 /turf/simulated/floor,
 /area/station/security/brig)
 "bfK" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/junction{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/security/brig)
@@ -26924,22 +21676,7 @@
 "bfP" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/courtroom)
-"bfQ" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/security/brig)
 "bfR" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/pyro/security{
 	dir = 4;
 	icon_state = "sec_closed";
@@ -26949,15 +21686,10 @@
 /turf/simulated/floor,
 /area/station/security/armory)
 "bfS" = (
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "bfT" = (
@@ -26966,6 +21698,9 @@
 	name = "Head of Security'"
 	},
 /obj/access_spawn/hos,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/grey/side{
 	dir = 2
 	},
@@ -26975,6 +21710,13 @@
 	name = "Bridge"
 	},
 /obj/access_spawn/head_of_personnel,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/grey/side{
 	dir = 2
 	},
@@ -27018,63 +21760,47 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/bridge)
 "bgd" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable,
-/obj/cable{
-	icon_state = "0-2";
-	tag = "icon-0-2"
-	},
 /obj/machinery/power/data_terminal,
-/obj/machinery/computer/card,
+/obj/machinery/computer/card{
+	dir = 4
+	},
 /obj/machinery/camera{
 	c_tag = "Bridge Checkpoint";
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor,
 /area/station/bridge)
 "bge" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/stool/chair{
 	dir = 1
 	},
-/turf/simulated/floor,
-/area/station/bridge)
-"bgf" = (
+/obj/cable,
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "0-2"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor,
 /area/station/bridge)
 "bgg" = (
+/obj/wingrille_spawn/auto,
+/obj/disposalpipe/segment,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/cable,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/wingrille_spawn/auto,
-/obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "bgh" = (
@@ -27100,24 +21826,22 @@
 /obj/machinery/vending/security,
 /turf/simulated/floor/red,
 /area/station/security/brig)
-"bgl" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor/red,
-/area/station/security/brig)
 "bgm" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/mining/magnet)
 "bgn" = (
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/red/side{
 	dir = 9
 	},
@@ -27130,9 +21854,13 @@
 /turf/space,
 /area/station/turret_protected/ai)
 "bgq" = (
-/obj/cable,
 /obj/machinery/power/data_terminal,
-/obj/machinery/computer3/generic/secure_data,
+/obj/machinery/computer3/generic/secure_data{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor,
 /area/station/bridge)
 "bgr" = (
@@ -27151,6 +21879,9 @@
 	icon_state = "minifire";
 	pixel_y = 32
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
@@ -27165,37 +21896,14 @@
 /turf/simulated/floor/red,
 /area/station/security/brig)
 "bgu" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/red,
 /area/station/security/brig)
 "bgv" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	layer = 3.5;
 	pixel_y = -24
-	},
-/turf/simulated/floor/red/side,
-/area/station/security/brig)
-"bgw" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/red/side,
 /area/station/security/brig)
@@ -27209,9 +21917,7 @@
 /area/station/hydroponics)
 "bgy" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/red/side{
 	dir = 10
@@ -27225,49 +21931,6 @@
 /obj/machinery/vending/medical_public,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
-"bgA" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/solar{
-	id = "aisolar";
-	name = "AI Satellite Solar Array"
-	},
-/turf/simulated/floor/airless{
-	icon_state = "solarpanel";
-	name = "solar paneling"
-	},
-/area/station/turret_protected/ai)
-"bgB" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating/airless,
-/area/station/turret_protected/ai)
-"bgC" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/solar{
-	id = "aisolar";
-	name = "AI Satellite Solar Array"
-	},
-/turf/simulated/floor/airless{
-	icon_state = "solarpanel";
-	name = "solar paneling"
-	},
-/area/station/turret_protected/ai)
 "bgD" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/heads)
@@ -27279,15 +21942,10 @@
 /obj/machinery/manufacturer/uniform,
 /turf/simulated/floor,
 /area/station/bridge)
-"bgG" = (
+"bgH" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/bridge)
-"bgH" = (
 /turf/simulated/floor/grey/side{
 	dir = 2
 	},
@@ -27301,14 +21959,6 @@
 "bgJ" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/hos)
-"bgK" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/bridge)
 "bgL" = (
 /obj/disposalpipe/segment,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -27317,22 +21967,6 @@
 /obj/item/a_gift/festive,
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
-"bgN" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating/airless,
-/area/station/turret_protected/ai)
 "bgO" = (
 /obj/machinery/light/lamp,
 /obj/table/wood/auto,
@@ -27346,12 +21980,11 @@
 	name = "N APC";
 	pixel_y = 24
 	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/table/wood/auto,
 /obj/item/storage/firstaid/regular,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor,
 /area/station/crew_quarters/heads)
 "bgQ" = (
@@ -27366,29 +21999,10 @@
 	name = "Bridge"
 	},
 /obj/access_spawn/heads,
-/turf/simulated/floor/black,
-/area/station/bridge)
-"bgR" = (
-/obj/cable,
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/bridge)
-"bgS" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
+/turf/simulated/floor/black,
 /area/station/bridge)
 "bgT" = (
 /obj/machinery/door/poddoor{
@@ -27407,26 +22021,23 @@
 /area/station/bridge)
 "bgU" = (
 /obj/disposalpipe/segment,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/medical{
 	name = "Chemistry Department Access"
 	},
 /obj/access_spawn/research,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/white,
 /area/station/chemistry)
 "bgV" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/table/wood/auto,
 /obj/item/device/camera_viewer,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
 /turf/simulated/floor/black,
 /area/station/security/hos)
 "bgW" = (
@@ -27439,7 +22050,6 @@
 /turf/simulated/floor/black,
 /area/station/security/hos)
 "bgY" = (
-/obj/cable,
 /obj/machinery/genetics_scanner,
 /turf/simulated/floor/greenwhite,
 /area/station/medical/research)
@@ -27448,14 +22058,6 @@
 /obj/lattice,
 /turf/space,
 /area)
-"bha" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads)
 "bhb" = (
 /obj/window/reinforced{
 	dir = 4;
@@ -27464,18 +22066,6 @@
 	},
 /turf/space,
 /area)
-"bhc" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/bridge)
 "bhd" = (
 /obj/item/spacecash,
 /obj/item/coin,
@@ -27487,39 +22077,32 @@
 	},
 /area/station/crew_quarters/heads)
 "bhe" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/stool/chair{
 	dir = 8
 	},
+/obj/cable,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/heads)
 "bhf" = (
+/obj/machinery/power/data_terminal,
+/obj/machinery/computer/ATM{
+	dir = 8
+	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/computer/ATM,
 /turf/simulated/floor,
 /area/station/crew_quarters/heads)
 "bhg" = (
 /turf/simulated/floor/black,
 /area/station/bridge)
 "bhh" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/trunk{
 	dir = 4
 	},
@@ -27539,6 +22122,9 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/black,
 /area/station/bridge)
 "bhj" = (
@@ -27549,11 +22135,6 @@
 /turf/simulated/floor/black,
 /area/station/bridge)
 "bhk" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/table/wood/auto,
 /obj/item/reagent_containers/food/snacks/spaghetti/spicy,
 /obj/item/kitchen/utensil/fork{
@@ -27569,70 +22150,33 @@
 /turf/simulated/floor/black,
 /area/station/security/hos)
 "bhl" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/segment,
 /obj/stool/chair/comfy{
 	dir = 8;
 	icon_state = "chair_comfy";
 	tag = "icon-chair_comfy (WEST)"
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/landmark/start{
 	name = "Head of Security"
 	},
-/turf/simulated/floor/black,
-/area/station/security/hos)
-"bhm" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/black,
 /area/station/security/hos)
 "bhn" = (
+/obj/machinery/computer/security{
+	dir = 8
+	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/computer/security,
 /turf/simulated/floor/red,
-/area/station/security/hos)
-"bho" = (
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
 /area/station/security/hos)
 "bhp" = (
 /obj/grille/steel,
 /turf/space,
 /area)
-"bhq" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/bridge)
 "bhr" = (
 /obj/machinery/recharger{
 	pixel_y = 3
@@ -27643,22 +22187,12 @@
 	icon_state = "bulb1";
 	tag = "icon-bulb1 (WEST)"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/green/side{
 	dir = 8
 	},
-/area/station/crew_quarters/heads)
-"bhs" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
 /area/station/crew_quarters/heads)
 "bht" = (
 /obj/machinery/light_switch{
@@ -27666,15 +22200,16 @@
 	pixel_x = 24;
 	pixel_y = 0
 	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/power/data_terminal,
-/obj/machinery/computer/bank_data,
+/obj/machinery/computer/bank_data{
+	dir = 8
+	},
 /obj/machinery/camera{
 	c_tag = "Head Office";
 	dir = 8
+	},
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/heads)
@@ -27690,14 +22225,6 @@
 	dir = 8
 	},
 /area/station/crew_quarters/kitchen)
-"bhv" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/black,
-/area/station/bridge)
 "bhw" = (
 /obj/machinery/light{
 	dir = 4;
@@ -27722,37 +22249,15 @@
 /turf/simulated/floor/black,
 /area/station/security/hos)
 "bhy" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/black,
 /area/station/security/hos)
 "bhz" = (
 /obj/table/wood/auto,
 /turf/simulated/floor/red,
-/area/station/security/hos)
-"bhA" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
-"bhB" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
 /area/station/security/hos)
 "bhC" = (
 /obj/machinery/manufacturer/personnel,
@@ -27760,33 +22265,20 @@
 	dir = 8
 	},
 /area/station/crew_quarters/heads)
-"bhD" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/heads)
 "bhE" = (
+/obj/cable,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/heads)
 "bhF" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1";
@@ -27797,27 +22289,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/central)
-"bhG" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black,
-/area/station/bridge)
-"bhH" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/black,
-/area/station/bridge)
 "bhI" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -27826,14 +22297,12 @@
 /turf/simulated/floor/black,
 /area/station/bridge)
 "bhJ" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
 /area/station/security/hos)
@@ -27889,6 +22358,9 @@
 /area/station/crew_quarters/captain)
 "bhP" = (
 /obj/landmark/halloween,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/black,
 /area/station/bridge)
 "bhQ" = (
@@ -27903,7 +22375,7 @@
 	pixel_y = 21
 	},
 /turf/simulated/floor,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "bhR" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/heads)
@@ -27920,46 +22392,11 @@
 	icon_state = "blue2"
 	},
 /area/station/bridge)
-"bhU" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/carpet{
-	dir = 1;
-	icon_state = "blue2"
-	},
-/area/station/bridge)
-"bhV" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet{
-	dir = 1;
-	icon_state = "blue2"
-	},
-/area/station/bridge)
 "bhW" = (
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "N APC";
 	pixel_y = 24
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -27967,32 +22404,19 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/carpet{
 	dir = 1;
 	icon_state = "blue2"
 	},
 /area/station/bridge)
 "bhX" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/item/storage/wall/fire{
 	dir = 1;
 	icon_state = "minifire";
 	pixel_y = 32
-	},
-/turf/simulated/floor/carpet{
-	dir = 1;
-	icon_state = "blue2"
-	},
-/area/station/bridge)
-"bhY" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
 	},
 /turf/simulated/floor/carpet{
 	dir = 1;
@@ -28012,20 +22436,9 @@
 "bia" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/captain)
-"bib" = (
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
 "bic" = (
 /turf/simulated/floor/purplewhite,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "bid" = (
 /obj/rack,
 /obj/item/tank/jetpack,
@@ -28068,17 +22481,6 @@
 	icon_state = "fblue1"
 	},
 /area/station/bridge)
-"bih" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet{
-	dir = 2;
-	icon_state = "fblue1"
-	},
-/area/station/bridge)
 "bii" = (
 /turf/simulated/floor/carpet{
 	dir = 1;
@@ -28102,28 +22504,12 @@
 	},
 /area/station/bridge)
 "bil" = (
-/obj/cable,
 /obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/security/hos)
-"bim" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/blueblack{
-	dir = 8
-	},
-/area/station/crew_quarters/captain)
-"bin" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/captain)
 "bio" = (
 /obj/disposalpipe/switch_junction{
 	dir = 8;
@@ -28140,33 +22526,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/south)
-"bip" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet{
-	dir = 1;
-	icon_state = "fgreen2"
-	},
-/area/station/bridge)
-"biq" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet{
-	dir = 1;
-	icon_state = "fgreen2"
-	},
-/area/station/bridge)
 "bir" = (
 /obj/landmark/start{
 	name = "Chief Engineer"
@@ -28249,11 +22608,6 @@
 	},
 /area/station/bridge)
 "biA" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/table/wood/auto,
 /obj/item/storage/box/trackimp_kit2,
 /turf/simulated/floor/carpet{
@@ -28317,7 +22671,6 @@
 	},
 /area/station/bridge)
 "biH" = (
-/obj/cable,
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer/genetics,
 /turf/simulated/floor/greenwhite,
@@ -28333,26 +22686,20 @@
 	pixel_x = 24;
 	pixel_y = 0
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/captain)
 "biK" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/greenwhite/corner{
 	dir = 2
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "biL" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/table/wood/auto,
 /obj/item/device/infra,
 /obj/item/handcuffs,
@@ -28427,52 +22774,36 @@
 	},
 /area/station/bridge)
 "biS" = (
-/obj/cable,
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/heads)
 "biT" = (
 /obj/machinery/power/data_terminal,
+/obj/machinery/computer3/generic/communications{
+	dir = 4
+	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/computer3/generic/communications,
 /turf/simulated/floor/blueblack{
 	dir = 10
 	},
 /area/station/crew_quarters/captain)
 "biU" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	layer = 3.5;
 	pixel_y = -24
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/blueblack,
 /area/station/crew_quarters/captain)
 "biV" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/door_control{
 	id = "emergencyinternals";
 	name = "Emergency Internals Release";
@@ -28484,6 +22815,13 @@
 	icon_state = "tube1";
 	layer = 9.1;
 	pixel_x = 10
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/blueblack,
 /area/station/crew_quarters/captain)
@@ -28498,17 +22836,6 @@
 	},
 /area/station/bridge)
 "biX" = (
-/turf/simulated/floor/carpet{
-	dir = 2;
-	icon_state = "fgreen2"
-	},
-/area/station/bridge)
-"biY" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/carpet{
 	dir = 2;
 	icon_state = "fgreen2"
@@ -28557,11 +22884,6 @@
 	},
 /area/station/bridge)
 "bjd" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/firedoor_spawn,
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -28573,6 +22895,9 @@
 	name = "Biodome"
 	},
 /obj/access_spawn/hydro,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/green,
 /area/station/hydroponics)
 "bje" = (
@@ -28581,6 +22906,9 @@
 	icon_state = "tube1";
 	layer = 9.1;
 	pixel_x = -10
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
@@ -28624,74 +22952,15 @@
 /turf/simulated/floor/blue,
 /area/station/crew_quarters/captain)
 "bjj" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/camera{
 	c_tag = "Bridge Storage";
 	dir = 8
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/blue,
 /area/station/crew_quarters/captain)
-"bjk" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/carpet{
-	dir = 2;
-	icon_state = "blue2"
-	},
-/area/station/bridge)
-"bjl" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet{
-	dir = 2;
-	icon_state = "blue2"
-	},
-/area/station/bridge)
-"bjm" = (
-/obj/cable,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/carpet{
-	dir = 2;
-	icon_state = "blue2"
-	},
-/area/station/bridge)
-"bjn" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet{
-	dir = 2;
-	icon_state = "blue2"
-	},
-/area/station/bridge)
 "bjo" = (
 /obj/machinery/light_switch{
 	name = "W light switch";
@@ -28709,14 +22978,6 @@
 	icon_state = "fblue1"
 	},
 /area/station/bridge)
-"bjp" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/captain)
 "bjq" = (
 /obj/table/wood/auto,
 /obj/item/card/id/captains_spare,
@@ -28725,11 +22986,6 @@
 /turf/simulated/floor/blue,
 /area/station/crew_quarters/captain)
 "bjr" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/table/wood/auto,
 /obj/machinery/recharger{
 	pixel_y = 3
@@ -28738,6 +22994,9 @@
 	pixel_y = -10
 	},
 /obj/item/camera_test,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/blue,
 /area/station/crew_quarters/captain)
 "bjs" = (
@@ -28753,9 +23012,7 @@
 /area/station/bridge)
 "bjt" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/carpet{
 	dir = 2;
@@ -28780,9 +23037,9 @@
 	},
 /area/station/bridge)
 "bjv" = (
-/obj/cable,
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer3/generic/communications,
+/obj/cable,
 /turf/simulated/floor/black,
 /area/station/bridge)
 "bjw" = (
@@ -28790,71 +23047,19 @@
 /turf/simulated/floor/black,
 /area/station/bridge)
 "bjx" = (
-/obj/cable,
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer3/generic/med_data,
+/obj/cable,
 /turf/simulated/floor/black,
 /area/station/bridge)
-"bjy" = (
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/captain)
-"bjz" = (
-/obj/cable,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/captain)
 "bjA" = (
 /obj/machinery/turret,
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/ai)
-"bjB" = (
-/obj/cable,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/captain)
-"bjC" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/bridge)
 "bjD" = (
 /obj/machinery/turretid,
 /turf/simulated/wall/auto/supernorn,
 /area/station/turret_protected/ai)
-"bjE" = (
-/obj/cable,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/bridge)
 "bjF" = (
 /obj/window/reinforced{
 	dir = 8;
@@ -28869,54 +23074,6 @@
 /obj/lattice,
 /turf/space,
 /area)
-"bjG" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/turret_protected/ai)
-"bjH" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable,
-/turf/simulated/floor/plating/airless,
-/area/station/turret_protected/ai)
-"bjI" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/airless,
-/area/station/turret_protected/ai)
-"bjJ" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable,
-/turf/simulated/floor/plating/airless,
-/area/station/turret_protected/ai)
-"bjK" = (
-/obj/cable,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating/airless,
-/area/station/turret_protected/ai)
 "bjL" = (
 /obj/window/reinforced{
 	dir = 1;
@@ -28934,24 +23091,7 @@
 	},
 /turf/space,
 /area)
-"bjN" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/airless,
-/area/station/turret_protected/ai)
 "bjO" = (
-/obj/grille/steel,
-/turf/simulated/floor/plating/airless,
-/area/station/turret_protected/ai)
-"bjP" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/grille/steel,
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/ai)
@@ -28963,163 +23103,16 @@
 	},
 /turf/space,
 /area/station/turret_protected/ai)
-"bjR" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/turret_protected/ai)
 "bjS" = (
 /turf/simulated/floor/engine,
-/area/station/turret_protected/ai)
-"bjT" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/engine,
-/area/station/turret_protected/ai)
-"bjU" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/auto/supernorn,
 /area/station/turret_protected/ai)
 "bjV" = (
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "bjW" = (
-/obj/cable,
 /obj/machinery/power/terminal,
-/turf/simulated/floor/black,
-/area/station/turret_protected/ai)
-"bjX" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/cable,
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai)
-"bjY" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/solar{
-	id = "aisolar";
-	name = "AI Satellite Solar Array"
-	},
-/turf/simulated/floor/airless{
-	icon_state = "solarpanel";
-	name = "solar paneling"
-	},
-/area/station/turret_protected/ai)
-"bjZ" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/ai)
-"bka" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating/airless,
-/area/station/turret_protected/ai)
-"bkb" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating/airless,
-/area/station/turret_protected/ai)
-"bkc" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating/airless,
-/area/station/turret_protected/ai)
-"bkd" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/turret,
-/turf/simulated/floor/black,
-/area/station/turret_protected/ai)
-"bke" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/ai)
-"bkf" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/ai)
-"bkg" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/ai)
-"bkh" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/wall/auto/supernorn,
 /area/station/turret_protected/ai)
 "bki" = (
 /obj/machinery/light{
@@ -29130,149 +23123,49 @@
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
-"bkj" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating/airless,
-/area/station/turret_protected/ai)
 "bkk" = (
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/landmark{
 	name = "Loot spawn"
 	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/ai)
 "bkl" = (
-/obj/cable,
 /obj/machinery/power/solar{
 	id = "aisolar";
 	name = "AI Satellite Solar Array"
+	},
+/obj/cable{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/airless{
 	icon_state = "solarpanel";
 	name = "solar paneling"
 	},
 /area/station/turret_protected/ai)
-"bkm" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/ai)
-"bkn" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/ai)
 "bko" = (
-/obj/cable,
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "S APC";
 	pixel_y = -24
 	},
 /obj/machinery/turretid,
-/turf/simulated/floor/black,
-/area/station/turret_protected/ai)
-"bkp" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/ai)
-"bkq" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/ai)
-"bkr" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/cable,
-/turf/simulated/floor/plating/airless,
-/area/station/turret_protected/ai)
-"bks" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/space,
-/area/station/turret_protected/ai)
-"bkt" = (
-/obj/grille/steel,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "bku" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/sleep_console{
 	dir = 8
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
-"bkv" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/engine,
-/area/station/turret_protected/ai)
 "bkw" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/light_switch{
 	name = "S light switch";
 	pixel_y = -24
@@ -29280,46 +23173,8 @@
 /obj/machinery/light,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
-"bkx" = (
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/ai)
-"bky" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/ai)
-"bkz" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/ai)
 "bkA" = (
 /obj/machinery/vending/monkey,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/light{
 	dir = 1;
 	icon_state = "tube1";
@@ -29330,58 +23185,17 @@
 	dir = 8
 	},
 /area/station/crew_quarters/kitchen)
-"bkB" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/ai)
-"bkC" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/ai)
 "bkD" = (
 /obj/machinery/power/terminal{
 	dir = 8
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
-"bkE" = (
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating/airless,
-/area/station/turret_protected/ai)
 "bkF" = (
 /obj/machinery/power/data_terminal,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
 /obj/machinery/sleeper{
 	dir = 8
 	},
@@ -29391,39 +23205,19 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
+/obj/cable,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
-"bkG" = (
-/obj/machinery/turret,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/ai)
 "bkH" = (
 /obj/machinery/turret,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
-"bkI" = (
-/obj/cable,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating/airless,
-/area/station/turret_protected/ai)
 "bkJ" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/power/terminal{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
@@ -29432,7 +23226,6 @@
 	charge = 5e+006
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/black,
@@ -29446,11 +23239,6 @@
 /turf/simulated/floor/greenwhite,
 /area/station/medical/research)
 "bkN" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
@@ -29458,6 +23246,9 @@
 	dir = 4;
 	icon_state = "glass_closed";
 	name = "glass airlock"
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -29490,15 +23281,6 @@
 /turf/simulated/floor/plating/airless,
 /area)
 "bkS" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable,
 /obj/table/auto/desk,
 /obj/item/paper_bin{
 	pixel_x = -5
@@ -29507,17 +23289,7 @@
 /obj/machinery/door/window/westright,
 /obj/access_spawn/medical,
 /turf/simulated/floor/blue,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
-"bkT" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/airless,
-/area)
+/area/station/medical/medbay/lobby)
 "bkU" = (
 /turf/simulated/wall/asteroid{
 	dir = 1;
@@ -29533,8 +23305,6 @@
 /area)
 "bkW" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/shuttle/wall{
@@ -29571,16 +23341,6 @@
 	icon_state = "wall3"
 	},
 /area/listeningpost/power)
-"bld" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/shuttle/wall{
-	icon_state = "wall3"
-	},
-/area/listeningpost/power)
 "ble" = (
 /turf/simulated/wall/asteroid{
 	dir = 4;
@@ -29605,14 +23365,6 @@
 	},
 /turf/simulated/floor/circuit,
 /area/listeningpost/power)
-"blh" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/circuit,
-/area/listeningpost/power)
 "bli" = (
 /obj/machinery/light{
 	dir = 1;
@@ -29627,30 +23379,28 @@
 	icon_state = "shock";
 	name = "Danger: High Voltage"
 	},
-/turf/simulated/wall,
+/turf/simulated/shuttle/wall{
+	icon_state = "wall3"
+	},
 /area/listeningpost/power)
 "blk" = (
+/obj/machinery/power/monitor,
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "0-2"
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/machinery/power/monitor,
 /turf/simulated/floor/plating,
 /area/listeningpost/power)
 "bll" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/power/smes{
 	charge = 100000;
 	chargelevel = 4000;
 	output = 2500
+	},
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/listeningpost/power)
@@ -29680,29 +23430,21 @@
 /area/listeningpost/power)
 "blp" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/circuit,
 /area/listeningpost/power)
 "blq" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/caution/west,
 /area/listeningpost/power)
 "blr" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/stairs{
@@ -29711,8 +23453,6 @@
 /area/listeningpost/power)
 "bls" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
@@ -29723,7 +23463,6 @@
 	icon_state = "term"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -29749,13 +23488,11 @@
 	},
 /area/listeningpost)
 "blx" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock,
 /obj/access_spawn/syndie_shuttle,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/bot,
 /area/listeningpost/power)
 "bly" = (
@@ -29763,20 +23500,15 @@
 /turf/simulated/floor/plating,
 /area/listeningpost/power)
 "blz" = (
-/obj/cable,
 /obj/machinery/power/furnace{
 	active = 1;
 	fuel = 600
 	},
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/listeningpost/power)
 "blA" = (
 /obj/firedoor_spawn,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
 	name = "Hydroponics"
@@ -29812,24 +23544,6 @@
 	dir = 8
 	},
 /area/listeningpost)
-"blF" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost)
-"blG" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/grey/side{
-	dir = 8
-	},
-/area/listeningpost)
 "blH" = (
 /turf/simulated/shuttle/wall{
 	icon_state = "wall3"
@@ -29857,15 +23571,13 @@
 	},
 /area)
 "blL" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/light_switch{
 	name = "W light switch";
 	pixel_x = -24;
 	pixel_y = 0
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/red,
 /area/listeningpost)
@@ -29920,14 +23632,6 @@
 	dir = 4
 	},
 /area/listeningpost)
-"blV" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost)
 "blW" = (
 /turf/simulated/floor/black,
 /area/listeningpost)
@@ -29941,37 +23645,15 @@
 /obj/machinery/bot/medbot/no_camera,
 /turf/simulated/floor/black,
 /area/listeningpost)
-"blY" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating/airless,
-/area/station/turret_protected/ai)
-"blZ" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable,
-/turf/simulated/floor/plating/airless,
-/area/station/turret_protected/ai)
 "bma" = (
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "0-2"
 	},
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/ai)
@@ -29985,57 +23667,17 @@
 /area/listeningpost)
 "bmc" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/red,
 /area/listeningpost)
-"bmd" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/grey/side{
-	dir = 8
-	},
-/area/listeningpost)
 "bme" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/glass,
 /obj/access_spawn/syndie_shuttle,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/delivery,
-/area/listeningpost)
-"bmf" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black,
-/area/listeningpost)
-"bmg" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black,
 /area/listeningpost)
 "bmh" = (
 /obj/item/device/radio/intercom{
@@ -30043,10 +23685,6 @@
 	dir = 8;
 	frequency = 1489;
 	name = "Brig Intercom"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/guardbot_dock,
@@ -30056,6 +23694,9 @@
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
+	},
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/black,
 /area/listeningpost)
@@ -30080,8 +23721,8 @@
 /area/listeningpost)
 "bml" = (
 /obj/machinery/power/data_terminal,
-/obj/cable,
 /obj/computer3frame,
+/obj/cable,
 /turf/simulated/floor/black,
 /area/listeningpost)
 "bmm" = (
@@ -30158,10 +23799,6 @@
 	},
 /area/listeningpost)
 "bmx" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "W APC";
@@ -30170,16 +23807,14 @@
 	pixel_y = 0
 	},
 /obj/marker/supplymarker,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/grey/side{
 	dir = 4
 	},
 /area/listeningpost)
 "bmy" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/npc/trader/robot{
 	icon = 'icons/mob/robots.dmi';
 	icon_state = "syndibot";
@@ -30196,6 +23831,9 @@
 	invisibility = 101;
 	luminosity = 0;
 	name = "glow - WHITE"
+	},
+/obj/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/red,
 /area/listeningpost)
@@ -30301,22 +23939,19 @@
 	},
 /area/station/hallway/primary/south)
 "bmO" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/landmark/artifact{
 	name = "artifact spawner (10%)";
 	spawnchance = 10
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/ai)
@@ -30327,12 +23962,13 @@
 /turf/space,
 /area)
 "bmQ" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/greenwhite/corner{
 	dir = 4
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "bmR" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -30340,9 +23976,7 @@
 /turf/simulated/floor/greenwhite/corner{
 	dir = 1
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "bmS" = (
 /turf/simulated/floor/bluewhite{
 	dir = 5
@@ -30355,40 +23989,13 @@
 	dir = 4
 	},
 /area/station/security/main)
-"bmU" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/bluewhite{
-	dir = 8
-	},
-/area/station/medical/research)
 "bmV" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/blueblack/corner{
 	dir = 1
 	},
 /area/station/medical/robotics)
-"bmW" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/blackwhite{
-	dir = 1
-	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
 "bmX" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/table/auto,
 /obj/item/storage/firstaid/brain,
 /obj/item/storage/firstaid/brain,
@@ -30396,16 +24003,12 @@
 /obj/item/reagent_containers/food/snacks/ingredient/meat/monkeymeat,
 /obj/item/reagent_containers/food/snacks/ingredient/meat/monkeymeat,
 /turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "bmY" = (
 /turf/simulated/floor/bluewhite{
 	dir = 9
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "bmZ" = (
 /turf/simulated/floor/red/corner{
 	dir = 8
@@ -30432,9 +24035,7 @@
 /turf/simulated/floor/bluewhite/corner{
 	dir = 4
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "bnd" = (
 /obj/rack,
 /obj/item/clothing/suit/space/emerg,
@@ -30445,10 +24046,6 @@
 /obj/item/device/audio_log,
 /obj/item/camera_test,
 /obj/item/device/radio/headset/multifreq,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/item/camera_test,
 /turf/simulated/floor/purple/side{
 	dir = 4
@@ -30458,13 +24055,15 @@
 /turf/simulated/floor/bluewhite/corner{
 	dir = 8
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "bnf" = (
-/obj/machinery/networked/teleconsole,
-/obj/cable,
+/obj/machinery/networked/teleconsole{
+	dir = 8
+	},
 /obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/purple,
 /area/station/science/teleporter)
 "bng" = (
@@ -30478,30 +24077,11 @@
 /obj/item/clothing/head/helmet/camera,
 /turf/simulated/floor/purple,
 /area/station/science/teleporter)
-"bni" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/purplewhite{
-	dir = 1
-	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
 "bnj" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/purplewhite{
 	dir = 1
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "bnk" = (
 /obj/table/wood/auto,
 /obj/machinery/recharger{
@@ -30514,6 +24094,9 @@
 	},
 /area/station/crew_quarters/hor)
 "bnl" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/carpet{
 	dir = 10;
 	icon_state = "red2"
@@ -30530,7 +24113,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/carpet{
@@ -30540,22 +24122,15 @@
 /area/station/crew_quarters/hor)
 "bnn" = (
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
-/obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
 /turf/simulated/floor/purple/side,
 /area/station/crew_quarters/hor)
 "bno" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1"
@@ -30564,8 +24139,6 @@
 /area/station/turret_protected/Zeta)
 "bnp" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/purple,
@@ -30592,8 +24165,6 @@
 	dir = 1
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/purple,
@@ -30605,24 +24176,6 @@
 	},
 /turf/simulated/floor/purple,
 /area/station/science/lab)
-"bnu" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/purple/side,
-/area/station/science)
-"bnv" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/purple/corner{
-	dir = 1
-	},
-/area/station/science)
 "bnw" = (
 /obj/table/auto,
 /obj/item/storage/toolbox/mechanical,
@@ -30640,31 +24193,22 @@
 /obj/landmark{
 	name = "peststart"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/purple/side,
 /area/station/science)
 "bny" = (
 /turf/simulated/floor/blackwhite{
 	dir = 1
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "bnz" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/bluewhite{
 	dir = 8
 	},
 /area/station/medical/research)
 "bnA" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/bluewhite{
 	dir = 4
 	},
@@ -30674,37 +24218,7 @@
 	dir = 2
 	},
 /area/station/medical/research)
-"bnC" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/bluewhite{
-	dir = 2
-	},
-/area/station/medical/research)
-"bnD" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/bluewhite{
-	dir = 2
-	},
-/area/station/medical/research)
 "bnE" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/stool/chair,
 /obj/landmark/start{
 	name = "Geneticist"
@@ -30755,8 +24269,6 @@
 	name = "monkeyspawn_horse"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/grass{
@@ -30771,20 +24283,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/grass,
 /area/station/medical/research)
-"bnM" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light,
-/turf/simulated/floor/red/side,
-/area/station/security/brig)
 "bnN" = (
 /obj/machinery/door_control{
 	id = "kitchen";
@@ -30848,45 +24346,16 @@
 	},
 /turf/simulated/floor/green,
 /area/station/hydroponics/lobby)
-"bnU" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor{
-	icon = 'icons/misc/beach.dmi';
-	icon_state = "sand";
-	name = "sand"
-	},
-/area/station/crew_quarters/pool)
-"bnV" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor{
-	icon = 'icons/misc/beach.dmi';
-	icon_state = "sand";
-	name = "sand"
-	},
-/area/station/crew_quarters/pool)
 "bnW" = (
 /obj/window/reinforced{
 	dir = 2;
 	icon_state = "rwindow"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellow,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "bnX" = (
 /obj/window/reinforced{
 	dir = 8;
@@ -30921,23 +24390,11 @@
 /obj/item/device/audio_log,
 /obj/item/camera_test,
 /obj/item/device/radio/headset/multifreq,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/item/camera_test,
 /turf/simulated/floor/purple/side{
 	dir = 6
 	},
 /area/station/science/teleporter)
-"boa" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/captain)
 "bob" = (
 /obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
@@ -30970,13 +24427,9 @@
 /area/station/quartermaster)
 "boh" = (
 /obj/machinery/power/data_terminal,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/computer/ordercomp,
+/obj/cable,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/orangeblack/side{
@@ -30984,11 +24437,6 @@
 	},
 /area/station/quartermaster)
 "boi" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/segment,
 /obj/machinery/light{
 	dir = 4;
@@ -31009,23 +24457,21 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bok" = (
-/obj/cable,
 /obj/wingrille_spawn/auto,
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "bol" = (
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/wingrille_spawn/auto,
 /obj/cable,
 /turf/simulated/floor/plating,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "bom" = (
 /obj/machinery/light{
 	dir = 4;
@@ -31043,16 +24489,10 @@
 /turf/space,
 /area)
 "bor" = (
-/obj/cable,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/captain)
 "bov" = (
@@ -31093,9 +24533,7 @@
 "boC" = (
 /obj/decal/poster/wallsign/medbay_text,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "boD" = (
 /obj/decal/poster/wallsign/poster_borg,
 /turf/simulated/wall/auto/supernorn,
@@ -31139,23 +24577,18 @@
 /turf/space,
 /area/station/turret_protected/ai)
 "boM" = (
-/obj/cable,
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer3/terminal/network{
 	setup_os_string = "MAIN_DISH_SS13"
 	},
+/obj/cable,
 /turf/simulated/floor/black,
 /area/station/bridge)
 "boN" = (
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "boO" = (
@@ -31166,27 +24599,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/chapel/main)
-"boP" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/brig)
-"boQ" = (
-/obj/cable,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/wingrille_spawn/auto/crystal,
-/turf/simulated/floor/plating,
-/area/station/security/brig)
 "boR" = (
 /obj/machinery/light{
 	dir = 8;
@@ -31197,11 +24609,6 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "boS" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/light/small{
 	dir = 8;
 	icon_state = "bulb1";
@@ -31230,10 +24637,6 @@
 	tag = "icon-tube1 (NORTH)"
 	},
 /obj/machinery/power/data_terminal,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/computer3/generic/communications,
 /turf/simulated/floor/caution/west,
 /area/station/security/armory)
@@ -31253,18 +24656,16 @@
 /turf/simulated/floor/grass,
 /area/station/medical/research)
 "boY" = (
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/wingrille_spawn/auto,
 /obj/cable,
 /turf/simulated/floor/plating,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "boZ" = (
 /obj/machinery/light/emergency,
 /turf/simulated/floor/neutral/side{
@@ -31294,10 +24695,13 @@
 /obj/landmark{
 	name = "monkeyspawn_rathen"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 2
 	},
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "bpe" = (
 /obj/landmark{
 	name = "monkeyspawn_mrsmuggles"
@@ -31313,16 +24717,6 @@
 /obj/storage/secure/crate/weapon/armory/tranquilizer,
 /turf/simulated/floor/red,
 /area/station/security/armory)
-"bph" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/red/side{
-	dir = 1
-	},
-/area/station/security/brig)
 "bpi" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -31350,13 +24744,13 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/quarters)
 "bpm" = (
-/obj/cable,
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "S APC";
 	pixel_y = -24
 	},
 /obj/machinery/vending/floppy,
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "bpn" = (
@@ -31367,7 +24761,6 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/red/side{
@@ -31375,21 +24768,13 @@
 	},
 /area/station/security/brig)
 "bpo" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/light,
 /turf/simulated/floor/red/side,
 /area/station/security/brig)
 "bpp" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/wingrille_spawn/auto/crystal,
-/turf/simulated/floor/red/side,
+/obj/cable,
+/turf/simulated/floor/plating,
 /area/station/security/brig)
 "bpq" = (
 /turf/simulated/floor/red/corner{
@@ -31434,9 +24819,7 @@
 /area/station/science/lab)
 "bpw" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/bluewhite/corner{
 	dir = 4
@@ -31444,8 +24827,6 @@
 /area/station/medical/medbay)
 "bpx" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/bluewhite{
@@ -31456,20 +24837,13 @@
 /turf/simulated/floor/bluewhite/corner{
 	dir = 1
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "bpz" = (
 /obj/disposalpipe/segment,
 /obj/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-s";
 	tag = "icon-pipe-s (EAST)"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /turf/simulated/floor/neutral/corner{
 	dir = 1
@@ -31483,37 +24857,13 @@
 	dir = 2
 	},
 /area/station/crew_quarters/courtroom)
-"bpB" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s";
-	tag = "icon-pipe-s (EAST)"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/neutral/corner{
-	dir = 8
-	},
-/area/station/hallway/primary/west)
-"bpC" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/camera,
-/turf/simulated/floor/black,
-/area/station/turret_protected/ai)
 "bpD" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/quartermaster/office)
 "bpE" = (
-/obj/cable,
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer3/generic/secure_data,
+/obj/cable,
 /turf/simulated/floor/black,
 /area/station/bridge)
 "bpF" = (
@@ -31556,59 +24906,50 @@
 /area/station/hallway/primary/south)
 "bpK" = (
 /obj/machinery/power/collector_array,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/window/reinforced{
+	dir = 1;
+	icon_state = "rwindow";
+	tag = "icon-rwindow (NORTH)"
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow";
-	tag = "icon-rwindow (NORTH)"
-	},
-/turf/simulated/floor/yellow,
-/area/station/engine/engineering)
-"bpL" = (
-/obj/machinery/power/collector_array,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
+/turf/simulated/floor/yellow,
+/area/station/engine/inner)
+"bpL" = (
+/obj/machinery/power/collector_array,
 /obj/window/reinforced{
 	dir = 1;
 	icon_state = "rwindow";
 	tag = "icon-rwindow (NORTH)"
 	},
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/yellow,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "bpM" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /turf/simulated/floor,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "bpN" = (
 /obj/machinery/camera{
 	c_tag = "Engineering East";
 	dir = 8
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "bpO" = (
 /obj/machinery/emitter{
 	dir = 4;
@@ -31624,100 +24965,74 @@
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "bpP" = (
 /turf/simulated/floor/yellow/side{
 	dir = 6
 	},
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "bpQ" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "bpR" = (
 /turf/simulated/floor/yellow/corner,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "bpS" = (
 /turf/simulated/floor/yellow/corner{
 	dir = 8
 	},
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "bpT" = (
 /turf/simulated/floor/yellow/corner{
 	dir = 4
 	},
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "bpU" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/yellow/corner{
 	dir = 1
 	},
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "bpV" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/yellow,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "bpW" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/yellow,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "bpX" = (
 /obj/landmark{
 	name = "peststart"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 2
 	},
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "bpY" = (
-/obj/cable{
-	icon_state = "1-4";
-	tag = "icon-1-4"
-	},
 /turf/simulated/floor/yellow/side{
 	dir = 9
 	},
-/area/station/engine/engineering)
-"bpZ" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/yellow,
-/area/station/engine/engineering)
+/area/station/engine/inner)
 "bqa" = (
 /turf/space,
 /area/mining/magnet)
 "bqb" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "0-4"
 	},
+/obj/cable,
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "bqc" = (
@@ -31766,20 +25081,7 @@
 	dir = 2
 	},
 /area/station/engine/elect)
-"bqh" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/orangeblack,
-/area/station/engine/elect)
 "bqi" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/light_switch{
 	name = "W light switch";
 	pixel_x = -24;
@@ -31839,17 +25141,6 @@
 	dir = 2
 	},
 /area/station/crew_quarters/courtroom)
-"bqs" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/stool/chair,
-/turf/simulated/floor/neutral/side{
-	dir = 2
-	},
-/area/station/crew_quarters/courtroom)
 "bqt" = (
 /obj/stool/chair,
 /turf/simulated/floor/neutral/corner{
@@ -31870,11 +25161,6 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "bqw" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment,
 /obj/table/wood/auto,
 /obj/item/paper_bin,
@@ -31885,11 +25171,6 @@
 /turf/simulated/floor/grime,
 /area/station/storage/warehouse)
 "bqy" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/storage/closet/office,
 /turf/simulated/floor,
 /area/station/security/checkpoint)
@@ -31901,9 +25182,7 @@
 /obj/table/glass/auto,
 /obj/random_item_spawner/med_tool,
 /turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "bqA" = (
 /obj/machinery/light,
 /turf/simulated/floor,
@@ -31930,17 +25209,10 @@
 	},
 /area/station/hallway/secondary/exit)
 "bqF" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "bqG" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/escape{
@@ -31966,27 +25238,20 @@
 /area/station/hallway/primary/south)
 "bqK" = (
 /obj/firedoor_spawn,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/pyro/medical{
 	dir = 8;
 	icon_state = "research_closed";
 	name = "Artifact Lab"
 	},
 /obj/access_spawn/research,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/white/side{
 	dir = 4
 	},
 /area/station/science/artifact)
 "bqL" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment,
 /obj/firedoor_spawn,
 /turf/simulated/floor,
@@ -32003,8 +25268,8 @@
 /area/station/hallway/primary/south)
 "bqO" = (
 /obj/machinery/power/data_terminal,
-/obj/cable,
 /obj/machinery/computer/security,
+/obj/cable,
 /turf/simulated/floor/black,
 /area/station/bridge)
 "bqP" = (
@@ -32012,19 +25277,6 @@
 /obj/item/storage/belt/utility,
 /turf/simulated/floor/grime,
 /area/station/storage/warehouse)
-"bqQ" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/blue,
-/area/station/medical/medbay)
 "bqR" = (
 /obj/table/auto,
 /obj/item/storage/box/stma_kit,
@@ -32038,21 +25290,10 @@
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "bqS" = (
-/obj/firedoor_spawn,
-/obj/machinery/door/airlock/pyro/engineering{
-	dir = 2;
-	name = "Power Substation"
-	},
-/obj/access_spawn/engineering,
+/obj/grille,
+/obj/structure/woodwall,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
-"bqT" = (
-/obj/cable,
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/blue,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
 "bqU" = (
 /obj/health_scanner/floor{
 	dir = 4;
@@ -32061,17 +25302,15 @@
 	id = "lobby"
 	},
 /turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "bqV" = (
 /obj/wingrille_spawn/auto,
-/turf/simulated/floor/blue,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/lobby)
 "bqW" = (
-/obj/cable,
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "S APC";
@@ -32090,6 +25329,7 @@
 	name = "QM Announcement Computer";
 	req_access_txt = "31"
 	},
+/obj/cable,
 /turf/simulated/floor/orangeblack/side{
 	dir = 10
 	},
@@ -32110,20 +25350,20 @@
 /turf/simulated/floor/orangeblack/side,
 /area/station/quartermaster/office)
 "bra" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "brb" = (
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "brc" = (
@@ -32143,11 +25383,6 @@
 	},
 /area/station/hallway/primary/south)
 "bre" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/light/emergency,
 /turf/simulated/floor/purple,
 /area/station/science)
@@ -32160,11 +25395,6 @@
 /turf/simulated/floor/purple/side,
 /area/station/science)
 "brg" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/segment,
 /obj/machinery/light/emergency{
 	dir = 4;
@@ -32222,11 +25452,6 @@
 	pixel_y = -24
 	},
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor,
@@ -32234,8 +25459,6 @@
 "bro" = (
 /obj/stool/bench/red/auto,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -32259,21 +25482,6 @@
 	dir = 6
 	},
 /area/station/medical/research)
-"brr" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/white,
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
 "brs" = (
 /obj/landmark/start{
 	name = "predator"
@@ -32284,25 +25492,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
-"brt" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/blue,
-/area/station/medical/medbay)
 "bru" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -32317,16 +25507,14 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "brw" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/security{
 	name = "Head of Security'"
 	},
 /obj/access_spawn/hos,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/black,
 /area/station/security/hos)
 "brz" = (
@@ -32343,13 +25531,6 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/research)
-"brB" = (
-/obj/storage/closet/emergency,
-/obj/machinery/light/incandescent/netural{
-	dir = 1
-	},
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
 "brC" = (
 /obj/machinery/light,
 /turf/simulated/floor/purple,
@@ -32361,13 +25542,6 @@
 	tag = "icon-grass1"
 	},
 /area/station/hydroponics)
-"brE" = (
-/obj/cable{
-	icon_state = "1-4";
-	tag = "icon-1-4"
-	},
-/turf/simulated/floor/blue,
-/area/station/medical/medbay)
 "brF" = (
 /obj/machinery/camera,
 /obj/lattice{
@@ -32388,14 +25562,6 @@
 /obj/item/clothing/head/helmet/riot,
 /turf/simulated/floor,
 /area/station/security/armory)
-"brH" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/engineering)
 "brI" = (
 /obj/machinery/neosmelter,
 /turf/simulated/floor/shuttlebay{
@@ -32476,8 +25642,6 @@
 /area/station/mining/magnet)
 "brV" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating/airless,
@@ -32488,11 +25652,10 @@
 	name = "S APC";
 	pixel_y = -24
 	},
+/obj/machinery/processor,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/processor,
 /turf/simulated/floor/grime,
 /area/station/mining/magnet)
 "brX" = (
@@ -32532,18 +25695,19 @@
 /obj/landmark{
 	name = "blobstart"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/red/corner{
 	dir = 1
 	},
 /area/station/security/brig)
 "bsc" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/pyro/external,
 /obj/access_spawn/mining,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating/airless,
 /area/station/mining/magnet)
 "bsd" = (
@@ -32552,11 +25716,6 @@
 /turf/simulated/floor/plating/airless,
 /area/station/mining/magnet)
 "bse" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
@@ -32566,15 +25725,6 @@
 /obj/item/device/detective_scanner,
 /turf/simulated/floor,
 /area/station/security/main)
-"bsf" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/medical/research)
 "bsg" = (
 /obj/overlay{
 	anchored = 1;
@@ -32603,13 +25753,6 @@
 	},
 /turf/space,
 /area)
-"bsi" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/medical/research)
 "bsj" = (
 /obj/grille/catwalk{
 	dir = 4
@@ -32621,8 +25764,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/space,
@@ -32641,11 +25782,6 @@
 /turf/simulated/floor/red,
 /area/station/security/brig)
 "bsn" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
@@ -32653,6 +25789,9 @@
 	name = "Mechanic's Lab"
 	},
 /obj/access_spawn/engineering_mechanic,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/engine/elect)
 "bso" = (
@@ -32660,8 +25799,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/space,
@@ -32671,14 +25808,7 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
 /turf/space,
 /area/station/mining/magnet)
@@ -32687,11 +25817,6 @@
 /turf/space,
 /area/mining/magnet)
 "bsr" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
@@ -32699,16 +25824,14 @@
 	name = "Research Sector"
 	},
 /obj/access_spawn/research,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/white/side{
 	dir = 8
 	},
 /area/station/science)
 "bss" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
@@ -32765,17 +25888,15 @@
 /area/station/mining/magnet)
 "bsB" = (
 /obj/firedoor_spawn,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	icon_state = "glass_closed";
 	name = "Research Sector"
 	},
 /obj/access_spawn/research,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/white/side{
 	dir = 2
 	},
@@ -32788,27 +25909,18 @@
 /turf/space,
 /area)
 "bsD" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/command{
 	name = "AI Module Storage"
 	},
 /obj/access_spawn/heads,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/grey/side{
 	tag = "icon-dark"
 	},
 /area/station/turret_protected/Zeta)
-"bsE" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/medical/research)
 "bsF" = (
 /obj/landmark{
 	name = "monkeyspawn_mrmuggles"
@@ -32838,6 +25950,13 @@
 "bsI" = (
 /obj/landmark{
 	name = "monkeyspawn_tanhony"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
@@ -32885,25 +26004,21 @@
 /area/station/engine/engineering)
 "bsN" = (
 /obj/firedoor_spawn,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/pyro/medical{
 	dir = 8;
 	icon_state = "research_closed";
 	name = "Mixing Room"
 	},
 /obj/access_spawn/research,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/white/side{
 	dir = 4
 	},
 /area/station/science/lab)
 "bsO" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow/side{
@@ -32912,13 +26027,6 @@
 /area/station/engine/engineering)
 "bsP" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow/side{
@@ -32931,11 +26039,6 @@
 	dir = 8;
 	frequency = 1441;
 	name = "Station Intercom (Engineering)"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
@@ -32958,16 +26061,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/teleporter)
-"bsU" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/red/corner{
-	dir = 1
-	},
-/area/station/security/brig)
 "bsV" = (
 /obj/landmark/start{
 	name = "AI"
@@ -32985,8 +26078,10 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
@@ -32999,6 +26094,9 @@
 	name = "Research Director's Office"
 	},
 /obj/access_spawn/research_director,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/blue,
 /area/station/crew_quarters/hor)
 "bsY" = (
@@ -33008,12 +26106,6 @@
 	},
 /turf/space,
 /area)
-"bsZ" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor,
-/area/station/engine/engineering)
 "bta" = (
 /obj/table/auto,
 /turf/simulated/floor/specialroom/cafeteria{
@@ -33034,43 +26126,18 @@
 	},
 /turf/space,
 /area/station/turret_protected/ai)
-"btd" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/caution/west,
-/area/station/security/armory)
 "bte" = (
 /obj/storage/secure/crate/plasma/armory/anti_biological,
 /turf/simulated/floor,
 /area/station/security/armory)
-"btf" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/red/side{
-	dir = 4
-	},
-/area/station/security/brig)
 "btg" = (
 /turf/simulated/floor/carpet{
 	dir = 1;
 	icon_state = "red2"
 	},
-/area/station/hallway/primary/west)
+/area/station/crew_quarters/cafeteria)
 "bth" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/red,
-/area/station/security/armory)
-"bti" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/caution/west,
 /area/station/security/armory)
 "btj" = (
 /obj/table/auto,
@@ -33116,7 +26183,7 @@
 	dir = 5;
 	icon_state = "red2"
 	},
-/area/station/hallway/primary/west)
+/area/station/crew_quarters/cafeteria)
 "bto" = (
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance{
@@ -33132,8 +26199,11 @@
 	icon_state = "pipe-s";
 	tag = "icon-pipe-s (EAST)"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/carpet,
-/area/station/hallway/primary/west)
+/area/station/crew_quarters/cafeteria)
 "btq" = (
 /obj/stool/bench/blue/auto,
 /obj/machinery/light{
@@ -33143,9 +26213,7 @@
 /turf/simulated/floor/purplewhite{
 	dir = 8
 	},
-/area/station/medical/cdc{
-	name = "Medbay Lobby"
-	})
+/area/station/medical/medbay/lobby)
 "btr" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -33159,11 +26227,14 @@
 	icon_state = "glass_closed";
 	name = "Cafeteria"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/carpet{
 	dir = 4;
 	icon_state = "red2"
 	},
-/area/station/hallway/primary/west)
+/area/station/crew_quarters/cafeteria)
 "bts" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -33173,7 +26244,7 @@
 	dir = 2;
 	icon_state = "red2"
 	},
-/area/station/hallway/primary/west)
+/area/station/crew_quarters/cafeteria)
 "btt" = (
 /obj/landmark/artifact{
 	name = "artifact spawner (10%)";
@@ -33229,20 +26300,17 @@
 /turf/space,
 /area/station/com_dish/comdish)
 "btB" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/communications_dish{
 	tag = "MAIN_DISH_SS13"
+	},
+/obj/cable{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/com_dish/comdish)
 "btC" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
@@ -33269,7 +26337,7 @@
 	dir = 6;
 	icon_state = "red2"
 	},
-/area/station/hallway/primary/west)
+/area/station/crew_quarters/cafeteria)
 "btF" = (
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass{
@@ -33326,6 +26394,9 @@
 	name = "Kitchen"
 	},
 /obj/access_spawn/kitchen,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/kitchen)
 "btL" = (
@@ -33335,19 +26406,6 @@
 /obj/access_spawn/forensics,
 /turf/simulated/floor/delivery,
 /area/station/security/detectives_office)
-"btM" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4;
-	icon_state = "glass_closed";
-	name = "True Reality"
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/arcade)
 "btN" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
@@ -33361,6 +26419,9 @@
 	name = "Interrogation Room"
 	},
 /obj/access_spawn/security,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/delivery,
 /area/station/security/main)
 "btP" = (
@@ -33382,14 +26443,12 @@
 	icon_state = "glass_closed";
 	name = "glass airlock"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "btT" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
@@ -33397,16 +26456,14 @@
 	name = "Head of Personnel"
 	},
 /obj/access_spawn/head_of_personnel,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/grey/side{
 	dir = 4
 	},
 /area/station/crew_quarters/heads)
 "btU" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
@@ -33414,649 +26471,4087 @@
 	name = "Captain's Quarters"
 	},
 /obj/access_spawn/captain,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/captain)
 "btV" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/door/window/southleft,
 /obj/access_spawn/captain,
-/turf/simulated/floor/blue,
-/area/station/crew_quarters/captain)
-"btW" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/door/airlock/pyro/external,
-/obj/access_spawn/ai_upload,
-/turf/simulated/floor/black/side,
-/area/station/turret_protected/ai)
-"btX" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
+/turf/simulated/floor/blue,
+/area/station/crew_quarters/captain)
+"btX" = (
 /obj/machinery/door/airlock/pyro/external,
 /obj/access_spawn/ai_upload,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai)
 "btY" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/pyro/external,
 /obj/access_spawn/ai_upload,
 /turf/simulated/floor/black/side,
 /area/station/turret_protected/ai)
-"bDG" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4;
-	name = "Pod Bay"
-	},
-/obj/machinery/secscanner{
-	dir = 4;
-	icon_state = "scanner_on";
-	pixel_x = -20
+"buO" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-6"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
+	icon_state = "0-9"
+	},
+/obj/cable{
+	icon_state = "0-10"
+	},
+/turf/simulated/floor/plating,
+/area/station/hydroponics)
+"bwb" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/fitness)
+"bxO" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet{
+	dir = 2;
+	icon_state = "fgreen3"
+	},
+/area/station/bridge)
+"bAO" = (
+/obj/cable{
+	icon_state = "2-10"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
+"bAQ" = (
+/obj/machinery/camera,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/engine,
+/area/station/turret_protected/ai)
+"bCy" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/courtroom)
+"bCV" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/security/detectives_office)
+"bDa" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig)
+"bET" = (
+/obj/cable{
+	icon_state = "2-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
+"bKe" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/purple,
+/area/station/science/teleporter)
+"bKs" = (
+/obj/cable{
+	icon_state = "2-5"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SWmaint)
+"bMH" = (
+/obj/cable,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/orangeblack/side{
+	dir = 1
+	},
+/area/station/science)
+"bOO" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/captain)
+"bRC" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor,
+/area/station/ai_monitored/storage/eva)
+"bSt" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-6"
+	},
+/turf/simulated/floor/plating,
+/area/station/hydroponics)
+"cdX" = (
+/obj/cable{
+	icon_state = "1-6"
+	},
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/Zeta)
+"ceG" = (
+/obj/cable{
+	icon_state = "6-8"
+	},
+/turf/simulated/floor/carpet{
+	dir = 1;
+	icon_state = "fgreen2"
+	},
+/area/station/bridge)
+"ceU" = (
+/obj/cable{
+	icon_state = "6-8"
+	},
+/obj/cable{
+	icon_state = "2-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
+"cfw" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/station/hangar/main)
-"crI" = (
-/obj/landmark{
-	name = "Observer-Start"
+/area/station/hallway/primary/south)
+"cjc" = (
+/obj/disposalpipe/segment{
+	dir = 4
 	},
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"cKf" = (
-/turf/simulated/wall/auto/shuttle{
-	icon_state = "2"
-	},
-/area/shuttle/arrival/station)
-"cTH" = (
-/turf/simulated/wall/auto/shuttle{
-	icon_state = "4"
-	},
-/area/shuttle/arrival/station)
-"dlG" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/hangar/main)
-"doP" = (
-/obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 2;
+	icon_state = "4-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"clo" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
 	icon_state = "0-2"
 	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/captain)
+"cmU" = (
 /obj/cable{
-	d2 = 8;
+	icon_state = "2-10"
+	},
+/obj/cable{
+	icon_state = "6-8"
+	},
+/obj/landmark/start{
+	name = "predator"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"cnN" = (
+/obj/disposalpipe/segment,
+/turf/simulated/wall/auto/supernorn,
+/area/station/maintenance/SEmaint)
+"cnU" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/white,
+/area/station/science/artifact)
+"crw" = (
+/obj/cable{
+	icon_state = "8-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/chapel/main)
+"csn" = (
+/obj/cable{
+	icon_state = "1-10"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/NEmaint)
+"ctu" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/cable{
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/engine/engineering)
-"dEm" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/shuttle/engine/heater{
-	dir = 8;
-	icon_state = "alt_heater-L"
+/area/station/security/checkpoint)
+"cvJ" = (
+/obj/machinery/power/solar{
+	id = "aisolar";
+	name = "AI Satellite Solar Array"
 	},
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"dRv" = (
-/obj/machinery/computer/riotgear{
-	dir = 8;
-	pixel_x = 32
+/obj/cable{
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/red/side{
-	dir = 4
+/turf/simulated/floor/airless{
+	icon_state = "solarpanel";
+	name = "solar paneling"
 	},
+/area/station/turret_protected/ai)
+"cws" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor{
+	icon = 'icons/misc/beach.dmi';
+	icon_state = "sand";
+	name = "sand"
+	},
+/area/station/crew_quarters/pool)
+"cxd" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/hor)
+"cxT" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/turret_protected/ai_upload_foyer)
+"czC" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
 /area/station/security/brig)
-"dVg" = (
-/obj/machinery/camera{
-	c_tag = "Escape Shuttle Dock"
+"cCv" = (
+/obj/cable{
+	icon_state = "2-5"
 	},
-/turf/simulated/floor/escape{
+/turf/simulated/floor/plating,
+/area/station/maintenance/SEmaint)
+"cFZ" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/science/teleporter)
+"cHJ" = (
+/obj/cable{
+	icon_state = "5-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/NEmaint)
+"cIr" = (
+/obj/cable{
+	icon_state = "1-6"
+	},
+/turf/simulated/floor/grass{
+	name = "astroturf";
+	tag = "icon-grass1"
+	},
+/area/station/hydroponics)
+"cPd" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/purple,
+/area/station/science)
+"cPw" = (
+/obj/cable{
+	icon_state = "4-10"
+	},
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/Zeta)
+"cTL" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/turret_protected/ai)
+"cWq" = (
+/turf/simulated/wall/auto/supernorn,
+/area/station/storage/warehouse)
+"cXe" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost)
+"dbJ" = (
+/obj/shrub{
+	dir = 8;
+	icon_state = "shrub";
+	tag = "icon-shrub (WEST)"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/grass/random{
+	dir = 2
+	},
+/area/station/owlery)
+"dch" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/listeningpost)
+"dcW" = (
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/orangeblack/side{
 	dir = 1
 	},
-/area/station/hallway/secondary/exit)
-"dVq" = (
+/area/station/science)
+"dqc" = (
+/obj/machinery/turret,
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
+	icon_state = "4-10"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"drC" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/caution/west,
+/area/station/science/artifact)
+"dte" = (
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/red,
+/area/station/security/brig)
+"duf" = (
+/obj/cable{
+	icon_state = "1-10"
+	},
+/turf/simulated/floor/carpet{
+	dir = 1;
+	icon_state = "blue2"
+	},
+/area/station/bridge)
+"dvP" = (
+/obj/stool/chair,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 2
+	},
+/area/station/crew_quarters/courtroom)
+"dxn" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/security/main)
+"dxI" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/turret_protected/ai)
+"dyi" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/engine,
+/area/station/turret_protected/ai)
+"dBh" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "5-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/NEmaint)
+"dDL" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/red/side{
+	dir = 1
+	},
+/area/station/security/brig)
+"dEg" = (
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/greenwhite{
+	dir = 8
+	},
+/area/station/medical/research)
+"dGj" = (
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
+"dJn" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/bluewhite{
+	dir = 1
+	},
+/area/station/medical/research)
+"dJX" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/blue,
+/area/station/medical/medbay)
+"dLk" = (
+/obj/cable{
 	icon_state = "1-4"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
-"edh" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/shuttle/engine/heater{
-	dir = 8;
-	icon_state = "alt_heater-M"
+"dMp" = (
+/obj/cable{
+	icon_state = "1-2"
 	},
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"eiT" = (
-/turf/simulated/shuttle/wall/corner{
-	dir = 1
+/obj/cable{
+	icon_state = "2-9"
 	},
-/area/shuttle/arrival/station)
-"eoJ" = (
-/obj/storage/closet/emergency,
-/obj/machinery/light/incandescent/netural,
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"eoM" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/shuttle/engine/heater{
-	dir = 8;
-	icon_state = "alt_heater-R"
+/turf/simulated/floor/carpet{
+	dir = 2;
+	icon_state = "fgreen3"
 	},
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"eGe" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	layer = 9.1;
-	pixel_x = 10
-	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 5
-	},
-/area/station/hangar/main)
-"eIb" = (
-/turf/simulated/wall/auto/shuttle{
-	icon_state = "3"
-	},
-/area/shuttle/arrival/station)
-"eUm" = (
-/turf/simulated/floor/engine,
-/area/station/hangar/main)
-"faB" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/hallway/secondary/exit)
-"fYD" = (
-/obj/machinery/light/emergency{
-	dir = 1;
-	icon_state = "ebulb1"
-	},
-/obj/table/auto,
-/obj/machinery/shieldgenerator/meteorshield,
-/turf/simulated/floor/escape{
-	dir = 5
-	},
-/area/station/hallway/secondary/exit)
-"gjD" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/hangar/main)
-"gOt" = (
+/area/station/bridge)
+"dNU" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/engine/engineering)
-"gYQ" = (
-/obj/decal/poster/wallsign/escape,
-/turf/simulated/wall/auto/supernorn,
-/area/station/hallway/secondary/exit)
-"hfV" = (
-/obj/lattice{
-	dir = 5;
-	icon_state = "lattice-dir"
-	},
-/obj/warp_beacon{
-	name = "Hangar Beacon"
-	},
-/turf/space,
-/area)
-"hKB" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	layer = 9.1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/arrival{
-	dir = 10
-	},
-/area/station/hallway/secondary/entry)
-"ioE" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "qmout"
+/area/station/maintenance/east)
+"dQl" = (
+/obj/stool/chair{
+	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/caution/northsouth,
-/area/station/quartermaster/office)
-"ixI" = (
-/obj/machinery/light/emergency{
-	dir = 8;
-	icon_state = "ebulb1";
-	pixel_x = -16
+/turf/simulated/floor{
+	icon_state = "0,6";
+	tag = "icon-0,6"
 	},
-/obj/decal/tile_edge/stripe/big{
-	dir = 1;
-	icon_state = "xtra_bigstripe-edge"
-	},
-/turf/simulated/floor/engine,
-/area/station/hangar/main)
-"iyS" = (
-/obj/machinery/power/apc/autoname_north,
+/area/station/crew_quarters/fitness)
+"dVu" = (
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/escape{
-	dir = 1
+/obj/cable{
+	icon_state = "8-9"
 	},
-/area/station/hallway/secondary/exit)
-"jpv" = (
-/obj/machinery/vehicle/miniputt/armed,
+/turf/simulated/floor,
+/area/station/turret_protected/ai_upload_foyer)
+"dYm" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/engine,
-/area/station/hangar/main)
-"jAM" = (
-/obj/cable,
+/area/station/turret_protected/ai)
+"eaS" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/turret_protected/ai)
+"ebf" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/medical/research)
+"ebm" = (
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	icon_state = "glass_closed";
+	name = "True Reality"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/arcade)
+"ebZ" = (
+/obj/cable{
+	icon_state = "1-6"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"eca" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/hydroponics)
-"jDr" = (
-/obj/wingrille_spawn/auto,
+"ect" = (
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/security/brig)
+"ecT" = (
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "5-6"
 	},
 /obj/cable{
-	d2 = 8;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"eec" = (
+/obj/cable{
+	icon_state = "1-10"
+	},
+/turf/simulated/floor/grass,
+/area/station/medical/research)
+"efD" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/maintenance/SWmaint)
+"egL" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/cable{
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/turf/simulated/floor/grass{
+	name = "astroturf";
+	tag = "icon-grass1"
+	},
+/area/station/hydroponics)
+"ehp" = (
+/obj/landmark/start{
+	name = "Medical Doctor"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/blue,
+/area/station/medical/medbay)
+"eht" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/captain)
+"eol" = (
+/obj/cable{
+	icon_state = "4-10"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"eqv" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/greenwhite{
+	dir = 1
+	},
+/area/station/medical/research)
+"eqJ" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
+"eII" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/engine/engineering)
-"jGu" = (
-/obj/machinery/r_door_control{
-	id = "hangar_arrivals"
+/area/station/crew_quarters/captain)
+"eKg" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-s";
+	tag = "icon-pipe-s (EAST)"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/hangar/main)
-"jIj" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor,
-/area/station/hangar/main)
-"jKR" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/orangeblack/side{
+/turf/simulated/floor/neutral/corner{
 	dir = 8
 	},
-/area/station/hangar/main)
-"jMS" = (
+/area/station/hallway/primary/west)
+"eLN" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/station/medical/research)
+"eNp" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 2;
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/arcade)
+"eRC" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/grass{
+	name = "astroturf";
+	tag = "icon-grass1"
+	},
+/area/station/hydroponics)
+"eTY" = (
+/obj/stool/bar,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/cafeteria)
+"eUg" = (
+/obj/cable{
+	icon_state = "4-9"
+	},
+/obj/cable{
+	icon_state = "4-10"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"eUi" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/courtroom)
+"eVp" = (
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "4-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SEmaint)
+"eWO" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/hydroponics)
+"eWZ" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/quartermaster/office)
-"jYd" = (
-/obj/decal/tile_edge/stripe/big{
+/area/station/medical/research)
+"eYg" = (
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/turret_protected/ai)
+"eYV" = (
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "1-10"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/NWmaint)
+"fai" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-6"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
+"ffn" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
+"fke" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/cafeteria)
+"flL" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/grey/side{
+	dir = 8
+	},
+/area/listeningpost)
+"fnB" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/arcade)
+"fox" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/bridge)
+"frX" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"fsH" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/medical/research)
+"ftu" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/yellow/corner{
+	dir = 8
+	},
+/area/station/hallway/primary/central)
+"fuK" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "6-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"fuR" = (
+/obj/machinery/light,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 2
+	},
+/area/station/hallway/primary/central)
+"fvo" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/purplewhite/corner{
+	dir = 8
+	},
+/area/station/medical/medbay/lobby)
+"fyG" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/cable{
+	icon_state = "6-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"fFS" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/turret_protected/ai)
+"fGD" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/purplewhite/corner{
+	dir = 1
+	},
+/area/station/medical/medbay/lobby)
+"fGE" = (
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/carpet{
+	dir = 2;
+	icon_state = "fblue1"
+	},
+/area/station/bridge)
+"fGZ" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
+/turf/simulated/floor/yellow/side{
+	dir = 2
+	},
+/area/station/hallway/primary/central)
+"fHj" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/black,
+/area/station/security/hos)
+"fHn" = (
+/obj/cable{
+	icon_state = "2-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SEmaint)
+"fIb" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/medical/robotics)
+"fMg" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/turret_protected/ai)
+"fOh" = (
+/obj/cable{
+	icon_state = "6-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/NEmaint)
+"fPW" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/arcade)
+"fQU" = (
+/obj/cable{
+	icon_state = "2-5"
+	},
+/turf/simulated/floor/grass{
+	name = "astroturf";
+	tag = "icon-grass1"
+	},
+/area/station/hydroponics)
+"fSC" = (
+/obj/cable{
+	icon_state = "1-5"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SWmaint)
+"fUe" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
+"fVw" = (
+/obj/cable{
+	icon_state = "5-6"
+	},
+/turf/simulated/floor/plating/scorched,
+/area/station/maintenance/NWmaint)
+"fWY" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
+"fXp" = (
+/obj/cable{
+	icon_state = "6-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SWmaint)
+"fXN" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hydroponics)
+"fXO" = (
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/cable{
+	icon_state = "6-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"fZF" = (
+/obj/machinery/power/solar{
+	id = "aisolar";
+	name = "AI Satellite Solar Array"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/airless{
+	icon_state = "solarpanel";
+	name = "solar paneling"
+	},
+/area/station/turret_protected/ai)
+"gcn" = (
+/obj/cable{
+	icon_state = "1-9"
+	},
+/obj/cable{
+	icon_state = "4-10"
+	},
+/obj/cable{
+	icon_state = "4-6"
+	},
+/turf/simulated/floor/plating/damaged1,
+/area/station/chapel/main)
+"gdH" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/security/main)
+"gdQ" = (
+/obj/cable{
+	icon_state = "5-8"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"gez" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SEmaint)
+"gfM" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/ai_upload_foyer)
+"ggE" = (
+/obj/cable{
+	icon_state = "1-6"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SWmaint)
+"gjW" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-s";
+	tag = "icon-pipe-s (EAST)"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/neutral/corner{
+	dir = 8
+	},
+/area/station/hallway/primary/west)
+"gkg" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/hydroponics)
+"gnE" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/bridge)
+"gpb" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/bar)
+"gpP" = (
+/obj/cable{
+	icon_state = "2-10"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SEmaint)
+"gsD" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
+/turf/simulated/floor/carpet{
+	dir = 2;
+	icon_state = "fblue1"
+	},
+/area/station/bridge)
+"gtl" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"gAL" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/turret_protected/ai)
+"gDK" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner)
+"gGS" = (
+/obj/cable{
+	icon_state = "1-6"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"gLY" = (
+/obj/cable{
+	icon_state = "4-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SEmaint)
+"gNd" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/purple,
+/area/station/science)
+"gOS" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/blue,
+/area/station/medical/medbay)
+"gQO" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/research)
+"gTj" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet{
 	dir = 1;
-	icon_state = "xtra_bigstripe-edge"
+	icon_state = "fgreen3"
+	},
+/area/station/bridge)
+"gVZ" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
+"gWu" = (
+/obj/landmark{
+	name = "monkeyspawn_normal"
+	},
+/obj/cable{
+	icon_state = "2-9"
+	},
+/turf/simulated/floor/grass,
+/area/station/medical/research)
+"haT" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/bar)
+"hcu" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/purple/side,
+/area/station/science)
+"hdy" = (
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/red/side{
+	dir = 4
+	},
+/area/station/security/main)
+"hgD" = (
+/obj/cable{
+	icon_state = "4-6"
+	},
+/obj/cable{
+	icon_state = "1-6"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/NEmaint)
+"hgP" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
+"hhS" = (
+/obj/cable{
+	icon_state = "4-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"hkO" = (
+/obj/disposalpipe/segment,
+/turf/simulated/wall/auto/supernorn,
+/area/station/storage/emergency)
+"hoZ" = (
+/obj/cable{
+	icon_state = "4-9"
+	},
+/obj/cable{
+	icon_state = "8-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"hpS" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/purple/corner{
+	dir = 4
+	},
+/area/station/hallway/primary/central)
+"hsU" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/heads)
+"huW" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "1-6"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
+"hvE" = (
+/obj/cable{
+	icon_state = "4-9"
+	},
+/turf/simulated/floor/grass{
+	name = "astroturf";
+	tag = "icon-grass1"
+	},
+/area/station/hydroponics)
+"hvS" = (
+/obj/cable{
+	icon_state = "1-10"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"hAd" = (
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/blue/checker,
+/area/station/medical/research)
+"hAn" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/lobby)
+"hAu" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/research)
+"hAU" = (
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
-/area/station/hangar/main)
-"kbh" = (
+/area/station/turret_protected/ai)
+"hBl" = (
+/obj/cable{
+	icon_state = "2-5"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
+"hBw" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/courtroom)
+"hIi" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/storage/emergency)
+"hIl" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-s";
+	tag = "icon-pipe-s (EAST)"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/security/brig)
+"hLp" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/arcade)
+"hMo" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/yellow/corner{
+	dir = 1
+	},
+/area/station/engine/elect)
+"hPj" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/purplewhite{
+	dir = 9
+	},
+/area/station/science/lab)
+"hQk" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
+"hQH" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/carpet{
+	dir = 2;
+	icon_state = "blue2"
+	},
+/area/station/bridge)
+"hRQ" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
+/turf/simulated/floor/grass{
+	name = "astroturf";
+	tag = "icon-grass1"
+	},
+/area/station/hydroponics)
+"hTJ" = (
+/turf/simulated/floor/plating,
+/area/station/maintenance/eastsolar)
+"hWg" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/ai_monitored/storage/eva)
+"hXL" = (
+/obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-6"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SEmaint)
+"icj" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"iee" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/fitness)
+"ieo" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/plating,
+/area/station/engine/elect)
+"ifC" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/purple,
+/area/station/science/teleporter)
+"ijy" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/purple/side{
+	dir = 4
+	},
+/area/station/hallway/primary/central)
+"ilb" = (
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "4-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/NWmaint)
+"imI" = (
+/obj/item/sheet/steel{
+	amount = 50
+	},
+/obj/item/sheet/steel{
+	amount = 50
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor,
+/area/station/ai_monitored/storage/eva)
+"irT" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/bridge)
+"ivd" = (
+/obj/cable{
+	icon_state = "1-10"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SWmaint)
+"iyq" = (
+/obj/cable{
+	icon_state = "1-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"iBf" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/security/main)
+"iBB" = (
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "2-5"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SEmaint)
+"iBE" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/bar)
+"iFD" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"iGF" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/bridge)
+"iHJ" = (
+/obj/cable{
+	icon_state = "6-8"
+	},
+/obj/cable{
+	icon_state = "5-8"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"iIy" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "5-8"
+	},
+/turf/simulated/floor/carpet{
+	dir = 2;
+	icon_state = "fblue1"
+	},
+/area/station/bridge)
+"iIT" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/cable{
+	icon_state = "2-6"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"iIU" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"iJD" = (
+/obj/cable{
+	icon_state = "6-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/NEmaint)
+"iNj" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-s";
+	tag = "icon-pipe-s (EAST)"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/turf/simulated/floor/neutral/corner{
+	dir = 1
+	},
+/area/station/hallway/primary/west)
+"iNv" = (
+/obj/cable{
+	icon_state = "2-10"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/NEmaint)
+"iPl" = (
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "1-6"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"iQr" = (
+/obj/cable{
+	icon_state = "4-5"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SEmaint)
+"iWI" = (
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable,
+/turf/simulated/floor/black,
+/area/station/bridge)
+"iWS" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"iXx" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/turret_protected/ai)
+"iYw" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/security/main)
+"jfa" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
+"jgD" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
+"jlr" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/heads)
+"jnJ" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor{
+	icon_state = "0,6";
+	tag = "icon-0,6"
+	},
+/area/station/crew_quarters/fitness)
+"jrr" = (
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor,
+/area/station/security/brig)
+"jrR" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/grass/random{
+	dir = 2
+	},
+/area/station/owlery)
+"jsr" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/science/storage)
+"jvN" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/robotics)
+"jBH" = (
+/obj/cable{
+	icon_state = "1-10"
+	},
+/turf/simulated/floor/carpet{
+	dir = 2;
+	icon_state = "fgreen2"
+	},
+/area/station/bridge)
+"jBS" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/NEmaint)
+"jCK" = (
+/obj/cable{
+	icon_state = "1-6"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/NEmaint)
+"jDd" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/NEmaint)
+"jEe" = (
+/obj/machinery/power/solar{
+	id = "aisolar";
+	name = "AI Satellite Solar Array"
+	},
+/obj/cable,
+/turf/simulated/floor/airless{
+	icon_state = "solarpanel";
+	name = "solar paneling"
+	},
+/area/station/turret_protected/ai)
+"jFn" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/purplewhite{
+	dir = 1
+	},
+/area/station/medical/medbay/lobby)
+"jGs" = (
+/obj/cable{
+	icon_state = "4-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/NWmaint)
+"jKz" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/bridge)
+"jLz" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 1
+	},
+/area/station/hallway/primary/west)
+"jOO" = (
+/obj/cable,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/purple,
+/area/station/science)
+"jQi" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig)
+"jTu" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/maintenance/inner)
+"jXg" = (
+/obj/cable{
+	icon_state = "1-6"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
+"jXE" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/red/side{
+	dir = 1
+	},
+/area/station/security/brig)
+"kao" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/research)
+"kaN" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/yellow/corner,
+/area/station/engine/elect)
+"kdK" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/carpet{
+	dir = 2;
+	icon_state = "blue2"
+	},
+/area/station/bridge)
+"keX" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "5-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
+"kir" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
+"kiU" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/red/side{
+	dir = 4
+	},
+/area/station/security/main)
+"kkl" = (
+/obj/cable{
+	icon_state = "2-10"
+	},
+/obj/cable{
+	icon_state = "4-5"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
+"knT" = (
+/obj/machinery/light,
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/red/side,
+/area/station/security/brig)
+"kpQ" = (
+/obj/cable{
+	icon_state = "4-9"
+	},
+/turf/simulated/floor/carpet{
+	dir = 2;
+	icon_state = "fblue1"
+	},
+/area/station/bridge)
+"kqW" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/courtroom)
+"ksc" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/bar)
+"kvN" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-s";
+	tag = "icon-pipe-s (EAST)"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/neutral/corner{
+	dir = 1
+	},
+/area/station/hallway/primary/west)
+"kwA" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-s";
+	tag = "icon-pipe-s (EAST)"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor,
+/area/station/security/brig)
+"kyS" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/quarters)
+"kCT" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "4-10"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"kDT" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/grass/random{
+	dir = 2
+	},
+/area/station/owlery)
+"kJy" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/turret_protected/ai)
+"kKS" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
+/turf/simulated/floor,
+/area/station/hydroponics)
+"kRk" = (
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "2-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SWmaint)
+"kRJ" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor,
+/area/station/ai_monitored/storage/eva)
+"kUT" = (
+/obj/cable{
+	icon_state = "2-5"
+	},
+/obj/cable{
+	icon_state = "2-9"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"kVy" = (
+/obj/cable{
+	icon_state = "5-8"
+	},
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/Zeta)
+"kZu" = (
+/obj/cable{
+	icon_state = "2-5"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"lfe" = (
+/obj/cable{
+	icon_state = "4-10"
+	},
+/turf/simulated/floor/carpet{
+	dir = 2;
+	icon_state = "fblue1"
+	},
+/area/station/bridge)
+"lfq" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/yellow/corner{
+	dir = 1
+	},
+/area/station/engine/elect)
+"lhE" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/station/security/hos)
+"lhH" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/bridge)
+"llx" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SEmaint)
+"lmH" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/grass{
+	name = "astroturf";
+	tag = "icon-grass1"
+	},
+/area/station/hydroponics)
+"lwm" = (
+/obj/cable{
+	icon_state = "2-9"
+	},
+/turf/simulated/floor/carpet{
+	dir = 1;
+	icon_state = "fgreen2"
+	},
+/area/station/bridge)
+"lyL" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/shuttle/wall{
+	icon_state = "wall3"
+	},
+/area/listeningpost/power)
+"lCr" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
+"lCL" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/listeningpost)
+"lEL" = (
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/black,
+/area/station/medical/research)
+"lFU" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor,
+/area/station/security/main)
+"lFW" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/ai_monitored/storage/eva)
+"lGQ" = (
+/obj/cable{
+	icon_state = "5-8"
+	},
+/obj/cable{
+	icon_state = "1-5"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
+"lMW" = (
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/cable{
+	icon_state = "1-6"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"lNq" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
+"lNv" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/blueblack{
+	dir = 8
+	},
+/area/station/crew_quarters/captain)
+"lOU" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/grime,
+/area/station/storage/warehouse)
+"lQE" = (
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "6-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SEmaint)
+"lRM" = (
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/cable{
+	icon_state = "4-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"lSd" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/security/brig)
+"lSh" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/blue,
+/area/station/medical/medbay)
+"mbT" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/grass/random{
+	dir = 2
+	},
+/area/station/owlery)
+"mcF" = (
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 2
+	},
+/area/station/hallway/primary/central)
+"mfm" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-5"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/NEmaint)
+"mhO" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
+/turf/simulated/floor{
+	icon = 'icons/misc/beach.dmi';
+	icon_state = "sand";
+	name = "sand"
+	},
+/area/station/crew_quarters/pool)
+"mhX" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/bluewhite{
+	dir = 2
+	},
+/area/station/medical/research)
+"mid" = (
+/obj/cable{
+	icon_state = "1-10"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal)
+"miQ" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/cable{
+	icon_state = "8-10"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"mks" = (
+/obj/cable{
+	icon_state = "2-9"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"mlv" = (
+/obj/grille/steel,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/turret_protected/ai)
+"mmX" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/grey/side{
+	dir = 8
+	},
+/area/listeningpost)
+"mrE" = (
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SWmaint)
+"msW" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/barber_shop)
+"mwh" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/purple,
+/area/station/turret_protected/ai_upload_foyer)
+"mzE" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/turret_protected/ai)
+"mzV" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/turret_protected/ai)
+"mAF" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor,
+/area/station/science/artifact)
+"mBx" = (
+/obj/cable{
+	icon_state = "6-9"
+	},
+/turf/simulated/floor/grass{
+	name = "astroturf";
+	tag = "icon-grass1"
+	},
+/area/station/hydroponics)
+"mEh" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/security/detectives_office)
+"mEk" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"mEm" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"mGW" = (
+/obj/cable{
+	icon_state = "1-5"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "2-5"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SWmaint)
+"mHv" = (
+/obj/cable{
+	icon_state = "5-6"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"mJK" = (
+/obj/cable{
+	icon_state = "2-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SWmaint)
+"mMs" = (
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/security/detectives_office)
+"mNS" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/security/brig)
+"mRC" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-9"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
+"mSI" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-5"
+	},
+/turf/simulated/floor/plating,
+/area/station/hydroponics)
+"mUu" = (
+/obj/cable{
+	icon_state = "2-5"
+	},
+/turf/simulated/floor/carpet{
+	dir = 1;
+	icon_state = "fgreen2"
+	},
+/area/station/bridge)
+"nbL" = (
+/obj/cable{
+	icon_state = "8-9"
+	},
+/obj/cable{
+	icon_state = "4-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/NEmaint)
+"nbT" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-5"
+	},
+/obj/cable{
+	icon_state = "0-10"
+	},
+/obj/cable{
+	icon_state = "0-6"
+	},
+/turf/simulated/floor/plating,
+/area/station/hydroponics)
+"nje" = (
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/cable{
+	icon_state = "2-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SEmaint)
+"nvi" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/turf/simulated/floor/plating/airless,
+/area/station/turret_protected/ai)
+"nAh" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/heads)
+"nAs" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/bridge)
+"nHp" = (
+/obj/cable{
+	icon_state = "2-5"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/NEmaint)
+"nJv" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/NEmaint)
+"nMH" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/security/detectives_office)
+"nRJ" = (
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/storage/emergency)
+"nTR" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 2
+	},
+/area/station/hallway/primary/central)
+"oaT" = (
+/obj/cable{
+	icon_state = "5-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SEmaint)
+"obB" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/purple/corner{
+	dir = 1
+	},
+/area/station/science)
+"oes" = (
+/obj/cable{
+	icon_state = "4-9"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"ogt" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/engine,
+/area/station/science/teleporter)
+"okt" = (
+/obj/cable{
+	icon_state = "4-10"
+	},
+/turf/simulated/floor/grass{
+	name = "astroturf";
+	tag = "icon-grass1"
+	},
+/area/station/hydroponics)
+"okA" = (
+/obj/firedoor_spawn,
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SEmaint)
+"olQ" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/lobby)
+"omp" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/bluewhite{
+	dir = 8
+	},
+/area/station/medical/research)
+"opW" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/yellow/corner,
+/area/station/engine/elect)
+"ouT" = (
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
+"ozy" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/maintenance/SEmaint)
+"oBp" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/purplewhite{
+	dir = 1
+	},
+/area/station/science/lab)
+"oDp" = (
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1";
 	layer = 9.1;
 	pixel_x = -10
 	},
-/turf/simulated/floor/escape{
-	dir = 9
-	},
-/area/station/hallway/secondary/exit)
-"knq" = (
-/obj/machinery/light/emergency{
-	dir = 4;
-	icon_state = "ebulb1";
-	pixel_x = 16
-	},
-/obj/decal/tile_edge/stripe/big{
-	dir = 1;
-	icon_state = "xtra_bigstripe-edge"
-	},
-/turf/simulated/floor/engine,
-/area/station/hangar/main)
-"koq" = (
-/obj/grille,
-/turf/simulated/floor/plating/airless,
-/area)
-"kFX" = (
-/turf/simulated/floor,
-/area/station/hangar/main)
-"kHs" = (
-/obj/storage/closet/wardrobe/mixed,
-/obj/random_item_spawner/dressup/one_or_zero,
-/obj/machinery/light/incandescent/netural,
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"kMX" = (
-/turf/simulated/shuttle/wall/corner{
-	dir = 4
-	},
-/area/shuttle/arrival/station)
-"kNi" = (
-/turf/simulated/floor/escape{
-	dir = 5
-	},
-/area/station/hallway/secondary/exit)
-"kPL" = (
-/turf/simulated/shuttle/wall/cockpit,
-/area/shuttle/arrival/station)
-"lFp" = (
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/brig)
-"lHG" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	layer = 9.1;
-	pixel_x = 10
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
-"lKO" = (
-/obj/storage/closet/wardrobe/mixed,
-/obj/random_item_spawner/dressup/one_or_zero,
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"mwI" = (
-/turf/simulated/wall/auto/shuttle{
-	icon_state = "8"
-	},
-/area/shuttle/arrival/station)
-"mHo" = (
-/obj/cable,
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/quartermaster/office)
-"mJu" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/engineering)
-"npP" = (
-/obj/grille,
-/turf/simulated/floor/plating/airless,
-/area/station/com_dish/auxdish)
-"nzu" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/engineering)
-"nFY" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
-"nNR" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/station/hangar/main)
-"ohn" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	layer = 9.1;
-	pixel_x = 10
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
-"oGB" = (
+/area/station/hallway/primary/central)
+"oDt" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-2"
 	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
-"oPn" = (
-/obj/firedoor_spawn,
-/obj/machinery/door/airlock/pyro/external,
-/turf/simulated/floor/escape{
-	dir = 1
-	},
-/area/station/hallway/secondary/exit)
-"oXE" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
-/obj/wingrille_spawn/auto,
 /obj/cable,
-/turf/simulated/floor/plating,
-/area/station/quartermaster/office)
-"pdx" = (
-/turf/simulated/floor/orangeblack/side{
-	dir = 1
-	},
-/area/station/hangar/main)
-"pfN" = (
-/obj/submachine/cargopad/podbay,
-/turf/simulated/floor/orangeblack/side{
-	dir = 4
-	},
-/area/station/hangar/main)
-"puW" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=crewhall";
-	location = "escape"
-	},
-/obj/stool/bench/red/auto,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-4"
 	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
-"pwm" = (
-/turf/simulated/floor/orangeblack/side{
-	dir = 9
-	},
-/area/station/hangar/main)
-"pyH" = (
-/obj/machinery/door_control{
-	id = "hangar_arrivals";
-	name = "Pod Door Control";
-	pixel_x = 24
-	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 4
-	},
-/area/station/hangar/main)
-"qfM" = (
-/turf/simulated/floor/orangeblack/corner{
-	dir = 1
-	},
-/area/station/hangar/main)
-"qYM" = (
-/obj/wingrille_spawn/auto/crystal,
-/turf/simulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"rkJ" = (
-/obj/indestructible/shuttle_corner{
-	dir = 4
-	},
-/turf/space,
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"rwY" = (
-/obj/table/reinforced/auto,
-/obj/item/storage/toolbox/electrical{
-	pixel_y = -3
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 7
-	},
-/obj/random_item_spawner/tools,
-/obj/random_item_spawner/tools,
-/turf/simulated/floor/orangeblack/side{
-	dir = 1
-	},
-/area/station/hangar/main)
-"rBk" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4;
-	name = "Pod Bay"
-	},
-/obj/machinery/secscanner{
-	dir = 4;
-	icon_state = "scanner_on";
-	pixel_x = -20
-	},
-/turf/simulated/floor,
-/area/station/hangar/main)
-"rCc" = (
-/obj/machinery/vehicle/pod_smooth/light,
-/turf/simulated/floor/engine,
-/area/station/hangar/main)
-"rOd" = (
+/turf/simulated/floor/blue,
+/area/station/medical/medbay)
+"oDO" = (
 /obj/cable{
-	d2 = 8;
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/cable{
 	icon_state = "0-8"
 	},
-/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/purplewhite,
+/area/station/science/lab)
+"oFX" = (
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
+	icon_state = "6-8"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"oGg" = (
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "1-6"
+	},
+/obj/cable{
+	icon_state = "6-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/security/brig)
-"rXY" = (
-/obj/machinery/light,
-/turf/simulated/floor/engine,
-/area/station/hangar/main)
-"tgU" = (
+/area/station/maintenance/SEmaint)
+"oGD" = (
+/obj/cable{
+	icon_state = "2-10"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SWmaint)
+"oIX" = (
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/captain)
+"oLL" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/ai_monitored/storage/eva)
+"oMV" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/damaged1,
+/area/station/maintenance/west)
+"oQx" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/bridge)
+"oRf" = (
 /obj/cable{
 	icon_state = "2-4"
 	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
+"oRk" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/robotics)
+"oWh" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "4-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"oWq" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/hydroponics)
+"oXd" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/orangeblack/side{
+	dir = 1
+	},
+/area/station/science)
+"paR" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
+"pcb" = (
+/obj/cable{
+	icon_state = "6-9"
+	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/exit)
-"tlJ" = (
-/obj/machinery/light{
-	dir = 1;
-	name = "light fixture";
-	pixel_y = 21;
-	rigged = 0
+/area/station/hallway/primary/south)
+"pcD" = (
+/obj/cable{
+	icon_state = "1-10"
+	},
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/Zeta)
+"pde" = (
+/obj/cable{
+	icon_state = "2-5"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"pee" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/red,
+/area/station/security/brig)
+"pfQ" = (
+/obj/cable{
+	icon_state = "8-10"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
+"phw" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/bridge)
+"pka" = (
+/obj/cable{
+	icon_state = "1-6"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SEmaint)
+"pmT" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
+"pny" = (
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SWmaint)
+"psc" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost)
+"pvJ" = (
+/obj/cable{
+	icon_state = "9-10"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"pwO" = (
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "2-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/NWmaint)
+"pyh" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor{
+	icon = 'icons/misc/beach.dmi';
+	icon_state = "sand";
+	name = "sand"
+	},
+/area/station/crew_quarters/pool)
+"pAp" = (
+/obj/cable{
+	icon_state = "6-8"
+	},
+/turf/simulated/floor/grass{
+	name = "astroturf";
+	tag = "icon-grass1"
+	},
+/area/station/hydroponics)
+"pAK" = (
+/obj/cable{
+	icon_state = "4-10"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
+"pBt" = (
+/obj/cable{
+	icon_state = "1-5"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
+"pDP" = (
+/obj/cable{
+	icon_state = "1-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SWmaint)
+"pDV" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig)
+"pIT" = (
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "chemistry";
+	name = "Chemistry Privacy Shutters";
+	opacity = 0
+	},
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/chemistry)
+"pMq" = (
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
+"pNu" = (
+/obj/cable{
+	icon_state = "4-10"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SWmaint)
+"pOz" = (
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/escape{
 	dir = 1
 	},
 /area/station/hallway/secondary/exit)
-"tzR" = (
-/obj/shrub,
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
-"tRh" = (
-/turf/simulated/floor/arrival{
-	dir = 5
-	},
-/area/station/hallway/secondary/entry)
-"tUc" = (
-/obj/wingrille_spawn/auto/crystal,
+"pQE" = (
 /obj/cable{
-	d2 = 8;
+	icon_state = "2-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/NEmaint)
+"pTJ" = (
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor,
+/area/station/engine/elect)
+"pVr" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/NWmaint)
+"pYE" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/airless,
+/area)
+"pYF" = (
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SEmaint)
+"qaE" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/bridge)
+"qbe" = (
+/obj/cable{
+	icon_state = "5-8"
+	},
+/turf/simulated/floor/grass{
+	name = "astroturf";
+	tag = "icon-grass1"
+	},
+/area/station/hydroponics)
+"qbB" = (
+/obj/cable{
+	icon_state = "1-6"
+	},
+/turf/simulated/floor/carpet{
+	dir = 2;
+	icon_state = "fgreen2"
+	},
+/area/station/bridge)
+"qeg" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/purple,
+/area/station/science)
+"qfj" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/main)
+"qfx" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/brig)
-"uEP" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/hallway/secondary/entry)
-"uJW" = (
+"qfU" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
+/turf/simulated/floor/red/side{
+	dir = 1
+	},
+/area/station/security/brig)
+"qfV" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/hos)
+"qke" = (
+/obj/critter/parrot/random,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/grass/random{
+	dir = 2
+	},
+/area/station/owlery)
+"qlN" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig)
+"qnk" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "1-10"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SWmaint)
+"qqx" = (
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "chemistry";
+	name = "Chemistry Privacy Shutters";
+	opacity = 0
+	},
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/chemistry)
+"qsg" = (
+/obj/cable{
+	icon_state = "5-8"
+	},
+/turf/simulated/floor/carpet{
+	dir = 2;
+	icon_state = "fblue1"
+	},
+/area/station/bridge)
+"quR" = (
+/obj/machinery/door/airlock/pyro/external,
+/obj/access_spawn/ai_upload,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black/side,
+/area/station/turret_protected/ai)
+"qva" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet{
+	dir = 1;
+	icon_state = "blue2"
+	},
+/area/station/bridge)
+"qyt" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"qyy" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/security/detectives_office)
+"qzc" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
+"qzK" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/turret_protected/ai)
+"qAl" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/courtroom)
+"qAA" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor,
+/area/station/storage/primary)
+"qBe" = (
+/obj/cable{
 	icon_state = "4-8"
 	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner)
+"qBr" = (
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/cable{
+	icon_state = "2-5"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"qDW" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/hydroponics)
+"qNU" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 2
+	},
+/area/station/hallway/primary/central)
+"qPi" = (
+/obj/cable{
+	icon_state = "6-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
+"qQh" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner)
+"qSk" = (
+/obj/cable{
+	icon_state = "5-10"
+	},
+/turf/simulated/floor/grass{
+	name = "astroturf";
+	tag = "icon-grass1"
+	},
+/area/station/hydroponics)
+"qTB" = (
+/obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "2-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"qUv" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/red,
+/area/station/security/brig)
+"qWj" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/blue,
+/area/station/medical/medbay)
+"qWl" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor,
+/area/station/security/main)
+"qYV" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/purple,
+/area/station/turret_protected/ai_upload_foyer)
+"rak" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/captain)
+"raE" = (
+/obj/cable{
+	icon_state = "1-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/chapel/main)
+"rdl" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"rdY" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/fitness)
+"rjw" = (
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/caution/west,
+/area/station/science/artifact)
+"rlS" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/turret_protected/ai)
+"roE" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/station/bridge)
+"rqE" = (
+/obj/machinery/turret,
+/obj/cable{
+	icon_state = "6-8"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"rrV" = (
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1";
+	layer = 9.1;
+	pixel_y = 21
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/courtroom)
+"rrW" = (
+/obj/cable{
+	icon_state = "8-10"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SEmaint)
+"rsO" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet{
+	dir = 2;
+	icon_state = "blue2"
+	},
+/area/station/bridge)
+"rvJ" = (
+/obj/cable{
+	icon_state = "6-8"
+	},
+/turf/simulated/floor/carpet{
+	dir = 2;
+	icon_state = "fblue1"
+	},
+/area/station/bridge)
+"rvL" = (
+/obj/machinery/door,
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/engine,
+/area/station/turret_protected/ai)
+"rwf" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/purple/side,
+/area/station/science)
+"rzT" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/security/brig)
+"rzV" = (
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "2-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"rBQ" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/station/bridge)
+"rCy" = (
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/turret_protected/ai)
+"rCO" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/research)
+"rFx" = (
+/obj/cable{
+	icon_state = "8-10"
+	},
+/turf/simulated/floor/plating/damaged1,
+/area/station/maintenance/west)
+"rKh" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/storage/emergency)
+"rOY" = (
+/obj/cable{
+	icon_state = "6-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SEmaint)
+"rXg" = (
+/obj/cable{
+	icon_state = "4-9"
+	},
+/obj/cable{
+	icon_state = "1-5"
+	},
+/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/damaged2,
+/area/station/maintenance/west)
+"rXC" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	icon_state = "0,6";
+	tag = "icon-0,6"
+	},
+/area/station/crew_quarters/fitness)
+"sbx" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/hydroponics)
+"sbz" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/red/side{
+	dir = 8
+	},
+/area/station/security/brig)
+"sbA" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/NEmaint)
+"sfL" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SWmaint)
+"sge" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/escape/corner{
+	dir = 1
+	},
+/area/station/hallway/secondary/exit)
+"sgi" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/grass{
+	name = "astroturf";
+	tag = "icon-grass1"
+	},
+/area/station/hydroponics)
+"sjH" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/purple/corner{
+	dir = 1
+	},
+/area/station/science)
+"skZ" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"slg" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
+"smU" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"snJ" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-10"
+	},
+/turf/simulated/floor/plating,
+/area/station/hydroponics)
+"snR" = (
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/red,
+/area/station/security/brig)
+"spR" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/black,
+/area/station/bridge)
+"ssU" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-6"
+	},
+/obj/cable{
+	icon_state = "1-10"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"svG" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/hydroponics)
+"swD" = (
+/obj/machinery/atmospherics/valve,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/purple,
+/area/station/science/lab)
+"sHo" = (
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/cafeteria)
+"sKj" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/orangeblack/side{
+	dir = 1
+	},
+/area/station/teleporter)
+"sMo" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/purple,
+/area/station/science/teleporter)
+"sMU" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/captain)
+"sNI" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/captain)
+"sON" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 2
+	},
+/area/station/hallway/primary/west)
+"sVS" = (
+/obj/cable,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/orangeblack/side{
+	dir = 1
+	},
+/area/station/science)
+"sWI" = (
+/obj/cable{
+	icon_state = "2-9"
+	},
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/Zeta)
+"sXw" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/security/main)
+"sYO" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/yellow/corner,
+/area/station/engine/elect)
+"tdj" = (
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "2-5"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"tfa" = (
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
+"tip" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
+"tjX" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/purple,
+/area/station/turret_protected/ai_upload)
+"tmG" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/station/security/main)
+"tnV" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/black,
+/area/station/security/hos)
+"toB" = (
+/obj/cable{
+	icon_state = "2-5"
+	},
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/Zeta)
+"toE" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/purple,
+/area/station/turret_protected/ai_upload)
+"trA" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/security/hos)
+"tsB" = (
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"tuz" = (
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "1-6"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SWmaint)
+"tvk" = (
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
+"twy" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/bluewhite{
+	dir = 2
+	},
+/area/station/medical/research)
+"txb" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
+"tzx" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-5"
+	},
+/turf/simulated/floor/plating,
+/area/station/turret_protected/Zeta)
+"tAh" = (
+/obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
+"tAr" = (
+/obj/cable{
+	icon_state = "2-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"tAB" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/blue,
+/area/station/medical/medbay)
+"tBb" = (
+/obj/cable{
+	icon_state = "1-10"
+	},
+/obj/cable{
+	icon_state = "8-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
+"tBJ" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/courtroom)
+"tIy" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "6-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"tKl" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/heads)
+"tKp" = (
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/maintenance,
+/obj/access_spawn/maint,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"tLI" = (
+/obj/cable{
+	icon_state = "1-10"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SEmaint)
+"tMd" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/research)
+"tMO" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/barber_shop)
+"tPG" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/red/corner{
+	dir = 1
+	},
+/area/station/security/brig)
+"tTC" = (
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/maintenance,
+/obj/access_spawn/maint,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SWmaint)
+"uby" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"ueo" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-9"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-5"
+	},
+/turf/simulated/floor/plating,
+/area/station/hydroponics)
+"ugm" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/turret_protected/ai)
+"uhK" = (
+/obj/disposalpipe/segment,
+/turf/simulated/wall/auto/supernorn,
+/area/station/medical/morgue)
+"uiU" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/research)
+"umj" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-s";
+	tag = "icon-pipe-s (EAST)"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/security/brig)
+"upu" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
+/turf/simulated/floor/purple/side,
+/area/station/science)
+"urh" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "6-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/NEmaint)
+"urS" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/medical/research)
+"uyA" = (
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "5-6"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SEmaint)
+"uzM" = (
+/obj/disposalpipe/segment,
+/turf/simulated/wall/auto/supernorn,
+/area/station/maintenance/inner)
+"uCl" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/security/detectives_office)
+"uFt" = (
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "4-10"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
+"uHv" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
+"uHy" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/hydroponics)
+"uHG" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/turret_protected/ai)
+"uIh" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/purple/side,
+/area/station/science)
+"uJW" = (
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
@@ -34064,126 +30559,693 @@
 	},
 /obj/access_spawn/engineering,
 /obj/access_spawn/mining,
-/turf/simulated/floor/yellow,
-/area/station/engine/engineering)
-"vnv" = (
-/obj/firedoor_spawn,
-/obj/machinery/door/airlock/pyro/external,
-/turf/simulated/floor/caution/northsouth,
-/area/station/hallway/secondary/exit)
-"vvM" = (
-/obj/reagent_dispensers/fueltank,
-/obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 1
-	},
-/area/station/hangar/main)
-"weg" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
-/area/station/hangar/main)
-"wms" = (
-/obj/storage/closet/welding_supply,
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	layer = 9.1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 9
-	},
-/area/station/hangar/main)
-"wyc" = (
-/obj/wingrille_spawn/auto,
+/turf/simulated/floor/yellow,
+/area/station/engine/engineering)
+"uNS" = (
+/obj/cable,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
+/turf/simulated/floor/grass{
+	name = "astroturf";
+	tag = "icon-grass1"
+	},
+/area/station/hydroponics)
+"uPG" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/turf/simulated/floor/white,
+/area/station/science/artifact)
+"uSK" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/purple/corner{
+	dir = 1
+	},
+/area/station/science)
+"uTY" = (
+/obj/wingrille_spawn/auto,
 /obj/cable,
 /turf/simulated/floor/plating,
-/area/station/engine/engineering)
-"wFe" = (
+/area/station/medical/research)
+"uVe" = (
+/obj/cable,
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/NWmaint)
-"wFx" = (
-/obj/indestructible/shuttle_corner{
-	dir = 8
-	},
-/turf/simulated/shuttle/wall/corner{
-	dir = 4
-	},
-/area/shuttle/arrival/station)
-"wFA" = (
-/obj/machinery/computer/mining_shuttle{
-	dir = 4
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/exit)
-"wHO" = (
-/obj/indestructible/shuttle_corner,
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"xbr" = (
-/obj/machinery/camera{
-	c_tag = "Escape Shuttle Dock"
-	},
-/obj/machinery/light/emergency{
-	dir = 1;
-	icon_state = "ebulb1"
-	},
-/turf/simulated/floor/escape{
-	dir = 1
-	},
-/area/station/hallway/secondary/exit)
-"xGC" = (
-/obj/wingrille_spawn/auto,
-/obj/cable,
+/area/station/bridge)
+"uWp" = (
+/obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating,
-/area/station/engine/engineering)
-"xGY" = (
-/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/arrivals_horizontal{
+/area/station/maintenance/SEmaint)
+"uXY" = (
+/obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/engine,
-/area/station/hangar/main)
-"xRp" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
 /obj/cable,
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
+"uYg" = (
+/obj/cable{
+	icon_state = "6-8"
+	},
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/Zeta)
+"vdC" = (
+/obj/cable{
+	icon_state = "5-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"vdE" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/crew_quarters/courtroom)
+"vfi" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/caution/west,
+/area/station/science/artifact)
+"viT" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/purple,
+/area/station/turret_protected/ai_upload)
+"vlK" = (
+/obj/cable{
+	icon_state = "9-10"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SEmaint)
+"vmu" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 8;
+	icon_state = "0-10"
+	},
+/obj/cable{
+	icon_state = "0-5"
+	},
+/obj/cable{
+	icon_state = "0-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/hydroponics)
+"vnw" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"voT" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/quarters)
+"vqc" = (
+/obj/cable{
+	icon_state = "6-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
+"vqW" = (
+/obj/machinery/light/small,
+/obj/random_item_spawner/junk/one_or_zero,
+/obj/decal/cleanable/dirt/jen,
+/obj/decal/cleanable/rust/jen,
+/turf/simulated/floor/plating,
+/area/station/maintenance/SEmaint)
+"vrm" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner)
+"vtm" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "2-5"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"vwF" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
+"vxo" = (
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/plating,
+/area/station/engine/elect)
+"vyl" = (
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"vAG" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/courtroom)
+"vBt" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/circuit,
+/area/listeningpost/power)
+"vDI" = (
+/obj/cable{
+	icon_state = "5-8"
+	},
+/obj/cable{
+	icon_state = "4-6"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/NEmaint)
+"vIF" = (
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/west)
+"vNm" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
+"vPu" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/hydroponics)
+"vWl" = (
+/obj/cable{
+	icon_state = "1-10"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"vXg" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/cable{
+	icon_state = "2-9"
+	},
+/obj/cable{
+	icon_state = "4-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"vYk" = (
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"vZd" = (
+/obj/machinery/door/airlock/pyro/security,
+/obj/access_spawn/security,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor,
+/area/station/security/brig)
+"waK" = (
+/obj/cable{
+	icon_state = "4-10"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"wgs" = (
+/obj/cable{
+	icon_state = "1-10"
+	},
+/obj/cable{
+	icon_state = "1-6"
+	},
+/obj/cable{
+	icon_state = "2-6"
+	},
+/obj/cable{
+	icon_state = "2-10"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"wiS" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/fitness)
+"wku" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/cable{
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/engine/power)
-"ybh" = (
-/obj/machinery/manufacturer/hangar,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13"
+/area/station/security/main)
+"wmR" = (
+/obj/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/orangeblack/side{
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
+"wrJ" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/courtroom)
+"wrZ" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/purple,
+/area/station/science)
+"wsx" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/yellow/corner{
 	dir = 1
 	},
-/area/station/hangar/main)
+/area/station/engine/elect)
+"wuc" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor,
+/area/station/security/brig)
+"wxS" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/research)
+"wyl" = (
+/turf/simulated/wall/auto/supernorn,
+/area/station/engine/inner)
+"wGn" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/blue/checker,
+/area/station/medical/research)
+"wHt" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/cable{
+	icon_state = "5-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"wHy" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 2
+	},
+/area/station/hallway/primary/central)
+"wIj" = (
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/cable{
+	icon_state = "4-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
+"wIK" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/SEmaint)
+"wMi" = (
+/obj/machinery/door/unpowered/wood/pyro{
+	dir = 4;
+	name = "The Snip"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/barber_shop)
+"wOC" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/heads)
+"wPs" = (
+/obj/grille/steel,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/turret_protected/ai)
+"wQZ" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/storage/primary)
+"wUv" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/cafeteria)
+"xcM" = (
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/caution/west,
+/area/station/science/artifact)
+"xen" = (
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/turret_protected/ai)
+"xeK" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/hydroponics)
+"xhh" = (
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/greenwhite{
+	dir = 1
+	},
+/area/station/medical/research)
+"xlI" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
+"xqd" = (
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/carpet{
+	dir = 2;
+	icon_state = "blue2"
+	},
+/area/station/bridge)
+"xtT" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/arcade)
+"xvY" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/bridge)
+"xzm" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/lobby)
+"xBp" = (
+/obj/storage/secure/closet/security/equipment,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/red/side{
+	dir = 4
+	},
+/area/station/security/main)
+"xCN" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet{
+	dir = 2;
+	icon_state = "fblue1"
+	},
+/area/station/bridge)
+"xEf" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "2-6"
+	},
+/turf/simulated/floor/plating,
+/area/station/chapel/main)
+"xEo" = (
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor,
+/area/station/security/main)
+"xEQ" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/hor)
+"xFS" = (
+/obj/cable{
+	icon_state = "5-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"xJQ" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"xMb" = (
+/obj/cable{
+	icon_state = "8-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
+"xQl" = (
+/obj/cable{
+	icon_state = "2-9"
+	},
+/turf/simulated/floor/grass{
+	name = "astroturf";
+	tag = "icon-grass1"
+	},
+/area/station/hydroponics)
+"xRT" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/purple,
+/area/station/turret_protected/ai_upload)
+"xSu" = (
+/obj/cable{
+	icon_state = "6-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"yag" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/bar)
+"yam" = (
+/obj/cable{
+	icon_state = "2-6"
+	},
+/turf/simulated/floor/plating,
+/area/station/chapel/main)
+"ybx" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/grass{
+	name = "astroturf";
+	tag = "icon-grass1"
+	},
+/area/station/hydroponics)
+"ydz" = (
+/obj/stool/chair,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/courtroom)
+"yfg" = (
+/obj/cable{
+	icon_state = "5-8"
+	},
+/obj/cable{
+	icon_state = "6-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
+"yfD" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/turret_protected/ai)
 
 (1,1,1) = {"
 aaa
@@ -40509,20 +37571,20 @@ aaa
 aaa
 acT
 bkR
-bkT
+pYE
 bkW
 bkW
-bld
-blh
+lyL
 blp
+vBt
 blc
-blF
-blL
-blV
 bmc
-blV
-blV
-blV
+blL
+cXe
+psc
+cXe
+cXe
+cXe
 bmy
 blH
 bla
@@ -40743,10 +37805,10 @@ blc
 bli
 blq
 blx
-blG
+flL
 blM
 blM
-bmd
+mmX
 blM
 bmt
 blM
@@ -41200,7 +38262,7 @@ bly
 blH
 blN
 blW
-bmf
+lCL
 bml
 blH
 bmu
@@ -41427,7 +38489,7 @@ blz
 blH
 blO
 blW
-bmg
+dch
 bmm
 blH
 bmv
@@ -41654,7 +38716,7 @@ blc
 blH
 blP
 blW
-bmg
+dch
 bmn
 blH
 bmw
@@ -46085,7 +43147,7 @@ aBC
 aBC
 aBC
 aFY
-aIz
+aFY
 aFY
 aIO
 bsY
@@ -46307,12 +43369,12 @@ aaa
 aaa
 bsu
 aAQ
-aBL
-aEz
-aEz
-aEz
+aAu
+aBC
+aBC
+aBC
 aHl
-aIE
+aII
 aII
 aKm
 aaa
@@ -46534,7 +43596,7 @@ axg
 axg
 ayo
 bsj
-bso
+bsj
 ayo
 axg
 axg
@@ -46761,7 +43823,7 @@ brP
 brU
 ayo
 bsj
-bso
+bsj
 bsw
 bsw
 bsw
@@ -48370,23 +45432,23 @@ aaa
 aaB
 aCP
 aCP
-aJb
-aJW
-aFr
+vPu
+sbx
+uHy
 aCP
 aCP
 aaB
 aaa
 aaa
 aaB
-aOd
-aQs
-aQs
-aQs
-aQs
-aQs
-aQs
-aXA
+yag
+haT
+haT
+haT
+haT
+haT
+haT
+iBE
 aVs
 aVT
 aWD
@@ -48593,8 +45655,8 @@ aaa
 aaa
 aaa
 aaa
-aDQ
-aFr
+bSt
+mSI
 aCP
 aDh
 aDi
@@ -48602,11 +45664,11 @@ aEQ
 aDi
 aJq
 aCP
-aJb
-aEC
+bSt
+mSI
 aaB
-aOd
-aPd
+yag
+ksc
 aOk
 aPe
 aQM
@@ -48616,7 +45678,7 @@ aTQ
 aTS
 aUX
 aVU
-aVU
+gpb
 btI
 aZA
 aZH
@@ -48819,27 +45881,27 @@ ahe
 aaa
 aaa
 aaa
-aDQ
-aEq
-aEr
-aDS
-aDS
-aDS
-aGZ
-aDS
-aDS
+bSt
+nbT
+aDh
+aDi
+aDi
+aDi
+ybx
+aDi
+aDi
 aKu
-aDT
-aMq
-jAM
-aOB
+aDh
+ueo
+oWq
+ksc
 aDv
 aDP
 aPf
 aQN
 aQN
 aSs
-aDP
+aDQ
 aTT
 aUY
 aPR
@@ -49046,16 +46108,16 @@ ahe
 aaa
 aaB
 aaB
-aDy
+snJ
 aDh
-aEs
-aDi
-aDi
-aDi
-aEs
-aDi
-aDi
-aDi
+mBx
+fQU
+lmH
+lmH
+uNS
+lmH
+lmH
+cIr
 aLd
 aDi
 aMU
@@ -49065,8 +46127,8 @@ aDP
 aDP
 aDP
 aRD
-aSt
-aSt
+aDy
+aDS
 aTU
 aUZ
 aVV
@@ -49247,19 +46309,19 @@ aaa
 aaa
 aaa
 aaa
-aoO
-aoO
-aoO
-aoO
-aoO
-aoO
-aoO
-aoO
-aoO
-aoO
-aoO
-aoO
-aoO
+azW
+azW
+azW
+azW
+azW
+azW
+azW
+azW
+azW
+azW
+azW
+azW
+azW
 aaa
 aaa
 aaa
@@ -49275,15 +46337,15 @@ aaB
 aCP
 aCP
 aDR
-aEs
+okt
 aDi
 aFq
 aDi
-aHa
+aEO
 aDi
 aFq
 aDi
-aDi
+hvE
 aMb
 aCP
 aCP
@@ -49293,11 +46355,11 @@ bsF
 aQO
 aRE
 aDP
-aDP
+aDT
 aVY
 aVa
 aVU
-aVU
+gpb
 aTm
 aXS
 aXT
@@ -49473,21 +46535,21 @@ aaa
 aaa
 aaa
 aaa
-aoO
-aoO
-app
+azW
+azW
+avh
 aqK
-app
+avh
 atR
-app
-aAp
-app
+avh
+auP
+avh
 bpO
-app
+avh
 aqK
-app
-aoO
-aoO
+avh
+azW
+azW
 aaa
 aaa
 aaa
@@ -49502,7 +46564,7 @@ aaa
 aCP
 aDh
 aDi
-aEs
+ybx
 aEN
 aFT
 aGj
@@ -49510,7 +46572,7 @@ aHb
 aIr
 aFT
 aKv
-aDi
+ybx
 aDi
 aDh
 aCP
@@ -49520,7 +46582,7 @@ aQg
 aQP
 aRF
 aSu
-aDP
+aDU
 aVY
 aVb
 aVW
@@ -49699,23 +46761,23 @@ aaa
 aaa
 aaa
 aaa
-aoO
-aoO
+azW
+azW
 bpR
-app
-aAp
-ary
-aAp
+avh
+auP
+bpM
+auP
 auo
-aAp
-app
-aAp
+auP
+avh
+auP
 bpM
 auP
 avh
 bpT
-aoO
-aoO
+azW
+azW
 aaa
 aaa
 aaa
@@ -49726,10 +46788,10 @@ aRW
 ahT
 aaa
 aaa
-aDg
+svG
 aDi
 aDi
-aEs
+ybx
 aDi
 aFs
 aGk
@@ -49737,17 +46799,17 @@ aHc
 bsS
 aJr
 aDi
+ybx
 aDi
 aDi
-aDi
-aDg
+svG
 aOg
 aDP
 aQg
 aQQ
 aRG
 aTd
-aDP
+aEb
 aVY
 aVc
 aVU
@@ -49926,23 +46988,23 @@ aaa
 aaa
 aaa
 aaa
-aoO
-apm
-asZ
-aqk
+azW
+aAy
+aAE
+bpV
 art
 arU
 aut
 aut
-aqk
+bpV
 aut
 aut
 arU
 art
-avk
+bpV
 bpY
 aww
-aoO
+azW
 aaa
 aaa
 aaa
@@ -49953,10 +47015,10 @@ aRW
 ahe
 aaa
 aaa
-aDk
+gkg
 aDj
-aDS
-aEt
+lmH
+hRQ
 aEO
 aFt
 aGl
@@ -49964,10 +47026,10 @@ aHd
 aIs
 aJs
 aEO
-aDi
-aDi
+sgi
+lmH
 aGY
-aGi
+eWO
 aOh
 aDP
 aDP
@@ -49978,7 +47040,7 @@ aDP
 aWI
 aVd
 aVX
-aVU
+gpb
 btJ
 aXT
 aXT
@@ -50153,23 +47215,23 @@ aaa
 aaa
 aaa
 aaa
-aoO
+azW
 apn
-aqk
-aqk
+bpV
+bpV
 aqM
 aqN
 arV
-arV
+aAL
 asV
 arV
 arV
 aup
 aqM
-aqk
 bpV
-ata
-aoO
+bpV
+aAG
+azW
 aaa
 axF
 axE
@@ -50180,10 +47242,10 @@ aSw
 aPp
 aPp
 aaa
-aDy
+qDW
 aDi
 aDi
-aDi
+ybx
 aDi
 aFu
 aES
@@ -50191,21 +47253,21 @@ aHe
 aES
 aJt
 aDi
+ybx
 aDi
-aMc
-aDS
-aKt
+aDi
+qDW
 aOi
 aOl
 aDP
-aDP
+fke
 aSp
-aRD
+wUv
 aSt
 aSt
 aSt
 aSt
-aSt
+sHo
 btK
 aXV
 aYF
@@ -50380,7 +47442,7 @@ aaa
 aaa
 aaa
 aaa
-aoO
+azW
 apo
 apO
 bnW
@@ -50395,8 +47457,8 @@ auq
 auN
 avl
 bpQ
-app
-aoO
+avh
+azW
 aaa
 axE
 azb
@@ -50410,7 +47472,7 @@ aaa
 aCP
 aDh
 aDi
-aDi
+ybx
 aEN
 aFT
 aGm
@@ -50418,12 +47480,12 @@ aHf
 aIt
 aFT
 aKw
+ybx
 aDi
-aEs
 aDh
 aCP
 aOj
-aOl
+eTY
 aQh
 aRB
 aSq
@@ -50577,13 +47639,13 @@ aal
 acG
 aal
 aal
-aal
-aal
-aal
+arg
+arq
+arq
 aey
 aey
 aey
-aeV
+asL
 aaa
 aaa
 aaa
@@ -50607,11 +47669,11 @@ aaa
 aaa
 aaa
 aaa
-aoO
-asc
-aqk
+azW
+bpQ
+bpV
 aqL
-aqO
+auO
 arv
 arW
 asv
@@ -50623,7 +47685,7 @@ auO
 avm
 bpV
 awx
-aoO
+azW
 aaa
 axE
 azc
@@ -50637,19 +47699,19 @@ aaB
 aCP
 aCP
 aDR
-aDi
-aDi
-aFv
-aDi
-aHa
+pAp
 aDi
 aFv
 aDi
+aEO
 aDi
-aMd
+aFv
+aDi
+qbe
+aIv
 aCP
 aCP
-aOm
+aPh
 aPh
 aPh
 btg
@@ -50834,24 +47896,24 @@ aaa
 aaa
 aaa
 aaa
-aoO
+azW
 apq
-ata
+aAG
 aqL
-aqO
+auO
 arv
 arX
-app
-app
-app
+avh
+avh
+avh
 atT
 arv
 auO
-avn
+bpK
 bpQ
-app
-aoO
-brH
+avh
+azW
+axE
 aoO
 aoO
 aNn
@@ -50862,19 +47924,19 @@ aoO
 aoO
 aaB
 aaB
-aDQ
-aDT
-aDS
-aDS
-aDS
-aDS
-aHg
-aDi
-aDi
+bSt
+aDh
+qSk
+xQl
+lmH
+lmH
+eRC
+lmH
+lmH
 aKx
-aDi
-aMe
-aEC
+mBx
+aDh
+mSI
 aMY
 aOn
 aPi
@@ -51061,16 +48123,16 @@ aaa
 aaa
 aaa
 aaa
-aoO
+azW
 apn
-aqk
-aqk
+bpV
+bpV
 aqP
 arv
 arX
-app
+avh
 asW
-app
+avh
 atT
 arv
 auO
@@ -51078,30 +48140,30 @@ avQ
 bpW
 aAr
 awW
-gOt
+axE
 ayn
 bsM
 app
 azd
 biC
-asA
+aCW
 bsW
 aoO
 aaa
 aaa
-aDU
-aEC
+snJ
+buO
 aDh
 aEP
 aFw
 aFw
 aHh
-aIu
-aIu
-aIu
+aFw
+aFw
+aFw
 aLe
-aNd
-aNx
+vmu
+xeK
 aNA
 aOo
 aPj
@@ -51288,46 +48350,46 @@ aaa
 aaa
 aaa
 aaB
-aoO
-app
-ata
+azW
+avh
+aAG
 aqL
-aqO
+auO
 arv
 arX
-app
-app
-app
+avh
+avh
+avh
 atT
 arv
 auO
 bpK
-asc
-app
+aCw
+auw
 awX
-mJu
+axE
 ayn
 app
 app
-app
-app
-asA
+aCT
+aCS
+aDt
 bsW
 aoO
 aaa
 aaa
 aaa
-aDU
-aFr
+snJ
+xeK
 aCP
 aFx
 aDi
-aHi
+aHk
 aDi
 brD
 aCP
-aJb
-aNx
+snJ
+xeK
 aMi
 aiV
 aOp
@@ -51342,7 +48404,7 @@ aWa
 aWa
 aWL
 aTm
-aYa
+aYG
 aXT
 aXT
 aXT
@@ -51515,11 +48577,11 @@ aaB
 aaB
 aaB
 aaB
-aoO
-asc
-aqk
+azW
+bpQ
+bpV
 aqL
-aqO
+auO
 arv
 arY
 asw
@@ -51529,16 +48591,16 @@ atU
 arv
 auO
 avm
-aqk
+aCy
 bpd
-app
-doP
+avh
+axE
 bdk
 app
 azf
-avt
+aCW
 bsQ
-bsZ
+app
 brL
 aoO
 aaa
@@ -51549,7 +48611,7 @@ aaa
 aCP
 aCP
 aDR
-aHi
+aHk
 aIv
 aCP
 aCP
@@ -51557,11 +48619,11 @@ ajM
 aKC
 aMj
 aNB
-aOq
+aMX
 aPk
 aPh
 aQV
-aRM
+gjW
 aSy
 aTg
 aTY
@@ -51742,8 +48804,8 @@ amM
 anm
 ann
 als
-aoO
-app
+azW
+avh
 apP
 bnW
 boY
@@ -51754,14 +48816,14 @@ arv
 arv
 arv
 aur
-auN
+aBT
 bpL
-asc
-app
+aCw
+auw
 aAo
 axF
-jDr
-xGC
+axE
+axE
 axF
 aQp
 axF
@@ -51774,11 +48836,11 @@ aaa
 aaB
 aaa
 aaa
-aGa
-aDS
-aHj
+svG
 aDi
-aDg
+aHk
+aDi
+svG
 aiT
 aKz
 aLf
@@ -51969,28 +49031,28 @@ amN
 ano
 anQ
 aon
-aoO
-asc
-aqk
-aqk
+azW
+bpQ
+bpV
+bpV
 aqM
 aqQ
 arV
-arV
+aAL
 asX
 arV
-arV
+aAW
 aus
 aqM
-aqk
-aqk
+bpV
+aCy
 bpX
-app
-nzu
+avh
+axE
 aAP
 brJ
 azg
-asB
+aDa
 aAp
 app
 aBh
@@ -52001,11 +49063,11 @@ aaB
 aDV
 aaB
 aaB
-aGi
-aDi
-aHi
-aDi
-aGi
+eca
+lmH
+egL
+lmH
+eWO
 aiU
 aKA
 aLg
@@ -52015,7 +49077,7 @@ aOs
 aMX
 aPh
 aQW
-aRM
+gjW
 aSy
 aTg
 aTg
@@ -52023,7 +49085,7 @@ btw
 aTg
 btw
 aXz
-aZs
+aXt
 aXt
 aXt
 aXt
@@ -52148,7 +49210,7 @@ aaa
 aag
 aag
 aag
-cTH
+aej
 aag
 aag
 aag
@@ -52191,28 +49253,28 @@ aaa
 aaa
 alr
 alS
-amp
 amO
-amp
+amO
+azu
 anR
 bpm
-aoO
+azW
 bhQ
 bpP
-aqk
+bpV
 arx
 arZ
 avi
 avi
-aqk
+bpV
 avi
-avi
+aBf
 avj
-arx
-aqk
-asd
-app
-app
+aBU
+aCm
+aCz
+aCB
+avh
 axG
 app
 aqk
@@ -52228,17 +49290,17 @@ aaa
 aaB
 aaa
 aaa
-aDy
+qDW
 aDi
 aHk
-aDS
-aKt
+aDi
+qDW
 aiV
 aKz
 aLg
 aLg
 aNC
-aOq
+aMX
 aMX
 aPh
 aQX
@@ -52250,7 +49312,7 @@ aUe
 aUd
 aUe
 aUe
-aVl
+aUe
 aYJ
 aZl
 aZN
@@ -52374,11 +49436,11 @@ aaa
 aag
 aaT
 aaZ
-eoM
-mwI
-dEm
-edh
-eoM
+adH
+aem
+afd
+ahj
+adH
 aag
 aaa
 aaa
@@ -52418,32 +49480,32 @@ aaa
 aaa
 alr
 alT
-amp
-amO
+ayX
+ayZ
 anp
-amO
+azy
 aoq
-aoO
+azW
 apr
 bpS
-app
-aqR
+avh
+asz
 ars
-aqR
-app
+asz
+avh
 asu
-app
-aqR
-asA
+avh
+aBg
+aBM
 bpN
-app
+auy
 bpU
-app
-avt
-wyc
+avh
+avh
+axE
 ayp
-bpZ
-aAr
+aqk
+ata
 bsP
 aqk
 app
@@ -52465,20 +49527,20 @@ aKz
 aLg
 aMV
 aNE
-aOt
-aPl
-aQm
-aQY
-aRN
-aSA
-aRI
-aUc
-aVk
-aUc
-aUc
-aUc
-aYe
-aYK
+aMX
+aPk
+aPh
+aQV
+gjW
+aSy
+aSv
+aUe
+aUe
+aUe
+aUe
+aUe
+aUe
+aUe
 aUe
 aUe
 aOH
@@ -52600,11 +49662,11 @@ aaa
 aaa
 aah
 aaS
-acJ
+abr
 bsv
-lKO
-lKO
-kHs
+aeD
+aeD
+ahn
 aaS
 aah
 aaa
@@ -52646,32 +49708,32 @@ aaa
 alr
 alU
 amq
-amO
 amp
-amO
+amp
+azA
 ayF
-aoO
-aps
+azW
+atC
 apQ
-app
-aqR
-app
-aqR
-app
-aqR
-app
-aqR
+avh
+asz
+avh
+asz
+avh
+asz
+avh
+aBg
 auu
 auQ
 avo
 avR
-avR
-xRp
+aCH
+aCR
 auU
 auQ
 app
 app
-asA
+aCW
 app
 app
 aBj
@@ -52692,15 +49754,15 @@ aKB
 aLh
 aMW
 aNF
-aOq
-aMX
+cws
+pyh
 aQo
-aQV
-aRS
-aSy
-aSv
-aUd
-aVl
+jLz
+iNj
+sON
+vIF
+qke
+mbT
 aUe
 aUe
 aXy
@@ -52827,13 +49889,13 @@ aQe
 aaa
 aaA
 aaN
-ahn
+abt
 bsv
 bsv
 bsv
 bsv
 aFe
-wFx
+alH
 aaa
 aaa
 aaa
@@ -52846,7 +49908,7 @@ aaa
 aaa
 aaa
 acU
-ade
+adR
 adA
 adR
 acV
@@ -52873,31 +49935,31 @@ aaa
 als
 als
 amr
-amP
+ann
 als
 anS
 als
-aoO
-aoO
-aoO
+azW
+azW
+azW
 aql
 aql
 aql
-app
-app
-app
-app
-app
+aAJ
+auy
+auy
+auy
+aBD
 auv
 aAZ
 avp
 avS
-avS
+aCQ
 awZ
 awY
 aAZ
 azO
-auM
+aCS
 bqb
 bqc
 aoO
@@ -52911,28 +49973,28 @@ aCP
 aCP
 aCP
 aES
-aHn
+aHp
 aES
 aCP
 aCP
 aMh
 bnK
-bnU
-bnU
-bnV
+pyh
+pyh
+mhO
 aPG
 aSS
 aQV
-aRO
+gjW
 aSy
 aSv
 aUe
-aVl
+jrR
 aUe
 aUe
 aUe
 aUe
-aVl
+aUe
 aUe
 aZO
 bak
@@ -53102,21 +50164,21 @@ alt
 ams
 alv
 alv
-anr
+azQ
 alv
-aqU
+fVw
 alv
-aoO
-aoO
-aoO
-aoO
+azW
+azW
+azW
+azW
 asa
-asx
+auP
 asY
 atC
 atV
 auw
-auS
+auU
 avq
 avT
 avT
@@ -53125,8 +50187,8 @@ axI
 auU
 ayG
 azh
-asB
-aAp
+aDc
+aDm
 aoO
 aaa
 aaa
@@ -53137,8 +50199,8 @@ aaa
 aCP
 axH
 aFA
-aGp
-aHo
+fXN
+kKS
 aES
 aJw
 aCP
@@ -53150,16 +50212,16 @@ aOu
 aLi
 aPH
 aQV
-aRS
+aRR
 aSy
 aOH
 aUf
 aVm
-aUe
-aYJ
-aUd
-aUe
-aVl
+kDT
+dbJ
+qke
+kDT
+mbT
 aUe
 aZP
 aOH
@@ -53281,11 +50343,11 @@ aaa
 aaa
 aaa
 aFe
-awU
+abI
 bsv
 aam
 aap
-cKf
+ahr
 aaN
 awC
 awC
@@ -53309,16 +50371,16 @@ aaa
 aaa
 aaa
 aaa
-jMS
-ioE
-oXE
+akp
+atn
+atN
 ahG
 ahg
 agK
 aic
-agj
+avX
 aie
-agj
+avX
 aaa
 akr
 akK
@@ -53328,20 +50390,20 @@ aaB
 alV
 amt
 alv
-wFe
+anr
 anT
-alx
-alx
-alx
-alx
-aqm
+ayJ
+alv
+azS
+aAv
+alv
 aqS
-aoO
-aoO
+azW
+azW
 asy
-aoO
-aoO
-aoO
+azW
+azW
+aBK
 ayl
 auT
 avr
@@ -53363,7 +50425,7 @@ aaa
 aaa
 aCP
 aJu
-aFB
+aES
 aES
 aHp
 aES
@@ -53373,20 +50435,20 @@ aLl
 aLl
 aLl
 aLl
-aOv
+rXC
 aPm
 aPz
 aQV
-aRO
+gjW
 aSy
 aTM
 aXK
-aVn
+wMi
 aWc
 aXK
 aXJ
 aXJ
-btM
+ebm
 btN
 aXJ
 aXJ
@@ -53508,14 +50570,14 @@ aaa
 aaa
 aaa
 aaM
-awV
+abL
 aBR
 aBR
 aBR
 bsv
-qYM
+alx
 aaX
-hKB
+anM
 awC
 awC
 awC
@@ -53523,7 +50585,7 @@ awC
 awC
 awC
 awC
-uEP
+ape
 acq
 acq
 acV
@@ -53538,15 +50600,15 @@ bpD
 bpD
 bpD
 agL
-ahh
+bra
 ahF
 akp
-akp
-akp
+avM
+avM
 ajU
 ahV
-ajU
-akp
+awk
+akK
 akH
 aoi
 bpD
@@ -53561,15 +50623,15 @@ alV
 alv
 alv
 amS
-anr
+jGs
 alv
-aoO
+azW
 asb
 asz
-asZ
-aoO
+aAE
+azW
 atW
-asA
+auw
 auU
 avs
 avV
@@ -53579,7 +50641,7 @@ axK
 auU
 aoO
 azj
-asz
+aDg
 aAq
 aoO
 aaa
@@ -53590,7 +50652,7 @@ aaa
 aaa
 boJ
 aKy
-aFB
+aES
 aES
 aHp
 aES
@@ -53598,22 +50660,22 @@ aJy
 aCP
 aLj
 aMZ
-aNG
-aNG
-aOw
+jnJ
+jnJ
+dQl
 aPn
 aPz
 aQX
-aRS
+aRR
 aSz
 boK
 aUh
-aVo
+tMO
 aWd
 aWO
 aXJ
 aYf
-aYN
+ffn
 aZn
 aYj
 aZQ
@@ -53735,9 +50797,9 @@ aaa
 aaa
 aaa
 aaM
-axw
+acC
 bsv
-crI
+aeG
 bsv
 bsv
 aaR
@@ -53750,16 +50812,16 @@ ayi
 ayi
 abQ
 ayi
-uEP
+ape
 acr
 acK
-acW
+acs
 acW
 adE
-acW
+arC
 aek
-acs
-acs
+asC
+asE
 acs
 bpD
 afM
@@ -53782,21 +50844,21 @@ alu
 alu
 alV
 amQ
-anr
+azv
 anU
 alV
 alV
 alV
 alV
-anr
+azv
 alv
-aoO
-asc
-asA
-ata
-aoO
+azW
+bpQ
+avh
+aAG
+azW
 atX
-asA
+auw
 auT
 auT
 auT
@@ -53806,7 +50868,7 @@ auT
 auT
 aoO
 azk
-asA
+aCW
 ata
 aoO
 atZ
@@ -53817,10 +50879,10 @@ aBX
 atZ
 aCP
 aER
-aFC
-aGp
-aHq
-aIx
+aES
+aES
+aHp
+aES
 bgx
 aCP
 aLl
@@ -53831,21 +50893,21 @@ aMl
 aMm
 aPz
 aQV
-aRO
+gjW
 aSy
 aTM
 aUi
-aVp
+msW
 aWd
 aWP
 aXJ
 aYg
-aYO
-aZo
-aZo
-aZo
-aZo
-bbR
+fUe
+lNq
+lNq
+lNq
+lNq
+fPW
 abm
 aaa
 aaa
@@ -53962,7 +51024,7 @@ aaa
 aaa
 aaa
 aaM
-aUu
+acE
 aBR
 aBR
 aBR
@@ -53977,27 +51039,27 @@ abn
 ayi
 ayi
 ayi
-uEP
-acs
+ape
+aqm
 acL
+aqF
+aqZ
 acs
 acs
+aqo
 acs
 acs
-acs
-acs
-acs
-acs
+aqF
 afx
-afN
-aiJ
+asT
+ate
 ahW
-aiJ
+akJ
 ahW
 aiJ
 aig
 aiJ
-aiJ
+akJ
 aiJ
 aiJ
 aiJ
@@ -54009,35 +51071,35 @@ alv
 alv
 ale
 alv
-anr
+azx
 anV
 alV
 bof
 bof
 alV
-anr
+arn
 alv
 arz
-asc
-asA
+bpQ
+avh
 atb
-aoO
+azW
 atX
-asA
-app
+aBN
+aBV
 avt
 avW
-atZ
+wyl
 atZ
 atZ
 ayq
 aoO
 azl
 azP
-aAr
+aDn
 aOP
 aua
-aBM
+jXg
 aEu
 aEu
 aDX
@@ -54047,7 +51109,7 @@ aER
 aES
 aES
 aHp
-aFB
+aES
 aJA
 aCP
 aLl
@@ -54058,21 +51120,21 @@ aOy
 aMn
 aSN
 aQV
-aRS
+aRR
 aSy
 aTI
 aUj
-aVo
+aWd
 aWd
 aWQ
 aXJ
 aYh
-aYP
+pmT
 aZn
 aZn
 aZn
 baZ
-bcL
+eNp
 btt
 aaa
 aaa
@@ -54189,7 +51251,7 @@ aaa
 aaa
 aaa
 aaM
-aUu
+acE
 bsv
 bsv
 bsv
@@ -54199,13 +51261,13 @@ ayi
 apV
 aaY
 ayH
-tRh
+aoS
 aaY
 abv
 abE
 ayi
-uEP
-acs
+ape
+aqo
 acM
 acX
 acX
@@ -54217,79 +51279,79 @@ acX
 acX
 bpD
 afN
-aiJ
-aiJ
-aiJ
-aiJ
-aiJ
-aiJ
-aiJ
-aiJ
-aiJ
-aiJ
-aiJ
-akJ
-aiJ
-bqZ
+atk
+atw
+auj
+atw
+atw
+atw
+atw
+auj
+atw
+atw
+atw
+awm
+atw
+axw
 amX
-alv
-alv
-ale
-alv
+axQ
+ayJ
+aou
+aza
 ant
-alv
+azS
 aot
-alv
+aAv
 alv
 alV
-anr
 alv
-aoO
+jGs
+azW
 asd
-asB
-atc
-aoO
-atX
+auP
+aAN
+azW
+aBL
 auy
 auM
 avu
 avW
-atZ
+wyl
 axb
-axL
-aua
-aHQ
+aEu
+hBl
+aOP
 azm
-azQ
+aAp
 atc
 aoO
 aDX
-aBN
-aua
-aua
-aBM
+aEu
+bET
+jXg
+aEu
 aEu
 aCP
 aET
 aFD
 aES
 aHp
-aFB
+aES
 aJB
 aCP
 aLk
 aMo
 aNb
 aNb
-aOz
+aNb
 aMo
 aSN
 aQV
-aRO
+gjW
 aSy
 aTP
 aUk
-aVo
+aWd
 aWd
 aWR
 aXJ
@@ -54299,7 +51361,7 @@ aZp
 aZn
 aZn
 bba
-bcL
+eNp
 abm
 aaa
 aaa
@@ -54416,22 +51478,22 @@ aaa
 aaa
 aaa
 aaM
-bfE
+acJ
 aBR
 aBR
 aBR
-bfE
-qYM
+acJ
+alx
 aaY
 awo
 awC
 awC
 awC
 awC
-uEP
+ape
 abC
 abK
-uEP
+ape
 acs
 acM
 acX
@@ -54467,27 +51529,27 @@ anu
 anW
 alV
 aoQ
-alv
+aAB
 alV
 aqn
-alv
-aoO
-aoO
+pVr
+azW
+azW
 asy
-aoO
-aoO
+azW
+azW
 atY
-app
-app
+avh
+aCb
 avv
 avW
-atZ
+wyl
 axc
-axM
-aEu
+kkl
+pBt
 aoO
 azi
-uJW
+aDk
 aoO
 aoO
 atZ
@@ -54501,18 +51563,18 @@ aEU
 aFE
 aGq
 aHp
-aFB
+aES
 aJC
 boH
 aLl
 aMo
 aNb
 aNb
-aOz
+aNb
 aMo
 aSN
 aQV
-aRS
+aRR
 aSy
 aTM
 aTM
@@ -54526,7 +51588,7 @@ aZq
 aZn
 aZn
 bal
-bcL
+eNp
 aaa
 aaa
 aaa
@@ -54643,11 +51705,11 @@ aaa
 aaa
 aaa
 aaS
-brB
+acS
 bsv
 bsv
 bsv
-eoJ
+ahv
 aaS
 awC
 awC
@@ -54655,10 +51717,10 @@ awC
 aaa
 aaa
 aaa
-uEP
+ape
 brz
 ayi
-uEP
+ape
 acs
 acM
 acX
@@ -54679,49 +51741,49 @@ aiJ
 bqZ
 aiu
 aiv
-aaO
+akK
 aiF
-aiG
+akK
 agQ
-aaO
-mHo
+akK
+bok
 ald
 alv
 alW
 alV
 alV
-anv
+alV
 alV
 alV
 aoR
 alv
 alV
-anr
 alv
+jGs
 apE
 ase
-asD
+axh
 atd
-amT
-atZ
-atZ
+wyl
+wyl
+wyl
 aBt
-atZ
-atZ
-atZ
+wyl
+wyl
+wyl
+pAK
+pfQ
 aEu
-axM
-aEu
-amT
+atZ
 azn
-asD
+axh
 atd
 amT
 aBl
 aBO
 aCo
-aCT
-aDm
+atZ
+yfg
 aEu
 aCP
 aCP
@@ -54735,15 +51797,15 @@ aLl
 aMo
 aNb
 aNb
-aOz
+aNb
 bpb
 aSN
 aQV
-aRO
+gjW
 brc
 aTM
 aUl
-aVr
+aWe
 aWe
 aWS
 aXJ
@@ -54752,8 +51814,8 @@ aYS
 aMC
 aZn
 bam
-bbB
-bbC
+fnB
+hLp
 aaa
 aaa
 aaa
@@ -54870,7 +51932,7 @@ aaa
 aaa
 aaa
 aaS
-axw
+acC
 aBR
 aBR
 aBR
@@ -54881,12 +51943,12 @@ aaa
 aaa
 aaa
 aaa
-uEP
-uEP
+ape
+ape
 abG
 ayi
-uEP
-uEP
+ape
+ape
 acj
 acX
 adj
@@ -54908,8 +51970,8 @@ aiv
 aiL
 ajp
 ajF
-ahj
 ajF
+awS
 amA
 boh
 aiO
@@ -54917,39 +51979,39 @@ alv
 alX
 alV
 atP
-anw
-alx
-alx
-aoS
+alv
+aHQ
+aAv
+alv
 apt
 alV
-anr
 alv
+azv
 amT
 any
-asE
-ate
+any
+wHy
 atD
 aua
 aua
 aua
-aua
-aua
+huW
+kir
 awz
-aua
-axN
+xMb
+aEu
 bob
-amT
+atZ
 axV
-aqr
+any
 atf
 amT
 aBm
 aBP
 aCp
 aCg
-aDn
-aDX
+oRf
+rXg
 atZ
 aaa
 aaa
@@ -54962,24 +52024,24 @@ aLl
 aLm
 aNc
 aNH
-aOA
+aNH
 aMp
 aSN
 aQV
-aRS
+aRR
 aSy
 aTM
 aUm
-aVr
+aWe
 aWe
 aWT
 aXJ
 aXJ
 aXJ
 aXJ
-baH
-bbd
-bbC
+bbR
+xtT
+hLp
 aaa
 aaa
 aaa
@@ -55097,24 +52159,24 @@ aQe
 aaa
 aaa
 aaA
-rkJ
+adp
 aam
 aBR
 aam
-wHO
-wFx
+ahw
+alH
 aaa
 aaa
 aaa
 aaa
-uEP
-uEP
+ape
+ape
 abw
 abH
 ayi
 abZ
 abQ
-oGB
+aqr
 acX
 adk
 adi
@@ -55131,11 +52193,11 @@ ahk
 aie
 aie
 aii
-aiw
+bra
 aJT
 aiN
 aiN
-ajD
+aiN
 aiN
 aks
 akt
@@ -55147,36 +52209,36 @@ alv
 anr
 alv
 aos
-alv
-alv
+azS
+pVr
 alV
-anr
 alv
+azv
 amT
 any
-aqr
-atf
-amT
+any
+nTR
+atZ
 aEu
 aEu
 aEu
-aEu
-aEu
+txb
+tBb
 aEu
 axd
 axd
 ayr
-amT
+atZ
 azp
-aqr
+any
 atf
 amT
 aBn
 aBQ
 aCq
 atZ
-aDn
-aEu
+bAO
+lGQ
 atZ
 aaa
 aaa
@@ -55185,15 +52247,15 @@ aHt
 aIA
 aJE
 aGs
-aLn
-aNy
-aNI
-aOI
-aPt
-aLn
+aPz
+bwb
+iee
+wiS
+rdY
+aPz
 aPz
 aQX
-aRO
+gjW
 aSz
 aTM
 aTM
@@ -55324,17 +52386,17 @@ aaa
 aaa
 aaa
 aaa
-eiT
-eIb
-eIb
-eIb
-kMX
+adx
+adX
+adX
+adX
+ahN
 aaa
 aaa
 aaa
 aaa
 aaa
-uEP
+ape
 abo
 ayi
 ayi
@@ -55346,7 +52408,7 @@ acX
 adl
 adi
 adi
-aem
+adi
 adi
 adi
 adi
@@ -55371,19 +52433,18 @@ alv
 alv
 alV
 amS
-anr
+azv
 alV
 alV
 alV
 alV
 alV
-anr
+alv
 aqT
 amT
 asf
-aqr
-atg
-amT
+any
+fuR
 auc
 auc
 auc
@@ -55393,34 +52454,35 @@ auc
 auc
 auc
 auc
-amT
+auc
+auc
 axV
-aqr
+any
 atg
 amT
 atZ
 atZ
 atZ
 aCV
-aDn
+qPi
 aEu
 atZ
 aEV
 aaa
 aGs
 aHu
-aIB
+aIC
 aJF
 aGs
 aLo
+bKs
+mGW
+ggE
 aLo
-aLo
-aNJ
-aNJ
 aPo
 aLn
 aQV
-aRS
+aRR
 aSy
 aLn
 abm
@@ -55553,7 +52615,7 @@ aaa
 aaa
 aaa
 aaa
-kPL
+aeL
 aaa
 aaa
 aaa
@@ -55561,22 +52623,22 @@ aaa
 aaa
 aaa
 aaa
-uEP
+ape
 ayi
 ayi
-ohn
+aqf
 ayi
 ayi
 ayi
 brn
 acX
 aoo
-adH
-adX
+adi
+adi
 aen
-adX
-adH
-afk
+adi
+adi
+adi
 afE
 afR
 agq
@@ -55589,48 +52651,48 @@ brb
 aiX
 aiN
 aiN
-ajD
+aiN
 aiN
 aks
 akP
 alc
-alx
-alx
-amv
-alx
-anx
-alx
+alv
+alv
+alV
+alv
+arn
+alv
 aou
-alx
-alx
-alx
-aqo
+alv
+aHQ
+aAv
+anr
 aqU
 amT
 any
-aqr
-atf
-amT
+any
+nTR
+auc
 aud
 auz
 aud
 avw
-avX
+aue
 awA
 axe
 axe
 axe
-amT
+auc
 axV
-aqr
+any
 atf
 amT
 bob
 bod
 aEu
 aEw
-aDn
 aEu
+vqc
 atZ
 atZ
 atZ
@@ -55639,19 +52701,19 @@ aHv
 aIC
 aJG
 aQB
-aLp
-aLp
-aLp
-aNK
-aOC
-aLp
-aQr
-aQZ
-aRP
-aSB
-aQr
-aQr
-aVO
+ivd
+oGD
+sfL
+bdA
+fXp
+aLo
+aLn
+aQV
+gjW
+aSy
+aLn
+aLn
+aLn
 aLn
 aaB
 aaa
@@ -55792,14 +52854,14 @@ abd
 aai
 abd
 abd
-ado
-ado
-ado
+bqF
+bqF
+bqF
 acP
 acX
-adm
+afl
 abb
-adm
+afl
 acX
 aeC
 abb
@@ -55816,7 +52878,7 @@ bpD
 aiO
 ajC
 ajX
-akM
+akQ
 akQ
 bog
 boi
@@ -55826,30 +52888,30 @@ aly
 amw
 aly
 aly
-aly
+pwO
 apw
+eYV
 aly
 aly
-aly
-aqp
+ilb
 aly
 apv
 asg
-aqr
-atf
-atE
+any
+qNU
+nRJ
+hIi
+hIi
+hIi
+rKh
 aue
-aue
-aue
-aue
-avY
 aue
 aue
 aue
 aue
 atE
 axV
-aqr
+any
 atf
 amT
 boc
@@ -55857,10 +52919,10 @@ boe
 aEu
 aEu
 aCU
-aua
-aua
-aEW
-aFF
+aEu
+bET
+fai
+oMV
 aQB
 aHw
 aID
@@ -55871,14 +52933,14 @@ aLq
 aLq
 aNL
 aOD
-aLo
-aPM
-aQV
-aRR
-aSy
-aTb
+mJK
+tTC
+jLz
+iNj
+sON
+tTC
 aUn
-aNJ
+aLo
 aLn
 aLn
 aaa
@@ -56019,7 +53081,7 @@ abd
 abq
 abx
 abd
-ado
+bqF
 aca
 act
 bqF
@@ -56030,9 +53092,9 @@ adn
 afS
 adn
 adn
-afm
-adp
-aor
+adn
+adn
+afS
 agr
 boy
 adn
@@ -56042,9 +53104,9 @@ adn
 aix
 afF
 aiY
-ajq
-ajo
-ajW
+akL
+ajY
+ajY
 ajY
 akL
 afF
@@ -56058,14 +53120,14 @@ amT
 amT
 amT
 amT
-arn
+ans
 amT
 amT
 ash
-ara
-ath
-apv
-auf
+apU
+mcF
+hkO
+auA
 auA
 auW
 avx
@@ -56074,9 +53136,9 @@ awB
 boW
 axf
 axf
-apv
+hkO
 azo
-ara
+apU
 ath
 apv
 aBo
@@ -56087,7 +53149,7 @@ aCY
 aDY
 aEu
 aEX
-aDY
+wIj
 aGs
 aHs
 aGV
@@ -56101,11 +53163,11 @@ aLq
 aLq
 aLq
 aQV
-aRM
+gjW
 aSz
 aOH
 aUo
-aNJ
+pDP
 aLo
 aLn
 aaa
@@ -56120,9 +53182,9 @@ aaa
 aaa
 aLn
 brs
-bcd
+bKs
 bbI
-bej
+tBJ
 beu
 beG
 bqr
@@ -56243,9 +53305,9 @@ aaa
 aaa
 abd
 abi
-abr
+aso
 bqy
-abI
+abe
 abU
 acb
 acu
@@ -56257,11 +53319,11 @@ adn
 adn
 adn
 adn
-aeF
 adn
 adn
 adn
-agO
+adn
+agR
 aqB
 adn
 adn
@@ -56271,13 +53333,13 @@ afS
 aiZ
 adn
 adn
-aeF
+adn
 adn
 adn
 adn
 ajH
 alY
-amu
+amx
 aCZ
 any
 any
@@ -56285,25 +53347,25 @@ awG
 any
 aDG
 any
-aqr
-any
-awG
-any
-aqr
-atf
-amT
-aug
-aug
-aug
+hgP
+slg
+oDp
+slg
+slg
+fGZ
+auc
+axC
+axC
+axC
 auc
 avK
 auc
 axC
 axC
 axC
-amT
+auc
 brl
-aqr
+any
 atf
 amT
 amT
@@ -56328,12 +53390,12 @@ aOE
 bsR
 aLq
 aQV
-aRR
+kvN
 aSC
 aOH
 aUp
-aNJ
-aLo
+mJK
+fSC
 aLn
 aaa
 aaa
@@ -56346,14 +53408,14 @@ aLn
 aLn
 aLn
 aLn
+pNu
 aLo
-aNJ
 aLn
+eUi
 bek
-bev
-beH
-bqs
-bfk
+beG
+bqr
+wrJ
 beI
 bek
 beo
@@ -56362,16 +53424,16 @@ aaB
 aaB
 bgD
 bgD
-bhA
-bib
 biS
-bib
-bha
-bjy
-bjz
-bjy
-bjy
-bjB
+jlr
+hsU
+wOC
+bgD
+bor
+sNI
+clo
+clo
+sMU
 bia
 aaB
 aaB
@@ -56470,73 +53532,73 @@ aaa
 aaa
 abe
 abj
-abs
+ass
 abs
 abF
-abN
+bqF
 acc
 acv
-acQ
-acN
-adp
-adp
-adp
-adp
-aeD
-adp
-afn
-adp
-adp
-adp
-agd
-adp
-aeD
-adp
-adp
-adp
-adp
-aja
-adp
-adp
-ajZ
-adp
-adp
-adp
-adp
-adp
+bqF
+acY
+adn
+adn
+adn
+adn
+adn
+adn
+adn
+adn
+adn
+adn
+agP
+adn
+adn
+adn
+adn
+adn
+adn
+aiZ
+adn
+adn
+adn
+adn
+adn
+adn
+adn
+adn
 amx
-amU
-anz
-anz
-anz
-anz
+aCZ
+any
+any
+any
+any
 bru
-anz
-aqs
-anz
-anz
-anz
-asF
-ati
+any
+any
+any
+any
+any
+any
+ftu
 bhF
-auh
-auh
-auh
-avy
-awb
+axh
+axh
+axh
+axO
+axh
 awh
 axh
 axO
 axh
 bhF
 azq
-aqs
+any
 aAs
 bhF
-auh
+axh
 azq
 aCr
-aCW
+any
 awG
 aAV
 aEv
@@ -56551,16 +53613,16 @@ aLs
 aMs
 aMs
 aMs
-aOF
-aPq
+voT
+kyS
 aPT
-aRa
-bpB
+jLz
+eKg
 aSD
 aOH
 aOH
-aNJ
-aLo
+oGD
+ggE
 aLn
 aZR
 aZR
@@ -56572,15 +53634,15 @@ aaa
 aLn
 aLo
 aLo
+bKs
+sfL
 aLo
-aLo
-bdz
-aQr
+aLn
 bel
 bsI
-beG
-bqr
-bfo
+ydz
+dvP
+bCy
 bfm
 bek
 bfF
@@ -56595,7 +53657,7 @@ bhC
 bhM
 bhR
 bhO
-bim
+lNv
 biw
 biI
 biT
@@ -56695,15 +53757,15 @@ aaa
 aaa
 aaa
 aaa
-abe
+asl
 abk
-abs
+avz
 aby
 abJ
-ado
+bqF
 acd
 acw
-ado
+bqF
 acY
 adn
 adn
@@ -56717,7 +53779,7 @@ adn
 adn
 agP
 adn
-aeF
+adn
 adn
 adn
 adn
@@ -56731,7 +53793,7 @@ aaP
 adn
 adn
 adn
-amu
+amx
 alz
 any
 any
@@ -56744,7 +53806,7 @@ any
 any
 any
 any
-aqr
+gVZ
 any
 any
 any
@@ -56763,10 +53825,10 @@ any
 any
 any
 any
-aqr
+any
 any
 aAV
-aEu
+pAK
 aFa
 aFH
 aGv
@@ -56787,27 +53849,27 @@ aSE
 aDJ
 aUU
 aVt
-aLp
-aLp
-aXB
+aLo
+mJK
+ggE
 aLo
 aYT
 aLn
 aLn
-bau
+efD
 aLn
 aLn
-bcd
-aLp
-aLp
-aLp
-bce
+bKs
+ivd
+aLo
+aLo
+aLo
 aLn
 bem
-bek
+eUi
 beG
 bqr
-bfo
+qAl
 bfn
 bek
 bfG
@@ -56817,19 +53879,19 @@ aaa
 bgD
 bgP
 bhe
-bhs
-bhD
+bhE
+nAh
 bhN
 bhR
 bid
-bin
+eht
 bix
 bix
 biU
 bia
 bji
 bjq
-boa
+eII
 bjL
 aaa
 aaa
@@ -56924,19 +53986,19 @@ aaa
 aaa
 abd
 abl
-abt
-abt
-abL
-dVq
+avL
+aTb
+ctu
+dLk
 ace
 acx
-ado
+bqF
 acY
 adn
 adn
 adn
 adn
-aeF
+adn
 adn
 adn
 adn
@@ -56944,7 +54006,7 @@ adn
 adn
 agR
 aqB
-aeF
+adn
 adn
 adn
 adn
@@ -56971,7 +54033,7 @@ aqV
 arA
 asi
 bfV
-aqr
+gVZ
 any
 any
 any
@@ -56993,8 +54055,8 @@ aCs
 aCX
 any
 aAV
-aEw
-aFa
+rFx
+jgD
 aFI
 aGw
 aHA
@@ -57016,25 +54078,25 @@ aOH
 aVu
 aWf
 aWf
-aXC
-aYl
-aYU
-aYl
-aYl
-aYU
+aWf
+kRk
+pny
+tuz
+aWf
+mrE
 bbe
-aLp
-bce
+ivd
+aLo
 aLo
 aLn
 bbg
 bbg
 aLn
 ben
-aQT
+vdE
 bqq
 bqt
-bfo
+qAl
 bfn
 bek
 bfH
@@ -57045,18 +54107,18 @@ bgD
 bgD
 bhf
 bht
-bhE
+tKl
 btv
 bhR
 aTn
-bin
-bix
+oIX
+rak
 biJ
 biV
 btV
 bjj
 bjr
-bor
+bOO
 bjL
 aaa
 aaa
@@ -57157,13 +54219,13 @@ abd
 abW
 acf
 acy
-ado
+bqF
 aat
 aqB
 adn
 adn
 adn
-aeF
+adn
 adn
 adn
 afG
@@ -57172,10 +54234,10 @@ ags
 boz
 adn
 aeF
-adn
-adn
-adn
-adn
+auS
+auS
+auS
+auS
 aiK
 ajr
 ajr
@@ -57191,41 +54253,41 @@ amW
 amW
 aow
 amW
-amT
+amW
 apT
 any
 aqW
-amT
-amT
-amT
-atj
-amT
-apE
-apE
-apE
-apE
-amT
-amT
-amT
-amT
-aym
-ays
-asl
-asl
-asl
-asl
-asl
-aBT
+avd
+avd
+avd
+atL
+avd
+atH
+atH
+atH
+atH
+cWq
+cWq
+cWq
+cWq
+aCD
+aCD
+cWq
+cWq
+cWq
+cWq
+cWq
+cWq
 aCe
-aCt
+aCZ
 aCZ
 aAV
 aEu
-aFa
+keX
 aFJ
 aGx
 aHB
-aJJ
+aJM
 aJM
 aGu
 aLu
@@ -57247,8 +54309,8 @@ aLn
 aLn
 aLn
 aLn
-aLo
-aLo
+mJK
+qnk
 bbf
 aLo
 bcf
@@ -57260,12 +54322,12 @@ aLn
 beo
 btQ
 beo
-beY
-bfp
+kqW
+vAG
 bfn
 bek
 bek
-bgK
+boN
 bgd
 bgq
 bgE
@@ -57283,7 +54345,7 @@ bia
 bia
 bia
 bia
-bjp
+bia
 aXe
 aaB
 aaa
@@ -57381,29 +54443,29 @@ abd
 abd
 abd
 abd
-bqF
+ard
 acg
 acz
-ado
+bqF
 aat
 adq
 adJ
 adY
 bom
-aeG
+aeo
 aeo
 afo
 afH
 afH
 afF
 afF
-aho
+ahX
 ahI
 ahX
 afF
 afF
 adn
-aiZ
+awi
 ajr
 ajI
 aka
@@ -57418,14 +54480,14 @@ anB
 anY
 aox
 anY
-amT
+amW
 any
 any
 aqW
-amT
+avd
 asj
 asj
-atk
+qBe
 asj
 atH
 auB
@@ -57442,17 +54504,17 @@ axP
 aAt
 aAS
 avC
-aBU
+cWq
 aCe
 aCZ
 aCZ
 aDZ
-aBS
+uFt
 aFb
 aFJ
 aFJ
 aHC
-aJK
+bnS
 bnS
 aFJ
 aLv
@@ -57469,7 +54531,7 @@ aTp
 aOH
 aVv
 aWj
-aOH
+aZx
 aXD
 aYm
 aYV
@@ -57485,7 +54547,7 @@ aLo
 aLo
 bdP
 beo
-aQT
+vdE
 aQT
 aRK
 aQT
@@ -57494,21 +54556,21 @@ bek
 bek
 bdf
 bge
-bgh
-bgh
+uVe
+iGF
 bfU
-bhg
+rBQ
 bje
-bhG
+iWI
 bhg
 bhT
 bgi
-bip
+ceG
 biz
 biG
 biW
 bjo
-bjk
+bjt
 bjv
 boN
 bjL
@@ -57606,9 +54668,9 @@ aaa
 aaB
 aaa
 aaa
-faB
+aeb
 abM
-bqF
+iIU
 ach
 acA
 brm
@@ -57616,8 +54678,8 @@ ada
 ada
 ada
 adZ
-adZ
-abc
+lFW
+aef
 aef
 ada
 ada
@@ -57625,7 +54687,7 @@ afU
 agt
 agS
 ahp
-ahJ
+auD
 ahJ
 aik
 agS
@@ -57645,11 +54707,11 @@ anC
 anZ
 aoy
 anZ
-apv
+uhK
 apU
 apU
 aqX
-apv
+uzM
 ask
 ask
 atl
@@ -57669,17 +54731,17 @@ auE
 auE
 auE
 aBq
-aBU
+cWq
 aCv
-aqr
+any
 aDs
 amT
-aEu
-aEu
-aEu
+qPi
+oRf
+kir
 aFJ
 aHC
-aJK
+bnS
 bnS
 aFJ
 aLw
@@ -57696,14 +54758,14 @@ aTq
 btH
 aVw
 aWh
-aOH
+aZx
 aXE
 aXH
 aYW
 aZt
 aNu
 baq
-bbh
+bbj
 bbE
 aZx
 bct
@@ -57712,32 +54774,32 @@ aLo
 aLo
 bdQ
 beo
+eUi
 bek
 bek
-bev
-bej
-bej
-bej
-bej
-bgR
-bgf
+bek
+bek
+bek
+bek
+phw
+qaE
 bgh
 bgF
-bhq
+phw
 bhg
 bhg
-bhG
+roE
 bhg
 bii
 big
-bip
-biZ
-biG
-biX
+mUu
+dMp
+gTj
+qbB
 bik
-bjl
+rsO
 bjw
-boN
+fox
 bjL
 aaa
 aaa
@@ -57834,11 +54896,11 @@ aaB
 aaa
 aaa
 bow
-aak
+pOz
 bqF
-ado
-ado
-ado
+bqF
+bqF
+bqF
 ada
 adr
 adK
@@ -57857,7 +54919,7 @@ aij
 aop
 agS
 abY
-afg
+awj
 ajr
 ajK
 akc
@@ -57865,10 +54927,10 @@ akb
 ajr
 alh
 alD
-akb
-akb
+ayM
+ayY
 alE
-anD
+aoa
 aoa
 aoz
 aoU
@@ -57876,10 +54938,10 @@ aob
 any
 any
 aqW
-amT
+avd
 asj
 asj
-atm
+qQh
 asj
 atH
 auC
@@ -57896,17 +54958,17 @@ awF
 auE
 auE
 alO
-aBU
+cWq
 aCv
-aqr
+any
 any
 amT
 aEu
-aEu
+ceU
 aFK
 aFJ
 aHD
-aJK
+bnS
 bnT
 aFJ
 aLx
@@ -57923,7 +54985,7 @@ aTr
 aOH
 aOH
 aOH
-aOH
+aZx
 aXF
 aYn
 aXH
@@ -57939,7 +55001,7 @@ aLo
 bdA
 bdR
 beo
-bki
+rrV
 bek
 beR
 bfa
@@ -57947,24 +55009,24 @@ bek
 bek
 bqA
 bfP
-bhc
-bgR
-bgG
-bgS
+xvY
+nAs
+bhS
+bhS
 bhh
-bhv
-bhH
-bhv
-bhU
-bih
-biq
+bhg
+roE
+bhg
+bii
+lfe
+biv
 biA
 biL
-biY
-bih
-bjm
+biX
+kpQ
+hQH
 bjx
-boN
+fox
 bjM
 aaa
 aaa
@@ -58060,31 +55122,31 @@ aaa
 aaB
 aaB
 aaa
-faB
-iyS
-nFY
+aeb
+aqg
+bqF
 aci
 ajb
 acR
 ada
 ads
 adL
-aeb
+oLL
 adL
-aeb
+adL
 adL
 afq
 ada
 afW
 agv
 agS
-ahr
+agS
 agS
 ahY
 anP
 agS
 aiQ
-afg
+dBh
 ajr
 ajr
 ajr
@@ -58099,14 +55161,14 @@ amW
 amb
 amW
 amW
-amT
+amW
 apS
 any
 aqW
-amT
-amT
+avd
+avd
 asj
-atm
+qQh
 atH
 atH
 auC
@@ -58123,19 +55185,19 @@ auE
 awE
 auE
 axl
-aBY
+aCD
 aCv
-aqr
+any
 any
 amT
 atZ
 aEu
 aFL
-aFc
+aFJ
 aHE
 blA
-aFc
-aFc
+aFJ
+aFJ
 aLy
 aMu
 bpl
@@ -58150,16 +55212,16 @@ aTq
 btH
 aXR
 aXY
-aOH
+aZx
 aXG
 aXH
 aXH
 aXH
 aZT
 aXH
-bbj
+qAA
 bbG
-aFc
+aZx
 aFc
 baF
 aFc
@@ -58167,31 +55229,31 @@ aFc
 aFc
 beo
 bex
-bek
-bek
-bek
-bek
-bek
-bek
+hBw
+hBw
+hBw
+hBw
+hBw
+hBw
 beC
-bgh
-bgh
+iGF
+iGF
 bgH
 bgQ
 bhi
-bhg
-bhg
+rBQ
+spR
 bhP
-bhV
-bik
+qva
+gsD
 bir
 biB
 biM
 bja
-bik
-bjl
+xCN
+rsO
 bhg
-boN
+fox
 bjM
 aaa
 aaa
@@ -58278,7 +55340,7 @@ aaa
 aaa
 aaa
 aaa
-faB
+aeb
 bqH
 bqH
 bqH
@@ -58287,18 +55349,18 @@ bqH
 bqH
 bqH
 bqH
-faB
-aak
+aeb
+pOz
 bqF
-faB
-faB
-faB
+aeb
+aeb
+aeb
 ada
 adt
 adM
-aeb
+oLL
 aeq
-aeb
+adL
 adL
 afr
 ada
@@ -58310,20 +55372,20 @@ agb
 abD
 abD
 abD
-abY
-afg
+iNv
+mfm
 abY
 aiR
 akd
 ajO
 akh
 akE
-alF
-ajO
+ajw
+ayN
 amC
 amY
 ajw
-ame
+ajO
 akh
 aoV
 amT
@@ -58331,20 +55393,20 @@ brk
 any
 aqY
 arB
-amT
+avd
 asj
-atm
+qQh
 atH
 aui
-auD
-ava
-avz
-ava
-ava
-ava
-axQ
-ava
-ayM
+auC
+auE
+atH
+auE
+auE
+auE
+awF
+auE
+auE
 ayK
 auE
 auE
@@ -58352,7 +55414,7 @@ auE
 auE
 aBa
 aCv
-aqr
+any
 any
 aEa
 amT
@@ -58377,7 +55439,7 @@ boZ
 aOH
 aXU
 aYC
-aOH
+aZx
 aYo
 aYX
 aZv
@@ -58385,8 +55447,8 @@ aZU
 bar
 bbk
 bbH
-bdg
-aFc
+aYo
+aZx
 bcv
 aFN
 bgz
@@ -58409,16 +55471,16 @@ bhj
 bhw
 bhI
 bhg
-bhV
-bik
+bii
+xCN
 bis
 aWM
 biN
 bjb
-bik
-bjn
+xCN
+hQH
 boM
-boN
+fox
 bjM
 aaa
 aaa
@@ -58506,7 +55568,7 @@ aaa
 aaa
 aaa
 bqH
-kbh
+ahO
 aaE
 aaE
 aaE
@@ -58515,54 +55577,54 @@ aaE
 aaE
 aaE
 abp
-aay
+sge
 bqF
-faB
+aeb
 acB
 abY
 ada
 adu
-adM
-aeb
-adL
-aeb
+imI
+kRJ
+hWg
+bRC
 adL
 afs
 ada
 afY
 agx
-agw
+aht
 aht
 aeK
-abY
+ava
 ail
 abD
 afv
-afg
+nJv
 abY
 aiR
 ake
+awV
+axz
+axM
+alG
+amc
+ajv
+ajN
+alR
 ajl
 ajv
 ajN
-alG
-amc
-akl
-amZ
-ajx
-aoc
-akl
-amZ
 apy
-anz
-anz
-aqZ
-arC
-asl
-asG
-atn
+any
+any
+any
+aqW
+avd
+asj
+gDK
 atI
-auj
+lOU
 auE
 auE
 avA
@@ -58571,23 +55633,23 @@ auE
 axl
 auE
 ayt
-ayN
-ava
-ava
-ava
-ava
+auE
+auE
+auE
+auE
+auE
 aBs
-aBZ
-aCw
-asF
-aCW
+aCD
+aCv
+any
+any
 any
 aDp
 aDr
-aFN
+eqJ
 aGy
 aHG
-aHS
+bcN
 aJP
 aKD
 btk
@@ -58604,28 +55666,28 @@ bqm
 aOH
 aOH
 aOH
-aOH
-aVN
-aFc
-aQC
-aQC
-aQC
-aQC
-aPI
+aZx
 aYD
-aFc
+aZx
+wQZ
+wQZ
+wQZ
+wQZ
+aHa
+aYD
+aZx
 bdB
 aFN
 aFN
 aFN
-bef
+aQC
 bki
 bek
 bek
 bfc
 bqv
-bfQ
-bfq
+pDV
+mNS
 bcS
 bcS
 bcS
@@ -58637,15 +55699,15 @@ bgJ
 bgJ
 bgJ
 bhW
-bik
+gsD
 bit
 biD
 biO
 bjc
-bik
-bjl
-bhg
-boN
+fGE
+xqd
+rBQ
+jKz
 bjL
 aaa
 aaa
@@ -58734,45 +55796,45 @@ aaa
 aaa
 bqH
 aak
-tgU
-abN
-abN
-abN
-abN
-abN
-abN
+arc
+arO
+arO
+arO
+arO
+arO
+arO
 abA
-abN
-abX
+frX
+arO
 abS
-acC
+ava
 abY
 ada
 adv
 adN
 aec
 aer
-aeb
+oLL
 adL
 aft
 boA
 afZ
-agw
+atm
 agU
 ahu
 agb
-abY
+asG
 abY
 abD
 abD
-afg
+urh
 aiz
 ajL
-akf
+awT
 aky
 akR
 ali
-alH
+akf
 aky
 akR
 ali
@@ -58783,9 +55845,9 @@ ali
 apK
 apU
 apU
-ara
+apU
 arD
-apv
+uzM
 asH
 ato
 atJ
@@ -58807,14 +55869,14 @@ aQf
 aCa
 aCx
 apU
-aDt
-aEb
+apU
+apU
 aDq
 bqL
-aFO
-aFO
 aHH
-aHR
+bcN
+aJP
+aFN
 aJQ
 aFN
 aFN
@@ -58839,40 +55901,40 @@ aVz
 aVz
 bas
 bio
-bbJ
+bcg
 bcg
 bcx
 bcN
 bcN
 bcN
-bcz
+bcM
 ber
 ber
 ber
 bqu
 bfd
-bfS
+jQi
 bfz
 bfJ
 bcS
 bgk
 bgt
-bho
+bil
 bgV
 bhk
 bhx
 bgX
 bgJ
 bhX
-bik
+iIy
 biu
 biE
 biP
 bjc
-bik
-bjn
+xCN
+hQH
 bpE
-boN
+fox
 bjL
 aaB
 aaa
@@ -58961,19 +56023,19 @@ aaa
 aaa
 bqH
 aak
+ard
+anv
 bqF
-lHG
-ado
-ado
+bqF
 abf
-ado
-ado
+bqF
+bqF
 abB
-lHG
-tzR
-faB
-acD
-abY
+anv
+aqi
+aeb
+sbA
+jCK
 ada
 ada
 ada
@@ -58986,20 +56048,20 @@ ada
 aga
 agy
 agV
-ahv
+agb
 agb
 ahZ
 abY
 abD
 abD
 ajc
-afg
+awl
 ajG
 alP
-amZ
-ajx
-amc
-asC
+ajN
+alR
+ajl
+ajv
 ajN
 alR
 ajl
@@ -59010,9 +56072,9 @@ aoW
 amT
 apE
 any
-aqr
+any
 arE
-amT
+avd
 asI
 atp
 atK
@@ -59031,58 +56093,58 @@ auE
 auE
 auE
 aBu
-aCi
-aCw
-aDa
-aDc
+aCD
+aCv
+any
+any
 any
 aDp
 aDr
 aFN
-aFN
+pcb
 aHI
-aIJ
-aJR
-aFO
-aFO
-aFO
-aFO
-aFO
-aOK
-aPy
-aJR
-aFO
-aFO
+bcN
 aSI
-aFO
-aFO
-aFO
-aFO
-aFO
-aFO
-aFO
-aFO
+bcN
+bcN
+bcN
+bcN
+bcN
+bcN
+aPy
+aSI
+bcN
+bcN
+aSI
+bcN
+bcN
+bcN
+bcN
+bcN
+bcN
+bcN
+bcN
 aPy
 aZV
-aOK
+bcN
 bbm
-bbK
-aFO
-aFO
-aFO
-aFO
-aFO
+bcN
+bcN
+bcN
+bcN
+bcN
+bcN
 bcM
-bes
-bey
-bes
+ber
+ber
+ber
 bqw
 bfe
 bgg
 bfA
 bfK
 bfw
-bgl
+snR
 bgu
 bgL
 aWg
@@ -59090,16 +56152,16 @@ bhl
 bhy
 bhJ
 brw
-bhY
-bik
+duf
+rvJ
 biv
 biF
 biQ
 biX
-bik
-bjl
+qsg
+rsO
 bpF
-boN
+fox
 bjL
 aaB
 aaa
@@ -59188,20 +56250,20 @@ aaa
 aaa
 bqH
 aak
-bqF
+ard
 bqH
 bqH
 bqH
 bqH
 bqH
 bqH
-faB
-faB
-faB
-faB
-acD
+aeb
+aeb
+aeb
+aeb
 abY
 abY
+cHJ
 abY
 abY
 ada
@@ -59212,10 +56274,10 @@ ada
 ada
 agb
 agb
-agW
+agb
 agb
 ahM
-abY
+vDI
 abY
 aiy
 abD
@@ -59227,7 +56289,7 @@ ajO
 akT
 alj
 alJ
-ajO
+ayT
 amD
 ana
 anE
@@ -59235,14 +56297,14 @@ aod
 aod
 aod
 aod
-apE
+aod
 any
-aqr
+any
 arF
-amT
+avd
 asI
 atq
-asj
+vrm
 asj
 asj
 avc
@@ -59260,14 +56322,14 @@ auE
 aBv
 aBa
 aCv
-aqr
+any
 any
 auX
 amT
 aFP
 boB
 aGn
-aGH
+mRC
 aFN
 aFN
 aFN
@@ -59275,7 +56337,7 @@ aFN
 aFN
 aFN
 aFN
-aHR
+aFN
 aJQ
 aQu
 aFN
@@ -59291,7 +56353,7 @@ aYp
 aVA
 bbl
 aVA
-bat
+aVA
 aZw
 aVA
 aVA
@@ -59299,34 +56361,34 @@ bcy
 aVA
 aVA
 aVA
-bei
+aQC
 beJ
-bez
+bek
 bek
 bek
 bff
-bdL
+qfx
 bfB
 bfL
 bcW
 bgn
 bgy
 bfT
-bgX
-bhm
-bgX
+lhE
+fHj
+tnV
 bhK
 bgJ
 bhZ
 biy
-biv
-biZ
-biG
-biX
+lwm
+bxO
+gTj
+jBH
 bik
-bjt
+kdK
 bqO
-boN
+fox
 bjL
 aaa
 aaa
@@ -59426,24 +56488,24 @@ abD
 abO
 abY
 ack
-acE
-acS
-acS
-acS
-acS
-aed
-acS
-aeL
-afb
-acS
-acS
+abY
+abY
+pQE
+jBS
+jBS
+hgD
+abY
+fOh
+nHp
+jCK
+abY
 afD
 agz
-agX
-abY
-abY
-abY
-abY
+nHp
+jBS
+csn
+nbL
+iJD
 abY
 abY
 aje
@@ -59462,14 +56524,14 @@ aod
 aoA
 aoX
 apz
-apE
+aod
 any
-aqr
+any
 aqW
-amT
+avd
 asJ
 atr
-asj
+qBe
 asj
 asj
 avd
@@ -59487,7 +56549,7 @@ auE
 aBw
 aCD
 aCv
-aqr
+any
 any
 amT
 asN
@@ -59497,14 +56559,14 @@ bqN
 bkN
 bqJ
 bqM
-aFc
+aKH
 aMg
 aHJ
 aMg
-aFc
+aKH
 bss
 aPI
-aFc
+aKH
 bto
 bto
 aFc
@@ -59518,20 +56580,20 @@ aXM
 aXM
 bad
 aXM
-baJ
+aXM
 aXI
-bcO
+bcU
 aXM
 aXM
-bds
+bfS
 btP
-bds
+bfS
 bcS
 bcS
-lFp
+bDa
 bcS
 bcS
-rOd
+bDa
 bcW
 bcW
 bcW
@@ -59552,8 +56614,8 @@ biR
 bjf
 bjs
 bju
-bjC
-bjE
+lhH
+gnE
 bjM
 aaa
 aaa
@@ -59642,7 +56704,7 @@ aab
 aaa
 bqH
 aak
-puW
+ame
 bqH
 aaa
 aaa
@@ -59658,21 +56720,21 @@ abY
 abD
 adw
 abY
-aee
+jDd
+pQE
+csn
 abY
-abY
+asF
 acD
-afv
-abY
 agc
-abY
-acD
-abY
+csn
 abY
 abY
 abY
-aiz
-afy
+asG
+abY
+avN
+avY
 ajf
 ajt
 aiR
@@ -59687,49 +56749,49 @@ anc
 anG
 aod
 aoB
-aoY
+aoZ
 apA
 aqq
-anz
-arb
+vNm
+any
 aqW
-amT
-amT
-ats
+avd
+avd
+jTu
 atL
-amT
-amT
-amT
-amT
-amT
-amT
-amT
-amT
-amT
-amT
-apE
+avd
+avd
+avd
+cWq
+cWq
+cWq
+cWq
+cWq
+cWq
+cWq
+atH
 aAa
 aRf
 aRf
 aAa
-apE
+atH
 aCv
-aqr
+any
 any
 amT
-asM
-asM
-aso
+iWS
+skZ
+tKp
 aFf
-aGH
+uXY
 aFN
 aIQ
-aFc
+aKH
 aLA
 aLG
 aNQ
 bqi
-aPA
+aLG
 aPE
 aKH
 aKK
@@ -59751,11 +56813,11 @@ bbM
 bch
 aXM
 aCI
-bdj
-bcR
-beF
+dte
+pee
+bDa
 bet
-beA
+czC
 bed
 bcW
 beX
@@ -59763,12 +56825,12 @@ bfr
 bfC
 bcW
 bfW
-bnJ
+dDL
 bgv
 bgJ
 bgJ
-bhB
-bil
+qfV
+trA
 bgJ
 bgJ
 bhS
@@ -59777,9 +56839,9 @@ bhS
 bhS
 bhS
 bhS
-bgK
-bgR
-bjE
+irT
+oQx
+gnE
 bjF
 aaa
 aaa
@@ -59867,8 +56929,8 @@ aab
 aab
 aab
 aaa
-faB
-xbr
+aeb
+ahQ
 bro
 bqH
 aaa
@@ -59888,14 +56950,14 @@ abD
 adI
 abD
 abD
-afc
+abY
 afw
 abD
 afJ
 afJ
-agY
-ahw
-ahN
+ahb
+ahb
+ahb
 aia
 afJ
 aiA
@@ -59914,47 +56976,47 @@ and
 amB
 aod
 aoC
-aoZ
+sKj
 apB
-apE
+aod
 aqu
-aqr
-aqY
+dGj
+hpS
 asm
 asm
 att
-any
-awG
-any
-any
-aCZ
-aCZ
-awG
-any
+lCr
+oDp
+slg
+slg
+tAh
+tAh
+oDp
+slg
 axS
 any
 ayQ
-apE
+atH
 aPW
 auY
 auY
 aQq
-apE
+atH
 aCv
-aqr
+any
 any
 amT
-asM
+smU
 asN
 aFc
 aGn
-aHK
-aIK
+wmR
+qzc
 aJS
-aFc
+aKH
 aLB
 aNg
-bqh
+bqj
 bqj
 bql
 aPF
@@ -59965,23 +57027,23 @@ aTf
 aTt
 aUv
 aTu
-aWl
-aGF
+uCl
+mEh
 aXM
 aYr
-aYZ
+sXw
 aZz
-aYZ
+xEo
 baw
-aZz
-aYZ
+lFU
+dxn
 bci
 bao
 aCl
+qUv
 aCl
-aCl
-tUc
-bph
+qlN
+jXE
 beB
 beK
 bcW
@@ -59990,8 +57052,8 @@ bfs
 bec
 bcW
 bfW
-bnJ
-bgw
+dDL
+bfX
 bcS
 aaa
 beg
@@ -60115,15 +57177,15 @@ adO
 aeg
 abY
 abD
-acD
 abY
+asG
 afI
 afJ
 agA
 agZ
 agC
-ahO
 agC
+avJ
 afJ
 aiB
 aiR
@@ -60141,11 +57203,11 @@ aiR
 aiR
 aod
 aoD
-aoZ
+sKj
 apC
-apE
+aod
 any
-aqr
+gVZ
 any
 any
 any
@@ -60158,31 +57220,31 @@ aCZ
 aCZ
 any
 any
-axT
-anz
+any
+any
 ayR
-avz
+atH
 azU
-aAv
-aAv
+auY
+auY
 aBy
-aCb
-aCw
-arb
+atH
+aCv
+any
 any
 amT
-asM
+xSu
 asM
 aFc
 aGA
-aGH
+uHv
 aFN
 brd
-aFc
+aKH
 aLC
 aNg
-bqh
-bqj
+vxo
+vxo
 bqk
 bqd
 aKH
@@ -60193,14 +57255,14 @@ aTu
 aTu
 aUx
 aWm
-aWY
-baf
+mMs
+gdH
 aYs
 aZa
 bse
-aZX
 bax
-aZz
+bax
+iBf
 aYZ
 bcj
 aXM
@@ -60208,17 +57270,17 @@ aCM
 bcP
 bdC
 bcS
-boP
+qlN
 bdT
-beL
+bpp
 bcS
 bfh
 bdU
 bpp
 bcS
 bfY
-bnJ
-bgw
+dDL
+bfX
 bcS
 aaB
 aaa
@@ -60319,10 +57381,10 @@ aab
 aab
 aab
 aab
-faB
+aeb
 bqH
-faB
-tlJ
+aeb
+aiD
 bro
 bqH
 aaa
@@ -60342,14 +57404,14 @@ adP
 aeh
 aet
 abD
-acD
 abY
+asG
 afJ
 afJ
 agB
-aha
-aha
 ahP
+ahP
+mid
 agZ
 ahb
 aiC
@@ -60370,9 +57432,9 @@ aoe
 aoE
 apa
 apD
-apW
+aoe
 aqv
-ara
+pMq
 arG
 apR
 asK
@@ -60393,23 +57455,23 @@ atH
 aAw
 aAT
 atH
-apE
+atH
 aCv
 aDb
 any
 amT
 asM
-asM
+hhS
 aFc
 aGn
-aHN
+cfw
 aIL
 aLV
-aFc
+aKH
 aLD
 aLF
-aNh
-bqk
+hMo
+lfq
 aLG
 bqe
 aKH
@@ -60420,7 +57482,7 @@ aTf
 aUw
 aVC
 aWn
-aWr
+bCV
 aXM
 aYt
 aYZ
@@ -60436,7 +57498,7 @@ bcV
 bdE
 bcS
 bnJ
-beN
+umj
 bdm
 bcS
 bft
@@ -60444,8 +57506,8 @@ beN
 bfX
 boF
 bgj
-bnJ
-bgw
+dDL
+bfX
 bcS
 aaB
 aaa
@@ -60546,7 +57608,7 @@ aab
 aab
 aab
 aab
-gYQ
+aed
 bov
 aaE
 aay
@@ -60563,32 +57625,32 @@ aaa
 aaa
 aaa
 aaB
-acT
-abD
+aqI
+ara
 adQ
 aei
 aeu
-abD
-afd
+apW
+apW
 aeH
-afJ
+apW
 age
 agC
 agC
 agC
-ahQ
-aha
+agC
+agC
 alm
 aiC
 aiR
 aji
 ajw
 ajO
-amj
-akE
-ajw
-ajO
-akh
+awU
+axu
+axL
+axN
+axT
 ayg
 aiR
 anf
@@ -60597,9 +57659,9 @@ aod
 aod
 aod
 aod
-apE
+aod
 aqw
-aqr
+gVZ
 aqW
 amT
 amT
@@ -60615,28 +57677,28 @@ axp
 axV
 any
 ayQ
-apE
+atH
 azV
 aAx
 aAx
 aBz
-apE
-aCy
-aDc
+atH
+aCv
+any
 aDu
 amT
-asM
-asM
+iWS
+vdC
 aFc
 aGn
-aHN
+cfw
 aIM
-aFc
-aFc
+aKH
+aKH
 aLE
-aLG
-aNi
-aNg
+pTJ
+kaN
+opW
 aLG
 bqf
 aKH
@@ -60653,26 +57715,26 @@ aYu
 aYZ
 aYZ
 aZZ
-baz
-aZz
+aYZ
+iBf
 bbO
 bmZ
 bna
-bds
-bdF
+bfS
+sbz
 bdX
 bnG
 bdI
-beN
-beT
+umj
+bpq
 bfi
-bsU
+tPG
 bfM
 bpq
 bpr
 bdF
 bsb
-bgw
+bfX
 bcS
 aaB
 aaa
@@ -60773,11 +57835,11 @@ aab
 aab
 aab
 aab
-oPn
+aee
 aak
 adD
 adD
-bqF
+ard
 bqH
 aaa
 abg
@@ -60790,12 +57852,12 @@ aaa
 aaa
 aaa
 aaa
-adb
-adx
-adx
-aej
+adc
 abD
 abD
+abD
+apW
+apW
 afe
 afy
 afK
@@ -60805,13 +57867,13 @@ agC
 ahx
 ahR
 aib
-agY
-aiD
-aiS
+ahb
+aiC
+aiR
 ajj
-ajx
-ajP
-aqf
+alR
+ajl
+ajv
 akF
 akZ
 alp
@@ -60826,44 +57888,44 @@ apb
 apE
 apX
 aqw
-arc
-arC
-asl
-asL
-atw
-atN
-atN
-atN
-atN
-atN
-awi
+gVZ
+aqW
+amT
+asM
+awK
+tdj
+iPl
+awn
+tdj
+iPl
+awI
 amT
 amT
 axW
 any
 ayQ
-apE
-apE
-apE
-apE
-apE
+atH
+atH
+atH
+atH
+atH
 aCc
-aCz
+aCv
 any
 aDs
 amT
-avF
-asM
+cmU
+gtl
 aFc
 aGD
 aHO
 aIN
-aFc
+aKH
 aKE
 aLH
-aNg
-bqh
-bqj
+sYO
+ieo
+ieo
 bqk
 bqf
 aKH
@@ -60879,27 +57941,27 @@ aXM
 aYv
 aZC
 baa
-baA
-bdD
+kiU
+hdy
 bbq
 bbP
-bck
-bck
-bbn
-bdl
-bdG
-bdi
-bdi
-bdG
+qWl
+sXw
+bcT
 beO
-bdl
-beO
-bfv
-bdi
-bdi
-bdi
-bdl
-bnM
+hIl
+ect
+ect
+kwA
+ect
+ect
+wuc
+lSd
+ect
+ect
+ect
+jrr
+knT
 bcS
 bgZ
 aaa
@@ -61000,11 +58062,11 @@ aab
 aab
 aab
 aab
-oPn
+aee
 aak
 adD
 adD
-bqF
+ard
 bqH
 bqH
 abg
@@ -61025,7 +58087,7 @@ aev
 aeM
 aff
 afz
-afJ
+apW
 afJ
 afJ
 ahL
@@ -61053,17 +58115,17 @@ apc
 apE
 apY
 aqx
-ard
+ijy
 arH
-aso
-asM
+tKp
+skZ
 atx
 asM
 asM
-asM
+pvJ
 asM
 avF
-awj
+lRM
 awI
 amT
 axX
@@ -61080,16 +58142,16 @@ any
 any
 amT
 asM
-asM
+hhS
 aFc
 aGG
-aHR
+eqJ
 bmN
-aFc
+aKH
 aKF
 aOM
-aNg
-bqh
+sYO
+bqj
 bqj
 bql
 bqg
@@ -61101,31 +58163,31 @@ aTx
 aUy
 aVF
 aWq
-aTu
+bCV
 aXo
 aYw
 aYw
 aTf
-bab
 baB
+tmG
 boG
 bbQ
+xBp
 bcB
-bcB
-bdL
-bph
+qfx
+dDL
 bnH
 bps
 bnI
 bdY
 bnI
-beP
+bnI
 bnI
 beV
 bfj
 bfj
-dRv
-btf
+aEq
+bfj
 bpn
 bcS
 aaB
@@ -61227,12 +58289,12 @@ aab
 aab
 aab
 aab
-gYQ
-fYD
+aed
+afb
 aaJ
 bqE
-bqF
-wFA
+ard
+anw
 bqH
 abg
 abg
@@ -61242,7 +58304,7 @@ abg
 abg
 abg
 abg
-koq
+aqs
 add
 akj
 aim
@@ -61250,8 +58312,8 @@ aim
 aaa
 aew
 aeN
-afg
-abY
+aqp
+hTJ
 afL
 agg
 agE
@@ -61290,7 +58352,7 @@ atO
 asN
 asN
 asN
-awk
+xSu
 awJ
 amT
 axX
@@ -61302,21 +58364,21 @@ any
 any
 any
 any
-aqr
+any
 any
 any
 amT
 asM
-asM
+smU
 aFc
 avg
-aHS
+tvk
 aHM
-aFc
+aKH
 aKG
 aON
 aMx
-aNR
+wsx
 aPB
 aPC
 aKH
@@ -61327,26 +58389,26 @@ aTf
 aTu
 aTu
 aTu
-aWr
+aTu
 aXb
 aXo
 aYx
 aYw
 aZD
-bab
 baB
+tmG
 bbr
-bcU
-baf
-bcO
+qfj
+wku
+gdH
 bcS
 aNZ
 beN
 bdZ
 bcS
+qUv
 aCl
 aCl
-bdo
 aCl
 bfZ
 bfZ
@@ -61454,13 +58516,13 @@ aab
 aab
 aab
 aab
-faB
+aeb
 bqH
-faB
-dVg
+aeb
+aiS
+ard
 bqF
-ado
-vnv
+aoc
 abg
 abg
 abg
@@ -61469,7 +58531,7 @@ abg
 abg
 abg
 abg
-koq
+aqs
 add
 akk
 aim
@@ -61477,9 +58539,9 @@ aim
 aaa
 aew
 aeO
-afg
+aqp
 afA
-afJ
+apW
 agh
 afJ
 ahb
@@ -61502,8 +58564,8 @@ aiR
 aiR
 aiR
 aiR
-aoK
-aoK
+yam
+raE
 apG
 amK
 aqy
@@ -61517,8 +58579,8 @@ aul
 auH
 asN
 avG
-awl
-awJ
+gGS
+cjc
 amT
 axY
 apU
@@ -61534,12 +58596,12 @@ azt
 apU
 apv
 awI
-asM
+xFS
 aFc
 aGG
-aHR
+eqJ
 aIQ
-aFc
+aKH
 aKH
 aLI
 aKH
@@ -61554,8 +58616,8 @@ aTf
 aTf
 aUz
 aVG
-aWr
-aTu
+nMH
+qyy
 btL
 aYw
 aZb
@@ -61566,14 +58628,14 @@ bbr
 bbS
 bcm
 bcA
-bds
-bph
+bfS
+dDL
 beN
 bfX
 bcS
 beD
 bsm
-bdo
+aCl
 beU
 bfZ
 boT
@@ -61684,7 +58746,7 @@ aab
 aaa
 aaa
 bqH
-kNi
+aja
 bqG
 bqH
 bqH
@@ -61696,7 +58758,7 @@ abg
 abg
 abg
 abg
-koq
+aqs
 aim
 aim
 aim
@@ -61705,8 +58767,8 @@ aaB
 aew
 aeP
 afh
-abD
-afJ
+apW
+apW
 agi
 afJ
 aez
@@ -61729,12 +58791,12 @@ aaB
 abm
 aiR
 aog
-aoJ
-ape
+xEf
+gcn
 apH
-apZ
+amK
 aqz
-aqE
+cxT
 arJ
 amK
 asP
@@ -61744,8 +58806,8 @@ atz
 auI
 asN
 asN
-awk
-awJ
+asM
+oWh
 amT
 amT
 amT
@@ -61756,7 +58818,7 @@ amT
 aAV
 amT
 amT
-aBU
+amT
 amT
 amT
 amT
@@ -61764,18 +58826,18 @@ aEy
 awn
 aFQ
 aGE
-aHS
+tvk
 aIR
-aFQ
+cnN
 aKI
 aLJ
 aMy
-aNk
+lQE
 aNS
-aKK
-aMA
-aKK
-aKK
+cCv
+hXL
+cCv
+pka
 aKK
 aSK
 aTf
@@ -61787,26 +58849,26 @@ aXo
 aYy
 aZc
 aZF
-bab
 baB
+tmG
 bbr
 bbT
 aYZ
 aYZ
-bcT
-bdH
+vZd
+qfU
 beN
 bfX
 bcS
-bdW
-beM
-beW
-beZ
+qlN
+rzT
+rzT
+bpp
 bfZ
 boV
-btd
-btd
-bti
+bgo
+bgo
+bgo
 bgo
 bqI
 bfZ
@@ -61910,10 +58972,10 @@ aab
 aab
 aaa
 aaa
-gjD
-rBk
-bDG
-gjD
+afc
+ajx
+arj
+afc
 aaa
 abg
 abg
@@ -61923,8 +58985,8 @@ abg
 abg
 abg
 aaa
-koq
-npP
+aqs
+aqs
 aki
 aki
 aki
@@ -61957,11 +59019,11 @@ aaB
 aiR
 aoh
 aoK
-aoK
+crw
 apI
 aqa
 aqA
-arg
+dVu
 arK
 amK
 asQ
@@ -61971,57 +59033,57 @@ atz
 atz
 ave
 asM
-awk
-awK
+asM
+fXO
 awn
 awn
+ecT
+iPl
 awn
-awn
-awn
-awI
+qBr
+mEm
+vtm
+gGS
+aBc
 asM
-awJ
-asM
-awa
-awk
-asM
+mHv
 asM
 asM
-asM
+xFS
 asM
 aFc
 aGI
 aHT
 aIS
-aJU
-aKJ
-aLK
-aLM
-aNl
-aNT
+aKN
+aKK
+iQr
+cCv
+tLI
+aXd
 aOO
-aNj
-aQw
-aQw
-aQw
-aQw
 aTc
-aQw
-aQw
-aWt
-aXc
+aMy
+aMy
+eVp
+iBB
+okA
+pYF
+pYF
+oGg
+aNS
 aXo
 aXo
 aXo
 aXo
-bae
+aXM
 btO
 bbr
 bbU
 aYZ
 aYZ
-bdL
-bph
+qfx
+dDL
 beN
 bea
 bcS
@@ -62137,10 +59199,10 @@ aab
 aab
 aaa
 aaa
-dlG
-pwm
-jKR
-dlG
+afk
+ajD
+amv
+afk
 aaa
 abg
 abg
@@ -62198,22 +59260,22 @@ atz
 auJ
 asN
 avH
-awm
-asL
-asL
-asL
-asL
-asL
-azu
-azW
-aAy
-aAW
-asL
-aBc
-aAB
+asM
+asM
+tAr
+hvS
+vnw
+iyq
+pvJ
+iIT
+kCT
+awJ
+asM
+qTB
+hvS
 aDd
-asM
-asM
+tAr
+hvS
 asM
 asM
 aFR
@@ -62222,7 +59284,7 @@ aGC
 aFR
 aFR
 aKK
-aLL
+vlK
 aKN
 aKN
 aKN
@@ -62230,17 +59292,17 @@ aKN
 aKN
 aKN
 aKK
-aKK
+rrW
 aKK
 aMA
 aKK
 aKK
 aKK
-aXd
-aQw
-aYz
-aYz
-aYz
+nje
+uyA
+aMy
+aMy
+aMy
 bap
 baE
 bbs
@@ -62248,9 +59310,9 @@ aYZ
 bcn
 bmT
 bcS
-anH
+beF
 bdS
-bdq
+bpp
 bcS
 aaa
 aaa
@@ -62364,10 +59426,10 @@ aab
 aaa
 aaa
 aaa
-dlG
-pdx
-weg
-dlG
+afk
+ajP
+arl
+afk
 aaa
 aaa
 aaa
@@ -62431,9 +59493,9 @@ asN
 asN
 asN
 asN
-azv
+asN
 azX
-awk
+hoZ
 awJ
 asN
 asN
@@ -62449,9 +59511,9 @@ aHV
 aIT
 aFR
 aKK
-aKM
-aMz
-aLM
+oaT
+aKN
+uWp
 aNU
 aKN
 aaa
@@ -62463,13 +59525,13 @@ aKN
 aKN
 aKN
 aKN
+gpP
+wIK
+fHn
+gez
 aKK
-aKK
-aKK
-aKK
-aKK
-bae
-aYZ
+aXM
+iYw
 bbt
 bbV
 aXM
@@ -62590,16 +59652,16 @@ aab
 aab
 aaa
 aaa
-gjD
-gjD
-pdx
-weg
-gjD
-gjD
-dlG
-dlG
-gjD
-gjD
+afc
+afc
+ajP
+arl
+afc
+afc
+afk
+afk
+afc
+afc
 aaa
 aaa
 aaa
@@ -62635,7 +59697,7 @@ aaa
 aaa
 amK
 akO
-anM
+anN
 aoj
 anN
 apf
@@ -62658,7 +59720,7 @@ aaB
 aaa
 aaa
 aaa
-azv
+asN
 azY
 aAz
 aAX
@@ -62675,10 +59737,10 @@ aGL
 aHW
 aIU
 aHU
-aKL
+tLI
 aKK
 bqS
-aKK
+aNV
 aNV
 aKN
 aez
@@ -62693,9 +59755,9 @@ aKN
 aKN
 aKN
 aKN
-aKK
+rOY
 bpH
-bae
+aXM
 aWs
 aXM
 aXM
@@ -62817,40 +59879,40 @@ aab
 aaa
 aaa
 aaa
-gjD
-wms
-qfM
-weg
-ixI
-eUm
-eUm
-jpv
-rXY
-gjD
+afc
+afm
+ajZ
+arl
+anx
+aok
+aok
+aoN
+apM
+afc
 bsh
 bsh
 bsh
 aco
 acF
-acF
-acF
-acF
+aqE
+aqE
+aqE
 axD
-acF
+aqE
 aex
 aeR
 aex
-acF
-acF
+aqE
+aqE
 aex
-acF
-acF
-acF
-acF
-acF
-acF
-acF
-acF
+aqE
+aqE
+aqE
+aqE
+aqE
+aqE
+aqE
+aqE
 aiE
 aaa
 aaa
@@ -62863,13 +59925,13 @@ aaa
 amK
 anj
 anN
-aok
+anN
 anN
 apg
 amK
 aqb
 aqD
-arj
+cxT
 arN
 asp
 amK
@@ -62885,7 +59947,7 @@ axq
 aaB
 aaB
 aaB
-azS
+azr
 azY
 aJg
 aAX
@@ -62902,11 +59964,11 @@ aGM
 aHX
 aIV
 aFR
-aKM
-aLM
-aMB
+aKK
+aKK
+aKN
 aNm
-aNW
+vqW
 aKN
 aaa
 aaa
@@ -62921,17 +59983,17 @@ aaa
 amL
 aKN
 aKK
-aKK
-aLL
+fHn
+pka
 baG
 aKK
 aKK
 aKK
 aKK
 bcS
-bdV
-beM
-boQ
+qlN
+rzT
+bpp
 bcS
 aaa
 aaa
@@ -63044,16 +60106,16 @@ aab
 aaa
 aaa
 aaa
-gjD
-vvM
-nNR
-jIj
-jYd
-rCc
-eUm
-eUm
-eUm
-dlG
+afc
+afn
+arb
+arp
+anz
+aol
+aok
+aok
+aok
+afk
 aaa
 aaa
 aaa
@@ -63090,14 +60152,14 @@ aaa
 amK
 ank
 anO
-aol
-aoN
+mwh
+qYV
 aph
 apx
 aqc
-aqE
-ark
-arO
+aEt
+bbK
+aEt
 asq
 amK
 aaa
@@ -63112,9 +60174,9 @@ aaB
 aaa
 aaa
 aaa
-azv
+asN
 azY
-awk
+smU
 aAX
 asN
 aaa
@@ -63149,8 +60211,8 @@ aaa
 aKN
 aKK
 aKK
-aLL
 aKK
+gLY
 aKK
 bbW
 bco
@@ -63271,16 +60333,16 @@ aaa
 aaa
 aaa
 aaa
-gjD
-ybh
-kFX
-kFX
-jYd
-eUm
-eUm
-jpv
-eUm
-dlG
+afc
+agW
+akl
+akl
+anz
+aok
+aok
+aoN
+aok
+afk
 aaa
 aaa
 aaa
@@ -63317,13 +60379,13 @@ aaa
 amK
 anl
 anN
-aok
+gfM
 anN
 api
 amK
 aqd
-aqF
-arl
+ark
+cxT
 arP
 arL
 amK
@@ -63339,9 +60401,9 @@ asN
 asN
 asN
 asN
-azv
+asN
 avO
-awk
+xSu
 awJ
 asN
 asN
@@ -63376,9 +60438,9 @@ aaa
 aKN
 aKN
 aKN
-bbc
-bbu
 bbD
+llx
+ozy
 aKN
 aKN
 aKN
@@ -63498,16 +60560,16 @@ aaa
 aaa
 aaa
 aaa
-gjD
-rwY
-kFX
-kFX
-jYd
-eUm
-eUm
-eUm
-eUm
-dlG
+afc
+agX
+akl
+akl
+anz
+aok
+aok
+aok
+aok
+afk
 aaa
 aaa
 aaa
@@ -63562,14 +60624,14 @@ asN
 avI
 awn
 awn
-awn
+tdj
 axZ
 awn
 awn
-azx
+awn
 azZ
-awk
-awJ
+gGS
+fuK
 asM
 asM
 asM
@@ -63593,8 +60655,8 @@ aaa
 aaa
 aPS
 aRh
-aRV
 aTA
+ifC
 aVH
 bng
 aPS
@@ -63725,38 +60787,38 @@ aaa
 aaa
 aaa
 aaa
-gjD
-eGe
-pfN
-pyH
-knq
-eUm
-eUm
-eUm
-rXY
-gjD
+afc
+agY
+akM
+amZ
+anH
+aok
+aok
+aok
+apM
+afc
 bsh
 bsh
 bsh
 bsh
 aco
-acF
-acF
+aqE
+aqE
 adz
-acF
-acF
+aqE
+aqE
 aex
 aeT
 aex
 afB
-acF
+aqE
 aex
-acF
-acF
-acF
-acF
-acF
-acF
+aqE
+aqE
+aqE
+aqE
+aqE
+aqE
 aiE
 aaa
 aaa
@@ -63786,18 +60848,18 @@ aaa
 aaa
 aaa
 asN
-avJ
-asL
-asL
-asL
-asL
-asL
-asL
-azy
-asL
-aAB
-aUr
+avO
+pde
+hvS
 asM
+asM
+tAr
+skZ
+hvS
+asM
+asM
+aUr
+iyq
 avI
 awn
 awn
@@ -63807,7 +60869,7 @@ aEB
 aAD
 aAD
 aGO
-aIa
+tfa
 aIY
 aAC
 aAC
@@ -63819,8 +60881,8 @@ aFR
 aaa
 aaa
 boI
-aRT
-aSM
+aTA
+sMo
 aUB
 bnf
 bnh
@@ -63952,16 +61014,16 @@ aaa
 aaa
 aaa
 aaa
-gjD
-gjD
-gjD
-gjD
-gjD
-xGY
-xGY
-xGY
-jGu
-gjD
+afc
+afc
+afc
+afc
+afc
+aor
+aor
+aor
+apZ
+afc
 aaa
 aaa
 aaa
@@ -64004,7 +61066,7 @@ aaa
 aaa
 apk
 aqH
-arp
+toE
 aqH
 apk
 aaB
@@ -64014,7 +61076,7 @@ aaa
 asN
 asN
 avE
-awa
+aBc
 awr
 awr
 awr
@@ -64034,9 +61096,9 @@ aAD
 aAD
 aAD
 bne
-aAJ
+fWY
 aBE
-aKQ
+xzm
 aKO
 aLN
 aLN
@@ -64046,7 +61108,7 @@ aFR
 aPS
 aPS
 aPS
-aRV
+bKe
 aTG
 aTG
 aTG
@@ -64231,7 +61293,7 @@ aaa
 aaB
 apk
 arm
-arp
+toE
 arR
 apk
 abm
@@ -64240,7 +61302,7 @@ aaa
 aaa
 asN
 avf
-avL
+tIy
 awp
 awr
 axr
@@ -64248,7 +61310,7 @@ ayb
 ayx
 ayU
 ayV
-aAc
+aAl
 aAI
 aBE
 aXr
@@ -64261,13 +61323,13 @@ aAD
 aAD
 bnc
 bmY
-aIc
-aIZ
-aJX
-bni
-aAD
+jfa
+tip
+paR
+jFn
+vwF
 aQx
-aQx
+fGD
 aNX
 aFR
 aPJ
@@ -64467,7 +61529,7 @@ aaa
 aaa
 asN
 asM
-avM
+wHt
 awq
 boD
 axs
@@ -64476,33 +61538,33 @@ ayA
 axs
 axs
 aQS
-bmW
-aBD
-aAE
-aBD
-aCB
-aAE
-aAE
-aAE
-aAE
-aAE
-aAE
-aAE
-brr
+bny
+aBE
+aAD
+aBE
+aAD
+aAD
+aAD
+aAD
+aAD
+hQk
+vwF
+vwF
+xlI
 aJY
 aKa
 bnj
 aAD
 aSL
-aSL
+fvo
 bic
 aRU
 aPK
-aQy
 aRi
+cFZ
 aRY
 aSO
-aTC
+ogt
 aUC
 aTB
 aPS
@@ -64685,7 +61747,7 @@ apk
 apL
 aqJ
 aqJ
-arp
+toE
 arS
 aqJ
 asS
@@ -64693,29 +61755,29 @@ apk
 aaB
 aaB
 asN
-asM
-avL
+eol
+avO
 awr
 awr
 aya
 ayc
 ayz
-axu
-axu
+axv
+axv
 aAl
 bny
 aBE
 aAD
 aBE
-aAJ
+aAD
 aDe
 aDx
 aAD
 aAD
-aAD
+fWY
 aAD
 bqU
-aAJ
+aAD
 aJa
 aLz
 aKP
@@ -64909,19 +61971,19 @@ aaa
 aaa
 aaa
 apk
-apM
-aqg
-aqg
-arq
-aqg
-aqg
-asT
+aqH
+aqH
+aqH
+xRT
+viT
+viT
+tjX
 apk
 abm
 abm
 asN
-asM
-avL
+xSu
+avO
 awr
 awL
 axs
@@ -64937,15 +61999,15 @@ aCf
 aCC
 aAC
 aAC
-aFm
-aFy
+bqV
+olQ
 bew
-aGP
+aAC
 aJc
 bkS
-aJZ
+bqV
 aMf
-bqT
+hAn
 aIj
 aIj
 bsr
@@ -65139,34 +62201,34 @@ apk
 apN
 aqJ
 aqJ
-arp
+toE
 aqJ
 aqJ
 asU
 apk
 aaB
 aaB
-atO
-asM
-avN
-aws
+mEk
+hvS
+vXg
+fIb
 awM
-axu
-axu
+axv
+axv
 ayB
 axv
 azB
 awr
-aBA
+aKQ
 aAA
 aAA
 aBW
-aCO
+aKQ
 aAC
 aDz
 aEF
 aGS
-aED
+tAB
 aIb
 aJh
 aED
@@ -65175,10 +62237,10 @@ aKT
 bkF
 aIj
 aMD
-bnv
+obB
 brf
 aOQ
-aKl
+cPd
 aSj
 aDD
 aRo
@@ -65366,46 +62428,46 @@ apk
 apk
 aqh
 aqJ
-arp
+toE
 aqJ
 asr
 apk
 apk
 aaa
 aaa
-atO
+dNU
 asM
-avO
-awt
+icj
+jvN
 awN
 axs
 ayw
-azA
+axs
 axs
 azD
 awr
 aAH
 biK
-aAD
+ouT
 aCJ
 bdn
-bqV
+aKQ
 aDB
 aDA
 aEG
-aED
-aGQ
-aED
-aED
-brt
-aKg
+gOS
+ehp
+oDt
+qWj
+qWj
+dJX
 bku
 aIj
 aME
-bnv
+sjH
 aOa
-aKV
-aKl
+qeg
+jOO
 bsX
 aRk
 aRZ
@@ -65591,30 +62653,30 @@ aaa
 aaa
 apl
 apk
-aqi
-aqI
-arq
-aqI
-ass
+aqJ
+aqJ
+toE
+aqJ
+aqJ
 apk
 apl
 aaa
 aaa
-atO
+dNU
 asM
-avO
-awt
+icj
+jvN
 awO
 axv
 aye
-ayT
+axv
 axv
 azC
 awr
 aAK
-aBg
+vwF
 aBJ
-aZS
+tip
 bfI
 aAC
 aDC
@@ -65623,16 +62685,16 @@ aEH
 aED
 aGT
 bpw
-aGR
-bqQ
-aKR
+aED
+aED
+aKg
 bkw
 aIj
 aMF
-bnv
-aOa
+aMH
+rwf
 aOR
-aPN
+brC
 aSj
 aRl
 aSa
@@ -65827,23 +62889,23 @@ apk
 apl
 aaa
 aaa
-atO
+iFD
 asM
-avO
-awu
+wHt
+oRk
 awP
 axs
 ayy
-azA
+axs
 axs
 bmV
 awr
 bmX
 bmQ
-aAD
+xlI
 bmR
 aCF
-bqV
+aKQ
 aEg
 aEj
 aFi
@@ -65856,11 +62918,11 @@ bqR
 aKc
 aIj
 aMG
-bnv
-aOa
+aMH
+rwf
 aKV
-aPO
-aTl
+aKV
+xEQ
 aRm
 aSP
 aTF
@@ -66001,7 +63063,7 @@ aaa
 aaa
 aaa
 aaa
-hfV
+aoJ
 aaa
 aaa
 aaa
@@ -66055,18 +63117,18 @@ apl
 aaB
 aaa
 asN
-asM
+eol
 avO
 awr
 awQ
 axv
 axv
-ayT
+axv
 axv
 azE
 aAd
 aCE
-aBb
+tfa
 aBb
 aCh
 aXk
@@ -66076,18 +63138,18 @@ aED
 aED
 aED
 aED
-aId
+tAB
 aGT
 aJf
 aKd
 aIj
 aIj
 aMO
-bnv
-aOa
-aOS
-aNo
-aTl
+aMH
+rwf
+aKV
+aKV
+cxd
 aRn
 aSb
 aTE
@@ -66282,7 +63344,7 @@ apl
 aaB
 aaa
 asN
-asM
+xSu
 avO
 awr
 awr
@@ -66292,26 +63354,26 @@ ayC
 ayf
 azF
 azF
-aAN
+hAu
 aWH
-aBK
+ebf
 aCG
-aCQ
+uTY
 azF
 aEf
 aEE
 aFj
 aFU
-aGR
+qWj
 aIi
 aIf
 aEi
 aKe
 aIj
 aLP
-aMJ
-aUN
-bnu
+aMM
+aMH
+uIh
 aOT
 aQj
 aQj
@@ -66510,7 +63572,7 @@ aaB
 aaa
 asN
 asM
-avO
+fyG
 awv
 awr
 aFd
@@ -66520,7 +63582,7 @@ awr
 azF
 aAe
 aBd
-aBf
+dEg
 aCj
 aUO
 aCL
@@ -66530,24 +63592,24 @@ aDE
 aDE
 aFV
 aED
-aId
+tAB
 aIg
 aEi
 brj
 aIj
 aLQ
-aMK
-bnv
-aOa
-aKl
+sVS
+aMH
+rwf
+aKV
 aQj
 aQD
 aRp
 bno
-aST
-aRt
-aRt
-aVK
+aRs
+toB
+cdX
+aVM
 aQj
 aaB
 aaa
@@ -66738,16 +63800,16 @@ asN
 asN
 asN
 bie
-awn
-awn
-awI
+rzV
+tsB
+lMW
 ayh
 avF
 ayW
 azF
 aAf
 aBH
-bmU
+omp
 bnz
 aBG
 aCN
@@ -66757,22 +63819,22 @@ aEA
 aEI
 aFk
 aFX
-aId
+tAB
 aWi
 aEJ
 aKf
 aIj
 aLP
-aMK
-bnv
-aOa
+bMH
+uSK
+upu
 bre
 aQj
 aQE
 aRq
 aRs
-aSU
-aUg
+cPw
+aWk
 aUJ
 aWk
 aQj
@@ -66967,16 +64029,16 @@ aun
 asM
 asM
 asM
-avO
+miQ
 asM
-asM
-asM
+tAr
+skZ
 aIP
 aAh
-aCk
-aAg
-aCH
-bnB
+dJn
+hAd
+wGn
+mhX
 aZr
 azF
 aDH
@@ -66984,16 +64046,16 @@ aEi
 aEi
 aEi
 bfN
-aJd
-brE
+gOS
+lSh
 aED
 aKS
 aIj
 aLR
-aML
-bnv
-aOa
-aJk
+dcW
+aMH
+uIh
+qeg
 bsD
 bnp
 aRr
@@ -67202,8 +64264,8 @@ azF
 aAi
 aCk
 aAg
-aCm
-bnC
+aAg
+twy
 aZy
 azF
 aEk
@@ -67217,18 +64279,18 @@ bnP
 bpi
 aIj
 aLS
-aMM
-bnv
-aOa
+dcW
+aMH
+rwf
 aKV
 aQj
 aQG
 aRs
-aRs
-aSU
-aWk
+kVy
+uYg
+tzx
 aUL
-aUg
+tzx
 aQj
 aaB
 aaa
@@ -67429,31 +64491,31 @@ azF
 aAj
 aCk
 aAg
-aCm
-bnD
+aAg
+bnB
 bgY
 aDf
 aDf
 aDf
 aEK
-aFz
-aGX
+qqx
+pIT
 aDf
 aIj
 aIj
 aKh
 aIj
 aLT
-aMM
-bnv
+oXd
+aMH
 bnx
 brC
 aQj
 aDw
-aRt
+pcD
 aSd
-aSW
-aRt
+aRs
+sWI
 aUM
 aVM
 aQj
@@ -67647,16 +64709,16 @@ aaa
 aaa
 aaa
 aaB
-awS
-axz
+hAu
+eLN
 ayk
-axz
-ayX
+ayj
+ayj
 brA
-aAh
+eqv
 aCk
 aAg
-aCH
+aAg
 bnE
 biH
 aDf
@@ -67672,8 +64734,8 @@ aKi
 aKU
 aLU
 aMN
-bnv
-aOa
+aMH
+rwf
 aOU
 aQj
 aQj
@@ -67876,32 +64938,32 @@ aaa
 aaB
 awR
 axA
-ayj
+lEL
 ayE
-ayY
+eLN
 aOL
-aAL
+xhh
 aCk
 aAg
-aCH
+aAg
 bnB
 bkM
 aDf
 arM
 aEn
 aEn
-aFo
+aEn
 aGc
 bgU
-aIl
+aJj
 aJj
 aKj
-aMH
-aMH
-aMH
-bnv
-aOa
-aKV
+uSK
+uSK
+uSK
+uSK
+hcu
+gNd
 aPU
 aOc
 aQL
@@ -68105,7 +65167,7 @@ awR
 brA
 aHZ
 brA
-ayZ
+awR
 azF
 aAk
 bmS
@@ -68121,14 +65183,14 @@ aEn
 aGd
 aDf
 aIm
-aJk
-aKk
-aKW
-aKW
-aKk
-aNo
-aKk
-aKW
+aKV
+cPd
+aKV
+aKV
+aKV
+aKV
+cPd
+wrZ
 aPP
 aOc
 aRw
@@ -68328,18 +65390,18 @@ aaa
 aaa
 aaa
 aaa
-awT
-boU
+eWZ
+eec
 boX
-boX
-ayJ
+gWu
+fsH
 azF
-aAG
+uiU
 aBe
 aBI
 aCn
 aWX
-aCR
+tMd
 aDf
 aDL
 aPQ
@@ -68349,14 +65411,14 @@ aGe
 aDf
 aIn
 aJl
-aKl
+cPd
 aKX
 aLW
 aMP
 aNq
 aOb
 aKV
-aKl
+cPd
 aOc
 aRy
 aSg
@@ -68555,18 +65617,18 @@ aaa
 aaa
 aaa
 aaa
-ayJ
+uiU
 aAM
 bpc
 boX
-ayJ
+uiU
 azJ
-aAN
-aBK
-aBK
-aBV
-aBK
-aCS
+wxS
+ebf
+ebf
+ebf
+ebf
+gQO
 aDf
 aDM
 aEo
@@ -68782,11 +65844,11 @@ aaa
 aaa
 aaa
 aaa
-ayJ
+uiU
 boU
 boX
 boU
-ayJ
+uiU
 aaa
 aAm
 aAO
@@ -68810,7 +65872,7 @@ aMQ
 aNr
 aOc
 aOV
-aPX
+hPj
 aQI
 aUS
 aSg
@@ -69009,11 +66071,11 @@ aaa
 aaa
 aaa
 aaa
-aza
+uiU
 boU
 boU
 bnL
-aza
+uiU
 aaa
 aaa
 aaa
@@ -69031,21 +66093,21 @@ aDf
 aIp
 aJn
 aKn
-aKZ
-aLY
 aMR
+aLY
+uPG
 aNs
 aOc
 aOW
-aPY
-aQK
+aQa
+oDO
 aQJ
-aSh
+swD
 aTa
-aSh
+swD
 bns
 aTi
-aWz
+jsr
 aXi
 aWW
 aaa
@@ -69098,15 +66160,15 @@ bga
 bga
 bgb
 bga
-bjY
-bka
-bkl
+fZF
+dxI
+jEe
 bqD
 bga
 bga
-bjY
-bka
-bkl
+fZF
+dxI
+jEe
 bga
 bgb
 bga
@@ -69236,11 +66298,11 @@ aaa
 aaa
 aaa
 aaa
-aza
+uiU
 boU
 boX
 boU
-aza
+uiU
 aaa
 aaa
 aaa
@@ -69260,11 +66322,11 @@ aJn
 aKp
 aLa
 aLa
-aKo
+cnU
 aNt
 aOc
 aOX
-aPX
+hPj
 aRv
 aRx
 aSe
@@ -69325,15 +66387,15 @@ bga
 bga
 bgb
 bga
-bjY
-bkb
-bkl
+fZF
+fFS
+jEe
 bga
 bga
 bga
-bjY
-bkb
-bkl
+fZF
+fFS
+jEe
 bga
 bgb
 bga
@@ -69463,11 +66525,11 @@ aaa
 aaa
 aaa
 aaa
-aza
+uiU
 bsg
 boU
 boU
-aza
+uiU
 aaa
 aaa
 aaa
@@ -69491,7 +66553,7 @@ aUP
 bpt
 aOc
 aOY
-aQa
+oBp
 bpu
 aSe
 aSY
@@ -69552,15 +66614,15 @@ bga
 bga
 bgb
 bga
-bjY
-bkb
-bkl
+fZF
+fFS
+jEe
 bga
 bga
 bga
-bjY
-bkb
-bkl
+fZF
+fFS
+jEe
 bga
 bgb
 bga
@@ -69690,11 +66752,11 @@ aaa
 aaa
 aaa
 aaa
-bsf
-bsi
-bsi
-bsi
-bsE
+kao
+rCO
+rCO
+rCO
+urS
 aaa
 aaa
 aaa
@@ -69711,10 +66773,10 @@ aaa
 aGW
 aIq
 aJo
-aKr
-aLc
-aLc
-aMS
+vfi
+drC
+xcM
+rjw
 aNv
 aOc
 aOZ
@@ -69779,15 +66841,15 @@ bga
 bga
 bgb
 bga
-bjY
-bkb
-bkl
+fZF
+fFS
+jEe
 bga
 bga
 bga
-bjY
-bkb
-bkl
+fZF
+fFS
+jEe
 bga
 bgb
 bga
@@ -69941,7 +67003,7 @@ aJp
 aKs
 aIp
 aLZ
-aMT
+mAF
 aNw
 aOc
 aPa
@@ -70006,15 +67068,15 @@ bga
 bga
 bgb
 bga
-bjY
-bkb
-bkl
+fZF
+fFS
+jEe
 bga
 bga
 bga
-bjY
-bkb
-bkl
+fZF
+fFS
+jEe
 bga
 bgb
 bga
@@ -70233,15 +67295,15 @@ bga
 bga
 bgb
 bga
-bjY
-bkb
-bkl
+fZF
+fFS
+jEe
 aUs
 aUs
 aUs
-bjY
-bkb
-bkl
+fZF
+fFS
+jEe
 bga
 bgb
 bga
@@ -70460,15 +67522,15 @@ bga
 bga
 bgb
 bga
-bjY
-bkb
-bkl
+fZF
+fFS
+jEe
 bga
 bga
 bga
-bjY
-bkb
-bkl
+fZF
+fFS
+jEe
 bga
 bgb
 bga
@@ -70687,15 +67749,15 @@ bga
 bga
 bgb
 bga
-bjY
-bkb
-bkl
+fZF
+fFS
+jEe
 bga
 bga
 bga
-bjY
-bkb
-bkl
+fZF
+fFS
+jEe
 bga
 bgb
 bga
@@ -70914,15 +67976,15 @@ bga
 bga
 bgb
 bga
-bjY
-bkb
-bkl
+fZF
+fFS
+jEe
 bga
 bga
 bga
-bjY
-bkb
-bkl
+fZF
+fFS
+jEe
 bga
 bgb
 bga
@@ -71141,15 +68203,15 @@ bga
 bga
 bgb
 bga
-bjY
-bkb
-bkl
+fZF
+fFS
+jEe
 bga
 bga
 bga
-bjY
-bkb
-bkl
+fZF
+fFS
+jEe
 bga
 bgb
 bga
@@ -71368,15 +68430,15 @@ bga
 bga
 bgb
 bga
-bjY
-bkb
-bkl
+fZF
+fFS
+jEe
 aUs
 aUs
 aUs
-bjY
-bkb
-bkl
+fZF
+fFS
+jEe
 bga
 bgb
 bga
@@ -71595,15 +68657,15 @@ bga
 bga
 bgb
 bga
-bjY
-bkb
-bkl
+fZF
+fFS
+jEe
 bga
 bga
 bga
-bjY
-bkb
-bkl
+fZF
+fFS
+jEe
 bga
 bgb
 bga
@@ -71822,15 +68884,15 @@ bga
 bga
 bgb
 bga
-bjY
-bkb
-bkl
+fZF
+fFS
+jEe
 bga
 bga
 bga
-bjY
-bkb
-bkl
+fZF
+fFS
+jEe
 bga
 bgb
 bga
@@ -72049,15 +69111,15 @@ bga
 bga
 bgb
 bga
-bjY
-bkb
-bkl
+fZF
+fFS
+jEe
 bga
 bga
 bga
-bjY
-bkb
-bkl
+fZF
+fFS
+jEe
 bga
 bgb
 bga
@@ -72276,15 +69338,15 @@ bga
 bga
 bgb
 bga
-bjY
-bkb
-bkl
+fZF
+fFS
+jEe
 bga
 bga
 bga
-bjY
-bkb
-bkl
+fZF
+fFS
+jEe
 bga
 bgb
 bga
@@ -72503,15 +69565,15 @@ bga
 aVy
 bgb
 bga
-bjY
-bkb
-bkl
+fZF
+fFS
+jEe
 bga
 bga
 bga
-bjY
-bkb
-bkl
+fZF
+fFS
+jEe
 bga
 bgb
 aXp
@@ -72731,13 +69793,13 @@ bgp
 bgb
 bga
 aVJ
-bkc
-bjN
-bjN
-bkr
-bjN
-bjN
-bjK
+cTL
+rlS
+rlS
+qzK
+rlS
+rlS
+mzE
 beq
 bga
 bgb
@@ -72961,7 +70023,7 @@ bga
 bga
 bga
 bga
-bks
+ugm
 bga
 bga
 bga
@@ -73188,7 +70250,7 @@ bjO
 bjO
 bjO
 bjO
-bkt
+wPs
 bjO
 bjO
 bjO
@@ -73415,7 +70477,7 @@ bif
 bif
 bif
 bif
-bjR
+yfD
 bif
 bif
 bif
@@ -73642,7 +70704,7 @@ bjS
 bjS
 bjS
 bjS
-bkv
+hAU
 bjS
 bjS
 bjS
@@ -73869,7 +70931,7 @@ bif
 bif
 bif
 bif
-bjR
+yfD
 bif
 bif
 bif
@@ -74096,7 +71158,7 @@ bjS
 bjS
 bjS
 bjS
-bkv
+hAU
 bjS
 bjS
 bjS
@@ -74323,7 +71385,7 @@ bjS
 bif
 bif
 bif
-bjR
+yfD
 bif
 bif
 bif
@@ -74550,7 +71612,7 @@ bif
 bif
 bif
 bif
-bjR
+yfD
 bif
 bif
 bif
@@ -74777,7 +71839,7 @@ bif
 bif
 bif
 bjV
-bkx
+bkJ
 bjV
 bif
 bif
@@ -75004,7 +72066,7 @@ bif
 bif
 bjV
 bjV
-bky
+vYk
 beb
 bjV
 bif
@@ -75200,22 +72262,22 @@ aaa
 aaa
 bgb
 bga
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
 aXp
 bga
 bjO
@@ -75231,9 +72293,9 @@ bif
 bjV
 bjV
 bjV
-bkz
-bkp
-bkG
+iHJ
+bjV
+bkH
 bjV
 bif
 bif
@@ -75250,22 +72312,22 @@ bif
 bjO
 bga
 aVy
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
 bga
 bgb
 aaa
@@ -75427,23 +72489,23 @@ aaa
 aaa
 bgb
 aUs
-bgB
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bjH
+bma
+xen
+xen
+xen
+xen
+xen
+xen
+xen
+xen
+xen
+xen
+xen
+xen
+xen
+xen
+eYg
+uHG
 bga
 bjO
 bif
@@ -75456,11 +72518,11 @@ bif
 bif
 beb
 bjV
-bke
-bjZ
-bkn
-bkz
-bkn
+kZu
+vWl
+bjV
+mks
+ebZ
 bjV
 bjV
 bif
@@ -75476,23 +72538,23 @@ bjS
 bif
 bjO
 bga
-blY
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-blZ
+kJy
+xen
+xen
+xen
+xen
+xen
+xen
+xen
+xen
+xen
+xen
+xen
+xen
+xen
+xen
+xen
+rCy
 aUs
 bgb
 aaa
@@ -75654,23 +72716,23 @@ aaa
 aaa
 bgb
 bga
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bjI
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+ugm
 bga
 bjO
 bif
@@ -75682,17 +72744,17 @@ bif
 bif
 bjV
 bjV
-bkd
-bkm
+dqc
+bjV
 bjV
 bif
-bjR
+bif
 bjV
+oes
 bjV
-bjV
-bkJ
-bkh
-bkP
+uby
+mzV
+rvL
 bif
 bif
 bif
@@ -75703,23 +72765,23 @@ bjS
 bif
 bjO
 bga
-bjI
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
+ugm
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
 bga
 bgb
 aaa
@@ -75897,7 +72959,7 @@ bga
 bga
 bga
 bga
-bjI
+ugm
 bga
 bjO
 bif
@@ -75909,17 +72971,17 @@ bif
 bjV
 bjV
 bjV
-bke
-bkn
-bjV
-bjV
-bjR
+gdQ
+kZu
+rdl
+qyt
 bif
+bif
+oFX
 bjV
-bjV
-bkK
-bjR
-bqB
+vYk
+bif
+bAQ
 bif
 bjS
 bjS
@@ -75930,7 +72992,7 @@ bjS
 bif
 bjO
 bga
-bjI
+ugm
 bga
 bga
 bga
@@ -76124,40 +73186,40 @@ bga
 bga
 bga
 bga
-bjJ
-bjN
-bjP
-bjG
-bjT
-bjG
-bjT
-bjG
-bjG
+eaS
+rlS
+mlv
+mzV
+dyi
+mzV
+dyi
+mzV
+mzV
 bjW
-bjX
-bjZ
-bkf
+bkK
+wgs
+ssU
 bko
 bif
 bsV
-bjU
-bjG
-bpC
-bjZ
-bkn
-btW
-bjT
-btX
-bjT
-bjT
-bjT
-bjT
-bjT
-bjT
+bif
+bif
+beb
+kUT
+xJQ
 btY
-bjN
-bjN
-blZ
+dYm
+btX
+dyi
+dyi
+dyi
+dyi
+dyi
+dyi
+quR
+rlS
+rlS
+iXx
 bga
 bga
 bga
@@ -76351,7 +73413,7 @@ bga
 bga
 bga
 bga
-bjI
+ugm
 bga
 bjO
 bif
@@ -76363,13 +73425,13 @@ bif
 bjV
 bjV
 bjV
-bkg
-bkp
-bjV
-bjV
-bjR
+oes
+mks
+rdl
+xJQ
 bif
-bjV
+bif
+waK
 bjV
 bjV
 bif
@@ -76384,7 +73446,7 @@ bjS
 bif
 bjO
 bga
-bjI
+ugm
 bga
 bga
 bga
@@ -76562,23 +73624,23 @@ aaa
 aaa
 bgb
 bga
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bjI
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+ugm
 bga
 bjO
 bif
@@ -76590,13 +73652,13 @@ bif
 bif
 bjV
 bjV
-bkd
-bkq
+rqE
+bjV
 bjV
 bif
-bjR
+bif
 bjV
-bjV
+gdQ
 bjV
 bkL
 bif
@@ -76611,23 +73673,23 @@ bjS
 bif
 bjO
 bga
-bjI
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
-bgA
+ugm
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
 bga
 bgb
 aaa
@@ -76789,23 +73851,23 @@ aaa
 aaa
 bgb
 aUs
-bgB
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bjK
+bma
+xen
+xen
+xen
+xen
+xen
+xen
+xen
+xen
+xen
+xen
+xen
+xen
+xen
+xen
+eYg
+mzE
 bga
 bjO
 bif
@@ -76818,11 +73880,11 @@ bif
 bif
 beb
 bjV
-bkg
-bjZ
-bkp
-bkB
-bkp
+mks
+ebZ
+bjV
+kZu
+vWl
 bjV
 bjV
 bif
@@ -76838,23 +73900,23 @@ bjS
 bif
 bjO
 bga
-bma
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
-bgN
+cTL
+xen
+xen
+xen
+xen
+xen
+xen
+xen
+xen
+xen
+xen
+xen
+xen
+xen
+xen
 bmO
-blZ
+rCy
 aUs
 bgb
 aaa
@@ -77016,22 +74078,22 @@ aaa
 aaa
 bgb
 bga
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
 beq
 bga
 bjO
@@ -77047,8 +74109,8 @@ bif
 bjV
 bjV
 bjV
-bkB
-bkn
+eUg
+bjV
 bkH
 bjV
 bif
@@ -77066,22 +74128,22 @@ bif
 bjO
 bga
 aVJ
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
-bgC
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
+cvJ
 bga
 bgb
 aaa
@@ -77274,7 +74336,7 @@ bif
 bif
 bjV
 bjV
-bkC
+vyl
 beb
 bjV
 bif
@@ -77728,7 +74790,7 @@ bif
 bif
 bif
 bif
-bjR
+yfD
 bif
 bif
 bif
@@ -77955,7 +75017,7 @@ bjS
 bif
 bif
 bif
-bjR
+yfD
 bif
 bif
 bif
@@ -78182,7 +75244,7 @@ bjS
 bjS
 bjS
 bjS
-bkv
+hAU
 bjS
 bjS
 bjS
@@ -78409,7 +75471,7 @@ bif
 bif
 bif
 bif
-bjR
+yfD
 bif
 bif
 bif
@@ -78636,7 +75698,7 @@ bjS
 bjS
 bjS
 bjS
-bkv
+hAU
 bjS
 bjS
 bjS
@@ -78863,7 +75925,7 @@ bif
 bif
 bif
 bif
-bjR
+yfD
 bif
 bif
 bif
@@ -79090,7 +76152,7 @@ bjO
 bjO
 bjO
 bjO
-bkt
+wPs
 bjO
 bjO
 bjO
@@ -79317,7 +76379,7 @@ bga
 bga
 bga
 bga
-bks
+ugm
 bga
 bga
 bga
@@ -79541,13 +76603,13 @@ bgp
 bgb
 bga
 aVy
-bkj
-bjN
-bjN
-bkE
-bjN
-bjN
-bkI
+kJy
+rlS
+rlS
+fMg
+rlS
+rlS
+uHG
 aXp
 bga
 bgb
@@ -79767,15 +76829,15 @@ bga
 aVJ
 bgb
 bga
-bjY
-bkb
-bkl
+fZF
+gAL
+jEe
 bga
 bga
 bga
-bjY
-bkb
-bkl
+fZF
+gAL
+jEe
 bga
 bgb
 beq
@@ -79994,15 +77056,15 @@ bga
 bga
 bgb
 bga
-bjY
-bkb
-bkl
+fZF
+gAL
+jEe
 bga
 bga
 bga
-bjY
-bkb
-bkl
+fZF
+gAL
+jEe
 bga
 bgb
 bga
@@ -80221,15 +77283,15 @@ bga
 bga
 bgb
 bga
-bjY
-bkb
-bkl
+fZF
+gAL
+jEe
 bga
 bga
 bga
-bjY
-bkb
-bkl
+fZF
+gAL
+jEe
 bga
 bgb
 bga
@@ -80448,15 +77510,15 @@ bga
 bga
 bgb
 bga
-bjY
-bkb
-bkl
+fZF
+gAL
+jEe
 bga
 bga
 bga
-bjY
-bkb
-bkl
+fZF
+gAL
+jEe
 bga
 bgb
 bga
@@ -80675,15 +77737,15 @@ bga
 bga
 bgb
 bga
-bjY
-bkb
-bkl
+fZF
+gAL
+jEe
 bga
 bga
 bga
-bjY
-bkb
-bkl
+fZF
+gAL
+jEe
 bga
 bgb
 bga
@@ -80902,15 +77964,15 @@ bga
 bga
 bgb
 bga
-bjY
-bkb
-bkl
+fZF
+gAL
+jEe
 aUs
 aUs
 aUs
-bjY
-bkb
-bkl
+fZF
+gAL
+jEe
 bga
 bgb
 bga
@@ -81129,15 +78191,15 @@ bga
 bga
 bgb
 bga
-bjY
-bkb
-bkl
+fZF
+gAL
+jEe
 bga
 bga
 bga
-bjY
-bkb
-bkl
+fZF
+gAL
+jEe
 bga
 bgb
 bga
@@ -81356,15 +78418,15 @@ bga
 bga
 bgb
 bga
-bjY
-bkb
-bkl
+fZF
+gAL
+jEe
 bga
 bga
 bga
-bjY
-bkb
-bkl
+fZF
+gAL
+jEe
 bga
 bgb
 bga
@@ -81583,15 +78645,15 @@ bga
 bga
 bgb
 bga
-bjY
-bkb
-bkl
+fZF
+gAL
+jEe
 bga
 bga
 bga
-bjY
-bkb
-bkl
+fZF
+gAL
+jEe
 bga
 bgb
 bga
@@ -81810,15 +78872,15 @@ bga
 bga
 bgb
 bga
-bjY
-bkb
-bkl
+fZF
+gAL
+jEe
 bga
 bga
 bga
-bjY
-bkb
-bkl
+fZF
+gAL
+jEe
 bga
 bgb
 bga
@@ -82037,15 +79099,15 @@ bga
 bga
 bgb
 bga
-bjY
-bkb
-bkl
+fZF
+gAL
+jEe
 aUs
 aUs
 aUs
-bjY
-bkb
-bkl
+fZF
+gAL
+jEe
 bga
 bgb
 bga
@@ -82264,15 +79326,15 @@ bga
 bga
 bgb
 bga
-bjY
-bkb
-bkl
+fZF
+gAL
+jEe
 bga
 bga
 bga
-bjY
-bkb
-bkl
+fZF
+gAL
+jEe
 bga
 bgb
 bga
@@ -82491,15 +79553,15 @@ bga
 bga
 bgb
 bga
-bjY
-bkb
-bkl
+fZF
+gAL
+jEe
 bga
 bga
 bga
-bjY
-bkb
-bkl
+fZF
+gAL
+jEe
 bga
 bgb
 bga
@@ -82718,15 +79780,15 @@ bga
 bga
 bgb
 bga
-bjY
-bkb
-bkl
+fZF
+gAL
+jEe
 bga
 bga
 bga
-bjY
-bkb
-bkl
+fZF
+gAL
+jEe
 bga
 bgb
 bga
@@ -82945,15 +80007,15 @@ bga
 bga
 bgb
 bga
-bjY
-bkb
-bkl
+fZF
+gAL
+jEe
 bga
 bga
 bga
-bjY
-bkb
-bkl
+fZF
+gAL
+jEe
 bga
 bgb
 bga
@@ -83172,15 +80234,15 @@ bga
 bga
 bgb
 bga
-bjY
+fZF
 bkk
-bkl
+jEe
 bqD
 bga
 bga
-bjY
-bkE
-bkl
+fZF
+nvi
+jEe
 bga
 bgb
 bga

--- a/maps/unused/mushroom_new_walls.dmm
+++ b/maps/unused/mushroom_new_walls.dmm
@@ -14854,15 +14854,16 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/pyro/external{
 	autoclose = 0;
 	density = 0;
+	dir = 4;
 	frequency = 1449;
-	icon_state = "door_open";
+	icon_state = "airlock_open";
 	id_tag = "dc_hydro_door";
 	locked = 1;
 	name = "Grove Module Airlock";
-	opacity = 0
+	opacity = 1
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/hydroponics)
@@ -15081,15 +15082,16 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/pyro/external{
 	autoclose = 0;
 	density = 0;
+	dir = 4;
 	frequency = 1449;
-	icon_state = "door_open";
+	icon_state = "airlock_open";
 	id_tag = "dc_hydro_door";
 	locked = 1;
 	name = "Grove Module Airlock";
-	opacity = 0
+	opacity = 1
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/hydroponics/lobby)
@@ -33687,6 +33689,15 @@
 /obj/access_spawn/ai_upload,
 /turf/simulated/floor/black/side,
 /area/station/turret_protected/ai)
+"kSN" = (
+/obj/machinery/computer/riotgear{
+	dir = 8;
+	pixel_x = 32
+	},
+/turf/simulated/floor/red/side{
+	dir = 4
+	},
+/area/station/security/brig)
 "uJW" = (
 /obj/cable{
 	d1 = 4;
@@ -60642,7 +60653,7 @@ bnI
 beV
 bfj
 bfj
-bfj
+kSN
 btf
 bpn
 bcS

--- a/maps/unused/mushroom_new_walls.dmm
+++ b/maps/unused/mushroom_new_walls.dmm
@@ -22314,10 +22314,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/unpowered/wood{
+/obj/machinery/door/unpowered/wood/pyro{
+	dir = 4;
 	name = "The Snip"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/wood/two,
 /area/station/crew_quarters/barber_shop)
 "aVo" = (
 /obj/cable{
@@ -22341,11 +22342,14 @@
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/barber_shop)
 "aVq" = (
-/obj/machinery/door/unpowered/wood,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/door/unpowered/wood/pyro{
+	dir = 4;
+	name = "The Snip"
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/barber_shop)
@@ -22618,10 +22622,11 @@
 	},
 /area/station/crew_quarters/bar)
 "aWc" = (
-/obj/machinery/door/unpowered/wood{
+/obj/machinery/door/unpowered/wood/pyro{
+	dir = 4;
 	name = "The Snip"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/wood/two,
 /area/station/crew_quarters/barber_shop)
 "aWd" = (
 /turf/simulated/floor/wood/two,
@@ -33403,7 +33408,7 @@
 	icon_state = "intact";
 	tag = "icon-intact (EAST)"
 	},
-/obj/wingrille_spawn/crystal/full,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage/secure{
 	name = "Mixing Room"
@@ -33426,11 +33431,11 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/heads)
 "btw" = (
-/obj/wingrille_spawn/crystal/full,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/bar)
 "btx" = (
-/obj/wingrille_spawn/crystal/full,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "bty" = (

--- a/maps/unused/mushroom_new_walls.dmm
+++ b/maps/unused/mushroom_new_walls.dmm
@@ -2535,7 +2535,8 @@
 "afx" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance{
-	name = "Cargo Maintenance"
+	name = "Cargo Maintenance";
+	req_access = null
 	},
 /obj/access_spawn/cargo,
 /turf/simulated/floor/plating,
@@ -5032,7 +5033,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro/maintenance,
+/obj/machinery/door/airlock/pyro/maintenance{
+	req_access = null
+	},
 /obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
@@ -5999,7 +6002,8 @@
 "amX" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance{
-	name = "Cargo Maintenance"
+	name = "Cargo Maintenance";
+	req_access = null
 	},
 /obj/access_spawn/cargo,
 /turf/simulated/floor/plating,
@@ -14212,8 +14216,8 @@
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
-	icon_state = "maint_closed";
-	name = "Robotics Storage"
+	name = "Robotics Storage";
+	req_access = null
 	},
 /obj/access_spawn/robotics,
 /turf/simulated/floor,
@@ -14614,10 +14618,10 @@
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
-	icon_state = "maint_closed";
-	name = "Med-Sci Maintenance"
+	name = "Med-Sci Maintenance";
+	req_access = null
 	},
-/obj/access_spawn/morgue,
+/obj/access_spawn/medlab,
 /turf/simulated/floor/black,
 /area/station/medical/research)
 "aFX" = (
@@ -15636,7 +15640,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/maintenance{
-	name = "Engineering Maintenance"
+	name = "Engineering Maintenance";
+	req_access = null
 	},
 /obj/access_spawn/engineering,
 /turf/simulated/floor/plating,
@@ -16135,7 +16140,8 @@
 "aIP" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance{
-	name = "Med-Sci Maintenance"
+	name = "Med-Sci Maintenance";
+	req_access = null
 	},
 /obj/access_spawn/medlab,
 /turf/simulated/floor/plating,
@@ -18225,8 +18231,8 @@
 	},
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
-	icon_state = "com_closed";
-	name = "Cheif Engineer"
+	name = "Cheif Engineer";
+	req_access = null
 	},
 /obj/access_spawn/engineering_chief,
 /turf/simulated/floor,
@@ -19049,7 +19055,8 @@
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance{
-	name = "Engineering Maintenance"
+	name = "Engineering Maintenance";
+	req_access = null
 	},
 /obj/access_spawn/engineering,
 /turf/simulated/floor/plating,
@@ -19865,7 +19872,8 @@
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance{
-	name = "Botany Maintenance"
+	name = "Botany Maintenance";
+	req_access = null
 	},
 /obj/access_spawn/hydro,
 /turf/simulated/floor/plating,
@@ -20888,8 +20896,8 @@
 	},
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
-	icon_state = "eng_closed";
-	name = "Mining"
+	name = "Mining";
+	req_access = null
 	},
 /obj/access_spawn/mining,
 /turf/simulated/floor,
@@ -21304,8 +21312,8 @@
 	},
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
-	icon_state = "eng_closed";
-	name = "Mining"
+	name = "Mining";
+	req_access = null
 	},
 /obj/access_spawn/mining,
 /turf/simulated/floor,

--- a/maps/unused/mushroom_new_walls.dmm
+++ b/maps/unused/mushroom_new_walls.dmm
@@ -950,23 +950,19 @@
 /turf/simulated/floor/plating/airless,
 /area/station/solar/west)
 "acJ" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/cryotron{
+	layer = 3.9
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/westsolar)
+/obj/machinery/light/incandescent/netural{
+	dir = 1
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
 "acK" = (
 /obj/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
@@ -3092,12 +3088,7 @@
 /turf/simulated/floor/orangeblack,
 /area/station/quartermaster/office)
 "ahn" = (
-/obj/cryotron{
-	layer = 3.9
-	},
-/obj/machinery/light/incandescent/netural{
-	dir = 1
-	},
+/turf/space,
 /turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "aho" = (
@@ -4570,6 +4561,10 @@
 	},
 /obj/cable,
 /obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "akI" = (
@@ -4577,6 +4572,11 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
@@ -4606,6 +4606,10 @@
 "akL" = (
 /obj/cable,
 /obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/quartermaster)
 "akM" = (
@@ -6125,9 +6129,7 @@
 	icon_state = "0-8"
 	},
 /obj/wingrille_spawn/auto/crystal,
-/turf/simulated/floor/red/side{
-	dir = 1
-	},
+/turf/simulated/floor/plating,
 /area/station/security/brig)
 "anI" = (
 /obj/stool,
@@ -6224,6 +6226,11 @@
 /obj/machinery/light/small{
 	brightness = 2;
 	dir = 4
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
@@ -10273,25 +10280,14 @@
 /turf/simulated/floor/plating,
 /area/station/medical/research)
 "awU" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "1"
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/grass,
-/area/station/medical/research)
+/area/shuttle/arrival/station)
 "awV" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/grass,
-/area/station/medical/research)
+/obj/machinery/computer/arcade,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
 "awW" = (
 /obj/cable,
 /obj/machinery/power/data_terminal,
@@ -10460,7 +10456,8 @@
 /turf/simulated/floor/blueblack/corner,
 /area/station/medical/robotics)
 "axw" = (
-/turf/space,
+/obj/table/reinforced/auto,
+/obj/item/storage/firstaid/regular,
 /turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "axx" = (
@@ -11563,6 +11560,11 @@
 	icon_state = "0-8"
 	},
 /obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4";
+	pixel_y = 0
+	},
 /turf/simulated/floor/plating/airless,
 /area/station/maintenance/east)
 "azT" = (
@@ -11981,6 +11983,9 @@
 /area)
 "aAP" = (
 /obj/storage/secure/closet/engineering/welding,
+/obj/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "aAQ" = (
@@ -12665,6 +12670,11 @@
 /obj/item/storage/goodybag,
 /obj/item/peripheral/videocard,
 /obj/item/storage/pill_bottle/cyberpunk,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating/scorched,
 /area/station/maintenance/west)
 "aCp" = (
@@ -17974,11 +17984,6 @@
 /area/station/maintenance/SEmaint)
 "aNn" = (
 /obj/firedoor_spawn,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
 	name = "Cheif Engineer";
@@ -18656,6 +18661,7 @@
 	icon_state = "0-8"
 	},
 /obj/wingrille_spawn/auto,
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/bar)
 "aOC" = (
@@ -21609,9 +21615,16 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "aUu" = (
-/turf/simulated/wall/auto/shuttle{
-	icon_state = "1"
+/obj/table/reinforced/auto,
+/obj/item/device/radio{
+	pixel_x = -3;
+	pixel_y = 4
 	},
+/obj/item/device/radio{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "aUv" = (
 /obj/machinery/light{
@@ -25626,6 +25639,11 @@
 /area/station/security/brig)
 "bdk" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "bdl" = (
@@ -25686,7 +25704,7 @@
 	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto/crystal,
-/turf/simulated/floor/red/side,
+/turf/simulated/floor/plating,
 /area/station/security/brig)
 "bdr" = (
 /obj/cable{
@@ -25959,6 +25977,11 @@
 	name = "Cell #1"
 	},
 /obj/access_spawn/brig,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/security/brig)
 "bdU" = (
@@ -26299,6 +26322,16 @@
 /area/station/hallway/primary/west)
 "beF" = (
 /obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4";
+	pixel_y = 0
+	},
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "beG" = (
@@ -26353,7 +26386,8 @@
 	pixel_y = 0
 	},
 /obj/wingrille_spawn/auto/crystal,
-/turf/simulated/floor/red/side,
+/obj/cable,
+/turf/simulated/floor/plating,
 /area/station/security/brig)
 "beM" = (
 /obj/cable,
@@ -26790,9 +26824,9 @@
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "bfE" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor,
-/area/station/mining/magnet)
+/obj/storage/closet/emergency,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
 "bfF" = (
 /obj/random_item_spawner/desk_stuff,
 /obj/table/glass/auto,
@@ -27040,6 +27074,7 @@
 	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "bgh" = (
@@ -31137,6 +31172,10 @@
 	icon_state = "0-8"
 	},
 /obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "boQ" = (
@@ -32305,9 +32344,12 @@
 /turf/simulated/floor/plating,
 /area/station/medical/research)
 "brB" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/black,
-/area/station/medical/research)
+/obj/storage/closet/emergency,
+/obj/machinery/light/incandescent/netural{
+	dir = 1
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
 "brC" = (
 /obj/machinery/light,
 /turf/simulated/floor/purple,
@@ -32348,7 +32390,11 @@
 /area/station/security/armory)
 "brH" = (
 /obj/wingrille_spawn/auto,
-/turf/simulated/floor,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
 /area/station/engine/engineering)
 "brI" = (
 /obj/machinery/neosmelter,
@@ -32527,7 +32573,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/grass,
+/turf/simulated/floor/plating,
 /area/station/medical/research)
 "bsg" = (
 /obj/overlay{
@@ -32562,7 +32608,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/grass,
+/turf/simulated/floor/plating,
 /area/station/medical/research)
 "bsj" = (
 /obj/grille/catwalk{
@@ -32761,7 +32807,7 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/grass,
+/turf/simulated/floor/plating,
 /area/station/medical/research)
 "bsF" = (
 /obj/landmark{
@@ -33410,173 +33456,64 @@
 /obj/access_spawn/ai_upload,
 /turf/simulated/floor/black/side,
 /area/station/turret_protected/ai)
-"bOS" = (
-/turf/simulated/floor/engine,
+"bDG" = (
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	name = "Pod Bay"
+	},
+/obj/machinery/secscanner{
+	dir = 4;
+	icon_state = "scanner_on";
+	pixel_x = -20
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
 /area/station/hangar/main)
-"ctx" = (
-/turf/simulated/shuttle/wall/corner{
-	dir = 4
+"crI" = (
+/obj/landmark{
+	name = "Observer-Start"
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
+"cKf" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "2"
 	},
 /area/shuttle/arrival/station)
-"dic" = (
-/obj/machinery/camera{
-	c_tag = "Escape Shuttle Dock"
+"cTH" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "4"
 	},
-/obj/machinery/light/emergency{
-	dir = 1;
-	icon_state = "ebulb1"
-	},
-/turf/simulated/floor/escape{
-	dir = 1
-	},
-/area/station/hallway/secondary/exit)
-"diB" = (
+/area/shuttle/arrival/station)
+"dlG" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hangar/main)
-"djX" = (
-/obj/machinery/r_door_control{
-	id = "hangar_arrivals"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/hangar/main)
-"dtV" = (
-/obj/storage/closet/wardrobe/mixed,
-/obj/random_item_spawner/dressup/one_or_zero,
-/obj/machinery/light/incandescent/netural,
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"dGY" = (
+"doP" = (
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 8
-	},
-/area/station/hangar/main)
-"ecE" = (
 /obj/cable{
-	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "0-8"
 	},
-/turf/simulated/floor,
-/area/station/hangar/main)
-"epj" = (
-/obj/machinery/light,
-/turf/simulated/floor/engine,
-/area/station/hangar/main)
-"esU" = (
-/obj/storage/closet/emergency,
-/obj/machinery/light/incandescent/netural,
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"eyu" = (
-/obj/machinery/light{
-	dir = 1;
-	name = "light fixture";
-	pixel_y = 21;
-	rigged = 0
-	},
-/turf/simulated/floor/escape{
-	dir = 1
-	},
-/area/station/hallway/secondary/exit)
-"eOZ" = (
+/turf/simulated/floor/plating,
+/area/station/engine/engineering)
+"dEm" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/machinery/shuttle/engine/heater{
 	dir = 8;
-	icon_state = "alt_heater-R"
+	icon_state = "alt_heater-L"
 	},
 /turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
-"eZI" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	layer = 9.1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/escape{
-	dir = 9
-	},
-/area/station/hallway/secondary/exit)
-"fgT" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/hallway/secondary/entry)
-"ftA" = (
-/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/arrivals_horizontal{
-	dir = 4
-	},
-/turf/simulated/floor/engine,
-/area/station/hangar/main)
-"ftH" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/hangar/main)
-"fzE" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	layer = 9.1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/arrival{
-	dir = 10
-	},
-/area/station/hallway/secondary/entry)
-"fKD" = (
-/obj/storage/closet/welding_supply,
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	layer = 9.1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 9
-	},
-/area/station/hangar/main)
-"fUf" = (
-/obj/indestructible/shuttle_corner{
-	dir = 8
-	},
-/turf/simulated/shuttle/wall/corner{
-	dir = 4
-	},
-/area/shuttle/arrival/station)
-"gAo" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/hallway/secondary/exit)
-"gQo" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
-"hkT" = (
-/turf/simulated/wall/auto/shuttle{
-	icon_state = "8"
-	},
-/area/shuttle/arrival/station)
-"hxB" = (
-/obj/shrub,
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
-"hKt" = (
+"dRv" = (
 /obj/machinery/computer/riotgear{
 	dir = 8;
 	pixel_x = 32
@@ -33585,31 +33522,49 @@
 	dir = 4
 	},
 /area/station/security/brig)
-"jlZ" = (
-/obj/machinery/computer/mining_shuttle{
-	dir = 4
+"dVg" = (
+/obj/machinery/camera{
+	c_tag = "Escape Shuttle Dock"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/escape{
+	dir = 1
+	},
 /area/station/hallway/secondary/exit)
-"jSH" = (
-/obj/firedoor_spawn,
-/obj/machinery/door/airlock/pyro/external,
-/turf/simulated/floor/caution/northsouth,
-/area/station/hallway/secondary/exit)
-"kLb" = (
+"dVq" = (
 /obj/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor,
-/area/station/hangar/main)
-"kRF" = (
-/turf/simulated/wall/auto/shuttle{
-	icon_state = "2"
+/area/station/hallway/secondary/exit)
+"edh" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater-M"
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
+"eiT" = (
+/turf/simulated/shuttle/wall/corner{
+	dir = 1
 	},
 /area/shuttle/arrival/station)
-"kTd" = (
+"eoJ" = (
+/obj/storage/closet/emergency,
+/obj/machinery/light/incandescent/netural,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
+"eoM" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater-R"
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
+"eGe" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/light{
 	dir = 4;
@@ -33621,32 +33576,398 @@
 	dir = 5
 	},
 /area/station/hangar/main)
-"kVF" = (
-/obj/storage/closet/emergency,
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"ljX" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/hangar/main)
-"lkX" = (
+"eIb" = (
 /turf/simulated/wall/auto/shuttle{
-	icon_state = "4"
+	icon_state = "3"
 	},
 /area/shuttle/arrival/station)
-"loM" = (
+"eUm" = (
+/turf/simulated/floor/engine,
+/area/station/hangar/main)
+"faB" = (
+/turf/simulated/wall/auto/supernorn,
+/area/station/hallway/secondary/exit)
+"fYD" = (
+/obj/machinery/light/emergency{
+	dir = 1;
+	icon_state = "ebulb1"
+	},
+/obj/table/auto,
+/obj/machinery/shieldgenerator/meteorshield,
+/turf/simulated/floor/escape{
+	dir = 5
+	},
+/area/station/hallway/secondary/exit)
+"gjD" = (
+/turf/simulated/wall/auto/supernorn,
+/area/station/hangar/main)
+"gOt" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/engineering)
+"gYQ" = (
+/obj/decal/poster/wallsign/escape,
+/turf/simulated/wall/auto/supernorn,
+/area/station/hallway/secondary/exit)
+"hfV" = (
+/obj/lattice{
+	dir = 5;
+	icon_state = "lattice-dir"
+	},
+/obj/warp_beacon{
+	name = "Hangar Beacon"
+	},
+/turf/space,
+/area)
+"hKB" = (
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/arrival{
+	dir = 10
+	},
+/area/station/hallway/secondary/entry)
+"ioE" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "qmout"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/caution/northsouth,
+/area/station/quartermaster/office)
+"ixI" = (
+/obj/machinery/light/emergency{
+	dir = 8;
+	icon_state = "ebulb1";
+	pixel_x = -16
+	},
+/obj/decal/tile_edge/stripe/big{
+	dir = 1;
+	icon_state = "xtra_bigstripe-edge"
+	},
+/turf/simulated/floor/engine,
+/area/station/hangar/main)
+"iyS" = (
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/escape{
+	dir = 1
+	},
+/area/station/hallway/secondary/exit)
+"jpv" = (
 /obj/machinery/vehicle/miniputt/armed,
 /turf/simulated/floor/engine,
 /area/station/hangar/main)
-"lxX" = (
-/obj/machinery/vehicle/pod_smooth/light,
+"jAM" = (
+/obj/cable,
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/hydroponics)
+"jDr" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/engineering)
+"jGu" = (
+/obj/machinery/r_door_control{
+	id = "hangar_arrivals"
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/hangar/main)
+"jIj" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/hangar/main)
+"jKR" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/orangeblack/side{
+	dir = 8
+	},
+/area/station/hangar/main)
+"jMS" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/quartermaster/office)
+"jYd" = (
+/obj/decal/tile_edge/stripe/big{
+	dir = 1;
+	icon_state = "xtra_bigstripe-edge"
+	},
 /turf/simulated/floor/engine,
 /area/station/hangar/main)
-"lzK" = (
+"kbh" = (
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/escape{
+	dir = 9
+	},
+/area/station/hallway/secondary/exit)
+"knq" = (
+/obj/machinery/light/emergency{
+	dir = 4;
+	icon_state = "ebulb1";
+	pixel_x = 16
+	},
+/obj/decal/tile_edge/stripe/big{
+	dir = 1;
+	icon_state = "xtra_bigstripe-edge"
+	},
+/turf/simulated/floor/engine,
+/area/station/hangar/main)
+"koq" = (
+/obj/grille,
+/turf/simulated/floor/plating/airless,
+/area)
+"kFX" = (
+/turf/simulated/floor,
+/area/station/hangar/main)
+"kHs" = (
+/obj/storage/closet/wardrobe/mixed,
+/obj/random_item_spawner/dressup/one_or_zero,
+/obj/machinery/light/incandescent/netural,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
+"kMX" = (
+/turf/simulated/shuttle/wall/corner{
+	dir = 4
+	},
+/area/shuttle/arrival/station)
+"kNi" = (
+/turf/simulated/floor/escape{
+	dir = 5
+	},
+/area/station/hallway/secondary/exit)
+"kPL" = (
+/turf/simulated/shuttle/wall/cockpit,
+/area/shuttle/arrival/station)
+"lFp" = (
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig)
+"lHG" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"lKO" = (
+/obj/storage/closet/wardrobe/mixed,
+/obj/random_item_spawner/dressup/one_or_zero,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
+"mwI" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "8"
+	},
+/area/shuttle/arrival/station)
+"mHo" = (
+/obj/cable,
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/quartermaster/office)
+"mJu" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/engineering)
+"npP" = (
+/obj/grille,
+/turf/simulated/floor/plating/airless,
+/area/station/com_dish/auxdish)
+"nzu" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/engineering)
+"nFY" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"nNR" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hangar/main)
+"ohn" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
+"oGB" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
+"oPn" = (
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/external,
+/turf/simulated/floor/escape{
+	dir = 1
+	},
+/area/station/hallway/secondary/exit)
+"oXE" = (
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4";
+	pixel_y = 0
+	},
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/quartermaster/office)
+"pdx" = (
+/turf/simulated/floor/orangeblack/side{
+	dir = 1
+	},
+/area/station/hangar/main)
+"pfN" = (
+/obj/submachine/cargopad/podbay,
+/turf/simulated/floor/orangeblack/side{
+	dir = 4
+	},
+/area/station/hangar/main)
+"puW" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=crewhall";
+	location = "escape"
+	},
+/obj/stool/bench/red/auto,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"pwm" = (
 /turf/simulated/floor/orangeblack/side{
 	dir = 9
 	},
 /area/station/hangar/main)
-"lGr" = (
+"pyH" = (
+/obj/machinery/door_control{
+	id = "hangar_arrivals";
+	name = "Pod Door Control";
+	pixel_x = 24
+	},
+/turf/simulated/floor/orangeblack/side{
+	dir = 4
+	},
+/area/station/hangar/main)
+"qfM" = (
+/turf/simulated/floor/orangeblack/corner{
+	dir = 1
+	},
+/area/station/hangar/main)
+"qYM" = (
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/shuttle,
+/area/shuttle/arrival/station)
+"rkJ" = (
+/obj/indestructible/shuttle_corner{
+	dir = 4
+	},
+/turf/space,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
+"rwY" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/toolbox/electrical{
 	pixel_y = -3
@@ -33660,175 +33981,7 @@
 	dir = 1
 	},
 /area/station/hangar/main)
-"lHJ" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=crewhall";
-	location = "escape"
-	},
-/obj/stool/bench/red/auto,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
-"lIn" = (
-/turf/simulated/floor/orangeblack/corner{
-	dir = 1
-	},
-/area/station/hangar/main)
-"meL" = (
-/obj/landmark{
-	name = "Observer-Start"
-	},
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"mfr" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/shuttle/engine/heater{
-	dir = 8;
-	icon_state = "alt_heater-L"
-	},
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"mnq" = (
-/obj/grille,
-/turf/simulated/floor/plating/airless,
-/area)
-"mIg" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
-"nbH" = (
-/obj/machinery/light/emergency{
-	dir = 4;
-	icon_state = "ebulb1";
-	pixel_x = 16
-	},
-/obj/decal/tile_edge/stripe/big{
-	dir = 1;
-	icon_state = "xtra_bigstripe-edge"
-	},
-/turf/simulated/floor/engine,
-/area/station/hangar/main)
-"nir" = (
-/obj/indestructible/shuttle_corner,
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"nln" = (
-/turf/simulated/floor/arrival{
-	dir = 5
-	},
-/area/station/hallway/secondary/entry)
-"nrV" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	layer = 9.1;
-	pixel_x = 10
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
-"nwF" = (
-/obj/storage/closet/wardrobe/mixed,
-/obj/random_item_spawner/dressup/one_or_zero,
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"oez" = (
-/obj/machinery/manufacturer/hangar,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13"
-	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 1
-	},
-/area/station/hangar/main)
-"ofi" = (
-/obj/decal/poster/wallsign/escape,
-/turf/simulated/wall/auto/supernorn,
-/area/station/hallway/secondary/exit)
-"ogN" = (
-/obj/machinery/light/emergency{
-	dir = 8;
-	icon_state = "ebulb1";
-	pixel_x = -16
-	},
-/obj/decal/tile_edge/stripe/big{
-	dir = 1;
-	icon_state = "xtra_bigstripe-edge"
-	},
-/turf/simulated/floor/engine,
-/area/station/hangar/main)
-"okT" = (
-/turf/simulated/floor,
-/area/station/hangar/main)
-"oFx" = (
-/obj/storage/closet/emergency,
-/obj/machinery/light/incandescent/netural{
-	dir = 1
-	},
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"peF" = (
-/obj/submachine/cargopad/podbay,
-/turf/simulated/floor/orangeblack/side{
-	dir = 4
-	},
-/area/station/hangar/main)
-"pnW" = (
-/turf/simulated/shuttle/wall/cockpit,
-/area/shuttle/arrival/station)
-"pBN" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	layer = 9.1;
-	pixel_x = 10
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
-"pNZ" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/shuttle/engine/heater{
-	dir = 8;
-	icon_state = "alt_heater-M"
-	},
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"pRW" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
-"qyL" = (
-/obj/lattice{
-	dir = 5;
-	icon_state = "lattice-dir"
-	},
-/obj/warp_beacon{
-	name = "Hangar Beacon"
-	},
-/turf/space,
-/area)
-"qKD" = (
-/turf/simulated/wall/auto/shuttle{
-	icon_state = "3"
-	},
-/area/shuttle/arrival/station)
-"ryg" = (
-/turf/simulated/floor/orangeblack/side{
-	dir = 1
-	},
-/area/station/hangar/main)
-"stv" = (
+"rBk" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Pod Bay"
@@ -33840,54 +33993,64 @@
 	},
 /turf/simulated/floor,
 /area/station/hangar/main)
-"tgv" = (
-/obj/machinery/door_control{
-	id = "hangar_arrivals";
-	name = "Pod Door Control";
-	pixel_x = 24
-	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 4
-	},
+"rCc" = (
+/obj/machinery/vehicle/pod_smooth/light,
+/turf/simulated/floor/engine,
 /area/station/hangar/main)
-"tAB" = (
-/obj/table/reinforced/auto,
-/obj/item/storage/firstaid/regular,
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"tRe" = (
-/obj/machinery/light/emergency{
-	dir = 1;
-	icon_state = "ebulb1"
-	},
-/obj/table/auto,
-/obj/machinery/shieldgenerator/meteorshield,
-/turf/simulated/floor/escape{
-	dir = 5
-	},
-/area/station/hallway/secondary/exit)
-"tYo" = (
-/obj/machinery/power/apc/autoname_north,
+"rOd" = (
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4";
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig)
+"rXY" = (
+/obj/machinery/light,
+/turf/simulated/floor/engine,
+/area/station/hangar/main)
+"tgU" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"tlJ" = (
+/obj/machinery/light{
+	dir = 1;
+	name = "light fixture";
+	pixel_y = 21;
+	rigged = 0
 	},
 /turf/simulated/floor/escape{
 	dir = 1
 	},
 /area/station/hallway/secondary/exit)
-"uqH" = (
-/obj/table/reinforced/auto,
-/obj/item/device/radio{
-	pixel_x = -3;
-	pixel_y = 4
+"tzR" = (
+/obj/shrub,
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"tRh" = (
+/turf/simulated/floor/arrival{
+	dir = 5
 	},
-/obj/item/device/radio{
-	pixel_x = 6;
-	pixel_y = 5
+/area/station/hallway/secondary/entry)
+"tUc" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
+/turf/simulated/floor/plating,
+/area/station/security/brig)
+"uEP" = (
+/turf/simulated/wall/auto/supernorn,
+/area/station/hallway/secondary/entry)
 "uJW" = (
 /obj/cable{
 	d1 = 4;
@@ -33903,21 +34066,12 @@
 /obj/access_spawn/mining,
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
-"uMt" = (
+"vnv" = (
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/external,
-/turf/simulated/floor/escape{
-	dir = 1
-	},
+/turf/simulated/floor/caution/northsouth,
 /area/station/hallway/secondary/exit)
-"uUi" = (
-/obj/indestructible/shuttle_corner{
-	dir = 4
-	},
-/turf/space,
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"uYJ" = (
+"vvM" = (
 /obj/reagent_dispensers/fueltank,
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
@@ -33928,70 +34082,107 @@
 	dir = 1
 	},
 /area/station/hangar/main)
-"vdI" = (
-/obj/grille,
-/turf/simulated/floor/plating/airless,
-/area/station/com_dish/auxdish)
-"vCC" = (
-/turf/space,
+"weg" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hangar/main)
+"wms" = (
+/obj/storage/closet/welding_supply,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/orangeblack/side{
+	dir = 9
+	},
+/area/station/hangar/main)
+"wyc" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/engine/engineering)
+"wFe" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/NWmaint)
+"wFx" = (
+/obj/indestructible/shuttle_corner{
+	dir = 8
+	},
+/turf/simulated/shuttle/wall/corner{
+	dir = 4
+	},
 /area/shuttle/arrival/station)
-"vOu" = (
+"wFA" = (
+/obj/machinery/computer/mining_shuttle{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"wHO" = (
+/obj/indestructible/shuttle_corner,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
+"xbr" = (
 /obj/machinery/camera{
 	c_tag = "Escape Shuttle Dock"
 	},
+/obj/machinery/light/emergency{
+	dir = 1;
+	icon_state = "ebulb1"
+	},
 /turf/simulated/floor/escape{
 	dir = 1
 	},
 /area/station/hallway/secondary/exit)
-"wKz" = (
-/obj/decal/tile_edge/stripe/big{
-	dir = 1;
-	icon_state = "xtra_bigstripe-edge"
+"xGC" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/engine/engineering)
+"xGY" = (
+/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/arrivals_horizontal{
+	dir = 4
 	},
 /turf/simulated/floor/engine,
 /area/station/hangar/main)
-"wOE" = (
-/turf/simulated/shuttle/wall/corner{
+"xRp" = (
+/obj/cable,
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/power)
+"ybh" = (
+/obj/machinery/manufacturer/hangar,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13"
+	},
+/turf/simulated/floor/orangeblack/side{
 	dir = 1
 	},
-/area/shuttle/arrival/station)
-"wVc" = (
-/turf/simulated/floor/escape{
-	dir = 5
-	},
-/area/station/hallway/secondary/exit)
-"xFl" = (
-/obj/machinery/computer/arcade,
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"xMs" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
-"xPf" = (
-/obj/wingrille_spawn/auto/crystal,
-/turf/simulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"ybI" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4;
-	name = "Pod Bay"
-	},
-/obj/machinery/secscanner{
-	dir = 4;
-	icon_state = "scanner_on";
-	pixel_x = -20
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
 /area/station/hangar/main)
 
 (1,1,1) = {"
@@ -48640,7 +48831,7 @@ aDS
 aKu
 aDT
 aMq
-aFr
+jAM
 aOB
 aDv
 aDP
@@ -50214,7 +50405,7 @@ axE
 aQc
 bgm
 aVj
-bfE
+axg
 aaa
 aCP
 aDh
@@ -50441,7 +50632,7 @@ axE
 aQc
 bgm
 aVj
-bfE
+axg
 aaB
 aCP
 aCP
@@ -50887,7 +51078,7 @@ avQ
 bpW
 aAr
 awW
-axE
+gOt
 ayn
 bsM
 app
@@ -51114,7 +51305,7 @@ bpK
 asc
 app
 awX
-axE
+mJu
 ayn
 app
 app
@@ -51341,7 +51532,7 @@ avm
 aqk
 bpd
 app
-axE
+doP
 bdk
 app
 azf
@@ -51569,8 +51760,8 @@ asc
 app
 aAo
 axF
-axE
-axE
+jDr
+xGC
 axF
 aQp
 axF
@@ -51743,7 +51934,7 @@ aaa
 aaa
 aaa
 aaa
-vCC
+aaa
 aaa
 aaa
 aaa
@@ -51795,7 +51986,7 @@ aqk
 aqk
 bpX
 app
-axE
+nzu
 aAP
 brJ
 azg
@@ -51957,7 +52148,7 @@ aaa
 aag
 aag
 aag
-lkX
+cTH
 aag
 aag
 aag
@@ -52183,11 +52374,11 @@ aaa
 aag
 aaT
 aaZ
-eOZ
-hkT
-mfr
-pNZ
-eOZ
+eoM
+mwI
+dEm
+edh
+eoM
 aag
 aaa
 aaa
@@ -52248,8 +52439,8 @@ bpN
 app
 bpU
 app
-app
-axE
+avt
+wyc
 ayp
 bpZ
 aAr
@@ -52409,11 +52600,11 @@ aaa
 aaa
 aah
 aaS
-ahn
+acJ
 bsv
-nwF
-nwF
-dtV
+lKO
+lKO
+kHs
 aaS
 aah
 aaa
@@ -52475,7 +52666,7 @@ auQ
 avo
 avR
 avR
-avR
+xRp
 auU
 auQ
 app
@@ -52636,13 +52827,13 @@ aQe
 aaa
 aaA
 aaN
-axw
+ahn
 bsv
 bsv
 bsv
 bsv
 aFe
-fUf
+wFx
 aaa
 aaa
 aaa
@@ -52910,7 +53101,7 @@ aaB
 alt
 ams
 alv
-anr
+alv
 anr
 alv
 aqU
@@ -53090,11 +53281,11 @@ aaa
 aaa
 aaa
 aFe
-aUu
+awU
 bsv
 aam
 aap
-kRF
+cKf
 aaN
 awC
 awC
@@ -53118,9 +53309,9 @@ aaa
 aaa
 aaa
 aaa
-agj
-agM
-agj
+jMS
+ioE
+oXE
 ahG
 ahg
 agK
@@ -53137,7 +53328,7 @@ aaB
 alV
 amt
 alv
-anr
+wFe
 anT
 alx
 alx
@@ -53317,14 +53508,14 @@ aaa
 aaa
 aaa
 aaM
-xFl
+awV
 aBR
 aBR
 aBR
 bsv
-xPf
+qYM
 aaX
-fzE
+hKB
 awC
 awC
 awC
@@ -53332,9 +53523,9 @@ awC
 awC
 awC
 awC
-fgT
+uEP
 acq
-acJ
+acq
 acV
 acV
 aba
@@ -53544,9 +53735,9 @@ aaa
 aaa
 aaa
 aaM
-tAB
+axw
 bsv
-meL
+crI
 bsv
 bsv
 aaR
@@ -53559,7 +53750,7 @@ ayi
 ayi
 abQ
 ayi
-fgT
+uEP
 acr
 acK
 acW
@@ -53771,7 +53962,7 @@ aaa
 aaa
 aaa
 aaM
-uqH
+aUu
 aBR
 aBR
 aBR
@@ -53786,7 +53977,7 @@ abn
 ayi
 ayi
 ayi
-fgT
+uEP
 acs
 acL
 acs
@@ -53998,7 +54189,7 @@ aaa
 aaa
 aaa
 aaM
-uqH
+aUu
 bsv
 bsv
 bsv
@@ -54008,12 +54199,12 @@ ayi
 apV
 aaY
 ayH
-nln
+tRh
 aaY
 abv
 abE
 ayi
-fgT
+uEP
 acs
 acM
 acX
@@ -54225,22 +54416,22 @@ aaa
 aaa
 aaa
 aaM
-kVF
+bfE
 aBR
 aBR
 aBR
-kVF
-xPf
+bfE
+qYM
 aaY
 awo
 awC
 awC
 awC
 awC
-fgT
+uEP
 abC
 abK
-fgT
+uEP
 acs
 acM
 acX
@@ -54452,11 +54643,11 @@ aaa
 aaa
 aaa
 aaS
-oFx
+brB
 bsv
 bsv
 bsv
-esU
+eoJ
 aaS
 awC
 awC
@@ -54464,10 +54655,10 @@ awC
 aaa
 aaa
 aaa
-fgT
+uEP
 brz
 ayi
-fgT
+uEP
 acs
 acM
 acX
@@ -54493,7 +54684,7 @@ aiF
 aiG
 agQ
 aaO
-bok
+mHo
 ald
 alv
 alW
@@ -54679,7 +54870,7 @@ aaa
 aaa
 aaa
 aaS
-tAB
+axw
 aBR
 aBR
 aBR
@@ -54690,12 +54881,12 @@ aaa
 aaa
 aaa
 aaa
-fgT
-fgT
+uEP
+uEP
 abG
 ayi
-fgT
-fgT
+uEP
+uEP
 acj
 acX
 adj
@@ -54906,24 +55097,24 @@ aQe
 aaa
 aaa
 aaA
-uUi
+rkJ
 aam
 aBR
 aam
-nir
-fUf
+wHO
+wFx
 aaa
 aaa
 aaa
 aaa
-fgT
-fgT
+uEP
+uEP
 abw
 abH
 ayi
 abZ
 abQ
-xMs
+oGB
 acX
 adk
 adi
@@ -55133,17 +55324,17 @@ aaa
 aaa
 aaa
 aaa
-wOE
-qKD
-qKD
-qKD
-ctx
+eiT
+eIb
+eIb
+eIb
+kMX
 aaa
 aaa
 aaa
 aaa
 aaa
-fgT
+uEP
 abo
 ayi
 ayi
@@ -55362,7 +55553,7 @@ aaa
 aaa
 aaa
 aaa
-pnW
+kPL
 aaa
 aaa
 aaa
@@ -55370,10 +55561,10 @@ aaa
 aaa
 aaa
 aaa
-fgT
+uEP
 ayi
 ayi
-pBN
+ohn
 ayi
 ayi
 ayi
@@ -56736,7 +56927,7 @@ abl
 abt
 abt
 abL
-pRW
+dVq
 ace
 acx
 ado
@@ -57415,7 +57606,7 @@ aaa
 aaB
 aaa
 aaa
-gAo
+faB
 abM
 bqF
 ach
@@ -57869,9 +58060,9 @@ aaa
 aaB
 aaB
 aaa
-gAo
-tYo
-gQo
+faB
+iyS
+nFY
 aci
 ajb
 acR
@@ -58087,7 +58278,7 @@ aaa
 aaa
 aaa
 aaa
-gAo
+faB
 bqH
 bqH
 bqH
@@ -58096,12 +58287,12 @@ bqH
 bqH
 bqH
 bqH
-gAo
+faB
 aak
 bqF
-gAo
-gAo
-gAo
+faB
+faB
+faB
 ada
 adt
 adM
@@ -58315,7 +58506,7 @@ aaa
 aaa
 aaa
 bqH
-eZI
+kbh
 aaE
 aaE
 aaE
@@ -58326,7 +58517,7 @@ aaE
 abp
 aay
 bqF
-gAo
+faB
 acB
 abY
 ada
@@ -58543,7 +58734,7 @@ aaa
 aaa
 bqH
 aak
-mIg
+tgU
 abN
 abN
 abN
@@ -58771,16 +58962,16 @@ aaa
 bqH
 aak
 bqF
-nrV
+lHG
 ado
 ado
 abf
 ado
 ado
 abB
-nrV
-hxB
-gAo
+lHG
+tzR
+faB
 acD
 abY
 ada
@@ -59004,10 +59195,10 @@ bqH
 bqH
 bqH
 bqH
-gAo
-gAo
-gAo
-gAo
+faB
+faB
+faB
+faB
 acD
 abY
 abY
@@ -59337,10 +59528,10 @@ btP
 bds
 bcS
 bcS
-boP
+lFp
 bcS
 bcS
-boP
+rOd
 bcW
 bcW
 bcW
@@ -59451,7 +59642,7 @@ aab
 aaa
 bqH
 aak
-lHJ
+puW
 bqH
 aaa
 aaa
@@ -59676,8 +59867,8 @@ aab
 aab
 aab
 aaa
-gAo
-dic
+faB
+xbr
 bro
 bqH
 aaa
@@ -59789,7 +59980,7 @@ bao
 aCl
 aCl
 aCl
-beF
+tUc
 bph
 beB
 beK
@@ -60128,10 +60319,10 @@ aab
 aab
 aab
 aab
-gAo
+faB
 bqH
-gAo
-eyu
+faB
+tlJ
 bro
 bqH
 aaa
@@ -60355,7 +60546,7 @@ aab
 aab
 aab
 aab
-ofi
+gYQ
 bov
 aaE
 aay
@@ -60582,7 +60773,7 @@ aab
 aab
 aab
 aab
-uMt
+oPn
 aak
 adD
 adD
@@ -60809,7 +61000,7 @@ aab
 aab
 aab
 aab
-uMt
+oPn
 aak
 adD
 adD
@@ -60933,7 +61124,7 @@ bnI
 beV
 bfj
 bfj
-hKt
+dRv
 btf
 bpn
 bcS
@@ -61036,12 +61227,12 @@ aab
 aab
 aab
 aab
-ofi
-tRe
+gYQ
+fYD
 aaJ
 bqE
 bqF
-jlZ
+wFA
 bqH
 abg
 abg
@@ -61051,7 +61242,7 @@ abg
 abg
 abg
 abg
-mnq
+koq
 add
 akj
 aim
@@ -61263,13 +61454,13 @@ aab
 aab
 aab
 aab
-gAo
+faB
 bqH
-gAo
-vOu
+faB
+dVg
 bqF
 ado
-jSH
+vnv
 abg
 abg
 abg
@@ -61278,7 +61469,7 @@ abg
 abg
 abg
 abg
-mnq
+koq
 add
 akk
 aim
@@ -61493,7 +61684,7 @@ aab
 aaa
 aaa
 bqH
-wVc
+kNi
 bqG
 bqH
 bqH
@@ -61505,7 +61696,7 @@ abg
 abg
 abg
 abg
-mnq
+koq
 aim
 aim
 aim
@@ -61719,10 +61910,10 @@ aab
 aab
 aaa
 aaa
-ljX
-stv
-ybI
-ljX
+gjD
+rBk
+bDG
+gjD
 aaa
 abg
 abg
@@ -61732,8 +61923,8 @@ abg
 abg
 abg
 aaa
-mnq
-vdI
+koq
+npP
 aki
 aki
 aki
@@ -61946,10 +62137,10 @@ aab
 aab
 aaa
 aaa
-diB
-lzK
-dGY
-diB
+dlG
+pwm
+jKR
+dlG
 aaa
 abg
 abg
@@ -62173,10 +62364,10 @@ aab
 aaa
 aaa
 aaa
-diB
-ryg
-ftH
-diB
+dlG
+pdx
+weg
+dlG
 aaa
 aaa
 aaa
@@ -62399,16 +62590,16 @@ aab
 aab
 aaa
 aaa
-ljX
-ljX
-ryg
-ftH
-ljX
-ljX
-diB
-diB
-ljX
-ljX
+gjD
+gjD
+pdx
+weg
+gjD
+gjD
+dlG
+dlG
+gjD
+gjD
 aaa
 aaa
 aaa
@@ -62626,16 +62817,16 @@ aab
 aaa
 aaa
 aaa
-ljX
-fKD
-lIn
-ftH
-ogN
-bOS
-bOS
-loM
-epj
-ljX
+gjD
+wms
+qfM
+weg
+ixI
+eUm
+eUm
+jpv
+rXY
+gjD
 bsh
 bsh
 bsh
@@ -62853,16 +63044,16 @@ aab
 aaa
 aaa
 aaa
-ljX
-uYJ
-kLb
-ecE
-wKz
-lxX
-bOS
-bOS
-bOS
-diB
+gjD
+vvM
+nNR
+jIj
+jYd
+rCc
+eUm
+eUm
+eUm
+dlG
 aaa
 aaa
 aaa
@@ -63080,16 +63271,16 @@ aaa
 aaa
 aaa
 aaa
-ljX
-oez
-okT
-okT
-wKz
-bOS
-bOS
-loM
-bOS
-diB
+gjD
+ybh
+kFX
+kFX
+jYd
+eUm
+eUm
+jpv
+eUm
+dlG
 aaa
 aaa
 aaa
@@ -63307,16 +63498,16 @@ aaa
 aaa
 aaa
 aaa
-ljX
-lGr
-okT
-okT
-wKz
-bOS
-bOS
-bOS
-bOS
-diB
+gjD
+rwY
+kFX
+kFX
+jYd
+eUm
+eUm
+eUm
+eUm
+dlG
 aaa
 aaa
 aaa
@@ -63534,16 +63725,16 @@ aaa
 aaa
 aaa
 aaa
-ljX
-kTd
-peF
-tgv
-nbH
-bOS
-bOS
-bOS
-epj
-ljX
+gjD
+eGe
+pfN
+pyH
+knq
+eUm
+eUm
+eUm
+rXY
+gjD
 bsh
 bsh
 bsh
@@ -63761,16 +63952,16 @@ aaa
 aaa
 aaa
 aaa
-ljX
-ljX
-ljX
-ljX
-ljX
-ftA
-ftA
-ftA
-djX
-ljX
+gjD
+gjD
+gjD
+gjD
+gjD
+xGY
+xGY
+xGY
+jGu
+gjD
 aaa
 aaa
 aaa
@@ -65810,7 +66001,7 @@ aaa
 aaa
 aaa
 aaa
-qyL
+hfV
 aaa
 aaa
 aaa
@@ -67911,9 +68102,9 @@ aaa
 aaa
 aaB
 awR
-brB
+brA
 aHZ
-brB
+brA
 ayZ
 azF
 aAk
@@ -68364,7 +68555,7 @@ aaa
 aaa
 aaa
 aaa
-awU
+ayJ
 aAM
 bpc
 boX
@@ -68591,7 +68782,7 @@ aaa
 aaa
 aaa
 aaa
-awU
+ayJ
 boU
 boX
 boU
@@ -68818,7 +69009,7 @@ aaa
 aaa
 aaa
 aaa
-awV
+aza
 boU
 boU
 bnL
@@ -69045,11 +69236,11 @@ aaa
 aaa
 aaa
 aaa
-awV
+aza
 boU
 boX
 boU
-awV
+aza
 aaa
 aaa
 aaa
@@ -69272,11 +69463,11 @@ aaa
 aaa
 aaa
 aaa
-awV
+aza
 bsg
 boU
 boU
-awV
+aza
 aaa
 aaa
 aaa

--- a/maps/unused/mushroom_new_walls.dmm
+++ b/maps/unused/mushroom_new_walls.dmm
@@ -281,7 +281,6 @@
 	name = "N APC";
 	pixel_y = 24
 	},
-/obj/critter/domestic_bee/bubs,
 /obj/cable{
 	icon_state = "0-2"
 	},
@@ -2720,8 +2719,12 @@
 /turf/space,
 /area/supply/spawn_point)
 "ahA" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "qmin"
+	},
 /turf/space,
-/area/supply/delivery_point)
+/area)
 "ahB" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -2738,7 +2741,7 @@
 	id = "qmin"
 	},
 /turf/space,
-/area)
+/area/supply/delivery_point)
 "ahD" = (
 /obj/machinery/door/poddoor/blast{
 	dir = 1;
@@ -5575,7 +5578,9 @@
 /area/station/chapel/main)
 "aoi" = (
 /obj/machinery/power/data_terminal,
-/obj/machinery/computer/supplycomp,
+/obj/machinery/computer/supplycomp{
+	dir = 4
+	},
 /obj/cable{
 	icon_state = "0-4"
 	},
@@ -7116,6 +7121,9 @@
 "ass" = (
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/landmark{
+	name = "bubsbeejob"
 	},
 /turf/simulated/floor,
 /area/station/security/checkpoint)
@@ -9407,6 +9415,9 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/blueblack/corner,
 /area/station/medical/robotics)
 "ayy" = (
@@ -9418,6 +9429,9 @@
 "ayz" = (
 /obj/landmark/start{
 	name = "Roboticist"
+	},
+/obj/cable{
+	icon_state = "5-8"
 	},
 /turf/simulated/floor/blueblack/corner,
 /area/station/medical/robotics)
@@ -24441,7 +24455,9 @@
 /area/station/quartermaster)
 "boh" = (
 /obj/machinery/power/data_terminal,
-/obj/machinery/computer/ordercomp,
+/obj/machinery/computer/ordercomp{
+	dir = 4
+	},
 /obj/cable,
 /obj/cable{
 	icon_state = "0-4"
@@ -26354,11 +26370,11 @@
 /turf/simulated/floor/plating/airless,
 /area/station/com_dish/comdish)
 "btD" = (
-/obj/warp_beacon{
-	name = "Satellite A3-67 Beacon"
+/obj/cable{
+	icon_state = "4-10"
 	},
-/turf/space,
-/area)
+/turf/simulated/floor/blueblack/corner,
+/area/station/medical/robotics)
 "btE" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -26891,6 +26907,12 @@
 	dir = 1
 	},
 /area/station/science)
+"dnQ" = (
+/obj/warp_beacon{
+	name = "Satellite A3-67 Beacon"
+	},
+/turf/space,
+/area)
 "dpx" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/storage/warehouse)
@@ -27739,6 +27761,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
+"gua" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/blueblack/corner,
+/area/station/medical/robotics)
 "gAL" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -28585,6 +28613,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
+"kny" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/blueblack/corner{
+	dir = 1
+	},
+/area/station/medical/robotics)
 "knT" = (
 /obj/machinery/light,
 /obj/cable{
@@ -29375,6 +29411,17 @@
 	},
 /turf/simulated/floor/purplewhite,
 /area/station/science/lab)
+"oEy" = (
+/obj/landmark/start{
+	name = "Cyborg"
+	},
+/obj/cable{
+	icon_state = "5-10"
+	},
+/turf/simulated/floor/blueblack/corner{
+	dir = 1
+	},
+/area/station/medical/robotics)
 "oFX" = (
 /obj/cable{
 	icon_state = "6-8"
@@ -29474,6 +29521,17 @@
 	dir = 1
 	},
 /area/station/science)
+"oXm" = (
+/obj/landmark/start{
+	name = "Roboticist"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/blueblack/corner{
+	dir = 1
+	},
+/area/station/medical/robotics)
 "paR" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -30435,6 +30493,7 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
+/obj/critter/turtle/sylvester/HoS,
 /turf/simulated/floor/black,
 /area/station/security/hos)
 "toB" = (
@@ -31759,13 +31818,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
 agF
 agF
 agF
 agF
 agF
-aaa
+agF
+agF
 aaa
 aaa
 aaa
@@ -31986,13 +32045,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
 agF
 agF
 agF
 agF
 agF
-aaa
+agF
+agF
 aaa
 aaa
 aaa
@@ -32213,13 +32272,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
 agF
 agF
 agF
+ahz
 agF
 agF
-aaa
+agF
 aaa
 aaa
 aaa
@@ -32443,7 +32502,7 @@ aaa
 aaa
 aaa
 aaa
-ahz
+aaa
 aaa
 aaa
 aaa
@@ -32897,7 +32956,7 @@ aaa
 aaa
 aaa
 aaa
-ahA
+aaa
 aaa
 aaa
 aaa
@@ -48559,9 +48618,9 @@ aaa
 aaa
 aaa
 aaa
+ahc
 aaa
-aaa
-aaa
+ahc
 aaa
 aaa
 aaa
@@ -48786,9 +48845,9 @@ aaa
 aaa
 aaa
 aaa
-ahc
-aaa
-ahc
+ahe
+ahA
+ahe
 aaa
 aaa
 aaa
@@ -61763,7 +61822,7 @@ awq
 boD
 axs
 ayd
-ayA
+oXm
 axs
 axs
 aQS
@@ -62216,7 +62275,7 @@ avO
 awr
 awL
 axs
-ayd
+oEy
 ayA
 axs
 azz
@@ -62442,7 +62501,7 @@ hvS
 vXg
 fIb
 awM
-axv
+btD
 axv
 ayB
 axv
@@ -62669,7 +62728,7 @@ asM
 icj
 jvN
 awN
-axs
+kny
 ayw
 axs
 axs
@@ -62896,7 +62955,7 @@ asM
 icj
 jvN
 awO
-axv
+gua
 aye
 axv
 axv
@@ -63123,7 +63182,7 @@ asM
 wHt
 oRk
 awP
-axs
+kny
 ayy
 axs
 axs
@@ -63350,7 +63409,7 @@ eol
 avO
 awr
 awQ
-axv
+gua
 axv
 axv
 axv
@@ -67552,7 +67611,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+dnQ
 aaa
 aaa
 aaa
@@ -67779,7 +67838,7 @@ aaa
 aaa
 aaa
 aaa
-btD
+aaa
 aaa
 aaa
 aaa

--- a/maps/unused/mushroom_new_walls.dmm
+++ b/maps/unused/mushroom_new_walls.dmm
@@ -65,7 +65,7 @@
 	},
 /area/shuttle/arrival/station)
 "aai" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/secscanner{
 	dir = 4;
 	icon_state = "scanner_on";
@@ -244,7 +244,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
 	icon_state = "eng_closed";
@@ -254,7 +254,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/westsolar)
 "abb" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	icon_state = "glass_closed";
@@ -263,7 +263,7 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "abc" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -380,7 +380,7 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "abp" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1";
@@ -482,7 +482,7 @@
 /turf/simulated/floor,
 /area/station/security/checkpoint)
 "abA" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -491,7 +491,7 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "abB" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/camera{
 	c_tag = "Escape Shuttle Hallway";
 	dir = 8
@@ -499,9 +499,7 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "abC" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/arrival{
 	dir = 1
 	},
@@ -524,7 +522,7 @@
 	icon_state = "reinf_tabledir";
 	tag = "icon-reinf_tabledir"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/item/pen,
 /turf/simulated/floor,
 /area/station/security/checkpoint)
@@ -552,13 +550,11 @@
 	icon_state = "reinf_tabledir";
 	tag = "icon-reinf_tabledir"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/security/checkpoint)
 "abK" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "abL" = (
@@ -612,7 +608,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/access_spawn/maint,
 /turf/simulated/floor/plating,
@@ -729,7 +725,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
 	icon_state = "maint_closed"
@@ -999,7 +995,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor,
 /area/station/hallway/secondary/shuttle)
@@ -1076,7 +1072,7 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/market)
 "acY" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor,
 /area/station/hallway/secondary/shuttle)
@@ -1086,7 +1082,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
 	icon_state = "com_closed";
@@ -1384,7 +1380,7 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "adI" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -1615,7 +1611,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "aef" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
 	icon_state = "com_closed";
@@ -1887,7 +1883,7 @@
 	},
 /area/station/hallway/primary/north)
 "aeH" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
 	icon_state = "eng_closed";
@@ -1922,7 +1918,7 @@
 	},
 /area/station/ai_monitored/storage/eva)
 "aeK" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro{
 	name = "Custodial Closet"
 	},
@@ -2352,7 +2348,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "afx" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance{
 	name = "Cargo Maintenance";
 	req_access = null
@@ -2409,7 +2405,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "afE" = (
@@ -2568,7 +2564,7 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/janitor)
 "agc" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "agd" = (
@@ -2585,7 +2581,7 @@
 	icon_state = "0-8"
 	},
 /obj/cable,
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -2893,7 +2889,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -2908,9 +2904,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
+/obj/firedoor_spawn,
 /obj/machinery/door/window/westleft{
 	name = "Cargo Office"
 	},
@@ -3424,7 +3418,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "aia" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
 	icon_state = "maint_closed"
@@ -3655,9 +3649,7 @@
 	},
 /obj/table/reinforced,
 /obj/machinery/cashreg,
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/orangeblack,
 /area/station/quartermaster/office)
 "aiG" = (
@@ -3675,7 +3667,7 @@
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "aiH" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
 	name = "Crematorium"
@@ -3721,7 +3713,7 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/quartermaster)
 "aiP" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
 	icon_state = "maint_closed"
@@ -3954,9 +3946,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
@@ -4103,7 +4093,7 @@
 	},
 /area/station/quartermaster)
 "ajG" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/access_spawn/maint,
 /turf/simulated/floor/plating,
@@ -4245,9 +4235,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
@@ -4268,9 +4256,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
@@ -4477,7 +4463,7 @@
 /turf/simulated/floor/black,
 /area/station/chapel/office)
 "akx" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/disposalpipe/segment{
 	dir = 4
 	},
@@ -4850,7 +4836,7 @@
 	},
 /area/station/chapel/main)
 "alc" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -4866,7 +4852,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/quartermaster)
 "ale" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "alf" = (
@@ -5063,7 +5049,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "alz" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1";
@@ -5101,7 +5087,7 @@
 /turf/simulated/floor/black,
 /area/station/chapel/office)
 "alE" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro{
 	name = "Crematorium"
 	},
@@ -5374,7 +5360,7 @@
 	},
 /area/station/chapel/office)
 "amb" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -5602,7 +5588,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "amu" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "amv" = (
@@ -5623,13 +5609,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
-"amy" = (
-/obj/machinery/door/firedoor/pyro,
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
 "amz" = (
 /obj/table/wood/auto,
 /obj/item/storage/bible,
@@ -5811,7 +5793,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "amV" = (
@@ -5823,7 +5805,7 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/morgue)
 "amX" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance{
 	name = "Cargo Maintenance";
 	req_access = null
@@ -5992,7 +5974,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
 	icon_state = "maint_closed"
@@ -6219,7 +6201,7 @@
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "anS" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -6294,7 +6276,7 @@
 /turf/simulated/floor/black,
 /area/station/medical/morgue)
 "aob" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro{
 	name = "Crematorium"
 	},
@@ -6472,7 +6454,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "aot" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/access_spawn/maint,
 /turf/simulated/floor/plating,
@@ -6483,7 +6465,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "aov" = (
@@ -6895,7 +6877,7 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/central)
 "apw" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
@@ -6905,7 +6887,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/command{
 	name = "AI Module Storage"
 	},
@@ -6913,7 +6895,7 @@
 /turf/simulated/floor/purple,
 /area/station/turret_protected/ai_upload_foyer)
 "apy" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -7001,7 +6983,7 @@
 /turf/simulated/floor/plating/scorched,
 /area/station/chapel/main)
 "apK" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/window/southright,
 /obj/disposalpipe/segment,
 /turf/simulated/floor/grey/side{
@@ -7259,7 +7241,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/NWmaint)
 "aqq" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -7607,9 +7589,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
 	icon_state = "com_closed";
@@ -7647,15 +7627,13 @@
 	},
 /area/station/turret_protected/ai_upload_foyer)
 "ari" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/purple,
 /area/station/turret_protected/ai_upload_foyer)
 "arj" = (
@@ -7695,7 +7673,7 @@
 /turf/simulated/floor/purple,
 /area/station/turret_protected/ai_upload)
 "arn" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -7821,7 +7799,7 @@
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "arz" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance{
 	name = "Engineering Maintenance"
 	},
@@ -8112,7 +8090,7 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "aso" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/access_spawn/maint,
 /turf/simulated/floor/plating,
@@ -8196,7 +8174,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
 	icon_state = "eng_closed"
@@ -8515,7 +8493,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
 	icon_state = "maint_closed"
@@ -8706,12 +8684,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "atE" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro,
 /turf/simulated/floor,
 /area/station/storage/emergency)
@@ -8764,7 +8742,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/storage/warehouse)
 "atL" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
 	icon_state = "maint_closed"
@@ -9407,7 +9385,7 @@
 /turf/simulated/floor/grime,
 /area/station/storage/warehouse)
 "avc" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
@@ -9415,7 +9393,7 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/inner)
 "ave" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro,
 /turf/simulated/floor,
 /area/station/maintenance/east)
@@ -9664,7 +9642,7 @@
 /area/station/storage/warehouse)
 "avD" = (
 /obj/disposalpipe/segment,
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "avE" = (
@@ -9673,7 +9651,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/disposalpipe/segment{
 	dir = 4;
 	pixel_y = 0
@@ -9726,7 +9704,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "avK" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -9901,7 +9879,7 @@
 /turf/simulated/floor,
 /area/station/storage/emergency)
 "awa" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "awb" = (
@@ -9953,7 +9931,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
@@ -10903,7 +10881,7 @@
 /turf/simulated/floor/grime,
 /area/station/storage/warehouse)
 "ayv" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Pod Bay"
 	},
@@ -11030,7 +11008,7 @@
 	},
 /area/station/engine/engineering)
 "ayH" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Pod Bay"
 	},
@@ -11374,7 +11352,7 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/east)
 "azw" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/access_spawn/maint,
 /obj/disposalpipe/segment,
@@ -11848,9 +11826,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "aAA" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/white,
 /area/station/medical/cdc{
 	name = "Medbay Lobby"
@@ -12081,7 +12057,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/engineering{
 	name = "Power Room"
 	},
@@ -12089,7 +12065,7 @@
 /turf/simulated/floor,
 /area/station/engine/power)
 "aBa" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -12105,7 +12081,7 @@
 	name = "Medbay Lobby"
 	})
 "aBc" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -12521,9 +12497,7 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/white,
 /area/station/medical/cdc{
 	name = "Medbay Lobby"
@@ -12589,18 +12563,8 @@
 	dir = 8
 	},
 /area/station/hallway/primary/central)
-"aCd" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
-/turf/simulated/floor/neutral/side{
-	dir = 1
-	},
-/area/station/hallway/primary/central)
 "aCe" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/neutral/side{
 	dir = 1
 	},
@@ -12615,7 +12579,7 @@
 	name = "Medbay Lobby"
 	})
 "aCg" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/classic{
 	aiControlDisabled = 0;
 	locked = 0
@@ -12748,15 +12712,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
-"aCu" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "aCv" = (
@@ -13017,7 +12973,7 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/west)
 "aCU" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/cable{
 	d1 = 2;
 	d2 = 8;
@@ -13051,14 +13007,12 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "aCY" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aCZ" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 8
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "aDa" = (
@@ -13216,7 +13170,7 @@
 	},
 /area/station/mining/magnet)
 "aDp" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -13227,12 +13181,12 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "aDr" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "aDs" = (
@@ -14016,7 +13970,7 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/south)
 "aFd" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
 	name = "Robotics Storage";
@@ -14413,7 +14367,7 @@
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "aFW" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
 	name = "Med-Sci Maintenance";
@@ -14651,7 +14605,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/external{
 	autoclose = 0;
 	density = 0;
@@ -14672,9 +14626,7 @@
 	},
 /area/station/hallway/primary/south)
 "aGC" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/blue,
 /area/station/medical/cdc{
 	name = "Medbay Lobby"
@@ -14879,7 +14831,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/external{
 	autoclose = 0;
 	density = 0;
@@ -15433,7 +15385,7 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "aHQ" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -15479,7 +15431,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/access_spawn/maint,
 /turf/simulated/floor/plating,
@@ -15521,9 +15473,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/bluewhite{
 	dir = 8
 	},
@@ -15938,7 +15888,7 @@
 	},
 /area/station/mining/magnet)
 "aIP" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance{
 	name = "Med-Sci Maintenance";
 	req_access = null
@@ -16105,7 +16055,7 @@
 	},
 /area/station/medical/medbay)
 "aJg" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -16418,7 +16368,7 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/south)
 "aJV" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor/grey/side{
 	dir = 1
@@ -17605,7 +17555,7 @@
 /area/station/hallway/primary/south)
 "aMw" = (
 /obj/table/reinforced,
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -17638,7 +17588,7 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/SEmaint)
 "aMA" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "aMB" = (
@@ -17985,7 +17935,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
@@ -18023,7 +17973,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
 "aNn" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -18853,7 +18803,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance{
 	name = "Engineering Maintenance";
 	req_access = null
@@ -19285,7 +19235,7 @@
 	},
 /area/station/crew_quarters/pool)
 "aPH" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor,
 /area/station/crew_quarters/fitness)
@@ -19332,7 +19282,7 @@
 /turf/simulated/floor/purple,
 /area/station/science/teleporter)
 "aPM" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/access_spawn/maint,
 /turf/simulated/floor/plating,
@@ -19380,7 +19330,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/teleporter)
 "aPT" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -19527,9 +19477,7 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/pool)
 "aQl" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
 	icon_state = "maint_closed"
@@ -19549,14 +19497,14 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/west)
 "aQo" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Pool"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/pool)
 "aQp" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -19670,7 +19618,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance{
 	name = "Botany Maintenance";
 	req_access = null
@@ -19832,7 +19780,7 @@
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
 "aQS" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -20271,7 +20219,7 @@
 	icon_state = "1-2";
 	tag = "icon-1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
@@ -20684,7 +20632,7 @@
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
 "aSv" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
@@ -21062,13 +21010,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
 "aTc" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -21119,7 +21067,7 @@
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "aTi" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -21144,7 +21092,7 @@
 /area/station/crew_quarters/hor)
 "aTm" = (
 /obj/table/reinforced,
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -21222,7 +21170,7 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aTy" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/security{
 	dir = 4;
 	icon_state = "sec_closed";
@@ -22334,7 +22282,7 @@
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/Zeta)
 "aVN" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
 	icon_state = "maint_closed";
@@ -22570,7 +22518,7 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aWs" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/security{
 	dir = 8;
 	icon_state = "sec_closed"
@@ -22693,9 +22641,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	icon_state = "glass_closed";
@@ -22902,7 +22848,7 @@
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "aXh" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -23124,7 +23070,7 @@
 /turf/simulated/floor,
 /area/station/storage/primary)
 "aXI" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -23630,7 +23576,7 @@
 /turf/simulated/floor/sanitary,
 /area/station/hallway/primary/west)
 "aYD" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -24377,7 +24323,7 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/bar)
 "bao" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/security,
 /obj/access_spawn/security,
 /turf/simulated/floor,
@@ -24543,7 +24489,7 @@
 /turf/simulated/floor,
 /area/station/security/main)
 "baF" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
 	icon_state = "maint_closed"
@@ -24774,7 +24720,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
 "bbg" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
 "bbh" = (
@@ -25056,7 +25002,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/access_spawn/maint,
 /turf/simulated/floor,
@@ -25393,7 +25339,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/disposalpipe/segment,
 /obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor,
@@ -25493,7 +25439,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/disposalpipe/segment,
 /obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor,
@@ -25572,7 +25518,7 @@
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "bcV" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/security{
 	dir = 4;
 	icon_state = "sec_closed";
@@ -25640,7 +25586,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
 "bdf" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/table/reinforced,
 /turf/simulated/floor,
 /area/station/bridge)
@@ -26266,9 +26212,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/firedoor_spawn,
 /obj/machinery/secscanner{
 	dir = 4;
 	icon_state = "scanner_on";
@@ -26333,7 +26277,7 @@
 /turf/simulated/floor,
 /area/station/security/brig)
 "beC" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/secscanner{
 	pixel_y = 10
 	},
@@ -26751,7 +26695,7 @@
 	},
 /area/station/security/brig)
 "bfu" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/disposalpipe/segment,
 /obj/machinery/secscanner{
 	pixel_y = 10
@@ -26780,7 +26724,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/disposalpipe/segment,
 /obj/machinery/door/airlock/pyro/security,
 /turf/simulated/floor,
@@ -26934,7 +26878,7 @@
 	},
 /area/station/medical/medbay)
 "bfO" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	icon_state = "glass_closed";
@@ -26983,7 +26927,7 @@
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "bfT" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/security{
 	name = "Head of Security'"
 	},
@@ -27433,7 +27377,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/medical{
 	name = "Chemistry Department Access"
 	},
@@ -28583,7 +28527,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/disposalpipe/segment{
 	dir = 4;
 	pixel_y = 0
@@ -29792,7 +29736,7 @@
 /turf/simulated/floor/plating,
 /area/listeningpost/power)
 "blA" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -31982,7 +31926,7 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bqK" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -32005,7 +31949,7 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bqM" = (
@@ -32055,7 +31999,7 @@
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "bqS" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 2;
 	name = "Power Substation"
@@ -32339,7 +32283,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/security{
 	name = "Head of Security'"
 	},
@@ -32656,7 +32600,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
 	icon_state = "eng_closed";
@@ -32702,9 +32646,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	icon_state = "glass_closed";
@@ -32721,7 +32663,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
 	icon_state = "eng_closed";
@@ -32776,7 +32718,7 @@
 /turf/simulated/floor/plating/airless,
 /area/station/mining/magnet)
 "bsB" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -32805,7 +32747,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/command{
 	name = "AI Module Storage"
 	},
@@ -32896,7 +32838,7 @@
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "bsN" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -33118,9 +33060,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	icon_state = "glass_closed";
@@ -33132,7 +33072,7 @@
 	},
 /area/station/hallway/primary/west)
 "bto" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
 	icon_state = "maint_closed"
@@ -33167,9 +33107,7 @@
 	tag = "icon-pipe-s (EAST)"
 	},
 /obj/disposalpipe/segment,
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	icon_state = "glass_closed";
@@ -33275,9 +33213,7 @@
 	pixel_y = 0
 	},
 /obj/disposalpipe/segment,
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	icon_state = "glass_closed";
@@ -33289,7 +33225,7 @@
 	},
 /area/station/hallway/primary/west)
 "btF" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass{
 	autoclose = 0;
 	dir = 4;
@@ -33305,7 +33241,7 @@
 	},
 /area/station/science/lab)
 "btG" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass{
 	autoclose = 0;
 	dir = 4;
@@ -33408,7 +33344,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
 	icon_state = "com_closed";
@@ -33425,7 +33361,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
 	icon_state = "com_closed";
@@ -33474,67 +33410,89 @@
 /obj/access_spawn/ai_upload,
 /turf/simulated/floor/black/side,
 /area/station/turret_protected/ai)
-"cPd" = (
-/turf/simulated/floor/orangeblack/corner{
-	dir = 1
-	},
-/area/station/hangar/main)
-"cTu" = (
-/turf/simulated/floor/orangeblack/side{
-	dir = 9
-	},
-/area/station/hangar/main)
-"dkK" = (
-/obj/wingrille_spawn/auto/crystal,
-/turf/simulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"dIu" = (
-/obj/machinery/light/emergency{
-	dir = 8;
-	icon_state = "ebulb1";
-	pixel_x = -16
-	},
-/obj/decal/tile_edge/stripe/big{
-	dir = 1;
-	icon_state = "xtra_bigstripe-edge"
-	},
+"bOS" = (
 /turf/simulated/floor/engine,
 /area/station/hangar/main)
-"egi" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"ctx" = (
+/turf/simulated/shuttle/wall/corner{
+	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/hangar/main)
-"enb" = (
+/area/shuttle/arrival/station)
+"dic" = (
+/obj/machinery/camera{
+	c_tag = "Escape Shuttle Dock"
+	},
+/obj/machinery/light/emergency{
+	dir = 1;
+	icon_state = "ebulb1"
+	},
+/turf/simulated/floor/escape{
+	dir = 1
+	},
+/area/station/hallway/secondary/exit)
+"diB" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hangar/main)
-"epu" = (
-/obj/machinery/vehicle/pod_smooth/light,
-/turf/simulated/floor/engine,
+"djX" = (
+/obj/machinery/r_door_control{
+	id = "hangar_arrivals"
+	},
+/turf/simulated/wall/auto/supernorn,
 /area/station/hangar/main)
-"exP" = (
-/obj/table/reinforced/auto,
-/obj/item/storage/firstaid/regular,
+"dtV" = (
+/obj/storage/closet/wardrobe/mixed,
+/obj/random_item_spawner/dressup/one_or_zero,
+/obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
-"eND" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=crewhall";
-	location = "escape"
-	},
-/obj/stool/bench/red/auto,
+"dGY" = (
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/turf/simulated/floor/orangeblack/side{
+	dir = 8
+	},
+/area/station/hangar/main)
+"ecE" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor,
+/area/station/hangar/main)
+"epj" = (
+/obj/machinery/light,
+/turf/simulated/floor/engine,
+/area/station/hangar/main)
+"esU" = (
+/obj/storage/closet/emergency,
+/obj/machinery/light/incandescent/netural,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
+"eyu" = (
+/obj/machinery/light{
+	dir = 1;
+	name = "light fixture";
+	pixel_y = 21;
+	rigged = 0
+	},
+/turf/simulated/floor/escape{
+	dir = 1
+	},
 /area/station/hallway/secondary/exit)
-"eXa" = (
+"eOZ" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater-R"
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
+"eZI" = (
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1";
@@ -33545,29 +33503,16 @@
 	dir = 9
 	},
 /area/station/hallway/secondary/exit)
-"fiF" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/shuttle/engine/heater{
-	dir = 8;
-	icon_state = "alt_heater-M"
+"fgT" = (
+/turf/simulated/wall/auto/supernorn,
+/area/station/hallway/secondary/entry)
+"ftA" = (
+/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/arrivals_horizontal{
+	dir = 4
 	},
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"fki" = (
-/turf/simulated/shuttle/wall/corner{
-	dir = 1
-	},
-/area/shuttle/arrival/station)
-"flX" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4;
-	name = "Pod Bay"
-	},
-/obj/machinery/secscanner{
-	dir = 4;
-	icon_state = "scanner_on";
-	pixel_x = -20
-	},
+/turf/simulated/floor/engine,
+/area/station/hangar/main)
+"ftH" = (
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -33575,17 +33520,18 @@
 	},
 /turf/simulated/floor,
 /area/station/hangar/main)
-"fqo" = (
-/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/arrivals_horizontal{
-	dir = 4
+"fzE" = (
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	layer = 9.1;
+	pixel_x = -10
 	},
-/turf/simulated/floor/engine,
-/area/station/hangar/main)
-"fGz" = (
-/obj/machinery/computer/arcade,
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"ghi" = (
+/turf/simulated/floor/arrival{
+	dir = 10
+	},
+/area/station/hallway/secondary/entry)
+"fKD" = (
 /obj/storage/closet/welding_supply,
 /obj/machinery/light{
 	dir = 8;
@@ -33597,114 +33543,18 @@
 	dir = 9
 	},
 /area/station/hangar/main)
-"gkb" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	layer = 9.1;
-	pixel_x = 10
+"fUf" = (
+/obj/indestructible/shuttle_corner{
+	dir = 8
 	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
-"gqz" = (
-/obj/storage/closet/wardrobe/mixed,
-/obj/random_item_spawner/dressup/one_or_zero,
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"gMq" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
-"gWe" = (
-/obj/shrub,
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
-"hsO" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
-"hUl" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/hallway/secondary/exit)
-"hYt" = (
-/obj/decal/poster/wallsign/escape,
-/turf/simulated/wall/auto/supernorn,
-/area/station/hallway/secondary/exit)
-"iPq" = (
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/escape{
-	dir = 1
-	},
-/area/station/hallway/secondary/exit)
-"jjg" = (
-/obj/decal/tile_edge/stripe/big{
-	dir = 1;
-	icon_state = "xtra_bigstripe-edge"
-	},
-/turf/simulated/floor/engine,
-/area/station/hangar/main)
-"jOo" = (
-/obj/machinery/light,
-/turf/simulated/floor/engine,
-/area/station/hangar/main)
-"kFk" = (
-/obj/storage/closet/emergency,
-/obj/machinery/light/incandescent/netural,
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"kNj" = (
-/turf/simulated/wall/auto/shuttle{
-	icon_state = "2"
-	},
-/area/shuttle/arrival/station)
-"luV" = (
-/obj/grille,
-/turf/simulated/floor/plating/airless,
-/area)
-"lAX" = (
-/obj/machinery/computer/riotgear{
-	dir = 8;
-	pixel_x = 32
-	},
-/turf/simulated/floor/red/side{
-	dir = 4
-	},
-/area/station/security/brig)
-"lBZ" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/hangar/main)
-"lLU" = (
 /turf/simulated/shuttle/wall/corner{
 	dir = 4
 	},
 /area/shuttle/arrival/station)
-"mHW" = (
-/obj/indestructible/shuttle_corner{
-	dir = 4
-	},
-/turf/space,
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"mWm" = (
-/obj/machinery/computer/mining_shuttle{
-	dir = 4
-	},
-/turf/simulated/floor,
+"gAo" = (
+/turf/simulated/wall/auto/supernorn,
 /area/station/hallway/secondary/exit)
-"mWC" = (
-/turf/simulated/floor/engine,
-/area/station/hangar/main)
-"nfV" = (
+"gQo" = (
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -33717,35 +33567,36 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
-"nsN" = (
-/turf/simulated/floor/escape{
-	dir = 5
+"hkT" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "8"
 	},
-/area/station/hallway/secondary/exit)
-"nxw" = (
-/obj/storage/closet/wardrobe/mixed,
-/obj/random_item_spawner/dressup/one_or_zero,
-/obj/machinery/light/incandescent/netural,
-/turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
-"nBW" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4;
-	name = "Pod Bay"
+"hxB" = (
+/obj/shrub,
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"hKt" = (
+/obj/machinery/computer/riotgear{
+	dir = 8;
+	pixel_x = 32
 	},
-/obj/machinery/secscanner{
-	dir = 4;
-	icon_state = "scanner_on";
-	pixel_x = -20
+/turf/simulated/floor/red/side{
+	dir = 4
+	},
+/area/station/security/brig)
+"jlZ" = (
+/obj/machinery/computer/mining_shuttle{
+	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/hangar/main)
-"nLO" = (
-/turf/simulated/wall/auto/shuttle{
-	icon_state = "3"
-	},
-/area/shuttle/arrival/station)
-"nMl" = (
+/area/station/hallway/secondary/exit)
+"jSH" = (
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/external,
+/turf/simulated/floor/caution/northsouth,
+/area/station/hallway/secondary/exit)
+"kLb" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -33753,34 +33604,12 @@
 	},
 /turf/simulated/floor,
 /area/station/hangar/main)
-"ojw" = (
-/obj/machinery/light{
-	dir = 1;
-	name = "light fixture";
-	pixel_y = 21;
-	rigged = 0
+"kRF" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "2"
 	},
-/turf/simulated/floor/escape{
-	dir = 1
-	},
-/area/station/hallway/secondary/exit)
-"oov" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/external,
-/turf/simulated/floor/caution/northsouth,
-/area/station/hallway/secondary/exit)
-"pmN" = (
-/turf/simulated/floor,
-/area/station/hangar/main)
-"pqZ" = (
-/turf/simulated/shuttle/wall/cockpit,
 /area/shuttle/arrival/station)
-"pFl" = (
-/turf/simulated/floor/arrival{
-	dir = 5
-	},
-/area/station/hallway/secondary/entry)
-"pPg" = (
+"kTd" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/light{
 	dir = 4;
@@ -33792,51 +33621,32 @@
 	dir = 5
 	},
 /area/station/hangar/main)
-"pQb" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor,
+"kVF" = (
+/obj/storage/closet/emergency,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
+"ljX" = (
+/turf/simulated/wall/auto/supernorn,
 /area/station/hangar/main)
-"pTE" = (
-/obj/machinery/manufacturer/hangar,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13"
+"lkX" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "4"
 	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 1
-	},
-/area/station/hangar/main)
-"qhU" = (
-/obj/lattice{
-	dir = 5;
-	icon_state = "lattice-dir"
-	},
-/obj/warp_beacon{
-	name = "Hangar Beacon"
-	},
-/turf/space,
-/area)
-"qnv" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/external,
-/turf/simulated/floor/escape{
-	dir = 1
-	},
-/area/station/hallway/secondary/exit)
-"qvd" = (
-/obj/grille,
-/turf/simulated/floor/plating/airless,
-/area/station/com_dish/auxdish)
-"qwu" = (
+/area/shuttle/arrival/station)
+"loM" = (
 /obj/machinery/vehicle/miniputt/armed,
 /turf/simulated/floor/engine,
 /area/station/hangar/main)
-"qwR" = (
+"lxX" = (
+/obj/machinery/vehicle/pod_smooth/light,
+/turf/simulated/floor/engine,
+/area/station/hangar/main)
+"lzK" = (
+/turf/simulated/floor/orangeblack/side{
+	dir = 9
+	},
+/area/station/hangar/main)
+"lGr" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/toolbox/electrical{
 	pixel_y = -3
@@ -33850,135 +33660,31 @@
 	dir = 1
 	},
 /area/station/hangar/main)
-"qSZ" = (
+"lHJ" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=crewhall";
+	location = "escape"
+	},
+/obj/stool/bench/red/auto,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"lIn" = (
+/turf/simulated/floor/orangeblack/corner{
+	dir = 1
+	},
+/area/station/hangar/main)
+"meL" = (
 /obj/landmark{
 	name = "Observer-Start"
 	},
 /turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
-"rre" = (
-/obj/storage/closet/emergency,
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"slX" = (
-/obj/reagent_dispensers/fueltank,
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 1
-	},
-/area/station/hangar/main)
-"smC" = (
-/turf/simulated/wall/auto/shuttle{
-	icon_state = "8"
-	},
-/area/shuttle/arrival/station)
-"svx" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
-"sxM" = (
-/turf/space,
-/area/shuttle/arrival/station)
-"tqT" = (
-/obj/machinery/door_control{
-	id = "hangar_arrivals";
-	name = "Pod Door Control";
-	pixel_x = 24
-	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 4
-	},
-/area/station/hangar/main)
-"tsx" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	layer = 9.1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/arrival{
-	dir = 10
-	},
-/area/station/hallway/secondary/entry)
-"tEe" = (
-/turf/simulated/floor/orangeblack/side{
-	dir = 1
-	},
-/area/station/hangar/main)
-"tFy" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 8
-	},
-/area/station/hangar/main)
-"tIG" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/hallway/secondary/entry)
-"tJP" = (
-/obj/submachine/cargopad/podbay,
-/turf/simulated/floor/orangeblack/side{
-	dir = 4
-	},
-/area/station/hangar/main)
-"tRT" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	layer = 9.1;
-	pixel_x = 10
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
-"utI" = (
-/obj/machinery/r_door_control{
-	id = "hangar_arrivals"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/hangar/main)
-"uxG" = (
-/obj/indestructible/shuttle_corner,
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"uJW" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/engineering{
-	dir = 4;
-	icon_state = "eng_closed"
-	},
-/obj/access_spawn/engineering,
-/obj/access_spawn/mining,
-/turf/simulated/floor/yellow,
-/area/station/engine/engineering)
-"uNb" = (
-/obj/table/reinforced/auto,
-/obj/item/device/radio{
-	pixel_x = -3;
-	pixel_y = 4
-	},
-/obj/item/device/radio{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"uUb" = (
+"mfr" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/machinery/shuttle/engine/heater{
 	dir = 8;
@@ -33986,22 +33692,17 @@
 	},
 /turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
-"veN" = (
-/obj/storage/closet/emergency,
-/obj/machinery/light/incandescent/netural{
-	dir = 1
+"mnq" = (
+/obj/grille,
+/turf/simulated/floor/plating/airless,
+/area)
+"mIg" = (
+/obj/cable{
+	icon_state = "2-4"
 	},
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"vCk" = (
-/obj/machinery/camera{
-	c_tag = "Escape Shuttle Dock"
-	},
-/turf/simulated/floor/escape{
-	dir = 1
-	},
+/turf/simulated/floor,
 /area/station/hallway/secondary/exit)
-"wfC" = (
+"nbH" = (
 /obj/machinery/light/emergency{
 	dir = 4;
 	icon_state = "ebulb1";
@@ -34013,28 +33714,148 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/hangar/main)
-"wpN" = (
-/obj/indestructible/shuttle_corner{
-	dir = 8
-	},
-/turf/simulated/shuttle/wall/corner{
-	dir = 4
-	},
+"nir" = (
+/obj/indestructible/shuttle_corner,
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
-"wtx" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/shuttle/engine/heater{
+"nln" = (
+/turf/simulated/floor/arrival{
+	dir = 5
+	},
+/area/station/hallway/secondary/entry)
+"nrV" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"nwF" = (
+/obj/storage/closet/wardrobe/mixed,
+/obj/random_item_spawner/dressup/one_or_zero,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
+"oez" = (
+/obj/machinery/manufacturer/hangar,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13"
+	},
+/turf/simulated/floor/orangeblack/side{
+	dir = 1
+	},
+/area/station/hangar/main)
+"ofi" = (
+/obj/decal/poster/wallsign/escape,
+/turf/simulated/wall/auto/supernorn,
+/area/station/hallway/secondary/exit)
+"ogN" = (
+/obj/machinery/light/emergency{
 	dir = 8;
-	icon_state = "alt_heater-R"
+	icon_state = "ebulb1";
+	pixel_x = -16
+	},
+/obj/decal/tile_edge/stripe/big{
+	dir = 1;
+	icon_state = "xtra_bigstripe-edge"
+	},
+/turf/simulated/floor/engine,
+/area/station/hangar/main)
+"okT" = (
+/turf/simulated/floor,
+/area/station/hangar/main)
+"oFx" = (
+/obj/storage/closet/emergency,
+/obj/machinery/light/incandescent/netural{
+	dir = 1
 	},
 /turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
-"wML" = (
+"peF" = (
+/obj/submachine/cargopad/podbay,
+/turf/simulated/floor/orangeblack/side{
+	dir = 4
+	},
+/area/station/hangar/main)
+"pnW" = (
+/turf/simulated/shuttle/wall/cockpit,
+/area/shuttle/arrival/station)
+"pBN" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
+"pNZ" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater-M"
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
+"pRW" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"qyL" = (
+/obj/lattice{
+	dir = 5;
+	icon_state = "lattice-dir"
+	},
+/obj/warp_beacon{
+	name = "Hangar Beacon"
+	},
+/turf/space,
+/area)
+"qKD" = (
 /turf/simulated/wall/auto/shuttle{
-	icon_state = "4"
+	icon_state = "3"
 	},
 /area/shuttle/arrival/station)
-"wTS" = (
+"ryg" = (
+/turf/simulated/floor/orangeblack/side{
+	dir = 1
+	},
+/area/station/hangar/main)
+"stv" = (
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	name = "Pod Bay"
+	},
+/obj/machinery/secscanner{
+	dir = 4;
+	icon_state = "scanner_on";
+	pixel_x = -20
+	},
+/turf/simulated/floor,
+/area/station/hangar/main)
+"tgv" = (
+/obj/machinery/door_control{
+	id = "hangar_arrivals";
+	name = "Pod Door Control";
+	pixel_x = 24
+	},
+/turf/simulated/floor/orangeblack/side{
+	dir = 4
+	},
+/area/station/hangar/main)
+"tAB" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/firstaid/regular,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
+"tRe" = (
 /obj/machinery/light/emergency{
 	dir = 1;
 	icon_state = "ebulb1"
@@ -34045,18 +33866,133 @@
 	dir = 5
 	},
 /area/station/hallway/secondary/exit)
-"xVX" = (
-/obj/machinery/camera{
-	c_tag = "Escape Shuttle Dock"
-	},
-/obj/machinery/light/emergency{
-	dir = 1;
-	icon_state = "ebulb1"
+"tYo" = (
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/escape{
 	dir = 1
 	},
 /area/station/hallway/secondary/exit)
+"uqH" = (
+/obj/table/reinforced/auto,
+/obj/item/device/radio{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/obj/item/device/radio{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
+"uJW" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/engineering{
+	dir = 4;
+	icon_state = "eng_closed"
+	},
+/obj/access_spawn/engineering,
+/obj/access_spawn/mining,
+/turf/simulated/floor/yellow,
+/area/station/engine/engineering)
+"uMt" = (
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/external,
+/turf/simulated/floor/escape{
+	dir = 1
+	},
+/area/station/hallway/secondary/exit)
+"uUi" = (
+/obj/indestructible/shuttle_corner{
+	dir = 4
+	},
+/turf/space,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
+"uYJ" = (
+/obj/reagent_dispensers/fueltank,
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/orangeblack/side{
+	dir = 1
+	},
+/area/station/hangar/main)
+"vdI" = (
+/obj/grille,
+/turf/simulated/floor/plating/airless,
+/area/station/com_dish/auxdish)
+"vCC" = (
+/turf/space,
+/area/shuttle/arrival/station)
+"vOu" = (
+/obj/machinery/camera{
+	c_tag = "Escape Shuttle Dock"
+	},
+/turf/simulated/floor/escape{
+	dir = 1
+	},
+/area/station/hallway/secondary/exit)
+"wKz" = (
+/obj/decal/tile_edge/stripe/big{
+	dir = 1;
+	icon_state = "xtra_bigstripe-edge"
+	},
+/turf/simulated/floor/engine,
+/area/station/hangar/main)
+"wOE" = (
+/turf/simulated/shuttle/wall/corner{
+	dir = 1
+	},
+/area/shuttle/arrival/station)
+"wVc" = (
+/turf/simulated/floor/escape{
+	dir = 5
+	},
+/area/station/hallway/secondary/exit)
+"xFl" = (
+/obj/machinery/computer/arcade,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
+"xMs" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
+"xPf" = (
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/shuttle,
+/area/shuttle/arrival/station)
+"ybI" = (
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	name = "Pod Bay"
+	},
+/obj/machinery/secscanner{
+	dir = 4;
+	icon_state = "scanner_on";
+	pixel_x = -20
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hangar/main)
 
 (1,1,1) = {"
 aaa
@@ -51807,7 +51743,7 @@ aaa
 aaa
 aaa
 aaa
-sxM
+vCC
 aaa
 aaa
 aaa
@@ -52021,7 +51957,7 @@ aaa
 aag
 aag
 aag
-wML
+lkX
 aag
 aag
 aag
@@ -52247,11 +52183,11 @@ aaa
 aag
 aaT
 aaZ
-wtx
-smC
-uUb
-fiF
-wtx
+eOZ
+hkT
+mfr
+pNZ
+eOZ
 aag
 aaa
 aaa
@@ -52475,9 +52411,9 @@ aah
 aaS
 ahn
 bsv
-gqz
-gqz
-nxw
+nwF
+nwF
+dtV
 aaS
 aah
 aaa
@@ -52706,7 +52642,7 @@ bsv
 bsv
 bsv
 aFe
-wpN
+fUf
 aaa
 aaa
 aaa
@@ -53158,7 +53094,7 @@ aUu
 bsv
 aam
 aap
-kNj
+kRF
 aaN
 awC
 awC
@@ -53381,14 +53317,14 @@ aaa
 aaa
 aaa
 aaM
-fGz
+xFl
 aBR
 aBR
 aBR
 bsv
-dkK
+xPf
 aaX
-tsx
+fzE
 awC
 awC
 awC
@@ -53396,7 +53332,7 @@ awC
 awC
 awC
 awC
-tIG
+fgT
 acq
 acJ
 acV
@@ -53608,9 +53544,9 @@ aaa
 aaa
 aaa
 aaM
-exP
+tAB
 bsv
-qSZ
+meL
 bsv
 bsv
 aaR
@@ -53623,7 +53559,7 @@ ayi
 ayi
 abQ
 ayi
-tIG
+fgT
 acr
 acK
 acW
@@ -53835,7 +53771,7 @@ aaa
 aaa
 aaa
 aaM
-uNb
+uqH
 aBR
 aBR
 aBR
@@ -53850,7 +53786,7 @@ abn
 ayi
 ayi
 ayi
-tIG
+fgT
 acs
 acL
 acs
@@ -54062,7 +53998,7 @@ aaa
 aaa
 aaa
 aaM
-uNb
+uqH
 bsv
 bsv
 bsv
@@ -54072,12 +54008,12 @@ ayi
 apV
 aaY
 ayH
-pFl
+nln
 aaY
 abv
 abE
 ayi
-tIG
+fgT
 acs
 acM
 acX
@@ -54289,22 +54225,22 @@ aaa
 aaa
 aaa
 aaM
-rre
+kVF
 aBR
 aBR
 aBR
-rre
-dkK
+kVF
+xPf
 aaY
 awo
 awC
 awC
 awC
 awC
-tIG
+fgT
 abC
 abK
-tIG
+fgT
 acs
 acM
 acX
@@ -54516,11 +54452,11 @@ aaa
 aaa
 aaa
 aaS
-veN
+oFx
 bsv
 bsv
 bsv
-kFk
+esU
 aaS
 awC
 awC
@@ -54528,10 +54464,10 @@ awC
 aaa
 aaa
 aaa
-tIG
+fgT
 brz
 ayi
-tIG
+fgT
 acs
 acM
 acX
@@ -54743,7 +54679,7 @@ aaa
 aaa
 aaa
 aaS
-exP
+tAB
 aBR
 aBR
 aBR
@@ -54754,12 +54690,12 @@ aaa
 aaa
 aaa
 aaa
-tIG
-tIG
+fgT
+fgT
 abG
 ayi
-tIG
-tIG
+fgT
+fgT
 acj
 acX
 adj
@@ -54970,24 +54906,24 @@ aQe
 aaa
 aaa
 aaA
-mHW
+uUi
 aam
 aBR
 aam
-uxG
-wpN
+nir
+fUf
 aaa
 aaa
 aaa
 aaa
-tIG
-tIG
+fgT
+fgT
 abw
 abH
 ayi
 abZ
 abQ
-hsO
+xMs
 acX
 adk
 adi
@@ -55197,17 +55133,17 @@ aaa
 aaa
 aaa
 aaa
-fki
-nLO
-nLO
-nLO
-lLU
+wOE
+qKD
+qKD
+qKD
+ctx
 aaa
 aaa
 aaa
 aaa
 aaa
-tIG
+fgT
 abo
 ayi
 ayi
@@ -55426,7 +55362,7 @@ aaa
 aaa
 aaa
 aaa
-pqZ
+pnW
 aaa
 aaa
 aaa
@@ -55434,10 +55370,10 @@ aaa
 aaa
 aaa
 aaa
-tIG
+fgT
 ayi
 ayi
-tRT
+pBN
 ayi
 ayi
 ayi
@@ -56151,7 +56087,7 @@ adn
 ajH
 alY
 amu
-amy
+aCZ
 any
 any
 awG
@@ -56624,7 +56560,7 @@ any
 any
 any
 any
-amy
+aCZ
 any
 any
 any
@@ -56800,7 +56736,7 @@ abl
 abt
 abt
 abL
-svx
+pRW
 ace
 acx
 ado
@@ -56851,7 +56787,7 @@ any
 any
 any
 bfV
-amy
+aCZ
 any
 any
 any
@@ -57089,7 +57025,7 @@ asl
 asl
 asl
 aBT
-aCd
+aCe
 aCt
 aCZ
 aAV
@@ -57317,8 +57253,8 @@ aAS
 avC
 aBU
 aCe
-aCu
-aCu
+aCZ
+aCZ
 aDZ
 aBS
 aFb
@@ -57479,7 +57415,7 @@ aaa
 aaB
 aaa
 aaa
-hUl
+gAo
 abM
 bqF
 ach
@@ -57933,9 +57869,9 @@ aaa
 aaB
 aaB
 aaa
-hUl
-iPq
-nfV
+gAo
+tYo
+gQo
 aci
 ajb
 acR
@@ -58151,7 +58087,7 @@ aaa
 aaa
 aaa
 aaa
-hUl
+gAo
 bqH
 bqH
 bqH
@@ -58160,12 +58096,12 @@ bqH
 bqH
 bqH
 bqH
-hUl
+gAo
 aak
 bqF
-hUl
-hUl
-hUl
+gAo
+gAo
+gAo
 ada
 adt
 adM
@@ -58379,7 +58315,7 @@ aaa
 aaa
 aaa
 bqH
-eXa
+eZI
 aaE
 aaE
 aaE
@@ -58390,7 +58326,7 @@ aaE
 abp
 aay
 bqF
-hUl
+gAo
 acB
 abY
 ada
@@ -58607,7 +58543,7 @@ aaa
 aaa
 bqH
 aak
-gMq
+mIg
 abN
 abN
 abN
@@ -58835,16 +58771,16 @@ aaa
 bqH
 aak
 bqF
-gkb
+nrV
 ado
 ado
 abf
 ado
 ado
 abB
-gkb
-gWe
-hUl
+nrV
+hxB
+gAo
 acD
 abY
 ada
@@ -59068,10 +59004,10 @@ bqH
 bqH
 bqH
 bqH
-hUl
-hUl
-hUl
-hUl
+gAo
+gAo
+gAo
+gAo
 acD
 abY
 abY
@@ -59515,7 +59451,7 @@ aab
 aaa
 bqH
 aak
-eND
+lHJ
 bqH
 aaa
 aaa
@@ -59740,8 +59676,8 @@ aab
 aab
 aab
 aaa
-hUl
-xVX
+gAo
+dic
 bro
 bqH
 aaa
@@ -59800,8 +59736,8 @@ any
 awG
 any
 any
-amy
-amy
+aCZ
+aCZ
 awG
 any
 axS
@@ -60027,8 +59963,8 @@ any
 any
 any
 any
-amy
-amy
+aCZ
+aCZ
 any
 any
 axT
@@ -60192,10 +60128,10 @@ aab
 aab
 aab
 aab
-hUl
+gAo
 bqH
-hUl
-ojw
+gAo
+eyu
 bro
 bqH
 aaa
@@ -60419,7 +60355,7 @@ aab
 aab
 aab
 aab
-hYt
+ofi
 bov
 aaE
 aay
@@ -60646,7 +60582,7 @@ aab
 aab
 aab
 aab
-qnv
+uMt
 aak
 adD
 adD
@@ -60873,7 +60809,7 @@ aab
 aab
 aab
 aab
-qnv
+uMt
 aak
 adD
 adD
@@ -60997,7 +60933,7 @@ bnI
 beV
 bfj
 bfj
-lAX
+hKt
 btf
 bpn
 bcS
@@ -61100,12 +61036,12 @@ aab
 aab
 aab
 aab
-hYt
-wTS
+ofi
+tRe
 aaJ
 bqE
 bqF
-mWm
+jlZ
 bqH
 abg
 abg
@@ -61115,7 +61051,7 @@ abg
 abg
 abg
 abg
-luV
+mnq
 add
 akj
 aim
@@ -61327,13 +61263,13 @@ aab
 aab
 aab
 aab
-hUl
+gAo
 bqH
-hUl
-vCk
+gAo
+vOu
 bqF
 ado
-oov
+jSH
 abg
 abg
 abg
@@ -61342,7 +61278,7 @@ abg
 abg
 abg
 abg
-luV
+mnq
 add
 akk
 aim
@@ -61557,7 +61493,7 @@ aab
 aaa
 aaa
 bqH
-nsN
+wVc
 bqG
 bqH
 bqH
@@ -61569,7 +61505,7 @@ abg
 abg
 abg
 abg
-luV
+mnq
 aim
 aim
 aim
@@ -61783,10 +61719,10 @@ aab
 aab
 aaa
 aaa
-lBZ
-nBW
-flX
-lBZ
+ljX
+stv
+ybI
+ljX
 aaa
 abg
 abg
@@ -61796,8 +61732,8 @@ abg
 abg
 abg
 aaa
-luV
-qvd
+mnq
+vdI
 aki
 aki
 aki
@@ -62010,10 +61946,10 @@ aab
 aab
 aaa
 aaa
-enb
-cTu
-tFy
-enb
+diB
+lzK
+dGY
+diB
 aaa
 abg
 abg
@@ -62237,10 +62173,10 @@ aab
 aaa
 aaa
 aaa
-enb
-tEe
-egi
-enb
+diB
+ryg
+ftH
+diB
 aaa
 aaa
 aaa
@@ -62463,16 +62399,16 @@ aab
 aab
 aaa
 aaa
-lBZ
-lBZ
-tEe
-egi
-lBZ
-lBZ
-enb
-enb
-lBZ
-lBZ
+ljX
+ljX
+ryg
+ftH
+ljX
+ljX
+diB
+diB
+ljX
+ljX
 aaa
 aaa
 aaa
@@ -62690,16 +62626,16 @@ aab
 aaa
 aaa
 aaa
-lBZ
-ghi
-cPd
-egi
-dIu
-mWC
-mWC
-qwu
-jOo
-lBZ
+ljX
+fKD
+lIn
+ftH
+ogN
+bOS
+bOS
+loM
+epj
+ljX
 bsh
 bsh
 bsh
@@ -62917,16 +62853,16 @@ aab
 aaa
 aaa
 aaa
-lBZ
-slX
-nMl
-pQb
-jjg
-epu
-mWC
-mWC
-mWC
-enb
+ljX
+uYJ
+kLb
+ecE
+wKz
+lxX
+bOS
+bOS
+bOS
+diB
 aaa
 aaa
 aaa
@@ -63144,16 +63080,16 @@ aaa
 aaa
 aaa
 aaa
-lBZ
-pTE
-pmN
-pmN
-jjg
-mWC
-mWC
-qwu
-mWC
-enb
+ljX
+oez
+okT
+okT
+wKz
+bOS
+bOS
+loM
+bOS
+diB
 aaa
 aaa
 aaa
@@ -63371,16 +63307,16 @@ aaa
 aaa
 aaa
 aaa
-lBZ
-qwR
-pmN
-pmN
-jjg
-mWC
-mWC
-mWC
-mWC
-enb
+ljX
+lGr
+okT
+okT
+wKz
+bOS
+bOS
+bOS
+bOS
+diB
 aaa
 aaa
 aaa
@@ -63598,16 +63534,16 @@ aaa
 aaa
 aaa
 aaa
-lBZ
-pPg
-tJP
-tqT
-wfC
-mWC
-mWC
-mWC
-jOo
-lBZ
+ljX
+kTd
+peF
+tgv
+nbH
+bOS
+bOS
+bOS
+epj
+ljX
 bsh
 bsh
 bsh
@@ -63825,16 +63761,16 @@ aaa
 aaa
 aaa
 aaa
-lBZ
-lBZ
-lBZ
-lBZ
-lBZ
-fqo
-fqo
-fqo
-utI
-lBZ
+ljX
+ljX
+ljX
+ljX
+ljX
+ftA
+ftA
+ftA
+djX
+ljX
 aaa
 aaa
 aaa
@@ -65874,7 +65810,7 @@ aaa
 aaa
 aaa
 aaa
-qhU
+qyL
 aaa
 aaa
 aaa

--- a/maps/unused/mushroom_new_walls.dmm
+++ b/maps/unused/mushroom_new_walls.dmm
@@ -48,27 +48,22 @@
 	name = "solar paneling"
 	},
 /area/station/solar/west)
-"aaf" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/hallway/secondary/shuttle)
 "aag" = (
-/obj/lattice{
-	dir = 9;
-	icon_state = "lattice-dir"
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "alt_propulsion"
 	},
 /turf/space,
-/area)
+/area/shuttle/arrival/station)
 "aah" = (
-/obj/lattice,
-/obj/warp_beacon{
-	name = "Hangar Beacon"
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater"
 	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "12"
 	},
-/turf/space,
-/area)
+/area/shuttle/arrival/station)
 "aai" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/secscanner{
@@ -83,17 +78,11 @@
 /obj/access_spawn/security,
 /turf/simulated/floor,
 /area/station/security/checkpoint)
-"aaj" = (
-/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/arrivals_horizontal,
-/turf/simulated/floor/engine,
-/area/station/hallway/secondary/shuttle)
 "aak" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/external,
 /turf/simulated/floor/escape{
 	dir = 1
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "aal" = (
 /obj/cable{
 	d2 = 8;
@@ -111,188 +100,77 @@
 /turf/simulated/floor/plating/airless,
 /area/station/solar/west)
 "aam" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/arrivals_horizontal,
-/turf/simulated/floor/engine,
-/area/station/hallway/secondary/shuttle)
-"aan" = (
-/obj/machinery/r_door_control{
-	id = "hangar_arrivals"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/hallway/secondary/shuttle)
-"aao" = (
-/obj/machinery/door_control{
-	id = "hangar_arrivals";
-	name = "Pod Door Control";
-	pixel_x = -24
-	},
-/turf/simulated/floor/engine,
-/area/station/hallway/secondary/shuttle)
+/obj/machinery/light/small/floor/netural,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
 "aap" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/machinery/sleeper/compact,
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor3"
 	},
-/turf/simulated/floor/engine,
-/area/station/hallway/secondary/shuttle)
-"aaq" = (
-/turf/simulated/floor/engine,
-/area/station/hallway/secondary/shuttle)
-"aar" = (
-/obj/table/reinforced/auto,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/electrical,
-/obj/machinery/camera{
-	c_tag = "Medical External Airlock";
-	dir = 2
-	},
-/obj/random_item_spawner/tools,
-/turf/simulated/floor/engine,
-/area/station/hallway/secondary/shuttle)
-"aas" = (
-/obj/table/reinforced/auto,
-/obj/random_item_spawner/tools,
-/turf/simulated/floor/engine,
-/area/station/hallway/secondary/shuttle)
+/area/shuttle/arrival/station)
 "aat" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/shuttle)
-"aau" = (
-/obj/machinery/light/emergency{
-	dir = 1;
-	icon_state = "ebulb1"
-	},
-/turf/simulated/floor/escape{
-	dir = 9
-	},
-/area/station/hallway/secondary/shuttle)
-"aav" = (
-/turf/simulated/floor/escape{
+"aay" = (
+/turf/simulated/floor/escape/corner{
 	dir = 1
 	},
-/area/station/hallway/secondary/shuttle)
-"aaw" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/engine,
-/area/station/hallway/secondary/shuttle)
-"aax" = (
-/obj/machinery/manufacturer/hangar,
-/turf/simulated/floor/engine,
-/area/station/hallway/secondary/shuttle)
-"aay" = (
-/turf/simulated/floor/escape{
-	dir = 8
-	},
-/area/station/hallway/secondary/shuttle)
-"aaz" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=crewhall";
-	location = "escape"
-	},
-/obj/stool/bench/red/auto,
-/turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "aaA" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/external,
-/turf/simulated/floor/caution/northsouth,
-/area/station/hallway/secondary/shuttle)
+/obj/indestructible/shuttle_corner{
+	dir = 1
+	},
+/turf/simulated/shuttle/wall/corner{
+	dir = 1
+	},
+/area/shuttle/arrival/station)
 "aaB" = (
 /obj/lattice,
 /turf/space,
 /area)
-"aaC" = (
-/obj/storage/closet/welding_supply,
-/turf/simulated/floor/engine,
-/area/station/hallway/secondary/shuttle)
 "aaD" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	layer = 9.1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/engine,
-/area/station/hallway/secondary/shuttle)
+/obj/storage/closet/wardrobe/pride,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
 "aaE" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	layer = 9.1;
-	pixel_x = -10
-	},
 /turf/simulated/floor/escape{
-	dir = 9
+	dir = 8
 	},
-/area/station/hallway/secondary/shuttle)
-"aaF" = (
-/obj/machinery/camera{
-	c_tag = "Escape Shuttle Dock"
-	},
-/turf/simulated/floor/escape{
-	dir = 1
-	},
-/area/station/hallway/secondary/shuttle)
-"aaG" = (
-/obj/machinery/light{
-	dir = 1;
-	name = "light fixture";
-	pixel_y = 21;
-	rigged = 0
-	},
-/turf/simulated/floor/escape{
-	dir = 1
-	},
-/area/station/hallway/secondary/shuttle)
-"aaH" = (
-/turf/simulated/floor/escape/corner{
-	dir = 1
-	},
-/area/station/hallway/secondary/shuttle)
-"aaI" = (
-/turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "aaJ" = (
-/obj/machinery/light/emergency{
-	dir = 1;
-	icon_state = "ebulb1"
-	},
-/turf/simulated/floor/escape{
-	dir = 5
-	},
-/area/station/hallway/secondary/shuttle)
-"aaK" = (
-/obj/table/auto,
-/obj/machinery/shieldgenerator/meteorshield,
-/turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
-"aaL" = (
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1";
 	layer = 9.1;
 	pixel_x = 10
 	},
-/turf/simulated/floor/engine,
-/area/station/hallway/secondary/shuttle)
+/turf/simulated/floor/escape{
+	dir = 4
+	},
+/area/station/hallway/secondary/exit)
+"aaL" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/toolbox/emergency{
+	pixel_x = -1;
+	pixel_y = 9
+	},
+/obj/item/storage/toolbox/emergency{
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
 "aaM" = (
-/obj/machinery/light/emergency{
-	dir = 8;
-	icon_state = "ebulb1";
-	pixel_x = -16
-	},
-/turf/simulated/floor/engine,
-/area/station/hallway/secondary/shuttle)
+/obj/wingrille_spawn/auto/crystal,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
 "aaN" = (
-/obj/machinery/vehicle/pod_smooth/light,
-/obj/cable{
-	icon_state = "1-2"
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "13"
 	},
-/turf/simulated/floor/engine,
-/area/station/hallway/secondary/shuttle)
+/area/shuttle/arrival/station)
 "aaO" = (
 /obj/cable{
 	d2 = 2;
@@ -312,56 +190,27 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "aaQ" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/turf/simulated/floor/arrival/corner{
+	dir = 8
 	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/entry)
 "aaR" = (
-/obj/machinery/vehicle/miniputt/armed,
-/turf/simulated/floor/engine,
-/area/station/hallway/secondary/shuttle)
+/obj/machinery/door/airlock/pyro/external,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
 "aaS" = (
-/obj/machinery/light/emergency{
-	dir = 4;
-	icon_state = "ebulb1";
-	pixel_x = 16
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "12"
 	},
-/turf/simulated/floor/engine,
-/area/station/hallway/secondary/shuttle)
+/area/shuttle/arrival/station)
 "aaT" = (
-/obj/machinery/power/apc{
+/obj/machinery/shuttle/engine/heater{
 	dir = 8;
-	name = "W APC";
-	pixel_x = -24;
-	pixel_y = 0
+	icon_state = "alt_heater-L"
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
-/turf/simulated/floor/engine,
-/area/station/hallway/secondary/shuttle)
-"aaU" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/engine,
-/area/station/hallway/secondary/shuttle)
-"aaV" = (
-/obj/machinery/computer/mining_shuttle,
-/turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/obj/wingrille_spawn/auto/crystal,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
 "aaW" = (
 /obj/cable{
 	d1 = 1;
@@ -371,22 +220,24 @@
 /turf/simulated/floor/plating/airless,
 /area/station/solar/west)
 "aaX" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/turf/simulated/floor/arrival{
+	dir = 8
 	},
-/turf/simulated/floor/engine,
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/entry)
 "aaY" = (
 /turf/simulated/floor/arrival{
 	dir = 4
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/entry)
 "aaZ" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area)
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater-M"
+	},
+/obj/wingrille_spawn/auto/crystal,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
 "aba" = (
 /obj/cable{
 	d1 = 4;
@@ -442,24 +293,21 @@
 	network = "SS13"
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "abg" = (
 /turf/space,
 /area/shuttle/mining/station)
 "abh" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1";
 	layer = 9.1;
 	pixel_x = -10
 	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/turf/simulated/floor/arrival{
+	dir = 1
+	},
+/area/station/hallway/secondary/entry)
 "abi" = (
 /obj/cable{
 	d2 = 2;
@@ -526,11 +374,11 @@
 	location = "arrivals"
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/entry)
 "abo" = (
 /obj/shrub,
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/entry)
 "abp" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/light{
@@ -542,7 +390,7 @@
 /turf/simulated/floor/escape{
 	dir = 8
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "abq" = (
 /obj/machinery/light_switch{
 	name = "N light switch";
@@ -591,7 +439,7 @@
 /turf/simulated/floor/arrival{
 	dir = 4
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/entry)
 "abw" = (
 /obj/machinery/light{
 	dir = 8;
@@ -602,7 +450,7 @@
 /turf/simulated/floor/arrival{
 	dir = 8
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/entry)
 "abx" = (
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
@@ -635,8 +483,13 @@
 /area/station/security/checkpoint)
 "abA" = (
 /obj/machinery/door/firedoor/pyro,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "abB" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/camera{
@@ -644,7 +497,7 @@
 	dir = 8
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "abC" = (
 /obj/machinery/door/firedoor/pyro{
 	dir = 8
@@ -652,7 +505,7 @@
 /turf/simulated/floor/arrival{
 	dir = 1
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/entry)
 "abD" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/NEmaint)
@@ -660,7 +513,7 @@
 /turf/simulated/floor/arrival/corner{
 	dir = 4
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/entry)
 "abF" = (
 /obj/cable{
 	d1 = 2;
@@ -679,12 +532,12 @@
 /turf/simulated/floor/arrival{
 	dir = 1
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/entry)
 "abH" = (
 /turf/simulated/floor/arrival/corner{
 	dir = 1
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/entry)
 "abI" = (
 /obj/cable,
 /obj/cable{
@@ -703,16 +556,11 @@
 /turf/simulated/floor,
 /area/station/security/checkpoint)
 "abK" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/firedoor/pyro{
 	dir = 8
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/entry)
 "abL" = (
 /obj/cable,
 /obj/cable{
@@ -732,14 +580,15 @@
 /turf/simulated/floor/escape{
 	dir = 1
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "abN" = (
 /obj/cable{
+	d1 = 1;
 	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "abO" = (
 /obj/item/device/analyzer/atmospheric,
 /turf/simulated/floor/plating,
@@ -756,15 +605,7 @@
 	pixel_x = -10
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
-"abR" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/entry)
 "abS" = (
 /obj/cable{
 	d1 = 1;
@@ -775,15 +616,7 @@
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/access_spawn/maint,
 /turf/simulated/floor/plating,
-/area/station/maintenance/NEmaint)
-"abT" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "abU" = (
 /obj/machinery/light{
 	dir = 1;
@@ -792,15 +625,7 @@
 	rigged = 0
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
-"abV" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "abW" = (
 /obj/cable{
 	d1 = 4;
@@ -812,7 +637,7 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "abX" = (
 /obj/cable{
 	d1 = 2;
@@ -825,7 +650,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "abY" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
@@ -835,19 +660,19 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/entry)
 "aca" = (
 /turf/simulated/floor{
 	icon_state = "L1";
 	tag = "icon-L1"
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "acb" = (
 /turf/simulated/floor{
 	icon_state = "L3";
 	tag = "icon-L3"
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "acc" = (
 /obj/cable{
 	d1 = 1;
@@ -858,37 +683,37 @@
 	icon_state = "L5";
 	tag = "icon-L5"
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "acd" = (
 /turf/simulated/floor{
 	icon_state = "L7";
 	tag = "icon-L7"
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "ace" = (
 /turf/simulated/floor{
 	icon_state = "L9";
 	tag = "icon-L9"
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "acf" = (
 /turf/simulated/floor{
 	icon_state = "L11";
 	tag = "icon-L11"
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "acg" = (
 /turf/simulated/floor{
 	icon_state = "L13";
 	tag = "icon-L13"
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "ach" = (
 /turf/simulated/floor{
 	icon_state = "L15";
 	tag = "icon-L15"
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "aci" = (
 /obj/machinery/camera{
 	c_tag = "Shuttle Bay East";
@@ -897,7 +722,7 @@
 /obj/table/glass/auto,
 /obj/random_item_spawner/med_kit,
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "acj" = (
 /obj/cable{
 	d1 = 4;
@@ -999,13 +824,13 @@
 	icon_state = "L2";
 	tag = "icon-L2"
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "acu" = (
 /turf/simulated/floor{
 	icon_state = "L4";
 	tag = "icon-L4"
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "acv" = (
 /obj/cable{
 	d1 = 1;
@@ -1016,37 +841,37 @@
 	icon_state = "L6";
 	tag = "icon-L6"
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "acw" = (
 /turf/simulated/floor{
 	icon_state = "L8";
 	tag = "icon-L8"
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "acx" = (
 /turf/simulated/floor{
 	icon_state = "L10";
 	tag = "icon-L10"
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "acy" = (
 /turf/simulated/floor{
 	icon_state = "L12";
 	tag = "icon-L12"
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "acz" = (
 /turf/simulated/floor{
 	icon_state = "L14";
 	tag = "icon-L14"
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "acA" = (
 /turf/simulated/floor{
 	icon_state = "L16";
 	tag = "icon-L16"
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "acB" = (
 /obj/storage/closet/emergency,
 /turf/simulated/floor/plating,
@@ -1186,7 +1011,7 @@
 	},
 /obj/machinery/light/emergency,
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/entry)
 "acP" = (
 /obj/cable{
 	d1 = 4;
@@ -1195,7 +1020,7 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "acQ" = (
 /obj/cable{
 	d1 = 1;
@@ -1208,7 +1033,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "acR" = (
 /obj/submachine/ATM{
 	pixel_x = 30
@@ -1220,7 +1045,7 @@
 	tag = "icon-rwindow (NORTH)"
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "acS" = (
 /obj/cable{
 	d1 = 1;
@@ -1372,14 +1197,8 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "ado" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	layer = 9.1;
-	pixel_x = 10
-	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "adp" = (
 /obj/cable{
 	d1 = 1;
@@ -1533,7 +1352,7 @@
 /turf/simulated/floor/white/checker{
 	dir = 9
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "adE" = (
 /obj/cable{
 	d1 = 1;
@@ -3279,10 +3098,14 @@
 /turf/simulated/floor/orangeblack,
 /area/station/quartermaster/office)
 "ahn" = (
-/obj/dummy_pad,
-/obj/landmark/start/latejoin,
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
+/obj/cryotron{
+	layer = 3.9
+	},
+/obj/machinery/light/incandescent/netural{
+	dir = 1
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
 "aho" = (
 /obj/cable{
 	d2 = 2;
@@ -4008,7 +3831,7 @@
 /obj/random_item_spawner/tools,
 /obj/random_item_spawner/tools,
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "ajc" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -7067,14 +6890,6 @@
 /turf/simulated/floor/plating,
 /turf/simulated/floor/plating/damaged2,
 /area/station/maintenance/NWmaint)
-"apu" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/engine,
-/area/station/hallway/secondary/shuttle)
 "apv" = (
 /obj/disposalpipe/segment,
 /turf/simulated/wall/auto/supernorn,
@@ -7293,7 +7108,7 @@
 /turf/simulated/floor/arrival/corner{
 	dir = 2
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/entry)
 "apW" = (
 /obj/disposalpipe/segment,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -10200,10 +10015,16 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "awo" = (
-/turf/simulated/floor/arrival{
-	dir = 2
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	layer = 9.1;
+	pixel_x = 10
 	},
-/area/station/hallway/secondary/shuttle)
+/turf/simulated/floor/arrival{
+	dir = 6
+	},
+/area/station/hallway/secondary/entry)
 "awp" = (
 /obj/machinery/camera{
 	c_tag = "Medical Maintenance - North";
@@ -10308,11 +10129,9 @@
 /turf/simulated/floor,
 /area/station/storage/emergency)
 "awC" = (
-/obj/machinery/light,
-/turf/simulated/floor/arrival/corner{
-	dir = 8
-	},
-/area/station/hallway/secondary/shuttle)
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry)
 "awD" = (
 /obj/machinery/bot/cleanbot,
 /turf/simulated/floor/grime,
@@ -10663,15 +10482,9 @@
 /turf/simulated/floor/blueblack/corner,
 /area/station/medical/robotics)
 "axw" = (
-/obj/reagent_dispensers/fueltank,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	layer = 9.1;
-	pixel_x = 10
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/turf/space,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
 "axx" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -11000,9 +10813,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "ayi" = (
-/obj/submachine/cargopad/podbay,
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/entry)
 "ayj" = (
 /turf/simulated/floor/black,
 /area/station/medical/research)
@@ -11092,19 +10904,13 @@
 /area/station/storage/warehouse)
 "ayv" = (
 /obj/machinery/door/firedoor/pyro,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Pod Bay"
 	},
-/obj/machinery/secscanner{
-	pixel_y = 10
+/turf/simulated/floor/arrival{
+	dir = 10
 	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/entry)
 "ayw" = (
 /obj/table/auto,
 /turf/simulated/floor/blueblack/corner{
@@ -11228,13 +11034,10 @@
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Pod Bay"
 	},
-/obj/machinery/secscanner{
-	pixel_y = 10
-	},
 /turf/simulated/floor/arrival{
-	dir = 4
+	dir = 6
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/entry)
 "ayI" = (
 /obj/decal/cleanable/cobweb,
 /obj/storage/secure/closet/engineering/mining,
@@ -11277,7 +11080,6 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/dummy_pad,
 /turf/simulated/floor/grime,
 /area/station/storage/warehouse)
 "ayO" = (
@@ -12676,9 +12478,12 @@
 /turf/simulated/floor/plating/damaged1,
 /area/station/maintenance/west)
 "aBR" = (
-/obj/machinery/light/small,
-/turf/space,
-/area)
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 4
+	},
+/obj/landmark/start/latejoin,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
 "aBS" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -13464,8 +13269,6 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
-/obj/dummy_pad,
-/obj/landmark/start/latejoin,
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
 "aDw" = (
@@ -14223,15 +14026,10 @@
 /turf/simulated/floor,
 /area/station/medical/robotics)
 "aFe" = (
-/obj/lattice{
-	dir = 2;
-	icon_state = "lattice-dir"
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "14"
 	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/space,
-/area)
+/area/shuttle/arrival/station)
 "aFf" = (
 /obj/machinery/light{
 	dir = 8;
@@ -21863,12 +21661,10 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "aUu" = (
-/obj/dummy_pad,
-/obj/landmark/start/latejoin,
-/turf/simulated/floor/red/side{
-	dir = 4
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "1"
 	},
-/area/station/hallway/primary/south)
+/area/shuttle/arrival/station)
 "aUv" = (
 /obj/machinery/light{
 	dir = 8;
@@ -31281,13 +31077,20 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/captain)
 "bov" = (
-/obj/decal/poster/wallsign/escape,
-/turf/simulated/wall/auto/supernorn,
-/area/station/hallway/secondary/shuttle)
+/obj/machinery/light/emergency{
+	dir = 1;
+	icon_state = "ebulb1"
+	},
+/obj/table/auto,
+/obj/table/auto,
+/turf/simulated/floor/escape{
+	dir = 9
+	},
+/area/station/hallway/secondary/exit)
 "bow" = (
 /obj/decal/poster/wallsign/escape_right,
 /turf/simulated/wall/auto/supernorn,
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "box" = (
 /obj/machinery/door/airlock/pyro/external,
 /turf/simulated/floor/plating,
@@ -31667,8 +31470,6 @@
 	},
 /area/station/medical/medbay)
 "bpy" = (
-/obj/dummy_pad,
-/obj/landmark/start/latejoin,
 /turf/simulated/floor/bluewhite/corner{
 	dir = 1
 	},
@@ -32141,32 +31942,32 @@
 /turf/space,
 /area/station/turret_protected/ai)
 "bqE" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	layer = 9.1;
-	pixel_x = 10
-	},
-/turf/simulated/floor/escape{
-	dir = 4
-	},
-/area/station/hallway/secondary/shuttle)
-"bqF" = (
 /turf/simulated/floor/white/corner{
 	dir = 4
 	},
-/area/station/hallway/secondary/shuttle)
-"bqG" = (
-/obj/table/auto,
-/obj/machinery/shieldgenerator/meteorshield,
-/turf/simulated/floor/escape{
-	dir = 1
+/area/station/hallway/secondary/exit)
+"bqF" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/area/station/hallway/secondary/shuttle)
-"bqH" = (
-/obj/stool/bench/red/auto,
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
+"bqG" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/escape{
+	dir = 4
+	},
+/area/station/hallway/secondary/exit)
+"bqH" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/exit)
 "bqI" = (
 /obj/machinery/light,
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
@@ -32430,7 +32231,7 @@
 "brm" = (
 /obj/machinery/light/emergency,
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "brn" = (
 /obj/machinery/power/apc{
 	dir = 2;
@@ -32445,32 +32246,26 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
+"bro" = (
+/obj/stool/bench/red/auto,
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
-"bro" = (
-/obj/machinery/camera{
-	c_tag = "Escape Shuttle Dock"
-	},
-/obj/machinery/light/emergency{
-	dir = 1;
-	icon_state = "ebulb1"
-	},
-/turf/simulated/floor/escape{
-	dir = 1
-	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/exit)
 "brp" = (
 /obj/machinery/light/emergency{
 	dir = 1;
 	icon_state = "ebulb1"
 	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/turf/simulated/floor/arrival{
+	dir = 1
+	},
+/area/station/hallway/secondary/entry)
 "brq" = (
 /obj/storage/closet,
 /obj/machinery/light/small{
@@ -32560,7 +32355,7 @@
 /turf/simulated/floor/arrival{
 	dir = 1
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hallway/secondary/entry)
 "brA" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -32952,18 +32747,8 @@
 /turf/space,
 /area)
 "bsv" = (
-/obj/lattice{
-	dir = 2;
-	icon_state = "lattice-dir"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/space,
-/area)
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
 "bsw" = (
 /turf/simulated/floor/plating/airless,
 /area/station/mining/magnet)
@@ -33689,7 +33474,204 @@
 /obj/access_spawn/ai_upload,
 /turf/simulated/floor/black/side,
 /area/station/turret_protected/ai)
-"kSN" = (
+"cPd" = (
+/turf/simulated/floor/orangeblack/corner{
+	dir = 1
+	},
+/area/station/hangar/main)
+"cTu" = (
+/turf/simulated/floor/orangeblack/side{
+	dir = 9
+	},
+/area/station/hangar/main)
+"dkK" = (
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/shuttle,
+/area/shuttle/arrival/station)
+"dIu" = (
+/obj/machinery/light/emergency{
+	dir = 8;
+	icon_state = "ebulb1";
+	pixel_x = -16
+	},
+/obj/decal/tile_edge/stripe/big{
+	dir = 1;
+	icon_state = "xtra_bigstripe-edge"
+	},
+/turf/simulated/floor/engine,
+/area/station/hangar/main)
+"egi" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hangar/main)
+"enb" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/hangar/main)
+"epu" = (
+/obj/machinery/vehicle/pod_smooth/light,
+/turf/simulated/floor/engine,
+/area/station/hangar/main)
+"exP" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/firstaid/regular,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
+"eND" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=crewhall";
+	location = "escape"
+	},
+/obj/stool/bench/red/auto,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"eXa" = (
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/escape{
+	dir = 9
+	},
+/area/station/hallway/secondary/exit)
+"fiF" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater-M"
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
+"fki" = (
+/turf/simulated/shuttle/wall/corner{
+	dir = 1
+	},
+/area/shuttle/arrival/station)
+"flX" = (
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	name = "Pod Bay"
+	},
+/obj/machinery/secscanner{
+	dir = 4;
+	icon_state = "scanner_on";
+	pixel_x = -20
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hangar/main)
+"fqo" = (
+/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/arrivals_horizontal{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/station/hangar/main)
+"fGz" = (
+/obj/machinery/computer/arcade,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
+"ghi" = (
+/obj/storage/closet/welding_supply,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/orangeblack/side{
+	dir = 9
+	},
+/area/station/hangar/main)
+"gkb" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"gqz" = (
+/obj/storage/closet/wardrobe/mixed,
+/obj/random_item_spawner/dressup/one_or_zero,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
+"gMq" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"gWe" = (
+/obj/shrub,
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"hsO" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
+"hUl" = (
+/turf/simulated/wall/auto/supernorn,
+/area/station/hallway/secondary/exit)
+"hYt" = (
+/obj/decal/poster/wallsign/escape,
+/turf/simulated/wall/auto/supernorn,
+/area/station/hallway/secondary/exit)
+"iPq" = (
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/escape{
+	dir = 1
+	},
+/area/station/hallway/secondary/exit)
+"jjg" = (
+/obj/decal/tile_edge/stripe/big{
+	dir = 1;
+	icon_state = "xtra_bigstripe-edge"
+	},
+/turf/simulated/floor/engine,
+/area/station/hangar/main)
+"jOo" = (
+/obj/machinery/light,
+/turf/simulated/floor/engine,
+/area/station/hangar/main)
+"kFk" = (
+/obj/storage/closet/emergency,
+/obj/machinery/light/incandescent/netural,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
+"kNj" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "2"
+	},
+/area/shuttle/arrival/station)
+"luV" = (
+/obj/grille,
+/turf/simulated/floor/plating/airless,
+/area)
+"lAX" = (
 /obj/machinery/computer/riotgear{
 	dir = 8;
 	pixel_x = 32
@@ -33698,6 +33680,277 @@
 	dir = 4
 	},
 /area/station/security/brig)
+"lBZ" = (
+/turf/simulated/wall/auto/supernorn,
+/area/station/hangar/main)
+"lLU" = (
+/turf/simulated/shuttle/wall/corner{
+	dir = 4
+	},
+/area/shuttle/arrival/station)
+"mHW" = (
+/obj/indestructible/shuttle_corner{
+	dir = 4
+	},
+/turf/space,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
+"mWm" = (
+/obj/machinery/computer/mining_shuttle{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"mWC" = (
+/turf/simulated/floor/engine,
+/area/station/hangar/main)
+"nfV" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"nsN" = (
+/turf/simulated/floor/escape{
+	dir = 5
+	},
+/area/station/hallway/secondary/exit)
+"nxw" = (
+/obj/storage/closet/wardrobe/mixed,
+/obj/random_item_spawner/dressup/one_or_zero,
+/obj/machinery/light/incandescent/netural,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
+"nBW" = (
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	name = "Pod Bay"
+	},
+/obj/machinery/secscanner{
+	dir = 4;
+	icon_state = "scanner_on";
+	pixel_x = -20
+	},
+/turf/simulated/floor,
+/area/station/hangar/main)
+"nLO" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
+	},
+/area/shuttle/arrival/station)
+"nMl" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hangar/main)
+"ojw" = (
+/obj/machinery/light{
+	dir = 1;
+	name = "light fixture";
+	pixel_y = 21;
+	rigged = 0
+	},
+/turf/simulated/floor/escape{
+	dir = 1
+	},
+/area/station/hallway/secondary/exit)
+"oov" = (
+/obj/machinery/door/firedoor/pyro,
+/obj/machinery/door/airlock/pyro/external,
+/turf/simulated/floor/caution/northsouth,
+/area/station/hallway/secondary/exit)
+"pmN" = (
+/turf/simulated/floor,
+/area/station/hangar/main)
+"pqZ" = (
+/turf/simulated/shuttle/wall/cockpit,
+/area/shuttle/arrival/station)
+"pFl" = (
+/turf/simulated/floor/arrival{
+	dir = 5
+	},
+/area/station/hallway/secondary/entry)
+"pPg" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/simulated/floor/orangeblack/side{
+	dir = 5
+	},
+/area/station/hangar/main)
+"pQb" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/hangar/main)
+"pTE" = (
+/obj/machinery/manufacturer/hangar,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13"
+	},
+/turf/simulated/floor/orangeblack/side{
+	dir = 1
+	},
+/area/station/hangar/main)
+"qhU" = (
+/obj/lattice{
+	dir = 5;
+	icon_state = "lattice-dir"
+	},
+/obj/warp_beacon{
+	name = "Hangar Beacon"
+	},
+/turf/space,
+/area)
+"qnv" = (
+/obj/machinery/door/firedoor/pyro,
+/obj/machinery/door/airlock/pyro/external,
+/turf/simulated/floor/escape{
+	dir = 1
+	},
+/area/station/hallway/secondary/exit)
+"qvd" = (
+/obj/grille,
+/turf/simulated/floor/plating/airless,
+/area/station/com_dish/auxdish)
+"qwu" = (
+/obj/machinery/vehicle/miniputt/armed,
+/turf/simulated/floor/engine,
+/area/station/hangar/main)
+"qwR" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/toolbox/electrical{
+	pixel_y = -3
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 7
+	},
+/obj/random_item_spawner/tools,
+/obj/random_item_spawner/tools,
+/turf/simulated/floor/orangeblack/side{
+	dir = 1
+	},
+/area/station/hangar/main)
+"qSZ" = (
+/obj/landmark{
+	name = "Observer-Start"
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
+"rre" = (
+/obj/storage/closet/emergency,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
+"slX" = (
+/obj/reagent_dispensers/fueltank,
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/orangeblack/side{
+	dir = 1
+	},
+/area/station/hangar/main)
+"smC" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "8"
+	},
+/area/shuttle/arrival/station)
+"svx" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"sxM" = (
+/turf/space,
+/area/shuttle/arrival/station)
+"tqT" = (
+/obj/machinery/door_control{
+	id = "hangar_arrivals";
+	name = "Pod Door Control";
+	pixel_x = 24
+	},
+/turf/simulated/floor/orangeblack/side{
+	dir = 4
+	},
+/area/station/hangar/main)
+"tsx" = (
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/arrival{
+	dir = 10
+	},
+/area/station/hallway/secondary/entry)
+"tEe" = (
+/turf/simulated/floor/orangeblack/side{
+	dir = 1
+	},
+/area/station/hangar/main)
+"tFy" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/orangeblack/side{
+	dir = 8
+	},
+/area/station/hangar/main)
+"tIG" = (
+/turf/simulated/wall/auto/supernorn,
+/area/station/hallway/secondary/entry)
+"tJP" = (
+/obj/submachine/cargopad/podbay,
+/turf/simulated/floor/orangeblack/side{
+	dir = 4
+	},
+/area/station/hangar/main)
+"tRT" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
+"utI" = (
+/obj/machinery/r_door_control{
+	id = "hangar_arrivals"
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/hangar/main)
+"uxG" = (
+/obj/indestructible/shuttle_corner,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
 "uJW" = (
 /obj/cable{
 	d1 = 4;
@@ -33713,6 +33966,97 @@
 /obj/access_spawn/mining,
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
+"uNb" = (
+/obj/table/reinforced/auto,
+/obj/item/device/radio{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/obj/item/device/radio{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
+"uUb" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater-L"
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
+"veN" = (
+/obj/storage/closet/emergency,
+/obj/machinery/light/incandescent/netural{
+	dir = 1
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
+"vCk" = (
+/obj/machinery/camera{
+	c_tag = "Escape Shuttle Dock"
+	},
+/turf/simulated/floor/escape{
+	dir = 1
+	},
+/area/station/hallway/secondary/exit)
+"wfC" = (
+/obj/machinery/light/emergency{
+	dir = 4;
+	icon_state = "ebulb1";
+	pixel_x = 16
+	},
+/obj/decal/tile_edge/stripe/big{
+	dir = 1;
+	icon_state = "xtra_bigstripe-edge"
+	},
+/turf/simulated/floor/engine,
+/area/station/hangar/main)
+"wpN" = (
+/obj/indestructible/shuttle_corner{
+	dir = 8
+	},
+/turf/simulated/shuttle/wall/corner{
+	dir = 4
+	},
+/area/shuttle/arrival/station)
+"wtx" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater-R"
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/arrival/station)
+"wML" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "4"
+	},
+/area/shuttle/arrival/station)
+"wTS" = (
+/obj/machinery/light/emergency{
+	dir = 1;
+	icon_state = "ebulb1"
+	},
+/obj/table/auto,
+/obj/machinery/shieldgenerator/meteorshield,
+/turf/simulated/floor/escape{
+	dir = 5
+	},
+/area/station/hallway/secondary/exit)
+"xVX" = (
+/obj/machinery/camera{
+	c_tag = "Escape Shuttle Dock"
+	},
+/obj/machinery/light/emergency{
+	dir = 1;
+	icon_state = "ebulb1"
+	},
+/turf/simulated/floor/escape{
+	dir = 1
+	},
+/area/station/hallway/secondary/exit)
 
 (1,1,1) = {"
 aaa
@@ -51453,7 +51797,6 @@ aaa
 aaa
 aaa
 aaa
-aaB
 aaa
 aaa
 aaa
@@ -51464,6 +51807,7 @@ aaa
 aaa
 aaa
 aaa
+sxM
 aaa
 aaa
 aaa
@@ -51674,13 +52018,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaB
+aag
+aag
+aag
+wML
+aag
+aag
+aag
 aaa
 aaa
 aaa
@@ -51900,15 +52244,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaB
-aaa
+aag
+aaT
+aaZ
+wtx
+smC
+uUb
+fiF
+wtx
+aag
 aaa
 aaa
 aaa
@@ -52127,15 +52471,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaB
-aaa
+aah
+aaS
+ahn
+bsv
+gqz
+gqz
+nxw
+aaS
+aah
 aaa
 aaa
 aaa
@@ -52354,17 +52698,17 @@ aaa
 aaa
 aQe
 aaa
+aaA
+aaN
+axw
+bsv
+bsv
+bsv
+bsv
+aFe
+wpN
 aaa
 aaa
-aQe
-aaa
-aaf
-aaf
-aaf
-aaf
-aaf
-aat
-aat
 aaa
 aaa
 aaa
@@ -52575,7 +52919,6 @@ aaa
 aaa
 aaa
 aaa
-aag
 aaa
 aaa
 aaa
@@ -52583,15 +52926,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaj
-aao
+aaM
+bsv
+bsv
+bsv
+bsv
 aaD
 aaM
-aaT
-abQ
-aat
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -52801,24 +53145,24 @@ aaa
 aaa
 aaa
 aaa
-bkO
-aah
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aFe
-aFe
-aFe
-aFe
-aFe
-aFe
-aFe
-aFe
+aUu
 bsv
 aam
 aap
-aap
+kNj
 aaN
-aaU
-aaI
-aat
+awC
+awC
+awC
 aaa
 aaa
 aaa
@@ -53029,7 +53373,6 @@ aaa
 aaa
 aaa
 aaa
-boo
 aaa
 aaa
 aaa
@@ -53037,22 +53380,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaj
-aaq
-aaq
-aaq
+aaM
+fGz
+aBR
+aBR
+aBR
+bsv
+dkK
 aaX
-aaI
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aaf
+tsx
+awC
+awC
+awC
+awC
+awC
+awC
+awC
+tIG
 acq
 acJ
 acV
@@ -53263,23 +53607,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaj
-aaq
-aaq
-aaq
-apu
+aaM
+exP
+bsv
+qSZ
+bsv
+bsv
+aaR
+ayi
 aaQ
-aaQ
+aaX
 ayv
 abh
-aaQ
-aaQ
-abh
-abV
-aaf
+ayi
+ayi
+abQ
+ayi
+tIG
 acr
 acK
 acW
@@ -53490,23 +53834,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+aaM
+uNb
 aBR
-aan
-aar
-aaq
-aaq
-aaq
-aaI
+aBR
+aBR
+bsv
+aaM
 ayi
-aat
+ayi
+ayi
+awC
 brp
 abn
-aaI
-aaI
-abR
-aaf
+ayi
+ayi
+ayi
+tIG
 acs
 acL
 acs
@@ -53717,23 +54061,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaf
-aas
-aaq
+aaM
+uNb
+bsv
+bsv
+bsv
+bsv
 aaR
-aaq
+ayi
 apV
 aaY
 ayH
-aaY
+pFl
 aaY
 abv
 abE
-abR
-aaf
+ayi
+tIG
 acs
 acM
 acX
@@ -53944,23 +54288,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaf
-aaw
-aaq
-aaq
-aaq
+aaM
+rre
+aBR
+aBR
+aBR
+rre
+dkK
+aaY
 awo
-aat
-aat
-aat
-aat
-aaf
+awC
+awC
+awC
+awC
+tIG
 abC
 abK
-aaf
+tIG
 acs
 acM
 acX
@@ -54171,23 +54515,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaf
-aax
-aaq
-aaR
-aaq
+aaS
+veN
+bsv
+bsv
+bsv
+kFk
+aaS
 awC
-aat
+awC
+awC
 aaa
 aaa
 aaa
-aaf
+tIG
 brz
-abR
-aaf
+ayi
+tIG
 acs
 acM
 acX
@@ -54398,24 +54742,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaf
-aaC
+aaS
+exP
+aBR
+aBR
+aBR
 aaL
 aaS
-aaq
-axw
-aat
 aaa
 aaa
-aaf
-aaf
+aaa
+aaa
+aaa
+tIG
+tIG
 abG
-abR
-aaf
-aaf
+ayi
+tIG
+tIG
 acj
 acX
 adj
@@ -54625,25 +54969,25 @@ aaa
 aQe
 aaa
 aaa
+aaA
+mHW
+aam
+aBR
+aam
+uxG
+wpN
 aaa
-aQe
 aaa
-aaf
-aaf
-aaf
-aaf
-aaf
-aat
-aat
-aaB
-aaf
-aaf
+aaa
+aaa
+tIG
+tIG
 abw
 abH
-abR
+ayi
 abZ
 abQ
-abR
+hsO
 acX
 adk
 adi
@@ -54853,23 +55197,23 @@ aaa
 aaa
 aaa
 aaa
+fki
+nLO
+nLO
+nLO
+lLU
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
+tIG
 abo
-aaI
-aaI
-abR
-aaI
-aaI
+ayi
+ayi
+ayi
+ayi
+ayi
 acO
 acX
 adl
@@ -55082,6 +55426,7 @@ aaa
 aaa
 aaa
 aaa
+pqZ
 aaa
 aaa
 aaa
@@ -55089,14 +55434,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaf
-aaI
-aaI
-ado
-abT
-aaQ
-aaQ
+tIG
+ayi
+ayi
+tRT
+ayi
+ayi
+ayi
 brn
 acX
 aoo
@@ -55321,9 +55665,9 @@ abd
 aai
 abd
 abd
-aaI
-aaI
-aaI
+ado
+ado
+ado
 acP
 acX
 adm
@@ -55548,10 +55892,10 @@ abd
 abq
 abx
 abd
-aaI
+ado
 aca
 act
-abR
+bqF
 aat
 aiM
 adn
@@ -55564,7 +55908,7 @@ adp
 aor
 agr
 boy
-ahn
+adn
 ahH
 adn
 adn
@@ -55778,7 +56122,7 @@ abI
 abU
 acb
 acu
-abR
+bqF
 aat
 aqB
 adn
@@ -56002,7 +56346,7 @@ abj
 abs
 abs
 abF
-aaQ
+abN
 acc
 acv
 acQ
@@ -56229,10 +56573,10 @@ abk
 abs
 aby
 abJ
-aaI
+ado
 acd
 acw
-aaI
+ado
 acY
 adn
 adn
@@ -56456,10 +56800,10 @@ abl
 abt
 abt
 abL
-abV
+svx
 ace
 acx
-aaI
+ado
 acY
 adn
 adn
@@ -56686,7 +57030,7 @@ abd
 abW
 acf
 acy
-aaI
+ado
 aat
 aqB
 adn
@@ -56910,10 +57254,10 @@ abd
 abd
 abd
 abd
-abR
+bqF
 acg
 acz
-aaI
+ado
 aat
 adq
 adJ
@@ -57135,9 +57479,9 @@ aaa
 aaB
 aaa
 aaa
-aaf
+hUl
 abM
-abR
+bqF
 ach
 acA
 brm
@@ -57363,11 +57707,11 @@ aaB
 aaa
 aaa
 bow
-aav
-abR
-aaI
-aaI
-aaI
+aak
+bqF
+ado
+ado
+ado
 ada
 adr
 adK
@@ -57589,9 +57933,9 @@ aaa
 aaB
 aaB
 aaa
-aaf
-aav
-abR
+hUl
+iPq
+nfV
 aci
 ajb
 acR
@@ -57807,21 +58151,21 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaf
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aaf
-aav
-abR
-aaf
-aaf
-aaf
+hUl
+bqH
+bqH
+bqH
+bqH
+bqH
+bqH
+bqH
+bqH
+hUl
+aak
+bqF
+hUl
+hUl
+hUl
 ada
 adt
 adM
@@ -58034,19 +58378,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aat
+bqH
+eXa
 aaE
-aay
-aay
-aay
-aay
-aay
-aay
+aaE
+aaE
+aaE
+aaE
+aaE
+aaE
 abp
-aaH
-abR
-aaf
+aay
+bqF
+hUl
 acB
 abY
 ada
@@ -58261,15 +58605,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aat
-aav
-aaI
-aaI
-aaI
-aaI
-aaI
-aaI
+bqH
+aak
+gMq
+abN
+abN
+abN
+abN
+abN
+abN
 abA
 abN
 abX
@@ -58477,7 +58821,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aab
 aab
 aab
@@ -58489,18 +58832,19 @@ aab
 aab
 aaa
 aaa
-aat
-aav
-aaI
+bqH
+aak
+bqF
+gkb
 ado
-aaI
+ado
 abf
-aaI
-aaI
-abB
 ado
-abo
-aaf
+ado
+abB
+gkb
+gWe
+hUl
 acD
 abY
 ada
@@ -58704,7 +59048,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aab
 aab
 aab
@@ -58716,18 +59059,19 @@ aab
 aab
 aaa
 aaa
-aat
-aav
-aaI
-aat
-aat
-aat
-aat
-aat
-aaf
-aaf
-aaf
-aaf
+bqH
+aak
+bqF
+bqH
+bqH
+bqH
+bqH
+bqH
+bqH
+hUl
+hUl
+hUl
+hUl
 acD
 abY
 abY
@@ -58930,7 +59274,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aab
 aab
 aab
@@ -58943,13 +59286,14 @@ aab
 aab
 aab
 aaa
-aat
-aav
 bqH
-aat
+aak
+bro
+bqH
 aaa
 aaa
-aaB
+aaa
+bsu
 aaa
 abD
 abO
@@ -59038,7 +59382,7 @@ bto
 bto
 aFc
 aFc
-aUu
+aVA
 aVA
 aVA
 aWV
@@ -59157,7 +59501,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aab
 aab
 aab
@@ -59170,13 +59513,14 @@ aab
 aab
 aab
 aaa
-aat
-aav
-aaz
-aat
+bqH
+aak
+eND
+bqH
 aaa
 aaa
-aaB
+aaa
+bsu
 aaa
 abD
 abP
@@ -59384,7 +59728,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aab
 aab
 aab
@@ -59397,13 +59740,14 @@ aab
 aab
 aab
 aaa
-aaf
+hUl
+xVX
 bro
 bqH
-aat
 aaa
 aaa
-aaB
+aaa
+bsu
 aaa
 abD
 abD
@@ -59612,7 +59956,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aab
 aab
 aab
@@ -59624,15 +59967,16 @@ aab
 aab
 aaa
 aaa
-aat
-aav
 bqH
-aat
-aaB
-aaB
+aak
+bro
+bqH
+bsh
+bsh
+bsh
 abm
-aaB
-aaB
+bsh
+bsh
 abD
 avP
 acm
@@ -59839,7 +60183,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aab
 aab
 aab
@@ -59849,12 +60192,13 @@ aab
 aab
 aab
 aab
-aaf
-aat
-aaf
-aaG
+hUl
 bqH
-aat
+hUl
+ojw
+bro
+bqH
+aaa
 aaa
 aaa
 aaa
@@ -60066,7 +60410,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aab
 aab
 aab
@@ -60076,19 +60419,20 @@ aab
 aab
 aab
 aab
+hYt
 bov
-aau
+aaE
 aay
-aaH
+bro
 bqH
-aat
 aaa
-abg
-abg
-abg
-abg
-abg
-abg
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaB
@@ -60293,7 +60637,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aab
 aab
 aab
@@ -60303,20 +60646,21 @@ aab
 aab
 aab
 aab
+qnv
 aak
-aav
 adD
 adD
-aaI
-aat
-aaZ
+bqF
+bqH
+aaa
 abg
 abg
 abg
 abg
 abg
 abg
-abg
+aaa
+aaa
 aaa
 aaa
 adb
@@ -60520,7 +60864,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aab
 aab
 aab
@@ -60530,13 +60873,13 @@ aab
 aab
 aab
 aab
+qnv
 aak
-aav
 adD
 adD
-aaI
-aaV
-aaZ
+bqF
+bqH
+bqH
 abg
 abg
 abg
@@ -60544,7 +60887,8 @@ abg
 abg
 abg
 abg
-abg
+aaa
+aaa
 aaa
 adc
 ady
@@ -60653,7 +60997,7 @@ bnI
 beV
 bfj
 bfj
-kSN
+lAX
 btf
 bpn
 bcS
@@ -60747,7 +61091,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aab
 aab
 aab
@@ -60757,13 +61100,13 @@ aab
 aab
 aab
 aab
-bov
+hYt
+wTS
 aaJ
 bqE
 bqF
-aaI
-aaI
-aaA
+mWm
+bqH
 abg
 abg
 abg
@@ -60772,6 +61115,7 @@ abg
 abg
 abg
 abg
+luV
 add
 akj
 aim
@@ -60974,7 +61318,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aab
 aab
 aab
@@ -60984,13 +61327,13 @@ aab
 aab
 aab
 aab
-aaf
-aat
-aaf
-aaF
-aaI
-aat
-aaZ
+hUl
+bqH
+hUl
+vCk
+bqF
+ado
+oov
 abg
 abg
 abg
@@ -60999,6 +61342,7 @@ abg
 abg
 abg
 abg
+luV
 add
 akk
 aim
@@ -61201,7 +61545,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aab
 aab
 aab
@@ -61213,11 +61556,11 @@ aab
 aab
 aaa
 aaa
-aat
+bqH
+nsN
 bqG
-aaK
-aat
-aaa
+bqH
+bqH
 abg
 abg
 abg
@@ -61225,7 +61568,8 @@ abg
 abg
 abg
 abg
-aaa
+abg
+luV
 aim
 aim
 aim
@@ -61428,7 +61772,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aab
 aab
 aab
@@ -61440,10 +61783,10 @@ aab
 aab
 aaa
 aaa
-aaf
-aat
-aat
-aat
+lBZ
+nBW
+flX
+lBZ
 aaa
 abg
 abg
@@ -61451,9 +61794,10 @@ abg
 abg
 abg
 abg
+abg
 aaa
-aaa
-aki
+luV
+qvd
 aki
 aki
 aki
@@ -61655,7 +61999,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aab
 aab
 aab
@@ -61667,16 +62010,17 @@ aab
 aab
 aaa
 aaa
+enb
+cTu
+tFy
+enb
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abg
+abg
+abg
+abg
+abg
+abg
 aaa
 aaa
 aaa
@@ -61883,7 +62227,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aab
 aab
 aab
@@ -61894,9 +62237,10 @@ aab
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+enb
+tEe
+egi
+enb
 aaa
 aaa
 aaa
@@ -62110,7 +62454,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aab
 aab
 aab
@@ -62120,15 +62463,16 @@ aab
 aab
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lBZ
+lBZ
+tEe
+egi
+lBZ
+lBZ
+enb
+enb
+lBZ
+lBZ
 aaa
 aaa
 aaa
@@ -62338,7 +62682,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aab
 aab
 aab
@@ -62347,18 +62690,19 @@ aab
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lBZ
+ghi
+cPd
+egi
+dIu
+mWC
+mWC
+qwu
+jOo
+lBZ
+bsh
+bsh
+bsh
 aco
 acF
 acF
@@ -62565,7 +62909,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aab
 aab
 aab
@@ -62574,15 +62917,16 @@ aab
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lBZ
+slX
+nMl
+pQb
+jjg
+epu
+mWC
+mWC
+mWC
+enb
 aaa
 aaa
 aaa
@@ -62793,7 +63137,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aab
 aab
 aab
@@ -62801,15 +63144,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lBZ
+pTE
+pmN
+pmN
+jjg
+mWC
+mWC
+qwu
+mWC
+enb
 aaa
 aaa
 aaa
@@ -63027,16 +63371,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lBZ
+qwR
+pmN
+pmN
+jjg
+mWC
+mWC
+mWC
+mWC
+enb
 aaa
 aaa
 aaa
@@ -63254,20 +63598,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lBZ
+pPg
+tJP
+tqT
+wfC
+mWC
+mWC
+mWC
+jOo
+lBZ
+bsh
+bsh
+bsh
+bsh
 aco
 acF
 acF
@@ -63481,16 +63825,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lBZ
+lBZ
+lBZ
+lBZ
+lBZ
+fqo
+fqo
+fqo
+utI
+lBZ
 aaa
 aaa
 aaa
@@ -63714,7 +64058,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+bsu
 aaa
 aaa
 aaa
@@ -63941,7 +64285,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+bsu
 aaa
 aaa
 aaa
@@ -64168,7 +64512,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+bsu
 aaa
 aaa
 aaa
@@ -64395,7 +64739,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+bsu
 aaa
 aaa
 aaa
@@ -64622,7 +64966,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+bsu
 aaa
 aaa
 aaa
@@ -64849,7 +65193,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+bsu
 aaa
 aaa
 aaa
@@ -65076,7 +65420,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+bsu
 aaa
 aaa
 aaa
@@ -65303,7 +65647,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+bsu
 aaa
 aaa
 aaa
@@ -65530,7 +65874,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+qhU
 aaa
 aaa
 aaa

--- a/maps/unused/mushroom_new_walls.dmm
+++ b/maps/unused/mushroom_new_walls.dmm
@@ -2809,6 +2809,7 @@
 /area/station/maintenance/disposal)
 "ahM" = (
 /obj/item/device/light/glowstick,
+/obj/machinery/recharge_station,
 /turf/simulated/floor/plating,
 /area/station/maintenance/NEmaint)
 "ahN" = (
@@ -5017,22 +5018,23 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/chapel/main)
 "amI" = (
-/obj/machinery/door/unpowered/wood{
+/obj/disposalpipe/segment,
+/obj/machinery/door/unpowered/wood/pyro{
 	autoclose = 0;
 	name = "Confession Booth"
 	},
-/obj/disposalpipe/segment,
 /turf/simulated/floor/black,
 /area/station/chapel/main)
 "amJ" = (
-/obj/machinery/door/unpowered/wood{
-	autoclose = 0;
-	name = "Confession Booth (Chaplain)";
-	req_access_txt = "22"
-	},
 /obj/cable{
 	icon_state = "2-9"
 	},
+/obj/machinery/door/unpowered/wood/pyro{
+	autoclose = 0;
+	name = "Confession Booth (Chaplain)";
+	req_access_txt = null
+	},
+/obj/access_spawn/chapel_office,
 /turf/simulated/floor/black,
 /area/station/chapel/main)
 "amK" = (
@@ -6931,7 +6933,8 @@
 "arT" = (
 /obj/item/device/radio/intercom{
 	broadcasting = 1;
-	dir = 8 frequency = 1447
+	dir = 8;
+	frequency = 1447
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
@@ -27655,6 +27658,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SEmaint)
+"gfL" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/plating,
+/area/station/maintenance/SWmaint)
 "gfM" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -28359,6 +28366,10 @@
 	tag = "icon-0,6"
 	},
 /area/station/crew_quarters/fitness)
+"joQ" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/plating,
+/area/station/maintenance/SEmaint)
 "jrr" = (
 /obj/cable,
 /obj/cable{
@@ -29266,6 +29277,10 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/teleporter)
+"ogC" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "okt" = (
 /obj/cable{
 	icon_state = "4-10"
@@ -29531,6 +29546,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/SWmaint)
+"pnN" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/recharge_station,
+/turf/simulated/floor/plating,
+/area/station/maintenance/NWmaint)
 "psc" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -52417,7 +52439,7 @@ anr
 alv
 aos
 azS
-pVr
+pnN
 alV
 alv
 azv
@@ -54521,7 +54543,7 @@ qnk
 bbf
 aLo
 bcf
-aLo
+gfL
 aLn
 aLo
 aLo
@@ -59484,7 +59506,7 @@ aDd
 tAr
 hvS
 asM
-asM
+ogC
 aFR
 aGJ
 aGC
@@ -60423,7 +60445,7 @@ gLY
 aKK
 bbW
 bco
-aKK
+joQ
 aKN
 bdt
 bdt


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MAPPING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Corrects Access on a few doors
- Corrects a few windows & such I missed on my first PR
- The arrivals Shuttle is back again, docked where it used to. The hanger has been moved east of Escape to accommodate this
- Minor changes to the boundaries of a few areas, swapping others over to their modern equivalent
- Completely re-wired the entire map so as to follow modern wiring standards (The original chapel wire art lives on dont worry)
- Made it so the map actually compiles (Blame Pali and their [god damn Intercom changes](https://cdn.discordapp.com/attachments/383743035894267905/744264407156129876/unknown.png))
- Added a few Cyborg Docking Stations due to the only ones being in Robotics
- Gave the AI Satellite Lighting due to the darkness update, plus gave it fancy Jeni Walls
- Fixes a lot of minor errors with missing pipes & such from the original map

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Cleanliness, Mushroom didn't compile (well done pali)& generally a lot less updated then a lot of AssJam playable maps.
Plus the wiring was a fucking mess.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Comradef191:
(+) Completely rewired Mushroom Station, Moved the Hanger & Re-Added the Arrivals Shuttle.
(+) Mushroom Station now has a few Cyborg Docking Stations scattered around Maintenance.
```