### PR TITLE
Fixes 2299

### DIFF
--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -361,17 +361,14 @@
 	proc/MutateMutant(var/mob/living/carbon/human/H, var/mode as text)
 		if (!H || !mode || !race_mutation)
 			return
+		var/datum/bioEffect/mutantrace/mr = src.race_mutation
 		switch (mode)
 			if ("set")
-				var/datum/bioEffect/mutantrace/mr = new src.race_mutation
-				if(!H.bioHolder.HasEffect(mr.id))
-					H.bioHolder.AddEffect(mr.id, 0, 0, 0, 1)
-				qdel(mr)
+				if(!H.bioHolder.HasEffect(initial(mr.id)))
+					H.bioHolder.AddEffect(initial(mr.id), 0, 0, 0, 1)
 			if ("reset")
-				var/datum/bioEffect/mutantrace/mr = new src.race_mutation
-				if(H.bioHolder.HasEffect(mr.id))
-					H.bioHolder.RemoveEffect(mr.id)
-				qdel(mr)
+				if(H.bioHolder.HasEffect(initial(mr.id)))
+					H.bioHolder.RemoveEffect(initial(mr.id))
 
 /datum/mutantrace/blob // podrick's july assjam submission, it's pretty cute
 	name = "blob"

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -7,6 +7,9 @@
 // Now a robust object-oriented version!!!!
 /datum/mutantrace
 	var/name = null				// used for identification in diseases, clothing, etc
+	/// The mutation associted with the mutantrace. Saurian genetics for lizards, for instance
+	var/race_mutation = null
+
 	var/datum/appearanceHolder/AH
 	var/mutant_color_flags = null
 	var/override_eyes = 1
@@ -110,6 +113,7 @@
 				AHM.mutant_race = src.type
 			var/list/obj/item/clothing/restricted = list(mob.w_uniform, mob.shoes, mob.wear_suit)
 			AppearanceSetter(M, "set")
+			MutateMutant(M, "set")
 			for(var/obj/item/clothing/W in restricted)
 				if (istype(W,/obj/item/clothing))
 					if(W.compatible_species.Find(src.name) || (src.human_compatible && W.compatible_species.Find("human")))
@@ -250,6 +254,7 @@
 			if (ishuman(mob))
 				var/mob/living/carbon/human/H = mob
 				AppearanceSetter(H, "reset")
+				MutateMutant(H, "reset")
 				H.image_eyes.pixel_y = initial(H.image_eyes.pixel_y)
 				H.image_cust_one.pixel_y = initial(H.image_cust_one.pixel_y)
 				H.image_cust_two.pixel_y = initial(H.image_cust_two.pixel_y)
@@ -323,6 +328,7 @@
 			return rgb(L["r"], L["g"], L["b"])
 		return rgb(22, 210, 22)
 
+	/// Backs up the character's hair colors, then does fix_colors on those colors if the FIX_COLORS flag is set
 	proc/AppearanceSetter(var/mob/living/carbon/human/Q, var/mode as text)
 		if(!ishuman(Q) || !(Q?.bioHolder?.mobAppearance))
 			return // please dont call set_mutantrace on a non-human non-appearanceholder
@@ -350,6 +356,22 @@
 				detail_2 = null
 				detail_3 = null
 				detail_over_suit = null
+
+	/// Applies or removes the bioeffect associated with the mutantrace
+	proc/MutateMutant(var/mob/living/carbon/human/H, var/mode as text)
+		if (!H || !mode || !race_mutation)
+			return
+		switch (mode)
+			if ("set")
+				var/datum/bioEffect/mutantrace/mr = new src.race_mutation
+				if(!H.bioHolder.HasEffect(mr.id))
+					H.bioHolder.AddEffect(mr.id, 0, 0, 0, 1)
+				qdel(mr)
+			if ("reset")
+				var/datum/bioEffect/mutantrace/mr = new src.race_mutation
+				if(H.bioHolder.HasEffect(mr.id))
+					H.bioHolder.RemoveEffect(mr.id)
+				qdel(mr)
 
 /datum/mutantrace/blob // podrick's july assjam submission, it's pretty cute
 	name = "blob"
@@ -420,6 +442,7 @@
 	override_beard = 0
 	override_detail = 0
 	override_attack = 0
+	race_mutation = /datum/bioEffect/mutantrace/flashy
 
 /datum/mutantrace/virtual
 	name = "virtual"
@@ -448,6 +471,7 @@
 	override_beard = 0
 	override_detail = 0
 	override_attack = 0
+	race_mutation = /datum/bioEffect/mutantrace/blank
 
 /datum/mutantrace/grey
 	name = "grey"
@@ -495,12 +519,12 @@
 
 /datum/mutantrace/lizard
 	name = "lizard"
-	// icon_state = "lizard"
 	icon_state = "lizard"
 	icon_override_static = 1
 	allow_fat = 1
 	override_attack = 0
 	voice_override = "lizard"
+	race_mutation = /datum/bioEffect/mutantrace // Most mutants are just another form of lizard, didn't you know?
 	mutant_color_flags = (BODY_DETAIL_1 | BODY_DETAIL_2 | BODY_DETAIL_3 | HAS_HAIR_COLORED_DETAILS | BODY_DETAIL_OVERSUIT_1 | BODY_DETAIL_OVERSUIT_IS_COLORFUL | FIX_COLORS)
 
 	New(var/mob/living/carbon/human/H)
@@ -731,6 +755,7 @@
 	icon_override_static = 1
 	voice_override = "skelly"
 	decomposes = FALSE
+	race_mutation = /datum/bioEffect/mutantrace/skeleton
 
 	New(var/mob/living/carbon/human/M)
 		..()
@@ -988,6 +1013,7 @@
 	override_attack = 0
 	aquatic = 1
 	voice_override = "blub"
+	race_mutation = /datum/bioEffect/mutantrace/ithillid
 
 	say_verb()
 		return "glubs"
@@ -1004,6 +1030,7 @@
 	override_beard = 0
 	override_skintone = 0
 	override_attack = 0
+	race_mutation = /datum/bioEffect/mutantrace/dwarf
 
 /datum/mutantrace/monkey
 	name = "monkey"
@@ -1013,7 +1040,7 @@
 	head_offset = -9
 	hand_offset = -5
 	body_offset = -7
-//	uses_human_clothes = 0 // Guess they can keep that ability for now (Convair880).
+	//	uses_human_clothes = 0 // Guess they can keep that ability for now (Convair880).
 	human_compatible = 0
 	exclusive_language = 1
 	voice_message = "chimpers"
@@ -1021,6 +1048,7 @@
 	override_language = "monkey"
 	understood_languages = list("english")
 	clothing_icon_override = 'icons/mob/monkey.dmi'
+	race_mutation = /datum/bioEffect/mutantrace/monkey
 	var/sound_monkeyscream = 'sound/voice/screams/monkey_scream.ogg'
 	var/had_tablepass = 0
 	var/table_hide = 0
@@ -1207,6 +1235,7 @@
 	icon = 'icons/mob/monkey.dmi'
 	icon_state = "seamonkey"
 	aquatic = 1
+	race_mutation = /datum/bioEffect/mutantrace/seamonkey
 
 /datum/mutantrace/martian
 	name = "martian"
@@ -1301,6 +1330,7 @@
 	icon_state = "roach"
 	icon_override_static = 1
 	override_attack = 0
+	race_mutation = /datum/bioEffect/mutantrace/roach
 
 	say_verb()
 		return "clicks"
@@ -1316,6 +1346,7 @@
 	jerk = 1
 	override_attack = 0
 	firevuln = 1.5 // very flammable catthings
+	race_mutation = /datum/bioEffect/mutantrace/cat
 
 	say_verb()
 		return "meows"
@@ -1617,6 +1648,7 @@
 	allow_fat = 1
 	override_attack = 0
 	voice_override = "cow"
+	race_mutation = /datum/bioEffect/mutantrace/cow
 	mutant_color_flags = (HAS_HAIR_COLORED_DETAILS | BODY_DETAIL_1 | BODY_DETAIL_OVERSUIT_1 | FIX_COLORS)
 
 	New(var/mob/living/carbon/human/H)

--- a/code/modules/medical/genetics/bioEffects/mutantrace.dm
+++ b/code/modules/medical/genetics/bioEffects/mutantrace.dm
@@ -25,7 +25,8 @@
 				// clear away any existing mutantraces first
 				if (istype(H.bioHolder.GetEffect(ID), /datum/bioEffect/mutantrace) && ID != src.id)
 					H.bioHolder.RemoveEffect(ID)
-			H.set_mutantrace(src.mutantrace_path)
+			if (!istype(H.mutantrace, src.mutantrace_path))
+				H.set_mutantrace(src.mutantrace_path)
 		return
 
 	OnRemove()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

So the way the mutant traits worked was that it set the character's mutantrace on spawn. Problem was, this didn't give them the mutant bioeffect, which the cloner needs to TF the thing inside into a horrible mutant (like a dwarf). This fixes that by making it so that becoming a mutantrace also gives you the corresponding mutation, if any.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #2299 