### PR TITLE
Small rod changes

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -528,14 +528,14 @@
 	item_amounts = list(1)
 	item_outputs = list(/obj/item/rods)
 	time = 3
-	create = 5
 	category = "Resource"
 	apply_material = 1
 
 	modify_output(var/obj/machinery/manufacturer/M, var/atom/A)
 		..()
-		var/obj/item/sheet/S = A
+		var/obj/item/sheet/S = A // this way they are instantly stacked rather than just 2 rods
 		S.amount = 2
+		S.inventory_counter.update_number(S.amount)
 
 /datum/manufacture/atmos_can
 	name = "Portable Gas Canister"

--- a/code/obj/item/building_materials.dm
+++ b/code/obj/item/building_materials.dm
@@ -771,9 +771,9 @@ MATERIAL
 			var/turf/T = usr.loc
 			SPAWN_DBG(1.5 SECONDS)
 				if (T == usr.loc && !usr.getStatusDuration("weakened") && !usr.getStatusDuration("stunned"))
-					src.consume_rods(2)
 					var/atom/G = new /obj/grille(usr.loc)
 					G.setMaterial(src.material)
+					src.consume_rods(2)
 					logTheThing("station", usr, null, "builds a grille (<b>Material:</b> [G.material && G.material.mat_id ? "[G.material.mat_id]" : "*UNKNOWN*"]) at [log_loc(usr)].")
 		src.add_fingerprint(user)
 		return

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -1808,6 +1808,7 @@
 		/datum/manufacture/multitool,
 		/datum/manufacture/metal,
 		/datum/manufacture/metalR,
+		/datum/manufacture/rods2,
 		/datum/manufacture/glass,
 		/datum/manufacture/glassR,
 		/datum/manufacture/atmos_can,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This fixes a bug with rods where using the last two rods in a stack to build a grille would not properly set the grilles material.

It also adds the rod recipe to the general manufacturer.
(Since the mining, medical, and robotics ones already had it, I felt excluding the general manufacturer made little sense.)

It also changes the amount of rods that one gets from one material from 5*2 to 2, since one material can make one sheet, which one could turn into 2 rods. Giving 5 times as many rods as the non-manufacturer process felt kind of weird to me.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bright, material-less
-  grilles are weird.
- General manufacturers being able to make rods is just a time-saving measure.
- Giving 5 stacks of 2 rods is weird, and I don't think this will really cause a shortage of material for rods, since people presumably just made them by hand before addition to the general manufacturer list, which gives the same amount of rods.
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)zjdtmkhzt:
(+)General Manufacturers can now produce rods directly.
```
