### PR TITLE
Makes the 'steal a horse mask' objective functional

### DIFF
--- a/code/datums/objective.dm
+++ b/code/datums/objective.dm
@@ -173,6 +173,8 @@ proc/create_fluff(var/datum/mind/target)
 				steal_target = /obj/item/firstbill
 			if("much coveted Gooncode")
 				steal_target = /obj/item/toy/gooncode
+			if("horse mask")
+				steal_target = /obj/item/clothing/mask/horse_mask
 #else
 	set_up()
 		var/list/items = list("Head of Security\'s beret", "prisoner\'s beret", "DetGadget hat", "horse mask", "authentication disk",
@@ -200,6 +202,8 @@ proc/create_fluff(var/datum/mind/target)
 				steal_target = /obj/item/storage/belt/utility/prepared/ceshielded
 			if("much coveted Gooncode")
 				steal_target = /obj/item/toy/gooncode
+			if("horse mask")
+				steal_target = /obj/item/clothing/mask/horse_mask
 #endif
 
 		explanation_text = "Steal the [target_name]."
@@ -207,7 +211,7 @@ proc/create_fluff(var/datum/mind/target)
 
 	check_completion()
 		if(steal_target)
-			if(owner.current && owner.current.check_contents_for(steal_target, 1))
+			if(owner.current && owner.current.check_contents_for(steal_target, 1, 1))
 				return 1
 			else
 				return 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I've seen a bunch of postround OOC complaints about not getting greentext from this objective because they wore it, because it was in their backpack, etc. Turns out there was no code that associated the item string with a path, so this objective is currently just impossible to complete. 

To make the cursed mask and cursed monkey mask also count, I changed the completion check to accept subtypes. I don't _think_ this impacts any other objectives, but yell at me if I missed something and it does.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Objectives should be possible to complete.
