### PR TITLE
matches now need to be lit to turn on stove

### DIFF
--- a/code/obj/soup_pot.dm
+++ b/code/obj/soup_pot.dm
@@ -93,6 +93,8 @@
 				return
 
 			else if ((istype(W, /obj/item/match) || istype(W, /obj/item/device/light/candle)) && W:on)
+				if (W:on <= 0)
+					return
 				src.light(user, "<span class='alert'><b>[user] lights [src] with [W].</span>")
 				return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Matches need to be lit now in order to light the stove
closes #2046 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Kinda unrealistic

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Michaellaneous:
(+)Check if match is lit .
```
