### PR TITLE
Fixes spider drain ability to match the description

### DIFF
--- a/code/datums/abilities/critter/spider.dm
+++ b/code/datums/abilities/critter/spider.dm
@@ -161,6 +161,7 @@
 			return 1
 		var/mob/living/carbon/human/H = target
 		if(!istype(H) || !isdead(H))
+			boutput(holder.owner, "<span class='alert'>That isn't a dead human.</span>")
 			return 1
 		var/mob/living/critter/spider/S = holder.owner
 		holder.owner.visible_message("<span class='combat'><b>[holder.owner] starts draining the fluids out of [H]!</b></span>",\

--- a/code/datums/abilities/critter/spider.dm
+++ b/code/datums/abilities/critter/spider.dm
@@ -160,6 +160,8 @@
 			boutput(holder.owner, __red("That is too far away to drain."))
 			return 1
 		var/mob/living/carbon/human/H = target
+		if(!istype(H) || !isdead(H))
+			return 1
 		var/mob/living/critter/spider/S = holder.owner
 		holder.owner.visible_message("<span class='combat'><b>[holder.owner] starts draining the fluids out of [H]!</b></span>",\
 		"<span class='combat'><b>You start draining the fluids out of [H]!</b></span>")


### PR DESCRIPTION
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #2560 . According to the description the ability should only drain dead humans. However, this is only checked when targeting a turf under the target. This PR makes it so it is checked no matter what.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug


## Changelog
