### PR TITLE
Espresso/coffee machine fix

### DIFF
--- a/code/obj/machinery/espresso.dm
+++ b/code/obj/machinery/espresso.dm
@@ -93,7 +93,7 @@
 								C:set_loc(src.loc)
 							user.show_text("You have removed the [src.cup_name] from the [src].")
 							src.update()
-							if ("Nothing")
+						if ("Nothing")
 								return
 			else return ..()
 

--- a/code/obj/machinery/espresso.dm
+++ b/code/obj/machinery/espresso.dm
@@ -94,7 +94,7 @@
 							user.show_text("You have removed the [src.cup_name] from the [src].")
 							src.update()
 						if ("Nothing")
-								return
+							return
 			else return ..()
 
 	ex_act(severity)

--- a/code/obj/machinery/espresso.dm
+++ b/code/obj/machinery/espresso.dm
@@ -13,9 +13,6 @@
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_WELDER | DECON_WIRECUTTERS
 	var/cupinside = 0 //true or false
 	var/top_on = 1 //screwed on or screwed off
-	var/water_level = 100 //water level, used to press the coffee
-	var/water_level_max = 100
-	var/wateramt = 0 //temp water value used for putting water in
 	var/cup_name = "espresso cup"
 	var/image/image_top = null
 	var/image/image_cup = null
@@ -24,12 +21,6 @@
 		..()
 		UnsubscribeProcess()
 		src.update()
-
-	get_desc(dist, mob/user)
-		if (dist <= 2)
-			. += "There's [src.water_level] out of [src.water_level_max] units of water in the [src]'s tank."
-		if (src.top_on == 0)
-			. += " It appears that the water tank's lid has been screwed off."
 
 	attackby(var/obj/item/W as obj, var/mob/user as mob)
 		if (istype(W, /obj/item/reagent_containers/food/drinks/espressocup))
@@ -43,122 +34,67 @@
 				user.show_text ("You place the [src.cup_name] into the [src].")
 				src.update()
 				return ..()
-		if (istype(W, /obj/item/reagent_containers/glass/)) //	pour water in the reagent_container inside and update water level
-			if (src.top_on == 0)
-				if (W.reagents.has_reagent("water"))
-					if (src.water_level >= src.water_level_max)
-						user.show_text("You can't pour any more water into the [src].")
-						return ..()
-					else
-						src.wateramt = W.reagents.get_reagent_amount("water")
-						if ((src.water_level + src.wateramt) > src.water_level_max)
-							user.show_text("You can't pour any more water into the [src].")
-							return ..()
-						else
-							W.reagents.isolate_reagent("water")
-							W.reagents.del_reagent("water")
-							src.water_level += src.wateramt
-							user.show_text("You dumped [src.wateramt] units of water into the [src].")
-							src.wateramt = 0
-							return ..()
-				else
-					user.show_text("The container does not have any water in it!")
-					return ..()
-			else
-				user.show_text("Why are you trying to pour junk everywhere? Get the top off, ya fool!")
-				return ..()
 
 	attack_hand(mob/user as mob)
 		if (can_reach(user,src))
 			src.add_fingerprint(user)
-			if (src.cupinside == 1 && top_on == 1) //freaking spacing errors made me waste hours on this
+			if (src.cupinside == 1) //freaking spacing errors made me waste hours on this
 				if(!status & (NOPOWER|BROKEN))
 					switch(alert("What would you like to do with [src]?",,"Make espresso","Remove cup","Nothing"))
 						if ("Make espresso")
-							if (src.water_level >= 10)
-								src.water_level -= 10
-								var/drink_choice = input(user, "What kind of espresso do you want to make?", "Selection") as null|anything in list("Espresso","Latte","Mocha","Cappuchino","Americano", "Decaf", "Flat White")
-								if (!drink_choice)
+							var/drink_choice = input(user, "What kind of espresso do you want to make?", "Selection") as null|anything in list("Espresso","Latte","Mocha","Cappuchino","Americano", "Decaf", "Flat White")
+							if (!drink_choice)
+								return
+							switch (drink_choice)  //finds cup in contents and adds chosen drink to it
+								if ("Espresso")
+									for(var/obj/item/reagent_containers/food/drinks/espressocup/C in src.contents)
+										C.reagents.add_reagent("espresso",10)
+										playsound(src.loc, 'sound/misc/pourdrink.ogg', 50, 1)
 									return
-								switch (drink_choice)  //finds cup in contents and adds chosen drink to it
-									if ("Espresso")
-										for(var/obj/item/reagent_containers/food/drinks/espressocup/C in src.contents)
-											C.reagents.add_reagent("espresso",10)
-											playsound(src.loc, 'sound/misc/pourdrink.ogg', 50, 1)
-										return
-									if ("Latte") // 5:1 milk:espresso
-										for(var/obj/item/reagent_containers/food/drinks/espressocup/C in src.contents)
-											C.reagents.add_reagent("espresso", 1.6)
-											C.reagents.add_reagent("milk", 8.4)
-											playsound(src.loc, 'sound/misc/pourdrink.ogg', 50, 1)
-										return
-									if ("Mocha") // 3:1:3 espresso:milk:chocolate
-										for(var/obj/item/reagent_containers/food/drinks/espressocup/C in src.contents)
-											C.reagents.add_reagent("espresso", 4.3)
-											C.reagents.add_reagent("milk", 1.4)
-											C.reagents.add_reagent("chocolate", 4.3)
-											playsound(src.loc, 'sound/misc/pourdrink.ogg', 50, 1)
-										return
-									if ("Cappuchino") // 1:1:1 milk foam:milk:espresso
-										for(var/obj/item/reagent_containers/food/drinks/espressocup/C in src.contents)
-											C.reagents.add_reagent("espresso", 3.5)
-											C.reagents.add_reagent("milk", 6.5)
-											playsound(src.loc, 'sound/misc/pourdrink.ogg', 50, 1)
-										return
-									if ("Americano") // 3:2 water:espresso
-										for(var/obj/item/reagent_containers/food/drinks/espressocup/C in src.contents)
-											C.reagents.add_reagent("espresso", 4)
-											C.reagents.add_reagent("water", 6)
-											playsound(src.loc, 'sound/misc/pourdrink.ogg', 50, 1)
-										return
-									if ("Decaf") // 1 decaf espresso
-										for(var/obj/item/reagent_containers/food/drinks/espressocup/C in src.contents)
-											C.reagents.add_reagent("decafespresso", 10)
-											playsound(src.loc, 'sound/misc/pourdrink.ogg', 50, 1)
-										return
-									if ("Flat White") // 3:2 milk:espresso
-										for(var/obj/item/reagent_containers/food/drinks/espressocup/C in src.contents)
-											C.reagents.add_reagent("espresso", 4)
-											C.reagents.add_reagent("milk", 6)
-											playsound(src.loc, 'sound/misc/pourdrink.ogg', 50, 1)
-										return
-							else
-								user.show_text("You don't have enough water in the machine to do that!")
-								return ..()
+								if ("Latte") // 5:1 milk:espresso
+									for(var/obj/item/reagent_containers/food/drinks/espressocup/C in src.contents)
+										C.reagents.add_reagent("espresso", 1.6)
+										C.reagents.add_reagent("milk", 8.4)
+										playsound(src.loc, 'sound/misc/pourdrink.ogg', 50, 1)
+									return
+								if ("Mocha") // 3:1:3 espresso:milk:chocolate
+									for(var/obj/item/reagent_containers/food/drinks/espressocup/C in src.contents)
+										C.reagents.add_reagent("espresso", 4.3)
+										C.reagents.add_reagent("milk", 1.4)
+										C.reagents.add_reagent("chocolate", 4.3)
+										playsound(src.loc, 'sound/misc/pourdrink.ogg', 50, 1)
+									return
+								if ("Cappuchino") // 1:1:1 milk foam:milk:espresso
+									for(var/obj/item/reagent_containers/food/drinks/espressocup/C in src.contents)
+										C.reagents.add_reagent("espresso", 3.5)
+										C.reagents.add_reagent("milk", 6.5)
+										playsound(src.loc, 'sound/misc/pourdrink.ogg', 50, 1)
+									return
+								if ("Americano") // 3:2 water:espresso
+									for(var/obj/item/reagent_containers/food/drinks/espressocup/C in src.contents)
+										C.reagents.add_reagent("espresso", 4)
+										C.reagents.add_reagent("water", 6)
+										playsound(src.loc, 'sound/misc/pourdrink.ogg', 50, 1)
+									return
+								if ("Decaf") // 1 decaf espresso
+									for(var/obj/item/reagent_containers/food/drinks/espressocup/C in src.contents)
+										C.reagents.add_reagent("decafespresso", 10)
+										playsound(src.loc, 'sound/misc/pourdrink.ogg', 50, 1)
+									return
+								if ("Flat White") // 3:2 milk:espresso
+									for(var/obj/item/reagent_containers/food/drinks/espressocup/C in src.contents)
+										C.reagents.add_reagent("espresso", 4)
+										C.reagents.add_reagent("milk", 6)
+										playsound(src.loc, 'sound/misc/pourdrink.ogg', 50, 1)
+									return
 						if ("Remove cup")
 							src.cupinside = 0
 							for(var/obj/item/reagent_containers/food/drinks/espressocup/C in src.contents) //removes cup from contents and ejects
 								C:set_loc(src.loc)
 							user.show_text("You have removed the [src.cup_name] from the [src].")
 							src.update()
-						if ("Nothing")
-							return
-				else
-			if (src.cupinside == 0 && top_on == 1)
-				user.show_text("You begin unscrewing the top of the [src].")
-				if (!do_after(user, 30))
-					boutput(user, "<span class='alert'>You were interrupted!</span>")
-				else
-					src.top_on = 0
-					user.show_text("You have unscrewed the top of the [src].")
-					src.update()
-			if (src.cupinside == 0 && top_on == 0)
-				user.show_text("You begin screwing the top of the [src] back on.")
-				if (!do_after(user, 30))
-					boutput(user, "<span class='alert'>You were interrupted!</span>")
-				else
-					src.top_on = 1
-					user.show_text("You have screwed the top of the [src] back on.")
-					src.update()
-			if (src.cupinside == 1 && top_on == 0)
-				user.show_text("You begin screwing the top of the [src] back on.")
-				if (!do_after(user, 30))
-					boutput(user, "<span class='alert'>You were interrupted!</span>")
-				else
-					src.top_on = 1
-					user.show_text("You have screwed the top of the [src] back on.")
-					src.update()
-				return ..()
+							if ("Nothing")
+								return
 			else return ..()
 
 	ex_act(severity)


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
'Fixes' an espresso/coffee machine bug (where just interacting with it kept unscrewing it even if you didn't mean to) by just removing the code! I had previously suggested to just make the process reqiure a screwdriver to start however Mordent suggested just cutting that code out entirely. This also removes the need to refill the machines water level.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It aint great trying to use something and it just not working for you properly

## Changelog
```
(u)Carbadox:
(+)Coffee/espresso machines no longer have removeable tops and don't need to be manually refilled with water anymore. This should solve the issue with unscrewing the machine even when unintended. 
```
