### PR TITLE
Ejecting beaker from chemdisps now go into hand / Interface opens on insertion

### DIFF
--- a/code/modules/chemistry/Chemistry-Dispenser.dm
+++ b/code/modules/chemistry/Chemistry-Dispenser.dm
@@ -245,6 +245,8 @@
 			send_beaker_details()
 			send_reagent_details(0)
 		src.update_icon()
+		src.add_dialog(user)
+		ch_window.Subscribe(user.client)
 
 	handle_event(var/event, var/sender)
 		if (event == "reagent_holder_update")
@@ -338,8 +340,7 @@
 
 		else if (href_list["eject"])
 			if (beaker)
-				// should this use "put in hands or drop"? seems like a better idea. idk
-				beaker:set_loc(src.output_target ? src.output_target : get_turf(src))
+				usr.put_in_hand_or_drop(beaker)
 				beaker = null
 			else
 				var/obj/item/I = usr.equipped()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL][MINOR]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The chem dispenser was the only machine not putting the beaker in your hand.
Fixed; in addition, slotting a beaker into the machine now auto-opens the menu
closes #1621 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
small qol and consistency


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Michaellaneous:
(+)Ejecting beaker from chem dispensers now go into hand
(+)Putting beaker into chem dispenser now opens interface
```
