### PR TITLE
adds bootleg fireworks and the ability to purchase them from Sketchy D-5

### DIFF
--- a/code/datums/commodity.dm
+++ b/code/datums/commodity.dm
@@ -870,7 +870,7 @@
 
 /datum/commodity/relics/bootlegfirework
 	comname = "Bootleg Firework (1x rocket)"
-	comtype = /obj/item/bootleg_firework
+	comtype = /obj/item/firework/bootleg
 	desc = "Bootleg fireworks, found deep in the back of an old warehouse."
 	price = 60
 	baseprice = 60

--- a/code/datums/commodity.dm
+++ b/code/datums/commodity.dm
@@ -868,6 +868,15 @@
 	upperfluc = 5000
 	lowerfluc = -3000
 
+/datum/commodity/relics/bootlegfirework
+	comname = "Bootleg Firework (1x rocket)"
+	comtype = /obj/item/bootleg_firework
+	desc = "Bootleg fireworks, found deep in the back of an old warehouse."
+	price = 60
+	baseprice = 60
+	upperfluc = 10
+	lowerfluc = -10
+
 ////////////////////////////////
 ///// syndicate trader /////////
 ////////////////////////////////

--- a/code/modules/economy/trader.dm
+++ b/code/modules/economy/trader.dm
@@ -751,6 +751,8 @@
 				src.goods_buy += new /datum/commodity/drugs/cannabis_white(src)
 				src.goods_buy += new /datum/commodity/drugs/cannabis_omega(src)
 
+				src.goods_buy += new /datum/commodity/relics/bootlegfirework(src)
+
 			if(2) // diner attendant
 				src.goods_sell += new /datum/commodity/diner/mysteryburger(src)
 				src.goods_sell += new /datum/commodity/diner/monster(src)

--- a/code/modules/economy/trader.dm
+++ b/code/modules/economy/trader.dm
@@ -743,6 +743,7 @@
 				src.goods_sell += new /datum/commodity/drugs/krokodil(src)
 				src.goods_sell += new /datum/commodity/drugs/lsd(src)
 				src.goods_sell += new /datum/commodity/drugs/lsd_bee(src)
+				src.goods_sell += new /datum/commodity/relics/bootlegfirework(src)
 				src.goods_sell += new /datum/commodity/pills/uranium(src)
 
 				src.goods_buy += new /datum/commodity/drugs/shrooms(src)
@@ -750,8 +751,6 @@
 				src.goods_buy += new /datum/commodity/drugs/cannabis_mega(src)
 				src.goods_buy += new /datum/commodity/drugs/cannabis_white(src)
 				src.goods_buy += new /datum/commodity/drugs/cannabis_omega(src)
-
-				src.goods_buy += new /datum/commodity/relics/bootlegfirework(src)
 
 			if(2) // diner attendant
 				src.goods_sell += new /datum/commodity/diner/mysteryburger(src)

--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -903,16 +903,16 @@ PIPE BOMBS + CONSTRUCTION
 		create_reagents(10)
 		reagents.add_reagent("magnesium", 10)
 
-	afterattack(atom/target as mob|obj|turf|area, mob/user as mob)
+	afterattack(atom/target as mob|obj|turf, mob/user as mob)
 		if (user.equipped() == src)
 			if (src.primer_burnt)
-				boutput(user, "<span class='alert'>You can't light a firework more than once!</span>")
+				boutput(user, "<span class='alert'>You accidentally strike the primer, but it's already burnt!</span>")
 				return
 
 			else if (src.slashed)
-				boutput(user, "<span class='alert'>You prime the firework! [det_time/10] seconds!</span>")
+				boutput(user, "<span class='alert'>You accidentally prime the firework! [det_time/10] seconds!</span>")
 				SPAWN_DBG( src.det_time )
-					boutput(user, "<span class='alert'>The firework probably should have exploded by now. Fuck.</span>")
+					boutput(user, "<span class='alert'>The firework probably should have exploded by now.</span>")
 					src.primer_burnt = TRUE
 					return
 
@@ -924,7 +924,7 @@ PIPE BOMBS + CONSTRUCTION
 					return
 
 			else
-				boutput(user, "<span class='alert'>You prime the firework! [det_time/10] seconds!</span>")
+				boutput(user, "<span class='alert'>You accidentally prime the firework! [det_time/10] seconds!</span>")
 				src.primed = TRUE
 				SPAWN_DBG( src.det_time )
 					boom(user)
@@ -932,15 +932,13 @@ PIPE BOMBS + CONSTRUCTION
 
 	proc/boom(mob/user as mob)
 		var/turf/location = get_turf(src.loc)
-		if (!ishuman(user))
-			return
-		var/mob/living/carbon/human/H = user
 
 		if(location)
 			if((prob(10)) || (src.bootleg_level == 2))
 				explosion(src, location, 0, 0, 1, 1)
 
-				if (src.bootleg_level == 2)
+				if ((src.bootleg_level == 2) && (ishuman(user)))
+					var/mob/living/carbon/human/H = user
 					H.sever_limb(H.hand == 1 ? "l_arm" : "r_arm") // copied from weapon_racks.dm
 
 			else
@@ -1023,9 +1021,9 @@ PIPE BOMBS + CONSTRUCTION
 		else
 			reagents.add_reagent("magnesium", 10)
 
-	afterattack(atom/target as mob|obj|turf|area, mob/user as mob)
+	afterattack(atom/target as mob|obj|turf, mob/user as mob)
 		if (src.bootleg_level > 0)
-			boutput(user, "<span class='alert'>You try to prime the firework, but the contents ignite immediately!</span>")
+			boutput(user, "<span class='alert'>You accidentally prime the firework, and the contents ignite immediately!</span>")
 			boom(user)
 			return
 

--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -988,6 +988,166 @@ PIPE BOMBS + CONSTRUCTION
 			boutput(user, "[src] has already been cut open and emptied.")
 			return
 
+/obj/item/bootleg_firework
+	name = "bootleg firework"
+	desc = "A consumer-grade pyrotechnic, often used in celebrations. This one seems to be missing a label, weird."
+	icon = 'icons/obj/items/items.dmi'
+	icon_state = "firework"
+	opacity = 0
+	density = 0
+	anchored = 0.0
+	force = 1.0
+	throwforce = 1.0
+	throw_speed = 1
+	throw_range = 5
+	w_class = 1.0
+	var/det_time = 20
+	stamina_damage = 5
+	stamina_cost = 5
+	stamina_crit_chance = 5
+	var/slashed = FALSE // has it been emptied out? if so, better dud!
+	var/primer_burnt = FALSE // avoid priming a firework multiple times, that doesn't make sense!
+	var/primed = FALSE // cutting open lit fireworks is a BAD idea
+	var/bootleg_level = 0 // 0 = normal, 1 = unstable, 2 = unstable and you arm fall off
+
+	New()
+		..()
+		create_reagents(10)
+
+		if (prob(30))
+			reagents.add_reagent("flashpowder", 5) // must've been a mix-up!
+
+			if (prob(15))
+				reagents.add_reagent("blackpowder", 5) // thats one hell of a mix-up
+				src.bootleg_level = 2
+			else
+				reagents.add_reagent("flashpowder", 5) // this way every firework has 10u reagents
+				src.bootleg_level = 1
+
+		else
+			reagents.add_reagent("magnesium", 10)
+
+	afterattack(atom/target as mob|obj|turf|area, mob/user as mob)
+		if (user.equipped() == src)
+			if (src.primer_burnt)
+				boutput(user, "<span class='alert'>You can't light a firework more than once!</span>")
+				return
+
+			else if (src.slashed)
+				boutput(user, "<span class='alert'>You prime the firework! [det_time/10] seconds!</span>")
+				SPAWN_DBG( src.det_time )
+					boutput(user, "<span class='alert'>The firework probably should have exploded by now. Fuck.</span>")
+					src.primer_burnt = TRUE
+					return
+
+			else if (user.bioHolder.HasEffect("clumsy"))
+				boutput(user, "<span class='alert'>Huh? How does this thing work?!</span>")
+				if (src.bootleg_level > 0)
+					boom(user)
+					return
+
+				src.primed = TRUE
+				SPAWN_DBG( 5 )
+					boom(user)
+					return
+
+			else
+				if (src.bootleg_level > 0)
+					boutput(user, "<span class='alert'>You prime the firework, but the contents ignite immediately!</span>")
+					boom(user)
+					return
+
+				boutput(user, "<span class='alert'>You prime the firework! [det_time/10] seconds!</span>")
+				src.primed = TRUE
+				SPAWN_DBG( src.det_time )
+					boom(user)
+					return
+
+	proc/boom(mob/user as mob)
+		var/turf/location = get_turf(src.loc)
+		if (!ishuman(user))
+			return
+		var/mob/living/carbon/human/H = user
+
+		if(location)
+			if((prob(10)) || (src.bootleg_level == 2))
+				explosion(src, location, 0, 0, 1, 1)
+
+				if (src.bootleg_level == 2)
+					H.sever_limb(H.hand == 1 ? "l_arm" : "r_arm") // copied from weapon_racks.dm
+
+			else
+				elecflash(src,power = 2)
+
+				if (src.bootleg_level == 0)
+					playsound(src.loc, "sound/effects/Explosion1.ogg", 75, 1)
+				else
+					playsound(src.loc, "sound/effects/Explosion2.ogg", 75, 1)
+
+		src.visible_message("<span class='alert'>\The [src] explodes!</span>")
+
+		qdel(src)
+
+	attack_self(mob/user as mob)
+		if (user.equipped() == src)
+			if (src.primer_burnt)
+				boutput(user, "<span class='alert'>You can't light a firework more than once!</span>")
+				return
+
+			else if (src.slashed)
+				boutput(user, "<span class='alert'>You prime the firework! [det_time/10] seconds!</span>")
+				SPAWN_DBG( src.det_time )
+					boutput(user, "<span class='alert'>The firework probably should have exploded by now. Fuck.</span>")
+					src.primer_burnt = TRUE
+					return
+
+			else if (user.bioHolder.HasEffect("clumsy"))
+				boutput(user, "<span class='alert'>Huh? How does this thing work?!</span>")
+				if (src.bootleg_level > 0)
+					boom(user)
+					return
+
+				src.primed = TRUE
+				SPAWN_DBG( 5 )
+					boom(user)
+					return
+
+			else
+				if (src.bootleg_level > 0)
+					boutput(user, "<span class='alert'>You prime the firework, but the contents ignite immediately!</span>")
+					boom(user)
+					return
+
+				boutput(user, "<span class='alert'>You prime the firework! [det_time/10] seconds!</span>")
+				src.primed = TRUE
+				SPAWN_DBG( src.det_time )
+					boom(user)
+					return
+
+	attackby(obj/A as obj, mob/user as mob) // adapted from iv_drips.dm
+		if (iscuttingtool(A) && !(src.slashed) && (src.bootleg_level > 0))
+			boutput(user, "You try to cut [src] open, but the contents spontaneously ignite!")
+			boom(user)
+			return
+
+		else if (iscuttingtool(A) && !(src.slashed) && !(src.primed))
+			src.slashed = TRUE
+			src.name = "empty [src.name]" // its empty now!
+			src.desc = "[src.desc] It has been cut open and emptied out."
+			boutput(user, "You carefully cut [src] open and dump out the contents.")
+
+			make_cleanable(/obj/decal/cleanable/magnesiumpile, get_turf(src.loc)) // create magnesium pile
+			src.reagents.clear_reagents() // remove magnesium from firework
+			return
+
+		else if (iscuttingtool(A) && !(src.slashed) && (src.primed)) // cutting open a lit firework is a bad idea!
+			boutput(user, "<span class='alert'>You cut open [src], but the lit primer ignites the contents!</span>")
+			boom(user)
+			return
+
+		else if (iscuttingtool(A) && (src.slashed))
+			boutput(user, "[src] has already been cut open and emptied.")
+			return
 //////////////////////// Breaching charges //////////////////////////////////
 
 /obj/item/breaching_charge


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds bootleg fireworks. Most bootleg fireworks behave identically to normal fireworks. Some though will have untimely detonations and even fewer will also cause arm loss. Also adds bootleg fireworks to Sketchy D-5's selling menu as a means of acquisition.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
After adding magnesium to fireworks I've come to realize that fireworks aren't really all that easy to come by, like at all. Having a sketchy analogue means that hobos will actually be able to get their greasy hands on them!
