### PR TITLE
set_loc Entered/Exited calling now mirrors BYOND's built-in Move

### DIFF
--- a/code/atom.dm
+++ b/code/atom.dm
@@ -816,12 +816,13 @@
 
 	oldloc?.Exited(src, newloc)
 
+	// area.Exited called if we are on turfs and changing areas or if exiting a turf into a non-turf (just like Move does it internally)
 	if((my_area != new_area || !isturf(newloc)) && isturf(oldloc))
 		my_area.Exited(src, newloc)
 
 	newloc?.Entered(src, oldloc)
 
-	//Required for objects coming out of other objects / mobs; otherwise they will not call entered on the area when a mob drops items etc. This is not a perfect solution.
+	// area.Entered called if we are on turfs and changing areas or if entering a turf from a non-turf (just like Move does it internally)
 	if((my_area != new_area || !isturf(oldloc)) && isturf(newloc))
 		new_area.Entered(src, oldloc)
 

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -798,7 +798,7 @@
   * there are lots of old places in the code that set loc directly.
 	* ignore them they'll be fixed later, please use this proc in the future
   */
-/atom/movable/proc/set_loc(var/newloc as turf|mob|obj in world)
+/atom/movable/proc/set_loc(atom/newloc)
 	SHOULD_CALL_PARENT(TRUE)
 	if (loc == newloc)
 		return src
@@ -811,15 +811,15 @@
 	var/area/my_area = get_area(src)
 	var/area/new_area = get_area(newloc)
 
-	var/oldloc = loc
+	var/atom/oldloc = loc
 	loc = newloc
 
-	oldloc.Exited(src, newloc)
+	oldloc?.Exited(src, newloc)
 
 	if(my_area != new_area && my_area)
 		my_area.Exited(src, newloc)
 
-	newloc.Entered(src, oldloc)
+	newloc?.Entered(src, oldloc)
 
 	//Required for objects coming out of other objects / mobs; otherwise they will not call entered on the area when a mob drops items etc. This is not a perfect solution.
 	if(((my_area != new_area && isturf(oldloc)) || !isturf(oldloc)) && new_area)

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -808,8 +808,7 @@
 			loc = src:client:player:shamecubed
 			return
 
-	if (isturf(loc))
-		loc.Exited(src, newloc)
+	loc.Exited(src, newloc)
 
 	var/area/my_area = get_area(src)
 	var/area/new_area = get_area(newloc)
@@ -823,9 +822,7 @@
 	if(((my_area != new_area && isturf(oldloc)) || !isturf(oldloc)) && new_area)
 		new_area.Entered(src, oldloc)
 
-	if(isturf(newloc))
-		var/turf/nloc = newloc
-		nloc.Entered(src, oldloc)
+	newloc.Entered(src, oldloc)
 
 	if (islist(src.attached_objs) && attached_objs.len)
 		for (var/atom/movable/M in src.attached_objs)

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -816,13 +816,13 @@
 
 	oldloc?.Exited(src, newloc)
 
-	if(my_area != new_area && my_area)
+	if((my_area != new_area || !isturf(newloc)) && isturf(oldloc))
 		my_area.Exited(src, newloc)
 
 	newloc?.Entered(src, oldloc)
 
 	//Required for objects coming out of other objects / mobs; otherwise they will not call entered on the area when a mob drops items etc. This is not a perfect solution.
-	if(((my_area != new_area && isturf(oldloc)) || !isturf(oldloc)) && new_area)
+	if((my_area != new_area || !isturf(oldloc)) && isturf(newloc))
 		new_area.Entered(src, oldloc)
 
 	if (islist(src.attached_objs) && attached_objs.len)

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -808,21 +808,22 @@
 			loc = src:client:player:shamecubed
 			return
 
-	loc.Exited(src, newloc)
-
 	var/area/my_area = get_area(src)
 	var/area/new_area = get_area(newloc)
+
+	var/oldloc = loc
+	loc = newloc
+
+	oldloc.Exited(src, newloc)
 
 	if(my_area != new_area && my_area)
 		my_area.Exited(src, newloc)
 
-	var/oldloc = loc
-	loc = newloc
-	 //Required for objects coming out of other objects / mobs; otherwise they will not call entered on the area when a mob drops items etc. This is not a perfect solution.
+	newloc.Entered(src, oldloc)
+
+	//Required for objects coming out of other objects / mobs; otherwise they will not call entered on the area when a mob drops items etc. This is not a perfect solution.
 	if(((my_area != new_area && isturf(oldloc)) || !isturf(oldloc)) && new_area)
 		new_area.Entered(src, oldloc)
-
-	newloc.Entered(src, oldloc)
 
 	if (islist(src.attached_objs) && attached_objs.len)
 		for (var/atom/movable/M in src.attached_objs)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FUCK]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
See #2783 for some context.
Basically this brings set_loc's calling of Entered/Exited more in line with what BYOND does internally when `Move` happens.
That means:

- Both Entered and Exited are now called *after* the atom changes locations. Previous behaviour: Exited happens before.
- Area's Entered and Exited is now called *after* turf's Entered / Exited. Previous behaviour: one of them did it the other way around.
- Entered and Exited are called on the atom we are leaving / entering no matter what it is. Previous behaviour: It was only called for turfs.
 - Entered and Exited for areas are now called if moving between turfs and changing areas or if moving between a turf and a non-turf even if in the same area. Previous behaviour: I don't even know, it was a bit of a mess.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Having Entered and Exited work more consistently no matter what the source of the movement was is good.
I suspect the first point might cause some bugs, hard to say.
The last point will be useful in implementing automated UI updating for storage as outlined in #2783 . Other possible uses are stuff like vehicles reacting properly to mobs transforming into other mobs as they can now detect stuff entering / exiting no matter what etc.


## Changelog