### PR TITLE
Adjust furnace loading to be easier

### DIFF
--- a/code/modules/power/furnace.dm
+++ b/code/modules/power/furnace.dm
@@ -98,10 +98,6 @@
 			..()
 			return
 
-		if(src.fuel > src.maxfuel)
-			src.fuel = src.maxfuel
-			boutput(user, "<span class='notice'>The furnace is now full!</span>")
-
 	MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
 		if (get_dist(src,user) > 1)
 			boutput(user, "<span class='alert'>You are too far away to do that.</span>")
@@ -112,6 +108,9 @@
 			return
 
 		if (istype(O, /obj/storage/crate/))
+			var/obj/storage/crate/C = O
+			if (C.spawn_contents && C.make_my_stuff()) //Ensure contents have been spawned properly
+				C.spawn_contents = null
 			if (src.fuel >= src.maxfuel)
 				boutput(user, "<span class='alert'>The furnace is already full!</span>")
 				return
@@ -119,13 +118,9 @@
 			var/amtload = 0
 			for (var/obj/item/raw_material/M in O.contents)
 				if (istype(M,/obj/item/raw_material/char))
-					src.fuel += 60 * M.amount
-					amtload += M.amount
-					pool(M)
+					amtload += load_fuel_and_pool(M, 60)
 				else if (istype(M,/obj/item/raw_material/plasmastone))
-					src.fuel += 800 * M.amount
-					amtload += M.amount
-					pool(M)
+					amtload += load_fuel_and_pool(M, 800)
 				if (src.fuel >= src.maxfuel)
 					src.fuel = src.maxfuel
 					boutput(user, "<span class='notice'>The furnace is now full!</span>")
@@ -140,8 +135,7 @@
 			user.visible_message("<span class='notice'>[user] begins quickly stuffing ore into [src]!</span>")
 			var/staystill = user.loc
 			for(var/obj/item/raw_material/char/M in view(1,user))
-				src.fuel += 60 * M.amount
-				pool (M)
+				load_fuel_and_pool(M, 60)
 				if (src.fuel >= src.maxfuel)
 					src.fuel = src.maxfuel
 					boutput(user, "<span class='notice'>The furnace is now full!</span>")
@@ -157,9 +151,7 @@
 			user.visible_message("<span class='notice'>[user] begins quickly stuffing weed into [src]!</span>") // four fuckin twenty all day
 			var/staystill = user.loc
 			for(var/obj/item/plant/herb/cannabis/M in view(1,user))
-				src.fuel += 30
-				src.stoked += 10
-				pool (M)
+				load_fuel_and_pool(M, 30, 10)
 				if (src.fuel >= src.maxfuel)
 					src.fuel = src.maxfuel
 					boutput(user, "<span class='notice'>The furnace is now full!</span>")
@@ -175,8 +167,7 @@
 			user.visible_message("<span class='notice'>[user] begins quickly stuffing ore into [src]!</span>")
 			var/staystill = user.loc
 			for(var/obj/item/raw_material/plasmastone/M in view(1,user))
-				src.fuel += 800 * M.amount
-				pool (M)
+				load_fuel_and_pool(M, 800)
 				if (src.fuel >= src.maxfuel)
 					src.fuel = src.maxfuel
 					boutput(user, "<span class='notice'>The furnace is now full!</span>")
@@ -200,6 +191,23 @@
 		else ..()
 		src.updateUsrDialog()
 
+	// Loads items into furnace with provided fuel and stoked values
+	// Returns number of items loaded
+	proc/load_fuel_and_pool(obj/item/F, fuel_value, stoked_value=0)
+		var/amtload = 0
+		if (istype(F))
+			amtload = min( ceil( (src.maxfuel - src.fuel) / fuel_value ), F.amount )
+			src.fuel += fuel_value * amtload
+			src.stoked += stoked_value * amtload
+			F.amount -= amtload
+			if (F.amount <= 0)
+				pool(F)
+			else
+				if(amtload && F.inventory_counter)
+					F.inventory_counter.update_number(F.amount)
+					F.update_stack_appearance()
+		return amtload
+
 	custom_suicide = 1
 	suicide(var/mob/user as mob)
 		if (!src.user_can_suicide(user))
@@ -211,6 +219,7 @@
 			qdel(user)
 		else qdel(user)
 		src.fuel += 400
+		src.stoked += 50
 		if(src.fuel >= src.maxfuel)
 			src.fuel = src.maxfuel
 		return 1
@@ -220,19 +229,24 @@
 	// original is 1 only if it's the item a person directly puts in, so that putting in a
 	// fried item doesn't say each item in it was put in
 	proc/load_into_furnace(obj/item/W as obj, var/original, mob/user as mob)
-		var/do_pool = 0
+		var/pooled_type = 0
+		var/started_full = fuel == maxfuel
+		var/fuel_name = initial(W.name)
 		if (istype(W, /obj/item/raw_material/char))
-			fuel += 60 * W.amount
-			do_pool = 1
+			load_fuel_and_pool(W, 60)
+			pooled_type = TRUE
 		else if (istype(W, /obj/item/raw_material/plasmastone))
-			fuel += 800 * W.amount
-			do_pool = 1
+			load_fuel_and_pool(W, 800)
+			pooled_type = TRUE
 		else if (istype(W, /obj/item/paper/))
-			fuel += 6
-			do_pool = 1
+			load_fuel_and_pool(W, 6)
+			pooled_type = TRUE
 		else if (istype(W, /obj/item/spacecash/))
-			fuel += 6
-			do_pool = 1
+			if( load_fuel_and_pool(W, 2) > 1)
+				fuel_name = "credits"
+			else
+				fuel_name = "a credit"
+			pooled_type = TRUE
 		else if (istype(W, /obj/item/clothing/gloves/)) fuel += 10
 		else if (istype(W, /obj/item/clothing/head/)) fuel += 20
 		else if (istype(W, /obj/item/clothing/mask/)) fuel += 10
@@ -258,20 +272,27 @@
 					var/obj/item/O = fried_content
 					load_into_furnace(O, 0)
 		else if (istype(W, /obj/item/plant/herb/cannabis))
-			fuel += 30
-			stoked += 10
-			do_pool = 1
+			load_fuel_and_pool(W, 30, 10)
+			pooled_type = TRUE
 		else
 			return 0
 
-		if(original == 1)
-			boutput(user, "<span class='notice'>You load [W] into [src]!</span>")
-			user.u_equip(W)
-			W.dropped()
+		if( started_full )
+			boutput(user, "<span class='alert'>The furnace is already full!</span>")
+			return 1
 
-		if (do_pool)
-			pool(W)
-		else
-			qdel (W)
+		if (original == 1)
+			if(!pooled_type)
+				fuel_name = W.name
+				user.u_equip(W)
+				W.dropped()
+			boutput(user, "<span class='notice'>You load [fuel_name] into [src]!</span>")
+
+			if(src.fuel > src.maxfuel)
+				src.fuel = src.maxfuel
+				boutput(user, "<span class='notice'>The furnace is now full!</span>")
+
+		if (!pooled_type)
+			qdel(W)
 
 		return 1

--- a/code/modules/power/furnace.dm
+++ b/code/modules/power/furnace.dm
@@ -229,7 +229,7 @@
 	// original is 1 only if it's the item a person directly puts in, so that putting in a
 	// fried item doesn't say each item in it was put in
 	proc/load_into_furnace(obj/item/W as obj, var/original, mob/user as mob)
-		var/pooled_type = 0
+		var/pooled_type = FALSE
 		var/started_full = fuel == maxfuel
 		var/fuel_name = initial(W.name)
 		if (istype(W, /obj/item/raw_material/char))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Cleanup
 - Consolidate some logic in furnaces to handle fuel and stoked.

Bugs
 - Handle unopened crates being used by crate loader. Now calls make_my_stuff()
 - Better support for furnace to handle stacks of objects, allowing excess to go back to player.

Changes
- Money as a fuel source now scales with the stack. Less fuel per unit.
- Suicide will now stoke furnace.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes it easier to load various fuel types into furnaces.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Azrun:
(+)Furnaces easier to load.  Resolved issue where excess items in stacks would get consumed without benefit.
```
