### PR TITLE
Cambots no longer slow down every single machine when frustrated

### DIFF
--- a/code/modules/robotics/bot/cambot.dm
+++ b/code/modules/robotics/bot/cambot.dm
@@ -223,7 +223,6 @@
 			src.path.Remove(src.path[1])
 		else
 			src.frustration++
-			sleep (10)
 
 		SPAWN_DBG (3)
 			if (src && src.path && src.path.len)
@@ -278,11 +277,12 @@
 
 /obj/machinery/bot/cambot/proc/flash_blink(var/loops, var/delay)
 	set waitfor = 0
-	for (var/i=loops, i>0, i--)
-		add_simple_light("cambot", list(255,255,255,255 * (src.emagged ? 0.8 : 0.6)))
-		sleep(delay)
-		remove_simple_light("cambot")
-		sleep(delay)
+	SPAWN_DBG(0)
+		for (var/i=loops, i>0, i--)
+			add_simple_light("cambot", list(255,255,255,255 * (src.emagged ? 0.8 : 0.6)))
+			sleep(delay)
+			remove_simple_light("cambot")
+			sleep(delay)
 
 /obj/machinery/bot/cambot/proc/photograph(var/atom/target)
 	if (!src || !src.on || !target)

--- a/code/modules/robotics/bot/cambot.dm
+++ b/code/modules/robotics/bot/cambot.dm
@@ -277,12 +277,11 @@
 
 /obj/machinery/bot/cambot/proc/flash_blink(var/loops, var/delay)
 	set waitfor = 0
-	SPAWN_DBG(0)
-		for (var/i=loops, i>0, i--)
-			add_simple_light("cambot", list(255,255,255,255 * (src.emagged ? 0.8 : 0.6)))
-			sleep(delay)
-			remove_simple_light("cambot")
-			sleep(delay)
+	for (var/i=loops, i>0, i--)
+		add_simple_light("cambot", list(255,255,255,255 * (src.emagged ? 0.8 : 0.6)))
+		sleep(delay)
+		remove_simple_light("cambot")
+		sleep(delay)
 
 /obj/machinery/bot/cambot/proc/photograph(var/atom/target)
 	if (!src || !src.on || !target)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUGFIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Cambots used to call sleep(10) when it couldnt reach a thing it wanted to photograph. And its flashy-thing also used some sleeps when pretending to flash their thing. Not anymore