### PR TITLE
Add Enchanted Gemstones to The Red Indy Loot crate

### DIFF
--- a/code/WorkInProgress/wizardset.dm
+++ b/code/WorkInProgress/wizardset.dm
@@ -576,6 +576,7 @@ var/global/datum/wizard_zone_controller/wizard_zone_controller
 	attack()
 		return
 
+ABSTRACT_TYPE(/obj/item/wizard_crystal)
 /obj/item/wizard_crystal
 	name = "enchanted quartz"
 	desc = "A magically infused piece of crystal. It seems to emit a minimal amount of light. Some magical object could perhaps amplify this."

--- a/code/obj/storage/loot_crates.dm
+++ b/code/obj/storage/loot_crates.dm
@@ -16,8 +16,8 @@
 		src.light = image('icons/obj/large_storage.dmi',"lootcratelocklight")
 		src.stripes = image('icons/obj/large_storage.dmi',"lootcratestripes")
 
-		tier = 3
-		var/kind = 3
+		tier = RarityClassRoll(100,0,list(95,70))
+		var/kind = rand(1,5)
 		// kinds: (1) Civilian (2) Scientific (3) Industrial (4) Military (5) Criminal
 
 		var/list/items = list()

--- a/code/obj/storage/loot_crates.dm
+++ b/code/obj/storage/loot_crates.dm
@@ -16,8 +16,8 @@
 		src.light = image('icons/obj/large_storage.dmi',"lootcratelocklight")
 		src.stripes = image('icons/obj/large_storage.dmi',"lootcratestripes")
 
-		tier = RarityClassRoll(100,0,list(95,70))
-		var/kind = rand(1,5)
+		tier = 3
+		var/kind = 3
 		// kinds: (1) Civilian (2) Scientific (3) Industrial (4) Military (5) Criminal
 
 		var/list/items = list()
@@ -99,11 +99,15 @@
 
 				// INDUSTRIAL GOODS LOOT TABLE
 				if (tier == 3)
-					picker = rand(1,3)
+					picker = 2
 					switch(picker)
-						if(1 to 2)
+						if(1)
 							items += /obj/item/clothing/shoes/jetpack
 							item_amounts += 1
+						if(2)
+							var/crystal_type = pick(concrete_typesof(/obj/item/wizard_crystal))
+							items += new crystal_type
+							item_amounts += 10
 						else
 							items += /obj/item/shipcomponent/mainweapon/rockdrills
 							item_amounts += 1

--- a/code/obj/storage/loot_crates.dm
+++ b/code/obj/storage/loot_crates.dm
@@ -105,8 +105,7 @@
 							items += /obj/item/clothing/shoes/jetpack
 							item_amounts += 1
 						if(2)
-							var/crystal_type = pick(concrete_typesof(/obj/item/wizard_crystal))
-							items += new crystal_type
+							items += pick(concrete_typesof(/obj/item/wizard_crystal))
 							item_amounts += 10
 						else
 							items += /obj/item/shipcomponent/mainweapon/rockdrills

--- a/code/obj/storage/loot_crates.dm
+++ b/code/obj/storage/loot_crates.dm
@@ -99,7 +99,7 @@
 
 				// INDUSTRIAL GOODS LOOT TABLE
 				if (tier == 3)
-					picker = 2
+					picker = rand(1,3)
 					switch(picker)
 						if(1)
 							items += /obj/item/clothing/shoes/jetpack


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
adds the Enchanted gems to the red industrial loot crates


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Red Indy loot crate has little loot, only drill and jet boot


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)RSG250:
(+)Enchanted Gems can now be found in the red industrial crates
```
