### PR TITLE
Ghost drones can't duplicate popsicles

### DIFF
--- a/code/modules/food_and_drink/popsicles.dm
+++ b/code/modules/food_and_drink/popsicles.dm
@@ -37,7 +37,7 @@
 			user.put_in_hand_or_drop(P)
 			if(prob(8))
 				P.melt(user)
-			dispose(src)
+			qdel(src)
 
 /obj/item/reagent_containers/food/snacks/popsicle
 	name = "popsicle"
@@ -121,7 +121,7 @@
 		src.reagents.reaction(get_turf(src))
 		user.u_equip(src)
 		src.set_loc(get_turf(user))
-		dispose(src)
+		qdel(src)
 		var/obj/item/stick/S = new
 		user.put_in_hand_or_drop(S)
 		return

--- a/code/modules/food_and_drink/popsicles.dm
+++ b/code/modules/food_and_drink/popsicles.dm
@@ -37,7 +37,7 @@
 			user.put_in_hand_or_drop(P)
 			if(prob(8))
 				P.melt(user)
-			qdel(src)
+			dispose(src)
 
 /obj/item/reagent_containers/food/snacks/popsicle
 	name = "popsicle"
@@ -121,7 +121,7 @@
 		src.reagents.reaction(get_turf(src))
 		user.u_equip(src)
 		src.set_loc(get_turf(user))
-		qdel(src)
+		dispose(src)
 		var/obj/item/stick/S = new
 		user.put_in_hand_or_drop(S)
 		return

--- a/code/obj/item/magtractor.dm
+++ b/code/obj/item/magtractor.dm
@@ -37,7 +37,7 @@
 	process()
 		//power usage here maybe??
 
-		if (!src.holding && src.holder && processHeld) //If the item has been consumed somehow
+		if ((!src.holding || src.holding.disposed) && src.holder && processHeld) //If the item has been consumed somehow
 			actions.stopId("magpickerhold", src.holder)
 			processHeld = 0
 		return
@@ -82,7 +82,7 @@
 		return 1
 
 	attack_self(mob/user as mob)
-		if (src.holding)
+		if (src.holding && !src.holding.disposed)
 			//activate held item (if possible)
 			src.holding.attack_self(user)
 			src.updateHeldOverlay(src.holding) //for items that update icon on activation (e.g. welders)
@@ -109,7 +109,7 @@
 			//pick up item
 			actions.start(new/datum/action/bar/private/icon/magPicker(target, src), user)
 
-		else if (src.holding && src.holding.loc != src) // it's gone!!
+		else if ((src.holding && src.holding.loc != src) || src.holding.disposed) // it's gone!!
 			actions.stopId("magpickerhold", usr)
 
 		return 1
@@ -168,7 +168,7 @@
 		return 1
 
 	proc/updateHeldOverlay(obj/item/W as obj)
-		if (W)
+		if (W && !W.disposed)
 			var/image/heldItem = GetOverlayImage("heldItem")
 			if (!heldItem) heldItem = image(W.icon, W.icon_state)
 			heldItem.color = W.color


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Ghost drones used to be able to make infinite popsicles using their mag tractor. Now they can't! `qdel` calls were replaced with `dispose`, and some logic was added to the magtractor code to make sure that you can't use an object that has been disposed.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #1921 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Jawns:
(+)Ghost drone popsicle duplication feature removed
```
