### PR TITLE
Enzymatic Reclaimer now removes the implants from a body as well as stripping them

### DIFF
--- a/code/obj/machinery/clonepod.dm
+++ b/code/obj/machinery/clonepod.dm
@@ -1143,7 +1143,7 @@
 			message_admins("[key_name(owner)] forced [key_name(target, 1)] ([target == 2 ? "dead" : "alive"]) into \an [grinder] at [log_loc(grinder)].")
 		if (grinder.auto_strip && !grinder.emagged)
 			target.unequip_all()
-			if (target.implant.len > 0)
+			if (length(target.implant))
 				for (var/obj/item/implant/I in target.implant)
 					if (istype(I,/obj/item/implant/projectile))
 						continue

--- a/code/obj/machinery/clonepod.dm
+++ b/code/obj/machinery/clonepod.dm
@@ -1143,6 +1143,17 @@
 			message_admins("[key_name(owner)] forced [key_name(target, 1)] ([target == 2 ? "dead" : "alive"]) into \an [grinder] at [log_loc(grinder)].")
 		if (grinder.auto_strip && !grinder.emagged)
 			target.unequip_all()
+			if (target.implant.len > 0)
+				for (var/obj/item/implant/I in target.implant)
+					if (istype(I,/obj/item/implant/projectile))
+						continue
+					var/obj/item/implantcase/newcase = new /obj/item/implantcase(target.loc)
+					newcase.imp = I
+					I.on_remove(target)
+					target.implant.Remove(I)
+					I.set_loc(newcase)
+					newcase.icon_state = "implantcase-b"
+
 		target.set_loc(grinder)
 		grinder.occupant = target
 		qdel(grab)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE][INPUT WANTED]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When reclaiming bodies in the enzymatic reclaimer, if they had any implants in them, they will be dropped in implant cases along with their belongings. This does not include shrapnel.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It would be neat if this was a thing? This is primarily aimed at security officers, as their security health implants are only found in secoffs, and if your body gets reclaimed before you pop out of the cloner, you can't get another one, meaning you lose a very important part of the secoffs toolkit. For civilians, it also means that any implants you had in you before dying can be reused once you pop out, so you don't have to print them again. Recycling!


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)TrustworthyFella:
(+)The enzymatic reclaimer now spits out any implants that were in the body when reclaiming
```
