### PR TITLE
Bubsium scaling fix

### DIFF
--- a/code/atom.dm
+++ b/code/atom.dm
@@ -158,6 +158,11 @@
 	proc/Scale(var/scalex = 1, var/scaley = 1)
 		src.transform = matrix(src.transform, scalex, scaley, MATRIX_SCALE)
 
+	// a turn-safe scale, for temporary anisotropic scales
+	proc/SafeScale(var/scalex = 1, var/scaley = 1)
+		var/rot = arctan(src.transform.b, src.transform.a)
+		src.transform = matrix(matrix(matrix(src.transform, -rot, MATRIX_ROTATE), scalex, scaley, MATRIX_SCALE), rot, MATRIX_ROTATE)
+
 	proc/Translate(var/x = 0, var/y = 0)
 		src.transform = matrix(src.transform, x, y, MATRIX_TRANSLATE)
 

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -3662,12 +3662,14 @@ datum
 			on_add()
 				if(!holder || !holder.my_atom || istype(holder.my_atom, /turf))
 					return
-				holder.my_atom.Scale(4,1.5)
+				holder.my_atom.SafeScale(4,1.5)
+
 
 			on_remove()
 				if(!holder || !holder.my_atom  || istype(holder.my_atom, /turf))
 					return
-				holder.my_atom.Scale(1/4,1/1.5)
+				holder.my_atom.SafeScale(1/4,1/1.5)
+
 
 			on_mob_life(var/mob/M, var/mult = 1)
 				if (!M)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Bubsium now uses a new proc for its scaling effect, `atom/proc/SafeScale`, which correctly applies temporary anisotropic scalings to atoms.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #2474 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

N/A
