### PR TITLE
Different-colored medibots get different chems

### DIFF
--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -43,6 +43,7 @@ datum
 		var/viscosity = 0 // determines interactions in fluids. 0 for least viscous, 1 for most viscous. use decimals!
 		var/block_slippy = 0 //fluid flag for slippage control
 		var/list/target_organs
+		var/list/target_plant_reagents
 		var/heat_capacity = 100 /* how much heat a reagent can hold */
 		var/blocks_sight_gas = 0 //opacity
 		var/pierces_outerwear = 0//whether or not this penetrates outerwear that may protect the victim(e.g. biosuit)

--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -2203,6 +2203,15 @@ datum
 			result_amount = 2
 			mix_phrase = "The mixture bubbles slowly, making a slightly sweet odor."
 
+		dexamethasone // COGWERKS CHEM REVISION PROJECT: possibly dexamesothone, anti-edema medication
+			name = "Dexamethasone"
+			id = "dexamethasone"
+			result = "dexamethasone"
+			required_reagents = list("hydrogen" = 1, "oxygen" = 1, "sodium" = 1, "carbon" = 1, "fluorine" = 1, "bromine" = 1)
+			result_amount = 6
+			mix_phrase = "The liquid fizzles and turns a light shade of blue."
+			mix_sound = 'sound/misc/drinkfizz.ogg'
+
 		salbutamol // COGWERKS CHEM REVISION PROJECT: possibly dexamesothone, anti-edema medication
 			name = "Salbutamol"
 			id = "salbutamol"

--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -2141,6 +2141,14 @@ datum
 			required_reagents = list("silver" = 1, "sulfur" = 1, "oxygen" = 1, "weedkiller" = 3)
 			result_amount = 5
 		*/
+		healing_crystals
+			name = "Healing Crystals"
+			id = "healing_crystals"
+			result = "healing_crystals"
+			required_reagents = list("salt" = 1, "plasma" = 1)
+			result_amount = 4
+			mix_phrase = "The salt crystals precipitate. You feel pretty silly."
+
 		charcoal // antitoxin
 			name = "Activated Charcoal"
 			id = "charcoal"

--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -2141,13 +2141,13 @@ datum
 			required_reagents = list("silver" = 1, "sulfur" = 1, "oxygen" = 1, "weedkiller" = 3)
 			result_amount = 5
 		*/
-		healing_crystals
-			name = "Healing Crystals"
-			id = "healing_crystals"
-			result = "healing_crystals"
-			required_reagents = list("salt" = 1, "plasma" = 1)
-			result_amount = 4
-			mix_phrase = "The salt crystals precipitate. You feel pretty silly."
+		silibinin
+			name = "Silibinin"
+			id = "silibinin"
+			result = "silibinin"
+			required_reagents = list("lithium" = 1, "aluminium" = 1, "silver" = 1, "carbon" = 1, "oxygen" = 1, "water" = 1)
+			result_amount = 6
+			mix_phrase = "An herbal smell rises from the solution"
 
 		charcoal // antitoxin
 			name = "Activated Charcoal"

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -1507,7 +1507,7 @@ datum
 				return
 
 			on_plant_life(var/obj/machinery/plantpot/P)
-				for(var/reagent in target_plant_reagents)
+				for(var/reagent in src.target_plant_reagents)
 					if(P.reagents.has_reagent(reagent))
 						P.reagents.remove_reagent(reagent, 1)
 
@@ -1540,7 +1540,7 @@ datum
 				return
 
 			on_plant_life(var/obj/machinery/plantpot/P)
-				for(var/reagent in target_plant_reagents)
+				for(var/reagent in src.target_plant_reagents)
 					if(P.reagents.has_reagent(reagent))
 						P.reagents.remove_reagent(reagent, 2)
 

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -1487,6 +1487,30 @@ datum
 				..()
 				return
 
+		medical/healing_crystals
+			name = "healing crystals"
+			id = "healing_crystals"
+			description = "Is this really state-of-the-art medicine?"
+			reagent_state = SOLID
+			fluid_r = 216
+			fluid_b = 161
+			fluid_g = 201
+			transparency = 200
+			value = 0 // fuck you
+			depletion_rate = 0.2
+			target_plant_reagents = list("toxin", "toxic_slurry", "acid", "plasma", "mercury", "fuel", "chlorine", "radium")
+
+			on_mob_life(var/mob/M, var/mult = 1)
+				if(!M) M = holder.my_atom
+				M.take_toxin_damage(-0.75 * mult)
+				..()
+				return
+
+			on_plant_life(var/obj/machinery/plantpot/P)
+				for(var/reagent in target_plant_reagents)
+					if(P.reagents.has_reagent(reagent))
+						P.reagents.remove_reagent(reagent, 1)
+
 		medical/charcoal
 			name = "charcoal"
 			id = "charcoal"
@@ -1497,6 +1521,7 @@ datum
 			fluid_g = 0
 			value = 5 // 3c + 1c + heat
 			target_organs = list("left_kidney", "right_kidney", "liver", "stomach", "intestines")
+			target_plant_reagents = list("toxin", "toxic_slurry", "acid", "plasma", "mercury", "fuel", "chlorine", "radium")
 
 			on_mob_life(var/mob/M, var/mult = 1)
 				if(!M) M = holder.my_atom
@@ -1515,22 +1540,9 @@ datum
 				return
 
 			on_plant_life(var/obj/machinery/plantpot/P)
-				if(P.reagents.has_reagent("toxin"))
-					P.reagents.remove_reagent("toxin", 2)
-				if(P.reagents.has_reagent("toxic_slurry"))
-					P.reagents.remove_reagent("toxic_slurry", 2)
-				if(P.reagents.has_reagent("acid"))
-					P.reagents.remove_reagent("acid", 2)
-				if(P.reagents.has_reagent("plasma"))
-					P.reagents.remove_reagent("plasma", 2)
-				if(P.reagents.has_reagent("mercury"))
-					P.reagents.remove_reagent("mercury", 2)
-				if(P.reagents.has_reagent("fuel"))
-					P.reagents.remove_reagent("fuel", 2)
-				if(P.reagents.has_reagent("chlorine"))
-					P.reagents.remove_reagent("chlorine", 2)
-				if(P.reagents.has_reagent("radium"))
-					P.reagents.remove_reagent("radium", 2)
+				for(var/reagent in target_plant_reagents)
+					if(P.reagents.has_reagent(reagent))
+						P.reagents.remove_reagent(reagent, 2)
 
 		medical/antihol // COGWERKS CHEM REVISION PROJECT. maybe a diuretic or some sort of goofy common hangover cure
 			name = "antihol"

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -1487,16 +1487,16 @@ datum
 				..()
 				return
 
-		medical/healing_crystals
-			name = "healing crystals"
-			id = "healing_crystals"
-			description = "Is this really state-of-the-art medicine?"
+		medical/silibinin
+			name = "Silibinin"
+			id = "silibinin"
+			description = "An extract from the milk thistle plant, an herbal remedy for minor poisoning"
 			reagent_state = SOLID
 			fluid_r = 216
 			fluid_b = 161
 			fluid_g = 201
 			transparency = 200
-			value = 0 // fuck you
+			value = 6
 			depletion_rate = 0.2
 			target_plant_reagents = list("toxin", "toxic_slurry", "acid", "plasma", "mercury", "fuel", "chlorine", "radium")
 

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -1378,6 +1378,26 @@ datum
 				..()
 				return
 
+		medical/dexamethasone // Same volume heals same amount as salbutamol, but twice as slow, no overdose, no organ healing
+			name = "dexamethasone"
+			id = "dexamethasone"
+			description = "Dexamethasone is a corticosteroid hormone used to treat asthma and other chronic obstructive lung disorders."
+			reagent_state = LIQUID
+			fluid_r = 102
+			fluid_g = 178
+			fluid_b = 255
+			transparency = 255
+			depletion_rate = 0.1
+			value = 6 // 1 1 1 1 1 1
+
+			on_mob_life(var/mob/M, var/mult = 1)
+				if(!M) M = holder.my_atom
+				M.take_oxygen_deprivation(-3 * mult)
+				if(M.losebreath)
+					M.losebreath = max(0, M.losebreath-(2 * mult))
+				..()
+				return
+
 		medical/salbutamol // COGWERKS CHEM REVISION PROJECT. marked for revision. Could be Dexamesathone
 			name = "salbutamol"
 			id = "salbutamol"

--- a/code/modules/robotics/bot/medbot.dm
+++ b/code/modules/robotics/bot/medbot.dm
@@ -172,7 +172,7 @@
 		src.treatment_eye_ear = "oculine"
 		src.treatment_emag = "acetaldehyde"
 	else if ((src.skin == "toxin1") || (src.skin == "toxin2") || (src.skin == "toxin3") || (src.skin == "toxin4"))
-		src.treatment_tox = "smelling_salt"
+		src.treatment_tox = "ammoniumbicarbonate"
 		src.treatment_rad = "anti_rad"
 		src.treatment_emag = "weedkiller"
 	else if ((src.skin == "O21") || (src.skin == "O22") || (src.skin == "O23") || (src.skin == "O24"))

--- a/code/modules/robotics/bot/medbot.dm
+++ b/code/modules/robotics/bot/medbot.dm
@@ -43,7 +43,7 @@
 	var/treatment_brute = "saline"
 	var/treatment_oxy = "dexamethasone"
 	var/treatment_fire = "saline"
-	var/treatment_tox = "healing_crystals"
+	var/treatment_tox = "silibinin"
 	var/treatment_virus = "spaceacillin"
 	var/treatment_hypertension = null
 	var/treatment_hypotension = null

--- a/code/modules/robotics/bot/medbot.dm
+++ b/code/modules/robotics/bot/medbot.dm
@@ -172,7 +172,7 @@
 		src.treatment_eye_ear = "oculine"
 		src.treatment_emag = "acetaldehyde"
 	else if ((src.skin == "toxin1") || (src.skin == "toxin2") || (src.skin == "toxin3") || (src.skin == "toxin4"))
-		src.treatment_tox = "ammoniumbicarbonate"
+		src.treatment_tox = "smelling_salt"
 		src.treatment_rad = "anti_rad"
 		src.treatment_emag = "weedkiller"
 	else if ((src.skin == "O21") || (src.skin == "O22") || (src.skin == "O23") || (src.skin == "O24"))

--- a/code/modules/robotics/bot/medbot.dm
+++ b/code/modules/robotics/bot/medbot.dm
@@ -79,7 +79,6 @@
 	name = "Medibot - 'Head Surgeon'"
 	desc = "The HS sure looks different today! Maybe he got a haircut?"
 	skin = "hs"
-	treatment_oxy = "perfluorodecalin"
 	access_lookup = "Head Surgeon"
 	text2speech = 1
 
@@ -158,7 +157,48 @@
 			src.update_icon()
 			var/datum/reagent/dummy = /datum/reagent/harmful/histamine // hack to make sure histamine overdose amount is set correctly
 			src.histamine_overdose_amount = initial(dummy.overdose)
+			if (src.skin)
+				src.initialize_custom_skin()
 	return
+
+/obj/machinery/bot/medbot/proc/initialize_custom_skin()
+	if ((src.skin == "brute1") || (src.skin == "brute2") || (src.skin == "brute3") || (src.skin == "brute3"))
+		src.treatment_brute = "salicylic_acid"
+		src.treatment_hypertension = "heparin"
+		src.treatment_hypotension = "filgrastim"
+		src.treatment_emag = "ants"
+	else if ((src.skin == "burn1") || (src.skin == "burn2") || (src.skin == "burn3") || (src.skin == "burn4"))
+		src.treatment_fire = "menthol"
+		src.treatment_eye_ear = "oculine"
+		src.treatment_emag = "acetaldehyde"
+	else if ((src.skin == "toxin1") || (src.skin == "toxin2") || (src.skin == "toxin3") || (src.skin == "toxin4"))
+		src.treatment_tox = "smelling_salt"
+		src.treatment_rad = "anti_rad"
+		src.treatment_emag = "weedkiller"
+	else if ((src.skin == "O21") || (src.skin == "O22") || (src.skin == "O23") || (src.skin == "O24"))
+		src.treatment_oxy = "perfluorodecalin"
+		src.treatment_anaphylaxis = "antihistamine"
+		src.treatment_emag = "cyanide"
+	else if ((src.skin == "brain1") || (src.skin == "brain2") || (src.skin == "brain3"))
+		src.treatment_virus = "robustussin"
+		src.treatment_brain = "synaptizine"
+		src.treatment_emag = "neurotoxin"
+	else if ((src.skin == "berserk1") || (src.skin == "berserk2") || (src.skin == "berserk3"))
+		src.treatment_crit = "epinephrine"
+		src.treatment_emag = "formaldehyde"
+	else if (src.skin == "psych")
+		src.treatment_brute = "LSD"
+		src.treatment_oxy = "psilocybin"
+		src.treatment_fire = "LSD"
+		src.treatment_tox = "psilocybin"
+		src.treatment_virus = "loose screws"
+	else if (src.skin == "hs")
+		src.treatment_brute = "salicylic_acid"
+		src.treatment_fire = "menthol"
+		src.treatment_tox = "smelling_salt"
+		src.treatment_oxy = "perfluorodecalin"
+		src.treatment_virus = "robustussin"
+		src.treatment_emag = "sarin"
 
 /obj/machinery/bot/medbot/attack_ai(mob/user as mob)
 	return toggle_power()

--- a/code/modules/robotics/bot/medbot.dm
+++ b/code/modules/robotics/bot/medbot.dm
@@ -35,8 +35,9 @@
 	var/oxy_additional_heal_threshold = 15 // additional heal threshold for oxy damage
 	var/brain_heal_threshold = 10 // hardcoded brain heal threshold
 	var/blood_pressure_hypertensive_status = "HYPERTENSIVE"
-	var/blood_pressure_hypotensive_Status = "HYPOTENSIVE"
+	var/blood_pressure_hypotensive_status = "HYPOTENSIVE"
 	var/histamine_overdose_amount = null
+	var/eye_damage_threshold = 12 // hardcoded eye heal threshold
 	var/use_beaker = 0 //Use reagents in beaker instead of default treatment agents.
 	//Setting which reagents to use to treat what by default. By id.
 	var/treatment_brute = "saline"
@@ -48,10 +49,10 @@
 	var/treatment_hypotension = null
 	var/treatment_eye_ear = null
 	var/treatment_anaphylaxis = null
-	var/treatment_radiation = null
+	var/treatment_rad = null
 	var/treatment_brain = null
 	var/treatment_crit = null
-	var/treament_emag = "pancuronium"
+	var/treatment_emag = "pancuronium"
 	var/treatment_terrifying = "haloperidol"
 	var/terrifying = 0 // for making the medbots all super fucked up
 
@@ -347,7 +348,7 @@
 		SPAWN_DBG(2.5 SECONDS)
 			qdel(D)
 
-/obj/machinery/bot/medbot/reset_status(var/last_found = null)
+/obj/machinery/bot/medbot/proc/reset_status(var/last_found = null)
 	src.oldpatient = src.patient
 	src.patient = null
 	src.current_treatments = list()
@@ -364,7 +365,7 @@
 		src.update_icon(stun = 1)
 		src.stunned--
 
-		src.reset_status
+		src.reset_status()
 
 		if(src.stunned <= 0)
 			src.stunned = 0
@@ -493,7 +494,7 @@
 
 /obj/machinery/bot/medbot/proc/hypotension_check(mob/living/carbon/C as mob)
 	var/blood_pressure_status = C.blood_pressure["status"]
-	return (blood_pressure_status = blood_pressure_hypotensive_status)
+	return (blood_pressure_status = src.blood_pressure_hypotensive_status)
 
 /obj/machinery/bot/medbot/proc/anaphylaxis_check(mob/living/carbon/C as mob)
 	var/histamine_amt = C.reagents.get_reagent_amount("histamine")
@@ -502,13 +503,12 @@
 /obj/machinery/bot/medbot/proc/eye_ear_check(mob/living/carbon/C as mob)
 	var/eye = C.get_eye_damage()
 	var/ear = C.get_ear_damage()
-	var/eye_natural_threshold = C.get_eye_damage_natural_healing_threshold()
-	var/ear_natural_threshold = C.get_eye_damage_natural_healing_threshold()
-	return ((eye >= eye_natural_threshold) || (ear >= ear_natural_threshold))
+	var/ear_natural_threshold = C.get_ear_damage_natural_healing_threshold()
+	return ((eye >= src.eye_damage_threshold) || (ear >= ear_natural_threshold))
 /obj/machinery/bot/medbot/proc/virus_check(mob/living/carbon/C as mob)
 	for(var/datum/ailment_data/disease/am in C.ailments)
 		if((am.stage > 1) || (am.spread == "Airborne"))
-				return 1 //STOP DISEASE FOREVER
+			return 1 //STOP DISEASE FOREVER
 	return 0
 
 /obj/machinery/bot/medbot/proc/assess_patient(mob/living/carbon/C as mob)
@@ -533,7 +533,7 @@
 		if(brute_check(C))
 			.+= src.treatment_brute
 		if(burn_check(C))
-			.+= src.treatment_burn
+			.+= src.treatment_fire
 		if(tox_check(C))
 			.+= src.treatment_tox
 		if(oxy_check(C))

--- a/code/modules/robotics/bot/medbot.dm
+++ b/code/modules/robotics/bot/medbot.dm
@@ -41,9 +41,9 @@
 	var/use_beaker = 0 //Use reagents in beaker instead of default treatment agents.
 	//Setting which reagents to use to treat what by default. By id.
 	var/treatment_brute = "saline"
-	var/treatment_oxy = "salbutamol"
+	var/treatment_oxy = "dexamethasone"
 	var/treatment_fire = "saline"
-	var/treatment_tox = "charcoal"
+	var/treatment_tox = "healing_crystals"
 	var/treatment_virus = "spaceacillin"
 	var/treatment_hypertension = null
 	var/treatment_hypotension = null
@@ -172,11 +172,11 @@
 		src.treatment_eye_ear = "oculine"
 		src.treatment_emag = "acetaldehyde"
 	else if ((src.skin == "toxin1") || (src.skin == "toxin2") || (src.skin == "toxin3") || (src.skin == "toxin4"))
-		src.treatment_tox = "smelling_salt"
+		src.treatment_tox = "charcoal"
 		src.treatment_rad = "anti_rad"
 		src.treatment_emag = "weedkiller"
 	else if ((src.skin == "O21") || (src.skin == "O22") || (src.skin == "O23") || (src.skin == "O24"))
-		src.treatment_oxy = "perfluorodecalin"
+		src.treatment_oxy = "salbutamol"
 		src.treatment_anaphylaxis = "antihistamine"
 		src.treatment_emag = "cyanide"
 	else if ((src.skin == "brain1") || (src.skin == "brain2") || (src.skin == "brain3"))
@@ -195,7 +195,7 @@
 	else if (src.skin == "hs")
 		src.treatment_brute = "salicylic_acid"
 		src.treatment_fire = "menthol"
-		src.treatment_tox = "smelling_salt"
+		src.treatment_tox = "charcoal"
 		src.treatment_oxy = "perfluorodecalin"
 		src.treatment_virus = "robustussin"
 		src.treatment_emag = "sarin"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE][BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Medibots get a slight rework. Depending on the base medkit a medibot is constructed from, the medibot gets a different base healing chem, a new ailment to treat, and a new chemical to use when emagged. 

```
medkit  - base chem        - condition          - emagged chem
vanilla - n/a              - n/a                - n/a
brute   - salicylic acid   - hypo/hypertension  - ants
burn    - menthol          - ear/eye            - acetaldehyde
tox     - smelling salts   - radiation          - atrazine
oxy     - perfluorodecalin - anaphylaxis        - cyanide
neuro   - robustussin      - brain              - neurotoxin
crit    - n/a              - crit               - formaldehyde
head    - all of the above - n/a                - sarin
```

To make this work, the procs that govern medibot behavior were slightly refactored.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This PR gives the active roboticist the ability to enhance medbay significantly. This PR also buffs medibots (which I find are currently underused) significantly for both normal and traitor uses. I chose the new conditions to be treated carefully, to make sure that doctors were still required for a functioning medbay:

1. A patient just barely in crit might be fully healed by a series of medibots, but deep crit requires atropine or electric shock.
2. Synaptizine is not a very efficient chem for dealing with brain damage, and even a stack of saline and salicylic acid is a slow treatment for brute damage. A human or borg can treat patients much faster than even a stack of medibots.
3. Surgery and bleed damage are completely untouched by medibots
4. Most of the high-tier healing chems are not synthesized by medibots (other than perfluorodecalin, which was already synthesized by the Head Surgeon). Additionally, any chemicals that heal on `TOUCH` can't be applied by medibots.

With the exception of the head surgeon, the emagged chemicals are all easy to acquire or produce, and a chemist could synthesize a cocktail of the other new chemicals with little effort in only a few minutes.

Finally, the distribution of conditions and base chemicals was chosen for balance. The crit (or berserker, dusty medkit, etc.) medibot can heal patients in crit by itself, but only gets base chemicals to do it. The oxygen medibot has a strong base chemical, but anaphylaxis is quite rare. The tox medibot treats radiation (which is very helpful!) but its new base chem is smelling salts, which works only against a handful of knockout chems. 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Jawns:
(*) Medibots constructed from different medkits have different chemicals and treat different ailments.
```
