### PR TITLE
Atmos System regrouping and hotspot handling

### DIFF
--- a/code/modules/atmospherics/FEA_airgroup.dm
+++ b/code/modules/atmospherics/FEA_airgroup.dm
@@ -360,6 +360,10 @@
 */
 		minDist = member.dist_to_space
 
+		// Don't space hotspots, it breaks them
+		if(member.active_hotspot)
+			return 0
+
 		if (member.air && !isnull(minDist))
 			var/datum/gas_mixture/member_air = member.air
 			// Todo - retain nearest space tile border and apply force proportional to amount

--- a/code/modules/atmospherics/FEA_fire.dm
+++ b/code/modules/atmospherics/FEA_fire.dm
@@ -185,15 +185,15 @@
 		if(bypassing)
 			if(!just_spawned)
 				volume = location.air.fuel_burnt*FIRE_GROWTH_RATE
-				temperature = location.air.temperature
+				src.temperature = location.air.temperature
 		else
 			var/datum/gas_mixture/affected = location.air.remove_ratio(volume/max((location.air.volume/5),1))
 
 			affected.temperature = temperature
 
 			affected.react()
+			src.temperature = affected.temperature
 
-			temperature = affected.temperature
 			volume = affected.fuel_burnt*FIRE_GROWTH_RATE
 
 			location.assume_air(affected)

--- a/code/modules/atmospherics/FEA_gas_mixture.dm
+++ b/code/modules/atmospherics/FEA_gas_mixture.dm
@@ -112,31 +112,31 @@ What are the archived variables for?
 /datum/gas_mixture/proc/react(atom/dump_location)
 	var/reacting = 0 //set to 1 if a notable reaction occured (used by pipe_network)
 
-	if(length(trace_gases) > 0)
-		if(temperature > 900)
-			if(toxins > MINIMUM_HEAT_CAPACITY && carbon_dioxide > MINIMUM_HEAT_CAPACITY)
+	if(length(src.trace_gases) > 0)
+		if(src.temperature > 900)
+			if(src.toxins > MINIMUM_HEAT_CAPACITY && src.carbon_dioxide > MINIMUM_HEAT_CAPACITY)
 				var/datum/gas/oxygen_agent_b/trace_gas = locate(/datum/gas/oxygen_agent_b/) in trace_gases
 				if(trace_gas)
-					var/reaction_rate = min(carbon_dioxide*0.75, toxins*0.25, trace_gas.moles*0.05)
+					var/reaction_rate = min(src.carbon_dioxide*0.75, src.toxins*0.25, trace_gas.moles*0.05)
 
-					carbon_dioxide -= reaction_rate
-					oxygen += reaction_rate
+					src.carbon_dioxide -= reaction_rate
+					src.oxygen += reaction_rate
 
 					trace_gas.moles -= reaction_rate*0.05
 
-					temperature += (reaction_rate*20000)/HEAT_CAPACITY(src)
+					src.temperature += (reaction_rate*20000)/HEAT_CAPACITY(src)
 
 					reacting = 1
 
-	if(temperature > 900 && farts && toxins > MINIMUM_HEAT_CAPACITY && carbon_dioxide > MINIMUM_HEAT_CAPACITY)
-		var/reaction_rate = min(carbon_dioxide*0.75, toxins*0.25, farts*0.05)
+	if(src.temperature > 900 && src.farts && src.toxins > MINIMUM_HEAT_CAPACITY && src.carbon_dioxide > MINIMUM_HEAT_CAPACITY)
+		var/reaction_rate = min(src.carbon_dioxide*0.75, src.toxins*0.25, src.farts*0.05)
 
-		carbon_dioxide -= reaction_rate
-		toxins += reaction_rate
+		src.carbon_dioxide -= reaction_rate
+		src.toxins += reaction_rate
 
-		farts -= reaction_rate*0.05
+		src.farts -= reaction_rate*0.05
 
-		temperature += (reaction_rate*10000)/HEAT_CAPACITY(src)
+		src.temperature += (reaction_rate*10000)/HEAT_CAPACITY(src)
 
 		reacting = 1
 
@@ -151,18 +151,18 @@ What are the archived variables for?
 	var/energy_released = 0
 	var/old_heat_capacity = HEAT_CAPACITY(src)
 
-	if(length(trace_gases))
+	if(length(src.trace_gases))
 		var/datum/gas/volatile_fuel/fuel_store = locate(/datum/gas/volatile_fuel/) in trace_gases
 		if(fuel_store) //General volatile gas burn
 			var/burned_fuel = 0
 
-			if(oxygen < fuel_store.moles)
-				burned_fuel = oxygen
+			if(src.oxygen < fuel_store.moles)
+				burned_fuel = src.oxygen
 				fuel_store.moles -= burned_fuel
-				oxygen = 0
+				src.oxygen = 0
 			else
 				burned_fuel = fuel_store.moles
-				oxygen -= fuel_store.moles
+				src.oxygen -= fuel_store.moles
 				//qdel(fuel_store)
 				trace_gases -= fuel_store
 				if(!trace_gases.len)
@@ -170,38 +170,38 @@ What are the archived variables for?
 				fuel_store = null
 
 			energy_released += FIRE_CARBON_ENERGY_RELEASED * burned_fuel
-			carbon_dioxide += burned_fuel
-			fuel_burnt += burned_fuel
+			src.carbon_dioxide += burned_fuel
+			src.fuel_burnt += burned_fuel
 
 	//Handle plasma burning
-	if(toxins > MINIMUM_HEAT_CAPACITY)
+	if(src.toxins > MINIMUM_HEAT_CAPACITY)
 		var/plasma_burn_rate = 0
 		var/oxygen_burn_rate = 0
-		//more plasma released at higher temperatures
+		//more energy released at higher temperatures
 		var/temperature_scale
 		if(src.temperature > PLASMA_UPPER_TEMPERATURE)
 			temperature_scale = 1
 		else
-			temperature_scale = (temperature-PLASMA_MINIMUM_BURN_TEMPERATURE)/(PLASMA_UPPER_TEMPERATURE-PLASMA_MINIMUM_BURN_TEMPERATURE)
+			temperature_scale = (temperature - PLASMA_MINIMUM_BURN_TEMPERATURE) / (PLASMA_UPPER_TEMPERATURE - PLASMA_MINIMUM_BURN_TEMPERATURE)
 		if(temperature_scale > 0)
 			oxygen_burn_rate = 1.4 - temperature_scale
-			if(src.oxygen > src.toxins*PLASMA_OXYGEN_FULLBURN)
-				plasma_burn_rate = (src.toxins*temperature_scale)/4
+			if(src.oxygen > src.toxins * PLASMA_OXYGEN_FULLBURN)
+				plasma_burn_rate = (src.toxins * temperature_scale) / 4
 			else
-				plasma_burn_rate = (temperature_scale*(oxygen/PLASMA_OXYGEN_FULLBURN))/4
+				plasma_burn_rate = (temperature_scale * (src.oxygen / PLASMA_OXYGEN_FULLBURN)) / 4
 			if(plasma_burn_rate > MINIMUM_HEAT_CAPACITY)
-				src.toxins -= plasma_burn_rate/3
-				src.oxygen -= plasma_burn_rate*oxygen_burn_rate
-				src.carbon_dioxide += plasma_burn_rate/3
+				src.toxins -= plasma_burn_rate / 3
+				src.oxygen -= plasma_burn_rate * oxygen_burn_rate
+				src.carbon_dioxide += plasma_burn_rate / 3
 
 				energy_released += FIRE_PLASMA_ENERGY_RELEASED * (plasma_burn_rate)
 
-				fuel_burnt += (plasma_burn_rate)*(1+oxygen_burn_rate)
+				src.fuel_burnt += (plasma_burn_rate) * ( 1 + oxygen_burn_rate)
 
 	if(energy_released > 0)
 		var/new_heat_capacity = HEAT_CAPACITY(src)
 		if(new_heat_capacity > MINIMUM_HEAT_CAPACITY)
-			temperature = (temperature*old_heat_capacity + energy_released)/new_heat_capacity
+			src.temperature = (src.temperature * old_heat_capacity + energy_released) / new_heat_capacity
 
 	return fuel_burnt
 

--- a/code/modules/atmospherics/FEA_system.dm
+++ b/code/modules/atmospherics/FEA_system.dm
@@ -221,6 +221,8 @@ datum/controller/air_system
 					if ((test.dist_to_space == null) || (dist < test.dist_to_space))
 						test.dist_to_space = dist
 
+			// Allow groups to determine if group processing is applicable after FEA setup
+			if(current_cycle) group.group_processing = 0
 			group.members = members
 			air_groups += group
 
@@ -273,6 +275,8 @@ datum/controller/air_system
 		var/list/turf/turf_list = list()
 
 		for(var/datum/air_group/turf_AG in groups_to_rebuild) // Deconstruct groups, gathering their old members
+			if(turf_AG.group_processing)	// Ensure correct air is used for reconstruction, otherwise parent is destroyed
+				turf_AG.suspend_group_processing()
 			for(var/turf/simulated/T as() in turf_AG.members)
 				T.parent = null
 				turf_list += T

--- a/code/modules/atmospherics/FEA_turf_tile.dm
+++ b/code/modules/atmospherics/FEA_turf_tile.dm
@@ -321,7 +321,7 @@ turf
 
 		process_cell()
 			var/list/turf/simulated/possible_fire_spreads
-			if(processing && air)
+			if(src.processing && src.air)
 #ifdef ATMOS_ARCHIVING
 				if(archived_cycle < air_master.current_cycle) //archive self if not already done
 					archive()
@@ -343,14 +343,14 @@ turf
 							if(sharegroup?.group_processing)
 								if(sharegroup.current_cycle < current_cycle)
 									if(sharegroup.air.check_gas_mixture(air))
-										connection_difference = air.share(sharegroup.air)
+										connection_difference = src.air.share(sharegroup.air)
 									else
 										sharegroup.suspend_group_processing()
-										connection_difference = air.share(enemy_tile.air)
+										connection_difference = src.air.share(enemy_tile.air)
 										//group processing failed so interact with individual tile
 							else
 								if(enemy_tile.current_cycle < current_cycle)
-									connection_difference = air.share(enemy_tile.air)
+									connection_difference = src.air.share(enemy_tile.air)
 							if(active_hotspot)
 								if(!possible_fire_spreads)
 									possible_fire_spreads = list()
@@ -368,22 +368,23 @@ turf
 				air_master.active_singletons -= src //not active if not processing!
 				return
 
-			air.react()
 
-			if(active_hotspot && possible_fire_spreads)
-				active_hotspot.process(possible_fire_spreads)
+			src.air.react()
 
-			if(air.temperature > MINIMUM_TEMPERATURE_START_SUPERCONDUCTION)
+			if(src.active_hotspot && possible_fire_spreads)
+				src.active_hotspot.process(possible_fire_spreads)
+
+			if(src.air.temperature > MINIMUM_TEMPERATURE_START_SUPERCONDUCTION)
 				consider_superconductivity(starting = 1)
 
-			if(air.check_tile_graphic())
+			if(src.air.check_tile_graphic())
 				update_visuals(air)
 
-			if(air.temperature > FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
+			if(src.air.temperature > FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
 				hotspot_expose(air.temperature, CELL_VOLUME)
 				for(var/atom/movable/item in src)
-					item.temperature_expose(air, air.temperature, CELL_VOLUME)
-				temperature_expose(air, air.temperature, CELL_VOLUME)
+					item.temperature_expose(src.air, src.air.temperature, CELL_VOLUME)
+				temperature_expose(src.air, src.air.temperature, CELL_VOLUME)
 
 			return 1
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[cleanliness][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Add more logic from check_regroup() to space_fastpath() to ensure ATMOS hotspots don't just randomly get spaced.
  - Corrects odd behavior in burn chamber.
- Ensure ATMOS groups to be sub-divided check to ensure the group suspended so we don't start using other gas_mixtures.
  - Corrects odd behavior when group and turf air are sufficiently de-synced where air just disappears OR is added.
- Ensure new ATMOS groups are not automatically set to group_process when generated after FEA setup.
  - Resolves odd behavior of RCD use in/on/around the burn chamber.  All tiles would be grouped and picked randomly, maybe good RNG (hottest turf)... maybe bad (turf behind airlock).
  - Presumably this should might resolve some oddities in construction mode.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More consistent ATMOS behavior for player base. 

```
(u)Azrun:
(+)Addressed some incorrect grouping in atmospherics when turfs are converted to other turfs. RCDs and space should be more predictable.
```
