### PR TITLE
Shield Generator State FeedBack When turning on and off

### DIFF
--- a/code/obj/machinery/shield_generators/shield_generator.dm
+++ b/code/obj/machinery/shield_generators/shield_generator.dm
@@ -133,7 +133,7 @@
 
 		if(diff > 1500)
 			lastuse = world.timeofday
-			user.show_text("You flip the switch on [src].")
+			visible_message("You flip the switch on [src].","You feel around the object and accidentally hit a switch")
 			if (src.active)
 				src.deactivate()
 				user.show_text("Shields Deactivated.")

--- a/code/obj/machinery/shield_generators/shield_generator.dm
+++ b/code/obj/machinery/shield_generators/shield_generator.dm
@@ -136,8 +136,10 @@
 			user.show_text("You flip the switch on [src].")
 			if (src.active)
 				src.deactivate()
+				user.show_text("Shields Deactivated.")
 			else
 				src.activate()
+				user.show_text("Shields Activated.")
 			message_admins("<span class='internal'>[key_name(user)] [src.active ? "activated" : "deactivated"] shields</span>")
 			logTheThing("station", null, null, "[key_name(user)] [src.active ? "activated" : "deactivated"] shields")
 		else

--- a/code/obj/machinery/shield_generators/shield_generator.dm
+++ b/code/obj/machinery/shield_generators/shield_generator.dm
@@ -132,7 +132,7 @@
 
 		if(diff > 1500)
 			lastuse = world.timeofday
-			visible_message("[src] makes an annoyed beep.","You hear an annoyed beep.")
+			visible_message("[src] beeps loudly.","You hear a loud beep.")
 			if (src.active)
 				src.deactivate()
 				user.show_text("Shields Deactivated.")

--- a/code/obj/machinery/shield_generators/shield_generator.dm
+++ b/code/obj/machinery/shield_generators/shield_generator.dm
@@ -130,10 +130,9 @@
 		var/diff = world.timeofday - lastuse
 		if(diff < 0) diff += 864000 //Wrapping protection.
 
-
 		if(diff > 1500)
 			lastuse = world.timeofday
-			visible_message("You flip the switch on [src].","You feel around the object and accidentally hit a switch")
+			visible_message("[src] makes an annoyed beep.","You hear an annoyed beep.")
 			if (src.active)
 				src.deactivate()
 				user.show_text("Shields Deactivated.")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
adds messages to activating/deactivating the shields at a the shield generator (the kind in engine control on manta and atlas)
Messages are short simple "Shields Activated." and "Shields Deactivated."

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
there is currently ZERO feedback to what your doing to the state of the shields at the generator other than
"you flick the switch on the shield generator"
this is horrendous as it can lead to a lot of confusion. 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)RSG250:
(+)Shield Generators (like the one in manta engine control) now give you feedback when activating/deactivating the shields.
```
