### PR TITLE
Removes the "Activate the computer mainframe's self-destruct charge." objective

### DIFF
--- a/code/datums/objective.dm
+++ b/code/datums/objective.dm
@@ -404,13 +404,6 @@ proc/create_fluff(var/datum/mind/target)
 			return 1
 		return 0
 
-/datum/objective/regular/destroy_outpost
-	explanation_text = "Activate the computer mainframe's self-destruct charge."
-
-	check_completion()
-		if (outpost_destroyed == 1) return 1
-		else return 0
-
 /datum/objective/regular/cash
 	var/target_cash
 	var/current_cash


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[REMOVAL][BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Every now and then I see a mhelp about this objective and I'm pretty sure there is no way to actually complete it, unless you're on donut 2 which never really happens. So this PR just removes this outdated objective

outpost_destroyed is tied to all the nuke detonations apparently so I'm not gonna touch it

