### PR TITLE
Added medal for loot crate trap trigger

### DIFF
--- a/code/obj/storage/loot_crates.dm
+++ b/code/obj/storage/loot_crates.dm
@@ -599,6 +599,7 @@
 		if (opener)
 			random_brute_damage(opener,damage,1)
 			playsound(opener.loc, "sound/impact_sounds/Flesh_Stab_1.ogg", 60, 1)
+			opener.unlock_medal("This object menaces with spikes of...", 1)
 		return
 
 /datum/loot_crate_trap/zap


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Another repurposed objective medal. "This object menaces with spikes of..." used to be awarded for the miner objective "Collect 10 gems". When that objective was removed the medal became unachievable. This PR makes it so triggering a spike trap on a loot crate awards the medal.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

All medals should be achievable! And while people other than miners run into loot crates, miners get them all the time. So now miners can earn their medal again, and so can other people who screw up opening booby trapped loot crates.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->
<!--
```
(u)CodeDude:
(*)Added soft soft pizza to the game - a tasty drink found in soda machines!
(+)Made some small sprite changes to the base pizza sprite.
```
-->
N/A
