### PR TITLE
Fix sec clone record disk implant reference and traits record

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -86,9 +86,6 @@
 						return
 					R.fields["imp"] = "\ref[I]"
 
-					if(H.traitHolder && H.traitHolder.traits.len)
-						R.fields["traits"] = H.traitHolder.traits.Copy()
-
 			var/give_access_implant = ismobcritter(M)
 			if(!spawn_id && (access.len > 0 || access.len == 1 && access[1] != access_fuck_all))
 				give_access_implant = 1

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -75,11 +75,19 @@
 				I.implanted = 1
 				if(ishuman(M)) H.implant.Add(I)
 				I.implanted(M)
-				if (receives_disk && ishuman(M))
-					if (istype(H.back, /obj/item/storage))
-						var/obj/item/disk/data/floppy/D = locate(/obj/item/disk/data/floppy) in H.back
-						if (D)
-							D.data["imp"] = "\ref[I]"
+				if (src.receives_disk && ishuman(M))
+					if (!istype(H.back, /obj/item/storage))
+						return
+					var/obj/item/disk/data/floppy/D = locate(/obj/item/disk/data/floppy) in H.back
+					if (!D)
+						return
+					var/datum/computer/file/clone/R = locate(/datum/computer/file/clone/) in D.root.contents
+					if (!R)
+						return
+					R.fields["imp"] = "\ref[I]"
+
+					if(H.traitHolder && H.traitHolder.traits.len)
+						R.fields["traits"] = H.traitHolder.traits.Copy()
 
 			var/give_access_implant = ismobcritter(M)
 			if(!spawn_id && (access.len > 0 || access.len == 1 && access[1] != access_fuck_all))

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -76,15 +76,12 @@
 				if(ishuman(M)) H.implant.Add(I)
 				I.implanted(M)
 				if (src.receives_disk && ishuman(M))
-					if (!istype(H.back, /obj/item/storage))
-						return
-					var/obj/item/disk/data/floppy/D = locate(/obj/item/disk/data/floppy) in H.back
-					if (!D)
-						return
-					var/datum/computer/file/clone/R = locate(/datum/computer/file/clone/) in D.root.contents
-					if (!R)
-						return
-					R.fields["imp"] = "\ref[I]"
+					if (istype(H.back, /obj/item/storage))
+						var/obj/item/disk/data/floppy/D = locate(/obj/item/disk/data/floppy) in H.back
+						if (D)
+							var/datum/computer/file/clone/R = locate(/datum/computer/file/clone/) in D.root.contents
+							if (R)
+								R.fields["imp"] = "\ref[I]"
 
 			var/give_access_implant = ismobcritter(M)
 			if(!spawn_id && (access.len > 0 || access.len == 1 && access[1] != access_fuck_all))

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -438,6 +438,10 @@
 					var/datum/abilityHolder/A = src.abilityHolder.deepCopy()
 					R.fields["abilities"] = A
 
+				SPAWN_DBG(0)
+					if(src.traitHolder && src.traitHolder.traits.len)
+						R.fields["traits"] = src.traitHolder.traits.Copy()
+
 				R.fields["imp"] = null
 				R.fields["mind"] = src.mind
 				R.name = "CloneRecord-[ckey(src.real_name)]"

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -438,10 +438,6 @@
 					var/datum/abilityHolder/A = src.abilityHolder.deepCopy()
 					R.fields["abilities"] = A
 
-				R.fields["traits"] = list()
-				if(src.traitHolder && src.traitHolder.traits.len)
-					R.fields["traits"] = src.traitHolder.traits.Copy()
-
 				R.fields["imp"] = null
 				R.fields["mind"] = src.mind
 				R.name = "CloneRecord-[ckey(src.real_name)]"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][RUNTIME][BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Sec clone record disk now properly receives the reference to their health implant allowing the cloner to display implant status
- Sec traits are now properly stored in the cloning record. Prevents sec from losing their security training (and hos his career alcoholic) if clone by disk

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
- closes #1644
- Fixes the following runtime that occurs every time a sec player joins

File | jobs.dm
-- | --
Line | 82
Error | bad index

```
proc name: special setup (/datum/job/proc/special_setup)
  source file: jobs.dm,82
  usr: null
  src: Head of Security (/datum/job/command/head_of_security)
  call stack:
Head of Security (/datum/job/command/head_of_security): special setup(Sov Extant (/mob/living/carbon/human), null
```