### PR TITLE
small change to artifact names

### DIFF
--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -148,7 +148,8 @@
 		return 1
 	var/datum/artifact/A = src.artifact
 	if(A.internal_name)
-		src.name = A.internal_name
+		src.real_name = A.internal_name
+		UpdateName()
 	if (A.activated)
 		return 1
 	if (A.triggers.len < 1 && !A.automatic_activation)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This change should make it so that the real artifact names that are revealed after one is activated are not lost when the artifact name is updated again. (For instance by labeling it.)
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Lots of people label artifacts, it was dumb.