### PR TITLE
Fix oceanify on space maps

### DIFF
--- a/code/modules/fluids/fluid_commands.dm
+++ b/code/modules/fluids/fluid_commands.dm
@@ -147,10 +147,12 @@ client/proc/replace_space_exclusive()
 		for(var/turf/space/S in world)
 			if (S.z != 1 || istype(S, /turf/space/fluid/warp_z5)) continue
 
-#ifdef MOVING_SUB_MAP
+#if defined(MOVING_SUB_MAP)
 			var/turf/space/fluid/manta/T = new /turf/space/fluid/manta( locate(S.x, S.y, S.z) )
-#else
+#elif defined(UNDERWATER_MAP)
 			var/turf/space/fluid/T = new /turf/space/fluid( locate(S.x, S.y, S.z) )
+#else //space map
+			var/turf/space/fluid/T = new /turf/space/fluid/fullbright( locate(S.x, S.y, S.z) )
 #endif
 
 #ifdef UNDERWATER_MAP

--- a/code/modules/fluids/fluid_turf.dm
+++ b/code/modules/fluids/fluid_turf.dm
@@ -79,7 +79,7 @@
 		if(current_state > GAME_STATE_WORLD_INIT)
 			for(var/dir in cardinal)
 				var/turf/T = get_step(src, dir)
-				if(T.ocean_canpass() && !istype(T, /turf/space))
+				if(T?.ocean_canpass() && !istype(T, /turf/space))
 					src.tilenotify(T)
 					break
 
@@ -372,6 +372,9 @@
 	ex_act(severity)
 		return
 
+//full bright, used by oceanify on space maps
+/turf/space/fluid/fullbright
+	fullbright = 1
 
 //Manta
 /turf/space/fluid/manta


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG][RUNTIME] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Workaround for broken lighting and fix for the runtimes as proc tries to find turfs on edge outside of the 300x300 map


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

File | fluid_turf.dm
-- | --
Line | 82
Error | Cannot execute null.ocean canpass().
```dm
proc name: New (/turf/space/fluid/New)
  source file: fluid_turf.dm,82
  usr: Frankie Batten (/mob/dead/observer)
  src: the ocean floor (1,1,1) (/turf/space/fluid/fullbright)
  usr.loc: the steel floor (159,180,1) (/turf/simulated/floor)
  call stack:
the ocean floor (1,1,1) (/turf/space/fluid/fullbright): New(the ocean floor (1,1,1) (/turf/space/fluid/fullbright))
Sovexe (/client): Oceanify()
```