### PR TITLE
HoS Cape Rebalancing/Availability Changes

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -253,7 +253,7 @@
 
 #ifdef SUBMARINE_MAP
 	slot_jump = /obj/item/clothing/under/rank/head_of_securityold/fancy_alt
-	slot_suit = /obj/item/clothing/suit/armor/hoscape
+	slot_suit = /obj/item/clothing/suit/armor/vest
 	slot_back = /obj/item/storage/backpack/withO2
 	slot_belt = /obj/item/device/pda2/hos
 	slot_poc1 = /obj/item/requisition_token/security

--- a/code/obj/item/clothing/armor.dm
+++ b/code/obj/item/clothing/armor.dm
@@ -395,12 +395,13 @@
 		setProperty("exploprot", 60)
 
 /obj/item/clothing/suit/armor/hoscape
-	name = "head of securitys cape"
-	desc = "A rather dashing cape."
+	name = "Head of Security's cape"
+	desc = "A lightly-armored and stylish cape, made of heat-resistant materials. It probably won't keep you warm, but it would make a great security blanket!"
 	icon_state = "hos-cape"
 	item_state = "hos-cape"
-
 	setupProperties()
 		..()
-		setProperty("meleeprot", 7)
-		setProperty("rangedprot", 1.5)
+		setProperty("meleeprot", 3)
+		setProperty("rangedprot", 0.7)
+		setProperty("coldprot", 5)
+		setProperty("heatprot", 35)

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -338,7 +338,7 @@
 		setProperty("rangedprot", 0.5)
 
 /obj/item/clothing/suit/det_suit/hos
-	name = "HoS jacket"
+	name = "Head of Security's jacket"
 	desc = "A slightly armored jacket favored by security personnel. It looks cozy and warm; you could probably sleep in this if you wanted to!"
 	icon = 'icons/obj/clothing/overcoats/item_suit_armor.dmi'
 	wear_image_icon = 'icons/mob/overcoats/worn_suit_armor.dmi'

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -58,6 +58,7 @@
 	/obj/item/device/flash,
 	/obj/item/storage/box/clothing/hos,
 	/obj/item/clothing/suit/det_suit/hos,
+	/obj/item/clothing/suit/armor/hoscape,
 	/obj/item/clothing/shoes/brown,
 	/obj/item/clothing/suit/armor/vest,
 	/obj/item/clothing/head/helmet/hardhat/security,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE] [INPUT WANTED]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Basically, the HoS cape is overpowered and kind of in a weird spot. Currently the HoS spawns with it on submarine maps, but it's effectively Captain armor with a different sprite. This is a really powerful thing to have as a spawn item and completely throws any other clothing item that the HoS has out the window in terms of viability! My PR here turns it into a sidegrade of the HoS' Jacket instead, where the jacket has cold resistance, the cape has heat resistance properties due to the fabric it's made from. The description has been updated to reflect this. 
The cape has been placed next to the jacket in the HoS' locker on ALL maps, so you can flaunt your style anywhere. It was also removed as a spawn item, and I corrected a few weird naming conventions with both the jacket and the cape.

![Cape](https://user-images.githubusercontent.com/68257280/92553053-0d142f00-f230-11ea-8008-da70e8d57643.png)
![Jacket](https://user-images.githubusercontent.com/68257280/92553056-0eddf280-f230-11ea-9acf-c1182b946c83.png)
![Locker](https://user-images.githubusercontent.com/68257280/92553060-10a7b600-f230-11ea-95e0-3585244c22e9.png)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Personally I feel like the cape being the equivalent to a full suit of armor is really silly. It's a cape, a whispy and lightweight thing that flows beautifully in the cool breeze from the air ducts! Balancing issues aside, nowadays it's super easy for the HoS to walk into the armory and get full riot gear now if they really want that kind of armor. Having it an exclusive to the submarine maps is really odd too, considering all the other clothing options have been in the HoS' clothing box in their locker for ages. 
It being comparable to the jacket yet slightly different allows it to be somewhat more interesting in terms of a situational choice too, would you rather wear the jacket to protect against potential hull breaches? Or should you wear the cape since the CE going insane and superheating the station?

Any comments from current HoS players would be welcome, for or against these changes! Kyle mentioned on discord that the cape shouldn't have that much armor, so I figured this would be an interesting way to make it more available and less overpowered.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)makkipakki:
(*)Added the HoS' Cape to their locker on all maps! Comes with a rebalancing to make it a sidegrade to the HoS' Jacket.
(+)HoS no longer spawns with the Cape on submarine maps.
(+)Changes to both the HoS Jacket and Cape names and descriptions.
```
