### PR TITLE
buff bloodtrack

### DIFF
--- a/code/obj/item/pinpointer.dm
+++ b/code/obj/item/pinpointer.dm
@@ -185,7 +185,7 @@
 	var/active = 0
 	var/target = null
 	mats = 4
-	desc = "Tracks down people from their blood puddles! Requires you to stand still to function."
+	desc = "Tracks down people from their blood puddles!"
 	var/blood_timer = 0
 
 	afterattack(atom/A as mob|obj|turf|area, mob/user as mob)

--- a/code/obj/item/pinpointer.dm
+++ b/code/obj/item/pinpointer.dm
@@ -186,6 +186,7 @@
 	var/target = null
 	mats = 4
 	desc = "Tracks down people from their blood puddles! Requires you to stand still to function."
+	var/blood_timer = 0
 
 	afterattack(atom/A as mob|obj|turf|area, mob/user as mob)
 		if(!active && istype(A, /obj/decal/cleanable/blood))
@@ -196,6 +197,7 @@
 			for(var/mob/living/carbon/human/H in mobs)
 				if(B.blood_DNA == H.bioHolder.Uid)
 					target = H
+					blood_timer = TIME + (B.dry==-1?8 MINUTES:4 MINUTES)
 					break
 			active = 1
 			work()
@@ -206,10 +208,10 @@
 		if(!active) return
 		if(!T)
 			T = get_turf(src)
-		if(get_turf(src) != T)
+		if(TIME > blood_timer)
 			icon_state = "blood_pinoff"
 			active = 0
-			boutput(usr, "<span class='alert'>[src] shuts down because you moved!</span>")
+			boutput(usr, "<span class='alert'>[src] shuts down because the blood in it became too dry!</span>")
 			return
 		if(!target)
 			icon_state = "blood_pinonnull"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This makes it so that the BloodTrak can now be used while walking instead of shutting down.
Instead, there is a timer for how long the device will operate with the blood, this is 8 minutes for very fresh blood and 4 minutes for semi-dried blood.
Dried blood remains useless.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
BloodTrak seems to never be used right now, because being able to see the general direction of a person while standing still is kind of not very useful.
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u) zjdtmkhzt:
(+) The Detectives BloodTrak now also works while moving but will shut down after a while, depending on how fresh the used blood was.
```
