### PR TITLE
Change records to use UpdateOverlays

### DIFF
--- a/code/modules/telescience/radiostation.dm
+++ b/code/modules/telescience/radiostation.dm
@@ -258,7 +258,7 @@
 /obj/item/record/New()
 	..()
 	if (add_overlay)
-		src.overlays += "record_[rand(1,10)]"
+		src.UpdateOverlays(new /image(src.icon, "record_[rand(1,10)]"), "recordlabel")
 	if (record_name)
 		src.desc = "A fairly large record. There's a sticker on it that says \"[record_name]\"."
 
@@ -401,7 +401,7 @@
 
 	New()
 		..()
-		src.overlays += "record_6"	//it should always be green because I'm so funny.
+		src.UpdateOverlays(new /image(src.icon, "record_6"), "recordlabel") //it should always be green because I'm so funny.
 
 /obj/item/record/spacebux/New()
 	..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [CHORE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes records to use `UpdateOverlays()` instead of `src.overlays +=`


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Using `src.overlays +=` prevents anything else from adding overlays to the objects using `UpdateOverlays()` such as fluids which could cause runtimes in the future