### PR TITLE
adds a 20 round timegate to ghost drones

### DIFF
--- a/code/obj/machinery/drone_factory.dm
+++ b/code/obj/machinery/drone_factory.dm
@@ -96,7 +96,7 @@
 		return 0
 	if (G.client.player)
 		var/round_num = G.client.player.get_rounds_participated()
-		if (!isnull(round_num) && round_num >= 20)
+		if (!isnull(round_num) && round_num < 20)
 			boutput(G, "<span class='alert'>You only have [round_num] rounds played. You need 20 rounds to play this role.")
 			return 0
 	return 1

--- a/code/obj/machinery/drone_factory.dm
+++ b/code/obj/machinery/drone_factory.dm
@@ -94,6 +94,11 @@
 		return 0
 	if (jobban_isbanned(G, "Ghostdrone"))
 		return 0
+	if (G.client.player)
+		var/round_num = G.client.player.get_rounds_participated()
+		if (!isnull(round_num) && round_num >= 20)
+			boutput(G, "<span class='alert'>You only have [round_num] rounds played. You need 20 rounds to play this role.")
+			return 0
 	return 1
 
 #define GHOSTDRONE_BUILD_INTERVAL 1000


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
adds a 20 round requirement to be eligible for ghostdrone. this could probably be tied into some medal for ending a round as ai / cyborg with nonstandard laws, to prove that people know how to follow and understand the laws. but this is a bandaid fix for right now that the devs wanted to do anyways. and im bored.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
new players tend to grief as ghostdrones because they dont understand / dont care about the rules behind them. this should cut down on that. (apparently a lot of ahelps are about ghostdrone grief)


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)adharainspace:
(*)adds a 20 rounds played requirement to be a ghostdrone
```