### PR TITLE
Avoid negative molar quantities on gas removal

### DIFF
--- a/code/modules/atmospherics/FEA_gas_mixture.dm
+++ b/code/modules/atmospherics/FEA_gas_mixture.dm
@@ -294,7 +294,7 @@ What are the archived variables for?
 		removed.GAS = QUANTIZE((GAS/sum)*amount); \
 		GAS -= removed.GAS/group_multiplier; \
 		removed.GAS -= min(GAS, 0);  \
-		GAS = max(GAS, 0)
+		GAS = max(GAS, 0);
 	APPLY_TO_GASES(_REMOVE_GAS)
 	#undef _REMOVE_GAS
 

--- a/code/modules/atmospherics/FEA_gas_mixture.dm
+++ b/code/modules/atmospherics/FEA_gas_mixture.dm
@@ -291,8 +291,10 @@ What are the archived variables for?
 	var/datum/gas_mixture/removed = unpool(/datum/gas_mixture)
 
 	#define _REMOVE_GAS(GAS, ...) \
-		removed.GAS = min(QUANTIZE((GAS/sum)*amount), GAS); \
-		GAS -= removed.GAS/group_multiplier;
+		removed.GAS = QUANTIZE((GAS/sum)*amount); \
+		GAS -= removed.GAS/group_multiplier; \
+		removed.GAS -= min(GAS, 0);  \
+		GAS = max(GAS, 0)
 	APPLY_TO_GASES(_REMOVE_GAS)
 	#undef _REMOVE_GAS
 

--- a/code/modules/atmospherics/FEA_gas_mixture.dm
+++ b/code/modules/atmospherics/FEA_gas_mixture.dm
@@ -291,7 +291,7 @@ What are the archived variables for?
 	var/datum/gas_mixture/removed = unpool(/datum/gas_mixture)
 
 	#define _REMOVE_GAS(GAS, ...) \
-		removed.GAS = QUANTIZE((GAS/sum)*amount); \
+		removed.GAS = min(QUANTIZE((GAS/sum)*amount), GAS); \
 		GAS -= removed.GAS/group_multiplier;
 	APPLY_TO_GASES(_REMOVE_GAS)
 	#undef _REMOVE_GAS

--- a/code/modules/atmospherics/FEA_gas_mixture.dm
+++ b/code/modules/atmospherics/FEA_gas_mixture.dm
@@ -291,10 +291,8 @@ What are the archived variables for?
 	var/datum/gas_mixture/removed = unpool(/datum/gas_mixture)
 
 	#define _REMOVE_GAS(GAS, ...) \
-		removed.GAS = QUANTIZE((GAS/sum)*amount); \
-		GAS -= removed.GAS/group_multiplier; \
-		removed.GAS -= min(GAS, 0);  \
-		GAS = max(GAS, 0);
+		removed.GAS = min(QUANTIZE((GAS/sum)*amount), GAS); \
+		GAS -= removed.GAS/group_multiplier;
 	APPLY_TO_GASES(_REMOVE_GAS)
 	#undef _REMOVE_GAS
 


### PR DESCRIPTION
[bug - minor]
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Resolves case where non-trace gas quantities could become negative due to rounding from quantization during gas removal.  This will cause very small amounts of gas components to get stuck in pipes (ATMOS_EPSILON/2) but that seems desirable vs the negative quantity as that would break most calculated values based on that data. Something something perfect vacuum?

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Resolves some UI bugs from #432  and flicking behavior of the atmos pipes overlay when adjacent groups are working with low molar quantities.
