### PR TITLE
Sing on the radio with Y and sundry other adjustments

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -797,10 +797,17 @@
 						secure_headset_mode = lowertext(copytext(message,2,3))
 					message = copytext(message, 3)
 
-	// check for singing prefix
-	if (dd_hasprefix(message, singing_prefix) && isalive(src))
-		singing = NORMAL_SINGING
-		message = copytext(message, 2)
+	// check for "%""
+	singing = 0
+	if (isalive(src))
+		if (dd_hasprefix(message, singing_prefix))
+			message = copytext(message, 2)
+			singing = NORMAL_SINGING
+			// check for " %"
+		else if (dd_hasprefix(copytext(message, 1, 3), " [singing_prefix]"))
+			message = copytext(message, 3)
+			singing = NORMAL_SINGING
+	if (singing)
 		// Scots can only sing Danny Boy
 		if (src.bioHolder?.HasEffect("accent_scots"))
 			var/scots = src.bioHolder.GetEffect("accent_scots")
@@ -809,8 +816,6 @@
 				S.danny_index = (S.danny_index % 16) + 1
 				var/lyrics = dd_file2list("strings/danny.txt")
 				message = lyrics[S.danny_index]
-	else
-		singing = 0
 
 	forced_language = get_special_language(secure_headset_mode)
 

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -735,6 +735,9 @@
 		return
 	*/
 
+	// check for singing prefix before radio prefix
+	message = check_singing_prefix(message)
+
 	var/italics = 0
 	var/forced_language = null
 	var/message_range = null
@@ -797,16 +800,9 @@
 						secure_headset_mode = lowertext(copytext(message,2,3))
 					message = copytext(message, 3)
 
-	// check for "%""
-	singing = 0
-	if (isalive(src))
-		if (dd_hasprefix(message, singing_prefix))
-			message = copytext(message, 2)
-			singing = NORMAL_SINGING
-			// check for " %"
-		else if (dd_hasprefix(copytext(message, 1, 3), " [singing_prefix]"))
-			message = copytext(message, 3)
-			singing = NORMAL_SINGING
+	// check for singing prefix after radio prefix
+	if (!singing)
+		message = check_singing_prefix(message)
 	if (singing)
 		// Scots can only sing Danny Boy
 		if (src.bioHolder?.HasEffect("accent_scots"))
@@ -2018,3 +2014,16 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 			if(thr?.user)
 				src.was_harmed(thr.user, AM)
 	..()
+
+/mob/living/proc/check_singing_prefix(var/message)
+	if (isalive(src))
+		// check for "%"
+		if (dd_hasprefix(message, singing_prefix))
+			src.singing = NORMAL_SINGING
+			return copytext(message, 2)
+		// check for " %"
+		else if (dd_hasprefix(copytext(message, 1, 3), " [singing_prefix]"))
+			src.singing = NORMAL_SINGING
+			return copytext(message, 3)
+	src.singing = 0
+	return message

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -735,6 +735,8 @@
 		return
 	*/
 
+	message = trim(message)
+
 	// check for singing prefix before radio prefix
 	message = check_singing_prefix(message)
 
@@ -800,6 +802,10 @@
 						secure_headset_mode = lowertext(copytext(message,2,3))
 					message = copytext(message, 3)
 
+	forced_language = get_special_language(secure_headset_mode)
+
+	message = trim(message)
+
 	// check for singing prefix after radio prefix
 	if (!singing)
 		message = check_singing_prefix(message)
@@ -812,10 +818,6 @@
 				S.danny_index = (S.danny_index % 16) + 1
 				var/lyrics = dd_file2list("strings/danny.txt")
 				message = lyrics[S.danny_index]
-
-	forced_language = get_special_language(secure_headset_mode)
-
-	message = trim(message)
 
 	if (!message)
 		return
@@ -2021,9 +2023,5 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 		if (dd_hasprefix(message, singing_prefix))
 			src.singing = NORMAL_SINGING
 			return copytext(message, 2)
-		// check for " %"
-		else if (dd_hasprefix(copytext(message, 1, 3), " [singing_prefix]"))
-			src.singing = NORMAL_SINGING
-			return copytext(message, 3)
 	src.singing = 0
 	return message

--- a/code/procs/mobprocs/chatprocs.dm
+++ b/code/procs/mobprocs/chatprocs.dm
@@ -476,8 +476,7 @@
 		// combine adverb and verb
 			speechverb = "[adverb] [speechverb]"
 		// add style for singing
-		if (!src.speech_void)
-			text = "<i>[text]</i>"
+		text = "<i>[text]</i>"
 		style = "color:thistle;"
 
 	if (special)

--- a/code/procs/mobprocs/chatprocs.dm
+++ b/code/procs/mobprocs/chatprocs.dm
@@ -476,7 +476,8 @@
 		// combine adverb and verb
 			speechverb = "[adverb] [speechverb]"
 		// add style for singing
-		text = "<i>[text]</i>"
+		if (!src.speech_void)
+			text = "<i>[text]</i>"
 		style = "color:thistle;"
 
 	if (special)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Singing prefix '%' will now be parsed when using radio with the Y key .
- You can still use say or T with radio prefixes and '%' for same result e.g. ";%lalala. Now "%;lalala" will work, as will "; %lalala".
- ~~Fixed bug where \<i> tags were appearing with void voice (e.g. when wearing obsidian crown).~~

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

- Y is the easiest way to use the radio. (Your author was not aware of this when he implemented singing.)
- Some people were confused about how to sing on the radio.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)austin:
(+)Can now use Y then prefix with '%' to sing on the radio.
```
[ENHANCEMENT]