### PR TITLE
Portasci can no longer mindswap silicons

### DIFF
--- a/code/obj/machinery/porters.dm
+++ b/code/obj/machinery/porters.dm
@@ -730,7 +730,7 @@ var/global/list/portable_machinery = list() // stop looping through world for th
 			//Body swapping
 			if((force_body_swap || prob(1)) && has_mob)
 				var/list/mob/body_list = list()
-				for(var/mob/living/M in src.contents) //Don't think you're gonna get lucky, ghosts!
+				for(var/mob/living/carbon/M in src.contents) //Don't think you're gonna get lucky, ghosts!
 					if(!isdead(M)) body_list += M
 				if(body_list.len > 1)
 


### PR DESCRIPTION
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes an exploit in which ghostdrones could repeatedly use portasci to mindswap into a monkey and become alive again. Also likely fixes other similar exploits.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug


## Changelog
