### PR TITLE
UM-055 - QM Clock 180 Spawns Unloaded

### DIFF
--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -447,6 +447,9 @@
 	ammo_type = new/datum/projectile/bullet/nine_mm_NATO
 	caliber = 0.355
 
+/obj/item/ammo/bullets/nine_mm_NATO/boomerang //empty clip for the clock_188/boomerang
+	amount_left = 0
+
 /obj/item/ammo/bullets/a12
 	sname = "12ga Buckshot"
 	name = "12ga buckshot ammo box"

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -500,8 +500,13 @@
 			icon_state = "glocktan"
 			item_state = "glocktan"
 
-		ammo = new/obj/item/ammo/bullets/nine_mm_NATO
+		if(throw_return)
+			ammo = new/obj/item/ammo/bullets/nine_mm_NATO/boomerang
+		else
+			ammo = new/obj/item/ammo/bullets/nine_mm_NATO
+
 		current_projectile = new/datum/projectile/bullet/nine_mm_NATO
+
 		if(throw_return)
 			projectiles = list(current_projectile)
 		else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- clock 180s now start unloaded

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

- go get your own ammo, freeloaders

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)UrsulaMejor:
(+)Clock 180s at QM now spawn unloaded
```
