### PR TITLE
Adds transformation of a corpse into a meatcube via doors.

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -44,6 +44,7 @@
 	var/in_point_mode = 0
 	var/butt_op_stage = 0.0 // sigh
 	var/dna_to_absorb = 10
+	var/squish_axis = "None"
 
 	var/canspeak = 1
 

--- a/code/obj/machinery/door/door_parent.dm
+++ b/code/obj/machinery/door/door_parent.dm
@@ -572,7 +572,7 @@
 							src.meatcube_present = TRUE
 							break
 					if (src.meatcube_present == FALSE)
-						L.make_cube(life = INFINITY, T = get_turf(L))
+						L.make_cube(life = 20 MINUTES, T = get_turf(L))
 				L.TakeDamageAccountArmor("All", rand(20, 50), 0, 0, DAMAGE_CRUSH)
 				if (isdead(L) && src.dir == SOUTH || src.dir == NORTH)
 					L.squish_axis = "Vertical"

--- a/code/obj/machinery/door/door_parent.dm
+++ b/code/obj/machinery/door/door_parent.dm
@@ -13,7 +13,7 @@
 	var/visible = 1
 	var/p_open = 0
 	var/operating = 0
-	var/operation_time = 10
+	var/operation_time = 1 SECONDS
 	anchored = 1
 	var/autoclose = 0
 	var/interrupt_autoclose = 0
@@ -25,10 +25,11 @@
 	var/icon_base = "door"
 	var/brainloss_stumble = 0 // Can a mob stumble into this door if they have enough brain damage? Won't work if you override Bumped() or attackby() and don't check for it separately.
 	var/brainloss_nospam = 1 // In relation to world time.
-	var/crush_delay = 60
+	var/crush_delay = 6 SECONDS
 	var/sound_deny = 0
 	var/has_crush = 1 //flagged to true when the door has a secret admirer. also if the var == 1 then the door doesn't have the ability to crush items.
 	var/close_trys = 0
+	var/meatcube_present = FALSE //used to prevent creating multiple meatcubes with one mob
 
 	var/health = 600
 	var/health_max = 600
@@ -564,9 +565,19 @@
 				L.layer = src.layer - 0.01
 				playsound(get_turf(src), 'sound/impact_sounds/Flesh_Break_1.ogg', 100, 1)
 				L.emote("scream")
-
+				if (isdead(L) && (((src.dir == SOUTH || src.dir == NORTH) && (L.squish_axis == "Horizontal")) || ((src.dir == EAST || src.dir == WEST) && (L.squish_axis == "Vertical"))))
+					var/mob/M
+					for(M in get_turf(src))
+						if (istype(M, /mob/living/carbon/cube))
+							src.meatcube_present = TRUE
+							break
+					if (src.meatcube_present == FALSE)
+						L.make_cube(life = INFINITY, T = get_turf(L))
 				L.TakeDamageAccountArmor("All", rand(20, 50), 0, 0, DAMAGE_CRUSH)
-
+				if (isdead(L) && src.dir == SOUTH || src.dir == NORTH)
+					L.squish_axis = "Vertical"
+				if (isdead(L) && src.dir == EAST || src.dir == WEST)
+					L.squish_axis = "Horizontal"
 				L.changeStatus("weakened", 3 SECONDS)
 				L.stuttering += 10
 				did_crush = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Doors with perpendicular directions crushing a dead mob of type living, while there is no other meatcube on the tile, transforms it into a meatcube.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Meatcubes are fun to play as for some people, and there should be a way to transform into them that can actually last for a round. This way is only as much of a weapon as normal safety removed doors, and there is plenty of ways to gib corpses, so this shouldn't be a problem.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Chickenish:
(*)Perpendicular doors closing on one corpse now transforms it into a meatcube.
```
