### PR TITLE
Adds a more navyish red alert for manta

### DIFF
--- a/code/obj/machinery/shipalert.dm
+++ b/code/obj/machinery/shipalert.dm
@@ -96,9 +96,12 @@ var/global/soundGeneralQuarters = sound('sound/machines/siren_generalquarters_qu
 			return
 
 		//alert and siren
-		world << soundGeneralQuarters
+#ifdef MAP_OVERRIDE_MANTA
+		command_alert("This is not a drill. This is not a drill. General Quarters, General Quarters. All hands man your battle stations. Crew without military training shelter in place. Set material condition '[rand(1, 100)]-[pick(phonetic_alphabet)]' throughout the ship. The route of travel is forward and up to starboard, down and aft to port. Prepare for hostile contact.", "NSS Manta - General Quarters")
+#else
 		command_alert("All personnel, this is not a test. There is a confirmed, hostile threat on-board and/or near the station. Report to your stations. Prepare for the worst.", "Alert - Condition Red")
-
+#endif
+		world << soundGeneralQuarters
 		//toggle on
 		shipAlertState = SHIP_ALERT_BAD
 


### PR DESCRIPTION
[ENHANCEMENT]
## About the PR 
Changes the NSS Manta red alert to make it sound more naval.
## Why's this needed? 
Improves immersion and sounds cooler. Seeing as the NSS Manta is (correct me if I'm wrong and dumb with lore) supposed to be a naval vessel that's part of NT's military, I don't see why it shouldn't have a 😎cool😎 general quarters alert instead of a 🤓lame🤓 red alert.
## Changelog
```
(u)Fosstar:
(+)New red alert message for the NSS Manta
```
