### PR TITLE
add some move_trigger to notable poisoning methods

### DIFF
--- a/code/modules/chemistry/tools/sleepy_pen.dm
+++ b/code/modules/chemistry/tools/sleepy_pen.dm
@@ -27,6 +27,9 @@
 			user.show_text("The sleepy pen is empty.", "red")
 		return
 
+	move_trigger(var/mob/M, kindof)
+		if (..() && reagents)
+			reagents.move_trigger(M, kindof)
 /obj/item/pen/sleepypen/discount
 	name = "greasy pen"
 	icon_state = "pen-greasy"

--- a/code/modules/medical/surgery_tools.dm
+++ b/code/modules/medical/surgery_tools.dm
@@ -64,6 +64,10 @@ CONTAINS:
 				src.reagents.trans_to(M,5)
 			return
 
+	move_trigger(var/mob/M, kindof)
+		if (..() && reagents)
+			reagents.move_trigger(M, kindof)
+
 	custom_suicide = 1
 	suicide(var/mob/user as mob)
 		if (!src.user_can_suicide(user))
@@ -142,6 +146,10 @@ CONTAINS:
 				user.suiciding = 0
 		return 1
 
+	move_trigger(var/mob/M, kindof)
+		if (..() && reagents)
+			reagents.move_trigger(M, kindof)
+
 /obj/item/circular_saw/vr
 	icon = 'icons/effects/VR.dmi'
 	icon_state = "saw"
@@ -205,6 +213,10 @@ CONTAINS:
 			if (user && !isdead(user))
 				user.suiciding = 0
 		return 1
+
+	move_trigger(var/mob/M, kindof)
+		if (..() && reagents)
+			reagents.move_trigger(M, kindof)
 
 /* ==================================================== */
 /* -------------------- Staple Gun -------------------- */
@@ -1648,3 +1660,7 @@ keeping this here because I want to make something else with it eventually
 		handle = null
 		Poisoner = null
 		..()
+
+	move_trigger(var/mob/M, kindof)
+		if (..() && reagents)
+			reagents.move_trigger(M, kindof)

--- a/code/obj/item/gun/reagent.dm
+++ b/code/obj/item/gun/reagent.dm
@@ -17,6 +17,10 @@
 		src.create_reagents(capacity)
 		..()
 
+	move_trigger(var/mob/M, kindof)
+		if (..() && reagents)
+			reagents.move_trigger(M, kindof)
+
 	is_open_container()
 		return 1
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Implements move_trigger() for syringe gun, sleepypen, poisoned surgical tools


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes nitro being oddly stable inside of those items
