### PR TITLE
Make cyborgs twitch upon being disoriented and stunned

### DIFF
--- a/code/mob/living/stamina_stuns.dm
+++ b/code/mob/living/stamina_stuns.dm
@@ -365,6 +365,11 @@
 		.= 0
 		src.changeStatus("disorient", disorient)
 
+/mob/living/silicon/do_disorient(var/stamina_damage, var/weakened, var/stunned, var/paralysis, var/disorient = 60, var/remove_stamina_below_zero = 0, var/target_type = DISORIENT_BODY)
+	// Apply the twitching disorient animation for as long as the maximum stun duration is.
+	src.changeStatus("cyborg-disorient", max(weakened, stunned, paralysis))
+	. = ..()
+
 //STAMINA UTILITY PROCS
 
 

--- a/code/modules/status_system/statusSystem.dm
+++ b/code/modules/status_system/statusSystem.dm
@@ -1085,6 +1085,27 @@ var/global/list/statusGroupLimits = list("Food"=4)
 				violent_twitch(owner)
 			.=..(timePassed)
 
+	// Basically disorient, but only does the animation and its maxDuration is
+	// upped a bit to synchronize with other stuns.
+	cyborg_disorient
+		id = "cyborg-disorient"
+		name = "Disoriented"
+		icon_state = "disorient"
+		visible = 0
+		unique = 1
+		maxDuration = 30 SECONDS
+		var/counter = 0
+		var/sound = "sound/effects/electric_shock_short.ogg"
+		var/count = 7
+
+		onUpdate(var/timePassed)
+			counter += timePassed
+			if (counter >= count && owner)
+				counter -= count
+				playsound(get_turf(owner), sound, 17, 1, 0.4, 1.6)
+				violent_twitch(owner)
+			.=..(timePassed)
+
 	drunk
 		id = "drunk"
 		name = "Drunk"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Make cyborgs twitch violently just like humans when they get disoriented.

If this is a bad way to do it, please yell at me. This seemed like an easy solution without breaking normal stun mechanics.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Cyborgs do not have any visual or sound feedback when stunned by flashers or anything else that stuns them. Its very possible to get stuck by a security flasher while a human keeps repeatedly walking past it.

The only thing you can do currently is scream and wiggle alot and hope a friendly human notices you and pushes you away from the flasher. This change hopefully makes it more obvious that a cyborg is being stunned by a flash.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Luxizzle:
(+)Cyborgs now twitch when being disoriented.
```
