### PR TITLE
Add TTVs to the chest item whitelist

### DIFF
--- a/code/modules/medical/surgery_procs.dm
+++ b/code/modules/medical/surgery_procs.dm
@@ -35,7 +35,7 @@ limbs are their own thing not included here.
 */
 
 // chest item whitelist, because some things are more important than being reasonable
-var/global/list/chestitem_whitelist = list(/obj/item/gnomechompski, /obj/item/gnomechompski/elf, /obj/item/gnomechompski/mummified)
+var/global/list/chestitem_whitelist = list(/obj/item/gnomechompski, /obj/item/gnomechompski/elf, /obj/item/gnomechompski/mummified, /obj/item/device/transfer_valve)
 
 // ~make procs 4 everything~
 /proc/surgeryCheck(var/mob/living/carbon/human/patient as mob, var/mob/surgeon as mob)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feat][input wanted]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds TTVs to the chest item surgery whitelist, so you can be medically and ethically irresponsible in one action again.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
People seem to want chest TTVs back. I figured making a PR with attached forum thread is going to get more discussion (if any) rolling than discord will.