### PR TITLE
Atlas AI Reset Fix

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -1916,6 +1916,7 @@
 "eQ" = (
 /obj/table/auto,
 /obj/random_item_spawner/ai_experimental,
+/obj/item/aiModule/reset,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/Zeta)
 "eS" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MAPPING] [BUG]
## About the PR and why it's needed! <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Apparently Atlas completely lacks an AI Reset board for whatever reason. This fixes that and adds one next to the AI Upload Computer on the same table as the random spawner. I cannot fathom why there wasn't one to begin with so maybe it got removed accidentally? If it wasn't an oversight, feel free to close this PR but I will be very cross with you and question your design choices.

Thanks to Varali for pointing this out.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)virvatuli:
(+)Added the AI Reset Board to Atlas. Why was it missing? Nobody knows! But now it's a certified feature.
```
