### PR TITLE
Let mappers specify turretArea on turret control

### DIFF
--- a/code/obj/machinery/turret.dm
+++ b/code/obj/machinery/turret.dm
@@ -36,11 +36,13 @@
 	var/area/station/turret_protected/TP = get_area(src)
 	if(istype(TP))
 		TP.turret_list += src
+	START_TRACKING
 
 /obj/machinery/turret/disposing()
 	var/area/station/turret_protected/TP = get_area(src)
 	if(istype(TP))
 		TP.turret_list -= src
+	STOP_TRACKING
 	..()
 
 /obj/machinery/turret/proc/isPopping()
@@ -345,10 +347,16 @@
 	var/lethal = 0
 	var/locked = 1
 	var/emagged = 0
-	var/turretsExist = 1
+	var/turretArea = null
 
 	req_access = list(access_ai_upload)
 	object_flags = CAN_REPROGRAM_ACCESS
+
+	New()
+		..()
+		if (!src.turretArea)
+			var/area/A = get_area(src)
+			src.turretArea = A.type
 
 /obj/machinery/turretid/attackby(obj/item/W, mob/user)
 	if(status & BROKEN) return
@@ -389,7 +397,7 @@
 		return
 	var/t = "<TT><B>Turret Control Panel</B> ([area.name])<HR>"
 
-	if(!src.emagged && turretsExist)
+	if(!src.emagged)
 		if(src.locked && (!issilicon(user) && !isAI(user)))
 			t += "<I>(Swipe ID card to unlock control panel.)</I><BR>"
 		else
@@ -467,23 +475,23 @@
 
 
 /obj/machinery/turretid/proc/updateTurrets()
-	if(turretsExist) //Let's not waste a lot of time here.
-		if (src.enabled)
-			if (src.lethal)
-				icon_state = "ai1"
-			else
-				icon_state = "ai3"
-		else
-			icon_state = "ai0"
+	if (!by_type[/obj/machinery/turret].len)
+		return
 
-		var/area/area = get_area(src)
-		if (!istype(area))
-			logTheThing("debug", null, null, "Turret badly positioned.")
-			return
-		turretsExist = 0
-		for (var/obj/machinery/turret/aTurret in get_area_all_atoms(area))
-			aTurret.setState(enabled, lethal)
-			turretsExist = 1
+	for (var/obj/machinery/turret/turret in by_type[/obj/machinery/turret])
+		var/area/A = get_area(turret)
+		if (A.type == src.turretArea)
+			turret.setState(enabled, lethal)
+			src.updateicon()
+
+/obj/machinery/turretid/proc/updateicon()
+	if (src.enabled)
+		if (src.lethal)
+			icon_state = "ai1"
+		else
+			icon_state = "ai3"
+	else
+		icon_state = "ai0"
 
 /obj/machinery/turretid/emag_act(var/mob/user)
 	if(!emagged)
@@ -519,4 +527,4 @@
 		updateTurrets()
 
 		sleep(rand(1, 10) * 10)
-	while(emagged && turretsExist)
+	while(emagged)

--- a/code/obj/machinery/turret.dm
+++ b/code/obj/machinery/turret.dm
@@ -475,9 +475,6 @@
 
 
 /obj/machinery/turretid/proc/updateTurrets()
-	if (!by_type[/obj/machinery/turret].len)
-		return
-
 	for (var/obj/machinery/turret/turret in by_type[/obj/machinery/turret])
 		var/area/A = get_area(turret)
 		if (A.type == src.turretArea)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [BUG][QOL][FEAT] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
-Allows mappers to specify an area type in the var turretArea to dictate the area that it controls
-If no area is specified at time of creation the control will use its current location's area
-turrets are now stored in the by_type list
-deleting all the turrets in an area no longer permanently breaks the turret control and allows newly built turrets to be controlled by it.
-breaks icon changes out into their own `updateicon()` proc for consistency


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
-Turret controls currently work by looping through every atom in their area, seeing if it's a turret, and then updating its state
-Turret controls are currently required to exist in the same area as the turrets that they are controlling. This has lead to some odd area placements that can be confusing, such as the control room for the exterior donut turrets being considered as outside the armory.

open to suggestions on ways this could be done even better without breaking existing maps
