### PR TITLE
Increase Nuclear Operative Specialist armor values

### DIFF
--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -1049,7 +1049,7 @@
 
 		setupProperties()
 			..()
-			setProperty("exploprot", 25)
+			setProperty("exploprot", 4)
 			setProperty("meleeprot", 6)
 			setProperty("rangedprot", 3)
 
@@ -1073,7 +1073,7 @@
 
 		setupProperties()
 			..()
-			setProperty("exploprot", 10)
+			setProperty("exploprot", 2)
 			setProperty("meleeprot", 4)
 			setProperty("rangedprot", 1.5)
 
@@ -1115,7 +1115,7 @@
 
 			setupProperties()
 				..()
-				setProperty("exploprot", 25)
+				setProperty("exploprot", 6)
 
 		unremovable
 			cant_self_remove = 1

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -1072,10 +1072,10 @@
 		item_state = "syndie_specialist"
 
 		setupProperties()
-		..()
-		setProperty("exploprot", 10)
-		setProperty("meleeprot", 4)
-		setProperty("rangedprot", 1.5)
+			..()
+			setProperty("exploprot", 10)
+			setProperty("meleeprot", 4)
+			setProperty("rangedprot", 1.5)
 
 		medic
 			name = "specialist operative medic uniform"

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -1049,7 +1049,7 @@
 
 		setupProperties()
 			..()
-			setProperty("exploprot", 3)
+			setProperty("exploprot", 25)
 			setProperty("meleeprot", 6)
 			setProperty("rangedprot", 3)
 
@@ -1070,6 +1070,12 @@
 		desc = "A syndicate issue combat dress system, pressurized for space travel."
 		icon_state = "syndie_specialist"
 		item_state = "syndie_specialist"
+
+		setupProperties()
+		..()
+		setProperty("exploprot", 10)
+		setProperty("meleeprot", 4)
+		setProperty("rangedprot", 1.5)
 
 		medic
 			name = "specialist operative medic uniform"
@@ -1103,6 +1109,13 @@
 			name = "specialist operative marksman's suit"
 			icon_state = "syndie_specialist-sniper"
 			item_state = "syndie_specialist-sniper"
+
+		grenadier
+			name = "specialist operative bombsuit"
+
+			setupProperties()
+				..()
+				setProperty("exploprot", 25)
 
 		unremovable
 			cant_self_remove = 1

--- a/code/obj/storage/crates.dm
+++ b/code/obj/storage/crates.dm
@@ -364,7 +364,7 @@
 		/obj/item/storage/pouch/grenade_round,
 		/obj/item/storage/grenade_pouch/mixed_explosive,
 		/obj/item/clothing/suit/space/syndicate/specialist,
-		/obj/item/clothing/head/helmet/space/syndicate/specialist)
+		/obj/item/clothing/head/helmet/space/syndicate/specialist/grenadier)
 
 	heavy
 		name = "Class Crate - Heavy Weapons Specialist"

--- a/code/obj/storage/crates.dm
+++ b/code/obj/storage/crates.dm
@@ -363,8 +363,8 @@
 		spawn_contents = list(/obj/item/gun/kinetic/grenade_launcher,
 		/obj/item/storage/pouch/grenade_round,
 		/obj/item/storage/grenade_pouch/mixed_explosive,
-		/obj/item/clothing/suit/space/syndicate/specialist,
-		/obj/item/clothing/head/helmet/space/syndicate/specialist/grenadier)
+		/obj/item/clothing/suit/space/syndicate/specialist/grenadier,
+		/obj/item/clothing/head/helmet/space/syndicate/specialist)
 
 	heavy
 		name = "Class Crate - Heavy Weapons Specialist"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a level of melee, ranged and explosion resistance to Nuclear Operative Specialist uniforms, values tweaked to be slightly higher than the security vest.
A new uniform for grenadiers has been added with additional explosive resistance.



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Improves survivability for nuclear operatives. Previously their suits were less protective than a standard armor vest.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Gannets:
(+)Improved armour values for Nuclear Operative Specialist uniforms.
```
