### PR TITLE
Tweaked secbots to accomodate movement change

### DIFF
--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -120,7 +120,6 @@
 	loot_baton_type = /obj/item/baton/beepsky
 	is_beepsky = IS_BEEPSKY_AND_HAS_HIS_SPECIAL_BATON
 	hat = "nt"
-	attack_per_step = 1
 
 	New()
 		. = ..()

--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -60,13 +60,6 @@
 	var/loot_baton_type = /obj/item/scrap
 	var/stun_type = "stun"
 	var/mode = 0
-#define SECBOT_IDLE 		0		// idle
-#define SECBOT_HUNT 		1		// found target, hunting
-#define SECBOT_PREP_ARREST 	2		// at target, preparing to arrest
-#define SECBOT_ARREST		3		// arresting target
-#define SECBOT_START_PATROL	4		// start patrol
-#define SECBOT_PATROL		5		// patrolling
-#define SECBOT_SUMMON		6		// summoned by PDA
 
 	var/auto_patrol = 0		// set to make bot automatically patrol
 	var/beacon_freq = 1445		// navigation beacon frequency
@@ -429,7 +422,6 @@ Report Arrests: <A href='?src=\ref[src];operation=report'>[report_arrests ? "On"
 
 	proc/baton_attack(var/mob/living/carbon/M)
 		sleep(BATON_INITIAL_DELAY)
-		// if they moved while we were sleeping, abort
 		if(!IN_RANGE(src, src.target, 1))
 			return
 
@@ -449,7 +441,7 @@ Report Arrests: <A href='?src=\ref[src];operation=report'>[report_arrests ? "On"
 			src.our_baton = new our_baton_type(src)
 
 		while (stuncount > 0 && src.target)
-			// don't try to arrest if they moved
+			// they moved while we were sleeping, abort
 			if(!IN_RANGE(src, src.target, 1))
 				return
 
@@ -481,7 +473,7 @@ Report Arrests: <A href='?src=\ref[src];operation=report'>[report_arrests ? "On"
 		if (src.attack_per_step && prob(src.attack_per_step == 2 ? 25 : 75))
 			if (oldloc != NewLoc && world.time != last_attack)
 				if (mode == SECBOT_HUNT && target)
-					if (get_dist(src, src.target) <= 1)
+					if (IN_RANGE(src, src.target))
 						src.baton_attack(src.target)
 
 	process()

--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -473,7 +473,7 @@ Report Arrests: <A href='?src=\ref[src];operation=report'>[report_arrests ? "On"
 		if (src.attack_per_step && prob(src.attack_per_step == 2 ? 25 : 75))
 			if (oldloc != NewLoc && world.time != last_attack)
 				if (mode == SECBOT_HUNT && target)
-					if (IN_RANGE(src, src.target))
+					if (IN_RANGE(src, src.target, 1))
 						src.baton_attack(src.target)
 
 	process()

--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -116,7 +116,7 @@
 	idcheck = 1
 	auto_patrol = 1
 	report_arrests = 1
-	move_arrest_delay_mult = 1.2 // beepsky has some experience chasing crimers
+	move_arrest_delay_mult = 0.9 // beepsky has some experience chasing crimers
 	loot_baton_type = /obj/item/baton/beepsky
 	is_beepsky = IS_BEEPSKY_AND_HAS_HIS_SPECIAL_BATON
 	hat = "nt"

--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -4,6 +4,21 @@
 #define IS_BEEPSKY_BUT_HAS_SOME_GENERIC_BATON 3						// A generic-ass shitcurity baton
 #define IS_NOT_BEEPSKY_BUT_HAS_A_GENERIC_SPECIAL_BATON 4	// A generic, non-Beepsky brand secboton
 
+#define SECBOT_IDLE 		0		// idle
+#define SECBOT_HUNT 		1		// found target, hunting
+#define SECBOT_PREP_ARREST 	2		// at target, preparing to arrest
+#define SECBOT_ARREST		3		// arresting target
+#define SECBOT_START_PATROL	4		// start patrol
+#define SECBOT_PATROL		5		// patrolling
+#define SECBOT_SUMMON		6		// summoned by PDA
+
+#define PATROL_SPEED 6
+#define SUMMON_SPEED 3
+#define ARREST_SPEED 2.5
+
+#define BATON_INITIAL_DELAY (0.3 SECONDS)
+#define BATON_DELAY_PER_STUN (0.2 SECONDS)
+
 /obj/machinery/bot/secbot
 	name = "Securitron"
 #ifdef HALLOWEEN
@@ -53,12 +68,7 @@
 #define SECBOT_PATROL		5		// patrolling
 #define SECBOT_SUMMON		6		// summoned by PDA
 
-#define PATROL_SPEED 6
-#define SUMMON_SPEED 3
-#define ARREST_SPEED 2.5
-
 	var/auto_patrol = 0		// set to make bot automatically patrol
-
 	var/beacon_freq = 1445		// navigation beacon frequency
 	var/control_freq = 1447		// bot control frequency
 	var/tacticool = 0 // Do we shit up our report with useless lingo?
@@ -113,6 +123,7 @@
 	idcheck = 1
 	auto_patrol = 1
 	report_arrests = 1
+	move_arrest_delay_mult = 1.2 // beepsky has some experience chasing crimers
 	loot_baton_type = /obj/item/baton/beepsky
 	is_beepsky = IS_BEEPSKY_AND_HAS_HIS_SPECIAL_BATON
 	hat = "nt"
@@ -301,12 +312,9 @@ Report Arrests: <A href='?src=\ref[src];operation=report'>[report_arrests ? "On"
 			mode = SECBOT_IDLE
 			src.target = null
 
-			#if ASS_JAM // triple-emagged bots move REALLY FUCKING FAST
+			#if ASS_JAM
 			if(src.emagged >= 3)
 				src.stun_type = "harm_classic"
-				move_arrest_delay_mult = 0.5
-				move_patrol_delay_mult = 0.1
-				move_summon_delay_mult = 0.1
 				processing_bucket = 1
 				processing_tier = PROCESSING_FULL
 				current_processing_tier = PROCESSING_FULL
@@ -396,7 +404,7 @@ Report Arrests: <A href='?src=\ref[src];operation=report'>[report_arrests ? "On"
 
 
 
-	proc/navigate_to(atom/the_target,var/move_delay=3,var/adjacent=0,max_dist=600)
+	proc/navigate_to(atom/the_target, var/move_delay = SUMMON_SPEED, var/adjacent = 0, max_dist=600)
 		src.frustration = 0
 		src.path = null
 		if(src.mover)
@@ -420,28 +428,37 @@ Report Arrests: <A href='?src=\ref[src];operation=report'>[report_arrests ? "On"
 		return 0
 
 	proc/baton_attack(var/mob/living/carbon/M)
+		sleep(BATON_INITIAL_DELAY)
+		// if they moved while we were sleeping, abort
+		if(!IN_RANGE(src, src.target, 1))
+			return
+
 		src.icon_state = "secbot-c[src.emagged >= 2 ? "-wild" : null]"
 		var/maxstuns = 4
 		var/stuncount = (src.emagged >= 2) ? rand(5,10) : 1
 
 		last_attack = world.time
 
+		// No need for unnecessary hassle, just make it ignore charges entirely for the time being.
+		if (src.our_baton && istype(src.our_baton))
+			if (src.our_baton.uses_electricity == 0)
+				src.our_baton.uses_electricity = 1
+			if (src.our_baton.uses_charges != 0)
+				src.our_baton.uses_charges = 0
+		else
+			src.our_baton = new our_baton_type(src)
+
 		while (stuncount > 0 && src.target)
-			// No need for unnecessary hassle, just make it ignore charges entirely for the time being.
-			if (src.our_baton && istype(src.our_baton))
-				if (src.our_baton.uses_electricity == 0)
-					src.our_baton.uses_electricity = 1
-				if (src.our_baton.uses_charges != 0)
-					src.our_baton.uses_charges = 0
-			else
-				src.our_baton = new our_baton_type(src)
+			// don't try to arrest if they moved
+			if(!IN_RANGE(src, src.target, 1))
+				return
 
 			stuncount--
 			src.our_baton.do_stun(src, M, src.stun_type, 2)
 			if (!stuncount && maxstuns-- <= 0)
 				target = null
 			if (stuncount > 0)
-				sleep(0.3 SECONDS)
+				sleep(BATON_DELAY_PER_STUN)
 
 		SPAWN_DBG(0.2 SECONDS)
 			src.icon_state = "secbot[src.on][(src.on && src.emagged >= 2) ? "-wild" : null]"
@@ -494,7 +511,7 @@ Report Arrests: <A href='?src=\ref[src];operation=report'>[report_arrests ? "On"
 				else if (target)		// make sure target exists
 					if (!IN_RANGE(src, src.target, 1))
 						src.moving = 0
-						navigate_to(src.target,(src.emagged >= 2) ? (ARREST_SPEED/2 * move_arrest_delay_mult) : (ARREST_SPEED * move_arrest_delay_mult), max_dist=50)
+						navigate_to(src.target, ARREST_SPEED * move_arrest_delay_mult, max_dist = 50)
 						return
 
 			if(SECBOT_PREP_ARREST)		// preparing to arrest target
@@ -1061,7 +1078,7 @@ Report Arrests: <A href='?src=\ref[src];operation=report'>[report_arrests ? "On"
 				master.moving = 0
 				master.mover = null
 				if(master.mode == SECBOT_HUNT && master.target && master.frustration < 8 && !IN_RANGE(master, master.target, 1))
-					master.navigate_to(master.target,(master.emagged >= 2) ? (ARREST_SPEED/2 * master.move_arrest_delay_mult) : (ARREST_SPEED * master.move_arrest_delay_mult), max_dist=max_dist)
+					master.navigate_to(master.target, ARREST_SPEED * master.move_arrest_delay_mult, max_dist = max_dist)
 				master = null
 
 
@@ -1204,7 +1221,6 @@ Report Arrests: <A href='?src=\ref[src];operation=report'>[report_arrests ? "On"
 				S.beacon_freq = src.beacon_freq
 				S.hat = src.hat
 				S.name = src.created_name		// We get an upgraded securitron
-				S.attack_per_step = 2				// 25% chance to attack_on_move, as opposed to 75%
 				S.loot_baton_type = W.type	// So we can drop it all over again.
 				if (Y.beepsky_held_this == 1)
 					S.is_beepsky = IS_NOT_BEEPSKY_BUT_HAS_HIS_SPECIAL_BATON	// So we drop Beepsky's baton, and not just some generic secbot one
@@ -1217,7 +1233,6 @@ Report Arrests: <A href='?src=\ref[src];operation=report'>[report_arrests ? "On"
 			if (src.is_dead_beepsky)	// On Beepsky's corpse
 				boutput(user, "You give Officer Beepsky a stun baton, reassembling the Securitron! Beep boop.")
 				var/obj/machinery/bot/secbot/beepsky/S = new /obj/machinery/bot/secbot/beepsky(get_turf(src))
-				S.attack_per_step = 0		// We just get a surly head of robosecurity
 				S.is_beepsky = IS_BEEPSKY_BUT_HAS_SOME_GENERIC_BATON // So Beepsky's corpse is his corpse
 				S.loot_baton_type = W.type	// Our baton isn't special
 				qdel(src)
@@ -1229,7 +1244,6 @@ Report Arrests: <A href='?src=\ref[src];operation=report'>[report_arrests ? "On"
 				S.beacon_freq = src.beacon_freq
 				S.hat = src.hat
 				S.name = src.created_name
-				S.attack_per_step = 0		// We get a loot pinata
 				S.is_beepsky = IS_NOT_BEEPSKY_AND_HAS_SOME_GENERIC_BATON // You're still not Beepsky
 				S.loot_baton_type = W.type	// Our baton isn't special either
 				qdel(src)
@@ -1256,7 +1270,6 @@ Report Arrests: <A href='?src=\ref[src];operation=report'>[report_arrests ? "On"
 		else if (src.is_dead_beepsky)	// On Beepsky's corpse
 			boutput(user, "You add wires to Officer Beepsky, reassembling the Securitron! Beep boop.")
 			var/obj/machinery/bot/secbot/beepsky/S = new /obj/machinery/bot/secbot/beepsky(get_turf(src))
-			S.attack_per_step = 0		// We just get a surly head of robosecurity
 			S.is_beepsky = IS_BEEPSKY_BUT_HAS_SOME_GENERIC_BATON	// So Beepsky's corpse is his corpse
 			S.loot_baton_type = /obj/item/scrap	// our baton's a hunk of junk!
 			qdel(src)
@@ -1288,3 +1301,5 @@ Report Arrests: <A href='?src=\ref[src];operation=report'>[report_arrests ? "On"
 #undef PATROL_SPEED
 #undef SUMMON_SPEED
 #undef ARREST_SPEED
+#undef BATON_INITIAL_DELAY
+#undef BATON_DELAY_PER_STUN

--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -443,6 +443,7 @@ Report Arrests: <A href='?src=\ref[src];operation=report'>[report_arrests ? "On"
 		while (stuncount > 0 && src.target)
 			// they moved while we were sleeping, abort
 			if(!IN_RANGE(src, src.target, 1))
+				src.icon_state = "secbot[src.on][(src.on && src.emagged >= 2) ? "-wild" : null]"
 				return
 
 			stuncount--


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Secbots recently received a cool new movement change. However, this made them a little overly-adapt at oppressing our fellow spacemen, so I've tweaked them a little bit.

- Movement speed tuned down a bit, should be roughly equal to what it was (Beepsky is a little faster though!)
- Removed Beepsky's baton attack per movement step (definitely not needed, easy revert if people disagree)

I also moved things around and tried to clean up a bit in `secbot.dm`.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I'll just leave this here, the current state:
Double emagged: https://i.imgur.com/TICfiD7.mp4
Triple emagged: https://streamable.com/cp7z2c


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)RichardGere:
(+)Tweaked secbots responsiveness to accommodate the new movement change.
```
