### PR TITLE
Fire Extinguisher Fixes

### DIFF
--- a/code/modules/chemistry/tools/extinguisher.dm
+++ b/code/modules/chemistry/tools/extinguisher.dm
@@ -5,6 +5,9 @@
 	icon_state = "fire_extinguisher0"
 	var/safety = 1
 	var/extinguisher_special = 0
+	var/const/min_distance = 1
+	var/const/max_distance = 5
+	var/const/reagents_per_dist = 5
 	hitsound = 'sound/impact_sounds/Metal_Hit_1.ogg'
 	flags = FPRINT | EXTRADELAY | TABLEPASS | CONDUCT | OPENCONTAINER
 	tooltip_flags = REBUILD_DIST
@@ -77,10 +80,11 @@
 	//TODO; Add support for reagents in water.
 	if (!src.reagents)
 		boutput(user, "<span class='alert'>Man, the handle broke off, you won't spray anything with this.</span>")
+		return
 
 	if ( istype(target, /obj/reagent_dispensers) && get_dist(src,target) <= 1)
 		var/obj/o = target
-		o.reagents.trans_to(src, 75)
+		o.reagents.trans_to(src, src.reagents.maximum_volume)
 		src.inventory_counter.update_percent(src.reagents.total_volume, src.reagents.maximum_volume)
 		boutput(user, "<span class='notice'>Extinguisher refilled...</span>")
 		playsound(src.loc, "sound/effects/zzzt.ogg", 50, 1, -6)
@@ -142,11 +146,16 @@
 
 		var/list/the_targets = list(T,T1,T2)
 
+		var/datum/reagents/R = new
+		var/distance = clamp(get_dist(get_turf(src), get_turf(target)), min_distance, max_distance)
+		src.reagents.trans_to_direct(R, min(src.reagents.total_volume, (distance * reagents_per_dist)))
+		src.inventory_counter.update_percent(src.reagents.total_volume, src.reagents.maximum_volume)
+
 		logTheThing("combat", user, T, "sprays [src] at [constructTarget(T,"combat")], [log_reagents(src)] at [showCoords(user.x, user.y, user.z)] ([get_area(user)])")
 
 		user.lastattacked = target
 
-		for (var/a=0, a<5, a++)
+		for (var/a = 0, a < reagents_per_dist, a++)
 			SPAWN_DBG (0)
 				if (disposed)
 					return
@@ -156,8 +165,7 @@
 				if (!W) return
 				W.set_loc( get_turf(src) )
 				var/turf/my_target = pick(the_targets)
-				W.spray_at(my_target, src.reagents, try_connect_fluid = 1)
-				src.inventory_counter.update_percent(src.reagents.total_volume, src.reagents.maximum_volume)
+				W.spray_at(my_target, R, try_connect_fluid = 1)
 
 		if (istype(usr.loc, /turf/space))
 			user.inertia_dir = get_dir(target, user)

--- a/code/modules/chemistry/tools/extinguisher.dm
+++ b/code/modules/chemistry/tools/extinguisher.dm
@@ -84,7 +84,7 @@
 
 	if ( istype(target, /obj/reagent_dispensers) && get_dist(src,target) <= 1)
 		var/obj/o = target
-		o.reagents.trans_to(src, src.reagents.maximum_volume)
+		o.reagents.trans_to(src, (src.reagents.maximum_volume - src.reagents.total_volume))
 		src.inventory_counter.update_percent(src.reagents.total_volume, src.reagents.maximum_volume)
 		boutput(user, "<span class='notice'>Extinguisher refilled...</span>")
 		playsound(src.loc, "sound/effects/zzzt.ogg", 50, 1, -6)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [BUG][RUNTIME] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Fire extinguishers now calculate the amount of reagents to be sprayed, move it to a new reagent container, and pass that to `spray_at()`
- If reagent container is null (aka 'handle is broken' status) return early instead of runtiming
- filling an extinguisher from a foam tank will now attempt to fill it entirely


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
- `spray_at` takes reagents from the extinguisher inside of a `spawn_dbg()` call recently added by Pali because it calls `sleep`. This caused the inventory counter to update before extracting the reagents
- When `reagents` is null spraying the extinguisher caused runtimes
- Filling an extinguisher will now fill it with however many units it is missing, rather than a flat 75u regardless of how full or empty it was

File | extinguisher.dm
-- | --
Line | 91
Error | Cannot read null.total_volume

```
proc name: afterattack (/obj/item/extinguisher/afterattack)
  source file: extinguisher.dm,91
  usr: Sov Extant (/mob/living/carbon/human)
  src: the fire extinguisher (/obj/item/extinguisher/virtual)
  usr.loc: the steel floor (128,108,1) (/turf/simulated/floor)
  src.loc: Sov Extant (/mob/living/carbon/human)
  call stack:
the fire extinguisher (/obj/item/extinguisher/virtual): afterattack(the steel floor (123,107,1) (/turf/simulated/floor/blue/side), Sov Extant (/mob/living/carbon/human), 0, /list (/list))
Sov Extant (/mob/living/carbon/human): weapon attack(the steel floor (123,107,1) (/turf/simulated/floor/blue/side), the fire extinguisher (/obj/item/extinguisher/virtual), 0, /list (/list))
Sov Extant (/mob/living/carbon/human): click(the steel floor (123,107,1) (/turf/simulated/floor/blue/side), /list (/list), the steel floor (123,107,1) (/turf/simulated/floor/blue/side), "mapwindow.map")
Sov Extant (/mob/living/carbon/human): click(the steel floor (123,107,1) (/turf/simulated/floor/blue/side), /list (/list), the steel floor (123,107,1) (/turf/simulated/floor/blue/side), "mapwindow.map")
Sovexe (/client): Click(the steel floor (123,107,1) (/turf/simulated/floor/blue/side), the steel floor (123,107,1) (/turf/simulated/floor/blue/side), "mapwindow.map", "icon-x=14;icon-y=24;left=1;scr...")
```