### PR TITLE
Virtual antagonists no longer receive bonus spacebux

### DIFF
--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -679,7 +679,7 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 			else if (istype(player.loc, /obj/cryotron) || player.mind && all_the_baddies.Find(player.mind)) // Cryo'd or was a baddie at any point? Keep your shit, but you don't get the extra bux
 				player_loses_held_item = 0
 			//some might not actually have a wage
-			if (isnukeop(player) ||  (isblob(player) && (player.mind && player.mind.special_role == "blob")) || iswraith(player) || (iswizard(player) && (player.mind && player.mind.special_role == "wizard")) )
+			if (!isvirtual(player) && (isnukeop(player) ||  (isblob(player) && (player.mind && player.mind.special_role == "blob")) || iswraith(player) || (iswizard(player) && (player.mind && player.mind.special_role == "wizard")) ))
 				bank_earnings.wage_base = 0 //only effects the end of round display
 				earnings = 800
 


### PR DESCRIPTION
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Note that this is sort of a bad patch of the exploit since it means that if a nukie / wizard etc. dies and goes to VR they don't get the bonus either which sucks, feel free to make a better bugfix instead of this.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug


## Changelog