### PR TITLE
Candles are lit by environmental heat

### DIFF
--- a/code/obj/item/device/lights.dm
+++ b/code/obj/item/device/lights.dm
@@ -329,6 +329,12 @@
 		else
 			return ..()
 
+	temperature_expose(datum/gas_mixture/air, temperature, volume)
+		if (src.on == 0)
+			if (temperature > T0C+430)
+				src.visible_message("<span class='alert'> [src] ignites!</span>", group = "candle_ignite")
+				src.light()
+
 	process()
 		if (src.on)
 			var/turf/location = src.loc

--- a/code/obj/item/device/lights.dm
+++ b/code/obj/item/device/lights.dm
@@ -331,7 +331,7 @@
 
 	temperature_expose(datum/gas_mixture/air, temperature, volume)
 		if (src.on == 0)
-			if (temperature > T0C+430)
+			if (temperature > (T0C + 430))
 				src.visible_message("<span class='alert'> [src] ignites!</span>", group = "candle_ignite")
 				src.light()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes candles light when they are exposed to temps above T0C+430, which means candles, cigarettes, burning bodies, and such do not light them, while flamethrowers, igniter inhands, burning items, and plasma fires can.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Candles are really time consuming to light in mass amounts, making candle crates harder to use than they should be.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->
```
(u)Chickenish:
(+)Candles are now lit by environmental heat.
```
