### PR TITLE
Port-A-Gene feature partity with its counterpart

### DIFF
--- a/code/modules/medical/genetics/portagene.dm
+++ b/code/modules/medical/genetics/portagene.dm
@@ -56,8 +56,17 @@
 			logTheThing("station", usr, null, "sets [src.name]'s home turf to [log_loc(src.homeloc)].")
 		return
 
-	relaymove(mob/user as mob, dir)
-		eject(user)
+	relaymove(mob/usr as mob, dir)
+		if (!isalive(usr))
+			return
+		if (src.locked)
+			boutput(usr, "<span class='alert'><b>The scanner door is locked!</b></span>")
+			return
+
+		src.go_out()
+		add_fingerprint(usr)
+		playsound(src.loc, "sound/machines/sleeper_open.ogg", 50, 1)
+		return
 
 	MouseDrop_T(mob/living/target, mob/user)
 		if (!istype(target) || isAI(user))
@@ -170,7 +179,7 @@
 	power_change()
 		return
 
-	verb/eject(var/mob/usr)
+	verb/eject()
 		set name = "Eject Occupant"
 		set src in oview(1)
 		set category = "Local"
@@ -203,6 +212,7 @@
 		src.go_in(usr)
 		add_fingerprint(usr)
 		return
+
 
 	verb/lock()
 		set name = "Scanner Lock"

--- a/code/modules/medical/genetics/portagene.dm
+++ b/code/modules/medical/genetics/portagene.dm
@@ -56,6 +56,55 @@
 			logTheThing("station", usr, null, "sets [src.name]'s home turf to [log_loc(src.homeloc)].")
 		return
 
+	relaymove(mob/user as mob, dir)
+		eject(user)
+
+	MouseDrop_T(mob/living/target, mob/user)
+		if (!istype(target) || isAI(user))
+			return
+
+		if (get_dist(src,user) > 1 || get_dist(user, target) > 1)
+			return
+
+		if (target == user)
+			go_in(target)
+		else if (can_operate(user,target))
+			var/previous_user_intent = user.a_intent
+			user.a_intent = INTENT_GRAB
+			user.drop_item()
+			target.attack_hand(user)
+			user.a_intent = previous_user_intent
+			SPAWN_DBG(user.combat_click_delay + 2)
+				if (can_operate(user,target))
+					if (istype(user.equipped(), /obj/item/grab))
+						src.attackby(user.equipped(), user)
+		return
+
+	proc/can_operate(var/mob/M, var/mob/living/target)
+		if (!isalive(M))
+			return 0
+		if (get_dist(src,M) > 1)
+			return 0
+		if (M.getStatusDuration("paralysis") || M.getStatusDuration("stunned") || M.getStatusDuration("weakened"))
+			return 0
+		if (src.occupant)
+			boutput(M, "<span class='notice'><B>The scanner is already occupied!</B></span>")
+			return 0
+		if(ismobcritter(target))
+			boutput(M, "<span class='alert'><B>The scanner doesn't support this body type.</B></span>")
+			return 0
+		if(!iscarbon(target) )
+			boutput(M, "<span class='alert'><B>The scanner supports only carbon based lifeforms.</B></span>")
+			return 0
+		if (src.occupant)
+			boutput(M, "<span class='notice'><B>The scanner is already occupied!</B></span>")
+			return 0
+		if (src.locked)
+			boutput(M, "<span class='alert'><B>You need to unlock the scanner first.</B></span>")
+			return 0
+
+		.= 1
+
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (isscrewingtool(W) && (src.status & BROKEN))
 			playsound(src.loc, "sound/items/Screwdriver.ogg", 50, 1)
@@ -73,6 +122,20 @@
 				A.icon_state = "3"
 				A.anchored = 1
 				qdel(src)
+
+		else if (istype(W,/obj/item/genetics_injector/dna_activator))
+			var/obj/item/genetics_injector/dna_activator/DNA = W
+			if (DNA.expended_properly)
+				user.drop_item()
+				qdel(DNA)
+				activated_bonus(user)
+			else if (DNA.uses < 1)
+				// You get nothing from these but at least let people clean em up
+				boutput(user, "You dispose of the [DNA].")
+				user.drop_item()
+				qdel(DNA)
+			else
+				src.attack_hand(user)
 
 		else if (istype(W, /obj/item/grab))
 			var/obj/item/grab/G = W
@@ -107,7 +170,7 @@
 	power_change()
 		return
 
-	verb/eject()
+	verb/eject(var/mob/usr)
 		set name = "Eject Occupant"
 		set src in oview(1)
 		set category = "Local"
@@ -120,6 +183,7 @@
 
 		src.go_out()
 		add_fingerprint(usr)
+		playsound(src.loc, "sound/machines/sleeper_open.ogg", 50, 1)
 		return
 
 	verb/enter()
@@ -188,6 +252,7 @@
 		M.set_loc(src)
 		src.occupant = M
 		src.icon_state = "PAG_1"
+		playsound(src.loc, "sound/machines/sleeper_close.ogg", 50, 1)
 		return
 
 	get_scan_subject()


### PR DESCRIPTION
[QoL]
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Port-A-Gene now allows drag and drop entering, moving to leave, sounds when entering and leaving and can redeem filled injectors

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Mostly QoL, so people don't have to carry around filled injectors or throw them on the floor.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)ThePotato97:
(+)Port-a-Gene can now be entered by dragging and can also redeem filled injectors!
```
