### PR TITLE
Adds the Syndicate Wet Floor sign

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -613,8 +613,8 @@ This is basically useless for anyone but miners.
 		if (istype(cart) && owner)
 			cart.owner_ckey = owner.ckey
 
-/datum/syndicate_buylist/traitor/wet_floor_sign
-	name = "Lubed Floor Sign" // better name pending
+/datum/syndicate_buylist/traitor/slip_and_sign
+	name = "Slip and Sign"
 	item = /obj/item/caution/traitor
 	cost = 2
 	desc = "This Wet Floor Sign spits out organic superlubricant under everyone nearby unless they are wearing galoshes. That'll teach them to ignore the signs. Click with a bucket (or beaker or drinking glass etc.) to replace the payload."

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -617,7 +617,7 @@ This is basically useless for anyone but miners.
 	name = "Slip and Sign"
 	item = /obj/item/caution/traitor
 	cost = 2
-	desc = "This Wet Floor Sign spits out organic superlubricant under everyone nearby unless they are wearing galoshes. That'll teach them to ignore the signs. Click with a bucket (or beaker or drinking glass etc.) to replace the payload."
+	desc = "This Wet Floor Sign spits out organic superlubricant under everyone nearby unless they are wearing galoshes. That'll teach them to ignore the signs. If you are wearing the long janitor gloves you can click with a bucket (or beaker or drinking glass etc.) to replace the payload."
 	job = list("Janitor")
 
 /datum/syndicate_buylist/traitor/syndanalyser

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -26,7 +26,7 @@ proc/build_syndi_buylist_cache()
 	var/vr_allowed = 1
 	var/not_in_crates = 0 // This should not go in surplus crates.
 
-	proc/run_on_spawn(var/obj/item, var/mob/living/owner) // Use this to run code when the item is spawned.
+	proc/run_on_spawn(obj/item, mob/living/owner, in_surplus_crate=FALSE) // Use this to run code when the item is spawned.
 		return
 
 ////////////////////////////////////////// Standard items (generic & nukeops uplink) ///////////////////////////////
@@ -357,7 +357,7 @@ proc/build_syndi_buylist_cache()
 	desc = "A crate containing 18-24 credits worth of whatever junk we had lying around."
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 
-	run_on_spawn(var/obj/storage/crate/syndicate_surplus/crate, var/mob/living/owner)
+	run_on_spawn(var/obj/storage/crate/syndicate_surplus/crate, var/mob/living/owner, in_surplus_crate)
 		crate.spawn_items(owner)
 /*
 This is basically useless for anyone but miners.
@@ -383,7 +383,7 @@ This is basically useless for anyone but miners.
 	vr_allowed = 0
 	objective = /datum/objective/regular/assassinate
 
-	run_on_spawn(var/obj/item/idtracker/tracker,var/mob/living/owner)
+	run_on_spawn(var/obj/item/idtracker/tracker,var/mob/living/owner, in_surplus_crate)
 		tracker.owner = owner
 		return
 
@@ -396,7 +396,7 @@ This is basically useless for anyone but miners.
 	not_in_crates = 1
 	objective = /datum/objective/spy_theft/assasinate
 
-	run_on_spawn(var/obj/item/idtracker/tracker,var/mob/living/owner)
+	run_on_spawn(var/obj/item/idtracker/tracker,var/mob/living/owner, in_surplus_crate)
 		tracker.owner = owner
 		return
 
@@ -533,7 +533,7 @@ This is basically useless for anyone but miners.
 	vr_allowed = 0
 	blockedmode = list(/datum/game_mode/revolution)
 
-	run_on_spawn(var/obj/item/storage/briefcase/satan/Q,var/mob/living/owner)
+	run_on_spawn(var/obj/item/storage/briefcase/satan/Q,var/mob/living/owner, in_surplus_crate)
 		if (istype(Q) && owner)
 			owner.make_merchant() //give them the power to summon more contracts
 			Q.merchant = owner
@@ -609,7 +609,7 @@ This is basically useless for anyone but miners.
 	job = list("Janitor")
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 
-	run_on_spawn(var/obj/storage/cart/trash/syndicate/cart,var/mob/living/owner)
+	run_on_spawn(var/obj/storage/cart/trash/syndicate/cart,var/mob/living/owner, in_surplus_crate)
 		if (istype(cart) && owner)
 			cart.owner_ckey = owner.ckey
 
@@ -619,6 +619,11 @@ This is basically useless for anyone but miners.
 	cost = 2
 	desc = "This Wet Floor Sign spits out organic superlubricant under everyone nearby unless they are wearing galoshes. That'll teach them to ignore the signs. If you are wearing the long janitor gloves you can click with a bucket (or beaker or drinking glass etc.) to replace the payload."
 	job = list("Janitor")
+
+	run_on_spawn(obj/item/caution/traitor/sign, mob/living/owner, in_surplus_crate)
+		if(in_surplus_crate)
+			new /obj/item/clothing/shoes/galoshes(sign.loc)
+			new /obj/item/clothing/gloves/long(sign.loc)
 
 /datum/syndicate_buylist/traitor/syndanalyser
 	name = "Syndicate Device Analyzer"

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -613,6 +613,13 @@ This is basically useless for anyone but miners.
 		if (istype(cart) && owner)
 			cart.owner_ckey = owner.ckey
 
+/datum/syndicate_buylist/traitor/wet_floor_sign
+	name = "Lubed Floor Sign" // better name pending
+	item = /obj/item/caution/traitor
+	cost = 2
+	desc = "This Wet Floor Sign spits out organic superlubricant under everyone nearby unless they are wearing galoshes. That'll teach them to ignore the signs. Click with a bucket (or beaker or drinking glass etc.) to replace the payload."
+	job = list("Janitor")
+
 /datum/syndicate_buylist/traitor/syndanalyser
 	name = "Syndicate Device Analyzer"
 	item = /obj/item/electronics/scanner/syndicate

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -1014,6 +1014,10 @@
 		if (isliving(checkloc) && checkloc != user)
 			return 0
 		checkloc = checkloc:loc
+
+	if(!src.can_pickup(user))
+		return 0
+
 	src.throwing = 0
 
 	if (isobj(src.loc))
@@ -1475,3 +1479,6 @@
 
 /obj/item/proc/intent_switch_trigger(mob/user)
 	return
+
+/obj/item/proc/can_pickup(mob/user)
+	return !src.anchored

--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -634,7 +634,7 @@ WET FLOOR SIGN
 		. = ..()
 
 	HasProximity(atom/movable/AM)
-		if(iscarbon(AM) && isturf(src.loc) && prob(40) && !ON_COOLDOWN(src, "spray", 3 SECONDS) && src.payload?.reagents)
+		if(iscarbon(AM) && isturf(src.loc) && prob(20) && !ON_COOLDOWN(src, "spray", 3 SECONDS) && src.payload?.reagents)
 			if(ishuman(AM))
 				var/mob/living/carbon/human/H = AM
 				if(istype(H.shoes, /obj/item/clothing/shoes/galoshes))

--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -634,7 +634,7 @@ WET FLOOR SIGN
 		. = ..()
 
 	HasProximity(atom/movable/AM)
-		if (iscarbon(AM) && prob(40) && !ON_COOLDOWN(src, "spray", 3 SECONDS) && src.payload?.reagents)
+		if(iscarbon(AM) && isturf(src.loc) && prob(40) && !ON_COOLDOWN(src, "spray", 3 SECONDS) && src.payload?.reagents)
 			if(ishuman(AM))
 				var/mob/living/carbon/human/H = AM
 				if(istype(H.shoes, /obj/item/clothing/shoes/galoshes))
@@ -643,6 +643,8 @@ WET FLOOR SIGN
 			src.payload.reagents.trans_to(src, 1)
 			src.reagents.reaction(T)
 			src.reagents.clear_reagents()
+		else
+			. = ..()
 
 
 /obj/item/holoemitter

--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -622,7 +622,8 @@ WET FLOOR SIGN
 		src.create_reagents(1)
 
 	attackby(obj/item/W, mob/user, params)
-		if(istype(W, /obj/item/reagent_containers))
+		var/mob/living/carbon/human/H = user
+		if(istype(W, /obj/item/reagent_containers) && istype(H) && istype(H.gloves, /obj/item/clothing/gloves/long))
 			boutput(user, "You stealthily replace the hidden [payload.name] with [W].")
 			user.drop_item(W)
 			src.payload.set_loc(src.loc)

--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -624,7 +624,7 @@ WET FLOOR SIGN
 	attackby(obj/item/W, mob/user, params)
 		var/mob/living/carbon/human/H = user
 		if(istype(W, /obj/item/reagent_containers) && istype(H) && istype(H.gloves, /obj/item/clothing/gloves/long))
-			boutput(user, "You stealthily replace the hidden [payload.name] with [W].")
+			boutput(user, "<span class='notice'>You stealthily replace the hidden [payload.name] with [W].</span>")
 			user.drop_item(W)
 			src.payload.set_loc(src.loc)
 			user.put_in_hand_or_drop(src.payload)

--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -605,6 +605,12 @@ WET FLOOR SIGN
 		JOB_XP(usr, "Janitor", 2)
 		return
 
+	attackby(obj/item/W, mob/user, params)
+		if(iswrenchingtool(W))
+			actions.start(new /datum/action/bar/icon/anchor_or_unanchor(src, W, duration=2 SECONDS), user)
+			return
+		. = ..()
+
 /obj/item/caution/traitor
 	event_handler_flags = USE_PROXIMITY
 	var/obj/item/reagent_containers/payload
@@ -623,6 +629,7 @@ WET FLOOR SIGN
 			user.put_in_hand_or_drop(src.payload)
 			src.payload = W
 			W.set_loc(src)
+			return
 		. = ..()
 
 	HasProximity(atom/movable/AM)

--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -605,6 +605,38 @@ WET FLOOR SIGN
 		JOB_XP(usr, "Janitor", 2)
 		return
 
+/obj/item/caution/traitor
+	event_handler_flags = USE_PROXIMITY
+	var/obj/item/reagent_containers/payload
+
+	New()
+		. = ..()
+		payload = new /obj/item/reagent_containers/glass/bucket/red(src)
+		payload.reagents.add_reagent("superlube", payload.reagents.maximum_volume)
+		src.create_reagents(1)
+
+	attackby(obj/item/W, mob/user, params)
+		if(istype(W, /obj/item/reagent_containers))
+			boutput(user, "You stealthily replace the hidden [payload.name] with [W].")
+			user.drop_item(W)
+			src.payload.set_loc(src.loc)
+			user.put_in_hand_or_drop(src.payload)
+			src.payload = W
+			W.set_loc(src)
+		. = ..()
+
+	HasProximity(atom/movable/AM)
+		if (iscarbon(AM) && prob(40) && !ON_COOLDOWN(src, "spray", 3 SECONDS) && src.payload?.reagents)
+			if(ishuman(AM))
+				var/mob/living/carbon/human/H = AM
+				if(istype(H.shoes, /obj/item/clothing/shoes/galoshes))
+					return
+			var/turf/T = AM.loc
+			src.payload.reagents.trans_to(src, 1)
+			src.reagents.reaction(T)
+			src.reagents.clear_reagents()
+
+
 /obj/item/holoemitter
 	name = "Holo-emitter"
 	desc = "A compact holo emitter pre-loaded with various holographic signs. Fits into pockets and boxes."

--- a/code/obj/storage/crates.dm
+++ b/code/obj/storage/crates.dm
@@ -279,7 +279,7 @@
 				if(telecrystals + item_datum.cost > 24) continue
 				var/obj/item/I = new item_datum.item(src)
 				if (owner)
-					item_datum.run_on_spawn(I, owner)
+					item_datum.run_on_spawn(I, owner, TRUE)
 					if (owner.mind)
 						owner.mind.traitor_crate_items += item_datum
 				telecrystals += item_datum.cost

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -586,7 +586,8 @@
 	/obj/item/reagent_containers/glass/bottle/acetone/janitors = 1,\
 	/obj/item/reagent_containers/glass/bottle/ammonia/janitors = 1,\
 	/obj/item/device/light/flashlight,\
-	/obj/item/caution = 4)
+	/obj/item/caution = 4,
+	/obj/item/clothing/gloves/long)
 
 /obj/storage/secure/closet/civilian/hydro
 	name = "\improper Botanical supplies locker"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a new traitor item for the janitor - the Lubed Floor Sign (please suggest a better name). Costs 2 evil coins.

It looks like a regular wet floor sign but has a (red) bucket full of superlube loaded inside. When someone steps near it sprays 1 unit of that bucket under their feet with some probability and cooldown. Galoshes protect you from the spray (but not from already applied lube). You can click on the sign with a different reagent container (as long as you are wearing the long gloves) to replace the payload (yes, nitroglycerin works).

Not sure about the price, tell me if 2 is too much or too little.

Idea credit: uranium 235 on discord

Now you can anchor / unanchor all wet floor signs with a wrench. Also adds a general purpose anchoring / unanchoring action. Also as an internal change there's now `/obj/item/proc/can_pickup(mob/user)` and by default anchored items can't be picked up. I couldn't find a case where it would break things, let me know if you think otherwise. Also adds a var to traitor item datums which says if they are surplus crate spawned. The sign spawns you galoshes and gloves if in a crate.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
We need more traitor items.
We also need people to respect the damn wet floor signs.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)pali
(*)Traitor janitors can now buy a very special wet floor sign. Also wet floor signs can now be anchored / unanchored with a wrench.
```
