### PR TITLE
Adds magnesium to fireworks, the ability to cut them open, and fixes magnesium pile behavior

### DIFF
--- a/code/obj/decal/cleanable.dm
+++ b/code/obj/decal/cleanable.dm
@@ -1576,6 +1576,10 @@ var/list/blood_decal_violent_icon_states = list("floor1", "floor2", "floor3", "f
 		..()
 		updateSurroundingMagnesium(T)
 
+	pooled()
+		..()
+		src.sampled = 0 // stop fucking breaking butthead! >:(
+
 	Sample(var/obj/item/W as obj, var/mob/user as mob)
 		..()
 		pool(src)

--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -907,18 +907,21 @@ PIPE BOMBS + CONSTRUCTION
 			if (src.primer_burnt)
 				boutput(user, "<span class='alert'>You can't light a firework more than once!</span>")
 				return
+
 			else if (src.slashed)
 				boutput(user, "<span class='alert'>You prime the firework! [det_time/10] seconds!</span>")
 				SPAWN_DBG( src.det_time )
 					boutput(user, "<span class='alert'>The firework probably should have exploded by now. Fuck.</span>")
 					src.primer_burnt = 1
 					return
+
 			else if (user.bioHolder.HasEffect("clumsy"))
 				boutput(user, "<span class='alert'>Huh? How does this thing work?!</span>")
 				src.primed = 1
 				SPAWN_DBG( 5 )
 					boom()
 					return
+
 			else
 				boutput(user, "<span class='alert'>You prime the firework! [det_time/10] seconds!</span>")
 				src.primed = 1
@@ -929,32 +932,35 @@ PIPE BOMBS + CONSTRUCTION
 	proc/boom()
 		var/turf/location = get_turf(src.loc)
 		if(location)
-			src.visible_message("<span class='alert'>\The [src] explodes!</span>") // moving to avoid race condition
 			if(prob(10))
 				explosion(src, location, 0, 0, 1, 1)
-				qdel (src) // moving to avoid race condition
 			else
 				elecflash(src,power = 2)
 				playsound(src.loc, "sound/effects/Explosion1.ogg", 75, 1)
-				qdel (src)
+		src.visible_message("<span class='alert'>\The [src] explodes!</span>")
+
+		qdel(src)
 
 	attack_self(mob/user as mob)
 		if (user.equipped() == src)
 			if (src.primer_burnt)
 				boutput(user, "<span class='alert'>You can't light a firework more than once!</span>")
 				return
+
 			else if (src.slashed)
 				boutput(user, "<span class='alert'>You prime the firework! [det_time/10] seconds!</span>")
 				SPAWN_DBG( src.det_time )
 					boutput(user, "<span class='alert'>The firework probably should have exploded by now. Fuck.</span>")
 					src.primer_burnt = 1
 					return
+
 			else if (user.bioHolder.HasEffect("clumsy"))
 				boutput(user, "<span class='alert'>Huh? How does this thing work?!</span>")
 				src.primed = 1
 				SPAWN_DBG( 5 )
 					boom()
 					return
+
 			else
 				boutput(user, "<span class='alert'>You prime the firework! [det_time/10] seconds!</span>")
 				src.primed = 1
@@ -965,16 +971,19 @@ PIPE BOMBS + CONSTRUCTION
 	attackby(obj/A as obj, mob/user as mob) // adapted from iv_drips.dm
 		if (iscuttingtool(A) && !(src.slashed) && !(src.primed))
 			src.slashed = 1
+			src.name = "empty [src.name]" // its empty now!
 			src.desc = "[src.desc] It has been cut open and emptied out."
 			boutput(user, "You carefully cut [src] open and dump out the contents.")
-			src.name = "empty [src.name]" // its empty now!
+
 			make_cleanable(/obj/decal/cleanable/magnesiumpile, get_turf(src.loc)) // create magnesium pile
 			src.reagents.clear_reagents() // remove magnesium from firework
 			return
+
 		else if (iscuttingtool(A) && !(src.slashed) && (src.primed)) // cutting open a lit firework is a bad idea!
 			boutput(user, "<span class='alert'>You cut open [src], but the lit primer ignites the contents!</span>")
 			boom()
 			return
+
 		else if (iscuttingtool(A) && (src.slashed))
 			boutput(user, "[src] has already been cut open and emptied.")
 			return

--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -893,9 +893,9 @@ PIPE BOMBS + CONSTRUCTION
 	stamina_damage = 5
 	stamina_cost = 5
 	stamina_crit_chance = 5
-	var/slashed = 0 // has it been emptied out? if so, better dud!
-	var/primer_burnt = 0 // avoid priming a firework multiple times, that doesn't make sense!
-	var/primed = 0 // cutting open lit fireworks is a BAD idea
+	var/slashed = FALSE // has it been emptied out? if so, better dud!
+	var/primer_burnt = FALSE // avoid priming a firework multiple times, that doesn't make sense!
+	var/primed = FALSE // cutting open lit fireworks is a BAD idea
 
 	New()
 		..()

--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -912,19 +912,19 @@ PIPE BOMBS + CONSTRUCTION
 				boutput(user, "<span class='alert'>You prime the firework! [det_time/10] seconds!</span>")
 				SPAWN_DBG( src.det_time )
 					boutput(user, "<span class='alert'>The firework probably should have exploded by now. Fuck.</span>")
-					src.primer_burnt = 1
+					src.primer_burnt = TRUE
 					return
 
 			else if (user.bioHolder.HasEffect("clumsy"))
 				boutput(user, "<span class='alert'>Huh? How does this thing work?!</span>")
-				src.primed = 1
+				src.primed = TRUE
 				SPAWN_DBG( 5 )
 					boom()
 					return
 
 			else
 				boutput(user, "<span class='alert'>You prime the firework! [det_time/10] seconds!</span>")
-				src.primed = 1
+				src.primed = TRUE
 				SPAWN_DBG( src.det_time )
 					boom()
 					return
@@ -951,26 +951,26 @@ PIPE BOMBS + CONSTRUCTION
 				boutput(user, "<span class='alert'>You prime the firework! [det_time/10] seconds!</span>")
 				SPAWN_DBG( src.det_time )
 					boutput(user, "<span class='alert'>The firework probably should have exploded by now. Fuck.</span>")
-					src.primer_burnt = 1
+					src.primer_burnt = TRUE
 					return
 
 			else if (user.bioHolder.HasEffect("clumsy"))
 				boutput(user, "<span class='alert'>Huh? How does this thing work?!</span>")
-				src.primed = 1
+				src.primed = TRUE
 				SPAWN_DBG( 5 )
 					boom()
 					return
 
 			else
 				boutput(user, "<span class='alert'>You prime the firework! [det_time/10] seconds!</span>")
-				src.primed = 1
+				src.primed = TRUE
 				SPAWN_DBG( src.det_time )
 					boom()
 					return
 
 	attackby(obj/A as obj, mob/user as mob) // adapted from iv_drips.dm
 		if (iscuttingtool(A) && !(src.slashed) && !(src.primed))
-			src.slashed = 1
+			src.slashed = TRUE
 			src.name = "empty [src.name]" // its empty now!
 			src.desc = "[src.desc] It has been cut open and emptied out."
 			boutput(user, "You carefully cut [src] open and dump out the contents.")

--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -878,7 +878,7 @@ PIPE BOMBS + CONSTRUCTION
 
 /obj/item/firework
 	name = "firework"
-	desc = "BOOM!"
+	desc = "A consumer-grade pyrotechnic, often used in celebrations. This one says it was manufactured in Space-China."
 	icon = 'icons/obj/items/items.dmi'
 	icon_state = "firework"
 	opacity = 0
@@ -893,16 +893,35 @@ PIPE BOMBS + CONSTRUCTION
 	stamina_damage = 5
 	stamina_cost = 5
 	stamina_crit_chance = 5
+	var/slashed = 0 // has it been emptied out? if so, better dud!
+	var/primer_burnt = 0 // avoid priming a firework multiple times, that doesn't make sense!
+	var/primed = 0 // cutting open lit fireworks is a BAD idea
+
+	New()
+		..()
+		create_reagents(10)
+		reagents.add_reagent("magnesium", 10)
 
 	afterattack(atom/target as mob|obj|turf|area, mob/user as mob)
 		if (user.equipped() == src)
-			if (user.bioHolder.HasEffect("clumsy"))
+			if (src.primer_burnt)
+				boutput(user, "<span class='alert'>You can't light a firework more than once!</span>")
+				return
+			else if (src.slashed)
+				boutput(user, "<span class='alert'>You prime the firework! [det_time/10] seconds!</span>")
+				SPAWN_DBG( src.det_time )
+					boutput(user, "<span class='alert'>The firework probably should have exploded by now. Fuck.</span>")
+					src.primer_burnt = 1
+					return
+			else if (user.bioHolder.HasEffect("clumsy"))
 				boutput(user, "<span class='alert'>Huh? How does this thing work?!</span>")
+				src.primed = 1
 				SPAWN_DBG( 5 )
 					boom()
 					return
 			else
 				boutput(user, "<span class='alert'>You prime the firework! [det_time/10] seconds!</span>")
+				src.primed = 1
 				SPAWN_DBG( src.det_time )
 					boom()
 					return
@@ -910,27 +929,55 @@ PIPE BOMBS + CONSTRUCTION
 	proc/boom()
 		var/turf/location = get_turf(src.loc)
 		if(location)
+			src.visible_message("<span class='alert'>\The [src] explodes!</span>") // moving to avoid race condition
 			if(prob(10))
 				explosion(src, location, 0, 0, 1, 1)
+				qdel (src) // moving to avoid race condition
 			else
 				elecflash(src,power = 2)
 				playsound(src.loc, "sound/effects/Explosion1.ogg", 75, 1)
-		src.visible_message("<span class='alert'>\The [src] explodes!</span>")
-
-		qdel(src)
+				qdel (src)
 
 	attack_self(mob/user as mob)
 		if (user.equipped() == src)
-			if (user.bioHolder.HasEffect("clumsy"))
+			if (src.primer_burnt)
+				boutput(user, "<span class='alert'>You can't light a firework more than once!</span>")
+				return
+			else if (src.slashed)
+				boutput(user, "<span class='alert'>You prime the firework! [det_time/10] seconds!</span>")
+				SPAWN_DBG( src.det_time )
+					boutput(user, "<span class='alert'>The firework probably should have exploded by now. Fuck.</span>")
+					src.primer_burnt = 1
+					return
+			else if (user.bioHolder.HasEffect("clumsy"))
 				boutput(user, "<span class='alert'>Huh? How does this thing work?!</span>")
+				src.primed = 1
 				SPAWN_DBG( 5 )
 					boom()
 					return
 			else
 				boutput(user, "<span class='alert'>You prime the firework! [det_time/10] seconds!</span>")
+				src.primed = 1
 				SPAWN_DBG( src.det_time )
 					boom()
 					return
+
+	attackby(obj/A as obj, mob/user as mob) // adapted from iv_drips.dm
+		if (iscuttingtool(A) && !(src.slashed) && !(src.primed))
+			src.slashed = 1
+			src.desc = "[src.desc] It has been cut open and emptied out."
+			boutput(user, "You carefully cut [src] open and dump out the contents.")
+			src.name = "empty [src.name]" // its empty now!
+			make_cleanable(/obj/decal/cleanable/magnesiumpile, get_turf(src.loc)) // create magnesium pile
+			src.reagents.clear_reagents() // remove magnesium from firework
+			return
+		else if (iscuttingtool(A) && !(src.slashed) && (src.primed)) // cutting open a lit firework is a bad idea!
+			boutput(user, "<span class='alert'>You cut open [src], but the lit primer ignites the contents!</span>")
+			boom()
+			return
+		else if (iscuttingtool(A) && (src.slashed))
+			boutput(user, "[src] has already been cut open and emptied.")
+			return
 
 //////////////////////// Breaching charges //////////////////////////////////
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Firstly, this adds the ability to cut open fireworks using any "cutting tool" to dump the magnesium inside onto the ground, which can then be scooped up. This will also make magnesium piles behave more consistently when it comes to being able to scrape them off the ground.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
By adding a method of obtaining magnesium, a hobo route to hydrogen is made possible. Hydrogen is used in quite a number of hobo-esque reactions, and having a dispenser-less way to obtain it would bring us closer to making some of them feasible. In this case methamphetamine, which would have a complete hobo path to creation. 

Also, by making sure the "sampled" var is reset to 0 when pool() is called, magnesium piles are made to behave more consistently. Specifically in regards to being able to scoop them up off the ground. In my testing there were many instances where all magnesium piles would be created with a "sampled" value of 1, not allowing them to be scooped.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)PissOffMate18:
(+)Added the ability to cut open fireworks as a hobo source of magnesium.
```
