### PR TITLE
Removes extraneous brackets on labeler suicide

### DIFF
--- a/code/obj/item/pens_writing_etc.dm
+++ b/code/obj/item/pens_writing_etc.dm
@@ -728,7 +728,7 @@
 		if (!src.user_can_suicide(user))
 			return 0
 		user.visible_message("<span class='alert'><b>[user] labels [him_or_her(user)]self \"DEAD\"!</b></span>")
-		src.label = "(DEAD)"
+		src.label = "DEAD"
 		Label(user,user,1)
 
 		user.TakeDamage("chest", 300, 0) //they have to die fast or it'd make even less sense


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[trivial]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR removes the brackets around the DEAD label for when you commit suicide with one. The label proc already adds some, so you'd end up with two pairs.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It looked somewhat silly and it bothered me.