### PR TITLE
Patches picking up deployed body bags (+ resets offsets on deploy)

### DIFF
--- a/code/modules/medical/surgery_tools.dm
+++ b/code/modules/medical/surgery_tools.dm
@@ -1148,8 +1148,18 @@ CONTAINS:
 		src.open()
 		src.visible_message("<span class='alert'><b>[user]</b> unzips themselves from [src]!</span>")
 
-	MouseDrop(mob/user as mob)
+	MouseDrop(atom/over_object)
+		if (!over_object) return
+		if(isturf(over_object))
+			..() //Lets it do the turf-to-turf slide
+			return
+		else if (istype(over_object, /obj/screen/hud))
+			MouseDrop(usr) //Try to fold & pick up the bag instead
+			return
+		else if (!ismob(over_object))
+			return
 		..()
+		var/mob/user = over_object
 		if (!(src.contents && src.contents.len) && (usr == user && !usr.restrained() && !usr.stat && in_range(src, usr) && !issilicon(usr)))
 			if (src.icon_state != "bodybag")
 				usr.visible_message("<b>[usr]</b> folds up [src].",\

--- a/code/modules/medical/surgery_tools.dm
+++ b/code/modules/medical/surgery_tools.dm
@@ -1122,6 +1122,8 @@ CONTAINS:
 			user.visible_message("<b>[user]</b> unfolds [src].",\
 			"You unfold [src].")
 			user.drop_item()
+			pixel_x = 0
+			pixel_y = 0
 			src.update_icon()
 		else
 			return

--- a/code/modules/medical/surgery_tools.dm
+++ b/code/modules/medical/surgery_tools.dm
@@ -1156,13 +1156,11 @@ CONTAINS:
 			..() //Lets it do the turf-to-turf slide
 			return
 		else if (istype(over_object, /obj/screen/hud))
-			MouseDrop(usr) //Try to fold & pick up the bag instead
-			return
-		else if (!ismob(over_object))
+			over_object = usr //Try to fold & pick up the bag with your mob instead
+		else if (!(over_object == usr))
 			return
 		..()
-		var/mob/user = over_object
-		if (!(src.contents && src.contents.len) && (usr == user && !usr.restrained() && !usr.stat && in_range(src, usr) && !issilicon(usr)))
+		if (!length(src.contents) && usr.can_use_hands() && isalive(usr) && IN_RANGE(src, usr, 1) && !issilicon(usr))
 			if (src.icon_state != "bodybag")
 				usr.visible_message("<b>[usr]</b> folds up [src].",\
 				"You fold up [src].")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[major][minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes an oversight where dragging a deployed body bag onto your HUD lets you pick one up in its deployed state. 
There's quite a added checks: The parent call includes a QOL tile-to-tile drag I wanted to keep, and I figured dragging to HUD should try to pick up the bag instead of doing nothing (It will just open a closed bag without picking up). The others are more or less sanity checks.

I also made it so the sprite offsets get reset if you deploy a body bag, so the visual effect with the layers doesn't break if you threw it around before deploying

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Some nerds figured out you could pick up shit including *other players* using body bags aaaaaa