### PR TITLE
Introduces Smokeless flag and applies to Thermal Paper.

### DIFF
--- a/_std/defines/item.dm
+++ b/_std/defines/item.dm
@@ -49,6 +49,8 @@
 #define USE_INTENT_SWITCH_TRIGGER 1
 /// allows special attacks to be performed on help and grab intent with this item
 #define USE_SPECIALS_ON_ALL_INTENTS 2
+/// prevents items from creating smoke while burning
+#define SMOKELESS 4
 
 //tool flags
 #define TOOL_CLAMPING 1

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -783,10 +783,11 @@
 		if (prob(7))
 			elecflash(src)
 		if (prob(7))
-			var/datum/effects/system/bad_smoke_spread/smoke = new /datum/effects/system/bad_smoke_spread()
-			smoke.set_up(1, 0, src.loc)
-			smoke.attach(src)
-			smoke.start()
+			if(!(src.item_function_flags & SMOKELESS))// maybe a better way to make this if no?
+				var/datum/effects/system/bad_smoke_spread/smoke = new /datum/effects/system/bad_smoke_spread()
+				smoke.set_up(1, 0, src.loc)
+				smoke.attach(src)
+				smoke.start()
 		if (prob(7))
 			fireflash(src, 0)
 

--- a/code/obj/item/paper.dm
+++ b/code/obj/item/paper.dm
@@ -386,6 +386,7 @@
 	stampable = 0
 	icon_state = "thermal_paper"
 	sealed = 1
+	item_function_flags = SMOKELESS
 
 /obj/item/paper/alchemy/
 	name = "'Chemistry Information'"


### PR DESCRIPTION
makes Thermal Paper not smoke on burning.

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes an item function flag, Smokeless, which makes items not create smoke when burning.
Smokeless is now a flag of Thermal Paper, to make burning mass amounts of it less laggy.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Reducing lag is good.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Chickenish:
(+)Thermal Paper no longer creates smoke when burning.
```
