### PR TITLE
Increase max number of Nuclear Operatives to 8

### DIFF
--- a/code/datums/gamemodes/nuclear.dm
+++ b/code/datums/gamemodes/nuclear.dm
@@ -14,7 +14,7 @@
 #if ASS_JAM
 	var/const/agents_possible = 30 // on ass jam theres up to 30 nukies to compensate for the warcrime of the kinetitech
 #else
-	var/const/agents_possible = 6 //If we ever need more syndicate agents. cogwerks - raised from 5
+	var/const/agents_possible = 8 //If we ever need more syndicate agents. cogwerks - raised from 5
 #endif
 
 	var/const/waittime_l = 600 //lower bound on time before intercept arrives (in tenths of seconds)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Nuclear Operative rounds used to have a maximum number of Ops capped at 6, this PR raises it to 8.



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Higher player counts and a dramatically falling Nuke Op win-rate suggets that this would improve Nuke rounds.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Gannets:
(*)Increased maximum number of Nuclear Operatives to 8 from 6.
```
