### PR TITLE
Enzymatic Reclaimer: Eject the meats!

### DIFF
--- a/code/obj/machinery/clonepod.dm
+++ b/code/obj/machinery/clonepod.dm
@@ -811,9 +811,9 @@
 	verb/eject()
 		set src in oview(1)
 		set category = "Local"
-
 		if (!isalive(usr)) return
 		if (src.process_timer > 0) return
+		src.eject_meats()
 		src.go_out()
 		add_fingerprint(usr)
 		return
@@ -821,6 +821,11 @@
 	relaymove(mob/user as mob)
 		src.go_out()
 		return
+
+	proc/eject_meats()
+		for (var/obj/item/meat in src.meats)
+			meat.set_loc(src.loc)
+		src.meats = list()
 
 	proc/go_out()
 		if (!src.occupant)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feat]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Previously, if you put meats into the enzymatic reclaimer, you couldn't eject them. This is bad! I accidentally put a brain in and couldn't get it out, so that person could not be borged nor have their brain placed into another corpse for cloning. I fixed this. You can eject meats now.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

You should be able to eject meat from the reclaimer.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

 ```
 (u)Jawns:
 (+)Enzymatic reclaimer now ejects meats, organs, and various limbs.
 ```
