### PR TITLE
Fix renaming the AI while dead

### DIFF
--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -2119,9 +2119,13 @@ proc/get_mobs_trackable_by_AI()
 
 /mob/living/silicon/ai/choose_name(var/retries = 3)
 	var/randomname = pick_string_autokey("names/ai.txt")
+	var/obj/item/organ/brain/brain_owner = src.brain.owner
 	var/newname
+
 	for (retries, retries > 0, retries--)
 		newname = input(src, "You are an AI. Would you like to change your name to something else?", "Name Change", randomname) as null|text
+		if (src.brain.owner != brain_owner)
+			return
 		if (!newname)
 			src.real_name = randomname
 			src.name = src.real_name

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -2121,7 +2121,6 @@ proc/get_mobs_trackable_by_AI()
 	var/randomname = pick_string_autokey("names/ai.txt")
 	var/obj/item/organ/brain/brain_owner = src.brain.owner
 	var/newname
-
 	for (retries, retries > 0, retries--)
 		newname = input(src, "You are an AI. Would you like to change your name to something else?", "Name Change", randomname) as null|text
 		if (src.brain.owner != brain_owner)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes renaming the AI when dead / not the AI anymore.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Should fix #1267 
