### PR TITLE
Stops device analysers from scanning objects queued for deletion.

### DIFF
--- a/code/WorkInProgress/Electronics.dm
+++ b/code/WorkInProgress/Electronics.dm
@@ -454,7 +454,7 @@
 	if(istype(O,/obj/machinery/rkit))
 		return
 	if(istype(O,/obj/))
-		if(O.mats == 0 || (O.is_syndicate != 0 && src.is_syndicate == 0))
+		if(O.mats == 0 || O.mats == null || (O.is_syndicate != 0 && src.is_syndicate == 0))
 			// if this item doesn't have mats defined or was constructed or
 			// attempting to scan a syndicate item and this is a normal scanner
 			boutput(user, "<span class='alert'>The structure of this object is not compatible with the scanner.</span>")

--- a/code/WorkInProgress/Electronics.dm
+++ b/code/WorkInProgress/Electronics.dm
@@ -454,7 +454,7 @@
 	if(istype(O,/obj/machinery/rkit))
 		return
 	if(istype(O,/obj/))
-		if(O.mats == 0 || O.mats == null || (O.is_syndicate != 0 && src.is_syndicate == 0))
+		if(O.mats == 0 || O.disposed || (O.is_syndicate != 0 && src.is_syndicate == 0))
 			// if this item doesn't have mats defined or was constructed or
 			// attempting to scan a syndicate item and this is a normal scanner
 			boutput(user, "<span class='alert'>The structure of this object is not compatible with the scanner.</span>")

--- a/code/obj/item/device/pda2/scanners.dm
+++ b/code/obj/item/device/pda2/scanners.dm
@@ -90,7 +90,7 @@
 			if(istype(O,/obj/machinery/rkit))
 				return
 
-			if(O.mats == 0 || O.mats == null || O.is_syndicate != 0)
+			if(O.mats == 0 || O.disposed || O.is_syndicate != 0)
 				return "<span class='alert'>Unable to scan.</span>"
 
 			if (!istype(master.host_program, /datum/computer/file/pda_program/os/main_os) || !master.host_program:message_on)

--- a/code/obj/item/device/pda2/scanners.dm
+++ b/code/obj/item/device/pda2/scanners.dm
@@ -90,7 +90,7 @@
 			if(istype(O,/obj/machinery/rkit))
 				return
 
-			if(O.mats == 0 || O.is_syndicate != 0)
+			if(O.mats == 0 || O.mats == null || O.is_syndicate != 0)
 				return "<span class='alert'>Unable to scan.</span>"
 
 			if (!istype(master.host_program, /datum/computer/file/pda_program/os/main_os) || !master.host_program:message_on)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds a mats == null check to device analyzers, so they can't accidentally scan things that are in the process of deleting themselves. (disposing in /obj/ sets mats to null)
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #1854

