### PR TITLE
fixes a robusttec bug

### DIFF
--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -418,7 +418,7 @@ THROWING DARTS
 	do_process(var/mult = 1)
 		if (ishuman(src.owner))
 			var/mob/living/carbon/human/H = owner
-			if (src.health < 40 && !src.inactive)
+			if (H.health < 40 && !src.inactive)
 				if (!H.reagents.has_reagent("omnizine", 10))
 					H.reagents.add_reagent("omnizine", 10)
 				src.inactive = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I assume this was supposed to check if the implantee's health was under 40, not if the _implant_'s health is under 40 (spoilers, it is 4).


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
lol, idk, it probably makes little to no difference, people can just punch themselves to 40 and heal back up