### PR TITLE
Add requires_power bool to machinery for TGUI SMES UI

### DIFF
--- a/_std/machinery.dm
+++ b/_std/machinery.dm
@@ -23,6 +23,7 @@
 #define POWEROFF 4		// machine shut down, but may still draw a trace amount
 #define MAINT 8			// under maintainance
 #define HIGHLOAD 16		// using a lot of power
+#define NOPOWERREQUIRED 32 // machine does not require power to function
 
 //recharger stuff
 #define CELLRATE 0.002  // multiplier for watts per tick <> cell storage (eg: .002 means if there is a load of 1000 watts, 20 units will be taken from a cell per second)

--- a/_std/machinery.dm
+++ b/_std/machinery.dm
@@ -23,7 +23,6 @@
 #define POWEROFF 4		// machine shut down, but may still draw a trace amount
 #define MAINT 8			// under maintainance
 #define HIGHLOAD 16		// using a lot of power
-#define NOPOWERREQUIRED 32 // machine does not require power to function
 
 //recharger stuff
 #define CELLRATE 0.002  // multiplier for watts per tick <> cell storage (eg: .002 means if there is a load of 1000 watts, 20 units will be taken from a cell per second)

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -18,6 +18,7 @@
 	icon_state = "smes"
 	density = 1
 	anchored = 1
+	status = NOPOWERREQUIRED
 	var/output = 30000
 	var/lastout = 0
 	var/loaddemand = 0

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -18,7 +18,7 @@
 	icon_state = "smes"
 	density = 1
 	anchored = 1
-	status = NOPOWERREQUIRED
+	requires_power = FALSE
 	var/output = 30000
 	var/lastout = 0
 	var/loaddemand = 0

--- a/code/modules/tgui/states/not_broken.dm
+++ b/code/modules/tgui/states/not_broken.dm
@@ -16,7 +16,7 @@ var/global/datum/ui_state/tgui_broken_state/tgui_broken_state = new /datum/ui_st
 	. = user.shared_ui_interaction(src)
 	if (status & BROKEN)
 		return min(., UI_CLOSE)
-	else if (status & (NOPOWER | POWEROFF) && !(src.status & NOPOWERREQUIRED))
+	else if (requires_power && status & (NOPOWER | POWEROFF))
 		return min(., UI_DISABLED)
 	else if (status & MAINT)
 		return min(., UI_UPDATE)

--- a/code/modules/tgui/states/not_broken.dm
+++ b/code/modules/tgui/states/not_broken.dm
@@ -16,7 +16,7 @@ var/global/datum/ui_state/tgui_broken_state/tgui_broken_state = new /datum/ui_st
 	. = user.shared_ui_interaction(src)
 	if (status & BROKEN)
 		return min(., UI_CLOSE)
-	else if (status & (NOPOWER | POWEROFF))
+	else if (status & (NOPOWER | POWEROFF) && !(src.status & NOPOWERREQUIRED))
 		return min(., UI_DISABLED)
 	else if (status & MAINT)
 		return min(., UI_UPDATE)

--- a/code/obj/machinery.dm
+++ b/code/obj/machinery.dm
@@ -26,7 +26,7 @@
 	var/base_tick_spacing = 6 // Machines proc every 1*(2^tier-1) seconds. Or something like that.
 	var/cap_base_tick_spacing = 60
 	var/last_process
-
+	var/requires_power = TRUE // machine requires power, used in tgui_broken_state
 	// New() and disposing() add and remove machines from the global "machines" list
 	// This list is used to call the process() proc for all machines ~1 per second during a round
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [BUG][FEAT][TGUI] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Adds new machinery bool `requires_power`
- Adjust TGUI broken state to not return `UI_DISABLED` when machine does not have power if it is also marked as not requiring it.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
- SMES's don't actually need power to work, but the TGUI broken state checks if they had power anyway