### PR TITLE
Requires a minimum of 20 rounds to play as the captain on RP1

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -162,6 +162,9 @@
 	slot_ears = /obj/item/device/radio/headset/command/captain
 	slot_poc1 = /obj/item/disk/data/floppy/read_only/authentication
 	items_in_backpack = list(/obj/item/storage/box/id_kit,/obj/item/device/flash)
+	#ifdef RP_MODE
+	rounds_needed_to_play = 20
+	#endif
 
 	New()
 		..()

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -162,9 +162,9 @@
 	slot_ears = /obj/item/device/radio/headset/command/captain
 	slot_poc1 = /obj/item/disk/data/floppy/read_only/authentication
 	items_in_backpack = list(/obj/item/storage/box/id_kit,/obj/item/device/flash)
-	#ifdef RP_MODE
+#ifdef RP_MODE
 	rounds_needed_to_play = 20
-	#endif
+#endif
 
 	New()
 		..()


### PR DESCRIPTION
## About the PR
This PR timelocks captain on the RP server to 20 rounds.

## Why's this needed?
I understand incompetent captains are somewhat the norm and part of the culture on 2 and overflow, but on RP and RPO they kinda ruin the atmosphere, that's why I think an RP server only lock may be good for em, to keep the stereotypical green staffies on 2 while requiring a bit of competence on 1. This would likely both ensure higher round quality and help protect against people evading timegates for security by picking captain.

## Changelog
```
(u)Fosstar:
(*)The captain is now timelocked to 20 rounds or more on the RP servers.
```
