### PR TITLE
Pod shotgun uses ammo

### DIFF
--- a/code/modules/transport/pods/MainWeapon.dm
+++ b/code/modules/transport/pods/MainWeapon.dm
@@ -168,6 +168,8 @@
 	name = "SPK-12 Ballistic System"
 	desc = "A one of it's kind kinetic podweapon, designed to fire shotgun rounds similar to those in a SPES-12."
 	weapon_score = 1.25
+	uses_ammunition = 1
+	remaining_ammunition = 18
 	current_projectile = new/datum/projectile/bullet/a12
 	appearanceString = "pod_weapon_gun_off"
 	firerate = 10


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The pod shotgun ammo system has unlimited ammo. This adjusts it to 18.
The other projectile weapon, the 40mm, has 14 shots.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
On a syndicate minisub this lets you cruise corridors with a SPES 12 (same projectile) with unlimited ammo.
Pods aren't invincible but it can kill a ton of unarmored and melee weapon equipped crew.
As far as I know the 40mm is armory only but the shotgun is available at the start.