### PR TITLE
Adds prodocs to Roboticists

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -551,6 +551,7 @@
 	slot_suit = /obj/item/clothing/suit/labcoat/robotics
 	slot_glov = /obj/item/clothing/gloves/latex
 	slot_lhan = /obj/item/storage/toolbox/mechanical
+	slot_eyes = /obj/item/clothing/glasses/healthgoggles
 	slot_ears = /obj/item/device/radio/headset/medical
 	items_in_backpack = list(/obj/item/crowbar)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes Roboticists start with ProDoc Healthgoggles.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Roboticists do more surgery than any job, and the amount of inexperienced Roboticists (or even experienced ones) letting patients die on the operating table is criminal. With healthgoggles, they can at least see when their patient is dying. Most competent Roboticists find and equip a pair of healthgoggles from the rest of medbay at roundstart anyway.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Arahimine:
(+)Roboticists now start with ProDoc healthgoggles.
```
