### PR TITLE
Atlas Teleporter Powergrid Fix

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -12841,6 +12841,9 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/purplewhite{
 	dir = 9
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR and why it's needed!<!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Another Atlas bugfix. Apparently this entire time the Research Teleporter APC was not connected to the powergrid, which meant that it could never charge. As seen in the picture below. Rather silly!
![2020-10-21 07_04_44-Goonstation Development_ NCS Atlas](https://user-images.githubusercontent.com/68257280/96712356-028ba000-136d-11eb-8b54-ed6273fd0240.png)
This PR fixes that. Now it's connected to the powergrid and you can telesci to your heart's desire, assuming you have an engineering team.

Thanks to Varali again for letting me know about the issue.
