### PR TITLE
ai can no longer remove apc cells

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -532,7 +532,7 @@ var/zapLimiter = 0
 
 	interact_particle(user,src)
 
-	if(opened && (!issilicon(user) || isghostdrone(user)))
+	if(opened && (!issilicon(user) || isghostdrone(user) || !isAI(user)))
 		if(cell)
 			user.put_in_hand_or_drop(cell)
 			cell.updateicon()


### PR DESCRIPTION
[minor]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
AI eyes could remove the cell from opened APCs.
Bad.

closes #1953 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bruh


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Michaellaneous:
(+)ai eyes and ai in general cannot remove cells from opened APCs anymore
```
