### PR TITLE
Admin/Mentor Mouse Dance

### DIFF
--- a/code/WorkInProgress/AnimationLibrary.dm
+++ b/code/WorkInProgress/AnimationLibrary.dm
@@ -1321,3 +1321,11 @@ var/global/icon/scanline_icon = icon('icons/effects/scanning.dmi', "scanline")
 		SPAWN_DBG(time)
 			A.filters.len -= 2
 			A.alpha = 0
+
+/proc/animate_bouncy(var/atom/A) // little bouncy dance for admin and mentor mice, could be used for other stuff
+	if (!istype(A))
+		return
+	animate(A, pixel_y = (A.pixel_y + 4), time = 1.5, dir = EAST)
+	animate(pixel_y = (A.pixel_y - 4), time = 1.5, dir = EAST)
+	animate(pixel_y = (A.pixel_y + 4), time = 1.5, dir = WEST)
+	animate(pixel_y = (A.pixel_y - 4), time = 1.5, dir = WEST)

--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -2589,21 +2589,8 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 			if ("dance")
 				if (src.emote_check(voluntary, 50))
 					SPAWN_DBG(0)
-						for (var/i = 0, i < 4, i++) // bouncy!
-							src.pixel_y+= 1
-							src.dir = EAST
-							sleep(0.05 SECONDS)
-						for (var/i = 0, i < 4, i++)
-							src.pixel_y-= 1
-							sleep(0.05 SECONDS)
-						for (var/i = 0, i < 4, i++)
-							src.pixel_y+= 1
-							src.dir = WEST
-							sleep(0.05 SECONDS)
-						for (var/i = 0, i < 4, i++)
-							src.pixel_y-= 1
-							sleep(0.05 SECONDS)
-					return "<span class='emote'><b>[src]</b> [pick("bounces","dances","boogies","frolics","prances","hops")] around with [pick("joy","fervor","excitement","vigor","happiness")]!</span>"
+					animate_bouncy(src) // bouncy!
+				return "<span class='emote'><b>[src]</b> [pick("bounces","dances","boogies","frolics","prances","hops")] around with [pick("joy","fervor","excitement","vigor","happiness")]!</span>"
 		return ..()
 
 /mob/living/critter/small_animal/mouse/weak/mentor/admin

--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -2584,6 +2584,28 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 				return 2
 		return ..()
 
+	specific_emotes(var/act, var/param = null, var/voluntary = 0)
+		switch (act)
+			if ("dance")
+				if (src.emote_check(voluntary, 50))
+					SPAWN_DBG(0)
+						for (var/i = 0, i < 4, i++) // bouncy!
+							src.pixel_y+= 1
+							src.dir = EAST
+							sleep(0.05 SECONDS)
+						for (var/i = 0, i < 4, i++)
+							src.pixel_y-= 1
+							sleep(0.05 SECONDS)
+						for (var/i = 0, i < 4, i++)
+							src.pixel_y+= 1
+							src.dir = WEST
+							sleep(0.05 SECONDS)
+						for (var/i = 0, i < 4, i++)
+							src.pixel_y-= 1
+							sleep(0.05 SECONDS)
+					return "<span class='emote'><b>[src]</b> [pick("bounces","dances","boogies","frolics","prances","hops")] around with [pick("joy","fervor","excitement","vigor","happiness")]!</span>"
+		return ..()
+
 /mob/living/critter/small_animal/mouse/weak/mentor/admin
 	name = "admin mouse"
 	real_name = "mentor mouse"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]
## About the PR and why it's needed <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a basic happy bouncy dance for mentor and admin mice with flavour text, based off of the :bouncerat: emoji on discord.
It's important to have a way to show how amused you are when the clown you were teaching how to honk ran full-tilt into a borging artifact. You can only *flip so many times, variety is good.

I based the code off of current dance code and puzzled the movement and stuff together, if anything is glaringly bad please point it out so I can fix it.

![2020-09-29 04_19_08-Window](https://user-images.githubusercontent.com/68257280/94531765-01060680-020b-11eb-9aa6-d29cf412926c.png)
![bouncy](https://user-images.githubusercontent.com/68257280/94531804-0a8f6e80-020b-11eb-9a57-b877b5f1c605.gif)


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)makkipakki:
(+)For mentor and admin mice, added a bouncy dance animation and text for the *dance emote
```
