### PR TITLE
Oshan armory hardening, additional weaponry, and turret whitelisting

### DIFF
--- a/code/obj/machinery/turret.dm
+++ b/code/obj/machinery/turret.dm
@@ -127,6 +127,8 @@
 			continue
 		if (!istype(C.loc.loc,A))
 			continue
+		if ((src.req_access || src.req_access_txt) && src.allowed(C))
+			continue //optional whitelist
 		. += C
 
 	if (istype(A, /area/station/turret_protected))

--- a/code/obj/machinery/turret.dm
+++ b/code/obj/machinery/turret.dm
@@ -128,7 +128,7 @@
 		if (!istype(C.loc.loc,A))
 			continue
 		if ((src.req_access || src.req_access_txt) && src.allowed(C))
-			continue //optional whitelist
+			continue //optional access whitelist
 		. += C
 
 	if (istype(A, /area/station/turret_protected))

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -43097,7 +43097,6 @@
 /turf/simulated/floor,
 /area/research_outpost/toxins)
 "bYt" = (
-/obj/table/reinforced/industrial,
 /obj/machinery/recharger/wall{
 	pixel_y = -24
 	},
@@ -43105,6 +43104,7 @@
 	pixel_y = 4;
 	rand_pos = 0
 	},
+/obj/table/reinforced/industrial/auto,
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
@@ -47553,12 +47553,6 @@
 /obj/machinery/light/incandescent/cool,
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/pharmacy)
-"cJo" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/south)
 "cSE" = (
 /obj/machinery/door/airlock/pyro/security/alt{
 	req_access_txt = "1"
@@ -47582,28 +47576,9 @@
 /obj/disposalpipe/segment,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/sec)
-"giY" = (
-/obj/rack,
-/obj/item/device/radio/electropack,
-/obj/item/device/radio/electropack,
-/obj/item/device/radio/signaler,
-/obj/item/device/radio/signaler,
-/obj/item/chem_grenade/pepper,
-/obj/item/chem_grenade/pepper,
-/obj/item/chem_grenade/pepper,
-/turf/simulated/floor/redblack/corner{
-	dir = 1
-	},
-/area/station/ai_monitored/armory)
-"ikb" = (
+"iGY" = (
 /obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/south)
-"iJK" = (
-/obj/cable{
-	icon_state = "2-4"
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
@@ -47613,6 +47588,12 @@
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
+"iMg" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/south)
 "iPV" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/caution/west,
@@ -47641,6 +47622,12 @@
 	},
 /turf/space/fluid,
 /area/space)
+"kWM" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/south)
 "lbK" = (
 /obj/storage/cart/trash,
 /turf/simulated/floor/plating/random,
@@ -47666,6 +47653,12 @@
 "nhW" = (
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
+"nlQ" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/south)
 "nDS" = (
 /obj/table/auto,
 /obj/item/coin{
@@ -47702,13 +47695,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hangar/sec)
-"orE" = (
-/obj/table/reinforced/industrial,
-/obj/item/kitchen/food_box/donut_box,
-/turf/simulated/floor/redblack{
-	dir = 1
-	},
-/area/station/ai_monitored/armory)
 "pIo" = (
 /obj/machinery/light/incandescent/greenish,
 /turf/simulated/floor,
@@ -47742,6 +47728,29 @@
 /obj/machinery/vending/janitor,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/office)
+"ryf" = (
+/obj/rack,
+/obj/item/device/radio/electropack,
+/obj/item/device/radio/electropack,
+/obj/item/device/radio/signaler,
+/obj/item/device/radio/signaler,
+/obj/item/chem_grenade/pepper,
+/obj/item/chem_grenade/pepper,
+/obj/item/chem_grenade/pepper,
+/turf/simulated/floor/redblack/corner{
+	dir = 1
+	},
+/area/station/ai_monitored/armory)
+"slW" = (
+/obj/item/kitchen/food_box/donut_box{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/table/reinforced/industrial/auto,
+/turf/simulated/floor/redblack{
+	dir = 1
+	},
+/area/station/ai_monitored/armory)
 "sBu" = (
 /obj/cable{
 	d1 = 4;
@@ -47803,12 +47812,6 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
-"xJz" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/south)
 "xVc" = (
 /obj/machinery/vehicle/tank/minisub/secsub,
 /turf/simulated/floor/shuttlebay,
@@ -91232,8 +91235,8 @@ bTR
 bXu
 bTR
 bTR
-ikb
-cJo
+kWM
+nlQ
 bLr
 bOR
 aqn
@@ -92439,7 +92442,7 @@ bXw
 bXx
 bVX
 bVX
-orE
+slW
 bTR
 bRU
 bLr
@@ -92741,7 +92744,7 @@ bVZ
 bWH
 bwE
 bVb
-giY
+ryf
 bTR
 bRU
 bLr
@@ -93346,8 +93349,8 @@ bWK
 bXA
 bVc
 bTR
-iJK
-xJz
+iMg
+iGY
 bLr
 bVo
 aqn

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -42761,6 +42761,9 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/recharger/wall{
+	pixel_y = 28
+	},
 /turf/simulated/floor/redblack,
 /area/station/ai_monitored/armory)
 "bXx" = (
@@ -43097,9 +43100,6 @@
 /turf/simulated/floor,
 /area/research_outpost/toxins)
 "bYt" = (
-/obj/machinery/recharger/wall{
-	pixel_y = -24
-	},
 /obj/item/reagent_containers/food/snacks/donut/robust{
 	pixel_y = 4;
 	rand_pos = 0
@@ -47576,9 +47576,9 @@
 /obj/disposalpipe/segment,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/sec)
-"iGY" = (
+"ghV" = (
 /obj/cable{
-	icon_state = "1-8"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
@@ -47588,12 +47588,16 @@
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
-"iMg" = (
-/obj/cable{
-	icon_state = "2-4"
+"iPj" = (
+/obj/item/kitchen/food_box/donut_box{
+	pixel_x = -3;
+	pixel_y = 6
 	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/south)
+/obj/table/reinforced/industrial/auto,
+/turf/simulated/floor/redblack{
+	dir = 1
+	},
+/area/station/ai_monitored/armory)
 "iPV" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/caution/west,
@@ -47622,12 +47626,6 @@
 	},
 /turf/space/fluid,
 /area/space)
-"kWM" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/south)
 "lbK" = (
 /obj/storage/cart/trash,
 /turf/simulated/floor/plating/random,
@@ -47653,12 +47651,6 @@
 "nhW" = (
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
-"nlQ" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/south)
 "nDS" = (
 /obj/table/auto,
 /obj/item/coin{
@@ -47714,6 +47706,12 @@
 /obj/item/clothing/mask/breath,
 /turf/simulated/floor,
 /area/station/hangar/sec)
+"qjw" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/south)
 "qBd" = (
 /obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{
 	id = "secure_dock"
@@ -47728,29 +47726,6 @@
 /obj/machinery/vending/janitor,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/office)
-"ryf" = (
-/obj/rack,
-/obj/item/device/radio/electropack,
-/obj/item/device/radio/electropack,
-/obj/item/device/radio/signaler,
-/obj/item/device/radio/signaler,
-/obj/item/chem_grenade/pepper,
-/obj/item/chem_grenade/pepper,
-/obj/item/chem_grenade/pepper,
-/turf/simulated/floor/redblack/corner{
-	dir = 1
-	},
-/area/station/ai_monitored/armory)
-"slW" = (
-/obj/item/kitchen/food_box/donut_box{
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/obj/table/reinforced/industrial/auto,
-/turf/simulated/floor/redblack{
-	dir = 1
-	},
-/area/station/ai_monitored/armory)
 "sBu" = (
 /obj/cable{
 	d1 = 4;
@@ -47758,6 +47733,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light/incandescent/greenish,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/south)
+"toE" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
 "tWV" = (
@@ -47788,9 +47769,28 @@
 	},
 /turf/simulated/floor,
 /area/station/hangar/sec)
+"vcb" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/south)
 "vIJ" = (
 /turf/simulated/floor/caution/south,
 /area/station/hangar/sec)
+"vLB" = (
+/obj/rack,
+/obj/item/device/radio/electropack,
+/obj/item/device/radio/electropack,
+/obj/item/device/radio/signaler,
+/obj/item/device/radio/signaler,
+/obj/item/chem_grenade/pepper,
+/obj/item/chem_grenade/pepper,
+/obj/item/chem_grenade/pepper,
+/turf/simulated/floor/redblack/corner{
+	dir = 1
+	},
+/area/station/ai_monitored/armory)
 "wis" = (
 /obj/machinery/hydro_growlamp,
 /turf/simulated/floor/grass,
@@ -91235,8 +91235,8 @@ bTR
 bXu
 bTR
 bTR
-kWM
-nlQ
+vcb
+ghV
 bLr
 bOR
 aqn
@@ -92442,7 +92442,7 @@ bXw
 bXx
 bVX
 bVX
-slW
+iPj
 bTR
 bRU
 bLr
@@ -92744,7 +92744,7 @@ bVZ
 bWH
 bwE
 bVb
-ryf
+vLB
 bTR
 bRU
 bLr
@@ -93349,8 +93349,8 @@ bWK
 bXA
 bVc
 bTR
-iMg
-iGY
+qjw
+toE
 bLr
 bVo
 aqn

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -31653,11 +31653,17 @@
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/escape)
 "bwD" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/quartermaster/office)
+/obj/access_spawn/security,
+/obj/machinery/turret,
+/turf/simulated/floor/delivery/caution,
+/area/station/ai_monitored/armory)
 "bwE" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/quartermaster/office)
+/obj/machinery/light/incandescent/greenish,
+/obj/machinery/weapon_stand/rifle_rack/recharger,
+/turf/simulated/floor/redblack{
+	dir = 9
+	},
+/area/station/ai_monitored/armory)
 "bwF" = (
 /obj/disposalpipe/segment/morgue,
 /turf/simulated/floor/yellow/corner{
@@ -35669,8 +35675,11 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bFX" = (
-/turf/simulated/floor/bot,
-/area/station/quartermaster/office)
+/obj/disposalpipe/segment/mail,
+/obj/storage/secure/crate/weapon/confiscated_items,
+/obj/item/storage/box/prosthesis_kit/eye_laser,
+/turf/simulated/floor/delivery,
+/area/station/security/main)
 "bFY" = (
 /obj/item/mine/stun/armed,
 /turf/space/fluid,
@@ -40853,7 +40862,6 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/firedoor_spawn,
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bSO" = (
@@ -41783,15 +41791,13 @@
 /area/station/ai_monitored/armory)
 "bVb" = (
 /obj/rack,
-/obj/item/device/radio/electropack,
-/obj/item/device/radio/electropack,
-/obj/item/device/radio/signaler,
-/obj/item/device/radio/signaler,
-/obj/item/chem_grenade/pepper,
-/obj/item/chem_grenade/pepper,
-/obj/item/chem_grenade/pepper,
+/obj/item/storage/box/stinger_kit,
+/obj/item/storage/box/flashbang_kit,
+/obj/item/storage/box/revimp_kit,
+/obj/item/gun/energy/phaser_gun,
+/obj/item/gun/energy/phaser_gun,
 /turf/simulated/floor/redblack{
-	dir = 1
+	dir = 8
 	},
 /area/station/ai_monitored/armory)
 "bVc" = (
@@ -42407,6 +42413,9 @@
 	},
 /obj/access_spawn/hos,
 /obj/firedoor_spawn,
+/obj/machinery/secscanner{
+	pixel_y = 10
+	},
 /turf/simulated/floor/red,
 /area/station/ai_monitored/armory)
 "bWH" = (
@@ -42782,6 +42791,11 @@
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet/red,
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
+/obj/machinery/turretid{
+	pixel_x = -24;
+	turretArea = /area/station/ai_monitored/armory
+	},
+/obj/access_spawn/hos,
 /turf/simulated/floor/black,
 /area/station/security/hos)
 "bXB" = (
@@ -43038,6 +43052,11 @@
 	},
 /area/station/ai_monitored/armory)
 "bYp" = (
+/turf/simulated/floor/redblack{
+	dir = 5
+	},
+/area/station/ai_monitored/armory)
+"bYq" = (
 /obj/rack,
 /obj/item/clothing/suit/armor/heavy,
 /obj/item/clothing/suit/armor/heavy,
@@ -43049,19 +43068,9 @@
 /obj/item/clothing/head/helmet/riot,
 /obj/item/clothing/glasses/nightvision,
 /obj/item/clothing/glasses/nightvision,
-/turf/simulated/floor/redblack{
-	dir = 1
-	},
-/area/station/ai_monitored/armory)
-"bYq" = (
-/obj/storage/secure/crate/plasma/armory/anti_biological,
-/obj/item/gun/kinetic/flaregun,
-/obj/item/ammo/bullets/flare,
-/obj/item/ammo/bullets/flare,
-/obj/item/flamethrower/assembled/loaded,
 /obj/machinery/light/incandescent/greenish,
-/turf/simulated/floor/redblack{
-	dir = 1
+/turf/simulated/floor/redblack/corner{
+	dir = 8
 	},
 /area/station/ai_monitored/armory)
 "bYr" = (
@@ -43088,12 +43097,14 @@
 /turf/simulated/floor,
 /area/research_outpost/toxins)
 "bYt" = (
-/obj/rack,
-/obj/item/storage/box/stinger_kit,
-/obj/item/storage/box/flashbang_kit,
-/obj/item/storage/box/revimp_kit,
-/obj/item/gun/energy/phaser_gun,
-/obj/item/gun/energy/phaser_gun,
+/obj/table/reinforced/industrial,
+/obj/machinery/recharger/wall{
+	pixel_y = -24
+	},
+/obj/item/reagent_containers/food/snacks/donut/robust{
+	pixel_y = 4;
+	rand_pos = 0
+	},
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
@@ -45143,8 +45154,11 @@
 /turf/simulated/floor/bot,
 /area/station/security/main)
 "ceT" = (
-/obj/storage/secure/crate/weapon/confiscated_items,
-/obj/item/storage/box/prosthesis_kit/eye_laser,
+/obj/storage/secure/crate/plasma/armory/anti_biological,
+/obj/item/gun/kinetic/flaregun,
+/obj/item/ammo/bullets/flare,
+/obj/item/ammo/bullets/flare,
+/obj/item/flamethrower/assembled/loaded,
 /turf/simulated/floor/delivery,
 /area/station/security/main)
 "ceU" = (
@@ -47539,6 +47553,12 @@
 /obj/machinery/light/incandescent/cool,
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/pharmacy)
+"cJo" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/south)
 "cSE" = (
 /obj/machinery/door/airlock/pyro/security/alt{
 	req_access_txt = "1"
@@ -47562,6 +47582,31 @@
 /obj/disposalpipe/segment,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/sec)
+"giY" = (
+/obj/rack,
+/obj/item/device/radio/electropack,
+/obj/item/device/radio/electropack,
+/obj/item/device/radio/signaler,
+/obj/item/device/radio/signaler,
+/obj/item/chem_grenade/pepper,
+/obj/item/chem_grenade/pepper,
+/obj/item/chem_grenade/pepper,
+/turf/simulated/floor/redblack/corner{
+	dir = 1
+	},
+/area/station/ai_monitored/armory)
+"ikb" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/south)
+"iJK" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/south)
 "iLO" = (
 /obj/item/device/radio/intercom/AI{
 	dir = 4
@@ -47657,6 +47702,13 @@
 	},
 /turf/simulated/floor,
 /area/station/hangar/sec)
+"orE" = (
+/obj/table/reinforced/industrial,
+/obj/item/kitchen/food_box/donut_box,
+/turf/simulated/floor/redblack{
+	dir = 1
+	},
+/area/station/ai_monitored/armory)
 "pIo" = (
 /obj/machinery/light/incandescent/greenish,
 /turf/simulated/floor,
@@ -47751,6 +47803,12 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
+"xJz" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/south)
 "xVc" = (
 /obj/machinery/vehicle/tank/minisub/secsub,
 /turf/simulated/floor/shuttlebay,
@@ -77859,17 +77917,17 @@ buE
 bbi
 btZ
 btZ
-bwD
-bwD
-bwD
-bwD
-bwD
-bwD
-bwD
-bwD
-bwD
-bwD
-bwD
+bJw
+bJw
+bJw
+bJw
+bJw
+bJw
+bJw
+bJw
+bJw
+bJw
+bJw
 bJw
 bJw
 bJw
@@ -78160,8 +78218,8 @@ buH
 buE
 btZ
 btZ
-bwD
-bwD
+bJw
+bJw
 bzm
 bAr
 bBI
@@ -78461,8 +78519,8 @@ bub
 btX
 buE
 bua
-bwD
-bwD
+bJw
+bJw
 byr
 bzn
 bAs
@@ -78763,7 +78821,7 @@ buc
 btX
 bvr
 btZ
-bwD
+bJw
 aMK
 bys
 bzo
@@ -78772,8 +78830,8 @@ bBK
 bCU
 bEg
 bFe
-bFX
-bFX
+bMS
+bMS
 bHR
 bIC
 bJy
@@ -79065,7 +79123,7 @@ cgp
 btX
 buE
 btZ
-bwD
+bJw
 aTb
 bys
 bzo
@@ -79074,10 +79132,10 @@ bBL
 bCV
 bEg
 bFf
-bwE
+bJA
 bGT
 bHS
-bwE
+bJA
 bJA
 bKk
 bLL
@@ -79367,7 +79425,7 @@ bot
 buI
 buL
 bvY
-bwD
+bJw
 bHP
 bys
 bzp
@@ -79376,7 +79434,7 @@ bAv
 bAv
 bEh
 bys
-bwE
+bJA
 bGU
 bHT
 bID
@@ -79669,7 +79727,7 @@ bBC
 bqs
 buL
 btZ
-bwD
+bJw
 bxB
 byt
 bzq
@@ -79678,7 +79736,7 @@ bBM
 bys
 bEi
 bFg
-bwE
+bJA
 bGV
 bHU
 bIE
@@ -79974,13 +80032,13 @@ btZ
 ciq
 bxC
 byu
-bwE
+bJA
 bzr
 bBN
 bCW
 bEj
 bzr
-bwE
+bJA
 cfG
 bHU
 bIE
@@ -80273,7 +80331,7 @@ bFZ
 bqs
 buL
 bua
-bwE
+bJA
 bxC
 bxC
 bzr
@@ -80575,7 +80633,7 @@ bFZ
 buJ
 buL
 btZ
-bwE
+bJA
 bxD
 bxC
 bzr
@@ -80877,7 +80935,7 @@ bKO
 bqs
 buL
 btZ
-bwE
+bJA
 bxC
 bxC
 bzs
@@ -81179,7 +81237,7 @@ bug
 bqs
 buL
 btZ
-bwE
+bJA
 bxC
 byv
 bzr
@@ -81481,10 +81539,10 @@ buh
 buK
 buL
 btZ
-bwE
+bJA
 bxE
 byw
-bwE
+bJA
 bAA
 bBP
 bCZ
@@ -81783,10 +81841,10 @@ bot
 bot
 bot
 cjd
-bwE
+bJA
 bxF
 bxF
-bwE
+bJA
 aax
 aax
 bDa
@@ -91174,9 +91232,9 @@ bTR
 bXu
 bTR
 bTR
-bRU
+ikb
+cJo
 bLr
-bOR
 bOR
 aqn
 aqn
@@ -91476,10 +91534,10 @@ bWF
 bXv
 bYo
 bTR
+bTR
 bRU
 bLr
 bVo
-aqn
 aqn
 aqn
 aqn
@@ -91777,11 +91835,11 @@ bVX
 bWH
 bVX
 bYp
+bYq
 bTR
 bRU
 bLr
 bVo
-aqn
 aqn
 aqn
 aqn
@@ -92077,13 +92135,13 @@ bTR
 bVa
 bWJ
 bWH
+bwD
 bVX
-bYq
+bYt
 bTR
 bRU
 bLr
 bVo
-aqn
 aqn
 aqn
 aqn
@@ -92380,12 +92438,12 @@ bTR
 bXw
 bXx
 bVX
-bYt
+bVX
+orE
 bTR
 bRU
 bLr
 bVo
-aqn
 aqn
 aqn
 aqn
@@ -92681,13 +92739,13 @@ apB
 bTR
 bVZ
 bWH
-bVX
+bwE
 bVb
+giY
 bTR
 bRU
 bLr
 bVo
-aqn
 aqn
 aqn
 aqn
@@ -92986,10 +93044,10 @@ clX
 bVc
 bVc
 bTR
+bTR
 bRU
 bLr
 bVo
-aqn
 aqn
 aqn
 aqn
@@ -93287,11 +93345,11 @@ bWa
 bWK
 bXA
 bVc
-bLr
-bRU
+bTR
+iJK
+xJz
 bLr
 bVo
-aqn
 aqn
 aqn
 aqn
@@ -93593,7 +93651,7 @@ bLr
 bRU
 bLr
 bVo
-aqn
+bVo
 aqn
 aqn
 aqn
@@ -93893,7 +93951,7 @@ bXC
 bVc
 bLr
 bRU
-bLr
+bVo
 bVo
 aqn
 aqn
@@ -95097,7 +95155,7 @@ ado
 bJR
 bVY
 bWI
-bMp
+bFX
 bJS
 iPV
 yhP

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -31654,7 +31654,9 @@
 /area/station/security/checkpoint/escape)
 "bwD" = (
 /obj/access_spawn/security,
-/obj/machinery/turret,
+/obj/machinery/turret{
+	name = "armory turret"
+	},
 /turf/simulated/floor/delivery/caution,
 /area/station/ai_monitored/armory)
 "bwE" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][FEATURE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Expands Oshan armory slightly
* Adds new feature to turrets that allows them to whitelist by access
* Oshan armory turret is whitelisted to not shoot anyone with sec access. Can be set to lethal or disabled by HoS in office.
* Add a cool blue donut
* Add the pulse rifle rack
* Move the anti-bio crate outside to be consistent with other maps
* adds a wall charger

![image](https://user-images.githubusercontent.com/33204415/98499153-b4084d80-2216-11eb-9434-227115924278.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Armory hardening