### PR TITLE
Fixes Oshan elevator graphics

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -45550,14 +45550,18 @@
 	dir = 5;
 	icon_state = "catwalk_cross"
 	},
-/turf/simulated/floor/bot,
+/turf/simulated/floor/bot{
+	dir = NORTH
+	},
 /area/shuttle/sea_elevator/upper)
 "cgh" = (
 /obj/grille/catwalk{
 	dir = 10;
 	icon_state = "catwalk_cross"
 	},
-/turf/simulated/floor/bot,
+/turf/simulated/floor/bot{
+	dir = WEST
+	},
 /area/shuttle/sea_elevator/upper)
 "cgi" = (
 /obj/machinery/light/incandescent/greenish,
@@ -45577,7 +45581,9 @@
 	dir = 6;
 	icon_state = "catwalk_cross"
 	},
-/turf/simulated/floor/bot,
+/turf/simulated/floor/bot{
+	dir = EAST
+	},
 /area/shuttle/sea_elevator/upper)
 "cgl" = (
 /turf/space/fluid/warp_z5,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[trivial]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR changes some floors' ```dir``` so the sea elevator shaft uses the right graphics, instead of the top-left corner repeating.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Looks nicer.
![oshanelevator](https://user-images.githubusercontent.com/31984217/93020031-38ee3680-f5db-11ea-9d00-8fa4dd3b9c94.png)
