### PR TITLE
AI PDA name now matches AI name

### DIFF
--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -2125,6 +2125,8 @@ proc/get_mobs_trackable_by_AI()
 		if (!newname)
 			src.real_name = randomname
 			src.name = src.real_name
+			src.internal_pda.name = "[src]'s Internal PDA Unit"
+			src.internal_pda.owner = "[src]"
 			return
 		else
 			newname = strip_html(newname, MOB_NAME_MAX_LENGTH, 1)
@@ -2138,6 +2140,8 @@ proc/get_mobs_trackable_by_AI()
 				if (alert(src, "Use the name [newname]?", newname, "Yes", "No") == "Yes")
 					src.real_name = newname
 					src.name = newname
+					src.internal_pda.name = "[src]'s Internal PDA Unit"
+					src.internal_pda.owner = "[src]"
 					return 1
 				else
 					continue


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

An AI's internal PDA is now properly named to be the AI's actual name instead of just 'AI', similar to how cyborg PDAs work. This change is visible both in the main PDA menu and in the messenger list.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Reduces confusion as a result of multiple AIs that, before, would all have the same name of 'AI' in the messenger rather than the actual name of the AI.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Aft2001:
(+)An AI's PDA name is now based on its actual name, instead of just being labeled as 'AI'
```
