### PR TITLE
Gas meter feedback

### DIFF
--- a/code/obj/machinery/meter.dm
+++ b/code/obj/machinery/meter.dm
@@ -75,7 +75,9 @@
 
 /obj/machinery/meter/examine()
 	. = list("A gas flow meter. ")
-	if (src.target)
+	if(status & (NOPOWER|BROKEN))
+		. += "Something seems wrong with it..."
+	else if (src.target)
 		var/datum/gas_mixture/environment = target.return_air()
 		if(environment)
 			. += text("The pressure gauge reads [] kPa", round(MIXTURE_PRESSURE(environment), 0.1))

--- a/code/obj/machinery/meter.dm
+++ b/code/obj/machinery/meter.dm
@@ -76,7 +76,7 @@
 /obj/machinery/meter/examine()
 	. = list("A gas flow meter. ")
 	if(status & (NOPOWER|BROKEN))
-		. += "Something seems wrong with it..."
+		. += "It appears to be nonfunctional."
 	else if (src.target)
 		var/datum/gas_mixture/environment = target.return_air()
 		if(environment)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug - minor]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add text for when gas meters are broken or without-power to be consistent with other machinery (okay maybe just chem dispensers...).  Otherwise no power and no pressure are indistinguishable with examine().


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Increase user feedback in broken/no-power state for Gas Meters
