### PR TITLE
Jukeboxes can now play records

### DIFF
--- a/code/modules/telescience/radiostation.dm
+++ b/code/modules/telescience/radiostation.dm
@@ -239,10 +239,10 @@
 /obj/submachine/record_player/jukebox/attackby(obj/item/W as obj, mob/user as mob)
 	if (istype(W, /obj/item/record))
 		if(has_record)
-			boutput(user, "The record player already has a record inside!")
+			boutput(user, "\The [src] already has a record inside!")
 		else if(!is_playing)
-			boutput(user, "You insert the record into the record player.")
-			src.visible_message("<span class='notice'><b>[user] inserts the record into the record player.</b></span>")
+			boutput(user, "You insert the record into \the [src].")
+			src.visible_message("<span class='notice'><b>[user] inserts the record into \the [src].</b></span>")
 			user.drop_item()
 			W.set_loc(src)
 			src.record_inside = W

--- a/code/modules/telescience/radiostation.dm
+++ b/code/modules/telescience/radiostation.dm
@@ -229,6 +229,27 @@
 	else
 		..()
 
+/obj/submachine/record_player/jukebox
+	name = "old jukebox"
+	desc = "A vintage jukebox. It looks like this one has been modified to play vinyl records."
+	anchored = 1
+	icon = 'icons/obj/decoration.dmi'
+	icon_state = "jukebox"
+
+/obj/submachine/record_player/jukebox/attackby(obj/item/W as obj, mob/user as mob)
+	if (istype(W, /obj/item/record))
+		if(has_record)
+			boutput(user, "The record player already has a record inside!")
+		else if(!is_playing)
+			boutput(user, "You insert the record into the record player.")
+			src.visible_message("<span class='notice'><b>[user] inserts the record into the record player.</b></span>")
+			user.drop_item()
+			W.set_loc(src)
+			src.record_inside = W
+			src.has_record = 1
+			src.is_playing = 1
+			playsound(src,record_inside.song, 50, extrarange = -1)
+
 /obj/submachine/record_player/attack_hand(mob/user as mob)
 	if(has_record)
 		if(!is_playing)

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -6643,7 +6643,7 @@
 /turf/simulated/floor/blueblack,
 /area/station/bridge)
 "rH" = (
-/obj/item/instrument/large/jukebox,
+/obj/submachine/record_player/jukebox,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "rI" = (

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -18293,7 +18293,7 @@
 	dir = 9;
 	icon_state = "line1"
 	},
-/obj/item/instrument/large/jukebox,
+/obj/submachine/record_player/jukebox,
 /obj/decal/tile_edge/line/blue{
 	dir = 8;
 	icon_state = "line1"

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -23722,7 +23722,7 @@
 	},
 /area/station/crew_quarters/jazz)
 "aZw" = (
-/obj/item/instrument/large/jukebox,
+/obj/submachine/record_player/jukebox,
 /obj/decal/glow{
 	brightness = 3;
 	color_b = 0.2;

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -2887,7 +2887,7 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quartersB)
 "agi" = (
-/obj/item/instrument/large/jukebox{
+/obj/submachine/record_player/jukebox{
 	pixel_x = 2
 	},
 /obj/decal/glow{

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -5976,7 +5976,7 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/obj/item/instrument/large/jukebox,
+/obj/submachine/record_player/jukebox,
 /turf/simulated/floor/wood/eight{
 	dir = 4
 	},
@@ -7531,7 +7531,7 @@
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
 "bTd" = (
-/obj/item/instrument/large/jukebox,
+/obj/submachine/record_player/jukebox,
 /turf/simulated/floor/wood/seven,
 /area/station/security/detectives_office)
 "bTA" = (
@@ -36677,7 +36677,7 @@
 	},
 /area/station/chapel/main)
 "kXm" = (
-/obj/item/instrument/large/jukebox,
+/obj/submachine/record_player/jukebox,
 /obj/machinery/light/small/sticky,
 /turf/simulated/floor/specialroom/bar,
 /area/station/wreckage{

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -1328,7 +1328,7 @@
 "azB" = (/obj/disposalpipe/segment/transport{dir = 4},/turf/simulated/floor/carpet/purple/fancy,/area/station/crew_quarters/quartersB)
 "azC" = (/obj/disposalpipe/segment/transport{dir = 4},/turf/simulated/floor/carpet/purple/fancy/edge/east,/area/station/crew_quarters/quartersB)
 "azD" = (/obj/disposalpipe/segment/transport{dir = 4},/turf/simulated/floor/carpet/grime,/area/station/crew_quarters/quartersB)
-"azE" = (/obj/disposalpipe/segment/transport{dir = 4},/obj/item/instrument/large/jukebox,/obj/decal/glow{brightness = 3; color_b = 0.2; color_g = 0.45; color_r = 0.5; invisibility = 101; name = "glow - YELLOW"},/turf/simulated/floor/carpet/grime,/area/station/crew_quarters/quartersB)
+"azE" = (/obj/disposalpipe/segment/transport{dir = 4},/obj/submachine/record_player/jukebox,/obj/decal/glow{brightness = 3; color_b = 0.2; color_g = 0.45; color_r = 0.5; invisibility = 101; name = "glow - YELLOW"},/turf/simulated/floor/carpet/grime,/area/station/crew_quarters/quartersB)
 "azF" = (/obj/disposalpipe/segment/transport{dir = 4},/obj/stool/chair/wooden,/obj/landmark/start{name = "Staff Assistant"},/turf/simulated/floor/white/checker{dir = 6},/area/station/crew_quarters/quartersB)
 "azG" = (/obj/disposalpipe/trunk{dir = 8},/obj/machinery/disposal/transport{name = "transport chute - Fore"},/turf/simulated/floor/white/checker{dir = 6},/area/station/crew_quarters/quartersB)
 "azH" = (/obj/grille/steel,/obj/window/auto/reinforced,/turf/simulated/floor/plating,/area/station/medical/breakroom)

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -12985,7 +12985,7 @@
 /turf/simulated/floor/carpet/red/fancy/edge/north,
 /area/station/maintenance/inner)
 "aDy" = (
-/obj/item/instrument/large/jukebox,
+/obj/submachine/record_player/jukebox,
 /turf/simulated/floor/carpet/red/fancy/narrow/ne,
 /area/station/maintenance/inner)
 "aDz" = (

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -1646,7 +1646,7 @@
 /turf/simulated/floor/specialroom/bar,
 /area/bee_trader)
 "adC" = (
-/obj/item/instrument/large/jukebox,
+/obj/submachine/record_player/jukebox,
 /turf/simulated/floor/specialroom/bar,
 /area/diner/dining)
 "adD" = (
@@ -30693,7 +30693,7 @@
 	dir = 1;
 	icon_state = "frug1"
 	},
-/obj/item/instrument/large/jukebox,
+/obj/submachine/record_player/jukebox,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -39951,7 +39951,7 @@
 /turf/simulated/floor/wood/six,
 /area/station/security/detectives_office_manta)
 "bJZ" = (
-/obj/item/instrument/large/jukebox,
+/obj/submachine/record_player/jukebox,
 /turf/simulated/floor/wood/six,
 /area/station/security/detectives_office_manta)
 "bKa" = (

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -39246,7 +39246,7 @@
 /turf/simulated/floor/bot,
 /area/station/quartermaster)
 "bPk" = (
-/obj/item/instrument/large/jukebox,
+/obj/submachine/record_player/jukebox,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/jazz)
 "bPl" = (
@@ -43771,7 +43771,7 @@
 /turf/simulated/floor/specialroom/bar,
 /area/diner/dining)
 "caK" = (
-/obj/item/instrument/large/jukebox,
+/obj/submachine/record_player/jukebox,
 /turf/simulated/floor/specialroom/bar,
 /area/diner/dining)
 "caL" = (

--- a/maps/unused/cogmap.dmm
+++ b/maps/unused/cogmap.dmm
@@ -25129,7 +25129,7 @@
 	},
 /area/station/crew_quarters/jazz)
 "baX" = (
-/obj/item/instrument/large/jukebox,
+/obj/submachine/record_player/jukebox,
 /obj/decal/glow{
 	brightness = 3;
 	invisibility = 101;

--- a/maps/z5.dmm
+++ b/maps/z5.dmm
@@ -339,7 +339,7 @@
 "gA" = (/obj/table/reinforced/bar/auto,/obj/item/reagent_containers/food/snacks/condiment/syrup,/turf/simulated/floor/carpet{icon_state = "red2"},/area/diner/dining)
 "gB" = (/obj/table/reinforced/bar/auto,/obj/item/reagent_containers/food/snacks/pancake,/turf/simulated/floor/carpet{icon_state = "red2"},/area/diner/dining)
 "gC" = (/obj/lattice{dir = 1; icon_state = "lattice-dir"},/turf/space,/area/noGenerate)
-"gD" = (/obj/item/instrument/large/jukebox,/turf/simulated/floor/carpet{icon_state = "red2"},/area/diner/dining)
+"gD" = (/obj/submachine/record_player/jukebox,/turf/simulated/floor/carpet{icon_state = "red2"},/area/diner/dining)
 "gE" = (/obj/table/reinforced/bar/auto,/obj/machinery/light,/obj/item/kitchen/utensil/fork,/turf/simulated/floor/carpet{icon_state = "red2"},/area/diner/dining)
 "gF" = (/obj/table/reinforced/bar/auto,/obj/item/plate,/obj/item/reagent_containers/food/snacks/onion_slice,/obj/item/reagent_containers/food/snacks/onion_slice,/turf/simulated/floor/carpet{icon_state = "red2"},/area/diner/dining)
 "gG" = (/obj/decal/cleanable/dirt,/turf/simulated/floor/carpet{icon_state = "red2"},/area/diner/dining)


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Instead of playing a short random clip of music, records can now be inserted into the Jukebox to play music locally.
Old jukebox is still in the code, however I've replaced most instances of the old one in maps with the new one.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Jukeboxes are kinda bad honestly. Making it play records should make it better IMO and it also lets people listen to records privately

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Carbadox:
(*)Jukebox have been updated to allow you to play records on them.
```
a post script note -
with the way that the jukebox works, playsound isnt dynamic so unfortunately the music doesnt get louder/quieter the closer/further away you are, however most jukeboxes are situated in a rooms that are very much to side (EG Jazz Lounge on Cog1). Obviously its not perfect but I also don't think its half bad