### PR TITLE
Ties ghostdrone ocean movement on Manta to the magnetic tether

### DIFF
--- a/code/datums/controllers/process/forcedMovement.dm
+++ b/code/datums/controllers/process/forcedMovement.dm
@@ -175,6 +175,9 @@ datum/controller/process/fMove
 								if(J.allow_thrust(0.01, H))
 									continue
 
+					if (isghostdrone(B) && MagneticTether)
+						continue
+
 					M.setStatus("slowed", 20, 20)
 
 				if(!step(M, SOUTH))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[input wanted] [feat]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR lets ghostdrones ignore Manta's currents if the magnetic tether is active, as they currently can't get on board if the ship is moving. (I think there might be some movement trick that lets you fight the current but it might require being able to sprint, and I don't think that kind of stuff should be your only recourse regardless.)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Putting the ghostdrone factory behind the Manta with no way for drones to get on board is cruel.
Also the tether doesn't really factor into gameplay at the moment - I can't remember the last time that crew used a jetpack for EVA stuff on Manta. This gives it a bit more purpose.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)BatElite:
(+)Ghostdrones now ignore Manta's water currents so long as the magnetic tether is functional.
```

## Wanted Input
Is it cruel to still strand the drones on the factory if the tether is down? Making them ignore currents always isn't that difficult to change, but I'd like the tether to have some impact on the round.