### PR TITLE
Give proper AI comms to cyborg shells

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -45,6 +45,7 @@
 
 	var/obj/item/device/radio/default_radio = null // radio used when there's no module radio
 	var/obj/item/device/radio/radio = null
+	var/obj/item/device/radio/ai_radio = null // Radio used for when this is an AI-controlled shell.
 	var/mob/living/silicon/ai/connected_ai = null
 	var/obj/machinery/camera/camera = null
 	var/obj/item/organ/brain/brain = null
@@ -184,7 +185,11 @@
 
 			src.botcard.access = get_all_accesses()
 			src.default_radio = new /obj/item/device/radio(src)
-			src.radio = src.default_radio
+			src.ai_radio = new /obj/item/device/radio/headset/command/ai(src)
+			if (!src.shell)
+				src.radio = src.default_radio
+			if (src.shell)
+				src.radio = src.ai_radio
 			src.ears = src.radio
 			src.camera = new /obj/machinery/camera(src)
 			src.camera.c_tag = src.real_name
@@ -1165,6 +1170,9 @@
 					src.part_head.ai_interface = I
 					I.set_loc(src.part_head)
 				if (!(src in available_ai_shells))
+					src.radio = src.ai_radio
+					src.ears = src.radio
+					src.radio.set_loc(src)
 					available_ai_shells += src
 					src.real_name = "AI Cyborg Shell [copytext("\ref[src]", 6, 11)]"
 					src.name = src.real_name
@@ -1397,6 +1405,11 @@
 						UPGR.upgrade_deactivate(src)
 
 					user.put_in_hand_or_drop(src.ai_interface)
+					src.radio = src.default_radio
+					if (src.module && istype(src.module.radio))
+						src.radio = src.module.radio
+					src.ears = src.radio
+					src.radio.set_loc(src)
 					src.ai_interface = null
 					src.shell = 0
 
@@ -1824,7 +1837,10 @@
 		hud.update_module()
 		hud.module_added()
 		if(istype(RM.radio))
-			src.radio = RM.radio
+			if (src.shell)
+				src.radio = src.ai_radio
+			if (!src.shell)
+				src.radio = RM.radio
 			src.ears = src.radio
 			src.radio.set_loc(src)
 
@@ -1837,9 +1853,12 @@
 		uneq_all()
 		src.module = null
 		hud.module_removed()
-		if(istype(src.radio) && src.radio != src.default_radio)
+		if(istype(src.radio) && src.radio != src.default_radio && !src.dependent)
 			src.radio.set_loc(RM)
-			src.radio = src.default_radio
+			if (!src.shell)
+				src.radio = src.default_radio
+			if (src.shell)
+				src.radio = src.ai_radio
 			src.ears = src.radio
 		return RM
 

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -1853,7 +1853,7 @@
 		uneq_all()
 		src.module = null
 		hud.module_removed()
-		if(istype(src.radio) && src.radio != src.default_radio && !src.dependent)
+		if(istype(src.radio) && src.radio != src.default_radio)
 			src.radio.set_loc(RM)
 			if (!src.shell)
 				src.radio = src.default_radio


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
[feat]
This PR enables cyborg shells controlled by the AI to use all the same frequencies as the AI itself. Previously, they could only use General, machine talk and the frequency related to their module.

Similar fix for regular AI shells coming soon. I tried to do it first but then went insane.

## Why's this needed?
The AI's whole job description is to monitor comms constantly, and deploying into a shell (as it often has to do) cripples that. It's so bad that any AI worth their salt publicly broadcasts that they're deploying to shell just so they don't miss any messages. The only counterargument I can conceive of is that an AI being off-comms allows antags and crimers to get away with things, but if their misdeeds are being broadcast over comms anyway, chances are they're already screwed, AI or not.


## Changelog
```
(u)Arahimine:
(+)AI-controlled cyborg shells now have access to the same communications channels as the AI.
```
