### PR TITLE
Fixes the heaterpad icon state between 231 - 249

### DIFF
--- a/code/modules/networks/computer3/mainframe2/misc_terms.dm
+++ b/code/modules/networks/computer3/mainframe2/misc_terms.dm
@@ -4417,7 +4417,7 @@
 				heat_overlay.icon_state = "heat-1"
 			if (250 to 269)
 				heat_overlay.icon_state = "heat-2"
-			if (230 to -99)
+			if (249 to -99)
 				heat_overlay.icon_state = "heat-3"
 			else
 				heat_overlay.icon_state = ""


### PR DESCRIPTION
[FIX] [MINOR]
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #2120

Removes gap between the temperatures 231 - 249 by increasing 230 to 249

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes broken icon state

