### PR TITLE
Mark monkey mutantrace as human compatible (aka stop dropping stuff on transform)

### DIFF
--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -1081,7 +1081,7 @@
 	hand_offset = -5
 	body_offset = -7
 	//	uses_human_clothes = 0 // Guess they can keep that ability for now (Convair880).
-	human_compatible = 0
+	human_compatible = TRUE
 	exclusive_language = 1
 	voice_message = "chimpers"
 	voice_name = "monkey"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][QOL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Mark the monkey mutant race as human compatible
* Players no longer drop half their stuff when made into monkeys


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
the `New` proc of `/datum/mutantrace` does a check for gear compatibility that causes monkeys to drop their jumpsuits as they are 'not compatible'. This provides the player with the incorrect message of `You can no longer wear the [W.name] in your current state!"`.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.

Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Sovexe:
(+)Becoming a monkey no longer makes you drop half your stuff.
```
