### PR TITLE
med and small spiders cant grab anymore

### DIFF
--- a/code/mob/living/critter/spider.dm
+++ b/code/mob/living/critter/spider.dm
@@ -174,6 +174,7 @@
 	density = 0
 	flags = TABLEPASS
 	fits_under_table = 1
+	can_grab = 0 // Causes issues with tablepass, and doesn't make too much sense
 	health_brute = 25
 	health_burn = 25
 	good_grip = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Small and medium size spiders could pass under tables and grab people. under tables. while grabbing them.
Also, how does a small spider grab a human?

closes #1908 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
see #1908 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Michaellaneous:
(+)Medium and small spiders now can't grab people anymore.
```
