### PR TITLE
small deconstructor fixes

### DIFF
--- a/code/WorkInProgress/multiContext.dm
+++ b/code/WorkInProgress/multiContext.dm
@@ -941,9 +941,9 @@ var/list/globalContextActions = null
 			icon_state = "weld"
 
 			execute(var/atom/target, var/mob/user)
-				user.show_text("You weld [target] carefully.", "blue")
 				for (var/obj/item/weldingtool/W in user.equipped_list())
 					if(W.try_weld(user, 2))
+						user.show_text("You weld [target] carefully.", "blue")
 						return ..()
 
 		pry

--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -74,7 +74,7 @@
 	attackby(var/obj/item/I, var/mob/user)
 		if(status & BROKEN)
 			return
-		if (istype(I,/obj/item/electronics/scanner))
+		if (istype(I,/obj/item/electronics/scanner) || istype(I,/obj/item/deconstructor))
 			user.visible_message("<span class='alert'><B>[user] hits [src] with [I]!</B></span>")
 			return
 		if (istype(I,/obj/item/satchel/))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I saw that disposal chutes already had a check for mechanics scanners, so I added deconstructors to that too, so you can deconstruct them now.

Maybe there should be some sort of generic solution for this in the future so that all kinds of stuff can be properly scanned or deconstructed, ignoring attackby with scanners or deconstructors if it has the mats flag or something?

Because I happened to see it, I also changed a line in the deconstructor thing a little because before you would always get the welding message, no matter what tool you used to try and weld.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Someone sent a mentorhelp on how to deconstruct chutes and we said "explosions".1
