### PR TITLE
Security Department Table Defibrillators

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -4623,6 +4623,9 @@
 /area/station/bridge/captain)
 "mt" = (
 /obj/table/auto,
+/obj/machinery/defib_mount{
+	pixel_y = 2
+	},
 /obj/item/kitchen/food_box/donut_box{
 	desc = "How are these not stale?";
 	name = "Robust Donuts"

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -26196,6 +26196,9 @@
 	dir = 4
 	},
 /obj/table/reinforced/auto,
+/obj/machinery/defib_mount{
+	pixel_y = 3
+	},
 /obj/random_item_spawner/med_kit,
 /obj/item/storage/firstaid/regular,
 /turf/simulated/floor/carpet{

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -6972,6 +6972,9 @@
 /area/station/hangar/sec)
 "aqf" = (
 /obj/table/auto,
+/obj/machinery/defib_mount{
+	pixel_y = 2
+	},
 /obj/item/storage/firstaid/regular,
 /obj/item/device/analyzer/healthanalyzer,
 /obj/item/reagent_containers/syringe,

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -46561,6 +46561,9 @@
 	icon_state = "1-2"
 	},
 /obj/table/reinforced/auto,
+/obj/machinery/defib_mount{
+	pixel_y = 3
+	},
 /obj/random_item_spawner/med_kit,
 /turf/simulated/floor/red/side,
 /area/station/security/main)

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -33691,6 +33691,10 @@
 /obj/table/reinforced/auto,
 /obj/window/crystal/reinforced/north,
 /obj/machinery/light_switch/west,
+/obj/machinery/defib_mount{
+	pixel_x = 2;
+	pixel_y = -4
+	},
 /obj/item/paper/Port_A_Brig,
 /obj/item/remote/porter/port_a_brig,
 /obj/window/crystal/reinforced/north,

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -14549,6 +14549,10 @@
 "eaL" = (
 /obj/machinery/light/incandescent/warm,
 /obj/table/auto,
+/obj/machinery/defib_mount{
+	pixel_x = 2;
+	pixel_y = 2
+	},
 /obj/random_item_spawner/med_kit,
 /obj/item/device/analyzer/healthanalyzer{
 	pixel_x = -4;

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -45130,6 +45130,10 @@
 /area/station/security/brig)
 "bXr" = (
 /obj/table/reinforced/auto,
+/obj/machinery/defib_mount{
+	pixel_x = 2;
+	pixel_y = 3
+	},
 /obj/item/storage/firstaid/regular,
 /obj/item/device/analyzer/healthanalyzer,
 /obj/item/reagent_containers/syringe,

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -23427,6 +23427,9 @@
 /area/station/security/secoffquarters)
 "baU" = (
 /obj/table/reinforced/auto,
+/obj/machinery/defib_mount{
+	pixel_y = 2
+	},
 /obj/item/storage/firstaid,
 /obj/item/storage/firstaid/brute{
 	pixel_y = 4

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -7488,6 +7488,10 @@
 /area/station/security/main)
 "aql" = (
 /obj/table/reinforced/auto,
+/obj/machinery/defib_mount{
+	pixel_x = -2;
+	pixel_y = 2
+	},
 /obj/item/reagent_containers/glass/bottle/epinephrine,
 /obj/item/reagent_containers/syringe,
 /obj/machinery/light/incandescent/cool,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds a table-mounted defibrillator to the Security Department to the majority of current normal-round maps, where they make sense. It is either located wherever the current medical supplies are or an easily accessible central table that everyone with Sec access can reach. I tried to make sure it wasn't on an overloaded table already in most cases.

Maps altered:
Atlas, Clarion, Cog1, Cog2, Destiny, Donut3, Kondaru, Manta, Oshan

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
As per my suggestion in the forums https://forum.ss13.co/showthread.php?tid=14805 , this adds an alternative way to restart someone's heart than a stun baton or shocking doors. With the decrease in available stun batons, players with Sec access may not actually have one to use in an emergency, and sometimes it's just too dang far to get to medbay when you really need to. A mounted one prevents it from disappearing into someone's pack to be used as a makeshift baton or something. Also, it makes sense from an immersion point of view, why wouldn't the security department have a defib for medical emergencies?
The response was positive in the thread but I feel actually making a PR would allow people to discuss it better, balance-wise.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)makkipakki:
(*)Added a table-mounted defibrillator to the security department.
```
