### PR TITLE
refactors by_type tracking, adds by_cat tracking 

### DIFF
--- a/_std/macros/macros.dm
+++ b/_std/macros/macros.dm
@@ -74,16 +74,6 @@ var/list/detailed_spawn_dbg = list()
 #define GLOBAL_PROC "THIS_IS_A_GLOBAL_PROC_CALLBACK" //used instead of null because clients can be callback targets and then go null from disconnect before invoked, and we need to be able to differentiate when that happens or when it's just a global proc.
 #define CALLBACK new /datum/callback //not a macro to make it 510 compatible
 
-#ifdef SPACEMAN_DMM // just don't ask
-#define START_TRACKING
-#define STOP_TRACKING
-#else
-// sometimes we want to have all objects of a certain type stored (bibles, staffs of cthulhu, ...)
-// to do that add START_TRACKING to New (or unpooled) and STOP_TRACKING to disposing, then use by_type[/obj/item/storage/bible] to access the list of things
-#define START_TRACKING do { var/_type = text2path(replacetext("[.disposing]", "/disposing", "")); if(!by_type[_type]) { by_type[_type] = list(src) } else { by_type[_type].Add(src) } } while (FALSE)
-#define STOP_TRACKING do { var/_type = text2path(replacetext("[.disposing]", "/disposing", "")); by_type[_type].Remove(src) } while (FALSE)
-#endif
-
 // replacement for world.timeofday that shouldn't break around midnight, please use this
 #define TIME ((world.timeofday - server_start_time + 24 HOURS) % (24 HOURS))
 

--- a/_std/types.dm
+++ b/_std/types.dm
@@ -102,3 +102,23 @@ proc/get_singleton(type)
 		singletons[type] = new type
 	return singletons[type]
 var/global/list/singletons
+
+//by_type and by_cat stuff
+
+#ifdef SPACEMAN_DMM // just don't ask
+#define START_TRACKING
+#define STOP_TRACKING
+#else
+// sometimes we want to have all objects of a certain type stored (bibles, staffs of cthulhu, ...)
+// to do that add START_TRACKING to New (or unpooled) and STOP_TRACKING to disposing, then use by_type[/obj/item/storage/bible] to access the list of things
+#define START_TRACKING if(!by_type[......]) { by_type[......] = list() }; by_type[.......][src] = 1 //we use an assoc list here because removing from one is a lot faster
+#define STOP_TRACKING by_type[.....].Remove(src) //ok if ur seeing this and thinking "wtf is up with the ...... in THIS use case it gives us the type path at the particular scope this is called. and the amount of dots varies based on scope in the macro! fun
+#endif
+
+// sometimes we want to have a list of objects of multiple types, without having to traverse multiple lists
+// to do that add START_TRACKING_CAT("category") to New, unpooled, or whatever proc you want to start tracking the objects in (eg: tracking dead humans, put start tracking in death())
+// and add STOP_TRACKING_CAT("category") to disposing, or whatever proc you want to stop tracking the objects in (eg: tracking live humans, put stop tracking in death())
+// and to traverse the list, use by_type_cat["category"] to get the list of objects in that category
+// also ideally youd use defines for by_cat categories!
+#define START_TRACKING_CAT(x) if(!by_cat[x]) { by_cat[x] = list() }; by_cat[x][src] = 1
+#define STOP_TRACKING_CAT(x) by_cat[x].Remove(src)

--- a/code/global.dm
+++ b/code/global.dm
@@ -33,6 +33,7 @@ var/global
 	turf/buzztile = null
 
 	list/list/by_type = list() // contains lists of objects indexed by their type based on START_TRACKING / STOP_TRACKING
+	list/list/by_cat = list() // contains lists of objects indexed by a category string based on START_TRACKING_CAT / STOP_TRACKING_CAT
 
 	obj/screen/renderSourceHolder
 	obj/overlay/zamujasa/round_start_countdown/game_start_countdown	// Countdown clock for round start


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[CLEANLINESS] [ENHANCEMENT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
this adds a new framework for organising a list of objects to loop thru globally, by_cat. 
it also refactors by_type a lot to be cleaner and quicker. 
also moves these to types.dm in the std folder

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
*so by_type relied on disposing being overridden to work properly. you needed to stop tracking in disposing, which was ok, but it can be better! so i used some ```......``` scope magic (w/ help from pali) to get rid of the need to override disposing (which shouldnt rly happen but if it does itll be less hellish to figure out why it wont work) and also itll be faster now because theres no additional proc calls. 
*also i changed by_type to use an associative list, because removing things from associative lists is much faster than on normal lists when the lists have a lot of items, so deleting wires or cameras or doors or something should be much quicker. 
*also i added a framework to do a by_type style list, where its a global list of lists, but these lists are sorted by a category string instead of a type. nothing uses this right now, but if stuff does, it should use defines to organise the categories in a new defines/categories.dm file. or something. also you can use it to do stuff like keep track of alive humans or something. idk


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
```
