### PR TITLE
Lets you dissolve pills by attacking them with a container

### DIFF
--- a/code/modules/chemistry/tools/pills.dm
+++ b/code/modules/chemistry/tools/pills.dm
@@ -11,6 +11,7 @@
 	icon_state = "pill0"
 	item_state = "pill"
 	rc_flags = RC_SPECTRO		// only spectroscopic analysis
+	flags = NOSPLASH
 	module_research = list("medicine" = 0.5, "science" = 0.5)
 	module_research_type = /obj/item/reagent_containers/pill
 	rand_pos = 1
@@ -37,8 +38,6 @@
 		if (src.random_icon)
 			src.create_random_icon()
 
-	attackby(obj/item/W as obj, mob/user as mob)
-		return
 
 	attack_self(mob/user as mob)
 		if (!src.reagents || !src.reagents.total_volume)
@@ -97,6 +96,10 @@
 		return 0
 
 	attackby(obj/item/I as obj, mob/user as mob)
+		if (!I)
+			return
+		if (I.is_open_container() && I.reagents)
+			afterattack(I, user)	//Probably weird but afterattack contains the dissolving code
 		return
 
 	proc/create_random_icon()

--- a/code/modules/chemistry/tools/pills.dm
+++ b/code/modules/chemistry/tools/pills.dm
@@ -99,6 +99,8 @@
 		if (!I)
 			return
 		if (I.is_open_container() && I.reagents)
+			if (istype(I, /obj/item/clothing/mask/cigarette)) //Apparently you can smush a lit cigarette into a pill and destroy both
+				return
 			afterattack(I, user)	//Probably weird but afterattack contains the dissolving code
 		return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feat][qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes it possible to dissolve pills in a reagent container by attacking the pill with one, similar to how you can pick up stuff with backpacks and boxes.

I also removed a superfluous copy of attackby from pill code.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Partially it's an ease of use thing, but mainly it allows borgs to pick up chems in pill form easily. It's especially relevant to medborgs wrt salbutamol & mannitol, but borgs can also feasibly store intermediate chem steps in pill form without taking up a beaker.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)BatElite:
(+)You can now dissolve pills by using a suitable container on them instead of only the other way around. Cyborgs might find this particularly useful.
```
