### PR TITLE
Add a proc to handle maxz adjustments

### DIFF
--- a/code/modules/sound/sound.dm
+++ b/code/modules/sound/sound.dm
@@ -112,9 +112,6 @@ var/global/list/falloff_cache = list()
 	if (!source || !source.loc || source.z <= 0)
 		return
 
-	if (!length(spatial_z_maps))
-		return
-
 	EARLY_RETURN_IF_QUIET(vol)
 
 	var/area/source_location = get_area(source)

--- a/code/modules/spatial_hashing.dm
+++ b/code/modules/spatial_hashing.dm
@@ -10,13 +10,15 @@ var/cellposition = CELL_POSITION(X,Y);\
 buckets_holding_atom[cellposition] = 1;\
 } while (false)
 
-var/global/list/datum/spatial_hashmap/spatial_z_maps
+var/global/list/datum/spatial_hashmap/spatial_z_maps = init_spatial_maps()
 
-/proc/init_spatial_map()
-	spatial_z_maps = list()
-	spatial_z_maps.len = world.maxz
+/proc/init_spatial_maps()
+	. = new /list(world.maxz)
 	for (var/zlevel = 1; zlevel <= world.maxz; zlevel++)
-		spatial_z_maps[zlevel] = new/datum/spatial_hashmap(world.maxx,world.maxy,60,zlevel)
+		.[zlevel] = new/datum/spatial_hashmap(world.maxx,world.maxy,60,zlevel)
+
+/proc/init_spatial_map(zlevel)
+	spatial_z_maps[zlevel] = new/datum/spatial_hashmap(world.maxx,world.maxy,60,zlevel)
 
 /datum/spatial_hashmap
 	var/list/list/hashmap

--- a/code/world.dm
+++ b/code/world.dm
@@ -611,10 +611,6 @@ var/f_color_selector_handler/F_Color_Selector
 	makeMiningLevel()
 	#endif
 
-	UPDATE_TITLE_STATUS("Mapping spatials")
-	Z_LOG_DEBUG("World/New", "Setting up spatial map...")
-	init_spatial_map()
-
 	UPDATE_TITLE_STATUS("Calculating cameras")
 	Z_LOG_DEBUG("World/Init", "Updating camera visibility...")
 	aiDirty = 2

--- a/code/world.dm
+++ b/code/world.dm
@@ -1653,6 +1653,16 @@ var/f_color_selector_handler/F_Color_Selector
 
 				return 1
 
+/world/proc/setMaxZ(new_maxz)
+	if (!isnum(new_maxz) || new_maxz <= src.maxz)
+		return src.maxz
+	for (var/zlevel = world.maxz+1; zlevel <= new_maxz; zlevel++)
+		src.maxz++
+		src.setupZLevel(zlevel)
+	return src.maxz
+
+/world/proc/setupZLevel(new_zlevel)
+	init_spatial_map(new_zlevel)
 
 /// EXPERIMENTAL STUFF
 var/opt_inactive = null

--- a/code/z_dmm_suite/reader.dm
+++ b/code/z_dmm_suite/reader.dm
@@ -74,7 +74,8 @@ dmm_suite
 			coordShifts.Add(list(list(grid.group[1], grid.group[2], grid.group[3])))
 			maxZFound = max(maxZFound, text2num(grid.group[3]))
 		// Create all Atoms at map location, from model key
-		world.maxz = max(world.maxz, coordZ+maxZFound-1)
+		if ((coordZ+maxZFound-1) > world.maxz)
+			world.setMaxZ(coordZ+maxZFound-1)
 		for(var/posZ = 1 to gridLevels.len)
 			var zGrid = gridLevels[posZ]
 			// Reverse Y coordinate


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Just something I noticed was distinctly missing when I was looking into playsound stuff. Probably doesn't come too handy in current gooncode, but it costs nothing.

I also changed how spatial maps get initialized to ensure they're always around so playsound doesn't have to check for them, it's VERY minor but I felt it more correct.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
When/if someone needs runtime addition of new z-levels, z-level number dependant setup tasks can be plopped into the `setupZLevel` proc. 
