### PR TITLE
New Chief Engineer Objective (and repurposed medal)

### DIFF
--- a/code/datums/crew_objective.dm
+++ b/code/datums/crew_objective.dm
@@ -150,6 +150,14 @@ ABSTRACT_TYPE(/datum/objective/crew/chiefengineer)
 				if(F.z == 1 && F.active == 1)
 					return 1
 			return 0
+	ptl
+		explanation_text = "Earn at least a million credits via the PTL"
+		medal_name = "1.21 Jiggawatts"
+		check_completion()
+			for(var/obj/machinery/power/pt_laser/P in machine_registry[MACHINES_POWER])
+				if(P.lifetime_earnings >= 1 MEGA)
+					return 1
+			return 0
 
 ABSTRACT_TYPE(/datum/objective/crew/securityofficer)
 /datum/objective/crew/securityofficer // grabbed the HoS's two antag-related objectives cause they work just fine for regular sec too, so...?

--- a/code/datums/crew_objective.dm
+++ b/code/datums/crew_objective.dm
@@ -151,7 +151,7 @@ ABSTRACT_TYPE(/datum/objective/crew/chiefengineer)
 					return 1
 			return 0
 	ptl
-		explanation_text = "Earn at least a million credits via the PTL"
+		explanation_text = "Earn at least a million credits via the PTL."
 		medal_name = "1.21 Jiggawatts"
 		check_completion()
 			for(var/obj/machinery/power/pt_laser/P in machine_registry[MACHINES_POWER])


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE] [MEDAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Added a new objective for the Chief Engineer, "Earn at least a million credits via the PTL". Completing this new objective awards the "1.21 Jiggawatts" medal, which could previously be obtained by completing the Chief Engineer objective to have all APCs powered at round end. The medal was awarded once in 2019, but otherwise nobody earned in after 2016, and it's not in the public codebase, so I'm pretty sure it's currently unearnable.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This brings back a cool medal and adds a crew objective for doing a good job producing power. 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Jawns:
(*)New Chief Engineer objective rewards excessive competence
```
