### PR TITLE
Miner dwarfism no longer overrides trait race

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -707,7 +707,7 @@
 		if (!M)
 			return
 		M.bioHolder.AddEffect("training_miner")
-		if (prob(20))
+		if (prob(20) && !M.mutantrace)
 			M.bioHolder.AddEffect("dwarf") // heh
 
 /datum/job/engineering/mechanic
@@ -2250,7 +2250,7 @@
 		if (!M)
 			return
 		M.bioHolder.AddEffect("training_miner")
-		if (prob(20))
+		if (prob(20) && !M.mutantrace)
 			M.bioHolder.AddEffect("dwarf") // heh
 
 /datum/job/special/machoman

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -460,16 +460,6 @@
 			W.addAbility(/datum/targetable/virtual/logout)
 //for sure didnt steal code from ww. no siree
 
-/datum/mutantrace/blank
-	name = "blank"
-	icon_state = "blank"
-	override_eyes = 0
-	override_hair = 0
-	override_beard = 0
-	override_detail = 0
-	override_attack = 0
-	race_mutation = /datum/bioEffect/mutantrace/blank
-
 /datum/mutantrace/grey
 	name = "grey"
 	icon_state = "grey"

--- a/code/modules/medical/genetics/bioEffects/mutantrace.dm
+++ b/code/modules/medical/genetics/bioEffects/mutantrace.dm
@@ -55,16 +55,6 @@
 	msgLose = "Your flashy glow fades away."
 	icon_state  = "flashy"
 
-/datum/bioEffect/mutantrace/blank
-	name = "Melanin Eraser"
-	desc = "Shuts down all melanin production in subject's body, and eradicates all existing melanin."
-	id = "blankman"
-	mutantrace_option = "Blank"
-	mutantrace_path = /datum/mutantrace/blank
-	msgGain = "You feel oddly plain."
-	msgLose = "You don't feel boring anymore."
-	icon_state  = "blank"
-
 /datum/bioEffect/mutantrace/skeleton
 	name = "Ossification"
 	desc = "Compacts the subject's living tissues into their skeleton. This is somehow not fatal."

--- a/code/modules/medical/genetics/bioEffects/useless.dm
+++ b/code/modules/medical/genetics/bioEffects/useless.dm
@@ -108,54 +108,39 @@
 	var/eye_color_to_use = "#FF0000"
 	var/color_to_use = "#FFFFFF"
 	var/skintone_to_use = "#FFFFFF"
-	var/holder_eyes = null
-	var/holder_hair = null
-	var/holder_det1 = null
-	var/holder_det2 = null
-	var/holder_skin = null
 
 	OnAdd()
-		if (!ishuman(owner))
-			return
+		if (ishuman(owner))
+			var/mob/living/carbon/human/H = owner
+			for (var/ID in H.bioHolder.effects)
+				if (istype(H.bioHolder.GetEffect(ID), /datum/bioEffect/color_changer) && ID != src.id)
+					H.bioHolder.RemoveEffect(ID)
+			var/datum/appearanceHolder/AH = H.bioHolder.mobAppearance
+			AH.e_color_carry = AH.e_color
+			AH.customization_first_color_carry = AH.customization_first_color
+			AH.customization_second_color_carry = AH.customization_second_color
+			AH.customization_third_color_carry = AH.customization_third_color
+			AH.s_tone_carry = AH.s_tone
 
-		var/mob/living/carbon/human/H = owner
-		if (!H.bioHolder)
-			return
-		var/datum/bioHolder/B = H.bioHolder
-		if (!B.mobAppearance)
-			return
-		var/datum/appearanceHolder/AH = H.bioHolder.mobAppearance
-		holder_eyes = AH.e_color
-		holder_hair = AH.customization_first_color
-		holder_det1 = AH.customization_second_color
-		holder_det2 = AH.customization_third_color
-		holder_skin = AH.s_tone
-		AH.e_color = eye_color_to_use
-		AH.s_tone = skintone_to_use
-		AH.customization_first_color = color_to_use
-		AH.customization_second_color = color_to_use
-		AH.customization_third_color = color_to_use
-		H.update_face()
-		H.update_body()
+			AH.e_color = eye_color_to_use
+			AH.s_tone = skintone_to_use
+			AH.customization_first_color = color_to_use
+			AH.customization_second_color = color_to_use
+			AH.customization_third_color = color_to_use
+			H.update_face()
+			H.update_body()
 
 	OnRemove()
-		if (!ishuman(owner))
-			return
-
-		var/mob/living/carbon/human/H = owner
-		if (!H.bioHolder)
-			return
-		var/datum/bioHolder/B = H.bioHolder
-		if (!B.mobAppearance)
-			return
-		var/datum/appearanceHolder/AH = H.bioHolder.mobAppearance
-		AH.e_color = holder_eyes
-		AH.s_tone = holder_skin
-		AH.customization_first_color = holder_hair
-		AH.customization_second_color = holder_det1
-		AH.customization_third_color = holder_det2
-		H.update_face()
-		H.update_body()
+		if (ishuman(owner))
+			var/mob/living/carbon/human/H = owner
+			var/datum/appearanceHolder/AH = H.bioHolder.mobAppearance
+			AH.e_color = AH.e_color_carry
+			AH.s_tone = AH.s_tone_carry
+			AH.customization_first_color = AH.customization_first_color_carry
+			AH.customization_second_color = AH.customization_second_color_carry
+			AH.customization_third_color = AH.customization_third_color_carry
+			H.update_face()
+			H.update_body()
 
 /datum/bioEffect/color_changer/black
 	name = "Melanin Stimulator"
@@ -167,6 +152,26 @@
 	eye_color_to_use = "#572E0B"
 	color_to_use = "#000000"
 	skintone_to_use = "#000000"
+
+/datum/bioEffect/color_changer/blank
+	name = "Melanin Eraser"
+	desc = "Shuts down all melanin production in subject's body, and eradicates all existing melanin."
+	id = "blankman"
+	msgGain = "You feel oddly plain."
+	msgLose = "You don't feel boring anymore."
+	icon_state  = "blank"
+	effectType = EFFECT_TYPE_POWER
+	probability = 99
+	isBad = 1
+	color_to_use = "#FFFFFF"
+	skintone_to_use = "#FFFFFF"
+
+	OnAdd()
+		if (ishuman(owner))
+			var/mob/living/carbon/human/H = owner
+			var/datum/appearanceHolder/AH = H.bioHolder.mobAppearance
+			eye_color_to_use = AH.e_color
+		. = ..()
 
 /datum/bioEffect/stinky
 	name = "Apocrine Enhancement"

--- a/code/modules/medical/genetics/bioHolder.dm
+++ b/code/modules/medical/genetics/bioHolder.dm
@@ -15,7 +15,7 @@ var/list/datum/bioEffect/mutini_effects = list()
 	return
 
 /// Holds all the appearance information.
-/datum/appearanceHolder	
+/datum/appearanceHolder
 
 	//_carry holds our "actual" color, in case it changes and we want the old one back
 	var/mob_color_flags = (HAS_HAIR_COLORED_HAIR)
@@ -33,6 +33,7 @@ var/list/datum/bioEffect/mutini_effects = list()
 	var/customization_third = "None"
 
 	var/e_color = "#101010"
+	var/e_color_carry = "#101010"
 
 	var/s_tone_carry = "#FFCC99"
 	var/s_tone = "#FFCC99"

--- a/code/modules/medical/genetics/combo_recipes.dm
+++ b/code/modules/medical/genetics/combo_recipes.dm
@@ -47,7 +47,7 @@
 /datum/geneticsrecipe/radio_brain
 	required_effects = list("psy_resist","loud_voice")
 	result = /datum/bioEffect/radio_brain
-	
+
 /datum/geneticsrecipe/blood_overdrive
 	required_effects = list("anemia","polycythemia")
 	result = /datum/bioEffect/blood_overdrive
@@ -97,11 +97,11 @@
 /datum/geneticsrecipe/tourettes
 	required_effects = list("clumsy","coprolalia")
 	result = /datum/bioEffect/tourettes
-	
+
 /datum/geneticsrecipe/buzz
 	required_effects = list("bee","stinky")
 	result = /datum/bioEffect/buzz
-	
+
 // Useless
 
 /datum/geneticsrecipe/glowy_one
@@ -185,8 +185,8 @@
 /datum/geneticsrecipe/healing_touch // Discovered
 	required_effects = list("midas","detox")
 	result = /datum/bioEffect/power/healing_touch
-	
-/datum/geneticsrecipe/healing_touch_two 
+
+/datum/geneticsrecipe/healing_touch_two
 	required_effects = list("midas","melt")
 	result = /datum/bioEffect/power/healing_touch
 
@@ -332,7 +332,7 @@
 
 /datum/geneticsrecipe/blank // Discovered
 	required_effects = list("albinism","melanism")
-	result = /datum/bioEffect/mutantrace/blank
+	result = /datum/bioEffect/color_changer/blank
 
 /datum/geneticsrecipe/skeleton // Discovered
 	required_effects = list("screamer","dead_scan")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

If you have a mutant trait and roll a miner, you won't get dwarfism.

Also, the Blank mutation has been adopted out to the colorchange bioeffect family and has been removed as a mutant race. Also the colorchange mutations now remove each other and use the new appearanceholder carry thing.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Mimes and miners could potentially not be lizards.