### PR TITLE
Chainable flips

### DIFF
--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -1608,6 +1608,9 @@
 									continue
 								if (!G.affecting) //Wire note: Fix for Cannot read null.loc
 									continue
+								if (src.a_intent == INTENT_HELP)
+									M.emote("flip", 1) // make it voluntary so there's a cooldown and stuff
+									continue
 								flipped_a_guy = 1
 								if (G.state >= 1 && isturf(src.loc) && isturf(G.affecting.loc))
 									var/obj/table/tabl = locate() in src.loc.contents


### PR DESCRIPTION
[ENHANCEMENT]

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Flipping with a grab (any grab; ignore my commit message about upgraded grabs) in hand while on help intent will cause both you and your grabee to flip (as opposed to you flipping over them with regular grabs and you suplexing them with upgraded grabs). If your grabee is also on help intent and has grabs of people, those people will also flip. And so on.

See an example [here](https://i.imgur.com/AGhK29T.gif). The solo flips in-between are due to admin lack-of-cooldown; the other mobs aren't flipping because their cooldowns are still in effect. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Mbc suggested it and it's a cool idea.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Flourish:
(*)If you flip with a grab on help intent, your grabee will flip with you. And if they also have a grab and are on help intent, their grabee will also flip. And so on. 
```
