### PR TITLE
Fixed AI and cyborg cartridge spawning in spare pda box

### DIFF
--- a/code/obj/item/storage/electronics.dm
+++ b/code/obj/item/storage/electronics.dm
@@ -21,7 +21,9 @@
 		var/list/invalid_carts = list(/obj/item/disk/data/cartridge,
 		/obj/item/disk/data/cartridge/captain,
 		/obj/item/disk/data/cartridge/nuclear,
-		/obj/item/disk/data/cartridge/syndicate)
+		/obj/item/disk/data/cartridge/syndicate,
+		/obj/item/disk/data/cartridge/ai,
+		/obj/item/disk/data/cartridge/cyborg)
 
 		var/list/spawnable = typesof(/obj/item/disk/data/cartridge)
 		spawnable -= invalid_carts


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes an issue where the AI (and cyborg) internal cartridge could spawn in the spare PDA box. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Doesn't sound intended (so bug fix), and if it is I think it should be changed regardless, because getting the AI internal cartridge as a crew member is ridiculous.
