### PR TITLE
Fixes vending machine throwing runtime

### DIFF
--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -800,7 +800,8 @@
 			if (R.product_amount <= 0) //Try to use a record that actually has something to dump.
 				continue
 			valid_products.Add(R)
-		thrown = throw_item_act(pick(valid_products), target)
+		if (valid_products.len)
+			thrown = throw_item_act(pick(valid_products), target)
 	return thrown
 
 /obj/machinery/vending/proc/throw_item_act(var/datum/data/vending_product/R, var/mob/living/target)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes a runtime where empty vending machines trying to throw a random item would use ```pick()``` on an empty list.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Runtimes aren't cool.