### PR TITLE
Removes pyrosium volatility

### DIFF
--- a/code/modules/chemistry/Reagents-ExplosiveFire.dm
+++ b/code/modules/chemistry/Reagents-ExplosiveFire.dm
@@ -537,7 +537,6 @@ datum
 			fluid_b = 150
 			transparency = 150
 			viscosity = 0.7
-			volatility = 2.5
 			minimum_reaction_temperature = 1000
 
 			reaction_temperature(exposed_temperature, exposed_volume)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes pyrosium non-volatile. Volatility is used solely within the context of pipebomb assemblies, determining the explosive power of a pipebomb. Currently pyrosium has a volatility equivalent to black powder, making pyrosium pipebombs just as effective as black powder bombs, despite black powder being a significantly harder chem to produce.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's dumb and makes black powder undesired in pipebomb assemblies.

