### PR TITLE
Allow ruptured pipes to have a vacuum with respect to turf location

### DIFF
--- a/code/modules/atmospherics/machinery/pipe.dm
+++ b/code/modules/atmospherics/machinery/pipe.dm
@@ -261,7 +261,11 @@ obj/machinery/atmospherics/pipe
 		process()
 			if(!parent) //This should cut back on the overhead calling build_network thousands of times per cycle
 				..()
-			if(!parent?.air || TOTAL_MOLES(parent.air) < ATMOS_EPSILON || !loc)
+			if(!parent?.air || !loc)
+				return
+
+			if(TOTAL_MOLES(parent.air) < ATMOS_EPSILON )
+				if(ruptured) leak_gas()
 				return
 
 			if(!node1)
@@ -277,15 +281,7 @@ obj/machinery/atmospherics/pipe
 					nodealert = 1
 
 			else if(ruptured)
-				var/datum/gas_mixture/gas = return_air()
-				var/pressure = min(100*ruptured, MIXTURE_PRESSURE(gas))
-
-				if(pressure > 0)
-					var/datum/gas_mixture/environment = loc.return_air()
-					var/transfer_moles = pressure*environment.volume/(gas.temperature * R_IDEAL_GAS_EQUATION)
-					var/datum/gas_mixture/removed = gas.remove(transfer_moles)
-
-					if (removed) loc.assume_air(removed)
+				leak_gas()
 
 			else if(parent)
 				var/environment_temperature = 0
@@ -308,6 +304,25 @@ obj/machinery/atmospherics/pipe
 			var/datum/gas_mixture/gas = return_air()
 			var/pressure = MIXTURE_PRESSURE(gas)
 			if(!ruptured && pressure > fatigue_pressure) check_pressure(pressure)
+
+		proc/leak_gas()
+			var/datum/gas_mixture/gas = return_air()
+			var/datum/gas_mixture/environment = loc.return_air()
+
+			var/datum/gas_mixture/hi_side = gas
+			var/datum/gas_mixture/lo_side = environment
+
+			// vacuum
+			if( MIXTURE_PRESSURE(lo_side) > MIXTURE_PRESSURE(hi_side) )
+				hi_side = environment
+				lo_side = gas
+
+			var/pressure = min(100*ruptured, MIXTURE_PRESSURE(hi_side) - MIXTURE_PRESSURE(lo_side))
+
+			if(pressure > 0 && hi_side.temperature )
+				var/transfer_moles = pressure*lo_side.volume/(hi_side.temperature * R_IDEAL_GAS_EQUATION)
+				var/datum/gas_mixture/removed = hi_side.remove(transfer_moles)
+				if(removed) lo_side==environment ? loc.assume_air(removed) : lo_side.merge(removed)
 
 		check_pressure(pressure)
 			if (!loc)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows for vacuums to occur with atmos pipes.  Could impact cold loop behavior during Hellburns if those pipes were to rupture.  Pipes will only leak until they equalize pressure with outside air.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Pipes should not be equipped with one-way valves over the strategic rupture locations.  Nanotrasen does not have the budget for that.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Azrun:
(*)Atmospheric pipes now properly rupture and leak gas.
```
