### PR TITLE
Player Constructible Atmospherics!

### DIFF
--- a/code/modules/atmospherics/atmos-construction.dm
+++ b/code/modules/atmospherics/atmos-construction.dm
@@ -1,0 +1,10 @@
+//Buildable atmospherics, hell yeah
+#if ASS_JAM
+ABSTRACT_TYPE(/obj/atmosphericsconstruct)
+/obj/atmosphericsconstruct
+
+	name = "You shouldn't see me!"
+	desc = "Something's gone horribly wrong, tell a coder!"
+	icon = 'icons/obj/atmospherics/pipes/regular_pipe.dmi'
+	icon_state = "intact"
+#endif

--- a/code/modules/atmospherics/machinery/pipe.dm
+++ b/code/modules/atmospherics/machinery/pipe.dm
@@ -601,7 +601,7 @@ obj/machinery/atmospherics/pipe
 		process()
 			..()
 			if(!node1)
-				parent.mingle_with_turf(loc, 200)
+				parent?.mingle_with_turf(loc, 200)
 
 		carbon_dioxide
 			name = "Pressure Tank (Carbon Dioxide)"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[INPUT WANTED][BALANCE][FEATURE][REWORK][WIP][ASS-JAM]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds player buildable atmospherics to the station! This will let players use a portable dispenser similar to disposal pipes to construct atmospherics machines, and possibly the RCDD, which function exactly like the ones currently in game! Pre-existing atmospherics will also be deconstructible, movable, and whatnot. Putting this in as an ass jam change because will my code work well? Probably not, so its best to keep it for ass jam until its optimised and stuff. Things I plan to do:

- [ ] Make `obj/atmosphericsconstruct` contain fake atmospherics objects
- [ ] Make these fake atmospherics objects turn into real atmospherics when anchored 
- [ ] Make real atmospherics be able to fucking work with player constructible atmos in any way at all
- [ ] Add proper logging for this shit, because its definitely gonna be gamebreaking
- [ ] Make it possible to get these atmospherics constructs in game some way or another
- [ ] Re-add atmospheric technicians, and get some good mapper to make a cool atmospherics room
- [ ] Make pre-existing atmospherics be unanchorable, where they turn into fake atmos constructs.

Now currently, I have not done a single one of these. This draft PR just serves as a way for me to get feedback on this idea, and to motivate myself to not procrastinate and actually work on this. Also for other coders to shout at my shitcode, but thats a given with my coding skills.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I mean its kinda cool, and allows for more interesting engine stuff to be done, plus its *really* cool. Originally meant to be a shitty ass jam PR, realised how much effort it would take, and Flab said it'd be a good non ass jam feature, so I decided to make it part of the game!


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)TrustworthyFella:
(*)Player constructible atmospherics are here! Ass jam exclusive currently, look for an atmospherics fabricator in engineering, and try not to break it too badly.
```
