### PR TITLE
Added "High Five!" medal to charged gloves' spark attack

### DIFF
--- a/code/WorkInProgress/ItemSpecials.dm
+++ b/code/WorkInProgress/ItemSpecials.dm
@@ -976,6 +976,8 @@
 						on_hit(A,2)
 						attacked += A
 						hit = 1
+						if (ishuman(user) && master  && istype(master, /obj/item/clothing/gloves))
+							user.unlock_medal("High Five!", 1)
 						break
 				if (!hit)
 					SPAWN_DBG(secondhit_delay)
@@ -997,8 +999,6 @@
 						G.icon_state = "yellow"
 						G.item_state = "ygloves"
 						user.update_clothing() // Was missing (Convair880).
-
-					if (G.uses <= 0)
 						user.show_text("The gloves are no longer electrically charged.", "red")
 						G.overridespecial = 0
 					else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Commit a0c2198fd6efc6ad8130f8e274283d4bb9801e3a commented out a call to the `stun_glove_attack` proc, which is where the "High Five!" medal was awarded, in favor of the item special attack system. That made the medal unobtainable. This PR makes the medal obtainable again.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This medal was not intentionally made unobtainable.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

N/A
