### PR TITLE
Draw from a held sword sheath

### DIFF
--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -1204,6 +1204,23 @@
 		else
 			return ..()
 
+	attack_self(mob/living/carbon/human/user as mob)
+		if(src.sword_inside) //Checks if a katana is inside
+			if (!user.r_hand || !user.l_hand)
+				sword_inside.clean_forensic()
+				boutput(user, "You draw [sword_inside] from your sheath.")
+				playsound(get_turf(user), pick("sound/effects/sword_unsheath1.ogg","sound/effects/sword_unsheath2.ogg"), 70, 0, 0)
+				icon_state = sheath_state
+				item_state = ih_sheath_state
+				user.put_in_hand_or_drop(sword_inside)
+				sword_inside = null //No more sword inside.
+				user.update_clothing()
+			else
+				boutput(user, "You don't have a free hand to draw with!")
+				return ..()
+		else
+			return ..()
+
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (istype(W, /obj/item/katana) && !src.sword_inside && !W.cant_drop == 1)
 			icon_state = sheathed_state

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -1189,35 +1189,13 @@
 
 	attack_hand(mob/living/carbon/human/user as mob)
 		if(user.r_hand == src || user.l_hand == src || user.belt == src)
-			if(src.sword_inside) //Checks if a katana is inside
-				sword_inside.clean_forensic()
-				boutput(user, "You draw [sword_inside] from your sheath.")
-				playsound(get_turf(user), pick("sound/effects/sword_unsheath1.ogg","sound/effects/sword_unsheath2.ogg"), 70, 0, 0)
-				icon_state = sheath_state
-				item_state = ih_sheath_state
-				user.put_in_hand_or_drop(sword_inside)
-				sword_inside = null //No more sword inside.
-				user.update_clothing()
-			else
-				return ..()//Katana doesn't exist, and takes the sheath off your belt or switches hands.
-
+			draw_sword(user)
 		else
 			return ..()
 
 	attack_self(mob/living/carbon/human/user as mob)
-		if(src.sword_inside) //Checks if a katana is inside
-			if (!user.r_hand || !user.l_hand)
-				sword_inside.clean_forensic()
-				boutput(user, "You draw [sword_inside] from your sheath.")
-				playsound(get_turf(user), pick("sound/effects/sword_unsheath1.ogg","sound/effects/sword_unsheath2.ogg"), 70, 0, 0)
-				icon_state = sheath_state
-				item_state = ih_sheath_state
-				user.put_in_hand_or_drop(sword_inside)
-				sword_inside = null //No more sword inside.
-				user.update_clothing()
-			else
-				boutput(user, "You don't have a free hand to draw with!")
-				return ..()
+		if(user.r_hand == src || user.l_hand == src || user.belt == src)
+			draw_sword(user)
 		else
 			return ..()
 
@@ -1235,6 +1213,23 @@
 			..()
 			if(W.cant_drop == 1)
 				boutput(user, "<span class='notice'>You can't sheathe the [W] while its attached to your arm.</span>")
+
+/obj/item/katana_sheath/proc/draw_sword(mob/living/carbon/human/user)
+	if(src.sword_inside) //Checks if a katana is inside
+		if (!user.r_hand || !user.l_hand)
+			sword_inside.clean_forensic()
+			boutput(user, "You draw [sword_inside] from your sheath.")
+			playsound(get_turf(user), pick("sound/effects/sword_unsheath1.ogg","sound/effects/sword_unsheath2.ogg"), 70, 0, 0)
+			icon_state = sheath_state
+			item_state = ih_sheath_state
+			user.put_in_hand_or_drop(sword_inside)
+			sword_inside = null //No more sword inside.
+			user.update_clothing()
+		else
+			boutput(user, "You don't have a free hand to draw with!")
+			return
+	else
+		return
 
 /obj/item/katana_sheath/reverse
 	name = "reverse-blade katana sheath"

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -1194,7 +1194,7 @@
 			return ..()
 
 	attack_self(mob/living/carbon/human/user as mob)
-		if(user.r_hand == src || user.l_hand == src || user.belt == src)
+		if(user.r_hand == src || user.l_hand == src)
 			draw_sword(user)
 		else
 			return ..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Let's you draw a sword straight from a held sheath to your free hand if your belt slot is unavailable
Checks if your hand is empty rather than dropping the sword on the ground.
Works with all sheathed sword as they are based off the katana.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
If your belt is occupied trying to draw a sword by hand is too fiddly in combat and has gotten me killed.