### PR TITLE
Spy thief area storage fix

### DIFF
--- a/code/datums/gamemodes/mixed.dm
+++ b/code/datums/gamemodes/mixed.dm
@@ -55,8 +55,11 @@
 	src.latejoin_antag_roles += "grinch"
 #endif
 
-	if ((num_enemies >= 4 && prob(20)) || debug_mixed_forced_wraith || debug_mixed_forced_blob)
-		if (prob(50) || debug_mixed_forced_wraith)
+	if ((num_enemies >= 4 && prob(20)) || debug_mixed_forced_wraith || debug_mixed_forced_blob || debug_mixed_forced_spy)
+		if(debug_mixed_forced_spy)
+			num_enemies = max(num_enemies - 4, 1)
+			num_spy_thiefs = 1
+		else if (prob(50) || debug_mixed_forced_wraith)
 			num_enemies = max(num_enemies - 4, 1)
 			num_wraiths = 1
 		else if (has_blobs)

--- a/code/datums/gamemodes/spy_theft.dm
+++ b/code/datums/gamemodes/spy_theft.dm
@@ -578,7 +578,7 @@
 			choice = pick(S)
 			item_existing = locate(choice)
 			var/turf/T = get_turf(item_existing)
-			if (item_existing && !isnull(T) && T.z == 1)
+			if (item_existing && T?.z == 1)
 				break
 			else
 				item_existing = 0

--- a/code/datums/gamemodes/spy_theft.dm
+++ b/code/datums/gamemodes/spy_theft.dm
@@ -30,6 +30,9 @@
 
 	var/list/uplinks = list()
 
+	var/list/area_blacklist = list()
+
+
 /datum/bounty_item
 	var/name = "bounty name (this is a BUG)" 	//when a bounty object is deleted, we will still need a ref to its name
 	var/obj/item = 0							//ref to exact item
@@ -125,6 +128,10 @@
 		return 1
 
 
+
+/datum/game_mode/spy_theft/New()
+	src.area_blacklist = list("AI Perimeter Defenses", "VR Test Area", "Storage Area")
+	return ..()
 
 /datum/game_mode/spy_theft/announce()
 	boutput(world, "<B>The current game mode is - Spy!</B>")
@@ -577,7 +584,7 @@
 			choice = pick(S)
 			item_existing = locate(choice)
 			var/turf/T = get_turf(item_existing)
-			if (item_existing && T.z == 1)
+			if (item_existing && istype(T) && T.z == 1)
 				break
 			else
 				item_existing = 0
@@ -599,22 +606,13 @@
 
 
 	//Set delivery areas
-	possible_areas = get_areas_with_turfs(/area/station)
-	possible_areas += get_areas_with_turfs(/area/diner)
+	possible_areas = get_nonvirtual_areas_with_turfs(/area/station, src.area_blacklist)
+	possible_areas += get_nonvirtual_areas_with_turfs(/area/diner, src.area_blacklist)
 	possible_areas -= get_areas_with_turfs(/area/diner/tug)
 	possible_areas -= get_areas_with_turfs(/area/station/maintenance)
 	possible_areas -= get_areas_with_turfs(/area/station/hallway)
 	possible_areas -= get_areas_with_turfs(/area/station/engine/substation)
 	possible_areas -= /area/station/test_area
-
-	for (var/area/A in possible_areas)
-		LAGCHECK(LAG_LOW)
-		if (A.virtual)
-			possible_areas -= A
-			break
-		if (A.name == "AI Perimeter Defenses" || A.name == "VR Test Area") //I have no idea what this "AI Perimeter Defenses" is, can't find it in code! All I know is that it's an area that the game can choose that DOESNT HAVE ANY TURFS
-			possible_areas -= A
-			break
 
 	for (var/datum/bounty_item/B in active_bounties)
 		if ((B.item && !istype(B.item,/obj/item)) || B.organ)

--- a/code/datums/gamemodes/spy_theft.dm
+++ b/code/datums/gamemodes/spy_theft.dm
@@ -30,7 +30,7 @@
 
 	var/list/uplinks = list()
 
-	var/list/area_blacklist = list()
+	var/list/area_blacklist = list("AI Perimeter Defenses", "VR Test Area", "Storage Area")
 
 
 /datum/bounty_item
@@ -126,12 +126,6 @@
 
 		reward_was_spawned = 1
 		return 1
-
-
-
-/datum/game_mode/spy_theft/New()
-	src.area_blacklist = list("AI Perimeter Defenses", "VR Test Area", "Storage Area")
-	return ..()
 
 /datum/game_mode/spy_theft/announce()
 	boutput(world, "<B>The current game mode is - Spy!</B>")

--- a/code/datums/gamemodes/spy_theft.dm
+++ b/code/datums/gamemodes/spy_theft.dm
@@ -584,7 +584,7 @@
 			choice = pick(S)
 			item_existing = locate(choice)
 			var/turf/T = get_turf(item_existing)
-			if (item_existing && istype(T) && T.z == 1)
+			if (item_existing && !isnull(T) && T.z == 1)
 				break
 			else
 				item_existing = 0

--- a/code/global.dm
+++ b/code/global.dm
@@ -410,6 +410,7 @@ var/global
 	deadchat_allowed = 1
 	debug_mixed_forced_wraith = 0
 	debug_mixed_forced_blob = 0
+	debug_mixed_forced_spy = 0
 	farting_allowed = 1
 	blood_system = 1
 	bone_system = 0

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -64,7 +64,7 @@ var/list/admin_verbs = list(
 		/client/proc/cmd_admin_remove_label_from,
 		/client/proc/cmd_admin_antag_popups,
 		/client/proc/retreat_to_office,
-		
+
 		),
 
 
@@ -214,6 +214,7 @@ var/list/admin_verbs = list(
 		/client/proc/cmd_admin_rejuvenate_all,
 		/client/proc/toggle_force_mixed_blob,
 		/client/proc/toggle_force_mixed_wraith,
+		/client/proc/toggle_force_mixed_spy,
 		///proc/possess,
 		/proc/possessmob,
 		/proc/releasemob,

--- a/code/modules/admin/toggles.dm
+++ b/code/modules/admin/toggles.dm
@@ -375,6 +375,15 @@ var/global/IP_alerts = 1
 	logTheThing("diary", usr, null, "toggled force mixed blob [debug_mixed_forced_blob ? "on" : "off"]")
 	message_admins("[key_name(usr)] toggled force mixed blob [debug_mixed_forced_blob ? "on" : "off"]")
 
+/client/proc/toggle_force_mixed_spy()
+	SET_ADMIN_CAT(ADMIN_CAT_DEBUG)
+	set name = "Toggle Force Spy"
+	set desc = "If turned on, a spy will always appear in mixed or traitor, regardless of player count or probabilities."
+	debug_mixed_forced_spy = !debug_mixed_forced_spy
+	logTheThing("admin", usr, null, "toggled force mixed spy [debug_mixed_forced_wraith ? "on" : "off"]")
+	logTheThing("diary", usr, null, "toggled force mixed spy [debug_mixed_forced_spy ? "on" : "off"]")
+	message_admins("[key_name(usr)] toggled force mixed spy [debug_mixed_forced_spy ? "on" : "off"]")
+
 /client/proc/toggle_jobban_announcements()
 	SET_ADMIN_CAT(ADMIN_CAT_SERVER_TOGGLES)
 	set name = "Toggle Jobban Alerts"

--- a/code/procs/gamehelpers.dm
+++ b/code/procs/gamehelpers.dm
@@ -452,6 +452,28 @@ var/obj/item/dummy/click_dummy = new
 				. += R
 				break
 
+/proc/get_nonvirtual_areas_with_turfs(var/areatype, var/list/blacklist = null) // for spy thief!
+	//Takes: Area type as text string or as typepath OR an instance of the area.
+	//Returns: A list of all areas of that type in the world that aren't virtual, or aren't in the blacklist.
+	//Notes: Simple!
+	if(!areatype) return null
+	if(istext(areatype)) areatype = text2path(areatype)
+	if(isarea(areatype))
+		var/area/areatemp = areatype
+		areatype = areatemp.type
+
+	. = new/list()
+
+	for(var/area/R in world)
+		LAGCHECK(LAG_LOW)
+		if(!(istype(R, areatype) || R.virtual))
+			continue
+		if (istype(blacklist) && (R.name in blacklist))
+			continue
+		for (var/turf/T in R)
+			. += R
+			break
+
 /proc/get_area_turfs(var/areatype, var/floors_only)
 	//Takes: Area type as text string or as typepath OR an instance of the area.
 	//Returns: A list of all turfs in areas of that type of that type in the world.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

The spy thief area bounty list builder proc now checks a blacklist of areas, including `/area/station/storage`, which could previously be chosen as a prefab on the mining level has this area type for its turfs. I also added an `istype` check for the turf a chosen object is on, as during testing I received a runtime error from this. I also added an admin verb to allow forcing of a spy thief during mixed rounds.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Spy thieves shouldn't have to go trawling around the mining level looking for a prefab to fence their goods. 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

N/A