### PR TITLE
adds playtime tracking

### DIFF
--- a/_std/macros/ismob.dm
+++ b/_std/macros/ismob.dm
@@ -31,3 +31,5 @@
 #define issmallanimal(x) istype(x, /mob/living/critter/small_animal)
 #define isghostcritter(x) (istype(x, /mob/living/critter) && x:ghost_spawned)
 #define ishelpermouse(x) (istype(x, /mob/living/critter/small_animal/mouse/weak/mentor))//mentor and admin mice
+
+#define isnewplayer(x) (istype(x, /mob/new_player)) //new player mobs (what u r if ur in the lobby screen, usually)

--- a/code/client.dm
+++ b/code/client.dm
@@ -141,8 +141,7 @@
 		src.holder.dispose()
 		src.holder = null
 
-	if (src.player)
-		src.player.log_leave_time() //logs leave time, calculates played time on player datum
+	src.player?.log_leave_time() //logs leave time, calculates played time on player datum
 
 	return ..()
 

--- a/code/client.dm
+++ b/code/client.dm
@@ -140,6 +140,10 @@
 		onlineAdmins.Remove(src)
 		src.holder.dispose()
 		src.holder = null
+
+	if (src.player)
+		src.player.log_leave_time() //logs leave time, calculates played time on player datum
+
 	return ..()
 
 /client/New()
@@ -164,8 +168,11 @@
 		player = make_player(key)
 	player.client = src
 
+	if (!isnewplayer(src.mob) && !isnull(src.mob)) //playtime logging stuff
+		src.player.log_join_time()
+
 	Z_LOG_DEBUG("Client/New", "[src.ckey] - Player set ([player])")
-	
+
 	// moved preferences from new_player so it's accessible in the client scope
 	if (!preferences)
 		preferences = new
@@ -190,7 +197,7 @@
 		)
 		src.loadResourcesFromList(chuiResources)
 
-	if (!istype(src.mob, /mob/new_player))
+	if (!isnewplayer(src.mob))
 		src.loadResources()
 
 /*

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -768,7 +768,7 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 
 	var/list/playtimes = list() //associative list with the format list("ckeys\[[player_ckey]]" = playtime_in_seconds)
 	for(var/datum/player/P in by_type[/datum/player])
-		if (!P || !P.ckey)
+		if (!P.ckey)
 			continue
 		P.log_leave_time() //get our final playtime for the round (wont cause errors with people who already d/ced bc of smart code)
 		if (isnull(P.current_playtime)) //not sure this will ever even happen but better safe than sorry

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -771,11 +771,14 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 		if (!P || !P.ckey)
 			continue
 		P.log_leave_time() //get our final playtime for the round (wont cause errors with people who already d/ced bc of smart code)
+		if (isnull(P.current_playtime)) //not sure this will ever even happen but better safe than sorry
+			P.current_playtime = 0
 		playtimes["ckeys\[[P.ckey]]"] = round((P.current_playtime / (1 SECOND))) //rounds 1/10th seconds to seconds
 	try
 		apiHandler.queryAPI("playtime/record-multiple", playtimes)
-	catch
-		logTheThing("debug", null, null, "playtime was unable to be logged because of an api error")
+	catch(var/exception/e)
+		logTheThing("debug", null, null, "playtime was unable to be logged because of: [e.name]")
+		logTheThing("diary", null, null, "playtime was unable to be logged because of: [e.name]", "debug")
 	return 1
 
 /////

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -774,9 +774,8 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 		playtimes["ckeys\[[P.ckey]]"] = round((P.current_playtime / (1 SECOND))) //rounds 1/10th seconds to seconds
 	try
 		apiHandler.queryAPI("playtime/record-multiple", playtimes)
-		logTheThing("debug", null, null, "playtime successfully logged") //lmk if this is bad practice
 	catch
-
+		logTheThing("debug", null, null, "playtime was unable to be logged because of an api error")
 	return 1
 
 /////

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -766,6 +766,16 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 
 	//logTheThing("debug", null, null, "Zamujasa: [world.timeofday] finished spacebux updates")
 
+	var/list/playtimes = list() //associative list with the format list("ckeys\[[player_ckey]]" = playtime_in_seconds)
+	for(var/datum/player/P in by_type[/datum/player])
+		if (!P || !P.ckey)
+			continue
+		P.log_leave_time() //get our final playtime for the round (wont cause errors with people who already d/ced bc of smart code)
+		playtimes["ckeys\[[P.ckey]]"] = round((P.current_playtime / (1 SECOND))) //rounds 1/10th seconds to seconds
+	try
+		apiHandler.queryAPI("playtime/record-multiple", playtimes)
+		logTheThing("debug", null, null, "playtime successfully logged") //lmk if this is bad practice
+	catch
 
 	return 1
 

--- a/code/mob/new_player.dm
+++ b/code/mob/new_player.dm
@@ -41,7 +41,7 @@ mob/new_player
 			mind = new(src)
 			keyd = mind.key
 
-		if (src?.client?.player) //playtime logging stuff
+		if (src.client?.player) //playtime logging stuff
 			var/datum/player/P = src.client.player
 			if (!isnull(P.round_join_time) && isnull(P.round_leave_time)) //they likely died but didnt d/c b4 respawn
 				P.log_leave_time()
@@ -93,8 +93,7 @@ mob/new_player
 		if (src.ckey) //Null if the client changed to another mob, but not null if they disconnected.
 			spawned_in_keys -= "[src.ckey]"
 		else if (isclient(src.last_client)) //playtime logging stuff
-			var/client/C = src.last_client
-			C.player.log_join_time()
+			src.last_client.player.log_join_time()
 
 		..()
 		close_spawn_windows()

--- a/code/mob/new_player.dm
+++ b/code/mob/new_player.dm
@@ -41,6 +41,11 @@ mob/new_player
 			mind = new(src)
 			keyd = mind.key
 
+		if (src?.client?.player) //playtime logging stuff
+			var/datum/player/P = src.client.player
+			if (!isnull(P.round_join_time) && isnull(P.round_leave_time)) //they likely died but didnt d/c b4 respawn
+				P.log_leave_time()
+
 		new_player_panel()
 		src.set_loc(pick_landmark(LANDMARK_NEW_PLAYER, locate(1,1,1)))
 		src.sight |= SEE_TURFS
@@ -87,6 +92,10 @@ mob/new_player
 		ready = 0
 		if (src.ckey) //Null if the client changed to another mob, but not null if they disconnected.
 			spawned_in_keys -= "[src.ckey]"
+		else if (isclient(src.last_client)) //playtime logging stuff
+			var/client/C = src.last_client
+			C.player.log_join_time()
+
 		..()
 		close_spawn_windows()
 		if(!spawning)


### PR DESCRIPTION
[ENHANCEMENT]

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
this makes it so that playtime is tracked. heres how it works

- in the lobby: no playtime tracking
- once you join: playtime begins tracking
- close the game midround (crash, cryo, whatever): playtime stops tracking
- rejoin midround: playtime resumes tracking
- get respawned to lobby screen: playtime stops tracking
- round ends: everyones playtime stops tracking, gets calculated and sent in a batch to goonhub thru api
(wire said api path is ready so i am trusting him)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
i think itd be neat. right now theres no way to see your playtime, but eventually spacebee might be open source or someone will just add playtime integration to .stats 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)adharainspace:
(+) your playtime is now tracked (you cant see it yet tho sorry)
```
