### PR TITLE
Solar Flare change.

### DIFF
--- a/code/datums/communications.dm
+++ b/code/datums/communications.dm
@@ -80,8 +80,9 @@ datum/radio_frequency
 	var/frequency
 	var/list/obj/devices = list()
 
-	//MBC : check_for_jammer proc was being called thousands of times per second. Do its initial check in a define instead, because proc call overhead. Then call check_for_jammer_bare
-	#define can_check_jammer (!prob(signal_loss) && radio_controller.active_jammers.len)
+	//MBC : check_for_jammer proc was being called thousands of times per second. 
+	//Do its initial check in a define instead, because proc call overhead. Then call check_for_jammer_bare
+	#define can_check_jammer (radio_controller.active_jammers.len)
 
 	disposing()
 		devices = null
@@ -100,8 +101,9 @@ datum/radio_frequency
 						reusable_signals += signal
 					return 0
 
-			if (check_for_jammer(source))
-				return 0
+			if (can_check_jammer)
+				if (check_for_jammer(source))
+					return 0
 
 			signal.channels_passed += "[src.frequency];"
 
@@ -110,7 +112,7 @@ datum/radio_frequency
 
 					//MBC : Do checks here and call check_for_jammer_bare instead. reduces proc calls.
 					if (can_check_jammer)
-						if (check_for_jammer_bare(device))
+						if (check_for_jammer(device))
 							continue
 
 					if(range)
@@ -132,23 +134,24 @@ datum/radio_frequency
 				reusable_signals |= signal
 			LAGCHECK(LAG_MED)
 
-		check_for_jammer(obj/source)
-			.= 0
-			if (prob(signal_loss))
-				.= 1
-			else
-				if (radio_controller.active_jammers.len)
-					for (var/atom in radio_controller.active_jammers) // Can be a mob or obj.
-						var/atom/A = atom
-						if (A && get_dist(get_turf(source), get_turf(A)) <= 6)
-							.= 1
+		// check_for_jammer(obj/source)
+		// 	.= 0
+		// 	if (prob(signal_loss))
+		// 		.= 1
+		// 	else
+		// 		if (radio_controller.active_jammers.len)
+		// 			for (var/atom in radio_controller.active_jammers) // Can be a mob or obj.
+		// 				var/atom/A = atom
+		// 				if (A && get_dist(get_turf(source), get_turf(A)) <= 6)
+		// 					return 1
 
-		check_for_jammer_bare(obj/source)
+		//assumes that list radio_controller.active_jammers is not null or empty.
+		check_for_jammer(obj/source)
 			.= 0
 			for (var/atom in radio_controller.active_jammers) // Can be a mob or obj.
 				var/atom/A = atom
 				if (A && get_dist(get_turf(source), get_turf(A)) <= 6)
-					.= 1
+					return 1
 
 obj/proc
 	receive_signal(datum/signal/signal, receive_method, receive_param)

--- a/code/datums/communications.dm
+++ b/code/datums/communications.dm
@@ -134,17 +134,6 @@ datum/radio_frequency
 				reusable_signals |= signal
 			LAGCHECK(LAG_MED)
 
-		// check_for_jammer(obj/source)
-		// 	.= 0
-		// 	if (prob(signal_loss))
-		// 		.= 1
-		// 	else
-		// 		if (radio_controller.active_jammers.len)
-		// 			for (var/atom in radio_controller.active_jammers) // Can be a mob or obj.
-		// 				var/atom/A = atom
-		// 				if (A && get_dist(get_turf(source), get_turf(A)) <= 6)
-		// 					return 1
-
 		//assumes that list radio_controller.active_jammers is not null or empty.
 		check_for_jammer(obj/source)
 			.= 0

--- a/code/obj/item/device/radio.dm
+++ b/code/obj/item/device/radio.dm
@@ -24,6 +24,8 @@
 	var/datum/radio_frequency/radio_connection
 	var/speaker_range = 2
 	var/static/image/speech_bubble = image('icons/mob/mob.dmi', "speech")
+	var/hardened = 1	//This is for being able to run through signal jammers (just solar flares for now). acceptable values = 0 and 1. 
+
 	flags = FPRINT | TABLEPASS | ONBELT | CONDUCT
 	throw_speed = 2
 	throw_range = 9
@@ -250,7 +252,7 @@ Green Wire: <a href='?src=\ref[src];wires=[WIRE_TRANSMIT]'>[src.wires & WIRE_TRA
 /obj/item/device/radio/talk_into(mob/M as mob, messages, secure, real_name, lang_id)
 	// According to a pair of DEBUG calls set up for testing, no radio jammer check for the src radio was performed.
 	// As improbable as this sounds, there are bug reports too to back up the findings. So uhm...
-	if (src.radio_connection.check_for_jammer(src) != 0)
+	if (radio_controller.active_jammers.len && src.radio_connection.check_for_jammer(src) != 0)	//First bit is basically can_check_jammer but on this connection
 		return
 	if (!(src.wires & WIRE_TRANSMIT))
 		return
@@ -293,7 +295,11 @@ Green Wire: <a href='?src=\ref[src];wires=[WIRE_TRANSMIT]'>[src.wires & WIRE_TRA
 			var/obj/item/device/radio/R = I
 			//MBC : Do checks here and call check_for_jammer_bare instead. reduces proc calls.
 			if (can_check_jammer)
-				if (connection.check_for_jammer_bare(R))
+				if (connection.check_for_jammer(R))
+					continue
+			//if we have signal_loss (solar flare), and the radio isn't hardened don't send message, then block general frequencies.
+			if (signal_loss && !src.hardened)
+				if (connection.frequency >= R_FREQ_MINIMUM && connection.frequency <= R_FREQ_MAXIMUM)
 					continue
 
 			if (R.accept_rad(src, messages, connection))

--- a/code/obj/item/device/radio.dm
+++ b/code/obj/item/device/radio.dm
@@ -307,6 +307,9 @@ Green Wire: <a href='?src=\ref[src];wires=[WIRE_TRANSMIT]'>[src.wires & WIRE_TRA
 				if (secure)
 					for (var/i in R.send_hear())
 						if (!(i in receive))
+							if (signal_loss && !I.hardened && I.frequency >= R_FREQ_MINIMUM && I.frequency <= R_FREQ_MAXIMUM)
+								continue
+
 							receive += i
 
 							//mbc : i dont like doing this here but its the easiest place to fit it in since this is a point where we have access to both the receiving mob and the radio they are receiving through
@@ -320,6 +323,8 @@ Green Wire: <a href='?src=\ref[src];wires=[WIRE_TRANSMIT]'>[src.wires & WIRE_TRA
 				else
 					for (var/i in R.send_hear())
 						if (!(i in receive))
+							if (signal_loss && !I.hardened && I.frequency >= R_FREQ_MINIMUM && I.frequency <= R_FREQ_MAXIMUM)
+								continue
 							receive += i
 
 							if (ai_sender)
@@ -360,6 +365,7 @@ Green Wire: <a href='?src=\ref[src];wires=[WIRE_TRANSMIT]'>[src.wires & WIRE_TRA
 		var/mob/dead/D = C.mob
 
 		if ((istype(D, /mob/dead/observer) || (iswraith(D) && !D.density)) || ((!isturf(src.loc) && src.loc == D.loc) && !istype(D, /mob/dead/target_observer)))
+
 			if (!(D in receive))
 				receive += D
 

--- a/code/obj/item/device/radio.dm
+++ b/code/obj/item/device/radio.dm
@@ -307,8 +307,6 @@ Green Wire: <a href='?src=\ref[src];wires=[WIRE_TRANSMIT]'>[src.wires & WIRE_TRA
 				if (secure)
 					for (var/i in R.send_hear())
 						if (!(i in receive))
-							// if (signal_loss && !R.hardened && R.frequency >= R_FREQ_MINIMUM && R.frequency <= R_FREQ_MAXIMUM)
-							// 	continue
 							receive += i
 
 							//mbc : i dont like doing this here but its the easiest place to fit it in since this is a point where we have access to both the receiving mob and the radio they are receiving through

--- a/code/obj/item/device/radio.dm
+++ b/code/obj/item/device/radio.dm
@@ -298,7 +298,7 @@ Green Wire: <a href='?src=\ref[src];wires=[WIRE_TRANSMIT]'>[src.wires & WIRE_TRA
 				if (connection.check_for_jammer(R))
 					continue
 			//if we have signal_loss (solar flare), and the radio isn't hardened don't send message, then block general frequencies.
-			if (signal_loss && !src.hardened)
+			if (signal_loss && !src.hardened && !secure)
 				if (connection.frequency >= R_FREQ_MINIMUM && connection.frequency <= R_FREQ_MAXIMUM)
 					continue
 
@@ -307,9 +307,8 @@ Green Wire: <a href='?src=\ref[src];wires=[WIRE_TRANSMIT]'>[src.wires & WIRE_TRA
 				if (secure)
 					for (var/i in R.send_hear())
 						if (!(i in receive))
-							if (signal_loss && !R.hardened && R.frequency >= R_FREQ_MINIMUM && R.frequency <= R_FREQ_MAXIMUM)
-								continue
-
+							// if (signal_loss && !R.hardened && R.frequency >= R_FREQ_MINIMUM && R.frequency <= R_FREQ_MAXIMUM)
+							// 	continue
 							receive += i
 
 							//mbc : i dont like doing this here but its the easiest place to fit it in since this is a point where we have access to both the receiving mob and the radio they are receiving through

--- a/code/obj/item/device/radio.dm
+++ b/code/obj/item/device/radio.dm
@@ -307,7 +307,7 @@ Green Wire: <a href='?src=\ref[src];wires=[WIRE_TRANSMIT]'>[src.wires & WIRE_TRA
 				if (secure)
 					for (var/i in R.send_hear())
 						if (!(i in receive))
-							if (signal_loss && !I.hardened && I.frequency >= R_FREQ_MINIMUM && I.frequency <= R_FREQ_MAXIMUM)
+							if (signal_loss && !R.hardened && R.frequency >= R_FREQ_MINIMUM && R.frequency <= R_FREQ_MAXIMUM)
 								continue
 
 							receive += i
@@ -323,7 +323,7 @@ Green Wire: <a href='?src=\ref[src];wires=[WIRE_TRANSMIT]'>[src.wires & WIRE_TRA
 				else
 					for (var/i in R.send_hear())
 						if (!(i in receive))
-							if (signal_loss && !I.hardened && I.frequency >= R_FREQ_MINIMUM && I.frequency <= R_FREQ_MAXIMUM)
+							if (signal_loss && !R.hardened && R.frequency >= R_FREQ_MINIMUM && R.frequency <= R_FREQ_MAXIMUM)
 								continue
 							receive += i
 

--- a/code/obj/item/device/radios/headsets.dm
+++ b/code/obj/item/device/radios/headsets.dm
@@ -14,6 +14,7 @@
 	flags = FPRINT | TABLEPASS | CONDUCT | ONBELT
 	icon_override = "civ"
 	var/haswiretap
+	hardened = 0
 
 	attackby(obj/item/R as obj, mob/user as mob)
 		if (istype(R, /obj/item/device/radio_upgrade))

--- a/code/obj/item/device/radios/intercoms.dm
+++ b/code/obj/item/device/radios/intercoms.dm
@@ -12,7 +12,8 @@
 	var/number = 0
 	rand_pos = 0
 	desc = "A wall-mounted radio intercom, used to communicate with the specified frequency. Usually turned off except during emergencies."
-
+	hardened = 0
+	
 /obj/item/device/radio/intercom/New()
 	. = ..()
 	if(src.icon_state == "intercom") // if something overrides the icon we don't want this

--- a/code/obj/item/stickers.dm
+++ b/code/obj/item/stickers.dm
@@ -561,6 +561,7 @@
 	name = "spy radio"
 	desc = "Spy radio housed in a sticker. Wait, how are you reading this?"
 	listening = 0
+	hardened = 0
 
 /obj/item/device/radio/spy/sec_only
 	locked_frequency = 1


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes Solar Flare random events block the general radio frequencies 100%, but secure channels like: Command, Engineering, Civilian, Security, Medical, and Research still work. As should gang and nukeops. 

Station bounced radios do work, but Intercoms currently don't work through solar flares, but we can change that with the flick of a switch.

TY to Grifflez for helping me test.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Solar flare is pretty boring. It basically cuts off communication for everyone who isn't willing to spam chat with the same message over and over again. It's a good event for traitors to do activities, _sorta_, because it's basically a prob roll, which doesn't feel good if someone gets a message through or doesn't get one through via the random chance.

Now it'll be more about picking someone who has a bad radio low amount of people on frequencies list. I suppose this is sort of nerfing the event in terms of antags, but it's also sorta a test to see how departmental radios and command working as an interdepartmental liason works.


## Changelog
```
(u)kyle:
(*)Solar Flares block all general radio frequencies from and to headsets. Secure/department radios now work through the solar flare though to compensate. Station bounced radios can send and receive radio signals through the flare.
```
