### PR TITLE
/atom/movable/New now calls Entered on its loc

### DIFF
--- a/code/WorkInProgress/zamujasa.dm
+++ b/code/WorkInProgress/zamujasa.dm
@@ -582,7 +582,7 @@
 
 		Entered(atom/movable/O)
 			..()
-			if (isobserver(O) || !istype(ticker.mode, /datum/game_mode/football))
+			if (isobserver(O) || !istype(ticker?.mode, /datum/game_mode/football))
 				return
 			var/datum/game_mode/football/F = ticker.mode
 			if (ismob(O))

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -390,6 +390,8 @@
 			T.opaque_atom_count++
 	if(!isnull(src.loc))
 		src.loc.Entered(src, null)
+		if(isturf(src.loc)) // call it on the area too
+			src.loc.loc.Entered(src, null)
 
 /atom/movable/disposing()
 	if (temp_flags & MANTA_PUSHING)

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -388,6 +388,8 @@
 			T.checkinghasproximity++
 		if(src.opacity)
 			T.opaque_atom_count++
+	if(!isnull(src.loc))
+		src.loc.Entered(src, null)
 
 /atom/movable/disposing()
 	if (temp_flags & MANTA_PUSHING)

--- a/code/turf/turf.dm
+++ b/code/turf/turf.dm
@@ -348,6 +348,8 @@
 	if (src.checkinghasentered > 0)  //dont bother checking unless the turf actually contains a checkable :)
 		for(var/thing in src)
 			var/atom/A = thing
+			if(A == thing)
+				continue
 			// I Said No sanity check
 			if(i++ >= 50)
 				break


### PR DESCRIPTION
[FUCK]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
BYOND itself calls `Entered` on `A` whenever an atom moves into `A`'s contents via `Move`. Other ways of moving trigger no such thing. In our code 99% of those cases are covered by:
 - creating an atom inside `A`
 - using `set_loc` to move an atom into `A`

I think it makes sense to have both of those things call `Entered` on `A`. This PR accomplishes the first half of that.
This will allow for some much nicer treatment of some objects, like storage items. With this PR storage items could automatically update their UI when their `Entered` gets called and so creating items directly inside backpacks will need to additional boilerplate code.
This PR also fixes some instances of conveyor belts having slow reactions to items spawned on them.
However, this PR also likely causes some minor bugs which are hard to locate. I saw none during very brief testing locally but it's quite impossible to guess at what a change like this might break.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's a step towards some cleaner and more modular code. Makes it possible for turfs and objects to do things when something gets created on their turf.


## Changelog
