### PR TITLE
"This object menaces with spikes of..." reintroduced for making a really good mining tool

### DIFF
--- a/_std/__std.dme
+++ b/_std/__std.dme
@@ -37,6 +37,7 @@
 #include "defines\layer.dm"
 #include "defines\logic.dm"
 #include "defines\material_properties.dm"
+#include "defines\medals.dm"
 #include "defines\message_lengths.dm"
 #include "defines\mob.dm"
 #include "defines\movement.dm"

--- a/_std/defines/medals.dm
+++ b/_std/defines/medals.dm
@@ -1,0 +1,2 @@
+//Pick power threshold for "This object menaces with spikes of..." medal
+#define SPIKES_MEDAL_POWER_THRESHOLD 600

--- a/code/modules/materials/Mat_FabRecipes.dm
+++ b/code/modules/materials/Mat_FabRecipes.dm
@@ -223,6 +223,10 @@
 				newObj.desc = "[initial(newObj.desc)] It has \a [head.name]."
 
 			newObj.set_loc(getOutputLocation(owner))
+			if(newObj.power > SPIKES_MEDAL_POWER_THRESHOLD)
+				var/mob/living/player = usr
+				if(istype(player))
+					player.unlock_medal("This object menaces with spikes of...", 1)
 		return
 
 /datum/matfab_recipe/coilsmall


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

The medal "This object menaces with spikes of..." used to be awarded to miners for completing the objective "Find at least ten gems between all miners." When that objective was removed from the game, the medal become unachievable. This PR reintroduced the medal as a reward for creating a really strong mining tool in the nano-fab. Specifically, the `power` of the custom mining tool needs to be above 600 for the medal to be awarded. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This is the last of the unachievable medals that has no good reason to stay unachievable. It also rewards miners (and others) for exploring the materials and crafting systems. 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Jawns:
(*)"This object menaces with spikes of..." medal reintroduced. Try your hand at crafting the ultimate mining tool!
```
