### PR TITLE
Fixed scanner occupants not being ejected properly

### DIFF
--- a/code/modules/medical/genetics/geneticsScanner.dm
+++ b/code/modules/medical/genetics/geneticsScanner.dm
@@ -244,11 +244,14 @@ var/list/genescanner_addresses = list()
 		if (src.locked)
 			return
 
-		for(var/obj/O in src)
-			O.set_loc(src.loc)
+		if(!src.occupant.disposed)
+			src.occupant.set_loc(src.loc)
 
-		src.occupant.set_loc(src.loc)
 		src.occupant = null
+
+		for(var/atom/movable/A in src)
+			A.set_loc(src.loc)
+
 		src.icon_state = "scanner_0"
 
 		playsound(src.loc, "sound/machines/sleeper_open.ogg", 50, 1)

--- a/code/obj/machinery/computer/cloning.dm
+++ b/code/obj/machinery/computer/cloning.dm
@@ -749,11 +749,14 @@
 		if ((!( src.occupant ) || src.locked))
 			return
 
-		for(var/obj/O in src)
-			O.set_loc(src.loc)
+		if(!src.occupant.disposed)
+			src.occupant.set_loc(src.loc)
 
-		src.occupant.set_loc(src.loc)
 		src.occupant = null
+
+		for(var/atom/movable/A in src)
+			A.set_loc(src.loc)
+
 		src.icon_state = "scanner_0"
 
 		playsound(src.loc, "sound/machines/sleeper_open.ogg", 50, 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title. Affected scanners include the cloning scanner and the genetek scanner.
There was an issue where if the occupant was transformed into another mob, then they'd be unable to exit the scanner.
The scanner would also hold a reference to the old mob until someone entered the scanner again.

I've made it so it ejects all `atom/movable` types inside the scanner, and clears the old reference without runtiming (it used to try and `set_loc` on the old occupant, which was disposed, which triggered a runtime error).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
resolves https://github.com/goonstation/goonstation/issues/1724