### PR TITLE
Removed Duplicate Intercoms

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -40886,12 +40886,6 @@
 	broadcasting = 0;
 	dir = 4
 	},
-/obj/item/device/radio/intercom/bridge{
-	dir = 4
-	},
-/obj/item/device/radio/intercom/bridge{
-	dir = 4
-	},
 /turf/simulated/floor/carpet{
 	dir = 10;
 	icon_state = "fblue2"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR 
Removes two duplicated intercoms from the CEs office on Clarion.



## Why's this needed? 
Having three intercoms in total is annyoing.



