### PR TITLE
Add 1 second cooldown for noisemakers

### DIFF
--- a/code/obj/item/noisemaker.dm
+++ b/code/obj/item/noisemaker.dm
@@ -7,6 +7,8 @@
 	var/custom_file = null
 
 	attack_self(var/mob/user as mob)
+		if (PROC_ON_COOLDOWN(1 SECOND))
+			return
 		if(custom_file)
 			playsound(src.loc, custom_file, 100, 1)
 			return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a one (1) second cooldown to sound synthesizers. Still very spammable, but slightly less ear-destroying.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Player ear health.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Mordent:
(+)Sound synthesizers have 1 second use delay.
```