### PR TITLE
Toilets can no longer teleport into restricted areas

### DIFF
--- a/code/obj/item/toilets.dm
+++ b/code/obj/item/toilets.dm
@@ -62,7 +62,7 @@ TOILET
 			var/list/destinations = list()
 
 			for_by_tcl(T, /obj/item/storage/toilet)
-				if (T == src || !isturf(T.loc) || T.z != src.z  || isrestrictedz(T.z) || (istype(T.loc,/area) && T.loc:teleport_blocked))
+				if (T == src || !isturf(T.loc) || T.z != src.z  || isrestrictedz(T.z) || (istype(T.loc.loc,/area) && T.loc.loc:teleport_blocked))
 					continue
 				destinations.Add(T)
 


### PR DESCRIPTION
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This was already intended, the check was just not deep enough. It could let you enter the listening post easily on Kondaru.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug


## Changelog
