### PR TITLE
Allowed pews to be deconstructed and unanchored

### DIFF
--- a/code/obj/item/table_rack_parts.dm
+++ b/code/obj/item/table_rack_parts.dm
@@ -326,6 +326,18 @@ RACK PARTS
 	icon = 'icons/obj/furniture/bench_wood.dmi'
 	furniture_type = /obj/stool/chair/pew
 
+	construct(mob/user as mob, turf/T as turf)
+		var/obj/stool/chair/pew/P = ..()
+		P.dir = user.dir
+		P.realign()
+		return P
+
+/obj/item/furniture_parts/bench/pew/fancy
+	name = "fancy pew parts"
+	desc = "A collection of parts that can be used to make a <i>pew</i>"
+	icon = 'icons/obj/furniture/bench_wood.dmi'
+	furniture_type = /obj/stool/chair/pew/fancy
+
 /* ---------- Chair Parts ---------- */
 /obj/item/furniture_parts/wood_chair
 	name = "wooden chair parts"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This pull request adds a deconstruction path for pews and fancy pews. Pews are now also unanchorable and can be moved around very easily, as well as rotated with a crowbar.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Pews were indestructible and immovable unless you blew them up. This will allow the chaplain to more easily redecorate his chapel.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)DeadMan164:
(+)Pews can now be deconstructed, unanchored, and rotated.
```
