### PR TITLE
Manta fixes, re-does Assault Vessel wiring

### DIFF
--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -3931,8 +3931,12 @@
 /area/station/hallway/starboardlowerhallway)
 "akS" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
+	icon_state = "1-10"
+	},
+/obj/cable{
+	icon_state = "1-6"
+	},
+/obj/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/red,
@@ -4016,63 +4020,31 @@
 	dir = 4
 	},
 /area/listeningpost/syndicateassaultvessel)
-"alf" = (
-/obj/machinery/computer3/terminal,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/circuit/red,
-/area/listeningpost/syndicateassaultvessel)
 "alg" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/stairs/dark/wide{
-	dir = 5
+	dir = 4
 	},
 /area/listeningpost/syndicateassaultvessel)
 "alh" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "6-10"
 	},
 /turf/simulated/floor/red,
 /area/listeningpost/syndicateassaultvessel)
 "ali" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/stairs/dark/wide{
-	dir = 8
+	dir = 9
 	},
 /area/listeningpost/syndicateassaultvessel)
 "alj" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/porttorpedoes)
 "alk" = (
-/obj/machinery/computer3/terminal,
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
+/obj/machinery/computer3/terminal,
 /turf/simulated/floor/circuit/red,
 /area/listeningpost/syndicateassaultvessel)
 "all" = (
@@ -4098,16 +4070,17 @@
 /turf/simulated/floor/circuit/red,
 /area/listeningpost/syndicateassaultvessel)
 "alo" = (
-/turf/simulated/floor/stairs/dark/wide{
+/obj/cable{
+	icon_state = "6-8"
+	},
+/obj/cable{
+	icon_state = "5-6"
+	},
+/turf/simulated/floor/stairs/dark{
 	dir = 5
 	},
 /area/listeningpost/syndicateassaultvessel)
 "alp" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/npc/trader/robot{
 	icon = 'icons/mob/robots.dmi';
 	icon_state = "syndibot";
@@ -4179,9 +4152,10 @@
 /area/station/bridge)
 "alw" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "2-9"
+	},
+/obj/cable{
+	icon_state = "2-5"
 	},
 /obj/marker/supplymarker,
 /turf/simulated/floor/red,
@@ -4207,19 +4181,6 @@
 	dir = 4
 	},
 /area/listeningpost/syndicateassaultvessel)
-"alz" = (
-/obj/machinery/door/airlock/pyro/syndicate{
-	desc = "Seems to be a pretty sturdy door.";
-	name = "Syndicate Assault Vessel"
-	},
-/obj/access_spawn/syndie_shuttle,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
 "alA" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 8
@@ -4228,9 +4189,7 @@
 /area/station/hangar/starboard)
 "alB" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "4-10"
 	},
 /turf/simulated/floor/red,
 /area/listeningpost/syndicateassaultvessel)
@@ -4309,19 +4268,8 @@
 	},
 /area/listeningpost/syndicateassaultvessel)
 "alL" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
-"alM" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hallway/portlowerhallway)
 "alN" = (
 /obj/machinery/torpedo_console,
 /turf/simulated/floor/redblack{
@@ -4350,6 +4298,9 @@
 	name = "Listening Post"
 	},
 /obj/access_spawn/syndie_shuttle,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/red,
 /area/listeningpost/syndicateassaultvessel)
 "alR" = (
@@ -4405,7 +4356,7 @@
 	dir = 1
 	},
 /obj/cable{
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/circuit/red,
 /area/listeningpost/syndicateassaultvessel)
@@ -4426,8 +4377,6 @@
 /area/listeningpost/syndicateassaultvessel)
 "amc" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/light/incandescent/warm{
@@ -4457,6 +4406,9 @@
 	},
 /area/listeningpost/syndicateassaultvessel)
 "amg" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
 /obj/machinery/light/incandescent/warm{
 	dir = 8
 	},
@@ -4553,16 +4505,26 @@
 	},
 /area/listeningpost/syndicateassaultvessel)
 "amr" = (
-/obj/machinery/computer3/generic/secure_data,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
+/obj/machinery/computer3/generic/secure_data,
 /turf/simulated/floor/redblack/corner{
 	dir = 6
 	},
 /area/listeningpost/syndicateassaultvessel)
 "ams" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/mainframe/zeta{
+	tag = "OTHER_MAINFRAME"
+	},
+/obj/machinery/light/incandescent/warm{
+	dir = 1
+	},
 /obj/decal/fakeobjects{
 	anchored = 1;
 	desc = "A security camera that is not on but, instead, off.";
@@ -4570,24 +4532,14 @@
 	icon_state = "camerax";
 	name = "security camera"
 	},
-/obj/machinery/light/incandescent/warm{
-	dir = 1
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/networked/mainframe/zeta{
-	tag = "OTHER_MAINFRAME"
-	},
-/obj/machinery/power/data_terminal,
 /turf/simulated/floor/redblack,
 /area/listeningpost/syndicateassaultvessel)
 "amt" = (
-/obj/machinery/computer/security,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
+/obj/machinery/computer/security,
 /turf/simulated/floor/redblack/corner{
 	dir = 4
 	},
@@ -4621,14 +4573,7 @@
 /area/listeningpost/syndicateassaultvessel)
 "amy" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/red,
 /area/listeningpost/syndicateassaultvessel)
@@ -4638,6 +4583,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/cable{
+	icon_state = "4-10"
+	},
 /turf/simulated/floor/redblack,
 /area/listeningpost/syndicateassaultvessel)
 "amA" = (
@@ -4645,9 +4593,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/redblack{
 	dir = 6
@@ -4655,18 +4603,23 @@
 /area/listeningpost/syndicateassaultvessel)
 "amB" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
 /obj/cable{
-	icon_state = "1-8"
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/red,
 /area/listeningpost/syndicateassaultvessel)
 "amC" = (
 /obj/cable{
 	icon_state = "1-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/redblack{
 	dir = 10
@@ -4807,8 +4760,7 @@
 "amY" = (
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-5"
 	},
 /turf/simulated/floor/redblack{
 	dir = 4
@@ -4816,16 +4768,14 @@
 /area/listeningpost/syndicateassaultvessel)
 "amZ" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "2-8"
 	},
 /turf/simulated/floor/red,
 /area/listeningpost/syndicateassaultvessel)
 "ana" = (
+/obj/cable{
+	icon_state = "2-9"
+	},
 /turf/simulated/floor/carpet/red/fancy/edge/west,
 /area/listeningpost/syndicateassaultvessel)
 "anb" = (
@@ -4849,6 +4799,9 @@
 /turf/simulated/floor/carpet/red/fancy,
 /area/listeningpost/syndicateassaultvessel)
 "ane" = (
+/obj/cable{
+	icon_state = "2-5"
+	},
 /turf/simulated/floor/carpet/red/fancy/edge/east,
 /area/listeningpost/syndicateassaultvessel)
 "anf" = (
@@ -4909,12 +4862,36 @@
 /turf/simulated/floor/red,
 /area/listeningpost/syndicateassaultvessel)
 "anm" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "4-9"
+	},
 /turf/simulated/floor/carpet/red/fancy/edge/sw,
 /area/listeningpost/syndicateassaultvessel)
 "ann" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "4-9"
+	},
 /turf/simulated/floor/carpet/red/fancy/edge/south,
 /area/listeningpost/syndicateassaultvessel)
 "ano" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "5-8"
+	},
 /turf/simulated/floor/carpet/red/fancy/edge/se,
 /area/listeningpost/syndicateassaultvessel)
 "anp" = (
@@ -4925,11 +4902,6 @@
 /area/listeningpost/syndicateassaultvessel)
 "anq" = (
 /obj/decal/cleanable/blood,
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /turf/simulated/floor/red,
 /area/listeningpost/syndicateassaultvessel)
 "anr" = (
@@ -4939,11 +4911,6 @@
 	name = "Prison";
 	req_access = null;
 	req_access_txt = "52"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/access_spawn/syndie_shuttle,
 /turf/simulated/floor/red,
@@ -4966,7 +4933,6 @@
 	icon_state = "floor5"
 	},
 /obj/machinery/light/incandescent/warm,
-/obj/cable,
 /turf/simulated/floor/red,
 /area/listeningpost/syndicateassaultvessel)
 "anv" = (
@@ -5079,18 +5045,10 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
-"anI" = (
-/obj/machinery/door/airlock/pyro/syndicate{
-	desc = "Seems to be a pretty sturdy door.";
-	name = "Syndicate Assault Vessel"
-	},
+"anJ" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/access_spawn/syndie_shuttle,
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
-"anJ" = (
 /obj/machinery/door/airlock/pyro/syndicate{
 	desc = "Seems to be a pretty sturdy door.";
 	name = "Syndicate Assault Vessel"
@@ -5147,14 +5105,12 @@
 /area/station/hallway/starboardupperhallway)
 "anO" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "4-9"
 	},
 /turf/simulated/floor/black,
 /area/listeningpost/syndicateassaultvessel)
@@ -5178,21 +5134,23 @@
 /area/listeningpost/syndicateassaultvessel)
 "anR" = (
 /obj/cable{
-	icon_state = "1-8"
-	},
-/obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating/random,
 /area/listeningpost/syndicateassaultvessel)
 "anS" = (
 /obj/cable{
-	icon_state = "2-8"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "1-8"
+	icon_state = "5-8"
 	},
 /turf/simulated/floor/black,
 /area/listeningpost/syndicateassaultvessel)
@@ -5213,6 +5171,10 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperport)
 "anV" = (
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /obj/machinery/power/furnace,
 /obj/decal/fakeobjects{
 	anchored = 1;
@@ -5222,20 +5184,14 @@
 	icon_state = "camerax";
 	name = "security camera"
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /turf/simulated/floor/plating/random,
 /area/listeningpost/syndicateassaultvessel)
 "anW" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "5-8"
 	},
 /obj/cable{
-	icon_state = "2-8"
+	icon_state = "2-5"
 	},
 /turf/simulated/floor/plating/random,
 /area/listeningpost/syndicateassaultvessel)
@@ -5243,14 +5199,6 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8;
 	tag = "icon-xtra_bigstripe-edge (WEST)"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
 	dir = 1;
@@ -5260,7 +5208,7 @@
 /area/listeningpost/syndicateassaultvessel)
 "anY" = (
 /obj/cable{
-	icon_state = "1-8"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/black,
 /area/listeningpost/syndicateassaultvessel)
@@ -5274,11 +5222,14 @@
 /area/listeningpost/syndicateassaultvessel)
 "aoa" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "4-10"
 	},
-/turf/simulated/floor/black,
+/obj/cable{
+	icon_state = "9-10"
+	},
+/turf/simulated/floor/stairs/dark{
+	dir = 9
+	},
 /area/listeningpost/syndicateassaultvessel)
 "aob" = (
 /obj/disposalpipe/segment,
@@ -5293,14 +5244,6 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
 	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
 /obj/machinery/light/small{
 	dir = 1;
 	status = 2
@@ -5309,18 +5252,18 @@
 /area/listeningpost/syndicateassaultvessel)
 "aod" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "4-9"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-9"
 	},
 /turf/simulated/floor/plating/random,
 /area/listeningpost/syndicateassaultvessel)
 "aoe" = (
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /obj/machinery/power/furnace,
 /obj/decal/fakeobjects{
 	anchored = 1;
@@ -5329,10 +5272,6 @@
 	icon = 'icons/obj/monitors.dmi';
 	icon_state = "camerax";
 	name = "security camera"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating/random,
 /area/listeningpost/syndicateassaultvessel)
@@ -5343,11 +5282,11 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
 "aog" = (
-/obj/machinery/power/furnace,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/power/furnace,
 /turf/simulated/floor/plating/random,
 /area/listeningpost/syndicateassaultvessel)
 "aoh" = (
@@ -5378,18 +5317,16 @@
 /area/listeningpost/syndicateassaultvessel)
 "aom" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating/random,
 /area/listeningpost/syndicateassaultvessel)
 "aon" = (
-/obj/machinery/power/furnace,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/power/furnace,
 /turf/simulated/floor/plating/random,
 /area/listeningpost/syndicateassaultvessel)
 "aoo" = (
@@ -6434,63 +6371,34 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/lowerport)
 "aqe" = (
-/obj/storage/crate/furnacefuel,
+/obj/cable{
+	icon_state = "0-6"
+	},
+/obj/machinery/power/terminal{
+	dir = 4
+	},
 /turf/simulated/floor/plating/random,
 /area/listeningpost/syndicateassaultvessel)
 "aqf" = (
-/obj/machinery/power/smes/magical,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8;
 	tag = "icon-xtra_bigstripe-edge (WEST)"
 	},
-/turf/simulated/floor/black,
-/area/listeningpost/syndicateassaultvessel)
-"aqg" = (
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "0-6"
 	},
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
+/obj/machinery/power/smes/magical,
 /turf/simulated/floor/black,
 /area/listeningpost/syndicateassaultvessel)
 "aqh" = (
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
+/obj/storage/crate/furnacefuel,
 /turf/simulated/floor/black,
 /area/listeningpost/syndicateassaultvessel)
 "aqi" = (
+/obj/cable{
+	icon_state = "0-10"
+	},
 /obj/machinery/power/smes/magical,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/black,
 /area/listeningpost/syndicateassaultvessel)
 "aqj" = (
@@ -6498,43 +6406,41 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/power/data_terminal,
 /obj/machinery/networked/storage/tape_drive{
 	bank_id = "Control";
 	locked = 0;
 	name = "Databank - Control";
 	setup_drive_type = /obj/item/disk/data/tape/master
 	},
-/obj/machinery/power/data_terminal,
 /turf/simulated/floor/plating/random,
 /area/listeningpost/syndicateassaultvessel)
 "aqk" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8;
 	tag = "icon-xtra_bigstripe-edge (WEST)"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "9-10"
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/listeningpost/syndicateassaultvessel)
 "aql" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "5-6"
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/listeningpost/syndicateassaultvessel)
@@ -6543,8 +6449,8 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/networked/radio,
 /obj/machinery/power/data_terminal,
+/obj/machinery/networked/radio,
 /turf/simulated/floor/plating/random,
 /area/listeningpost/syndicateassaultvessel)
 "aqn" = (
@@ -7946,22 +7852,11 @@
 	dir = 8;
 	tag = "icon-xtra_bigstripe-edge (WEST)"
 	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/circuit/red,
 /area/listeningpost/syndicateassaultvessel)
 "atC" = (
+/obj/cable,
 /obj/submachine/syndicate_teleporter,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/circuit/red,
 /area/listeningpost/syndicateassaultvessel)
 "atD" = (
@@ -7993,8 +7888,17 @@
 /turf/simulated/floor/bot/blue,
 /area/station/ai_monitored/storage/eva)
 "atG" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/portlowerhallway)
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/black,
+/area/listeningpost/syndicateassaultvessel)
+"atH" = (
+/obj/cable{
+	icon_state = "5-8"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "atI" = (
 /obj/storage/closet/syndicate/personal,
 /obj/item/clothing/under/misc/syndicate,
@@ -8102,13 +8006,11 @@
 /turf/simulated/floor,
 /area/station/security/starboardtorpedoes)
 "atX" = (
-/obj/machinery/door/airlock/pyro/glass,
-/obj/access_spawn/syndie_shuttle,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/glass,
+/obj/access_spawn/syndie_shuttle,
 /turf/simulated/floor/red,
 /area/listeningpost/syndicateassaultvessel)
 "atY" = (
@@ -18055,6 +17957,12 @@
 	},
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
+"aPq" = (
+/obj/cable{
+	icon_state = "4-9"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "aPr" = (
 /obj/cable{
 	d1 = 4;
@@ -44840,6 +44748,15 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
+"cud" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-6"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "cuz" = (
 /obj/machinery/recharger/wall/sticky{
 	dir = 8
@@ -44983,6 +44900,15 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
+"dPH" = (
+/obj/stool/chair/comfy/red{
+	dir = 8
+	},
+/obj/cable{
+	icon_state = "1-10"
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/east,
+/area/listeningpost/syndicateassaultvessel)
 "dWi" = (
 /obj/cable{
 	d1 = 4;
@@ -45030,6 +44956,32 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/construction2)
+"enA" = (
+/obj/stool/chair/red{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "5-6"
+	},
+/turf/simulated/floor/redblack{
+	dir = 4
+	},
+/area/listeningpost/syndicateassaultvessel)
+"eyj" = (
+/obj/cable{
+	icon_state = "2-9"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
+"eEJ" = (
+/obj/cable{
+	icon_state = "0-10"
+	},
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/turf/simulated/floor/plating/random,
+/area/listeningpost/syndicateassaultvessel)
 "eFJ" = (
 /obj/lattice{
 	icon_state = "lattice-dir"
@@ -45200,6 +45152,17 @@
 	},
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
+"gtD" = (
+/obj/stool/chair/red{
+	dir = 8
+	},
+/obj/cable{
+	icon_state = "9-10"
+	},
+/turf/simulated/floor/redblack{
+	dir = 8
+	},
+/area/listeningpost/syndicateassaultvessel)
 "gtZ" = (
 /obj/landmark{
 	name = "bubsbeejob"
@@ -45305,6 +45268,17 @@
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/south,
 /area/station/security/hos)
+"hxU" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "5-8"
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/south,
+/area/listeningpost/syndicateassaultvessel)
 "hAj" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/right{
@@ -45616,6 +45590,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/hos)
+"lRZ" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-10"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "lSg" = (
 /obj/decal/tile_edge/line/purple{
 	dir = 10;
@@ -45664,6 +45647,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
+"mgj" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "4-9"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "mnz" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -45715,6 +45707,17 @@
 	},
 /turf/space/fluid/manta,
 /area/mantaSpace)
+"mPH" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/random,
+/area/listeningpost/syndicateassaultvessel)
 "mSY" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -45881,6 +45884,15 @@
 	dir = 1
 	},
 /area/station/engine/inner)
+"oqw" = (
+/obj/stool/chair/comfy/red{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-6"
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/west,
+/area/listeningpost/syndicateassaultvessel)
 "ozn" = (
 /obj/wingrille_spawn/auto,
 /obj/wingrille_spawn/auto,
@@ -46069,6 +46081,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/sec_foyer)
+"rcL" = (
+/obj/cable{
+	icon_state = "2-5"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "rdE" = (
 /obj/cable{
 	d1 = 1;
@@ -46153,6 +46171,15 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/security/hos)
+"sRL" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "5-8"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "sTs" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -46228,6 +46255,12 @@
 /obj/item/pen/pencil,
 /turf/simulated/floor/carpet/grime,
 /area/station/communications/bedroom)
+"ulO" = (
+/obj/cable{
+	icon_state = "6-8"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "uFt" = (
 /obj/decal/tile_edge/line/green{
 	color = "#e7c88c";
@@ -46308,6 +46341,17 @@
 /obj/machinery/light/runway_light/delay4,
 /turf/space/fluid/manta,
 /area/mantaSpace)
+"vuB" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "6-8"
+	},
+/turf/simulated/floor/redblack,
+/area/listeningpost/syndicateassaultvessel)
 "vzA" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -46327,6 +46371,14 @@
 "vRo" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/secondary/construction)
+"vVw" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/south,
+/area/listeningpost/syndicateassaultvessel)
 "vWe" = (
 /obj/lattice{
 	dir = 4;
@@ -46471,6 +46523,12 @@
 	},
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/communications/office)
+"wWK" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "xaf" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/secondary/construction)
@@ -86051,7 +86109,7 @@ buY
 buY
 buY
 bAp
-atG
+alL
 bFQ
 bGM
 auh
@@ -88563,12 +88621,12 @@ amQ
 akF
 anh
 anl
-alB
+alD
 anv
 akH
-aqg
+aqh
 anO
-anY
+avM
 akH
 aoi
 aap
@@ -89165,9 +89223,9 @@ amx
 alF
 amR
 amY
-amR
+enA
 alF
-alB
+alD
 aly
 anB
 akH
@@ -89450,29 +89508,29 @@ aln
 alt
 akV
 alC
-alL
-akS
-akS
-akS
+alD
+rcL
+amZ
+amZ
 amc
 atX
-akS
-akS
-akS
-akS
-akS
-akS
+amZ
+amZ
+amZ
+amZ
+amZ
+amZ
 atX
 amy
-akS
-akS
+rcL
+lRZ
 amZ
-akS
-akS
+cud
+mgj
 amZ
-akS
-akS
-anI
+amZ
+amZ
+anJ
 anR
 akH
 aoi
@@ -89747,8 +89805,8 @@ bMv
 ale
 bMy
 akV
-alf
-avM
+alk
+anY
 avM
 akV
 alr
@@ -89769,7 +89827,7 @@ amz
 amJ
 amS
 ana
-amS
+oqw
 anm
 akH
 akH
@@ -90054,7 +90112,7 @@ alo
 alu
 akV
 alr
-alB
+atH
 akH
 alY
 atB
@@ -90349,14 +90407,14 @@ akF
 akP
 alD
 alD
-akS
+alD
 aub
 alh
 alp
 alw
-alz
+anJ
 akS
-alM
+amZ
 alQ
 alZ
 atC
@@ -90374,7 +90432,7 @@ amK
 amT
 anc
 ani
-ann
+vVw
 ans
 anx
 anD
@@ -90654,11 +90712,11 @@ alD
 bMA
 akV
 ali
-alq
+aoa
 alq
 akV
 alr
-alD
+aPq
 akH
 ama
 atD
@@ -90676,7 +90734,7 @@ amK
 amT
 amT
 and
-ann
+hxU
 akH
 any
 anE
@@ -90956,11 +91014,11 @@ bMx
 bMB
 akV
 alk
-avM
+atG
 avM
 akV
 alr
-alD
+ulO
 alR
 akH
 akH
@@ -90973,11 +91031,11 @@ avS
 alD
 akH
 akH
-alr
+vuB
 amL
 amU
 ane
-amU
+dPH
 ano
 akH
 akH
@@ -91263,29 +91321,29 @@ alt
 akV
 alC
 alD
-alD
-alD
-alD
+eyj
+amZ
+amZ
 amg
-aub
-alD
-alD
-alD
-alD
-alD
-alD
-aub
-alD
-alD
-alD
-alD
-alD
-alD
-alD
-alD
-alD
+atX
+amZ
+amZ
+amZ
+amZ
+amZ
+amZ
+atX
+wWK
+eyj
+amZ
+amZ
+lRZ
+sRL
+amZ
+amZ
+amZ
 anJ
-anQ
+mPH
 akH
 aok
 aap
@@ -91581,7 +91639,7 @@ amD
 alx
 amV
 alD
-amV
+gtD
 alx
 alG
 alE
@@ -92192,7 +92250,7 @@ anz
 akH
 aqh
 anS
-aoa
+avM
 akH
 aok
 aap
@@ -92794,7 +92852,7 @@ amM
 amv
 anz
 akH
-aqe
+eEJ
 anQ
 aod
 aom

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -22,36 +22,22 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/bridge)
 "aah" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/door/poddoor/blast/single{
-	density = 0;
-	icon_state = "bdoorsingle0";
-	id = "lockdown";
-	layer = 4;
-	name = "Bridge Lockdown Door";
-	opacity = 0
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/plating,
-/area/station/bridge)
-"aai" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/door/poddoor/blast/single{
+/obj/machinery/door/poddoor/pyro{
 	density = 0;
-	icon_state = "bdoorsingle0";
+	icon_state = "pdoor0";
 	id = "lockdown";
 	layer = 4;
 	name = "Bridge Lockdown Door";
 	opacity = 0
 	},
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating,
+/area/station/bridge)
+"aai" = (
 /obj/cable{
 	d1 = 2;
 	d2 = 4;
@@ -66,18 +52,18 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/plating,
-/area/station/bridge)
-"aaj" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/door/poddoor/blast/single{
+/obj/machinery/door/poddoor/pyro{
 	density = 0;
-	icon_state = "bdoorsingle0";
+	icon_state = "pdoor0";
 	id = "lockdown";
 	layer = 4;
 	name = "Bridge Lockdown Door";
 	opacity = 0
 	},
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating,
+/area/station/bridge)
+"aaj" = (
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -87,6 +73,15 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "lockdown";
+	layer = 4;
+	name = "Bridge Lockdown Door";
+	opacity = 0
+	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "aak" = (
@@ -4275,27 +4270,26 @@
 	},
 /area/listeningpost/syndicateassaultvessel)
 "alL" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
-	dir = 5;
 	icon_state = "pdoor0";
-	id = "ai_core";
+	id = "lockdown";
 	layer = 4;
-	name = "AI Core Shield";
+	name = "Bridge Lockdown Door";
 	opacity = 0
 	},
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/wingrille_spawn/auto,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
-/area/station/turret_protected/ai_upload)
+/area/station/bridge)
 "alN" = (
 /obj/machinery/torpedo_console,
 /turf/simulated/floor/redblack{
@@ -5233,23 +5227,21 @@
 /turf/simulated/floor/black,
 /area/listeningpost/syndicateassaultvessel)
 "anY" = (
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
-	dir = 4;
 	icon_state = "pdoor0";
-	id = "ai_core";
+	id = "lockdown";
 	layer = 4;
-	name = "AI Core Shield";
+	name = "Bridge Lockdown Door";
 	opacity = 0
 	},
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/wingrille_spawn/auto,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
-/area/station/turret_protected/ai_upload)
+/area/station/bridge)
 "anZ" = (
 /obj/machinery/door/airlock/pyro/syndicate{
 	desc = "Seems to be a pretty sturdy door.";
@@ -5261,18 +5253,21 @@
 "aoa" = (
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
+	dir = 5;
 	icon_state = "pdoor0";
 	id = "ai_core";
 	layer = 4;
 	name = "AI Core Shield";
 	opacity = 0
 	},
+/obj/cable,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
-	},
-/obj/cable{
-	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -5449,21 +5444,11 @@
 /turf/simulated/floor,
 /area/station/hallway/portupperhallway)
 "aou" = (
-/obj/machinery/door/poddoor/blast{
-	density = 0;
-	dir = 4;
-	icon_state = "bdoormid0";
-	id = "lockdown";
-	layer = 4;
-	name = "Bridge Lockdown Door";
-	opacity = 0
-	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/firedoor_spawn,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
@@ -5472,10 +5457,20 @@
 	icon_state = "scanner_off";
 	pixel_x = 20
 	},
-/obj/access_spawn/heads,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "lockdown";
+	layer = 4;
+	name = "Bridge Lockdown Door";
+	opacity = 0
+	},
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4
 	},
+/obj/access_spawn/heads,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/bridge)
 "aov" = (
@@ -6062,21 +6057,11 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperport)
 "apx" = (
-/obj/machinery/door/poddoor/blast{
-	density = 0;
-	dir = 4;
-	icon_state = "bdoormid0";
-	id = "lockdown";
-	layer = 4;
-	name = "Bridge Lockdown Door";
-	opacity = 0
-	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/firedoor_spawn,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
@@ -6085,10 +6070,20 @@
 	icon_state = "scanner_off";
 	pixel_x = -20
 	},
-/obj/access_spawn/heads,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "lockdown";
+	layer = 4;
+	name = "Bridge Lockdown Door";
+	opacity = 0
+	},
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4
 	},
+/obj/access_spawn/heads,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/bridge)
 "apy" = (
@@ -7940,7 +7935,7 @@
 "atG" = (
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
-	dir = 6;
+	dir = 4;
 	icon_state = "pdoor0";
 	id = "ai_core";
 	layer = 4;
@@ -7949,15 +7944,31 @@
 	},
 /obj/cable,
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/turret_protected/ai_upload)
 "atH" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/portlowerhallway)
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "ai_core";
+	layer = 4;
+	name = "AI Core Shield";
+	opacity = 0
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/turret_protected/ai_upload)
 "atI" = (
 /obj/storage/closet/syndicate/personal,
 /obj/item/clothing/under/misc/syndicate,
@@ -12055,11 +12066,23 @@
 /turf/simulated/floor/longtile/black,
 /area/station/turret_protected/ai_upload_foyer)
 "aCh" = (
-/obj/cable{
-	icon_state = "1-4"
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 6;
+	icon_state = "pdoor0";
+	id = "ai_core";
+	layer = 4;
+	name = "AI Core Shield";
+	opacity = 0
 	},
-/turf/simulated/floor/black,
-/area/listeningpost/syndicateassaultvessel)
+/obj/cable,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/turret_protected/ai_upload)
 "aCi" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -17999,16 +18022,8 @@
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
 "aPq" = (
-/obj/cable{
-	icon_state = "4-10"
-	},
-/obj/cable{
-	icon_state = "9-10"
-	},
-/turf/simulated/floor/stairs/dark{
-	dir = 9
-	},
-/area/listeningpost/syndicateassaultvessel)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hallway/portlowerhallway)
 "aPr" = (
 /obj/cable{
 	d1 = 4;
@@ -44804,6 +44819,17 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
+"czF" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "5-8"
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/south,
+/area/listeningpost/syndicateassaultvessel)
 "czS" = (
 /obj/disposalpipe/switch_junction/left/south{
 	mail_tag = "Mining"
@@ -44869,6 +44895,12 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/checkpoint/sec_foyer)
+"duO" = (
+/obj/cable{
+	icon_state = "4-9"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "dCn" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -45013,12 +45045,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
-"eTE" = (
-/obj/cable{
-	icon_state = "2-9"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
 "fcc" = (
 /obj/wingrille_spawn/auto,
 /obj/cable,
@@ -45062,17 +45088,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
-"ftH" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "5-8"
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/south,
-/area/listeningpost/syndicateassaultvessel)
 "ftP" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -45157,6 +45172,26 @@
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
+"geV" = (
+/obj/stool/chair/red{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "5-6"
+	},
+/turf/simulated/floor/redblack{
+	dir = 4
+	},
+/area/listeningpost/syndicateassaultvessel)
+"glR" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "4-9"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "goo" = (
 /obj/cable{
 	d1 = 2;
@@ -45223,6 +45258,12 @@
 	},
 /turf/simulated/floor/longtile/black,
 /area/station/turret_protected/ai_upload)
+"gGi" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/black,
+/area/listeningpost/syndicateassaultvessel)
 "gYm" = (
 /obj/machinery/computer/shuttle_bus{
 	dir = 8
@@ -45298,23 +45339,6 @@
 	},
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
-"hGW" = (
-/obj/stool/chair/red{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "5-6"
-	},
-/turf/simulated/floor/redblack{
-	dir = 4
-	},
-/area/listeningpost/syndicateassaultvessel)
-"hJp" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/black,
-/area/listeningpost/syndicateassaultvessel)
 "hMH" = (
 /obj/storage/crate{
 	desc = "Wow! Crate may or may not still contain bottles.";
@@ -45400,16 +45424,11 @@
 /obj/machinery/drainage/big,
 /turf/simulated/floor/grime,
 /area/diner/hangar)
-"isp" = (
-/obj/stool/chair/red{
-	dir = 8
-	},
+"iqB" = (
 /obj/cable{
-	icon_state = "9-10"
+	icon_state = "2-9"
 	},
-/turf/simulated/floor/redblack{
-	dir = 8
-	},
+/turf/simulated/floor/red,
 /area/listeningpost/syndicateassaultvessel)
 "ivY" = (
 /obj/lattice{
@@ -45461,9 +45480,12 @@
 	},
 /turf/space/fluid/manta,
 /area/mantaSpace)
-"jfP" = (
+"jdS" = (
 /obj/cable{
-	icon_state = "5-8"
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-10"
 	},
 /turf/simulated/floor/red,
 /area/listeningpost/syndicateassaultvessel)
@@ -45486,6 +45508,15 @@
 /obj/machinery/photocopier,
 /turf/simulated/floor/carpet/grime,
 /area/station/communications/bedroom)
+"jQU" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "5-8"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "keQ" = (
 /obj/decal/tile_edge/line/purple{
 	dir = 6;
@@ -45535,16 +45566,14 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/starboardlowerhallway)
-"ksM" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"kGq" = (
+/obj/stool/chair/comfy/red{
+	dir = 8
 	},
 /obj/cable{
-	icon_state = "1-4"
+	icon_state = "1-10"
 	},
-/turf/simulated/floor/plating/random,
+/turf/simulated/floor/carpet/red/fancy/edge/east,
 /area/listeningpost/syndicateassaultvessel)
 "kIf" = (
 /obj/cable,
@@ -45567,6 +45596,12 @@
 	},
 /turf/simulated/floor/caution/south,
 /area/station/engine/inner)
+"kSH" = (
+/obj/cable{
+	icon_state = "5-8"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "lfN" = (
 /obj/cable{
 	d1 = 4;
@@ -45626,6 +45661,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/hos)
+"lPz" = (
+/obj/cable{
+	icon_state = "2-5"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "lSg" = (
 /obj/decal/tile_edge/line/purple{
 	dir = 10;
@@ -45705,14 +45746,6 @@
 	},
 /turf/simulated/floor/sanitary,
 /area/station/engine/engineering/restroom)
-"mzd" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/south,
-/area/listeningpost/syndicateassaultvessel)
 "mGJ" = (
 /obj/machinery/light/runway_light,
 /obj/lattice{
@@ -45733,6 +45766,12 @@
 	},
 /turf/space/fluid/manta,
 /area/mantaSpace)
+"mSi" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/black,
+/area/listeningpost/syndicateassaultvessel)
 "mSY" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -45764,12 +45803,6 @@
 	},
 /turf/space/fluid/manta,
 /area/diner/hangar)
-"mWM" = (
-/obj/cable{
-	icon_state = "6-8"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
 "mXU" = (
 /obj/wingrille_spawn/auto,
 /obj/cable,
@@ -45779,6 +45812,17 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/gas)
+"mYV" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "6-8"
+	},
+/turf/simulated/floor/redblack,
+/area/listeningpost/syndicateassaultvessel)
 "naL" = (
 /obj/disposalpipe/segment,
 /obj/cable{
@@ -45813,6 +45857,17 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
+"nzJ" = (
+/obj/stool/chair/red{
+	dir = 8
+	},
+/obj/cable{
+	icon_state = "9-10"
+	},
+/turf/simulated/floor/redblack{
+	dir = 8
+	},
+/area/listeningpost/syndicateassaultvessel)
 "nHa" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/arrival{
@@ -45905,17 +45960,6 @@
 	dir = 1
 	},
 /area/station/engine/inner)
-"owv" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "6-8"
-	},
-/turf/simulated/floor/redblack,
-/area/listeningpost/syndicateassaultvessel)
 "ozn" = (
 /obj/wingrille_spawn/auto,
 /obj/wingrille_spawn/auto,
@@ -46008,6 +46052,15 @@
 /obj/decal/cleanable/oil,
 /turf/simulated/floor/shuttlebay,
 /area/diner/hangar)
+"phW" = (
+/obj/cable{
+	icon_state = "0-10"
+	},
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/turf/simulated/floor/plating/random,
+/area/listeningpost/syndicateassaultvessel)
 "pnh" = (
 /obj/machinery/door/airlock/pyro/medical,
 /obj/firedoor_spawn,
@@ -46029,12 +46082,9 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
-"pwu" = (
+"pui" = (
 /obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-10"
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/red,
 /area/listeningpost/syndicateassaultvessel)
@@ -46048,6 +46098,15 @@
 	},
 /turf/simulated/floor,
 /area/station/security/brig/genpop)
+"pMy" = (
+/obj/stool/chair/comfy/red{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-6"
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/west,
+/area/listeningpost/syndicateassaultvessel)
 "qrl" = (
 /obj/cable{
 	d1 = 1;
@@ -46168,12 +46227,6 @@
 	},
 /turf/space/fluid/manta,
 /area/diner/hangar)
-"slU" = (
-/obj/cable{
-	icon_state = "4-9"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
 "swZ" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 8
@@ -46203,6 +46256,17 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/security/hos)
+"sLH" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/random,
+/area/listeningpost/syndicateassaultvessel)
 "sTs" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -46271,12 +46335,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/hos)
-"tKn" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
 "uhU" = (
 /obj/table/glass/reinforced/auto,
 /obj/item/clipboard,
@@ -46284,23 +46342,13 @@
 /obj/item/pen/pencil,
 /turf/simulated/floor/carpet/grime,
 /area/station/communications/bedroom)
-"uqx" = (
+"uEG" = (
 /obj/cable{
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/cable{
-	icon_state = "5-8"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
-"uwg" = (
-/obj/stool/chair/comfy/red{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "1-6"
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/west,
+/turf/simulated/floor/carpet/red/fancy/edge/south,
 /area/listeningpost/syndicateassaultvessel)
 "uFt" = (
 /obj/decal/tile_edge/line/green{
@@ -46310,6 +46358,17 @@
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
+"uJe" = (
+/obj/cable{
+	icon_state = "4-10"
+	},
+/obj/cable{
+	icon_state = "9-10"
+	},
+/turf/simulated/floor/stairs/dark{
+	dir = 9
+	},
+/area/listeningpost/syndicateassaultvessel)
 "uRg" = (
 /obj/decal/tile_edge/line/purple{
 	icon_state = "line1"
@@ -46361,14 +46420,20 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/checkpoint/sec_foyer)
-"vfw" = (
+"vaU" = (
 /obj/cable{
-	icon_state = "0-10"
+	icon_state = "1-2"
 	},
-/obj/machinery/power/terminal{
-	dir = 8
+/obj/cable{
+	icon_state = "1-6"
 	},
-/turf/simulated/floor/plating/random,
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
+"vbj" = (
+/obj/cable{
+	icon_state = "6-8"
+	},
+/turf/simulated/floor/red,
 /area/listeningpost/syndicateassaultvessel)
 "vjQ" = (
 /obj/cable{
@@ -46407,15 +46472,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/hor)
-"vAM" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-6"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
 "vRo" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/secondary/construction)
@@ -46458,21 +46514,6 @@
 	dir = 4
 	},
 /area/station/security/secoffquarters)
-"wmQ" = (
-/obj/cable{
-	icon_state = "2-5"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
-"wqk" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "4-9"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
 "wsX" = (
 /obj/decal/tile_edge/line/purple{
 	dir = 10;
@@ -46650,15 +46691,6 @@
 	dir = 6
 	},
 /area/station/security/secoffquarters)
-"xCO" = (
-/obj/stool/chair/comfy/red{
-	dir = 8
-	},
-/obj/cable{
-	icon_state = "1-10"
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/east,
-/area/listeningpost/syndicateassaultvessel)
 "xHd" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/right{
@@ -86167,7 +86199,7 @@ buY
 buY
 buY
 bAp
-atH
+aPq
 bFQ
 bGM
 auh
@@ -89124,7 +89156,7 @@ aaa
 aaa
 aaa
 act
-aah
+alL
 aal
 aaw
 aaI
@@ -89281,7 +89313,7 @@ amx
 alF
 amR
 amY
-hGW
+geV
 alF
 alD
 aly
@@ -89426,7 +89458,7 @@ aaa
 aaa
 aaa
 act
-aah
+alL
 aam
 aax
 aaI
@@ -89567,7 +89599,7 @@ alt
 akV
 alC
 alD
-wmQ
+lPz
 amZ
 amZ
 amc
@@ -89580,11 +89612,11 @@ amZ
 amZ
 atX
 amy
-wmQ
-pwu
+lPz
+jdS
 amZ
-vAM
-wqk
+vaU
+glR
 amZ
 amZ
 amZ
@@ -89728,7 +89760,7 @@ aaa
 aaa
 aaa
 act
-aah
+alL
 aan
 aan
 aaJ
@@ -89864,7 +89896,7 @@ ale
 bMy
 akV
 alk
-aCh
+mSi
 avM
 akV
 alr
@@ -89885,7 +89917,7 @@ amz
 amJ
 amS
 ana
-uwg
+pMy
 anm
 akH
 akH
@@ -90030,7 +90062,7 @@ aaa
 aaa
 aaa
 act
-aah
+alL
 aao
 aay
 aaI
@@ -90048,7 +90080,7 @@ aBX
 aPI
 aPV
 abZ
-anY
+atG
 aoU
 aqO
 aSj
@@ -90170,7 +90202,7 @@ alo
 alu
 akV
 alr
-jfP
+kSH
 akH
 alY
 atB
@@ -90351,7 +90383,7 @@ dWm
 aPW
 aaV
 aQB
-aoa
+atH
 aqO
 aRd
 aRp
@@ -90490,7 +90522,7 @@ amK
 amT
 anc
 ani
-mzd
+uEG
 ans
 anx
 anD
@@ -90651,9 +90683,9 @@ aAF
 bNP
 gDn
 aPX
-alL
-anY
+aoa
 atG
+aCh
 aqO
 aIK
 aRq
@@ -90770,11 +90802,11 @@ alD
 bMA
 akV
 ali
-aPq
+uJe
 alq
 akV
 alr
-slU
+duO
 akH
 ama
 atD
@@ -90792,7 +90824,7 @@ amK
 amT
 amT
 and
-ftH
+czF
 akH
 any
 anE
@@ -91072,11 +91104,11 @@ bMx
 bMB
 akV
 alk
-hJp
+gGi
 avM
 akV
 alr
-mWM
+vbj
 alR
 akH
 akH
@@ -91089,11 +91121,11 @@ avS
 alD
 akH
 akH
-owv
+mYV
 amL
 amU
 ane
-xCO
+kGq
 ano
 akH
 akH
@@ -91379,7 +91411,7 @@ alt
 akV
 alC
 alD
-eTE
+iqB
 amZ
 amZ
 amg
@@ -91391,17 +91423,17 @@ amZ
 amZ
 amZ
 atX
-tKn
-eTE
+pui
+iqB
 amZ
 amZ
-pwu
-uqx
+jdS
+jQU
 amZ
 amZ
 amZ
 anJ
-ksM
+sLH
 akH
 aok
 aap
@@ -91697,7 +91729,7 @@ amD
 alx
 amV
 alD
-isp
+nzJ
 alx
 alG
 alE
@@ -91842,7 +91874,7 @@ aaa
 aaa
 act
 act
-aaj
+anY
 aau
 aaE
 aaS
@@ -92910,7 +92942,7 @@ amM
 amv
 anz
 akH
-vfw
+phW
 anQ
 aod
 aom

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -2564,6 +2564,11 @@
 	},
 /turf/simulated/floor,
 /area/station/security/starboardtorpedoes)
+"aha" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/left,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/bar)
 "ahb" = (
 /obj/table/reinforced/auto,
 /obj/item/aiModule/freeform,
@@ -6456,6 +6461,18 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/starboardupperhallway)
+"aqJ" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/middle,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/bar)
+"aqK" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/left{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/bar)
 "aqL" = (
 /obj/decal/cleanable/cobweb,
 /turf/simulated/floor/plating/random,
@@ -6859,6 +6876,14 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/storage/tech)
+"arM" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/left{
+	layer = 2.9;
+	pixel_y = 13
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/hor)
 "arN" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/box/diskbox,
@@ -6979,7 +7004,9 @@
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
 "asa" = (
-/obj/machinery/computer/ordercomp,
+/obj/machinery/computer/ordercomp{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
 "asb" = (
@@ -7060,9 +7087,6 @@
 /obj/disposalpipe/segment/mail{
 	dir = 2;
 	icon_state = "pipe-c"
-	},
-/obj/cable{
-	icon_state = "1-2"
 	},
 /turf/simulated/floor/arrival{
 	dir = 4
@@ -10584,6 +10608,17 @@
 "aAh" = (
 /turf/simulated/floor,
 /area/station/engine/power)
+"aAi" = (
+/obj/disposalpipe/segment/mail,
+/obj/decal/fakeobjects{
+	desc = "Under construction";
+	dir = 1;
+	icon = 'icons/obj/junk.dmi';
+	icon_state = "constructionsign";
+	name = "construction zone"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/construction2)
 "aAj" = (
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
@@ -11764,6 +11799,16 @@
 	},
 /turf/simulated/floor,
 /area/station/security/starboardtorpedoes)
+"aCO" = (
+/obj/decal/fakeobjects{
+	desc = "Under construction";
+	dir = 1;
+	icon = 'icons/obj/junk.dmi';
+	icon_state = "constructionsign";
+	name = "construction zone"
+	},
+/turf/simulated/floor,
+/area/station/construction/under_construction)
 "aCP" = (
 /obj/stool/bed,
 /obj/item/storage/secure/ssafe{
@@ -13590,10 +13635,6 @@
 	name = "autoname - SS13";
 	pixel_x = 10;
 	tag = ""
-	},
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	icon_state = "0-2"
 	},
 /turf/simulated/floor/arrival{
 	dir = 5
@@ -30988,17 +31029,6 @@
 /obj/table/glass/auto,
 /turf/simulated/floor,
 /area/station/crewquarters/cryotron)
-"btT" = (
-/obj/disposalpipe/segment,
-/obj/decal/fakeobjects{
-	desc = "Under construction";
-	dir = 1;
-	icon = 'icons/obj/junk.dmi';
-	icon_state = "constructionsign";
-	name = "construction zone"
-	},
-/turf/simulated/floor,
-/area/station/hallway/portlowerhallway)
 "btU" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
@@ -31013,6 +31043,13 @@
 /obj/disposalpipe/segment/mail{
 	dir = 1;
 	icon_state = "pipe-c"
+	},
+/obj/decal/fakeobjects{
+	desc = "Under construction";
+	dir = 1;
+	icon = 'icons/obj/junk.dmi';
+	icon_state = "constructionsign";
+	name = "construction zone"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/construction2)
@@ -31063,13 +31100,9 @@
 /turf/simulated/floor,
 /area/station/construction/under_construction)
 "buc" = (
-/obj/disposalpipe/junction/right/north,
-/obj/decal/fakeobjects{
-	desc = "Under construction";
-	dir = 1;
-	icon = 'icons/obj/junk.dmi';
-	icon_state = "constructionsign";
-	name = "construction zone"
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/station/hallway/seaturtlehallway)
@@ -31085,13 +31118,6 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/lowerport)
 "bue" = (
-/obj/decal/fakeobjects{
-	desc = "Under construction";
-	dir = 1;
-	icon = 'icons/obj/junk.dmi';
-	icon_state = "constructionsign";
-	name = "construction zone"
-	},
 /obj/machinery/light/small/floor/netural,
 /turf/simulated/floor,
 /area/station/hallway/seaturtlehallway)
@@ -32401,7 +32427,7 @@
 "bxn" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	icon_state = "1-4"
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/arrival{
 	dir = 4
@@ -35552,7 +35578,10 @@
 /area/station/crewquarters/garbagegarbs)
 "bEv" = (
 /obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/left,
+/obj/window_blinds/cog2/left{
+	layer = 2.9;
+	pixel_y = 13
+	},
 /turf/simulated/floor/plating,
 /area/station/engine/elect)
 "bEw" = (
@@ -35817,6 +35846,9 @@
 /area/station/maintenance/lowerport)
 "bFh" = (
 /obj/disposalpipe/segment/mail,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/arrival{
 	dir = 4
 	},
@@ -42120,13 +42152,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/seaturtlehallway)
-"bUz" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/junction/left/north,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
 "bUA" = (
 /obj/disposalpipe/trunk{
 	dir = 1
@@ -42646,10 +42671,10 @@
 	dir = 4
 	},
 /obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/right,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/window_blinds/cog2/left,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/hor)
 "hhp" = (
@@ -42840,7 +42865,10 @@
 /area/station/hallway/secondary/construction2)
 "jLO" = (
 /obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/right,
+/obj/window_blinds/cog2/right{
+	layer = 2.9;
+	pixel_y = 13
+	},
 /turf/simulated/floor/plating,
 /area/station/engine/elect)
 "jMM" = (
@@ -43150,6 +43178,8 @@
 /area/station/hallway/portlowerhallway)
 "nHa" = (
 /obj/disposalpipe/segment/mail,
+/obj/machinery/power/apc/autoname_east,
+/obj/cable,
 /turf/simulated/floor/arrival{
 	dir = 6
 	},
@@ -43713,13 +43743,13 @@
 	dir = 4
 	},
 /obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/right,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/window_blinds/cog2/right,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/hor)
 "vzC" = (
@@ -77121,7 +77151,7 @@ nHa
 ain
 bsO
 asl
-asl
+aAi
 ebD
 btV
 jnl
@@ -77725,9 +77755,9 @@ bsZ
 byk
 bzI
 bjW
-btT
+bcj
 bGV
-btT
+bcj
 bcj
 bLC
 bsZ
@@ -90389,7 +90419,7 @@ aMU
 ben
 bda
 bcb
-aDb
+aha
 aFZ
 aDo
 bet
@@ -90691,7 +90721,7 @@ aMU
 ben
 bda
 bcb
-aDb
+aqJ
 aGa
 aDo
 beu
@@ -91599,7 +91629,7 @@ bda
 bcb
 aDa
 aHH
-aDC
+aqK
 aDC
 bew
 aDa
@@ -101883,7 +101913,7 @@ bxH
 bzp
 bAM
 bCp
-bDI
+arM
 bEV
 bGh
 bHt
@@ -124855,7 +124885,7 @@ bTT
 bUq
 bUr
 buc
-bUz
+bOC
 bue
 bON
 bPS
@@ -125458,9 +125488,9 @@ bSv
 bva
 bub
 bSI
-bSI
+aCO
 bST
-bSI
+aCO
 ase
 bSJ
 aaa

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -23,7 +23,6 @@
 /area/station/bridge)
 "aah" = (
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/door/poddoor/pyro{
@@ -39,17 +38,12 @@
 /area/station/bridge)
 "aai" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/door/poddoor/pyro{
@@ -65,12 +59,9 @@
 /area/station/bridge)
 "aaj" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/door/poddoor/pyro{
@@ -87,7 +78,6 @@
 "aak" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/computer/announcement/console_upper{
@@ -108,12 +98,9 @@
 "aal" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/computer/security/console_upper,
@@ -126,12 +113,9 @@
 "aam" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/computer3/generic/med_data/console_upper{
@@ -141,8 +125,6 @@
 /area/station/bridge)
 "aan" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/wingrille_spawn/auto/crystal,
@@ -150,13 +132,10 @@
 /area/station/bridge)
 "aao" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/computer3/generic/shield_control/console_upper{
@@ -176,13 +155,10 @@
 /area/station/security/starboardtorpedoes)
 "aar" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/computer3/generic/communications/console_upper{
@@ -193,12 +169,9 @@
 "aas" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/computer/bank_data/console_upper{
@@ -209,12 +182,9 @@
 "aat" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/power/monitor/console_upper,
@@ -227,7 +197,6 @@
 "aau" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/computer/ordercomp/console_upper{
@@ -245,7 +214,6 @@
 "aav" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/light/emergency{
@@ -261,8 +229,6 @@
 /area/station/bridge)
 "aaw" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/stool/chair/office/blue{
@@ -273,12 +239,9 @@
 "aax" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/computer3/generic/secure_data/console_lower{
@@ -288,8 +251,6 @@
 /area/station/bridge)
 "aay" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/mantalog,
@@ -327,18 +288,12 @@
 /area/diner/backroom)
 "aaB" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/stool/chair/office/blue{
@@ -348,8 +303,6 @@
 /area/station/bridge)
 "aaC" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/fakeobjects/console_radar{
@@ -360,12 +313,9 @@
 "aaD" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/computer3/generic/engine/console_lower{
@@ -376,7 +326,6 @@
 "aaE" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/light/emergency{
@@ -386,8 +335,6 @@
 	dir = 8
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/longtile,
@@ -437,8 +384,6 @@
 /area/station/bridge)
 "aaK" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/longtile,
@@ -459,7 +404,6 @@
 "aaM" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/computer3/generic/communications,
@@ -495,7 +439,6 @@
 "aaP" = (
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/item/storage/wall/fire{
@@ -506,8 +449,6 @@
 /area/station/security/visitation)
 "aaQ" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/longtile,
@@ -518,8 +459,6 @@
 /area/station/bridge)
 "aaS" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/longtile,
@@ -533,8 +472,6 @@
 /area/station/turret_protected/starboard)
 "aaU" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/stairs,
@@ -555,7 +492,6 @@
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/wingrille_spawn/auto,
@@ -581,7 +517,6 @@
 "aaX" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/computer/card,
@@ -659,7 +594,6 @@
 /obj/table/wood/auto,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/computer3/generic/personal/personel_alt{
@@ -714,8 +648,6 @@
 /area/station/bridge)
 "abr" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
@@ -778,7 +710,6 @@
 	name = "mail chute-'Head of Security'"
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/disposalpipe/trunk/mail{
@@ -788,8 +719,6 @@
 /area/station/security/hos)
 "abz" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/critter/turtle/sylvester/HoS,
@@ -823,8 +752,6 @@
 	nostick = 1
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/longtile,
@@ -836,20 +763,15 @@
 	pixel_y = 5
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/darkblue,
 /area/station/bridge)
 "abF" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/redblack{
@@ -858,16 +780,12 @@
 /area/station/security/hos)
 "abG" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/security/starboardtorpedoes)
 "abH" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/device/radio/beacon,
@@ -893,13 +811,9 @@
 /area/station/bridge)
 "abK" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/red,
@@ -907,8 +821,6 @@
 "abL" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor,
@@ -916,12 +828,9 @@
 "abM" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/wood/two,
@@ -943,8 +852,6 @@
 	},
 /obj/machinery/light/incandescent/warm,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/device/radio/intercom{
@@ -972,8 +879,6 @@
 /area/station/bridge)
 "abQ" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
@@ -1021,13 +926,9 @@
 /area/station/hydroponics/bay)
 "abU" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/disposal/mail/small{
@@ -1073,8 +974,6 @@
 /area/station/turret_protected/starboard)
 "abX" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment{
@@ -1106,7 +1005,6 @@
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
@@ -1210,7 +1108,6 @@
 /obj/machinery/power/apc/autoname_east,
 /obj/table/reinforced/auto,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/item/paper/book/torpedo,
@@ -1406,13 +1303,9 @@
 /area/skeleton_trader)
 "acL" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood/two,
@@ -1477,7 +1370,6 @@
 "acW" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/light/incandescent/netural{
@@ -1702,8 +1594,6 @@
 /area/bee_trader)
 "adL" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/storage/wall/fire{
@@ -2467,8 +2357,6 @@
 /obj/firedoor_spawn,
 /obj/access_spawn/hos,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -2484,7 +2372,6 @@
 	print_id = "Bridge"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/darkblue,
@@ -2522,8 +2409,6 @@
 /obj/access_spawn/medical,
 /obj/access_spawn/medlab,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
@@ -2535,8 +2420,6 @@
 	},
 /obj/firedoor_spawn,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/access_spawn/forensics,
@@ -2681,14 +2564,6 @@
 	},
 /turf/simulated/floor,
 /area/station/security/starboardtorpedoes)
-"aha" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/engine/inner)
 "ahb" = (
 /obj/table/reinforced/auto,
 /obj/item/aiModule/freeform,
@@ -2954,8 +2829,6 @@
 /area/station/medical/medbay/restroom)
 "aii" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/camera{
@@ -3734,8 +3607,6 @@
 /area/station/bridge)
 "akz" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/dialogueobj/ntrepresentative,
@@ -3796,13 +3667,9 @@
 /area/station/bridge)
 "akD" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/circuit,
@@ -3835,19 +3702,13 @@
 	name = "table"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/phone,
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment/mail{
@@ -3855,8 +3716,6 @@
 	},
 /obj/machinery/drainage/big,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet{
@@ -3874,8 +3733,6 @@
 	},
 /obj/firedoor_spawn,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/access_spawn/cargo,
@@ -3910,13 +3767,9 @@
 /area/listeningpost/syndicateassaultvessel)
 "akQ" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/circuit,
@@ -4271,12 +4124,9 @@
 /area/listeningpost/syndicateassaultvessel)
 "alL" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/door/poddoor/pyro{
@@ -4599,8 +4449,6 @@
 /area/listeningpost/syndicateassaultvessel)
 "amz" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -4613,8 +4461,6 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/redblack{
@@ -4626,8 +4472,6 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/red,
@@ -4637,8 +4481,6 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/redblack{
@@ -4883,8 +4725,6 @@
 /area/listeningpost/syndicateassaultvessel)
 "anm" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -4894,8 +4734,6 @@
 /area/listeningpost/syndicateassaultvessel)
 "ann" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -4905,8 +4743,6 @@
 /area/listeningpost/syndicateassaultvessel)
 "ano" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -5045,8 +4881,6 @@
 /area/listeningpost/syndicateassaultvessel)
 "anG" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/junctionbox{
@@ -5056,8 +4890,6 @@
 /area/station/maintenance/upperstarboard)
 "anH" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -5086,18 +4918,12 @@
 /area/station/hallway/starboardupperhallway)
 "anL" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/light/incandescent/cool{
@@ -5125,8 +4951,6 @@
 /area/station/hallway/starboardupperhallway)
 "anO" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -5136,8 +4960,6 @@
 /area/listeningpost/syndicateassaultvessel)
 "anP" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless/stairs/dark{
@@ -5146,16 +4968,12 @@
 /area/listeningpost/syndicateassaultvessel)
 "anQ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/random,
 /area/listeningpost/syndicateassaultvessel)
 "anR" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -5165,8 +4983,6 @@
 /area/listeningpost/syndicateassaultvessel)
 "anS" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -5176,8 +4992,6 @@
 /area/listeningpost/syndicateassaultvessel)
 "anT" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/storage/closet/electrical_supply,
@@ -5192,7 +5006,6 @@
 /area/station/maintenance/upperport)
 "anV" = (
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/furnace,
@@ -5228,7 +5041,6 @@
 /area/listeningpost/syndicateassaultvessel)
 "anY" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/door/poddoor/pyro{
@@ -5262,11 +5074,9 @@
 	},
 /obj/cable,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/wingrille_spawn/auto,
@@ -5275,8 +5085,6 @@
 "aob" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor,
@@ -5302,7 +5110,6 @@
 /area/listeningpost/syndicateassaultvessel)
 "aoe" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/furnace,
@@ -5324,7 +5131,6 @@
 /area/station/maintenance/upperstarboard)
 "aog" = (
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/furnace,
@@ -5364,7 +5170,6 @@
 /area/listeningpost/syndicateassaultvessel)
 "aon" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/furnace,
@@ -5381,8 +5186,6 @@
 	name = "factory pipe"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
@@ -5417,8 +5220,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -5437,16 +5238,12 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/portupperhallway)
 "aou" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -5483,8 +5280,6 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -5495,8 +5290,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -5507,8 +5300,6 @@
 /area/station/hallway/starboardupperhallway)
 "aox" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor,
@@ -5619,8 +5410,6 @@
 /area/station/maintenance/upperport)
 "aoJ" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating/random,
@@ -5630,8 +5419,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/access_spawn/maint,
@@ -5643,8 +5430,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -5658,8 +5443,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
@@ -5806,23 +5589,18 @@
 /area/station/medical/crematorium)
 "apa" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/sanitary,
 /area/station/medical/crematorium)
 "apb" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/sanitary,
 /area/station/medical/crematorium)
 "apc" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/autoname_east,
@@ -5835,8 +5613,6 @@
 "ape" = (
 /obj/item/device/radio/beacon,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/sanitary,
@@ -5856,8 +5632,6 @@
 /area/station/medical/crematorium)
 "aph" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/sanitary,
@@ -5873,8 +5647,6 @@
 	name = "Crematorium"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
@@ -5883,8 +5655,6 @@
 /area/station/medical/crematorium)
 "apk" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/medical{
@@ -5940,8 +5710,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor,
@@ -5955,8 +5723,6 @@
 /area/station/science/restroom)
 "app" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/line/red{
@@ -5978,8 +5744,6 @@
 "apq" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
@@ -5998,7 +5762,6 @@
 	dir = 1
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/red/checker,
@@ -6006,19 +5769,15 @@
 "aps" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/treatment1)
 "apt" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/drainage/big,
@@ -6030,8 +5789,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -6046,8 +5803,6 @@
 /area/station/medical/medbay/lobby)
 "apw" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/light/incandescent/blueish{
@@ -6058,8 +5813,6 @@
 /area/station/maintenance/upperport)
 "apx" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -6124,8 +5877,6 @@
 	},
 /obj/shrub,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposaloutlet{
@@ -6149,8 +5900,6 @@
 /area/station/hallway/portupperhallway)
 "apD" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating/random,
@@ -6175,8 +5924,6 @@
 	name = "Visitation"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/ejection,
@@ -6189,8 +5936,6 @@
 	req_access = null
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
@@ -6251,8 +5996,6 @@
 /area/station/medical/medbay/lobby)
 "apM" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/drainage/big,
@@ -6276,8 +6019,6 @@
 /area/station/hallway/starboardupperhallway)
 "apO" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/storage/closet/electrical_supply,
@@ -6292,8 +6033,6 @@
 /area/station/hallway/portupperhallway)
 "apQ" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment/mail{
@@ -6319,8 +6058,6 @@
 /area/station/science/lobby)
 "apT" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/drainage/big,
@@ -6345,8 +6082,6 @@
 /area/station/hangar/security)
 "apX" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/drainage/big,
@@ -6354,14 +6089,10 @@
 /area/station/hangar/port)
 "apY" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/decal/tile_edge/line/blue{
@@ -6373,13 +6104,9 @@
 /area/station/hallway/portupperhallway)
 "apZ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/decal/tile_edge/line/blue{
@@ -6448,7 +6175,6 @@
 /area/listeningpost/syndicateassaultvessel)
 "aqj" = (
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
@@ -6469,8 +6195,6 @@
 	icon_state = "9-10"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -6483,15 +6207,12 @@
 	icon_state = "5-6"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/listeningpost/syndicateassaultvessel)
 "aqm" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/data_terminal,
@@ -6500,14 +6221,10 @@
 /area/listeningpost/syndicateassaultvessel)
 "aqn" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable{
@@ -6534,8 +6251,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -6550,7 +6265,6 @@
 	},
 /obj/disposalpipe/segment,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/light/incandescent/netural{
@@ -6566,7 +6280,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/light/incandescent/netural{
@@ -6578,7 +6291,6 @@
 /obj/machinery/networked/test_apparatus/heater,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor,
@@ -6590,15 +6302,12 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor,
 /area/station/science/artifact)
 "aqu" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/decal/tile_edge/stripe/extra_big{
@@ -6607,8 +6316,6 @@
 	},
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
@@ -6621,8 +6328,6 @@
 /area/station/science/artifact)
 "aqw" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/decal/tile_edge/stripe/extra_big{
@@ -6630,8 +6335,6 @@
 	},
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
@@ -6644,8 +6347,6 @@
 	name = "Scientist"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
@@ -6667,16 +6368,12 @@
 	},
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor,
 /area/station/science/artifact)
 "aqA" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/light/incandescent/netural{
@@ -6759,20 +6456,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/starboardupperhallway)
-"aqJ" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/starboardupperhallway)
-"aqK" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/upperport)
 "aqL" = (
 /obj/decal/cleanable/cobweb,
 /turf/simulated/floor/plating/random,
@@ -6823,8 +6506,6 @@
 /obj/item/ammo/bullets/autocannon/seeker,
 /obj/machinery/light/incandescent/warm,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -6888,8 +6569,6 @@
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/disposalpipe/segment{
@@ -6998,13 +6677,9 @@
 /area/station/communications/office)
 "aru" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/device/radio/beacon,
@@ -7095,8 +6770,6 @@
 /area/station/crew_quarters/cafeteria/the_rising_tide_bar)
 "arC" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/landmark,
@@ -7116,8 +6789,6 @@
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/decal/tile_edge/stripe/extra_big{
@@ -7156,8 +6827,6 @@
 	req_access = null
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
@@ -7186,18 +6855,10 @@
 	},
 /obj/firedoor_spawn,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/storage/tech)
-"arM" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/upperport)
 "arN" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/box/diskbox,
@@ -7214,8 +6875,6 @@
 /area/station/turret_protected/starboard)
 "arO" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/red,
@@ -7335,8 +6994,6 @@
 /area/station/hallway/secondary/construction2)
 "asd" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/line/red{
@@ -7405,8 +7062,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/arrival{
@@ -7433,8 +7088,6 @@
 /area/station/hallway/centralhallway)
 "aso" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/light/incandescent/blueish{
@@ -7446,8 +7099,6 @@
 /area/station/maintenance/upperport)
 "asp" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -7467,16 +7118,12 @@
 /area/station/shield_zone/manta)
 "asr" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/mining)
 "ass" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/shuttlebay,
@@ -7492,8 +7139,6 @@
 	req_access = null
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
@@ -7502,13 +7147,9 @@
 /area/station/hangar/mining)
 "asv" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor,
@@ -7587,8 +7228,6 @@
 	},
 /obj/access_spawn/medical_director,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood/eight{
@@ -7602,7 +7241,6 @@
 	},
 /obj/machinery/manufacturer/qm,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/bot,
@@ -7920,7 +7558,6 @@
 "atF" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/rack,
@@ -7944,7 +7581,6 @@
 	},
 /obj/cable,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
@@ -7960,7 +7596,6 @@
 	opacity = 0
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
@@ -8304,7 +7939,6 @@
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/decal/poster/wallsign/warning2,
@@ -8313,7 +7947,6 @@
 "auA" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/decal/poster/wallsign/warning2,
@@ -8340,8 +7973,6 @@
 /obj/access_spawn/engineering,
 /obj/firedoor_spawn,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow,
@@ -8402,13 +8033,9 @@
 /area/station/engine/engineering/restroom)
 "auJ" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -8468,7 +8095,6 @@
 /obj/disposalpipe/segment,
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor,
@@ -8490,8 +8116,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/yellow/side{
@@ -8554,13 +8178,9 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -8834,8 +8454,6 @@
 	},
 /obj/access_spawn/engineering,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
@@ -8844,7 +8462,6 @@
 "avG" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable,
@@ -8950,8 +8567,6 @@
 /area/station/engine/inner)
 "avV" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -8961,8 +8576,6 @@
 /obj/item/plate,
 /obj/item/kitchen/utensil/fork,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellow,
@@ -9011,8 +8624,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor{
@@ -9074,8 +8685,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor{
@@ -9096,8 +8705,6 @@
 	tag = ""
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/caution/south,
@@ -9117,8 +8724,6 @@
 	},
 /obj/item/clothing/glasses/meson,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
@@ -9128,8 +8733,6 @@
 /area/station/engine/engineering/ce)
 "awk" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor,
@@ -9164,8 +8767,6 @@
 /obj/machinery/door/airlock/pyro/engineering,
 /obj/access_spawn/engineering,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
@@ -9211,8 +8812,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -9228,11 +8827,9 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/carpet{
@@ -9394,7 +8991,6 @@
 /obj/wingrille_spawn/auto,
 /obj/cable,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/window_blinds/cog2/right{
@@ -9423,16 +9019,12 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/inner)
 "awQ" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/camera{
@@ -9448,8 +9040,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/damaged2,
@@ -9462,8 +9052,6 @@
 	icon_state = "2-8"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -9505,12 +9093,9 @@
 "awY" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/window_blinds/cog2/left,
@@ -9537,12 +9122,9 @@
 "axa" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/window_blinds/cog2/left,
@@ -9680,7 +9262,6 @@
 /obj/disposalpipe/segment,
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor{
@@ -9690,8 +9271,6 @@
 /area/station/engine/engineering/breakroom)
 "axu" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
@@ -9780,11 +9359,9 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor,
@@ -9792,11 +9369,9 @@
 "axE" = (
 /obj/machinery/power/apc/autoname_south,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor,
@@ -9934,8 +9509,6 @@
 	icon_state = "6-10"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
@@ -9947,8 +9520,6 @@
 /area/station/engine/inner)
 "axQ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow,
@@ -9987,8 +9558,6 @@
 /area/station/engine/engineering/private)
 "axU" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/yellow,
@@ -9999,8 +9568,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow,
@@ -10077,7 +9644,6 @@
 "ayd" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/window_blinds/cog2/left{
@@ -10098,8 +9664,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow,
@@ -10113,8 +9677,6 @@
 	},
 /obj/access_spawn/engineering,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
@@ -10123,8 +9685,6 @@
 "ayg" = (
 /obj/disposalpipe/junction,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow,
@@ -10135,8 +9695,6 @@
 /obj/item/kitchen/utensil/fork,
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow,
@@ -10146,8 +9704,6 @@
 /obj/item/plate,
 /obj/item/kitchen/utensil/fork,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
@@ -10256,11 +9812,9 @@
 	icon_state = "2-8"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor,
@@ -10300,8 +9854,6 @@
 /area/station/engine/engineering/private)
 "ayy" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellow,
@@ -10350,8 +9902,6 @@
 	name = "Engineer"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellow,
@@ -10413,13 +9963,9 @@
 	name = "Chief Engineer"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet{
@@ -10459,8 +10005,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/damaged2,
@@ -10486,8 +10030,6 @@
 	name = "Engineering"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -10495,13 +10037,9 @@
 "ayS" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/yellow,
@@ -10572,8 +10110,6 @@
 	pixel_y = -24
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/carpet{
@@ -10589,7 +10125,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/carpet{
@@ -10611,8 +10146,6 @@
 /area/station/engine/inner)
 "aze" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -10629,8 +10162,6 @@
 /obj/disposalpipe/segment/mail,
 /obj/access_spawn/engineering,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
@@ -10738,16 +10269,12 @@
 /area/station/ai_monitored/armory)
 "azq" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/inner)
 "azr" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow/side{
@@ -10756,8 +10283,6 @@
 /area/station/engine/inner)
 "azs" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow,
@@ -10800,8 +10325,6 @@
 "azA" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
@@ -10826,8 +10349,6 @@
 "azE" = (
 /obj/storage/closet/law,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
@@ -10859,8 +10380,6 @@
 /area/station/engine/power)
 "azK" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/light/incandescent/cool{
@@ -10951,8 +10470,6 @@
 "azT" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
@@ -10975,8 +10492,6 @@
 /area/station/engine/power)
 "azX" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/cable{
@@ -10988,7 +10503,6 @@
 /obj/machinery/power/smes,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -11017,8 +10531,6 @@
 "aAb" = (
 /obj/item/device/radio/intercom/loudspeaker/speaker/south,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -11038,7 +10550,6 @@
 "aAd" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/computer3/generic/engine/manta_computer,
@@ -11049,8 +10560,6 @@
 /area/station/engine/monitoring)
 "aAe" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -11075,22 +10584,12 @@
 "aAh" = (
 /turf/simulated/floor,
 /area/station/engine/power)
-"aAi" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/engine/power)
 "aAj" = (
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
 	name = "AI Server Tunnel"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
@@ -11112,15 +10611,12 @@
 /obj/machinery/power/smes,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/power)
 "aAm" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable{
@@ -11151,13 +10647,9 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/engine/glow/blue,
@@ -11167,21 +10659,15 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/engine/glow/blue,
 /area/station/engine/singcore)
 "aAs" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine/glow/blue,
@@ -11194,8 +10680,6 @@
 	dir = 1
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -11243,24 +10727,18 @@
 /area/station/hos)
 "aAz" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/engine/power)
 "aAA" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -11297,8 +10775,6 @@
 /area/station/engine/power)
 "aAF" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -11326,12 +10802,9 @@
 /obj/machinery/the_singularitygen,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/engine/glow/blue,
@@ -11342,7 +10815,6 @@
 	icon_state = "line4"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/clonegrinder,
@@ -11372,8 +10844,6 @@
 /area/station/engine/power)
 "aAO" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/light/incandescent/cool{
@@ -11384,8 +10854,6 @@
 /area/station/turret_protected/starboard)
 "aAP" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/turretid{
@@ -11408,7 +10876,6 @@
 /obj/machinery/shield_generator,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/light/incandescent/netural,
@@ -11419,8 +10886,6 @@
 /area/station/engine/monitoring)
 "aAS" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
@@ -11448,8 +10913,6 @@
 	},
 /obj/firedoor_spawn,
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/yellow,
@@ -11483,8 +10946,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
@@ -11501,8 +10962,6 @@
 /area/station/engine/gas)
 "aBb" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor,
@@ -11510,8 +10969,6 @@
 "aBc" = (
 /obj/stool/chair,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood/two,
@@ -11529,8 +10986,6 @@
 /area/station/communications/bedroom)
 "aBe" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/firealarm{
@@ -11542,8 +10997,6 @@
 /area/station/captain)
 "aBf" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/cable{
@@ -11565,8 +11018,6 @@
 	},
 /obj/firedoor_spawn,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -11614,8 +11065,6 @@
 	name = "Communications"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -11716,8 +11165,6 @@
 /area/station/hallway/starboardupperhallway)
 "aBz" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -11727,16 +11174,12 @@
 /area/station/bridge)
 "aBA" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/black,
@@ -11750,8 +11193,6 @@
 	name = "Research Director"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -11780,8 +11221,6 @@
 	pixel_y = 9
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -11808,8 +11247,6 @@
 	pixel_y = 10
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -11828,8 +11265,6 @@
 	name = "Captain"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -11842,8 +11277,6 @@
 /area/station/bridge)
 "aBH" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/switch_junction/right/east{
@@ -11898,8 +11331,6 @@
 /area/station/hallway/starboardupperhallway)
 "aBO" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet{
@@ -11984,7 +11415,6 @@
 /obj/item/device/radio/intercom/loudspeaker/speaker/north,
 /obj/machinery/guardbot_dock,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/bot/guardbot/safety,
@@ -12002,13 +11432,9 @@
 /area/station/turret_protected/port)
 "aCa" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor,
@@ -12026,8 +11452,6 @@
 /area/station/hallway/portupperhallway)
 "aCd" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/glass/windoor{
@@ -12040,8 +11464,6 @@
 	icon_state = "pipe-j2"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/line/blue{
@@ -12077,7 +11499,6 @@
 	},
 /obj/cable,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/wingrille_spawn/auto,
@@ -12086,7 +11507,6 @@
 "aCi" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor,
@@ -12094,7 +11514,6 @@
 "aCj" = (
 /obj/machinery/recharge_station,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/circuit,
@@ -12114,8 +11533,6 @@
 /area/station/security/visitation)
 "aCl" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/longtile/black,
@@ -12129,8 +11546,6 @@
 /area/station/turret_protected/port)
 "aCn" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable{
@@ -12174,16 +11589,12 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
 "aCt" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/decal/tile_edge/stripe/extra_big{
@@ -12217,7 +11628,6 @@
 	},
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor,
@@ -12239,7 +11649,6 @@
 /obj/item/clothing/under/misc/america,
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor,
@@ -12303,8 +11712,6 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor,
@@ -12357,16 +11764,6 @@
 	},
 /turf/simulated/floor,
 /area/station/security/starboardtorpedoes)
-"aCO" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light/incandescent/blueish{
-	dir = 4;
-	nostick = 1
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/upperport)
 "aCP" = (
 /obj/stool/bed,
 /obj/item/storage/secure/ssafe{
@@ -12403,8 +11800,6 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -12437,8 +11832,6 @@
 /area/station/crew_quarters/captain)
 "aCX" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/switch_junction/right/north{
@@ -12451,15 +11844,12 @@
 /obj/critter/cat/jones,
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
 "aCZ" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/carpet/arcade,
@@ -12556,8 +11946,6 @@
 /area/station/crew_quarters/cafeteria/the_rising_tide_bar)
 "aDn" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/wood/seven,
@@ -12570,13 +11958,9 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment/ejection{
@@ -12606,8 +11990,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor,
@@ -12630,8 +12012,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
@@ -12714,8 +12094,6 @@
 /area/station/crew_quarters/cafeteria/the_rising_tide_bar)
 "aDE" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -12736,8 +12114,6 @@
 /area/station/crew_quarters/quartersC)
 "aDG" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/longtile/black,
@@ -12769,8 +12145,6 @@
 	},
 /obj/firedoor_spawn,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -12870,15 +12244,12 @@
 	dir = 8
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/power)
 "aDY" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -12910,12 +12281,9 @@
 "aEb" = (
 /obj/machinery/power/apc/autoname_south,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -12934,8 +12302,6 @@
 /area/station/maintenance/upperstarboard)
 "aEe" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/longtile/black,
@@ -12953,13 +12319,9 @@
 /area/station/maintenance/upperport)
 "aEg" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/longtile/black,
@@ -12999,7 +12361,6 @@
 /area/station/chapel/sanctuary)
 "aEm" = (
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
@@ -13057,8 +12418,6 @@
 "aEq" = (
 /obj/machinery/light/incandescent/netural,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
@@ -13099,8 +12458,6 @@
 /area/station/security/hos)
 "aEw" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/longtile/black,
@@ -13124,7 +12481,6 @@
 	pixel_x = -5
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/redblack{
@@ -13285,16 +12641,12 @@
 	dir = 8
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/longtile/black,
 /area/station/turret_protected/starboard)
 "aEU" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -13310,13 +12662,9 @@
 /area/station/crew_quarters/quarters)
 "aEW" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/disposalpipe/segment/mail{
@@ -13358,8 +12706,6 @@
 /area/station/engine/elect)
 "aFb" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/turretid{
@@ -13405,8 +12751,6 @@
 /area/station/crew_quarters/quarters)
 "aFg" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/decal/tile_edge/line/red{
@@ -13417,8 +12761,6 @@
 /area/station/hallway/starboardupperhallway)
 "aFh" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/longtile/black,
@@ -13502,8 +12844,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
@@ -13512,8 +12852,6 @@
 /area/station/crew_quarters/bar)
 "aFr" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
@@ -13553,8 +12891,6 @@
 	name = "AI Upload Foyer"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
@@ -13567,8 +12903,6 @@
 "aFx" = (
 /obj/plasticflaps,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/random,
@@ -13608,8 +12942,6 @@
 	name = "AI Chamber"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
@@ -13716,7 +13048,6 @@
 	opacity = 0
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -13735,8 +13066,6 @@
 	opacity = 0
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/cable{
@@ -13752,8 +13081,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
@@ -13774,7 +13101,6 @@
 "aFV" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -13787,8 +13113,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
@@ -13830,8 +13154,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
@@ -13912,7 +13234,6 @@
 	opacity = 0
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -13960,8 +13281,6 @@
 /area/station/crew_quarters/fitness)
 "aGs" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -13977,8 +13296,6 @@
 /area/station/security/secwing)
 "aGt" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment{
@@ -13997,13 +13314,9 @@
 /area/station/hallway/portupperhallway)
 "aGv" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -14041,7 +13354,6 @@
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -14070,7 +13382,6 @@
 "aGC" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -14087,8 +13398,6 @@
 /area/station/security/secwing)
 "aGE" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood/seven,
@@ -14114,8 +13423,6 @@
 /area/station/science/chemistry)
 "aGI" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
@@ -14125,8 +13432,6 @@
 /area/station/crew_quarters/cafeteria/the_rising_tide_bar)
 "aGJ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
@@ -14159,8 +13464,6 @@
 /area/station/security/brig/cell_block_control)
 "aGN" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
@@ -14170,8 +13473,6 @@
 /area/station/crew_quarters/cafeteria/the_rising_tide_bar)
 "aGO" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/wood/seven,
@@ -14210,8 +13511,6 @@
 /area/station/crew_quarters/quarters)
 "aGT" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/table/reinforced/auto,
@@ -14244,8 +13543,6 @@
 /area/station/hydroponics/bay)
 "aGW" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/camera{
@@ -14258,8 +13555,6 @@
 /area/station/maintenance/upperport)
 "aGX" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/random,
@@ -14298,7 +13593,6 @@
 	},
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/arrival{
@@ -14334,8 +13628,6 @@
 	text = "NF"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/random,
@@ -14403,8 +13695,6 @@
 /area/station/hallway/portlowerhallway)
 "aHn" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/junctionbox/variantb{
@@ -14419,8 +13709,6 @@
 	text = "NF"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor,
@@ -14458,8 +13746,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/access_spawn/maint,
@@ -14471,8 +13757,6 @@
 /area/station/engine/gas)
 "aHu" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/storage/wall/fire{
@@ -14480,24 +13764,9 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperport)
-"aHv" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/upperstarboard)
 "aHw" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -14532,8 +13801,6 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
@@ -14546,8 +13813,6 @@
 /obj/firedoor_spawn,
 /obj/access_spawn/security,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/ejection{
@@ -14558,8 +13823,6 @@
 "aHA" = (
 /obj/access_spawn/medlab,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/maintenance{
@@ -14570,16 +13833,12 @@
 "aHB" = (
 /obj/machinery/light/incandescent/cool,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/medical/robotics)
 "aHC" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/firealarm{
@@ -14603,8 +13862,6 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -14618,8 +13875,6 @@
 /area/station/maintenance/disposal)
 "aHG" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/light/incandescent/blueish{
@@ -14646,7 +13901,6 @@
 /obj/machinery/guardbot_dock,
 /obj/machinery/bot/guardbot/ranger,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/bot,
@@ -14715,8 +13969,6 @@
 /area/station/crewquarters/garbagegarbs)
 "aHU" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/decal/tile_edge/line/red{
@@ -14739,8 +13991,6 @@
 	},
 /obj/item/clothing/suit/bedsheet/green,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/camera{
@@ -14756,8 +14006,6 @@
 /area/station/crew_quarters/quartersC)
 "aHW" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/light/incandescent/blueish{
@@ -14789,8 +14037,6 @@
 /area/station/engine/gas)
 "aIa" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine/caution/northsouth,
@@ -14801,8 +14047,6 @@
 	name = "Crew Quarters"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
@@ -14841,8 +14085,6 @@
 	opacity = 0
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/ejection,
@@ -14856,7 +14098,6 @@
 /obj/item/clothing/suit/bedsheet/blue,
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/carpet{
@@ -14866,8 +14107,6 @@
 /area/station/crew_quarters/quartersB)
 "aIg" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/carpet/arcade/half,
@@ -14893,8 +14132,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor,
@@ -14923,8 +14160,6 @@
 	},
 /obj/firedoor_spawn,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -14990,8 +14225,6 @@
 /area/station/crewquarters/garbagegarbs)
 "aIt" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/random,
@@ -15016,8 +14249,6 @@
 	},
 /obj/item/clothing/suit/bedsheet/blue,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/item/clothing/mask/horse_mask,
@@ -15154,7 +14385,6 @@
 /obj/decal/cleanable/dirt,
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/floorflusher/solitary{
@@ -15261,8 +14491,6 @@
 /area/station/crew_quarters/quarters)
 "aIZ" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment{
@@ -15272,8 +14500,6 @@
 /area/station/crew_quarters/quarters)
 "aJa" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/disposal/small,
@@ -15297,8 +14523,6 @@
 /area/station/medical/research)
 "aJe" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/grass{
@@ -15312,7 +14536,6 @@
 	},
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/sanitary/blue,
@@ -15328,16 +14551,12 @@
 "aJh" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/portupperhallway)
 "aJi" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light/incandescent/netural,
@@ -15438,8 +14657,6 @@
 /area/station/medical/cdc)
 "aJq" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor,
@@ -15492,7 +14709,6 @@
 	opacity = 0
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
@@ -15576,7 +14792,6 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating/random,
@@ -15616,8 +14831,6 @@
 /area/station/crew_quarters/quartersB)
 "aJL" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/orangeblack,
@@ -15628,12 +14841,9 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/orangeblack,
@@ -15674,8 +14884,6 @@
 /area/station/hydroponics/bay)
 "aJQ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/landmark/start{
@@ -15749,7 +14957,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/orangeblack,
@@ -15774,8 +14981,6 @@
 	name = "Solitary"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/disposalpipe/junction/middle/south,
@@ -15794,8 +14999,6 @@
 /area/station/engine/elect)
 "aKd" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -15805,8 +15008,6 @@
 /area/station/science/teleporter)
 "aKe" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable{
@@ -15884,8 +15085,6 @@
 /area/station/hydroponics/bay)
 "aKp" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
@@ -15946,8 +15145,6 @@
 	req_access = null
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/access_spawn/maint,
@@ -15959,8 +15156,6 @@
 /area/station/hallway/starboardupperhallway)
 "aKA" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/firealarm{
@@ -16012,8 +15207,6 @@
 /area/station/maintenance/upperport)
 "aKG" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/black,
@@ -16037,16 +15230,12 @@
 /area/station/ai_monitored/storage/eva)
 "aKI" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/engine/elect)
 "aKJ" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/light/incandescent/harsh{
@@ -16074,8 +15263,6 @@
 	pixel_y = 32
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/sanitary/blue,
@@ -16183,8 +15370,6 @@
 /area/station/security/detectives_office_manta/detectives_bedroom)
 "aLb" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/rack,
@@ -16208,8 +15393,6 @@
 /area/station/crew_quarters/sauna)
 "aLe" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/landmark/start{
@@ -16239,8 +15422,6 @@
 /area/station/crew_quarters/quartersC)
 "aLg" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/red,
@@ -16269,8 +15450,6 @@
 "aLk" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
@@ -16326,13 +15505,9 @@
 	name = "Bridge Access"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/cable{
@@ -16384,7 +15559,6 @@
 "aLx" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/wood{
@@ -16394,8 +15568,6 @@
 "aLy" = (
 /obj/machinery/shower,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable{
@@ -16415,8 +15587,6 @@
 /area/station/crew_quarters/bathroom)
 "aLA" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mineral,
@@ -16483,8 +15653,6 @@
 "aLG" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable,
@@ -16575,7 +15743,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -16663,18 +15830,12 @@
 /area/station/ai_monitored/storage/eva)
 "aMh" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/yellowblack,
@@ -16685,16 +15846,12 @@
 	name = "factory pipe"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood/two,
 /area/station/captain)
 "aMj" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
@@ -16710,8 +15867,6 @@
 	dir = 1
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellowblack,
@@ -16736,8 +15891,6 @@
 /area/station/engine/monitoring)
 "aMo" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/blue,
@@ -16746,8 +15899,6 @@
 /obj/machinery/door/airlock/pyro/engineering,
 /obj/access_spawn/engineering,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
@@ -16813,7 +15964,6 @@
 "aMw" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/yellow,
@@ -16844,7 +15994,6 @@
 "aMD" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating/random,
@@ -16852,7 +16001,6 @@
 "aME" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating/random,
@@ -16863,18 +16011,12 @@
 	name = "factory pipe"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet{
@@ -16908,8 +16050,6 @@
 /area/station/hallway/portupperhallway)
 "aMI" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail{
@@ -16920,13 +16060,9 @@
 /area/station/hallway/starboardupperhallway)
 "aMJ" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/white,
@@ -16961,7 +16097,6 @@
 "aMR" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/window_blinds/cog2/left,
@@ -17011,12 +16146,9 @@
 /area/station/crew_quarters/courtroom)
 "aMY" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto,
@@ -17043,7 +16175,6 @@
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/wingrille_spawn/auto,
@@ -17051,12 +16182,9 @@
 /area/station/crew_quarters/courtroom)
 "aNc" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/wingrille_spawn/auto,
@@ -17100,8 +16228,6 @@
 /area/station/crew_quarters/quarters)
 "aNi" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/light/incandescent/blueish{
@@ -17109,14 +16235,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperport)
-"aNk" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/upperstarboard)
 "aNl" = (
 /obj/decoration/junctionbox{
 	pixel_y = 32
@@ -17197,8 +16315,6 @@
 	dir = 1
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor,
@@ -17271,7 +16387,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/darkblue/checker/other,
@@ -17295,7 +16410,6 @@
 	setup_os_string = "ZETA_MAINFRAME"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/decal/tile_edge/stripe{
@@ -17361,7 +16475,6 @@
 /obj/machinery/power/data_terminal,
 /obj/item/device/net_sniffer,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/decal/tile_edge/stripe{
@@ -17388,7 +16501,6 @@
 /obj/machinery/networked/printer,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/table/wood/auto,
@@ -17465,7 +16577,6 @@
 "aNX" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/redblack,
@@ -17595,8 +16706,6 @@
 /area/station/security/hos)
 "aOk" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/cable{
@@ -17634,8 +16743,6 @@
 /area/station/medical/cdc)
 "aOp" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/darkblue/checker/other,
@@ -17646,13 +16753,9 @@
 /area/station/crew_quarters/arcade)
 "aOs" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/wood/five,
@@ -17687,8 +16790,6 @@
 /area/station/bridge)
 "aOw" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/light_switch/auto{
@@ -17717,8 +16818,6 @@
 /area/station/engine/power)
 "aOy" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
@@ -18030,8 +17129,6 @@
 /area/station/medical/head)
 "aPr" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light/incandescent/cool{
@@ -18041,8 +17138,6 @@
 /area/station/turret_protected/ai_upload_foyer)
 "aPs" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating/random,
@@ -18079,8 +17174,6 @@
 "aPx" = (
 /obj/access_spawn/medical,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/glass,
@@ -18089,8 +17182,6 @@
 "aPy" = (
 /obj/access_spawn/medical,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/glass,
@@ -18102,8 +17193,6 @@
 	name = "AI Upload Foyer"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
@@ -18213,12 +17302,6 @@
 /obj/cable,
 /turf/simulated/floor/longtile/black,
 /area/station/turret_protected/port)
-"aPR" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/upperstarboard)
 "aPS" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
@@ -18227,8 +17310,6 @@
 /area/station/turret_protected/ai_upload)
 "aPT" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/decal/tile_edge/stripe/extra_big{
@@ -18239,8 +17320,6 @@
 /area/station/turret_protected/ai_upload)
 "aPU" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/circuit,
@@ -18254,34 +17333,24 @@
 	icon_state = "xtra_bigstripe-edge"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/longtile/black,
 /area/station/turret_protected/ai_upload)
 "aPW" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/decal/tile_edge/stripe{
 	icon_state = "xtra_bigstripe-edge"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/longtile/black,
@@ -18295,21 +17364,15 @@
 	icon_state = "xtra_bigstripe-edge"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/longtile/black,
 /area/station/turret_protected/ai_upload)
 "aPY" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/decal/tile_edge/stripe/extra_big{
@@ -18333,8 +17396,6 @@
 /area/station/hallway/starboardlowerhallway)
 "aQb" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/camera{
@@ -18427,17 +17488,12 @@
 "aQm" = (
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/circuit,
@@ -18447,21 +17503,15 @@
 /area/station/turret_protected/ai_upload)
 "aQo" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
 "aQp" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -18472,8 +17522,6 @@
 /area/station/security/visitation)
 "aQr" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/light/incandescent/blueish{
@@ -18538,8 +17586,6 @@
 /area/station/teleporter)
 "aQz" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -18621,8 +17667,6 @@
 	req_access_txt = "17"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
@@ -18631,7 +17675,6 @@
 /area/station/teleporter)
 "aQM" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/autoname_north,
@@ -18662,8 +17705,6 @@
 /area/station/crew_quarters/captain)
 "aQX" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/camera{
@@ -18730,7 +17771,6 @@
 "aRf" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -18738,8 +17778,6 @@
 "aRg" = (
 /obj/decal/cleanable/dirt,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
@@ -18754,8 +17792,6 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -18764,8 +17800,6 @@
 /obj/item/device/radio/intercom/security,
 /obj/decal/cleanable/dirt/dirt5,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -18781,7 +17815,6 @@
 	},
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor,
@@ -18832,8 +17865,6 @@
 /area/station/security/hos)
 "aRs" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/light/incandescent/netural{
@@ -18844,8 +17875,6 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/ejection,
@@ -18859,8 +17888,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/redblack/corner,
@@ -18870,8 +17897,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/redblack{
@@ -18884,8 +17909,6 @@
 	},
 /obj/machinery/light/incandescent/netural,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/redblack{
@@ -18903,13 +17926,9 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/disposalpipe/segment/ejection{
@@ -18922,8 +17941,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/floorflusher/genpop,
@@ -19019,8 +18036,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/darkblue/checker/other,
@@ -19041,12 +18056,9 @@
 "aRI" = (
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/disposalpipe/segment/ejection,
@@ -19063,12 +18075,9 @@
 "aRK" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -19079,7 +18088,6 @@
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -19090,7 +18098,6 @@
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -19098,12 +18105,9 @@
 "aRN" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor,
@@ -19152,8 +18156,6 @@
 	name = "table"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/phone,
@@ -19167,8 +18169,6 @@
 	},
 /obj/machinery/light/incandescent/warm,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/computer/announcement{
@@ -19177,7 +18177,6 @@
 	voice_name = "Captain's Announcement Computer"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/data_terminal,
@@ -19187,8 +18186,6 @@
 /area/station/captain)
 "aRV" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
@@ -19211,8 +18208,6 @@
 /area/station/crew_quarters/captain)
 "aRY" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/cable{
@@ -19241,29 +18236,21 @@
 "aSb" = (
 /obj/stool/chair/office/blue,
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/communications/office)
 "aSc" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/communications/office)
 "aSd" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/darkblue/checker/other,
@@ -19289,7 +18276,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/item/device/radio/intercom/security,
@@ -19301,8 +18287,6 @@
 /area/station/security/hos)
 "aSh" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/poster/wallsign/medal{
@@ -19314,8 +18298,6 @@
 /area/station/security/hos)
 "aSi" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/device/radio/intercom/bridge{
@@ -19342,8 +18324,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/ejection,
@@ -19363,12 +18343,9 @@
 "aSn" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -19405,8 +18382,6 @@
 "aSr" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable,
@@ -19516,8 +18491,6 @@
 "aSK" = (
 /obj/machinery/disposal/small,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/trunk{
@@ -19533,7 +18506,6 @@
 "aSM" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/redblack{
@@ -19581,15 +18553,12 @@
 "aSS" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/brig/cell1)
 "aST" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/ejection,
@@ -19648,7 +18617,6 @@
 /obj/machinery/computer/card,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/item_dispenser/idcarddispenser,
@@ -19658,7 +18626,6 @@
 /obj/machinery/computer/bank_data,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/decoration/clock{
@@ -19781,8 +18748,6 @@
 /area/station/security/interrogation)
 "aTv" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
@@ -19800,8 +18765,6 @@
 /area/station/security/interrogation)
 "aTy" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -19817,8 +18780,6 @@
 /area/station/security/brig/cell1)
 "aTz" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
@@ -19829,13 +18790,9 @@
 	name = "Cell #1"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment/ejection{
@@ -19845,18 +18802,12 @@
 /area/station/security/brig/cell1)
 "aTA" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/disposalpipe/junction/left/south,
@@ -19866,8 +18817,6 @@
 /area/station/security/brig)
 "aTB" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/redblack{
@@ -19878,13 +18827,9 @@
 /obj/firedoor_spawn,
 /obj/access_spawn/brig,
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/door/airlock/pyro/glass/security{
@@ -19892,16 +18837,12 @@
 	name = "Cell Block Control Room"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/security/brig/cell_block_control)
 "aTD" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
@@ -20032,8 +18973,6 @@
 /area/station/security/beepsky)
 "aTS" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/light/incandescent/blueish,
@@ -20104,8 +19043,6 @@
 /area/station/security/interrogation)
 "aUe" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/redblack,
@@ -20138,7 +19075,6 @@
 /obj/decal/cleanable/dirt/dirt3,
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/camera{
@@ -20152,8 +19088,6 @@
 "aUi" = (
 /obj/machinery/light/incandescent/netural,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
@@ -20234,7 +19168,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/green,
@@ -20247,8 +19180,6 @@
 	pixel_y = 30
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/blue,
@@ -20259,12 +19190,9 @@
 	dir = 4
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/green,
@@ -20294,7 +19222,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/greenwhite{
@@ -20311,7 +19238,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/landmark/start{
@@ -20471,8 +19397,6 @@
 	name = "Interrogation"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
@@ -20502,8 +19426,6 @@
 	name = "Cell Block"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/ejection,
@@ -20647,7 +19569,6 @@
 /obj/storage/secure/closet/command/hop,
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/camera{
@@ -20701,12 +19622,9 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/white,
@@ -20722,8 +19640,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
@@ -20794,8 +19710,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/ejection,
@@ -20835,8 +19749,6 @@
 /area/station/security/secwing)
 "aVs" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment/mail{
@@ -20848,8 +19760,6 @@
 /area/station/security/secwing)
 "aVt" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -20868,8 +19778,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
@@ -20893,8 +19801,6 @@
 /area/station/medical/medbay/restroom)
 "aVy" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/space_heater,
@@ -20925,8 +19831,6 @@
 "aVB" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -20934,8 +19838,6 @@
 "aVC" = (
 /obj/disposalpipe/junction,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -20959,8 +19861,6 @@
 /area/station/security/secwing)
 "aVG" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light/incandescent/netural,
@@ -20970,8 +19870,6 @@
 /area/station/security/secwing)
 "aVH" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/redblack{
@@ -20980,8 +19878,6 @@
 /area/station/security/secwing)
 "aVI" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -20993,8 +19889,6 @@
 /area/station/security/secwing)
 "aVJ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light_switch/auto{
@@ -21006,8 +19900,6 @@
 /area/station/security/secwing)
 "aVK" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/redblack/corner{
@@ -21016,18 +19908,12 @@
 /area/station/security/secwing)
 "aVL" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/black{
@@ -21036,8 +19922,6 @@
 /area/station/security/secwing)
 "aVN" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black{
@@ -21046,13 +19930,9 @@
 /area/station/security/secwing)
 "aVO" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black{
@@ -21061,8 +19941,6 @@
 /area/station/security/secwing)
 "aVP" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black{
@@ -21071,18 +19949,12 @@
 /area/station/security/secwing)
 "aVR" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/disposalpipe/segment/ejection,
@@ -21092,21 +19964,16 @@
 /area/station/security/secwing)
 "aVS" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/redblack/corner,
 /area/station/security/secwing)
 "aVT" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/power/apc/autoname_south,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/redblack{
@@ -21115,13 +19982,9 @@
 /area/station/security/secwing)
 "aVU" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/redblack{
@@ -21132,7 +19995,6 @@
 /obj/table/wood/auto,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/networked/printer{
@@ -21165,8 +20027,6 @@
 /area/station/maintenance/upperport)
 "aVY" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
@@ -21267,8 +20127,6 @@
 	name = "Sec. Officers Quarters"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
@@ -21285,8 +20143,6 @@
 /area/station/security/secwing)
 "aWl" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/redblack/corner,
@@ -21296,8 +20152,6 @@
 /area/station/security/secwing)
 "aWo" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/device/radio/beacon,
@@ -21307,8 +20161,6 @@
 /area/station/security/secwing)
 "aWp" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/ejection,
@@ -21341,8 +20193,6 @@
 /area/station/hallway/portlowerhallway)
 "aWs" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/random,
@@ -21392,8 +20242,6 @@
 /area/station/security/secoffquarters)
 "aWB" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/redblack{
@@ -21459,8 +20307,6 @@
 /obj/firedoor_spawn,
 /obj/access_spawn/security,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
@@ -21536,8 +20382,6 @@
 /area/station/medical/robotics)
 "aWU" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/light/incandescent/netural,
@@ -21623,8 +20467,6 @@
 /area/station/security/secoffquarters)
 "aXd" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
@@ -21731,8 +20573,6 @@
 /area/station/crew_quarters/courtroom)
 "aXs" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/cable{
@@ -21860,8 +20700,6 @@
 /area/station/crew_quarters/kitchen/freezer)
 "aXJ" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/specialroom/freezer,
@@ -21961,7 +20799,6 @@
 /obj/item/cloneModule/genepowermodule,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/blue,
@@ -21974,16 +20811,12 @@
 	name = "Geneticist"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/green,
 /area/station/medical/research)
 "aXT" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
@@ -21996,24 +20829,18 @@
 /area/station/medical/research)
 "aXU" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/green,
 /area/station/medical/research)
 "aXV" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/research)
 "aXW" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail,
@@ -22025,16 +20852,12 @@
 	},
 /obj/access_spawn/medlab,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/research)
 "aXY" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/grass{
@@ -22046,8 +20869,6 @@
 	name = "monkeyspawn_normal"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/grass{
@@ -22091,8 +20912,6 @@
 /area/station/medical/medbay/restroom)
 "aYe" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/sanitary/blue,
@@ -22104,8 +20923,6 @@
 /area/station/medical/robotics)
 "aYg" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/random,
@@ -22173,7 +20990,6 @@
 /obj/item/clothing/suit/bedsheet/pink,
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/carpet{
@@ -22266,8 +21082,6 @@
 /area/station/security/secoffquarters)
 "aYv" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/camera{
@@ -22325,7 +21139,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/disposalpipe/segment{
@@ -22335,8 +21148,6 @@
 /area/station/crew_quarters/bar)
 "aYG" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
@@ -22349,8 +21160,6 @@
 "aYH" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -22380,8 +21189,6 @@
 	name = "monkeyspawn_normal"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/green,
@@ -22462,8 +21269,6 @@
 /obj/machinery/door/airlock/pyro/medical,
 /obj/access_spawn/robotics,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
@@ -22475,8 +21280,6 @@
 	},
 /obj/firedoor_spawn,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -22488,8 +21291,6 @@
 	},
 /obj/item/clothing/suit/bedsheet/pink,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/item/storage/box/crayon,
@@ -22601,8 +21402,6 @@
 "aZl" = (
 /obj/stool/chair/wooden,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable,
@@ -22637,15 +21436,12 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/research)
 "aZp" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
@@ -22684,8 +21480,6 @@
 /obj/machinery/door/airlock/pyro/medical,
 /obj/access_spawn/medical,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/sanitary/blue,
@@ -22699,20 +21493,15 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "aZw" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
@@ -22733,8 +21522,6 @@
 /area/station/maintenance/upperstarboard)
 "aZB" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
@@ -23080,7 +21867,6 @@
 "bak" = (
 /obj/machinery/genetics_scanner,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/disposalpipe/segment/mail{
@@ -23093,8 +21879,6 @@
 	dir = 1
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -23104,13 +21888,9 @@
 /area/station/medical/research)
 "bam" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -23164,8 +21944,6 @@
 /area/station/medical/medbay/surgery)
 "bav" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/redwhite{
@@ -23229,8 +22007,6 @@
 	icon_state = "xtra_bigstripe-corner2"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
@@ -23256,8 +22032,6 @@
 "baF" = (
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
@@ -23269,15 +22043,12 @@
 "baH" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/chapel/office)
 "baI" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/grime,
@@ -23291,7 +22062,6 @@
 	print_id = "Bridge"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/data_terminal,
@@ -23512,8 +22282,6 @@
 /obj/machinery/door/airlock/pyro/glass,
 /obj/access_spawn/medlab,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
@@ -23568,8 +22336,6 @@
 /area/station/medical/medbay/surgery)
 "bbv" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/white,
@@ -23579,15 +22345,12 @@
 	name = "Medical Doctor"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "bbx" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
@@ -23618,8 +22381,6 @@
 	dir = 8
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
@@ -23668,16 +22429,12 @@
 	nostick = 1
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/chapel/office)
 "bbH" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/poster/wallsign/landscape{
@@ -23687,8 +22444,6 @@
 /area/station/chapel/office)
 "bbI" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/grime,
@@ -23701,8 +22456,6 @@
 	pixel_y = 32
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/trunk/mail{
@@ -23712,8 +22465,6 @@
 /area/station/chapel/office)
 "bbK" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable{
@@ -23727,8 +22478,6 @@
 /area/station/chapel/office)
 "bbL" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/carpet/grime,
@@ -23951,8 +22700,6 @@
 	icon_state = "line3"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/greenwhite{
@@ -23965,7 +22712,6 @@
 	icon_state = "line3"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/greenwhite{
@@ -24060,8 +22806,6 @@
 /area/station/medical/medbay/surgery)
 "bcu" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
@@ -24072,7 +22816,6 @@
 "bcv" = (
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/redwhite{
@@ -24091,8 +22834,6 @@
 	icon_state = "xtra_bigstripe-corner2"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
@@ -24128,8 +22869,6 @@
 /area/station/crew_quarters/fitness)
 "bcC" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/disposal/small{
@@ -24423,8 +23162,6 @@
 /area/station/hallway/portlowerhallway)
 "bdh" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/special/risingtide{
@@ -24436,8 +23173,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon4,
@@ -24464,8 +23199,6 @@
 /area/station/medical/medbay/cloner)
 "bdm" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
@@ -24480,8 +23213,6 @@
 	name = "crematorium pipe"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -24499,8 +23230,6 @@
 	name = "crematorium pipe"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -24521,8 +23250,6 @@
 /obj/access_spawn/medical,
 /obj/access_spawn/medlab,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/sanitary,
@@ -24533,8 +23260,6 @@
 	name = "crematorium pipe"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/sanitary,
@@ -24545,13 +23270,9 @@
 	name = "crematorium pipe"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/sanitary,
@@ -24563,8 +23284,6 @@
 	name = "crematorium pipe"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/sanitary,
@@ -24579,16 +23298,12 @@
 	name = "crematorium pipe"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/sanitary,
 /area/station/medical/morgue)
 "bdu" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/sanitary,
@@ -24599,16 +23314,12 @@
 	},
 /obj/access_spawn/medical,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/sanitary,
 /area/station/medical/medbay/surgery)
 "bdw" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/redwhite{
@@ -24617,8 +23328,6 @@
 /area/station/medical/medbay/surgery)
 "bdx" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -24629,8 +23338,6 @@
 /area/station/medical/medbay/surgery)
 "bdy" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -24644,8 +23351,6 @@
 "bdz" = (
 /obj/item/clothing/suit/cardboard_box/head_surgeon,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -24655,8 +23360,6 @@
 /area/station/medical/medbay/surgery)
 "bdA" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -24666,8 +23369,6 @@
 /area/station/medical/medbay/surgery)
 "bdB" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
@@ -24710,8 +23411,6 @@
 /area/station/hydroponics/bay)
 "bdE" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/stairs/dark/wide{
@@ -24755,8 +23454,6 @@
 	name = "Chaplain's Office"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
@@ -24850,14 +23547,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/quartermaster/cargobay)
-"bdW" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/portlowerhallway)
 "bdX" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
@@ -24882,8 +23571,6 @@
 /area/station/maintenance/lowerport)
 "bdZ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/line/red{
@@ -24897,8 +23584,6 @@
 /area/station/hallway/centralhallway)
 "bea" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/line/red{
@@ -24915,8 +23600,6 @@
 /area/station/hallway/centralhallway)
 "beb" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/line/red{
@@ -24930,8 +23613,6 @@
 /area/station/hallway/centralhallway)
 "bec" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/poster/wallsign/poster_y4nt{
@@ -24948,8 +23629,6 @@
 /area/station/hallway/centralhallway)
 "bed" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/line/red{
@@ -24960,16 +23639,12 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/centralhallway)
 "bee" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/food{
@@ -24979,16 +23654,12 @@
 /area/station/hallway/centralhallway)
 "bef" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/disposalpipe/segment/food{
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light/incandescent/netural,
@@ -25000,8 +23671,6 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/food{
@@ -25019,8 +23688,6 @@
 	dir = 10
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/grass/random,
@@ -25034,8 +23701,6 @@
 	dir = 1
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/grass/random,
@@ -25046,21 +23711,15 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/centralhallway)
 "bek" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light/incandescent/netural,
@@ -25069,8 +23728,6 @@
 /area/station/hallway/centralhallway)
 "bel" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/morgue{
@@ -25080,8 +23737,6 @@
 /area/station/hallway/centralhallway)
 "bem" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/line/red{
@@ -25092,8 +23747,6 @@
 /area/station/hallway/centralhallway)
 "ben" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/line/red{
@@ -25104,8 +23757,6 @@
 /area/station/hallway/centralhallway)
 "beo" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/line/red{
@@ -25119,8 +23770,6 @@
 /area/station/hallway/centralhallway)
 "bep" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/line/red{
@@ -25134,8 +23783,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
@@ -25195,8 +23842,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor,
@@ -25207,8 +23852,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -25222,8 +23865,6 @@
 /area/station/medical/morgue)
 "beA" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/sanitary,
@@ -25257,8 +23898,6 @@
 /area/station/medical/morgue)
 "beE" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/maintenance{
@@ -25273,8 +23912,6 @@
 /area/station/medical/medbay/surgery)
 "beG" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
@@ -25294,8 +23931,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/redwhite,
@@ -25327,8 +23962,6 @@
 /area/station/medical/robotics)
 "beM" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail{
@@ -25384,8 +24017,6 @@
 	name = "Roboticist"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/black,
@@ -25398,7 +24029,6 @@
 /obj/machinery/light/incandescent/cool,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/camera{
@@ -25458,8 +24088,6 @@
 /area/station/crew_quarters/fitness)
 "beX" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment,
@@ -25467,21 +24095,15 @@
 /area/station/crew_quarters/fitness)
 "beY" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/caution/north,
 /area/station/crew_quarters/fitness)
 "beZ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/caution/north,
@@ -25489,15 +24111,12 @@
 "bfa" = (
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/caution/corner/ne,
 /area/station/crew_quarters/fitness)
 "bfb" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood/five,
@@ -25579,8 +24198,6 @@
 	nostick = 1
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
@@ -25649,15 +24266,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
-"bft" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/portlowerhallway)
 "bfu" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
@@ -25676,7 +24284,6 @@
 	name = "crematorium pipe"
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/greenwhite{
@@ -25689,8 +24296,6 @@
 	name = "crematorium pipe"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
@@ -25701,8 +24306,6 @@
 	name = "crematorium pipe"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
@@ -25749,15 +24352,12 @@
 /obj/machinery/light/incandescent/cool/very,
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/sanitary,
 /area/station/medical/morgue)
 "bfB" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
@@ -25794,8 +24394,6 @@
 /area/station/medical/medbay/surgery)
 "bfG" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/redwhite/corner{
@@ -25817,8 +24415,6 @@
 /obj/disposalpipe/segment,
 /obj/access_spawn/medical,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/red,
@@ -25842,8 +24438,6 @@
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
@@ -25851,8 +24445,6 @@
 /area/station/medical/robotics)
 "bfN" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -25862,8 +24454,6 @@
 	name = "Cyborg"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -25877,8 +24467,6 @@
 	name = "Roboticist"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -25892,7 +24480,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/black,
@@ -25907,7 +24494,6 @@
 	},
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/yellow/checker{
@@ -26000,7 +24586,6 @@
 /obj/stool/chair/wooden,
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/trigger/mantasecrettrigger,
@@ -26025,8 +24610,6 @@
 /area/station/chapel/sanctuary)
 "bge" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/cable{
@@ -26047,13 +24630,9 @@
 /area/station/chapel/sanctuary)
 "bgg" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/carpet{
@@ -26201,8 +24780,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
@@ -26267,8 +24844,6 @@
 	icon_state = "line3"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/greenwhite,
@@ -26280,8 +24855,6 @@
 /obj/machinery/door/airlock/pyro/medical,
 /obj/access_spawn/medical,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/sanitary,
@@ -26310,8 +24883,6 @@
 /area/station/medical/medbay/lobby)
 "bgI" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/redwhite{
@@ -26351,8 +24922,6 @@
 "bgK" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/red,
@@ -26386,8 +24955,6 @@
 	icon_state = "xtra_bigstripe-corner2"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -26398,8 +24965,6 @@
 	name = "Cyborg"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -26407,8 +24972,6 @@
 "bgQ" = (
 /obj/decal/tile_edge/stripe/extra_big,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -26417,7 +24980,6 @@
 /obj/decal/tile_edge/stripe/extra_big,
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/black,
@@ -26439,8 +25001,6 @@
 /area/station/medical/medbay/surgery/storage)
 "bgT" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/yellow/checker{
@@ -26449,8 +25009,6 @@
 /area/station/medical/medbay/surgery/storage)
 "bgU" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/yellow/checker{
@@ -26546,8 +25104,6 @@
 	nostick = 1
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood/five,
@@ -26567,8 +25123,6 @@
 /area/station/chapel/sanctuary)
 "bhe" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/cable{
@@ -26581,8 +25135,6 @@
 "bhf" = (
 /obj/mic_stand,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
@@ -26631,16 +25183,6 @@
 /obj/disposalpipe/switch_junction/right/east{
 	mail_tag = "Crew Quarters"
 	},
-/turf/simulated/floor,
-/area/station/hallway/portlowerhallway)
-"bhl" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
 "bhm" = (
@@ -26700,8 +25242,6 @@
 /area/station/medical/medbay/lobby)
 "bht" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/specialroom/medbay,
@@ -26765,8 +25305,6 @@
 /area/station/medical/medbay/lobby)
 "bhz" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/redwhite{
@@ -26778,7 +25316,6 @@
 	dir = 8
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/data_terminal,
@@ -26802,8 +25339,6 @@
 /area/station/hallway/portlowerhallway)
 "bhD" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
@@ -26864,13 +25399,9 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellow/checker{
@@ -26882,8 +25413,6 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow/checker{
@@ -26899,8 +25428,6 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow/checker{
@@ -26927,8 +25454,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
@@ -27018,7 +25543,6 @@
 	},
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/landmark/start{
@@ -27108,8 +25632,6 @@
 /area/station/hallway/portlowerhallway)
 "bik" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
@@ -27124,31 +25646,24 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/lobby)
 "bim" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/lobby)
 "bin" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/specialroom/medbay,
@@ -27158,7 +25673,6 @@
 	dir = 8
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/data_terminal,
@@ -27221,8 +25735,6 @@
 /obj/disposalpipe/segment,
 /obj/access_spawn/medical,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/blue,
@@ -27235,8 +25747,6 @@
 /obj/machinery/door/airlock/pyro/glass,
 /obj/access_spawn/robotics,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
@@ -27246,8 +25756,6 @@
 /obj/machinery/door/airlock/pyro/medical,
 /obj/access_spawn/medical,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
@@ -27257,8 +25765,6 @@
 /area/station/medical/head)
 "biA" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light/incandescent/blueish{
@@ -27307,8 +25813,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood/five,
@@ -27401,13 +25905,9 @@
 /area/station/medical/medbay/lobby)
 "biR" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment/mail{
@@ -27418,8 +25918,6 @@
 /area/station/medical/medbay/lobby)
 "biS" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -27433,8 +25931,6 @@
 	},
 /obj/access_spawn/medical,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -27444,8 +25940,6 @@
 /area/station/medical/medbay/lobby)
 "biU" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -27456,8 +25950,6 @@
 /area/station/medical/medbay/lobby)
 "biV" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
@@ -27480,8 +25972,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -27534,8 +26024,6 @@
 	},
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/bluewhite{
@@ -27548,8 +26036,6 @@
 	icon_state = "line4"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
@@ -27606,8 +26092,6 @@
 /area/station/medical/medbay/lobby)
 "bjn" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/blue,
@@ -27681,8 +26165,6 @@
 	network = "Zeta"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/clothing/head/helmet/camera{
@@ -27781,8 +26263,6 @@
 	nostick = 1
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood/five,
@@ -27877,8 +26357,6 @@
 /area/station/crew_quarters/cafeteria/the_rising_tide_bar)
 "bjQ" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/disposal/small,
@@ -27906,8 +26384,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor,
@@ -27956,8 +26432,6 @@
 /area/station/medical/medbay/lobby)
 "bka" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail{
@@ -28008,21 +26482,15 @@
 "bkg" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "bkh" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
@@ -28033,13 +26501,9 @@
 	icon_state = "line3"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/disposalpipe/segment/mail,
@@ -28049,21 +26513,15 @@
 /area/station/medical/medbay/lobby)
 "bkj" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/lobby)
 "bkk" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/blue,
@@ -28074,8 +26532,6 @@
 	},
 /obj/access_spawn/medical,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/blue,
@@ -28086,8 +26542,6 @@
 	icon_state = "line2"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -28101,8 +26555,6 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
@@ -28219,8 +26671,6 @@
 	pixel_y = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood/five,
@@ -28292,13 +26742,9 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/drainage/big,
@@ -28329,16 +26775,12 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/medical/medbay/lobby)
 "bkP" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/bluewhite{
@@ -28347,13 +26789,9 @@
 /area/station/medical/medbay/lobby)
 "bkQ" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
@@ -28364,7 +26802,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/specialroom/medbay,
@@ -28375,21 +26812,15 @@
 	name = "Medical Doctor"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/lobby)
 "bkT" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/specialroom/medbay,
@@ -28405,7 +26836,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/specialroom/medbay,
@@ -28453,8 +26883,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
@@ -28513,7 +26941,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/wood/eight{
@@ -28568,7 +26995,6 @@
 	},
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/purple/checker{
@@ -28600,8 +27026,6 @@
 "blo" = (
 /obj/machinery/computer/arcade,
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/specialroom/arcade,
@@ -28609,8 +27033,6 @@
 "blp" = (
 /obj/machinery/computer/arcade,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/arcade,
@@ -28622,8 +27044,6 @@
 	icon_state = "check1"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/arcade,
@@ -28631,7 +27051,6 @@
 "blr" = (
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/carpet/arcade,
@@ -28640,15 +27059,12 @@
 /obj/machinery/manufacturer/uniform,
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/bathroom)
 "blt" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
@@ -28733,8 +27149,6 @@
 "blA" = (
 /obj/loudspeaker,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood/five,
@@ -28982,13 +27396,9 @@
 "bmb" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/black,
@@ -29046,7 +27456,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/white,
@@ -29058,14 +27467,12 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/white,
@@ -29075,8 +27482,6 @@
 	dir = 8
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -29086,8 +27491,6 @@
 /area/station/medical/medbay/lobby)
 "bmi" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
@@ -29108,8 +27511,6 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
@@ -29119,29 +27520,21 @@
 	dir = 1
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/nw,
 /area/station/medical/head)
 "bml" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
 /area/station/medical/head)
 "bmm" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/poster/wallsign/mdlicense{
@@ -29151,21 +27544,15 @@
 /area/station/medical/head)
 "bmn" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
 /area/station/medical/head)
 "bmo" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
@@ -29173,12 +27560,9 @@
 "bmp" = (
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/ne,
@@ -29468,8 +27852,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail,
@@ -29477,8 +27859,6 @@
 /area/station/medical/medbay/lobby)
 "bmV" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -29496,16 +27876,12 @@
 	icon_state = "line2"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/lobby)
 "bmX" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/redwhite/corner{
@@ -29518,13 +27894,9 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/white,
@@ -29557,7 +27929,6 @@
 /obj/item/reagent_containers/pill/cyberpunk,
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/red/checker,
@@ -29567,8 +27938,6 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/red/checker,
@@ -29577,8 +27946,6 @@
 /obj/machinery/power/apc/autoname_west,
 /obj/cable,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/red/checker,
@@ -29630,8 +27997,6 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
@@ -29667,7 +28032,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
@@ -29678,8 +28042,6 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/blue,
@@ -29703,8 +28065,6 @@
 /area/station/medical/head)
 "bnr" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/stool/chair/comfy{
@@ -29714,8 +28074,6 @@
 /area/station/medical/head)
 "bns" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/east,
@@ -29766,8 +28124,6 @@
 	icon_state = "line2"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light_switch/auto{
@@ -29785,8 +28141,6 @@
 	dir = 1
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail,
@@ -29799,8 +28153,6 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light/incandescent/harsh,
@@ -29816,8 +28168,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/disposal/small,
@@ -29915,8 +28265,6 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/wood/five,
@@ -29924,8 +28272,6 @@
 "bnP" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/wood/five,
@@ -29965,8 +28311,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/green,
@@ -29993,8 +28337,6 @@
 /area/station/hallway/starboardlowerhallway)
 "bnX" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/switch_junction/right/east{
@@ -30063,8 +28405,6 @@
 /area/station/medical/medbay/lobby)
 "bog" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -30079,8 +28419,6 @@
 	},
 /obj/access_spawn/medical,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
@@ -30092,8 +28430,6 @@
 	},
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door_control{
@@ -30113,8 +28449,6 @@
 	dir = 1
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/bluewhite,
@@ -30135,8 +28469,6 @@
 "bom" = (
 /obj/machinery/manufacturer/medical,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/bluewhite,
@@ -30227,8 +28559,6 @@
 	name = "Medical Doctor"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/red/checker,
@@ -30238,8 +28568,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/red/checker,
@@ -30261,8 +28589,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -30278,8 +28604,6 @@
 /area/station/medical/medbay/lobby)
 "boz" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
@@ -30306,7 +28630,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
@@ -30404,13 +28727,9 @@
 /area/station/medical/head/private)
 "boL" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/random,
@@ -30422,8 +28741,6 @@
 	pixel_y = -24
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/random,
@@ -30501,8 +28818,6 @@
 	name = "Chapel"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
@@ -30523,8 +28838,6 @@
 /area/station/hydroponics/bay)
 "boZ" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
@@ -30556,8 +28869,6 @@
 /area/station/maintenance/upperport)
 "bpc" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/random,
@@ -30579,8 +28890,6 @@
 	},
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
@@ -30608,8 +28917,6 @@
 /area/station/crew_quarters/cafeteria/the_rising_tide_bar)
 "bpj" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light/small/floor/netural,
@@ -30617,8 +28924,6 @@
 /area/station/crew_quarters/cafeteria/the_rising_tide_bar)
 "bpk" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
@@ -30628,8 +28933,6 @@
 /area/station/crew_quarters/cafeteria/the_rising_tide_bar)
 "bpl" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
@@ -30639,8 +28942,6 @@
 /area/station/crew_quarters/cafeteria/the_rising_tide_bar)
 "bpm" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
@@ -30655,8 +28956,6 @@
 	},
 /obj/item/instrument/large/jukebox,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
@@ -30666,8 +28965,6 @@
 /area/station/crew_quarters/cafeteria/the_rising_tide_bar)
 "bpo" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
@@ -30677,8 +28974,6 @@
 /area/station/crew_quarters/cafeteria/the_rising_tide_bar)
 "bpp" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -30691,8 +28986,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/poster/wallsign/submarines_left{
@@ -30748,8 +29041,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/bluewhite,
@@ -30814,12 +29105,9 @@
 "bpC" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -30827,7 +29115,6 @@
 "bpD" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -30855,8 +29142,6 @@
 "bpI" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/cable,
@@ -30865,7 +29150,6 @@
 "bpJ" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -30873,7 +29157,6 @@
 "bpK" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -30881,12 +29164,9 @@
 "bpL" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -30895,14 +29175,10 @@
 /obj/machinery/door/airlock/pyro/glass,
 /obj/access_spawn/medical,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/cable{
@@ -30952,8 +29228,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light/incandescent/netural,
@@ -30967,13 +29241,9 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor,
@@ -30981,8 +29251,6 @@
 "bpX" = (
 /obj/disposalpipe/junction/right/east,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -30995,8 +29263,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/line/green{
@@ -31009,8 +29275,6 @@
 /area/station/hallway/portlowerhallway)
 "bpZ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/junction/right/east,
@@ -31021,8 +29285,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/line/green{
@@ -31036,8 +29298,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -31054,13 +29314,9 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/decal/tile_edge/line/green{
@@ -31074,8 +29330,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/line/green{
@@ -31090,8 +29344,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -31104,8 +29356,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/poster/wallsign/submarines_left{
@@ -31124,13 +29374,9 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon15,
@@ -31145,16 +29391,12 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
 "bqi" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -31172,8 +29414,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
@@ -31185,13 +29425,9 @@
 /area/station/hallway/portlowerhallway)
 "bqk" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/disposalpipe/junction/right/east,
@@ -31200,8 +29436,6 @@
 /area/station/hallway/portlowerhallway)
 "bql" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/junction{
@@ -31219,8 +29453,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -31233,8 +29465,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
@@ -31258,13 +29488,9 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/light/incandescent/netural{
@@ -31280,8 +29506,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
@@ -31364,13 +29588,9 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/disposalpipe/junction{
@@ -31381,8 +29601,6 @@
 /area/station/hallway/portlowerhallway)
 "bqC" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -31392,8 +29610,6 @@
 /area/station/hallway/portlowerhallway)
 "bqD" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/disposalpipe/segment{
@@ -31430,8 +29646,6 @@
 	},
 /obj/machinery/door/airlock/pyro/glass,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -31442,8 +29656,6 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/junction{
@@ -31453,8 +29665,6 @@
 /area/station/hallway/portlowerhallway)
 "bqJ" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/disposalpipe/segment{
@@ -31507,8 +29717,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -31516,8 +29724,6 @@
 "bqP" = (
 /obj/disposalpipe/junction/right/east,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -31527,8 +29733,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light/incandescent/netural{
@@ -31541,8 +29745,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -31555,13 +29757,9 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor,
@@ -31575,8 +29773,6 @@
 /obj/access_spawn/engineering,
 /obj/firedoor_spawn,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -31614,8 +29810,6 @@
 /area/station/maintenance/upperstarboard)
 "bqZ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -31625,13 +29819,9 @@
 /area/station/hallway/starboardlowerhallway)
 "bra" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/drainage/big,
@@ -31642,8 +29832,6 @@
 /area/station/hallway/starboardlowerhallway)
 "brb" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/junction{
@@ -31666,8 +29854,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light/incandescent/netural,
@@ -31678,8 +29864,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/poster/wallsign/submarines_right{
@@ -31689,8 +29873,6 @@
 /area/station/hallway/starboardlowerhallway)
 "brf" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/junction{
@@ -31700,13 +29882,9 @@
 /area/station/hallway/starboardlowerhallway)
 "brg" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/disposalpipe/junction{
@@ -31720,8 +29898,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon1_start,
@@ -31729,8 +29905,6 @@
 /area/station/hallway/starboardlowerhallway)
 "bri" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/junction{
@@ -31744,14 +29918,10 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light/incandescent/netural,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
@@ -31765,8 +29935,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -31783,8 +29951,6 @@
 /area/station/hallway/starboardlowerhallway)
 "brm" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/poster/wallsign/submarines_right{
@@ -31812,8 +29978,6 @@
 "bro" = (
 /obj/disposalpipe/junction/middle,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -31854,13 +30018,9 @@
 /area/station/hallway/starboardlowerhallway)
 "bru" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/random,
@@ -31871,8 +30031,6 @@
 	},
 /obj/firedoor_spawn,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -31883,8 +30041,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -31902,8 +30058,6 @@
 /area/station/science/lobby)
 "brB" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/submachine/ATM/atm_alt{
@@ -31916,8 +30070,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -31934,8 +30086,6 @@
 /area/station/hallway/portlowerhallway)
 "brE" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail{
@@ -32127,8 +30277,6 @@
 /area/station/hallway/portlowerhallway)
 "bsb" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
@@ -32139,8 +30287,6 @@
 /area/station/hallway/portlowerhallway)
 "bsc" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/junction{
@@ -32155,8 +30301,6 @@
 	},
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -32172,8 +30316,6 @@
 /obj/shrub,
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -32266,8 +30408,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/storage/wall/fire{
@@ -32288,18 +30428,8 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/starboardlowerhallway)
-"bsu" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/starboardlowerhallway)
 "bsv" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon2,
@@ -32311,8 +30441,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -32322,8 +30450,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -32331,8 +30457,6 @@
 "bsy" = (
 /obj/machinery/door/airlock/pyro/engineering,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
@@ -32358,8 +30482,6 @@
 	dir = 1
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/special/submarinesdown,
@@ -32410,8 +30532,6 @@
 /area/station/hallway/portlowerhallway)
 "bsM" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor,
@@ -32520,8 +30640,6 @@
 /area/station/hallway/portlowerhallway)
 "bta" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
@@ -32550,8 +30668,6 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/camera{
@@ -32569,7 +30685,6 @@
 "btg" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -32618,8 +30733,6 @@
 "btn" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/camera{
@@ -32644,8 +30757,6 @@
 /area/station/hallway/starboardlowerhallway)
 "btr" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/decal/tile_edge/line/red{
@@ -32682,8 +30793,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/storage/wall/fire{
@@ -32696,8 +30805,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/access_spawn/maint,
@@ -32711,8 +30818,6 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -32776,8 +30881,6 @@
 /obj/disposalpipe/segment,
 /obj/firedoor_spawn,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -32902,8 +31005,6 @@
 	},
 /obj/firedoor_spawn,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/orange,
@@ -33018,8 +31119,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/light/incandescent/netural{
@@ -33064,8 +31163,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/light/incandescent/netural{
@@ -33080,8 +31177,6 @@
 	},
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
@@ -33279,8 +31374,6 @@
 /obj/disposalpipe/segment,
 /obj/firedoor_spawn,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -33298,7 +31391,6 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/light/incandescent/netural{
@@ -33319,8 +31411,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable{
@@ -33334,8 +31424,6 @@
 	},
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/black,
@@ -33383,15 +31471,7 @@
 /area/station/quartermaster/cargobay)
 "bvd" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
-	},
-/turf/simulated/floor,
-/area/station/quartermaster/cargobay)
-"bve" = (
-/obj/cable{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
@@ -33410,8 +31490,6 @@
 	icon_state = "xtra_bigstripe-corner2"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -33419,8 +31497,6 @@
 "bvh" = (
 /obj/decal/tile_edge/stripe/extra_big,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -33431,16 +31507,12 @@
 	icon_state = "xtra_bigstripe-corner2"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
 "bvj" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor,
@@ -33456,8 +31528,6 @@
 /area/station/quartermaster/cargobay)
 "bvm" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
@@ -33646,8 +31716,6 @@
 "bvE" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/cable{
@@ -33659,8 +31727,6 @@
 /obj/table/auto,
 /obj/item/storage/toolbox/mechanical,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -33815,7 +31881,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/east,
@@ -33828,15 +31893,12 @@
 	dir = 8
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/bot,
 /area/station/science/bot_storage)
 "bwf" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
@@ -33950,8 +32012,6 @@
 /obj/disposalpipe/segment,
 /obj/firedoor_spawn,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/access_spawn/security,
@@ -33998,13 +32058,9 @@
 "bww" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor,
@@ -34012,13 +32068,9 @@
 "bwx" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
@@ -34059,8 +32111,6 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -34069,7 +32119,6 @@
 /obj/storage/closet/welding_supply,
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor,
@@ -34090,8 +32139,6 @@
 /area/station/quartermaster/cargobay)
 "bwG" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mineral{
@@ -34131,8 +32178,6 @@
 /area/station/quartermaster/cargobay)
 "bwK" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -34162,8 +32207,6 @@
 /area/station/quartermaster/cargobay)
 "bwQ" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/disposal/mail/small{
@@ -34198,7 +32241,6 @@
 "bwT" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -34206,13 +32248,9 @@
 "bwU" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/cable,
@@ -34221,7 +32259,6 @@
 "bwV" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -34267,7 +32304,6 @@
 	req_access = null
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor,
@@ -34362,20 +32398,9 @@
 /obj/item/reagent_containers/food/drinks/fueltank,
 /turf/simulated/floor,
 /area/station/hangar/starboard)
-"bxm" = (
-/obj/disposalpipe/segment/mail,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/starboardlowerhallway)
 "bxn" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/arrival{
@@ -34400,8 +32425,6 @@
 "bxr" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -34415,8 +32438,6 @@
 /area/station/hallway/starboardlowerhallway)
 "bxt" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
@@ -34432,8 +32453,6 @@
 	dir = 8
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail,
@@ -34595,20 +32614,15 @@
 /obj/machinery/guardbot_dock,
 /obj/machinery/bot/guardbot/gunner,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/bot,
 /area/station/science/bot_storage)
 "bxL" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
@@ -34620,7 +32634,6 @@
 /obj/item/clothing/suit/robuddy,
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor,
@@ -34815,8 +32828,6 @@
 /area/station/hangar/starboard)
 "bym" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
@@ -34844,8 +32855,6 @@
 /area/station/hangar/mining)
 "byq" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/caution/south,
@@ -34872,8 +32881,6 @@
 /area/station/quartermaster/cargooffice)
 "byv" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/stairs{
@@ -34886,8 +32893,6 @@
 /area/station/quartermaster/cargooffice)
 "byx" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/light/emergency{
@@ -34897,21 +32902,15 @@
 /area/station/quartermaster/cargobay)
 "byy" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
 "byz" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -34952,8 +32951,6 @@
 	dir = 1
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/drainage/big,
@@ -35002,8 +32999,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/redblack/corner{
@@ -35051,16 +33046,12 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/blue/checker,
 /area/station/hallway/secondary/construction)
 "byQ" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
@@ -35118,8 +33109,6 @@
 /area/station/science/teleporter)
 "byW" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine/caution/corner{
@@ -35131,8 +33120,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
@@ -35141,8 +33128,6 @@
 /area/station/science/teleporter)
 "byY" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light_switch/auto{
@@ -35153,8 +33138,6 @@
 /area/station/science/teleporter)
 "byZ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail,
@@ -35165,8 +33148,6 @@
 "bza" = (
 /obj/item/device/radio/beacon,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
@@ -35187,8 +33168,6 @@
 /area/station/science/teleporter)
 "bzc" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/white,
@@ -35209,7 +33188,6 @@
 "bze" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -35265,7 +33243,6 @@
 /obj/storage/secure/closet/research/chemical,
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/blackwhite{
@@ -35285,8 +33262,6 @@
 	pixel_y = 32
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
@@ -35321,7 +33296,6 @@
 /obj/machinery/guardbot_dock,
 /obj/machinery/bot/guardbot,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/firealarm{
@@ -35336,13 +33310,9 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor,
@@ -35350,8 +33320,6 @@
 "bzu" = (
 /obj/machinery/light/incandescent/netural,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -35361,7 +33329,6 @@
 /obj/machinery/guardbot_dock,
 /obj/machinery/bot/guardbot/gunner/vaquero,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/bot,
@@ -35387,8 +33354,6 @@
 /area/station/medical/cdc)
 "bzx" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/green,
@@ -35405,7 +33370,6 @@
 /obj/machinery/centrifuge,
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/greenwhite{
@@ -35418,7 +33382,6 @@
 	},
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating/random,
@@ -35505,8 +33468,6 @@
 /area/station/hangar/port)
 "bzL" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/decal/tile_edge/line/red{
@@ -35564,7 +33525,6 @@
 "bzU" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/shuttlebay,
@@ -35628,8 +33588,6 @@
 /area/station/janitor/supply)
 "bAa" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/drainage,
@@ -35657,8 +33615,6 @@
 /area/station/maintenance/lowerstarboard)
 "bAd" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
@@ -35691,8 +33647,6 @@
 /area/station/maintenance/lowerstarboard)
 "bAg" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -35795,13 +33749,9 @@
 	},
 /obj/cable,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
@@ -35901,8 +33851,6 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
@@ -35958,7 +33906,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/wood/eight{
@@ -35968,7 +33915,6 @@
 "bAI" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable{
@@ -36031,8 +33977,6 @@
 	req_access = null
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
@@ -36207,8 +34151,6 @@
 "bBl" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -36229,8 +34171,6 @@
 /area/station/hangar/starboard)
 "bBo" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -36301,8 +34241,6 @@
 /area/station/quartermaster/cargooffice)
 "bBv" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
@@ -36331,7 +34269,6 @@
 /obj/machinery/computer/stockexchange,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/carpet{
@@ -36355,8 +34292,6 @@
 /area/station/quartermaster/cargobay)
 "bBB" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/conveyor_switch{
@@ -36432,8 +34367,6 @@
 /area/station/hangar/starboard)
 "bBK" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/light/incandescent/blueish{
@@ -36464,8 +34397,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/orangeblack,
@@ -36503,8 +34434,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -36568,7 +34497,6 @@
 "bCa" = (
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/orangeblack/side/white{
@@ -36628,8 +34556,6 @@
 	icon_state = "line3"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
@@ -36676,7 +34602,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/wood/eight{
@@ -36701,8 +34626,6 @@
 /area/station/crew_quarters/hor)
 "bCm" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
@@ -36743,8 +34666,6 @@
 /area/station/crew_quarters/hor)
 "bCq" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/wood/eight{
@@ -36779,8 +34700,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/purple,
@@ -36790,8 +34709,6 @@
 	dir = 1
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/purple,
@@ -36805,8 +34722,6 @@
 	icon_state = "xtra_bigstripe-corner2"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/purple,
@@ -36817,8 +34732,6 @@
 	req_access = null
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -36834,8 +34747,6 @@
 	dir = 1
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
@@ -36848,8 +34759,6 @@
 "bCy" = (
 /obj/machinery/light/incandescent/cool,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/orange,
@@ -36881,8 +34790,6 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/greenwhite{
@@ -36897,8 +34804,6 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/green,
@@ -36917,7 +34822,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/camera{
@@ -36969,8 +34873,6 @@
 "bCI" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/decal/poster/wallsign/escape_right{
@@ -37213,14 +35115,10 @@
 /area/station/maintenance/upperport)
 "bDo" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
@@ -37247,8 +35145,6 @@
 /area/station/maintenance/upperport)
 "bDs" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
@@ -37266,8 +35162,6 @@
 	},
 /obj/firedoor_spawn,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/access_spawn/maint,
@@ -37288,8 +35182,6 @@
 /area/station/crew_quarters/hor)
 "bDv" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -37299,8 +35191,6 @@
 /area/station/science/lobby)
 "bDw" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -37311,8 +35201,6 @@
 /area/station/science/lobby)
 "bDx" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
@@ -37334,7 +35222,6 @@
 "bDz" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -37344,8 +35231,6 @@
 	req_access = null
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
@@ -37375,7 +35260,6 @@
 "bDF" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -37543,8 +35427,6 @@
 "bEb" = (
 /obj/decal/cleanable/dirt,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
@@ -37564,8 +35446,6 @@
 "bEd" = (
 /obj/machinery/light/incandescent/netural,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/shuttlebay,
@@ -37573,8 +35453,6 @@
 "bEe" = (
 /obj/machinery/light/incandescent/netural,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/shuttlebay,
@@ -37637,24 +35515,18 @@
 	},
 /obj/firedoor_spawn,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/green,
 /area/station/crewquarters/garbagegarbs)
 "bEr" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/green,
 /area/station/crewquarters/garbagegarbs)
 "bEs" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/greenblack{
@@ -37719,8 +35591,6 @@
 "bED" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/bot/blue,
@@ -37784,8 +35654,6 @@
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/disposalpipe/segment{
@@ -37801,8 +35669,6 @@
 	dir = 1
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -37824,15 +35690,6 @@
 	},
 /obj/cable{
 	icon_state = "1-8"
-	},
-/turf/simulated/floor/purple,
-/area/station/science/lobby)
-"bEO" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "2-8"
 	},
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
@@ -37888,8 +35745,6 @@
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/purple,
@@ -37907,8 +35762,6 @@
 /area/station/science/lobby)
 "bEY" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/purple,
@@ -37930,8 +35783,6 @@
 /area/station/hangar/security)
 "bFc" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -37972,16 +35823,12 @@
 /area/station/crewquarters/cryotron)
 "bFi" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/starboard)
 "bFj" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
@@ -38016,8 +35863,6 @@
 "bFn" = (
 /obj/machinery/light/incandescent/warm/very,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/shuttlebay,
@@ -38067,8 +35912,6 @@
 /area/station/maintenance/lowerstarboard)
 "bFu" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
@@ -38103,8 +35946,6 @@
 	name = "Submarine Bay (Port)"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/access_spawn/maint,
@@ -38143,16 +35984,12 @@
 	},
 /obj/firedoor_spawn,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/green,
 /area/station/crewquarters/garbagegarbs)
 "bFG" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/green,
@@ -38217,7 +36054,6 @@
 "bFN" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -38225,12 +36061,9 @@
 "bFO" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -38239,8 +36072,6 @@
 /obj/wingrille_spawn/auto,
 /obj/cable,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
@@ -38300,8 +36131,6 @@
 /area/station/science/lobby)
 "bFX" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail{
@@ -38322,8 +36151,6 @@
 /area/station/science/lobby)
 "bFZ" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail{
@@ -38386,8 +36213,6 @@
 /area/station/science/lobby)
 "bGh" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/decal/tile_edge/stripe/extra_big,
@@ -38480,8 +36305,6 @@
 /area/station/hangar/port)
 "bGu" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/shuttlebay,
@@ -38507,8 +36330,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable/reinforced{
@@ -38535,15 +36356,12 @@
 "bGB" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/computer/card/console_lower{
 	dir = 8
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor,
@@ -38609,8 +36427,6 @@
 /area/station/crewquarters/cryotron)
 "bGL" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light/incandescent/blueish,
@@ -38621,8 +36437,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/access_spawn/maint,
@@ -38653,8 +36467,6 @@
 "bGV" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -38665,16 +36477,12 @@
 	},
 /obj/firedoor_spawn,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/crewquarters/garbagegarbs)
 "bGY" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/landmark/start{
@@ -38691,28 +36499,6 @@
 "bHa" = (
 /obj/cable{
 	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/lowerstarboard)
-"bHb" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/lowerstarboard)
-"bHc" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/lowerstarboard)
@@ -38747,22 +36533,8 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/lowerstarboard)
-"bHl" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/lowerport)
 "bHm" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating/random,
@@ -38779,7 +36551,6 @@
 "bHp" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/window_blinds/cog2/left,
@@ -38800,7 +36571,6 @@
 "bHr" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/window_blinds/cog2/right,
@@ -38814,8 +36584,6 @@
 	req_access = null
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
@@ -38872,12 +36640,6 @@
 "bHD" = (
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/lowerport)
-"bHE" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/lowerport)
 "bHF" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -38886,8 +36648,6 @@
 /area/station/maintenance/lowerport)
 "bHG" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/random,
@@ -38897,8 +36657,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/access_spawn/maint,
@@ -38906,8 +36664,6 @@
 /area/station/maintenance/disposal)
 "bHI" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/light/incandescent/blueish{
@@ -38962,8 +36718,6 @@
 /area/station/quartermaster/cargobay)
 "bHR" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/firealarm{
@@ -39002,8 +36756,6 @@
 /area/station/crewquarters/garbagegarbs)
 "bHY" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -39037,12 +36789,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/lowerstarboard)
-"bIc" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/lowerstarboard)
 "bId" = (
 /obj/machinery/drainage/big,
 /turf/simulated/floor,
@@ -39067,19 +36813,12 @@
 /obj/machinery/drainage/big,
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
-"bIi" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/lowerport)
 "bIj" = (
 /obj/machinery/networked/test_apparatus/pitching_machine{
 	dir = 4
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/airless/caution/misc{
@@ -39096,7 +36835,6 @@
 /obj/machinery/networked/test_apparatus/impact_pad,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
@@ -39174,8 +36912,6 @@
 /area/station/science/testchamber)
 "bIs" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/item_dispenser/latex_gloves,
@@ -39186,8 +36922,6 @@
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor,
@@ -39220,8 +36954,6 @@
 	nostick = 1
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/camera{
@@ -39234,8 +36966,6 @@
 /area/station/science/testchamber)
 "bIx" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/switch_junction/right/south{
@@ -39272,8 +37002,6 @@
 /area/station/maintenance/upperstarboard)
 "bIC" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment{
@@ -39316,13 +37044,9 @@
 /area/station/maintenance/lowerstarboard)
 "bIG" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/camera{
@@ -39335,8 +37059,6 @@
 /area/station/maintenance/lowerstarboard)
 "bIH" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light/incandescent/blueish{
@@ -39349,8 +37071,6 @@
 	req_access = null
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
@@ -39437,8 +37157,6 @@
 /area/station/maintenance/lowerport)
 "bIW" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
@@ -39487,8 +37205,6 @@
 /area/station/science/artifact)
 "bJb" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -39548,8 +37264,6 @@
 	name = "Scientist"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet,
@@ -39561,7 +37275,6 @@
 	},
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/carpet{
@@ -39746,8 +37459,6 @@
 /area/station/hallway/starboardlowerhallway)
 "bJF" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/blind_switch/area/north{
@@ -39779,8 +37490,6 @@
 	dir = 1
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor,
@@ -39892,8 +37601,6 @@
 /area/station/maintenance/lowerstarboard)
 "bJW" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating/random,
@@ -39901,7 +37608,6 @@
 "bJX" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/window_blinds/cog2/right{
@@ -40084,7 +37790,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/carpet{
@@ -40125,12 +37830,9 @@
 "bKu" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/window_blinds/cog2/left{
@@ -40169,8 +37871,6 @@
 /area/station/security/detectives_office_manta)
 "bKz" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet{
@@ -40238,8 +37938,6 @@
 /area/station/science/restroom)
 "bKF" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
@@ -40290,12 +37988,9 @@
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/carpet{
@@ -40305,8 +38000,6 @@
 /area/station/security/detectives_office_manta)
 "bKL" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/wood/six,
@@ -40340,8 +38033,6 @@
 	},
 /obj/firedoor_spawn,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/access_spawn/forensics,
@@ -40434,8 +38125,6 @@
 /area/station/maintenance/lowerport)
 "bLf" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/random,
@@ -40475,20 +38164,15 @@
 /obj/table/wood/auto,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office_manta/detectives_bedroom)
 "bLm" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/carpet/grime,
@@ -40496,24 +38180,18 @@
 "bLn" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office_manta/detectives_bedroom)
 "bLo" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/wingrille_spawn/auto,
@@ -40603,8 +38281,6 @@
 "bLB" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable,
@@ -40662,7 +38338,6 @@
 /obj/machinery/power/data_terminal,
 /obj/machinery/bot/guardbot/bootleg,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor,
@@ -40676,8 +38351,6 @@
 /area/station/science/restroom)
 "bLL" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/switch_junction/right/south{
@@ -40710,8 +38383,6 @@
 /area/station/security/detectives_office_manta/detectives_bedroom)
 "bLO" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
@@ -40730,16 +38401,12 @@
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
 /area/station/storage/tech)
 "bLR" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/light_switch/auto{
@@ -40800,8 +38467,6 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -40887,8 +38552,6 @@
 /area/station/engine/engineering/ce)
 "bMh" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/decal/tile_edge/line/red{
@@ -40916,8 +38579,6 @@
 /area/station/maintenance/lowerstarboard)
 "bMk" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/light/incandescent/blueish,
@@ -40941,15 +38602,12 @@
 	dir = 4
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/black,
 /area/station/engine/monitoring)
 "bMn" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/drainage/big,
@@ -40977,8 +38635,6 @@
 /area/station/maintenance/lowerstarboard)
 "bMq" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating/random,
@@ -41108,24 +38764,18 @@
 	name = "Communications Officer"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
 "bMG" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/black,
@@ -41142,8 +38792,6 @@
 /area/station/maintenance/lowerport)
 "bMI" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/light/incandescent/blueish{
@@ -41153,13 +38801,9 @@
 /area/station/maintenance/lowerport)
 "bMJ" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/drainage/big,
@@ -41168,8 +38812,6 @@
 "bMK" = (
 /obj/item/cigbutt,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/random,
@@ -41190,8 +38832,6 @@
 	tag = ""
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating/random,
@@ -41201,8 +38841,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/camera{
@@ -41239,8 +38877,6 @@
 /area/station/maintenance/lowerstarboard)
 "bMQ" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
@@ -41254,8 +38890,6 @@
 /area/station/maintenance/lowerstarboard)
 "bMU" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/reagent_dispensers/foamtank,
@@ -41263,8 +38897,6 @@
 /area/station/maintenance/lowerport)
 "bMW" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -41290,8 +38922,6 @@
 /area/station/maintenance/lowerstarboard)
 "bNa" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/stool/chair{
@@ -41308,8 +38938,6 @@
 /area/station/maintenance/lowerport)
 "bNc" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/camera{
@@ -41329,8 +38957,6 @@
 /area/station/maintenance/lowerstarboard)
 "bNe" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating/random,
@@ -41369,7 +38995,6 @@
 /obj/machinery/power/apc/autoname_west,
 /obj/table/reinforced/auto,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/item/paper/book/torpedo,
@@ -41455,8 +39080,6 @@
 	},
 /obj/firedoor_spawn,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/yellow,
@@ -41470,8 +39093,6 @@
 /area/station/hallway/starboardlowerhallway)
 "bNy" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
@@ -41564,8 +39185,6 @@
 "bNK" = (
 /obj/item/device/radio/beacon,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -41630,7 +39249,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor,
@@ -41638,7 +39256,6 @@
 "bNT" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/computer/ordercomp/console_upper{
@@ -41664,8 +39281,6 @@
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -41707,8 +39322,6 @@
 /area/station/construction)
 "bOa" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -41770,7 +39383,6 @@
 "bOk" = (
 /obj/machinery/power/apc/autoname_south,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor,
@@ -41819,15 +39431,12 @@
 "bOr" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/mining/staff_room)
 "bOs" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment{
@@ -41868,12 +39477,9 @@
 "bOA" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -41887,16 +39493,12 @@
 /area/station/maintenance/upperstarboard)
 "bOC" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/seaturtlehallway)
 "bOD" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
@@ -41910,8 +39512,6 @@
 /area/station/seaturtlebridge)
 "bOE" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment,
@@ -41925,8 +39525,6 @@
 /obj/access_spawn/engineering,
 /obj/firedoor_spawn,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
@@ -41962,20 +39560,15 @@
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/mining/staff_room)
 "bOM" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/disposalpipe/segment{
@@ -41998,8 +39591,6 @@
 /area/station/maintenance/seaturtle)
 "bOP" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment{
@@ -42028,8 +39619,6 @@
 "bOU" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable,
@@ -42037,8 +39626,6 @@
 /area/station/mining/staff_room)
 "bOV" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/decal/tile_edge/line/green{
@@ -42136,8 +39723,6 @@
 /area/station/mining/staff_room)
 "bPj" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/orange,
@@ -42147,8 +39732,6 @@
 	pixel_y = 32
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/orange,
@@ -42158,8 +39741,6 @@
 	dir = 1
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/orange,
@@ -42173,8 +39754,6 @@
 	icon_state = "xtra_bigstripe-corner2"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/orange,
@@ -42185,8 +39764,6 @@
 	},
 /obj/decal/tile_edge/stripe/extra_big,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/orange,
@@ -42200,8 +39777,6 @@
 	icon_state = "xtra_bigstripe-corner2"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/orange,
@@ -42240,8 +39815,6 @@
 /area/station/construction)
 "bPs" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/decal/tile_edge/line/green{
@@ -42322,8 +39895,6 @@
 /area/station/mining/staff_room)
 "bPD" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
@@ -42342,8 +39913,6 @@
 /area/station/hallway/seaturtlehallway)
 "bPF" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -42354,8 +39923,6 @@
 /area/station/hallway/seaturtlehallway)
 "bPG" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/line/purple{
@@ -42377,8 +39944,6 @@
 /obj/access_spawn/janitor,
 /obj/firedoor_spawn,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -42389,8 +39954,6 @@
 /area/station/janitor/supply)
 "bPJ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -42403,8 +39966,6 @@
 /area/station/janitor/supply)
 "bPK" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
@@ -42433,8 +39994,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -42454,8 +40013,6 @@
 	dir = 8
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -42463,7 +40020,6 @@
 "bPP" = (
 /obj/machinery/power/apc/autoname_south,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor,
@@ -42489,7 +40045,6 @@
 "bPU" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -42497,12 +40052,9 @@
 "bPV" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -42516,7 +40068,6 @@
 	icon_state = "2-8"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -42524,12 +40075,9 @@
 "bPX" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -42537,7 +40085,6 @@
 "bPY" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -42546,8 +40093,6 @@
 /obj/machinery/door/airlock/pyro/glass,
 /obj/firedoor_spawn,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -42616,8 +40161,6 @@
 /area/station/hallway/seaturtlehallway)
 "bQi" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/decal/tile_edge/line/red{
@@ -42642,8 +40185,6 @@
 /area/station/hallway/seaturtlehallway)
 "bQk" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/orange,
@@ -42751,8 +40292,6 @@
 /area/station/construction)
 "bQw" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/decal/tile_edge/line/green{
@@ -42803,8 +40342,6 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -42873,8 +40410,6 @@
 /area/station/hallway/seaturtlehallway)
 "bQK" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -42894,8 +40429,6 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/decal/tile_edge/line/green{
@@ -42962,8 +40495,6 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/decal/tile_edge/line/green{
@@ -43051,7 +40582,6 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -43063,8 +40593,6 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
@@ -43127,12 +40655,9 @@
 "bRp" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/disposalpipe/segment,
@@ -43141,7 +40666,6 @@
 "bRq" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable{
@@ -43151,8 +40675,6 @@
 /area/station/mining/staff_room)
 "bRr" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -43300,8 +40822,6 @@
 /area/station/mining/staff_room)
 "bRH" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
@@ -43325,8 +40845,6 @@
 /obj/firedoor_spawn,
 /obj/access_spawn/mining,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -43341,8 +40859,6 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
@@ -43376,8 +40892,6 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -43415,8 +40929,6 @@
 /area/station/mining/staff_room)
 "bRQ" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -43429,8 +40941,6 @@
 /obj/firedoor_spawn,
 /obj/access_spawn/mining,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -43455,8 +40965,6 @@
 /area/station/hangar/mining)
 "bRU" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -43470,8 +40978,6 @@
 /area/station/mining/staff_room)
 "bRX" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/light/incandescent/netural{
@@ -43505,8 +41011,6 @@
 /obj/item/shipcomponent/secondary_system/cargo,
 /obj/item/shipcomponent/secondary_system/cargo,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -43542,7 +41046,6 @@
 "bSf" = (
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor,
@@ -43552,16 +41055,12 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
 /area/station/mining/staff_room)
 "bSi" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/disposal/small,
@@ -43592,8 +41091,6 @@
 "bSm" = (
 /obj/decal/cleanable/dirt/dirt5,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -43609,8 +41106,6 @@
 /obj/machinery/door/airlock/pyro/glass,
 /obj/firedoor_spawn,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
@@ -43637,20 +41132,15 @@
 "bSs" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/mining/staff_room)
 "bSt" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/decal/tile_edge/line/green{
@@ -43751,7 +41241,6 @@
 "bSL" = (
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating/random,
@@ -43780,8 +41269,6 @@
 /area/station/maintenance/seaturtle/boiler)
 "bSP" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -43794,8 +41281,6 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -43803,7 +41288,6 @@
 "bSR" = (
 /obj/machinery/power/terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor,
@@ -43816,8 +41300,6 @@
 /area/station/construction/under_construction)
 "bST" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -43828,16 +41310,12 @@
 	},
 /obj/access_spawn/maint,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/construction/under_construction)
 "bSV" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/random,
@@ -43847,16 +41325,12 @@
 	nostick = 1
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/seaturtle)
 "bSX" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -43870,8 +41344,6 @@
 /area/station/maintenance/seaturtle/boiler)
 "bSZ" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -43904,8 +41376,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -43937,8 +41407,6 @@
 	},
 /obj/firedoor_spawn,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -43948,8 +41416,6 @@
 	icon_state = "2-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -43982,8 +41448,6 @@
 /area/mantaSpace)
 "bTm" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
@@ -44005,8 +41469,6 @@
 "bTo" = (
 /obj/machinery/drainage/big,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -44085,8 +41547,6 @@
 /area/station/hangar/mining)
 "bTv" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/camera{
@@ -44140,8 +41600,6 @@
 /area/station/maintenance/seaturtle/boiler)
 "bTA" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/camera{
@@ -44157,8 +41615,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -44170,8 +41626,6 @@
 "bTC" = (
 /obj/machinery/drainage/big,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -44279,8 +41733,6 @@
 /area/station/engine/engineering/ce/private)
 "bTN" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -44294,8 +41746,6 @@
 /area/station/hallway/seaturtlehallway)
 "bTO" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/line/green{
@@ -44311,16 +41761,12 @@
 /area/station/hallway/seaturtlehallway)
 "bTP" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
 	icon_state = "2-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/disposalpipe/junction/left/west,
@@ -44328,8 +41774,6 @@
 /area/station/hallway/seaturtlehallway)
 "bTQ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -44339,8 +41783,6 @@
 /area/station/hallway/seaturtlehallway)
 "bTR" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -44420,8 +41862,6 @@
 /area/station/hallway/seaturtlehallway)
 "bTY" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/line/green{
@@ -44443,8 +41883,6 @@
 /obj/access_spawn/mining,
 /obj/firedoor_spawn,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -44454,8 +41892,6 @@
 /area/station/hangar/mining)
 "bUa" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -44466,8 +41902,6 @@
 "bUb" = (
 /obj/decal/cleanable/dirt/dirt2,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -44477,8 +41911,6 @@
 /area/station/hangar/mining)
 "bUc" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -44496,8 +41928,6 @@
 /area/station/mining/staff_room)
 "bUe" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
@@ -44519,8 +41949,6 @@
 /area/station/mining/staff_room)
 "bUg" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/decal/tile_edge/line/green{
@@ -44629,8 +42057,6 @@
 /area/station/hallway/seaturtlehallway)
 "bUs" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
@@ -44648,8 +42074,6 @@
 /area/station/maintenance/seaturtle/boiler)
 "bUv" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
@@ -44662,8 +42086,6 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
@@ -44678,8 +42100,6 @@
 /obj/access_spawn/maint,
 /obj/firedoor_spawn,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -44689,13 +42109,9 @@
 /area/station/maintenance/seaturtle/boiler)
 "bUy" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -44706,8 +42122,6 @@
 /area/station/hallway/seaturtlehallway)
 "bUz" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/junction/left/north,
@@ -44723,8 +42137,6 @@
 "bUC" = (
 /obj/table/reinforced/industrial/auto,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/decoration/ashtray{
@@ -44746,8 +42158,6 @@
 "bUE" = (
 /obj/table/reinforced/industrial/auto,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/cigbutt{
@@ -44823,8 +42233,6 @@
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -44839,7 +42247,6 @@
 "cJT" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor,
@@ -44853,8 +42260,6 @@
 	nostick = 1
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor{
@@ -44867,7 +42272,6 @@
 /area/station/hallway/portlowerhallway)
 "dfY" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/autoname_north,
@@ -44878,7 +42282,6 @@
 	name = "Security Intercom"
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/black,
@@ -44891,8 +42294,6 @@
 /area/listeningpost/syndicateassaultvessel)
 "dxF" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -44905,8 +42306,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow,
@@ -44925,8 +42324,6 @@
 	pixel_y = 32
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/blackwhite,
@@ -44939,8 +42336,6 @@
 /obj/access_spawn/research,
 /obj/firedoor_spawn,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -44948,7 +42343,6 @@
 "dOI" = (
 /obj/machinery/computer3/generic/communications,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/weapon_stand/rifle_rack/recharger,
@@ -44956,24 +42350,18 @@
 /area/station/ai_monitored/armory)
 "dPl" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
 "dWi" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/construction2)
 "dWm" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/longtile/black,
@@ -45003,8 +42391,6 @@
 "ebD" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -45032,7 +42418,6 @@
 /obj/machinery/networked/radio,
 /obj/cable,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/circuit,
@@ -45059,7 +42444,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/black,
@@ -45068,11 +42452,9 @@
 /obj/wingrille_spawn/auto,
 /obj/cable,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -45089,7 +42471,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor,
@@ -45097,12 +42478,10 @@
 "fmU" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/decal/poster/wallsign/warning1,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -45110,11 +42489,9 @@
 "ftP" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor,
@@ -45135,8 +42512,6 @@
 /area/diner/hangar)
 "fCv" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/circuit,
@@ -45159,11 +42534,9 @@
 	nostick = 1
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/circuit,
@@ -45174,7 +42547,6 @@
 	dir = 8
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/black,
@@ -45185,7 +42557,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/black,
@@ -45195,15 +42566,12 @@
 /obj/machinery/computer/aiupload,
 /obj/cable,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
 "goo" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/black,
@@ -45213,15 +42581,12 @@
 	name = "bubsbeejob"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
 /area/station/security/checkpoint/sec_foyer)
 "gwj" = (
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto/crystal,
@@ -45247,20 +42612,15 @@
 	},
 /obj/cable,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
 "gAR" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -45288,7 +42648,6 @@
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/right,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -45297,7 +42656,6 @@
 /obj/wingrille_spawn/auto,
 /obj/cable,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor,
@@ -45308,16 +42666,12 @@
 	dir = 1
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light/incandescent/cool{
 	nostick = 1
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/south,
@@ -45369,8 +42723,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/blackwhite,
@@ -45392,8 +42744,6 @@
 	tag = ""
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/yellow,
@@ -45414,7 +42764,6 @@
 "ifi" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/window_blinds/cog2/right,
@@ -45425,8 +42774,6 @@
 /obj/item/device/reagentscanner,
 /obj/item/device/reagentscanner,
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/black,
@@ -45445,12 +42792,9 @@
 "iyE" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/sanitary/blue,
@@ -45459,8 +42803,6 @@
 /obj/table/reinforced/chemistry/auto,
 /obj/machinery/phone,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
@@ -45468,8 +42810,6 @@
 "iIQ" = (
 /obj/submachine/slot_machine,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/flasher/genpop/new_walls/west{
@@ -45488,11 +42828,9 @@
 "jmo" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -45512,8 +42850,6 @@
 "keB" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable,
@@ -45529,16 +42865,12 @@
 	},
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
 "kfj" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro{
@@ -45555,8 +42887,6 @@
 /area/station/security/hos)
 "kly" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -45575,15 +42905,12 @@
 /obj/cable,
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/sec_foyer)
 "kLh" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -45605,13 +42932,9 @@
 /area/station/engine/inner)
 "lfN" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor,
@@ -45622,8 +42945,6 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -45642,11 +42963,9 @@
 "lrl" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable,
@@ -45662,7 +42981,6 @@
 "lOW" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/window_blinds/cog2/left,
@@ -45681,8 +42999,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -45699,8 +43015,6 @@
 	},
 /obj/decal/cleanable/dirt,
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/stool/bench/red/auto,
@@ -45713,11 +43027,9 @@
 /obj/wingrille_spawn/auto,
 /obj/decal/poster/wallsign/warning1,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -45728,25 +43040,12 @@
 /area/station/hallway/secondary/construction2)
 "mrf" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black{
 	icon_state = "respect6"
 	},
 /area/station/security/secwing)
-"msu" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor,
-/area/station/engine/inner)
 "mxx" = (
 /obj/submachine/chef_sink/chem_sink{
 	pixel_y = 8
@@ -45778,21 +43077,15 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/redblack,
 /area/station/security/interrogation)
 "mTg" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
@@ -45808,7 +43101,6 @@
 /obj/wingrille_spawn/auto,
 /obj/cable,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor,
@@ -45816,8 +43108,6 @@
 "naL" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -45892,8 +43182,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/blackwhite,
@@ -45904,7 +43192,6 @@
 	icon_state = "0-2"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -45922,7 +43209,6 @@
 /area/diner/hangar)
 "ois" = (
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/autoname_north,
@@ -45937,11 +43223,9 @@
 /obj/cable,
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -45951,8 +43235,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/yellow/side{
@@ -45980,7 +43262,6 @@
 /obj/cable,
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor,
@@ -46025,8 +43306,6 @@
 /area/diner/hangar)
 "oWc" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/yellow,
@@ -46069,16 +43348,12 @@
 /obj/disposalpipe/segment/mail,
 /obj/access_spawn/medical_director,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
@@ -46098,8 +43373,6 @@
 /area/diner/hangar)
 "pEj" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/south,
@@ -46119,8 +43392,6 @@
 /area/station/engine/elect)
 "qrl" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -46139,15 +43410,12 @@
 	},
 /obj/cable,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
 "qMj" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black{
@@ -46163,8 +43431,6 @@
 /area/station/science/artifact)
 "qQk" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/yellow,
@@ -46175,8 +43441,6 @@
 /area/diner/hangar)
 "qSo" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -46189,7 +43453,6 @@
 "qZI" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -46205,8 +43468,6 @@
 /area/listeningpost/syndicateassaultvessel)
 "rdE" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/black,
@@ -46235,13 +43496,9 @@
 /area/diner/hangar)
 "rVZ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/special/submarinesdown,
@@ -46255,8 +43512,6 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/black,
@@ -46270,12 +43525,9 @@
 "stp" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/window_blinds/cog2/right,
@@ -46302,11 +43554,9 @@
 "sFy" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable,
@@ -46316,29 +43566,21 @@
 "sTs" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
 "sUv" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
@@ -46367,13 +43609,9 @@
 	dir = 1
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/special/submarinesdown,
@@ -46381,7 +43619,6 @@
 "tHP" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/window_blinds/cog2/right,
@@ -46389,8 +43626,6 @@
 /area/station/security/hos)
 "tLe" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -46418,18 +43653,12 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
@@ -46438,11 +43667,9 @@
 /obj/cable,
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -46458,8 +43685,6 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -46472,8 +43697,6 @@
 	dir = 1
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/purple,
@@ -46492,11 +43715,9 @@
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/right,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -46570,8 +43791,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/black,
@@ -46595,11 +43814,9 @@
 	nostick = 1
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/circuit,
@@ -46611,8 +43828,6 @@
 /area/station/hydroponics/bay)
 "wBW" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/yellow/side{
@@ -46634,12 +43849,9 @@
 "wDz" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/window_blinds/cog2/right,
@@ -46648,7 +43860,6 @@
 "wRO" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor,
@@ -46662,8 +43873,6 @@
 	dir = 1
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/yellow/side{
@@ -46674,7 +43883,6 @@
 /obj/machinery/power/apc/autoname_east,
 /obj/cable,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/darkblue/checker/other,
@@ -46688,8 +43896,6 @@
 	},
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -46731,21 +43937,15 @@
 /obj/machinery/light/small/floor/netural,
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
 "xyW" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/table/reinforced/auto,
@@ -46760,11 +43960,9 @@
 "xHd" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/window_blinds/cog2/left{
@@ -46797,8 +43995,6 @@
 "xRF" = (
 /obj/machinery/drainage,
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor,
@@ -46806,23 +44002,18 @@
 "xSi" = (
 /obj/cable,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/damaged2,
 /area/station/engine/inner)
 "xVU" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -64520,7 +61711,7 @@ act
 acO
 acO
 ait
-arM
+aGX
 buU
 buU
 bvN
@@ -65123,7 +62314,7 @@ act
 acO
 acO
 bpb
-arM
+aGX
 buU
 buU
 acM
@@ -65425,7 +62616,7 @@ act
 acO
 aES
 ait
-arM
+aGX
 buU
 bwr
 byg
@@ -66027,7 +63218,7 @@ act
 act
 acO
 bah
-arM
+aGX
 bai
 brv
 buU
@@ -66329,7 +63520,7 @@ act
 acO
 acO
 ait
-arM
+aGX
 bai
 btu
 boc
@@ -66932,7 +64123,7 @@ act
 act
 acO
 aES
-arM
+aGX
 bai
 bai
 box
@@ -67234,7 +64425,7 @@ act
 acO
 acO
 ait
-arM
+aGX
 bai
 bpd
 brx
@@ -67837,7 +65028,7 @@ act
 act
 acO
 ait
-arM
+aGX
 bai
 bai
 bhC
@@ -68441,7 +65632,7 @@ act
 acO
 aVW
 ait
-arM
+aGX
 bai
 bqW
 bjR
@@ -68743,7 +65934,7 @@ act
 acO
 aES
 ait
-arM
+aGX
 bai
 bqV
 bjS
@@ -69045,7 +66236,7 @@ acO
 acO
 ait
 ait
-arM
+aGX
 bai
 aAW
 bjT
@@ -69349,7 +66540,7 @@ ait
 ait
 aXs
 baF
-bdW
+bgy
 bkK
 boc
 boc
@@ -70552,7 +67743,7 @@ act
 acO
 acO
 ait
-arM
+aGX
 aLF
 bmu
 arJ
@@ -71155,7 +68346,7 @@ act
 acO
 acO
 aES
-arM
+aGX
 aLF
 aLF
 bmw
@@ -71467,7 +68658,7 @@ bgr
 box
 aKs
 btK
-bve
+byy
 bwF
 byu
 aLA
@@ -71758,7 +68949,7 @@ act
 acO
 acO
 ait
-arM
+aGX
 aLF
 aLF
 bll
@@ -72964,7 +70155,7 @@ act
 acO
 acO
 ait
-arM
+aGX
 aLq
 aLJ
 aNr
@@ -73567,7 +70758,7 @@ act
 acO
 acO
 ait
-arM
+aGX
 aLq
 aLq
 aLJ
@@ -73879,7 +71070,7 @@ blo
 bmC
 bnG
 boS
-bft
+brC
 bpW
 aKs
 atQ
@@ -74170,7 +71361,7 @@ act
 acO
 acO
 ait
-arM
+aGX
 aLq
 aLq
 aLq
@@ -74489,7 +71680,7 @@ aKs
 atQ
 atQ
 bwN
-bve
+byy
 bvk
 bvk
 bvk
@@ -74773,7 +71964,7 @@ aKL
 acO
 acO
 aES
-arM
+aGX
 aLq
 aLq
 aLv
@@ -74791,7 +71982,7 @@ aKs
 bvk
 bvk
 bwO
-bve
+byy
 bvk
 bBA
 bCY
@@ -75699,7 +72890,7 @@ bvk
 bwR
 bvk
 bvk
-bve
+byy
 bvk
 bEn
 bvk
@@ -76001,7 +73192,7 @@ bvn
 bwS
 bvk
 bvk
-bve
+byy
 bvk
 bvk
 bvk
@@ -76303,7 +73494,7 @@ bvo
 bwP
 byA
 bvk
-bve
+byy
 bvk
 bvk
 bvk
@@ -76613,7 +73804,7 @@ bwK
 bHR
 bII
 bLf
-bIi
+bMq
 bEF
 bEF
 act
@@ -76902,8 +74093,8 @@ aCb
 bhj
 bqe
 brC
-bdW
-bdW
+bgy
+bgy
 bwU
 byC
 bvk
@@ -76916,7 +74107,7 @@ bHS
 bwP
 bFR
 bHm
-bIi
+bMq
 bEF
 act
 act
@@ -77483,7 +74674,7 @@ acO
 acO
 aim
 ait
-arM
+aGX
 acD
 acD
 aIn
@@ -77503,7 +74694,7 @@ biD
 biD
 biD
 boU
-bhl
+bhQ
 bqi
 brD
 asb
@@ -77784,7 +74975,7 @@ acO
 acO
 ait
 aoJ
-aqK
+bpc
 apD
 acD
 aYj
@@ -79289,7 +76480,7 @@ acO
 acO
 ait
 ait
-arM
+aGX
 acD
 acD
 aJj
@@ -80493,7 +77684,7 @@ acO
 acO
 aBo
 ait
-arM
+aGX
 aCr
 aCr
 aCx
@@ -80544,7 +77735,7 @@ bjW
 bMl
 bgy
 bMs
-bHE
+bLf
 bMJ
 bMq
 bEF
@@ -80795,7 +77986,7 @@ acO
 aBn
 ait
 ait
-arM
+aGX
 aCr
 aCr
 aCr
@@ -81097,7 +78288,7 @@ acO
 auc
 ait
 ait
-arM
+aGX
 ait
 ait
 ait
@@ -81397,15 +78588,15 @@ act
 acO
 awF
 aoJ
-aqK
-aqK
+bpc
+bpc
 aCn
-aCO
-aqK
-aqK
-aqK
-aqK
-aqK
+bBK
+bpc
+bpc
+bpc
+bpc
+bpc
 aGW
 acf
 acf
@@ -81698,7 +78889,7 @@ act
 acO
 acO
 ait
-arM
+aGX
 atP
 atP
 atP
@@ -82301,7 +79492,7 @@ act
 acO
 acO
 ait
-arM
+aGX
 atP
 atP
 aIE
@@ -82904,7 +80095,7 @@ act
 acO
 acO
 ait
-arM
+aGX
 atP
 atP
 aNO
@@ -83507,7 +80698,7 @@ act
 acO
 acO
 ait
-arM
+aGX
 atP
 atP
 atP
@@ -84111,7 +81302,7 @@ acO
 aim
 ait
 ait
-arM
+aGX
 avP
 avP
 avP
@@ -84412,7 +81603,7 @@ acO
 anU
 ait
 aoJ
-aqK
+bpc
 aso
 avP
 avP
@@ -84466,18 +81657,18 @@ bFT
 bHD
 bHD
 bHF
-bHE
-bHE
-bHE
-bHE
+bLf
+bLf
+bLf
+bLf
 bMH
 bML
-bHE
-bHE
-bHE
+bLf
+bLf
+bLf
 bMH
-bHE
-bHE
+bLf
+bLf
 bMW
 bEF
 bEF
@@ -84765,8 +81956,8 @@ aFc
 aFc
 bHn
 bHF
-bHE
-bHE
+bLf
+bLf
 bJt
 avi
 avi
@@ -86596,7 +83787,7 @@ awN
 awO
 axj
 axj
-bHE
+bLf
 axu
 bMI
 bEF
@@ -88416,7 +85607,7 @@ azJ
 azJ
 bNJ
 bHm
-bHE
+bLf
 bMq
 bLw
 bMu
@@ -88719,7 +85910,7 @@ azJ
 azJ
 azJ
 bLD
-bHl
+bKF
 bEF
 bEF
 bEF
@@ -89924,7 +87115,7 @@ aEt
 azJ
 aAb
 aAh
-aAi
+aAM
 aAh
 aAh
 aOc
@@ -90224,9 +87415,9 @@ azu
 lfN
 bNO
 azV
-aAi
+aAM
 aAt
-aAi
+aAM
 aAh
 aAE
 axD
@@ -90830,7 +88021,7 @@ azG
 azV
 aAu
 aAh
-aAi
+aAM
 aAh
 aAG
 aAT
@@ -91130,9 +88321,9 @@ azu
 mTg
 aEt
 azJ
-aAi
+aAM
 aAh
-aAi
+aAM
 aAQ
 aAh
 bIt
@@ -91731,7 +88922,7 @@ axg
 axg
 auV
 azu
-msu
+mTg
 azG
 azQ
 aAl
@@ -92032,7 +89223,7 @@ ayN
 axf
 bNQ
 bJm
-aha
+axf
 bNy
 azG
 azQ
@@ -92945,7 +90136,7 @@ azJ
 azJ
 bFt
 bHa
-bIc
+bNe
 bEw
 bEw
 bEw
@@ -93246,7 +90437,7 @@ avp
 azJ
 bJx
 bHa
-bIc
+bNe
 bEw
 bEw
 act
@@ -93547,7 +90738,7 @@ avp
 avp
 asz
 bHa
-bIc
+bNe
 bEw
 bEw
 act
@@ -93848,7 +91039,7 @@ avp
 avp
 bFt
 bHa
-bIc
+bNe
 bEw
 bEw
 act
@@ -94118,9 +91309,9 @@ aDc
 aCM
 aCM
 buo
-bxm
+byn
 bwx
-bxm
+byn
 byn
 bBi
 bDd
@@ -94149,7 +91340,7 @@ avp
 avp
 bFt
 bHa
-bIc
+bNe
 bEw
 bEw
 act
@@ -94679,26 +91870,26 @@ apu
 aKz
 aKz
 aqa
-aqJ
-aqJ
-aqJ
-aqJ
-aqJ
-aqJ
-aqJ
+aPc
+aPc
+aPc
+aPc
+aPc
+aPc
+aPc
 aCa
-aqJ
-aqJ
-aqJ
-aqJ
+aPc
+aPc
+aPc
+aPc
 aFg
 aFr
 aGv
 aHC
 aHU
-aqJ
-aqJ
-aqJ
+aPc
+aPc
+aPc
 aKp
 aKA
 aMI
@@ -95052,7 +92243,7 @@ avp
 avp
 bJx
 bHa
-bIc
+bNe
 bEw
 bEw
 act
@@ -95279,7 +92470,7 @@ aBw
 aCV
 aBw
 aBw
-aNk
+aWe
 aHW
 aBr
 aDy
@@ -95353,7 +92544,7 @@ aui
 avp
 bFt
 bHa
-bIc
+bNe
 bEw
 bEw
 act
@@ -95582,7 +92773,7 @@ aBr
 aFe
 aBw
 aBw
-aNk
+aWe
 aPs
 aBr
 aDy
@@ -95654,7 +92845,7 @@ ayF
 aui
 bFt
 bHa
-bIc
+bNe
 bEw
 bEw
 aaa
@@ -95885,7 +93076,7 @@ aBr
 aBr
 aPm
 aBw
-aNk
+aWe
 anT
 aBr
 aDy
@@ -95955,7 +93146,7 @@ awy
 aui
 aui
 bFt
-bHb
+bHk
 bEw
 bEw
 aaa
@@ -96188,7 +93379,7 @@ aBr
 aBr
 aof
 bAB
-aNk
+aWe
 aPs
 aBr
 aDy
@@ -96491,8 +93682,8 @@ aBr
 aBr
 aCV
 aBw
-aNk
-aPR
+aWe
+aWs
 aQr
 aaf
 aaM
@@ -96853,14 +94044,14 @@ bFt
 bFt
 bFt
 aOF
-bHb
+bHk
 bFt
 bFt
 aOF
 bFt
 bFt
 bHa
-bIc
+bNe
 bEw
 act
 act
@@ -97701,7 +94892,7 @@ act
 act
 aBr
 aCV
-aNk
+aWe
 aPs
 aQW
 aCP
@@ -98306,7 +95497,7 @@ act
 act
 aBr
 aBw
-aNk
+aWe
 aQX
 aQW
 aCW
@@ -98911,7 +96102,7 @@ act
 act
 aBr
 aJH
-aNk
+aWe
 aPs
 aQW
 aaO
@@ -98970,7 +96161,7 @@ bLE
 bLE
 bLE
 bFt
-bHb
+bHk
 bEw
 bEw
 aab
@@ -99272,7 +96463,7 @@ bLK
 bHv
 bIb
 bHa
-bIc
+bNe
 bEw
 aaa
 aab
@@ -99516,16 +96707,16 @@ act
 aab
 aBr
 aQH
-aNk
-aPR
-aPR
+aWe
+aWs
+aWs
 aRY
 aSy
-aPR
-aPR
+aWs
+aWs
 aCs
-aPR
-aPR
+aWs
+aWs
 aVZ
 aVw
 aVw
@@ -99573,7 +96764,7 @@ bLu
 bHv
 bHv
 bFt
-bHb
+bHk
 bEw
 bEw
 aaa
@@ -99861,7 +97052,7 @@ aFt
 bAz
 bCc
 bDC
-bEO
+bEV
 bGc
 bDH
 bIo
@@ -100176,7 +97367,7 @@ bLa
 bHv
 bHv
 bFt
-bHb
+bHk
 bEw
 bEw
 aaa
@@ -100727,7 +97918,7 @@ act
 aBr
 aBr
 aJH
-aNk
+aWe
 aPs
 aTj
 aTj
@@ -100779,7 +97970,7 @@ bHy
 bHy
 bHy
 bFt
-bHb
+bHk
 bEw
 bEw
 act
@@ -101030,7 +98221,7 @@ act
 aBr
 aBr
 aBw
-aNk
+aWe
 aPs
 aTj
 aTj
@@ -101081,7 +98272,7 @@ bHy
 bHy
 bFt
 bHa
-bIc
+bNe
 bEw
 aab
 act
@@ -101333,7 +98524,7 @@ act
 aBr
 aBr
 aBw
-aNk
+aWe
 aTS
 aTj
 aTj
@@ -101382,7 +98573,7 @@ bHy
 bHy
 bHy
 bFt
-bHb
+bHk
 bEw
 bEw
 act
@@ -101636,7 +98827,7 @@ act
 aBr
 aBr
 aBw
-aNk
+aWe
 aPs
 aTj
 aVw
@@ -101684,7 +98875,7 @@ bHy
 bHy
 bIb
 bHa
-bIc
+bNe
 bEw
 aaa
 aqQ
@@ -101939,7 +99130,7 @@ act
 aBr
 aBr
 aBw
-aNk
+aWe
 aPs
 aVw
 aVw
@@ -101985,7 +99176,7 @@ bKs
 bHy
 bHy
 bFt
-bHb
+bHk
 bEw
 bEw
 aaa
@@ -102242,7 +99433,7 @@ act
 aBr
 aBr
 aUB
-aNk
+aWe
 aVy
 aWd
 aWd
@@ -102287,7 +99478,7 @@ bHy
 bHy
 bFt
 bHa
-bIc
+bNe
 bEw
 act
 act
@@ -102545,8 +99736,8 @@ act
 aBr
 aBr
 aBw
-aNk
-aHv
+aWe
+aRY
 aKy
 aHB
 aii
@@ -102588,7 +99779,7 @@ bHy
 bHy
 bHy
 bFt
-bHb
+bHk
 bEw
 bEw
 act
@@ -103151,7 +100342,7 @@ act
 aBr
 aBr
 aWe
-aPR
+aWs
 aWU
 aWd
 aWd
@@ -103191,7 +100382,7 @@ bJq
 bHy
 bHy
 bFt
-bHb
+bHk
 bEw
 bEw
 act
@@ -103454,7 +100645,7 @@ act
 aBr
 aBr
 aof
-aNk
+aWe
 aPs
 aWd
 aWd
@@ -103757,7 +100948,7 @@ act
 aBr
 aBr
 aBw
-aNk
+aWe
 aPs
 aWd
 aWd
@@ -103794,7 +100985,7 @@ bHx
 bHy
 bHy
 bFt
-bHb
+bHk
 bEw
 bEw
 act
@@ -104060,7 +101251,7 @@ act
 aBr
 aBr
 aBw
-aNk
+aWe
 aPs
 aWd
 aWd
@@ -104096,7 +101287,7 @@ bIu
 bHy
 bHy
 bFt
-bHc
+bMr
 bEw
 act
 act
@@ -104363,7 +101554,7 @@ act
 aBr
 aBr
 aYi
-aNk
+aWe
 aPs
 aWd
 aWd
@@ -104666,7 +101857,7 @@ aab
 aBr
 aBr
 aBw
-aNk
+aWe
 aPs
 bbD
 bbD
@@ -104699,7 +101890,7 @@ bHt
 bIw
 bHy
 bFt
-bHb
+bHk
 bEw
 bEw
 act
@@ -104969,7 +102160,7 @@ act
 aBr
 aBr
 aBw
-aNk
+aWe
 aWU
 bbD
 bbD
@@ -105001,7 +102192,7 @@ bHy
 bHy
 bHy
 bFt
-bHb
+bHk
 bEw
 act
 act
@@ -105272,7 +102463,7 @@ act
 aBr
 aBr
 aBw
-aNk
+aWe
 aPs
 bbD
 bbD
@@ -105303,7 +102494,7 @@ bHB
 bAq
 bJz
 bHa
-bIc
+bNe
 bEw
 act
 aaa
@@ -105575,7 +102766,7 @@ act
 aBr
 aZA
 aPd
-aNk
+aWe
 aPs
 bbD
 bfU
@@ -105604,7 +102795,7 @@ bDL
 bHC
 bAq
 bFt
-bHb
+bHk
 bEw
 bEw
 act
@@ -105906,7 +103097,7 @@ bDL
 bAq
 bAq
 bFt
-bHb
+bHk
 bEw
 act
 act
@@ -106180,7 +103371,7 @@ aBr
 aZA
 aBr
 aBw
-aNk
+aWe
 aPs
 bbD
 bgX
@@ -106509,7 +103700,7 @@ bEU
 aMs
 bAq
 bFt
-bHb
+bHk
 bEw
 bEw
 act
@@ -106785,8 +103976,8 @@ adx
 act
 aBr
 aBw
-aNk
-aHv
+aWe
+aRY
 beE
 bhO
 bgD
@@ -106811,7 +104002,7 @@ aip
 bAq
 bAq
 bFt
-bHb
+bHk
 bEw
 act
 act
@@ -107113,7 +104304,7 @@ bEU
 bAq
 bFt
 bHa
-bIc
+bNe
 bEw
 act
 aaa
@@ -107390,7 +104581,7 @@ act
 act
 aBr
 aBw
-aNk
+aWe
 aPs
 bhP
 biz
@@ -107995,7 +105186,7 @@ act
 act
 aBr
 aPd
-aNk
+aWe
 aPs
 bhP
 aNU
@@ -108018,7 +105209,7 @@ aHM
 aHM
 bAq
 bFt
-bHb
+bHk
 bEw
 act
 aaa
@@ -108320,7 +105511,7 @@ bDN
 aHM
 bAq
 bFt
-bHb
+bHk
 bEw
 act
 aaa
@@ -108600,7 +105791,7 @@ act
 act
 aBr
 aTT
-aNk
+aWe
 aPs
 bhP
 biz
@@ -108923,7 +106114,7 @@ bCC
 bDP
 aHM
 bMi
-bHb
+bHk
 bEw
 bEw
 act
@@ -109205,7 +106396,7 @@ act
 act
 aBr
 aBw
-aNk
+aWe
 aPs
 bhP
 blh
@@ -109810,7 +107001,7 @@ act
 act
 aBr
 aBw
-aNk
+aWe
 aPs
 bli
 bmr
@@ -110415,7 +107606,7 @@ act
 act
 aBr
 aBw
-aNk
+aWe
 aPs
 bli
 bnv
@@ -111020,9 +108211,9 @@ act
 act
 aBr
 aPd
-aNk
+aWe
 bms
-aPR
+aWs
 aPs
 aKa
 bpV
@@ -113741,11 +110932,11 @@ aaa
 act
 aBr
 aPd
-aNk
+aWe
 aPs
 aKa
 bNx
-bsu
+btB
 btA
 bwo
 byc
@@ -114648,7 +111839,7 @@ aaa
 act
 aBr
 aBw
-aNk
+aWe
 aPs
 aKa
 bsA
@@ -115555,8 +112746,8 @@ aaa
 act
 aBr
 aBr
-aNk
-aPR
+aWe
+aWs
 btw
 btx
 buV

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -8843,14 +8843,14 @@
 /area/station/engine/inner)
 "avG" = (
 /obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/right{
-	dir = 8
-	},
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable,
+/obj/window_blinds/cog2/middle{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering/ce)
 "avH" = (
@@ -9392,13 +9392,13 @@
 /area/station/engine/inner)
 "awM" = (
 /obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/right{
-	dir = 8
-	},
 /obj/cable,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
+	},
+/obj/window_blinds/cog2/right{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering/ce)
@@ -9504,7 +9504,6 @@
 /area/station/engine/engineering/ce)
 "awY" = (
 /obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/right,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -9514,6 +9513,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/window_blinds/cog2/left,
 /turf/simulated/floor/plating,
 /area/station/engine/engineering/ce)
 "awZ" = (
@@ -9536,7 +9536,6 @@
 /area/station/engine/engineering/ce)
 "axa" = (
 /obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/right,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -9546,6 +9545,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/window_blinds/cog2/left,
 /turf/simulated/floor/plating,
 /area/station/engine/engineering/ce)
 "axb" = (
@@ -10076,12 +10076,12 @@
 /area/station/engine/engineering/ce)
 "ayd" = (
 /obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/right{
-	dir = 8
-	},
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
+	},
+/obj/window_blinds/cog2/left{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering/ce)
@@ -18022,8 +18022,12 @@
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
 "aPq" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/portlowerhallway)
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/left{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/head)
 "aPr" = (
 /obj/cable{
 	d1 = 4;
@@ -37676,10 +37680,7 @@
 /area/station/crewquarters/garbagegarbs)
 "bEv" = (
 /obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/right{
-	layer = 2.9;
-	pixel_y = 13
-	},
+/obj/window_blinds/cog2/left,
 /turf/simulated/floor/plating,
 /area/station/engine/elect)
 "bEw" = (
@@ -38781,7 +38782,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window_blinds/cog2/right,
+/obj/window_blinds/cog2/left,
 /turf/simulated/floor/plating,
 /area/station/science/artifact)
 "bHq" = (
@@ -39899,12 +39900,12 @@
 /area/station/maintenance/lowerstarboard)
 "bJX" = (
 /obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/right{
-	dir = 4
-	},
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
+	},
+/obj/window_blinds/cog2/right{
+	dir = 4
 	},
 /turf/simulated/floor/plating/random,
 /area/station/security/detectives_office_manta)
@@ -40123,9 +40124,6 @@
 /area/station/hallway/starboardlowerhallway)
 "bKu" = (
 /obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/right{
-	dir = 4
-	},
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -40134,6 +40132,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/window_blinds/cog2/left{
+	dir = 4
 	},
 /turf/simulated/floor/plating/random,
 /area/station/security/detectives_office_manta)
@@ -40506,9 +40507,6 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office_manta/detectives_bedroom)
 "bLo" = (
-/obj/window_blinds/cog2/right{
-	dir = 8
-	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -40519,6 +40517,9 @@
 	icon_state = "2-8"
 	},
 /obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/left{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office_manta/detectives_bedroom)
 "bLp" = (
@@ -40601,15 +40602,15 @@
 /area/station/security/detectives_office_manta/detectives_bedroom)
 "bLB" = (
 /obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/right{
-	dir = 8
-	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable,
+/obj/window_blinds/cog2/right{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office_manta/detectives_bedroom)
 "bLC" = (
@@ -40839,16 +40840,11 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office_manta/detectives_bedroom)
 "bMb" = (
+/obj/cable,
+/obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/right{
 	dir = 8
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable,
-/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office_manta/detectives_bedroom)
 "bMc" = (
@@ -44866,17 +44862,9 @@
 	icon_state = "yellowblack"
 	},
 /area/station/engine/engineering/breakroom)
-"cYw" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "6-8"
-	},
-/turf/simulated/floor/redblack,
-/area/listeningpost/syndicateassaultvessel)
+"cYe" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hallway/portlowerhallway)
 "dfY" = (
 /obj/cable{
 	d2 = 8;
@@ -44895,6 +44883,23 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/checkpoint/sec_foyer)
+"doS" = (
+/obj/cable{
+	icon_state = "2-9"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
+"dxF" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/random,
+/area/listeningpost/syndicateassaultvessel)
 "dCn" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -45004,6 +45009,17 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/construction2)
+"eid" = (
+/obj/stool/chair/red{
+	dir = 8
+	},
+/obj/cable{
+	icon_state = "9-10"
+	},
+/turf/simulated/floor/redblack{
+	dir = 8
+	},
+/area/listeningpost/syndicateassaultvessel)
 "eFJ" = (
 /obj/lattice{
 	icon_state = "lattice-dir"
@@ -45021,6 +45037,15 @@
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
+"eNl" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "5-8"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "ePj" = (
 /obj/lattice{
 	dir = 5;
@@ -45052,17 +45077,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/courtroom)
-"ffY" = (
-/obj/stool/chair/red{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "5-6"
-	},
-/turf/simulated/floor/redblack{
-	dir = 4
-	},
-/area/listeningpost/syndicateassaultvessel)
 "fih" = (
 /obj/machinery/flasher/genpop/new_walls/west{
 	id = "cell1";
@@ -45080,18 +45094,6 @@
 	},
 /turf/simulated/floor,
 /area/station/security/brig/cell1)
-"flD" = (
-/obj/cable{
-	icon_state = "6-8"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
-"fmh" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
 "fmU" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -45139,6 +45141,15 @@
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
+"fOY" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "4-9"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "fRX" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/mainframe/zeta{
@@ -45179,17 +45190,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/checkpoint/sec_foyer)
-"gaC" = (
-/obj/stool/chair/red{
-	dir = 8
-	},
-/obj/cable{
-	icon_state = "9-10"
-	},
-/turf/simulated/floor/redblack{
-	dir = 8
-	},
-/area/listeningpost/syndicateassaultvessel)
 "gdN" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer/aiupload,
@@ -45219,15 +45219,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/checkpoint/sec_foyer)
-"gvt" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-10"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
 "gwj" = (
 /obj/cable{
 	d2 = 2;
@@ -45237,6 +45228,15 @@
 /obj/cable,
 /turf/simulated/floor,
 /area/station/security/visitation)
+"gxh" = (
+/obj/stool/chair/comfy/red{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-6"
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/west,
+/area/listeningpost/syndicateassaultvessel)
 "gzR" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/storage/tape_drive{
@@ -45275,15 +45275,6 @@
 	},
 /turf/simulated/floor/longtile/black,
 /area/station/turret_protected/ai_upload)
-"gFz" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-6"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
 "gYm" = (
 /obj/machinery/computer/shuttle_bus{
 	dir = 8
@@ -45494,15 +45485,6 @@
 	},
 /turf/space/fluid/manta,
 /area/mantaSpace)
-"iKJ" = (
-/obj/stool/chair/comfy/red{
-	dir = 8
-	},
-/obj/cable{
-	icon_state = "1-10"
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/east,
-/area/listeningpost/syndicateassaultvessel)
 "jmo" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -45518,30 +45500,28 @@
 "jnl" = (
 /turf/simulated/floor,
 /area/station/hallway/secondary/construction2)
-"jzF" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "5-8"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
+"jLO" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/right,
+/turf/simulated/floor/plating,
+/area/station/engine/elect)
 "jMM" = (
 /obj/machinery/photocopier,
 /turf/simulated/floor/carpet/grime,
 /area/station/communications/bedroom)
-"jQu" = (
+"keB" = (
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/cable{
-	icon_state = "5-8"
+/obj/cable,
+/obj/window_blinds/cog2/left{
+	dir = 8
 	},
-/turf/simulated/floor/carpet/red/fancy/edge/south,
-/area/listeningpost/syndicateassaultvessel)
+/turf/simulated/floor/plating,
+/area/station/security/detectives_office_manta/detectives_bedroom)
 "keQ" = (
 /obj/decal/tile_edge/line/purple{
 	dir = 6;
@@ -45600,6 +45580,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/sec_foyer)
+"kLh" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "6-8"
+	},
+/turf/simulated/floor/redblack,
+/area/listeningpost/syndicateassaultvessel)
 "kMM" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -45625,12 +45616,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/inner)
-"lgK" = (
-/obj/cable{
-	icon_state = "5-8"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
 "lmY" = (
 /obj/decal/tile_edge/line/green{
 	color = "#e7c88c";
@@ -45668,6 +45653,12 @@
 /obj/window_blinds/cog2/middle,
 /turf/simulated/floor/plating,
 /area/station/security/interrogation)
+"lNJ" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/black,
+/area/listeningpost/syndicateassaultvessel)
 "lOW" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -45696,6 +45687,12 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
+"lSE" = (
+/obj/cable{
+	icon_state = "5-8"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "lYo" = (
 /obj/item/device/radio/intercom/security{
 	dir = 4
@@ -45725,27 +45722,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
-"mfW" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating/random,
-/area/listeningpost/syndicateassaultvessel)
 "mnz" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/construction2)
-"mpL" = (
-/obj/cable{
-	icon_state = "2-9"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
 "mrf" = (
 /obj/cable{
 	d1 = 4;
@@ -45767,15 +45747,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/inner)
-"mth" = (
-/obj/cable{
-	icon_state = "0-10"
-	},
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/turf/simulated/floor/plating/random,
-/area/listeningpost/syndicateassaultvessel)
 "mxx" = (
 /obj/submachine/chef_sink/chem_sink{
 	pixel_y = 8
@@ -45851,6 +45822,11 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
+"ndD" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/left,
+/turf/simulated/floor,
+/area/station/engine/elect)
 "nji" = (
 /obj/table/reinforced/auto,
 /obj/machinery/computer3/generic/personal/personel_alt{
@@ -45860,6 +45836,12 @@
 /obj/cable,
 /turf/simulated/floor,
 /area/station/security/brig/genpop)
+"njQ" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "nkZ" = (
 /obj/disposalpipe/switch_junction/right/west{
 	mail_tag = "Research Director"
@@ -45869,17 +45851,6 @@
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/north,
 /area/station/crew_quarters/hor)
-"npb" = (
-/obj/cable{
-	icon_state = "4-10"
-	},
-/obj/cable{
-	icon_state = "9-10"
-	},
-/turf/simulated/floor/stairs/dark{
-	dir = 9
-	},
-/area/listeningpost/syndicateassaultvessel)
 "nuY" = (
 /obj/decal/tile_edge/line/green{
 	color = "#e7c88c";
@@ -45893,24 +45864,18 @@
 	dir = 6
 	},
 /area/station/crewquarters/cryotron)
-"nPi" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/black,
-/area/listeningpost/syndicateassaultvessel)
 "nTP" = (
 /obj/decal/cleanable/dirt,
 /turf/space/fluid/manta,
 /area/mantaSpace)
-"nVd" = (
+"nXz" = (
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "0-10"
 	},
-/obj/cable{
-	icon_state = "4-9"
+/obj/machinery/power/terminal{
+	dir = 8
 	},
-/turf/simulated/floor/red,
+/turf/simulated/floor/plating/random,
 /area/listeningpost/syndicateassaultvessel)
 "nZD" = (
 /obj/grille/catwalk{
@@ -46066,6 +46031,17 @@
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/inner)
+"oWi" = (
+/obj/cable{
+	icon_state = "4-10"
+	},
+/obj/cable{
+	icon_state = "9-10"
+	},
+/turf/simulated/floor/stairs/dark{
+	dir = 9
+	},
+/area/listeningpost/syndicateassaultvessel)
 "paG" = (
 /obj/stool/bench/red/auto,
 /obj/decal/cleanable/dirt/dirt5,
@@ -46107,16 +46083,40 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
+"pwt" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-6"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "pyg" = (
 /obj/decal/cleanable/dirt/dirt3,
 /turf/simulated/floor/grime,
 /area/diner/hangar)
+"pEj" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/south,
+/area/listeningpost/syndicateassaultvessel)
 "pFX" = (
 /obj/landmark/spawner{
 	name = "monkeyspawn_stirstir"
 	},
 /turf/simulated/floor,
 /area/station/security/brig/genpop)
+"pSV" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/left{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/elect)
 "qrl" = (
 /obj/cable{
 	d1 = 1;
@@ -46154,6 +46154,13 @@
 	icon_state = "respect2"
 	},
 /area/station/security/secwing)
+"qOO" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/middle{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/science/artifact)
 "qQk" = (
 /obj/cable{
 	d1 = 1;
@@ -46174,6 +46181,11 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
+"qZg" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2,
+/turf/simulated/floor,
+/area/station/engine/elect)
 "qZI" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -46182,6 +46194,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/sec_foyer)
+"rav" = (
+/obj/stool/chair/comfy/red{
+	dir = 8
+	},
+/obj/cable{
+	icon_state = "1-10"
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/east,
+/area/listeningpost/syndicateassaultvessel)
 "rdE" = (
 /obj/cable{
 	d1 = 1;
@@ -46190,6 +46211,15 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
+"rkT" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-10"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "rlZ" = (
 /obj/computerframe{
 	dir = 8
@@ -46237,6 +46267,20 @@
 	},
 /turf/space/fluid/manta,
 /area/diner/hangar)
+"stp" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/window_blinds/cog2/right,
+/turf/simulated/floor/plating,
+/area/station/engine/engineering/ce)
 "swZ" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 8
@@ -46248,6 +46292,13 @@
 	dir = 8
 	},
 /area/station/engine/inner)
+"sCW" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/left{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/science/artifact)
 "sFy" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -46292,6 +46343,12 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/checkpoint/sec_foyer)
+"sVZ" = (
+/obj/cable{
+	icon_state = "4-9"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "sXN" = (
 /obj/table/auto,
 /obj/item/circuitboard/teleporter,
@@ -46330,6 +46387,17 @@
 /obj/window_blinds/cog2/right,
 /turf/simulated/floor/plating,
 /area/station/security/hos)
+"tLe" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "5-8"
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/south,
+/area/listeningpost/syndicateassaultvessel)
 "uhU" = (
 /obj/table/glass/reinforced/auto,
 /obj/item/clipboard,
@@ -46337,12 +46405,6 @@
 /obj/item/pen/pencil,
 /turf/simulated/floor/carpet/grime,
 /area/station/communications/bedroom)
-"uFe" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/black,
-/area/listeningpost/syndicateassaultvessel)
 "uFt" = (
 /obj/decal/tile_edge/line/green{
 	color = "#e7c88c";
@@ -46402,12 +46464,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/checkpoint/sec_foyer)
-"uVZ" = (
-/obj/cable{
-	icon_state = "4-9"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
 "vjQ" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -46445,6 +46501,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/hor)
+"vzC" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/black,
+/area/listeningpost/syndicateassaultvessel)
+"vDw" = (
+/obj/stool/chair/red{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "5-6"
+	},
+/turf/simulated/floor/redblack{
+	dir = 4
+	},
+/area/listeningpost/syndicateassaultvessel)
 "vRo" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/secondary/construction)
@@ -46558,6 +46631,20 @@
 	dir = 4
 	},
 /area/station/security/secoffquarters)
+"wDz" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/window_blinds/cog2/right,
+/turf/simulated/floor/plating,
+/area/station/engine/engineering/ce)
 "wRO" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -46595,12 +46682,6 @@
 "xaf" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/secondary/construction)
-"xjj" = (
-/obj/cable{
-	icon_state = "2-5"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
 "xrm" = (
 /obj/decal/tile_edge/line/purple{
 	icon_state = "line1"
@@ -46638,6 +46719,12 @@
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/kitchen/therustykrab)
+"xyl" = (
+/obj/cable{
+	icon_state = "2-5"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "xyw" = (
 /obj/table/reinforced/chemistry/auto,
 /obj/item/storage/box/syringes,
@@ -46672,9 +46759,6 @@
 /area/station/security/secoffquarters)
 "xHd" = (
 /obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/right{
-	dir = 8
-	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -46683,17 +46767,11 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/window_blinds/cog2/left{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/station/communications/office)
-"xKe" = (
-/obj/stool/chair/comfy/red{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "1-6"
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/west,
-/area/listeningpost/syndicateassaultvessel)
 "xKw" = (
 /obj/lattice{
 	dir = 1;
@@ -46749,13 +46827,11 @@
 	},
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
-"ych" = (
+"yhC" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "6-8"
 	},
-/turf/simulated/floor/carpet/red/fancy/edge/south,
+/turf/simulated/floor/red,
 /area/listeningpost/syndicateassaultvessel)
 
 (1,1,1) = {"
@@ -83470,7 +83546,7 @@ wBy
 bqo
 bqm
 brV
-aFa
+ndD
 aGq
 bxj
 aIr
@@ -83792,7 +83868,7 @@ bKT
 bLo
 bLB
 agu
-bLB
+keB
 bMb
 bKT
 bHD
@@ -84376,7 +84452,7 @@ biK
 bqo
 bqm
 brV
-aFa
+qZg
 bvB
 aIi
 aIC
@@ -85289,7 +85365,7 @@ aIL
 aIi
 bBO
 aIQ
-bEv
+jLO
 bHD
 bHG
 auh
@@ -85890,7 +85966,7 @@ btc
 btG
 aFc
 aFc
-bAo
+pSV
 bAo
 aFc
 aFc
@@ -86195,7 +86271,7 @@ buY
 buY
 buY
 bAp
-aPq
+cYe
 bFQ
 bGM
 auh
@@ -86813,7 +86889,7 @@ axQ
 axn
 axQ
 azi
-awY
+wDz
 ayG
 axZ
 ayp
@@ -87719,7 +87795,7 @@ ayv
 ayO
 ayU
 azl
-axa
+stp
 bDf
 ayc
 ays
@@ -89309,7 +89385,7 @@ amx
 alF
 amR
 amY
-ffY
+vDw
 alF
 alD
 aly
@@ -89595,7 +89671,7 @@ alt
 akV
 alC
 alD
-xjj
+xyl
 amZ
 amZ
 amc
@@ -89608,11 +89684,11 @@ amZ
 amZ
 atX
 amy
-xjj
-gvt
+xyl
+rkT
 amZ
-gFz
-nVd
+pwt
+fOY
 amZ
 amZ
 amZ
@@ -89892,7 +89968,7 @@ ale
 bMy
 akV
 alk
-uFe
+lNJ
 avM
 akV
 alr
@@ -89913,7 +89989,7 @@ amz
 amJ
 amS
 ana
-xKe
+gxh
 anm
 akH
 akH
@@ -90198,7 +90274,7 @@ alo
 alu
 akV
 alr
-lgK
+lSE
 akH
 alY
 atB
@@ -90518,7 +90594,7 @@ amK
 amT
 anc
 ani
-ych
+pEj
 ans
 anx
 anD
@@ -90798,11 +90874,11 @@ alD
 bMA
 akV
 ali
-npb
+oWi
 alq
 akV
 alr
-uVZ
+sVZ
 akH
 ama
 atD
@@ -90820,7 +90896,7 @@ amK
 amT
 amT
 and
-jQu
+tLe
 akH
 any
 anE
@@ -91100,11 +91176,11 @@ bMx
 bMB
 akV
 alk
-nPi
+vzC
 avM
 akV
 alr
-flD
+yhC
 alR
 akH
 akH
@@ -91117,11 +91193,11 @@ avS
 alD
 akH
 akH
-cYw
+kLh
 amL
 amU
 ane
-iKJ
+rav
 ano
 akH
 akH
@@ -91407,7 +91483,7 @@ alt
 akV
 alC
 alD
-mpL
+doS
 amZ
 amZ
 amg
@@ -91419,17 +91495,17 @@ amZ
 amZ
 amZ
 atX
-fmh
-mpL
+njQ
+doS
 amZ
 amZ
-gvt
-jzF
+rkT
+eNl
 amZ
 amZ
 amZ
 anJ
-mfW
+dxF
 akH
 aok
 aap
@@ -91725,7 +91801,7 @@ amD
 alx
 amV
 alD
-gaC
+eid
 alx
 alG
 alE
@@ -92938,7 +93014,7 @@ amM
 amv
 anz
 akH
-mth
+nXz
 anQ
 aod
 aom
@@ -98883,8 +98959,8 @@ bEU
 bGb
 bHs
 bHs
-bJe
-bJe
+sCW
+qOO
 bJe
 bHs
 bHs
@@ -107323,7 +107399,7 @@ biz
 biz
 apk
 bnm
-bnm
+aPq
 bhP
 bkN
 bsx

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -545,19 +545,23 @@
 /turf/simulated/floor/stairs,
 /area/station/bridge)
 "aaV" = (
-/obj/cable,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor/blast/single{
+/obj/machinery/door/poddoor/pyro{
 	density = 0;
-	icon_state = "bdoorsingle0";
+	icon_state = "pdoor0";
 	id = "ai_core";
 	layer = 4;
 	name = "AI Core Shield";
 	opacity = 0
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -1093,21 +1097,24 @@
 /turf/simulated/floor/grime,
 /area/diner/backroom)
 "abZ" = (
-/obj/cable,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/wingrille_spawn/auto,
-/obj/machinery/door/poddoor/blast/single{
+/obj/machinery/door/poddoor/pyro{
 	density = 0;
-	icon_state = "bdoorsingle0";
+	dir = 9;
+	icon_state = "pdoor0";
 	id = "ai_core";
 	layer = 4;
 	name = "AI Core Shield";
 	opacity = 0
 	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/turret_protected/ai_upload)
 "aca" = (
@@ -4268,8 +4275,27 @@
 	},
 /area/listeningpost/syndicateassaultvessel)
 "alL" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/portlowerhallway)
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 5;
+	icon_state = "pdoor0";
+	id = "ai_core";
+	layer = 4;
+	name = "AI Core Shield";
+	opacity = 0
+	},
+/obj/cable,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/turret_protected/ai_upload)
 "alN" = (
 /obj/machinery/torpedo_console,
 /turf/simulated/floor/redblack{
@@ -5207,11 +5233,23 @@
 /turf/simulated/floor/black,
 /area/listeningpost/syndicateassaultvessel)
 "anY" = (
-/obj/cable{
-	icon_state = "1-4"
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "ai_core";
+	layer = 4;
+	name = "AI Core Shield";
+	opacity = 0
 	},
-/turf/simulated/floor/black,
-/area/listeningpost/syndicateassaultvessel)
+/obj/cable,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/turret_protected/ai_upload)
 "anZ" = (
 /obj/machinery/door/airlock/pyro/syndicate{
 	desc = "Seems to be a pretty sturdy door.";
@@ -5221,16 +5259,24 @@
 /turf/simulated/floor/plating/random,
 /area/listeningpost/syndicateassaultvessel)
 "aoa" = (
-/obj/cable{
-	icon_state = "4-10"
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "ai_core";
+	layer = 4;
+	name = "AI Core Shield";
+	opacity = 0
 	},
 /obj/cable{
-	icon_state = "9-10"
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/stairs/dark{
-	dir = 9
+/obj/cable{
+	icon_state = "0-4"
 	},
-/area/listeningpost/syndicateassaultvessel)
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/turret_protected/ai_upload)
 "aob" = (
 /obj/disposalpipe/segment,
 /obj/cable{
@@ -5699,16 +5745,20 @@
 /turf/space/fluid/manta/nospawn,
 /area/station/com_dish/manta)
 "aoU" = (
-/obj/cable,
-/obj/wingrille_spawn/auto,
-/obj/machinery/door/poddoor/blast/single{
+/obj/machinery/door/poddoor/pyro{
 	density = 0;
-	icon_state = "bdoorsingle0";
+	dir = 10;
+	icon_state = "pdoor0";
 	id = "ai_core";
 	layer = 4;
 	name = "AI Core Shield";
 	opacity = 0
 	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/turret_protected/ai_upload)
 "aoV" = (
@@ -7888,17 +7938,26 @@
 /turf/simulated/floor/bot/blue,
 /area/station/ai_monitored/storage/eva)
 "atG" = (
-/obj/cable{
-	icon_state = "1-8"
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 6;
+	icon_state = "pdoor0";
+	id = "ai_core";
+	layer = 4;
+	name = "AI Core Shield";
+	opacity = 0
 	},
-/turf/simulated/floor/black,
-/area/listeningpost/syndicateassaultvessel)
+/obj/cable,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/turret_protected/ai_upload)
 "atH" = (
-/obj/cable{
-	icon_state = "5-8"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hallway/portlowerhallway)
 "atI" = (
 /obj/storage/closet/syndicate/personal,
 /obj/item/clothing/under/misc/syndicate,
@@ -11997,25 +12056,10 @@
 /area/station/turret_protected/ai_upload_foyer)
 "aCh" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "1-4"
 	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/decal/fakeobjects{
-	anchored = 1;
-	density = 1;
-	desc = "A large rack of server modules.  It appears to be in a low-power idle state.";
-	icon = 'icons/obj/networked.dmi';
-	icon_state = "server0";
-	name = "idle server"
-	},
-/turf/simulated/floor/circuit,
-/area/station/turret_protected/ai_upload_foyer)
+/turf/simulated/floor/black,
+/area/listeningpost/syndicateassaultvessel)
 "aCi" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -17956,9 +18000,14 @@
 /area/station/hydroponics/bay)
 "aPq" = (
 /obj/cable{
-	icon_state = "4-9"
+	icon_state = "4-10"
 	},
-/turf/simulated/floor/red,
+/obj/cable{
+	icon_state = "9-10"
+	},
+/turf/simulated/floor/stairs/dark{
+	dir = 9
+	},
 /area/listeningpost/syndicateassaultvessel)
 "aPr" = (
 /obj/cable{
@@ -18477,15 +18526,10 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/construction2)
 "aQB" = (
+/obj/cable,
 /obj/machinery/power/data_terminal,
 /obj/landmark/start{
 	name = "AI"
-	},
-/obj/cable,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /obj/machinery/door_control{
 	id = "ai_core";
@@ -44732,15 +44776,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
-"cnq" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "4-9"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
 "coR" = (
 /obj/item/constructioncone,
 /turf/simulated/floor,
@@ -44950,12 +44985,6 @@
 /obj/machinery/light/runway_light/delay2,
 /turf/space/fluid/manta,
 /area/mantaSpace)
-"eGM" = (
-/obj/cable{
-	icon_state = "6-8"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
 "eNd" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/radio,
@@ -44966,15 +44995,6 @@
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
-"eNe" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "5-8"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
 "ePj" = (
 /obj/lattice{
 	dir = 5;
@@ -44993,6 +45013,12 @@
 	},
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
+"eTE" = (
+/obj/cable{
+	icon_state = "2-9"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "fcc" = (
 /obj/wingrille_spawn/auto,
 /obj/cable,
@@ -45036,6 +45062,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
+"ftH" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "5-8"
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/south,
+/area/listeningpost/syndicateassaultvessel)
 "ftP" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -45070,17 +45107,6 @@
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
-"fJe" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating/random,
-/area/listeningpost/syndicateassaultvessel)
 "fRX" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/mainframe/zeta{
@@ -45272,6 +45298,23 @@
 	},
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
+"hGW" = (
+/obj/stool/chair/red{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "5-6"
+	},
+/turf/simulated/floor/redblack{
+	dir = 4
+	},
+/area/listeningpost/syndicateassaultvessel)
+"hJp" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/black,
+/area/listeningpost/syndicateassaultvessel)
 "hMH" = (
 /obj/storage/crate{
 	desc = "Wow! Crate may or may not still contain bottles.";
@@ -45333,15 +45376,6 @@
 	},
 /turf/space/fluid/manta,
 /area/diner/hangar)
-"ier" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-10"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
 "ifi" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds,
@@ -45366,6 +45400,17 @@
 /obj/machinery/drainage/big,
 /turf/simulated/floor/grime,
 /area/diner/hangar)
+"isp" = (
+/obj/stool/chair/red{
+	dir = 8
+	},
+/obj/cable{
+	icon_state = "9-10"
+	},
+/turf/simulated/floor/redblack{
+	dir = 8
+	},
+/area/listeningpost/syndicateassaultvessel)
 "ivY" = (
 /obj/lattice{
 	icon_state = "lattice-dir"
@@ -45373,15 +45418,6 @@
 /obj/machinery/light/runway_light/delay5,
 /turf/space/fluid/manta,
 /area/mantaSpace)
-"iwS" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-6"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
 "iyE" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
@@ -45425,6 +45461,12 @@
 	},
 /turf/space/fluid/manta,
 /area/mantaSpace)
+"jfP" = (
+/obj/cable{
+	icon_state = "5-8"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "jmo" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -45493,6 +45535,17 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/starboardlowerhallway)
+"ksM" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/random,
+/area/listeningpost/syndicateassaultvessel)
 "kIf" = (
 /obj/cable,
 /obj/wingrille_spawn/auto,
@@ -45502,17 +45555,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/sec_foyer)
-"kJW" = (
-/obj/stool/chair/red{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "5-6"
-	},
-/turf/simulated/floor/redblack{
-	dir = 4
-	},
-/area/listeningpost/syndicateassaultvessel)
 "kMM" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -45663,6 +45705,14 @@
 	},
 /turf/simulated/floor/sanitary,
 /area/station/engine/engineering/restroom)
+"mzd" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/south,
+/area/listeningpost/syndicateassaultvessel)
 "mGJ" = (
 /obj/machinery/light/runway_light,
 /obj/lattice{
@@ -45714,6 +45764,12 @@
 	},
 /turf/space/fluid/manta,
 /area/diner/hangar)
+"mWM" = (
+/obj/cable{
+	icon_state = "6-8"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "mXU" = (
 /obj/wingrille_spawn/auto,
 /obj/cable,
@@ -45763,17 +45819,6 @@
 	dir = 6
 	},
 /area/station/crewquarters/cryotron)
-"nNd" = (
-/obj/stool/chair/red{
-	dir = 8
-	},
-/obj/cable{
-	icon_state = "9-10"
-	},
-/turf/simulated/floor/redblack{
-	dir = 8
-	},
-/area/listeningpost/syndicateassaultvessel)
 "nTP" = (
 /obj/decal/cleanable/dirt,
 /turf/space/fluid/manta,
@@ -45860,19 +45905,22 @@
 	dir = 1
 	},
 /area/station/engine/inner)
-"ozn" = (
-/obj/wingrille_spawn/auto,
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/diner/hangar)
-"oDH" = (
+"owv" = (
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet/red/fancy/edge/south,
+/obj/cable{
+	icon_state = "6-8"
+	},
+/turf/simulated/floor/redblack,
 /area/listeningpost/syndicateassaultvessel)
+"ozn" = (
+/obj/wingrille_spawn/auto,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/diner/hangar)
 "oGT" = (
 /obj/lattice{
 	icon_state = "lattice-dir"
@@ -45981,6 +46029,15 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
+"pwu" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-10"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "pyg" = (
 /obj/decal/cleanable/dirt/dirt3,
 /turf/simulated/floor/grime,
@@ -45991,15 +46048,6 @@
 	},
 /turf/simulated/floor,
 /area/station/security/brig/genpop)
-"pRa" = (
-/obj/stool/chair/comfy/red{
-	dir = 8
-	},
-/obj/cable{
-	icon_state = "1-10"
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/east,
-/area/listeningpost/syndicateassaultvessel)
 "qrl" = (
 /obj/cable{
 	d1 = 1;
@@ -46073,29 +46121,12 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
-"rkc" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "6-8"
-	},
-/turf/simulated/floor/redblack,
-/area/listeningpost/syndicateassaultvessel)
 "rlZ" = (
 /obj/computerframe{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/diner/hangar)
-"rIJ" = (
-/obj/cable{
-	icon_state = "2-5"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
 "rVY" = (
 /obj/grille/catwalk{
 	dir = 5;
@@ -46137,6 +46168,12 @@
 	},
 /turf/space/fluid/manta,
 /area/diner/hangar)
+"slU" = (
+/obj/cable{
+	icon_state = "4-9"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "swZ" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 8
@@ -46166,15 +46203,6 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/security/hos)
-"sNf" = (
-/obj/cable{
-	icon_state = "0-10"
-	},
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/turf/simulated/floor/plating/random,
-/area/listeningpost/syndicateassaultvessel)
 "sTs" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -46211,15 +46239,6 @@
 /obj/item/circuitboard/teleporter,
 /turf/simulated/floor/plating,
 /area/diner/hangar)
-"tcn" = (
-/obj/stool/chair/comfy/red{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "1-6"
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/west,
-/area/listeningpost/syndicateassaultvessel)
 "tmH" = (
 /obj/machinery/vehicle/tank/minisub,
 /turf/simulated/floor/shuttlebay,
@@ -46252,6 +46271,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/hos)
+"tKn" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "uhU" = (
 /obj/table/glass/reinforced/auto,
 /obj/item/clipboard,
@@ -46259,6 +46284,24 @@
 /obj/item/pen/pencil,
 /turf/simulated/floor/carpet/grime,
 /area/station/communications/bedroom)
+"uqx" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "5-8"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
+"uwg" = (
+/obj/stool/chair/comfy/red{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-6"
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/west,
+/area/listeningpost/syndicateassaultvessel)
 "uFt" = (
 /obj/decal/tile_edge/line/green{
 	color = "#e7c88c";
@@ -46267,12 +46310,6 @@
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
-"uFH" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
 "uRg" = (
 /obj/decal/tile_edge/line/purple{
 	icon_state = "line1"
@@ -46324,6 +46361,15 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/checkpoint/sec_foyer)
+"vfw" = (
+/obj/cable{
+	icon_state = "0-10"
+	},
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/turf/simulated/floor/plating/random,
+/area/listeningpost/syndicateassaultvessel)
 "vjQ" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -46345,12 +46391,6 @@
 /obj/machinery/light/runway_light/delay4,
 /turf/space/fluid/manta,
 /area/mantaSpace)
-"vww" = (
-/obj/cable{
-	icon_state = "2-9"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
 "vzA" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -46367,16 +46407,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/hor)
-"vEW" = (
+"vAM" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "5-8"
+	icon_state = "1-6"
 	},
-/turf/simulated/floor/carpet/red/fancy/edge/south,
+/turf/simulated/floor/red,
 /area/listeningpost/syndicateassaultvessel)
 "vRo" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -46420,6 +46458,21 @@
 	dir = 4
 	},
 /area/station/security/secoffquarters)
+"wmQ" = (
+/obj/cable{
+	icon_state = "2-5"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
+"wqk" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "4-9"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "wsX" = (
 /obj/decal/tile_edge/line/purple{
 	dir = 10;
@@ -46597,6 +46650,15 @@
 	dir = 6
 	},
 /area/station/security/secoffquarters)
+"xCO" = (
+/obj/stool/chair/comfy/red{
+	dir = 8
+	},
+/obj/cable{
+	icon_state = "1-10"
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/east,
+/area/listeningpost/syndicateassaultvessel)
 "xHd" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/right{
@@ -86105,7 +86167,7 @@ buY
 buY
 buY
 bAp
-alL
+atH
 bFQ
 bGM
 auh
@@ -89219,7 +89281,7 @@ amx
 alF
 amR
 amY
-kJW
+hGW
 alF
 alD
 aly
@@ -89376,7 +89438,7 @@ aBz
 abe
 aoj
 aBX
-aCh
+aCf
 aDG
 aFB
 aPH
@@ -89505,7 +89567,7 @@ alt
 akV
 alC
 alD
-rIJ
+wmQ
 amZ
 amZ
 amc
@@ -89518,11 +89580,11 @@ amZ
 amZ
 atX
 amy
-rIJ
-ier
+wmQ
+pwu
 amZ
-iwS
-cnq
+vAM
+wqk
 amZ
 amZ
 amZ
@@ -89802,7 +89864,7 @@ ale
 bMy
 akV
 alk
-anY
+aCh
 avM
 akV
 alr
@@ -89823,7 +89885,7 @@ amz
 amJ
 amS
 ana
-tcn
+uwg
 anm
 akH
 akH
@@ -89986,7 +90048,7 @@ aBX
 aPI
 aPV
 abZ
-abZ
+anY
 aoU
 aqO
 aSj
@@ -90108,7 +90170,7 @@ alo
 alu
 akV
 alr
-atH
+jfP
 akH
 alY
 atB
@@ -90289,7 +90351,7 @@ dWm
 aPW
 aaV
 aQB
-aoU
+aoa
 aqO
 aRd
 aRp
@@ -90428,7 +90490,7 @@ amK
 amT
 anc
 ani
-oDH
+mzd
 ans
 anx
 anD
@@ -90589,9 +90651,9 @@ aAF
 bNP
 gDn
 aPX
-abZ
-abZ
-aoU
+alL
+anY
+atG
 aqO
 aIK
 aRq
@@ -90708,11 +90770,11 @@ alD
 bMA
 akV
 ali
-aoa
+aPq
 alq
 akV
 alr
-aPq
+slU
 akH
 ama
 atD
@@ -90730,7 +90792,7 @@ amK
 amT
 amT
 and
-vEW
+ftH
 akH
 any
 anE
@@ -91010,11 +91072,11 @@ bMx
 bMB
 akV
 alk
-atG
+hJp
 avM
 akV
 alr
-eGM
+mWM
 alR
 akH
 akH
@@ -91027,11 +91089,11 @@ avS
 alD
 akH
 akH
-rkc
+owv
 amL
 amU
 ane
-pRa
+xCO
 ano
 akH
 akH
@@ -91188,7 +91250,7 @@ aBz
 abe
 aoj
 aBX
-aCh
+aCf
 aDG
 aFB
 aPL
@@ -91317,7 +91379,7 @@ alt
 akV
 alC
 alD
-vww
+eTE
 amZ
 amZ
 amg
@@ -91329,17 +91391,17 @@ amZ
 amZ
 amZ
 atX
-uFH
-vww
+tKn
+eTE
 amZ
 amZ
-ier
-eNe
+pwu
+uqx
 amZ
 amZ
 amZ
 anJ
-fJe
+ksM
 akH
 aok
 aap
@@ -91635,7 +91697,7 @@ amD
 alx
 amV
 alD
-nNd
+isp
 alx
 alG
 alE
@@ -92848,7 +92910,7 @@ amM
 amv
 anz
 akH
-sNf
+vfw
 anQ
 aod
 aom

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -9159,7 +9159,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/engineering/ce)
 "axc" = (
-/obj/cable{
+/obj/cable/colored/white{
 	icon_state = "4-6"
 	},
 /turf/simulated/floor/yellow,
@@ -9529,13 +9529,13 @@
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering/breakroom)
 "axP" = (
-/obj/cable{
+/obj/cable/colored/yellow{
 	icon_state = "6-10"
 	},
-/obj/cable{
+/obj/cable/colored/white{
 	icon_state = "2-8"
 	},
-/obj/cable{
+/obj/cable/colored/yellow{
 	icon_state = "4-10"
 	},
 /turf/simulated/floor/yellow/side{
@@ -9832,13 +9832,13 @@
 	},
 /area/station/engine/engineering/ce)
 "ayt" = (
-/obj/cable{
+/obj/cable/colored/yellow{
 	icon_state = "2-8"
 	},
-/obj/cable{
+/obj/cable/colored/yellow{
 	icon_state = "0-2"
 	},
-/obj/cable{
+/obj/cable/colored/yellow{
 	icon_state = "0-8"
 	},
 /turf/simulated/floor,
@@ -9950,16 +9950,16 @@
 	},
 /area/station/engine/engineering/ce)
 "ayH" = (
-/obj/cable{
+/obj/cable/colored/yellow{
 	icon_state = "5-6"
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/inner)
 "ayI" = (
-/obj/cable{
+/obj/cable/colored/yellow{
 	icon_state = "6-9"
 	},
-/obj/cable{
+/obj/cable/colored/white{
 	icon_state = "1-9"
 	},
 /turf/simulated/floor/yellow/side{
@@ -9967,10 +9967,10 @@
 	},
 /area/station/engine/inner)
 "ayJ" = (
-/obj/cable{
+/obj/cable/colored/yellow{
 	icon_state = "9-10"
 	},
-/obj/cable{
+/obj/cable/colored/yellow{
 	icon_state = "1-10"
 	},
 /turf/simulated/floor,
@@ -9997,7 +9997,7 @@
 	},
 /area/station/engine/engineering/ce)
 "ayL" = (
-/obj/cable{
+/obj/cable/colored/yellow{
 	icon_state = "5-9"
 	},
 /turf/simulated/floor/yellow/side{

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -2470,7 +2470,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/security/hos)
+/area/station/ai_monitored/armory)
 "agr" = (
 /obj/machinery/light/incandescent/cool{
 	dir = 4;
@@ -5418,7 +5418,7 @@
 /obj/item/bandage,
 /obj/item/staple_gun,
 /turf/simulated/floor/black,
-/area/mantaSpace)
+/area/station/medical/robotics)
 "aoq" = (
 /obj/lattice{
 	icon_state = "lattice-dir"
@@ -7993,18 +7993,8 @@
 /turf/simulated/floor/bot/blue,
 /area/station/ai_monitored/storage/eva)
 "atG" = (
-/obj/machinery/door/airlock/pyro/syndicate{
-	desc = "It's locked up pretty tight.";
-	dir = 4;
-	name = "Syndicate Assault Vessel"
-	},
-/obj/access_spawn/syndie_shuttle,
-/turf/simulated/floor/red,
-/area/mantaSpace)
-"atH" = (
-/obj/machinery/drainage/big,
-/turf/simulated/floor/red,
-/area/mantaSpace)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hallway/portlowerhallway)
 "atI" = (
 /obj/storage/closet/syndicate/personal,
 /obj/item/clothing/under/misc/syndicate,
@@ -9635,7 +9625,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor,
-/area/space)
+/area/station/engine/storage)
 "axj" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -18065,14 +18055,6 @@
 	},
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
-"aPq" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/upperstarboard)
 "aPr" = (
 /obj/cable{
 	d1 = 4;
@@ -20590,7 +20572,7 @@
 	},
 /obj/machinery/light/incandescent/cool,
 /turf/simulated/floor/black,
-/area/mantaSpace)
+/area/station/medical/robotics)
 "aUT" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -31340,7 +31322,7 @@
 	icon_state = "line1"
 	},
 /turf/simulated/floor,
-/area/station/hallway/starboardlowerhallway)
+/area/station/hallway/portlowerhallway)
 "bqr" = (
 /obj/disposalpipe/segment,
 /obj/disposalpipe/segment/mail{
@@ -32457,7 +32439,7 @@
 	icon_state = "line1"
 	},
 /turf/simulated/floor,
-/area/station/hallway/starboardlowerhallway)
+/area/station/hallway/portlowerhallway)
 "bsM" = (
 /obj/cable{
 	d1 = 1;
@@ -33043,7 +33025,7 @@
 	},
 /obj/machinery/light/small/floor/netural,
 /turf/simulated/floor,
-/area/space)
+/area/station/hallway/seaturtlehallway)
 "buf" = (
 /obj/lattice{
 	dir = 4;
@@ -33549,7 +33531,7 @@
 	},
 /obj/machinery/light/runway_light/delay2,
 /turf/space/fluid/manta,
-/area/space)
+/area/mantaSpace)
 "bvs" = (
 /obj/lattice{
 	dir = 4;
@@ -46432,7 +46414,7 @@
 /obj/storage/secure/closet/civilian/hydro,
 /obj/item/clothing/under/misc/hydroponics,
 /turf/simulated/floor/grass/random,
-/area/station/hydroponics)
+/area/station/hydroponics/bay)
 "wBW" = (
 /obj/cable{
 	d1 = 1;
@@ -78485,7 +78467,7 @@ acO
 acO
 aES
 aoJ
-aPq
+apD
 acD
 acD
 acD
@@ -79685,7 +79667,7 @@ aaa
 aaa
 act
 act
-aBr
+acO
 acO
 ait
 aoJ
@@ -79986,8 +79968,8 @@ aaa
 aaa
 act
 act
-aBr
-aBr
+acO
+acO
 auc
 aoJ
 apD
@@ -83673,7 +83655,7 @@ bHD
 bHD
 bHG
 bEF
-bEw
+bEF
 act
 aaa
 aaa
@@ -86069,7 +86051,7 @@ buY
 buY
 buY
 bAp
-bEF
+atG
 bFQ
 bGM
 auh
@@ -86751,7 +86733,7 @@ aaa
 aaa
 arH
 akE
-atG
+alO
 alU
 arH
 aaa
@@ -87053,7 +87035,7 @@ aaa
 akE
 akH
 akH
-atH
+alS
 akH
 akH
 alU

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -13643,7 +13643,6 @@
 /obj/wingrille_spawn/auto,
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
-	dir = 4;
 	icon_state = "pdoor0";
 	id = "scienceteleporter";
 	name = "Teleporter Pad Blast Shield";
@@ -13663,7 +13662,6 @@
 /obj/wingrille_spawn/auto,
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
-	dir = 4;
 	icon_state = "pdoor0";
 	id = "scienceteleporter";
 	name = "Teleporter Pad Blast Shield";
@@ -13841,7 +13839,6 @@
 /obj/wingrille_spawn/auto,
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
-	dir = 4;
 	icon_state = "pdoor0";
 	id = "scienceteleporter";
 	name = "Teleporter Pad Blast Shield";
@@ -35728,7 +35725,6 @@
 /obj/wingrille_spawn/auto,
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
-	dir = 4;
 	icon_state = "pdoor0";
 	id = "scienceteleporter";
 	name = "Teleporter Pad Blast Shield";
@@ -44736,6 +44732,15 @@
 	},
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
+"cnq" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "4-9"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "coR" = (
 /obj/item/constructioncone,
 /turf/simulated/floor,
@@ -44748,15 +44753,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
-"cud" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-6"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
 "cuz" = (
 /obj/machinery/recharger/wall/sticky{
 	dir = 8
@@ -44900,15 +44896,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
-"dPH" = (
-/obj/stool/chair/comfy/red{
-	dir = 8
-	},
-/obj/cable{
-	icon_state = "1-10"
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/east,
-/area/listeningpost/syndicateassaultvessel)
 "dWi" = (
 /obj/cable{
 	d1 = 4;
@@ -44956,32 +44943,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/construction2)
-"enA" = (
-/obj/stool/chair/red{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "5-6"
-	},
-/turf/simulated/floor/redblack{
-	dir = 4
-	},
-/area/listeningpost/syndicateassaultvessel)
-"eyj" = (
-/obj/cable{
-	icon_state = "2-9"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
-"eEJ" = (
-/obj/cable{
-	icon_state = "0-10"
-	},
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/turf/simulated/floor/plating/random,
-/area/listeningpost/syndicateassaultvessel)
 "eFJ" = (
 /obj/lattice{
 	icon_state = "lattice-dir"
@@ -44989,6 +44950,12 @@
 /obj/machinery/light/runway_light/delay2,
 /turf/space/fluid/manta,
 /area/mantaSpace)
+"eGM" = (
+/obj/cable{
+	icon_state = "6-8"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "eNd" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/radio,
@@ -44999,6 +44966,15 @@
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
+"eNe" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "5-8"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "ePj" = (
 /obj/lattice{
 	dir = 5;
@@ -45094,6 +45070,17 @@
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
+"fJe" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/random,
+/area/listeningpost/syndicateassaultvessel)
 "fRX" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/mainframe/zeta{
@@ -45152,17 +45139,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
-"gtD" = (
-/obj/stool/chair/red{
-	dir = 8
-	},
-/obj/cable{
-	icon_state = "9-10"
-	},
-/turf/simulated/floor/redblack{
-	dir = 8
-	},
-/area/listeningpost/syndicateassaultvessel)
 "gtZ" = (
 /obj/landmark{
 	name = "bubsbeejob"
@@ -45268,17 +45244,6 @@
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/south,
 /area/station/security/hos)
-"hxU" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "5-8"
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/south,
-/area/listeningpost/syndicateassaultvessel)
 "hAj" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/right{
@@ -45368,6 +45333,15 @@
 	},
 /turf/space/fluid/manta,
 /area/diner/hangar)
+"ier" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-10"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "ifi" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds,
@@ -45399,6 +45373,15 @@
 /obj/machinery/light/runway_light/delay5,
 /turf/space/fluid/manta,
 /area/mantaSpace)
+"iwS" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-6"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "iyE" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
@@ -45519,6 +45502,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/sec_foyer)
+"kJW" = (
+/obj/stool/chair/red{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "5-6"
+	},
+/turf/simulated/floor/redblack{
+	dir = 4
+	},
+/area/listeningpost/syndicateassaultvessel)
 "kMM" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -45590,15 +45584,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/hos)
-"lRZ" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-10"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
 "lSg" = (
 /obj/decal/tile_edge/line/purple{
 	dir = 10;
@@ -45647,15 +45632,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
-"mgj" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "4-9"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
 "mnz" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -45707,17 +45683,6 @@
 	},
 /turf/space/fluid/manta,
 /area/mantaSpace)
-"mPH" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating/random,
-/area/listeningpost/syndicateassaultvessel)
 "mSY" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -45798,6 +45763,17 @@
 	dir = 6
 	},
 /area/station/crewquarters/cryotron)
+"nNd" = (
+/obj/stool/chair/red{
+	dir = 8
+	},
+/obj/cable{
+	icon_state = "9-10"
+	},
+/turf/simulated/floor/redblack{
+	dir = 8
+	},
+/area/listeningpost/syndicateassaultvessel)
 "nTP" = (
 /obj/decal/cleanable/dirt,
 /turf/space/fluid/manta,
@@ -45884,20 +45860,19 @@
 	dir = 1
 	},
 /area/station/engine/inner)
-"oqw" = (
-/obj/stool/chair/comfy/red{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "1-6"
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/west,
-/area/listeningpost/syndicateassaultvessel)
 "ozn" = (
 /obj/wingrille_spawn/auto,
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/diner/hangar)
+"oDH" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/south,
+/area/listeningpost/syndicateassaultvessel)
 "oGT" = (
 /obj/lattice{
 	icon_state = "lattice-dir"
@@ -46016,6 +45991,15 @@
 	},
 /turf/simulated/floor,
 /area/station/security/brig/genpop)
+"pRa" = (
+/obj/stool/chair/comfy/red{
+	dir = 8
+	},
+/obj/cable{
+	icon_state = "1-10"
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/east,
+/area/listeningpost/syndicateassaultvessel)
 "qrl" = (
 /obj/cable{
 	d1 = 1;
@@ -46081,12 +46065,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/sec_foyer)
-"rcL" = (
-/obj/cable{
-	icon_state = "2-5"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
 "rdE" = (
 /obj/cable{
 	d1 = 1;
@@ -46095,12 +46073,29 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
+"rkc" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "6-8"
+	},
+/turf/simulated/floor/redblack,
+/area/listeningpost/syndicateassaultvessel)
 "rlZ" = (
 /obj/computerframe{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/diner/hangar)
+"rIJ" = (
+/obj/cable{
+	icon_state = "2-5"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "rVY" = (
 /obj/grille/catwalk{
 	dir = 5;
@@ -46171,14 +46166,14 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/security/hos)
-"sRL" = (
+"sNf" = (
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "0-10"
 	},
-/obj/cable{
-	icon_state = "5-8"
+/obj/machinery/power/terminal{
+	dir = 8
 	},
-/turf/simulated/floor/red,
+/turf/simulated/floor/plating/random,
 /area/listeningpost/syndicateassaultvessel)
 "sTs" = (
 /obj/wingrille_spawn/auto,
@@ -46216,6 +46211,15 @@
 /obj/item/circuitboard/teleporter,
 /turf/simulated/floor/plating,
 /area/diner/hangar)
+"tcn" = (
+/obj/stool/chair/comfy/red{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-6"
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/west,
+/area/listeningpost/syndicateassaultvessel)
 "tmH" = (
 /obj/machinery/vehicle/tank/minisub,
 /turf/simulated/floor/shuttlebay,
@@ -46255,12 +46259,6 @@
 /obj/item/pen/pencil,
 /turf/simulated/floor/carpet/grime,
 /area/station/communications/bedroom)
-"ulO" = (
-/obj/cable{
-	icon_state = "6-8"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
 "uFt" = (
 /obj/decal/tile_edge/line/green{
 	color = "#e7c88c";
@@ -46269,6 +46267,12 @@
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
+"uFH" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "uRg" = (
 /obj/decal/tile_edge/line/purple{
 	icon_state = "line1"
@@ -46341,16 +46345,11 @@
 /obj/machinery/light/runway_light/delay4,
 /turf/space/fluid/manta,
 /area/mantaSpace)
-"vuB" = (
+"vww" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-9"
 	},
-/obj/cable{
-	icon_state = "6-8"
-	},
-/turf/simulated/floor/redblack,
+/turf/simulated/floor/red,
 /area/listeningpost/syndicateassaultvessel)
 "vzA" = (
 /obj/disposalpipe/segment/mail{
@@ -46368,17 +46367,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/hor)
-"vRo" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/secondary/construction)
-"vVw" = (
+"vEW" = (
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/cable{
+	icon_state = "5-8"
+	},
 /turf/simulated/floor/carpet/red/fancy/edge/south,
 /area/listeningpost/syndicateassaultvessel)
+"vRo" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hallway/secondary/construction)
 "vWe" = (
 /obj/lattice{
 	dir = 4;
@@ -46523,12 +46525,6 @@
 	},
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/communications/office)
-"wWK" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
 "xaf" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/secondary/construction)
@@ -89223,7 +89219,7 @@ amx
 alF
 amR
 amY
-enA
+kJW
 alF
 alD
 aly
@@ -89509,7 +89505,7 @@ alt
 akV
 alC
 alD
-rcL
+rIJ
 amZ
 amZ
 amc
@@ -89522,11 +89518,11 @@ amZ
 amZ
 atX
 amy
-rcL
-lRZ
+rIJ
+ier
 amZ
-cud
-mgj
+iwS
+cnq
 amZ
 amZ
 amZ
@@ -89827,7 +89823,7 @@ amz
 amJ
 amS
 ana
-oqw
+tcn
 anm
 akH
 akH
@@ -90432,7 +90428,7 @@ amK
 amT
 anc
 ani
-vVw
+oDH
 ans
 anx
 anD
@@ -90734,7 +90730,7 @@ amK
 amT
 amT
 and
-hxU
+vEW
 akH
 any
 anE
@@ -91018,7 +91014,7 @@ atG
 avM
 akV
 alr
-ulO
+eGM
 alR
 akH
 akH
@@ -91031,11 +91027,11 @@ avS
 alD
 akH
 akH
-vuB
+rkc
 amL
 amU
 ane
-dPH
+pRa
 ano
 akH
 akH
@@ -91321,7 +91317,7 @@ alt
 akV
 alC
 alD
-eyj
+vww
 amZ
 amZ
 amg
@@ -91333,17 +91329,17 @@ amZ
 amZ
 amZ
 atX
-wWK
-eyj
+uFH
+vww
 amZ
 amZ
-lRZ
-sRL
+ier
+eNe
 amZ
 amZ
 amZ
 anJ
-mPH
+fJe
 akH
 aok
 aap
@@ -91639,7 +91635,7 @@ amD
 alx
 amV
 alD
-gtD
+nNd
 alx
 alG
 alE
@@ -92852,7 +92848,7 @@ amM
 amv
 anz
 akH
-eEJ
+sNf
 anQ
 aod
 aom

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -16960,11 +16960,11 @@
 /area/station/bridge)
 "aMR" = (
 /obj/wingrille_spawn/auto,
-/obj/window_blinds,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/window_blinds/cog2/left,
 /turf/simulated/floor/plating,
 /area/station/security/interrogation)
 "aMU" = (
@@ -44819,17 +44819,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
-"czF" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "5-8"
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/south,
-/area/listeningpost/syndicateassaultvessel)
 "czS" = (
 /obj/disposalpipe/switch_junction/left/south{
 	mail_tag = "Mining"
@@ -44877,6 +44866,17 @@
 	icon_state = "yellowblack"
 	},
 /area/station/engine/engineering/breakroom)
+"cYw" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "6-8"
+	},
+/turf/simulated/floor/redblack,
+/area/listeningpost/syndicateassaultvessel)
 "dfY" = (
 /obj/cable{
 	d2 = 8;
@@ -44895,12 +44895,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/checkpoint/sec_foyer)
-"duO" = (
-/obj/cable{
-	icon_state = "4-9"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
 "dCn" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -45058,6 +45052,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/courtroom)
+"ffY" = (
+/obj/stool/chair/red{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "5-6"
+	},
+/turf/simulated/floor/redblack{
+	dir = 4
+	},
+/area/listeningpost/syndicateassaultvessel)
 "fih" = (
 /obj/machinery/flasher/genpop/new_walls/west{
 	id = "cell1";
@@ -45075,6 +45080,18 @@
 	},
 /turf/simulated/floor,
 /area/station/security/brig/cell1)
+"flD" = (
+/obj/cable{
+	icon_state = "6-8"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
+"fmh" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "fmU" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -45162,6 +45179,17 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/checkpoint/sec_foyer)
+"gaC" = (
+/obj/stool/chair/red{
+	dir = 8
+	},
+/obj/cable{
+	icon_state = "9-10"
+	},
+/turf/simulated/floor/redblack{
+	dir = 8
+	},
+/area/listeningpost/syndicateassaultvessel)
 "gdN" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer/aiupload,
@@ -45172,26 +45200,6 @@
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
-"geV" = (
-/obj/stool/chair/red{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "5-6"
-	},
-/turf/simulated/floor/redblack{
-	dir = 4
-	},
-/area/listeningpost/syndicateassaultvessel)
-"glR" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "4-9"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
 "goo" = (
 /obj/cable{
 	d1 = 2;
@@ -45211,6 +45219,15 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/checkpoint/sec_foyer)
+"gvt" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-10"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "gwj" = (
 /obj/cable{
 	d2 = 2;
@@ -45258,11 +45275,14 @@
 	},
 /turf/simulated/floor/longtile/black,
 /area/station/turret_protected/ai_upload)
-"gGi" = (
+"gFz" = (
 /obj/cable{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/black,
+/obj/cable{
+	icon_state = "1-6"
+	},
+/turf/simulated/floor/red,
 /area/listeningpost/syndicateassaultvessel)
 "gYm" = (
 /obj/machinery/computer/shuttle_bus{
@@ -45402,11 +45422,11 @@
 /area/diner/hangar)
 "ifi" = (
 /obj/wingrille_spawn/auto,
-/obj/window_blinds,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/window_blinds/cog2/right,
 /turf/simulated/floor/plating,
 /area/station/security/interrogation)
 "ifM" = (
@@ -45424,12 +45444,6 @@
 /obj/machinery/drainage/big,
 /turf/simulated/floor/grime,
 /area/diner/hangar)
-"iqB" = (
-/obj/cable{
-	icon_state = "2-9"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
 "ivY" = (
 /obj/lattice{
 	icon_state = "lattice-dir"
@@ -45480,14 +45494,14 @@
 	},
 /turf/space/fluid/manta,
 /area/mantaSpace)
-"jdS" = (
-/obj/cable{
-	icon_state = "1-2"
+"iKJ" = (
+/obj/stool/chair/comfy/red{
+	dir = 8
 	},
 /obj/cable{
 	icon_state = "1-10"
 	},
-/turf/simulated/floor/red,
+/turf/simulated/floor/carpet/red/fancy/edge/east,
 /area/listeningpost/syndicateassaultvessel)
 "jmo" = (
 /obj/wingrille_spawn/auto,
@@ -45504,11 +45518,7 @@
 "jnl" = (
 /turf/simulated/floor,
 /area/station/hallway/secondary/construction2)
-"jMM" = (
-/obj/machinery/photocopier,
-/turf/simulated/floor/carpet/grime,
-/area/station/communications/bedroom)
-"jQU" = (
+"jzF" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -45516,6 +45526,21 @@
 	icon_state = "5-8"
 	},
 /turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
+"jMM" = (
+/obj/machinery/photocopier,
+/turf/simulated/floor/carpet/grime,
+/area/station/communications/bedroom)
+"jQu" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "5-8"
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/south,
 /area/listeningpost/syndicateassaultvessel)
 "keQ" = (
 /obj/decal/tile_edge/line/purple{
@@ -45566,15 +45591,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/starboardlowerhallway)
-"kGq" = (
-/obj/stool/chair/comfy/red{
-	dir = 8
-	},
-/obj/cable{
-	icon_state = "1-10"
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/east,
-/area/listeningpost/syndicateassaultvessel)
 "kIf" = (
 /obj/cable,
 /obj/wingrille_spawn/auto,
@@ -45596,12 +45612,6 @@
 	},
 /turf/simulated/floor/caution/south,
 /area/station/engine/inner)
-"kSH" = (
-/obj/cable{
-	icon_state = "5-8"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
 "lfN" = (
 /obj/cable{
 	d1 = 4;
@@ -45615,6 +45625,12 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/inner)
+"lgK" = (
+/obj/cable{
+	icon_state = "5-8"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "lmY" = (
 /obj/decal/tile_edge/line/green{
 	color = "#e7c88c";
@@ -45640,7 +45656,6 @@
 /area/station/security/secoffquarters)
 "lrl" = (
 /obj/wingrille_spawn/auto,
-/obj/window_blinds,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -45650,23 +45665,18 @@
 	icon_state = "0-4"
 	},
 /obj/cable,
+/obj/window_blinds/cog2/middle,
 /turf/simulated/floor/plating,
 /area/station/security/interrogation)
 "lOW" = (
 /obj/wingrille_spawn/auto,
-/obj/window_blinds,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/window_blinds/cog2/left,
 /turf/simulated/floor/plating,
 /area/station/security/hos)
-"lPz" = (
-/obj/cable{
-	icon_state = "2-5"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
 "lSg" = (
 /obj/decal/tile_edge/line/purple{
 	dir = 10;
@@ -45715,10 +45725,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
+"mfW" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/random,
+/area/listeningpost/syndicateassaultvessel)
 "mnz" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/construction2)
+"mpL" = (
+/obj/cable{
+	icon_state = "2-9"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "mrf" = (
 /obj/cable{
 	d1 = 4;
@@ -45740,6 +45767,15 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/inner)
+"mth" = (
+/obj/cable{
+	icon_state = "0-10"
+	},
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/turf/simulated/floor/plating/random,
+/area/listeningpost/syndicateassaultvessel)
 "mxx" = (
 /obj/submachine/chef_sink/chem_sink{
 	pixel_y = 8
@@ -45766,12 +45802,6 @@
 	},
 /turf/space/fluid/manta,
 /area/mantaSpace)
-"mSi" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/black,
-/area/listeningpost/syndicateassaultvessel)
 "mSY" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -45812,17 +45842,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/gas)
-"mYV" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "6-8"
-	},
-/turf/simulated/floor/redblack,
-/area/listeningpost/syndicateassaultvessel)
 "naL" = (
 /obj/disposalpipe/segment,
 /obj/cable{
@@ -45850,6 +45869,17 @@
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/north,
 /area/station/crew_quarters/hor)
+"npb" = (
+/obj/cable{
+	icon_state = "4-10"
+	},
+/obj/cable{
+	icon_state = "9-10"
+	},
+/turf/simulated/floor/stairs/dark{
+	dir = 9
+	},
+/area/listeningpost/syndicateassaultvessel)
 "nuY" = (
 /obj/decal/tile_edge/line/green{
 	color = "#e7c88c";
@@ -45857,27 +45887,31 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
-"nzJ" = (
-/obj/stool/chair/red{
-	dir = 8
-	},
-/obj/cable{
-	icon_state = "9-10"
-	},
-/turf/simulated/floor/redblack{
-	dir = 8
-	},
-/area/listeningpost/syndicateassaultvessel)
 "nHa" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/arrival{
 	dir = 6
 	},
 /area/station/crewquarters/cryotron)
+"nPi" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/black,
+/area/listeningpost/syndicateassaultvessel)
 "nTP" = (
 /obj/decal/cleanable/dirt,
 /turf/space/fluid/manta,
 /area/mantaSpace)
+"nVd" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "4-9"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "nZD" = (
 /obj/grille/catwalk{
 	dir = 10;
@@ -46052,15 +46086,6 @@
 /obj/decal/cleanable/oil,
 /turf/simulated/floor/shuttlebay,
 /area/diner/hangar)
-"phW" = (
-/obj/cable{
-	icon_state = "0-10"
-	},
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/turf/simulated/floor/plating/random,
-/area/listeningpost/syndicateassaultvessel)
 "pnh" = (
 /obj/machinery/door/airlock/pyro/medical,
 /obj/firedoor_spawn,
@@ -46082,12 +46107,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
-"pui" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
 "pyg" = (
 /obj/decal/cleanable/dirt/dirt3,
 /turf/simulated/floor/grime,
@@ -46098,15 +46117,6 @@
 	},
 /turf/simulated/floor,
 /area/station/security/brig/genpop)
-"pMy" = (
-/obj/stool/chair/comfy/red{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "1-6"
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/west,
-/area/listeningpost/syndicateassaultvessel)
 "qrl" = (
 /obj/cable{
 	d1 = 1;
@@ -46240,33 +46250,18 @@
 /area/station/engine/inner)
 "sFy" = (
 /obj/wingrille_spawn/auto,
-/obj/window_blinds,
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/cable,
+/obj/window_blinds/cog2/middle,
 /turf/simulated/floor/plating,
 /area/station/security/hos)
-"sLH" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating/random,
-/area/listeningpost/syndicateassaultvessel)
 "sTs" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -46328,11 +46323,11 @@
 /area/station/hallway/portlowerhallway)
 "tHP" = (
 /obj/wingrille_spawn/auto,
-/obj/window_blinds,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/window_blinds/cog2/right,
 /turf/simulated/floor/plating,
 /area/station/security/hos)
 "uhU" = (
@@ -46342,13 +46337,11 @@
 /obj/item/pen/pencil,
 /turf/simulated/floor/carpet/grime,
 /area/station/communications/bedroom)
-"uEG" = (
+"uFe" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/carpet/red/fancy/edge/south,
+/turf/simulated/floor/black,
 /area/listeningpost/syndicateassaultvessel)
 "uFt" = (
 /obj/decal/tile_edge/line/green{
@@ -46358,17 +46351,6 @@
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
-"uJe" = (
-/obj/cable{
-	icon_state = "4-10"
-	},
-/obj/cable{
-	icon_state = "9-10"
-	},
-/turf/simulated/floor/stairs/dark{
-	dir = 9
-	},
-/area/listeningpost/syndicateassaultvessel)
 "uRg" = (
 /obj/decal/tile_edge/line/purple{
 	icon_state = "line1"
@@ -46420,18 +46402,9 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/checkpoint/sec_foyer)
-"vaU" = (
+"uVZ" = (
 /obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-6"
-	},
-/turf/simulated/floor/red,
-/area/listeningpost/syndicateassaultvessel)
-"vbj" = (
-/obj/cable{
-	icon_state = "6-8"
+	icon_state = "4-9"
 	},
 /turf/simulated/floor/red,
 /area/listeningpost/syndicateassaultvessel)
@@ -46622,6 +46595,12 @@
 "xaf" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/secondary/construction)
+"xjj" = (
+/obj/cable{
+	icon_state = "2-5"
+	},
+/turf/simulated/floor/red,
+/area/listeningpost/syndicateassaultvessel)
 "xrm" = (
 /obj/decal/tile_edge/line/purple{
 	icon_state = "line1"
@@ -46706,6 +46685,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/communications/office)
+"xKe" = (
+/obj/stool/chair/comfy/red{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-6"
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/west,
+/area/listeningpost/syndicateassaultvessel)
 "xKw" = (
 /obj/lattice{
 	dir = 1;
@@ -46761,6 +46749,14 @@
 	},
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
+"ych" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/south,
+/area/listeningpost/syndicateassaultvessel)
 
 (1,1,1) = {"
 aaa
@@ -89313,7 +89309,7 @@ amx
 alF
 amR
 amY
-geV
+ffY
 alF
 alD
 aly
@@ -89599,7 +89595,7 @@ alt
 akV
 alC
 alD
-lPz
+xjj
 amZ
 amZ
 amc
@@ -89612,11 +89608,11 @@ amZ
 amZ
 atX
 amy
-lPz
-jdS
+xjj
+gvt
 amZ
-vaU
-glR
+gFz
+nVd
 amZ
 amZ
 amZ
@@ -89896,7 +89892,7 @@ ale
 bMy
 akV
 alk
-mSi
+uFe
 avM
 akV
 alr
@@ -89917,7 +89913,7 @@ amz
 amJ
 amS
 ana
-pMy
+xKe
 anm
 akH
 akH
@@ -90202,7 +90198,7 @@ alo
 alu
 akV
 alr
-kSH
+lgK
 akH
 alY
 atB
@@ -90522,7 +90518,7 @@ amK
 amT
 anc
 ani
-uEG
+ych
 ans
 anx
 anD
@@ -90802,11 +90798,11 @@ alD
 bMA
 akV
 ali
-uJe
+npb
 alq
 akV
 alr
-duO
+uVZ
 akH
 ama
 atD
@@ -90824,7 +90820,7 @@ amK
 amT
 amT
 and
-czF
+jQu
 akH
 any
 anE
@@ -91104,11 +91100,11 @@ bMx
 bMB
 akV
 alk
-gGi
+nPi
 avM
 akV
 alr
-vbj
+flD
 alR
 akH
 akH
@@ -91121,11 +91117,11 @@ avS
 alD
 akH
 akH
-mYV
+cYw
 amL
 amU
 ane
-kGq
+iKJ
 ano
 akH
 akH
@@ -91411,7 +91407,7 @@ alt
 akV
 alC
 alD
-iqB
+mpL
 amZ
 amZ
 amg
@@ -91423,17 +91419,17 @@ amZ
 amZ
 amZ
 atX
-pui
-iqB
+fmh
+mpL
 amZ
 amZ
-jdS
-jQU
+gvt
+jzF
 amZ
 amZ
 amZ
 anJ
-sLH
+mfW
 akH
 aok
 aap
@@ -91729,7 +91725,7 @@ amD
 alx
 amV
 alD
-nzJ
+gaC
 alx
 alG
 alE
@@ -92942,7 +92938,7 @@ amM
 amv
 anz
 akH
-phW
+mth
 anQ
 aod
 aom


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MAPPING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Removes self-feeding Assault Vessel SMES, redoes wiring to be _stylish_
Corrects the direction vars of the TeleSci blast shield
Updates the blast shields in the Bridge & AI chamber to use new perspective
Removed un-needed d1 &d2 vars from all cabling on map
Blinds now use the correct directional object
Swaps the Bee Wireart to use new yellow & white coloured cabling. Bzz bzz.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Looks better
why the fuck was there just random tiles of space in the hallways?
(or the area for a hallway on THE OTHER SIDE OF THE GOD DAMNED FUCKIN MAP)
we dont need the god damn d1&d2 vars no more so best to get em gone