### PR TITLE
DWAINE sleep now reads input in seconds

### DIFF
--- a/code/modules/networks/computer3/mainframe2/shell.dm
+++ b/code/modules/networks/computer3/mainframe2/shell.dm
@@ -393,7 +393,7 @@
 						if (!isnum(.) || . < 0)
 							continue
 
-						sleep ( max(0, min(., 30)) )
+						sleep(clamp(., 0, 30) SECONDS)
 						continue
 
 					if ("help", "man")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

What it says in the title. DWAINE's `sleep` command now reads its input in seconds, allowing you to sleep in your scripts for as long as 30 seconds!

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

DWAINE used to read everything in deciseconds, so the longest time you could sleep for was 3 seconds. Sometimes you might want to wait longer than that between commands!

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

N/A
