### PR TITLE
Fix: ChemiCompiler Dumping Double

### DIFF
--- a/code/modules/chemistry/Chemistry-Holder.dm
+++ b/code/modules/chemistry/Chemistry-Holder.dm
@@ -274,7 +274,7 @@ datum
 
 			if (do_fluid_react && issimulatedturf(target))
 				var/turf/simulated/T = target
-				T.fluid_react(src, amount)
+				return T.fluid_react(src, amount)
 
 			return trans_to_direct(target_reagents, amount, multiplier, index = index)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
ChemiCompiler no longer transfers double the intended amount when dumping.

This bug has existed since pre-open source! - Therefore I'm making a changelog, in-case others have factored it into their CC-codes.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #2000

Tested regular transfer and dumping - both worked.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)MarkNstein:
(*)ChemiCompiler no longer transfers double the intended amount when dumping.
```
[CRITICAL]