### PR TITLE
death alert message now includes whether or not they were scanned

### DIFF
--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -298,7 +298,7 @@ THROWING DARTS
 
 	proc/check_for_valid_record() //returns the area of the cloner where we found our valid record - jank, but idk
 		if (src.owner && src.owner.ckey)
-			for(var/obj/machinery/computer/cloning/comp as() in by_type[/obj/machinery/computer/cloning])
+			for(var/obj/machinery/computer/cloning/comp as anything in by_type[/obj/machinery/computer/cloning])
 				if (comp.find_record(src.owner.ckey))
 					return get_area(comp)
 		return null

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -19,7 +19,7 @@ THROWING DARTS
 	w_class = 1.0
 	var/implanted = null
 	var/impcolor = "g"
-	var/owner = null
+	var/mob/owner = null
 	var/mob/former_implantee = null
 	var/image/implant_overlay = null
 	var/life_tick_energy = 0
@@ -271,7 +271,14 @@ THROWING DARTS
 			return
 		var/coords = src.get_coords()
 		var/myarea = get_area(src)
-		src.message = "DEATH ALERT: [src.owner][coords] in [myarea]"
+		var/has_record = src.check_for_valid_record()
+		src.message = "DEATH ALERT: [src.owner][coords] in [myarea], " //youre lucky im not onelining this
+		if (has_record) //the title for this next section of code is grammar sucks
+			if (he_or_she(src.owner) == "they")
+				src.message += "they [has_record ? "have a record in the cloner at [has_record]" : "do not have a cloning record." ]"
+			else
+				src.message += "[he_or_she(src.owner)] [has_record ? "has a record in the cloner at [has_record]" : "does not have a cloning record."]"
+
 		//DEBUG_MESSAGE("implant reporting death")
 		src.send_message()
 
@@ -288,6 +295,13 @@ THROWING DARTS
 				var/turf/T = get_turf(C)
 				if (istype(T))
 					return " at [T.x],[T.y],[T.z]"
+
+	proc/check_for_valid_record() //returns the area of the cloner where we found our valid record - jank, but idk
+		if (src.owner && src.owner.ckey)
+			for(var/obj/machinery/computer/cloning/comp as() in by_type[/obj/machinery/computer/cloning])
+				if (comp.find_record(src.owner.ckey))
+					return get_area(comp)
+		return null
 
 	proc/send_message()
 		DEBUG_MESSAGE("sending message: [src.message]")

--- a/code/obj/machinery/computer/cloning.dm
+++ b/code/obj/machinery/computer/cloning.dm
@@ -37,6 +37,7 @@
 		pod1 = null
 		diskette = null
 		records = null
+		STOP_TRACKING
 		..()
 
 	old
@@ -74,6 +75,7 @@
 
 /obj/machinery/computer/cloning/New()
 	..()
+	START_TRACKING
 	SPAWN_DBG(0.7 SECONDS)
 		if(portable) return
 		src.scanner = locate(/obj/machinery/clone_scanner, orange(2,src))


### PR DESCRIPTION
[ENHANCEMENT] [INPUT WANTED]

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
this adds a check on health implants for if the dead person has a clone record, and if they do, which cloner its at (by area name). one potential downside to this is that it checks every cloner in the game, which could include hidden mindslave cloners. open to feedback. 

**[video](https://streamable.com/3amfa5)**


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
i think itd be nice and lead to more clonings happen after death alerts. maybe this is a change bc im salty bc of how many times ive died and then no ones bothered checking the records. the world will never know

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)adharainspace:
(+)if you die with a health implant, the pda message thats sent out now includes whether or not you were clonescanned. 
```
