### PR TITLE
Adds ghost vision genetic mutation

### DIFF
--- a/code/mob/living/life/sight.dm
+++ b/code/mob/living/life/sight.dm
@@ -148,7 +148,7 @@
 					human_owner.see_invisible = 2
 				human_owner.render_special.set_centerlight_icon("thermal", rgb(0.5 * 255, 0.5 * 255, 0.5 * 255))
 
-			else if (istype(human_owner.glasses, /obj/item/clothing/glasses/regular/ecto) || human_owner.eye_istype(/obj/item/organ/eye/cyber/ecto))
+			else if (istype(human_owner.glasses, /obj/item/clothing/glasses/regular/ecto) || human_owner.eye_istype(/obj/item/organ/eye/cyber/ecto) || human_owner.bioHolder && human_owner.bioHolder.HasEffect("sixthsense"))
 				if (human_owner.see_in_dark != 1)
 					human_owner.see_in_dark = 1
 				if (human_owner.see_invisible < 15)

--- a/code/modules/medical/genetics/bioEffects/beneficial.dm
+++ b/code/modules/medical/genetics/bioEffects/beneficial.dm
@@ -453,6 +453,26 @@ var/list/radio_brains = list()
 	degrade_to = "bad_eyesight"
 	icon_state  = "eye"
 
+/datum/bioEffect/sixthsense
+	name = "Sixth Sense"
+	desc = "Enables the subject to perceive super-natural occurences."
+	id = "sixthsense"
+	effectType = EFFECT_TYPE_POWER
+	probability = 33
+	blockCount = 3
+	blockGaps = 3
+	reclaim_mats = 30
+	msgGain = "A haunting dread fills the room."
+	msgLose = "The haunting feeling passes."
+	lockProb = 40
+	lockedGaps = 1
+	lockedDiff = 3
+	lockedChars = list("G","C","A","T")
+	lockedTries = 8
+	stability_loss = 25
+	degrade_to = "screamer"
+	icon_state  = "eye"
+
 /datum/bioEffect/toxic_farts
 	name = "High Decay Digestion"
 	desc = "Causes the subject's digestion to create a significant amount of noxious gas."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
New gene that allows the player to see ghosts, similar to ecto eyes.
The rarity is basically a mirror of the other two vision genes.
The rarity is on par with night vision and xray, so I feel balance wise it'll be in the same boat when it comes to most antags. I don't believe it will impact wraith more than xray or night vision impacts other antags.
_It may also get geneticists to notice the swarms of ghosts sitting around them.._


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I've always thought the ecto eyes & void goggles were a neat idea, who wouldn't want to see ghosts? So I added another avenue of being able to see them. 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)QTNeen
(*)Added a new genetic mutation that allows you to see ghosts! Spooky.
```
