### PR TITLE
slotting in a new cartridge now autoremoves the old one

### DIFF
--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -423,12 +423,18 @@
 		if (U.try_deliver(C, user))
 			return
 
-	if (istype(C, /obj/item/disk/data/cartridge) && isnull(src.cartridge))
+	if (istype(C, /obj/item/disk/data/cartridge))
 		user.drop_item()
 		C.set_loc(src)
-		boutput(user, "<span class='notice'>You insert [C] into [src].</span>")
-		src.cartridge = C
-		src.updateSelfDialog()
+		if (isnull(src.cartridge))
+			boutput(user, "<span class='notice'>You insert [C] into [src].</span>")
+			src.cartridge = C
+			src.updateSelfDialog()
+		else
+			boutput(user, "<span class='notice'>You remove the old cartridge and insert [C] into [src].</span>")
+			user.put_in_hand_or_eject(src.cartridge)
+			src.cartridge = C
+			src.updateSelfDialog()
 
 	else if (istype(C, /obj/item/device/pda_module))
 		if(src.closed)

--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -428,13 +428,11 @@
 		C.set_loc(src)
 		if (isnull(src.cartridge))
 			boutput(user, "<span class='notice'>You insert [C] into [src].</span>")
-			src.cartridge = C
-			src.updateSelfDialog()
 		else
 			boutput(user, "<span class='notice'>You remove the old cartridge and insert [C] into [src].</span>")
 			user.put_in_hand_or_eject(src.cartridge)
-			src.cartridge = C
-			src.updateSelfDialog()
+		src.cartridge = C
+		src.updateSelfDialog()
 
 	else if (istype(C, /obj/item/device/pda_module))
 		if(src.closed)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL][FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Slotting in a new cartridge now autoremoves the old one.
Something like this https://www.youtube.com/watch?v=Uiwhg6bHaYs
*ping*
closes #1897 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
its cool


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Michaellaneous:
(+)Slotting in a cartridge into a PDA now ejects the old one, if present
```
