### PR TITLE
Makes Material Processor Deconstructable/Scanable

### DIFF
--- a/code/modules/materials/Mat_Processing.dm
+++ b/code/modules/materials/Mat_Processing.dm
@@ -7,6 +7,9 @@
 	anchored = 1
 	density = 1
 	layer = FLOOR_EQUIP_LAYER1
+	mats = 20
+	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_WIRECUTTERS | DECON_MULTITOOL
+
 	var/atom/output_location = null
 
 	New()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes The Material Processor Deconstructable via deconstruction device by using a full set of tools +multitool
Makes it scannable by the device analyzer and related mechanic pda cart. thus making it producible at a Fabricator for 20 mats via blueprint


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
if some how all of the Material Processors were destroyed, there would be no way to get a replacement if all were destroyed 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)RSG250:
(+)Made the Material Processor Deconstructable by Deconstruction Device & Scannable by device analyzer
```
