### PR TITLE
Fixed runtime when melting floors with flamethrower

### DIFF
--- a/code/obj/item/flamethrower.dm
+++ b/code/obj/item/flamethrower.dm
@@ -671,8 +671,7 @@ GETLINEEEEEEEEEEEEEEEEEEEEE
 		reagentlefttotransfer -= reagentperturf
 		spray_turf(currentturf,reagentperturf, reagsource)
 		reagentperturf += increment
-		if(lit)
-			//currentturf.hotspot_expose(spray_temperature,2)
+		if(currentturf.reagents)
 			currentturf.reagents.set_reagent_temp(spray_temperature, TRUE)
 			spray_temperature = max(0,min(spray_temperature - temp_loss_per_tile, 700))
 

--- a/code/obj/item/flamethrower.dm
+++ b/code/obj/item/flamethrower.dm
@@ -671,8 +671,8 @@ GETLINEEEEEEEEEEEEEEEEEEEEE
 		reagentlefttotransfer -= reagentperturf
 		spray_turf(currentturf,reagentperturf, reagsource)
 		reagentperturf += increment
-		if(currentturf.reagents)
-			currentturf.reagents.set_reagent_temp(spray_temperature, TRUE)
+		if(lit)
+			currentturf?.reagents?.set_reagent_temp(spray_temperature, TRUE)
 			spray_temperature = max(0,min(spray_temperature - temp_loss_per_tile, 700))
 
 		var/logString = log_reagents(reagsource)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title. Flamethrowers heat up reagents that are on turfs along the path of the flame (including the reagents sprayed by the flamethrower). However, some mixes are able to melt the floors during the reaction (but before the temperature shift), and this caused a runtime when trying to set the temperature of the reagents.

Flamethrower code in general could probably use some cleanup but that's outside the scope of this PR.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
resolves https://github.com/goonstation/goonstation/issues/1905
