### PR TITLE
Random events process cleanliness and fix

### DIFF
--- a/code/datums/controllers/process/actions.dm
+++ b/code/datums/controllers/process/actions.dm
@@ -10,14 +10,3 @@ datum/controller/process/actions
 
 	doWork()
 		actions.process()
-
-
-
-// handles timed player actions
-datum/controller/process/randomevents
-	setup()
-		name = "Random Events"
-		schedule_interval = 2.5 MINUTES
-
-	doWork()
-		random_events.process()

--- a/code/datums/controllers/process/random_events.dm
+++ b/code/datums/controllers/process/random_events.dm
@@ -1,0 +1,12 @@
+// handles random events
+datum/controller/process/randomevents
+	hang_warning_time = 5 MINUTES
+	hang_alert_time = 5.5 MINUTES
+	hang_restart_time = 6 MINUTES
+
+	setup()
+		name = "Random Events"
+		schedule_interval = 2.5 MINUTES
+
+	doWork()
+		random_events.process()

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -302,6 +302,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\datums\controllers\process\particles.dm"
 #include "code\datums\controllers\process\process.dm"
 #include "code\datums\controllers\process\railway.dm"
+#include "code\datums\controllers\process\random_events.dm"
 #include "code\datums\controllers\process\respawn.dm"
 #include "code\datums\controllers\process\sea_hotspots.dm"
 #include "code\datums\controllers\process\statusEffects.dm"


### PR DESCRIPTION
[bug] [cleanliness]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes random events process hung time thresholds to sensible values since it runs much less often than other events.
Moves the process to its own file.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
it keeps spamming warnings into admin log now and restarting the process 💀


## Changelog