### PR TITLE
Signing a zoldorf scroll now produces more helpful messages about progress

### DIFF
--- a/code/obj/item/zoldorfmisc.dm
+++ b/code/obj/item/zoldorfmisc.dm
@@ -15,15 +15,18 @@
 			src.desc = "This is one WEIRD burrito..."
 
 	attackby(obj/item/weapon as obj,mob/user as mob)
-		if((istype(weapon, /obj/item/pen)) && (src.icon_state=="scrollopen"))
-			user.visible_message("<span class='alert'><b>[user.name] stabs themself with the [weapon] and sign the contract in blood!</b></span>","<span class='alert'><b>You stab yourself with the [weapon] and sign the contract in blood!</b></span>")
+		if(istype(weapon, /obj/item/pen) && src.icon_state=="scrollopen")
+			user.visible_message("<span class='alert'><b>[user.name] stabs themself with the [weapon] and starts signing the contract in blood!</b></span>","<span class='alert'><b>You stab yourself with the [weapon] and start signing the contract in blood!</b></span>")
 			playsound(user, "sound/impact_sounds/Flesh_Stab_1.ogg", 60, 1)
 			take_bleeding_damage(user, null, 10, DAMAGE_STAB)
 			src.icon_state = "signing"
 			if (do_after(user, 4.6 SECONDS))
+				user.visible_message("<span class='alert'><b>[user.name] finishes signing the contract in blood!</b></span>","<span class='alert'><b>You finish signing the contract in blood!</b></span>")
 				src.signer = user.real_name
 				src.name = "[user.real_name]'s signed demonic contract"
 				src.icon_state = "signed"
+			else
+				src.icon_state = "scrollopen"
 
 	attack(mob/user as mob,mob/target as mob)
 		if((user == target)&&(src.icon_state == "scrollclosed"))


### PR DESCRIPTION
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #2582 . Signing a zoldorf scroll now produces messages that indicate that this takes time. A message about completing the action is also provided. If signing fails the icon state now gets reverted correctly.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug


## Changelog