### PR TITLE
Fixes sheet amount used for clicking on a grill with glass sheets

### DIFF
--- a/code/obj/grille.dm
+++ b/code/obj/grille.dm
@@ -314,7 +314,7 @@
 
 		else if(istype(W, /obj/item/sheet/))
 			var/obj/item/sheet/S = W
-			if (S.material && S.material.material_flags & MATERIAL_CRYSTAL)
+			if (S.material && S.material.material_flags & MATERIAL_CRYSTAL && S.amount_check(2))
 				var/obj/window/WI
 				var/win_thin = 0
 				var/win_dir = 2
@@ -367,9 +367,7 @@
 					user.show_text("<b>Error:</b> Couldn't spawn window. Try again and please inform a coder if the problem persists.", "red")
 					return
 
-				S.amount--
-				if (S.amount < 1)
-					qdel(S)
+				S.consume_sheets(2)
 				return
 			else
 				..()


### PR DESCRIPTION
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Clicking on a grille with a stack of crystal sheets in your hand hasn't used the proper procs and subtracted only 1 sheet instead of the proper 2 sheets. This PR fixes that.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug


## Changelog
