### PR TITLE
Port-a-puke noise fix

### DIFF
--- a/code/WorkInProgress/what-the-fuck-am-i-doing.dm
+++ b/code/WorkInProgress/what-the-fuck-am-i-doing.dm
@@ -159,7 +159,7 @@
 		if (!isalive(usr))
 			return
 
-		if (!ishuman(src))
+		if (!ishuman(usr))
 			boutput(usr, "<span class='alert'>You're not a human, you can't put yourself in there!</span>")
 			return
 

--- a/code/WorkInProgress/what-the-fuck-am-i-doing.dm
+++ b/code/WorkInProgress/what-the-fuck-am-i-doing.dm
@@ -34,8 +34,8 @@
 
 			if (prob(5))
 				visible_message("<span class='alert'>[H] pukes their guts out!</span>")
+				playsound(get_turf(src), pick('sound/impact_sounds/Slimy_Splat_1.ogg','sound/misc/meat_plop.ogg'), 100, 1)
 				for (var/turf/T in range(src, rand(1, 3)))
-					playsound(get_turf(src), pick('sound/impact_sounds/Slimy_Splat_1.ogg','sound/misc/meat_plop.ogg'), 100, 1)
 					make_cleanable( /obj/decal/cleanable/blood/gibs,T)
 
 				if (prob(5) && H.organHolder && H.organHolder.heart)
@@ -44,8 +44,8 @@
 
 			if (prob(15))
 				visible_message("<span class='alert'>[src] sprays vomit all around itself!</span>")
+				playsound(get_turf(src), pick('sound/impact_sounds/Slimy_Splat_1.ogg','sound/misc/meat_plop.ogg'), 100, 1)
 				for (var/turf/T in range(src, rand(1, 3)))
-					playsound(get_turf(src), pick('sound/impact_sounds/Slimy_Splat_1.ogg','sound/misc/meat_plop.ogg'), 100, 1)
 					if (prob(5))
 						make_cleanable( /obj/decal/cleanable/greenpuke,T)
 					else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

The port-a-puke would not let players enter voluntarily because `ishuman` was checking `src` instead of `usr` it would also spam `playsound` for every single visible turf it's occupant would puke on.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

To let players force themselves to puke a lot, and prevent them from going deaf.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)2aa63b1b-7113-4f5a-8da3-7e8c95459c2c:
(*)Humans are once again allowed to voluntarily enter the port-a-puke.
```
