### PR TITLE
Adds rubber hammer as Clown level 10 job reward

### DIFF
--- a/code/WorkInProgress/JobXPRewards.dm
+++ b/code/WorkInProgress/JobXPRewards.dm
@@ -442,16 +442,18 @@ mob/verb/checkrewards()
 		return
 
 /datum/jobXpReward/clown10
-	name = "Nothing!!"
-	desc = "Nothing Again Again!!"
+	name = "Rubber Hammer"
+	desc = "Haha, hammer go 'boing'"
 	required_levels = list("Clown"=10)
 	icon_state = "?"
 	claimable = 1
 	claimPerRound = 1
 
 	activate(var/client/C)
-		boutput(C, "Nothing seems to happen!")
+		boutput(C, "You pull your rubber hamer out from your nose!")
+		new /obj/item/rubber_hammer(get_turf(C.mob))
 		return
+
 /datum/jobXpReward/clown15
 	name = "Nothing!!!"
 	desc = "Nothing Again Again Again!!!"


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the rubber hammer as a Clown level 10 job reward

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Rubber hammers arent used anywhere other than a crate in maintance on Oshan and I think it's a fitting item for the clown.

## Changelog
```
(u)Carbadox
(*)Added a rubber hammer as the Clowns level 10 job reward
```
