### PR TITLE
Cable coil stacking bugfix

### DIFF
--- a/code/obj/item/cable_coil.dm
+++ b/code/obj/item/cable_coil.dm
@@ -250,7 +250,7 @@ obj/item/cable_coil/abilities = list(/obj/ability_button/cable_toggle)
 			boutput(user, "You cannot link together cables made from different materials. That would be silly.")
 			return
 
-		if (C.amount == MAXCOIL)
+		if (C.amount >= MAXCOIL)
 			boutput(user, "The coil is too long, you cannot add any more cable to it.")
 			return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Previously, trying to stack cable coils when the coil-in-hand had more than `MAXCOIL` lengths led to some wonky reverse-stacking. This shows up when ghostdrones try to stack with their 1000-length stack of coil. Now, if the coil-in-hand has more than `MAXCOIL` lengths, 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #2461 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

N/A