### PR TITLE
Fix gang kidnapping breaking victim's client/ghost

### DIFF
--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -1112,7 +1112,7 @@
 
 						mode.kidnapping_target = null
 						mode.kidnapp_success = 1
-						qdel(G.affecting)
+						G.affecting.remove()
 						qdel(G)
 			return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[major]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR changes the gang war kidnapping event to call ```remove``` on the victim instead of directly ```qdel```ing their mob, so the player properly turns into a ghost.

(As far as I can tell I can't test kidnapping events on my own so I didn't test beyond building to see if it runs. If this isn't the way to go about it we can just close this PR and I'll make an issue for it instead. I just _thought_ that I could just as easily fix it myself once I figured out what the code was doing.)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I just came out of a round where I got kidnapped, and it just froze my client and spawned me as a default observer after I restarted. Whoops.