### PR TITLE
Small changes to make a few old/unused maps compile

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -82,6 +82,7 @@
 	layer = EFFECTS_LAYER_UNDER_1
 	plane = PLANE_NOSHADOW_ABOVE
 	text = ""
+	var/rigged = 0 // allows some older maps to compile
 	var/on = 0 // 1 if on, 0 if off
 	var/brightness = 1.6 // luminosity when on, also used in power calculation
 

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -82,7 +82,6 @@
 	layer = EFFECTS_LAYER_UNDER_1
 	plane = PLANE_NOSHADOW_ABOVE
 	text = ""
-	var/rigged = 0 // allows some older maps to compile
 	var/on = 0 // 1 if on, 0 if off
 	var/brightness = 1.6 // luminosity when on, also used in power calculation
 

--- a/maps/icarus.dmm
+++ b/maps/icarus.dmm
@@ -17271,7 +17271,7 @@
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "aLs" = (
-/obj/submachine/robomoduler,
+/obj/machinery/computer/robot_module_rewriter,
 /obj/cable{
 	icon_state = "0-2"
 	},

--- a/maps/setpieces/AIBM_lunar.dmm
+++ b/maps/setpieces/AIBM_lunar.dmm
@@ -2546,8 +2546,7 @@
 "gL" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -3977,8 +3976,7 @@
 "jt" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/unsimulated/floor/grey/side{
 	dir = 1
@@ -4791,8 +4789,7 @@
 "kU" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/unsimulated/floor/grey/side{
 	dir = 1
@@ -5415,8 +5412,7 @@
 "mn" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/unsimulated/floor/grey/checker,
 /area/moon/museum)
@@ -5505,8 +5501,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/unsimulated/floor/grey/checker,
 /area/moon/museum)
@@ -7264,8 +7259,7 @@
 "qA" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/kitchen)

--- a/maps/setpieces/AIBM_spacejunk.dmm
+++ b/maps/setpieces/AIBM_spacejunk.dmm
@@ -318,8 +318,7 @@
 "aS" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/unsimulated/floor/white,
 /area/h7/space_hive)

--- a/maps/setpieces/owlzone.dmm
+++ b/maps/setpieces/owlzone.dmm
@@ -1078,8 +1078,7 @@
 "cK" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
@@ -1149,8 +1148,7 @@
 "cU" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/unsimulated/floor/blackwhite{
 	icon_state = "darkwhite";
@@ -1160,8 +1158,7 @@
 "cV" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/machinery/vending/cigarette,
 /turf/unsimulated/floor/blackwhite{
@@ -1215,8 +1212,7 @@
 /obj/table/reinforced/auto,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/random_item_spawner/desk_stuff,
 /turf/unsimulated/floor/blackwhite{
@@ -1240,8 +1236,7 @@
 "dd" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/table/reinforced/auto,
 /obj/random_item_spawner/desk_stuff,
@@ -1509,8 +1504,7 @@
 "dM" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/unsimulated/floor/greenwhite{
 	icon_state = "greenwhite";
@@ -7911,8 +7905,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/table/reinforced/bar/auto,
 /obj/window{
@@ -7929,8 +7922,7 @@
 "st" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/table/reinforced/bar/auto,
 /obj/window{
@@ -9709,7 +9701,7 @@
 	name = "table"
 	},
 /obj/item/device/radio/intercom/adventure/syndcommand{
-	
+
 	},
 /turf/unsimulated/floor/black,
 /area/owlery/office)

--- a/maps/unused/chiron.dmm
+++ b/maps/unused/chiron.dmm
@@ -2101,8 +2101,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -5232,8 +5231,7 @@
 /obj/machinery/vending/monkey,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 1
@@ -6699,8 +6697,7 @@
 "alF" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -6735,8 +6732,7 @@
 "alL" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -7565,8 +7561,7 @@
 "anD" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/stairs/wide/other{
 	dir = 8
@@ -7582,8 +7577,7 @@
 "anF" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/stairs/wide{
 	dir = 4
@@ -8277,8 +8271,7 @@
 /obj/item/device/reagentscanner,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/green/side{
 	dir = 5
@@ -9922,8 +9915,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/item/paper/book/hydroponicsguide,
 /obj/item/reagent_containers/glass/bottle/eyedrops,
@@ -10974,8 +10966,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -11943,8 +11934,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/barber_shop)
@@ -12866,8 +12856,7 @@
 "ayP" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
@@ -12900,8 +12889,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
@@ -13907,8 +13895,7 @@
 /obj/item/storage/firstaid/regular,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/quarters_east)
@@ -14265,8 +14252,7 @@
 "aBJ" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/stool/chair{
 	dir = 4
@@ -17179,8 +17165,7 @@
 /obj/storage/secure/closet/medical/chemical,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/specialroom/medbay{
 	dir = 2
@@ -18473,8 +18458,7 @@
 "aKZ" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/storage/secure/closet/medical/anesthetic,
 /turf/simulated/floor/red,
@@ -21214,8 +21198,7 @@
 /obj/item/reagent_containers/hypospray,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/redwhite{
 	dir = 1
@@ -22869,8 +22852,7 @@
 /obj/storage/crate/rcd,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 9
@@ -22973,8 +22955,7 @@
 "aTv" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/table/auto,
 /obj/item/storage/toolbox/mechanical,
@@ -23361,8 +23342,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/red/corner{
 	dir = 4
@@ -23918,8 +23898,7 @@
 /obj/item/clothing/head/helmet/space/engineer,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/grime,
 /area/station/mining)
@@ -24040,8 +24019,7 @@
 "aVy" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
@@ -24383,8 +24361,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -25418,8 +25395,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/hos)
@@ -25994,16 +25970,14 @@
 "aZd" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "aZe" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=brig";
@@ -27303,8 +27277,7 @@
 /obj/item/reagent_containers/glass/bottle/holywater,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/carpet{
 	icon_state = "fred2";
@@ -27910,8 +27883,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/redwhite{
 	dir = 1
@@ -29046,8 +29018,7 @@
 "bfc" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
@@ -29704,8 +29675,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/heads)
@@ -30678,8 +30648,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/carpet{
 	icon_state = "red2";
@@ -31346,8 +31315,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)

--- a/maps/unused/clarion_xmas_2018.dmm
+++ b/maps/unused/clarion_xmas_2018.dmm
@@ -8907,8 +8907,7 @@
 "anP" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/machinery/disposal/small{
 	dir = 1;
@@ -36860,8 +36859,7 @@
 "bmq" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/machinery/door/window/southleft,
 /obj/window/reinforced/west,

--- a/maps/unused/cogmap.dmm
+++ b/maps/unused/cogmap.dmm
@@ -256,7 +256,7 @@
 "aaR" = (
 /obj/table/reinforced/auto,
 /obj/item/device/radio/intercom{
-	
+
 	},
 /obj/item/storage/toolbox/emergency,
 /obj/item/device/radio,
@@ -593,8 +593,7 @@
 "abx" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/caution/corner/nw,
 /area/station/hallway/secondary/entry)
@@ -623,8 +622,7 @@
 "abD" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/caution/corner/ne{
 	dir = 2
@@ -5282,8 +5280,7 @@
 "aly" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/item/satchel/hydro,
 /obj/machinery/firealarm{
@@ -8928,8 +8925,7 @@
 "atR" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
@@ -10272,8 +10268,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/item/paper/book/hydroponicsguide,
 /obj/disposalpipe/segment/mail{
@@ -10386,8 +10381,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/noticeboard{
 	pixel_y = 28
@@ -13602,8 +13596,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/noticeboard{
 	pixel_y = 28
@@ -13631,8 +13624,7 @@
 "aDK" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 1
@@ -15157,8 +15149,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -15832,8 +15823,7 @@
 "aIl" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
@@ -15988,8 +15978,7 @@
 /obj/disposalpipe/segment/brig,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/vehicle/segway,
 /turf/simulated/floor/bot,
@@ -20468,8 +20457,7 @@
 "aRq" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/machinery/light_switch{
 	name = "N light switch";
@@ -22161,8 +22149,7 @@
 "aVe" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/machinery/crema_switch{
 	id = "crematorium";
@@ -22210,8 +22197,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/cable{
 	d2 = 8;
@@ -23130,8 +23116,7 @@
 "aXc" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/grey/side{
 	dir = 1
@@ -26971,7 +26956,7 @@
 /area/station/crew_quarters/heads)
 "beC" = (
 /obj/item/device/radio/intercom{
-	
+
 	},
 /obj/cable{
 	icon_state = "4-8";
@@ -28396,7 +28381,7 @@
 	d2 = 8
 	},
 /obj/item/device/radio/intercom{
-	
+
 	},
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "captain";
@@ -29790,7 +29775,7 @@
 "bjX" = (
 /obj/machinery/space_heater,
 /obj/item/device/radio/intercom{
-	
+
 	},
 /turf/simulated/floor/purple/side{
 	dir = 5
@@ -34275,8 +34260,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
@@ -36627,8 +36611,7 @@
 "bxp" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
@@ -36661,8 +36644,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
@@ -36712,8 +36694,7 @@
 /obj/stool/chair,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -44046,7 +44027,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/item/device/radio/intercom{
-	
+
 	},
 /obj/cable{
 	d1 = 1;
@@ -44742,8 +44723,7 @@
 "bNf" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/table/auto,
 /obj/item/storage/toolbox/mechanical,
@@ -46142,7 +46122,7 @@
 	icon_state = "1-8"
 	},
 /obj/item/device/radio/intercom{
-	
+
 	},
 /turf/simulated/floor/white,
 /area/station/science/teleporter)
@@ -47573,8 +47553,7 @@
 "bSx" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/disposalpipe/segment/mail{
@@ -50441,8 +50420,7 @@
 "bXz" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/machinery/portable_reclaimer,
 /turf/simulated/floor/delivery,
@@ -50462,8 +50440,7 @@
 /obj/machinery/dispenser,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/delivery,
 /area/station/mining)
@@ -53732,8 +53709,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area/station/science/artifact)
@@ -53992,8 +53968,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/caution/south,
 /area/station/medical/robotics)
@@ -54976,8 +54951,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 1
@@ -55022,8 +54996,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 1
@@ -55213,8 +55186,7 @@
 "chM" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/grass,
 /area/station/hallway/secondary/exit)
@@ -58005,7 +57977,7 @@
 	d2 = 8
 	},
 /obj/item/device/radio/intercom{
-	
+
 	},
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -59225,8 +59197,7 @@
 "cpz" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/caution/south,
 /area/station/hallway/secondary/exit)
@@ -59487,8 +59458,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/disposalpipe/segment{
 	icon_state = "pipe-s";
@@ -59564,8 +59534,7 @@
 /obj/machinery/chem_master,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/machinery/light_switch{
 	name = "N light switch";
@@ -59808,8 +59777,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/disposalpipe/segment/morgue{
 	dir = 4
@@ -59845,8 +59813,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/disposalpipe/segment/morgue{
 	dir = 4
@@ -63233,8 +63200,7 @@
 /obj/reagent_dispensers/watertank/fountain,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor{
 	icon_state = "corner_east";
@@ -64807,8 +64773,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{

--- a/maps/unused/cogmap_new_walls_xmas_2017.dmm
+++ b/maps/unused/cogmap_new_walls_xmas_2017.dmm
@@ -269,7 +269,7 @@
 "aaS" = (
 /obj/table/reinforced/auto,
 /obj/item/device/radio/intercom{
-	
+
 	},
 /obj/item/storage/toolbox/emergency,
 /obj/item/device/radio,
@@ -9928,8 +9928,7 @@
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture";
-	pixel_y = 21;
-	rigged = 0
+	pixel_y = 21
 	},
 /obj/item/paper/book/hydroponicsguide,
 /obj/disposalpipe/segment/mail{
@@ -10040,8 +10039,7 @@
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture";
-	pixel_y = 21;
-	rigged = 0
+	pixel_y = 21
 	},
 /obj/noticeboard{
 	pixel_y = 28
@@ -19752,8 +19750,7 @@
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture";
-	pixel_y = 21;
-	rigged = 0
+	pixel_y = 21
 	},
 /obj/machinery/light_switch{
 	name = "N light switch";
@@ -26164,7 +26161,7 @@
 /area/station/crew_quarters/heads)
 "bdc" = (
 /obj/item/device/radio/intercom{
-	
+
 	},
 /obj/cable{
 	icon_state = "4-8";
@@ -27515,7 +27512,7 @@
 	d2 = 8
 	},
 /obj/item/device/radio/intercom{
-	
+
 	},
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "captain";
@@ -28814,7 +28811,7 @@
 "bim" = (
 /obj/machinery/space_heater,
 /obj/item/device/radio/intercom{
-	
+
 	},
 /turf/simulated/floor/purple/side{
 	dir = 5
@@ -42837,7 +42834,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/item/device/radio/intercom{
-	
+
 	},
 /obj/cable{
 	d1 = 1;
@@ -43537,8 +43534,7 @@
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture";
-	pixel_y = 21;
-	rigged = 0
+	pixel_y = 21
 	},
 /obj/table/auto,
 /obj/item/storage/toolbox/mechanical,
@@ -44981,7 +44977,7 @@
 	icon_state = "1-8"
 	},
 /obj/item/device/radio/intercom{
-	
+
 	},
 /turf/simulated/floor/white,
 /area/station/science/teleporter)
@@ -46319,8 +46315,7 @@
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture";
-	pixel_y = 21;
-	rigged = 0
+	pixel_y = 21
 	},
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/disposalpipe/segment/mail{
@@ -48122,8 +48117,7 @@
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture";
-	pixel_y = 21;
-	rigged = 0
+	pixel_y = 21
 	},
 /turf/simulated/floor/purple/side{
 	dir = 1
@@ -48151,8 +48145,7 @@
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture";
-	pixel_y = 21;
-	rigged = 0
+	pixel_y = 21
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -49114,8 +49107,7 @@
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture";
-	pixel_y = 21;
-	rigged = 0
+	pixel_y = 21
 	},
 /obj/machinery/portable_reclaimer,
 /turf/simulated/floor/delivery,
@@ -56479,7 +56471,7 @@
 	d2 = 8
 	},
 /obj/item/device/radio/intercom{
-	
+
 	},
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -57919,8 +57911,7 @@
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture";
-	pixel_y = 21;
-	rigged = 0
+	pixel_y = 21
 	},
 /obj/disposalpipe/segment{
 	icon_state = "pipe-s";
@@ -58238,8 +58229,7 @@
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture";
-	pixel_y = 21;
-	rigged = 0
+	pixel_y = 21
 	},
 /obj/disposalpipe/segment/morgue{
 	dir = 4
@@ -58276,8 +58266,7 @@
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture";
-	pixel_y = 21;
-	rigged = 0
+	pixel_y = 21
 	},
 /obj/disposalpipe/segment/morgue{
 	dir = 4

--- a/maps/unused/cogmap_xmas_2018.dmm
+++ b/maps/unused/cogmap_xmas_2018.dmm
@@ -270,7 +270,7 @@
 "aaS" = (
 /obj/table/reinforced/auto,
 /obj/item/device/radio/intercom{
-	
+
 	},
 /obj/item/storage/toolbox/emergency,
 /obj/item/device/radio,
@@ -9955,8 +9955,7 @@
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture";
-	pixel_y = 21;
-	rigged = 0
+	pixel_y = 21
 	},
 /obj/item/paper/book/hydroponicsguide,
 /obj/disposalpipe/segment/mail{
@@ -10067,8 +10066,7 @@
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture";
-	pixel_y = 21;
-	rigged = 0
+	pixel_y = 21
 	},
 /obj/noticeboard{
 	pixel_y = 28
@@ -19879,8 +19877,7 @@
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture";
-	pixel_y = 21;
-	rigged = 0
+	pixel_y = 21
 	},
 /obj/machinery/light_switch{
 	name = "N light switch";
@@ -26404,7 +26401,7 @@
 /area/station/crew_quarters/heads)
 "bdh" = (
 /obj/item/device/radio/intercom{
-	
+
 	},
 /obj/cable{
 	icon_state = "4-8";
@@ -27764,7 +27761,7 @@
 	d2 = 8
 	},
 /obj/item/device/radio/intercom{
-	
+
 	},
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "captain";
@@ -28995,7 +28992,7 @@
 "biq" = (
 /obj/machinery/space_heater,
 /obj/item/device/radio/intercom{
-	
+
 	},
 /turf/simulated/floor/purple/side{
 	dir = 5
@@ -43226,7 +43223,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/item/device/radio/intercom{
-	
+
 	},
 /obj/cable{
 	d1 = 1;
@@ -43932,8 +43929,7 @@
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture";
-	pixel_y = 21;
-	rigged = 0
+	pixel_y = 21
 	},
 /obj/table/auto,
 /obj/item/storage/toolbox/mechanical,
@@ -45329,7 +45325,7 @@
 	icon_state = "1-8"
 	},
 /obj/item/device/radio/intercom{
-	
+
 	},
 /turf/simulated/floor/white,
 /area/station/science/teleporter)
@@ -46724,8 +46720,7 @@
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture";
-	pixel_y = 21;
-	rigged = 0
+	pixel_y = 21
 	},
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/disposalpipe/segment/mail{
@@ -48502,8 +48497,7 @@
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture";
-	pixel_y = 21;
-	rigged = 0
+	pixel_y = 21
 	},
 /turf/simulated/floor/purple/side{
 	dir = 1
@@ -48531,8 +48525,7 @@
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture";
-	pixel_y = 21;
-	rigged = 0
+	pixel_y = 21
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -49498,8 +49491,7 @@
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture";
-	pixel_y = 21;
-	rigged = 0
+	pixel_y = 21
 	},
 /obj/machinery/portable_reclaimer,
 /turf/simulated/floor/delivery,
@@ -56943,7 +56935,7 @@
 	d2 = 8
 	},
 /obj/item/device/radio/intercom{
-	
+
 	},
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -58368,8 +58360,7 @@
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture";
-	pixel_y = 21;
-	rigged = 0
+	pixel_y = 21
 	},
 /obj/disposalpipe/segment{
 	icon_state = "pipe-s";
@@ -58694,8 +58685,7 @@
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture";
-	pixel_y = 21;
-	rigged = 0
+	pixel_y = 21
 	},
 /obj/disposalpipe/segment/morgue{
 	dir = 4
@@ -58732,8 +58722,7 @@
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture";
-	pixel_y = 21;
-	rigged = 0
+	pixel_y = 21
 	},
 /obj/disposalpipe/segment/morgue{
 	dir = 4

--- a/maps/unused/concept.dmm
+++ b/maps/unused/concept.dmm
@@ -15677,8 +15677,7 @@
 /obj/machinery/chem_master,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/machinery/camera{
 	c_tag = "Chemistry Department";
@@ -19670,8 +19669,7 @@
 "aLU" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor{
 	tag = "icon-0,6";
@@ -23079,8 +23077,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 1
@@ -26613,8 +26610,7 @@
 "aYU" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/specialroom/cafeteria{
 	dir = 8
@@ -26947,8 +26943,7 @@
 /obj/item/clothing/glasses/thermal,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/red/side{
 	dir = 1
@@ -29212,8 +29207,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area/security/brig)
@@ -52335,8 +52329,7 @@
 "caH" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/plating/airless,
 /area/ab_res{
@@ -52773,8 +52766,7 @@
 "cbr" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/closet/wardrobe/toxins_white,
 /turf/simulated/floor/white,
@@ -54589,8 +54581,7 @@
 "cek" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area/ab_res{
@@ -54690,8 +54681,7 @@
 "ces" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/cable{
 	icon_state = "4-8";
@@ -54781,8 +54771,7 @@
 "cey" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/cable{
 	icon_state = "4-8";
@@ -55354,8 +55343,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/item/storage/tapebox,
 /turf/simulated/floor/white,
@@ -55446,8 +55434,7 @@
 "cfC" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/cable{
 	d1 = 1;

--- a/maps/unused/concept_fixed.dmm
+++ b/maps/unused/concept_fixed.dmm
@@ -250,8 +250,7 @@
 "aaH" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/plating/airless,
 /area)
@@ -15749,8 +15748,7 @@
 /obj/machinery/chem_master,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/machinery/camera{
 	c_tag = "Chemistry Department";
@@ -19784,8 +19782,7 @@
 "aLU" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor{
 	tag = "icon-0,6";
@@ -22777,8 +22774,7 @@
 "aRd" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/storage/closet/wardrobe/white,
 /turf/simulated/floor/white,
@@ -23235,8 +23231,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 1
@@ -26813,8 +26808,7 @@
 "aYU" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/specialroom/cafeteria{
 	dir = 8
@@ -27147,8 +27141,7 @@
 /obj/item/clothing/glasses/thermal,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/red/side{
 	dir = 1
@@ -29402,8 +29395,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area/station/security/brig)
@@ -34237,8 +34229,7 @@
 "blV" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area)
@@ -34322,8 +34313,7 @@
 "bmd" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/cable{
 	icon_state = "4-8";
@@ -34401,8 +34391,7 @@
 "bmj" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/cable{
 	icon_state = "4-8";
@@ -34854,8 +34843,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/item/storage/box/tapebox,
 /turf/simulated/floor/white,
@@ -34930,8 +34918,7 @@
 "bnk" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/cable{
 	d1 = 1;

--- a/maps/unused/donut2.dmm
+++ b/maps/unused/donut2.dmm
@@ -1319,8 +1319,7 @@
 "adn" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
@@ -1810,8 +1809,7 @@
 "aeg" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/storage/secure/closet/research/chemical,
 /turf/simulated/floor/purplewhite{
@@ -3802,8 +3800,7 @@
 "aif" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 1
@@ -3853,8 +3850,7 @@
 "ail" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area/station/science)
@@ -3911,8 +3907,7 @@
 "aiq" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/cable{
 	icon_state = "4-8";
@@ -4012,8 +4007,7 @@
 "aix" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/cable{
 	icon_state = "4-8";
@@ -4809,8 +4803,7 @@
 /obj/table/auto,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/item/storage/box/tapebox,
 /turf/simulated/floor/white/checker2{
@@ -4921,8 +4914,7 @@
 "ake" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/cable{
 	d1 = 1;
@@ -8422,8 +8414,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
@@ -10373,8 +10364,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/red/corner{
 	dir = 4
@@ -10398,8 +10388,7 @@
 "auC" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/escape/corner{
 	dir = 1
@@ -11726,8 +11715,7 @@
 "axu" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/office)
@@ -13685,8 +13673,7 @@
 /obj/stool,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 8
@@ -13721,8 +13708,7 @@
 /obj/stool,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 6
@@ -13941,8 +13927,7 @@
 /obj/item/clothing/head/mailcap,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quarters)
@@ -19196,8 +19181,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -19395,8 +19379,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/disposalpipe/segment/mail{
 	icon_state = "pipe-s";
@@ -21042,8 +21025,7 @@
 "aQn" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
@@ -31320,8 +31302,7 @@
 "bjV" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/shrub{
 	icon_state = "shrub";
@@ -37938,8 +37919,7 @@
 "bxM" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
@@ -37976,8 +37956,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)

--- a/maps/unused/donut2_new_walls.dmm
+++ b/maps/unused/donut2_new_walls.dmm
@@ -1279,8 +1279,7 @@
 "adl" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
@@ -1626,8 +1625,7 @@
 "aeb" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/storage/secure/closet/research/chemical,
 /turf/simulated/floor/purplewhite{
@@ -1698,8 +1696,7 @@
 /obj/machinery/vending/coffee,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/greenwhite/other{
 	dir = 9
@@ -3321,8 +3318,7 @@
 "ahK" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 1
@@ -3372,8 +3368,7 @@
 "ahQ" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area/station/science)
@@ -3430,8 +3425,7 @@
 "ahV" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/cable{
 	d1 = 4;
@@ -3531,8 +3525,7 @@
 "aic" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/cable{
 	d1 = 4;
@@ -3680,8 +3673,7 @@
 "ain" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/bot,
 /area/station/science)
@@ -4212,8 +4204,7 @@
 /obj/table/auto,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/item/storage/box/tapebox,
 /turf/simulated/floor/white/checker2{
@@ -4528,8 +4519,7 @@
 "aka" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/space,
 /area)
@@ -7210,8 +7200,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
@@ -8765,8 +8754,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/red/corner{
 	dir = 4
@@ -8790,8 +8778,7 @@
 "atg" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/escape/corner{
 	dir = 1
@@ -9947,8 +9934,7 @@
 "avS" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/office)
@@ -11809,8 +11795,7 @@
 /obj/stool,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 8
@@ -11845,8 +11830,7 @@
 /obj/stool,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 6
@@ -12021,8 +12005,7 @@
 /obj/item/clothing/head/mailcap,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quarters)
@@ -16867,8 +16850,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -17032,8 +17014,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4;
@@ -18390,8 +18371,7 @@
 "aNZ" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
@@ -28206,8 +28186,7 @@
 "bhu" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/shrub{
 	dir = 6;
@@ -34535,8 +34514,7 @@
 "bvr" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
@@ -34573,8 +34551,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)

--- a/maps/unused/donut2_old.dmm
+++ b/maps/unused/donut2_old.dmm
@@ -483,8 +483,7 @@
 "abl" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/white,
 /area/chemistry)
@@ -938,8 +937,7 @@
 "acb" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/closet/wardrobe/toxins_white,
 /turf/simulated/floor/white,
@@ -2762,8 +2760,7 @@
 "afK" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area/zeta)
@@ -2844,8 +2841,7 @@
 "afS" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/cable{
 	icon_state = "4-8";
@@ -3624,8 +3620,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/item/storage/tapebox,
 /turf/simulated/floor/white,
@@ -3713,8 +3708,7 @@
 "ahw" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/cable{
 	d1 = 1;

--- a/maps/unused/halloween.dmm
+++ b/maps/unused/halloween.dmm
@@ -19697,8 +19697,7 @@
 "aKU" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area/station/bridge)
@@ -31465,8 +31464,7 @@
 "bir" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/closet/wardrobe/orange,
 /turf/simulated/floor,
@@ -37891,8 +37889,7 @@
 "bvF" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area{
@@ -37925,8 +37922,7 @@
 "bvI" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/cable{
 	icon_state = "4-8";
@@ -38334,8 +38330,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/item/storage/diskbox,
 /turf/simulated/floor/white,
@@ -38360,8 +38355,7 @@
 "bwt" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/cable{
 	d1 = 1;
@@ -39911,8 +39905,7 @@
 "bzn" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/space,
 /area)

--- a/maps/unused/halloween12.dmm
+++ b/maps/unused/halloween12.dmm
@@ -354,8 +354,7 @@
 "aaS" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/white,
 /area/station/chemistry)
@@ -788,8 +787,7 @@
 "abD" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/closet/wardrobe/toxins_white,
 /turf/simulated/floor/white,
@@ -2660,8 +2658,7 @@
 "afj" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area/station/science)
@@ -2742,8 +2739,7 @@
 "afr" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/cable{
 	icon_state = "4-8";
@@ -3557,8 +3553,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/item/storage/tapebox,
 /turf/simulated/floor/white,
@@ -3650,8 +3645,7 @@
 "agW" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/cable{
 	d1 = 1;

--- a/maps/unused/halloween14.dmm
+++ b/maps/unused/halloween14.dmm
@@ -1847,8 +1847,7 @@
 "aef" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/white,
 /area/station/chemistry)
@@ -2289,8 +2288,7 @@
 "aeR" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/closet/wardrobe/toxins_white,
 /turf/simulated/floor/white,
@@ -4166,8 +4164,7 @@
 "aix" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area/station/science)
@@ -4248,8 +4245,7 @@
 "aiF" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/cable{
 	icon_state = "4-8";
@@ -5063,8 +5059,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/item/storage/tapebox,
 /turf/simulated/floor/white,
@@ -5156,8 +5151,7 @@
 "akk" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/cable{
 	d1 = 1;
@@ -33980,8 +33974,7 @@
 "bqd" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
@@ -34018,8 +34011,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
@@ -41564,8 +41556,7 @@
 "bFN" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/reagent_dispensers/watertank/big,
 /turf/unsimulated/grass,
@@ -41578,8 +41569,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/unsimulated/grass,
 /area/crater/biodome/north)
@@ -41616,8 +41606,7 @@
 /obj/machinery/plantpot,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/spacevine{
 	density = 1;
@@ -41630,8 +41619,7 @@
 /obj/machinery/plantpot,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/spacevine{
 	density = 1;
@@ -41652,8 +41640,7 @@
 /obj/machinery/plantpot,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/spacevine{
 	density = 1;
@@ -41694,8 +41681,7 @@
 "bFX" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/spacevine{
 	density = 1;
@@ -44189,8 +44175,7 @@
 "bLU" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/unsimulated/floor/neutral/side{
 	dir = 1
@@ -44252,8 +44237,7 @@
 "bMd" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/machinery/vending/coffee,
 /turf/unsimulated/floor/specialroom/bar,
@@ -74452,8 +74436,7 @@
 "cXO" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/delivery,
 /area/crunch)

--- a/maps/unused/mushroom.dmm
+++ b/maps/unused/mushroom.dmm
@@ -739,8 +739,7 @@
 "abU" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/shuttle)
@@ -1343,8 +1342,7 @@
 "ado" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -3234,8 +3232,7 @@
 /obj/storage/closet,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area/station/storage/autolathe)
@@ -3833,8 +3830,7 @@
 "aiM" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster)
@@ -4000,8 +3996,7 @@
 "aji" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 10
@@ -4465,8 +4460,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 5
@@ -10293,8 +10287,7 @@
 /obj/item/parts/robot_parts/arm/right,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area/station/medical/robotics)
@@ -10488,8 +10481,7 @@
 "axt" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area/station/medical/robotics)
@@ -11682,8 +11674,7 @@
 "aAi" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/research)
@@ -14569,8 +14560,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 1
@@ -16947,8 +16937,7 @@
 "aLj" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor{
 	tag = "icon-0,6";
@@ -17078,8 +17067,7 @@
 /obj/item/clothing/gloves/yellow,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area/station/engine/elect)
@@ -17238,8 +17226,7 @@
 /obj/machinery/guardbot_dock,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/science)
@@ -17601,8 +17588,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area/station/science)
@@ -18856,8 +18842,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/white,
 /area/station/science/lab)
@@ -18913,8 +18898,7 @@
 /obj/item/assembly/time_ignite,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/white,
 /area/station/science/lab)
@@ -19773,8 +19757,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 1
@@ -19806,8 +19789,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 1
@@ -25409,8 +25391,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area/station/security/brig)
@@ -25911,8 +25892,7 @@
 "beq" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
@@ -29107,8 +29087,7 @@
 "bli" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/caution/west,
 /area/listeningpost/power)

--- a/maps/unused/mushroom_new_xmas.dmm
+++ b/maps/unused/mushroom_new_xmas.dmm
@@ -225,8 +225,7 @@
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture";
-	pixel_y = 21;
-	rigged = 0
+	pixel_y = 21
 	},
 /turf/simulated/floor/escape{
 	dir = 1
@@ -784,8 +783,7 @@
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture";
-	pixel_y = 21;
-	rigged = 0
+	pixel_y = 21
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/shuttle)
@@ -3300,8 +3298,7 @@
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture";
-	pixel_y = 21;
-	rigged = 0
+	pixel_y = 21
 	},
 /turf/simulated/floor,
 /area/station/storage/autolathe)
@@ -5147,8 +5144,7 @@
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture";
-	pixel_y = 21;
-	rigged = 0
+	pixel_y = 21
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/office)
@@ -7673,8 +7669,7 @@
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture";
-	pixel_y = 21;
-	rigged = 0
+	pixel_y = 21
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -10576,8 +10571,7 @@
 /obj/item/parts/robot_parts/arm/right,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/blueblack/corner,
 /area/station/medical/robotics)
@@ -11060,8 +11054,7 @@
 "aya" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/blueblack/corner,
 /area/station/medical/robotics)
@@ -12294,8 +12287,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc{
@@ -16949,8 +16941,7 @@
 "aJT" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 9
@@ -17561,8 +17552,7 @@
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture";
-	pixel_y = 21;
-	rigged = 0
+	pixel_y = 21
 	},
 /turf/simulated/floor{
 	tag = "icon-0,6";
@@ -17574,8 +17564,7 @@
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture";
-	pixel_y = 21;
-	rigged = 0
+	pixel_y = 21
 	},
 /turf/simulated/floor{
 	tag = "icon-0,6";
@@ -17710,8 +17699,7 @@
 /obj/item/clothing/gloves/yellow,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -17873,8 +17861,7 @@
 /obj/machinery/guardbot_dock,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/science)
@@ -18256,8 +18243,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/purple/corner{
 	dir = 1
@@ -19589,8 +19575,7 @@
 /obj/item/assembly/time_ignite,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 1
@@ -30369,8 +30354,7 @@
 "bli" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/caution/west,
 /area/listeningpost/power)

--- a/maps/unused/old_trunkmap.dmm
+++ b/maps/unused/old_trunkmap.dmm
@@ -1731,8 +1731,7 @@
 "adQ" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area/russian)
@@ -1759,8 +1758,7 @@
 "adT" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/cable{
 	icon_state = "4-8";
@@ -2312,8 +2310,7 @@
 /obj/table/auto,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/item/storage/box/diskbox,
 /turf/simulated/floor/white,
@@ -2327,8 +2324,7 @@
 "aeU" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/cable{
 	d1 = 1;
@@ -20722,8 +20718,7 @@
 "aWs" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area/station/hangar/main)
@@ -31756,8 +31751,7 @@
 "btX" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area/station/security/armory)
@@ -32082,8 +32076,7 @@
 "buE" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
@@ -32570,8 +32563,7 @@
 "bvA" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
@@ -32939,8 +32931,7 @@
 "bwq" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/cable{
 	icon_state = "4-8";
@@ -32995,8 +32986,7 @@
 "bwu" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/cable{
 	icon_state = "2-8";
@@ -33264,8 +33254,7 @@
 "bxa" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/machinery/door/poddoor{
 	density = 0;

--- a/maps/unused/oldmap.dmm
+++ b/maps/unused/oldmap.dmm
@@ -13475,8 +13475,7 @@
 "EJ" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/white,
 /area/chemistry)
@@ -13887,8 +13886,7 @@
 "Ft" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/closet/wardrobe/toxins_white,
 /turf/simulated/floor/white,
@@ -15578,8 +15576,7 @@
 "IM" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area/zeta)
@@ -15641,8 +15638,7 @@
 "IS" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/cable{
 	icon_state = "4-8";
@@ -16397,8 +16393,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/item/storage/tapebox,
 /turf/simulated/floor/white,
@@ -16486,8 +16481,7 @@
 "Kt" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/cable{
 	d1 = 1;

--- a/maps/unused/trunkmap.dmm
+++ b/maps/unused/trunkmap.dmm
@@ -1721,8 +1721,7 @@
 "adQ" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area/russian)
@@ -1749,8 +1748,7 @@
 "adT" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/cable{
 	d1 = 4;
@@ -2298,8 +2296,7 @@
 /obj/table/auto,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/item/storage/box/diskbox,
 /turf/simulated/floor/white,
@@ -2313,8 +2310,7 @@
 "aeU" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/cable{
 	d1 = 1;
@@ -20744,8 +20740,7 @@
 "aWs" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area/station/hangar/main)
@@ -31787,8 +31782,7 @@
 "btX" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area/station/security/armory)
@@ -32130,8 +32124,7 @@
 "buE" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
@@ -32598,8 +32591,7 @@
 "bvA" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
@@ -32962,8 +32954,7 @@
 "bwq" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/cable{
 	d1 = 4;
@@ -33018,8 +33009,7 @@
 "bwu" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/cable{
 	d1 = 2;
@@ -33302,8 +33292,7 @@
 "bxa" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/machinery/door/poddoor{
 	density = 0;

--- a/maps/unused/trunkmap.dmm
+++ b/maps/unused/trunkmap.dmm
@@ -33610,7 +33610,8 @@
 	},
 /obj/item/device/radio/intercom{
 	dir = 4;
-	name = "Prison Intercom (Prison)" frequency = 1357
+	name = "Prison Intercom (Prison)";
+	frequency = 1357
 	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor2"
@@ -34013,7 +34014,8 @@
 /area/station/security/hos)
 "byQ" = (
 /obj/item/device/radio/intercom{
-	name = "Prison Intercom (Prison)" frequency = 1357
+	name = "Prison Intercom (Prison)";
+	frequency = 1357
 	},
 /obj/cable{
 	icon_state = "4-8"

--- a/maps/unused/xmas.dmm
+++ b/maps/unused/xmas.dmm
@@ -774,8 +774,7 @@
 "abK" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/white,
 /area/chemistry)
@@ -1267,8 +1266,7 @@
 "acC" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/closet/wardrobe/toxins_white,
 /turf/simulated/floor/white,
@@ -3113,8 +3111,7 @@
 "agd" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor{
 	icon_state = "snow"
@@ -3211,8 +3208,7 @@
 "agl" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/cable{
 	icon_state = "4-8";
@@ -4005,8 +4001,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/item/storage/tapebox,
 /turf/simulated/floor/white,
@@ -4094,8 +4089,7 @@
 "ahK" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/cable{
 	d1 = 1;
@@ -44737,8 +44731,7 @@
 /obj/closet/emcloset,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/white,
 /area/ab_res{
@@ -44785,8 +44778,7 @@
 "bMp" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/white,
 /area/ab_res{
@@ -45367,8 +45359,7 @@
 	},
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/white,
 /area/ab_res{
@@ -45414,8 +45405,7 @@
 /obj/item/reagent_containers/pill/silver_sulfadiazine,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/white,
 /area/ab_res{
@@ -46016,8 +46006,7 @@
 "bPh" = (
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /obj/critter/spore,
 /turf/simulated/floor/white,

--- a/maps/unused/z4_old.dmm
+++ b/maps/unused/z4_old.dmm
@@ -3291,8 +3291,7 @@
 /obj/submachine/syndicate_teleporter,
 /obj/machinery/light{
 	dir = 1;
-	name = "light fixture";
-	rigged = 0
+	name = "light fixture"
 	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor4"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

A few typos were fixed and the `rigged` variable was added back to `/obj/item/machinery/light` to allow Icarus, Trunkmap, and Donut 2 to compile.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I couldn't compile these maps; now I can.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

N/A