### PR TITLE
Powerstart announce fix

### DIFF
--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -250,11 +250,11 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 		participationRecorder.releaseHold()
 
 	SPAWN_DBG (6000) // 10 minutes in
-		for(var/obj/machinery/power/generatorTemp/E in machine_registry[MACHINES_POWER])
-			LAGCHECK(LAG_LOW)
-			if (E.lastgen <= 0)
-				command_alert("Reports indicate that the engine on-board [station_name()] has not yet been started. Setting up the engine is strongly recommended, or else stationwide power failures may occur.", "Power Grid Warning")
-			break
+	for(var/obj/machinery/power/monitor/smes/E in machine_registry[MACHINES_POWER])
+		LAGCHECK(LAG_LOW)
+		if(E.powernet?.avail <= 0)
+			command_alert("Reports indicate that the engine on-board [station_name()] has not yet been started. Setting up the engine is strongly recommended, or else stationwide power failures may occur.", "Power Grid Warning")
+		break
 
 	processScheduler.start()
 

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -250,11 +250,11 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 		participationRecorder.releaseHold()
 
 	SPAWN_DBG (6000) // 10 minutes in
-	for(var/obj/machinery/power/monitor/smes/E in machine_registry[MACHINES_POWER])
-		LAGCHECK(LAG_LOW)
-		if(E.powernet?.avail <= 0)
-			command_alert("Reports indicate that the engine on-board [station_name()] has not yet been started. Setting up the engine is strongly recommended, or else stationwide power failures may occur.", "Power Grid Warning")
-		break
+		for(var/obj/machinery/power/monitor/smes/E in machine_registry[MACHINES_POWER])
+			LAGCHECK(LAG_LOW)
+			if(E.powernet?.avail <= 0)
+				command_alert("Reports indicate that the engine on-board [station_name()] has not yet been started. Setting up the engine is strongly recommended, or else stationwide power failures may occur.", "Power Grid Warning")
+			break
 
 	processScheduler.start()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes the engine hasn't been started up announcement.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

So players don't get told the engine hasn't been started when it has.

closes #1828 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)ThePotato97:
(*)Centcomm's power announcement is no longer hardcoded to the TEG and will work on any map.
```
