### PR TITLE
cant place more than one girder on a turf

### DIFF
--- a/code/obj/structure.dm
+++ b/code/obj/structure.dm
@@ -1,6 +1,14 @@
 obj/structure
 	icon = 'icons/obj/structures.dmi'
 
+	New()
+		..()
+		var/turf/T = get_turf(src)
+		var/obj/structure/S = locate(/obj/structure) in T
+		if (S != src)
+			src.visible_message("<span class='alert'>\The [src] couldn't be built because there's \a [S] there already.</span>")
+			qdel(src)
+
 	girder
 		icon_state = "girder"
 		anchored = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
when you click on turf with metal sheets, it makes a girder
you can do it again though even when theres a girder there
this disables that

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
i hate this bug, just leaves ugly girders everywhere


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
```
