### PR TITLE
Addicts no longer share their addiction.

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -793,7 +793,7 @@ obj/trait/pilot
 
 	var/allergen = ""
 	var/allergen_name = ""  //No idea what this var is doing, mind if someone explains?
-	var/allergic_players
+	var/list/allergic_players = list()
 
 	var/list/allergen_id_list = list("spaceacillin","morphine","teporone","salicylic_acid","calomel","synthflesh","omnizine","saline","anti_rad","smelling_salt",\
 	"haloperidol","epinephrine","insulin","silver_sulfadiazine","mutadone","ephedrine","penteticacid","antihistamine","styptic_powder","cryoxadone","atropine",\
@@ -839,7 +839,7 @@ obj/trait/pilot
 	isPositive = 0
 	var/selected_reagent = "ethanol"
 	var/addictive_reagents = list("bath salts", "lysergic acid diethylamide", "space drugs", "psilocybin", "cat drugs", "methamphetamine")
-	var/addicted_players
+	var/list/addicted_players = list()
 
 	onAdd(var/mob/owner)
 		if(isliving(owner))

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -855,8 +855,7 @@ obj/trait/pilot
 			selected_reagent = addicted_players[owner]
 			for(var/datum/ailment_data/addiction/A in M.ailments)
 				if(istype(A, /datum/ailment_data/addiction))
-					if(A.associated_reagent == selected_reagent)
-						 return
+					if(A.associated_reagent == selected_reagent) return
 			addAddiction(owner)
 		return
 

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -792,7 +792,8 @@ obj/trait/pilot
 	isPositive = 0
 
 	var/allergen = ""
-	var/allergen_name = ""
+	var/allergen_name = ""  //No idea what this var is doing, mind if someone explains?
+	var/allergic_players
 
 	var/list/allergen_id_list = list("spaceacillin","morphine","teporone","salicylic_acid","calomel","synthflesh","omnizine","saline","anti_rad","smelling_salt",\
 	"haloperidol","epinephrine","insulin","silver_sulfadiazine","mutadone","ephedrine","penteticacid","antihistamine","styptic_powder","cryoxadone","atropine",\
@@ -803,6 +804,7 @@ obj/trait/pilot
 
 	onAdd(var/mob/owner)
 		allergen = pick(allergen_id_list)
+		allergic_players[owner] = allergen
 		if (reagents_cache.len <= 0)
 			build_reagent_cache()
 		var/datum/reagent/R = reagents_cache[allergen]
@@ -812,6 +814,7 @@ obj/trait/pilot
 			throw EXCEPTION("Could not find reagent for id:[allergen]")
 
 	onLife(var/mob/owner)
+		allergen = allergic_players[owner]
 		if (owner?.reagents?.has_reagent(allergen))
 			owner.reagents.add_reagent("histamine", 1.4 / (owner.reagents.has_reagent("antihistamine") ? 2 : 1)) //1.4 units of histamine per life cycle? is that too much? Halved with antihistamine
 

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -754,7 +754,7 @@ obj/trait/pilot
 //	id = "color_shift"
 //	points = 0
 //	isPositive = 1
-//	
+//
 //	onAdd(var/mob/owner)	Not enforcing any of them with onLife because Hemochromia is a multi-mutation thing while Achromia would darken the skin color every tick until it's pitch black.
 //		if(owner.bioHolder)
 //			owner.bioHolder.AddEffect("achromia", 0, 0, 0, 1)
@@ -835,6 +835,8 @@ obj/trait/pilot
 	points = 2
 	isPositive = 0
 	var/selected_reagent = "ethanol"
+	var/addictive_reagents = list("bath salts", "lysergic acid diethylamide", "space drugs", "psilocybin", "cat drugs", "methamphetamine")
+	var/addicted_players
 
 	New()
 		selected_reagent = pick("bath salts", "lysergic acid diethylamide", "space drugs", "psilocybin", "cat drugs", "methamphetamine")
@@ -842,15 +844,19 @@ obj/trait/pilot
 
 	onAdd(var/mob/owner)
 		if(isliving(owner))
+			addicted_players[owner] = pick(addictive_reagents)
+			selected_reagent = addicted_players[owner]
 			addAddiction(owner)
 		return
 
 	onLife(var/mob/owner) //Just to be safe.
 		if(isliving(owner) && prob(1))
 			var/mob/living/M = owner
+			selected_reagent = addicted_players[owner]
 			for(var/datum/ailment_data/addiction/A in M.ailments)
 				if(istype(A, /datum/ailment_data/addiction))
-					if(A.associated_reagent == selected_reagent) return
+					if(A.associated_reagent == selected_reagent)
+						 return
 			addAddiction(owner)
 		return
 

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -838,10 +838,6 @@ obj/trait/pilot
 	var/addictive_reagents = list("bath salts", "lysergic acid diethylamide", "space drugs", "psilocybin", "cat drugs", "methamphetamine")
 	var/addicted_players
 
-	New()
-		selected_reagent = pick("bath salts", "lysergic acid diethylamide", "space drugs", "psilocybin", "cat drugs", "methamphetamine")
-		. = ..()
-
 	onAdd(var/mob/owner)
 		if(isliving(owner))
 			addicted_players[owner] = pick(addictive_reagents)

--- a/code/world.dm
+++ b/code/world.dm
@@ -396,7 +396,7 @@ var/f_color_selector_handler/F_Color_Selector
 
 		Z_LOG_DEBUG("Preload", "  /obj/trait")
 		for(var/A in childrentypesof(/obj/trait)) //Creating trait objects. I hate this.
-			var/obj/trait/T = new A( )
+			var/obj/trait/T = new A( )							//Sentiment shared -G
 			traitList.Add(T.id)
 			traitList[T.id] = T
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The Addict Trait forces everyone to have the same addiction each shift. The addict one also shares this as pointed in issue #2231.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes the addiction and allergy trait act more like a personal trait instead of having their behaviour share between players


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Gonzako:
(*)Everyone with the addict trait no longer shares their addiction with every other addict.
(+)New allergic players joining no longer change everybody else's allergy
```
