### PR TITLE
adds a multiplier to non-pathology virus life loop

### DIFF
--- a/code/datums/disease.dm
+++ b/code/datums/disease.dm
@@ -38,7 +38,7 @@
 	proc/on_infection(var/mob/living/affected_mob,var/datum/ailment_data/D)
 		return
 
-	// This is still subject to serious change. For now it's mostly a mockup.
+	// This is still subject to serious change. For now wit's mostly a mockup.
 	// Determines things that may happen during a surgery for different ailments
 	// requiring a surgeon's intervention. Currently used for the parasites.
 	// Returns a true value if the surgery was successful.
@@ -111,7 +111,6 @@
 			stage = master.max_stages
 
 		if (prob(stage_prob * mult) && stage < master.max_stages)
-			boutput(world, "[stage_prob * mult]")
 			stage++
 
 		master.stage_act(affected_mob,src)
@@ -152,7 +151,7 @@
 	var/develop_resist = 0 // can you develop a resistance to this?
 	var/cycles = 0         // does this disease have a cyclical nature? if so, how many cycles have elapsed?
 
-	stage_act()
+	stage_act(var/mult)
 		if (!affected_mob || disposed)
 			return 1
 
@@ -171,7 +170,7 @@
 		var/advance_prob = stage_prob
 		if (state == "Acute")
 			advance_prob *= 2
-		advance_prob = max(0,min(advance_prob,100))
+		advance_prob = clamp((advance_prob * mult), 0, 100)
 
 		if (prob(advance_prob))
 			if (state == "Remissive")
@@ -259,7 +258,7 @@
 		src.cure = master.cure
 		src.was_setup = 1
 
-	stage_act()
+	stage_act(var/mult)
 		if (!affected_mob)
 			return
 
@@ -277,7 +276,7 @@
 		if (stage > master.max_stages)
 			stage = master.max_stages
 
-		if (prob(stage_prob) && stage < master.max_stages)
+		if (prob(stage_prob * mult) && stage < master.max_stages)
 			stage++
 
 

--- a/code/datums/disease.dm
+++ b/code/datums/disease.dm
@@ -183,11 +183,11 @@
 
 		// Common cures
 		if (cure != "Incurable")
-			if (cure == "Sleep" && affected_mob.sleeping && prob(33))
+			if (cure == "Sleep" && affected_mob.sleeping && prob(33 * mult))
 				state = "Remissive"
 				return 1
 
-			else if (cure == "Self-Curing" && prob(5))
+			else if (cure == "Self-Curing" && prob(5 * mult))
 				state = "Remissive"
 				return 1
 
@@ -209,7 +209,7 @@
 						var/we_are_cured = 0
 						var/reagcure_prob = reagentcure[current_id]
 						if (isnum(reagcure_prob))
-							if (prob(reagcure_prob))
+							if (prob(max((reagcure_prob * mult), 100)))
 								we_are_cured = 1
 						else if (islist(reagcure_prob)) // we want to roll more than one prob() in order to succeed, aka we want a very low chance
 							var/list/cureprobs = reagcure_prob
@@ -217,11 +217,11 @@
 							for (var/thing in cureprobs)
 								if (!isnum(thing))
 									continue
-								if (!prob(thing))
+								if (!prob(max((thing * mult), 100)))
 									success = 0
 							if (success)
 								we_are_cured = 1
-						else if (prob(recureprob))
+						else if (prob(max((recureprob * mult), 100)))
 							we_are_cured = 1
 						if (we_are_cured)
 							state = "Remissive"

--- a/code/datums/disease.dm
+++ b/code/datums/disease.dm
@@ -38,7 +38,7 @@
 	proc/on_infection(var/mob/living/affected_mob,var/datum/ailment_data/D)
 		return
 
-	// This is still subject to serious change. For now wit's mostly a mockup.
+	// This is still subject to serious change. For now it's mostly a mockup.
 	// Determines things that may happen during a surgery for different ailments
 	// requiring a surgeon's intervention. Currently used for the parasites.
 	// Returns a true value if the surgery was successful.

--- a/code/datums/disease.dm
+++ b/code/datums/disease.dm
@@ -99,7 +99,7 @@
 
 		..()
 
-	proc/stage_act()
+	proc/stage_act(var/mult)
 		if (!affected_mob || disposed)
 			return 1
 
@@ -110,7 +110,8 @@
 		if (stage > master.max_stages)
 			stage = master.max_stages
 
-		if (prob(stage_prob) && stage < master.max_stages)
+		if (prob(stage_prob * mult) && stage < master.max_stages)
+			boutput(world, "[stage_prob * mult]")
 			stage++
 
 		master.stage_act(affected_mob,src)

--- a/code/mob/living/life/viruses.dm
+++ b/code/mob/living/life/viruses.dm
@@ -3,7 +3,6 @@
 	process(var/datum/gas_mixture/environment)
 		//proc/handle_virus_updates()
 		//might need human
-		boutput(world, "fuck")
 		if (length(owner.ailments))
 			for (var/mob/living/carbon/M in oviewers(4, owner))
 				if (prob(40))
@@ -12,11 +11,9 @@
 					owner.viral_transmission(M,"Sight", 0)
 
 			if (!isdead(owner))
-				boutput(world, "test 1")
 				for (var/datum/ailment_data/am in owner.ailments)
 					var/mult = src.get_multiplier()
 					am.stage_act(mult)
-					boutput(world, "test 2")
 
 		if (prob(40))
 			for (var/obj/decal/cleanable/blood/B in view(2, owner))

--- a/code/mob/living/life/viruses.dm
+++ b/code/mob/living/life/viruses.dm
@@ -3,6 +3,7 @@
 	process(var/datum/gas_mixture/environment)
 		//proc/handle_virus_updates()
 		//might need human
+		boutput(world, "fuck")
 		if (length(owner.ailments))
 			for (var/mob/living/carbon/M in oviewers(4, owner))
 				if (prob(40))
@@ -11,8 +12,11 @@
 					owner.viral_transmission(M,"Sight", 0)
 
 			if (!isdead(owner))
+				boutput(world, "test 1")
 				for (var/datum/ailment_data/am in owner.ailments)
-					am.stage_act()
+					var/mult = src.get_multiplier()
+					am.stage_act(mult)
+					boutput(world, "test 2")
 
 		if (prob(40))
 			for (var/obj/decal/cleanable/blood/B in view(2, owner))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[CLEANLINESS] [ENHANCEMENT]


## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
adds a multiplier into the existing virus life loop, to make disease progression much less slow. 
some stuff may not be covered by this, but this was all i could think of.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
its been something people report, where sometimes disease take ages to actually do their thing. turns out, there wasnt a mult added to the loop.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)adharainspace:
(*)fixes an oversight that made diseases (like avian flu) much slower than intended.
```
