### PR TITLE
Allow for Singularity Power in Power Checker and let singularity eat!

### DIFF
--- a/code/obj/item/device/pda2/smallprogs.dm
+++ b/code/obj/item/device/pda2/smallprogs.dm
@@ -556,7 +556,7 @@ Code:
 		if (length(collector_controlers))
 			var/controler_index = 1
 			var/collector_index = 1
-			for( var/obj/machinery/power/collector_control/C as() in collector_controlers)
+			for(var/obj/machinery/power/collector_control/C as() in collector_controlers)
 				collector_index = 1
 				if(C?.active)
 					engine_found = TRUE
@@ -568,7 +568,7 @@ Code:
 					if(C.CA4?.active) stuff += "Collector [collector_index++]: Tank Pressure: [C.P4 ? round(MIXTURE_PRESSURE(C.P4?.air_contents), 0.1) : "ERR"] kPa<BR>"
 					stuff += "<BR>"
 
-		if ( !engine_found )
+		if (!engine_found)
 			stuff += "<BR><B>Error!</B> No power source detected!<BR><BR>"
 
 		stuff += "<HR>"

--- a/code/obj/item/device/pda2/smallprogs.dm
+++ b/code/obj/item/device/pda2/smallprogs.dm
@@ -513,6 +513,7 @@ Code:
 	var/obj/machinery/atmospherics/binary/circulatorTemp/right/circ2
 	var/obj/machinery/power/pt_laser/laser
 	var/obj/machinery/power/generatorTemp/generator
+	var/list/obj/machinery/power/collector_control/collector_controlers
 
 	return_text()
 		if(..())
@@ -521,32 +522,58 @@ Code:
 			laser = locate() in machine_registry[MACHINES_POWER]
 		if (!generator)
 			generator = locate() in machine_registry[MACHINES_POWER]
-		if (!generator || !circ1)
+		if (generator && !circ1)
 			circ1 = generator.circ1
-		if (!generator || !circ2)
+		if (generator && !circ2)
 			circ2 = generator.circ2
+		if (!collector_controlers)
+			collector_controlers = list()
+			for (var/obj/machinery/power/collector_control/C in machine_registry[MACHINES_POWER])
+				collector_controlers.Add(C)
 
 
 		var/stuff = src.return_text_header()
+		var/engine_found = FALSE
 
 		if (generator)
-			stuff += "<BR><B>Thermo-Electric Generator Status</B><BR>"
+			engine_found = TRUE
+			stuff += "<BR><h4>Thermo-Electric Generator Status</h4>"
 			stuff += "Output : [engineering_notation(generator.lastgen)]W<BR>"
 			stuff += "<BR>"
 
-			stuff += "<B>Hot Loop</B><BR>"
-			stuff += "Temperature Inlet: [round(circ1.air1.temperature, 0.1)] K  Outlet: [round(circ1.air2.temperature, 0.1)] K<BR>"
-			stuff += "Pressure Inlet: [round(MIXTURE_PRESSURE(circ1.air1), 0.1)] kPa  Outlet: [round(MIXTURE_PRESSURE(circ1.air2), 0.1)] kPa<BR>"
-			stuff += "<BR>"
+			if(circ1)
+				stuff += "<B>Hot Loop</B><BR>"
+				stuff += "Temperature Inlet: [round(circ1.air1.temperature, 0.1)] K  Outlet: [round(circ1.air2.temperature, 0.1)] K<BR>"
+				stuff += "Pressure Inlet: [round(MIXTURE_PRESSURE(circ1.air1), 0.1)] kPa  Outlet: [round(MIXTURE_PRESSURE(circ1.air2), 0.1)] kPa<BR>"
+				stuff += "<BR>"
 
-			stuff += "<B>Cold Loop</B><BR>"
-			stuff += "Temperature Inlet: [round(circ2.air1.temperature, 0.1)] K  Outlet: [round(circ2.air2.temperature, 0.1)] K<BR>"
-			stuff += "Pressure Inlet: [round(MIXTURE_PRESSURE(circ2.air1), 0.1)] kPa  Outlet: [round(MIXTURE_PRESSURE(circ2.air2), 0.1)] kPa<BR>"
-			stuff += "<BR>"
-		else
-			stuff += "Error! No engine detected!<BR><BR>"
+			if(circ2)
+				stuff += "<B>Cold Loop</B><BR>"
+				stuff += "Temperature Inlet: [round(circ2.air1.temperature, 0.1)] K  Outlet: [round(circ2.air2.temperature, 0.1)] K<BR>"
+				stuff += "Pressure Inlet: [round(MIXTURE_PRESSURE(circ2.air1), 0.1)] kPa  Outlet: [round(MIXTURE_PRESSURE(circ2.air2), 0.1)] kPa<BR>"
+				stuff += "<BR>"
+
+		if (length(collector_controlers))
+			var/controler_index = 1
+			var/collector_index = 1
+			for( var/obj/machinery/power/collector_control/C as() in collector_controlers)
+				collector_index = 1
+				if(C?.active)
+					engine_found = TRUE
+					stuff += "<BR><h4>Radiation Collector [controler_index++] Status</h4>"
+					stuff += "Output: [engineering_notation(C.lastpower)]W<BR>"
+					if(C.CA1?.active) stuff += "Collector [collector_index++]: Tank Pressure: [C.P1 ? round(MIXTURE_PRESSURE(C.P1?.air_contents), 0.1) : "ERR"] kPa<BR>"
+					if(C.CA2?.active) stuff += "Collector [collector_index++]: Tank Pressure: [C.P2 ? round(MIXTURE_PRESSURE(C.P2?.air_contents), 0.1) : "ERR"] kPa<BR>"
+					if(C.CA3?.active) stuff += "Collector [collector_index++]: Tank Pressure: [C.P3 ? round(MIXTURE_PRESSURE(C.P3?.air_contents), 0.1) : "ERR"] kPa<BR>"
+					if(C.CA4?.active) stuff += "Collector [collector_index++]: Tank Pressure: [C.P4 ? round(MIXTURE_PRESSURE(C.P4?.air_contents), 0.1) : "ERR"] kPa<BR>"
+					stuff += "<BR>"
+
+		if ( !engine_found )
+			stuff += "<BR><B>Error!</B> No power source detected!<BR><BR>"
+
+		stuff += "<HR>"
 		if (laser)
-			stuff += "<B>Power Transmition Laser Status</B><BR>"
+			stuff += "<BR><B>Power Transmition Laser Status</B><BR>"
 			stuff += "Currently Active: "
 
 			if(laser.firing)
@@ -558,7 +585,7 @@ Code:
 			stuff += "Power Input: [engineering_notation(laser.chargelevel)]W<BR>"
 			stuff += "Power Output: [engineering_notation(laser.output)]W<BR>"
 		else
-			stuff += "Error! No PTL detected!"
+			stuff += "<B>Error!</B> No PTL detected!"
 		return stuff
 
 //Hydroponics plant monitor.

--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -144,10 +144,13 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 			grav_pull = 8
 
 /obj/machinery/the_singularity/proc/eat()
-	for (var/X in orange(grav_pull, src.get_center()))
+	for (var/X in range(grav_pull, src.get_center()))
 		LAGCHECK(LAG_LOW)
 		if (!X)
 			continue
+		if (X == src)
+			continue
+
 		var/atom/A = X
 
 		if (A.event_handler_flags & IMMUNE_SINGULARITY)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug - minor]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Avoid runtimes on non-TEG maps when viewing Power Check.
Add power information for maps with singularities.
Allow Singularity to nom-nom on contents of containers... eventually.  Iterating through spawn_contents would adds recursion with minimal benefit?


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Surface station power level to engineering for non-TEG.
Improve ability to feed singularity larger amounts of food/people!


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Azrun:
(+)PDA Power Checker now supports Radiation Collectors.  Singularity will now consume items at the singularity
```
