### PR TITLE
reclaimer didn't update stack count

### DIFF
--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -836,7 +836,7 @@
 			stack_amount = round(divide)
 			if (stack_amount != divide)
 				src.insufficient = 1
-				O.amount -= (stack_amount * amount_modifier)
+				O.change_stack_amount(-stack_amount * amount_modifier)
 				O.set_loc(src.loc)
 				if (!stack_amount)
 					return

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -779,38 +779,6 @@
 
 			sleep(smelt_interval)
 
-		/*var/list/cable_materials = list()
-		var/list/quality_sum = list()
-		for (var/obj/item/cable_coil/C in src.contents)
-			if (!(C.conductor.mat_id in cable_materials))
-				cable_materials += C.conductor.mat_id
-				cable_materials[C.conductor.mat_id] = 0
-				quality_sum += C.conductor.mat_id
-				quality_sum[C.conductor.mat_id] = 0
-			if (!(C.insulator.mat_id in cable_materials))
-				cable_materials += C.insulator.mat_id
-				cable_materials[C.insulator.mat_id] = 0
-				quality_sum += C.insulator.mat_id
-				quality_sum[C.insulator.mat_id] = 0
-			cable_materials[C.conductor.mat_id] += C.amount
-			quality_sum[C.conductor.mat_id] += C.amount * C.quality
-			cable_materials[C.insulator.mat_id] += C.amount
-			quality_sum[C.insulator.mat_id] += C.amount * C.quality
-			qdel(C)
-
-		var/bad_flag = 0
-		for (var/mat_id in cable_materials)
-			var/total = cable_materials[mat_id]
-			while(cable_materials[mat_id] >= 30)
-				output_bar_with_quality(quality_sum[mat_id] / total, mat_id)
-				cable_materials[mat_id] -= 30
-				sleep(smelt_interval)
-				if (cable_materials[mat_id] < 30)
-					bad_flag = 1
-
-		if (bad_flag)
-			src.visible_message("<b>[src]</b> emits a grumpy buzz.")*/
-
 		if (reject)
 			src.reject = 0
 			src.visible_message("<b>[src]</b> emits an angry buzz and rejects some unsuitable materials!")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Portable reclaimers didn't update the stack counter on stuff like sheets, so even if it only spit 9 sheets out, it would still seem like it was 49 or something, leading to confusion.

I made it so it uses the change_stack_amount proc now, not sure if that's the right thing to use now?

I also removed a big commented out block in reclaimer code, since it annoyed me and we have version control anyway, if we ever need it again.
It's a separate commit, so we can revert it easily if you would rather keep it.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Was confusing and annoying.
