### PR TITLE
Severely limit the number of farts that brown note can trigger at once

### DIFF
--- a/code/modules/medical/genetics/bioEffects/powers.dm
+++ b/code/modules/medical/genetics/bioEffects/powers.dm
@@ -1605,8 +1605,10 @@
 			return 1
 		owner.visible_message("<span class='alert'><b>[owner.name] makes a weird noise!</b></span>")
 		playsound(owner.loc, 'sound/musical_instruments/WeirdHorn_0.ogg', 50, 0)
+		var/count = 0
 		for (var/mob/living/L in range(7,owner))
 			if (L.hearing_check(1))
+				if(count++ > (src.linked_power.power ? 10 : 7)) break
 				if(locate(/obj/item/storage/bible) in get_turf(L))
 					owner.visible_message("<span class='alert'><b>A mysterious force smites [owner.name] for inciting blasphemy!</b></span>")
 					owner.gib()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Limits brown note to ~7 farts at once, and empowered to ~10 farts at once


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It causes a lot of lag and can crash some clients, especially on the shuttle
