### PR TITLE
Better description for trying to put someone in cuffs into cryo.

### DIFF
--- a/code/WorkInProgress/cryospawn.dm
+++ b/code/WorkInProgress/cryospawn.dm
@@ -190,10 +190,10 @@
 			return 0
 		if (L.stat || L.restrained() || L.getStatusDuration("paralysis") || L.sleeping)
 			boutput(L, "<b>You can't enter cryogenic storage while incapacitated!</b>")
-			boutput(user, "<b>You can't put someone in cryogenic storage while they're incapacitated!</b>")
+			boutput(user, "<b>You can't put someone in cryogenic storage while they're incapacitated or restrained!</b>")
 			return 0
 		if (user && (user.stat || user.restrained() || user.getStatusDuration("paralysis") || user.sleeping))
-			boutput(user, "<b>You can't put someone in cryogenic storage while you're incapacitated!</b>")
+			boutput(user, "<b>You can't put someone in cryogenic storage while you're incapacitated or restrained!</b>")
 			return 0
 		if (get_dist(src, L) > 1)
 			boutput(L, "<b>You need to be closer to [src] to enter cryogenic storage!</b>")


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Added description text about not being able to place restrained people into cyrogenic units. Currently it only mentions not being able to place incapacitated people.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Had no clue you couldnt put handcuffed people into cryo until I tried to place a disconnected player in yesterday and the description text wasn't very helpful.

