### PR TITLE
add 0.1s cooldown to toggling rest

### DIFF
--- a/_std/defines/mob.dm
+++ b/_std/defines/mob.dm
@@ -40,3 +40,6 @@
 #define HEARING_NORMAL 0
 #define HEARING_BLOCKED 1
 #define HEARING_ANTIDEAF -1 //what the fuck is an anti deaf
+
+//cooldowns
+#define REST_TOGGLE_COOLDOWN 0.1 SECONDS

--- a/code/datums/hud/critter.dm
+++ b/code/datums/hud/critter.dm
@@ -209,6 +209,7 @@
 				if ("health")
 					boutput(master, "<span class='notice'>Your health: [master.health]/[master.max_health]</span>")
 				if ("rest")
+					if(ON_COOLDOWN(src.master, "toggle_rest", REST_TOGGLE_COOLDOWN)) return
 					if(master.ai_active && !master.hasStatus("resting"))
 						master.show_text("You feel too restless to do that!", "red")
 					else

--- a/code/datums/hud/human.dm
+++ b/code/datums/hud/human.dm
@@ -434,6 +434,7 @@
 				src.update_pulling()
 
 			if ("rest")
+				if(ON_COOLDOWN(src.master, "toggle_rest", REST_TOGGLE_COOLDOWN)) return
 				if(master.ai_active && !master.hasStatus("resting"))
 					master.show_text("You feel too restless to do that!", "red")
 				else

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -894,6 +894,7 @@
 			out(src, "You are now [src.m_intent == "walk" ? "walking" : "running"].")
 			hud.update_mintent()
 		if ("rest")
+			if(ON_COOLDOWN(src, "toggle_rest", REST_TOGGLE_COOLDOWN)) return
 			if(src.ai_active && !src.hasStatus("resting"))
 				src.show_text("You feel too restless to do that!", "red")
 			else

--- a/code/modules/status_system/statusSystem.dm
+++ b/code/modules/status_system/statusSystem.dm
@@ -1170,6 +1170,7 @@ var/list/statusGroupLimits = list("Food"=4)
 				owner.delStatus("resting")
 
 		clicked(list/params)
+			if(ON_COOLDOWN(src.owner, "toggle_rest", REST_TOGGLE_COOLDOWN)) return
 			L.delStatus("resting")
 			L.force_laydown_standup()
 			if (ishuman(L))

--- a/code/world.dm
+++ b/code/world.dm
@@ -1143,6 +1143,7 @@ var/f_color_selector_handler/F_Color_Selector
 							return 1
 
 						if("rest")
+							if(ON_COOLDOWN(twitch_mob, "toggle_rest", REST_TOGGLE_COOLDOWN)) return
 							if (ishuman(twitch_mob))
 								var/mob/living/carbon/human/H = twitch_mob
 								H.setStatus("resting", INFINITE_STATUS)
@@ -1151,6 +1152,7 @@ var/f_color_selector_handler/F_Color_Selector
 							return 1
 
 						if("stand")
+							if(ON_COOLDOWN(twitch_mob, "toggle_rest", REST_TOGGLE_COOLDOWN)) return
 							if (ishuman(twitch_mob))
 								var/mob/living/carbon/human/H = twitch_mob
 								H.delStatus("resting")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a (configurable) 0.1 second cooldown to manually toggling resting status


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Resting makes a sound effect etc. This limits the ability to spam it arbitrarily quickly without impacting gameplay much (taser prone-dodging should still be quite possible)


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Tarmunora:
(+)Added very short cooldown to toggling rest state.
```
