### PR TITLE
Admin override access spawner

### DIFF
--- a/code/obj/access_spawn.dm
+++ b/code/obj/access_spawn.dm
@@ -28,6 +28,7 @@
 				M.req_access += src.req_access
 			//todo : autoname doors	here too. var editing is illegal!
 
+#define SPECIAL "#ffa135"
 #define MEDICAL "#3daff7"
 #define SECURITY "#f73d3d"
 #define MORGUE_BLACK "#002135"
@@ -37,6 +38,14 @@
 #define CARGO "#f7e43d"
 #define MAINTENANCE "#e5ff32"
 #define COMMAND "#00783c"
+
+/obj/access_spawn/admin_override //special admin override access spawner
+	name = "admin override access spawn"
+	color = SPECIAL
+
+	setup()
+		for (var/obj/O in src.loc)
+			O.admin_access_override = TRUE
 
 /obj/access_spawn/security
 	name = "security access spawn"
@@ -97,6 +106,11 @@
 	name = "emergency storage access spawn"
 	req_access = list(access_emergency_storage)
 	color = MAINTENANCE
+
+/obj/access_spawn/centcom
+	name = "centcom access spawn"
+	req_access = list(access_centcom)
+	color = COMMAND
 
 /obj/access_spawn/ai_upload
 	name = "ai upload access spawn"

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -93,7 +93,7 @@
 			return 1
 		// check for admin access override
 		if (src.admin_access_override)
-			if (M?.client?.holder?.level >= LEVEL_SA)
+			if (M.client?.holder?.level >= LEVEL_SA)
 				return 1
 	return 0
 

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -69,6 +69,10 @@
 	if (src.check_access(null))
 		return 1
 	if (M && ismob(M))
+		// check for admin access override
+		if (src.admin_access_override)
+			if (M.client?.holder?.level >= LEVEL_SA)
+				return 1
 		// check in-hand first
 		if (src.check_access(M.equipped()))
 			return 1
@@ -91,10 +95,6 @@
 		// check implant (last, so as to avoid using it unnecessarily)
 		if (src.check_implanted_access(M))
 			return 1
-		// check for admin access override
-		if (src.admin_access_override)
-			if (M.client?.holder?.level >= LEVEL_SA)
-				return 1
 	return 0
 
 

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -15,6 +15,10 @@
 /obj/New()
 	..()
 	src.update_access_from_txt()
+/*
+ * Override all access requirements if user is an administrator
+ */
+/obj/var/admin_access_override = FALSE
 
 /*
  * Overrides the object's req_access var based on what's in req_access_txt (if set).
@@ -87,6 +91,10 @@
 		// check implant (last, so as to avoid using it unnecessarily)
 		if (src.check_implanted_access(M))
 			return 1
+		// check for admin access override
+		if (src.admin_access_override)
+			if (M?.client?.holder?.level >= LEVEL_SA)
+				return 1
 	return 0
 
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Adds admin override access spawner
* adds new var to `obj` `admin_access_override`
* adds check for `admin_access_override` in `/obj/proc/allowed(mob/M)`
* adds `/obj/access_spawn/centcom` because it was missing but has a corresponding access level

alternatively this could be moved up to machinery, but would lose out on the ability to affect things like lockers


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Add a way to make things accessible to admins regardless of thing like implants and ID cards
* Allows for admin only access to objects