### PR TITLE
Makes borg only have AI radio if they contain an AI interface board

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -185,8 +185,8 @@
 
 			src.botcard.access = get_all_accesses()
 			src.default_radio = new /obj/item/device/radio(src)
-			src.ai_radio = new /obj/item/device/radio/headset/command/ai(src)
 			if (src.shell)
+				src.ai_radio = new /obj/item/device/radio/headset/command/ai(src)
 				src.radio = src.ai_radio
 			else
 				src.radio = src.default_radio
@@ -1170,6 +1170,8 @@
 					src.part_head.ai_interface = I
 					I.set_loc(src.part_head)
 				if (!(src in available_ai_shells))
+					if(isnull(src.ai_radio))
+						src.ai_radio = new /obj/item/device/radio/headset/command/ai(src)
 					src.radio = src.ai_radio
 					src.ears = src.radio
 					src.radio.set_loc(src)
@@ -1411,6 +1413,9 @@
 					src.ears = src.radio
 					src.radio.set_loc(src)
 					src.ai_interface = null
+					if(src.ai_radio)
+						qdel(src.ai_radio)
+						src.ai_radio = null
 					src.shell = 0
 
 					if (mainframe)
@@ -1841,6 +1846,8 @@
 		hud.module_added()
 		if(istype(RM.radio))
 			if (src.shell)
+				if(isnull(src.ai_radio))
+					src.ai_radio = new /obj/item/device/radio/headset/command/ai(src)
 				src.radio = src.ai_radio
 			else
 				src.radio = RM.radio
@@ -1859,6 +1866,8 @@
 		if(istype(src.radio) && src.radio != src.default_radio)
 			src.radio.set_loc(RM)
 			if (src.shell)
+				if(isnull(src.ai_radio))
+					src.ai_radio = new /obj/item/device/radio/headset/command/ai(src)
 				src.radio = src.ai_radio
 			else
 				src.radio = src.default_radio
@@ -2047,7 +2056,7 @@
 
 		src.show_laws(0)
 		return
-		
+
 	verb/cmd_state_standard_laws()
 		set category = "Robot Commands"
 		set name = "State Standard Laws"


### PR DESCRIPTION
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #2656. Internal AI radio now only gets initialized when necessary and is destroyed when removing the AI interface board. This is ugly but fixes the bug. A better solution might be to use the mainframe's radio instead but that seems like coding effort.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug


## Changelog