### PR TITLE
Prevent pressing mechcomp button when hitting it with a multitool

### DIFF
--- a/code/WorkInProgress/MechanicMadness.dm
+++ b/code/WorkInProgress/MechanicMadness.dm
@@ -2497,6 +2497,7 @@ var/list/mechanics_telepads = new/list()
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		if(..(W, user)) return 1
+		if(ispulsingtool(W)) return // Don't press the button with a multitool, it brings up the config menu instead
 		return attack_hand(user)
 
 	attack_hand(mob/user as mob)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Right now if you hit a mechcomp button with a multitool, it will bring up the config menu AND press the button. Now it will just bring up the configs, leaving the button unpressed.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
If you just want to disconnect the button or change the send signal, you probably don't want to press it at the same time.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->
