### PR TITLE
Non-lethal ling sting on RP mode

### DIFF
--- a/browserassets/html/traitorTips/changelingTips.html
+++ b/browserassets/html/traitorTips/changelingTips.html
@@ -14,7 +14,8 @@
 			<em>Absorb DNA</em>, to steal the DNA of your victims. They must be grabbed firmly.<br>
 			<em>Toxic Spit</em>, a homing projectile that instantly melts the victim's headgear.<br>
 			<em>Hallucinogenic Sting</em>, a stealthy sting that makes people trip.<br>
-			<em>Neurotoxic Sting</em>, stealthily KOs your victims in about 30 seconds. Also causes severe brain damage.<br>
+			On the non-RP servers, <em>Neurotoxic Sting</em>, stealthily KOs your victims in about 30 seconds. Also causes severe brain damage.<br>
+			On the RP servers, <em>Capulettium Sting</em>, which doesn't cause brain damage, but will make your victim appear dead while they're unconscious.<br>
 			<em>DNA Sting</em>, forces somebody to assume the appearance and name of one of your victims.<br>
 			<em>Lesser Form</em>, instantly transforms you into a monkey. Only some abilities are available while in this form. Use the command again to revert to a human body.<br>
 			<em>Regenerative Stasis</em>, you will appear dead, and slowly return to full health. You won't be able to move while in stasis.<br>

--- a/code/modules/antagonists/changeling/abilities/changeling.dm
+++ b/code/modules/antagonists/changeling/abilities/changeling.dm
@@ -19,7 +19,11 @@
 	C.addAbility(/datum/targetable/changeling/scream)
 	C.addAbility(/datum/targetable/changeling/spit)
 	C.addAbility(/datum/targetable/changeling/stasis)
+#ifdef RP_MODE
+	C.addAbility(/datum/targetable/changeling/sting/capulettium)
+#else
 	C.addAbility(/datum/targetable/changeling/sting/neurotoxin)
+#endif
 	C.addAbility(/datum/targetable/changeling/sting/lsd)
 	C.addAbility(/datum/targetable/changeling/sting/dna)
 	C.addAbility(/datum/targetable/changeling/transform)

--- a/code/modules/antagonists/changeling/abilities/stings.dm
+++ b/code/modules/antagonists/changeling/abilities/stings.dm
@@ -66,6 +66,14 @@
 		icon_state = "stingneuro"
 		venom_id = "neurotoxin"
 
+	//neuro replacement for RP
+	capulettium
+		name = "Capulettium Sting"
+		desc = "Transfer some capulettium into your target."
+		icon_state = "stingneuro"
+		venom_id = "capulettium"
+		inject_amount = 20
+
 	lsd
 		name = "Hallucinogenic Sting"
 		desc = "Transfer some LSD into your target."


### PR DESCRIPTION
[BALANCE] [INPUT]

## About the PR
Adds new sting ability which injects 20u of capulettium. Swaps changeling neurotoxin sting for capulettium sting on RP mode.


## Why's this needed?
 Changeling is pretty controversial on RP, in part because it has so many lethality-oriented abilities. This replaces one of them to give the changeling a more interesting non-lethal tool in their toolbox.
 Capulettium was chosen because:

1. It retains the interesting counterplay in that you can dose yourself with another drug to convert it to a slightly less bad poison (I explain this more [in this post.](https://forum.ss13.co/showthread.php?tid=10735&pid=122193#pid122193))
2. Your victims appearing to drop dead rather than simply fall unconscious offers more RP opportunities for the ability than simply removing somebody.

 I suggested this some time ago in [this forum thread.](https://forum.ss13.co/showthread.php?tid=10735) I also brought it up in the Discord, starting [from this message.](https://discordapp.com/channels/182249960895545344/298426468550180864/753762670863450182) The idea has been well received, but there have been other ideas for the implementation — some people want to see it in addition to neurotox, some people want to see it on both servers, some people suggest an ability to choose which one you use. I haven't implemented the latter or former suggestions because I lack the coding ability, and I've left it on the RP_MODE def here because I don't want to upset balance on the main server. Perhaps it would make a good Ass Jam experiment..?


## Changelog
```
(u)Enfaeutchie
(*)On the RP servers, changelings have had their neurotoxin sting replaced with a non-lethal capulettium sting which will make their victims appear to drop dead.
```
