### PR TITLE
Moves lunchboxes from being a Spacebux item to being a Trait item.

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -550,6 +550,15 @@
 	isPositive = 1
 	category = "trinkets"
 
+/obj/trait/lunchbox
+	name = "Lunchbox (-1) \[Trinkets\]"
+	cleanName = "Lunchbox"
+	desc = "Start your shift with a cute little lunchbox, packed with all your favourite foods!"
+	id = "lunchbox"
+	points = -1
+	isPositive = 1
+	category = "trinkets"
+
 // Skill - Undetermined Border
 
 /obj/trait/smoothtalker

--- a/code/modules/economy/persistent_bank_purchases.dm
+++ b/code/modules/economy/persistent_bank_purchases.dm
@@ -34,6 +34,7 @@ var/global/list/persistent_bank_purchaseables =	list(\
 	new /datum/bank_purchaseable/corpse,\
 	new /datum/bank_purchaseable/space_diner,\
 	new /datum/bank_purchaseable/mail_order,\
+	new /datum/bank_purchaseable/lunchbox,\
 
 	new /datum/bank_purchaseable/critter_respawn,\
 	new /datum/bank_purchaseable/golden_ghost,\
@@ -511,6 +512,19 @@ var/global/list/persistent_bank_purchaseables =	list(\
 					H.back.icon_state = "NTbackpack"
 					return 1
 				return 0
+
+	lunchbox
+		name = "Lunchbox"
+		cost = 600
+
+		Create(var/mob/living/M)
+			if (ishuman(M))
+				var/mob/living/carbon/human/H = M
+				var/obj/item/storage/lunchbox/L = pick(childrentypesof(/obj/item/storage/lunchbox))
+				if ((!H.l_hand && H.equip_if_possible(new L(H), H.slot_l_hand)) || (!H.r_hand && H.equip_if_possible(new L(H), H.slot_r_hand)) || (istype(H.back, /obj/item/storage) && H.equip_if_possible(new L(H), H.slot_in_backpack)))
+					return 1
+			return 0
+
 
 	/////////////////////////////////////
 	//CLOTHING (FITS HUMAN AND CYBORGS)//

--- a/code/modules/economy/persistent_bank_purchases.dm
+++ b/code/modules/economy/persistent_bank_purchases.dm
@@ -34,7 +34,6 @@ var/global/list/persistent_bank_purchaseables =	list(\
 	new /datum/bank_purchaseable/corpse,\
 	new /datum/bank_purchaseable/space_diner,\
 	new /datum/bank_purchaseable/mail_order,\
-	new /datum/bank_purchaseable/lunchbox,\
 
 	new /datum/bank_purchaseable/critter_respawn,\
 	new /datum/bank_purchaseable/golden_ghost,\
@@ -512,19 +511,6 @@ var/global/list/persistent_bank_purchaseables =	list(\
 					H.back.icon_state = "NTbackpack"
 					return 1
 				return 0
-
-	lunchbox
-		name = "Lunchbox"
-		cost = 600
-
-		Create(var/mob/living/M)
-			if (ishuman(M))
-				var/mob/living/carbon/human/H = M
-				var/obj/item/storage/lunchbox/L = pick(childrentypesof(/obj/item/storage/lunchbox))
-				if ((!H.l_hand && H.equip_if_possible(new L(H), H.slot_l_hand)) || (!H.r_hand && H.equip_if_possible(new L(H), H.slot_r_hand)) || (istype(H.back, /obj/item/storage) && H.equip_if_possible(new L(H), H.slot_in_backpack)))
-					return 1
-			return 0
-
 
 	/////////////////////////////////////
 	//CLOTHING (FITS HUMAN AND CYBORGS)//

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -1564,6 +1564,7 @@
 		product_list += new/datum/data/vending_product(/obj/item/kitchen/chopsticks_package, 5)
 		product_list += new/datum/data/vending_product(/obj/item/plate/tray, 3)
 		product_list += new/datum/data/vending_product(/obj/surgery_tray/kitchen_island, 2)
+		product_list += new/datum/data/vending_product(/obj/item/storage/lunchbox, 10)
 		product_list += new/datum/data/vending_product(/obj/item/ladle, 1)
 		product_list += new/datum/data/vending_product(/obj/item/soup_pot, 1)
 		product_list += new/datum/data/vending_product(/obj/item/kitchen/rollingpin, 2)

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -1564,7 +1564,7 @@
 		product_list += new/datum/data/vending_product(/obj/item/kitchen/chopsticks_package, 5)
 		product_list += new/datum/data/vending_product(/obj/item/plate/tray, 3)
 		product_list += new/datum/data/vending_product(/obj/surgery_tray/kitchen_island, 2)
-		product_list += new/datum/data/vending_product(/obj/item/storage/lunchbox, 10)
+		product_list += new/datum/data/vending_product(/obj/item/storage/lunchbox, 12)
 		product_list += new/datum/data/vending_product(/obj/item/ladle, 1)
 		product_list += new/datum/data/vending_product(/obj/item/soup_pot, 1)
 		product_list += new/datum/data/vending_product(/obj/item/kitchen/rollingpin, 2)

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -518,6 +518,7 @@
 
 	var/T = pick(trinket_safelist)
 	var/obj/item/trinket = null
+	var/random_lunchbox_path = pick(childrentypesof(/obj/item/storage/lunchbox))
 
 	if (src.traitHolder && src.traitHolder.hasTrait("pawnstar"))
 		trinket = null //You better stay null, you hear me!
@@ -535,6 +536,8 @@
 			trinket = new/obj/item/reagent_containers/food/snacks/ingredient/egg/bee(src)
 	else if (src.traitHolder && src.traitHolder.hasTrait("smoker"))
 		trinket = new/obj/item/device/light/zippo(src)
+	else if (src.traitHolder && src.traitHolder.hasTrait("lunchbox"))
+		trinket = new random_lunchbox_path(src)
 	else
 		trinket = new T(src)
 


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes lunchboxes as a purchasable Spacebux item and moves it to the traits menu. Also adds empty lunchboxes to the Kitchen Vendor. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I think its more fitting to be a trait item, its too minor IMO to be a spacebux item.
Adding lunch boxes to kitchen vendor also opens up the possibility of the chef preparing lunch boxes for the crew.

## Changelog

```
(u)Carbadox:
(*)Lunchboxes have been removed from the Spacebux purchase list. From now on, you can instead purchase it in your traits menu.
(+)Added a dozen of empty lunchboxes to the Kitchen vendor. Now chefs can prepare packed lunches for the whole crew! Maybe you'll cute handwritten note (or maybe death threat, who knows).
```
