### PR TITLE
Eject mobs from dissasembled objects

### DIFF
--- a/code/WorkInProgress/Electronics.dm
+++ b/code/WorkInProgress/Electronics.dm
@@ -136,7 +136,9 @@
 
 
 	disposing()
-		deconstructed_thing = null
+		if(deconstructed_thing)
+			deconstructed_thing.dispose()
+			deconstructed_thing = null
 		store_type = null
 		..()
 

--- a/code/WorkInProgress/simroom.dm
+++ b/code/WorkInProgress/simroom.dm
@@ -202,6 +202,11 @@
 	..()
 	src.update_icon()
 
+/obj/machinery/sim/vr_bed/disposing()
+	go_out()
+	. = ..()
+
+
 /obj/machinery/sim/vr_bed/proc/update_icon()
 	ENSURE_IMAGE(src.image_lid, src.icon, "lid[!isnull(occupant)]")
 	src.UpdateOverlays(src.image_lid, "lid")
@@ -333,9 +338,9 @@
 	if (!src.occupant)
 		return
 	for(var/obj/O in src)
-		O.set_loc(src.loc)
+		O.set_loc(get_turf(src.loc))
 //	src.verbs -= /mob/proc/jack_in
-	src.occupant.set_loc(src.loc)
+	src.occupant.set_loc(get_turf(src.loc))
 	src.occupant.changeStatus("weakened", 2 SECONDS)
 	src.occupant.network_device = null
 	src.occupant = null

--- a/code/modules/medical/genetics/geneticsBooth.dm
+++ b/code/modules/medical/genetics/geneticsBooth.dm
@@ -96,8 +96,10 @@
 
 	disposing()
 		STOP_TRACKING
+		if(occupant)
+			occupant.set_loc(get_turf(src.loc))
+			occupant = null
 		..()
-
 
 	process()
 		if (occupant)

--- a/code/modules/medical/genetics/geneticsScanner.dm
+++ b/code/modules/medical/genetics/geneticsScanner.dm
@@ -35,7 +35,9 @@ var/list/genescanner_addresses = list()
 		radio_connection = null
 		if (src.net_id)
 			genescanner_addresses -= src.net_id
-		occupant = null
+		if(occupant)
+			occupant.set_loc(get_turf(src.loc))
+			occupant = null
 		..()
 
 	allow_drop()

--- a/code/modules/medical/genetics/portagene.dm
+++ b/code/modules/medical/genetics/portagene.dm
@@ -21,6 +21,9 @@
 	disposing()
 		if (islist(portable_machinery))
 			portable_machinery.Remove(src)
+		if(occupant)
+			occupant.set_loc(get_turf(src.loc))
+			occupant = null
 		..()
 
 	examine()

--- a/code/modules/robotics/robot/robot_docking_station.dm
+++ b/code/modules/robotics/robot/robot_docking_station.dm
@@ -27,6 +27,13 @@
 	reagents.add_reagent("fuel", 250)
 	src.build_icon()
 
+/obj/machinery/recharge_station/disposing()
+	if(occupant)
+		occupant.set_loc(get_turf(src.loc))
+		occupant = null
+	..()
+
+
 /obj/machinery/recharge_station/process()
 	if (!(src.status & BROKEN))
 		// todo / at some point id like to fix the disparity between cells and 'normal power'

--- a/code/obj/machinery/clonepod.dm
+++ b/code/obj/machinery/clonepod.dm
@@ -95,7 +95,7 @@
 			connected?.scanner?.pods -= src
 		connected = null
 		if(occupant)
-			occupant.set_loc(src.loc)
+			occupant.set_loc(get_turf(src.loc))
 		occupant = null
 		..()
 
@@ -799,6 +799,13 @@
 		src.update_icon(1)
 		SPAWN_DBG(0)
 			src.find_pods()
+
+	disposing()
+		if(occupant)
+			occupant.set_loc(get_turf(src.loc))
+		occupant = null
+		..()
+
 
 	proc/find_pods()
 		if (!islist(src.pods))

--- a/code/obj/machinery/computer/cloning.dm
+++ b/code/obj/machinery/computer/cloning.dm
@@ -418,7 +418,9 @@ proc/find_ghost_by_key(var/find_key)
 		connected?.scanner = null
 		connected = null
 		pods = null
-		occupant = null
+		if(occupant)
+			occupant.set_loc(get_turf(src.loc))
+			occupant = null
 		..()
 
 	MouseDrop_T(mob/living/target, mob/user)

--- a/code/obj/machinery/drone_recharger.dm
+++ b/code/obj/machinery/drone_recharger.dm
@@ -17,6 +17,12 @@
 	New()
 		..()
 
+	disposing()
+		if(occupant)
+			occupant.set_loc(get_turf(src.loc))
+			occupant = null
+		..()
+
 	process()
 		if(!(status & BROKEN))
 			if (occupant)

--- a/code/obj/machinery/sleeper.dm
+++ b/code/obj/machinery/sleeper.dm
@@ -312,6 +312,12 @@
 					src.link.master = src
 			src.net_id = format_net_id("\ref[src]")
 
+	disposing()
+		if(occupant)
+			occupant.set_loc(get_turf(src.loc))
+			occupant = null
+		..()
+
 	proc/update_icon()
 		ENSURE_IMAGE(src.image_lid, src.icon, "sleeperlid[!isnull(occupant)]")
 		src.UpdateOverlays(src.image_lid, "lid")
@@ -745,7 +751,7 @@
 			// The crusher, hell fires etc. This feature enables quite a bit of mischief.
 			logTheThing("station", usr, null, "sets [src.name]'s home turf to [log_loc(src.homeloc)].")
 		return
- 
+
 /// Yells at doctors to check the thing when it's sent home
 /obj/machinery/sleeper/port_a_medbay/proc/PDA_alert_check()
 	if (src.loc != homeloc)


### PR DESCRIPTION
[bug]
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Ensure deconstructed_thing is disposed of prior to frame.  (May not be needed with `get_turf()` calls)
Move occupant of various machinery objects to turf location on disposal.  Some already dumped to src.loc but that fails if the frame is disassembled in hand.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Addressing [#2660].
Appears to address  [#2661], at least for the simian I tried it on.

## Other thoughts...
Would this be better in /obj/machinery/disposing()?  Seems like it could have unforeseen consequences. 

> 	for (var/mob/M in src)
> 		M.set_loc(get_turf(src.loc))


```
(u)Azrun:
(+)Reduced the likelihood of people being stuck inside inescapable dark pocket dimensions.
```
