### PR TITLE
Oshan PTL hotfix

### DIFF
--- a/code/modules/power/pt_laser.dm
+++ b/code/modules/power/pt_laser.dm
@@ -280,7 +280,8 @@
 
 	for(var/dist = 0, dist < range, dist += 1)
 		T = get_step(T, dir)
-		if(!T || T.density) return dist
+		if(!T || T.density) 
+			if(!istype(T, /turf/unsimulated/wall/trench)) return dist
 		for(var/obj/O in T)
 			if(!istype(O,/obj/window) && !istype(O,/obj/grille) && !ismob(O) && O.density)
 				blocking_objects += O


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a check to allow the PTL beam to pass through the unsimulated trench wall that surrounds Oshan.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #1135 
Longstanding bug that has yet to receive a more elegant fix.

Tested.
![dreamseeker_XEXcExcKIi](https://user-images.githubusercontent.com/9563541/92701768-3e126380-f305-11ea-8a45-6c17b2884a95.png)


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)MarkNstein:
(*)Oshan PTL now works.
```
[BUG]