### PR TITLE
elecflash TakeDamage runetime fix

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -992,7 +992,7 @@
 	return
 
 // for mobs without organs
-/mob/proc/TakeDamage(zone, brute, burn, tox, damage_type)
+/mob/proc/TakeDamage(zone, brute, burn, tox, damage_type, disallow_limb_loss)
 	hit_twitch(src)
 #if ASS_JAM//pausing damage for timestop
 	if(src.paused)

--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -721,7 +721,7 @@
 			return healthlist[assoc]
 		return null
 
-	TakeDamage(zone, brute, burn)
+	TakeDamage(zone, brute, burn, tox, damage_type, disallow_limb_loss)
 		hit_twitch(src)
 		if (nodamage)
 			return

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -466,7 +466,7 @@
 		src.harmedBy(M)
 
 // also maybe we've just had environmental damage, who knows
-/mob/living/critter/flock/drone/TakeDamage(zone, brute, burn)
+/mob/living/critter/flock/drone/TakeDamage(zone, brute, burn, tox, damage_type, disallow_limb_loss)
 	..()
 	var/prev_damaged = src.damaged
 	src.check_health()

--- a/code/mob/living/critter/misc.dm
+++ b/code/mob/living/critter/misc.dm
@@ -31,7 +31,7 @@
 
 		qdel(src)
 
-	TakeDamage(zone, brute, burn, no_brute_mult = 0, no_burn_mult = 0) // last two args used to ignore the health multipliers so that these things can still take damage from stun weapons
+	TakeDamage(zone, brute, burn, tox, damage_type, disallow_limb_loss, no_brute_mult = 0, no_burn_mult = 0) // last two args used to ignore the health multipliers so that these things can still take damage from stun weapons
 		hit_twitch(src)
 		if (nodamage)
 			return
@@ -57,7 +57,7 @@
 					user.visible_message("<span class='combat'><b>[user] shocks [src] with [B]!</b></span>", "<span class='combat'><b>While your baton passes through, [src] appears damaged!</b></span>")
 					B.process_charges(-1, user)
 
-					src.TakeDamage(null, 4, 4, 1, 1)
+					src.TakeDamage(null, 4, 4, no_brute_mult = 1, no_burn_mult = 1)
 					return
 
 			boutput(user, "<span class='combat'><b>[W] passes right through!</b></span>")
@@ -68,6 +68,6 @@
 		damage = round((P.power*(1-P.proj_data.ks_ratio)), 1.0)
 
 		if (P.proj_data.damage_type == D_ENERGY)
-			src.TakeDamage(null, damage, damage, 1, 1)
+			src.TakeDamage(null, damage, damage, no_brute_mult = 1, no_burn_mult = 1)
 		else
 			return

--- a/code/mob/living/object.dm
+++ b/code/mob/living/object.dm
@@ -178,7 +178,7 @@
 			user.visible_message("<span class='alert'>[user] punches [src]!</span>")
 			src.TakeDamage(null, rand(4, 7), 0)
 
-	TakeDamage(zone, brute, burn)
+	TakeDamage(zone, brute, burn, tox, damage_type, disallow_limb_loss)
 		health -= burn
 		health -= brute
 		health = min(max_health, health)

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -125,7 +125,7 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 	del(churn)
 	canmove = 1
 
-/mob/living/silicon/ai/TakeDamage(zone, brute, burn)
+/mob/living/silicon/ai/TakeDamage(zone, brute, burn, tox, damage_type, disallow_limb_loss)
 	bruteloss += brute
 	fireloss += burn
 	health_update_queue |= src

--- a/code/mob/living/silicon/ghostdrone.dm
+++ b/code/mob/living/silicon/ghostdrone.dm
@@ -192,7 +192,7 @@
 		if (before == 2 && src.stat < 2) //if we were dead, and now arent
 			src.updateSprite()
 
-	TakeDamage(zone, brute, burn)
+	TakeDamage(zone, brute, burn, tox, damage_type, disallow_limb_loss)
 		if (src.nodamage) return //godmode
 		src.health -= max(burn, brute)
 		if (!isdead(src) && src.health <= 0) //u ded

--- a/code/mob/living/silicon/hivebot.dm
+++ b/code/mob/living/silicon/hivebot.dm
@@ -32,7 +32,7 @@
 
 	var/obj/machinery/camera/camera = null
 
-/mob/living/silicon/hivebot/TakeDamage(zone, brute, burn)
+/mob/living/silicon/hivebot/TakeDamage(zone, brute, burn, tox, damage_type, disallow_limb_loss)
 	bruteloss += brute
 	fireloss += burn
 	health_update_queue |= src

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -2635,7 +2635,7 @@
 		hud.set_active_tool(null)
 		src.update_appearance()
 
-	TakeDamage(zone, brute, burn)
+	TakeDamage(zone, brute, burn, tox, damage_type, disallow_limb_loss)
 		brute = max(brute, 0)
 		burn = max(burn, 0)
 		if (burn == 0 && brute == 0)

--- a/code/mob/wraith.dm
+++ b/code/mob/wraith.dm
@@ -217,7 +217,7 @@
 			src.visible_message("<span class='alert'>[src] is hit by the [P]!</span>")
 
 
-	TakeDamage(zone, brute, burn)
+	TakeDamage(zone, brute, burn, tox, damage_type, disallow_limb_loss)
 		if (!src.density)
 			return
 		health -= burn


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [BUG][RUNTIME] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
-Adds the complete arg list to all overrides of `TakeDamage`


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
-electflash.dm uses a named arg to pass a value for `damage_type`. When this in turn calls the various overrides of TakeDamage they runtime if they can not handle the `damage_type` argument

File | null
-- | --
Line | null
Error | bad arg name 'damage_type'

```
proc name: TakeDamage (/mob/living/critter/TakeDamage)
  usr: (src)
  src: the space pig (/mob/living/critter/small_animal/pig)
  src.loc: the steel floor (203,176,1) (/turf/simulated/floor)
  call stack:
the space pig (/mob/living/critter/small_animal/pig): TakeDamage("chest", 0, 0, null)
the space pig (/mob/living/critter/small_animal/pig): electric expose(3)
the steel floor (203,176,1) (/turf/simulated/floor): hotspot expose(1000, 100, the space pig (/mob/living/critter/small_animal/pig), 3)
elecflash(the water (/obj/fluid), 0, 3, 1)
arcFlash(the space pig (/mob/living/critter/small_animal/pig), the water (/obj/fluid), 5000)
Arc Flash (/datum/buildmode/arcflash): click left(the water (/obj/fluid), 0, 0, 0)
/datum/buildmode_holder (/datum/buildmode_holder): build click(the water (/obj/fluid), the steel floor (204,178,1) (/turf/simulated/floor/neutral/side), "mapwindow.map", /list (/list))
Sovexe (/client): Click(the water (/obj/fluid), the steel floor (204,178,1) (/turf/simulated/floor/neutral/side), "mapwindow.map", "icon-x=23;icon-y=18;left=1;scr...")
```