### PR TITLE
Fixes and adds flavor text for crushing cigs

### DIFF
--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -92,6 +92,7 @@
 	module_research = list("cuisine" = 6)
 	module_research_type = /obj/item/reagent_containers/food/snacks
 	rand_pos = 1
+	var/has_cigs = 0
 
 	var/use_bite_mask = 1
 	var/current_mask = 5

--- a/code/obj/item/cigarette.dm
+++ b/code/obj/item/cigarette.dm
@@ -65,7 +65,7 @@
 			user.visible_message("<span class='notice'><b>[user]</b> crushes up [src] and sprinkles it onto [target], gross.</span>",\
 			"<span class='notice'>You crush up [src] and sprinkle it onto [target].</span>")
 			if (!(T.has_cigs))
-				T.desc = "[T.desc] Are those crushed cigarettes on top? That's disgusting!"
+				T.desc = "[T.desc]<br>Are those crushed cigarettes on top? That's disgusting!"
 				T.has_cigs = 1
 			if (src.reagents) // copied wirefix
 				src.reagents.trans_to(T, 5)

--- a/code/obj/item/cigarette.dm
+++ b/code/obj/item/cigarette.dm
@@ -59,15 +59,25 @@
 			reagents.add_reagent(src.flavor, 40)
 			return
 
-	afterattack(atom/target, mob/user, flag) // copied from the propuffs
-		if (istype(target, /obj/item/reagent_containers/))
-			user.visible_message("<span class='notice'><b>[user]</b> crushes up [src] in the [target].</span>",\
-			"<span class='notice'>You crush up the [src] in the [target].</span>")
-
-			if (src.reagents) //Wire: Fix for: Cannot execute null.trans to()
-				src.reagents.trans_to(target, 5)
-
+	afterattack(atom/target , mob/user, flag) // copied from the propuffs
+		if (istype(target, /obj/item/reagent_containers/food/snacks/)) // you dont crush cigs INTO food, you crush them ONTO food!
+			var/obj/item/reagent_containers/food/snacks/T = target // typecasting because atom/target was causing some STINKY problems
+			user.visible_message("<span class='notice'><b>[user]</b> crushes up [src] and sprinkles it onto [target], gross.</span>",\
+			"<span class='notice'>You crush up [src] and sprinkle it onto [target].</span>")
+			if (!(T.has_cigs))
+				T.desc = "[T.desc] Are those crushed cigarettes on top? That's disgusting!"
+				T.has_cigs = 1
+			if (src.reagents) // copied wirefix
+				src.reagents.trans_to(T, 5)
 			qdel (src)
+			return
+		else if (istype(target, /obj/item/reagent_containers/)) // crushing cigs into actual containers remains the same
+			user.visible_message("<span class='notice'><b>[user]</b> crushes up [src] into [target].</span>",\
+			"<span class='notice'>You crush up [src] into [target].</span>")
+			if (src.reagents) // copied wirefix
+				src.reagents.trans_to(target, 5)
+			qdel (src)
+			return
 		else if (istype(target, /obj/item/match) && src.on)
 			target:light(user, "<span class='alert'><b>[user]</b> lights [target] with [src].</span>")
 		else if (src.on == 0 && isitem(target) && target:burning)
@@ -973,11 +983,18 @@
 				"You light [src] with the flame from [target].")
 				src.light(user)
 				return
-			else if (istype (target, /obj/item/reagent_containers/)) // copied from cigarettes
-				user.visible_message("<span class='notice'><b>[user]</b> crushes up [src] in the [target].</span>",\
-				"<span class='notice'>You crush up the [src] in the [target].</span>")
-				if(src.reagents)
-					src.reagents.trans_to(target, 1)
+			else if (istype(target, /obj/item/reagent_containers/food/snacks/)) // RE-copied from cigarettes
+				user.visible_message("<span class='notice'><b>[user]</b> crushes up [src] and sprinkles it onto [target], what the fuck?.</span>",\
+				"<span class='notice'>You crush up [src] and sprinkle it onto [target].</span>")
+				if (src.reagents) // copied wirefix
+					src.reagents.trans_to(target, 5)
+				qdel (src)
+				return
+			else if (istype(target, /obj/item/reagent_containers/)) // crushing cigs into actual containers remains the same
+				user.visible_message("<span class='notice'><b>[user]</b> crushes up [src] into [target].</span>",\
+				"<span class='notice'>You crush up [src] into [target].</span>")
+				if (src.reagents) // copied wirefix
+					src.reagents.trans_to(target, 5)
 				qdel (src)
 				return
 			else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes "the" printing twice when crushing cigarettes or matches. Also adds description flavor text for having a food item topped with crushed cigarettes (gross!)



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Apart from "the" being printed twice in some spots, there is currently no way to tell if a food item has been tainted (or even worse, poisoned) with (a) crushed cigarette(s).