### PR TITLE
Allow pods to check for access. Cairngorm pods require agent access to board.

### DIFF
--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -962,6 +962,10 @@
 		boutput(boarder, "<span class='alert'>You're already inside [src]!</span>")
 		return
 
+	if (!src.allowed(boarder))
+		boutput(boarder, "<span class='alert'>Access denied.</span>")
+		return
+
 	passengers = 0 // reset this shit
 
 	for(var/mob/M in src) // nobody likes losing a pod to a dead pilot

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -55883,6 +55883,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	icon_state = "delivery2"
 	},
+/obj/access_spawn/syndie_shuttle,
 /turf/unsimulated/floor/shuttlebay,
 /area/syndicate_station/battlecruiser)
 "cIM" = (
@@ -65667,6 +65668,7 @@
 	dir = 6;
 	icon_state = "bot2"
 	},
+/obj/access_spawn/syndie_shuttle,
 /turf/unsimulated/floor/shuttlebay,
 /area/syndicate_station/battlecruiser)
 "ddt" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BALANCE][FEATURE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Pods cans now have access requirements placed on them - just slap an access_spawner on them in your map
* Cairngorm syndie pods now require syndicate access (from your agent card) to board


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Pod locks can be set for any access level desired
* Nuke Ops won't get their pods stolen without some high effort crew action