### PR TITLE
Fixes buying negative amount of ores

### DIFF
--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -765,7 +765,7 @@
 				account = FindBankAccountByName(src.scan.registered)
 				if (account)
 					var/quantity = 1
-					quantity = input("How many units do you want to purchase?", "Ore Purchase", null, null) as num
+					quantity = max(0, input("How many units do you want to purchase?", "Ore Purchase", null, null) as num)
 
 					////////////
 


### PR DESCRIPTION
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes an exploit in which you could buy a negative amount of an ore at a fabricator.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug


## Changelog
