### PR TITLE
blood, reagents, hearts

### DIFF
--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -736,6 +736,7 @@
 		..()
 		if(ishuman(M))
 			M.mob_flags |= IS_BONER
+		M.blood_id = "calcium"
 
 	disposing()
 		if (ishuman(mob) && (mob.mob_flags & IS_BONER))

--- a/code/mob/living/life/chems.dm
+++ b/code/mob/living/life/chems.dm
@@ -12,9 +12,9 @@
 
 			owner.reagents.temperature_reagents(owner.bodytemperature, 100, 35/reagent_time_multiplier, 15*reagent_time_multiplier)
 
-			if (blood_system && owner.reagents.get_reagent("blood"))
-				var/blood2absorb = min(owner.blood_absorption_rate, owner.reagents.get_reagent_amount("blood")) * reagent_time_multiplier
-				owner.reagents.remove_reagent("blood", blood2absorb)
+			if (blood_system && owner.reagents.get_reagent("[owner.blood_id]"))
+				var/blood2absorb = min(owner.blood_absorption_rate, owner.reagents.get_reagent_amount("[owner.blood_id]")) * reagent_time_multiplier
+				owner.reagents.remove_reagent("[owner.blood_id]", blood2absorb)
 				owner.blood_volume += blood2absorb
 			if (owner.metabolizes && owner.reagents)//idk it runtimes)
 				owner.reagents.metabolize(owner, multiplier = reagent_time_multiplier * (HAS_MOB_PROPERTY(owner, PROP_METABOLIC_RATE) ? GET_MOB_PROPERTY(owner, PROP_METABOLIC_RATE) : 1))

--- a/code/obj/item/organ_holder.dm
+++ b/code/obj/item/organ_holder.dm
@@ -537,8 +537,6 @@
 				if (!src.heart)
 					return 0
 				var/obj/item/organ/heart/myHeart = src.heart
-				if (src.donor.reagents)
-					src.donor.reagents.trans_to(myHeart, 330)
 				//Commented this out for some reason I forget. I'm sure I'll remember what it is one day. -kyle
 				// if (src.heart.robotic)
 				// 	src.donor.remove_stam_mod_regen("heart")
@@ -1038,8 +1036,6 @@
 			if (istype(I, /obj/item/organ))
 				var/obj/item/organ/O = I
 				O.on_transplant(src.donor)
-			if (I.reagents)
-				I.reagents.trans_to(src.donor, 330)
 			if (is_full_robotic())
 				donor.unlock_medal("Spaceship of Theseus", 1)
 			return 1

--- a/code/obj/item/organs/heart.dm
+++ b/code/obj/item/organs/heart.dm
@@ -18,10 +18,11 @@
 	var/body_image = null // don't have time to completely refactor this, but, what name does the heart icon have in human.dmi?
 	var/transplant_XP = 5
 	var/blood_id = "blood"
+	var/reag_cap = 100
 
 	New(loc, datum/organHolder/nholder)
 		. = ..()
-		reagents = new/datum/reagents(100)
+		reagents = new/datum/reagents(reag_cap)
 
 	disposing()
 		if (holder)

--- a/code/obj/item/organs/heart.dm
+++ b/code/obj/item/organs/heart.dm
@@ -17,6 +17,11 @@
 	var/list/diseases = null
 	var/body_image = null // don't have time to completely refactor this, but, what name does the heart icon have in human.dmi?
 	var/transplant_XP = 5
+	var/blood_id = "blood"
+
+	New(loc, datum/organHolder/nholder)
+		. = ..()
+		reagents = new/datum/reagents(100)
 
 	disposing()
 		if (holder)
@@ -25,6 +30,9 @@
 
 	on_transplant(var/mob/M as mob)
 		..()
+		if (src.donor.reagents && src.reagents)
+			src.reagents.trans_to(src.donor, src.reagents.total_volume)
+
 		if (src.robotic)
 			if (src.emagged)
 				src.donor.add_stam_mod_regen("heart", 15)
@@ -39,6 +47,7 @@
 			for (var/datum/ailment_data/disease in src.donor.ailments)
 				if (disease.cure == "Heart Transplant")
 					src.donor.cure_disease(disease)
+			src.donor.blood_id = (ischangeling(src.donor) && src.blood_id == "blood") ? "bloodc" : src.blood_id
 		if (ishuman(M) && islist(src.diseases))
 			var/mob/living/carbon/human/H = M
 			for (var/datum/ailment_data/AD in src.diseases)
@@ -49,6 +58,9 @@
 	on_removal()
 		..()
 		if (donor)
+			if (src.donor.reagents && src.reagents)
+				src.donor.reagents.trans_to(src, src.reagents.maximum_volume - src.reagents.total_volume)
+
 			if (src.robotic)
 				src.donor.remove_stam_mod_regen("heart")
 				src.donor.remove_stam_mod_max("heart")
@@ -119,6 +131,7 @@
 	var/resources = 0 // reagents for humans go in heart, resources for flockdrone go in heart, now, not the brain
 	var/flockjuice_limit = 20 // pump flockjuice into the human host forever, but only a small bit
 	var/min_blood_amount = 450
+	blood_id = "flockdrone_fluid"
 
 	on_transplant(var/mob/M as mob)
 		..()

--- a/code/obj/item/organs/heart.dm
+++ b/code/obj/item/organs/heart.dm
@@ -61,6 +61,8 @@
 			if (src.donor.reagents && src.reagents)
 				src.donor.reagents.trans_to(src, src.reagents.maximum_volume - src.reagents.total_volume)
 
+			src.blood_id = src.donor.blood_id //keep our owner's blood (for mutantraces etc)
+
 			if (src.robotic)
 				src.donor.remove_stam_mod_regen("heart")
 				src.donor.remove_stam_mod_max("heart")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Give skeletons calcium blood
blood absorption is based on blood_id, not hardcoded to blood chem
Codified 100u reagent cap on hearts; heart surgery only transfers up to the heart's capacity
flockhearts change blood id to gnesis
hearts keep the blood id of donor on removal
hearts set the blood id of mob on transplant


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
more blood system stuff, more functionality for hearts


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Tarmunora:
(*)Heart transplants only move a limited amount of reagents from the patient
(+)Skeletons have calcium blood.
```
