### PR TITLE
ghosts respawned as ghost critters/afterlife bar/ghost vr are scannable/cloneable

### DIFF
--- a/code/obj/machinery/computer/cloning.dm
+++ b/code/obj/machinery/computer/cloning.dm
@@ -430,7 +430,7 @@
 		if ((subject.ghost && subject.ghost.mind && subject.ghost.mind.key))
 			subjMind = subject.ghost.mind
 		else if (subject.last_client)
-			var/mob/M = find_ghost_by_key("[subject.last_client.ckey]")
+			var/mob/M = find_ghost_by_key(subject.last_client.ckey)
 			if (isVRghost(M) || inafterlifebar(M) || isghostcritter(M))
 				subjMind = M.mind
 			else
@@ -505,7 +505,7 @@
 		src.temp = "Abnormal reading from cloning pod."
 		return
 
-	var/mob/selected = find_ghost_by_key("[C.fields["ckey"]]")
+	var/mob/selected = find_ghost_by_key(C.fields["ckey"])
 
 	if (!selected)
 		src.temp = "Can't clone: Unable to locate mind."

--- a/code/obj/machinery/computer/cloning.dm
+++ b/code/obj/machinery/computer/cloning.dm
@@ -429,10 +429,10 @@
 	if ((!subjMind) || (!subjMind.key))
 		if ((subject.ghost && subject.ghost.mind && subject.ghost.mind.key))
 			subjMind = subject.ghost.mind
-		else if (subject.last_client && find_dead_player("[subject.last_client.ckey]"))
-			var/mob/living/carbon/human/virtual/V = find_dead_player("[subject.last_client.ckey]")
-			if ((istype(V) && V.isghost) || inafterlifebar(V))
-				subjMind = V.mind
+		else if (subject.last_client)
+			var/mob/M = find_ghost_by_key("[subject.last_client.ckey]")
+			if (isVRghost(M) || inafterlifebar(M) || isghostcritter(M))
+				subjMind = M.mind
 			else
 				src.temp = "Error: Mental interface failure."
 				return
@@ -505,7 +505,7 @@
 		src.temp = "Abnormal reading from cloning pod."
 		return
 
-	var/mob/selected = find_dead_player("[C.fields["ckey"]]")
+	var/mob/selected = find_ghost_by_key("[C.fields["ckey"]]")
 
 	if (!selected)
 		src.temp = "Can't clone: Unable to locate mind."
@@ -515,13 +515,13 @@
 		// leave the goddamn dnr ghosts alone
 		src.temp = "Cannot clone: Subject has set DNR."
 		return
-	else
-		//for deleting the mob in the afterlife bar if cloning person from there.
-		var/mob/ALB_selection = selected
-		if (inafterlifebar(ALB_selection))
-			boutput(selected, "<span class='notice'>You are being returned to the land of the living!</span>")
-			selected = ALB_selection.ghostize()
-			qdel(ALB_selection)
+
+	if (inafterlifebar(selected) || isghostcritter(selected) || isVRghost(selected))
+		//for deleting the mob if theyre in the bar, in vr, or a ghost critter
+		var/mob/soon_to_be_deleted = selected
+		boutput(selected, "<span class='notice'>You are being returned to the land of the living!</span>")
+		selected = soon_to_be_deleted.ghostize()
+		qdel(soon_to_be_deleted)
 
 	// at this point selected = the dude we wanna revive.
 
@@ -567,20 +567,15 @@
 				src.icon_state = "c_unpowered"
 				status |= NOPOWER
 
-//Find a dead mob with a brain and client.
-/proc/find_dead_player(var/find_key, needbrain=0)
-	if (isnull(find_key))
-		return
+/// find a ghost mob (or a ghost respawned as critter in vr/afterlife bar)
+proc/find_ghost_by_key(var/find_key)
+	if (!find_key)
+		return null
 
-	for(var/mob/M in mobs)
-		//Dead people only thanks!
-		if (!(isdead(M) || isVRghost(M) || isghostcritter(M) || inafterlifebar(M)) || (!M.client))
-			continue
-		//They need a brain!
-		if (needbrain && ishuman(M) && !M:brain)
-			continue
-
-		if (M.ckey == find_key)
+	var/datum/player/player = find_player(find_key)
+	if (player?.client?.mob)
+		var/mob/M = player.client.mob
+		if (isdead(M) || isVRghost(M) || inafterlifebar(M) || isghostcritter(M))
 			return M
 	return null
 


### PR DESCRIPTION
[CLEANLINESS] [ENHANCEMENT]
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
this is a minor refactor of some cloning stuff. code should be faster now, but im not sure it ever mattered. (instead of iterating over all mobs in mobs, we go thru player datums)

previously, corpses of people whose ghosts were in the afterlife bar / ghost vr were able to be scanned, but only those in the afterlife bar could be cloned. this makes it so that the bodies of people who are currently inhabiting a ghost critter, partying in the afterlife bar or running around in vr are able to both be scanned and cloned. if youre in any of those places and youre cloned, youre immediately pulled out into the clonepod. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
consistency and better code. i think that it kinda sucks for people to be a cockroach and goof around, and then get no opportunity to rejoin the round.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)adharainspace:
(+)The bodies of ghosts who have respawned as ghost critters/afterlife bar patrons/ghost vr people are now scannable/cloneable.
```
