### PR TITLE
Splitting reinforced sheets carries over reinforcement

### DIFF
--- a/code/obj/item/building_materials.dm
+++ b/code/obj/item/building_materials.dm
@@ -119,6 +119,8 @@ MATERIAL
 			var/obj/item/sheet/new_stack = new /obj/item/sheet(get_turf(usr))
 			if(src.material)
 				new_stack.setMaterial(src.material)
+			if (src.reinforcement)
+				new_stack.set_reinforcement(src.reinforcement)
 			new_stack.amount = splitnum
 			new_stack.attack_hand(user)
 			new_stack.add_fingerprint(user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes an oversight where splitting a stack of sheets didn't carry over the reinforcement, so splitting off sheets from a stack of reinforced material gave you regular sheets instead.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's more consistent and sensible.