### PR TITLE
make all sea plants removable

### DIFF
--- a/code/obj/sealab_objects.dm
+++ b/code/obj/sealab_objects.dm
@@ -49,9 +49,10 @@
 			src.pixel_y = rand(-8,8)
 
 	attackby(obj/item/W, mob/user)
-		if (drop_type && issnippingtool(W))
-			var/obj/item/drop = new drop_type
-			drop.set_loc(src.loc)
+		if (issnippingtool(W))
+			if(drop_type)
+				var/obj/item/drop = new drop_type
+				drop.set_loc(src.loc)
 			src.visible_message("<span class='alert'>[user] cuts down [src].</span>")
 			qdel(src)
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This changes it so that you can cut down a sea plant even if it does not yield an item.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allows you to cut down stuff like anemones, to make room for a gigantic ballroom or whatever, idk what you wanna build.
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u) zjdtmkhzt:
(+) All types of sea plants (or plantlike organisms) should now be removable with wirecutters.
```
