### PR TITLE
Unstick spaced atmos groups

### DIFF
--- a/code/modules/admin/diagnostics.dm
+++ b/code/modules/admin/diagnostics.dm
@@ -400,8 +400,7 @@ proc/debug_color_of(var/thing)
 				else
 
 					var/pressure = MIXTURE_PRESSURE(air)
-					img.app.desc = ""
-
+					img.app.desc = "Group \ref[group]<br>[MOLES_REPORT(air)]Temperature=[air.temperature]<br/>"
 
 					var/breath_pressure = ((TOTAL_MOLES(air) * R_IDEAL_GAS_EQUATION * air.temperature) * BREATH_PERCENTAGE) / BREATH_VOLUME
 					//Partial pressure of the O2 in our breath
@@ -562,6 +561,7 @@ proc/debug_color_of(var/thing)
 						if(TOTAL_MOLES(air) > ATMOS_EPSILON)
 							pipe_image.maptext = "<span class='pixel r ol'>[round(air.temperature, 0.1)]<br>[round(TOTAL_MOLES(air), 0.1)]<br>[round(MIXTURE_PRESSURE(air), 0.1)]</span>"
 							pipe_image.maptext_x = -3
+							img.app.desc = "[MOLES_REPORT(air)]"
 						else if(TOTAL_MOLES(air) > 0)
 							pipe_image.maptext = "<span class='pixel r ol'>&gt;0</span>"
 							pipe_image.maptext_x = -3

--- a/code/modules/atmospherics/FEA_airgroup.dm
+++ b/code/modules/atmospherics/FEA_airgroup.dm
@@ -116,6 +116,7 @@
 
 
 /datum/air_group/proc/process_group(var/datum/controller/process/parent_controller)
+	var/abort_group = 0
 	current_cycle = air_master.current_cycle
 
 	if (spaced)
@@ -180,7 +181,6 @@
 
 			LAGCHECK(LAG_REALTIME)
 
-		var/abort_group = 0
 
 		// Process connections to adjacent groups
 		var/border_index = 1
@@ -307,8 +307,8 @@
 	// This logic is not inverted because group processing may have been
 	// suspended in the above block.
 	if(!group_processing) //Revert to individual processing
-		// space fastpath
-		if (members.len && length_space_border)
+		// space fastpath if we didn't revert (avoid regrouping tiles prior to processing individual cells)
+		if (!abort_group && members.len && length_space_border)
 			if (space_fastpath(parent_controller))
 				// If the fastpath resulted in the group being zeroed, return early.
 				return

--- a/code/modules/atmospherics/FEA_gas_mixture.dm
+++ b/code/modules/atmospherics/FEA_gas_mixture.dm
@@ -179,20 +179,20 @@ What are the archived variables for?
 		var/oxygen_burn_rate = 0
 		//more plasma released at higher temperatures
 		var/temperature_scale
-		if(temperature > PLASMA_UPPER_TEMPERATURE)
+		if(src.temperature > PLASMA_UPPER_TEMPERATURE)
 			temperature_scale = 1
 		else
 			temperature_scale = (temperature-PLASMA_MINIMUM_BURN_TEMPERATURE)/(PLASMA_UPPER_TEMPERATURE-PLASMA_MINIMUM_BURN_TEMPERATURE)
 		if(temperature_scale > 0)
 			oxygen_burn_rate = 1.4 - temperature_scale
-			if(oxygen > toxins*PLASMA_OXYGEN_FULLBURN)
-				plasma_burn_rate = (toxins*temperature_scale)/4
+			if(src.oxygen > src.toxins*PLASMA_OXYGEN_FULLBURN)
+				plasma_burn_rate = (src.toxins*temperature_scale)/4
 			else
 				plasma_burn_rate = (temperature_scale*(oxygen/PLASMA_OXYGEN_FULLBURN))/4
 			if(plasma_burn_rate > MINIMUM_HEAT_CAPACITY)
-				toxins -= plasma_burn_rate/3
-				oxygen -= plasma_burn_rate*oxygen_burn_rate
-				carbon_dioxide += plasma_burn_rate/3
+				src.toxins -= plasma_burn_rate/3
+				src.oxygen -= plasma_burn_rate*oxygen_burn_rate
+				src.carbon_dioxide += plasma_burn_rate/3
 
 				energy_released += FIRE_PLASMA_ENERGY_RELEASED * (plasma_burn_rate)
 
@@ -584,7 +584,8 @@ What are the archived variables for?
 				if(abs(new_sharer_heat_capacity/old_sharer_heat_capacity - 1) < 0.10) // <10% change in sharer heat capacity
 					temperature_share(sharer, OPEN_HEAT_TRANSFER_COEFFICIENT)
 
-	if((delta_temperature > MINIMUM_TEMPERATURE_TO_MOVE) || abs(moved_moles) > MINIMUM_MOLES_DELTA_TO_MOVE)
+	// Check that either threshold was met for pressure_difference calculations
+	if((abs(delta_temperature) > MINIMUM_TEMPERATURE_TO_MOVE) || abs(moved_moles) > MINIMUM_MOLES_DELTA_TO_MOVE)
 		var/delta_pressure = ARCHIVED(temperature)*(TOTAL_MOLES(src) + moved_moles) - sharer.ARCHIVED(temperature)*(TOTAL_MOLES(sharer) - moved_moles)
 		return (delta_pressure*R_IDEAL_GAS_EQUATION/volume)
 

--- a/code/procs/gamehelpers.dm
+++ b/code/procs/gamehelpers.dm
@@ -555,7 +555,7 @@ var/obj/item/dummy/click_dummy = new
 
 	for (var/turf/S in turfs_src)
 		var/turf/T = locate(S.x - src_min_x + trg_min_x, S.y - src_min_y + trg_min_y, trg_z)
-		if(T.loc != A) continue
+		if(T?.loc != A) continue
 		T.ReplaceWith(S.type, keep_old_material = 0, force=1)
 		T.appearance = S.appearance
 		T.density = S.density


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug - major]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Skip space_fastpath() when a group aborts processing.  
Add diagnostics overlays to atmos and pipes to see molar distributions.
Cleanup a runtime found when trying to debug atmos.

Impacts:
Given an area that is spaced via bomb or RCD and was re-grouped...  That area will no longer act as a buffer when interacting with other groups. (Seems like the desired behavior, but will increase effect of spaced station sections)
![image](https://user-images.githubusercontent.com/1017374/98283304-56dd7500-1f54-11eb-9ea6-cdf7284396f7.png)



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Resolves issue of being unable to purge burn chamber due to spaced ATMOS group taking in gas, aborting group processing, spacing the group and merging before processing individual tile's neighbors are processed.  This was causing spaced groups to essentially be SPACE barriers. 

Current | Fix
---|---
 ![Previous Behavior](https://user-images.githubusercontent.com/1017374/98281022-103a4b80-1f51-11eb-8996-7af69b51d2d4.png) | ![Fix](https://user-images.githubusercontent.com/1017374/98279780-3fe85400-1f4f-11eb-82f3-831058b285b2.png)


## Changelog
```
(u)Azrun:
(+)Should now be able to vent combustion chambers.  Spaced areas of the station should now spread.
```
