### PR TITLE
More Robust Vending Machine Logging

### DIFF
--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -130,14 +130,13 @@
 	proc/vendinput(var/datum/mechanicsMessage/inp)
 		if( world.time < lastvend ) return//aaaaaaa
 		lastvend = world.time + 2
-		throw_item()
-		return TRUE
+		. = throw_item()
+
 	proc/vendname(var/datum/mechanicsMessage/inp)
 		if( world.time < lastvend || !inp) return//aaaaaaa
 		if(!length(inp.signal)) return//aaaaaaa
 		lastvend = world.time + 5 //Make it slower to vend by name?
-		throw_item(inp.signal)
-		return TRUE
+		. = throw_item(inp.signal)
 
 	// just making this proc so we don't have to override New() for every vending machine, which seems to lead to bad things
 	// because someone, somewhere, always forgets to use a ..()
@@ -799,7 +798,8 @@
 			if(item_name_to_throw == product.product_name_cache[product.product_path])
 				if(product.product_amount > 0)
 					thrown = throw_item_act(product, target)
-				break
+					return thrown
+				return
 	else
 		for(var/datum/data/vending_product/R in src.product_list)
 			if (R.product_amount <= 0) //Try to use a record that actually has something to dump.
@@ -807,7 +807,7 @@
 			valid_products.Add(R)
 		if (valid_products.len)
 			thrown = throw_item_act(pick(valid_products), target)
-	return thrown
+			return thrown
 
 /obj/machinery/vending/proc/throw_item_act(var/datum/data/vending_product/R, var/mob/living/target)
 	var/obj/throw_item = null
@@ -1680,11 +1680,11 @@
 
 	vendinput(var/datum/mechanicsMessage/inp)
 		if (..())
-			logTheThing("station", usr, null, "triggered a mechcomp random vend from [src] at [log_loc(src)].")
+			logTheThing("station", usr, null, "vended a random product using mechcomp from [src] at [log_loc(src)].")
 
 	vendname(var/datum/mechanicsMessage/inp)
 		if (..())
-			logTheThing("station", usr, null, "triggered a mechcomp vend by name ([inp.signal]) from [src] at [log_loc(src)].")
+			logTheThing("station", usr, null, "vended a product by name ([inp.signal]) using mechcomp from [src] at [log_loc(src)].")
 
 	Topic(href, href_list)
 		if (..() && href_list["vend"])

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -5,10 +5,11 @@
 	var/product_cost
 	var/product_amount
 	var/product_hidden
+	var/logged_on_vend
 
 	var/static/list/product_name_cache = list(/obj/item/reagent_containers/mender/brute = "brute auto-mender", /obj/item/reagent_containers/mender/burn = "burn auto-mender")
 
-	New(productpath, amount=0, cost=0, hidden=0)
+	New(productpath, amount=0, cost=0, hidden=0, logged_on_vend=FALSE)
 		..()
 		if (istext(productpath))
 			productpath = text2path(productpath)
@@ -33,6 +34,7 @@
 		src.product_cost -= 0.01
 #endif
 		src.product_hidden = hidden
+		src.logged_on_vend = logged_on_vend
 
 /obj/machinery/vending
 	name = "Vendomat"
@@ -127,16 +129,21 @@
 		..()
 		src.panel_image = image(src.icon, src.icon_panel)
 	var/lastvend = 0
+
 	proc/vendinput(var/datum/mechanicsMessage/inp)
 		if( world.time < lastvend ) return//aaaaaaa
 		lastvend = world.time + 2
-		. = throw_item()
+		var/datum/data/vending_product/R = throw_item()
+		if(R?.logged_on_vend)
+			logTheThing("station", usr, null, "randomly vended a logged product ([R.product_name]) using mechcomp from [src] at [log_loc(src)].")
 
 	proc/vendname(var/datum/mechanicsMessage/inp)
 		if( world.time < lastvend || !inp) return//aaaaaaa
 		if(!length(inp.signal)) return//aaaaaaa
 		lastvend = world.time + 5 //Make it slower to vend by name?
-		. = throw_item(inp.signal)
+		var/datum/data/vending_product/R = throw_item(inp.signal)
+		if(R?.logged_on_vend)
+			logTheThing("station", usr, null, "vended a logged product by name ([R.product_name]) using mechcomp from [src] at [log_loc(src)].")
 
 	// just making this proc so we don't have to override New() for every vending machine, which seems to lead to bad things
 	// because someone, somewhere, always forgets to use a ..()
@@ -620,7 +627,9 @@
 				src.paying_for = null
 				src.scan = null
 			src.generate_HTML(1)
-			return TRUE
+
+			if(R.logged_on_vend)
+				logTheThing("station", usr, null, "vended a logged procuct ([R.product_name]) from [src] at [log_loc(src)].")
 
 		if (href_list["logout"])
 			src.scan = null
@@ -787,27 +796,27 @@
 
 //Somebody cut an important wire and now we're following a new definition of "pitch."
 /obj/machinery/vending/proc/throw_item(var/item_name_to_throw = "")
-	var/thrown = 0
-	var/list/datum/data/vending_product/valid_products = list()
 	var/mob/living/target = locate() in view(7,src)
 	if(!target)
 		return 0
 
 	if(length(item_name_to_throw))
-		for(var/datum/data/vending_product/product in src.product_list)
-			if(item_name_to_throw == product.product_name_cache[product.product_path])
-				if(product.product_amount > 0)
-					thrown = throw_item_act(product, target)
-					return thrown
+		for(var/datum/data/vending_product/R in src.product_list)
+			if(item_name_to_throw == R.product_name_cache[R.product_path])
+				if(R.product_amount > 0)
+					throw_item_act(R, target)
+					return R
 				return
 	else
+		var/list/datum/data/vending_product/valid_products = list()
 		for(var/datum/data/vending_product/R in src.product_list)
-			if (R.product_amount <= 0) //Try to use a record that actually has something to dump.
+			if(R.product_amount <= 0) //Try to use a record that actually has something to dump.
 				continue
 			valid_products.Add(R)
-		if (valid_products.len)
-			thrown = throw_item_act(pick(valid_products), target)
-			return thrown
+		if(length(valid_products))
+			var/datum/data/vending_product/vending_product = pick(valid_products)
+			throw_item_act(vending_product, target)
+			return vending_product
 
 /obj/machinery/vending/proc/throw_item_act(var/datum/data/vending_product/R, var/mob/living/target)
 	var/obj/throw_item = null
@@ -1674,22 +1683,9 @@
 
 	create_products()
 		..()
-		product_list += new/datum/data/vending_product(/mob/living/carbon/human/npc/monkey, rand(10, 15))
+		product_list += new/datum/data/vending_product(/mob/living/carbon/human/npc/monkey, rand(10, 15), logged_on_vend=TRUE)
 
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/food/snacks/plant/banana, rand(1,20), hidden=1)
-
-	vendinput(var/datum/mechanicsMessage/inp)
-		if (..())
-			logTheThing("station", usr, null, "vended a random product using mechcomp from [src] at [log_loc(src)].")
-
-	vendname(var/datum/mechanicsMessage/inp)
-		if (..())
-			logTheThing("station", usr, null, "vended a product by name ([inp.signal]) using mechcomp from [src] at [log_loc(src)].")
-
-	Topic(href, href_list)
-		if (..() && href_list["vend"])
-			var/datum/data/vending_product/R = locate(href_list["vend"]) in src.product_list
-			logTheThing("station", usr, null, "vended [R.product_name] from [src] at [log_loc(src)].")
 
 /obj/machinery/vending/magivend
 	name = "MagiVend"

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -629,7 +629,7 @@
 			src.generate_HTML(1)
 
 			if(R.logged_on_vend)
-				logTheThing("station", usr, null, "vended a logged procuct ([R.product_name]) from [src] at [log_loc(src)].")
+				logTheThing("station", usr, null, "vended a logged product ([R.product_name]) from [src] at [log_loc(src)].")
 
 		if (href_list["logout"])
 			src.scan = null

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -131,13 +131,13 @@
 		if( world.time < lastvend ) return//aaaaaaa
 		lastvend = world.time + 2
 		throw_item()
-		return
+		return TRUE
 	proc/vendname(var/datum/mechanicsMessage/inp)
 		if( world.time < lastvend || !inp) return//aaaaaaa
 		if(!length(inp.signal)) return//aaaaaaa
 		lastvend = world.time + 5 //Make it slower to vend by name?
 		throw_item(inp.signal)
-		return
+		return TRUE
 
 	// just making this proc so we don't have to override New() for every vending machine, which seems to lead to bad things
 	// because someone, somewhere, always forgets to use a ..()
@@ -1677,6 +1677,14 @@
 		product_list += new/datum/data/vending_product(/mob/living/carbon/human/npc/monkey, rand(10, 15))
 
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/food/snacks/plant/banana, rand(1,20), hidden=1)
+
+	vendinput(var/datum/mechanicsMessage/inp)
+		if (..())
+			logTheThing("station", usr, null, "triggered a mechcomp random vend from [src] at [log_loc(src)].")
+
+	vendname(var/datum/mechanicsMessage/inp)
+		if (..())
+			logTheThing("station", usr, null, "triggered a mechcomp vend by name ([inp.signal]) from [src] at [log_loc(src)].")
 
 	Topic(href, href_list)
 		if (..() && href_list["vend"])

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -1681,7 +1681,7 @@
 	Topic(href, href_list)
 		if (..() && href_list["vend"])
 			var/datum/data/vending_product/R = locate(href_list["vend"]) in src.product_list
-			logTheThing("station", usr, null, "vended a [R.product_path] from [src] at [log_loc(src)].")
+			logTheThing("station", usr, null, "vended [R.product_name] from [src] at [log_loc(src)].")
 
 /obj/machinery/vending/magivend
 	name = "MagiVend"

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -621,6 +621,7 @@
 				src.paying_for = null
 				src.scan = null
 			src.generate_HTML(1)
+			return TRUE
 
 		if (href_list["logout"])
 			src.scan = null
@@ -1676,6 +1677,11 @@
 		product_list += new/datum/data/vending_product(/mob/living/carbon/human/npc/monkey, rand(10, 15))
 
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/food/snacks/plant/banana, rand(1,20), hidden=1)
+
+	Topic(href, href_list)
+		if (..() && href_list["vend"])
+			var/datum/data/vending_product/R = locate(href_list["vend"]) in src.product_list
+			logTheThing("station", usr, null, "vended a [R.product_path] from [src] at [log_loc(src)].")
 
 /obj/machinery/vending/magivend
 	name = "MagiVend"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][FEAT] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
EDIT: I did some refactoring and made this fancy

- Allows `datum/data/vending_product`s to be marked as `logged_on_vend`
- Marks monkeys as a logged product from the valuchimp
- New products can easily be logged by simply setting the flag on their record
- Logs manual vending, as well as both random and by name mechcomp vending
- Displays actual product name in log

![image](https://user-images.githubusercontent.com/33204415/95032305-02f71c00-0688-11eb-9aba-09cbfbaea4da.png)
old images:
[image](https://user-images.githubusercontent.com/33204415/95027485-dd0d4f80-0666-11eb-8971-fc4d7c1b81ed.png)
[image](https://user-images.githubusercontent.com/33204415/95028728-70974e00-0670-11eb-8b6c-19099bbeaadf.png)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Administrative need