### PR TITLE
Minor slipping fix

### DIFF
--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -1142,8 +1142,8 @@ datum
 				var/turf/simulated/T = target
 				if (istype(T) && T.wet) //Wire: fix for Undefined variable /turf/space/var/wet (&& T.wet)
 					src = null
-					if (T.wet >= 1) return
-					T.wet = 1
+					if (T.wet >= 2) return
+					T.wet = 2
 					if (!locate(/obj/decal/cleanable/oil) in T)
 						playsound(T, "sound/impact_sounds/Slimy_Splat_1.ogg", 50, 1)
 						switch(volume)

--- a/code/procs/mob_procs.dm
+++ b/code/procs/mob_procs.dm
@@ -145,7 +145,7 @@
 		.= 1
 
 /mob/living/carbon/human/slip(walking_matters = 1, running = 0, ignore_actual_delay = 0)
-	..(walking_matters, (src.client?.check_key(KEY_RUN) && src.get_stamina() > STAMINA_SPRINT), ignore_actual_delay)
+	. = ..(walking_matters, (src.client?.check_key(KEY_RUN) && src.get_stamina() > STAMINA_SPRINT), ignore_actual_delay)
 
 
 /mob/living/carbon/human/proc/skeletonize()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MINOR] [MEDAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

`/mob/living/carbon/human/slip()` had no return value set, which made the "I just cleaned that!" medal almost unachievable*. That bug is fixed.

Additionally, oil foam used to apply a wetness of 1 to a tile, while space lube was 2 and superlube was 3. Oil is increased to 2, so that the medal can't be unlocked by slipping on oil. Oil still only lasts for 20 seconds, while lube lasts for a very long time, so even though oil foam is now a little more dangerous it's still much less dangerous than lube.

<sub>*As far as I can tell, the only way you can achieve this medal currently requires you to be a meat cube.</sub> 
## Why's this needed? <!-- Describe why you= think this should be added to the game. -->

The `null` return value of  `/mob/living/carbon/human/slip()` is clearly a bug; the change to oil keeps the spirit of the medal intact.

## Changelog
<!-- If necessary, put yur changelog entry b-elow. Otherwise=, please delete it.
Use however you want to be credited in the changel0og inb place of CodeDude.
Use (*) for major canges and (+) for minor changes. For examp=le: -->

N/A