### PR TITLE
Remove binsult.ogg from secbot voice lines

### DIFF
--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -1096,6 +1096,14 @@ Report Arrests: <A href='?src=\ref[src];operation=report'>[report_arrests ? "On"
 	icon = 'icons/obj/items/items.dmi'
 	icon_state = "handcuff"
 	var/obj/machinery/bot/secbot/master
+	var/list/voice_lines = list(
+		  'sound/voice/bgod.ogg'
+		, 'sound/voice/biamthelaw.ogg'
+		, 'sound/voice/bsecureday.ogg'
+		, 'sound/voice/bradio.ogg'
+	//, 'sound/voice/binsult.ogg'
+		, 'sound/voice/bcreep.ogg'
+		)
 
 	New(var/the_bot)
 		src.master = the_bot
@@ -1155,7 +1163,7 @@ Report Arrests: <A href='?src=\ref[src];operation=report'>[report_arrests ? "On"
 				master.target.setStatus("handcuffed", duration = INFINITE_STATUS)
 
 			if(!uncuffable)
-				playsound(master.loc, pick('sound/voice/bgod.ogg', 'sound/voice/biamthelaw.ogg', 'sound/voice/bsecureday.ogg', 'sound/voice/bradio.ogg', 'sound/voice/binsult.ogg', 'sound/voice/bcreep.ogg'), 50, 0, 0, 1)
+				playsound(master.loc, pick(src.voice_lines), 50, 0, 0, 1)
 			if (master.report_arrests && !uncuffable)
 				var/bot_location = get_area(master)
 				var/last_target = master.target

--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -1097,11 +1097,11 @@ Report Arrests: <A href='?src=\ref[src];operation=report'>[report_arrests ? "On"
 	icon_state = "handcuff"
 	var/obj/machinery/bot/secbot/master
 	var/list/voice_lines = list(
-		  'sound/voice/bgod.ogg'
+			'sound/voice/bgod.ogg'
 		, 'sound/voice/biamthelaw.ogg'
 		, 'sound/voice/bsecureday.ogg'
 		, 'sound/voice/bradio.ogg'
-	//, 'sound/voice/binsult.ogg'
+		//, 'sound/voice/binsult.ogg'
 		, 'sound/voice/bcreep.ogg'
 		)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][REMOVAL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Reorganize the secbot voice lines into a list
* comment out `binsult.ogg` - remove entirely?


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* `binsult.ogg` contains content that violates our server rules