### PR TITLE
Move COMSIG_ATTACKBY call to where it SHOULD be

### DIFF
--- a/_std/defines/component_defines.dm
+++ b/_std/defines/component_defines.dm
@@ -102,9 +102,6 @@
 //attack_X signals
 /// Attacking wiht an item in-hand
 #define COMSIG_ATTACKBY "attackby"
-/// Bitflag return of an attackby proc successfuly reacting (based on it's own conditions)
-/// I dunno, feel free to improve this; make global bitflag returns for all components.
-#define COMSIGBIT_ATTACKBY_COMPLETE 1
 
 
 // projectile signals

--- a/code/WorkInProgress/MechanicMadness.dm
+++ b/code/WorkInProgress/MechanicMadness.dm
@@ -439,7 +439,7 @@
 
 			SEND_SIGNAL(src,COMSIG_MECHCOMP_RM_ALL_CONNECTIONS)
 			return 1
-		return SEND_SIGNAL(src,COMSIG_ATTACKBY,W,user) & COMSIGBIT_ATTACKBY_COMPLETE ? 1 : 0
+		return ..()
 
 	pick_up_by(var/mob/M)
 		if(level != 1) return ..()

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -615,7 +615,7 @@
 //mbc : sorry, i added a 'is_special' arg to this proc to avoid race conditions.
 /atom/proc/attackby(obj/item/W as obj, mob/user as mob, params, is_special = 0)
 	if (user && W && !(W.flags & SUPPRESSATTACK))  //!( istype(W, /obj/item/grab)  || istype(W, /obj/item/spraybottle) || istype(W, /obj/item/card/emag)))
-		if (SEND_SIGNAL(src,COMSIG_ATTACKBY,W,user) & COMSIGBIT_ATTACKBY_COMPLETE ? 0 : 1)
+		if(SEND_SIGNAL(src,COMSIG_ATTACKBY,W,user))
 			return
 		user.visible_message("<span class='combat'><B>[user] hits [src] with [W]!</B></span>")
 	return

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -615,6 +615,8 @@
 //mbc : sorry, i added a 'is_special' arg to this proc to avoid race conditions.
 /atom/proc/attackby(obj/item/W as obj, mob/user as mob, params, is_special = 0)
 	if (user && W && !(W.flags & SUPPRESSATTACK))  //!( istype(W, /obj/item/grab)  || istype(W, /obj/item/spraybottle) || istype(W, /obj/item/card/emag)))
+		if (SEND_SIGNAL(src,COMSIG_ATTACKBY,W,user) & COMSIGBIT_ATTACKBY_COMPLETE ? 0 : 1)
+			return
 		user.visible_message("<span class='combat'><B>[user] hits [src] with [W]!</B></span>")
 	return
 

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -614,9 +614,9 @@
 
 //mbc : sorry, i added a 'is_special' arg to this proc to avoid race conditions.
 /atom/proc/attackby(obj/item/W as obj, mob/user as mob, params, is_special = 0)
+	if(SEND_SIGNAL(src,COMSIG_ATTACKBY,W,user))
+		return
 	if (user && W && !(W.flags & SUPPRESSATTACK))  //!( istype(W, /obj/item/grab)  || istype(W, /obj/item/spraybottle) || istype(W, /obj/item/card/emag)))
-		if(SEND_SIGNAL(src,COMSIG_ATTACKBY,W,user))
-			return
 		user.visible_message("<span class='combat'><B>[user] hits [src] with [W]!</B></span>")
 	return
 

--- a/code/datums/components/mechComp_signals.dm
+++ b/code/datums/components/mechComp_signals.dm
@@ -311,7 +311,7 @@
 				else
 					//must be a custom config specific to the device, so let the device handle it
 					var/path = src.configs[selected_config]
-					var/ret = call(parent, path)(W, user)
+					call(parent, path)(W, user)
 
 //If it's a multi-tool, let the user configure the device.
 /datum/component/mechanics_holder/proc/compatible()

--- a/code/datums/components/mechComp_signals.dm
+++ b/code/datums/components/mechComp_signals.dm
@@ -298,25 +298,20 @@
 				if(SET_SEND)
 					var/inp = input(user,"Please enter Signal:","Signal setting","1") as text
 					if(!in_range(parent, user) || user.stat)
-						return 0
+						return
 					inp = trim(adminscrub(inp), 1)
 					if(length(inp))
 						defaultSignal = inp
 						boutput(user, "Signal set to [inp]")
-					return COMSIGBIT_ATTACKBY_COMPLETE
 				if(DC_ALL)
 					WipeConnections()
 					if(istype(parent, /atom))
 						var/atom/AP = parent
 						boutput(user, "<span class='notice'>You disconnect [AP.name].</span>")
-					return COMSIGBIT_ATTACKBY_COMPLETE
 				else
 					//must be a custom config specific to the device, so let the device handle it
 					var/path = src.configs[selected_config]
 					var/ret = call(parent, path)(W, user)
-					if(ret) ret = COMSIGBIT_ATTACKBY_COMPLETE
-					return ret
-	return 0
 
 //If it's a multi-tool, let the user configure the device.
 /datum/component/mechanics_holder/proc/compatible()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves the ATTACK_BY component signal event from deep in Mech Comp code (my fault, #1231), to the root attack_by() call.
Also removes "check if complete" define and returns from mechcomp. 

Changes tested. Works as expected. Mecahanic players will now slap mechanics devices with their multitools when setting devices.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
My current code stinks.
The Mechcomp code couldn't make use of the "check if complete" because it was async due to user input.


[CHORE]