### PR TITLE
Fixes vampire screech emagging robots

### DIFF
--- a/code/datums/abilities/vampire/screech.dm
+++ b/code/datums/abilities/vampire/screech.dm
@@ -8,7 +8,7 @@
 	cooldown = 300
 	pointCost = 60
 	when_stunned = 1
-	var/duration = 5 SECONDS
+	var/duration = 10 SECONDS
 	not_when_handcuffed = 0
 	unlock_message = "You have gained chiropteran screech. It deafens nearby foes, damages windows and lights."
 	var/level = 1

--- a/code/datums/abilities/vampire/screech.dm
+++ b/code/datums/abilities/vampire/screech.dm
@@ -8,6 +8,7 @@
 	cooldown = 300
 	pointCost = 60
 	when_stunned = 1
+	var/duration = 50
 	not_when_handcuffed = 0
 	unlock_message = "You have gained chiropteran screech. It deafens nearby foes, damages windows and lights."
 	var/level = 1
@@ -61,8 +62,10 @@
 			if (HH == M) continue
 
 			if (level == 2)
-				HH.emag_act() //disable gtheir radios
-
+				radio_controller.active_jammers.Add(M)
+				SPAWN_DBG (src.duration)
+					if (M && istype(M) && radio_controller && istype(radio_controller) && radio_controller.active_jammers.Find(M))
+						radio_controller.active_jammers.Remove(M)
 			if (isvampire(HH) && HH.check_vampire_power(3) == 1)
 				boutput(HH, __blue("You are immune to [M]'s screech!"))
 				continue
@@ -80,6 +83,6 @@
 
 /datum/targetable/vampire/vampire_scream/mk2
 	name = "Chiropteran Screech Mk2"
-	desc = "Deafens nearby foes, smashes windows and lights. Blocked by ear protection."
+	desc = "Deafens nearby foes, silences radios, smashes windows and lights. Blocked by ear protection."
 	unlock_message = "Your Chiropteran Screech power disables nearby radios in addition to its original effect."
 	level = 2

--- a/code/datums/abilities/vampire/screech.dm
+++ b/code/datums/abilities/vampire/screech.dm
@@ -8,7 +8,7 @@
 	cooldown = 300
 	pointCost = 60
 	when_stunned = 1
-	var/duration = 50
+	var/duration = 5 SECONDS
 	not_when_handcuffed = 0
 	unlock_message = "You have gained chiropteran screech. It deafens nearby foes, damages windows and lights."
 	var/level = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR 
Makes it so the vampire screech MK2 no longer Emags robots. Also fixes the MK2 so it now silences radios for 10 seconds.



## Why's this needed? 
It's a little strong to Emag a robot with a scream. Also the radio silencer did not function properly 



## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Medoublej:
(+) Vampire's chiropteran screech MK2 now silences radios properly and no longer emags robots.
```
