### PR TITLE
fixes bug which prevented manta from stopping

### DIFF
--- a/code/WorkInProgress/mantaObjects.dm
+++ b/code/WorkInProgress/mantaObjects.dm
@@ -170,6 +170,9 @@ var/obj/manta_speed_lever/mantaLever = null
 
 	for(var/A in mantaTiles)
 		var/turf/space/fluid/manta/T = A
+		if (!istype(T))
+			mantaTiles.Remove(T)
+			continue
 		T.setScroll(moving)
 	for(var/A in mantaBubbles)
 		var/obj/O = A


### PR DESCRIPTION
[BUGFIX]
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
if someone added floors to the ocean outside of manta, it would cause a proc crash when it tried to do stuff to that turf. this pr removes turfs that dont have the proc from the list, to avoid crashes! (also i tested this)

Fixes #1271

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
this is a HELLISH bug. makes manta one of the worst maps to play on because people get stuck and trapped and its nearly impossible to rescue them

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)adharainspace:
(*)manta should be able to start/stop effectively now, instead of being broken. 
```
