### PR TITLE
changed wand artifacts a little and fixed zap type

### DIFF
--- a/code/obj/artifacts/artifact_items/attack_wand.dm
+++ b/code/obj/artifacts/artifact_items/attack_wand.dm
@@ -97,12 +97,15 @@
 						if (!M.is_cold_resistant())
 							var/obj/icecube/cube = new /obj/icecube(get_turf(M), M)
 							cube.health = powerVars["cubeHealth"]
+							O.ArtifactFaultUsed(M)
 
 							ArtifactLogs(user, M, O, "weapon", "trapping them in an ice cube", 0)
 
 			if("lightning")
 				arcFlashTurf(user, T, powerVars["wattage"])
-				ArtifactLogs(user, T, O, "weapon", "zapping target turf with electricity", 0)
+				for (var/mob/living/M in range(T,powerVars["iceRadius"]))
+					O.ArtifactFaultUsed(M)
+					ArtifactLogs(user, M, O, "weapon", "zapping them with electricity", 0)
 
 			if("sonic")
 				playsound(T, "sound/effects/screech.ogg", 100, 1, 0)
@@ -112,6 +115,7 @@
 					if (isintangible(M))
 						continue
 					if (!M.ears_protected_from_sound())
+						O.ArtifactFaultUsed(M)
 						shake_camera(M, 10, 0)
 					else
 						continue

--- a/code/obj/artifacts/artifact_items/attack_wand.dm
+++ b/code/obj/artifacts/artifact_items/attack_wand.dm
@@ -41,6 +41,8 @@
 		recharge_phrase = pick("crackles with static.","emits a quiet tone.","bristles with energy!","heats up.")
 		error_phrase = pick("shudders briefly.","grows heavy for a moment.","emits a quiet buzz.","makes a small pop sound.")
 		attack_type = pick("lightning","fire","ice","sonic")
+		if(prob(10))
+			attack_type = "all"
 		cooldown = rand(25,900)
 		if (prob(5))
 			cooldown = 0
@@ -71,7 +73,11 @@
 				boutput(user, "<b>[O]</b> [recharge_phrase]")
 			ready = 1
 
-		switch(attack_type)
+		var/curAttack = attack_type
+		if(attack_type == "all")
+			curAttack = pick("lightning","fire","ice","sonic")
+
+		switch(curAttack)
 			if("fire")
 				playsound(T, "sound/effects/bamf.ogg", 50, 1, 0)
 				tfireflash(T, powerVars["fireRadius"], powerVars["fireTemp"])

--- a/code/obj/artifacts/artifact_items/attack_wand.dm
+++ b/code/obj/artifacts/artifact_items/attack_wand.dm
@@ -32,6 +32,7 @@
 	var/attack_type = null
 	var/recharge_phrase = ""
 	var/error_phrase = ""
+	var/list/powerVars = list()
 	module_research = list("weapons" = 5, "energy" = 5, "tools" = 5)
 	module_research_insight = 2
 
@@ -43,6 +44,20 @@
 		cooldown = rand(25,900)
 		if (prob(5))
 			cooldown = 0
+		// fire
+		powerVars["fireTemp"] = rand(1000,10000)
+		if(prob(10))
+			powerVars["fireTemp"] *= 4
+		powerVars["fireRadius"] = rand(1,4)
+		// ice
+		powerVars["cubeHealth"] = rand(5,25) // default cube is 10, 100 units of cryostylane would make 20, for reference
+		powerVars["iceRadius"] = rand(1,4)
+		// lightning
+		powerVars["wattage"] = rand(30000,2e6) 				// goes up to 80 damage, so no potential electrogibs or anything
+		if(prob(5))																		// unless...
+			powerVars["wattage"] *= 2
+		// sonic
+		// yeah, I got nothing
 
 	effect_click_tile(var/obj/O,var/mob/living/user,var/turf/T)
 		if (..())
@@ -59,42 +74,29 @@
 		switch(attack_type)
 			if("fire")
 				playsound(T, "sound/effects/bamf.ogg", 50, 1, 0)
-				fireflash(T, 2)
+				tfireflash(T, powerVars["fireRadius"], powerVars["fireTemp"])
 
 				ArtifactLogs(user, T, O, "used", "creating fireball on target turf", 0) // Attack wands need special log handling (Convair880).
 
 			if("ice")
 				playsound(T, "sound/effects/mag_iceburstlaunch.ogg", 50, 1, 0)
-				for (var/turf/TT in range(T,2))
+				for (var/turf/TT in range(T,powerVars["iceRadius"]))
 					if(locate(/obj/decal/icefloor) in TT.contents)
 						continue
 					var/obj/decal/icefloor/B = new /obj/decal/icefloor(TT)
 					SPAWN_DBG(80 SECONDS)
 						B.dispose()
-				for (var/mob/living/M in range(T,2))
+				for (var/mob/living/M in range(T,powerVars["iceRadius"]))
 					if (M.bioHolder)
 						if (!M.is_cold_resistant())
-							new /obj/icecube(get_turf(M), M)
+							var/obj/icecube/cube = new /obj/icecube(get_turf(M), M)
+							cube.health = powerVars["cubeHealth"]
 
 							ArtifactLogs(user, M, O, "weapon", "trapping them in an ice cube", 0)
 
 			if("lightning")
-				var/attack_amt = 0
-				for (var/mob/living/M in range(T,1))
-
-					ArtifactLogs(user, M, O, "weapon", "zapping them with electricity", 0)
-
-					attack_amt = 1
-					var/list/affected = DrawLine(get_turf(M), user, /obj/line_obj/elec ,'icons/obj/projectiles.dmi',"WholeLghtn",1,1,"HalfStartLghtn","HalfEndLghtn",OBJ_LAYER,1,PreloadedIcon='icons/effects/LghtLine.dmi')
-					for(var/obj/OB in affected)
-						SPAWN_DBG(0.6 SECONDS)
-							pool(OB)
-						M.TakeDamage("chest", 0, 25)
-						M.changeStatus("stunned", 50)
-				if (attack_amt)
-					playsound(user, "sound/effects/elec_bigzap.ogg", 40, 1)
-				else
-					boutput(user, "<span class='alert'><b>[O]</b> crackles with electricity for a moment. Perhaps it couldn't find a target?</span>")
+				arcFlashTurf(user, T, powerVars["wattage"])
+				ArtifactLogs(user, T, O, "weapon", "zapping target turf with electricity", 0)
 
 			if("sonic")
 				playsound(T, "sound/effects/screech.ogg", 100, 1, 0)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
~~Actually, I forgot another thing I wanted to do, but I already wrote all this garbage now, so I will just add DNM until tomorrow.~~

It was brought to my attention that the electric type of wand artifacts didn't actually work.
In the process of fixing this I noticed that wand type artifacts don't have any of the randomness usually associated with artifacts, so I thought I'd spice things up a little.

Fire wands can now have a radius that's a little smaller or bigger than before.
The fire temperature can vary a bit, with a wand rarely being super hot.

Ice artifacts can now have a radius that's a little smaller or bigger than before.
The hp of the cube encasing people now varies a llttle.

Zap type artifacts were changed to use arcflashes instead of the old way. (And also made to actually work.)
(What was up with the old thing anyway, it did a damage of 25 burn per distance or something?)
This also means that they can now be used on a tile without needing an actual person to target there.
Their wattage varies, with the damage potentially going up to 80 burn, so no elecgibs or anything.
However, rarely a wand may have up to double that wattage.

Also, there is a small chance that a wand may randomly choose one of the 4 attacks each time instead of always having the same one.

Also, wands now also attempt to apply their faults to targets too, like melee artifacts already do, for maximum confusion and weird stuff.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's good if features that are in the game actually work.

It's nice to have more variety in artifact effects, I think.
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u) zjdtmkhzt:
(+) Electric wand type artifacts should now actually work. Some other small changes to wand artifacts were made too.
```
