### PR TITLE
Fixes infravision trait

### DIFF
--- a/code/mob/living/life/sight.dm
+++ b/code/mob/living/life/sight.dm
@@ -93,8 +93,8 @@
 					return ..()
 
 		if (owner.traitHolder && owner.traitHolder.hasTrait("infravision"))
-			if (owner.see_infrared < 1)
-				owner.see_infrared = 1
+			if (owner.see_invisible < 1)
+				owner.see_invisible = 1
 ////Reagents
 		if (owner.reagents?.has_reagent("green_goop") && (T && !isrestrictedz(T.z)))
 			if (owner.see_in_dark != 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

The infravision trait now uses see_invisible rather than see_infrared like Lizards and HoS (possible lizard) it might also allow you to see Bloodlings but it makes sense considering it's infravision.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

So the Infravision trait is able to read infra-red ink (right now it does nothing).

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)ThePotato97:
(+)Fixed the Infravision trait.
```
