### PR TITLE
Muzzle flash improvements

### DIFF
--- a/code/WorkInProgress/AnimationLibrary.dm
+++ b/code/WorkInProgress/AnimationLibrary.dm
@@ -478,8 +478,10 @@ proc/muzzle_flash_any(var/atom/movable/A, var/firing_angle, var/muzzle_anim, var
 		muzzle_simple_light.color = muzzle_light_color
 		muzzleflash.overlays += muzzle_simple_light
 
-	muzzleflash.Translate(0, offset)
-	muzzleflash.Turn(firing_angle)
+	var/matrix/mat = new
+	mat.Translate(0, offset)
+	mat.Turn(firing_angle)
+	muzzleflash.transform = mat
 	muzzleflash.layer = A.layer
 	muzzleflash.set_loc(A)
 	A.vis_contents.Add(muzzleflash)

--- a/code/WorkInProgress/AnimationLibrary.dm
+++ b/code/WorkInProgress/AnimationLibrary.dm
@@ -448,7 +448,22 @@ proc/fuckup_attack_particle(var/mob/M)
 		y *= 22
 		animate(M.attack_particle, pixel_x = M.attack_particle.pixel_x + x , pixel_y = M.attack_particle.pixel_y + y, time = 5, easing = BOUNCE_EASING, flags = ANIMATION_END_NOW)
 
-proc/muzzle_flash_attack_particle(var/mob/M, var/turf/origin, var/turf/target, var/muzzle_anim)
+var/global/obj/overlay/simple_light/muzzle_simple_light = new	/obj/overlay/simple_light{appearance_flags = RESET_COLOR | RESET_TRANSFORM | NO_CLIENT_COLOR | KEEP_APART}
+
+var/global/list/default_muzzle_flash_colors = list(
+	"muzzle_flash" = "#FFEE9980",
+	"muzzle_flash_laser" = "#FF333380",
+	"muzzle_flash_elec" = "#FFC80080",
+	"muzzle_flash_bluezap" = "#00FFFF80",
+	"muzzle_flash_plaser" = "#00A9FB80",
+	"muzzle_flash_phaser" = "#F41C2080",
+	"muzzle_flash_launch" = "#FFFFFF50",
+	"muzzle_flash_wavep" = "#B3234E80",
+	"muzzle_flash_waveg" = "#33CC0080",
+	"muzzle_flash_waveb" = "#87BBE380"
+)
+
+proc/muzzle_flash_attack_particle(var/mob/M, var/turf/origin, var/turf/target, var/muzzle_anim, var/muzzle_light_color=null)
 	if (!M || !origin || !target || !muzzle_anim) return
 
 	var/offset = 22 //amt of pixels the muzzle flash sprite is offset the shooting mob by
@@ -456,6 +471,14 @@ proc/muzzle_flash_attack_particle(var/mob/M, var/turf/origin, var/turf/target, v
 	var/firing_dir = angle_to_dir(firing_angle)
 
 	var/obj/particle/attack/muzzleflash/muzzleflash = unpool(/obj/particle/attack/muzzleflash)
+
+	if(isnull(muzzle_light_color))
+		muzzle_light_color = default_muzzle_flash_colors[muzzle_anim]
+	muzzleflash.overlays.Cut()
+	if(muzzle_light_color)
+		muzzle_simple_light.alpha = 255 // alpha can get overriden if #RRGGBBAA but would otherwise stay at the old value with #RRGGBB
+		muzzle_simple_light.color = muzzle_light_color
+		muzzleflash.overlays += muzzle_simple_light
 
 	switch(firing_dir) //so we apply the correct offset
 		if (NORTH)
@@ -492,12 +515,20 @@ proc/muzzle_flash_attack_particle(var/mob/M, var/turf/origin, var/turf/target, v
 		M.vis_contents.Remove(muzzleflash)
 		pool(muzzleflash)
 
-proc/muzzle_flash_any(var/atom/movable/A, var/firing_angle, var/muzzle_anim)
+proc/muzzle_flash_any(var/atom/movable/A, var/firing_angle, var/muzzle_anim, var/muzzle_light_color)
 	if (!A || firing_angle == null || !muzzle_anim) return
 
 	var/obj/particle/attack/muzzleflash/muzzleflash = unpool(/obj/particle/attack/muzzleflash)
 	muzzleflash.pixel_y = cos(firing_angle) * 22
 	muzzleflash.pixel_x = sin(firing_angle) * 22
+
+	if(isnull(muzzle_light_color))
+		muzzle_light_color = default_muzzle_flash_colors[muzzle_anim]
+	muzzleflash.overlays.Cut()
+	if(muzzle_light_color)
+		muzzle_simple_light.alpha = 255 // alpha can get overriden if #RRGGBBAA but would otherwise stay at the old value with #RRGGBB
+		muzzle_simple_light.color = muzzle_light_color
+		muzzleflash.overlays += muzzle_simple_light
 
 	muzzleflash.Turn(firing_angle)
 	muzzleflash.layer = A.layer

--- a/code/WorkInProgress/AnimationLibrary.dm
+++ b/code/WorkInProgress/AnimationLibrary.dm
@@ -463,12 +463,12 @@ var/global/list/default_muzzle_flash_colors = list(
 	"muzzle_flash_waveb" = "#87BBE380"
 )
 
-proc/muzzle_flash_attack_particle(var/mob/M, var/turf/origin, var/turf/target, var/muzzle_anim, var/muzzle_light_color=null, var/offset=22)
+proc/muzzle_flash_attack_particle(var/mob/M, var/turf/origin, var/turf/target, var/muzzle_anim, var/muzzle_light_color=null, var/offset=25)
 	if (!M || !origin || !target || !muzzle_anim) return
 	var/firing_angle = get_angle(origin, target)
 	muzzle_flash_any(M, firing_angle, muzzle_anim, muzzle_light_color, offset)
 
-proc/muzzle_flash_any(var/atom/movable/A, var/firing_angle, var/muzzle_anim, var/muzzle_light_color, var/offset=22)
+proc/muzzle_flash_any(var/atom/movable/A, var/firing_angle, var/muzzle_anim, var/muzzle_light_color, var/offset=25)
 	if (!A || firing_angle == null || !muzzle_anim) return
 
 	var/obj/particle/attack/muzzleflash/muzzleflash = unpool(/obj/particle/attack/muzzleflash)

--- a/code/WorkInProgress/AnimationLibrary.dm
+++ b/code/WorkInProgress/AnimationLibrary.dm
@@ -507,9 +507,13 @@ proc/muzzle_flash_attack_particle(var/mob/M, var/turf/origin, var/turf/target, v
 	muzzleflash.layer = MOB_INHAND_LAYER
 	muzzleflash.set_loc(M)
 	M.vis_contents.Add(muzzleflash)
-	if (muzzleflash.icon_state == muzzle_anim)
-		flick(muzzle_anim,muzzleflash)
 	muzzleflash.icon_state = muzzle_anim
+	flick(muzzle_anim, muzzleflash)
+
+	muzzleflash.alpha = 0
+	animate(muzzleflash, alpha=255, easing=SINE_EASING, time=0.1 SECONDS)
+	animate(time=0.3 SECONDS)
+	animate(alpha=0, easing=SINE_EASING, time=0.2 SECONDS)
 
 	SPAWN_DBG(0.6 SECONDS)
 		M.vis_contents.Remove(muzzleflash)
@@ -534,9 +538,13 @@ proc/muzzle_flash_any(var/atom/movable/A, var/firing_angle, var/muzzle_anim, var
 	muzzleflash.layer = A.layer
 	muzzleflash.set_loc(A)
 	A.vis_contents.Add(muzzleflash)
-	if (muzzleflash.icon_state == muzzle_anim)
-		flick(muzzle_anim,muzzleflash)
 	muzzleflash.icon_state = muzzle_anim
+	flick(muzzle_anim, muzzleflash)
+
+	muzzleflash.alpha = 0
+	animate(muzzleflash, alpha=255, easing=SINE_EASING, time=0.1 SECONDS)
+	animate(time=0.3 SECONDS)
+	animate(alpha=0, easing=SINE_EASING, time=0.2 SECONDS)
 
 	SPAWN_DBG(0.6 SECONDS)
 		A.vis_contents.Remove(muzzleflash)

--- a/code/WorkInProgress/AnimationLibrary.dm
+++ b/code/WorkInProgress/AnimationLibrary.dm
@@ -463,12 +463,10 @@ var/global/list/default_muzzle_flash_colors = list(
 	"muzzle_flash_waveb" = "#87BBE380"
 )
 
-proc/muzzle_flash_attack_particle(var/mob/M, var/turf/origin, var/turf/target, var/muzzle_anim, var/muzzle_light_color=null)
+proc/muzzle_flash_attack_particle(var/mob/M, var/turf/origin, var/turf/target, var/muzzle_anim, var/muzzle_light_color=null, var/offset=22)
 	if (!M || !origin || !target || !muzzle_anim) return
 
-	var/offset = 22 //amt of pixels the muzzle flash sprite is offset the shooting mob by
 	var/firing_angle = get_angle(origin, target)
-	var/firing_dir = angle_to_dir(firing_angle)
 
 	var/obj/particle/attack/muzzleflash/muzzleflash = unpool(/obj/particle/attack/muzzleflash)
 
@@ -480,29 +478,7 @@ proc/muzzle_flash_attack_particle(var/mob/M, var/turf/origin, var/turf/target, v
 		muzzle_simple_light.color = muzzle_light_color
 		muzzleflash.overlays += muzzle_simple_light
 
-	switch(firing_dir) //so we apply the correct offset
-		if (NORTH)
-			muzzleflash.pixel_y = 32
-		if (SOUTH)
-			muzzleflash.pixel_y = -32
-		if (EAST)
-			muzzleflash.pixel_x = offset
-		if (WEST)
-			muzzleflash.pixel_x = -offset
-		if (NORTHEAST) //diags look a little weird but what can you do
-			muzzleflash.pixel_y = offset
-			muzzleflash.pixel_x = offset
-		if (NORTHWEST)
-			muzzleflash.pixel_y = offset
-			muzzleflash.pixel_x = -offset
-		if (SOUTHEAST)
-			muzzleflash.pixel_y = -offset
-			muzzleflash.pixel_x = offset
-		if (SOUTHWEST)
-			muzzleflash.pixel_y = -offset
-			muzzleflash.pixel_x = -offset
-
-
+	muzzleflash.Translate(0, offset)
 	muzzleflash.Turn(firing_angle)
 	muzzleflash.layer = MOB_INHAND_LAYER
 	muzzleflash.set_loc(M)

--- a/code/WorkInProgress/AnimationLibrary.dm
+++ b/code/WorkInProgress/AnimationLibrary.dm
@@ -465,35 +465,8 @@ var/global/list/default_muzzle_flash_colors = list(
 
 proc/muzzle_flash_attack_particle(var/mob/M, var/turf/origin, var/turf/target, var/muzzle_anim, var/muzzle_light_color=null, var/offset=22)
 	if (!M || !origin || !target || !muzzle_anim) return
-
 	var/firing_angle = get_angle(origin, target)
-
-	var/obj/particle/attack/muzzleflash/muzzleflash = unpool(/obj/particle/attack/muzzleflash)
-
-	if(isnull(muzzle_light_color))
-		muzzle_light_color = default_muzzle_flash_colors[muzzle_anim]
-	muzzleflash.overlays.Cut()
-	if(muzzle_light_color)
-		muzzle_simple_light.alpha = 255 // alpha can get overriden if #RRGGBBAA but would otherwise stay at the old value with #RRGGBB
-		muzzle_simple_light.color = muzzle_light_color
-		muzzleflash.overlays += muzzle_simple_light
-
-	muzzleflash.Translate(0, offset)
-	muzzleflash.Turn(firing_angle)
-	muzzleflash.layer = MOB_INHAND_LAYER
-	muzzleflash.set_loc(M)
-	M.vis_contents.Add(muzzleflash)
-	muzzleflash.icon_state = muzzle_anim
-	flick(muzzle_anim, muzzleflash)
-
-	muzzleflash.alpha = 0
-	animate(muzzleflash, alpha=255, easing=SINE_EASING, time=0.1 SECONDS)
-	animate(time=0.3 SECONDS)
-	animate(alpha=0, easing=SINE_EASING, time=0.2 SECONDS)
-
-	SPAWN_DBG(0.6 SECONDS)
-		M.vis_contents.Remove(muzzleflash)
-		pool(muzzleflash)
+	muzzle_flash_any(M, firing_angle, muzzle_anim, muzzle_light_color, offset)
 
 proc/muzzle_flash_any(var/atom/movable/A, var/firing_angle, var/muzzle_anim, var/muzzle_light_color, var/offset=22)
 	if (!A || firing_angle == null || !muzzle_anim) return

--- a/code/WorkInProgress/AnimationLibrary.dm
+++ b/code/WorkInProgress/AnimationLibrary.dm
@@ -495,12 +495,10 @@ proc/muzzle_flash_attack_particle(var/mob/M, var/turf/origin, var/turf/target, v
 		M.vis_contents.Remove(muzzleflash)
 		pool(muzzleflash)
 
-proc/muzzle_flash_any(var/atom/movable/A, var/firing_angle, var/muzzle_anim, var/muzzle_light_color)
+proc/muzzle_flash_any(var/atom/movable/A, var/firing_angle, var/muzzle_anim, var/muzzle_light_color, var/offset=22)
 	if (!A || firing_angle == null || !muzzle_anim) return
 
 	var/obj/particle/attack/muzzleflash/muzzleflash = unpool(/obj/particle/attack/muzzleflash)
-	muzzleflash.pixel_y = cos(firing_angle) * 22
-	muzzleflash.pixel_x = sin(firing_angle) * 22
 
 	if(isnull(muzzle_light_color))
 		muzzle_light_color = default_muzzle_flash_colors[muzzle_anim]
@@ -510,6 +508,7 @@ proc/muzzle_flash_any(var/atom/movable/A, var/firing_angle, var/muzzle_anim, var
 		muzzle_simple_light.color = muzzle_light_color
 		muzzleflash.overlays += muzzle_simple_light
 
+	muzzleflash.Translate(0, offset)
 	muzzleflash.Turn(firing_angle)
 	muzzleflash.layer = A.layer
 	muzzleflash.set_loc(A)

--- a/code/WorkInProgress/AnimationLibrary.dm
+++ b/code/WorkInProgress/AnimationLibrary.dm
@@ -446,7 +446,7 @@ proc/fuckup_attack_particle(var/mob/M)
 		y *= 22
 		animate(M.attack_particle, pixel_x = M.attack_particle.pixel_x + x , pixel_y = M.attack_particle.pixel_y + y, time = 5, easing = BOUNCE_EASING, flags = ANIMATION_END_NOW)
 
-var/global/obj/overlay/simple_light/muzzle_simple_light = new	/obj/overlay/simple_light{appearance_flags = RESET_COLOR | RESET_TRANSFORM | NO_CLIENT_COLOR | KEEP_APART}
+var/global/obj/overlay/simple_light/muzzle_simple_light = new	/obj/overlay/simple_light{appearance_flags = RESET_COLOR | NO_CLIENT_COLOR | KEEP_APART}
 
 var/global/list/default_muzzle_flash_colors = list(
 	"muzzle_flash" = "#FFEE9980",

--- a/code/WorkInProgress/AnimationLibrary.dm
+++ b/code/WorkInProgress/AnimationLibrary.dm
@@ -174,8 +174,6 @@
 		unpooled()
 			..()
 			src.alpha = 255
-			src.pixel_x = 0
-			src.pixel_y = 0
 
 		pooled()
 			..()
@@ -477,7 +475,6 @@ proc/muzzle_flash_any(var/atom/movable/A, var/firing_angle, var/muzzle_anim, var
 		muzzle_light_color = default_muzzle_flash_colors[muzzle_anim]
 	muzzleflash.overlays.Cut()
 	if(muzzle_light_color)
-		muzzle_simple_light.alpha = 255 // alpha can get overriden if #RRGGBBAA but would otherwise stay at the old value with #RRGGBB
 		muzzle_simple_light.color = muzzle_light_color
 		muzzleflash.overlays += muzzle_simple_light
 

--- a/code/modules/projectiles/disruptor_bolt.dm
+++ b/code/modules/projectiles/disruptor_bolt.dm
@@ -36,6 +36,10 @@ toxic - poisons
 
 	disruption = 12
 
+	color_red = 0.2
+	color_green = 0.2
+	color_blue = 1
+
 //Any special things when it hits shit?
 	on_hit(atom/hit)
 		if(istype(hit,/obj/window))

--- a/code/modules/projectiles/teleport.dm
+++ b/code/modules/projectiles/teleport.dm
@@ -25,6 +25,10 @@
 	//Can we pass windows
 	window_pass = 0
 
+	color_red = 0.2
+	color_green = 0.2
+	color_blue = 1
+
 	var/obj/item/target = null
 	var/failchance = 5
 

--- a/code/modules/projectiles/wavegun.dm
+++ b/code/modules/projectiles/wavegun.dm
@@ -35,6 +35,9 @@ toxic - poisons
 	//Can we pass windows
 	window_pass = 0
 
+	color_red = 1
+	color_green = 0
+	color_blue = 0
 
 /datum/projectile/wavegun/transverse //expensive taser shots that go through /everything/
 	shot_number = 1
@@ -51,7 +54,9 @@ toxic - poisons
 	damage_type = D_ENERGY
 	sname = "transverse wave"
 	icon_state = "wave-g"
-
+	color_red = 0
+	color_green = 1
+	color_blue = 0
 
 
 
@@ -68,6 +73,10 @@ toxic - poisons
 	sname = "electromagnetic distruption wave"
 	icon_state = "wave-emp"
 	disruption = 25
+
+	color_red = 0
+	color_green = 0
+	color_blue = 1
 
 	on_hit(atom/H, angle, var/obj/projectile/P)
 		var/turf/T = get_turf(H)

--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -48,7 +48,6 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 	var/shoot_delay = 4
 
 	var/muzzle_flash = null //set to a different icon state name if you want a different muzzle flash when fired, flash anims located in icons/mob/mob.dmi
-	var/list/muzzle_flash_simplelight_color
 
 	buildTooltipContent()
 		. = ..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
![PCTsnWqF5G](https://user-images.githubusercontent.com/358431/90987840-5ad13c00-e58e-11ea-9e53-97ba93045627.gif)
Muzzle flashes now emit a bit of light.
They also rotate a bit better.
And I added light to some projectiles that felt like they deserve it (telegun, disruptor, wavegun).


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Looks good and it's neat when you reveal yourself in the dark by shooting a gun.


## Changelog
```
(u)pali
(+)Muzzle flashes now emit a bit of light.
```
