### PR TITLE
make pipes nosplash during pipebomb construction

### DIFF
--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -1202,7 +1202,7 @@ PIPE BOMBS + CONSTRUCTION
 			else
 				name = "pipe bomb frame"
 
-			desc = "Two small pipes joined together, filled with welding fuel and connected with a cable. It needs some kind of ignition switch."
+			desc = "Two small pipes joined together, filled with explosives and connected with a cable. It needs some kind of ignition switch."
 			src.flags &= ~NOSPLASH
 
 		if(istype(W, /obj/item/assembly/time_ignite) && state == 4)

--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -1145,6 +1145,7 @@ PIPE BOMBS + CONSTRUCTION
 				name = "hollow [src.material.name] pipe frame"
 			else
 				name = "hollow pipe frame"
+			src.flags |= NOSPLASH
 
 		if (allowed_items.len && item_mods.len < 3 && state == 2)
 			var/ok = 0
@@ -1202,6 +1203,7 @@ PIPE BOMBS + CONSTRUCTION
 				name = "pipe bomb frame"
 
 			desc = "Two small pipes joined together, filled with welding fuel and connected with a cable. It needs some kind of ignition switch."
+			src.flags &= ~NOSPLASH
 
 		if(istype(W, /obj/item/assembly/time_ignite) && state == 4)
 			boutput(user, "<span class='notice'>You connect the cable to the timer/igniter assembly.</span>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Have you ever constructed a pipebomb?
Have you ever splashed the contents of an entire fuel tank onto a pipe frame even though only 20 units were necessary?

If you have answered yes to question 1 but not question 2, you are a liar.

This adds the NOSPLASH flag to pipe frames after the hollowing out step, so that chems can be filled into the pipe without splashing the rest of the reagent container contents onto the pipe frame.
The flag is removed at a later stage. (This was initially in case so pipe bombs could be melted with acid or whatever, but pipe bombs are a different item entirely, so it's really just because why not.)
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Because splashing all the stuff onto pipe frames was real annoying and also a waste of fuel if you wanted to make several pipe bombs.
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u) zjdtmkhzt:
(+) Filling a pipe with chems during pipebomb construction will no longer splash the rest of the chems onto it.
```
