### PR TITLE
Enable  Reactor Statistics Computer again

### DIFF
--- a/code/modules/power/reactor_stats.dm
+++ b/code/modules/power/reactor_stats.dm
@@ -111,7 +111,7 @@
 
 			/* get out of machine's scheduler, get in atmos_machines */
 			UnsubscribeProcess()
-			STOP_TRACKING_CAT(TR_CAT_ATMOS_MACHINES)
+			START_TRACKING_CAT(TR_CAT_ATMOS_MACHINES)
 
 			/* get all of the loop meters */
 			meters = get_meters()


### PR DESCRIPTION
add reactor_stats to atmos_machine

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Bring back Reactor Statistics Computer


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Reactor Statics Computer never got added back to a processing list with by_cat changes.  I want to see how/why the numbers go up!


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Azrun:
(+)Enable use of Reactor Statistics Computer
```
