### PR TITLE
The Manta Basketball Problem

### DIFF
--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -12865,6 +12865,8 @@
 /obj/item/bballbasket,
 /obj/item/bballbasket,
 /obj/item/bballbasket,
+/obj/item/basketball,
+/obj/item/basketball,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "aDR" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR and why it's needed<!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
There's 4 basketball nets on Manta, but zero basketballs. This is cruel and unwarranted punishment for B-ball players everywhere. This PR adds 2 basketballs to the same rack that the nets are on.

Come on and slam.