### PR TITLE
X-drones no longer cost less than a coffemaker to print

### DIFF
--- a/code/obj/critter/drone.dm
+++ b/code/obj/critter/drone.dm
@@ -573,6 +573,7 @@
 		droploot = /obj/item/spacecash/buttcoin // replace with railgun if that's ever safe enough to hand out? idk
 		attack_cooldown = 50
 		smashes_shit = 1
+		mats = 96
 
 		Shoot(var/atom/target, var/start, var/user, var/bullet = 0)
 			if(target == start)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Increased the mats required to print out an x-drone from 24 to 96.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

X-drones are _tough_, and a badguy mechanic can print out a shitload of em for next to nothing. A gaggle of these guys can force a shuttle call, and I think it should take a bit more effort to print em out.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Superlagg:
(+)X-Drones are now much more expensive to manufacture.
```
