### PR TITLE
Adds phosphorus to matches and the ability to crush them into containers

### DIFF
--- a/code/obj/item/cigarette.dm
+++ b/code/obj/item/cigarette.dm
@@ -851,6 +851,8 @@
 
 	New()
 		..()
+		src.create_reagents(1)
+		reagents.add_reagent("phosphorus", 1)
 		light = new /datum/light/point
 		light.set_brightness(0.4)
 		light.set_color(0.94, 0.69, 0.27)
@@ -970,6 +972,13 @@
 				user.visible_message("<b>[user]</b> lights [src] with the flame from [target].",\
 				"You light [src] with the flame from [target].")
 				src.light(user)
+				return
+			else if (istype (target, /obj/item/reagent_containers/)) // copied from cigarettes
+				user.visible_message("<span class='notice'><b>[user]</b> crushes up [src] in the [target].</span>",\
+				"<span class='notice'>You crush up the [src] in the [target].</span>")
+				if(src.reagents)
+					src.reagents.trans_to(target, 1)
+				qdel (src)
 				return
 			else
 				if (prob(10))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR
Adds 1u phosphorus to every match, clicking a container with a match will crush the match and add 1u phosphorus to the container. Overrides the ability to strike matches on any item, so striking matches on containers will no longer be possible. <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->



## Why's this needed?
Chem dispenser is currently the only way to acquire phosphorus. Phosphorus gets used in a handful of hobo drugs, so we need a hobo way to acquire it! <!-- Describe why you think this should be added to the game. -->