### PR TITLE
Escape pod landmark fix

### DIFF
--- a/_std/defines/shuttle.dm
+++ b/_std/defines/shuttle.dm
@@ -16,11 +16,12 @@
 
 // you might be asking "why in seconds?" the answer is that shuttle code uses seconds as a base unit and I'm too tired to refactor it
 
-#define SHUTTLE_NODEF    0
-#define SHUTTLE_COGMAP   1
-#define SHUTTLE_COGMAP2  2
-#define SHUTTLE_DONUT2   3
-#define SHUTTLE_DONUT3   4
-#define SHUTTLE_OSHAN    5
-#define SHUTTLE_MANTA    6
-#define SHUTTLE_DESTINY  7
+
+#define SHUTTLE_COGMAP   "cogmap"
+#define SHUTTLE_COGMAP2  "cogmap2"
+#define SHUTTLE_DONUT2   "donut2"
+#define SHUTTLE_DONUT3   "donut3"
+#define SHUTTLE_OSHAN    "oshan"
+#define SHUTTLE_MANTA    "manta"
+#define SHUTTLE_DESTINY  "destiny"
+#define SHUTTLE_NODEF    "nodef"

--- a/_std/defines/shuttle.dm
+++ b/_std/defines/shuttle.dm
@@ -17,11 +17,11 @@
 // you might be asking "why in seconds?" the answer is that shuttle code uses seconds as a base unit and I'm too tired to refactor it
 
 
-#define SHUTTLE_COGMAP   "cogmap"
-#define SHUTTLE_COGMAP2  "cogmap2"
-#define SHUTTLE_DONUT2   "donut2"
+#define SHUTTLE_SOUTH    "cogmap"
+#define SHUTTLE_EAST  	 "cogmap"
+#define SHUTTLE_WEST   	 "donut2"
 #define SHUTTLE_DONUT3   "donut3"
 #define SHUTTLE_OSHAN    "oshan"
 #define SHUTTLE_MANTA    "manta"
-#define SHUTTLE_DESTINY  "destiny"
+#define SHUTTLE_NORTH    "destiny"
 #define SHUTTLE_NODEF    "nodef"

--- a/_std/defines/shuttle.dm
+++ b/_std/defines/shuttle.dm
@@ -15,3 +15,12 @@
 #define SHUTTLETRANSITTIME (2 MINUTES / (1 SECOND))
 
 // you might be asking "why in seconds?" the answer is that shuttle code uses seconds as a base unit and I'm too tired to refactor it
+
+#define SHUTTLE_NODEF    0
+#define SHUTTLE_COGMAP   1
+#define SHUTTLE_COGMAP2  2
+#define SHUTTLE_DONUT2   3
+#define SHUTTLE_DONUT3   4
+#define SHUTTLE_OSHAN    5
+#define SHUTTLE_MANTA    6
+#define SHUTTLE_DESTINY  7

--- a/code/map.dm
+++ b/code/map.dm
@@ -41,13 +41,13 @@ var/global/list/mapNames = list(
 )
 
 var/global/list/map_escape_pod_dirs = list(
-	SHUTTLE_COGMAP = SOUTH,
-	SHUTTLE_COGMAP2 = EAST,
-	SHUTTLE_DONUT2 = WEST,
+	SHUTTLE_SOUTH = SOUTH,
+	SHUTTLE_EAST = EAST,
+	SHUTTLE_WEST = WEST,
 	SHUTTLE_DONUT3 = NORTH,
 	SHUTTLE_MANTA = NORTH,
 	SHUTTLE_OSHAN = EAST,
-	SHUTTLE_DESTINY = NORTH,
+	SHUTTLE_NORTH = NORTH,
 	SHUTTLE_NODEF = SOUTH
 )
 
@@ -107,7 +107,7 @@ var/global/list/map_escape_pod_dirs = list(
 	var/escape_centcom = /area/shuttle/escape/centcom
 	var/escape_transit = /area/shuttle/escape/transit
 	var/escape_station = /area/shuttle/escape/station
-	var/escape_define = SHUTTLE_NODEF
+	var/escape_def = SHUTTLE_NODEF
 	var/shuttle_map_turf = /turf/space
 
 	var/merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom
@@ -147,7 +147,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_centcom = /area/shuttle/escape/centcom/donut2
 	escape_transit = /area/shuttle/escape/transit/donut2
 	escape_station = /area/shuttle/escape/station/donut2
-	escape_define = SHUTTLE_DONUT2
+	escape_def = SHUTTLE_WEST
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/donut2
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/donut2
@@ -164,7 +164,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_centcom = /area/shuttle/escape/centcom/donut3
 	escape_transit = /area/shuttle/escape/transit/donut3
 	escape_station = /area/shuttle/escape/station/donut3
-	escape_define = SHUTTLE_DONUT3
+	escape_def = SHUTTLE_DONUT3
 	auto_windows = 1
 
 	windows = /obj/window/auto
@@ -199,7 +199,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_centcom = /area/shuttle/escape/centcom/cogmap
 	escape_transit = /area/shuttle/escape/transit/cogmap
 	escape_station = /area/shuttle/escape/station/cogmap
-	escape_define = SHUTTLE_COGMAP
+	escape_def = SHUTTLE_SOUTH
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap
@@ -230,7 +230,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_centcom = /area/shuttle/escape/centcom/cogmap
 	escape_transit = /area/shuttle/escape/transit/cogmap
 	escape_station = /area/shuttle/escape/station/cogmap
-	escape_define = SHUTTLE_COGMAP
+	escape_def = SHUTTLE_SOUTH
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap
@@ -261,7 +261,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_centcom = /area/shuttle/escape/centcom/cogmap2
 	escape_transit = /area/shuttle/escape/transit/cogmap2
 	escape_station = /area/shuttle/escape/station/cogmap2
-	escape_define = SHUTTLE_COGMAP2
+	escape_def = SHUTTLE_EAST
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap2
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap2
@@ -295,7 +295,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_centcom = /area/shuttle/escape/centcom/destiny
 	escape_transit = /area/shuttle/escape/transit/destiny
 	escape_station = /area/shuttle/escape/station/destiny
-	escape_define = SHUTTLE_DESTINY
+	escape_def = SHUTTLE_NORTH
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/destiny
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/destiny
@@ -356,7 +356,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_centcom = /area/shuttle/escape/centcom/cogmap2
 	escape_transit = /area/shuttle/escape/transit/cogmap2
 	escape_station = /area/shuttle/escape/station/cogmap2
-	escape_define = SHUTTLE_COGMAP2
+	escape_def = SHUTTLE_EAST
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap
@@ -420,7 +420,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_centcom = /area/shuttle/escape/centcom/manta
 	escape_transit = /area/shuttle/escape/transit/manta
 	escape_station = /area/shuttle/escape/station/manta
-	escape_define = SHUTTLE_MANTA
+	escape_def = SHUTTLE_MANTA
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap/manta
@@ -458,7 +458,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_centcom = /area/shuttle/escape/centcom/cogmap2
 	escape_transit = /area/shuttle/escape/transit/cogmap2
 	escape_station = /area/shuttle/escape/station/cogmap2
-	escape_define = SHUTTLE_COGMAP2
+	escape_def = SHUTTLE_EAST
 
 /datum/map_settings/trunkmap
 	name = "TRUNKMAP"
@@ -466,7 +466,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_centcom = /area/shuttle/escape/centcom/destiny
 	escape_transit = /area/shuttle/escape/transit/destiny
 	escape_station = /area/shuttle/escape/station/destiny
-	escape_define = SHUTTLE_DESTINY
+	escape_def = SHUTTLE_NORTH
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/destiny
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/destiny
@@ -489,7 +489,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_centcom = /area/shuttle/escape/centcom/cogmap2
 	escape_transit = /area/shuttle/escape/transit/cogmap2
 	escape_station = /area/shuttle/escape/station/cogmap2
-	escape_define = SHUTTLE_COGMAP2
+	escape_def = SHUTTLE_EAST
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap
@@ -531,7 +531,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_centcom = /area/shuttle/escape/centcom/cogmap2
 	escape_transit = /area/shuttle/escape/transit/cogmap2
 	escape_station = /area/shuttle/escape/station/cogmap2
-	escape_define = SHUTTLE_COGMAP2
+	escape_def = SHUTTLE_EAST
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap
@@ -580,7 +580,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_centcom = /area/shuttle/escape/centcom/cogmap2
 	escape_transit = /area/shuttle/escape/transit/cogmap2
 	escape_station = /area/shuttle/escape/station/cogmap2
-	escape_define = SHUTTLE_COGMAP2
+	escape_def = SHUTTLE_EAST
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap
@@ -625,7 +625,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_centcom = /area/shuttle/escape/centcom/cogmap2
 	escape_transit = /area/shuttle/escape/transit/cogmap2
 	escape_station = /area/shuttle/escape/station/cogmap2
-	escape_define = SHUTTLE_COGMAP2
+	escape_def = SHUTTLE_EAST
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap
@@ -667,7 +667,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_centcom = /area/shuttle/escape/centcom/destiny
 	escape_transit = /area/shuttle/escape/transit/destiny
 	escape_station = /area/shuttle/escape/station/destiny
-	escape_define = SHUTTLE_DESTINY
+	escape_def = SHUTTLE_NORTH
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/destiny
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/destiny
@@ -704,7 +704,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_centcom = /area/shuttle/escape/centcom/cogmap2
 	escape_transit = /area/shuttle/escape/transit/cogmap2
 	escape_station = /area/shuttle/escape/station/cogmap2
-	escape_define = SHUTTLE_COGMAP2
+	escape_def = SHUTTLE_EAST
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap2
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap2
@@ -746,7 +746,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_centcom = /area/shuttle/escape/centcom/cogmap
 	escape_transit = /area/shuttle/escape/transit/cogmap
 	escape_station = /area/shuttle/escape/station/cogmap
-	escape_define = SHUTTLE_COGMAP
+	escape_def = SHUTTLE_SOUTH
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap
@@ -784,7 +784,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_centcom = /area/shuttle/escape/centcom/sealab
 	escape_transit = /area/shuttle/escape/transit/sealab
 	escape_station = /area/shuttle/escape/station/sealab
-	escape_define = SHUTTLE_OSHAN
+	escape_def = SHUTTLE_OSHAN
 	shuttle_map_turf = /turf/space/fluid
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
@@ -826,7 +826,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_centcom = /area/shuttle/escape/centcom/destiny
 	escape_transit = /area/shuttle/escape/transit/destiny
 	escape_station = /area/shuttle/escape/station/destiny
-	escape_define = SHUTTLE_DESTINY
+	escape_def = SHUTTLE_NORTH
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap

--- a/code/map.dm
+++ b/code/map.dm
@@ -40,17 +40,6 @@ var/global/list/mapNames = list(
 	"blank_underwater" =  list("id" = "BLANK_UNDERWATER", "settings" = "", "playerPickable" = 0)
 )
 
-var/global/list/map_escape_pod_dirs = list(
-	SHUTTLE_SOUTH = SOUTH,
-	SHUTTLE_EAST = EAST,
-	SHUTTLE_WEST = WEST,
-	SHUTTLE_DONUT3 = NORTH,
-	SHUTTLE_MANTA = NORTH,
-	SHUTTLE_OSHAN = EAST,
-	SHUTTLE_NORTH = NORTH,
-	SHUTTLE_NODEF = SOUTH
-)
-
 /obj/landmark/map
 	name = "map_setting"
 	icon_state = "x3"
@@ -108,6 +97,8 @@ var/global/list/map_escape_pod_dirs = list(
 	var/escape_transit = /area/shuttle/escape/transit
 	var/escape_station = /area/shuttle/escape/station
 	var/escape_def = SHUTTLE_NODEF
+	var/escape_dir = SOUTH
+
 	var/shuttle_map_turf = /turf/space
 
 	var/merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom
@@ -148,6 +139,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_transit = /area/shuttle/escape/transit/donut2
 	escape_station = /area/shuttle/escape/station/donut2
 	escape_def = SHUTTLE_WEST
+	escape_dir = WEST
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/donut2
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/donut2
@@ -165,6 +157,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_transit = /area/shuttle/escape/transit/donut3
 	escape_station = /area/shuttle/escape/station/donut3
 	escape_def = SHUTTLE_DONUT3
+	escape_dir = NORTH
 	auto_windows = 1
 
 	windows = /obj/window/auto
@@ -200,6 +193,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_transit = /area/shuttle/escape/transit/cogmap
 	escape_station = /area/shuttle/escape/station/cogmap
 	escape_def = SHUTTLE_SOUTH
+	escape_dir = SOUTH
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap
@@ -231,6 +225,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_transit = /area/shuttle/escape/transit/cogmap
 	escape_station = /area/shuttle/escape/station/cogmap
 	escape_def = SHUTTLE_SOUTH
+	escape_dir = SOUTH
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap
@@ -262,6 +257,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_transit = /area/shuttle/escape/transit/cogmap2
 	escape_station = /area/shuttle/escape/station/cogmap2
 	escape_def = SHUTTLE_EAST
+	escape_dir = EAST
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap2
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap2
@@ -296,6 +292,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_transit = /area/shuttle/escape/transit/destiny
 	escape_station = /area/shuttle/escape/station/destiny
 	escape_def = SHUTTLE_NORTH
+	escape_dir = NORTH
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/destiny
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/destiny
@@ -357,6 +354,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_transit = /area/shuttle/escape/transit/cogmap2
 	escape_station = /area/shuttle/escape/station/cogmap2
 	escape_def = SHUTTLE_EAST
+	escape_dir = EAST
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap
@@ -421,6 +419,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_transit = /area/shuttle/escape/transit/manta
 	escape_station = /area/shuttle/escape/station/manta
 	escape_def = SHUTTLE_MANTA
+	escape_dir = NORTH
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap/manta
@@ -459,6 +458,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_transit = /area/shuttle/escape/transit/cogmap2
 	escape_station = /area/shuttle/escape/station/cogmap2
 	escape_def = SHUTTLE_EAST
+	escape_dir = EAST
 
 /datum/map_settings/trunkmap
 	name = "TRUNKMAP"
@@ -467,6 +467,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_transit = /area/shuttle/escape/transit/destiny
 	escape_station = /area/shuttle/escape/station/destiny
 	escape_def = SHUTTLE_NORTH
+	escape_dir = NORTH
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/destiny
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/destiny
@@ -490,6 +491,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_transit = /area/shuttle/escape/transit/cogmap2
 	escape_station = /area/shuttle/escape/station/cogmap2
 	escape_def = SHUTTLE_EAST
+	escape_dir = EAST
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap
@@ -532,6 +534,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_transit = /area/shuttle/escape/transit/cogmap2
 	escape_station = /area/shuttle/escape/station/cogmap2
 	escape_def = SHUTTLE_EAST
+	escape_dir = EAST
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap
@@ -581,6 +584,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_transit = /area/shuttle/escape/transit/cogmap2
 	escape_station = /area/shuttle/escape/station/cogmap2
 	escape_def = SHUTTLE_EAST
+	escape_dir = EAST
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap
@@ -626,6 +630,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_transit = /area/shuttle/escape/transit/cogmap2
 	escape_station = /area/shuttle/escape/station/cogmap2
 	escape_def = SHUTTLE_EAST
+	escape_dir = EAST
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap
@@ -668,6 +673,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_transit = /area/shuttle/escape/transit/destiny
 	escape_station = /area/shuttle/escape/station/destiny
 	escape_def = SHUTTLE_NORTH
+	escape_dir = NORTH
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/destiny
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/destiny
@@ -705,6 +711,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_transit = /area/shuttle/escape/transit/cogmap2
 	escape_station = /area/shuttle/escape/station/cogmap2
 	escape_def = SHUTTLE_EAST
+	escape_dir = EAST
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap2
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap2
@@ -747,6 +754,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_transit = /area/shuttle/escape/transit/cogmap
 	escape_station = /area/shuttle/escape/station/cogmap
 	escape_def = SHUTTLE_SOUTH
+	escape_dir = SOUTH
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap
@@ -785,6 +793,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_transit = /area/shuttle/escape/transit/sealab
 	escape_station = /area/shuttle/escape/station/sealab
 	escape_def = SHUTTLE_OSHAN
+	escape_dir = EAST
 	shuttle_map_turf = /turf/space/fluid
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
@@ -827,6 +836,7 @@ var/global/list/map_escape_pod_dirs = list(
 	escape_transit = /area/shuttle/escape/transit/destiny
 	escape_station = /area/shuttle/escape/station/destiny
 	escape_def = SHUTTLE_NORTH
+	escape_dir = NORTH
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap

--- a/code/map.dm
+++ b/code/map.dm
@@ -97,6 +97,7 @@ var/global/list/mapNames = list(
 	var/escape_transit = /area/shuttle/escape/transit
 	var/escape_station = /area/shuttle/escape/station
 	var/escape_dir = SOUTH
+	var/escape_define = SHUTTLE_NODEF
 	var/shuttle_map_turf = /turf/space
 
 	var/merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom
@@ -137,6 +138,7 @@ var/global/list/mapNames = list(
 	escape_transit = /area/shuttle/escape/transit/donut2
 	escape_station = /area/shuttle/escape/station/donut2
 	escape_dir = WEST // FUCK YOU DONUT2 I WAS NEARLY DONE AND THEN YOU THROW THIS AT ME AND NOW I HAVE TO ADD YOUR GODDAMN WEST-FACING SHUTTLE TO THE MAP ARGH *SCREAM *SCREAM *SCREAM
+	escape_define = SHUTTLE_DONUT2
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/donut2
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/donut2
@@ -154,6 +156,7 @@ var/global/list/mapNames = list(
 	escape_transit = /area/shuttle/escape/transit/donut3
 	escape_station = /area/shuttle/escape/station/donut3
 	escape_dir = NORTH
+	escape_define = SHUTTLE_DONUT3
 	auto_windows = 1
 
 	windows = /obj/window/auto
@@ -188,6 +191,7 @@ var/global/list/mapNames = list(
 	escape_centcom = /area/shuttle/escape/centcom/cogmap
 	escape_transit = /area/shuttle/escape/transit/cogmap
 	escape_station = /area/shuttle/escape/station/cogmap
+	escape_define = SHUTTLE_COGMAP
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap
@@ -218,6 +222,7 @@ var/global/list/mapNames = list(
 	escape_centcom = /area/shuttle/escape/centcom/cogmap
 	escape_transit = /area/shuttle/escape/transit/cogmap
 	escape_station = /area/shuttle/escape/station/cogmap
+	escape_define = SHUTTLE_COGMAP
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap
@@ -248,6 +253,7 @@ var/global/list/mapNames = list(
 	escape_centcom = /area/shuttle/escape/centcom/cogmap2
 	escape_transit = /area/shuttle/escape/transit/cogmap2
 	escape_station = /area/shuttle/escape/station/cogmap2
+	escape_define = SHUTTLE_COGMAP2
 	escape_dir = EAST
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap2
@@ -282,6 +288,7 @@ var/global/list/mapNames = list(
 	escape_centcom = /area/shuttle/escape/centcom/destiny
 	escape_transit = /area/shuttle/escape/transit/destiny
 	escape_station = /area/shuttle/escape/station/destiny
+	escape_define = SHUTTLE_DESTINY
 	escape_dir = NORTH
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/destiny
@@ -343,6 +350,7 @@ var/global/list/mapNames = list(
 	escape_centcom = /area/shuttle/escape/centcom/cogmap2
 	escape_transit = /area/shuttle/escape/transit/cogmap2
 	escape_station = /area/shuttle/escape/station/cogmap2
+	escape_define = SHUTTLE_COGMAP2
 	escape_dir = EAST
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
@@ -407,6 +415,7 @@ var/global/list/mapNames = list(
 	escape_centcom = /area/shuttle/escape/centcom/manta
 	escape_transit = /area/shuttle/escape/transit/manta
 	escape_station = /area/shuttle/escape/station/manta
+	escape_define = SHUTTLE_MANTA
 	escape_dir = NORTH
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
@@ -445,6 +454,7 @@ var/global/list/mapNames = list(
 	escape_centcom = /area/shuttle/escape/centcom/cogmap2
 	escape_transit = /area/shuttle/escape/transit/cogmap2
 	escape_station = /area/shuttle/escape/station/cogmap2
+	escape_define = SHUTTLE_COGMAP2
 	escape_dir = EAST
 
 /datum/map_settings/trunkmap
@@ -453,6 +463,7 @@ var/global/list/mapNames = list(
 	escape_centcom = /area/shuttle/escape/centcom/destiny
 	escape_transit = /area/shuttle/escape/transit/destiny
 	escape_station = /area/shuttle/escape/station/destiny
+	escape_define = SHUTTLE_DESTINY
 	escape_dir = NORTH
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/destiny
@@ -476,6 +487,7 @@ var/global/list/mapNames = list(
 	escape_centcom = /area/shuttle/escape/centcom/cogmap2
 	escape_transit = /area/shuttle/escape/transit/cogmap2
 	escape_station = /area/shuttle/escape/station/cogmap2
+	escape_define = SHUTTLE_COGMAP2
 	escape_dir = EAST
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
@@ -518,6 +530,7 @@ var/global/list/mapNames = list(
 	escape_centcom = /area/shuttle/escape/centcom/cogmap2
 	escape_transit = /area/shuttle/escape/transit/cogmap2
 	escape_station = /area/shuttle/escape/station/cogmap2
+	escape_define = SHUTTLE_COGMAP2
 	escape_dir = EAST
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
@@ -567,6 +580,7 @@ var/global/list/mapNames = list(
 	escape_centcom = /area/shuttle/escape/centcom/cogmap2
 	escape_transit = /area/shuttle/escape/transit/cogmap2
 	escape_station = /area/shuttle/escape/station/cogmap2
+	escape_define = SHUTTLE_COGMAP2
 	escape_dir = EAST
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
@@ -612,6 +626,7 @@ var/global/list/mapNames = list(
 	escape_centcom = /area/shuttle/escape/centcom/cogmap2
 	escape_transit = /area/shuttle/escape/transit/cogmap2
 	escape_station = /area/shuttle/escape/station/cogmap2
+	escape_define = SHUTTLE_COGMAP2
 	escape_dir = EAST
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
@@ -654,6 +669,7 @@ var/global/list/mapNames = list(
 	escape_centcom = /area/shuttle/escape/centcom/destiny
 	escape_transit = /area/shuttle/escape/transit/destiny
 	escape_station = /area/shuttle/escape/station/destiny
+	escape_define = SHUTTLE_DESTINY
 	escape_dir = NORTH
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/destiny
@@ -691,6 +707,7 @@ var/global/list/mapNames = list(
 	escape_centcom = /area/shuttle/escape/centcom/cogmap2
 	escape_transit = /area/shuttle/escape/transit/cogmap2
 	escape_station = /area/shuttle/escape/station/cogmap2
+	escape_define = SHUTTLE_COGMAP2
 	escape_dir = EAST
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap2
@@ -733,6 +750,7 @@ var/global/list/mapNames = list(
 	escape_centcom = /area/shuttle/escape/centcom/cogmap
 	escape_transit = /area/shuttle/escape/transit/cogmap
 	escape_station = /area/shuttle/escape/station/cogmap
+	escape_define = SHUTTLE_COGMAP
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap
@@ -770,6 +788,8 @@ var/global/list/mapNames = list(
 	escape_centcom = /area/shuttle/escape/centcom/sealab
 	escape_transit = /area/shuttle/escape/transit/sealab
 	escape_station = /area/shuttle/escape/station/sealab
+	escape_dir = EAST
+	escape_define = SHUTTLE_OSHAN
 	shuttle_map_turf = /turf/space/fluid
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
@@ -811,6 +831,7 @@ var/global/list/mapNames = list(
 	escape_centcom = /area/shuttle/escape/centcom/destiny
 	escape_transit = /area/shuttle/escape/transit/destiny
 	escape_station = /area/shuttle/escape/station/destiny
+	escape_define = SHUTTLE_DESTINY
 	escape_dir = NORTH
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap

--- a/code/map.dm
+++ b/code/map.dm
@@ -40,6 +40,17 @@ var/global/list/mapNames = list(
 	"blank_underwater" =  list("id" = "BLANK_UNDERWATER", "settings" = "", "playerPickable" = 0)
 )
 
+var/global/list/map_escape_pod_dirs = list(
+	SHUTTLE_COGMAP = SOUTH,
+	SHUTTLE_COGMAP2 = EAST,
+	SHUTTLE_DONUT2 = WEST,
+	SHUTTLE_DONUT3 = NORTH,
+	SHUTTLE_MANTA = NORTH,
+	SHUTTLE_OSHAN = EAST,
+	SHUTTLE_DESTINY = NORTH,
+	SHUTTLE_NODEF = SOUTH
+)
+
 /obj/landmark/map
 	name = "map_setting"
 	icon_state = "x3"
@@ -96,7 +107,6 @@ var/global/list/mapNames = list(
 	var/escape_centcom = /area/shuttle/escape/centcom
 	var/escape_transit = /area/shuttle/escape/transit
 	var/escape_station = /area/shuttle/escape/station
-	var/escape_dir = SOUTH
 	var/escape_define = SHUTTLE_NODEF
 	var/shuttle_map_turf = /turf/space
 
@@ -137,7 +147,6 @@ var/global/list/mapNames = list(
 	escape_centcom = /area/shuttle/escape/centcom/donut2
 	escape_transit = /area/shuttle/escape/transit/donut2
 	escape_station = /area/shuttle/escape/station/donut2
-	escape_dir = WEST // FUCK YOU DONUT2 I WAS NEARLY DONE AND THEN YOU THROW THIS AT ME AND NOW I HAVE TO ADD YOUR GODDAMN WEST-FACING SHUTTLE TO THE MAP ARGH *SCREAM *SCREAM *SCREAM
 	escape_define = SHUTTLE_DONUT2
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/donut2
@@ -155,7 +164,6 @@ var/global/list/mapNames = list(
 	escape_centcom = /area/shuttle/escape/centcom/donut3
 	escape_transit = /area/shuttle/escape/transit/donut3
 	escape_station = /area/shuttle/escape/station/donut3
-	escape_dir = NORTH
 	escape_define = SHUTTLE_DONUT3
 	auto_windows = 1
 
@@ -254,7 +262,6 @@ var/global/list/mapNames = list(
 	escape_transit = /area/shuttle/escape/transit/cogmap2
 	escape_station = /area/shuttle/escape/station/cogmap2
 	escape_define = SHUTTLE_COGMAP2
-	escape_dir = EAST
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap2
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap2
@@ -289,7 +296,6 @@ var/global/list/mapNames = list(
 	escape_transit = /area/shuttle/escape/transit/destiny
 	escape_station = /area/shuttle/escape/station/destiny
 	escape_define = SHUTTLE_DESTINY
-	escape_dir = NORTH
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/destiny
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/destiny
@@ -351,7 +357,6 @@ var/global/list/mapNames = list(
 	escape_transit = /area/shuttle/escape/transit/cogmap2
 	escape_station = /area/shuttle/escape/station/cogmap2
 	escape_define = SHUTTLE_COGMAP2
-	escape_dir = EAST
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap
@@ -416,7 +421,6 @@ var/global/list/mapNames = list(
 	escape_transit = /area/shuttle/escape/transit/manta
 	escape_station = /area/shuttle/escape/station/manta
 	escape_define = SHUTTLE_MANTA
-	escape_dir = NORTH
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap/manta
@@ -455,7 +459,6 @@ var/global/list/mapNames = list(
 	escape_transit = /area/shuttle/escape/transit/cogmap2
 	escape_station = /area/shuttle/escape/station/cogmap2
 	escape_define = SHUTTLE_COGMAP2
-	escape_dir = EAST
 
 /datum/map_settings/trunkmap
 	name = "TRUNKMAP"
@@ -464,7 +467,6 @@ var/global/list/mapNames = list(
 	escape_transit = /area/shuttle/escape/transit/destiny
 	escape_station = /area/shuttle/escape/station/destiny
 	escape_define = SHUTTLE_DESTINY
-	escape_dir = NORTH
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/destiny
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/destiny
@@ -488,7 +490,6 @@ var/global/list/mapNames = list(
 	escape_transit = /area/shuttle/escape/transit/cogmap2
 	escape_station = /area/shuttle/escape/station/cogmap2
 	escape_define = SHUTTLE_COGMAP2
-	escape_dir = EAST
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap
@@ -531,7 +532,6 @@ var/global/list/mapNames = list(
 	escape_transit = /area/shuttle/escape/transit/cogmap2
 	escape_station = /area/shuttle/escape/station/cogmap2
 	escape_define = SHUTTLE_COGMAP2
-	escape_dir = EAST
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap
@@ -581,7 +581,6 @@ var/global/list/mapNames = list(
 	escape_transit = /area/shuttle/escape/transit/cogmap2
 	escape_station = /area/shuttle/escape/station/cogmap2
 	escape_define = SHUTTLE_COGMAP2
-	escape_dir = EAST
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap
@@ -627,7 +626,6 @@ var/global/list/mapNames = list(
 	escape_transit = /area/shuttle/escape/transit/cogmap2
 	escape_station = /area/shuttle/escape/station/cogmap2
 	escape_define = SHUTTLE_COGMAP2
-	escape_dir = EAST
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap
@@ -670,7 +668,6 @@ var/global/list/mapNames = list(
 	escape_transit = /area/shuttle/escape/transit/destiny
 	escape_station = /area/shuttle/escape/station/destiny
 	escape_define = SHUTTLE_DESTINY
-	escape_dir = NORTH
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/destiny
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/destiny
@@ -708,7 +705,6 @@ var/global/list/mapNames = list(
 	escape_transit = /area/shuttle/escape/transit/cogmap2
 	escape_station = /area/shuttle/escape/station/cogmap2
 	escape_define = SHUTTLE_COGMAP2
-	escape_dir = EAST
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap2
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap2
@@ -788,7 +784,6 @@ var/global/list/mapNames = list(
 	escape_centcom = /area/shuttle/escape/centcom/sealab
 	escape_transit = /area/shuttle/escape/transit/sealab
 	escape_station = /area/shuttle/escape/station/sealab
-	escape_dir = EAST
 	escape_define = SHUTTLE_OSHAN
 	shuttle_map_turf = /turf/space/fluid
 
@@ -832,7 +827,6 @@ var/global/list/mapNames = list(
 	escape_transit = /area/shuttle/escape/transit/destiny
 	escape_station = /area/shuttle/escape/station/destiny
 	escape_define = SHUTTLE_DESTINY
-	escape_dir = NORTH
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/cogmap
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/cogmap

--- a/code/modules/transport/pods/ships.dm
+++ b/code/modules/transport/pods/ships.dm
@@ -1786,8 +1786,7 @@ obj/machinery/vehicle/miniputt/pilot
 			P.set_loc(get_turf(src))
 			var/turf/T = pick_landmark(LANDMARK_ESCAPE_POD_SUCCESS)
 			P.target = T
-			var/escape_define = map_settings ? map_settings.escape_define : SHUTTLE_NODEF
-			src.dir = map_escape_pod_dirs[escape_define]
+			src.dir = map_settings ? map_escape_pod_dirs[map_settings.escape_dir] : map_escape_pod_dirs[SHUTTLE_NODEF]
 			src.set_loc(T)
 			logTheThing("station", src, null, "creates an escape portal at [log_loc(src)].")
 

--- a/code/modules/transport/pods/ships.dm
+++ b/code/modules/transport/pods/ships.dm
@@ -1786,7 +1786,7 @@ obj/machinery/vehicle/miniputt/pilot
 			P.set_loc(get_turf(src))
 			var/turf/T = pick_landmark(LANDMARK_ESCAPE_POD_SUCCESS)
 			P.target = T
-			src.dir = map_settings ? map_escape_pod_dirs[map_settings.escape_dir] : map_escape_pod_dirs[SHUTTLE_NODEF]
+			src.dir = map_settings ? map_escape_pod_dirs[map_settings.escape_def] : map_escape_pod_dirs[SHUTTLE_NODEF]
 			src.set_loc(T)
 			logTheThing("station", src, null, "creates an escape portal at [log_loc(src)].")
 

--- a/code/modules/transport/pods/ships.dm
+++ b/code/modules/transport/pods/ships.dm
@@ -1785,10 +1785,9 @@ obj/machinery/vehicle/miniputt/pilot
 			var/obj/portal/P = unpool(/obj/portal)
 			P.set_loc(get_turf(src))
 			var/turf/T = pick_landmark(LANDMARK_ESCAPE_POD_SUCCESS)
-			src.dir = landmarks[LANDMARK_ESCAPE_POD_SUCCESS][T]
 			P.target = T
+			src.dir = map_settings ? map_settings.escape_dir : EAST
 			src.set_loc(T)
-
 			logTheThing("station", src, null, "creates an escape portal at [log_loc(src)].")
 
 

--- a/code/modules/transport/pods/ships.dm
+++ b/code/modules/transport/pods/ships.dm
@@ -1786,7 +1786,7 @@ obj/machinery/vehicle/miniputt/pilot
 			P.set_loc(get_turf(src))
 			var/turf/T = pick_landmark(LANDMARK_ESCAPE_POD_SUCCESS)
 			P.target = T
-			src.dir = map_settings ? map_escape_pod_dirs[map_settings.escape_def] : map_escape_pod_dirs[SHUTTLE_NODEF]
+			src.dir = map_settings ? map_settings.escape_dir : SOUTH
 			src.set_loc(T)
 			logTheThing("station", src, null, "creates an escape portal at [log_loc(src)].")
 

--- a/code/modules/transport/pods/ships.dm
+++ b/code/modules/transport/pods/ships.dm
@@ -1786,7 +1786,8 @@ obj/machinery/vehicle/miniputt/pilot
 			P.set_loc(get_turf(src))
 			var/turf/T = pick_landmark(LANDMARK_ESCAPE_POD_SUCCESS)
 			P.target = T
-			src.dir = map_settings ? map_settings.escape_dir : EAST
+			var/escape_define = map_settings ? map_settings.escape_define : SHUTTLE_NODEF
+			src.dir = map_escape_pod_dirs[escape_define]
 			src.set_loc(T)
 			logTheThing("station", src, null, "creates an escape portal at [log_loc(src)].")
 

--- a/code/modules/transport/shuttle/shuttle_controller.dm
+++ b/code/modules/transport/shuttle/shuttle_controller.dm
@@ -130,7 +130,8 @@ datum/shuttle_controller
 							if (T.x > eastBound) eastBound = T.x
 
 						// hey you, get out of the way!
-						var/shuttle_dir = map_settings ? map_settings.escape_dir : EAST // default to cog2 direction because EH
+						var/escape_define = map_settings ? map_settings.escape_define : SHUTTLE_NODEF
+						var/shuttle_dir = map_escape_pod_dirs[escape_define]
 						for (var/turf/T in dstturfs)
 							// find the turf to move things to
 							var/turf/D = locate(shuttle_dir == EAST ? eastBound + 1 : T.x, // X

--- a/code/modules/transport/shuttle/shuttle_controller.dm
+++ b/code/modules/transport/shuttle/shuttle_controller.dm
@@ -130,7 +130,7 @@ datum/shuttle_controller
 							if (T.x > eastBound) eastBound = T.x
 
 						// hey you, get out of the way!
-						var/shuttle_dir = map_settings ? map_settings.escape_def : SHUTTLE_NODEF
+						var/shuttle_dir = map_settings ? map_settings.escape_dir : SOUTH
 						for (var/turf/T in dstturfs)
 							// find the turf to move things to
 							var/turf/D = locate(shuttle_dir == EAST ? eastBound + 1 : T.x, // X

--- a/code/modules/transport/shuttle/shuttle_controller.dm
+++ b/code/modules/transport/shuttle/shuttle_controller.dm
@@ -130,7 +130,7 @@ datum/shuttle_controller
 							if (T.x > eastBound) eastBound = T.x
 
 						// hey you, get out of the way!
-						var/shuttle_dir = map_settings ? map_settings.escape_dir : SHUTTLE_NODEF
+						var/shuttle_dir = map_settings ? map_settings.escape_def : SHUTTLE_NODEF
 						for (var/turf/T in dstturfs)
 							// find the turf to move things to
 							var/turf/D = locate(shuttle_dir == EAST ? eastBound + 1 : T.x, // X
@@ -254,7 +254,7 @@ datum/shuttle_controller
 						if (particle_spawn)
 							particle_spawn.start_particles()
 
-						var/escape_def = map_settings ? map_settings.escape_dir : SHUTTLE_NODEF
+						var/escape_def = map_settings ? map_settings.escape_def : SHUTTLE_NODEF
 						for (var/turf/T in landmarks[LANDMARK_ESCAPE_POD_SUCCESS])
 							if (landmarks[LANDMARK_ESCAPE_POD_SUCCESS][T] != escape_def)
 								landmarks[LANDMARK_ESCAPE_POD_SUCCESS] -= T //leave behind only landmarks for the map's escape shuttle

--- a/code/modules/transport/shuttle/shuttle_controller.dm
+++ b/code/modules/transport/shuttle/shuttle_controller.dm
@@ -130,8 +130,7 @@ datum/shuttle_controller
 							if (T.x > eastBound) eastBound = T.x
 
 						// hey you, get out of the way!
-						var/escape_define = map_settings ? map_settings.escape_define : SHUTTLE_NODEF
-						var/shuttle_dir = map_escape_pod_dirs[escape_define]
+						var/shuttle_dir = map_settings ? map_settings.escape_dir : SHUTTLE_NODEF
 						for (var/turf/T in dstturfs)
 							// find the turf to move things to
 							var/turf/D = locate(shuttle_dir == EAST ? eastBound + 1 : T.x, // X
@@ -255,7 +254,7 @@ datum/shuttle_controller
 						if (particle_spawn)
 							particle_spawn.start_particles()
 
-						var/escape_def = map_settings ? map_settings.escape_define : SHUTTLE_NODEF
+						var/escape_def = map_settings ? map_settings.escape_dir : SHUTTLE_NODEF
 						for (var/turf/T in landmarks[LANDMARK_ESCAPE_POD_SUCCESS])
 							if (landmarks[LANDMARK_ESCAPE_POD_SUCCESS][T] != escape_def)
 								landmarks[LANDMARK_ESCAPE_POD_SUCCESS] -= T //leave behind only landmarks for the map's escape shuttle

--- a/code/modules/transport/shuttle/shuttle_controller.dm
+++ b/code/modules/transport/shuttle/shuttle_controller.dm
@@ -254,10 +254,10 @@ datum/shuttle_controller
 						if (particle_spawn)
 							particle_spawn.start_particles()
 
-						var/shuttle_dir = map_settings ? map_settings.escape_dir : EAST // default to cog2 direction because EH
+						var/escape_def = map_settings ? map_settings.escape_define : SHUTTLE_NODEF
 						for (var/turf/T in landmarks[LANDMARK_ESCAPE_POD_SUCCESS])
-							if (landmarks[LANDMARK_ESCAPE_POD_SUCCESS][T] != shuttle_dir)
-								landmarks[LANDMARK_ESCAPE_POD_SUCCESS] -= T //leave behind only landmarks that match our dir
+							if (landmarks[LANDMARK_ESCAPE_POD_SUCCESS][T] != escape_def)
+								landmarks[LANDMARK_ESCAPE_POD_SUCCESS] -= T //leave behind only landmarks for the map's escape shuttle
 
 						DEBUG_MESSAGE("Now moving shuttle!")
 						start_location.move_contents_to(end_location, map_turf)

--- a/code/obj/landmark.dm
+++ b/code/obj/landmark.dm
@@ -61,8 +61,9 @@ var/global/list/job_start_locations = list()
 /obj/landmark/escape_pod_succ
 	name = LANDMARK_ESCAPE_POD_SUCCESS
 	icon_state = "xp"
+	var/shuttle = SHUTTLE_NODEF
 	New()
-		src.data = src.dir // save dir
+		src.data = src.shuttle// save dir
 		..()
 
 /obj/landmark/tutorial_start

--- a/code/obj/landmark.dm
+++ b/code/obj/landmark.dm
@@ -62,6 +62,7 @@ var/global/list/job_start_locations = list()
 	name = LANDMARK_ESCAPE_POD_SUCCESS
 	icon_state = "xp"
 	var/shuttle = SHUTTLE_NODEF
+	
 	New()
 		src.data = src.shuttle// save dir
 		..()

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -68817,7 +68817,7 @@
 /area/shuttle/escape/transit/destiny)
 "dkP" = (
 /obj/landmark/escape_pod_succ{
-	shuttle = SHUTTLE_COGMAP
+	shuttle = SHUTTLE_SOUTH
 	},
 /turf/space/shuttle_transit,
 /area/shuttle_transit_space)
@@ -68838,7 +68838,7 @@
 "dkT" = (
 /obj/landmark/escape_pod_succ{
 	dir = 8;
-	shuttle = SHUTTLE_DONUT2
+	shuttle = SHUTTLE_WEST
 	},
 /turf/space/shuttle_transit,
 /area/shuttle_transit_space/east)
@@ -68851,7 +68851,7 @@
 "dkW" = (
 /obj/landmark/escape_pod_succ{
 	dir = 1;
-	shuttle = SHUTTLE_DESTINY
+	shuttle = SHUTTLE_NORTH
 	},
 /turf/space/shuttle_transit,
 /area/shuttle_transit_space/south)
@@ -85414,7 +85414,7 @@
 "qDq" = (
 /obj/landmark/escape_pod_succ{
 	dir = 4;
-	shuttle = SHUTTLE_COGMAP2
+	shuttle = SHUTTLE_EAST
 	},
 /turf/space/shuttle_transit,
 /area/shuttle_transit_space/west)

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -68816,7 +68816,9 @@
 /turf/space/shuttle_transit,
 /area/shuttle/escape/transit/destiny)
 "dkP" = (
-/obj/landmark/escape_pod_succ,
+/obj/landmark/escape_pod_succ{
+	shuttle = SHUTTLE_COGMAP
+	},
 /turf/space/shuttle_transit,
 /area/shuttle_transit_space)
 "dkQ" = (
@@ -68835,7 +68837,8 @@
 /area/shuttle/escape/transit/cogmap)
 "dkT" = (
 /obj/landmark/escape_pod_succ{
-	dir = 8
+	dir = 8;
+	shuttle = SHUTTLE_DONUT2
 	},
 /turf/space/shuttle_transit,
 /area/shuttle_transit_space/east)
@@ -68847,7 +68850,8 @@
 /area/shuttle_particle_spawn/east)
 "dkW" = (
 /obj/landmark/escape_pod_succ{
-	dir = 1
+	dir = 1;
+	shuttle = SHUTTLE_DESTINY
 	},
 /turf/space/shuttle_transit,
 /area/shuttle_transit_space/south)
@@ -69092,7 +69096,8 @@
 /area/shuttle/escape/transit/battle_shuttle)
 "dlJ" = (
 /obj/landmark/escape_pod_succ{
-	dir = 4
+	dir = 4;
+	shuttle = SHUTTLE_OSHAN
 	},
 /turf/space/shuttle_transit,
 /area/shuttle_transit_space/west)
@@ -85406,6 +85411,13 @@
 	icon_state = "floor2"
 	},
 /area/shuttle/merchant_shuttle/right_centcom/destiny)
+"qDq" = (
+/obj/landmark/escape_pod_succ{
+	dir = 4;
+	shuttle = SHUTTLE_COGMAP2
+	},
+/turf/space/shuttle_transit,
+/area/shuttle_transit_space/west)
 "qGG" = (
 /obj/machinery/light,
 /turf/unsimulated/floor/shuttle,
@@ -86183,6 +86195,13 @@
 /area/centcom/offices{
 	icon_state = "blue"
 	})
+"umY" = (
+/obj/landmark/escape_pod_succ{
+	dir = 1;
+	shuttle = SHUTTLE_DONUT3
+	},
+/turf/space/shuttle_transit,
+/area/shuttle_transit_space/south)
 "unN" = (
 /turf/space,
 /turf/unsimulated/floor/engine/caution/corner{
@@ -149732,7 +149751,7 @@ dkH
 dkH
 dkH
 dkH
-dkW
+umY
 dkH
 dkH
 dkH
@@ -155470,7 +155489,7 @@ dkH
 dkH
 dkH
 dkH
-dkW
+umY
 dkH
 dkH
 dkH
@@ -168706,7 +168725,7 @@ dly
 dly
 dly
 dly
-dlJ
+qDq
 dly
 dly
 dly
@@ -168720,7 +168739,7 @@ dly
 dly
 dly
 dly
-dlJ
+qDq
 dly
 dly
 dly


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

As noted in issue #441, escape pods sometimes choose the wrong escape pod landmark to warp to. This is because the code for filtering out improper escape pod landmarks didn't actually filter out all of the wrong ones. I refactored a bit of the landmark-filtering code to account for this, and now any map with a `map_settings` datum has a field to specify which escape shuttle it uses.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #441

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Jawns:
(+)Upgraded escape pod portal generator teleports you to the correct escape shuttle 
```
