### PR TITLE
Synth Leather/Blubber recipes

### DIFF
--- a/code/modules/materials/Mat_Recipes.dm
+++ b/code/modules/materials/Mat_Recipes.dm
@@ -146,3 +146,33 @@
 
 		if(one && two) return 1
 		else return 0
+
+/datum/material_recipe/synthleather
+	name = "synthleather"
+	result_id = "synthleather"
+
+	validate(var/datum/material/M)
+		var/one = 0
+		var/two = 0
+
+		for(var/datum/material/CM in M.parent_materials)
+			if(CM.mat_id == "latex") one = 1
+			if(CM.mat_id == "cotton") two = 1
+
+		if(one && two) return 1
+		else return 0
+
+/datum/material_recipe/synthblubber
+	name = "synthblubber"
+	result_id = "synthblubber"
+
+	validate(var/datum/material/M)
+		var/one = 0
+		var/two = 0
+
+		for(var/datum/material/CM in M.parent_materials)
+			if(CM.mat_id == "coral") one = 1
+			if(CM.mat_id == "synthrubber") two = 1
+
+		if(one && two) return 1
+		else return 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Added Synthleather and Synthblubber recipes for alloying
synthleather = latex + cotton
synthblubber = synthrubber + coral

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
currently there is no way to obtain synthleather, the aim is to fix that
also decided there should be a way to get synthblubber on water maps, cause water themes and stuff

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)RSG250:
(+)Synthleather and Synthblubber now have alloying recipes!
```
