### PR TITLE
Adds a formatting tag to center text on paper

### DIFF
--- a/code/obj/item/paper.dm
+++ b/code/obj/item/paper.dm
@@ -259,6 +259,8 @@
 		//t = copytext(sanitize(t),1,MAX_MESSAGE_LEN)
 
 		t = copytext(html_encode(t), 1, 2*MAX_MESSAGE_LEN)
+		t = replacetext(t, "\[center\]", "<CENTER>")
+		t = replacetext(t, "\[/center\]", "</CENTER>")
 		t = replacetext(t, "\n", "<BR>")
 		t = replacetext(t, "\[b\]", "<B>")
 		t = replacetext(t, "\[/b\]", "</B>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a formatting tag to allow for the center-alignment of text on paper documents. This is done by enclosing text within [center] and [/center]. Hoping it opens up the doors to more paper markdown changes in the future.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It increases the quality of life for bureaucrats and paper-pushers. [Plus, look at this beauty.](https://cdn.discordapp.com/attachments/743991129023840419/771313226579312650/unknown.png)


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it. -->
```
(u)DisturbHerb:
(+)Adds the ability to center writen text on paper by enclosing it between [center] and [/center].
```
