### PR TITLE
Allow using rods and popsicle sticks when crafting corndogs and "apple on a stick"

### DIFF
--- a/code/modules/food_and_drink/plants.dm
+++ b/code/modules/food_and_drink/plants.dm
@@ -772,19 +772,36 @@
 		M.take_brain_damage(0 - src.heal_amt)
 
 	attackby(obj/item/W as obj, mob/user as mob)
-		if(istype(W,/obj/item/stick))
-			var/obj/item/stick/S = W
-			if(S.broken)
-				boutput(user, __red("You can't use a broken stick!"))
+		// Apple on a stick
+		if(istype(W,/obj/item/stick) || istype(W,/obj/item/rods))
+			// Fail if already an apple on a stick
+			if(istype(src,/obj/item/reagent_containers/food/snacks/plant/apple/stick))
+				boutput(user, __red("This apple already has a stick!"))
 				return
+
+			// Check for broken sticks
+			if(istype(W,/obj/item/stick))
+				var/obj/item/stick/S = W
+				if(S.broken)
+					boutput(user, __red("You can't use a broken stick!"))
+					return
+
+			// Create apple on a stick
 			if(istype(src,/obj/item/reagent_containers/food/snacks/plant/apple/poison))
 				boutput(user, "<span class='notice'>You create an apple on a stick...</span>")
 				new/obj/item/reagent_containers/food/snacks/plant/apple/stick/poison(get_turf(src))
 			else
 				boutput(user, "<span class='notice'>You create a delicious apple on a stick...</span>")
 				new/obj/item/reagent_containers/food/snacks/plant/apple/stick(get_turf(src))
-			W.amount--
+
+			// Consume a rod or stick
+			if(istype(W,/obj/item/rods)) W.change_stack_amount(-1)
+			if(istype(W,/obj/item/stick)) W.amount--
+
+			// If no rods or sticks left, delete item
 			if(!W.amount) qdel(W)
+
+			// Consume apple
 			pool(src)
 		else ..()
 

--- a/code/modules/food_and_drink/snacks.dm
+++ b/code/modules/food_and_drink/snacks.dm
@@ -1551,10 +1551,17 @@
 			user.visible_message("[user] adds a bun to [src].","You add a bun to [src].")
 			src.update_icon()
 
-		else if (istype(W,/obj/item/rods))
+		else if (istype(W,/obj/item/rods) || istype(W,/obj/item/stick))
 			if(!src.bun)
 				boutput(user, "<span class='alert'>You need to bread it first!</span>")
 				return
+
+			// Check for broken sticks
+			if(istype(W,/obj/item/stick))
+				var/obj/item/stick/S = W
+				if(S.broken)
+					boutput(user, __red("You can't use a broken stick!"))
+					return
 
 			boutput(user, "<span class='notice'>You create a corndog...</span>")
 			var/obj/item/reagent_containers/food/snacks/corndog/newdog = null
@@ -1569,7 +1576,12 @@
 					newdog = new /obj/item/reagent_containers/food/snacks/corndog/spooky(get_turf(src))
 				else
 					newdog = new /obj/item/reagent_containers/food/snacks/corndog(get_turf(src))
-			W:amount--
+			
+			// Consume a rod or stick
+			if(istype(W,/obj/item/rods)) W.change_stack_amount(-1)
+			if(istype(W,/obj/item/stick)) W.amount--
+
+			// If no rods or sticks left, delete item
 			if(!W:amount) qdel(W)
 
 			if(newdog?.reagents && src.reagents)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #1517

To summarise, currently we can only create "apple on a stick" using popsicle sticks, so it was requested to be able to use rods as well.
This allows creation of "apple on a stick" using rods, as well as ensuring "apple on a stick" can't be created from "apple on a stick" + rods/popsicle stick.

Here's a gif of my change in action:
https://i.imgur.com/7mSiovE.gif

Edit: for consistency I have also allowed creating corndogs with popsicle sticks (previously only created with rods) and also found and fixed a bug where creating corndogs with rods wasn't consuming a rod (or not updating the stack visually)

Here's a gif of the corndogs!
https://i.imgur.com/pjNP7tM.gif

`minor note: the rods sprite doesn't change going from 2 rods to 1, not sure if this is a bug or not`

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It was requested and labeled as "Good first issue" so I figured it would make a good addition to the game, but also logically it makes sense to be able to create "apple on a stick" with a rod. And vise versa for corndogs.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Innox:
(+)Allowed creating apple on a stick with rods too - take that popsicle sticks!
(+)Allowed creating corndogs with popsicle sticks too - take that rods!
```
