### PR TITLE
Manufacturer backend improvements

### DIFF
--- a/code/datums/controllers/mechanic_controls.dm
+++ b/code/datums/controllers/mechanic_controls.dm
@@ -51,6 +51,12 @@ var/datum/mechanic_controller/mechanic_controls
 				return
 			if (get_schematic_from_name_in_custom(src.name))
 				return
+			var/mats_types = null // null = keep default
+			if(islist(mats_number))
+				mats_types = mats_number
+				mats_number = 0
+				for(var/mat in mats_types)
+					mats_number += mats_types[mat]
 			if (!isnum(mats_number))
 				mats_number = 10
 
@@ -64,7 +70,14 @@ var/datum/mechanic_controller/mechanic_controls
 				mats_number -= 3
 				// to cover the base materials
 
-			if (mats_number > 0)
+			if (!isnull(mats_types))
+				M.item_paths.Cut()
+				M.item_names = null // auto-generate
+				M.item_amounts.Cut()
+				for(var/mat in mats_types)
+					M.item_paths += mat
+					M.item_amounts += mats_types[mat]
+			else if (mats_number > 0)
 				for(var/tracker = 1, tracker <= mats_number, tracker ++)
 					M.item_amounts[rand(1,3)] += 1
 

--- a/code/datums/controllers/mechanic_controls.dm
+++ b/code/datums/controllers/mechanic_controls.dm
@@ -76,7 +76,10 @@ var/datum/mechanic_controller/mechanic_controls
 				M.item_amounts.Cut()
 				for(var/mat in mats_types)
 					M.item_paths += mat
-					M.item_amounts += mats_types[mat]
+					var/amt = mats_types[mat]
+					if(isnull(amt))
+						amt = 1
+					M.item_amounts += amt
 			else if (mats_number > 0)
 				for(var/tracker = 1, tracker <= mats_number, tracker ++)
 					M.item_amounts[rand(1,3)] += 1

--- a/code/datums/controllers/mechanic_controls.dm
+++ b/code/datums/controllers/mechanic_controls.dm
@@ -56,7 +56,10 @@ var/datum/mechanic_controller/mechanic_controls
 				mats_types = mats_number
 				mats_number = 0
 				for(var/mat in mats_types)
-					mats_number += mats_types[mat]
+					var/amt = mats_types[mat]
+					if(isnull(amt))
+						amt = 1
+					mats_number += amt
 			if (!isnum(mats_number))
 				mats_number = 10
 

--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -1,7 +1,31 @@
+var/global/list/manufacturer_nice_mat_names = list(
+	"ALL" = "Any Material",
+	"MET-1" = "Metal",
+	"MET-2" = "Sturdy Metal",
+	"MET-3" = "Dense Metal",
+	"CRY-1" = "Crystal",
+	"CON-1" = "Conductive Material",
+	"CON-2" = "High Energy Conductor",
+	"INS-1" = "Insulative Material",
+	"FAB-1" = "Fabric",
+	"POW-1" = "Power Source",
+	"POW-2" = "Significant Power Source",
+	"POW-3" = "Extreme Power Source",
+	"DEN-1" = "High Density Crystalline Matter",
+	"DEN-2" = "Very High Density Crystalline Matter",
+	"DEN-3" = "Extraordinarily Dense Crystalline Matter"
+)
+
+proc/get_nice_mat_name_for_manufacturers(mat)
+	if(mat in manufacturer_nice_mat_names)
+		return manufacturer_nice_mat_names[mat]
+	else
+		return capitalize(mat)
+
 /datum/manufacture
 	var/name = null                // Name of the schematic
 	var/list/item_paths = list()   // Materials required
-	var/list/item_names = list()   // Name of each material
+	var/list/item_names = null   // Name of each material (generated automatically if null)
 	var/list/item_amounts = list() // How many of each material is needed
 	var/list/item_outputs = list() // What the schematic outputs
 	var/randomise_output = 0
@@ -20,7 +44,7 @@
 			src.sanity_check()
 
 	proc/sanity_check()
-		if (item_paths.len != item_names.len || item_paths.len != item_amounts.len || item_names.len != item_amounts.len)
+		if (item_paths.len != item_amounts.len || !isnull(item_names) && (item_paths.len != item_names.len || item_names.len != item_amounts.len))
 			logTheThing("debug", null, null, "<b>Manufacturer:</b> [src.name]/[src.type] schematic requirement lists not properly configured")
 			qdel(src)
 			return
@@ -41,7 +65,6 @@
 /datum/manufacture/mechanics
 	name = "Reverse-Engineered Schematic"
 	item_paths = list("MET-1","CON-1","CRY-1")
-	item_names = list("Metal", "Conductive Material", "Crystal")
 	item_amounts = list(1,1,1)
 	item_outputs = list(/obj/item/electronics/frame)
 	var/frame_path = null
@@ -100,7 +123,6 @@
 	// purely a test
 	name = "Iron"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(1)
 	item_outputs = list("reagent-iron")
 	time = 1 SECONDS
@@ -111,7 +133,6 @@
 /datum/manufacture/crowbar
 	name = "Crowbar"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(1)
 	item_outputs = list(/obj/item/crowbar)
 	time = 5 SECONDS
@@ -121,7 +142,6 @@
 /datum/manufacture/screwdriver
 	name = "Screwdriver"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(1)
 	item_outputs = list(/obj/item/screwdriver)
 	time = 5 SECONDS
@@ -131,7 +151,6 @@
 /datum/manufacture/wirecutters
 	name = "Wirecutters"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(1)
 	item_outputs = list(/obj/item/wirecutters)
 	time = 5 SECONDS
@@ -141,7 +160,6 @@
 /datum/manufacture/wrench
 	name = "Wrench"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(1)
 	item_outputs = list(/obj/item/wrench)
 	time = 5 SECONDS
@@ -151,7 +169,6 @@
 /datum/manufacture/flashlight
 	name = "Flashlight"
 	item_paths = list("MET-1","CON-1","CRY-1")
-	item_names = list("Metal","Conductive Material","Crystal")
 	item_amounts = list(1,1,1)
 	item_outputs = list(/obj/item/device/light/flashlight)
 	time = 5 SECONDS
@@ -161,7 +178,6 @@
 /datum/manufacture/vuvuzela
 	name = "Vuvuzela"
 	item_paths = list("ALL")
-	item_names = list("Any Material")
 	item_amounts = list(1)
 	item_outputs = list(/obj/item/instrument/vuvuzela)
 	time = 5 SECONDS
@@ -171,7 +187,6 @@
 /datum/manufacture/harmonica
 	name = "Harmonica"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(1)
 	item_outputs = list(/obj/item/instrument/harmonica)
 	time = 5 SECONDS
@@ -181,7 +196,6 @@
 /datum/manufacture/bottle
 	name = "Glass Bottle"
 	item_paths = list("CRY-1")
-	item_names = list("Crystal")
 	item_amounts = list(1)
 	item_outputs = list(/obj/item/reagent_containers/food/drinks/bottle)
 	time = 4 SECONDS
@@ -191,7 +205,6 @@
 /datum/manufacture/bikehorn
 	name = "Bicycle Horn"
 	item_paths = list("ALL")
-	item_names = list("Any Material")
 	item_amounts = list(1)
 	item_outputs = list(/obj/item/instrument/bikehorn)
 	time = 5 SECONDS
@@ -201,7 +214,6 @@
 /datum/manufacture/stunrounds
 	name = ".38 Stunner Rounds"
 	item_paths = list("MET-1","CON-1", "CRY-1")
-	item_names = list("Metal","Conductive Material", "Crystal")
 	item_amounts = list(3,2,2)
 	item_outputs = list(/obj/item/ammo/bullets/a38/stun)
 	time = 20 SECONDS
@@ -211,7 +223,6 @@
 /datum/manufacture/bullet_22
 	name = ".22 Bullets"
 	item_paths = list("MET-2","CON-1")
-	item_names = list("Sturdy Metal","Conductive Material")
 	item_amounts = list(30,24)
 	item_outputs = list(/obj/item/ammo/bullets/bullet_22)
 	time = 30 SECONDS
@@ -221,7 +232,6 @@
 /datum/manufacture/bullet_12g_nail
 	name = "12 gauge nailshot"
 	item_paths = list("MET-2","CON-1")
-	item_names = list("Sturdy Metal","Conductive Material")
 	item_amounts = list(40,30)
 	item_outputs = list(/obj/item/ammo/bullets/nails)
 	time = 30 SECONDS
@@ -231,7 +241,6 @@
 /datum/manufacture/bullet_smoke
 	name = "40mm Smoke Grenade"
 	item_paths = list("MET-2","CON-1")
-	item_names = list("Sturdy Metal","Conductive Material")
 	item_amounts = list(30,25)
 	item_outputs = list(/obj/item/ammo/bullets/smoke)
 	time = 35 SECONDS
@@ -241,7 +250,6 @@
 /datum/manufacture/extinguisher
 	name = "Fire Extinguisher"
 	item_paths = list("MET-2","CRY-1")
-	item_names = list("Sturdy Metal","Crystal")
 	item_amounts = list(1,1)
 	item_outputs = list(/obj/item/extinguisher)
 	time = 8 SECONDS
@@ -251,7 +259,6 @@
 /datum/manufacture/welder
 	name = "Welding Tool"
 	item_paths = list("MET-2","CON-1")
-	item_names = list("Sturdy Metal","Conductive Material")
 	item_amounts = list(1,1)
 	item_outputs = list(/obj/item/weldingtool)
 	time = 8 SECONDS
@@ -261,7 +268,6 @@
 /datum/manufacture/soldering
 	name = "Soldering Iron"
 	item_paths = list("MET-2","CON-1")
-	item_names = list("Sturdy Metal","Conductive Material")
 	item_amounts = list(1,2)
 	item_outputs = list(/obj/item/electronics/soldering)
 	time = 8 SECONDS
@@ -271,7 +277,6 @@
 /datum/manufacture/stapler
 	name = "Staple Gun"
 	item_paths = list("MET-2","CON-1")
-	item_names = list("Sturdy Metal","Conductive Material")
 	item_amounts = list(2,1)
 	item_outputs = list(/obj/item/staple_gun)
 	time = 10 SECONDS
@@ -281,7 +286,6 @@
 /datum/manufacture/multitool
 	name = "Multi Tool"
 	item_paths = list("CRY-1","CON-2")
-	item_names = list("Crystal","High Energy Conductor")
 	item_amounts = list(1,1)
 	item_outputs = list(/obj/item/device/multitool)
 	time = 8 SECONDS
@@ -291,7 +295,6 @@
 /datum/manufacture/weldingmask
 	name = "Welding Mask"
 	item_paths = list("MET-2","CRY-1")
-	item_names = list("Sturdy Metal","Crystal")
 	item_amounts = list(2,2)
 	item_outputs = list(/obj/item/clothing/head/helmet/welding)
 	time = 10 SECONDS
@@ -301,7 +304,6 @@
 /datum/manufacture/light_bulb
 	name = "Light Bulb Box"
 	item_paths = list("CRY-1")
-	item_names = list("Crystal")
 	item_amounts = list(1)
 	item_outputs = list(/obj/item/storage/box/lightbox/bulbs)
 	time = 4 SECONDS
@@ -311,7 +313,6 @@
 /datum/manufacture/red_bulb
 	name = "Red Light Bulb Box"
 	item_paths = list("CRY-1","CON-1")
-	item_names = list("Crystal","Conductive Material")
 	item_amounts = list(1,1)
 	item_outputs = list(/obj/item/storage/box/lightbox/bulbs/red)
 	time = 8 SECONDS
@@ -321,7 +322,6 @@
 /datum/manufacture/yellow_bulb
 	name = "Yellow Light Bulb Box"
 	item_paths = list("CRY-1","CON-1")
-	item_names = list("Crystal","Conductive Material")
 	item_amounts = list(1,1)
 	item_outputs = list(/obj/item/storage/box/lightbox/bulbs/yellow)
 	time = 8 SECONDS
@@ -331,7 +331,6 @@
 /datum/manufacture/green_bulb
 	name = "Green Light Bulb Box"
 	item_paths = list("CRY-1","CON-1")
-	item_names = list("Crystal","Conductive Material")
 	item_amounts = list(1,1)
 	item_outputs = list(/obj/item/storage/box/lightbox/bulbs/green)
 	time = 8 SECONDS
@@ -341,7 +340,6 @@
 /datum/manufacture/cyan_bulb
 	name = "Cyan Light Bulb Box"
 	item_paths = list("CRY-1","CON-1")
-	item_names = list("Crystal","Conductive Material")
 	item_amounts = list(1,1)
 	item_outputs = list(/obj/item/storage/box/lightbox/bulbs/cyan)
 	time = 8 SECONDS
@@ -351,7 +349,6 @@
 /datum/manufacture/blue_bulb
 	name = "Blue Light Bulb Box"
 	item_paths = list("CRY-1","CON-1")
-	item_names = list("Crystal","Conductive Material")
 	item_amounts = list(1,1)
 	item_outputs = list(/obj/item/storage/box/lightbox/bulbs/blue)
 	time = 8 SECONDS
@@ -361,7 +358,6 @@
 /datum/manufacture/purple_bulb
 	name = "Purple Light Bulb Box"
 	item_paths = list("CRY-1","CON-1")
-	item_names = list("Crystal","Conductive Material")
 	item_amounts = list(1,1)
 	item_outputs = list(/obj/item/storage/box/lightbox/bulbs/purple)
 	time = 8 SECONDS
@@ -371,7 +367,6 @@
 /datum/manufacture/blacklight_bulb
 	name = "Blacklight Bulb Box"
 	item_paths = list("CRY-1","CON-1")
-	item_names = list("Crystal","Conductive Material")
 	item_amounts = list(1,1)
 	item_outputs = list(/obj/item/storage/box/lightbox/bulbs/blacklight)
 	time = 8 SECONDS
@@ -381,7 +376,6 @@
 /datum/manufacture/light_tube
 	name = "Light Tube Box"
 	item_paths = list("CRY-1")
-	item_names = list("Crystal")
 	item_amounts = list(1)
 	item_outputs = list(/obj/item/storage/box/lightbox/tubes)
 	time = 4 SECONDS
@@ -391,7 +385,6 @@
 /datum/manufacture/red_tube
 	name = "Red Light Tube Box"
 	item_paths = list("CRY-1","CON-1")
-	item_names = list("Crystal","Conductive Material")
 	item_amounts = list(1,1)
 	item_outputs = list(/obj/item/storage/box/lightbox/tubes/red)
 	time = 8 SECONDS
@@ -401,7 +394,6 @@
 /datum/manufacture/yellow_tube
 	name = "Yellow Light Tube Box"
 	item_paths = list("CRY-1","CON-1")
-	item_names = list("Crystal","Conductive Material")
 	item_amounts = list(1,1)
 	item_outputs = list(/obj/item/storage/box/lightbox/tubes/yellow)
 	time = 8 SECONDS
@@ -411,7 +403,6 @@
 /datum/manufacture/green_tube
 	name = "Green Light Tube Box"
 	item_paths = list("CRY-1","CON-1")
-	item_names = list("Crystal","Conductive Material")
 	item_amounts = list(1,1)
 	item_outputs = list(/obj/item/storage/box/lightbox/tubes/green)
 	time = 8 SECONDS
@@ -421,7 +412,6 @@
 /datum/manufacture/cyan_tube
 	name = "Cyan Light Tube Box"
 	item_paths = list("CRY-1","CON-1")
-	item_names = list("Crystal","Conductive Material")
 	item_amounts = list(1,1)
 	item_outputs = list(/obj/item/storage/box/lightbox/tubes/cyan)
 	time = 8 SECONDS
@@ -431,7 +421,6 @@
 /datum/manufacture/blue_tube
 	name = "Blue Light Tube Box"
 	item_paths = list("CRY-1","CON-1")
-	item_names = list("Crystal","Conductive Material")
 	item_amounts = list(1,1)
 	item_outputs = list(/obj/item/storage/box/lightbox/tubes/blue)
 	time = 8 SECONDS
@@ -441,7 +430,6 @@
 /datum/manufacture/purple_tube
 	name = "Purple Light Tube Box"
 	item_paths = list("CRY-1","CON-1")
-	item_names = list("Crystal","Conductive Material")
 	item_amounts = list(1,1)
 	item_outputs = list(/obj/item/storage/box/lightbox/tubes/purple)
 	time = 8 SECONDS
@@ -451,7 +439,6 @@
 /datum/manufacture/blacklight_tube
 	name = "Blacklight Tube Box"
 	item_paths = list("CRY-1","CON-1")
-	item_names = list("Crystal","Conductive Material")
 	item_amounts = list(1,1)
 	item_outputs = list(/obj/item/storage/box/lightbox/tubes/blacklight)
 	time = 8 SECONDS
@@ -461,7 +448,6 @@
 /datum/manufacture/table_folding
 	name = "Folding Table"
 	item_paths = list("MET-1","ALL")
-	item_names = list("Metal","Any Material")
 	item_amounts = list(1,2)
 	item_outputs = list(/obj/item/furniture_parts/table/folding)
 	time = 20 SECONDS
@@ -471,7 +457,6 @@
 /datum/manufacture/metal
 	name = "Metal Sheet"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(1)
 	item_outputs = list(/obj/item/sheet)
 	time = 2 SECONDS
@@ -482,7 +467,6 @@
 /datum/manufacture/metalR
 	name = "Reinforced Metal"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(2)
 	item_outputs = list(/obj/item/sheet)
 	time = 12 SECONDS
@@ -498,7 +482,6 @@
 /datum/manufacture/glass
 	name = "Glass Panel"
 	item_paths = list("CRY-1")
-	item_names = list("Crystal")
 	item_amounts = list(5)
 	item_outputs = list(/obj/item/sheet)
 	time = 8 SECONDS
@@ -509,7 +492,6 @@
 /datum/manufacture/glassR
 	name = "Reinforced Glass Panel"
 	item_paths = list("CRY-1","MET-2")
-	item_names = list("Crystal","Sturdy Metal")
 	item_amounts = list(1,1)
 	item_outputs = list(/obj/item/sheet/glass/reinforced)
 	time = 12 SECONDS
@@ -525,7 +507,6 @@
 /datum/manufacture/rods2
 	name = "Metal Rods (x2)"
 	item_paths = list("MET-2")
-	item_names = list("Sturdy Metal")
 	item_amounts = list(1)
 	item_outputs = list(/obj/item/rods)
 	time = 3 SECONDS
@@ -541,7 +522,6 @@
 /datum/manufacture/atmos_can
 	name = "Portable Gas Canister"
 	item_paths = list("MET-2")
-	item_names = list("Sturdy Metal")
 	item_amounts = list(3)
 	item_outputs = list(/obj/machinery/portable_atmospherics/canister)
 	time = 10 SECONDS
@@ -551,7 +531,6 @@
 /datum/manufacture/fluidcanister
 	name = "Fluid Canister"
 	item_paths = list("MET-2")
-	item_names = list("Sturdy Metal")
 	item_amounts = list(15)
 	item_outputs = list(/obj/machinery/fluid_canister)
 	time = 10 SECONDS
@@ -563,7 +542,6 @@
 /datum/manufacture/air_can/large
 	name = "High-Volume Air Canister"
 	item_paths = list("MET-2","molitz","viscerite")
-	item_names = list("Sturdy Metal","Molitz","Viscerite")
 	item_amounts = list(3,10,30)
 	item_outputs = list(/obj/machinery/portable_atmospherics/canister/air/large)
 	time = 100 SECONDS
@@ -573,7 +551,6 @@
 /datum/manufacture/co2_can
 	name = "CO2 Canister"
 	item_paths = list("MET-2","char")
-	item_names = list("Sturdy Metal","Char")
 	item_amounts = list(3,10)
 	item_outputs = list(/obj/machinery/portable_atmospherics/canister/carbon_dioxide)
 	time = 100 SECONDS
@@ -583,7 +560,6 @@
 /datum/manufacture/o2_can
 	name = "O2 Canister"
 	item_paths = list("MET-2","molitz")
-	item_names = list("Sturdy Metal","Molitz")
 	item_amounts = list(3,10)
 	item_outputs = list(/obj/machinery/portable_atmospherics/canister/oxygen)
 	time = 100 SECONDS
@@ -593,7 +569,6 @@
 /datum/manufacture/plasma_can
 	name = "Plasma Canister"
 	item_paths = list("MET-2","plasmastone")
-	item_names = list("Sturdy Metal","Plasmastone")
 	item_amounts = list(3,10)
 	item_outputs = list(/obj/machinery/portable_atmospherics/canister/toxins)
 	time = 100 SECONDS
@@ -603,7 +578,6 @@
 /datum/manufacture/n2_can
 	name = "N2 Canister"
 	item_paths = list("MET-2","viscerite")
-	item_names = list("Sturdy Metal","Viscerite")
 	item_amounts = list(3,10)
 	item_outputs = list(/obj/machinery/portable_atmospherics/canister/nitrogen)
 	time = 100 SECONDS
@@ -613,7 +587,6 @@
 /datum/manufacture/n2o_can
 	name = "N2O Canister"
 	item_paths = list("MET-2","koshmarite")
-	item_names = list("Sturdy Metal","Koshmarite")
 	item_amounts = list(3,10)
 	item_outputs = list(/obj/machinery/portable_atmospherics/canister/sleeping_agent)
 	time = 100 SECONDS
@@ -625,7 +598,6 @@
 /datum/manufacture/circuit_board
 	name = "Circuit Board"
 	item_paths = list("CON-1")
-	item_names = list("Conductive Material")
 	item_amounts = list(2)
 	item_outputs = list(/obj/item/electronics/board)
 	time = 5 SECONDS
@@ -635,7 +607,6 @@
 /datum/manufacture/cable
 	name = "Electrical Cable Coil"
 	item_paths = list("INS-1", "CON-1")
-	item_names = list("Insulative Material", "Conductive Material")
 	item_amounts = list(10, 10)
 	item_outputs = list(/obj/item/cable_coil)
 	time = 3 SECONDS
@@ -667,7 +638,6 @@
 /datum/manufacture/RCD
 	name = "Rapid Construction Device"
 	item_paths = list("MET-3","DEN-1","CON-1")
-	item_names = list("Heavy Metal","High Density Crystalline Material","Conductive Material")
 	item_amounts = list(5,1,10)
 	item_outputs = list(/obj/item/rcd)
 	time = 90 SECONDS
@@ -677,7 +647,6 @@
 /datum/manufacture/RCDammo
 	name = "Compressed Matter Cartridge"
 	item_paths = list("DEN-1")
-	item_names = list("High Density Crystalline Material")
 	item_amounts = list(5)
 	item_outputs = list(/obj/item/rcd_ammo)
 	time = 10 SECONDS
@@ -687,7 +656,6 @@
 /datum/manufacture/RCDammolarge
 	name = "Large Compressed Matter Cartridge"
 	item_paths = list("DEN-1")
-	item_names = list("High Density Crystalline Material")
 	item_amounts = list(45)
 	item_outputs = list(/obj/item/rcd_ammo/big)
 	time = 30 SECONDS
@@ -697,7 +665,6 @@
 /datum/manufacture/jumpsuit
 	name = "Grey Jumpsuit"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(4)
 	item_outputs = list(/obj/item/clothing/under/color/grey)
 	time = 5 SECONDS
@@ -707,7 +674,6 @@
 /datum/manufacture/shoes
 	name = "Black Shoes"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(3)
 	item_outputs = list(/obj/item/clothing/shoes/black)
 	time = 5 SECONDS
@@ -717,7 +683,6 @@
 /datum/manufacture/shoes_white
 	name = "White Shoes"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(3)
 	item_outputs = list(/obj/item/clothing/shoes/white)
 	time = 5 SECONDS
@@ -729,7 +694,6 @@
 /datum/manufacture/scalpel
 	name = "Scalpel"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(1)
 	item_outputs = list(/obj/item/scalpel)
 	time = 5 SECONDS
@@ -739,7 +703,6 @@
 /datum/manufacture/circular_saw
 	name = "Circular Saw"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(1)
 	item_outputs = list(/obj/item/circular_saw)
 	time = 5 SECONDS
@@ -749,7 +712,6 @@
 /datum/manufacture/surgical_scissors
 	name = "Surgical Scissors"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(1)
 	item_outputs = list(/obj/item/scissors/surgical_scissors)
 	time = 5 SECONDS
@@ -759,7 +721,6 @@
 /datum/manufacture/hemostat
 	name = "Hemostat"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(1)
 	item_outputs = list(/obj/item/hemostat)
 	time = 5 SECONDS
@@ -769,7 +730,6 @@
 /datum/manufacture/surgical_spoon
 	name = "Enucleation Spoon"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(1)
 	item_outputs = list(/obj/item/surgical_spoon)
 	time = 5 SECONDS
@@ -779,7 +739,6 @@
 /datum/manufacture/suture
 	name = "Suture"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(1)
 	item_outputs = list(/obj/item/suture)
 	time = 5 SECONDS
@@ -789,7 +748,6 @@
 /datum/manufacture/deafhs
 	name = "Auditory Headset"
 	item_paths = list("CON-1","CRY-1")
-	item_names = list("Conductive Material","Crystal")
 	item_amounts = list(3,3)
 	item_outputs = list(/obj/item/device/radio/headset/deaf)
 	time = 40 SECONDS
@@ -799,7 +757,6 @@
 /datum/manufacture/visor
 	name = "VISOR Prosthesis"
 	item_paths = list("CON-1","CRY-1")
-	item_names = list("Conductive Material","Crystal")
 	item_amounts = list(3,3)
 	item_outputs = list(/obj/item/clothing/glasses/visor)
 	time = 40 SECONDS
@@ -809,7 +766,6 @@
 /datum/manufacture/glasses
 	name = "Prescription Glasses"
 	item_paths = list("MET-1","CRY-1")
-	item_names = list("Metal","Crystal")
 	item_amounts = list(1,2)
 	item_outputs = list(/obj/item/clothing/glasses/regular)
 	time = 20 SECONDS
@@ -819,7 +775,6 @@
 /datum/manufacture/hypospray
 	name = "Hypospray"
 	item_paths = list("MET-1","CON-1","CRY-1")
-	item_names = list("Metal","Conductive Material","Crystal")
 	item_amounts = list(2,2,2)
 	item_outputs = list(/obj/item/reagent_containers/hypospray)
 	time = 40 SECONDS
@@ -829,7 +784,6 @@
 /datum/manufacture/prodocs
 	name = "ProDoc Healthgoggles"
 	item_paths = list("MET-1","CRY-1")
-	item_names = list("Metal","Crystal")
 	item_amounts = list(1,2)
 	item_outputs = list(/obj/item/clothing/glasses/healthgoggles)
 	time = 20 SECONDS
@@ -839,7 +793,6 @@
 /datum/manufacture/latex_gloves
 	name = "Latex Gloves"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(1)
 	item_outputs = list(/obj/item/clothing/gloves/latex)
 	time = 5 SECONDS
@@ -849,7 +802,6 @@
 /datum/manufacture/body_bag
 	name = "Body Bag"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(3)
 	item_outputs = list(/obj/item/body_bag)
 	time = 15 SECONDS
@@ -859,7 +811,6 @@
 /datum/manufacture/cyberheart
 	name = "Cyberheart"
 	item_paths = list("MET-1","CON-1","ALL")
-	item_names = list("Metal","Conductive Material","Any Material")
 	item_amounts = list(3,3,2)
 	item_outputs = list(/obj/item/organ/heart/cyber)
 	time = 25 SECONDS
@@ -869,7 +820,6 @@
 /datum/manufacture/cyberbutt
 	name = "Cyberbutt"
 	item_paths = list("MET-1","CON-1","ALL")
-	item_names = list("Metal","Conductive Material","Any Material")
 	item_amounts = list(2,2,2)
 	item_outputs = list(/obj/item/clothing/head/butt/cyberbutt)
 	time = 15 SECONDS
@@ -879,7 +829,6 @@
 /datum/manufacture/cyberappendix
 	name = "Cyberappendix"
 	item_paths = list("MET-1","CON-1","ALL")
-	item_names = list("Metal","Conductive Material","Any Material")
 	item_amounts = list(1,1,1)
 	item_outputs = list(/obj/item/organ/appendix/cyber)
 	time = 15 SECONDS
@@ -889,7 +838,6 @@
 /datum/manufacture/cyberpancreas
 	name = "Cyberpancreas"
 	item_paths = list("MET-1","CON-1","ALL")
-	item_names = list("Metal","Conductive Material","Any Material")
 	item_amounts = list(1,1,1)
 	item_outputs = list(/obj/item/organ/pancreas/cyber)
 	time = 15 SECONDS
@@ -899,7 +847,6 @@
 /datum/manufacture/cyberspleen
 	name = "Cyberspleen"
 	item_paths = list("MET-1","CON-1","ALL")
-	item_names = list("Metal","Conductive Material","Any Material")
 	item_amounts = list(1,1,1)
 	item_outputs = list(/obj/item/organ/spleen/cyber)
 	time = 15 SECONDS
@@ -909,7 +856,6 @@
 /datum/manufacture/cyberintestines
 	name = "Cyberintestines"
 	item_paths = list("MET-1","CON-1","ALL")
-	item_names = list("Metal","Conductive Material","Any Material")
 	item_amounts = list(1,1,1)
 	item_outputs = list(/obj/item/organ/intestines/cyber)
 	time = 15 SECONDS
@@ -919,7 +865,6 @@
 /datum/manufacture/cyberstomach
 	name = "Cyberstomach"
 	item_paths = list("MET-1","CON-1","ALL")
-	item_names = list("Metal","Conductive Material","Any Material")
 	item_amounts = list(1,1,1)
 	item_outputs = list(/obj/item/organ/stomach/cyber)
 	time = 15 SECONDS
@@ -929,7 +874,6 @@
 /datum/manufacture/cyberkidney
 	name = "Cyberkidney"
 	item_paths = list("MET-1","CON-1","ALL")
-	item_names = list("Metal","Conductive Material","Any Material")
 	item_amounts = list(1,1,1)
 	item_outputs = list(/obj/item/organ/kidney/cyber)
 	time = 15 SECONDS
@@ -939,7 +883,6 @@
 /datum/manufacture/cyberliver
 	name = "Cyberliver"
 	item_paths = list("MET-1","CON-1","ALL")
-	item_names = list("Metal","Conductive Material","Any Material")
 	item_amounts = list(1,1,1)
 	item_outputs = list(/obj/item/organ/liver/cyber)
 	time = 15 SECONDS
@@ -949,7 +892,6 @@
 /datum/manufacture/cyberlung_left
 	name = "Left Cyberlung"
 	item_paths = list("MET-1","CON-1","ALL")
-	item_names = list("Metal","Conductive Material","Any Material")
 	item_amounts = list(1,1,1)
 	item_outputs = list(/obj/item/organ/lung/cyber/left)
 	time = 15 SECONDS
@@ -959,7 +901,6 @@
 /datum/manufacture/cyberlung_right
 	name = "Right Cyberlung"
 	item_paths = list("MET-1","CON-1","ALL")
-	item_names = list("Metal","Conductive Material","Any Material")
 	item_amounts = list(1,1,1)
 	item_outputs = list(/obj/item/organ/lung/cyber/right)
 	time = 15 SECONDS
@@ -969,7 +910,6 @@
 /datum/manufacture/cybereye
 	name = "Cybereye"
 	item_paths = list("CRY-1","MET-1","CON-1","INS-1")
-	item_names = list("Crystal","Metal","Conductive Material","Insulative Material")
 	item_amounts = list(2,1,2,1)
 	item_outputs = list(/obj/item/organ/eye/cyber)
 	time = 20 SECONDS
@@ -979,7 +919,6 @@
 /datum/manufacture/cybereye_sunglass
 	name = "Polarized Cybereye"
 	item_paths = list("CRY-1","MET-1","CON-1","INS-1")
-	item_names = list("Crystal","Metal","Conductive Material","Insulative Material")
 	item_amounts = list(3,1,2,1)
 	item_outputs = list(/obj/item/organ/eye/cyber/sunglass)
 	time = 25 SECONDS
@@ -989,7 +928,6 @@
 /datum/manufacture/cybereye_sechud
 	name = "Security HUD Cybereye"
 	item_paths = list("CRY-1","MET-1","CON-1","INS-1")
-	item_names = list("Crystal","Metal","Conductive Material","Insulative Material")
 	item_amounts = list(3,1,2,1)
 	item_outputs = list(/obj/item/organ/eye/cyber/sechud)
 	time = 25 SECONDS
@@ -999,7 +937,6 @@
 /datum/manufacture/cybereye_thermal
 	name = "Thermal Imager Cybereye"
 	item_paths = list("CRY-1","MET-1","CON-1","INS-1")
-	item_names = list("Crystal","Metal","Conductive Material","Insulative Material")
 	item_amounts = list(3,1,2,1)
 	item_outputs = list(/obj/item/organ/eye/cyber/thermal)
 	time = 25 SECONDS
@@ -1009,7 +946,6 @@
 /datum/manufacture/cybereye_meson
 	name = "Mesonic Imager Cybereye"
 	item_paths = list("CRY-1","MET-1","CON-1","INS-1")
-	item_names = list("Crystal","Metal","Conductive Material","Insulative Material")
 	item_amounts = list(3,1,2,1)
 	item_outputs = list(/obj/item/organ/eye/cyber/meson)
 	time = 25 SECONDS
@@ -1019,7 +955,6 @@
 /datum/manufacture/cybereye_spectro
 	name = "Spectroscopic Imager Cybereye"
 	item_paths = list("CRY-1","MET-1","CON-1","INS-1")
-	item_names = list("Crystal","Metal","Conductive Material","Insulative Material")
 	item_amounts = list(3,1,2,1)
 	item_outputs = list(/obj/item/organ/eye/cyber/spectro)
 	time = 25 SECONDS
@@ -1029,7 +964,6 @@
 /datum/manufacture/cybereye_prodoc
 	name = "ProDoc Healthview Cybereye"
 	item_paths = list("CRY-1","MET-1","CON-1","INS-1")
-	item_names = list("Crystal","Metal","Conductive Material","Insulative Material")
 	item_amounts = list(3,1,2,1)
 	item_outputs = list(/obj/item/organ/eye/cyber/prodoc)
 	time = 25 SECONDS
@@ -1039,7 +973,6 @@
 /datum/manufacture/cybereye_camera
 	name = "Camera Cybereye"
 	item_paths = list("CRY-1","MET-1","CON-1","INS-1")
-	item_names = list("Crystal","Metal","Conductive Material","Insulative Material")
 	item_amounts = list(3,1,2,1)
 	item_outputs = list(/obj/item/organ/eye/cyber/camera)
 	time = 25 SECONDS
@@ -1049,7 +982,6 @@
 /datum/manufacture/cybereye_laser
 	name = "Laser Cybereye"
 	item_paths = list("CRY-1","MET-1","CON-1","INS-1","erebite")
-	item_names = list("Crystal","Metal","Conductive Material","Insulative Material","Erebite")
 	item_amounts = list(3,1,2,1,1)
 	item_outputs = list(/obj/item/organ/eye/cyber/laser)
 	time = 40 SECONDS
@@ -1059,7 +991,6 @@
 /datum/manufacture/implant_health
 	name = "Health Monitor Implant"
 	item_paths = list("CON-1","CRY-1")
-	item_names = list("Conductive Material","Crystal")
 	item_amounts = list(3,3)
 	item_outputs = list(/obj/item/implantcase/health)
 	time = 40 SECONDS
@@ -1069,7 +1000,6 @@
 /datum/manufacture/implant_antirot
 	name = "Rotbusttec Implant"
 	item_paths = list("CON-1","CRY-1")
-	item_names = list("Conductive Material","Crystal")
 	item_amounts = list(2,2)
 	item_outputs = list(/obj/item/implantcase/antirot)
 	time = 30 SECONDS
@@ -1081,7 +1011,6 @@
 /datum/manufacture/robo_frame
 	name = "Cyborg Frame"
 	item_paths = list("MET-2")
-	item_names = list("Sturdy Metal")
 	item_amounts = list(18)
 	item_outputs = list(/obj/item/parts/robot_parts/robot_frame)
 	time = 45 SECONDS
@@ -1091,7 +1020,6 @@
 /datum/manufacture/full_cyborg_standard
 	name = "Standard Cyborg Parts"
 	item_paths = list("MET-2")
-	item_names = list("Sturdy Metal")
 	item_amounts = list(48)
 	item_outputs = list(/obj/item/parts/robot_parts/chest,/obj/item/parts/robot_parts/head,
 /obj/item/parts/robot_parts/arm/right,/obj/item/parts/robot_parts/arm/left,
@@ -1103,7 +1031,6 @@
 /datum/manufacture/full_cyborg_light
 	name = "Light Cyborg Parts"
 	item_paths = list("MET-2")
-	item_names = list("Sturdy Metal")
 	item_amounts = list(24)
 	item_outputs = list(/obj/item/parts/robot_parts/chest/light,/obj/item/parts/robot_parts/head/light,
 /obj/item/parts/robot_parts/arm/right/light,/obj/item/parts/robot_parts/arm/left/light,
@@ -1115,7 +1042,6 @@
 /datum/manufacture/robo_chest
 	name = "Cyborg Chest"
 	item_paths = list("MET-2")
-	item_names = list("Sturdy Metal")
 	item_amounts = list(12)
 	item_outputs = list(/obj/item/parts/robot_parts/chest)
 	time = 30 SECONDS
@@ -1125,7 +1051,6 @@
 /datum/manufacture/robo_chest_light
 	name = "Light Cyborg Chest"
 	item_paths = list("MET-2")
-	item_names = list("Sturdy Metal")
 	item_amounts = list(6)
 	item_outputs = list(/obj/item/parts/robot_parts/chest/light)
 	time = 15 SECONDS
@@ -1135,7 +1060,6 @@
 /datum/manufacture/robo_head
 	name = "Cyborg Head"
 	item_paths = list("MET-2")
-	item_names = list("Sturdy Metal")
 	item_amounts = list(12)
 	item_outputs = list(/obj/item/parts/robot_parts/head)
 	time = 30 SECONDS
@@ -1145,7 +1069,6 @@
 /datum/manufacture/robo_head_light
 	name = "Light Cyborg Head"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(6)
 	item_outputs = list(/obj/item/parts/robot_parts/head/light)
 	time = 15 SECONDS
@@ -1155,7 +1078,6 @@
 /datum/manufacture/robo_arm_r
 	name = "Cyborg Arm (Right)"
 	item_paths = list("MET-2")
-	item_names = list("Sturdy Metal")
 	item_amounts = list(6)
 	item_outputs = list(/obj/item/parts/robot_parts/arm/right)
 	time = 15 SECONDS
@@ -1165,7 +1087,6 @@
 /datum/manufacture/robo_arm_r_light
 	name = "Light Cyborg Arm (Right)"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(3)
 	item_outputs = list(/obj/item/parts/robot_parts/arm/right/light)
 	time = 8 SECONDS
@@ -1175,7 +1096,6 @@
 /datum/manufacture/robo_arm_l
 	name = "Cyborg Arm (Left)"
 	item_paths = list("MET-2")
-	item_names = list("Sturdy Metal")
 	item_amounts = list(6)
 	item_outputs = list(/obj/item/parts/robot_parts/arm/left)
 	time = 15 SECONDS
@@ -1185,7 +1105,6 @@
 /datum/manufacture/robo_arm_l_light
 	name = "Light Cyborg Arm (Left)"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(3)
 	item_outputs = list(/obj/item/parts/robot_parts/arm/left/light)
 	time = 8 SECONDS
@@ -1195,7 +1114,6 @@
 /datum/manufacture/robo_leg_r
 	name = "Cyborg Leg (Right)"
 	item_paths = list("MET-2")
-	item_names = list("Sturdy Metal")
 	item_amounts = list(6)
 	item_outputs = list(/obj/item/parts/robot_parts/leg/right)
 	time = 15 SECONDS
@@ -1205,7 +1123,6 @@
 /datum/manufacture/robo_leg_r_light
 	name = "Light Cyborg Leg (Right)"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(3)
 	item_outputs = list(/obj/item/parts/robot_parts/leg/right/light)
 	time = 8 SECONDS
@@ -1215,7 +1132,6 @@
 /datum/manufacture/robo_leg_l
 	name = "Cyborg Leg (Left)"
 	item_paths = list("MET-2")
-	item_names = list("Sturdy Metal")
 	item_amounts = list(6)
 	item_outputs = list(/obj/item/parts/robot_parts/leg/left)
 	time = 15 SECONDS
@@ -1225,7 +1141,6 @@
 /datum/manufacture/robo_leg_l_light
 	name = "Light Cyborg Leg (Left)"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(3)
 	item_outputs = list(/obj/item/parts/robot_parts/leg/left/light)
 	time = 8 SECONDS
@@ -1235,7 +1150,6 @@
 /datum/manufacture/robo_leg_treads
 	name = "Cyborg Treads"
 	item_paths = list("MET-2","CON-1")
-	item_names = list("Sturdy Metal","Conductive Material")
 	item_amounts = list(12,6)
 	item_outputs = list(/obj/item/parts/robot_parts/leg/left/treads, /obj/item/parts/robot_parts/leg/right/treads)//list(/obj/item/parts/robot_parts/leg/treads)
 	time = 15 SECONDS
@@ -1245,7 +1159,6 @@
 /datum/manufacture/robo_module
 	name = "Blank Cyborg Module"
 	item_paths = list("CON-1","ALL")
-	item_names = list("Conductive Material","Any Material")
 	item_amounts = list(2,3)
 	item_outputs = list(/obj/item/robot_module)
 	time = 40 SECONDS
@@ -1255,7 +1168,6 @@
 /datum/manufacture/powercell
 	name = "Power Cell"
 	item_paths = list("MET-1","CON-1","ALL")
-	item_names = list("Metal","Conductive Material","Any Material")
 	item_amounts = list(4,4,4)
 	item_outputs = list(/obj/item/cell/supercell)
 	time = 30 SECONDS
@@ -1265,7 +1177,6 @@
 /datum/manufacture/powercellE
 	name = "Erebite Power Cell"
 	item_paths = list("MET-1","ALL","erebite")
-	item_names = list("Metal","Any Material","Erebite")
 	item_amounts = list(4,4,2)
 	item_outputs = list(/obj/item/cell/erebite)
 	time = 45 SECONDS
@@ -1275,7 +1186,6 @@
 /datum/manufacture/powercellC
 	name = "Cerenkite Power Cell"
 	item_paths = list("MET-1","ALL","cerenkite")
-	item_names = list("Metal","Any Material","Cerenkite")
 	item_amounts = list(4,4,2)
 	item_outputs = list(/obj/item/cell/cerenkite)
 	time = 45 SECONDS
@@ -1285,7 +1195,6 @@
 /datum/manufacture/core_frame
 	name = "AI Core Frame"
 	item_paths = list("MET-2")
-	item_names = list("Sturdy Metal")
 	item_amounts = list(20)
 	item_outputs = list(/obj/ai_core_frame)
 	time = 50 SECONDS
@@ -1295,7 +1204,6 @@
 /datum/manufacture/shell_frame
 	name = "AI Shell Frame"
 	item_paths = list("MET-2")
-	item_names = list("Sturdy Metal")
 	item_amounts = list(12)
 	item_outputs = list(/obj/item/shell_frame)
 	time = 25 SECONDS
@@ -1305,7 +1213,6 @@
 /datum/manufacture/ai_interface
 	name = "AI Interface Board"
 	item_paths = list("MET-2","CON-1","CRY-1")
-	item_names = list("Sturdy Metal","Conductive Material","Crystal")
 	item_amounts = list(3,5,2)
 	item_outputs = list(/obj/item/ai_interface)
 	time = 35 SECONDS
@@ -1315,7 +1222,6 @@
 /datum/manufacture/latejoin_brain
 	name = "Spontaneous Intelligence Creation Core"
 	item_paths = list("MET-1","CON-1","ALL")
-	item_names = list("Metal","Conductive Material","Any Material")
 	item_amounts = list(6,5,3)
 	item_outputs = list(/obj/item/organ/brain/latejoin)
 	time = 35 SECONDS
@@ -1325,7 +1231,6 @@
 /datum/manufacture/shell_cell
 	name = "AI Shell Power Cell"
 	item_paths = list("MET-1","CON-1","ALL")
-	item_names = list("Metal","Conductive Material","Any Material")
 	item_amounts = list(2,2,1)
 	item_outputs = list(/obj/item/cell/shell_cell)
 	time = 20 SECONDS
@@ -1335,7 +1240,6 @@
 /datum/manufacture/flash
 	name = "Flash"
 	item_paths = list("CRY-1","CON-1")
-	item_names = list("Crystal","Conductive Material")
 	item_amounts = list(2,2)
 	item_outputs = list(/obj/item/device/flash)
 	time = 15 SECONDS
@@ -1347,7 +1251,6 @@
 /datum/manufacture/implanter
 	name = "Implanter"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(1)
 	item_outputs = list(/obj/item/implanter)
 	time = 3 SECONDS
@@ -1357,7 +1260,6 @@
 /datum/manufacture/secbot
 	name = "Security Drone"
 	item_paths = list("MET-2","CON-2","POW-1")
-	item_names = list("Sturdy Metal","High Energy Conductor","Power Source")
 	item_amounts = list(30,20,20)
 	item_outputs = list(/obj/machinery/bot/secbot)
 	time = 120 SECONDS
@@ -1367,7 +1269,6 @@
 /datum/manufacture/floorbot
 	name = "Construction Drone"
 	item_paths = list("MET-1","CON-1","ALL")
-	item_names = list("Metal","Conductive Material","Any Material")
 	item_amounts = list(15,10,5)
 	item_outputs = list(/obj/machinery/bot/floorbot)
 	time = 60 SECONDS
@@ -1377,7 +1278,6 @@
 /datum/manufacture/medbot
 	name = "Medical Drone"
 	item_paths = list("MET-1","CON-1","POW-1")
-	item_names = list("Metal","Conductive Material","Power Source")
 	item_amounts = list(20,15,5)
 	item_outputs = list(/obj/machinery/bot/medbot)
 	time = 90 SECONDS
@@ -1387,7 +1287,6 @@
 /datum/manufacture/firebot
 	name = "Firefighting Drone"
 	item_paths = list("MET-1","CON-1","ALL")
-	item_names = list("Metal","Conductive Material","Any Material")
 	item_amounts = list(15,10,5)
 	item_outputs = list(/obj/machinery/bot/firebot)
 	time = 60 SECONDS
@@ -1397,7 +1296,6 @@
 /datum/manufacture/cleanbot
 	name = "Sanitation Drone"
 	item_paths = list("MET-1","CON-1","ALL")
-	item_names = list("Metal","Conductive Material","Any Material")
 	item_amounts = list(15,10,5)
 	item_outputs = list(/obj/machinery/bot/cleanbot)
 	time = 60 SECONDS
@@ -1407,7 +1305,6 @@
 /datum/manufacture/digbot
 	name = "Mining Drone"
 	item_paths = list("MET-1","MET-2","CON-1","ALL")
-	item_names = list("Metal","Sturdy Metal","Conductive Material","Any Material")
 	item_amounts = list(15,5,10,5)
 	item_outputs = list(/obj/machinery/bot/mining)
 	time = 0 SECONDS
@@ -1417,7 +1314,6 @@
 /datum/manufacture/robup_jetpack
 	name = "Propulsion Upgrade"
 	item_paths = list("CON-1","MET-1")
-	item_names = list("Conductive Material","Sturdy Metal")
 	item_amounts = list(3,5)
 	item_outputs = list(/obj/item/roboupgrade/jetpack)
 	time = 60 SECONDS
@@ -1427,7 +1323,6 @@
 /datum/manufacture/robup_speed
 	name = "Speed Upgrade"
 	item_paths = list("CON-1","CRY-1")
-	item_names = list("Conductive Material","Crystal")
 	item_amounts = list(3,5)
 	item_outputs = list(/obj/item/roboupgrade/speed)
 	time = 60 SECONDS
@@ -1437,7 +1332,6 @@
 /datum/manufacture/robup_recharge
 	name = "Recharge Pack"
 	item_paths = list("CON-1")
-	item_names = list("Conductive Material")
 	item_amounts = list(5)
 	item_outputs = list(/obj/item/roboupgrade/rechargepack)
 	time = 60 SECONDS
@@ -1447,7 +1341,6 @@
 /datum/manufacture/robup_repairpack
 	name = "Repair Pack"
 	item_paths = list("CON-1")
-	item_names = list("Conductive Material")
 	item_amounts = list(5)
 	item_outputs = list(/obj/item/roboupgrade/repairpack)
 	time = 60 SECONDS
@@ -1457,7 +1350,6 @@
 /datum/manufacture/robup_physshield
 	name = "Force Shield Upgrade"
 	item_paths = list("CON-2", "MET-2", "POW-2")
-	item_names = list("High Energy Conductor","Sturdy Metal","Significant Power Source")
 	item_amounts = list(2,10,2)
 	item_outputs = list(/obj/item/roboupgrade/physshield)
 	time = 90 SECONDS
@@ -1467,7 +1359,6 @@
 /datum/manufacture/robup_fireshield
 	name = "Heat Shield Upgrade"
 	item_paths = list("CON-2","CRY-1")
-	item_names = list("High Energy Conductor","Crystal")
 	item_amounts = list(2,10)
 	item_outputs = list(/obj/item/roboupgrade/fireshield)
 	time = 90 SECONDS
@@ -1477,7 +1368,6 @@
 /datum/manufacture/robup_aware
 	name = "Recovery Upgrade"
 	item_paths = list("CON-2","CRY-1","CON-1")
-	item_names = list("High Energy Conductor","Crystal","Conductive Material")
 	item_amounts = list(2,5,5)
 	item_outputs = list(/obj/item/roboupgrade/aware)
 	time = 90 SECONDS
@@ -1487,7 +1377,6 @@
 /datum/manufacture/robup_efficiency
 	name = "Efficiency Upgrade"
 	item_paths = list("DEN-1","CON-2")
-	item_names = list("High Density Crystalline Matter","High Energy Conductor")
 	item_amounts = list(3,10)
 	item_outputs = list(/obj/item/roboupgrade/efficiency)
 	time = 120 SECONDS
@@ -1497,7 +1386,6 @@
 /datum/manufacture/robup_repair
 	name = "Self-Repair Upgrade"
 	item_paths = list("DEN-1","MET-3")
-	item_names = list("High Density Crystalline Matter","Dense Metal")
 	item_amounts = list(3,10)
 	item_outputs = list(/obj/item/roboupgrade/repair)
 	time = 120 SECONDS
@@ -1507,7 +1395,6 @@
 /datum/manufacture/robup_teleport
 	name = "Teleport Upgrade"
 	item_paths = list("CON-1","DEN-1", "POW-2") //Okay enough roundstart teleportborgs. Fuck.
-	item_names = list("Conductive Material","High Density Crystalline Matter", "Significant Power Source")
 	item_amounts = list(10,1, 10)
 	item_outputs = list(/obj/item/roboupgrade/teleport)
 	time = 120 SECONDS
@@ -1517,7 +1404,6 @@
 /datum/manufacture/robup_expand
 	name = "Expansion Upgrade"
 	item_paths = list("DEN-3","POW-3")
-	item_names = list("Extraordinarily Dense Crystalline Matter","Extreme Power Source")
 	item_amounts = list(3,1)
 	item_outputs = list(/obj/item/roboupgrade/expand)
 	time = 120 SECONDS
@@ -1527,7 +1413,6 @@
 /datum/manufacture/robup_meson
 	name = "Optical Meson Upgrade"
 	item_paths = list("CRY-1","CON-1")
-	item_names = list("Crystal","Conductive Material")
 	item_amounts = list(2,4)
 	item_outputs = list(/obj/item/roboupgrade/opticmeson)
 	time = 90 SECONDS
@@ -1537,7 +1422,6 @@
 /datum/manufacture/robup_thermal
 	name = "Optical Thermal Upgrade"
 	item_paths = list("CRY-1","CON-1")
-	item_names = list("Crystal","Conductive Material")
 	item_amounts = list(4,8)
 	item_outputs = list(/obj/item/roboupgrade/opticthermal)
 	time = 90 SECONDS
@@ -1547,7 +1431,6 @@
 /datum/manufacture/robup_healthgoggles
 	name = "ProDoc Healthgoggle Upgrade"
 	item_paths = list("CRY-1","CON-1")
-	item_names = list("Crystal","Conductive Material")
 	item_amounts = list(4,6)
 	item_outputs = list(/obj/item/roboupgrade/healthgoggles)
 	time = 90 SECONDS
@@ -1557,7 +1440,6 @@
 /datum/manufacture/robup_sechudgoggles
 	name = "Security HUD Upgrade"
 	item_paths = list("CRY-1","CON-1")
-	item_names = list("Crystal","Conductive Material")
 	item_amounts = list(4,6)
 	item_outputs = list(/obj/item/roboupgrade/sechudgoggles)
 	time = 90 SECONDS
@@ -1567,7 +1449,6 @@
 /datum/manufacture/robup_spectro
 	name = "Spectroscopic Scanner Upgrade"
 	item_paths = list("CRY-1","CON-1")
-	item_names = list("Crystal","Conductive Material")
 	item_amounts = list(4,6)
 	item_outputs = list(/obj/item/roboupgrade/spectro)
 	time = 90 SECONDS
@@ -1577,7 +1458,6 @@
 /datum/manufacture/robup_visualizer
 	name = "Construction Visualizer"
 	item_paths = list("CRY-1","CON-1")
-	item_names = list("Crystal","Conductive Material")
 	item_amounts = list(4,6)
 	item_outputs = list(/obj/item/roboupgrade/visualizer)
 	time = 90 SECONDS
@@ -1587,7 +1467,6 @@
 /datum/manufacture/implant_robotalk
 	name = "Machine Translator Implant"
 	item_paths = list("CON-1","CRY-1")
-	item_names = list("Conductive Material","Crystal")
 	item_amounts = list(3,3)
 	item_outputs = list(/obj/item/implantcase/robotalk)
 	time = 40 SECONDS
@@ -1598,7 +1477,6 @@
 /datum/manufacture/sbradio
 	name = "Station Bounced Radio"
 	item_paths = list("CON-1","CRY-1")
-	item_names = list("Conductive Material","Crystal")
 	item_amounts = list(2,2)
 	item_outputs = list(/obj/item/device/radio)
 	time = 20 SECONDS
@@ -1608,7 +1486,6 @@
 /datum/manufacture/thrusters
 	name = "Alastor Pattern Thrusters "
 	item_paths = list("MET-2")
-	item_names = list("Sturdy Metal")
 	item_amounts = list(50)
 	item_outputs = list(/obj/item/parts/robot_parts/leg/right/thruster,/obj/item/parts/robot_parts/leg/left/thruster)
 	time = 120 SECONDS
@@ -1624,7 +1501,6 @@
 /datum/manufacture/mining_magnet
 	name = "Mining Magnet Replacement Parts"
 	item_paths = list("DEN-1","MET-3","CON-2")
-	item_names = list("High Density Crystalline Matter","Dense Metal","High Energy Conductor")
 	item_amounts = list(5,30,30)
 	item_outputs = list(/obj/item/magnet_parts)
 	time = 120 SECONDS
@@ -1634,7 +1510,6 @@
 /datum/manufacture/pick
 	name = "Pickaxe"
 	item_paths = list("MET-2")
-	item_names = list("Sturdy Metal")
 	item_amounts = list(1)
 	item_outputs = list(/obj/item/mining_tool)
 	time = 5 SECONDS
@@ -1644,7 +1519,6 @@
 /datum/manufacture/powerpick
 	name = "Powered Pick"
 	item_paths = list("MET-2","CON-1")
-	item_names = list("Sturdy Metal","Conductive Material")
 	item_amounts = list(2,5)
 	item_outputs = list(/obj/item/mining_tool/power_pick)
 	time = 10 SECONDS
@@ -1654,7 +1528,6 @@
 /datum/manufacture/blastchargeslite
 	name = "Low-Yield Mining Explosives (x5)"
 	item_paths = list("MET-1","CRY-1","CON-1")
-	item_names = list("Metal","Crystal","Conductive Material")
 	item_amounts = list(3,3,7)
 	item_outputs = list(/obj/item/breaching_charge/mining/light)
 	time = 40 SECONDS
@@ -1664,7 +1537,6 @@
 /datum/manufacture/blastcharges
 	name = "Mining Explosives (x5)"
 	item_paths = list("MET-1","CRY-1","CON-1")
-	item_names = list("Metal","Crystal","Conductive Material")
 	item_amounts = list(7,7,15)
 	item_outputs = list(/obj/item/breaching_charge/mining)
 	time = 60 SECONDS
@@ -1674,7 +1546,6 @@
 /datum/manufacture/powerhammer
 	name = "Power Hammer"
 	item_paths = list("DEN-1","CON-1")
-	item_names = list("High Density Crystalline Matter","Conductive Material")
 	item_amounts = list(1,8)
 	item_outputs = list(/obj/item/mining_tool/powerhammer)
 	time = 70 SECONDS
@@ -1684,7 +1555,6 @@
 /datum/manufacture/drill
 	name = "Laser Drill"
 	item_paths = list("MET-2","MET-3","CON-2")
-	item_names = list("Sturdy Metal","Dense Metal","High Energy Conductor")
 	item_amounts = list(15,7,10)
 	item_outputs = list(/obj/item/mining_tool/drill)
 	time = 90 SECONDS
@@ -1694,7 +1564,6 @@
 /datum/manufacture/conc_gloves
 	name = "Concussive Gauntlets"
 	item_paths = list("MET-3","CON-2","POW-1")
-	item_names = list("Dense Metal","High Energy Conductor","Power Source")
 	item_amounts = list(15,15,2)
 	item_outputs = list(/obj/item/clothing/gloves/concussive)
 	time = 120 SECONDS
@@ -1704,7 +1573,6 @@
 /datum/manufacture/ore_accumulator
 	name = "Mineral Accumulator"
 	item_paths = list("MET-2","CON-2","DEN-1")
-	item_names = list("Sturdy Metal","High Energy Conductor","High Density Crystalline Matter")
 	item_amounts = list(25,15,2)
 	item_outputs = list(/obj/machinery/oreaccumulator)
 	time = 120 SECONDS
@@ -1714,7 +1582,6 @@
 /datum/manufacture/eyes_meson
 	name = "Optical Meson Scanner"
 	item_paths = list("CRY-1","CON-1")
-	item_names = list("Crystal","Conductive Material")
 	item_amounts = list(3,2)
 	item_outputs = list(/obj/item/clothing/glasses/meson)
 	time = 10 SECONDS
@@ -1724,7 +1591,6 @@
 /datum/manufacture/geoscanner
 	name = "Geological Scanner"
 	item_paths = list("MET-1","CON-1","CRY-1")
-	item_names = list("Metal","Conductive Material","Crystal")
 	item_amounts = list(1,1,1)
 	item_outputs = list(/obj/item/oreprospector)
 	time = 8 SECONDS
@@ -1734,7 +1600,6 @@
 /datum/manufacture/geigercounter
 	name = "Geiger Counter"
 	item_paths = list("MET-1","CON-1","CRY-1")
-	item_names = list("Metal","Conductive Material","Crystal")
 	item_amounts = list(1,1,1)
 	item_outputs = list(/obj/item/device/geiger)
 	time = 8 SECONDS
@@ -1744,7 +1609,6 @@
 /datum/manufacture/industrialarmor
 	name = "Industrial Space Armor Set"
 	item_paths = list("MET-3","CON-2","DEN-2")
-	item_names = list("Dense Metal","High Energy Conductor","Very High Density Crystalline Matter")
 	item_amounts = list(15,7,3)
 	item_outputs = list(/obj/item/clothing/suit/space/industrial,/obj/item/clothing/head/helmet/space/industrial)
 	time = 90 SECONDS
@@ -1754,7 +1618,6 @@
 /datum/manufacture/industrialboots
 	name = "Mechanised Boots"
 	item_paths = list("MET-2","CON-2","POW-1")
-	item_names = list("Sturdy Metal","High Energy Conductor","Power Source")
 	item_amounts = list(15,7,3)
 	item_outputs = list(/obj/item/clothing/shoes/industrial)
 	time = 40 SECONDS
@@ -1764,7 +1627,6 @@
 /datum/manufacture/jetpackmkII
 	name = "Jetpack MKII"
 	item_paths = list("MET-2","CON-2","POW-1")
-	item_names = list("Sturdy Metal","High Energy Conductor","Power Source")
 	item_amounts = list(15,10,5)
 	item_outputs = list(/obj/item/tank/jetpack/jetpackmk2)
 	time = 40 SECONDS
@@ -1774,7 +1636,6 @@
 /datum/manufacture/breathmask
 	name = "Breath Mask"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(1)
 	item_outputs = list(/obj/item/clothing/mask/breath)
 	time = 5 SECONDS
@@ -1784,7 +1645,6 @@
 /datum/manufacture/patch
 	name = "Chemical Patch"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(1)
 	item_outputs = list(/obj/item/reagent_containers/patch)
 	time = 5 SECONDS
@@ -1794,7 +1654,6 @@
 /datum/manufacture/mender
 	name = "Auto Mender"
 	item_paths = list("MET-1","CRY-1")
-	item_names = list("Metal","Crystal")
 	item_amounts = list(3,4)
 	item_outputs = list(/obj/item/reagent_containers/mender)
 	time = 10 SECONDS
@@ -1804,7 +1663,6 @@
 /datum/manufacture/spacesuit
 	name = "Space Suit Set"
 	item_paths = list("FAB-1","MET-1","CRY-1")
-	item_names = list("Fabric","Metal","Crystal")
 	item_amounts = list(3,3,2)
 	item_outputs = list(/obj/item/clothing/suit/space,/obj/item/clothing/head/helmet/space)
 	time = 15 SECONDS
@@ -1814,7 +1672,6 @@
 /datum/manufacture/engspacesuit
 	name = "Engineering Space Suit Set"
 	item_paths = list("FAB-1","MET-1","CRY-1")
-	item_names = list("Fabric","Metal","Crystal")
 	item_amounts = list(3,3,2)
 	item_outputs = list(/obj/item/clothing/suit/space/engineer,/obj/item/clothing/head/helmet/space/engineer)
 	time = 15 SECONDS
@@ -1824,7 +1681,6 @@
 /datum/manufacture/oresatchel
 	name = "Ore Satchel"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(5)
 	item_outputs = list(/obj/item/satchel/mining)
 	time = 5 SECONDS
@@ -1834,7 +1690,6 @@
 /datum/manufacture/oresatchelL
 	name = "Large Ore Satchel"
 	item_paths = list("FAB-1","MET-3")
-	item_names = list("Fabric","Dense Metal")
 	item_amounts = list(25,3)
 	item_outputs = list(/obj/item/satchel/mining/large)
 	time = 15 SECONDS
@@ -1844,7 +1699,6 @@
 /datum/manufacture/jetpack
 	name = "Jetpack"
 	item_paths = list("MET-3","CON-1")
-	item_names = list("Dense Metal","Conductive Material")
 	item_amounts = list(2,10)
 	item_outputs = list(/obj/item/tank/jetpack)
 	time = 60 SECONDS
@@ -1856,7 +1710,6 @@
 /datum/manufacture/engine
 	name = "Warp-1 Engine"
 	item_paths = list("MET-2","CON-1")
-	item_names = list("Sturdy Metal","Conductive Material")
 	item_amounts = list(3,5)
 	item_outputs = list(/obj/item/shipcomponent/engine)
 	time = 10 SECONDS
@@ -1866,7 +1719,6 @@
 /datum/manufacture/engine2
 	name = "Helios Mark-II Engine"
 	item_paths = list("MET-2","MET-3","CON-2")
-	item_names = list("Sturdy Metal","Dense Metal","High Energy Conductor")
 	item_amounts = list(20,10,15)
 	item_outputs = list(/obj/item/shipcomponent/engine/helios)
 	time = 90 SECONDS
@@ -1876,7 +1728,6 @@
 /datum/manufacture/engine3
 	name = "Hermes 3.0 Engine"
 	item_paths = list("MET-3","CON-2","POW-1")
-	item_names = list("Dense Metal","High Energy Conductor","Power Source")
 	item_amounts = list(20,20,5)
 	item_outputs = list(/obj/item/shipcomponent/engine/hermes)
 	time = 120 SECONDS
@@ -1887,7 +1738,6 @@
 /datum/manufacture/gps
 	name = "Ship's Navigation GPS"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(2)
 	item_outputs = list(/obj/item/shipcomponent/secondary_system/gps)
 	time = 12 SECONDS
@@ -1897,7 +1747,6 @@
 /datum/manufacture/cargohold
 	name = "Cargo Hold"
 	item_paths = list("MET-2")
-	item_names = list("Sturdy Metal")
 	item_amounts = list(20)
 	item_outputs = list(/obj/item/shipcomponent/secondary_system/cargo)
 	time = 12 SECONDS
@@ -1907,7 +1756,6 @@
 /datum/manufacture/orescoop
 	name = "Alloyed Solutions Ore Scoop/Hold"
 	item_paths = list("MET-2","CON-1")
-	item_names = list("Sturdy Metal", "Conductive Material")
 	item_amounts = list(20, 10)
 	item_outputs = list(/obj/item/shipcomponent/secondary_system/orescoop)
 	time = 12 SECONDS
@@ -1917,7 +1765,6 @@
 /datum/manufacture/communications/mining
 	name = "NT Magnet Link Array"
 	item_paths = list("MET-2","CON-1")
-	item_names = list("Sturdy Metal", "Conductive Material")
 	item_amounts = list(10, 20)
 	item_outputs = list(/obj/item/shipcomponent/communications/mining)
 	time = 12 SECONDS
@@ -1927,7 +1774,6 @@
 /datum/manufacture/conclave
 	name = "Conclave A-1984 Sensor System"
 	item_paths = list("POW-1","CRY-1","CON-2")
-	item_names = list("Power Source","Crystal","High Energy Conductor")
 	item_amounts = list(1,5,2)
 	item_outputs = list(/obj/item/shipcomponent/sensor/mining)
 	time = 5 SECONDS
@@ -1937,7 +1783,6 @@
 /datum/manufacture/shipRCD
 	name = "Duracorp Construction Device"
 	item_paths = list("MET-3","DEN-1","CON-1")
-	item_names = list("Dense Metal","High Density Crystalline Matter","Conductive Material")
 	item_amounts = list(5,1,10)
 	item_outputs = list(/obj/item/shipcomponent/secondary_system/cargo)
 	time = 90 SECONDS
@@ -1949,7 +1794,6 @@
 /datum/manufacture/backpack
 	name = "Backpack"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(8)
 	item_outputs = list(/obj/item/storage/backpack)
 	time = 10 SECONDS
@@ -1959,7 +1803,6 @@
 /datum/manufacture/satchel
 	name = "Satchel"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(8)
 	item_outputs = list(/obj/item/storage/backpack/satchel)
 	time = 10 SECONDS
@@ -1969,7 +1812,6 @@
 /datum/manufacture/shoes_brown
 	name = "Brown Shoes"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(2)
 	item_outputs = list(/obj/item/clothing/shoes/brown)
 	time = 2 SECONDS
@@ -1979,7 +1821,6 @@
 /datum/manufacture/hat_white
 	name = "White Hat"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(2)
 	item_outputs = list(/obj/item/clothing/head/white)
 	time = 2 SECONDS
@@ -1989,7 +1830,6 @@
 /datum/manufacture/hat_black
 	name = "Black Hat"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(2)
 	item_outputs = list(/obj/item/clothing/head/black)
 	time = 2 SECONDS
@@ -1999,7 +1839,6 @@
 /datum/manufacture/hat_blue
 	name = "Blue Hat"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(2)
 	item_outputs = list(/obj/item/clothing/head/blue)
 	time = 2 SECONDS
@@ -2009,7 +1848,6 @@
 /datum/manufacture/hat_red
 	name = "Red Hat"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(2)
 	item_outputs = list(/obj/item/clothing/head/red)
 	time = 2 SECONDS
@@ -2019,7 +1857,6 @@
 /datum/manufacture/hat_green
 	name = "Green Hat"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(2)
 	item_outputs = list(/obj/item/clothing/head/green)
 	time = 2 SECONDS
@@ -2029,7 +1866,6 @@
 /datum/manufacture/hat_yellow
 	name = "Yellow Hat"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(2)
 	item_outputs = list(/obj/item/clothing/head/yellow)
 	time = 2 SECONDS
@@ -2039,7 +1875,6 @@
 /datum/manufacture/hat_pink
 	name = "Pink Hat"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(2)
 	item_outputs = list(/obj/item/clothing/head/pink)
 	time = 2 SECONDS
@@ -2049,7 +1884,6 @@
 /datum/manufacture/hat_orange
 	name = "Orange Hat"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(2)
 	item_outputs = list(/obj/item/clothing/head/orange)
 	time = 2 SECONDS
@@ -2059,7 +1893,6 @@
 /datum/manufacture/hat_tophat
 	name = "Top Hat"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(3)
 	item_outputs = list(/obj/item/clothing/head/that)
 	time = 3 SECONDS
@@ -2069,7 +1902,6 @@
 /datum/manufacture/hat_ltophat
 	name = "Large Top Hat"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(5)
 	item_outputs = list(/obj/item/clothing/head/longtophat)
 	time = 5 SECONDS
@@ -2079,7 +1911,6 @@
 /datum/manufacture/jumpsuit_white
 	name = "White Jumpsuit"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(4)
 	item_outputs = list(/obj/item/clothing/under/color/white)
 	time = 5 SECONDS
@@ -2089,7 +1920,6 @@
 /datum/manufacture/jumpsuit_red
 	name = "Red Jumpsuit"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(4)
 	item_outputs = list(/obj/item/clothing/under/color/red)
 	time = 5 SECONDS
@@ -2099,7 +1929,6 @@
 /datum/manufacture/jumpsuit_yellow
 	name = "Yellow Jumpsuit"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(4)
 	item_outputs = list(/obj/item/clothing/under/color/yellow)
 	time = 5 SECONDS
@@ -2109,7 +1938,6 @@
 /datum/manufacture/jumpsuit_green
 	name = "Green Jumpsuit"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(4)
 	item_outputs = list(/obj/item/clothing/under/color/green)
 	time = 5 SECONDS
@@ -2119,7 +1947,6 @@
 /datum/manufacture/jumpsuit_pink
 	name = "Pink Jumpsuit"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(4)
 	item_outputs = list(/obj/item/clothing/under/color/pink)
 	time = 5 SECONDS
@@ -2129,7 +1956,6 @@
 /datum/manufacture/jumpsuit_blue
 	name = "Blue Jumpsuit"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(4)
 	item_outputs = list(/obj/item/clothing/under/color/blue)
 	time = 5 SECONDS
@@ -2139,7 +1965,6 @@
 /datum/manufacture/jumpsuit_brown
 	name = "Brown Jumpsuit"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(4)
 	item_outputs = list(/obj/item/clothing/under/color/brown)
 	time = 5 SECONDS
@@ -2149,7 +1974,6 @@
 /datum/manufacture/jumpsuit_black
 	name = "Black Jumpsuit"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(4)
 	item_outputs = list(/obj/item/clothing/under/color)
 	time = 5 SECONDS
@@ -2159,7 +1983,6 @@
 /datum/manufacture/jumpsuit_orange
 	name = "Orange Jumpsuit"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(4)
 	item_outputs = list(/obj/item/clothing/under/color/orange)
 	time = 5 SECONDS
@@ -2169,7 +1992,6 @@
 /datum/manufacture/suit_black
 	name = "Fancy Black Suit"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(4)
 	item_outputs = list(/obj/item/clothing/under/suit)
 	time = 5 SECONDS
@@ -2179,7 +2001,6 @@
 /datum/manufacture/dress_black
 	name = "Fancy Black Dress"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(4)
 	item_outputs = list(/obj/item/clothing/under/suit/dress)
 	time = 5 SECONDS
@@ -2189,7 +2010,6 @@
 /datum/manufacture/labcoat
 	name = "Labcoat"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(4)
 	item_outputs = list(/obj/item/clothing/suit/labcoat)
 	time = 5 SECONDS
@@ -2199,7 +2019,6 @@
 /datum/manufacture/scrubs_white
 	name = "White Scrubs"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(4)
 	item_outputs = list(/obj/item/clothing/under/scrub)
 	time = 5 SECONDS
@@ -2209,7 +2028,6 @@
 /datum/manufacture/scrubs_teal
 	name = "Teal Scrubs"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(4)
 	item_outputs = list(/obj/item/clothing/under/scrub/teal)
 	time = 5 SECONDS
@@ -2219,7 +2037,6 @@
 /datum/manufacture/scrubs_maroon
 	name = "Maroon Scrubs"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(4)
 	item_outputs = list(/obj/item/clothing/under/scrub/maroon)
 	time = 5 SECONDS
@@ -2229,7 +2046,6 @@
 /datum/manufacture/scrubs_blue
 	name = "Blue Scrubs"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(4)
 	item_outputs = list(/obj/item/clothing/under/scrub/blue)
 	time = 5 SECONDS
@@ -2239,7 +2055,6 @@
 /datum/manufacture/scrubs_purple
 	name = "Purple Scrubs"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(4)
 	item_outputs = list(/obj/item/clothing/under/scrub/purple)
 	time = 5 SECONDS
@@ -2249,7 +2064,6 @@
 /datum/manufacture/scrubs_orange
 	name = "Orange Scrubs"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(4)
 	item_outputs = list(/obj/item/clothing/under/scrub/orange)
 	time = 5 SECONDS
@@ -2259,7 +2073,6 @@
 /datum/manufacture/scrubs_pink
 	name = "Pink Scrubs"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(4)
 	item_outputs = list(/obj/item/clothing/under/scrub/pink)
 	time = 5 SECONDS
@@ -2269,7 +2082,6 @@
 /datum/manufacture/patient_gown
 	name = "Gown"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(4)
 	item_outputs = list(/obj/item/clothing/under/patient_gown)
 	time = 5 SECONDS
@@ -2279,7 +2091,6 @@
 /datum/manufacture/surgical_mask
 	name = "Sterile Mask"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(1)
 	item_outputs = list(/obj/item/clothing/mask/surgical)
 	time = 5 SECONDS
@@ -2289,7 +2100,6 @@
 /datum/manufacture/surgical_shield
 	name = "Surgical Face Shield"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(1)
 	item_outputs = list(/obj/item/clothing/mask/surgical_shield)
 	time = 5 SECONDS
@@ -2299,7 +2109,6 @@
 /datum/manufacture/blindfold
 	name = "Blindfold"
 	item_paths = list("FAB-1")
-	item_names = list("Fabric")
 	item_amounts = list(4)
 	item_outputs = list(/obj/item/clothing/glasses/blindfold)
 	time = 5 SECONDS
@@ -2309,7 +2118,6 @@
 /datum/manufacture/muzzle
 	name = "Muzzle"
 	item_paths = list("FAB-1", "MET-1")
-	item_names = list("Fabric", "Metal")
 	item_amounts = list(4, 2)
 	item_outputs = list(/obj/item/clothing/mask/muzzle)
 	time = 5 SECONDS
@@ -2319,7 +2127,6 @@
 /datum/manufacture/hermes
 	name = "Offering to the Fabricator Gods"
 	item_paths = list("MET-3","CON-2","POW-3","DEN-3","FAB-1","INS-1")
-	item_names = list("Dense Metal","High Energy Conductor","Extreme Power Source","Extraordinarily Dense Crystalline Matter","Fabric","Insulative Material")
 	item_amounts = list(30,30,6,1,30,30)
 	item_outputs = list(/obj/item/clothing/shoes/hermes)
 	time = 120 //suspense
@@ -2331,7 +2138,6 @@
 /datum/manufacture/pod/parts
 	name = "Pod Frame Kit"
 	item_paths = list("MET-2")
-	item_names = list("Sturdy Metal")
 	item_amounts = list(30)
 	item_outputs = list(/obj/item/pod/frame_box)
 	time = 20 SECONDS
@@ -2341,7 +2147,6 @@
 /datum/manufacture/pod/engine
 	name = "Engine Manifold"
 	item_paths = list("MET-2","CON-1")
-	item_names = list("Sturdy Metal","Conductive Material")
 	item_amounts = list(10,5)
 	item_outputs = list(/obj/item/pod/engine)
 	time = 10 SECONDS
@@ -2351,7 +2156,6 @@
 /datum/manufacture/pod/boards
 	name = "Pod Circuitry"
 	item_paths = list("CRY-1","CON-1")
-	item_names = list("Crystal","Conductive Material")
 	item_amounts = list(5,5)
 	item_outputs = list(/obj/item/pod/boards)
 	time = 10 SECONDS
@@ -2361,7 +2165,6 @@
 /datum/manufacture/pod/armor_light
 	name = "Light Pod Armor"
 	item_paths = list("MET-2","CON-1")
-	item_names = list("Sturdy Metal","Conductive Material")
 	item_amounts = list(30,20)
 	item_outputs = list(/obj/item/pod/armor_light)
 	time = 20 SECONDS
@@ -2371,7 +2174,6 @@
 /datum/manufacture/pod/armor_heavy
 	name = "Heavy Pod Armor"
 	item_paths = list("MET-2","MET-3")
-	item_names = list("Sturdy Metal","Dense Metal")
 	item_amounts = list(30,20)
 	item_outputs = list(/obj/item/pod/armor_heavy)
 	time = 30 SECONDS
@@ -2381,7 +2183,6 @@
 /datum/manufacture/pod/armor_industrial
 	name = "Industrial Pod Armor"
 	item_paths = list("MET-3","CON-2","DEN-1")
-	item_names = list("Dense Metal","High Energy Conductor","High Density Crystalline Matter")
 	item_amounts = list(25,10,5)
 	item_outputs = list(/obj/item/pod/armor_industrial)
 	time = 50 SECONDS
@@ -2391,7 +2192,6 @@
 /datum/manufacture/pod/control
 	name = "Pod Control Interface"
 	item_paths = list("CRY-1","CON-1")
-	item_names = list("Crystal","Conductive Material")
 	item_amounts = list(10,10)
 	item_outputs = list(/obj/item/pod/control)
 	time = 10 SECONDS
@@ -2401,7 +2201,6 @@
 /datum/manufacture/putt/parts
 	name = "MiniPutt Frame Kit"
 	item_paths = list("MET-2")
-	item_names = list("Sturdy Metal")
 	item_amounts = list(15)
 	item_outputs = list(/obj/item/putt/frame_box)
 	time = 10 SECONDS
@@ -2411,7 +2210,6 @@
 /datum/manufacture/putt/engine
 	name = "MiniPutt Engine Manifold"
 	item_paths = list("MET-2","CON-1")
-	item_names = list("Sturdy Metal","Conductive Material")
 	item_amounts = list(5,2)
 	item_outputs = list(/obj/item/putt/engine)
 	time = 5 SECONDS
@@ -2421,7 +2219,6 @@
 /datum/manufacture/putt/boards
 	name = "MiniPutt Circuitry"
 	item_paths = list("CRY-1","CON-1")
-	item_names = list("Crystal","Conductive Material")
 	item_amounts = list(2,2)
 	item_outputs = list(/obj/item/putt/boards)
 	time = 5 SECONDS
@@ -2431,7 +2228,6 @@
 /datum/manufacture/putt/control
 	name = "MiniPutt Control Interface"
 	item_paths = list("CRY-1","CON-1")
-	item_names = list("Crystal","Conductive Material")
 	item_amounts = list(5,5)
 	item_outputs = list(/obj/item/putt/control)
 	time = 5 SECONDS
@@ -2443,7 +2239,6 @@
 /datum/manufacture/pod/weapon/mining
 	name = "Plasma Cutter System"
 	item_paths = list("POW-1","MET-3")
-	item_names = list("Power Source","Dense Metal")
 	item_amounts = list(10,10)
 	item_outputs = list(/obj/item/shipcomponent/mainweapon/mining)
 	time = 20 SECONDS
@@ -2453,7 +2248,6 @@
 /datum/manufacture/pod/weapon/mining/drill
 	name = "Rock Drilling Rig"
 	item_paths = list("POW-1","MET-3", "DEN-3")
-	item_names = list("Power Source","Dense Metal", "Extraordinarily Dense Crystalline Matter")
 	item_amounts = list(10,10,20)
 	item_outputs = list(/obj/item/shipcomponent/mainweapon/rockdrills)
 	time = 20 SECONDS
@@ -2463,7 +2257,6 @@
 /datum/manufacture/pod/weapon/ltlaser
 	name = "Mk.1.5 Light Phasers"
 	item_paths = list("MET-2","CON-1","CRY-1")
-	item_names = list("Sturdy Metal","Conductive Material","Crystal")
 	item_amounts = list(15,15,15)
 	item_outputs = list(/obj/item/shipcomponent/mainweapon/phaser)
 	time = 20 SECONDS
@@ -2473,7 +2266,6 @@
 /datum/manufacture/pod/lock
 	name = "Pod Locking Mechanism"
 	item_paths = list("CRY-1","CON-1")
-	item_names = list("Crystal","Conductive Material")
 	item_amounts = list(5,10)
 	item_outputs = list(/obj/item/shipcomponent/secondary_system/lock)
 	time = 10 SECONDS
@@ -2486,7 +2278,6 @@
 /datum/manufacture/id_card
 	name = "ID card"
 	item_paths = list("CON-1","CRY-1")
-	item_names = list("Conductive Material","Crystal")
 	item_amounts = list(3,3)
 	item_outputs = list(/obj/item/card/id)
 	time = 5 SECONDS
@@ -2496,7 +2287,6 @@
 /datum/manufacture/id_card_gold
 	name = "Gold ID card"
 	item_paths = list("REF-1", "CON-2","CRY-1")
-	item_names = list("Reflective Material", "High Energy Conductor","Crystal")
 	item_amounts = list(5,4,3)
 	item_outputs = list(/obj/item/card/id/gold)
 	time = 30 SECONDS
@@ -2506,7 +2296,6 @@
 /datum/manufacture/implant_access
 	name = "Electronic Access Implant (2 Access Charges)"
 	item_paths = list("CON-1","CRY-1")
-	item_names = list("Conductive Material","Crystal")
 	item_amounts = list(3,3)
 	item_outputs = list(/obj/item/implantcase/access)
 	time = 20 SECONDS
@@ -2516,7 +2305,6 @@
 /datum/manufacture/implant_access_infinite
 	name = "Electronic Access Implant (Unlimited Charge)"
 	item_paths = list("CON-1","CRY-1")
-	item_names = list("Conductive Material","Crystal")
 	item_amounts = list(9,15)
 	item_outputs = list(/obj/item/implantcase/access/unlimited)
 	time = 60 SECONDS
@@ -2528,7 +2316,6 @@
 /datum/manufacture/crate
 	name = "Crate"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(5)
 	item_outputs = list(/obj/storage/crate)
 	time = 10 SECONDS
@@ -2538,7 +2325,6 @@
 /datum/manufacture/packingcrate
 	name = "Random Packing Crate"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(5)
 	item_outputs = list(/obj/storage/crate/packing)
 	time = 10 SECONDS
@@ -2548,7 +2334,6 @@
 /datum/manufacture/pizzabox
 	name = "Pizza Box"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(5)
 	item_outputs = list(/obj/storage/crate/pizza)
 	time = 10 SECONDS
@@ -2558,7 +2343,6 @@
 /datum/manufacture/wooden
 	name = "Wooden Crate"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(5)
 	item_outputs = list(/obj/storage/crate/wooden)
 	time = 10 SECONDS
@@ -2568,7 +2352,6 @@
 /datum/manufacture/medical
 	name = "Medical Crate"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(5)
 	item_outputs = list(/obj/storage/crate/medical)
 	time = 10 SECONDS
@@ -2578,7 +2361,6 @@
 /datum/manufacture/biohazard
 	name = "Biohazard Crate"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(5)
 	item_outputs = list(/obj/storage/crate/biohazard)
 	time = 10 SECONDS
@@ -2588,7 +2370,6 @@
 /datum/manufacture/classcrate
 	name = "Class Crate"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(5)
 	item_outputs = list(/obj/storage/crate/classcrate)
 	time = 10 SECONDS
@@ -2600,7 +2381,6 @@
 /datum/manufacture/alastor
 	name = "Alastor pattern laser rifle"
 	item_paths = list("DEN-1","MET-3","CON-1","CRY-1")
-	item_names = list("High Density Crystalline Matter","Dense Metal","Conductive Material","Crystal")
 	item_amounts = list(1,10,20,20)
 	item_outputs = list(/obj/item/gun/energy/alastor)
 	time = 30 SECONDS
@@ -2611,7 +2391,6 @@
 /datum/manufacture/armor_vest	//
 	name = "Armor Vest"
 	item_paths = list("MET-3")
-	item_names = list("Dense Metal")
 	item_amounts = list(5)
 	item_outputs = list(/obj/item/clothing/suit/armor/vest)
 	time = 30 SECONDS
@@ -2621,7 +2400,6 @@
 /datum/manufacture/saa	//
 	name = "Colt SAA"
 	item_paths = list("MET-2")
-	item_names = list("Sturdy Metal")
 	item_amounts = list(7)
 	item_outputs = list(/obj/item/gun/kinetic/colt_saa)
 	time = 30 SECONDS
@@ -2630,7 +2408,6 @@
 /datum/manufacture/saa_ammo	//
 	name = "Colt Ammo"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(1)
 	item_outputs = list(/obj/item/ammo/bullets/c_45)
 	time = 7 SECONDS
@@ -2639,7 +2416,6 @@
 /datum/manufacture/clock	//
 	name = "Clock 188"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(10)
 	item_outputs = list(/obj/item/gun/kinetic/clock_188)
 	time = 10 SECONDS
@@ -2648,7 +2424,6 @@
 /datum/manufacture/clock_ammo	//
 	name = "Clock ammo"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(3)
 	item_outputs = list(/obj/item/ammo/bullets/nine_mm_NATO)
 	time = 7 SECONDS
@@ -2658,7 +2433,6 @@
 /datum/manufacture/riot_shotgun	//
 	name = "Riot Shotgun"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(20)
 	item_outputs = list(/obj/item/gun/kinetic/riotgun)
 	time = 20 SECONDS
@@ -2667,7 +2441,6 @@
 /datum/manufacture/riot_shotgun_ammo	//
 	name = "Rubber Bullet ammo"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(10)
 	item_outputs = list(/obj/item/ammo/bullets/abg)
 	time = 7 SECONDS
@@ -2677,7 +2450,6 @@
 /datum/manufacture/riot_launcher	//
 	name = "Riot Launcher"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(12)
 	item_outputs = list(/obj/item/gun/kinetic/riot40mm)
 	time = 10 SECONDS
@@ -2686,7 +2458,6 @@
 /datum/manufacture/riot_launcher_ammo_pbr	//
 	name = "Launcher PBR Ammo"
 	item_paths = list("MET-1", "CON-1", "CRY-1")
-	item_names = list("Metal", "Conductive Material", "Crystal")
 	item_amounts = list(2,4,1)
 	item_outputs = list(/obj/item/ammo/bullets/pbr)
 	time = 10 SECONDS
@@ -2695,7 +2466,6 @@
 /datum/manufacture/riot_launcher_ammo_flashbang	//
 	name = "Launcher Flashbang Box"
 	item_paths = list("MET-1", "CON-1")
-	item_names = list("Metal", "Conductive Material")
 	item_amounts = list(2,3)
 	item_outputs = list(/obj/item/storage/box/flashbang_kit)
 	time = 10 SECONDS
@@ -2704,7 +2474,6 @@
 /datum/manufacture/riot_launcher_ammo_tactical	//
 	name = "Launcher Tactical Box"
 	item_paths = list("MET-2", "CON-1", "CRY-1")
-	item_names = list("Metal", "Conductive Material", "Crystal")
 	item_amounts = list(5, 5, 3)
 	item_outputs = list(/obj/item/storage/box/tactical_kit)
 	time = 10 SECONDS
@@ -2714,7 +2483,6 @@
 /datum/manufacture/sniper	//
 	name = "Sniper"
 	item_paths = list("DEN-1","MET-3","CON-1","CRY-1")
-	item_names = list("High Density Crystalline Matter","Dense Metal","Conductive Material","Crystal")
 	item_amounts = list(2, 15, 4, 3)
 	item_outputs = list(/obj/item/gun/kinetic/sniper)
 	time = 25 SECONDS
@@ -2723,7 +2491,6 @@
 /datum/manufacture/sniper_ammo	//
 	name = "Sniper Ammo"
 	item_paths = list("MET-3")
-	item_names = list("Dense Metal")
 	item_amounts = list(6)
 	item_outputs = list(/obj/item/ammo/bullets/rifle_762_NATO)
 	time = 10 SECONDS
@@ -2732,7 +2499,6 @@
 /datum/manufacture/tac_shotgun	//
 	name = "Tactical Shotgun"
 	item_paths = list("MET-3", "CON-1")
-	item_names = list("Dense Metal", "Conductive Material")
 	item_amounts = list(15, 5)
 	item_outputs = list(/obj/item/gun/kinetic/tactical_shotgun)
 	time = 20 SECONDS
@@ -2741,7 +2507,6 @@
 /datum/manufacture/tac_shotgun_ammo	//
 	name = "Tactical Shotgun Ammo"
 	item_paths = list("MET-3")
-	item_names = list("Dense Metal")
 	item_amounts = list(5)
 	item_outputs = list(/obj/item/ammo/bullets/buckshot_burst)
 	time = 7 SECONDS
@@ -2750,7 +2515,6 @@
 /datum/manufacture/gyrojet	//
 	name = "Gyrojet"
 	item_paths = list("DEN-1","MET-3","CON-2")
-	item_names = list("High Density Crystalline Matter","Dense Metal","High Energy Conductor")
 	item_amounts = list(5, 10, 6)
 	item_outputs = list(/obj/item/gun/kinetic/gyrojet)
 	time = 30 SECONDS
@@ -2759,7 +2523,6 @@
 /datum/manufacture/gyrojet_ammo	//
 	name = "Gyrojet Ammo"
 	item_paths = list("MET-3", "CON-2")
-	item_names = list("Dense Metal", "High Energy Conductor")
 	item_amounts = list(5,2)
 	item_outputs = list(/obj/item/ammo/bullets/gyrojet)
 	time = 7 SECONDS
@@ -2768,7 +2531,6 @@
 /datum/manufacture/plank	//
 	name = "Plank/Barricade"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(1)
 	item_outputs = list(/obj/item/plank/anti_zombie)
 	time = 5 SECONDS
@@ -2777,7 +2539,6 @@
 /datum/manufacture/brute_kit	//
 	name = "Brute Kit"
 	item_paths = list("MET-1", "CON-1")
-	item_names = list("Metal", "Conductive Material")
 	item_amounts = list(2, 2)
 	item_outputs = list(/obj/item/storage/firstaid/brute)
 	time = 10 SECONDS
@@ -2786,7 +2547,6 @@
 /datum/manufacture/burn_kit	//
 	name = "Burn Kit"
 	item_paths = list("MET-1", "CON-1")
-	item_names = list("Metal", "Conductive Material")
 	item_amounts = list(2, 2)
 	item_outputs = list(/obj/item/storage/firstaid/fire)
 	time = 10 SECONDS
@@ -2795,7 +2555,6 @@
 /datum/manufacture/crit_kit //
 	name = "Crit Kit"
 	item_paths = list("MET-1", "CON-1")
-	item_names = list("Metal", "Conductive Material")
 	item_amounts = list(2, 2)
 	item_outputs = list(/obj/item/storage/firstaid/crit)
 	time = 9 SECONDS
@@ -2804,7 +2563,6 @@
 /datum/manufacture/empty_kit
 	name = "Empty First Aid Kit"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(1)
 	item_outputs = list(/obj/item/storage/firstaid/regular/empty)
 	time = 4 SECONDS
@@ -2813,7 +2571,6 @@
 /datum/manufacture/spacecillin	//
 	name = "Spacecillin"
 	item_paths = list("MET-1", "CON-1")
-	item_names = list("Metal", "Conductive Material")
 	item_amounts = list(3, 3)
 	item_outputs = list(/obj/item/reagent_containers/syringe/antiviral)
 	time = 10 SECONDS
@@ -2822,7 +2579,6 @@
 /datum/manufacture/bat	//
 	name = "Baseball Bat"
 	item_paths = list("MET-2")
-	item_names = list("Strudy Metal")
 	item_amounts = list(15)
 	item_outputs = list(/obj/item/bat)
 	time = 20 SECONDS
@@ -2831,7 +2587,6 @@
 /datum/manufacture/quarterstaff	//
 	name = "Quarterstaff"
 	item_paths = list("MET-2")
-	item_names = list("Strudy Metal")
 	item_amounts = list(10)
 	item_outputs = list(/obj/item/quarterstaff)
 	time = 10 SECONDS
@@ -2840,7 +2595,6 @@
 /datum/manufacture/cleaver	//
 	name = "Cleaver"
 	item_paths = list("MET-1")
-	item_names = list("Metal")
 	item_amounts = list(20)
 	item_outputs = list(/obj/item/kitchen/utensil/knife/cleaver)
 	time = 16 SECONDS
@@ -2849,7 +2603,6 @@
 /datum/manufacture/dsaber	//
 	name = "D-Saber"
 	item_paths = list("MET-2", "CON-1")
-	item_names = list("Sturdy Metal", "Conductive Material")
 	item_amounts = list(20, 10)
 	item_outputs = list(/obj/item/sword/discount)
 	time = 20 SECONDS
@@ -2858,7 +2611,6 @@
 /datum/manufacture/fireaxe	//
 	name = "Fireaxe"
 	item_paths = list("MET-3", "CON-2")
-	item_names = list("Dense Metal", "Conductive Material")
 	item_amounts = list(20, 5)
 	item_outputs = list(/obj/item/fireaxe)
 	time = 20 SECONDS
@@ -2867,7 +2619,6 @@
 /datum/manufacture/shovel	//
 	name = "Shovel"
 	item_paths = list("MET-3", "CON-2")
-	item_names = list("Dense Metal","High Energy Conductor")
 	item_amounts = list(25, 5)
 	item_outputs = list(/obj/item/shovel)	//this is powerful)
 	time = 40 SECONDS

--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -24,7 +24,7 @@ proc/get_nice_mat_name_for_manufacturers(mat)
 
 /datum/manufacture
 	var/name = null                // Name of the schematic
-	var/list/item_paths = list()   // Materials required
+	var/list/item_paths = null   // Materials required (generate from `mats` if null)
 	var/list/item_names = null   // Name of each material (generated automatically if null)
 	var/list/item_amounts = list() // How many of each material is needed
 	var/list/item_outputs = list() // What the schematic outputs
@@ -40,6 +40,21 @@ proc/get_nice_mat_name_for_manufacturers(mat)
 
 	New()
 		..()
+		if(isnull(item_paths) && length(item_outputs) == 1) // TODO generalize to multiple outputs (currently no such manufacture recipes exist)
+			// sadly we can't use initial() because it's a list :/
+			var/item_type = item_outputs[1]
+			var/obj/dummy = new item_type
+			if(islist(dummy.mats))
+				item_paths = list()
+				for(var/mat in dummy.mats)
+					item_paths += mat
+					var/amt = dummy.mats[mat]
+					if(isnull(amt))
+						amt = 1
+					item_amounts += amt
+			qdel(dummy)
+		if(isnull(item_paths))
+			item_paths = list() // a bunch of places expect this to be non-null, like the sanity check
 		if (!sanity_check_exemption)
 			src.sanity_check()
 
@@ -285,8 +300,6 @@ proc/get_nice_mat_name_for_manufacturers(mat)
 
 /datum/manufacture/multitool
 	name = "Multi Tool"
-	item_paths = list("CRY-1","CON-2")
-	item_amounts = list(1,1)
 	item_outputs = list(/obj/item/device/multitool)
 	time = 8 SECONDS
 	create = 1

--- a/code/obj.dm
+++ b/code/obj.dm
@@ -9,7 +9,7 @@
 	var/adaptable = 0
 
 	var/is_syndicate = 0
-	var/list/mats = 0
+	var/list/mats = 0 // either a number or a list of the form list("MET-1"=5, "erebite"=3)
 	var/deconstruct_flags = DECON_NONE
 
 	var/mechanics_type_override = null //Fix for children of scannable items being reproduced in mechanics

--- a/code/obj/item/device/multitool.dm
+++ b/code/obj/item/device/multitool.dm
@@ -10,7 +10,7 @@
 	desc = "You can use this on airlocks or APCs to try to hack them without cutting wires."
 	m_amt = 50
 	g_amt = 20
-	mats = 6
+	mats = list("CRY-1", "CON-2")
 	module_research = list("tools" = 5, "devices" = 2)
 
 

--- a/code/obj/item/device/pda2/scanners.dm
+++ b/code/obj/item/device/pda2/scanners.dm
@@ -101,7 +101,7 @@
 			var/datum/computer/file/electronics_scan/theScan = new
 			theScan.scannedName = initial(O.name)
 			theScan.scannedPath = O.mechanics_type_override ? O.mechanics_type_override : O.type
-			theScan.scannedMats = initial(O.mats)
+			theScan.scannedMats = O.mats
 
 			var/datum/signal/signal = get_free_signal()
 			signal.source = src.master

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -465,8 +465,13 @@
 			var/list/material_count = 0
 			for (var/i in 1 to A.item_paths.len)
 				material_count += A.item_amounts[i]
+				var/mat_name
+				if(isnull(A.item_names) || isnull(A.item_names[i]))
+					mat_name = get_nice_mat_name_for_manufacturers(A.item_paths[i])
+				else
+					mat_name = A.item_names[i]
 				material_text += {"
-				<span class='mat[mats_used[A.item_paths[i]] ? "" : "-missing"]'>[A.item_amounts[i]] [A.item_names[i]]</span>
+				<span class='mat[mats_used[A.item_paths[i]] ? "" : "-missing"]'>[A.item_amounts[i]] [mat_name]</span>
 				"}
 
 			dat += {"


### PR DESCRIPTION
[cleanliness] [bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
A number of backend improvements to manufacturer recipes.
 - objs `mats` var can now take lists of the form `list("CRY-1", "MET-2"=10, "erebite"=2)`
 - if a manufacturer recipe is not provided material names it uses an automatic lookup table (e,g, MET-1 -> Metal), scanned items with list `mats` do the same, if the material is not in the lookup table it's capitalized instead (e.g. erebite -> Erebite)
 - if a manufacturer recipe is not provided materials it tries to use the `mats` var of the object in question *if it is a list `mats`*
 - multitools now use this whole system so you can't get around their new building cost by scanning a multitool and building it that way


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Being able to set more specific material requirements for scannable objects sounds like an useful thing. Instead of just increasing the mats value on items that should be hard to build we can now add requirements for more exotic material types.
Also every manufacturer recipe writing "Conductive Material" and such stuff again and again was dumb and an easy place to make mistakes.


## Changelog
