### PR TITLE
Rewords escape pod description to be more accurate

### DIFF
--- a/code/modules/transport/pods/ships.dm
+++ b/code/modules/transport/pods/ships.dm
@@ -1724,7 +1724,7 @@ obj/machinery/vehicle/miniputt/pilot
 
 /obj/machinery/vehicle/escape_pod
 	name = "Escape Pod E-"
-	desc = "A small one-person pod for escaping the station in emergencies.<br>It looks sort of rickety..."
+	desc = "A small one-person pod that scans for the emergency shuttle's engine signature and warps to it mid-transit. These are notorious for lacking any safety checks. <br>It looks sort of rickety..."
 	icon_state = "escape"
 	capacity = 1
 	health = 60


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL] [trivial] maybe? I don't know what to tag this.
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Hi, it's been a while. This PR rewords the description for the escape pod to relate it to the emergency shuttle. It's kinda long now but I don't think that's an issue.

Before:

A small one-person pod for escaping the station in emergencies.
It looks sort of rickety...

After:

A small one-person pod that scans for the emergency shuttle's engine signature and warps to it mid-transit. These are notorious for lacking any safety checks. 
It looks sort of rickety...

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The old description doesn't tie in with the emergency shuttle, even though that's very important to their functioning. As much fun as it is to have to rely on dodgy deathtraps to escape, I don't think it's great when clueless players get themselves blown up and waste all the escape pods because the description implies they're more generally usable. I'm pretty sure I've seen quite a few mentorhelps about them.
