### PR TITLE
Fixes infinite recursion when trying to quick-swap a reinforced floor

### DIFF
--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -1439,6 +1439,14 @@
 				user.u_equip(T)
 				qdel(T)
 			return
+		if(intact)
+			var/obj/P = user.find_tool_in_hand(TOOL_PRYING)
+			if (!P)
+				return
+			// Call ourselves w/ the tool, then continue
+			src.attackby(P, user)
+
+		// Don't replace with an [else]! If a prying tool is found above [intact] might become 0 and this runs too, which is how floor swapping works now! - BatElite
 		if (!intact)
 			restore_tile()
 			src.plate_mat = src.material
@@ -1453,16 +1461,6 @@
 			//if(T && (--T.amount < 1))
 			//	qdel(T)
 			//	return
-
-		else
-			var/obj/P = user.find_tool_in_hand(TOOL_PRYING)
-
-			if (!P)
-				return
-
-			// Call ourselves w/ the tool, then the tile
-			src.attackby(P, user)
-			src.attackby(C, user)
 
 
 	if(istype(C, /obj/item/sheet))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug] and maybe [cleanliness]?
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR switches the cases for using a floor tile on a floor around, so it tries to look for a prying tool on an intact floor before doing the ```!intact``` check. The practical benefit of this is that we save recursively calling ```attackby``` with the floor tile, and an infinite recursion bug someone found with that.

closes #2252 
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Can't reach maximum recursion depth if you don't use recursion. :D
(Things would probably still go horribly wrong if we ever made a floortile that's also a prying tool though.)

I heard something about proc overhead in the coder channel and I'm assuming this is slightly better in that regard too, but I doubt that it matters much at the scale peeps replace floor tiles with.