### PR TITLE
Fixes ghost being able to scroll borg item bar

### DIFF
--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -53,7 +53,7 @@
 
 	MouseDrop_T(atom/movable/O as obj, mob/user as mob)
 		if (master && (!master.click_check || (usr in master.mobs)))
-			master.scrolled(src, O, user)
+			master.MouseDrop_T(src, O, user)
 
 
 /datum/hud

--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -179,7 +179,7 @@
 		return null
 
 	proc/clicked(id)
-	proc/scrolled(id, dx, dy, usr, parms)
+	proc/scrolled(id, dx, dy, user, parms)
 	proc/MouseEntered(id,location, control, params)
 	proc/MouseExited(id)
 	proc/MouseDrop(var/obj/screen/hud/H, atom/over_object, src_location, over_location, over_control, params)

--- a/code/datums/hud/ghostdrone.dm
+++ b/code/datums/hud/ghostdrone.dm
@@ -199,7 +199,7 @@
 
 
 	scrolled(id, dx, dy, user, parms, obj/screen/hud/scr)
-		if(!master) return
+		if(!master || user != master) return
 
 		if(scr.item)
 			if(dy < 0) items_screen++

--- a/code/datums/hud/ghostdrone.dm
+++ b/code/datums/hud/ghostdrone.dm
@@ -198,7 +198,7 @@
 		update_equipment()
 
 
-	scrolled(id, dx, dy, loc, parms, obj/screen/hud/scr)
+	scrolled(id, dx, dy, user, parms, obj/screen/hud/scr)
 		if(!master) return
 
 		if(scr.item)

--- a/code/datums/hud/robot.dm
+++ b/code/datums/hud/robot.dm
@@ -272,7 +272,7 @@
 
 
 	scrolled(id, dx, dy, user, parms, obj/screen/hud/scr)
-		if(!master) return
+		if(!master || user != master) return
 		switch(id)
 			if("object1", "object2", "object3", "object4", "object5", "object6", "object7", "next", "nextbg", "prev", "prevbg", "boxes")
 				if(dy < 0) items_screen++

--- a/code/datums/hud/robot.dm
+++ b/code/datums/hud/robot.dm
@@ -271,7 +271,7 @@
 		mainframe.underlays += "block"
 
 
-	scrolled(id, dx, dy, loc, parms, obj/screen/hud/scr)
+	scrolled(id, dx, dy, user, parms, obj/screen/hud/scr)
 		if(!master) return
 		switch(id)
 			if("object1", "object2", "object3", "object4", "object5", "object6", "object7", "next", "nextbg", "prev", "prevbg", "boxes")


### PR DESCRIPTION
[bug] [cleanliness]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #2700
Also fixes an unrelated bug where MouseDrop_T called scrolled (which might fix some human HUD behaviour).
Also makes some argument names more consistent.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug


## Changelog