### PR TITLE
NTSO Security Training and Sleeper Agent Fix

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -2163,6 +2163,7 @@
 		..()
 		if (!M)
 			return
+		M.traitHolder.addTrait("training_security")
 		M.show_text("<b>Hostile assault force incoming! Defend the crew from the attacking Syndicate Special Operatives!</b>", "blue")
 
 
@@ -2205,6 +2206,7 @@
 		..()
 		if (!M)
 			return
+		M.traitHolder.addTrait("training_security")
 		M.show_text("<b>Defend the crew from all current threats!</b>", "blue")
 
 

--- a/code/modules/events/sleeperagent.dm
+++ b/code/modules/events/sleeperagent.dm
@@ -154,7 +154,7 @@
 				if (Hs.frequency == frequency)
 					listeners += H
 					boutput(H, "<span class='notice'>A peculiar noise intrudes upon the radio frequency of your [Hs].</span>")
-					if(H.client && !checktraitor(H) && (H.client.preferences.be_traitor || src.override_player_pref) && !(H.mind.assigned_role in list("Head of Security", "Security Officer")))
+					if(H.client && !checktraitor(H) && (H.client.preferences.be_traitor || src.override_player_pref) && !(H.traitHolder.hasTrait("training_security")))
 						candidates += H
 				break
 		for (var/mob/living/silicon/robot/R in mobs)

--- a/code/modules/events/sleeperagent.dm
+++ b/code/modules/events/sleeperagent.dm
@@ -154,8 +154,10 @@
 				if (Hs.frequency == frequency)
 					listeners += H
 					boutput(H, "<span class='notice'>A peculiar noise intrudes upon the radio frequency of your [Hs].</span>")
-					if(H.client && !checktraitor(H) && (H.client.preferences.be_traitor || src.override_player_pref) && !(H.traitHolder.hasTrait("training_security")))
-						candidates += H
+					if (H.client && !checktraitor(H) && (H.client.preferences.be_traitor || src.override_player_pref))
+						var/datum/job/J = find_job_in_controller_by_string(H?.mind.assigned_role)
+						if (J.allow_traitors)
+							candidates.Add(H)
 				break
 		for (var/mob/living/silicon/robot/R in mobs)
 			if(!isalive(R))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR and why it's needed <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

For some reason, NTSOs were allowed to be in the pool for sleeper agents! I had this happen to me last night, which made for a very interesting RP shift. This is obviously unintended and shouldn't be possible. The way the sleeper event works currently is that it draws eligible candidates from all jobs, except those defined. The HoS and Security Officers were the only defined jobs. I changed this to instead use those that have the Security Training trait **Now changed to use the job var `allow_traitors` which basically ties the Sleeper Agent event selection directly into whether or not a job allows traitor roll in the first place!** 

This should also make it easier in the future if any more jobs need to be excluded from sleeper, it's as simple as making them ineligible to be a traitor. I also added Security Training to NTSOs of both types because it's just weird that they don't have it.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)makkipakki and (u)Adharainspace:
(+)NTSOs can no longer be sleeper agents, and the way the sleeper agent event chooses who is ineligible is now decided by whether the job can roll traitor, rather than a list of specific jobs.
(+)Added security training to NTSOs of both flavors
```
