### PR TITLE
Two new hotkeys: Hitting yourself with an item & hit your inactive hand with an item

### DIFF
--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -893,6 +893,14 @@
 			src.zone_sel.select_zone("l_leg")
 		if ("r_leg")
 			src.zone_sel.select_zone("r_leg")
+		if ("selfattack")
+			var/obj/item/W = src.equipped()
+			if (W)
+				src.click(src, list())
+		if ("usehand")
+			var/obj/item/W = src.hand ? src.r_hand : src.l_hand
+			if (W)
+				src.click(W, list())
 		else
 			return ..()
 

--- a/code/modules/interface/action_associations.dm
+++ b/code/modules/interface/action_associations.dm
@@ -7,6 +7,8 @@ var/list/action_names = list(
 	"swaphand" = "Swap Hand",
 	"equip" = "Equip",
 	"resist" = "Resist",
+	"selfattack" = "Attack self with in-hand",
+	"usehand" = "Use in-hand on other hand",
 
 	"fart" = "Fart",
 	"flip" = "Flip",

--- a/code/modules/interface/keybind_style.dm
+++ b/code/modules/interface/keybind_style.dm
@@ -166,6 +166,8 @@ var/global/list/datum/keybind_style/keybind_styles = null
 		"Q" = "drop",
 		"E" = "swaphand",
 		"C" = "attackself",
+		"H" = "selfattack",
+		"X" = "usehand",
 		"DELETE" = "togglethrow"
 	)
 

--- a/code/modules/interface/keybind_style.dm
+++ b/code/modules/interface/keybind_style.dm
@@ -190,7 +190,8 @@ var/global/list/datum/keybind_style/keybind_styles = null
 	"X" = "swaphand",
 	"Z" = "attackself",
 	"Q" = "drop",
-	"C" = "resist"
+	"C" = "resist",
+	"N" = "usehand"
 	)
 
 /datum/keybind_style/human/tg/azerty


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surroundedby brackets below, for example: [LABEL] -->
[FEATURE] [INPUT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR adds two new hotkeys to the default human hotkeys list: `H` lets you attack yourself with the item in your active hand, and `X` lets you attack the object in your off-hand with your active hand.

To be a bit more specific, we currently have a hotkey for `"attackself"`, which calls `src.click(W, list())`; essentially, this existing hotkey action is the same as clicking on the item in your active hand, with that item active (it ends up calling the item's `attack_self` proc). The new hotkey "selfattack", bound to "H" by default, calls `src.click(src, list())`, which ends up calling the item's `attack` proc on the user. This new hotkey does nothing if you have no item in your active hand.

The new hotkey for "usehand", bound to "X" by default, is the same as clicking on an object in your off hand. If you have nothing in your active hand, the item in your off hand will be switched to your active hand. This new hotkey does nothing if you have no item in your inactive hand.

(Edit: TG hotkey for `"usehand"` is "N" by default)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

These hotkeys make self-surgery, bomb-making, and drinking slightly less reliant on moving the mouse, among other actions.

The `H` hotkey is **really dangerous**; you will attack yourself with the object in your active hand, even if the object hurts a lot. Maybe this shouldn't be a default hotkey? Or maybe people shouldn't run with scissors? 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Jawns:
(*)New hotkeys for attacking yourself and clicking on your inactive hand with your active hand! Wow!
```
