### PR TITLE
pod balance change

### DIFF
--- a/code/datums/movement_controller/pod.dm
+++ b/code/datums/movement_controller/pod.dm
@@ -16,7 +16,7 @@
 
 		velocity_max = 6
 		velocity_max_no_input = 5
-		accel = 3
+		accel = 2
 
 		min_delay = 14
 
@@ -95,6 +95,11 @@
 
 				velocity_x	+= input_x * accel
 				velocity_y  += input_y * accel
+
+				//We're on autopilot before the warp, NO FUCKING IT UP!
+				if (owner?.engine?.warp_autopilot)
+					return 0
+
 
 				//braking
 				if (braking)

--- a/code/modules/projectiles/laser.dm
+++ b/code/modules/projectiles/laser.dm
@@ -102,7 +102,7 @@ toxic - poisons
 	power = 75
 	cost = 65
 	dissipation_delay = 5
-	dissipation_rate = 10
+	dissipation_rate = 5
 	sname = "assault laser"
 	shot_sound = 'sound/weapons/Laser.ogg'
 	color_red = 0
@@ -255,6 +255,7 @@ toxic - poisons
 	color_green = 0
 	color_blue = 1
 	icon_turf_hit = "burn2"
+	projectile_speed = 32
 
 /datum/projectile/laser/precursor // for precursor traps
 	name = "energy bolt"

--- a/code/modules/transport/pods/MainWeapon.dm
+++ b/code/modules/transport/pods/MainWeapon.dm
@@ -3,7 +3,7 @@
 	desc = "A simple phaser designed for scout vehicles."
 	var/r_gunner = 0
 	var/mob/gunner = null
-	var/datum/projectile/current_projectile = new/datum/projectile/laser/light
+	var/datum/projectile/current_projectile = new/datum/projectile/laser/light/pod
 	var/firerate = 8
 	var/isfiring = 0
 	var/weapon_score = 0.1
@@ -126,7 +126,7 @@
 	desc = "A basic, light weight phaser designed for scout vehicles."
 	weapon_score = 0.3
 	appearanceString = "pod_weapon_ltlaser"
-	current_projectile = new/datum/projectile/laser/light
+	current_projectile = new/datum/projectile/laser/light/pod
 	icon_state = "class-a"
 	muzzle_flash = "muzzle_flash_phaser"
 
@@ -356,3 +356,25 @@
 
 		opencomputer(usr)
 		return
+
+
+/datum/projectile/laser/pod
+	dissipation_rate = 2
+	dissipation_delay = 16
+	projectile_speed = 32
+
+/datum/projectile/laser/light/pod
+	impact_range = 2
+	dissipation_rate = 1
+	dissipation_delay = 14
+	projectile_speed = 32
+
+/datum/projectile/disruptor
+	impact_range = 4
+	dissipation_delay = 16
+	projectile_speed = 32
+
+/datum/projectile/disruptor/high
+	impact_range = 4
+	dissipation_delay = 16
+	projectile_speed = 32

--- a/code/modules/transport/pods/ships.dm
+++ b/code/modules/transport/pods/ships.dm
@@ -4,8 +4,8 @@
 	icon = 'icons/obj/ship.dmi'
 	icon_state = "pod"
 	capacity = 4
-	health = 70
-	maxhealth = 70
+	health = 140
+	maxhealth = 140
 	anchored = 0
 //////////Recon
 /obj/machinery/vehicle/recon
@@ -37,8 +37,8 @@
 	icon = 'icons/obj/ship.dmi'
 	icon_state = "cargo"
 	capacity = 2
-	health = 100
-	maxhealth = 100
+	health = 200
+	maxhealth = 200
 
 /obj/machinery/vehicle/cargo/New()
 	..()
@@ -91,8 +91,8 @@
 	icon_state = "miniputt"
 	capacity = 1
 	var/armor_score_multiplier = 0.5
-	health = 75
-	maxhealth = 75
+	health = 150
+	maxhealth = 150
 	weapon_class = 1
 	speed = 0.8
 	var/image/damaged = null
@@ -183,8 +183,8 @@ obj/machinery/vehicle/miniputt/pilot
 /obj/machinery/vehicle/miniputt/syndiputt
 	name = "SyndiPutt-"
 	icon_state = "syndiputt"
-	health = 125
-	maxhealth = 125
+	health = 250
+	maxhealth = 250
 	armor_score_multiplier = 0.7
 	speed = 0.8
 
@@ -218,8 +218,8 @@ obj/machinery/vehicle/miniputt/pilot
 /obj/machinery/vehicle/miniputt/nanoputt
 	name = "NanoPutt-"
 	icon_state = "nanoputt"
-	health = 125
-	maxhealth = 125
+	health = 200
+	maxhealth = 200
 	armor_score_multiplier = 0.7
 	speed = 0.9
 
@@ -229,8 +229,8 @@ obj/machinery/vehicle/miniputt/pilot
 	icon_state = "soviputt"
 	desc = "A little solo vehicle for scouting and exploration work. Seems to be a Russian model."
 	armor_score_multiplier = 1.0
-	health = 150
-	maxhealth = 150
+	health = 225
+	maxhealth = 225
 
 	New()
 		..()
@@ -269,8 +269,8 @@ obj/machinery/vehicle/miniputt/pilot
 	name = "IridiPutt-"
 	icon_state = "putt_pre"
 	armor_score_multiplier = 1.7
-	health = 200
-	maxhealth = 200
+	health = 400
+	maxhealth = 400
 	speed = 1
 	desc = "A smaller version of the experimental Y-series of pods."
 
@@ -278,8 +278,8 @@ obj/machinery/vehicle/miniputt/pilot
 /obj/machinery/vehicle/miniputt/gold
 	name = "PyriPutt-"
 	icon_state = "putt_gold"
-	health = 200
-	maxhealth = 200
+	health = 300
+	maxhealth = 300
 	armor_score_multiplier = 0.6
 	speed = 0.2
 	desc = "A light, high-speed MiniPutt with a gold-plated armor installed. Who the hell has this kind of money and this little sense?"
@@ -849,8 +849,8 @@ obj/machinery/vehicle/miniputt/pilot
 	var/armor_score_multiplier = 0.2
 	capacity = 2
 	weapon_class = 1
-	health = 75
-	maxhealth = 75
+	health = 150
+	maxhealth = 150
 	bound_width = 64
 	bound_height = 64
 	view_offset_x = 16
@@ -960,8 +960,8 @@ obj/machinery/vehicle/miniputt/pilot
 	name = "Pod C-"
 	desc = "A civilian-class vehicle pod, often used for exploration and trading."
 	icon_state = "pod_civ"
-	health = 100
-	maxhealth = 100
+	health = 200
+	maxhealth = 200
 	speed = 0
 
 /obj/machinery/vehicle/pod_smooth/gold // blingee
@@ -969,8 +969,8 @@ obj/machinery/vehicle/miniputt/pilot
 	desc = "A light, high-speed vehicle pod often used by underground pod racing clubs and people with more money than sense."
 	icon_state = "pod_gold"
 	armor_score_multiplier = 0.4
-	health = 200
-	maxhealth = 200
+	health = 400
+	maxhealth = 400
 	speed = 0.2
 
 /obj/machinery/vehicle/pod_smooth/heavy // pods made with reinforced armor
@@ -978,8 +978,8 @@ obj/machinery/vehicle/miniputt/pilot
 	desc = "A military-issue vehicle pod."
 	armor_score_multiplier = 1
 	icon_state = "pod_mil"
-	health = 250
-	maxhealth = 250
+	health = 500
+	maxhealth = 500
 	speed = 0.3
 
 	/*prearmed // this doesn't seem to work yet, dangit
@@ -995,8 +995,8 @@ obj/machinery/vehicle/miniputt/pilot
 	desc = "A syndicate-issue assault pod."
 	armor_score_multiplier = 1
 	icon_state = "pod_synd"
-	health = 250
-	maxhealth = 250
+	health = 500
+	maxhealth = 500
 	speed = 0.3
 
 	/*prearmed
@@ -1029,24 +1029,24 @@ obj/machinery/vehicle/miniputt/pilot
 	desc = "????"
 	armor_score_multiplier = 1.5
 	icon_state = "pod_black"
-	health = 500
-	maxhealth = 500
+	health = 800
+	maxhealth = 800
 
 /obj/machinery/vehicle/pod_smooth/iridium
 	name = "Pod Y-"
 	desc = "It appears to be an experimental vehicle based on the Syndicate's IRIDIUM project."
 	armor_score_multiplier = 1.25
 	icon_state = "pod_pre"
-	health = 400
-	maxhealth = 400
+	health = 700
+	maxhealth = 700
 
 /obj/machinery/vehicle/pod_smooth/industrial
 	name = "Pod I-"
 	desc = "A slow yet sturdy industrial pod, designed for hazardous work in asteroid belts. Can accomodate up to four passengers."
 	armor_score_multiplier = 1.25
 	icon_state = "pod_industrial"
-	health = 400
-	maxhealth = 400
+	health = 700
+	maxhealth = 700
 	speed = 0.6
 	capacity = 4
 


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
As per some balance discussion, did a bit of changes to pod balance stuff:
- Almost all pods have been given a bunch more health, usually about 1.5 to 2 times more.
- Certain projectiles used by pods now have a variant for pods that shoots faster than normal and goes a bit further than normal, such as the phaser projectile.
- Pod warping has been changed decently.
     *(previous behavior) ~Instead of making a portal instantly (with a cooldown afterwards) anywhere on a space tile, you have to~
    * You must be stationary to select a portal destination, when chosen, the pod moves in its current heading for several tiles before making the portal and being pushed through it.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Pods were a bit too flimsy and pod weapons were a bit too short ranged/slow to hit pods that weren't right next to you.
Warp engines were always intended to be a bit more like this iirc where you couldn't make a portal instantly. It should make pod fights more likely to result in actual battle instead of easily making a portal to escape.


## Changelog
```
(u)Kyle:
(*)Pod balance changes: more pod health, very slightly slower acceleration, faster pod weapon travel time, Wormholes must be made when stationary and with several tiles of clearance in front.
```
