### PR TITLE
Connects Security printer on oshan

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -40415,6 +40415,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bRN" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #2186 
Adds a data terminal to the security printer in oshan
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Not having to walk to netcafe when you print out a security record.
