### PR TITLE
Fixes set-env depreciation for Beepsky

### DIFF
--- a/.github/workflows/beepsky.yml
+++ b/.github/workflows/beepsky.yml
@@ -79,7 +79,7 @@ jobs:
           cd $GITHUB_WORKSPACE
           printenv
           echo "BYOND_SYSTEM=/home/runner/BYOND/byond" >> $GITHUB_ENV
-          echo "/home/runner/BYOND/byond/bin:" >> $GITHUB_PATH
+          echo "/home/runner/BYOND/byond/bin" >> $GITHUB_PATH
           echo "LD_LIBRARY_PATH=/home/runner/BYOND/byond/bin:$LD_LIBRARY_PATH" >> $GITHUB_ENV
           echo "MANPATH=/home/runner/BYOND/byond/man:$MANPATH" >> $GITHUB_ENV
           touch +secret/__secret.dme
@@ -129,7 +129,7 @@ jobs:
           cd $GITHUB_WORKSPACE
           printenv
           echo "BYOND_SYSTEM=/home/runner/BYOND/byond" >> $GITHUB_ENV
-          echo "/home/runner/BYOND/byond/bin:" >> $GITHUB_PATH
+          echo "/home/runner/BYOND/byond/bin" >> $GITHUB_PATH
           echo "LD_LIBRARY_PATH=/home/runner/BYOND/byond/bin:$LD_LIBRARY_PATH" >> $GITHUB_ENV
           echo "MANPATH=/home/runner/BYOND/byond/man:$MANPATH" >> $GITHUB_ENV
           touch +secret/__secret.dme
@@ -171,7 +171,7 @@ jobs:
           cd $GITHUB_WORKSPACE
           printenv
           echo "BYOND_SYSTEM=/home/runner/BYOND/byond" >> $GITHUB_ENV
-          echo "/home/runner/BYOND/byond/bin:" >> $GITHUB_PATH
+          echo "/home/runner/BYOND/byond/bin" >> $GITHUB_PATH
           echo "LD_LIBRARY_PATH=/home/runner/BYOND/byond/bin:$LD_LIBRARY_PATH" >> $GITHUB_ENV
           echo "MANPATH=/home/runner/BYOND/byond/man:$MANPATH" >> $GITHUB_ENV
 

--- a/.github/workflows/beepsky.yml
+++ b/.github/workflows/beepsky.yml
@@ -78,10 +78,10 @@ jobs:
           tools/ci/install_byond.sh
           cd $GITHUB_WORKSPACE
           printenv
-          echo "::set-env name=BYOND_SYSTEM::/home/runner/BYOND/byond"
-          echo "::set-env name=PATH::/home/runner/BYOND/byond/bin:$PATH"
-          echo "::set-env name=LD_LIBRARY_PATH::/home/runner/BYOND/byond/bin:$LD_LIBRARY_PATH"
-          echo "::set-env name=MANPATH::/home/runner/BYOND/byond/man:$MANPATH"
+          echo "BYOND_SYSTEM=/home/runner/BYOND/byond" >> $GITHUB_ENV
+          echo "/home/runner/BYOND/byond/bin:" >> $GITHUB_PATH
+          echo "LD_LIBRARY_PATH=/home/runner/BYOND/byond/bin:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+          echo "MANPATH=/home/runner/BYOND/byond/man:$MANPATH" >> $GITHUB_ENV
           touch +secret/__secret.dme
 
       - name: Compile
@@ -128,10 +128,10 @@ jobs:
           tools/ci/install_byond.sh
           cd $GITHUB_WORKSPACE
           printenv
-          echo "::set-env name=BYOND_SYSTEM::/home/runner/BYOND/byond"
-          echo "::set-env name=PATH::/home/runner/BYOND/byond/bin:$PATH"
-          echo "::set-env name=LD_LIBRARY_PATH::/home/runner/BYOND/byond/bin:$LD_LIBRARY_PATH"
-          echo "::set-env name=MANPATH::/home/runner/BYOND/byond/man:$MANPATH"
+          echo "BYOND_SYSTEM=/home/runner/BYOND/byond" >> $GITHUB_ENV
+          echo "/home/runner/BYOND/byond/bin:" >> $GITHUB_PATH
+          echo "LD_LIBRARY_PATH=/home/runner/BYOND/byond/bin:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+          echo "MANPATH=/home/runner/BYOND/byond/man:$MANPATH" >> $GITHUB_ENV
           touch +secret/__secret.dme
           sed -i 's/BUILD_TIME_DAY 01/BUILD_TIME_DAY 13/' _std/__build.dm
 

--- a/.github/workflows/beepsky.yml
+++ b/.github/workflows/beepsky.yml
@@ -170,10 +170,10 @@ jobs:
           tools/ci/install_byond.sh
           cd $GITHUB_WORKSPACE
           printenv
-          echo "::set-env name=BYOND_SYSTEM::/home/runner/BYOND/byond"
-          echo "::set-env name=PATH::/home/runner/BYOND/byond/bin:$PATH"
-          echo "::set-env name=LD_LIBRARY_PATH::/home/runner/BYOND/byond/bin:$LD_LIBRARY_PATH"
-          echo "::set-env name=MANPATH::/home/runner/BYOND/byond/man:$MANPATH"
+          echo "BYOND_SYSTEM=/home/runner/BYOND/byond" >> $GITHUB_ENV
+          echo "/home/runner/BYOND/byond/bin:" >> $GITHUB_PATH
+          echo "LD_LIBRARY_PATH=/home/runner/BYOND/byond/bin:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+          echo "MANPATH=/home/runner/BYOND/byond/man:$MANPATH" >> $GITHUB_ENV
 
       - name: Cache SpacemanDMM
         uses: actions/cache@v1


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes the GitHub depreciation warning for `set-env` in Beepsky.
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

bad
