### PR TITLE
Move cloud related stuff to /datum/player

### DIFF
--- a/code/client.dm
+++ b/code/client.dm
@@ -394,9 +394,6 @@ var/global/list/vpn_ip_checks = list() //assoc list of ip = true or ip = false. 
 
 	clients += src
 
-	if(!cloud_available())
-		src.player.cloud_fetch()
-
 	SPAWN_DBG(0) // to not lock up spawning process
 		if (IsGuestKey(src.key))
 			src.has_contestwinner_medal = 0
@@ -499,10 +496,8 @@ var/global/list/vpn_ip_checks = list() //assoc list of ip = true or ip = false. 
 #endif
 		//Cloud data
 		if (cdn)
-			var/tries = 10
-			while(!cloud_available() && tries) // we might sill be waiting for cloud_fetch triggered above
-				tries--
-				sleep(0.1 SECONDS)
+			if(!cloud_available())
+				src.player.cloud_fetch()
 
 			if(cloud_available())
 				src.load_antag_tokens()

--- a/code/client.dm
+++ b/code/client.dm
@@ -87,9 +87,6 @@ var/global/list/vpn_ip_checks = list() //assoc list of ip = true or ip = false. 
 
 	var/delete_state = DELETE_STOP
 
-	var/list/cloudsaves
-	var/list/clouddata
-
 	var/turf/stathover = null
 	var/turf/stathover_start = null//forgive me
 
@@ -397,6 +394,9 @@ var/global/list/vpn_ip_checks = list() //assoc list of ip = true or ip = false. 
 
 	clients += src
 
+	if(!cloud_available())
+		src.player.cloud_fetch()
+
 	SPAWN_DBG(0) // to not lock up spawning process
 		if (IsGuestKey(src.key))
 			src.has_contestwinner_medal = 0
@@ -499,25 +499,14 @@ var/global/list/vpn_ip_checks = list() //assoc list of ip = true or ip = false. 
 #endif
 		//Cloud data
 		if (cdn)
-			// Fetch via HTTP from goonhub
-			var/datum/http_request/request = new()
-			request.prepare(RUSTG_HTTP_METHOD_GET, "http://spacebee.goonhub.com/api/cloudsave?list&ckey=[ckey]&api_key=[config.ircbot_api]", "", "")
-			request.begin_async()
-			UNTIL(request.is_complete())
-			var/datum/http_response/response = request.into_response()
+			var/tries = 10
+			while(!cloud_available() && tries) // we might sill be waiting for cloud_fetch triggered above
+				tries--
+				sleep(0.1 SECONDS)
 
-			if (response.errored || !response.body)
-				logTheThing("debug", src, null, "failed to have their cloud data loaded: Couldn't reach Goonhub")
-				return
-
-			var/list/ret = json_decode(response.body)
-			if(ret["status"] == "error")
-				logTheThing( "debug", src, null, "failed to have their cloud data loaded: [ret["error"]["error"]]" )
-			else
-				cloudsaves = ret["saves"]
-				clouddata = ret["cdata"]
-				load_antag_tokens()
-				load_persistent_bank()
+			if(cloud_available())
+				src.load_antag_tokens()
+				src.load_persistent_bank()
 				var/decoded = cloud_get("audio_volume")
 				if(decoded)
 					var/cur = volumes.len
@@ -1111,27 +1100,17 @@ var/global/curr_day = null
 		return 0
 	return (src.ckey in muted_keys) && muted_keys[src.ckey]
 
-
-//drsingh, don't read the rest of this comment; BELOW: CLOUD STUFFS
-//Sets and uploads cloud data on the client
-//TODO: Pool puts, determine value of doing as such.
-/client/proc/cloud_put( var/key, var/value )
-	if( !clouddata )
-		return "Failed to talk to Goonhub; try rejoining." //oh no
-	clouddata[key] = "[value]"
-
-	// Via rust-g HTTP
-	var/datum/http_request/request = new() //If it fails, oh well...
-	request.prepare(RUSTG_HTTP_METHOD_GET, "http://spacebee.goonhub.com/api/cloudsave?dataput&api_key=[config.ircbot_api]&ckey=[ckey]&key=[url_encode(key)]&value=[url_encode(clouddata[key])]", "", "")
-	request.begin_async()
+/// Sets a cloud key value pair and sends it to goonhub
+/client/proc/cloud_put(key, value)
+	return src.player.cloud_put(key, value)
 
 /// Returns some cloud data on the client
-/client/proc/cloud_get( var/key )
-	return clouddata ? clouddata[key] : null
+/client/proc/cloud_get(key)
+	return src.player.cloud_get(key)
 
 /// Returns 1 if you can set or retrieve cloud data on the client
 /client/proc/cloud_available()
-	return !!clouddata
+	return src.player.cloud_available()
 
 /proc/add_test_screen_thing()
 	var/client/C = input("For who", "For who", null) in clients

--- a/code/datums/preferences.dm
+++ b/code/datums/preferences.dm
@@ -274,7 +274,7 @@ datum/preferences
 				rebuild_data["profile_name"] = 1
 				profile_cache.len = 0
 				profile_cache += "<div id='cloudsaves'><strong>Cloud Saves</strong><hr>"
-				for( var/name in client.cloudsaves )
+				for( var/name in client.player.cloudsaves )
 					profile_cache += "<a href='[pref_link]cloudload=[url_encode(name)]'>[html_encode(name)]</a> (<a href='[pref_link]cloudsave=[url_encode(name)]'>Save</a> - <a href='[pref_link]clouddelete=[url_encode(name)]'>Delete</a>)<br>"
 					LAGCHECK(LAG_REALTIME)
 				profile_cache += "<a href='[pref_link]cloudnew=1'>Create new save</a></div>"
@@ -1861,7 +1861,7 @@ $(function() {
 		*/
 
 		if (!isnull(user) && !IsGuestKey(user.key))
-			if (link_tags["cloudsave"] && user.client.cloudsaves[ link_tags["cloudsave"] ])
+			if (link_tags["cloudsave"] && user.client.player.cloudsaves[ link_tags["cloudsave"] ])
 				rebuild_profile = 1
 				var/ret = src.cloudsave_save( user.client, link_tags["cloudsave"] )
 				if( istext( ret ) )
@@ -1870,7 +1870,7 @@ $(function() {
 					boutput( user, "<span class='notice'>Savefile saved!</span>" )
 			else if (link_tags["cloudnew"])
 				rebuild_profile = 1
-				if( user.client.cloudsaves.len >= SAVEFILE_PROFILES_MAX )
+				if( user.client.player.cloudsaves.len >= SAVEFILE_PROFILES_MAX )
 					alert( user, "You have hit your cloud save limit. Please write over an existing save." )
 				else
 					var/newname = input( user, "What would you like to name the save?", "Save Name" ) as text
@@ -1882,14 +1882,14 @@ $(function() {
 							boutput( user, "<span class='alert'>Failed to save savefile: [ret]</span>" )
 						else
 							boutput( user, "<span class='notice'>Savefile saved!</span>" )
-			else if( link_tags["clouddelete"] && user.client.cloudsaves[ link_tags["clouddelete"] ] && alert( user, "Are you sure you want to delete [link_tags["clouddelete"]]?", "Uhm!", "Yes", "No" ) == "Yes" )
+			else if( link_tags["clouddelete"] && user.client.player.cloudsaves[ link_tags["clouddelete"] ] && alert( user, "Are you sure you want to delete [link_tags["clouddelete"]]?", "Uhm!", "Yes", "No" ) == "Yes" )
 				rebuild_profile = 1
 				var/ret = src.cloudsave_delete( user.client, link_tags["clouddelete"] )
 				if( istext( ret ) )
 					boutput( user, "<span class='alert'>Failed to delete savefile: [ret]</span>" )
 				else
 					boutput( user, "<span class='notice'>Savefile deleted!</span>" )
-			else if (link_tags["cloudload"] && user.client.cloudsaves[ link_tags["cloudload"] ])
+			else if (link_tags["cloudload"] && user.client.player.cloudsaves[ link_tags["cloudload"] ])
 				for (var/x in rebuild_data)
 					rebuild_data[x] = 1
 				rebuild_profile = 1

--- a/code/datums/savefile.dm
+++ b/code/datums/savefile.dm
@@ -361,7 +361,7 @@
 
 
 	cloudsave_load( client/user, var/name )
-		if(isnull( user.cloudsaves ))
+		if(isnull( user.player.cloudsaves ))
 			return "Failed to retrieve cloud data, try rejoining."
 
 		if (IsGuestKey(user.key))
@@ -387,7 +387,7 @@
 		return src.savefile_load(user, 1, save)
 
 	cloudsave_save( client/user, var/name )
-		if(isnull( user.cloudsaves ))
+		if(isnull( user.player.cloudsaves ))
 			return "Failed to retrieve cloud data, try rejoining."
 		if (IsGuestKey( user.key ))
 			return 0
@@ -409,7 +409,7 @@
 		var/list/ret = json_decode(response.body)
 		if( ret["status"] == "error" )
 			return ret["error"]["error"]
-		user.cloudsaves[ name ] = length( exported )
+		user.player.cloudsaves[ name ] = length( exported )
 		return 1
 
 	cloudsave_delete( client/user, var/name )
@@ -425,5 +425,5 @@
 			logTheThing("debug", null, null, "<b>cloudsave_delete:</b> Failed to contact goonhub. u: [user.ckey]")
 			return
 
-		user.cloudsaves.Remove( name )
+		user.player.cloudsaves.Remove( name )
 		return 1

--- a/code/player.dm
+++ b/code/player.dm
@@ -26,6 +26,10 @@
 	var/round_leave_time = null
 	/// the total time that this player has been playing the game this round, in 1/10ths of a second
 	var/current_playtime = null
+	/// saved profiles from the cloud
+	var/list/cloudsaves = null
+	/// saved data from the cloud (spacebux, volume settings, ...)
+	var/list/clouddata = null
 
 	/// sets up vars, caches player stats, adds by_type list entry for this datum
 	New(key)
@@ -102,6 +106,47 @@
 		src.current_playtime += (src.round_leave_time - round_join_time)
 		src.round_leave_time = null //reset this - null value is important
 		src.round_join_time = null //reset this - null value is important
+
+	/// Sets a cloud key value pair and sends it to goonhub
+	proc/cloud_put(key, value)
+		if(!clouddata)
+			return FALSE
+		clouddata[key] = "[value]"
+
+		// Via rust-g HTTP
+		var/datum/http_request/request = new() //If it fails, oh well...
+		request.prepare(RUSTG_HTTP_METHOD_GET, "http://spacebee.goonhub.com/api/cloudsave?dataput&api_key=[config.ircbot_api]&ckey=[ckey]&key=[url_encode(key)]&value=[url_encode(clouddata[key])]", "", "")
+		request.begin_async()
+		return TRUE // I guess
+
+	/// Returns some cloud data on the client
+	proc/cloud_get( var/key )
+		return clouddata ? clouddata[key] : null
+
+	/// Returns 1 if you can set or retrieve cloud data on the client
+	proc/cloud_available()
+		return !!clouddata
+
+	/// Downloads cloud data from goonhub
+	proc/cloud_fetch()
+		if(!cdn)
+			return
+		var/datum/http_request/request = new()
+		request.prepare(RUSTG_HTTP_METHOD_GET, "http://spacebee.goonhub.com/api/cloudsave?list&ckey=[ckey]&api_key=[config.ircbot_api]", "", "")
+		request.begin_async()
+		UNTIL(request.is_complete())
+		var/datum/http_response/response = request.into_response()
+
+		if (response.errored || !response.body)
+			logTheThing("debug", src.key, null, "failed to have their cloud data loaded: Couldn't reach Goonhub")
+			return
+
+		var/list/ret = json_decode(response.body)
+		if(ret["status"] == "error")
+			logTheThing( "debug", src.key, null, "failed to have their cloud data loaded: [ret["error"]["error"]]" )
+		else
+			cloudsaves = ret["saves"]
+			clouddata = ret["cdata"]
 
 /// returns a reference to a player datum based on the ckey you put into it
 /proc/find_player(key)

--- a/code/player.dm
+++ b/code/player.dm
@@ -139,14 +139,16 @@
 
 		if (response.errored || !response.body)
 			logTheThing("debug", src.key, null, "failed to have their cloud data loaded: Couldn't reach Goonhub")
-			return
+			return FALSE
 
 		var/list/ret = json_decode(response.body)
 		if(ret["status"] == "error")
 			logTheThing( "debug", src.key, null, "failed to have their cloud data loaded: [ret["error"]["error"]]" )
+			return FALSE
 		else
 			cloudsaves = ret["saves"]
 			clouddata = ret["cdata"]
+			return TRUE
 
 /// returns a reference to a player datum based on the ckey you put into it
 /proc/find_player(key)


### PR DESCRIPTION
[cleanliness] [help wanted]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves clouddata and cloudsaves from client to /datum/player. It's hard to test these things locally so I'd appreciate a closer look at the things to make sure I didn't screw up.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Reconnecting will now reuse the existing data instead of querying the cloud again which is good.
More importantly this allows for later modification of cloud data even if the client is logged out. For example currently spacebux and held spacebux item don't get updated at the end of the round for logged out players which sucks.
Also I plan on adding a spacebux purchasable persistent figurine case which will require this!


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->
