### PR TITLE
adds aerosol reaction to golem death

### DIFF
--- a/code/obj/critter/misc.dm
+++ b/code/obj/critter/misc.dm
@@ -686,7 +686,7 @@
 		smoke_reaction(src.reagents, 12, T)
 		classic_smoke_reaction(temporary_holder, 10, T)
 		invisibility = 100
-		sleep(5 SECONDS)
+		SPAWN_DBG(5 SECONDS)
 			qdel(src)
 
 /obj/critter/townguard

--- a/code/obj/critter/misc.dm
+++ b/code/obj/critter/misc.dm
@@ -680,10 +680,13 @@
 		..()
 
 		src.visible_message("<span class='combat'><b>[src]</b> bursts into a puff of smoke!</span>")
-		var/datum/chemical_reaction/smoke/thesmoke = new
-		thesmoke.on_reaction(src.reagents, 12)
+		var/datum/reagents/temporary_holder = new/datum/reagents(1000)
+		src.reagents.copy_to(temporary_holder)
+		var/turf/T = get_turf(src)
+		smoke_reaction(src.reagents, 12, T)
+		classic_smoke_reaction(temporary_holder, 10, T)
 		invisibility = 100
-		SPAWN_DBG(5 SECONDS)
+		sleep(5 SECONDS)
 			qdel(src)
 
 /obj/critter/townguard

--- a/code/obj/critter/misc.dm
+++ b/code/obj/critter/misc.dm
@@ -683,7 +683,7 @@
 		var/datum/reagents/temporary_holder = new/datum/reagents(1000)
 		src.reagents.copy_to(temporary_holder)
 		var/turf/T = get_turf(src)
-		smoke_reaction(src.reagents, 12, T)
+		smoke_reaction(src.reagents, 5, T)
 		classic_smoke_reaction(temporary_holder, 10, T)
 		invisibility = 100
 		SPAWN_DBG(5 SECONDS)


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This copies the contents of a golem to a temporary container on death, then triggers an aerosol reaction alongside the current smoke reaction. There's also a more direct reaction here than is currently used. The reactions are called directly from the containers instead of the unstable smoke/aerosol added to them and immediately reacting. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The idea here is to make golems of disease reagents and the more gimmicky poisons create a small aerosol reaction in addition to the existing smoke reacion on death, so that more exotic golems aren't easily handled by kiting with a basic melee weapon since the reagents don't have nearly enough time to infect on death. Hopefully this results in more interesting interactions with golems and more creative use of golems by wizards.

The tweaked smoke reaction code is something Adhara worked out while helping me out on this. If there's a reason it was done via unstable smoke reagents being inserted into the golem reagent container, I can go ahead and edit this to include the current method instead, but it works just fine in tests and I know some of you nerds are all about trimming things like this down where possible without breaking things.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

(u)Lurkey:
(+)Added an aerosol reaction to golem death, in addition to the existing smoke reaction.
