### PR TITLE
Potential performance upgrade for process_cell()

### DIFF
--- a/code/modules/atmospherics/FEA_turf_tile.dm
+++ b/code/modules/atmospherics/FEA_turf_tile.dm
@@ -363,14 +363,16 @@ turf
 							if(enemy_tile.archived_cycle < archived_cycle) //archive bordering tile information if not already done
 								enemy_tile.archive()
 #endif
-							if(enemy_tile.parent && enemy_tile.parent.group_processing) //apply tile to group sharing
-								if(enemy_tile.parent.current_cycle < current_cycle)
-									if(enemy_tile.parent.air.check_gas_mixture(air))
-										connection_difference = air.share(enemy_tile.parent.air)
-									else
-										enemy_tile.parent.suspend_group_processing()
-										connection_difference = air.share(enemy_tile.air)
-										//group processing failed so interact with individual tile
+							if(enemy_tile.parent) //apply tile to group sharing
+								var/datum/air_group/sharegroup = enemy_tile.parent
+								if(sharegroup.group_processing)
+									if(sharegroup.current_cycle < current_cycle)
+										if(sharegroup.air.check_gas_mixture(air))
+											connection_difference = air.share(sharegroup.air)
+										else
+											sharegroup.suspend_group_processing()
+											connection_difference = air.share(enemy_tile.air)
+											//group processing failed so interact with individual tile
 							else
 								if(enemy_tile.current_cycle < current_cycle)
 									connection_difference = air.share(enemy_tile.air)

--- a/code/modules/atmospherics/FEA_turf_tile.dm
+++ b/code/modules/atmospherics/FEA_turf_tile.dm
@@ -364,7 +364,7 @@ turf
 								enemy_tile.archive()
 #endif
 							if(enemy_tile.parent) //apply tile to group sharing
-								var/datum/air_group/sharegroup = enemy_tile.parent
+								var/datum/air_group/sharegroup = enemy_tile.parent //move tile's group to a new variable so we're not referencing multiple layers deep
 								if(sharegroup.group_processing)
 									if(sharegroup.current_cycle < current_cycle)
 										if(sharegroup.air.check_gas_mixture(air))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[PERF][INPUT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes a part of process_cell() that deals with adjacent tiles' atmosphere groups; instead of referencing the air group through its tile, a local variable is created for that air group and that's used in subsequent checks.

A brief local test seemed to indicate about a 10% performance improvement in the proc itself (Dream Daemon profiler, running Cog2 with nothing happening and cross-comparing Self CPU adjusted for call count after about 60k calls have accumulated), but I'm not confident in this result, so further advanced testing for this would be welcome.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Atmos go fast
