### PR TITLE
Underwater ghost house prefab abstract type violation fix

### DIFF
--- a/assets/maps/prefabs/prefab_water_ghosthouse.dmm
+++ b/assets/maps/prefabs/prefab_water_ghosthouse.dmm
@@ -78,7 +78,7 @@
 "bz" = (/obj/bedsheetbin,/obj/decal/cleanable/cobweb,/turf/simulated/floor/carpet/purple/fancy,/area/ghost_house)
 "bA" = (/turf/simulated/floor/carpet/purple/fancy,/area/ghost_house)
 "bB" = (/obj/storage/closet/dresser,/obj/item/clothing/under/color/purple,/obj/item/clothing/under/suit/purple,/obj/item/clothing/head/that/purple,/obj/item/clothing/glasses/thermal/orange,/turf/simulated/floor/carpet/purple/fancy,/area/ghost_house)
-"bC" = (/obj/storage/closet/dresser,/obj/item/clothing/under/gimmick/wedding_dress,/obj/item/clothing/under/misc/dress,/obj/item/clothing/glasses/regular/ecto,/obj/item/clothing/gloves/ring,/obj/item/clothing/head/veil,/obj/item/clothing/shoes/heels,/turf/simulated/floor/carpet/purple/fancy,/area/ghost_house)
+"bC" = (/obj/storage/closet/dresser,/obj/item/clothing/under/gimmick/wedding_dress,/obj/item/clothing/under/misc/dress,/obj/item/clothing/glasses/regular/ecto,/obj/item/clothing/gloves/ring/gold,/obj/item/clothing/head/veil,/obj/item/clothing/shoes/heels,/turf/simulated/floor/carpet/purple/fancy,/area/ghost_house)
 "bD" = (/obj/machinery/light/incandescent/warm/very,/turf/simulated/floor/carpet/purple/fancy,/area/ghost_house)
 "bE" = (/obj/critter/spirit,/turf/simulated/floor/carpet/purple/fancy,/area/ghost_house)
 "bF" = (/obj/storage/crate/biohazard,/obj/item/staff/crystal,/obj/item/staff,/obj/item/spacecash/thousand,/obj/item/spacecash/thousand,/obj/item/spacecash/thousand,/obj/item/wizard_crystal/sapphire,/obj/item/chem_grenade/cryo,/turf/simulated/floor/carpet/purple/fancy,/area/ghost_house)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Wizard rings are abstract, which makes the base ring abstract as well. This PR fixes an instantiation of the abstract type violation `/obj/item/clothing/gloves/ring` on the underwater ghost house prefab. The ring is now gold.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Abstract type violation bad!

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

N/A
