### PR TITLE
Added amount to sweet_tea for hottoddy recipe

### DIFF
--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -1602,7 +1602,7 @@ datum
 			name = "Hot Toddy"
 			id = "hottoddy"
 			result = "hottoddy"
-			required_reagents = list("sweet_tea", "bourbon" = 1, "juice_lemon" = 1)
+			required_reagents = list("sweet_tea" = 1, "bourbon" = 1, "juice_lemon" = 1)
 			result_amount = 3
 			mix_phrase = "The drink suddenly fills the room with a festive aroma."
 			mix_sound = 'sound/misc/drinkfizz.ogg'


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[CLEANLINESS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

The recipe for a Hot Toddy had no amount specified for sweet tea. This PR makes the amount required explicitly "1".

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This does not change gameplay; it is purely aesthetic. As far as I can tell, this ingredient in this recipe is the only one to not have an amount listed.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

N/A
