### PR TITLE
Destiny: Minor Cryo Chamber LateSpawn Fix

### DIFF
--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -14687,9 +14687,7 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment/mail,
-/obj/landmark{
-	name = "JoinLate"
-	},
+/obj/landmark/start/latejoin,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "aBm" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Corrects the landmark for latespawn.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I was told the cryo was a tile off. Seems fine. Not sure if this was the fix or what.
![image](https://user-images.githubusercontent.com/9563541/97793066-0bb61180-1ba4-11eb-9628-44a83cc77502.png)
