### PR TITLE
Playable pest and Antag Critter event mobs spawn with Staff Assistant level access

### DIFF
--- a/code/modules/events/antagonist_critter_ghost_respawn.dm
+++ b/code/modules/events/antagonist_critter_ghost_respawn.dm
@@ -188,6 +188,9 @@
 							M.current._AddComponent(list(/datum/component/drop_loot_on_death, items_to_drop))
 					else // only path provided
 						M.current.make_critter(picked_critter, pestlandmark)
+					var/obj/item/implant/access/infinite/assistant/O = new /obj/item/implant/access/infinite/assistant(M.current)
+					O.owner = M.current
+					O.implanted = 1
 					bad_traitorify(M.current)
 				candidates -= M
 

--- a/code/modules/events/playable_pests.dm
+++ b/code/modules/events/playable_pests.dm
@@ -91,6 +91,9 @@
 				var/datum/mind/M = pick(candidates)
 				if (M.current)
 					M.current.make_ghost_critter(pestlandmark,select)
+					var/obj/item/implant/access/infinite/assistant/O = new /obj/item/implant/access/infinite/assistant(M.current)
+					O.owner = M.current
+					O.implanted = 1
 				candidates -= M
 
 			pestlandmark.visible_message("A group of pests emerge from their hidey-hole!")

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -925,6 +925,10 @@ THROWING DARTS
 			if (dist <= 1)
 				. += "This one has unlimited charges."
 
+		assistant
+			New()
+				..()
+				access.access = get_access("Staff Assistant")
 
 		shittybill //give im some access
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [FEAT][QOL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Mob critters spawn from pests playable and antagonist critter spawn events will spawn with infinite use staff assistant access implants


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
- They spawn in maintenance a lot and get stuck there