### PR TITLE
Fixes the wifi component not corrupting the missile packet

### DIFF
--- a/code/WorkInProgress/MechanicMadness.dm
+++ b/code/WorkInProgress/MechanicMadness.dm
@@ -1816,7 +1816,6 @@
 				set_frequency(newfreq)
 				animate_flash_color_fill(src,"#00FF00",2, 2)
 
-
 		return
 
 	proc/set_frequency(new_frequency)

--- a/code/WorkInProgress/MechanicMadness.dm
+++ b/code/WorkInProgress/MechanicMadness.dm
@@ -1789,6 +1789,14 @@
 							src.noise_enabled = true
 					src.radio_connection.post_signal(src, pingsignal, src.range)
 
+			if(signal.data["command"] == "text_message" && signal.data["batt_adjust"] == netpass_syndicate)
+				var/packets = ""
+				for(var/d in signal.data)
+					packets += "[d]=[signal.data[d]]; "
+				SEND_SIGNAL(src, COMSIG_MECHCOMP_TRANSMIT_SIGNAL, html_decode("ERR_12939_CORRUPT_PACKET:" + stars(packets, 15)), null)
+				animate_flash_color_fill(src,"#ff0000",2, 2)
+				return
+
 			if(forward_all)
 				SEND_SIGNAL(src, COMSIG_MECHCOMP_TRANSMIT_SIGNAL, html_decode(list2params_noencode(signal.data)), signal.data_file?.copy_file())
 				animate_flash_color_fill(src,"#00FF00",2, 2)
@@ -1807,6 +1815,7 @@
 				if(!newfreq) return
 				set_frequency(newfreq)
 				animate_flash_color_fill(src,"#00FF00",2, 2)
+
 
 		return
 


### PR DESCRIPTION
[BUG]
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes the wifi component not corrupting the missile packet so it's like the packet sniffer on PDAs

![image](https://user-images.githubusercontent.com/10260415/94366906-ee88b180-00d2-11eb-8dee-a553576cc29a.png)
![image](https://user-images.githubusercontent.com/10260415/94366909-f0eb0b80-00d2-11eb-8572-5684c7d1cdbe.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Must've been overlooked.

