### PR TITLE
Set area on Solar Tracker to match adjacent tiles + StrongDMM cleanup

### DIFF
--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -1479,8 +1479,8 @@
 	},
 /obj/item/radio_tape/advertisement/cloning_psa,
 /obj/item/radio_tape/advertisement/captain_psa{
-	pixel_y = 6;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = 6
 	},
 /turf/simulated/floor/carpet/grime,
 /area/radiostation/studio)
@@ -16287,7 +16287,7 @@
 	id = "derelict_ai_sat"
 	},
 /turf/simulated/floor/plating/airless,
-/area)
+/area/derelict_ai_sat/solar)
 "aPL" = (
 /turf/space,
 /turf/simulated/shuttle/wall/cockpit/flock{


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug - minor][mapping]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Addressing observable behavior most similar to what is described by #1085.  Tracker in debris field is on a different area so doesn't have force_fullbright and thus missing /obj/overlay/tile_effect/lighting.  This gives the appearance that the tile has been full deleted unless you have a light source on it compared to adjacent tiles.

Slapped on mapping because technically?


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Polish.
