### PR TITLE
Additional cloning changes

### DIFF
--- a/code/obj/machinery/clonepod.dm
+++ b/code/obj/machinery/clonepod.dm
@@ -186,7 +186,6 @@
 		src.occupant.take_toxin_damage(50)
 		src.occupant.take_oxygen_deprivation(40)
 		src.occupant.take_brain_damage(60)
-		src.occupant.changeStatus("paralysis", 10 SECONDS)
 
 		//Here let's calculate their health so the pod doesn't immediately eject them!!!
 		src.occupant.health = (src.occupant.get_brute_damage() + src.occupant.get_toxin_damage() + src.occupant.get_oxygen_deprivation())
@@ -221,7 +220,7 @@
 		src.look_busy(1)
 		src.visible_message("<span class='alert'>[src] whirrs and starts up!</span>")
 
-		src.eject_wait = 10
+		src.eject_wait = 10 SECONDS
 
 		if (istype(oldholder))
 			oldholder.clone_generation++
@@ -337,7 +336,7 @@
 		if (src.BE)
 			src.occupant.bioHolder.AddEffectInstance(BE,1)
 
-		src.occupant.changeStatus("paralysis", 20 SECONDS)
+		src.occupant.changeStatus("paralysis", 10 SECONDS)
 		previous_heal = src.occupant.health
 		return 1
 
@@ -695,6 +694,7 @@
 			var/mob/living/carbon/C = src.occupant
 			C.remove_ailments() // no more cloning with heart failure
 
+		src.occupant.changeStatus("paralysis", 10 SECONDS)
 		src.occupant.set_loc(get_turf(src))
 		src.occupant = null
 		src.update_icon()

--- a/code/obj/machinery/computer/cloning.dm
+++ b/code/obj/machinery/computer/cloning.dm
@@ -264,8 +264,7 @@
 		if(5) //Advanced genetics analysis
 			dat += {"<h4>Advanced Genetic Analysis</h4>
 					<a href='byond://?src=\ref[src];menu=1'>Back</a><br>
-					<B>Notice:</B> Enabling this feature will prompt the attached clone pod to transfer active genetic mutations from the genetic record to the subject during cloning.
-					The cloning process will be slightly slower as a result.<BR><BR>"}
+					<B>Notice:</B> Enabling this feature will prompt the attached clone pod to transfer active genetic mutations from the genetic record to the subject during cloning.<BR>"}
 
 			if(pod1 && !pod1.attempting)
 				if(pod1.gen_analysis)

--- a/code/obj/machinery/computer/cloning.dm
+++ b/code/obj/machinery/computer/cloning.dm
@@ -6,7 +6,7 @@
 	desc = "Use this console to operate a cloning scanner and pod. There is a slot to insert modules - they can be removed with a screwdriver."
 	icon = 'icons/obj/computer.dmi'
 	icon_state = "dna"
-	req_access = list(access_heads) //Only used for record deletion right now.
+	req_access = list(access_medical_lockers) //Only used for record deletion right now.
 	object_flags = CAN_REPROGRAM_ACCESS
 	machine_registry_idx = MACHINES_CLONINGCONSOLES
 	var/obj/machinery/clone_scanner/scanner = null //Linked scanner. For scanning.
@@ -267,7 +267,7 @@
 					<B>Notice:</B> Enabling this feature will prompt the attached clone pod to transfer active genetic mutations from the genetic record to the subject during cloning.
 					The cloning process will be slightly slower as a result.<BR><BR>"}
 
-			if(pod1 && !pod1.operating)
+			if(pod1 && !pod1.attempting)
 				if(pod1.gen_analysis)
 					dat += {"Enabled<BR>
 							<a href='byond://?src=\ref[src];set_analysis=0'>Disable</A><BR>"}
@@ -322,10 +322,13 @@
 	else if (href_list["del_rec"])
 		if ((!src.active_record) || (src.menu < 3))
 			return
+		if (!src.allowed(usr))
+			src.temp = "Insufficient access."
+			src.updateUsrDialog()
+			return
 		if (src.menu == 3) //If we are viewing a record, confirm deletion
 			src.temp = "Delete record?"
 			src.menu = 4
-
 		else if (src.menu == 4)
 			logTheThing("combat", usr, null, "deletes the cloning record [src.active_record.fields["name"]] for player [src.active_record.fields["ckey"]] at [log_loc(src)].")
 			src.records.Remove(src.active_record)

--- a/code/obj/machinery/computer/cloning.dm
+++ b/code/obj/machinery/computer/cloning.dm
@@ -321,10 +321,6 @@
 	else if (href_list["del_rec"])
 		if ((!src.active_record) || (src.menu < 3))
 			return
-		if (!src.allowed(usr))
-			src.temp = "Insufficient access."
-			src.updateUsrDialog()
-			return
 		if (src.menu == 3) //If we are viewing a record, confirm deletion
 			src.temp = "Delete record?"
 			src.menu = 4

--- a/code/obj/machinery/computer/cloning.dm
+++ b/code/obj/machinery/computer/cloning.dm
@@ -579,8 +579,8 @@
 	for(var/mob/M in mobs)
 		//Dead people only thanks!
 		if (!(isdead(M) || isVRghost(M) || isghostcritter(M) || inafterlifebar(M)) || (!M.client))
-			//continue
-		They need a brain!
+			continue
+		//They need a brain!
 		if (needbrain && ishuman(M) && !M:brain)
 			continue
 

--- a/code/obj/machinery/computer/cloning.dm
+++ b/code/obj/machinery/computer/cloning.dm
@@ -580,8 +580,8 @@
 	for(var/mob/M in mobs)
 		//Dead people only thanks!
 		if (!(isdead(M) || isVRghost(M) || isghostcritter(M) || inafterlifebar(M)) || (!M.client))
-			continue
-		//They need a brain!
+			//continue
+		They need a brain!
 		if (needbrain && ishuman(M) && !M:brain)
 			continue
 
@@ -700,6 +700,7 @@
 			O.set_loc(src.loc)
 
 		src.add_fingerprint(usr)
+		src?.connected.updateUsrDialog()
 
 		playsound(src.loc, "sound/machines/sleeper_close.ogg", 50, 1)
 


### PR DESCRIPTION
[BALANCE] [FEATURE] [INPUT] [QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR builds upon @Xkeeper0's cloning changes. 

- Cloning pods require more materials to manufacture, and deploy without any biomatter.
- You need medical locker access instead of medical lab access to unlock cloning pods (this means medical doctors will be able to eject patients).
- Clicking the cloning pod will once again display the cloning progress.
- Cloning pods have a slightly longer delay (ten vs. five seconds) before they eject the occupant.
- Occupants will be paralyzed for ten seconds upon cloning pod ejection.
- Advanced genetic analysis is toggleable as long as there is not a player currently cloning.
- Someone moving into the cloning scanner will automatically update the cloning computer window. No more clicking refresh before scanning!

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I thought these changes would be good.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Flourish:
(+)You will now need medical locker access to unlock cloning pods. 
```
