### PR TITLE
ability_parent.dm runtime fix

### DIFF
--- a/code/datums/abilities/ability_parent.dm
+++ b/code/datums/abilities/ability_parent.dm
@@ -111,7 +111,7 @@
 
 			if (!called_by_owner)
 				for(var/obj/screen/ability/A in src.hud.objects)
-					src.hud -= A
+					src.hud.objects -= A
 
 			var/pos_x = start_x
 			var/pos_y = start_y
@@ -1125,7 +1125,7 @@
 	updateButtons(var/called_by_owner = 0, var/start_x = 1, var/start_y = 0)
 		if (src.topBarRendered && src.rendered && src.hud)
 			for(var/obj/screen/ability/A in src.hud.objects)
-				src.hud -= A
+				src.hud.objects -= A
 
 		x_occupied = 1
 		y_occupied = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [RUNTIME][BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
runtime fix


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
File | ability_parent.dm
-- | --
Line | 114
Error | type mismatch: /datum/hud (/datum/hud) -= Exit Pod (/obj/screen/ability/topBar/cruiser)

```
proc name: updateButtons (/datum/abilityHolder/proc/updateButtons)
  source file: ability_parent.dm,114
  usr: null
  src: /datum/abilityHolder/cruiser (/datum/abilityHolder/cruiser)
  call stack:
/datum/abilityHolder/cruiser (/datum/abilityHolder/cruiser): updateButtons(0, 1, 0)
/datum/abilityHolder/cruiser (/datum/abilityHolder/cruiser): addAbility(/datum/targetable/cruiser/togg... (/datum/targetable/cruiser/toggle_interior))
Engineering pod (/obj/machinery/cruiser_destroyable/cruiser_pod/engineering): New(the steel floor (234,46,2) (/turf/simulated/floor))
```