### PR TITLE
SPK-12 Name Change

### DIFF
--- a/code/modules/transport/pods/MainWeapon.dm
+++ b/code/modules/transport/pods/MainWeapon.dm
@@ -165,7 +165,7 @@
 	firerate = 25
 
 /obj/item/shipcomponent/mainweapon/gun
-	name = "SPK-12 Ballistic System"
+	name = "SPE-12 Ballistic System"
 	desc = "A one of it's kind kinetic podweapon, designed to fire shotgun rounds similar to those in a SPES-12."
 	weapon_score = 1.25
 	current_projectile = new/datum/projectile/bullet/a12


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[CLEANLINESS]
## About the PR and why it's needed <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the SPK-12 pod weapon to instead be called the SPE-12 to more accurately reflect the SPES-12 naming scheme. Getting rid of this will hopefully prevent silly naive people like myself from using the old name for the shotgun inadvertently.