### PR TITLE
Makes mobcritters (and other things) get thrown properly

### DIFF
--- a/code/WorkInProgress/actuallyKeelinsStuff.dm
+++ b/code/WorkInProgress/actuallyKeelinsStuff.dm
@@ -3113,7 +3113,7 @@ Returns:
 	var/my_dir=1
 
 	Move(NewLoc,Dir=0)
-		..(NewLoc,Dir)
+		. = ..(NewLoc,Dir)
 		src.set_dir(my_dir)
 
 	unpooled(var/poolname)

--- a/code/WorkInProgress/explosion_particles.dm
+++ b/code/WorkInProgress/explosion_particles.dm
@@ -12,10 +12,6 @@
 		dispose()
 	return
 
-/obj/effects/expl_particles/Move()
-	..()
-	return
-
 /datum/effects/system/expl_particles
 	var/number = 10
 	var/turf/location

--- a/code/WorkInProgress/torpedoes.dm
+++ b/code/WorkInProgress/torpedoes.dm
@@ -461,6 +461,7 @@
 				else
 					lastdir = dir
 					changeIcon()
+			return TRUE
 
 	set_loc(var/newloc as turf|mob|obj in world)
 		..(newloc)

--- a/code/WorkInProgress/tug.dm
+++ b/code/WorkInProgress/tug.dm
@@ -116,7 +116,7 @@
 
 	Move()
 		var/oldloc = src.loc
-		..()
+		. = ..()
 		if (src.loc == oldloc)
 			return
 		if (next_cart)
@@ -346,7 +346,7 @@
 
 	Move()
 		var/oldloc = src.loc
-		..()
+		. = ..()
 		if (src.loc == oldloc)
 			return
 		if (cart)

--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -456,7 +456,7 @@
 						playsound(NewLoc, src.stepsound, 50, 1)
 				else
 					playsound(NewLoc, src.stepsound, 20, 1)
-		..()
+		. = ..()
 
 	update_clothing()
 		equipment_image.overlays.len = 0

--- a/code/mob/living/critter/hastur.dm
+++ b/code/mob/living/critter/hastur.dm
@@ -63,7 +63,7 @@ var/HasturPresent = 0
 			else
 				lastdir = dir
 				changeIcon()
-		..()
+		. = ..()
 
 	set_loc(var/newloc as turf|mob|obj in world)
 		..(newloc)

--- a/code/mob/living/critter/mechmonstrosity.dm
+++ b/code/mob/living/critter/mechmonstrosity.dm
@@ -453,7 +453,7 @@
 
 	Move()
 		playsound(src.loc, "sound/machines/glitch4.ogg", 50, 0)
-		..()
+		. = ..()
 
 	seek_target()
 

--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -2114,7 +2114,7 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 		abilityHolder.updateButtons()
 
 	Move()
-		..()
+		. = ..()
 		misstep_chance = 23
 
 	setup_hands()
@@ -2178,7 +2178,7 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 		abilityHolder.updateButtons()
 
 	Move()
-		..()
+		. = ..()
 		misstep_chance = 23
 
 	setup_hands()

--- a/code/modules/events/gimmick/kudzu.dm
+++ b/code/modules/events/gimmick/kudzu.dm
@@ -162,7 +162,7 @@
 	Move()
 		var/turf/T = get_turf(src)
 		T.temp_flags &= ~HAS_KUDZU
-		..()
+		. = ..()
 
 	disposing()
 		var/turf/T = get_turf(src)

--- a/code/modules/events/meteor_shower.dm
+++ b/code/modules/events/meteor_shower.dm
@@ -227,6 +227,7 @@ var/global/meteor_shower_active = 0
 			if(NewLoc.Enter())
 				src.set_loc(NewLoc)
 				src.set_dir(Dir)
+				return TRUE
 		else
 			hit_object = 0
 		check_hits()

--- a/code/modules/holiday/spacemas.dm
+++ b/code/modules/holiday/spacemas.dm
@@ -149,6 +149,7 @@ var/static/list/santa_snacks = list(/obj/item/reagent_containers/food/drinks/egg
 				var/obj/sparks = unpool(/obj/effects/sparks)
 				sparks.set_loc(src.loc)
 				SPAWN_DBG(2 SECONDS) if (sparks) pool(sparks)
+			return TRUE
 
 /obj/machinery/bot/guardbot/xmas
 	name = "Jinglebuddy"

--- a/code/modules/robotics/bot/medbot.dm
+++ b/code/modules/robotics/bot/medbot.dm
@@ -226,7 +226,7 @@
 
 
 /obj/machinery/bot/medbot/Move(var/turf/NewLoc, direct)
-	..()
+	. = ..()
 	if (src.patient && (get_dist(src,src.patient) <= 1))
 		if (!src.currently_healing)
 			src.currently_healing = 1

--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -490,7 +490,7 @@ Report Arrests: <A href='?src=\ref[src];operation=report'>[report_arrests ? "On"
 
 	Move(var/turf/NewLoc, direct)
 		var/oldloc = src.loc
-		..()
+		. = ..()
 		if (src.attack_per_step && prob(src.attack_per_step == 2 ? 25 : 75))
 			if (oldloc != NewLoc && world.time != last_attack)
 				if (mode == SECBOT_HUNT && target)

--- a/code/obj/critter/big_animals.dm
+++ b/code/obj/critter/big_animals.dm
@@ -510,7 +510,7 @@ obj/critter/bear/care
 	Move()
 		if(prob(15))
 			playsound(src.loc, "rustle", 10, 1)
-		..()
+		. = ..()
 
 /obj/critter/bat/doctor
 	name = "Dr. Acula"

--- a/code/obj/critter/misc.dm
+++ b/code/obj/critter/misc.dm
@@ -484,7 +484,7 @@
 
 	Move()
 		playsound(src.loc, "sound/impact_sounds/Crystal_Hit_1.ogg", 50, 0)
-		..()
+		. = ..()
 
 	attackby(obj/item/W as obj, mob/living/user as mob)
 		..()

--- a/code/obj/critter/spider.dm
+++ b/code/obj/critter/spider.dm
@@ -140,7 +140,7 @@
 		if (src.stepsound)
 			if(prob(30))
 				playsound(src.loc, src.stepsound, 50, 0)
-		..()
+		. = ..()
 
 	CritterAttack(mob/M)
 		if(ismob(M))

--- a/code/obj/decal/cleanable.dm
+++ b/code/obj/decal/cleanable.dm
@@ -107,7 +107,7 @@ proc/make_cleanable(var/type,var/loc,var/list/viral_list)
 			pool(src)
 
 	Move(NewLoc, direct)
-		..()
+		. = ..()
 		if (last_turf && istype(last_turf))
 			last_turf.messy = max(last_turf.messy-1, 0)
 		last_turf = src.loc

--- a/code/obj/effects/bad_smoke.dm
+++ b/code/obj/effects/bad_smoke.dm
@@ -18,7 +18,7 @@
 	event_handler_flags = USE_HASENTERED
 
 /obj/effects/bad_smoke/Move()
-	..()
+	. = ..()
 	for(var/mob/living/carbon/M in get_turf(src))
 		if (M.internal != null && M.wear_mask && (M.wear_mask.c_flags & MASKINTERNALS))
 		else

--- a/code/obj/effects/fart_cloud.dm
+++ b/code/obj/effects/fart_cloud.dm
@@ -35,7 +35,7 @@
 	return
 
 /obj/effects/fart_cloud/Move()
-	..()
+	. = ..()
 	for(var/mob/living/carbon/human/R in get_turf(src))
 		if (R.internal != null && R.wear_mask && (R.wear_mask.c_flags & MASKINTERNALS))
 			continue

--- a/code/obj/effects/harmless_smoke.dm
+++ b/code/obj/effects/harmless_smoke.dm
@@ -24,10 +24,6 @@
 	SPAWN_DBG(time)
 		pool(src)
 
-/obj/effects/harmless_smoke/Move()
-	..()
-	return
-
 
 proc/harmless_smoke_puff(var/turf/location, var/duration = 100)
 	if(!istype(location)) return

--- a/code/obj/effects/mustard_gas.dm
+++ b/code/obj/effects/mustard_gas.dm
@@ -19,7 +19,7 @@
 	return
 
 /obj/effects/mustard_gas/Move()
-	..()
+	. = ..()
 	for(var/mob/living/carbon/human/R in get_turf(src))
 		if (R.internal != null && R.wear_mask && (R.wear_mask.c_flags & MASKINTERNALS))
 		else

--- a/code/obj/effects/sparks.dm
+++ b/code/obj/effects/sparks.dm
@@ -28,7 +28,7 @@
 	..()
 
 /obj/effects/sparks/Move()
-	..()
+	. = ..()
 	var/turf/T = src.loc
 	if (istype(T, /turf))
 		T.hotspot_expose(1000,100,usr)

--- a/code/obj/item/assembly/misc_assemblies.dm
+++ b/code/obj/item/assembly/misc_assemblies.dm
@@ -861,7 +861,7 @@ obj/item/assembly/radio_horn/receive_signal()
 	return
 
 /obj/item/assembly/rad_prox/Move()
-	..()
+	. = ..()
 	src.part2.sense()
 	return
 

--- a/code/obj/item/device/prox_sensor.dm
+++ b/code/obj/item/device/prox_sensor.dm
@@ -172,6 +172,6 @@
 	return
 
 /obj/item/device/prox_sensor/Move()
-	..()
+	. = ..()
 	src.sense()
 	return

--- a/code/obj/item/device/transfer_valve.dm
+++ b/code/obj/item/device/transfer_valve.dm
@@ -316,7 +316,7 @@
 //Prox sensor handling.
 
 	Move()
-		..()
+		. = ..()
 		if(istype(attached_device,/obj/item/device/prox_sensor))
 			var/obj/item/device/prox_sensor/A = attached_device
 			A.sense()

--- a/code/obj/item/keys.dm
+++ b/code/obj/item/keys.dm
@@ -99,7 +99,7 @@
 	virtual
 		desc = "A key made of a fancy, silvery set of pixels."
 		Move()
-			..()
+			. = ..()
 			var/area/A = get_area(src)
 			if (A && !A.virtual)
 				qdel(src)

--- a/code/obj/machinery/pipe/pipe_dispenser.dm
+++ b/code/obj/machinery/pipe/pipe_dispenser.dm
@@ -114,7 +114,7 @@
 
 	Move(var/turf/new_loc,direction)
 		var/old_loc = loc
-		..()
+		. = ..()
 		if(!(direction in cardinal)) // cardinal sin
 			return
 		if(old_loc != loc)

--- a/code/obj/vehicle.dm
+++ b/code/obj/vehicle.dm
@@ -585,7 +585,8 @@ Contains:
 		src.underlays = null
 
 /obj/vehicle/floorbuffer/Move()
-	if(..() && rider)
+	. = ..()
+	if(. && rider)
 		pixel_x = rand(-1, 1)
 		pixel_y = rand(-1, 1)
 		SPAWN_DBG(1 DECI SECOND)
@@ -1249,6 +1250,7 @@ obj/vehicle/clowncar/proc/log_me(var/mob/rider, var/mob/pax, var/action = "", va
 		SPAWN_DBG(1 DECI SECOND)
 			pixel_x = rand(-6, 6)
 			pixel_y = rand(-2, 2)
+		return TRUE
 
 /obj/vehicle/clowncar/cluwne/relaymove(mob/user as mob, dir)
 	..(user, dir)
@@ -1548,9 +1550,6 @@ obj/vehicle/clowncar/proc/log_me(var/mob/rider, var/mob/pax, var/action = "", va
 	var/obj/ability_button/togglespook/togglespook = new
 	togglespook.screen_loc = "NORTH-2"
 	ability_buttons += togglespook
-
-/obj/vehicle/adminbus/disposing()
-	..()
 
 /obj/vehicle/adminbus/Move()
 	if(src.darkness)

--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -79,7 +79,7 @@
 		set_density(0) //mbc : icky but useful for fluids
 		update_nearby_tiles(need_rebuild=1, selfnotify = 1) //only selfnotify when density is 0, because i dont want windows to displace fluids every single move() step. would be slow probably
 		set_density(1)
-		..()
+		. = ..()
 
 
 		src.set_dir(src.ini_dir)

--- a/code/z_adventurezones/mad_mars.dm
+++ b/code/z_adventurezones/mad_mars.dm
@@ -370,7 +370,7 @@
 
 
 	Move()
-		..()
+		. = ..()
 		playsound(src.loc, 'sound/effects/airbridge_dpl.ogg', 30, 10, -2)
 
 


### PR DESCRIPTION
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Mob critters and a bunch of other atoms didn't return proper values in `Move`, this fixes that. Throwing ends when Move returns 0/FALSE/null so this made mobcritters, windows etc. only move one tile when throwing.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Previous behaviour was a bug and unintuitive.


## Changelog
Such a minor bugfix that I don't think it warrants a changelog entry.
