### PR TITLE
Adds the "atheist" trait

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -1017,3 +1017,10 @@ obj/trait/pilot
 	points = 1
 	isPositive = 0
 
+/obj/trait/atheist
+	name = "Atheist (0)"
+	cleanName="Atheist"
+	desc = "In this moment, you are euphoric. Cannot pray, cannot receive help from chaplains, perhaps some other things..."
+	id = "atheist"
+	points = 0
+	isPositive = 0

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -1020,7 +1020,7 @@ obj/trait/pilot
 /obj/trait/atheist
 	name = "Atheist (0)"
 	cleanName = "Atheist"
-	desc = "In this moment, you are euphoric. Cannot pray, cannot receive help from chaplains, perhaps some other things..."
+	desc = "In this moment, you are euphoric. You cannot receive faith healing, and prayer makes you feel silly."
 	id = "atheist"
 	points = 0
 	isPositive = 0

--- a/code/modules/admin/adminhelp.dm
+++ b/code/modules/admin/adminhelp.dm
@@ -148,11 +148,6 @@
 		gib(client.mob)
 		return
 
-	if (client.mob.traitHolder?.hasTrait("atheist"))
-		boutput(client.mob, "You can't pray to what you don't believe in.")
-		client.mob.take_oxygen_deprivation(10)
-		return
-
 	if(ON_COOLDOWN(client.player, "ahelp", ADMINHELP_DELAY))
 		boutput(src, "You must wait [time_to_text(ON_COOLDOWN(src, "ahelp", 0))].")
 		return
@@ -168,7 +163,11 @@
 	if (client.mob.mind)
 		src.add_karma(-1)
 
-	boutput(client.mob, "<B>You whisper a silent prayer,</B> <I>\"[msg]\"</I>")
+	if (client.mob.traitHolder?.hasTrait("atheist"))
+		boutput(client.mob, "You feel ridiculous doing it, but manage to get through a silent prayer,</B> <I>\"[msg]\"</I>")
+		client.mob.take_oxygen_deprivation(10)
+	else
+		boutput(client.mob, "<B>You whisper a silent prayer,</B> <I>\"[msg]\"</I>")
 	logTheThing("admin_help", client.mob, null, "PRAYER: [msg]")
 	logTheThing("diary", client.mob, null, "PRAYER: [msg]", "ahelp")
 	var/audio

--- a/code/modules/admin/adminhelp.dm
+++ b/code/modules/admin/adminhelp.dm
@@ -148,6 +148,11 @@
 		gib(client.mob)
 		return
 
+	if (client.mob.traitHolder?.hasTrait("atheist"))
+		boutput(client.mob, "You can't pray to what you don't believe in.")
+		client.mob.take_oxygen_deprivation(10)
+		return
+
 	if(ON_COOLDOWN(client.player, "ahelp", ADMINHELP_DELAY))
 		boutput(src, "You must wait [time_to_text(ON_COOLDOWN(src, "ahelp", 0))].")
 		return

--- a/code/modules/admin/adminhelp.dm
+++ b/code/modules/admin/adminhelp.dm
@@ -166,10 +166,12 @@
 	if (client.mob.traitHolder?.hasTrait("atheist"))
 		boutput(client.mob, "You feel ridiculous doing it, but manage to get through a silent prayer,</B> <I>\"[msg]\"</I>")
 		client.mob.take_oxygen_deprivation(10)
+		logTheThing("admin_help", client.mob, null, "PRAYER (atheist): [msg]")
+		logTheThing("diary", client.mob, null, "PRAYER (atheist): [msg]", "ahelp")
 	else
 		boutput(client.mob, "<B>You whisper a silent prayer,</B> <I>\"[msg]\"</I>")
-	logTheThing("admin_help", client.mob, null, "PRAYER: [msg]")
-	logTheThing("diary", client.mob, null, "PRAYER: [msg]", "ahelp")
+		logTheThing("admin_help", client.mob, null, "PRAYER: [msg]")
+		logTheThing("diary", client.mob, null, "PRAYER: [msg]", "ahelp")
 	var/audio
 
 	for (var/client/C)

--- a/code/modules/chemistry/Reagents-Base.dm
+++ b/code/modules/chemistry/Reagents-Base.dm
@@ -825,8 +825,11 @@ datum
 						M.change_vampire_blood(-burndmg)
 						reacted = 1
 					else if (method == TOUCH)
-						boutput(M, "<span class='notice'>You feel somewhat purified... but mostly just wet.</span>")
-						M.take_brain_damage(-10)
+						if (M?.traitHolder?.hasTrait("atheist"))
+							boutput(M, "<span class='notice'>You feel insulted... and wet.</span>")
+						else
+							boutput(M, "<span class='notice'>You feel somewhat purified... but mostly just wet.</span>")
+							M.take_brain_damage(-10)
 						for (var/datum/ailment_data/disease/V in M.ailments)
 							if(prob(1))
 								M.cure_disease(V)

--- a/code/obj/item/storage/bible.dm
+++ b/code/obj/item/storage/bible.dm
@@ -83,7 +83,7 @@ var/global/list/bible_contents = list()
 		else if (!isdead(M))
 			var/mob/H = M
 			// ******* Check
-			if ((ishuman(H) && prob(60)))
+			if ((ishuman(H) && prob(60) && !(M?.traitHolder?.hasTrait("atheist"))))
 				bless(M)
 				M.visible_message("<span class='alert'><B>[user] heals [M] with the power of Christ!</B></span>")
 				boutput(M, "<span class='alert'>May the power of Christ compel you to be healed!</span>")
@@ -94,7 +94,10 @@ var/global/list/bible_contents = list()
 				logTheThing("combat", user, M, "biblically healed [constructTarget(M,"combat")]")
 			else
 				if (ishuman(M) && !istype(M:head, /obj/item/clothing/head/helmet))
-					M.take_brain_damage(10)
+					if (M?.traitHolder?.hasTrait("atheist"))
+						M.take_brain_damage(5)
+					else
+						M.take_brain_damage(10)
 					boutput(M, "<span class='alert'>You feel dazed from the blow to the head.</span>")
 				logTheThing("combat", user, M, "biblically injured [constructTarget(M,"combat")]")
 				M.visible_message("<span class='alert'><B>[user] beats [M] over the head with [src]!</B></span>")
@@ -161,9 +164,13 @@ var/global/list/bible_contents = list()
 			user.visible_message("<span class='alert'>[user] farts on the bible.<br><b>The gods seem to approve.</b></span>")
 			return 0
 
-		user.visible_message("<span class='alert'>[user] farts on the bible.<br><b>A mysterious force smites [user]!</b></span>")
-		user.gib()
-		return 0
+		if (user?.traitHolder?.hasTrait("atheist"))
+			user.visible_message("<span class='alert'>[user] farts on the bible with particular vindication.<br><b>Against all odds, [user] remains unharmed!</b></span>")
+			return
+		else
+			user.visible_message("<span class='alert'>[user] farts on the bible.<br><b>A mysterious force smites [user]!</b></span>")
+			user.gib()
+			return 0
 
 /obj/item/storage/bible/evil
 	name = "frayed bible"

--- a/code/obj/item/storage/bible.dm
+++ b/code/obj/item/storage/bible.dm
@@ -166,7 +166,7 @@ var/global/list/bible_contents = list()
 
 		if (user?.traitHolder?.hasTrait("atheist"))
 			user.visible_message("<span class='alert'>[user] farts on the bible with particular vindication.<br><b>Against all odds, [user] remains unharmed!</b></span>")
-			return
+			return 0
 		else
 			user.visible_message("<span class='alert'>[user] farts on the bible.<br><b>A mysterious force smites [user]!</b></span>")
 			user.gib()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a new trait, "atheist", that affects how you interact with prayer and chaplains. Namely:

- Prayer yields nonthreatening oxygen damage.
- Bible-based healing automatically fails, but the brain damage from this failure is halved for fairness.
- Holy water-based brain damage healing fails as well.
- Player cannot biblefart.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

It's funny and flavorful.

## Changelog

```
(u)monochromatism
(+) Added the "atheist" trait. Disables faith healing and has interesting flavor text about prayer, but might have an upside...
```