### PR TITLE
fix hunter popup

### DIFF
--- a/_std/macros/_antag_popups.dm
+++ b/_std/macros/_antag_popups.dm
@@ -55,7 +55,7 @@
 
 // various others
 #define SHOW_GRINCH_TIPS(M) M.Browse(grabResource("html/traitorTips/grinchTips.html"), ANTAG_TIPS_WINDOW)
-#define SHOW_HUNTER_TIPS(M) M.Browse(grabResource("html/traitorTips/hunterTips.html"), ANTAG_TIPS_WINDOW)
+#define SHOW_HUNTER_TIPS(M) M.Browse(grabResource("html/traitorTips/predatorTips.html"), ANTAG_TIPS_WINDOW)
 #define SHOW_WEREWOLF_TIPS(M) M.Browse(grabResource("html/traitorTips/werewolfTips.html"), ANTAG_TIPS_WINDOW)
 #define SHOW_WRESTLER_TIPS(M) M.Browse(grabResource("html/traitorTips/wrestlerTips.html"), ANTAG_TIPS_WINDOW)
 #define SHOW_BATTLE_ROYALE_TIPS(M) M.Browse(grabResource("html/traitorTips/battleTips.html"), ANTAG_TIPS_WINDOW)

--- a/code/datums/abilities/hunter.dm
+++ b/code/datums/abilities/hunter.dm
@@ -15,7 +15,7 @@
 		P.addAbility(/datum/targetable/hunter/hunter_trophycount)
 
 		if (src.mind && src.mind.special_role != "omnitraitor")
-			SHOW_TRAITOR_OMNI_TIPS(src)
+			SHOW_HUNTER_TIPS(src)
 
 	else return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Apparently being made a hunter showed the omnitraitor popup, leading to some confusion.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's good if antag roles show the right popup.