### PR TITLE
nanofab attackby checks if item is deconstructor

### DIFF
--- a/code/modules/materials/Mat_Fabrication.dm
+++ b/code/modules/materials/Mat_Fabrication.dm
@@ -334,6 +334,8 @@
 		W.set_loc(src)
 
 	attackby(var/obj/item/W , mob/user as mob)
+		if(istype(W, /obj/item/deconstructor))
+			return
 		if(issilicon(user)) // fix bug where borgs could put things into the nanofab and then reject them
 			boutput(user, "<span class='alert'>You can't put that in, it's attached to you.</span>")
 			return

--- a/code/modules/materials/Mat_Fabrication.dm
+++ b/code/modules/materials/Mat_Fabrication.dm
@@ -335,7 +335,7 @@
 
 	attackby(var/obj/item/W , mob/user as mob)
 		if(istype(W, /obj/item/deconstructor))
-			return
+			return ..()
 		if(issilicon(user)) // fix bug where borgs could put things into the nanofab and then reject them
 			boutput(user, "<span class='alert'>You can't put that in, it's attached to you.</span>")
 			return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Nanofabs used to eat your deconstruction device instead of allowing you to deconstruct them. This PR fixes that.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #2317 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

N/A
