### PR TITLE
Makes seal pups count as pets

### DIFF
--- a/code/modules/holiday/spacemas.dm
+++ b/code/modules/holiday/spacemas.dm
@@ -298,6 +298,7 @@ var/static/list/santa_snacks = list(/obj/item/reagent_containers/food/drinks/egg
 	firevuln = 1
 	brutevuln = 1
 	butcherable = 2
+	is_pet = 1
 
 	New()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
They now count towards pets when display round end stats for escaped pets.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Come on, they are cute, of course they are pets.


## Changelog
