### PR TITLE
Allow Player Options for mobs in null space

### DIFF
--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -22,7 +22,8 @@
 	// The topBar style here is so that it can continue to happily chill at the top of even chui windows
 	var/header_thing_chui_toggle = (usr.client && !usr.client.use_chui) ? "<style type='text/css'>#topBar { top: 0; left: 0; right: 0; background-color: white; } </style>" : "<style type='text/css'>#topBar { top: 46px; left: 4px; right: 10px; background: inherit; }</style>"
 
-	var/dat = {"
+	var/list/dat = list()
+	dat += {"
 	[header_thing_chui_toggle]
 	<title>[M.name] ([M.key ? M.key : "NO CKEY"]) Options</title>
 	<style>
@@ -207,7 +208,12 @@
 						<a href='[playeropt_link(M, "getmob")]'>Get</a> &bull;
 						<a href='[playeropt_link(M, "sendmob")]'>Send to...</a>
 						<br>Currently in [A]
-						<br>&nbsp;&nbsp;[T.x], [T.y], [T.z][(Q && Q != T) ? ", inside \the [Q]" : ""]
+			"}
+		if (T) //runtime fix for mobs in null space
+			dat += "<br>&nbsp;&nbsp;[T.x], [T.y], [T.z][(Q && Q != T) ? ", inside \the [Q]" : ""]"
+		else
+			dat += "Null Space"
+		dat += {"
 					</div>
 					<div class='l'>
 						Prison
@@ -368,4 +374,4 @@
 	else if (src.level == LEVEL_CODER)
 		windowHeight = "754"	//weird number, but for chui screen, it removes the scrolling.
 
-	usr.Browse(dat, "window=adminplayeropts[M.ckey];size=600x[windowHeight]")
+	usr.Browse(dat.Join(), "window=adminplayeropts[M.ckey];size=600x[windowHeight]")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG][RUNTIME] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Adds a null turf check when building the player options panel to detect if the target is in null space
- Change player options planel to use a list join rather than numerous individual string concatenations


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
- Attempting to open player options on a user in null space will runtime, preventing the panel from opening. This can cause issues for the administration team when they need to take action on such a player.
- List joins are more efficient than repeated concatenations per Pali


File | player_panel.dm
-- | --
Line | 222
Error | Cannot read null.x

```
proc name: playeropt (/datum/admins/proc/playeropt)
  source file: player_panel.dm,222
  usr: Sov Extant (/mob/dead/observer)
  src: admins (/datum/admins)
  usr.loc: the steel floor (189,103,1) (/turf/simulated/floor/darkpurple/side)
  call stack:
admins (/datum/admins): playeropt(Target Dummy (/mob/living/carbon/human))
admins (/datum/admins): Topic("src=\[0x2101ee2b];action=admin...", /list (/list))
Sovexe (/client): Topic("src=\[0x2101ee2b];action=admin...", /list (/list), admins (/datum/admins))
Sovexe (/client): Topic("src=\[0x2101ee2b];action=admin...", /list (/list), admins (/datum/admins))
Sovexe (/client): Topic("src=\[0x2101ee2b];action=admin...", /list (/list), admins (/datum/admins))
Sovexe (/client): Topic("src=\[0x2101ee2b];action=admin...", /list (/list), admins (/datum/admins))
```
Target is in null space
![image](https://user-images.githubusercontent.com/33204415/90970740-b7712000-e4d6-11ea-9d74-dabc2b2ed69b.png)
Normal location for comparison
![image](https://user-images.githubusercontent.com/33204415/90970754-c2c44b80-e4d6-11ea-99ab-02df5c3ca07f.png)
