### PR TITLE
Tool Actionbar and Speed Injector Fix

### DIFF
--- a/code/modules/medical/genetics/geneticsItems.dm
+++ b/code/modules/medical/genetics/geneticsItems.dm
@@ -141,8 +141,8 @@
 /obj/item/speed_injector
 	name = "screwdriver"
 	desc = "A hollow tool used to turn slotted screws and other slotted objects."
-	icon = 'icons/obj/items/items.dmi'
-	inhand_image_icon = 'icons/mob/inhand/hand_tools.dmi'
+	icon = 'icons/obj/items/tools/screwdriver.dmi'
+	inhand_image_icon = 'icons/mob/inhand/tools/screwdriver.dmi'
 	icon_state = "screwdriver"
 	flags = FPRINT | TABLEPASS | CONDUCT
 	w_class = 1

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -953,7 +953,7 @@
 	duration = 5 SECONDS
 	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
 	id = "right_vendor"
-	icon = 'icons/obj/items/items.dmi'
+	icon = 'icons/obj/items/tools/crowbar.dmi'
 	icon_state = "crowbar"
 	var/obj/machinery/vending/vendor = null
 

--- a/code/obj/item/assembly/dynassemblies.dm
+++ b/code/obj/item/assembly/dynassemblies.dm
@@ -124,7 +124,7 @@ For hairball DynAssemblies see: jonescity.dm
 	duration = 150
 	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
 	id = "dynassSecure"
-	icon = 'icons/obj/items/items.dmi'
+	icon = 'icons/obj/items/tools/screwdriver.dmi'
 	icon_state = "screwdriver"
 	var/obj/item/dynassembly/assembly
 	var/mob/user
@@ -156,7 +156,7 @@ For hairball DynAssemblies see: jonescity.dm
 	duration = 150
 	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
 	id = "dynassUnsecure"
-	icon = 'icons/obj/items/items.dmi'
+	icon = 'icons/obj/items/tools/wrench.dmi'
 	icon_state = "wrench"
 	var/obj/item/dynassembly/assembly
 	var/mob/user

--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -155,7 +155,7 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 	duration = 150
 	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
 	id = "guncharge"
-	icon = 'icons/obj/items/items.dmi'
+	icon = 'icons/obj/items/tools/screwdriver.dmi'
 	icon_state = "screwdriver"
 	var/obj/item/gun/ownerGun
 	var/pox

--- a/code/obj/machinery/camera.dm
+++ b/code/obj/machinery/camera.dm
@@ -82,7 +82,7 @@
 	duration = 150
 	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
 	id = "cameraSecure"
-	icon = 'icons/obj/items/items.dmi'
+	icon = 'icons/obj/items/tools/screwdriver.dmi'
 	icon_state = "screwdriver"
 	var/obj/machinery/camera/television/cam
 	var/secstate

--- a/code/obj/machinery/nuclearbomb.dm
+++ b/code/obj/machinery/nuclearbomb.dm
@@ -377,7 +377,7 @@
 	duration = 55
 	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
 	id = "unanchornuke"
-	icon = 'icons/obj/items/items.dmi'
+	icon = 'icons/obj/items/tools/screwdriver.dmi'
 	icon_state = "screwdriver"
 	var/obj/machinery/nuclearbomb/the_bomb = null
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR and why it's needed!<!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This originally was just going to be a fix for the Speed Injector sprite that I overlooked when putting Flaborized's new tool sprites in the game, but it uncovered the fact that all the actionbar things (and also said speed injector) were improperly hooked up to the new tool sprite locations. They were still using the legacy items.dmi which has redundant tool sprites in it for whatever reason. Also, the speed injector was completely missing inhands and has been invisible while being used this entire time. I think I found all the instances of the old tool sprites being used but if I didn't please let me know.