### PR TITLE
Adjust TEG for minimum power generation

### DIFF
--- a/code/WorkInProgress/TempEngine.dm
+++ b/code/WorkInProgress/TempEngine.dm
@@ -13,8 +13,8 @@
 
 	var/side = null // 1=left 2=right
 	var/last_pressure_delta = 0
-	var/fan_efficiency = 10 // 0.9 ideal, but I don't want everyone to suffer... yet.
-	var/min_circ_pressure = 10
+	var/fan_efficiency = 0.9 // 0.9 is considered an optimal fan
+	var/min_circ_pressure = 75
 
 	anchored = 1.0
 	density = 1


### PR DESCRIPTION
[balance]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adjust minimum circulator pressure (how much you get with the blower).
Adjusts cost of using blower to be an ideal fan instead of breaking physics fan. 

Change is also in line with desired variation in TEG and better defines a "default" case that should function better across maps.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Previous minimums provided negligible power especially on maps not equipped to provide circulation from outlet to inlet.


```
(u)Azrun:
(*)Adjusted TEG circulators "blowers" to be stronger and pull more power.
```
