### PR TITLE
Removes unintended advantages/disadvantages of player monkeys caused by ismonkey() checks

### DIFF
--- a/_std/macros/ismob.dm
+++ b/_std/macros/ismob.dm
@@ -16,7 +16,7 @@
 
 #define iscarbon(x) istype(x, /mob/living/carbon)
 #define ismonkey(x) (istype(x, /mob/living/carbon/human) && istype(x:mutantrace, /datum/mutantrace/monkey))
-#define isnpcmonkey(x) istype(x,/mob/living/carbon/human/npc/monkey)
+#define isnpcmonkey(x) (istype(x,/mob/living/carbon/human/npc/monkey) && istype(x:mutantrace, /datum/mutantrace/monkey))
 #define ishuman(x) istype(x, /mob/living/carbon/human)
 #define iscritter(x) istype(x, /obj/critter)
 #define isintangible(x) istype(x, /mob/living/intangible)

--- a/_std/macros/ismob.dm
+++ b/_std/macros/ismob.dm
@@ -16,6 +16,7 @@
 
 #define iscarbon(x) istype(x, /mob/living/carbon)
 #define ismonkey(x) (istype(x, /mob/living/carbon/human) && istype(x:mutantrace, /datum/mutantrace/monkey))
+#define isnpcmonkey(x) istype(x,/mob/living/carbon/human/npc/monkey)
 #define ishuman(x) istype(x, /mob/living/carbon/human)
 #define iscritter(x) istype(x, /obj/critter)
 #define isintangible(x) istype(x, /mob/living/intangible)

--- a/code/datums/abilities/hunter.dm
+++ b/code/datums/abilities/hunter.dm
@@ -143,7 +143,7 @@
 								if (iswerewolf(H))
 									skull_value = 4
 									skull_desc = "A grand trophy from a lycanthrope, a very capable hunter. It is an immense honor."
-								if (istype(H, /mob/living/carbon/human/npc/monkey))
+								if (isnpcmonkey(H))
 									skull_value = 0
 									skull_desc = "A meaningless trophy from a lab monkey. You feel disgusted to even look at it."
 

--- a/code/datums/abilities/hunter.dm
+++ b/code/datums/abilities/hunter.dm
@@ -143,7 +143,7 @@
 								if (iswerewolf(H))
 									skull_value = 4
 									skull_desc = "A grand trophy from a lycanthrope, a very capable hunter. It is an immense honor."
-								if (ismonkey(H) || H.bioHolder && H.bioHolder.HasEffect("monkey"))
+								if (istype(H, /mob/living/carbon/human/npc/monkey))
 									skull_value = 0
 									skull_desc = "A meaningless trophy from a lab monkey. You feel disgusted to even look at it."
 

--- a/code/datums/abilities/misc/hunter_taketrophy.dm
+++ b/code/datums/abilities/misc/hunter_taketrophy.dm
@@ -45,7 +45,7 @@
 
 			else
 				var/mob/living/carbon/human/HH = target
-				if (!ischangeling(HH) && (ismonkey(HH) || HH.bioHolder && HH.bioHolder.HasEffect("monkey"))) // Lesser form doesn't count.
+				if (istype(HH, /mob/living/carbon/human/npc/monkey)) // Lesser form doesn't count.
 					boutput(M, __red("This pitiful creature isn't worth your time."))
 					return 1
 

--- a/code/datums/abilities/misc/hunter_taketrophy.dm
+++ b/code/datums/abilities/misc/hunter_taketrophy.dm
@@ -45,7 +45,7 @@
 
 			else
 				var/mob/living/carbon/human/HH = target
-				if (istype(HH, /mob/living/carbon/human/npc/monkey)) // Lesser form doesn't count.
+				if (isnpcmonkey(HH)) // Lesser form doesn't count.
 					boutput(M, __red("This pitiful creature isn't worth your time."))
 					return 1
 

--- a/code/datums/abilities/misc/werewolf_attack.dm
+++ b/code/datums/abilities/misc/werewolf_attack.dm
@@ -133,7 +133,7 @@
 				interrupt(INTERRUPT_ALWAYS)
 				return
 
-			if (!isdead(target) && !(istype(target, /mob/living/carbon/human/npc/monkey))) // Can't farm npc monkeys.
+			if (!isdead(target) && !(isnpcmonkey(target))) // Can't farm npc monkeys.
 				src.do_we_get_points = 1
 
 		if (complete >= 0.8 && last_complete < 0.8)
@@ -142,7 +142,7 @@
 				interrupt(INTERRUPT_ALWAYS)
 				return
 
-			if (!isdead(target) && !(istype(target, /mob/living/carbon/human/npc/monkey)))
+			if (!isdead(target) && !(isnpcmonkey(target)))
 				src.do_we_get_points = 1
 
 		if (complete >= 0.9 && last_complete < 0.9)
@@ -151,7 +151,7 @@
 				interrupt(INTERRUPT_ALWAYS)
 				return
 
-			if (!isdead(target) && !(istype(target, /mob/living/carbon/human/npc/monkey)))
+			if (!isdead(target) && !(isnpcmonkey(target)))
 				src.do_we_get_points = 1
 
 		last_complete = complete

--- a/code/datums/abilities/misc/werewolf_attack.dm
+++ b/code/datums/abilities/misc/werewolf_attack.dm
@@ -133,7 +133,7 @@
 				interrupt(INTERRUPT_ALWAYS)
 				return
 
-			if (!isdead(target) && !(ismonkey(target) || target.bioHolder && target.bioHolder.HasEffect("monkey"))) // Can't farm monkeys.
+			if (!isdead(target) && !(istype(target, /mob/living/carbon/human/npc/monkey))) // Can't farm npc monkeys.
 				src.do_we_get_points = 1
 
 		if (complete >= 0.8 && last_complete < 0.8)
@@ -142,7 +142,7 @@
 				interrupt(INTERRUPT_ALWAYS)
 				return
 
-			if (!isdead(target) && !(ismonkey(target) || target.bioHolder && target.bioHolder.HasEffect("monkey")))
+			if (!isdead(target) && !(istype(target, /mob/living/carbon/human/npc/monkey)))
 				src.do_we_get_points = 1
 
 		if (complete >= 0.9 && last_complete < 0.9)
@@ -151,7 +151,7 @@
 				interrupt(INTERRUPT_ALWAYS)
 				return
 
-			if (!isdead(target) && !(ismonkey(target) || target.bioHolder && target.bioHolder.HasEffect("monkey")))
+			if (!isdead(target) && !(istype(target, /mob/living/carbon/human/npc/monkey)))
 				src.do_we_get_points = 1
 
 		last_complete = complete

--- a/code/datums/abilities/vampire/vampire_bite.dm
+++ b/code/datums/abilities/vampire/vampire_bite.dm
@@ -63,7 +63,7 @@
 		boutput(M, __red("You can't drink the blood of your own thralls!"))
 		return 0
 
-	if (istype(target, /mob/living/carbon/human/npc/monkey))
+	if (isnpcmonkey(target))
 		boutput(M, __red("Drink monkey blood?! That's disgusting!"))
 		return 0
 
@@ -227,7 +227,7 @@
 		boutput(M, __red("You can't drink the blood of your master's thralls!"))
 		return 0
 
-	if (istype(target, /mob/living/carbon/human/npc/monkey))
+	if (isnpcmonkey(target))
 		boutput(M, __red("Drink monkey blood?! That's disgusting!"))
 		return 0
 

--- a/code/datums/abilities/vampire/vampire_bite.dm
+++ b/code/datums/abilities/vampire/vampire_bite.dm
@@ -63,7 +63,7 @@
 		boutput(M, __red("You can't drink the blood of your own thralls!"))
 		return 0
 
-	if (ismonkey(target) || (target.bioHolder && target.bioHolder.HasEffect("monkey")))
+	if (istype(target, /mob/living/carbon/human/npc/monkey))
 		boutput(M, __red("Drink monkey blood?! That's disgusting!"))
 		return 0
 
@@ -227,7 +227,7 @@
 		boutput(M, __red("You can't drink the blood of your master's thralls!"))
 		return 0
 
-	if (ismonkey(target) || (target.bioHolder && target.bioHolder.HasEffect("monkey")))
+	if (istype(target, /mob/living/carbon/human/npc/monkey))
 		boutput(M, __red("Drink monkey blood?! That's disgusting!"))
 		return 0
 
@@ -390,7 +390,7 @@
 		HH.vamp_beingbitten = 1
 
 		src.loopStart()
-	
+
 	loopStart()
 		..()
 		var/obj/projectile/proj = initialize_projectile_ST(HH, new/datum/projectile/special/homing/vamp_blood, M)

--- a/code/datums/abilities/werewolf.dm
+++ b/code/datums/abilities/werewolf.dm
@@ -181,7 +181,7 @@
 
 				M.visible_message("<span class='alert'><B>[M] [pick("chomps on", "chews off a chunk of", "gnaws on")] [HH]'s [pick("right arm", "left arm", "head", "right leg", "left leg")]!</B></span>")
 
-			if (ismonkey(HH) || HH.bioHolder && HH.bioHolder.HasEffect("monkey"))
+			if (istype(HH, /mob/living/carbon/human/npc/monkey))
 				boutput(M, __red("Monkey flesh just isn't the real deal..."))
 				healing /= 2
 			else if (isdead(HH))

--- a/code/datums/abilities/werewolf.dm
+++ b/code/datums/abilities/werewolf.dm
@@ -181,7 +181,7 @@
 
 				M.visible_message("<span class='alert'><B>[M] [pick("chomps on", "chews off a chunk of", "gnaws on")] [HH]'s [pick("right arm", "left arm", "head", "right leg", "left leg")]!</B></span>")
 
-			if (istype(HH, /mob/living/carbon/human/npc/monkey))
+			if (isnpcmonkey(HH))
 				boutput(M, __red("Monkey flesh just isn't the real deal..."))
 				healing /= 2
 			else if (isdead(HH))

--- a/code/datums/abilities/werewolf/werewolf_feast.dm
+++ b/code/datums/abilities/werewolf/werewolf_feast.dm
@@ -136,7 +136,7 @@
 				interrupt(INTERRUPT_ALWAYS)
 				return
 
-			if (HH.decomp_stage <= 2 && !(istype(target, /mob/living/carbon/human/npc/monkey))) // Can't farm npc monkeys.
+			if (HH.decomp_stage <= 2 && !(isnpcmonkey(target))) // Can't farm npc monkeys.
 				src.do_we_get_points = 1
 
 		if (complete >= 0.8 && last_complete < 0.8)
@@ -145,7 +145,7 @@
 				interrupt(INTERRUPT_ALWAYS)
 				return
 
-			if (HH.decomp_stage <= 2 && !(istype(target, /mob/living/carbon/human/npc/monkey)))
+			if (HH.decomp_stage <= 2 && !(isnpcmonkey(target)))
 				src.do_we_get_points = 1
 
 		if (complete >= 0.9 && last_complete < 0.9)
@@ -154,7 +154,7 @@
 				interrupt(INTERRUPT_ALWAYS)
 				return
 
-			if (HH.decomp_stage <= 2 && !(istype(target, /mob/living/carbon/human/npc/monkey)))
+			if (HH.decomp_stage <= 2 && !(isnpcmonkey(target)))
 				src.do_we_get_points = 1
 
 		last_complete = complete

--- a/code/datums/abilities/werewolf/werewolf_feast.dm
+++ b/code/datums/abilities/werewolf/werewolf_feast.dm
@@ -136,7 +136,7 @@
 				interrupt(INTERRUPT_ALWAYS)
 				return
 
-			if (HH.decomp_stage <= 2 && !(ismonkey(target) || target.bioHolder && target.bioHolder.HasEffect("monkey"))) // Can't farm monkeys.
+			if (HH.decomp_stage <= 2 && !(istype(target, /mob/living/carbon/human/npc/monkey))) // Can't farm npc monkeys.
 				src.do_we_get_points = 1
 
 		if (complete >= 0.8 && last_complete < 0.8)
@@ -145,7 +145,7 @@
 				interrupt(INTERRUPT_ALWAYS)
 				return
 
-			if (HH.decomp_stage <= 2 && !(ismonkey(target) || target.bioHolder && target.bioHolder.HasEffect("monkey")))
+			if (HH.decomp_stage <= 2 && !(istype(target, /mob/living/carbon/human/npc/monkey)))
 				src.do_we_get_points = 1
 
 		if (complete >= 0.9 && last_complete < 0.9)
@@ -154,7 +154,7 @@
 				interrupt(INTERRUPT_ALWAYS)
 				return
 
-			if (HH.decomp_stage <= 2 && !(ismonkey(target) || target.bioHolder && target.bioHolder.HasEffect("monkey")))
+			if (HH.decomp_stage <= 2 && !(istype(target, /mob/living/carbon/human/npc/monkey)))
 				src.do_we_get_points = 1
 
 		last_complete = complete

--- a/code/modules/antagonists/blob/blob_abilities.dm
+++ b/code/modules/antagonists/blob/blob_abilities.dm
@@ -621,7 +621,7 @@
 		if (blob_o && blob_o.mind) //ahem ahem AI blobs exist
 			blob_o.mind.blob_absorb_victims += H
 
-		if (istype(H, /mob/living/carbon/human/npc/monkey))
+		if (isnpcmonkey(H))
 			blob_o.evo_points += 1
 		else
 			blob_o.evo_points += 4

--- a/code/modules/antagonists/blob/blob_abilities.dm
+++ b/code/modules/antagonists/blob/blob_abilities.dm
@@ -621,7 +621,7 @@
 		if (blob_o && blob_o.mind) //ahem ahem AI blobs exist
 			blob_o.mind.blob_absorb_victims += H
 
-		if (ismonkey(H))
+		if (istype(H, /mob/living/carbon/human/npc/monkey))
 			blob_o.evo_points += 1
 		else
 			blob_o.evo_points += 4

--- a/code/modules/antagonists/changeling/abilities/absorb.dm
+++ b/code/modules/antagonists/changeling/abilities/absorb.dm
@@ -78,7 +78,7 @@
 		if (!istype(T))
 			boutput(C, "<span class='alert'>This creature is not compatible with our biology.</span>")
 			return 1
-		if (ismonkey(T))
+		if (istype(T, /mob/living/carbon/human/npc/monkey))
 			boutput(C, "<span class='alert'>Our hunger will not be satisfied by this lesser being.</span>")
 			return 1
 		if (T.bioHolder.HasEffect("husk"))
@@ -192,7 +192,7 @@
 		if (!istype(T))
 			boutput(C, "<span class='alert'>This creature is not compatible with our biology.</span>")
 			return 1
-		if (ismonkey(T))
+		if (istype(T, /mob/living/carbon/human/npc/monkey))
 			boutput(C, "<span class='alert'>Our hunger will not be satisfied by this lesser being.</span>")
 			return 1
 		if (T.bioHolder.HasEffect("husk"))

--- a/code/modules/antagonists/changeling/abilities/absorb.dm
+++ b/code/modules/antagonists/changeling/abilities/absorb.dm
@@ -78,7 +78,7 @@
 		if (!istype(T))
 			boutput(C, "<span class='alert'>This creature is not compatible with our biology.</span>")
 			return 1
-		if (istype(T, /mob/living/carbon/human/npc/monkey))
+		if (isnpcmonkey(T))
 			boutput(C, "<span class='alert'>Our hunger will not be satisfied by this lesser being.</span>")
 			return 1
 		if (T.bioHolder.HasEffect("husk"))
@@ -192,7 +192,7 @@
 		if (!istype(T))
 			boutput(C, "<span class='alert'>This creature is not compatible with our biology.</span>")
 			return 1
-		if (istype(T, /mob/living/carbon/human/npc/monkey))
+		if (isnpcmonkey(T))
 			boutput(C, "<span class='alert'>Our hunger will not be satisfied by this lesser being.</span>")
 			return 1
 		if (T.bioHolder.HasEffect("husk"))

--- a/code/modules/events/minor/appendicitis_event.dm
+++ b/code/modules/events/minor/appendicitis_event.dm
@@ -15,5 +15,5 @@
 			var/num = rand(2, 4)
 			for (var/i = 0, i < num, i++)
 				var/mob/living/carbon/human/patient = pick(potential_victims)
-				if (!(istype(patient, /mob/living/carbon/human/npc/monkey)) && patient.organHolder && patient.organHolder.appendix && !patient.organHolder.appendix.robotic)
+				if (!(isnpcmonkey(patient)) && patient.organHolder && patient.organHolder.appendix && !patient.organHolder.appendix.robotic)
 					patient.contract_disease(/datum/ailment/disease/appendicitis,null,null,1)

--- a/code/modules/events/minor/appendicitis_event.dm
+++ b/code/modules/events/minor/appendicitis_event.dm
@@ -15,5 +15,5 @@
 			var/num = rand(2, 4)
 			for (var/i = 0, i < num, i++)
 				var/mob/living/carbon/human/patient = pick(potential_victims)
-				if (!ismonkey(patient) && patient.organHolder && patient.organHolder.appendix && !patient.organHolder.appendix.robotic)
-					patient.contract_disease(/datum/ailment/disease/appendicitis,null,null,1) 
+				if (!(istype(patient, /mob/living/carbon/human/npc/monkey)) && patient.organHolder && patient.organHolder.appendix && !patient.organHolder.appendix.robotic)
+					patient.contract_disease(/datum/ailment/disease/appendicitis,null,null,1)

--- a/code/modules/medical/genetics/geneticsItems.dm
+++ b/code/modules/medical/genetics/geneticsItems.dm
@@ -80,7 +80,7 @@
 			for(var/X in target.bioHolder.effectPool)
 				BE = target.bioHolder.effectPool[X]
 				if (BE && BE.id == gene_to_activate)
-					if (target.bioHolder.ActivatePoolEffect(BE,overrideDNA = 1,grant_research = 0) && !(istype(target, /mob/living/carbon/human/npc/monkey)) && target.client)
+					if (target.bioHolder.ActivatePoolEffect(BE,overrideDNA = 1,grant_research = 0) && !(isnpcmonkey(target)) && target.client)
 						src.expended_properly = 1
 					break
 			src.uses--

--- a/code/modules/medical/genetics/geneticsItems.dm
+++ b/code/modules/medical/genetics/geneticsItems.dm
@@ -80,7 +80,7 @@
 			for(var/X in target.bioHolder.effectPool)
 				BE = target.bioHolder.effectPool[X]
 				if (BE && BE.id == gene_to_activate)
-					if (target.bioHolder.ActivatePoolEffect(BE,overrideDNA = 1,grant_research = 0) && !ismonkey(target) && target.client)
+					if (target.bioHolder.ActivatePoolEffect(BE,overrideDNA = 1,grant_research = 0) && !(istype(target, /mob/living/carbon/human/npc/monkey)) && target.client)
 						src.expended_properly = 1
 					break
 			src.uses--

--- a/code/modules/medical/genetics/geneticsItems.dm
+++ b/code/modules/medical/genetics/geneticsItems.dm
@@ -80,7 +80,7 @@
 			for(var/X in target.bioHolder.effectPool)
 				BE = target.bioHolder.effectPool[X]
 				if (BE && BE.id == gene_to_activate)
-					if (target.bioHolder.ActivatePoolEffect(BE,overrideDNA = 1,grant_research = 0) && !(isnpcmonkey(target)) && target.client)
+					if (target.bioHolder.ActivatePoolEffect(BE,overrideDNA = 1,grant_research = 0) && !isnpcmonkey(target) && target.client)
 						src.expended_properly = 1
 					break
 			src.uses--

--- a/code/modules/medical/genetics/geneticsMachines.dm
+++ b/code/modules/medical/genetics/geneticsMachines.dm
@@ -1125,7 +1125,7 @@
 
 		src.log_me(subject, "mutation activated", E)
 
-		if (subject.bioHolder.ActivatePoolEffect(E) && !istype(subject, /mob/living/carbon/human/npc/monkey) && subject.client)
+		if (subject.bioHolder.ActivatePoolEffect(E) && !isnpcmonkey(subject) && subject.client)
 			activated_bonus(usr)
 		usr << link("byond://?src=\ref[src];menu=mutations")
 		//send them to the mutations page.

--- a/code/modules/medical/genetics/geneticsMachines.dm
+++ b/code/modules/medical/genetics/geneticsMachines.dm
@@ -1125,7 +1125,7 @@
 
 		src.log_me(subject, "mutation activated", E)
 
-		if (subject.bioHolder.ActivatePoolEffect(E) && !ismonkey(subject) && subject.client)
+		if (subject.bioHolder.ActivatePoolEffect(E) && !istype(subject, /mob/living/carbon/human/npc/monkey) && subject.client)
 			activated_bonus(usr)
 		usr << link("byond://?src=\ref[src];menu=mutations")
 		//send them to the mutations page.

--- a/code/obj/item/playing_cards.dm
+++ b/code/obj/item/playing_cards.dm
@@ -623,7 +623,7 @@
 		src.card_cyborg = list()
 		src.card_ai = list()
 		for (var/mob/living/carbon/human/H in mobs)
-			if (ismonkey(H))
+			if (istype(H, /mob/living/carbon/human/npc/monkey))
 				continue
 			if (iswizard(H))
 				continue

--- a/code/obj/item/playing_cards.dm
+++ b/code/obj/item/playing_cards.dm
@@ -623,7 +623,7 @@
 		src.card_cyborg = list()
 		src.card_ai = list()
 		for (var/mob/living/carbon/human/H in mobs)
-			if (istype(H, /mob/living/carbon/human/npc/monkey))
+			if (isnpcmonkey(H))
 				continue
 			if (iswizard(H))
 				continue

--- a/code/obj/machinery/navbeacon.dm
+++ b/code/obj/machinery/navbeacon.dm
@@ -178,7 +178,7 @@
 		interacted(user, 1)
 
 	attack_hand(var/mob/user)
-		if (istype(user, /mob/living/carbon/human/npc/monkey))
+		if (isnpcmonkey(user))
 			return
 		interacted(user, 0)
 

--- a/code/obj/machinery/navbeacon.dm
+++ b/code/obj/machinery/navbeacon.dm
@@ -178,7 +178,7 @@
 		interacted(user, 1)
 
 	attack_hand(var/mob/user)
-		if (ismonkey(user))
+		if (istype(user, /mob/living/carbon/human/npc/monkey))
 			return
 		interacted(user, 0)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE][INPUT WANTED]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes multiple `ismonkey()` checks to `istype(M, /mob/living/carbon/human/npc/monkey)` checks, so player monkeys aren't treated exactly the same as npc monkeys for better or worse, by some of the code. The exact list is below, a plus means I've changed it to this, a minus means I can change it to do so, but chose not to. Depending on feedback, certain parts may be changed.

+Werewolves can maul player monkeys and get the same amount of points as from a human
+Hunters can take skulls from player monkeys and get the same amount of points as from a human
+Vampires can drink player monkey blood
+Blobs get 4 evo points from player monkeys instead of 1 like npc monkeys
+Changelings can absorb player monkeys
+Player monkeys can get appendicits from the random event
+Player monkeys fill activators when they're used on them
+Player monkeys provide the activation bonus for genetics when their mutations are activated
+Player monkeys can interact with bot navigation beacons
+Player monkeys show up on playing cards
-Player monkeys can't be forcibly meatspiked, fried, and grilled
-Player monkeys don't become regular robots when forcibly borged via an artifact/nanites
-Player monkeys set off tripwires when trespassing


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
A lot of the `ismonkey()` checks were there to prevent people farming npc monkeys for certain purposes, and changing it to a check for if its an npc or not should still serve this purpose, while getting rid of any advantages/disadvantages the `ismonkey()` checks gave player monkeys. I assume these applying to player monkeys were either unintended, or not considered during coding.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)TrustworthyFella:
(+)Player monkeys are no longer affected by code designed with npc monkeys in mind. This includes: immunity to being sucked by vampires, immunity to being sucked by changelings, and not giving benefits to werewolves when mauled.
```
