### PR TITLE
Fix radio scanner runtime when speaker is not a mob

### DIFF
--- a/code/WorkInProgress/MechanicMadness.dm
+++ b/code/WorkInProgress/MechanicMadness.dm
@@ -148,7 +148,7 @@
 				src.icon_state=initial(src.icon_state)+"_w"
 			else if(src.open)
 				// ugly warning, the istype() is 1 when there's a trigger in the container
-				//	it subtracts 1 from the list of contents when there's a trigger 
+				//	it subtracts 1 from the list of contents when there's a trigger
 				//	doing arithmatic on bools is probably not good!
 				var/has_trigger = istype(locate(/obj/item/mechanics/trigger/trigger) in src.contents,/obj/item/mechanics/trigger/trigger)
 				var/len_contents = src.contents.len - has_trigger
@@ -216,7 +216,7 @@
 		can_be_welded=true
 		can_be_anchored=true
 		slots=CABINET_CAPACITY // wew, dont use this in-hand or equipped!
-		name="Component Cabinet" // i tried to replace "23" below with "[CABINET_CAPACITY]", but byond 
+		name="Component Cabinet" // i tried to replace "23" below with "[CABINET_CAPACITY]", but byond
 									 // thinks it's not a constant and refuses to work with it.
 		desc="A rather chunky cabinet for storing up to 23 active mechanic components\
 		 at once.<br>It can only be connected to external components when bolted to the floor.<br>"
@@ -2413,16 +2413,22 @@
 		frequency = new_frequency
 		radio_connection = radio_controller.add_object(src, "[frequency]")
 		tooltip_rebuild = 1
-	proc/hear_radio(mob/M as mob, msg, lang_id)
+	proc/hear_radio(atom/movable/AM as mob|obj, msg, lang_id)
 		if (level == 2) return
 		LIGHT_UP_HOUSING
 		var/message = msg[2]
 		if (lang_id in list("english", ""))
 			message = msg[1]
 		message = strip_html(html_decode(message))
-		var/heardname = M.real_name
-		if (M.wear_mask && M.wear_mask.vchange)
-			heardname = M:wear_id ? M:wear_id:registered : "Unknown"
+		var/heardname = AM:real_name
+		if (ishuman(AM))
+			var/mob/living/carbon/human/H = AM
+			if (H.wear_mask && H.wear_mask.vchange)
+				if (istype(H.wear_id, /obj/item/card/id))
+					var/obj/item/card/id/ID = H.wear_id
+					heardname = ID.registered
+				else
+					heardname = "Unknown"
 		SEND_SIGNAL(src,COMSIG_MECHCOMP_TRANSMIT_SIGNAL,"name=[heardname]&message=[message]")
 		animate_flash_color_fill(src,"#00FF00",2, 2)
 		return

--- a/code/WorkInProgress/MechanicMadness.dm
+++ b/code/WorkInProgress/MechanicMadness.dm
@@ -2420,15 +2420,20 @@
 		if (lang_id in list("english", ""))
 			message = msg[1]
 		message = strip_html(html_decode(message))
-		var/heardname = AM:real_name
-		if (ishuman(AM))
-			var/mob/living/carbon/human/H = AM
-			if (H.wear_mask && H.wear_mask.vchange)
-				if (istype(H.wear_id, /obj/item/card/id))
-					var/obj/item/card/id/ID = H.wear_id
-					heardname = ID.registered
-				else
-					heardname = "Unknown"
+		var/heardname = null
+		if (isobj(AM))
+			heardname = AM.name
+		else if (ismob(AM))
+			heardname = AM:real_name
+			if (ishuman(AM))
+				var/mob/living/carbon/human/H = AM
+				if (H.wear_mask && H.wear_mask.vchange)
+					if (istype(H.wear_id, /obj/item/card/id))
+						var/obj/item/card/id/ID = H.wear_id
+						heardname = ID.registered
+					else
+						heardname = "Unknown"
+
 		SEND_SIGNAL(src,COMSIG_MECHCOMP_TRANSMIT_SIGNAL,"name=[heardname]&message=[message]")
 		animate_flash_color_fill(src,"#00FF00",2, 2)
 		return

--- a/code/WorkInProgress/MechanicMadness.dm
+++ b/code/WorkInProgress/MechanicMadness.dm
@@ -2413,7 +2413,7 @@
 		frequency = new_frequency
 		radio_connection = radio_controller.add_object(src, "[frequency]")
 		tooltip_rebuild = 1
-	proc/hear_radio(atom/movable/AM as mob|obj, msg, lang_id)
+	proc/hear_radio(atom/movable/AM, msg, lang_id)
 		if (level == 2) return
 		LIGHT_UP_HOUSING
 		var/message = msg[2]


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [BUG][RUNTIME] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
proc now takes an atom movable and only checks for a voice changer if you're a human


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
File | MechanicMadness.dm
-- | --
Line | 2424
Error | undefined variable /obj/machinery/computer/announcement/var/wear_mask
```
proc name: hear radio (/obj/item/mechanics/radioscanner/proc/hear_radio)
  source file: MechanicMadness.dm,2424
  usr: null
  src: Radio Scanner Component (/obj/item/mechanics/radioscanner)
  src.loc: the steel floor (136,188,1) (/turf/simulated/floor)
  call stack:
Radio Scanner Component (/obj/item/mechanics/radioscanner): hear radio(Bridge Announcement Computer (/obj/machinery/computer/announcement), /list (/list), "english")
Station Intercom (Radio) (/obj/item/device/radio/intercom): talk into(Bridge Announcement Computer (/obj/machinery/computer/announcement), /list (/list), 0, "Bridge Announcement Computer", "english")
Bridge Announcement Computer (/obj/machinery/computer/announcement): announce arrival("Sov Extant", "Captain")
the industrial cryogenics unit (/obj/cryotron): spawn next person()
```