### PR TITLE
removes lag compensation from check_overdose

### DIFF
--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -258,7 +258,7 @@ datum
 			if(ishuman(M))
 				var/mob/living/carbon/human/H = M
 				if(H.traitHolder.hasTrait("chemresist"))
-					amount *= (0.65 ** mult)
+					amount *= 0.65
 			if (amount >= src.overdose * 2)
 				return do_overdose(2, M, mult)
 			else if (amount >= src.overdose)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Chem Resist currently becomes exponentially more potent based on mult.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
lag should not apply like this.


