### PR TITLE
fix ranged artifacts not working at range

### DIFF
--- a/code/obj/artifacts/artifact_items/attack_wand.dm
+++ b/code/obj/artifacts/artifact_items/attack_wand.dm
@@ -4,6 +4,8 @@
 	flags =  FPRINT | CONDUCT | EXTRADELAY
 	module_research_no_diminish = 1
 
+	// this is necessary so that this returns null
+	// else afterattack will not be called when out of range
 	pixelaction(atom/target, params, mob/user, reach)
 		..()
 

--- a/code/obj/artifacts/artifact_items/attack_wand.dm
+++ b/code/obj/artifacts/artifact_items/attack_wand.dm
@@ -4,6 +4,9 @@
 	flags =  FPRINT | CONDUCT | EXTRADELAY
 	module_research_no_diminish = 1
 
+	pixelaction(atom/target, params, mob/user, reach)
+		..()
+
 	afterattack(atom/target as mob|obj|turf|area, mob/user as mob, flag)
 		if (user.equipped() == src)
 			if (!src.ArtifactSanityCheck())

--- a/code/obj/artifacts/artifact_items/teleport_wand.dm
+++ b/code/obj/artifacts/artifact_items/teleport_wand.dm
@@ -5,6 +5,8 @@
 	flags =  FPRINT | CONDUCT | EXTRADELAY
 	module_research_no_diminish = 1
 
+	// this is necessary so that this returns null
+	// else afterattack will not be called when out of range
 	pixelaction(atom/target, params, mob/user, reach)
 		..()
 

--- a/code/obj/artifacts/artifact_items/teleport_wand.dm
+++ b/code/obj/artifacts/artifact_items/teleport_wand.dm
@@ -5,6 +5,9 @@
 	flags =  FPRINT | CONDUCT | EXTRADELAY
 	module_research_no_diminish = 1
 
+	pixelaction(atom/target, params, mob/user, reach)
+		..()
+
 	afterattack(atom/target as mob|obj|turf|area, mob/user as mob, flag)
 		if (!src.ArtifactSanityCheck())
 			return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Attack Wand and Teleport Wands did not work at a range past melee range, because their afterattack() was not called, because they instead tried to perform a special attack (which failed if you were not on harm intent).
I now did what fire extinguishers do and override pixelaction() in them, with just calling the parent but not returning the result of the parent. This makes it so that null is returned instead, so afterattack is always executed.
Uh, I am not sure if this is intended behavior, but it works, please comment if there is another way this should be done.

Also, I have no idea why this worked in the past, as I did not see any recent code changes in those areas.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Features should work, it's bad if features do not work.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u) zjdtmkhzt:
(+) Fixed a bug where magical artifact wands would not work past melee range.
```
