### PR TITLE
fix critters being unable to throw people

### DIFF
--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -354,8 +354,6 @@
 		if (!I || !isitem(I) || I.cant_drop)
 			return
 
-		u_equip(I)
-
 		if (istype(I, /obj/item/grab))
 			var/obj/item/grab/G = I
 			I = G.handle_throw(src,target)
@@ -364,6 +362,8 @@
 			if (!I) return
 
 		I.set_loc(src.loc)
+
+		u_equip(I)
 
 		if (isitem(I))
 			I.dropped(src) // let it know it's been dropped
@@ -651,8 +651,8 @@
 				clothing = 1
 		if (clothing)
 			update_clothing()
-
-		I.dropped(src)
+		if(isitem(I))
+			I.dropped(src)
 
 	put_in_hand(obj/item/I, t_hand)
 		if (!hands.len)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Critters are unable to throw people, because the grab is uneqipped for them before the throw is handled, making it so that the throw no longer has the target saved.
This PR fixes that by moving the u_equip proc lower, as Tarmunora has already done for humans in #1125 .

Since ´handle_throw returns the thrown person and we then try to unequip them for whatever god forsaken reason I added a check to critter's u_equip proc whether or not the item parameter we get is actually an item.
Because if it is not, throwing people tried to call their drop proc, which they did not have.

Maybe this whole area for critters could use a bit of a refactor? Anyway, this fixes the thing where critters can't throw people and it should not cause any issues.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Critters are scary and big and strong and should be able to toss humans to their doom.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u) zjdtmkhzt
(+) Fixed a bug where critters were unable to throw people.
```
