### PR TITLE
adds costume transformation event for Spooktober

### DIFF
--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -809,11 +809,12 @@ datum
 									boutput(M, "<span class='alert'>Your [H.wear_mask] protects you from the acid!</span>")
 								melted = 1
 							if (H.head)
-								boutput(M, "<span class='alert'>Your [H.head] melts into uselessness!</span>")
 								var/obj/item/clothing/head/D = H.head
-								D.dropped(H)
-								H.u_equip(D)
-								qdel(D)
+								if ( !D.acid_proof )
+									boutput(M, "<span class='alert'>Your [H.head] melts into uselessness!</span>")
+									D.dropped(H)
+									H.u_equip(D)
+									qdel(D)
 								melted = 1
 							if (melted)
 								return
@@ -837,9 +838,10 @@ datum
 							if (H.head)
 								boutput(M, "<span class='alert'>Your [H.head] melts into uselessness!</span>")
 								var/obj/item/clothing/head/D = H.head
-								D.dropped(H)
-								H.u_equip(D)
-								qdel(D)
+								if( !D.acid_proof )
+									D.dropped(H)
+									H.u_equip(D)
+									qdel(D)
 								melted = 1
 							if (melted)
 								return

--- a/code/modules/events/costume_transformation.dm
+++ b/code/modules/events/costume_transformation.dm
@@ -1,0 +1,70 @@
+/datum/random_event/major/spookycostumes
+	name = "Spooktober Curse"
+	centcom_headline = "Oh No!"
+	centcom_message = {"Unfortunately, our station has crashed into a space witch. Beware of curses."}
+	var/list/eligible_mobs = list()
+	event_effect()
+		..()
+		eligible_mobs = list()
+
+		for (var/mob/living/carbon/human/H in mobs)
+			if (isdead(H))
+				continue
+			if (!H.bioHolder)
+				continue
+			if(H.w_uniform || H.wear_mask || H.head || H.wear_suit )
+				eligible_mobs += H
+
+
+		if (!eligible_mobs.len)
+			message_admins("spooky random event could not find enough mobs to proceed")
+			return
+
+
+		sleep(5 SECONDS)
+
+		for (var/mob/living/carbon/human/H in eligible_mobs)
+
+			if ((H.head && findtext(H.head.name, "abomination")) || (H.w_uniform && findtext(H.w_uniform.name, "abomination")))
+				H.set_mutantrace(/datum/mutantrace/abomination/admin/)
+				boutput(H, "<span class='alert'><font  size='[1]'>for some reason, your costume feels a lot more rubbery</font></span>")
+				eligible_mobs -= H
+
+				return
+			if (H.wear_suit && findtext(H.wear_suit.name,"hotdog"))
+				var/obj/item/reagent_containers/food/snacks/hotdog/D = new /obj/item/reagent_containers/food/snacks/hotdog
+				D.loc = get_turf(H)
+				D.bun = 1
+				D.update_icon()
+				var/atom/movable/overlay/gibs/animation = null
+				animation = new(H.loc)
+				animation.master = H
+				flick("implode", animation)
+				boutput(H, "<span class='alert'><font  size='[10]'>NOOOOOOOOOOOO I DONT WANNA BE A WEENIE AAAAAAAAAAAAAAAAAAAA</font></span>")
+				H.set_loc(D)
+				H.bioHolder.AddEffect("telepathy",magical = 1)
+				for (var/datum/targetable/A in H.abilityHolder.abilities)
+					if(istype(A,/datum/targetable/geneticsAbility/telepathy))
+						A.cooldown = 0
+				if(!H.bioHolder.AddEffect("mute",magical = 1))
+					boutput(H, "<span class='alert'><font  size='[5]'>something broke</font></span>")
+				eligible_mobs -= H
+				return
+			if (H.wear_mask && findtext(H.wear_mask.name, "clown"))
+				H.reagents.add_reagent("rainbow fluid", 300)
+				eligible_mobs -= H
+				return
+			if ( H.wear_id && H.w_uniform && H.head && H.bioHolder.HasOneOfTheseEffects("lizard") && findtext(H.wear_id.name, "Discount Godzilla") && findtext(H.w_uniform.name,"green") && findtext(H.head.desc,"green"))
+
+				H.reagents.add_reagent("bubs", INFINITY)
+				for(var/reagent in H.reagents.reagent_list)
+					if(reagent == "bubs")
+						var/datum/reagent/R = H.reagents.reagent_list[reagent]
+						R.depletion_rate = 0
+				H.bioHolder.AddEffect("hulk",magical = 1)
+				eligible_mobs -= H
+				return
+			else
+				eligible_mobs -= H
+
+

--- a/code/modules/events/costume_transformation.dm
+++ b/code/modules/events/costume_transformation.dm
@@ -32,6 +32,7 @@ Need to add:
 	name = "Spooktober Curse"
 	centcom_headline = "Oh No!"
 	centcom_message = {"Unfortunately, our station has crashed into a space witch. Beware of curses."}
+	disabled = 1// press it though
 	var/list/eligible_mobs = list()
 	event_effect()
 		..()
@@ -92,18 +93,12 @@ Need to add:
 				H.bioHolder.AddEffect("hulk",magical = 1)
 				return
 			if (H.w_uniform && H.wear_mask && findtext(H.w_uniform.name,"linen") && findtext(H.wear_mask.name,"linen"))
-				var/list/limbs = list("l_arm","r_arm","l_leg","r_leg","head","chest")//it fit too good not to use
+				var/list/limbs = list("l_arm","r_arm","l_leg","r_leg","head","chest")
 				for (var/target in limbs)
 					if (!H.bandaged.Find(target))
 						H.bandaged += target
 						H.update_body()
-				if(H.reagents)
-					H.reagents.add_reagent("formaldehyde", 300)
-
-				boutput(H, "<span class='notice'>Wow, that witch's spooky halloween spell's cool and original effect did a really thorough job of mummifying you! It removed your organs and everything!</span>")
-				if(isliving(H))
-					var/mob/living/L = H
-					L.organHolder.drop_organ("all")
+				boutput(H, "<span class='alert'>You feel somewhat less susceptible to bleeding.</span>")
 				return
 			if(H.shoes && H.w_uniform && H.glasses && H.head && findtext(H.shoes.name,"wrestling") && findtext(H.w_uniform.name,"wrestling") && findtext(H.glasses.name,"yellow") && findtext(H.head.name,"macho"))
 				H.machoize()
@@ -135,27 +130,19 @@ Need to add:
 				boutput(H, "<span class='alert'>Your head feels mushy.</span>")
 				return
 			if(H.wear_suit && findtext(H.wear_suit.name,"bedsheet"))
-				boutput(H, "<span class='alert'>Darn, just one more page and you would have finished that book.</span>")//all three of these
-				animate_buff_out(H)
-				SPAWN_DBG(10)
-					animate_buff_in(H.ghostize())
-					qdel(H)
+				boutput(H, "<span class='alert'>Darn, just one more page and you would have finished that book.</span>")
+				H.alpha = 100
 				return
 			if(H.shoes && H.w_uniform && H.head && findtext(H.shoes.name, "magic") && findtext(H.w_uniform.name, "birdman") && findtext(H.head.name, "laurels"))
-				boutput(H, "<span class='alert'>A heavenly light engulfs you.</span>")//are basically
+				boutput(H, "<span class='alert'>A heavenly light engulfs you.</span>")
 				for (var/mob/M in viewers(H, null))
 					M.flash(10 SECONDS)
-				H.elecgib()
+				H.overlays += image('icons/misc/32x64.dmi',"halo")
 				return
 			if(H.shoes && H.w_uniform && H.wear_mask && H.head && findtext(H.shoes.name,"magic") && findtext(H.w_uniform.name, "lawyer") && findtext(H.wear_mask.name, "fake") && findtext(H.head.name, "devil"))
-				boutput(H, "<span class='alert'>A swathe of demonic flames engulf you.</span>")//the same thing anyways
-				var/datum/mind/M = H.mind
-				M.damned = 1
-				for(var/i = 0  , i<50 , i++)
-					H.say("*scream")
-				H.say("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
-				H.firegib()
-				M.damned = 0
+				boutput(H, "<span class='alert'>You feel somewhat different.</span>")
+				H.color = "#990000"
+
 				return
 			if(H.wear_suit && findtext(H.wear_suit.name,"bee"))
 				if (H.mind && (H.mind.assigned_role != "Animal") || (!H.mind || !H.client))
@@ -169,7 +156,7 @@ Need to add:
 				H.monkeyize()
 				return
 			if(H.w_uniform && H.wear_mask && findtext(H.w_uniform.name,"owl") && findtext(H.wear_mask.name,"owl"))
-				H.owlgib(1,100)
+				H.owlgib(1,100)//easiest way to turn someone into an owl
 				return
 			if(H.head && findtext(H.head.name,"zombie"))
 				H.zombify()

--- a/code/modules/events/costume_transformation.dm
+++ b/code/modules/events/costume_transformation.dm
@@ -1,3 +1,33 @@
+/*
+Costume Effects for:
+-abomination costume
+-hotdog costume
+-clown mask
+-godzilla
+-mummy
+-matehcto meanea
+-werewolf
+-vampire
+-pumpkin head
+-ghost
+-angle
+-debil
+-bee
+-monkey
+-owl
+-zombie
+-cat ears
+-robot costume
+-guardbuddy
+-spider
+-bat
+Need to add:
+
+
+
+
+*/
+#ifdef HALLOWEEN
 /datum/random_event/major/spookycostumes
 	name = "Spooktober Curse"
 	centcom_headline = "Oh No!"
@@ -28,7 +58,7 @@
 			if ((H.head && findtext(H.head.name, "abomination")) || (H.w_uniform && findtext(H.w_uniform.name, "abomination")))
 				H.set_mutantrace(/datum/mutantrace/abomination/admin/)
 				boutput(H, "<span class='alert'><font  size='[1]'>for some reason, your costume feels a lot more rubbery</font></span>")
-				eligible_mobs -= H
+
 
 				return
 			if (H.wear_suit && findtext(H.wear_suit.name,"hotdog"))
@@ -48,23 +78,145 @@
 						A.cooldown = 0
 				if(!H.bioHolder.AddEffect("mute",magical = 1))
 					boutput(H, "<span class='alert'><font  size='[5]'>something broke</font></span>")
-				eligible_mobs -= H
 				return
 			if (H.wear_mask && findtext(H.wear_mask.name, "clown"))
 				H.reagents.add_reagent("rainbow fluid", 300)
-				eligible_mobs -= H
 				return
 			if ( H.wear_id && H.w_uniform && H.head && H.bioHolder.HasOneOfTheseEffects("lizard") && findtext(H.wear_id.name, "Discount Godzilla") && findtext(H.w_uniform.name,"green") && findtext(H.head.desc,"green"))
 
-				H.reagents.add_reagent("bubs", INFINITY)
+				H.reagents.add_reagent("bubs", INFINITY)//make big like godzilla and the gravity effect emulates them stomping around
 				for(var/reagent in H.reagents.reagent_list)
 					if(reagent == "bubs")
 						var/datum/reagent/R = H.reagents.reagent_list[reagent]
 						R.depletion_rate = 0
 				H.bioHolder.AddEffect("hulk",magical = 1)
-				eligible_mobs -= H
 				return
-			else
-				eligible_mobs -= H
+			if (H.w_uniform && H.wear_mask && findtext(H.w_uniform.name,"linen") && findtext(H.wear_mask.name,"linen"))
+				var/list/limbs = list("l_arm","r_arm","l_leg","r_leg","head","chest")//it fit too good not to use
+				for (var/target in limbs)
+					if (!H.bandaged.Find(target))
+						H.bandaged += target
+						H.update_body()
+				if(H.reagents)
+					H.reagents.add_reagent("formaldehyde", 300)
 
+				boutput(H, "<span class='notice'>Wow, that witch's spooky halloween spell's cool and original effect did a really thorough job of mummifying you! It removed your organs and everything!</span>")
+				if(isliving(H))
+					var/mob/living/L = H
+					L.organHolder.drop_organ("all")
+				return
+			if(H.shoes && H.w_uniform && H.glasses && H.head && findtext(H.shoes.name,"wrestling") && findtext(H.w_uniform.name,"wrestling") && findtext(H.glasses.name,"yellow") && findtext(H.head.name,"macho"))
+				H.machoize()
+				return
+			if((H.head && findtext(H.head.name, "werewolf")) || (H.wear_suit && findtext(H.wear_suit.name, "werewolf")))
+				var/odd=0
+				var/newcolor
+				if (H.head && findtext(H.head.name, "odd"))
+					newcolor = H.head.color
+					odd = 1
+				else if (H.wear_suit && findtext(H.wear_suit.name, "odd"))
+					newcolor = H.w_uniform.color
+					odd = 1
+				H.werewolf_transform(1,0)
+				if(odd)
+					H.bioHolder.AddEffect("accent_uwu",magical = 1)
+					H.bioHolder.AddEffect("accent_owo",magical = 1)//I couldn't choose so I decided both
+					H.bioHolder.RemoveEffect("accent_scoob_nerf")
+					H.color = newcolor
+				return
+			if(H.shoes && H.w_uniform && H.wear_suit && H.head && findtext(H.shoes.name,"military") && findtext(H.w_uniform.name,"absurdly") && findtext(H.wear_suit.name,"absurdly") && findtext(H.head.name,"Hat"))
+				H.make_vampire()
+				return
+			if(H.head && findtext(H.head.name,"pumpkin"))
+				H.head.cant_self_remove = 1
+				H.head.cant_other_remove = 1
+				H.head.acid_proof = 1
+				H.head.w_class = 400
+				boutput(H, "<span class='alert'>Your head feels mushy.</span>")
+				return
+			if(H.wear_suit && findtext(H.wear_suit.name,"bedsheet"))
+				boutput(H, "<span class='alert'>Darn, just one more page and you would have finished that book.</span>")//all three of these
+				animate_buff_out(H)
+				SPAWN_DBG(10)
+					animate_buff_in(H.ghostize())
+					qdel(H)
+				return
+			if(H.shoes && H.w_uniform && H.head && findtext(H.shoes.name, "magic") && findtext(H.w_uniform.name, "birdman") && findtext(H.head.name, "laurels"))
+				boutput(H, "<span class='alert'>A heavenly light engulfs you.</span>")//are basically
+				for (var/mob/M in viewers(H, null))
+					M.flash(10 SECONDS)
+				H.elecgib()
+				return
+			if(H.shoes && H.w_uniform && H.wear_mask && H.head && findtext(H.shoes.name,"magic") && findtext(H.w_uniform.name, "lawyer") && findtext(H.wear_mask.name, "fake") && findtext(H.head.name, "devil"))
+				boutput(H, "<span class='alert'>A swathe of demonic flames engulf you.</span>")//the same thing anyways
+				var/datum/mind/M = H.mind
+				M.damned = 1
+				for(var/i = 0  , i<50 , i++)
+					H.say("*scream")
+				H.say("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+				H.firegib()
+				M.damned = 0
+				return
+			if(H.wear_suit && findtext(H.wear_suit.name,"bee"))
+				if (H.mind && (H.mind.assigned_role != "Animal") || (!H.mind || !H.client))
+					if (H.mind)
+						H.mind.assigned_role = "Animal"
+				particleMaster.SpawnSystem(new /datum/particleSystem/confetti(H.loc))
+				H.unequip_all()
+				H.make_critter(/mob/living/critter/small_animal/bee)
+				return
+			if(H.wear_suit && findtext(H.wear_suit.name,"monkey"))
+				H.monkeyize()
+				return
+			if(H.w_uniform && H.wear_mask && findtext(H.w_uniform.name,"owl") && findtext(H.wear_mask.name,"owl"))
+				H.owlgib(1,100)
+				return
+			if(H.head && findtext(H.head.name,"zombie"))
+				H.zombify()
+				return
+			if((H.head && findtext(H.head.name,"cat")) || (H.ears && findtext(H.ears.name, "cat")))
+				boutput(H, "<span class='alert'>You feel yourself begin to change into a... superior form.</span>")
+				SPAWN_DBG(5 SECONDS)
+					H.set_mutantrace(/datum/mutantrace/cat)
+				return
+			if(H.w_uniform && H.head && findtext(H.w_uniform.name,"mobile") && findtext(H.head.name,"mobile"))
+				H.reagents.add_reagent("nanites", INFINITY)
+				for(var/reagent in H.reagents.reagent_list)
+					if(reagent == "nanites")
+						var/datum/reagent/R = H.reagents.reagent_list[reagent]
+						R.depletion_rate = 0
+			if(H.wear_suit && findtext(H.wear_suit.name,"guardbuddy"))
+				var/mob/living/silicon/robot/buddy/B = new /mob/living/silicon/robot/buddy/
+				B.set_loc(H.loc)
 
+				H.mind.transfer_to(B)
+				H.implode()
+				B.set_module(new /obj/item/robot_module/guardbot(B))
+			if(H.w_uniform && H.wear_mask && findtext(H.w_uniform.name,"alien") && findtext(H.wear_mask.name,"alien"))
+				if (H.mind && (H.mind.assigned_role != "Animal") || (!H.mind || !H.client))
+					if (H.mind)
+						H.mind.assigned_role = "Animal"
+				H.unequip_all()
+				H.make_critter(/mob/living/critter/spider/baby)
+				return
+			if((H.wear_suit && findtext(H.wear_suit.name,"bat")) || (H.wear_mask && findtext(H.wear_mask.name,"bat")) || (H.head && findtext(H.head.name,"bat")))
+				if (H.mind && (H.mind.assigned_role != "Animal") || (!H.mind || !H.client))
+					if (H.mind)
+						H.mind.assigned_role = "Animal"
+				H.unequip_all()
+				H.make_critter(/mob/living/critter/small_animal/bat)
+				return
+//guardbuddy moduel for fun
+/datum/robot/module_tool_creator/recursive/module/guardbot
+	definitions = list(
+		/obj/item/device/flash/cyborg,
+		/obj/item/handcuffs/guardbot
+	)
+
+/obj/item/robot_module/guardbot
+	name = "guardbot module"
+	desc = "the good ol' flash and cuffs"
+	mod_hudicon = "unknown"
+	included_tools = /datum/robot/module_tool_creator/recursive/module/guardbot
+	radio_type = /obj/item/device/radio/headset/security
+#endif

--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -9,6 +9,7 @@
 	body_parts_covered = HEAD
 	compatible_species = list("human", "monkey", "werewolf", "flubber")
 	var/seal_hair = 0 // best variable name I could come up with, if 1 it forms a seal with a suit so no hair can stick out
+	var/acid_proof = 0 //hats should also be unmeltable objects
 	block_vision = 0
 
 

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -737,6 +737,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\modules\events\battle_storm.dm"
 #include "code\modules\events\black_hole.dm"
 #include "code\modules\events\blowout.dm"
+#include "code\modules\events\costume_transformation.dm"
 #include "code\modules\events\ion_storm.dm"
 #include "code\modules\events\locker_entanglement.dm"
 #include "code\modules\events\magnetic.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a fun new spooktober event that transmutes everyone wearing a costume, into their costume. 
Examples:
Godzilla costume:
![godzilla costume](https://user-images.githubusercontent.com/65260770/97122153-905ee680-16f1-11eb-908c-98e2edb24a93.png)
Hotdog Costume:
![91478f17cea3c71c6cb39259fd13ea41](https://user-images.githubusercontent.com/65260770/97122168-af5d7880-16f1-11eb-86da-18361e325965.png)
![hot dog costume](https://user-images.githubusercontent.com/65260770/97122154-9654c780-16f1-11eb-92d8-f9686ff785e9.png)
Abomination Costume before:
![abomination costume before](https://user-images.githubusercontent.com/65260770/97122160-9ce33f00-16f1-11eb-8df8-b9695553d48d.png)
and after:
![abomination costume after](https://user-images.githubusercontent.com/65260770/97122162-9fde2f80-16f1-11eb-8f05-9c66205b3030.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Because there is a lack of spooky and interesting events for the October season.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Mithsaxel:
(*)Adds the Spooktober Curse event, which transforms people into their costumes.

```
