### PR TITLE
New Medal: Party Hard.

### DIFF
--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -713,9 +713,10 @@
 
 		if (src.hasStatus("drunk"))
 			if(locate(/obj/item/device/light/glowstick) in src.contents)
-				for(var/turf/T in view(2, src.loc))
-					if(locate(/obj/neon_lining) in T.contents)
-						src.unlock_medal("Party Hard", 1)
+				src.unlock_medal("Party Hard", 1)
+			for(var/turf/T in view(2, src.loc))
+				if(locate(/obj/neon_lining) in T.contents)
+					src.unlock_medal("Party Hard", 1)
 
 	ticker.mode.check_win()
 

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -715,7 +715,7 @@
 			if(locate(/obj/item/device/light/glowstick) in src.contents)
 				for(var/turf/T in view(2, src.loc))
 					if(locate(/obj/neon_lining) in T.contents)
-						src.unlock_medal("Party hard", 1)
+						src.unlock_medal("Party Hard", 1)
 
 	ticker.mode.check_win()
 

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -711,6 +711,10 @@
 			src.unlock_medal("Black and Blue", 1)
 		JOB_XP(src, "Clown", 10)
 
+		if (src.hasStatus("drunk"))
+			istype(src.equipped(), /item/device/light/glowstick)
+				src.unlock_medal("Party hard", 1)
+
 	ticker.mode.check_win()
 
 #ifdef RESTART_WHEN_ALL_DEAD

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -712,8 +712,10 @@
 		JOB_XP(src, "Clown", 10)
 
 		if (src.hasStatus("drunk"))
-			istype(src.equipped(), /item/device/light/glowstick)
-				src.unlock_medal("Party hard", 1)
+			if(locate(/obj/item/device/light/glowstick) in src.contents)
+				for(var/turf/T in view(2, src.loc))
+					if(locate(/obj/neon_lining) in T.contents)
+						src.unlock_medal("Party hard", 1)
 
 	ticker.mode.check_win()
 


### PR DESCRIPTION
[FEATURE]
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a "Party Hard" medal for dying while drunk either near neon lining or with a glowstick in your pocket.
![ss13PartyHard](https://user-images.githubusercontent.com/55758339/90495349-811c5500-e112-11ea-9599-f51ab5df1dc0.png)
"You were the life of the party, before your own life got taken away."

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More medals is always nice, and dying while vibing sounds achievement-worthy to me.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Nebulacrity
(*)Added Party Hard medal for dying while drunk either near neon lining or with a glowstick in your pocket.
```
