### PR TITLE
Health analyser with organ scanner lists cyber organs

### DIFF
--- a/code/procs/scanprocs.dm
+++ b/code/procs/scanprocs.dm
@@ -246,21 +246,23 @@
 /proc/obfuscate_organ_health(var/obj/item/organ/O)
 	if (!O)
 		return null
+	. = ""
 	var/damage = O.get_damage()
 	if (damage >= O.MAX_DAMAGE)
-		return "<br><span class='alert'><b>[O.name]</b> - Dead</span>"
+		. = "<br><span class='alert'><b>[O.name]</b> - Dead</span>"
 	else if (damage >= O.MAX_DAMAGE*0.9)
-		return "<br><span class='alert'><b>[O.name]</b> - Critical</span>"
+		. = "<br><span class='alert'><b>[O.name]</b> - Critical</span>"
 	else if (damage >= O.MAX_DAMAGE*0.65)
-		return "<br><span class='alert'><b>[O.name]</b> - Significant</span>"
+		. = "<br><span class='alert'><b>[O.name]</b> - Significant</span>"
 	else if (damage >= O.MAX_DAMAGE*0.30)
-		return "<br><span style='color:purple'><b>[O.name]</b> - Moderate</span>"
+		. = "<br><span style='color:purple'><b>[O.name]</b> - Moderate</span>"
 	else if (damage > 0)
-		return "<br><span style='color:purple'><b>[O.name]</b> - Minor</span>"
-	else
-		if (O.robotic)
-			return "<br><span style='color:purple'><b>[O.name]</b> - Robotic organ detected</span>"
-	return null
+		. = "<br><span style='color:purple'><b>[O.name]</b> - Minor</span>"
+	else if (O.robotic)
+		. = "<br><span style='color:purple'><b>[O.name]</b>"
+	if (O.robotic)
+		. = (. + "<span style='color:purple'> - Robotic organ detected</span>")
+	return
 
 /proc/update_medical_record(var/mob/living/carbon/human/M)
 	if (!M || !ishuman(M))

--- a/code/procs/scanprocs.dm
+++ b/code/procs/scanprocs.dm
@@ -246,23 +246,23 @@
 /proc/obfuscate_organ_health(var/obj/item/organ/O)
 	if (!O)
 		return null
-	. = ""
+	var/list/ret = list()
 	var/damage = O.get_damage()
 	if (damage >= O.MAX_DAMAGE)
-		. = "<br><span class='alert'><b>[O.name]</b> - Dead</span>"
+		ret += "<br><span class='alert'><b>[O.name]</b> - Dead</span>"
 	else if (damage >= O.MAX_DAMAGE*0.9)
-		. = "<br><span class='alert'><b>[O.name]</b> - Critical</span>"
+		ret += "<br><span class='alert'><b>[O.name]</b> - Critical</span>"
 	else if (damage >= O.MAX_DAMAGE*0.65)
-		. = "<br><span class='alert'><b>[O.name]</b> - Significant</span>"
+		ret += "<br><span class='alert'><b>[O.name]</b> - Significant</span>"
 	else if (damage >= O.MAX_DAMAGE*0.30)
-		. = "<br><span style='color:purple'><b>[O.name]</b> - Moderate</span>"
+		ret += "<br><span style='color:purple'><b>[O.name]</b> - Moderate</span>"
 	else if (damage > 0)
-		. = "<br><span style='color:purple'><b>[O.name]</b> - Minor</span>"
+		ret += "<br><span style='color:purple'><b>[O.name]</b> - Minor</span>"
 	else if (O.robotic)
-		. = "<br><span style='color:purple'><b>[O.name]</b>"
+		ret += "<br><span style='color:purple'><b>[O.name]</b></span>"
 	if (O.robotic)
-		. = (. + "<span style='color:purple'> - Robotic organ detected</span>")
-	return
+		ret += "<span style='color:purple'> - Robotic organ detected</span>"
+	return ret.Join()
 
 /proc/update_medical_record(var/mob/living/carbon/human/M)
 	if (!M || !ishuman(M))

--- a/code/procs/scanprocs.dm
+++ b/code/procs/scanprocs.dm
@@ -247,7 +247,6 @@
 	if (!O)
 		return null
 	var/damage = O.get_damage()
-
 	if (damage >= O.MAX_DAMAGE)
 		return "<br><span class='alert'><b>[O.name]</b> - Dead</span>"
 	else if (damage >= O.MAX_DAMAGE*0.9)
@@ -258,7 +257,9 @@
 		return "<br><span style='color:purple'><b>[O.name]</b> - Moderate</span>"
 	else if (damage > 0)
 		return "<br><span style='color:purple'><b>[O.name]</b> - Minor</span>"
-
+	else
+		if (O.robotic)
+			return "<br><span style='color:purple'><b>[O.name]</b> - Robotic organ detected</span>"
 	return null
 
 /proc/update_medical_record(var/mob/living/carbon/human/M)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL][FEEDBACK]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the health analyser list cybernetic organs.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It seems logical to me that a non standard organ would be detected. There is no way to tell someone has them unless they are damaged. The organ scanner seemed the most appropriate location.
At the moment these are listed as injuries, this feels wrong but handles it in a fairly efficient way. An alternative is to have a second list but this could be quite spammy?


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

(u)Flappybat:
(+)Health analyser with organ scanner upgrade will list cybernetic organs.
