### PR TITLE
Makes bodies not decompose in space

### DIFF
--- a/code/mob/living/life/decomposition.dm
+++ b/code/mob/living/life/decomposition.dm
@@ -12,16 +12,18 @@
 			if (H.loc == T && T.temp_flags & HAS_KUDZU) //only infect if on the floor
 				H.infect_kudzu()
 
-			var/suspend_rot = 0
+			var/suspend_rot = \
+					istype(owner.loc, /obj/machinery/atmospherics/unary/cryo_cell) || \
+					istype(owner.loc, /obj/morgue) || \
+					T.type == /turf/space || \
+					owner.reagents?.has_reagent("formaldehyde")
 			if (H.decomp_stage >= 4)
-				suspend_rot = (istype(owner.loc, /obj/machinery/atmospherics/unary/cryo_cell) || istype(owner.loc, /obj/morgue) || (owner.reagents && owner.reagents.has_reagent("formaldehyde")))
 				if (!(suspend_rot || istype(owner.loc, /obj/item/body_bag) || (istype(owner.loc, /obj/storage) && owner.loc:welded)))
 					icky_icky_miasma(T)
 				return ..()
 
 			if (H.mutantrace)
 				return ..()
-			suspend_rot = (istype(owner.loc, /obj/machinery/atmospherics/unary/cryo_cell) || istype(owner.loc, /obj/morgue) || (owner.reagents && owner.reagents.has_reagent("formaldehyde")))
 			var/env_temp = 0
 			// cogwerks note: both the cryo cell and morgue things technically work, but the corpse rots instantly when removed
 			// if it has been in there longer than the next decomp time that was initiated before the corpses went in. fuck!
@@ -30,7 +32,7 @@
 			// hello I fixed the thing by making it so that next_decomp_time is added to even if src is in a morgue/cryo or they have formaldehyde in them - haine
 			if (!suspend_rot && environment)
 				env_temp = environment.temperature
-				H.next_decomp_time -= min(30, max(round((env_temp - T20C)/10), -60))
+				H.next_decomp_time -= clamp(round((env_temp - T20C)/10), -60, 30)
 				if(!(istype(owner.loc, /obj/item/body_bag) || (istype(owner.loc, /obj/storage) && owner.loc:welded)))
 					icky_icky_miasma(T)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes decomposition not happen if the body is in space (or in a container that's in space).

(Also some very mild code cleanup.)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I like the tradeoff this creates. Throwing a dead body into space is usually very easy and makes the body relatively hard to find. Making those space bodies cloneable would be the downside to this common strategy.

## Changelog

```
(u)pali
(+)Bodies no longer decompose in space.
```
