### PR TITLE
Make sure personal security note is not overwritten by jailbird note and notify the player of the crimes they've committed

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -143,6 +143,10 @@
 		boutput(H, "<span class='notice'>You are currently on the run because you've committed the following crimes:</span>")
 		boutput(H, "<span class='notice'>- [S.fields["mi_crim"]]</span>")
 		boutput(H, "<span class='notice'>- [S.fields["ma_crim"]]</span>")
+
+		H.mind.store_memory("You've committed the following crimes before arriving on the station:")
+		H.mind.store_memory("- [S.fields["mi_crim"]]")
+		H.mind.store_memory("- [S.fields["ma_crim"]]")
 	else
 		S.fields["criminal"] = "None"
 		S.fields["mi_crim"] = "None"

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -93,6 +93,11 @@
 
 	M.fields["traits"] = traitStr
 
+	if(!length(sec_note))
+		S.fields["notes"] = "No notes."
+	else
+		S.fields["notes"] = sec_note
+
 	if(H.traitHolder.hasTrait("jailbird"))
 		S.fields["criminal"] = "*Arrest*"
 		S.fields["mi_crim"] = pick(\
@@ -135,10 +140,12 @@
 								"Throwing explosive tomatoes at people.",\
 								"Caused multiple seemingly unrelated accidents.")
 		S.fields["ma_crim_d"] = "No details provided."
-		if(!length(sec_note))
-			S.fields["notes"] = pick("Huge nerd.", "Total jerkface.", "Absolute dingus.", "Insanely endearing.", "Worse than clown.", "Massive crapstain.");
+
+		var/randomNote = pick("Huge nerd.", "Total jerkface.", "Absolute dingus.", "Insanely endearing.", "Worse than clown.", "Massive crapstain.");
+		if(S.fields["notes"] == "No notes.")
+			S.fields["notes"] = randomNote
 		else
-			S.fields["notes"] = sec_note
+			S.fields["notes"] += " [randomNote]"
 
 		boutput(H, "<span class='notice'>You are currently on the run because you've committed the following crimes:</span>")
 		boutput(H, "<span class='notice'>- [S.fields["mi_crim"]]</span>")
@@ -154,10 +161,6 @@
 		S.fields["ma_crim"] = "None"
 		S.fields["ma_crim_d"] = "No major crime convictions."
 
-		if(!length(sec_note))
-			S.fields["notes"] = "No notes."
-		else
-			S.fields["notes"] = sec_note
 
 	B.fields["job"] = H.job
 	B.fields["current_money"] = 100.0

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -135,7 +135,14 @@
 								"Throwing explosive tomatoes at people.",\
 								"Caused multiple seemingly unrelated accidents.")
 		S.fields["ma_crim_d"] = "No details provided."
-		S.fields["notes"] = pick("Huge nerd.", "Total jerkface.", "Absolute dingus.", "Insanely endearing.", "Worse than clown.", "Massive crapstain.");
+		if(!length(sec_note))
+			S.fields["notes"] = pick("Huge nerd.", "Total jerkface.", "Absolute dingus.", "Insanely endearing.", "Worse than clown.", "Massive crapstain.");
+		else
+			S.fields["notes"] = sec_note
+
+		boutput(H, "<span class='notice'>You are currently on the run because you've committed the following crimes:</span>")
+		boutput(H, "<span class='notice'>- [S.fields["mi_crim"]]</span>")
+		boutput(H, "<span class='notice'>- [S.fields["ma_crim"]]</span>")
 	else
 		S.fields["criminal"] = "None"
 		S.fields["mi_crim"] = "None"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Makes sure that there is no random security note added when you have jailbird and you have a personal security note.

After setting the crimes, it notifies the player of the given crimes.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

A personal note is often added to add a personal story to the character you're playing, so overwriting it would make it useless.

Arriving at the station not knowing what kind of crimes you've committed is kinda dumb since this is information you should know about yourself, so it now shows it like your pin id in the chat.

Fixes #2145 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Luxizzle:
(+)Jailbird no longer overwrites personal security note.
(+)Jailbird now informs you of what crimes you've committed.
```
