### PR TITLE
pod engine stuff and stuff

### DIFF
--- a/code/modules/transport/pods/ships.dm
+++ b/code/modules/transport/pods/ships.dm
@@ -126,6 +126,13 @@
 		return */
 
 ////////armed civ putt
+	updateSpeed()
+		if(istype(src.movement_controller, /datum/movement_controller/pod))
+			var/datum/movement_controller/pod/MC = src.movement_controller
+			// accel scales from 4 (fastest) to 2 (slowest) with 3 being default
+			MC.accel = 5-src.engine.speedmod
+			// max speed scales from 12 (fastest) to 4 (slowest) with 6 being default
+			MC.velocity_max = 12/src.engine.speedmod
 
 /obj/machinery/vehicle/miniputt/armed
 	New()
@@ -865,6 +872,14 @@
 		myhud.update_systems()
 		myhud.update_states()
 		return
+
+	updateSpeed()
+		if(istype(src.movement_controller, /datum/movement_controller/pod))
+			var/datum/movement_controller/pod/MC = src.movement_controller
+			// accel scales from 4 (fastest) to 2 (slowest) with 3 being default
+			MC.accel = 5-src.engine.speedmod
+			// max speed scales from 12 (fastest) to 4 (slowest) with 6 being default
+			MC.velocity_max = 12/src.engine.speedmod
 
 	AmmoPerShot()
 		return 2

--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -61,6 +61,7 @@
 
 		. = ..()
 		START_TRACKING
+		src.updateSpeed()
 
 
 	remove_air(amount as num)
@@ -749,6 +750,7 @@
 		if("Engine")
 			if(!src.engine)
 				src.engine = S
+				src.updateSpeed()
 			else
 				boutput(usr, "That system already has a part!")
 				return
@@ -1646,7 +1648,8 @@
 	else
 		boutput(usr, "<span class='alert'>Uh-oh you aren't in a ship! Report this.</span>")
 
-
+/obj/machinery/vehicle/proc/updateSpeed()
+	return
 
 
 //TODO


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
So, pod engines claim that they affect pod speed, but they don't actually do that, I think.
This changes that, making it so that when the engine is changed the acceleration and top speed of the pod is updated as well.

I've made it so that the acceleration is less affected than the top speed, so that a strong ramming maneuver with something like the Helios II engine will still need to accelerate a bit more.

- These values could probably use fine tuning though.
- Is it even a good idea to change this now when it's been this way for so long?
- Should a higher tier engine need to be slower to be balanced? (Hermes 3.0 engine)
- Why is the slowest engine called Hermes?
- Will changes be necessary to ramming damage due to higher achievable pod max speed with Helios II engine?
- Did I implement this in a way that could be done better?
- Should we implement similar changes for subs?

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Even if we decide not to go forward with changing pod speeds, the engine descriptions should be updated to reflect this.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u) zjdtmkhzt:
(+) TODO: Write stuff once PR is ready to be merged.
```
