### PR TITLE
AI announcement computer runtime fixes

### DIFF
--- a/code/obj/objDialog.dm
+++ b/code/obj/objDialog.dm
@@ -63,7 +63,7 @@ var/global/list/objects_using_dialogs
 					src.attack_hand(C.mob)
 				else
 					if (C.mob.mob_flags & USR_DIALOG_UPDATES_RANGE)
-						src.attack_ai(usr)
+						src.attack_ai(C.mob)
 					else
 						src.remove_dialog(C.mob)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG][RUNTIME] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When the AI attempted to use the announcement computer it would generate 3 runtimes


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #1631 



File | computer.dm
-- | --
Line | 20
Error | Cannot read null.literate
```
proc name: attack hand (/obj/machinery/computer/attack_hand)
  source file: computer.dm,20
  usr: null
  src: Bridge Announcement Computer (/obj/machinery/computer/announcement)
  src.loc: the carpet (200,179,1) (/turf/simulated/floor/carpet)
  call stack:
Bridge Announcement Computer (/obj/machinery/computer/announcement): attack hand(null)
Bridge Announcement Computer (/obj/machinery/computer/announcement): attack hand(null)
Bridge Announcement Computer (/obj/machinery/computer/announcement): attack ai(null)
Bridge Announcement Computer (/obj/machinery/computer/announcement): updateUsrDialog()
Bridge Announcement Computer (/obj/machinery/computer/announcement): process(1)
Machine (/datum/controller/process/machines): doWork()
Machine (/datum/controller/process/machines): process()
/datum/controller/processSched... (/datum/controller/processScheduler): runProcess(Machine (/datum/controller/process/machines), 1.6)
```


File | objDialog.dm
-- | --
Line | 9
Error | Cannot read null.client
```
proc name: add dialog (/obj/proc/add_dialog)
  source file: objDialog.dm,9
  usr: null
  src: Bridge Announcement Computer (/obj/machinery/computer/announcement)
  src.loc: the carpet (200,179,1) (/turf/simulated/floor/carpet)
  call stack:
Bridge Announcement Computer (/obj/machinery/computer/announcement): add dialog(null)
Bridge Announcement Computer (/obj/machinery/computer/announcement): attack hand(null)
Bridge Announcement Computer (/obj/machinery/computer/announcement): attack ai(null)
Bridge Announcement Computer (/obj/machinery/computer/announcement): updateUsrDialog()
Bridge Announcement Computer (/obj/machinery/computer/announcement): process(1)
Machine (/datum/controller/process/machines): doWork()
Machine (/datum/controller/process/machines): process()
/datum/controller/processSched... (/datum/controller/processScheduler): runProcess(Machine (/datum/controller/process/machines), 1.6)
```


File | announcement.dm
-- | --
Line | 55
Error | Cannot execute null.Browse().
```
proc name: attack hand (/obj/machinery/computer/announcement/attack_hand)
  source file: announcement.dm,55
  usr: null
  src: Bridge Announcement Computer (/obj/machinery/computer/announcement)
  src.loc: the carpet (200,179,1) (/turf/simulated/floor/carpet)
  call stack:
Bridge Announcement Computer (/obj/machinery/computer/announcement): attack hand(null)
Bridge Announcement Computer (/obj/machinery/computer/announcement): attack ai(null)
Bridge Announcement Computer (/obj/machinery/computer/announcement): updateUsrDialog()
Bridge Announcement Computer (/obj/machinery/computer/announcement): process(1)
Machine (/datum/controller/process/machines): doWork()
Machine (/datum/controller/process/machines): process()
/datum/controller/processSched... (/datum/controller/processScheduler): runProcess(Machine (/datum/controller/process/machines), 1.6)
```