### PR TITLE
Re-names several kinetic firearms

### DIFF
--- a/code/obj/item/flamethrower.dm
+++ b/code/obj/item/flamethrower.dm
@@ -155,8 +155,8 @@ GETLINEEEEEEEEEEEEEEEEEEEEE
 		..()
 
 /obj/item/flamethrower/backtank
-	name = "tactical flamethrower"
-	desc = "A military-grade flamethrower, supplied with fuel and propellant from a back-mounted fuelpack."
+	name = "Vega flamethrower"
+	desc = "A military-grade flamethrower, supplied with fuel and propellant from a back-mounted fuelpack. Developed by Almagest Weapons Fabrication."
 	icon_state = "syndthrower_0"
 	item_state = "syndthrower_0"
 	uses_multiple_icon_states = 1

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -366,7 +366,7 @@
 		setProperty("movespeed", 0.4)
 
 /obj/item/gun/kinetic/revolver
-	name = "CPA Predator MKII"
+	name = "Predator revolver"
 	desc = "A hefty combat revolver developed by Cormorant Precision Arms. Uses .357 caliber rounds."
 	icon_state = "revolver"
 	item_state = "revolver"
@@ -426,7 +426,7 @@
 
 
 /obj/item/gun/kinetic/detectiverevolver
-	name = "CPA Detective Special"
+	name = "Detective Special revolver"
 	desc = "A snubnosed police-issue revolver developed by Cormorant Precision Arms. Uses .38-Special rounds."
 	icon_state = "detective"
 	item_state = "detective"
@@ -454,7 +454,7 @@
 	var/hammer_cocked = 0
 
 	detective
-		name = "peacemaker"
+		name = "Peacemaker"
 		desc = "A barely adequate replica of a nearly ancient single action revolver. Used by war reenactors for the last hundred years or so. Its calibur is obviously the wrong size though."
 		w_class = 2.0
 		force = 2.0
@@ -747,7 +747,7 @@
 		return
 
 /obj/item/gun/kinetic/silenced_22
-	name = "STL Orion"
+	name = "Orion silenced pistol"
 	desc = "A small pistol with an integrated flash and noise suppressor, developed by Specter Tactical Laboratory. Uses .22 rounds."
 	icon_state = "silenced"
 	w_class = 2
@@ -929,8 +929,8 @@
 
 // agent
 /obj/item/gun/kinetic/pistol
-	name = "M1992 pistol"
-	desc = "A semi-automatic, 9mm caliber service pistol issued by the Syndicate."
+	name = "Antares pistol"
+	desc = "A semi-automatic, 9mm caliber service pistol developed by Almagest Weapons Fabrication."
 	icon_state = "9mm_pistol"
 	w_class = 2
 	force = 3
@@ -996,8 +996,8 @@
 
 // assault
 /obj/item/gun/kinetic/assault_rifle
-	name = "M19A4 assault rifle"
-	desc = "A modified Syndicate battle rifle fitted with several fancy, tactically useless attachments."
+	name = "Sirius assault rifle"
+	desc = "A bullpup assault rifle capable of semi-automatic and burst fire modes, developed by Almagest Weapons Fabrication."
 	icon = 'icons/obj/64x32.dmi'
 	icon_state = "assault_rifle"
 	item_state = "assault_rifle"
@@ -1049,8 +1049,8 @@
 
 // heavy
 /obj/item/gun/kinetic/light_machine_gun
-	name = "M90 machine gun"
-	desc = "Looks pretty heavy to me."
+	name = "Canopus light machine gun"
+	desc = "A 100 round light machine gun, developed by Almagest Weapons Fabrication."
 	icon = 'icons/obj/64x32.dmi'
 	icon_state = "lmg"
 	item_state = "lmg"
@@ -1122,8 +1122,8 @@
 
 // demo
 /obj/item/gun/kinetic/grenade_launcher
-	desc = "A 40mm hand-held grenade launcher able to fire a variety of explosives."
-	name = "grenade launcher"
+	name = "Rigil grenade launcher"
+	desc = "A 40mm hand-held grenade launcher, developed by Almagest Weapons Fabrication."
 	icon = 'icons/obj/64x32.dmi'
 	icon_state = "grenade_launcher"
 	item_state = "grenade_launcher"
@@ -1282,8 +1282,8 @@
 
 // sniper
 /obj/item/gun/kinetic/sniper
-	name = "S90A1 marksman's rifle"
-	desc = "The Syndicate standard issue bolt-action sniper rifle, for engaging hostiles at range."
+	name = "Arcturus sniper rifle"
+	desc = "A semi-automatic bullpup sniper rifle, developed by Almagest Weapons Fabrication."
 	icon = 'icons/obj/64x32.dmi' // big guns get big icons
 	icon_state = "sniper"
 	item_state = "sniper"

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -929,8 +929,8 @@
 
 // agent
 /obj/item/gun/kinetic/pistol
-	name = "Antares pistol"
-	desc = "A semi-automatic, 9mm caliber service pistol developed by Almagest Weapons Fabrication."
+	name = "Branwen pistol"
+	desc = "A semi-automatic, 9mm caliber service pistol, developed by Mabinogi Firearms Company."
 	icon_state = "9mm_pistol"
 	w_class = 2
 	force = 3
@@ -946,8 +946,8 @@
 		..()
 
 /obj/item/gun/kinetic/tranq_pistol
-	name = "tranquilizer pistol"
-	desc = "A silenced tranquilizer pistol chambered in .308 caliber."
+	name = "Gwydion tranquilizer pistol"
+	desc = "A silenced tranquilizer pistol chambered in .308 caliber, developed by Mabinogi Firearms Company."
 	icon_state = "tranq_pistol"
 	item_state = "tranq_pistol"
 	w_class = 2
@@ -1049,7 +1049,7 @@
 
 // heavy
 /obj/item/gun/kinetic/light_machine_gun
-	name = "Canopus light machine gun"
+	name = "Antares light machine gun"
 	desc = "A 100 round light machine gun, developed by Almagest Weapons Fabrication."
 	icon = 'icons/obj/64x32.dmi'
 	icon_state = "lmg"
@@ -1282,7 +1282,7 @@
 
 // sniper
 /obj/item/gun/kinetic/sniper
-	name = "Arcturus sniper rifle"
+	name = "Betelgeuse sniper rifle"
 	desc = "A semi-automatic bullpup sniper rifle, developed by Almagest Weapons Fabrication."
 	icon = 'icons/obj/64x32.dmi' // big guns get big icons
 	icon_state = "sniper"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? --> 
This PR removes weapon company names from the names of several guns and adds them to their descriptions instead. It also adds new names to match the theme of the companies.

```
Mabinogi Firearms Company
	Gwydion	pistol
	Branwen silenced pistol
	
Almagest Weapons Fabrication
	Sirius assault rifle
	Antares light machine gun
	Betelgeuse sniper rifle
	Rigel grenade launcher
	Vega flamethrower
```

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Many guns received new sprites in the recent past but did not get new names to fit.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Gannets:
(+)Re-named many kinetic firearms.
```
