### PR TITLE
Kondaru arrivals changed to unsimulated turfs

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -15330,8 +15330,8 @@
 /turf/simulated/wall/auto/supernorn,
 /area)
 "aIY" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
+/obj/wingrille_spawn/auto/crystal,
+/turf/unsimulated/floor/circuit/vintage,
 /area/station/crewquarters/cryotron)
 "aIZ" = (
 /obj/machinery/conveyor{
@@ -20514,7 +20514,7 @@
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/quarters_east)
 "aUz" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
+/turf/unsimulated/wall/auto/reinforced/supernorn,
 /area/station/crewquarters/cryotron)
 "aUA" = (
 /obj/machinery/door/airlock/pyro/glass{
@@ -20524,7 +20524,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/grey,
+/turf/unsimulated/floor/circuit/vintage,
 /area/station/crewquarters/cryotron)
 "aUB" = (
 /obj/wingrille_spawn/auto,
@@ -20944,7 +20944,7 @@
 	dir = 8;
 	pixel_x = 20
 	},
-/turf/simulated/floor/sanitary,
+/turf/unsimulated/floor/sanitary,
 /area/station/crewquarters/cryotron)
 "aVA" = (
 /obj/table/reinforced/auto,
@@ -21649,7 +21649,8 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/turf/simulated/floor/sanitary,
+/obj/machinery/light/emergency,
+/turf/unsimulated/floor/sanitary,
 /area/station/crewquarters/cryotron)
 "aWP" = (
 /obj/machinery/door/airlock/pyro{
@@ -21660,7 +21661,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/sanitary,
+/turf/unsimulated/floor/circuit/vintage,
 /area/station/crewquarters/cryotron)
 "aWQ" = (
 /obj/cable{
@@ -22050,7 +22051,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/sanitary,
+/turf/unsimulated/floor/sanitary,
 /area/station/crewquarters/cryotron)
 "aXP" = (
 /obj/machinery/camera{
@@ -22059,15 +22060,14 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/obj/machinery/light/emergency,
-/turf/simulated/floor/sanitary,
+/turf/unsimulated/floor/sanitary,
 /area/station/crewquarters/cryotron)
 "aXQ" = (
 /obj/stool/chair{
 	dir = 8
 	},
 /obj/machinery/light,
-/turf/simulated/floor/sanitary,
+/turf/unsimulated/floor/sanitary,
 /area/station/crewquarters/cryotron)
 "aXR" = (
 /obj/table/round/auto,
@@ -22078,7 +22078,8 @@
 	dir = 8;
 	pixel_x = 32
 	},
-/turf/simulated/floor/sanitary,
+/obj/machinery/light/emergency,
+/turf/unsimulated/floor/sanitary,
 /area/station/crewquarters/cryotron)
 "aXS" = (
 /obj/machinery/vending/cigarette,
@@ -28507,7 +28508,7 @@
 /area/station/crew_quarters/catering)
 "bmO" = (
 /obj/cryotron,
-/turf/simulated/floor/sanitary,
+/turf/unsimulated/floor/sanitary,
 /area/station/crewquarters/cryotron)
 "bmP" = (
 /obj/table/auto,
@@ -29714,7 +29715,7 @@
 	pixel_y = 22
 	},
 /obj/landmark/start/latejoin,
-/turf/simulated/floor/sanitary,
+/turf/unsimulated/floor/sanitary,
 /area/station/crewquarters/cryotron)
 "bpC" = (
 /obj/machinery/plantpot,
@@ -53325,7 +53326,7 @@
 	},
 /area/station/hydroponics)
 "coV" = (
-/turf/simulated/floor/sanitary,
+/turf/unsimulated/floor/sanitary,
 /area/station/crewquarters/cryotron)
 "coW" = (
 /obj/machinery/light/small{
@@ -55493,7 +55494,7 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/sanitary,
+/turf/unsimulated/floor/sanitary,
 /area/station/crewquarters/cryotron)
 "kHZ" = (
 /obj/wingrille_spawn/auto/crystal,
@@ -55905,7 +55906,7 @@
 /area/station/routingdepot/security)
 "nbR" = (
 /obj/storage/secure/closet/personal,
-/turf/simulated/floor/sanitary,
+/turf/unsimulated/floor/sanitary,
 /area/station/crewquarters/cryotron)
 "ncP" = (
 /obj/lattice{
@@ -56325,7 +56326,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/sanitary,
+/turf/unsimulated/floor/sanitary,
 /area/station/crewquarters/cryotron)
 "pry" = (
 /obj/table/reinforced/auto,
@@ -57099,7 +57100,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/sanitary,
+/turf/unsimulated/floor/sanitary,
 /area/station/crewquarters/cryotron)
 "uaU" = (
 /obj/cable{


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Pretty much what it says on the tin - swaps the turfs in Kondaru's cryo unit to unsimulated ones so new arrivals can't emerge into a lack of a room.

This is not intended as a surrogate for potential changes that make the cryo unit less likely to be caught in the radius of bombs in the first place; those changes may take a while to come into being, and I didn't think that unsimulating arrivals needed to wait for them.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Keeps people from arriving directly into an airless void due to station damage.