### PR TITLE
Fix bad sleeper agent objectives

### DIFF
--- a/code/modules/events/sleeperagent.dm
+++ b/code/modules/events/sleeperagent.dm
@@ -132,7 +132,7 @@
 		var/datum/objective/new_objective = null
 		for(var/i = 0, i < num_objectives, i++)
 			new_objective = pick(eligible_objectives)
-			if (new_objective == /datum/objective/regular/killstirstir)
+			if (new_objective == /datum/objective/regular/killstirstir) // single-use
 				eligible_objectives -= /datum/objective/regular/killstirstir
 				escape_objectives -= /datum/objective/escape/stirstir
 			objectives += new new_objective

--- a/code/modules/events/sleeperagent.dm
+++ b/code/modules/events/sleeperagent.dm
@@ -113,16 +113,38 @@
 		return
 
 	proc/awaken_sleeper_agent(var/mob/living/carbon/human/H)
-		var/list/eligible_objectives = list()
-		eligible_objectives = typesof(/datum/objective/regular/) + typesof(/datum/objective/escape/) - /datum/objective/regular/
+		var/list/eligible_objectives = list(
+			/datum/objective/regular/assassinate,
+			/datum/objective/regular/steal,
+			/datum/objective/regular/multigrab,
+			/datum/objective/regular/killstirstir,
+		)
+
+		var/list/escape_objectives = list(
+			/datum/objective/escape,
+			/datum/objective/escape/hijack,
+			/datum/objective/escape/survive,
+			/datum/objective/escape/kamikaze,
+			/datum/objective/escape/stirstir,
+		)
+		var/list/objectives = list()
 		var/num_objectives = rand(1,3)
 		var/datum/objective/new_objective = null
 		for(var/i = 0, i < num_objectives, i++)
-			var/select_objective = pick(eligible_objectives)
-			new_objective = new select_objective
-			new_objective.owner = H.mind
-			new_objective.set_up()
-			H.mind.objectives += new_objective
+			new_objective = pick(eligible_objectives)
+			if (new_objective == /datum/objective/regular/killstirstir)
+				eligible_objectives -= /datum/objective/regular/killstirstir
+				escape_objectives -= /datum/objective/escape/stirstir
+			objectives += new new_objective
+		var/datum/objective/gimmick = new /datum/objective/regular/gimmick
+		objectives += gimmick
+		var/escape_objective = pick(escape_objectives)
+		var/datum/objective/esc = new escape_objective
+		objectives += esc
+		for(var/datum/objective/objective in objectives)
+			objective.owner = H.mind
+			objective.set_up()
+			H.mind.objectives += objective
 
 		H.show_text("<h2><font color=red><B>You have awakened as a syndicate sleeper agent!</B></font></h2>", "red")
 		H.mind.special_role = "sleeper agent"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Occasionally, sleeper agents could get inappropriate or impossible objectives (Force evac before 45 minutes, 60 minutes into a round, etc.). This PR limits the possible objectives a sleeper agent can get to a realistically achievable set: assassinate, steal a high-profile item, steal several smaller items, and kill Stirstir. A sleeper agent also gets a gimmick objective, and one of the escape objectives (Escape, survive, hijack, or escort Stirstir). The two Stirstir objectives cannot both be selected, so any combination of these objectives should be achievable by a sleeper agent.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Many of the traitor objectives weren't designed with sleeper agents in mind, so there's no logic to ensure that objectives are achievable. This PR makes sure a sleeper agent can always accomplish all of their objectives. It fixes #2251, fixes #2031, and fixes #1834.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Jawns:
(+)Sleeper agents should only get achievable objectives now- please submit a bug report if your objectives seem impossible!
```
