### PR TITLE
reclaimer bugfix

### DIFF
--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -794,7 +794,7 @@
 		icon_state = "reclaimer"
 		src.visible_message("<b>[src]</b> finishes working and shuts down.")
 
-	proc/output_bar_from_item(obj/item/O, var/amount_modifier, var/extra_mat)
+	proc/output_bar_from_item(obj/item/O, var/amount_modifier = 1, var/extra_mat)
 		if (!O || !O.material)
 			return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes a bug where items that did not use amount_modifier would not be consumed by the portable reclaimer.
This was pretty much only wizard crystals.