### PR TITLE
Transformations inherit the target's mutantrace

### DIFF
--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -99,6 +99,9 @@
 			APPLY_MOVEMENT_MODIFIER(M, movement_modifier, src.type)
 		if(ishuman(M))
 			src.mob = M
+			var/datum/appearanceHolder/AHM = mob?.bioHolder?.mobAppearance
+			if (AHM)
+				AHM.mutant_race = src.type
 			var/list/obj/item/clothing/restricted = list(mob.w_uniform, mob.shoes, mob.wear_suit)
 			for(var/obj/item/clothing/W in restricted)
 				if (istype(W,/obj/item/clothing))

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -244,6 +244,9 @@
 				H.image_cust_one.pixel_y = initial(H.image_cust_one.pixel_y)
 				H.image_cust_two.pixel_y = initial(H.image_cust_two.pixel_y)
 				H.image_cust_three.pixel_y = initial(H.image_cust_three.pixel_y)
+				var/datum/appearanceHolder/AHM = H?.bioHolder?.mobAppearance
+				if (AHM)
+					AHM.mutant_race = null
 
 				// And the other way around (Convair880).
 				if (src.r_limb_arm_type_mutantrace)

--- a/code/modules/antagonists/changeling/abilities/transform.dm
+++ b/code/modules/antagonists/changeling/abilities/transform.dm
@@ -100,7 +100,9 @@
 		C.real_name = target_name
 		C.bioHolder.CopyOther(D)
 		C.bioHolder.RemoveEffect("husk")
-		if (istype(C))
+		if (C.bioHolder?.mobAppearance?.mutant_race)
+			C.set_mutantrace(C.bioHolder.mobAppearance.mutant_race)
+		else
 			C.set_mutantrace(null)
 		C.update_face()
 		C.update_body()

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -1556,6 +1556,8 @@ datum
 						boutput(M, "<span class='notice'>You feel a little [pick("unlike yourself", "out of it", "different", "strange")].</span>")
 					if (progress_timer > 10)
 						M.real_name = M.bioHolder.ownerName
+						if (M.bioHolder?.mobAppearance?.mutant_race)
+							M.set_mutantrace(M.bioHolder.mobAppearance.mutant_race)
 						M.UpdateName()
 
 				..()

--- a/code/modules/medical/genetics/bioEffects/powers.dm
+++ b/code/modules/medical/genetics/bioEffects/powers.dm
@@ -453,7 +453,8 @@
 				owner.bioHolder.CopyOther(H.bioHolder, copyAppearance = 1, copyPool = 0, copyEffectBlocks = 0, copyActiveEffects = 0)
 				owner.real_name = H.real_name
 				owner.name = H.name
-
+				if(owner.bioHolder?.mobAppearance?.mutant_race)
+					owner.set_mutantrace(owner.bioHolder.mobAppearance.mutant_race)
 		return
 
 	cast_misfire(atom/target)

--- a/code/modules/medical/genetics/bioHolder.dm
+++ b/code/modules/medical/genetics/bioHolder.dm
@@ -47,6 +47,8 @@ var/list/datum/bioEffect/mutini_effects = list()
 	var/mob/owner = null
 	var/datum/bioHolder/parentHolder = null
 
+	var/datum/mutantrace/mutant_race = null
+
 	var/gender = MALE
 	var/pronouns = 0		//1 if using neutral pronouns (they/their);  0 if using gendered pronouns matching their gender var
 	var/screamsound = "male"
@@ -99,6 +101,7 @@ var/list/datum/bioEffect/mutini_effects = list()
 
 		gender = toCopy.gender
 		pronouns = toCopy.pronouns
+		mutant_race = toCopy.mutant_race
 
 		screamsound = toCopy.screamsound
 		fartsound = toCopy.fartsound
@@ -140,6 +143,7 @@ var/list/datum/bioEffect/mutini_effects = list()
 		if (progress > 7 || prob(progress * 10))
 			gender = toCopy.gender
 			pronouns = toCopy.pronouns
+			mutant_race = toCopy.mutant_race
 
 		if(progress >= 10) //Finalize the copying here, with anything we may have missed.
 			src.CopyOther(toCopy)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changeling transformations, polymorphism, and stable mutagen now also transfer over the target's mutant race. Meaning lings can finally have a cow, man.

Also stores the path to the player's mutantrace in their appearanceholder, updated whenever the race changes.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

So when I get eaten by a ling, they dont end up looking like some doofus with neon anime hair.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Superlagg:
(+)Certain transformations inherit the target's mutant race.
```
