### PR TITLE
Wiz ring random fixes

### DIFF
--- a/code/modules/admin/gimmick/wizard_rings.dm
+++ b/code/modules/admin/gimmick/wizard_rings.dm
@@ -241,17 +241,35 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves/ring/wizard)
 				L.spell_soulguard = 0
 
 	random_type
-		//Doesn't have these spells. no ring for em: kill, shockwave, and candy_ring. (last one isn't actually a spell)
+		var/list/possible_rings = null	//instead of picking from all spell types, pick from this list of spells to make the ring. should be the lowest level path name of the ring
 
-		New(loc)
+		New()
 			..()
-			//I'm lazy again.
-			var/list/L = concrete_typesof(/obj/item/clothing/gloves/ring/wizard) - /obj/item/clothing/gloves/ring/wizard/random_type
-			if (locate(/obj/item/clothing/gloves/ring/wizard/random_type) in L)
-				message_admins("WRONG WRONG WRONG")
-			var/path = pick(L)
-			new path(loc)
-			qdel(src)
+
+			var/obj/item/clothing/gloves/ring/wizard/ring
+			if (possible_rings)
+				var/ring_type = pick(possible_rings)
+				ring = text2path("/obj/item/clothing/gloves/ring/wizard/[ring_type]")
+			else
+				var/list/L = concrete_typesof(/obj/item/clothing/gloves/ring/wizard) - /obj/item/clothing/gloves/ring/wizard/random_type
+				ring = pick(L)
+			
+			src.name = initial(ring.name)
+			src.desc = initial(ring.desc)
+			src.icon_state = initial(ring.icon_state)
+			src.ability_path = initial(ring.ability_path)
+
+		offensive
+			possible_rings = list("fireball", "magic_missile", "blind", "ice_burst", "prismatic_spray", "cluwne", "shocking_touch", "rathens_secret", "pandemonium", "sticks_to_snakes", "staff", "golem", "polymorph")
+
+			less_deadly
+				possible_rings = list("fireball", "magic_missile", "blind", "ice_burst", "prismatic_spray", "pandemonium", "sticks_to_snakes", "golem")
+		defensive
+			possible_rings = list("phase_shift", "teleport", "blink", "spell_shield", "warp", "forcewall", "pandemonium", "doppelganger", "soulguard")
+		utility
+			possible_rings = list("knock", "empower", "phase_shift", "clairvoyance", "animate_dead", "teleport", "pandemonium", "sticks_to_snakes", "soulguard")
+		less_deadly
+			possible_rings = list("fireball", "magic_missile", "knock", "blind", "empower", "phase_shift", "clairvoyance", "ice_burst", "prismatic_spray", "animate_dead", "teleport", "blink", "rathens_secret", "spell_shield", "warp", "forcewall", "pandemonium", "bull_charge", "sticks_to_snakes", "doppelganger", "soulguard")
 
 /client/proc/create_all_wizard_rings()
 	set name = "Create All Wizard Rings"


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fix my old lazy ass way I made a "random" wizard ring subtype. Just making this so I don't have to build myself and push to master, should work.

Added a few new subtypes of random rings so you can easily spawn random rings without having to worry about a cluwne or staff of Cthulhu in the mix. 

Named em: less_deadly, defensive, utility, offensive, and offensive/less_deadly. So yeah. 