### PR TITLE
Beaker descriptions now mention/explain grip

### DIFF
--- a/code/modules/chemistry/Chemistry-Tools.dm
+++ b/code/modules/chemistry/Chemistry-Tools.dm
@@ -399,12 +399,28 @@
 
 	attack_self(mob/user as mob)
 		if (src.splash_all_contents)
-			boutput(user, "<span class='notice'>You tighten your grip on the [src].</span>")
+			boutput(user, "<span class='notice'>You tighten your grip on the [src]. You can apply its contents onto things with more control now.</span>")
+			src.desc = "[initial(src.desc)] Your grip on it is tight. You'll apply [src.amount_per_transfer_from_this] units of its contents on things."
 			src.splash_all_contents = 0
 		else
 			boutput(user, "<span class='notice'>You loosen your grip on the [src].</span>")
+			src.desc = "[initial(src.desc)] Your grip on it is loose. You'll splash everything in it onto things."
 			src.splash_all_contents = 1
 		return
+
+	pickup(var/mob/user)
+		..()
+		src.desc = "[initial(src.desc)] Your grip on it is loose. You'll splash everything in it onto things."
+
+	dropped(var/mob/user)
+		..()
+		src.splash_all_contents = 1
+		src.desc = initial(src.desc)
+
+	unequipped(var/mob/user)
+		..()
+		src.splash_all_contents = 1
+		src.desc = initial(src.desc)
 
 	proc/smash()
 		playsound(src.loc, pick('sound/impact_sounds/Glass_Shatter_1.ogg','sound/impact_sounds/Glass_Shatter_2.ogg','sound/impact_sounds/Glass_Shatter_3.ogg'), 100, 1)

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -455,12 +455,28 @@
 	//Wow, we copy+pasted the heck out of this... (Source is chemistry-tools dm)
 	attack_self(mob/user as mob)
 		if (src.splash_all_contents)
-			boutput(user, "<span class='notice'>You tighten your grip on the [src].</span>")
+			boutput(user, "<span class='notice'>You tighten your grip on the [src]. You can apply its contents onto things with more control now.</span>")
+			src.desc = "[initial(src.desc)] Your grip on it is tight. You'll apply [src.amount_per_transfer_from_this] units of its contents on things."
 			src.splash_all_contents = 0
 		else
 			boutput(user, "<span class='notice'>You loosen your grip on the [src].</span>")
+			src.desc = "[initial(src.desc)] Your grip on it is loose. You'll splash everything in it onto things."
 			src.splash_all_contents = 1
 		return
+
+	pickup(var/mob/user)
+		..()
+		src.desc = "[initial(src.desc)] Your grip on it is loose. You'll splash everything in it onto things."
+
+	dropped(var/mob/user)
+		..()
+		src.splash_all_contents = 1
+		src.desc = initial(src.desc)
+
+	unequipped(var/mob/user)
+		..()
+		src.splash_all_contents = 1
+		src.desc = initial(src.desc)
 
 	attack(mob/M as mob, mob/user as mob, def_zone)
 		// in this case m is the consumer and user is the one holding it


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR does some description shenanigans so that you're holding one you can tell from the description how you're holding it, what that practically does and in what increments you apply contents. It also changes them so that when a beaker is dropped or put away the grip resets to loose.

The code is copied between Chemistry-Tools.dm and food_and_drink.dm because I guess some drinks containers also function as beakers as far as pouring is concerned. Seems like a mess we should refactor someday, but in its own PR.

By-effects are that beaker artifacts are even easier to spot when held. Also this might break if you manage to make a beaker with matsci, because one of the description changes would override the other. Don't think that's possible though. :|

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Grip is kinda important for some uses of beakers but it's also opaque as heck right now.
Carrying over a tight grip because someone else held a beaker before you makes no sense.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)BatElite:
(+)Beakers and the like now indicate grip better. You'll always pick them up loosely now, beware your muscle memory!
```
