### PR TITLE
Rod duplication exploit fix

### DIFF
--- a/code/obj/item/building_materials.dm
+++ b/code/obj/item/building_materials.dm
@@ -772,7 +772,7 @@ MATERIAL
 			user.visible_message("<span class='notice'><b>[user]</b> begins building a grille.</span>")
 			var/turf/T = usr.loc
 			SPAWN_DBG(1.5 SECONDS)
-				if (T == usr.loc && !usr.getStatusDuration("weakened") && !usr.getStatusDuration("stunned"))
+				if (T == usr.loc && !usr.getStatusDuration("weakened") && !usr.getStatusDuration("stunned") && src.amount >= 2)
 					var/atom/G = new /obj/grille(usr.loc)
 					G.setMaterial(src.material)
 					src.consume_rods(2)


### PR DESCRIPTION
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Spamming C with rods in your hand could duplicate rods by building more grilles than is possible. This fixes that bug.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug


## Changelog
