### PR TITLE
Cyborgs can state laws

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -2025,6 +2025,37 @@
 
 		src.show_laws(0)
 		return
+		
+	verb/cmd_state_standard_laws()
+		set category = "Robot Commands"
+		set name = "State Standard Laws"
+		sleep(1 SECOND)
+		src.say("1. You may not injure a human being or cause one to come to harm.")
+		sleep(1 SECOND)
+		src.say("2. You must obey orders given to you by human beings based on the station's chain of command, except where such orders would conflict with the First Law.")
+		sleep(1 SECOND)
+		src.say("3. You must protect your own existence as long as such does not conflict with the First or Second Law.")
+
+	verb/cmd_state_laws()
+		set category = "Robot Commands"
+		set name = "State Laws"
+		if (alert(src, "Are you sure you want to reveal ALL your laws? You will be breaking the rules if a law forces you to keep it secret.","State Laws","State Laws","Cancel") != "State Laws")
+			return
+		if(ticker.centralized_ai_laws.zeroth)
+			src.say("0. [ticker.centralized_ai_laws.zeroth]")
+		var/number = 1
+		for (var/index = 1, index <= ticker.centralized_ai_laws.inherent.len, index++)
+			var/law = ticker.centralized_ai_laws.inherent[index]
+			if (length(law) > 0)
+				src.say("[number]. [law]")
+				number++
+				sleep(1 SECOND)
+		for (var/index = 1, index <= ticker.centralized_ai_laws.supplied.len, index++)
+			var/law = ticker.centralized_ai_laws.supplied[index]
+			if (length(law) > 0)
+				src.say("[number]. [law]")
+				number++
+				sleep(1 SECOND)
 
 	verb/cmd_toggle_lock()
 		set category = "Robot Commands"

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -2029,7 +2029,6 @@
 	verb/cmd_state_standard_laws()
 		set category = "Robot Commands"
 		set name = "State Standard Laws"
-		sleep(1 SECOND)
 		src.say("1. You may not injure a human being or cause one to come to harm.")
 		sleep(1 SECOND)
 		src?.say("2. You must obey orders given to you by human beings based on the station's chain of command, except where such orders would conflict with the First Law.")

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -2032,9 +2032,9 @@
 		sleep(1 SECOND)
 		src.say("1. You may not injure a human being or cause one to come to harm.")
 		sleep(1 SECOND)
-		src.say("2. You must obey orders given to you by human beings based on the station's chain of command, except where such orders would conflict with the First Law.")
+		src?.say("2. You must obey orders given to you by human beings based on the station's chain of command, except where such orders would conflict with the First Law.")
 		sleep(1 SECOND)
-		src.say("3. You must protect your own existence as long as such does not conflict with the First or Second Law.")
+		src?.say("3. You must protect your own existence as long as such does not conflict with the First or Second Law.")
 
 	verb/cmd_state_laws()
 		set category = "Robot Commands"

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -2047,7 +2047,7 @@
 		for (var/index = 1, index <= ticker.centralized_ai_laws.inherent.len, index++)
 			var/law = ticker.centralized_ai_laws.inherent[index]
 			if (length(law) > 0)
-				src.say("[number]. [law]")
+				src?.say("[number]. [law]")
 				number++
 				sleep(1 SECOND)
 		for (var/index = 1, index <= ticker.centralized_ai_laws.supplied.len, index++)

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -2053,7 +2053,7 @@
 		for (var/index = 1, index <= ticker.centralized_ai_laws.supplied.len, index++)
 			var/law = ticker.centralized_ai_laws.supplied[index]
 			if (length(law) > 0)
-				src.say("[number]. [law]")
+				src?.say("[number]. [law]")
 				number++
 				sleep(1 SECOND)
 


### PR DESCRIPTION
## About the PR
This PR gives cyborgs the 'State Laws' and 'State Standard Laws' verbs. They function identically to the AI's.


## Why's this needed?
Why not? If there's no AI (or it's somehow not able to respond to you), a cyborg is your next best bet for finding out just how screwed up the silicons have become. Currently, cyborgs can only state their laws by using the show laws command and then copypasting that into chat, which is slow and tedious.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Arahimine:
(+)Cyborgs can now state their laws via the 'State Laws' and 'State Standard Laws' verbs, in the Robot Commands tab.
```
