### PR TITLE
Fixes headlamps when they spawn on a mob

### DIFF
--- a/code/WorkInProgress/AbilityItem.dm
+++ b/code/WorkInProgress/AbilityItem.dm
@@ -385,8 +385,7 @@
 		var/obj/item/clothing/head/helmet/hardhat/J = the_item
 
 		J.flashlight_toggle(the_mob)
-		if (J.on) src.icon_state = "off"
-		else  src.icon_state = "on"
+		src.icon_state = J.on ? "off" : "on"
 		..()
 
 ////////////////////////////////////////////////////////////

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -73,6 +73,8 @@
 	New()
 		..()
 		light_dir = src.AddComponent(/datum/component/holdertargeting/medium_directional_light, 0.9 * 255, 0.9 * 255, 1 * 255, 210)
+		if(ismob(src.loc))
+			light_dir.light_target = src.loc
 		light_dir.update(0)
 
 	attack_self(mob/user)
@@ -367,6 +369,8 @@
 	New()
 		..()
 		light_dir = src.AddComponent(/datum/component/holdertargeting/medium_directional_light, 0.9 * 255, 0.9 * 255, 1 * 255, 210)
+		if(ismob(src.loc))
+			light_dir.light_target = src.loc
 		light_dir.update(0)
 
 	attack_self(mob/user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

The new proc sets the light_target to the loc if the loc is a mob.
Closes #2290 