### PR TITLE
Clarify antag roles tip

### DIFF
--- a/code/datums/preferences.dm
+++ b/code/datums/preferences.dm
@@ -1107,7 +1107,7 @@ $(function() {
 			<th>Medium Priority <span class="info-thing" title="Medium Priority Jobs are any jobs you would like to play that aren't your favorite. People with jobs in this category get priority over those who have the same job in their low priority bracket. It's best to put jobs here that you actively enjoy playing and wouldn't mind ending up with if you don't get your favorite.">?</span></th>
 			<th>Low Priority <span class="info-thing" title="Low Priority Jobs are jobs that you don't mind doing. When the game is finding candidates for a job, it will try to fill it with Medium Priority players first, then Low Priority players if there are still free slots.">?</span></th>
 			<th>Unwanted Jobs <span class="info-thing" title="Unwanted Jobs are jobs that you absolutely don't want to have. The game will never give you a job you list here. The 'Staff Assistant' role can't be put here, however, as it's the fallback job if there are no other openings.">?</span></th>
-			<th>Antagonist Roles <span class="info-thing" title="Antagonist roles are randomly chosen when the game starts, before jobs have been allocated. Having an antagonist role disabled means you will never be chosen for it automatically.">?</span></th>
+			<th>Antagonist Roles <span class="info-thing" title="Antagonist roles are randomly chosen when the game starts, before jobs have been allocated. Leaving an antagonist role unchecked means you will never be chosen for it automatically.">?</span></th>
 		</tr>
 		<tr>"}
 


### PR DESCRIPTION
## About the PR
Changes tooltip for antagonist settings in occupation preferences to specify that antagonists are disabled when unchecked, requested by Jan.antilles.


## Why's this needed?
Current wording can leave new players confused whether antagonists are enabled when checked or unchecked. New wording hopefully clearer.
