### PR TITLE
Removed duplicate items already present in adventure chest

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -13183,18 +13183,6 @@
 /area/station/science/teleporter)
 "aDD" = (
 /obj/storage/crate/adventure,
-/obj/item/device/audio_log,
-/obj/item/camera_test,
-/obj/item/device/light/flashlight,
-/obj/item/device/light/flashlight,
-/obj/item/reagent_containers/food/drinks/milk,
-/obj/item/reagent_containers/food/snacks/sandwich/pb,
-/obj/item/paper{
-	desc = "Aw dang, mooom";
-	info = "Good luck on your adventure, sweetie! Love, Mom.<br> <i>Whose mom? Yours? Who knows.</i>";
-	name = "note from mom"
-	},
-/obj/item/paper/book/critter_compendium,
 /turf/simulated/floor/orangeblack/side/white{
 	dir = 5
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The crate in the oshan telesci lab is already an adventure crate and has all the items manually added on the tile.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Removal of useless duplicates.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it. -->

```
(u)Michaellaneous:
(+)Oshan - Removed duplicate items already present in adventure chest.
```
