### PR TITLE
Adds map-specific job override settings

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -54,6 +54,7 @@
 	var/objective = null
 	var/spawn_miscreant = 0
 	var/rounds_needed_to_play = 0 //0 by default, set to the amount of rounds they should have in order to play this
+	var/map_can_autooverride = 1 // if set to 0 map can't change limit on this job automatically (it can still set it manually)
 
 	New()
 		..()
@@ -894,6 +895,7 @@
 	no_jobban_from_this_job = 1
 	low_priority_job = 1
 	cant_allocate_unwanted = 1
+	map_can_autooverride = 0
 	slot_jump = /obj/item/clothing/under/rank
 	slot_foot = /obj/item/clothing/shoes/black
 

--- a/code/map.dm
+++ b/code/map.dm
@@ -122,7 +122,7 @@ var/global/list/mapNames = list(
 		// map limits
 		if(job_limits_from_landmarks)
 			for(var/datum/job/J in job_controls.staple_jobs)
-				if(J.name in job_start_locations)
+				if(J.map_can_autooverride && (J.name in job_start_locations))
 					J.limit = length(job_start_locations[J.name])
 
 		for(var/datum/job/J in job_controls.staple_jobs + job_controls.special_jobs)

--- a/code/map.dm
+++ b/code/map.dm
@@ -115,6 +115,20 @@ var/global/list/mapNames = list(
 		"the robotics lab" = list(/area/station/medical/robotics))
 //		"the public pool" = list(/area/station/crew_quarters/pool))
 
+	var/job_limits_from_landmarks = FALSE /// if TRUE each job with a landmark will get as many slots as many landmarks there are (jobs without a landmark left on default)
+	var/list/job_limits_override = list() /// assoc list of the form `job_type=limit` to override other job settings, works on gimmick jobs too
+
+	proc/init() /// Map-specific initialization, feel free to override for your map!
+		// map limits
+		if(job_limits_from_landmarks)
+			for(var/datum/job/J in job_controls.staple_jobs)
+				if(J.name in job_start_locations)
+					J.limit = length(job_start_locations[J.name])
+
+		for(var/datum/job/J in job_controls.staple_jobs + job_controls.special_jobs)
+			if(J.type in src.job_limits_override)
+				J.limit = src.job_limits_override[J.type]
+
 /datum/map_settings/donut2
 	name = "DONUT2"
 	goonhub_map = "https://goonhub.com/maps/donut2"
@@ -704,6 +718,10 @@ var/global/list/mapNames = list(
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap
 	merchant_right_centcom = /area/shuttle/merchant_shuttle/right_centcom/cogmap
 	merchant_right_station = /area/shuttle/merchant_shuttle/right_station/cogmap
+
+	job_limits_override = list(
+		/datum/job/civilian/clown = 2 // pamgoc can have a little clown, as a treat
+	)
 
 /datum/map_settings/oshan
 	name = "OSHAN"

--- a/code/world.dm
+++ b/code/world.dm
@@ -627,6 +627,9 @@ var/f_color_selector_handler/F_Color_Selector
 	Z_LOG_DEBUG("World/Init", "Initializing worldgen...")
 	initialize_worldgen()
 
+	Z_LOG_DEBUG("World/Init", "Running map-specific initialization...")
+	map_settings.init()
+
 	UPDATE_TITLE_STATUS("Ready")
 	current_state = GAME_STATE_PREGAME
 	Z_LOG_DEBUG("World/Init", "Now in pre-game state.")
@@ -645,7 +648,6 @@ var/f_color_selector_handler/F_Color_Selector
 	Z_LOG_DEBUG("World/Init", "Init() complete")
 	TgsInitializationComplete()
 	//sleep_offline = 1
-
 
 	// Biodome elevator accident stats
 	bioele_load_stats()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Map config now allows you to turn on a mode where each job gets as many slots as many spawn landmarks it has (left at default if 0 landmarks).
Also you can set job limits manually in the map config for any job you want (including special gimmick jobs, scream).
If you need more finetuned initialization of your map (whether it's job or anything else) it can now be achieved by overriding `map_settings/init`.
As an example I gave Pamgoc an additional clown. Now that I think about it it probably should have been a second chaplain instead. God knows Pamgoc needs one.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's incredibly silly that Atlas has as many job slots as Donut 3.


