### PR TITLE
Atmos fixey, tweak plasmastone plasma generation

### DIFF
--- a/code/modules/atmospherics/FEA_airgroup.dm
+++ b/code/modules/atmospherics/FEA_airgroup.dm
@@ -48,10 +48,12 @@
 // Group procs
 /datum/air_group/proc/suspend_group_processing()
 	// Distribute air from the group out to members
+	ASSERT(group_processing == 1)
 	update_tiles_from_group()
 	group_processing = 0
 
 /datum/air_group/proc/resume_group_processing()
+	ASSERT(group_processing == 0)
 	update_group_from_tiles()
 	group_processing = 1
 
@@ -382,8 +384,10 @@
 		member.air?.zero()
 	if (length_space_border)
 		spaced = 1
-		resume_group_processing()
+		if(!group_processing)
+			resume_group_processing()
 
 /datum/air_group/proc/unspace_group()
-	suspend_group_processing()
+	if(group_processing)
+		suspend_group_processing()
 	spaced = 0

--- a/code/modules/atmospherics/FEA_group_helpers.dm
+++ b/code/modules/atmospherics/FEA_group_helpers.dm
@@ -70,7 +70,8 @@
 
 	if(west)
 		if(west.parent)
-			west.parent.suspend_group_processing()
+			if(west.parent.group_processing)
+				west.parent.suspend_group_processing()
 			west.parent.members += src
 			parent = west.parent
 
@@ -81,7 +82,8 @@
 			new_group_possible = 1
 
 	if(north_votes && (north_votes >= south_votes) && (north_votes >= east_votes))
-		north.parent.suspend_group_processing()
+		if(north.parent.group_processing)
+			north.parent.suspend_group_processing()
 		north.parent.members += src
 		parent = north.parent
 
@@ -90,7 +92,8 @@
 
 
 	if(south_votes  && (south_votes >= east_votes))
-		south.parent.suspend_group_processing()
+		if(south.parent.group_processing)
+			south.parent.suspend_group_processing()
 		south.parent.members += src
 		parent = south.parent
 
@@ -98,7 +101,8 @@
 		return 1
 
 	if(east_votes)
-		east.parent.suspend_group_processing()
+		if(east.parent.group_processing)
+			east.parent.suspend_group_processing()
 		east.parent.members += src
 		parent = east.parent
 

--- a/code/modules/materials/Mat_MaterialProcs.dm
+++ b/code/modules/materials/Mat_MaterialProcs.dm
@@ -343,12 +343,15 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 /datum/materialProc/plasmastone
 	execute(var/location) //exp and temp both have the location as first argument so i can use this for both.
 		for (var/turf/simulated/floor/target in range(1,location))
+			if(ON_COOLDOWN(target, "plasmastone_plasma_generate", 10 SECONDS)) continue
 			if(!target.blocks_air && target.air)
-				if(target.parent)
+				if(target.parent?.group_processing)
 					target.parent.suspend_group_processing()
 
 				var/datum/gas_mixture/payload = unpool(/datum/gas_mixture)
-				payload.toxins = 100
+				payload.toxins = 25
+				payload.temperature = T20C
+				payload.volume = R_IDEAL_GAS_EQUATION * T20C / 1000
 				target.air.merge(payload)
 		return
 

--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -1486,11 +1486,11 @@ PIPE BOMBS + CONSTRUCTION
 			if (plasma)
 				for (var/turf/simulated/floor/target in range(1,src.loc))
 					if(!target.blocks_air && target.air)
-						if(target.parent)
+						if(target.parent?.group_processing)
 							target.parent.suspend_group_processing()
 
 						var/datum/gas_mixture/payload = unpool(/datum/gas_mixture)
-						payload.toxins = plasma * 400
+						payload.toxins = plasma * 100
 						target.air.merge(payload)
 
 			if (throw_objs.len && throw_objs.len > 0)

--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -1491,6 +1491,8 @@ PIPE BOMBS + CONSTRUCTION
 
 						var/datum/gas_mixture/payload = unpool(/datum/gas_mixture)
 						payload.toxins = plasma * 100
+						payload.temperature = T20C
+						payload.volume = R_IDEAL_GAS_EQUATION * T20C / 1000
 						target.air.merge(payload)
 
 			if (throw_objs.len && throw_objs.len > 0)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes sure that suspending/resuming of group processing will only be called when needed

Adjusts plasmastone plasma generation to account for this fix (was previously bugged and hardly functioned), by putting a cooldown on how often a turf can have plasma added from plasmastone as well as reducing the base amount by a factor of 4.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Plasmastone plasma generation pretty much didn't work, and stacked plasmastone + heat sources would grind the game to a halt

Plasmastone tweak because after fixing the bug, dumping a satchel of plasmastone and a few packs of cigs would make millions of moles of plasma... every 3 seconds.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Tarmunora:
(+) Fix/adjust plasmastone plasma production
```
