### PR TITLE
Replaces cog1 decal broken bulb with a real one

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -218,6 +218,13 @@
 			name = "very harsh incandescent light bulb"
 			light_type = /obj/item/light/bulb/harsh/very
 
+	broken //Made at first to replace a decal in cog1's wreckage area
+		name = "shattered light bulb"
+
+		New()
+			..()
+			current_lamp.light_status = LIGHT_BROKEN
+
 	//The only difference between these small lights and others are that these automatically stick to walls! Wow!!
 	sticky
 		nostick = 0
@@ -256,6 +263,8 @@
 			very
 				name = "very harsh incandescent light bulb"
 				light_type = /obj/item/light/bulb/harsh/very
+
+
 
 //floor lights
 /obj/machinery/light/small/floor

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -6005,7 +6005,10 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/autoname_north,
+/obj/machinery/power/apc/autoname_north{
+	autoname_on_spawn = 0;
+	name = "Abandoned APC"
+	},
 /turf/simulated/floor/airless/damaged2,
 /area/station/wreckage)
 "anO" = (

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -6001,6 +6001,11 @@
 "anN" = (
 /obj/structure/girder,
 /obj/grille/steel,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/airless/damaged2,
 /area/station/wreckage)
 "anO" = (
@@ -6520,10 +6525,20 @@
 /area/station/wreckage)
 "aoY" = (
 /obj/decal/cleanable/oil,
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/airless/grime,
 /area/station/wreckage)
 "aoZ" = (
 /obj/item/raw_material/rock,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/airless/grime,
 /area/station/wreckage)
 "apa" = (
@@ -6533,6 +6548,11 @@
 	icon_state = "2-4"
 	},
 /obj/creepy_sound_trigger,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating/airless,
 /area/station/wreckage)
 "apb" = (
@@ -62997,6 +63017,13 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
+"fSi" = (
+/obj/lattice,
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/space,
+/area/station/wreckage)
 "fVA" = (
 /obj/machinery/portable_atmospherics/canister/empty,
 /obj/machinery/atmospherics/pipe/manifold{
@@ -63572,13 +63599,6 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
-"rxq" = (
-/obj/lattice,
-/obj/machinery/light/small/broken{
-	dir = 4
-	},
-/turf/space,
-/area/station/wreckage)
 "rEe" = (
 /obj/machinery/light_switch{
 	name = "S light switch";
@@ -98447,7 +98467,7 @@ aaa
 aaa
 ajz
 aky
-rxq
+fSi
 amz
 anO
 apa

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -5055,13 +5055,6 @@
 /obj/lattice,
 /turf/space,
 /area/station/wreckage)
-"alE" = (
-/obj/lattice,
-/obj/decal/fakeobjects/lightbulb_broken{
-	dir = 4
-	},
-/turf/space,
-/area/station/wreckage)
 "alF" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/wreckage)
@@ -63579,6 +63572,13 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
+"rxq" = (
+/obj/lattice,
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/space,
+/area/station/wreckage)
 "rEe" = (
 /obj/machinery/light_switch{
 	name = "S light switch";
@@ -98447,7 +98447,7 @@ aaa
 aaa
 ajz
 aky
-alE
+rxq
 amz
 anO
 apa


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR replaces the decal broken lightbulb object in cog1's twisted wreckage (that dump between the brig and crew quarters maint) with a proper light fitting, so it can be repaired or removed entirely by players.

Because you need to be able to disable lighting power to remove a fitting (not even borgs can bypass this) I also had to add an APC for the Twisted Wreckage area. I've tested setting up the engine and it did charge.
![afbeelding](https://user-images.githubusercontent.com/31984217/93637946-bc9e8d80-f9f6-11ea-84f2-e812a25f0c98.png)
(It's that fitting in the top right)
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The area is a prime contender for construction projects on cog1, and the unremovable decal bulb is very much an ugly bother.
The APC is more an unplanned necessity, but I feel like having one there already is actually a boon if you're going to build stuff there.