### PR TITLE
make combat flips (suplex/drunkflip) interrupt action bars that are interrupted by acting

### DIFF
--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -1529,7 +1529,7 @@
 
 			if ("flip")
 				if (src.emote_check(voluntary, 50))
-
+					var/combatflip = 0
 					//TODO: space flipping
 					//if ((!src.restrained()) && (!src.lying) && (istype(src.loc, /turf/space)))
 					//	message = "<B>[src]</B> does a flip!"
@@ -1625,6 +1625,7 @@
 									logTheThing("combat", src, G.affecting, "suplexes [constructTarget(G.affecting,"combat")][tabl ? " into \an [tabl]" : null] [log_loc(src)]")
 									M.lastattacker = src
 									M.lastattackertime = world.time
+									combatflip = 1
 									if (iswrestler(src))
 										if (prob(50))
 											M.ex_act(3) // this is hilariously overpowered, but WHATEVER!!!
@@ -1684,7 +1685,7 @@
 										if (!iswrestler(src) && src.traitHolder && !src.traitHolder.hasTrait("glasscannon"))
 											src.remove_stamina(STAMINA_FLIP_COST)
 											src.stamina_stun()
-
+										combatflip = 1
 										message = "<span class='alert'><B>[src]</B> flips into [M]!</span>"
 										logTheThing("combat", src, M, "flips into [constructTarget(M,"combat")]")
 										src.changeStatus("weakened", 6 SECONDS)
@@ -1697,7 +1698,8 @@
 									else
 										message = "<B>[src]</B> flips in [M]'s general direction."
 									break
-
+					if(combatflip)
+						actions.interrupt(src, INTERRUPT_ACT)
 					if (src.lying)
 						message = "<B>[src]</B> flops on the floor like a fish."
 					// If there is a chest item, see if its reagents can be dumped into the body


### PR DESCRIPTION

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
See title - suplex/drunkflips changed to interrupt all actions that interrupt on INTERRUPT_ACT


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Shamblers, thanks to their 100% stun resist, could suplex-lock a victim while devouring them, which felt pretty silly.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Tarmunora:
(+)Changed suplexing to interrupt some action bars, notably shambler devour
```
