### PR TITLE
reagents use abstract types now

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1413,10 +1413,10 @@ var/global/noir = 0
 				var/list/L = list()
 				var/searchFor = input(usr, "Look for a part of the reagent name (or leave blank for all)", "Add reagent") as null|text
 				if(searchFor)
-					for(var/R in childrentypesof(/datum/reagent))
+					for(var/R in concrete_typesof(/datum/reagent))
 						if(findtext("[R]", searchFor)) L += R
 				else
-					L = childrentypesof(/datum/reagent)
+					L = concrete_typesof(/datum/reagent)
 
 				var/type
 				if(L.len == 1)

--- a/code/modules/admin/randomverbs.dm
+++ b/code/modules/admin/randomverbs.dm
@@ -1534,10 +1534,10 @@
 	var/list/L = list()
 	var/searchFor = input(usr, "Look for a part of the reagent name (or leave blank for all)", "Add reagent") as null|text
 	if(searchFor)
-		for(var/R in childrentypesof(/datum/reagent))
+		for(var/R in concrete_typesof(/datum/reagent))
 			if(findtext("[R]", searchFor)) L += R
 	else
-		L = childrentypesof(/datum/reagent)
+		L = concrete_typesof(/datum/reagent)
 
 	var/type
 	if(L.len == 1)
@@ -1877,10 +1877,10 @@
 	var/list/L = list()
 	var/searchFor = input(usr, "Look for a part of the reagent name (or leave blank for all)", "Add reagent") as null|text
 	if(searchFor)
-		for(var/R in childrentypesof(/datum/reagent))
+		for(var/R in concrete_typesof(/datum/reagent))
 			if(findtext("[R]", searchFor)) L += R
 	else
-		L = childrentypesof(/datum/reagent)
+		L = concrete_typesof(/datum/reagent)
 
 	var/type
 	if(L.len == 1)
@@ -1923,10 +1923,10 @@
 	var/list/L = list()
 	var/searchFor = input(usr, "Look for a part of the reagent name (or leave blank for all)", "Add reagent") as null|text
 	if(searchFor)
-		for(var/R in childrentypesof(/datum/reagent))
+		for(var/R in concrete_typesof(/datum/reagent))
 			if(findtext("[R]", searchFor)) L += R
 	else
-		L = childrentypesof(/datum/reagent)
+		L = concrete_typesof(/datum/reagent)
 
 	var/type = 0
 	if(L.len == 1)
@@ -1962,10 +1962,10 @@
 	var/list/L = list()
 	var/searchFor = input(usr, "Look for a part of the reagent name (or leave blank for all)", "Add reagent") as null|text
 	if(searchFor)
-		for(var/R in childrentypesof(/datum/reagent))
+		for(var/R in concrete_typesof(/datum/reagent))
 			if(findtext("[R]", searchFor)) L += R
 	else
-		L = childrentypesof(/datum/reagent)
+		L = concrete_typesof(/datum/reagent)
 
 	var/type = 0
 	if(L.len == 1)

--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -4,6 +4,8 @@
 //important MBC reagent note : implement mult for on_mob_life(). needed for proper realtime processing. lookk for examples, there are plenty
 //dont put them on byond-time effects like drowsy. just use them for damage, counters, statuseffects(realtime) etc.
 
+ABSTRACT_TYPE(/datum/reagent)
+
 datum
 	reagent
 		var/name = "Reagent"

--- a/code/modules/chemistry/Chemistry-Structure.dm
+++ b/code/modules/chemistry/Chemistry-Structure.dm
@@ -22,7 +22,7 @@
 /proc/build_reagent_cache()
 	var/startTime = world.timeofday
 	reagents_cache.Cut()
-	for(var/R in childrentypesof(/datum/reagent))
+	for(var/R in concrete_typesof(/datum/reagent))
 		var/datum/reagent/Rinstance = new R()
 		//If R is not a datum/reagent then I don't think anything I can do will help here.
 		reagents_cache[Rinstance.id] = Rinstance

--- a/code/modules/chemistry/Reagents-Diseases.dm
+++ b/code/modules/chemistry/Reagents-Diseases.dm
@@ -1,5 +1,8 @@
 //Contains disease reagents.
 
+ABSTRACT_TYPE(/datum/reagent/disease)
+//this is the solution for now. until i refactor all reagents to use absolute pathing :x
+
 datum
 	reagent
 		disease/

--- a/code/modules/chemistry/Reagents-Diseases.dm
+++ b/code/modules/chemistry/Reagents-Diseases.dm
@@ -1,7 +1,6 @@
 //Contains disease reagents.
 
 ABSTRACT_TYPE(/datum/reagent/disease)
-//this is the solution for now. until i refactor all reagents to use absolute pathing :x
 
 datum
 	reagent

--- a/code/modules/chemistry/Reagents-Drugs.dm
+++ b/code/modules/chemistry/Reagents-Drugs.dm
@@ -1,4 +1,7 @@
 //Contains wacky space drugs
+
+ABSTRACT_TYPE(/datum/reagent/drug)
+
 datum
 	reagent
 		drug/

--- a/code/modules/chemistry/Reagents-ExplosiveFire.dm
+++ b/code/modules/chemistry/Reagents-ExplosiveFire.dm
@@ -1,4 +1,7 @@
 //Contains Fire / Explosion / Implosion related reagents.
+
+ABSTRACT_TYPE(/datum/reagent/combustible)
+
 datum
 	reagent
 		combustible/

--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -1,4 +1,9 @@
 //Contains reagents related to eating or drinking.
+
+ABSTRACT_TYPE(/datum/reagent/fooddrink)
+ABSTRACT_TYPE(/datum/reagent/fooddrink/alcoholic)
+ABSTRACT_TYPE(/datum/reagent/fooddrink/temp_bioeffect)
+
 datum
 	reagent
 		fooddrink/

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -1,4 +1,7 @@
 //Contains medical reagents / drugs.
+
+ABSTRACT_TYPE(/datum/reagent/medical)
+
 datum
 	reagent
 		medical/

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -1,4 +1,8 @@
 //Contains exotic or special reagents.
+
+ABSTRACT_TYPE(/datum/reagent/cement)
+ABSTRACT_TYPE(/datum/reagent/concrete)
+
 datum
 	reagent
 		nitroglycerin // Yes, this is a bad idea.

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -1,4 +1,9 @@
 //Contains reagents that are poisons or otherwise intended to be harmful
+
+ABSTRACT_TYPE(/datum/reagent/harmful)
+ABSTRACT_TYPE(/datum/reagent/harmful/simple_damage_toxin)
+ABSTRACT_TYPE(/datum/reagent/harmful/simple_damage_burn)
+
 datum
 	reagent
 		harmful/

--- a/code/modules/events/minor/gimmick_flood.dm
+++ b/code/modules/events/minor/gimmick_flood.dm
@@ -15,10 +15,10 @@
 			var/list/L = list()
 			var/searchFor = input(usr, "Look for a part of the reagent name (or leave blank for all)", "Add reagent") as null|text
 			if(searchFor)
-				for(var/R in childrentypesof(/datum/reagent))
+				for(var/R in concrete_typesof(/datum/reagent))
 					if(findtext("[R]", searchFor)) L += R
 			else
-				L = childrentypesof(/datum/reagent)
+				L = concrete_typesof(/datum/reagent)
 
 			if(L.len == 1)
 				reagent_type = L[1]
@@ -40,7 +40,7 @@
 		..()
 
 		if(isnull(src.reagent_type))
-			reagent_type = pick(childrentypesof(/datum/reagent))
+			reagent_type = pick(concrete_typesof(/datum/reagent))
 
 		var/datum/reagent/reagent = new reagent_type()
 

--- a/code/modules/fluids/fluid_commands.dm
+++ b/code/modules/fluids/fluid_commands.dm
@@ -64,10 +64,11 @@ client/proc/replace_space()
 	var/list/L = list()
 	var/searchFor = input(usr, "Look for a part of the reagent name (or leave blank for all)", "Add reagent") as null|text
 	if(searchFor)
-		for(var/R in childrentypesof(/datum/reagent))
+		for(var/R in concrete_typesof(/datum/reagent))
 			if(findtext("[R]", searchFor)) L += R
 	else
-		L = childrentypesof(/datum/reagent)
+		L = concrete_typesof(/datum/reagent)
+
 	var/type = 0
 	if(L.len == 1)
 		type = L[1]
@@ -105,10 +106,11 @@ client/proc/replace_space_exclusive()
 	var/list/L = list()
 	var/searchFor = input(usr, "Look for a part of the reagent name (or leave blank for all)", "Add reagent") as null|text
 	if(searchFor)
-		for(var/R in childrentypesof(/datum/reagent))
+		for(var/R in concrete_typesof(/datum/reagent))
 			if(findtext("[R]", searchFor)) L += R
 	else
-		L = childrentypesof(/datum/reagent)
+		L = concrete_typesof(/datum/reagent)
+
 	var/type = 0
 	if(L.len == 1)
 		type = L[1]

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -1435,8 +1435,9 @@ var/list/hex_chars = list("0","1","2","3","4","5","6","7","8","9","A","B","C","D
 var/list/all_functional_reagent_ids = list()
 
 proc/get_all_functional_reagent_ids()
-	for (var/X in childrentypesof(/datum/reagent) )
-		all_functional_reagent_ids += initial(X:id)
+	for (var/X in concrete_typesof(/datum/reagent))
+		var/datum/reagent/R = X
+		all_functional_reagent_ids += initial(R.id)
 
 proc/reagent_id_to_name(var/reagent_id)
 	if (!reagent_id || !reagents_cache.len)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
reagents use abstract types now!
parent reagents correctly use abstract types
and stuff that uses typesof / childrentypesof with reagents now use concrete_typesof

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
sometimes its funny to see like "dangerous stuff" but is it rly that funny. idk. consistency, use the good abstract type system please, avoid headaches in the future

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
```
