### PR TITLE
Increases borg's interaction range by 3 squares

### DIFF
--- a/code/modules/tgui/states.dm
+++ b/code/modules/tgui/states.dm
@@ -30,7 +30,7 @@
 			. = max(., UI_INTERACTIVE)
 
 		// Regular ghosts can always at least view if in range.
-		if(get_dist(src_object, user) < (SQUARE_TILE_WIDTH / 2))
+		if(get_dist(src, src_object) <= ((WIDE_TILE_WIDTH - 1)/ 2))
 			. = max(., UI_UPDATE)
 
 	// Check if the state allows interaction

--- a/code/modules/tgui/states/default.dm
+++ b/code/modules/tgui/states/default.dm
@@ -29,7 +29,7 @@ var/global/datum/ui_state/tgui_default_state/tgui_default_state = new /datum/ui_
 		return
 
 	// Robots can interact with anything they can see.
-	if(get_dist(src, src_object) <= SQUARE_TILE_WIDTH)
+	if(get_dist(src, src_object) <= (WIDE_TILE_WIDTH / 2))
 		return UI_INTERACTIVE
 
 	// AI Borgs can recieve updates from anything that the AI can see.
@@ -44,7 +44,7 @@ var/global/datum/ui_state/tgui_default_state/tgui_default_state = new /datum/ui_
 		return
 
 	// Robots can interact with anything they can see.
-	if(get_dist(src, src_object) <= SQUARE_TILE_WIDTH)
+	if(get_dist(src, src_object) <= (WIDE_TILE_WIDTH / 2))
 		return UI_INTERACTIVE
 
 	return UI_UPDATE // AI eyebots can recieve updates from anything that the AI can see.

--- a/code/modules/tgui/states/default.dm
+++ b/code/modules/tgui/states/default.dm
@@ -29,7 +29,7 @@ var/global/datum/ui_state/tgui_default_state/tgui_default_state = new /datum/ui_
 		return
 
 	// Robots can interact with anything they can see.
-	if(get_dist(src, src_object) <= (SQUARE_TILE_WIDTH / 2))
+	if(get_dist(src, src_object) <= SQUARE_TILE_WIDTH)
 		return UI_INTERACTIVE
 
 	// AI Borgs can recieve updates from anything that the AI can see.
@@ -44,7 +44,7 @@ var/global/datum/ui_state/tgui_default_state/tgui_default_state = new /datum/ui_
 		return
 
 	// Robots can interact with anything they can see.
-	if(get_dist(src, src_object) <= (SQUARE_TILE_WIDTH / 2))
+	if(get_dist(src, src_object) <= SQUARE_TILE_WIDTH)
 		return UI_INTERACTIVE
 
 	return UI_UPDATE // AI eyebots can recieve updates from anything that the AI can see.

--- a/code/modules/tgui/states/default.dm
+++ b/code/modules/tgui/states/default.dm
@@ -29,7 +29,7 @@ var/global/datum/ui_state/tgui_default_state/tgui_default_state = new /datum/ui_
 		return
 
 	// Robots can interact with anything they can see.
-	if(get_dist(src, src_object) <= (WIDE_TILE_WIDTH / 2))
+	if(get_dist(src, src_object) <= ((WIDE_TILE_WIDTH - 1)/ 2))
 		return UI_INTERACTIVE
 
 	// AI Borgs can recieve updates from anything that the AI can see.
@@ -44,7 +44,7 @@ var/global/datum/ui_state/tgui_default_state/tgui_default_state = new /datum/ui_
 		return
 
 	// Robots can interact with anything they can see.
-	if(get_dist(src, src_object) <= (WIDE_TILE_WIDTH / 2))
+	if(get_dist(src, src_object) <= ((WIDE_TILE_WIDTH - 1)/ 2))
 		return UI_INTERACTIVE
 
 	return UI_UPDATE // AI eyebots can recieve updates from anything that the AI can see.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Increases borg's interaction range by 3 squares by using WIDE_TILE_WIDTH instead of SQUARE_TILE_WIDTH.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Widescreen borgs will be able to interact with anything they can see and square screen borgs will be able to move a bit further away when interacting with things.

This borg can't interact with this airlock
![image](https://user-images.githubusercontent.com/10260415/94240871-cdc22f80-ff0b-11ea-9950-985ca2840e36.png)
