### PR TITLE
Make most gloves leave scrambled prints while having some leave only material prints

### DIFF
--- a/code/obj/item/clothing/gloves.dm
+++ b/code/obj/item/clothing/gloves.dm
@@ -17,7 +17,7 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 	var/activeweapon = 0 // Used for gloves that can be toggled to turn into a weapon (example, bladed gloves)
 
 	var/hide_prints = 1 // Seems more efficient to do this with one global proc and a couple of vars (Convair880).
-	var/scramble_prints = 0
+	var/scramble_prints = 1
 	var/material_prints = null
 
 	var/can_be_charged = 0 // Currently, there are provisions for icon state "yellow" only. You have to update this file and mob_procs.dm if you're wanna use other glove sprites (Convair880).
@@ -210,6 +210,7 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 	icon_state = "long_gloves"
 	item_state = "long_gloves"
 	protective_temperature = 550
+	scramble_prints = 0
 	material_prints = "synthetic silicone rubber fibers"
 	setupProperties()
 		..()
@@ -251,7 +252,8 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 	permeability_coefficient = 0.02
 	desc = "Thin gloves that offer minimal protection."
 	protective_temperature = 310
-	scramble_prints = 1
+	scramble_prints = 0
+	material_prints = "white talcum powder"
 	setupProperties()
 		..()
 		setProperty("conductivity", 0.3)
@@ -276,7 +278,7 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 	icon_state = "latex"
 	item_state = "lgloves"
 	desc = "Custom made gloves."
-	scramble_prints = 1
+	scramble_prints = 0
 
 	insulating
 		onMaterialChanged()
@@ -319,6 +321,7 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 	icon_state = "swat_syndie"
 	item_state = "swat_syndie"
 	protective_temperature = 1100
+	scramble_prints = 0
 	material_prints = "high-quality synthetic fibers"
 	setupProperties()
 		..()
@@ -384,6 +387,7 @@ var/list/glove_IDs = new/list() //Global list of all gloves. Identical to Cogwer
 	desc = "These gloves are for competitive boxing."
 	icon_state = "boxinggloves"
 	item_state = "bogloves"
+	scramble_prints = 0
 	material_prints = "red leather fibers"
 	crit_override = 1
 	bonus_crit_chance = 0


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Basically a reboot of one of my older PRs. Most gloves will now leave scrambled prints of the user (black, insulated, unsulated ,etc) while only a couple (latex, boxing, janitorial, etc) will only leave material prints.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Current forensics are not ideal, dare I say useless. For the most part, its ignored by Detectives and regular officers as confirming the prints on anything is unintuitive as it is. Both regular crew member and crimers alike wear insulated gloves and being able to confirm who's fibers belongs to who only via direct confrontation only hassles regular crew members and is a huge giveaway for antags.

By making most gloves leave partial prints, Security can now make actual use of said evidence by using cross examination of the prints with the given Security records. Being careful about what evidence you leave behind actually requires effort now and isnt something you did by accident just because you're wearing gloves. I think it would be beneficial to Sec gameplay as well that useful policing work can be done behind a desk, not just by being out in the field.

Regarding some comments from the previous PR:
I dont think having gloves that leave no prints whatsoever would be all that good for gameplay. If anything, Id imagine it would only cause confusion. (I'd say its also unrealistic but current forensics is kind of a mess in realism) 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Carbadox:
(*)Most gloves will now leave scrambled prints and only a couple will leave only material prints (eg, latex gloves, janitorial and boxing). Previously, all gloves would leave material prints and only latex gloves would leave scrambled prints.
```
