### PR TITLE
Hulk actually makes people green

### DIFF
--- a/code/modules/medical/genetics/bioEffects/beneficial.dm
+++ b/code/modules/medical/genetics/bioEffects/beneficial.dm
@@ -388,30 +388,44 @@ var/list/radio_brains = list()
 		owner.unlock_medal("It's not easy being green", 1)
 		if (ishuman(owner))
 			var/mob/living/carbon/human/H = owner
-			H.set_body_icon_dirty()
 			APPLY_MOVEMENT_MODIFIER(H, /datum/movement_modifier/hulkstrong, src.type)
+			if(H?.bioHolder?.mobAppearance)
+				var/datum/appearanceHolder/HAH = H.bioHolder.mobAppearance
+				HAH.customization_first_color_carry = HAH.customization_first_color
+				HAH.customization_second_color_carry = HAH.customization_second_color
+				HAH.customization_third_color_carry = HAH.customization_third_color
+				HAH.s_tone_carry = HAH.s_tone
+				var/hulk_skin = "#4CBB17" // a striking kelly green
+				if(prob(10)) // just the classics
+					var/gray_af = rand(60, 150) // as consistent as the classics too
+					hulk_skin = rgb(gray_af, gray_af, gray_af)
+				HAH.customization_first_color = "#4F7942" // a pleasant fern green
+				HAH.customization_second_color = "#3F704D" // a bold hunter green
+				HAH.customization_third_color = "#0B6623" // a vibrant forest green
+				HAH.s_tone = hulk_skin
+			H.set_body_icon_dirty()
 		..()
-
-	OnMobDraw()
-		if(disposed)
-			return
-
-		if(ishuman(owner))
-			owner:body_standing:overlays += image("icon" = 'icons/effects/genetics.dmi', "icon_state" = "hulk[owner.bioHolder?.HasEffect("fat") ? "fat" :""]", layer = MOB_LAYER)
 
 	OnRemove()
 		if (ishuman(owner))
 			var/mob/living/carbon/human/H = owner
+			if(H?.bioHolder?.mobAppearance) // colorize, but backwards
+				var/datum/appearanceHolder/HAH = H.bioHolder.mobAppearance
+				HAH.customization_first_color = HAH.customization_first_color_carry
+				HAH.customization_second_color = HAH.customization_second_color_carry
+				HAH.customization_third_color = HAH.customization_third_color_carry
+				HAH.s_tone = HAH.s_tone_carry
 			H.set_body_icon_dirty()
 			REMOVE_MOVEMENT_MODIFIER(H, /datum/movement_modifier/hulkstrong, src.type)
 
 	OnLife()
 		if(..()) return
-		if (owner:health <= 25)
+		var/mob/living/carbon/human/H = owner
+		if (H.health <= 25)
 			timeLeft = 1
 			boutput(owner, "<span class='alert'>You suddenly feel very weak.</span>")
-			owner:changeStatus("weakened", 3 SECONDS)
-			owner:emote("collapse")
+			H.changeStatus("weakened", 3 SECONDS)
+			H.emote("collapse")
 
 /datum/bioEffect/xray
 	name = "X-Ray Vision"

--- a/code/modules/medical/genetics/bioEffects/beneficial.dm
+++ b/code/modules/medical/genetics/bioEffects/beneficial.dm
@@ -396,7 +396,7 @@ var/list/radio_brains = list()
 				HAH.customization_third_color_carry = HAH.customization_third_color
 				HAH.s_tone_carry = HAH.s_tone
 				var/hulk_skin = "#4CBB17" // a striking kelly green
-				if(prob(10)) // just the classics
+				if(prob(1)) // just the classics
 					var/gray_af = rand(60, 150) // as consistent as the classics too
 					hulk_skin = rgb(gray_af, gray_af, gray_af)
 				HAH.customization_first_color = "#4F7942" // a pleasant fern green

--- a/code/modules/medical/genetics/bioHolder.dm
+++ b/code/modules/medical/genetics/bioHolder.dm
@@ -16,11 +16,11 @@ var/list/datum/bioEffect/mutini_effects = list()
 
 /datum/appearanceHolder
 	//Holds all the appearance information.
-	var/customization_first_color_carry = "#101010"
+	var/customization_first_color_carry = "#101010" //Holds someone's original colors if they need to be changed temporarily
 	var/customization_first_color = "#101010"
 	var/customization_first = "Trimmed"
 
-	var/customization_second_color_carry = "#101010"
+	var/customization_second_color_carry = "#101010" // This way, they can return to their orignal colors
 	var/customization_second_color = "#101010"
 	var/customization_second = "None"
 

--- a/code/modules/medical/genetics/bioHolder.dm
+++ b/code/modules/medical/genetics/bioHolder.dm
@@ -16,17 +16,21 @@ var/list/datum/bioEffect/mutini_effects = list()
 
 /datum/appearanceHolder
 	//Holds all the appearance information.
+	var/customization_first_color_carry = "#101010"
 	var/customization_first_color = "#101010"
 	var/customization_first = "Trimmed"
 
+	var/customization_second_color_carry = "#101010"
 	var/customization_second_color = "#101010"
 	var/customization_second = "None"
 
+	var/customization_third_color_carry = "#101010"
 	var/customization_third_color = "#101010"
 	var/customization_third = "None"
 
 	var/e_color = "#101010"
 
+	var/s_tone_carry = "#FFCC99"
 	var/s_tone = "#FFCC99"
 	// Standard tone reference:
 	// FAD7D0 - Albino
@@ -83,18 +87,22 @@ var/list/datum/bioEffect/mutini_effects = list()
 
 	proc/CopyOther(var/datum/appearanceHolder/toCopy)
 		//Copies settings of another given holder. Used for the bioholder copy proc and such things.
+		customization_first_color_carry = toCopy.customization_first_color_carry
 		customization_first_color = toCopy.customization_first_color
 		customization_first = toCopy.customization_first
 
+		customization_second_color_carry = toCopy.customization_second_color_carry
 		customization_second_color = toCopy.customization_second_color
 		customization_second = toCopy.customization_second
 
+		customization_third_color_carry = toCopy.customization_third_color_carry
 		customization_third_color = toCopy.customization_third_color
 		customization_third = toCopy.customization_third
 
 		e_color = toCopy.e_color
 
 		s_tone = toCopy.s_tone
+		s_tone_carry = toCopy.s_tone_carry
 
 		underwear = toCopy.underwear
 		u_color = toCopy.u_color


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Hulk, instead of overlaying a naked green person over the sprite, now sets their skintone and hair colors to various shades of green. Not yet effective with mutant races, since their colors are still baked into their sprites at birth, but should work eventually if that's ever changed.

Also there's a 10% chance of their skin to be gray instead, cus comic books.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

![Annotation 2020-09-11 142133](https://user-images.githubusercontent.com/13302055/92974517-3e147f80-f43b-11ea-8e49-884a95f67acb.png)
