### PR TITLE
adjust hyperallergenic, histamine and related stuff

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -799,7 +799,7 @@ obj/trait/pilot
 
 	onLife(var/mob/owner)
 		if (owner?.reagents?.has_reagent(allergen))
-			owner.reagents.add_reagent("histamine", 1.4) //1.4 units of histamine per life cycle? is that too much?
+			owner.reagents.add_reagent("histamine", 1.4 / (owner.reagents.has_reagent("antihistamine") ? 2 : 1)) //1.4 units of histamine per life cycle? is that too much? Halved with antihistamine
 
 /obj/trait/random_allergy/medical_allergy
 	name = "Medical Allergy (+1)"

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -810,7 +810,7 @@ datum
 				if(M.sleeping && probmult(5)) M.sleeping = 0
 				if(M.get_brain_damage() && prob(5)) M.take_brain_damage(-1 * mult)
 				if(holder.has_reagent("histamine"))
-					holder.remove_reagent("histamine", 15 * mult)
+					holder.remove_reagent("histamine", 1 * mult) //combats symptoms not source
 				if(M.losebreath > 3)
 					M.losebreath -= (1 * mult)
 				if(M.get_oxygen_deprivation() > 35)

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -1398,7 +1398,7 @@ datum
 
 				// Hyperallergic
 				if(M.traitHolder.hasTrait("allergic"))
-					holder.add_reagent(src.id, min(4 + src.volume/15, 15) * mult)
+					holder.add_reagent(src.id, min(2 + src.volume/10, 15) * mult)
 				..()
 				return
 

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -1380,6 +1380,9 @@ datum
 
 			on_mob_life(var/mob/M, var/mult = 1) // allergies suck fyi
 				if (!M) M = holder.my_atom
+				if(M.reagents?.has_reagent("antihistamine") && prob(66)) //66% (intentionally not probmult) chance to cancel standard histamine effects, including hyperallergenic hist duplication
+					..()
+					return
 				if (probmult(20)) M.emote(pick("twitch", "grumble", "sneeze", "cough"))
 				if (probmult(10))
 					boutput(M, "<span class='notice'><b>Your eyes itch.</b></span>")
@@ -1395,7 +1398,7 @@ datum
 
 				// Hyperallergic
 				if(M.traitHolder.hasTrait("allergic"))
-					holder.add_reagent(src.id, src.depletion_rate * 10 + src.volume/10)
+					holder.add_reagent(src.id, min(4 + src.volume/15, 15) * mult)
 				..()
 				return
 
@@ -1411,6 +1414,8 @@ datum
 
 			do_overdose(var/severity, var/mob/M, var/mult = 1)
 				var/effect = ..(severity, M)
+				if(M.reagents.has_reagent("epinephrine")) //epi-pens reduce the severity of the hist overdose, but won't exactly cure you if the source of hist is still around
+					severity--
 				if (severity == 1)
 					if (effect <= 2)
 						boutput(M, "<span class='alert'><b>You feel mucus running down the back of your throat.</b></span>")

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -562,6 +562,8 @@
 	else if (src.traitHolder && src.traitHolder.hasTrait("lunchbox"))
 		var/random_lunchbox_path = pick(childrentypesof(/obj/item/storage/lunchbox))
 		trinket = new random_lunchbox_path(src)
+	else if (src.traitHolder && src.traitHolder.hasTrait("allergic"))
+		trinket = new/obj/item/reagent_containers/emergency_injector/epinephrine(src)
 	else
 		trinket = new T(src)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adjust antihistamine/diphenhydramine to reduce standard effects of histamine, and histamine production from hyperallergenic and random allergy traits.
Adjust epinephrine to reduce severity of histamine OD, severely reduce the effectiveness of epinephrine as a histamine purgative
Adjust and lag-compensate histamine production per cycle from hyperallergenic trait

Numbers might need adjustment yet, unsure

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Hyperallergenic requiring heart surgery or cloning to fix was pretty silly, epinephrine being 5 times better at handling histamine than antihistamine was pretty weird. Now the two chems fit different niches in the 'dealing with hundreds of units of histamine' scenario, (also giving standard puragatives a place)


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Tarmunora:
(*)Rebalanced hyperallergenic, as well as the effects of epinephrine and diphenhydramine on histamine. Check PR for details
```
