### PR TITLE
make wizard gems reclaimable

### DIFF
--- a/code/WorkInProgress/wizardset.dm
+++ b/code/WorkInProgress/wizardset.dm
@@ -584,7 +584,7 @@ var/global/datum/wizard_zone_controller/wizard_zone_controller
 	var/light_b = 1
 	var/lum = 5
 	var/image/over_image
-	var/assoc_material = /datum/material/crystal/wizard/quartz
+	var/assoc_material = "wiz_quartz"
 	icon = 'icons/turf/adventure.dmi'
 
 	proc/create_bar(var/obj/machinery/portable_reclaimer/creator)
@@ -606,7 +606,7 @@ var/global/datum/wizard_zone_controller/wizard_zone_controller
 
 	quartz
 		name = "enchanted quartz"
-		assoc_material = /datum/material/crystal/wizard/quartz
+		assoc_material = "wiz_quartz"
 		icon_state = "quartz"
 
 	topaz
@@ -614,39 +614,39 @@ var/global/datum/wizard_zone_controller/wizard_zone_controller
 		light_r = 1
 		light_g = 0.8
 		light_b = 0.5
-		assoc_material = /datum/material/crystal/wizard/topaz
+		assoc_material = "wiz_topaz"
 		icon_state = "topaz"
-
-	amethyst
-		name = "enchanted amethyst"
-		light_r = 0.6
-		light_g = 0.4
-		assoc_material = /datum/material/crystal/wizard/amethyst
-		icon_state = "amethyst"
 
 	ruby
 		name = "enchanted ruby"
 		light_r = 0.6
 		light_g = 0.1
 		light_b = 0.2
-		assoc_material = /datum/material/crystal/wizard/ruby
+		assoc_material = "wiz_ruby"
 		icon_state = "ruby"
 
-	sapphire
-		name = "enchanted sapphire"
-		light_r = 0.1
+	amethyst
+		name = "enchanted amethyst"
+		light_r = 0.6
 		light_g = 0.4
-		light_b = 0.7
-		assoc_material = /datum/material/crystal/wizard/sapphire
-		icon_state = "sapphire"
+		assoc_material = "wiz_amethyst"
+		icon_state = "amethyst"
 
 	emerald
 		name = "enchanted emerald"
 		light_r = 0.3
 		light_g = 0.8
 		light_b = 0.4
-		assoc_material = /datum/material/crystal/wizard/emerald
+		assoc_material = "wiz_emerald"
 		icon_state = "emerald"
+
+	sapphire
+		name = "enchanted sapphire"
+		light_r = 0.1
+		light_g = 0.4
+		light_b = 0.7
+		assoc_material = "wiz_sapphire"
+		icon_state = "sapphire"
 
 /obj/wizard_light
 	name = "empty crystal socket"

--- a/code/modules/materials/Mat_Processing.dm
+++ b/code/modules/materials/Mat_Processing.dm
@@ -625,7 +625,7 @@
 				boutput(user, "<span class='alert'>This material can not be used in the [src].</span>")
 				return
 
-			if((W.material.material_flags & MATERIAL_METAL || W.material.material_flags & MATERIAL_CRYSTAL) && (istype(W, /obj/item/material_piece) || istype(W, /obj/item/raw_material)) )
+			if((W.material.material_flags & MATERIAL_METAL || W.material.material_flags & MATERIAL_CRYSTAL) && (istype(W, /obj/item/material_piece) || istype(W, /obj/item/raw_material) || istype(W, /obj/item/wizard_crystal)) )
 				if(components.len < 2)
 					src.visible_message("<span class='notice'>[user] puts [W] into [src]</span>")
 					user.drop_item()

--- a/code/modules/materials/Mat_Processing.dm
+++ b/code/modules/materials/Mat_Processing.dm
@@ -617,7 +617,8 @@
 				return
 
 		if(istype(W, /obj/item/wizard_crystal) && components.len < 2 && !W.material)
-			W.setMaterial(W:assoc_material, appearance = 0, setname = 0)
+			var/obj/item/wizard_crystal/wc = W
+			wc.setMaterial(getMaterial(wc.assoc_material), appearance = 0, setname = 0)
 
 		if(W.material != null)
 			if(!W.material.canMix)

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -769,9 +769,11 @@
 				if (output_bar_from_item(M, 30, C.conductor.mat_id))
 					qdel(C)
 
-			/*else if (istype(M, /obj/item/wizard_crystal))
-				W.create_bar(src)
-				qdel(W)*/
+			else if (istype(M, /obj/item/wizard_crystal))
+				var/obj/item/wizard_crystal/wc = M
+				wc.setMaterial(getMaterial(wc.assoc_material,0,0))
+				if (output_bar_from_item(M))
+					qdel(M)
 
 			sleep(smelt_interval)
 
@@ -869,7 +871,7 @@
 		playsound(src.loc, sound_process, 40, 1)
 
 	attackby(obj/item/W as obj, mob/user as mob)
-		if (istype(W,/obj/item/raw_material/) || istype(W,/obj/item/sheet/) || istype(W,/obj/item/rods/) || istype(W,/obj/item/tile/) || istype(W,/obj/item/cable_coil))
+		if (istype(W,/obj/item/raw_material/) || istype(W,/obj/item/sheet/) || istype(W,/obj/item/rods/) || istype(W,/obj/item/tile/) || istype(W,/obj/item/cable_coil) || istype(W,/obj/item/wizard_crystal))
 			boutput(user, "You load [W] into [src].")
 			W.set_loc(src)
 			user.u_equip(W)

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -743,6 +743,10 @@
 		icon_state = "reclaimer-on"
 
 		for (var/obj/item/M in src.contents)
+			if (istype(M, /obj/item/wizard_crystal))
+				var/obj/item/wizard_crystal/wc = M
+				wc.setMaterial(getMaterial(wc.assoc_material),0,0,1,0)
+
 			if (!istype(M.material) || !(M.material.material_flags & MATERIAL_CRYSTAL) && !(M.material.material_flags & MATERIAL_METAL) && !(M.material.material_flags & MATERIAL_RUBBER))
 				M.set_loc(src.loc)
 				src.reject = 1
@@ -770,8 +774,6 @@
 					qdel(C)
 
 			else if (istype(M, /obj/item/wizard_crystal))
-				var/obj/item/wizard_crystal/wc = M
-				wc.setMaterial(getMaterial(wc.assoc_material,0,0))
 				if (output_bar_from_item(M))
 					qdel(M)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
So, the wizard crystals have a material in the code which is pretty neat, but you could never actually make them into it. Since I saw some old unused code for reclaiming them, I assumed that feature was just kind of left behind at some point, so this makes them reclaimable.

I had to implement it a bit weirdly, since I assumed whoever made the crystals didn't want them to actually be radioactive and animated, judging by the code that was already there.

As far as I know, only the sapphire is obtainable right now, but maybe others are in some secret code that I am not aware of.

I also changed one line or so in the smelter before I realized that we actually use neosmelter now instead of smelter, I don't think the smelter object is actually used anymore? I can revert that change, if desired.

I also changed the order in which the wizard crystals are defined to be the same as the order in which the wizard gem materials are defined. I'm sorry, but I had to.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I just think they're neat!