### PR TITLE
Fixed issue with inserted disks making computers unusable

### DIFF
--- a/code/modules/networks/computer3/computer3.dm
+++ b/code/modules/networks/computer3/computer3.dm
@@ -587,7 +587,6 @@ function lineEnter (ev)
 				P.disk_ejected(src.diskette)
 
 			usr.put_in_hand_or_eject(src.diskette) // try to eject it into the users hand, if we can
-			src.diskette.set_loc(get_turf(src))
 			src.diskette = null
 			usr << output(url_encode("Disk: <a href='byond://?src=\ref[src];disk=1'>-----</a>"),"comp3.browser:setInternalDisk")
 		else
@@ -652,14 +651,18 @@ function lineEnter (ev)
 /obj/machinery/computer3/attackby(obj/item/W as obj, mob/user as mob)
 	if (istype(W, /obj/item/disk/data/floppy)) //INSERT SOME DISKETTES
 		if ((!src.diskette) && src.setup_has_internal_disk)
-			src.add_dialog(user)
 			user.drop_item()
 			W.set_loc(src)
 			src.diskette = W
 			boutput(user, "You insert [W].")
-			src.updateUsrDialog()
-			user << output(url_encode("Disk: <a href='byond://?src=\ref[src];eject=1'>Eject</a>"),"comp3.browser:setInternalDisk")
+			if(user.using_dialog_of(src))
+				src.updateUsrDialog()
+				user << output(url_encode("Disk: <a href='byond://?src=\ref[src];disk=1'>Eject</a>"),"comp3.browser:setInternalDisk")
 			return
+		else if(src.diskette)
+			boutput(user, "<span class='alert'>There's already a disk inside!</span>")
+		else if(!src.setup_has_internal_disk)
+			boutput(user, "<span class='alert'>There's no visible peripheral device to insert the disk into!</span>")
 
 	else if (isscrewingtool(W))
 		playsound(src.loc, "sound/items/Screwdriver.ogg", 50, 1)
@@ -1068,13 +1071,18 @@ function lineEnter (ev)
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (istype(W, /obj/item/disk/data/floppy)) //INSERT SOME DISKETTES
 			if ((!src.diskette) && src.setup_has_internal_disk)
-				src.add_dialog(user)
 				user.drop_item()
 				W.set_loc(src)
 				src.diskette = W
 				boutput(user, "You insert [W].")
-				src.updateUsrDialog()
+				if(user.using_dialog_of(src))
+					src.updateUsrDialog()
+					user << output(url_encode("Disk: <a href='byond://?src=\ref[src];disk=1'>Eject</a>"),"comp3.browser:setInternalDisk")
 				return
+			else if(src.diskette)
+				boutput(user, "<span class='alert'>There's already a disk inside!</span>")
+			else if(!src.setup_has_internal_disk)
+				boutput(user, "<span class='alert'>There's no visible peripheral device to insert the disk into!</span>")
 
 		else if (ispryingtool(W))
 			if(!src.cell)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title. If you inserted a disk into a computer without having the GUI open, then the computer would become unusable for the user. This fixes that and also adds some QoL messages for when the disk slot is occupied/unavailable.

Also fixes a "ghost item" issue where if you ejected the disk, it'd both simultaneously be in your hand and on the same turf as the computer it was ejected from.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
resolves https://github.com/goonstation/goonstation/issues/1995
