### PR TITLE
Cyberorgans are no longer edible

### DIFF
--- a/code/obj/item/organs/appendix.dm
+++ b/code/obj/item/organs/appendix.dm
@@ -20,6 +20,7 @@
 	icon_state = "cyber-appendix"
 	// item_state = "cyber-"
 	robotic = 1
+	made_from = "pharosium"
 	edible = 0
 	mats = 6
 

--- a/code/obj/item/organs/butt.dm
+++ b/code/obj/item/organs/butt.dm
@@ -194,7 +194,7 @@
 	icon_state = "butt-cyber"
 	allow_staple = 0
 	toned = 0
-	made_from = "slag"
+	made_from = "pharosium"
 	sound_fart = "sound/voice/farts/poo2_robot.ogg"
 // no this is not done and I dunno when it will be done
 // I am a bad person who accepts bribes of freaky macho butt drawings and then doesn't prioritize the request the bribe was for

--- a/code/obj/item/organs/instestines.dm
+++ b/code/obj/item/organs/instestines.dm
@@ -46,6 +46,7 @@
 	desc = "A fancy robotic intestines to replace one that someone's lost!"
 	icon_state = "cyber-intestines"
 	// item_state = "heart_robo1"
+	made_from = "pharosium"
 	robotic = 1
 	edible = 0
 	mats = 6

--- a/code/obj/item/organs/kidney.dm
+++ b/code/obj/item/organs/kidney.dm
@@ -117,6 +117,7 @@
 	desc = "A fancy robotic kidney to replace one that someone's lost!"
 	icon_state = "cyber-kidney-L"
 	// item_state = "heart_robo1"
+	made_from = "pharosium"
 	robotic = 1
 	edible = 0
 	mats = 6
@@ -134,7 +135,7 @@
 		if (!ispath(abil, /datum/targetable/organAbility/kidneypurge) || !aholder)
 			return ..()
 		var/datum/targetable/organAbility/kidneypurge/OA = aholder.getAbility(abil)//addAbility(abil)
-		if (istype(OA)) // already has an emagged kidney. having 2 makes it safer (damage is split between kidneys) and a little stronger 
+		if (istype(OA)) // already has an emagged kidney. having 2 makes it safer (damage is split between kidneys) and a little stronger
 			OA.linked_organ = list(OA.linked_organ, src)
 			OA.power = 9
 		else
@@ -164,7 +165,7 @@
 			chem_metabolism_modifier = clamp(chem_metabolism_modifier, 75, 150) / 100
 		else
 			. = ..()
-		
+
 /obj/item/organ/kidney/cyber/left
 	name = "left kidney"
 	desc = "A fancy robotic kidney to replace one that someone's lost! It's the left kidney!"

--- a/code/obj/item/organs/liver.dm
+++ b/code/obj/item/organs/liver.dm
@@ -16,7 +16,7 @@
 		return 1
 
 	on_broken(var/mult = 1)
-		donor.take_toxin_damage(2*mult, 1)				
+		donor.take_toxin_damage(2*mult, 1)
 
 	disposing()
 		if (holder)
@@ -29,6 +29,7 @@
 	desc = "A fancy robotic liver to replace one that someone's lost!"
 	icon_state = "cyber-liver"
 	// item_state = "heart_robo1"
+	made_from = "pharosium"
 	robotic = 1
 	edible = 0
 	mats = 6
@@ -54,7 +55,7 @@
 				donor.reagents.remove_reagent("ethanol", 5 * mult)
 				if(prob(20))
 					boutput(donor, "<span class='alert'>You feel painfully sober.</span>")
-				else if(prob(25)) //20% total 
+				else if(prob(25)) //20% total
 					boutput(donor, "<span class='alert'>You feel a burning in your liver!</span>")
 					src.take_damage(2 * mult, 2 * mult, 0)
 		return 1

--- a/code/obj/item/organs/lung.dm
+++ b/code/obj/item/organs/lung.dm
@@ -122,6 +122,7 @@
 	name = "cyberlungs"
 	desc = "Fancy robotic lungs!"
 	icon_state = "cyber-lungs_L"
+	made_from = "pharosium"
 	robotic = 1
 	edible = 0
 	mats = 6
@@ -132,7 +133,7 @@
 		if (!ispath(abil, /datum/targetable/organAbility/rebreather) || !aholder)
 			return ..()
 		var/datum/targetable/organAbility/rebreather/OA = aholder.getAbility(abil)//addAbility(abil)
-		if (istype(OA)) // already has an emagged lung. You need both for the ability to function 
+		if (istype(OA)) // already has an emagged lung. You need both for the ability to function
 			OA.linked_organ = list(OA.linked_organ, src)
 		else
 			OA = aholder.addAbility(abil)
@@ -157,7 +158,7 @@
 	on_life(var/mult = 1)
 		if(!..())
 			return 0
-			
+
 		if(overloading)
 			src.take_damage(0, 1 * mult)
 		return 1
@@ -166,7 +167,7 @@
 		if(donor)
 			REMOVE_MOB_PROPERTY(donor, PROP_REBREATHING, "cyberlungs")
 		..()
-		
+
 	emag_act(mob/user, obj/item/card/emag/E)
 		..()
 		organ_abilities = list(/datum/targetable/organAbility/rebreather)

--- a/code/obj/item/organs/pancreas.dm
+++ b/code/obj/item/organs/pancreas.dm
@@ -12,13 +12,13 @@
 		if (!..())
 			return 0
 		if(!emagged) //emagged pancreas doesn't regulate sugar for you anymore.
-			if (donor.reagents && donor.reagents.get_reagent_amount("sugar") > 80)	
+			if (donor.reagents && donor.reagents.get_reagent_amount("sugar") > 80)
 				if (prob(50))
 					donor.reagents.add_reagent("insulin", 1 * mult)
 					if(!robotic) //don't kill a cyberpancreas
 						src.take_damage(0, 0, 10)
 				else if (prob(50))
-					if (donor.reagents.get_reagent_amount("sugar") > 200)	
+					if (donor.reagents.get_reagent_amount("sugar") > 200)
 						donor.reagents.add_reagent("insulin", 2 * mult)
 						if(!robotic)
 							src.take_damage(0, 0, 40)
@@ -26,7 +26,7 @@
 			if (src.get_damage() >= 65 && prob(src.get_damage() * 0.2))
 				donor.contract_disease(failure_disease,null,null,1)
 		return 1
-		
+
 	disposing()
 		if (holder)
 			if (holder.pancreas == src)
@@ -38,6 +38,7 @@
 	desc = "A fancy robotic pancreas to replace one that someone's lost!"
 	icon_state = "cyber-pancreas"
 	// item_state = "heart_robo1"
+	made_from = "pharosium"
 	robotic = 1
 	edible = 0
 	mats = 6

--- a/code/obj/item/organs/spleen.dm
+++ b/code/obj/item/organs/spleen.dm
@@ -36,6 +36,7 @@
 	name = "cyberspleen"
 	desc = "A fancy robotic spleen to replace one that someone's lost!"
 	icon_state = "cyber-spleen"
+	made_from = "pharosium"
 	// item_state = "heart_robo1"
 	robotic = 1
 	edible = 0

--- a/code/obj/item/organs/stomach.dm
+++ b/code/obj/item/organs/stomach.dm
@@ -72,6 +72,7 @@
 	desc = "A fancy robotic stomach to replace one that someone's lost!"
 	icon_state = "cyber-stomach"
 	// item_state = "heart_robo1"
+	made_from = "pharosium"
 	robotic = 1
 	edible = 0
 	mats = 6
@@ -90,7 +91,7 @@
 		if(donor)
 			ADD_STATUS_LIMIT(src.donor, "Food", 6)
 
-	breakme() 
+	breakme()
 		..()
 		if(donor)
 			REMOVE_STATUS_LIMIT(src.donor, "Food")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Cyber organs are now made from pharosium, and thus properly inedible.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

They're not really supposed to be edible. I'd like to add a flag that'd override an item's edibility to make it inedible even if its made of something edible, or maybe rearrange the edibility checks so an item's edibility takes priority over the material's, but that's kind o a bigger thing and I want my metal organs!

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Superlagg:
(+)Metal organs are no longer made of delicious flesh.
```
