### PR TITLE
Makes mime a Job selectable via job preferences

### DIFF
--- a/code/modules/materials/Mat_Fabrication.dm
+++ b/code/modules/materials/Mat_Fabrication.dm
@@ -334,6 +334,8 @@
 		W.set_loc(src)
 
 	attackby(var/obj/item/W , mob/user as mob)
+		if(istype(W, /obj/item/deconstructor))
+			return ..()
 		if(issilicon(user)) // fix bug where borgs could put things into the nanofab and then reject them
 			boutput(user, "<span class='alert'>You can't put that in, it's attached to you.</span>")
 			return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Players can now select mime from the job preference screen allowing for more mime related fun -->



## Why's this needed?  mime is currently late join only which is a bit annoying given it is one of the most unique roles and many people enjoy the extra challenge of not being able to talk this would in my opinion open up more interesting things that are only possible with non late join jobs such as traitor or werewolf mimes it would also mean more players would have the opportunity to play as mime which is good.  
## Changelog
<!-- -->

```
(u)CodeDude:
(*)Added soft soft pizza to the game - a tasty drink found in soda machines!
(+)Made some small sprite changes to the base pizza sprite.
```
