### PR TITLE
Kondaru nov20 improvement batch

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -125930,7 +125930,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aci
 ach
 aMJ
 aNv

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -6498,15 +6498,14 @@
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/mining/staff_room)
 "apq" = (
-/obj/grille/catwalk{
-	dir = 9;
-	icon_state = "catwalk_cross"
+/obj/machinery/light/emergency{
+	dir = 8;
+	pixel_x = -10
 	},
-/obj/disposalpipe/segment/bent/east,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 9
+/turf/simulated/floor/escape{
+	dir = 8
 	},
-/area/station/mining/staff_room)
+/area/station/hallway/secondary/exit)
 "apr" = (
 /obj/stool/chair/office{
 	dir = 8
@@ -15149,15 +15148,15 @@
 /turf/simulated/floor/black/grime,
 /area/station/maintenance/disposal)
 "aJd" = (
-/obj/disposalpipe/segment/bent/west,
-/obj/grille/catwalk{
-	dir = 5
+/obj/machinery/door/airlock/pyro/external{
+	name = "Mining Hangar"
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	icon_state = "catwalk_cross"
+/obj/cable{
+	icon_state = "4-8"
 	},
-/area/station/mining/refinery)
+/obj/access_spawn/mining,
+/turf/simulated/floor/grey,
+/area/station/mining/staff_room)
 "aJe" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
@@ -16176,10 +16175,8 @@
 	},
 /area/station/mining/refinery)
 "aLt" = (
-/obj/grille/catwalk,
-/obj/machinery/oreaccumulator,
-/turf/simulated/floor/airless/plating/catwalk,
-/area/station/mining/refinery)
+/turf/simulated/floor/grey,
+/area/station/mining/staff_room)
 "aLu" = (
 /obj/cable{
 	d1 = 1;
@@ -16710,11 +16707,25 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "aMI" = (
-/turf/simulated/floor/plating,
-/area/station/maintenance/central)
+/obj/machinery/door/poddoor/blast/pyro{
+	autoclose = 1;
+	dir = 4;
+	icon_state = "bdoormid1"
+	},
+/turf/simulated/floor/shuttlebay{
+	icon_state = "engine_caution_east"
+	},
+/area/station/hallway/secondary/exit)
 "aMJ" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/maintenance/central)
+/obj/grille/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
+/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5
+	},
+/area/station/hangar/escape)
 "aMK" = (
 /obj/decal/poster/wallsign/hazard_exheat,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -17377,11 +17388,8 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "aOs" = (
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/stairs/wide/other{
-	dir = 8
+/turf/simulated/floor/shuttlebay{
+	icon_state = "engine_caution_west"
 	},
 /area/station/hallway/secondary/exit)
 "aOt" = (
@@ -17389,17 +17397,12 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "aOu" = (
-/obj/table/auto,
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
+/obj/machinery/alarm{
+	pixel_y = 24
 	},
-/obj/item/storage/toolbox/emergency,
-/obj/machinery/light_switch/north,
-/obj/item/device/light/glowstick,
-/obj/item/device/light/glowstick,
-/turf/simulated/floor,
+/turf/simulated/floor/stairs/wide/other{
+	dir = 8
+	},
 /area/station/hallway/secondary/exit)
 "aOv" = (
 /obj/lattice{
@@ -17514,8 +17517,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "aOI" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/central)
+/obj/stool/bench/blue/auto,
+/obj/machinery/light/emergency{
+	dir = 1;
+	pixel_y = 16
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "aOJ" = (
 /obj/decal/poster/wallsign/space,
 /turf/simulated/wall/auto/supernorn,
@@ -17713,26 +17721,32 @@
 	},
 /area/station/hallway/secondary/exit)
 "aPd" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/table/auto,
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
 	},
-/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon14,
+/obj/item/storage/toolbox/emergency,
+/obj/machinery/light_switch/north,
+/obj/item/device/light/glowstick,
+/obj/item/device/light/glowstick,
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "aPe" = (
-/turf/simulated/floor/stairs/wide/middle{
-	dir = 8
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 8;
+	icon_state = "on";
+	on = 1
 	},
+/turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "aPf" = (
 /turf/simulated/floor/escape,
 /area/station/hallway/secondary/exit)
 "aPg" = (
-/obj/machinery/firealarm{
-	pixel_x = 6;
-	pixel_y = 24
-	},
-/turf/simulated/floor/escape,
+/obj/machinery/door/airlock/pyro/external,
+/turf/simulated/floor/caution/northsouth,
 /area/station/hallway/secondary/exit)
 "aPh" = (
 /obj/lattice{
@@ -18207,15 +18221,11 @@
 	},
 /area/station/hallway/secondary/exit)
 "aQd" = (
-/obj/item/device/radio/beacon,
-/obj/cable{
-	icon_state = "1-2"
-	},
+/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon14,
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "aQe" = (
-/obj/machinery/light,
-/turf/simulated/floor/stairs/wide{
+/turf/simulated/floor/stairs/wide/middle{
 	dir = 8
 	},
 /area/station/hallway/secondary/exit)
@@ -18223,17 +18233,15 @@
 /turf/simulated/floor/grey,
 /area/station/hallway/secondary/exit)
 "aQg" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 10;
-	name = "autoname - SS13";
-	tag = ""
+/obj/machinery/firealarm{
+	pixel_x = 6;
+	pixel_y = 24
 	},
-/turf/simulated/floor/grey,
+/turf/simulated/floor/escape,
 /area/station/hallway/secondary/exit)
 "aQh" = (
-/obj/machinery/light,
-/turf/simulated/floor/grey,
+/obj/item/device/radio/beacon,
+/turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "aQi" = (
 /obj/decal/fakeobjects/pipe/heat{
@@ -18470,9 +18478,11 @@
 	name = "Genetic Research"
 	})
 "aQE" = (
-/obj/storage/closet/emergency,
-/turf/simulated/floor/plating,
-/area/station/maintenance/central)
+/obj/machinery/light,
+/turf/simulated/floor/stairs/wide{
+	dir = 8
+	},
+/area/station/hallway/secondary/exit)
 "aQF" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
@@ -18801,12 +18811,18 @@
 /area/station/hallway/secondary/exit)
 "aRl" = (
 /obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"aRm" = (
+/obj/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
-	},
-/obj/cable{
-	icon_state = "1-2"
 	},
 /obj/cable{
 	d1 = 2;
@@ -18814,18 +18830,6 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/escape/corner,
-/area/station/hallway/secondary/exit)
-"aRm" = (
-/obj/shrub{
-	dir = 1
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc/autoname_east,
-/obj/machinery/light/emergency,
-/turf/simulated/floor/escape,
 /area/station/hallway/secondary/exit)
 "aRn" = (
 /obj/machinery/door/airlock/pyro/external,
@@ -19136,9 +19140,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "aRR" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/maintenance/central)
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor/grey,
+/area/station/hallway/secondary/exit)
 "aRS" = (
 /obj/machinery/computer3/terminal/zeta{
 	dir = 4;
@@ -19419,25 +19428,13 @@
 	},
 /area/station/hallway/secondary/exit)
 "aSv" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/pyro/glass,
-/turf/simulated/floor/escape{
-	dir = 4
-	},
+/obj/machinery/light,
+/turf/simulated/floor/grey,
 /area/station/hallway/secondary/exit)
 "aSw" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/obj/machinery/light/small{
+/obj/machinery/light/emergency{
 	dir = 4;
-	pixel_x = 12
+	pixel_x = 10
 	},
 /turf/simulated/floor/grey,
 /area/station/hallway/secondary/exit)
@@ -19781,24 +19778,25 @@
 	},
 /area/station/hallway/secondary/exit)
 "aTo" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
+/obj/shrub{
+	dir = 1
 	},
 /obj/cable{
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/escape{
-	dir = 4
-	},
+/obj/machinery/power/apc/autoname_east,
+/obj/machinery/light/emergency,
+/turf/simulated/floor/escape,
 /area/station/hallway/secondary/exit)
 "aTp" = (
 /turf/space,
 /area/shuttle/escape/station/cogmap2)
 "aTq" = (
-/obj/decal/poster/wallsign/space,
-/turf/simulated/wall/auto/reinforced/supernorn,
+/obj/machinery/door/airlock/pyro/external{
+	name = "Auxiliary Docking Point"
+	},
+/turf/simulated/floor/caution/northsouth,
 /area/station/hallway/secondary/exit)
 "aTr" = (
 /obj/disposalpipe/segment/vertical,
@@ -20113,17 +20111,20 @@
 "aUd" = (
 /obj/disposaloutlet/south,
 /obj/disposalpipe/trunk/west,
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
 /turf/simulated/floor/escape{
 	dir = 5
 	},
 /area/station/hallway/primary/east)
 "aUe" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/decal/poster/wallsign/stencil/left/e{
+	pixel_x = -1
 	},
-/turf/simulated/floor/escape{
-	dir = 4
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/secondary/exit)
 "aUf" = (
 /obj/decal/fakeobjects/pipe/heat{
@@ -20382,10 +20383,6 @@
 /turf/simulated/floor/neutral/corner,
 /area/station/hallway/primary/east)
 "aUO" = (
-/obj/machinery/light/emergency{
-	dir = 4;
-	pixel_x = 10
-	},
 /turf/simulated/floor/escape/corner{
 	dir = 4
 	},
@@ -21019,17 +21016,10 @@
 /area/station/hallway/secondary/exit)
 "aVZ" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
 /obj/landmark/gps_waypoint,
-/turf/simulated/floor/escape{
-	dir = 4
-	},
+/turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "aWa" = (
 /obj/machinery/floorflusher/industrial,
@@ -21560,10 +21550,12 @@
 "aXg" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/west,
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 9;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
 	},
 /turf/simulated/floor/escape/corner,
 /area/station/hallway/primary/east)
@@ -21953,12 +21945,10 @@
 /obj/table/auto,
 /obj/machinery/cell_charger,
 /obj/item/cell/charged,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
 	},
 /turf/simulated/floor/escape{
 	dir = 4
@@ -21972,11 +21962,10 @@
 	},
 /area/station/hallway/secondary/exit)
 "aYk" = (
-/obj/machinery/door/airlock/pyro/glass,
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor/escape{
 	dir = 4
 	},
@@ -22357,13 +22346,12 @@
 	},
 /area/station/hallway/primary/east)
 "aZf" = (
-/obj/machinery/light{
+/obj/machinery/light/emergency{
 	dir = 8;
-	layer = 9.1;
 	pixel_x = -10
 	},
 /turf/simulated/floor/escape/corner{
-	dir = 1
+	dir = 8
 	},
 /area/station/hallway/secondary/exit)
 "aZg" = (
@@ -23389,10 +23377,6 @@
 	},
 /area/station/hallway/primary/east)
 "bbA" = (
-/obj/machinery/light/emergency{
-	dir = 4;
-	pixel_x = 10
-	},
 /turf/simulated/floor/escape/corner,
 /area/station/hallway/primary/east)
 "bbB" = (
@@ -23855,12 +23839,12 @@
 /obj/stool/chair{
 	dir = 4
 	},
-/obj/machinery/light,
 /turf/simulated/floor/escape,
 /area/station/hallway/primary/east)
 "bcF" = (
 /obj/table/auto,
 /obj/item/game_kit,
+/obj/machinery/light,
 /turf/simulated/floor/escape,
 /area/station/hallway/primary/east)
 "bcG" = (
@@ -25232,23 +25216,25 @@
 	},
 /area/station/crew_quarters/quarters_south)
 "bfX" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/grey,
+/area/station/hallway/secondary/exit)
+"bfY" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/escape/corner{
 	dir = 4
-	},
-/area/station/hallway/secondary/exit)
-"bfY" = (
-/obj/shrub{
-	dir = 1
-	},
-/obj/machinery/light/emergency{
-	dir = 1;
-	pixel_y = 16
-	},
-/turf/simulated/floor/escape{
-	dir = 1
 	},
 /area/station/hallway/secondary/exit)
 "bfZ" = (
@@ -25678,30 +25664,32 @@
 /area/station/maintenance/central)
 "bhd" = (
 /obj/machinery/light{
-	dir = 1;
+	dir = 4;
 	layer = 9.1;
-	pixel_y = 21
+	pixel_x = 10
 	},
-/turf/simulated/floor/stairs/wide/other{
-	dir = 8
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/escape{
+	dir = 4
 	},
 /area/station/hallway/secondary/exit)
 "bhe" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
+/obj/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/grey,
+/turf/simulated/floor/escape{
+	dir = 4
+	},
 /area/station/hallway/secondary/exit)
 "bhf" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
 	},
-/turf/simulated/floor/grey,
+/turf/simulated/floor/escape{
+	dir = 1
+	},
 /area/station/hallway/secondary/exit)
 "bhh" = (
 /turf/simulated/floor/shuttlebay{
@@ -26182,11 +26170,6 @@
 /area/station/hallway/secondary/exit)
 "bii" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -26194,15 +26177,21 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
-/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon15,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "bij" = (
-/obj/machinery/atmospherics/unary/outlet_injector{
-	dir = 8;
-	icon_state = "on";
-	on = 1
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
+	},
+/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon15,
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "bik" = (
@@ -26493,11 +26482,14 @@
 /turf/simulated/floor/plating,
 /area/station/engine/storage)
 "biM" = (
-/obj/lattice{
-	dir = 8;
-	icon_state = "lattice-dir"
+/obj/grille/catwalk{
+	dir = 9;
+	icon_state = "catwalk_cross"
 	},
-/turf/space,
+/obj/disposalpipe/segment/bent/east,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 9
+	},
 /area/station/mining/refinery)
 "biN" = (
 /obj/landmark{
@@ -26851,26 +26843,33 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "bjA" = (
-/turf/simulated/floor/stairs/wide{
-	dir = 8
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/escape{
+	dir = 4
 	},
 /area/station/hallway/secondary/exit)
 "bjB" = (
-/obj/table/auto,
-/obj/machinery/light,
-/obj/item/storage/toolbox/emergency,
-/obj/item/device/light/glowstick,
-/obj/item/device/light/glowstick,
-/turf/simulated/floor,
+/obj/machinery/door/airlock/pyro/glass,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/escape{
+	dir = 4
+	},
 /area/station/hallway/secondary/exit)
 "bjC" = (
-/obj/stool/bench/blue/auto,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/escape,
 /area/station/hallway/secondary/exit)
 "bjE" = (
 /obj/machinery/camera{
@@ -26884,13 +26883,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "bjF" = (
-/obj/machinery/light{
+/obj/shrub{
+	dir = 1
+	},
+/obj/machinery/light/emergency{
 	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
+	pixel_y = 16
 	},
 /turf/simulated/floor/escape{
-	dir = 8
+	dir = 1
 	},
 /area/station/hallway/secondary/exit)
 "bjH" = (
@@ -27474,10 +27475,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "bkS" = (
-/obj/machinery/door/airlock/pyro/external{
-	name = "Auxiliary Docking Point"
-	},
-/turf/simulated/floor/caution/northsouth,
+/obj/decal/poster/wallsign/space,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/secondary/exit)
 "bkT" = (
 /obj/machinery/atmospherics/pipe/simple{
@@ -28012,11 +28011,21 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/central)
 "bme" = (
-/turf/simulated/floor/caution/westeast,
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/grey,
 /area/station/hallway/secondary/exit)
 "bmf" = (
-/turf/simulated/floor/shuttlebay{
-	icon_state = "engine_caution_west"
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/stairs/wide/other{
+	dir = 8
 	},
 /area/station/hallway/secondary/exit)
 "bmg" = (
@@ -28138,7 +28147,6 @@
 /obj/table/auto,
 /obj/bedsheetbin,
 /obj/item/device/analyzer/healthanalyzer,
-/obj/item/remote/porter/port_a_nanomed,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -28147,6 +28155,7 @@
 /obj/machinery/light_switch/north{
 	pixel_x = -11
 	},
+/obj/item/remote/porter/port_a_nanomed,
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/lobby)
 "bmx" = (
@@ -28568,10 +28577,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "bnv" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
 	},
 /turf/simulated/floor/grey,
 /area/station/hallway/secondary/exit)
@@ -28634,7 +28644,7 @@
 /turf/simulated/floor/redwhite,
 /area/station/medical/medbay/surgery)
 "bnE" = (
-/obj/storage/secure/closet/medical/anesthetic,
+/obj/storage/secure/closet/fridge/blood,
 /turf/simulated/floor/redwhite{
 	dir = 6
 	},
@@ -28659,7 +28669,7 @@
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/surgery)
 "bnI" = (
-/obj/machinery/vending/port_a_nanomed,
+/obj/machinery/manufacturer/medical,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "bnJ" = (
@@ -28777,6 +28787,7 @@
 	pixel_x = -10;
 	tag = ""
 	},
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
@@ -28833,13 +28844,6 @@
 /obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/caution/corner/misc{
 	dir = 10
-	},
-/area/station/mining/refinery)
-"bod" = (
-/obj/machinery/manufacturer/hangar,
-/obj/machinery/light_switch/north,
-/turf/simulated/floor/orangeblack/side{
-	dir = 4
 	},
 /area/station/mining/refinery)
 "boe" = (
@@ -29349,11 +29353,7 @@
 	name = "Inner Southwest Maintenance"
 	})
 "bpk" = (
-/obj/table/reinforced/auto,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/shipcomponent/secondary_system/orescoop,
-/obj/item/shipcomponent/communications/mining,
+/obj/storage/closet/welding_supply,
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
@@ -29372,12 +29372,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/caution/west,
-/area/station/mining/refinery)
-"bpo" = (
-/obj/machinery/bot/medbot,
-/turf/simulated/floor/orangeblack/side{
-	dir = 4
-	},
 /area/station/mining/refinery)
 "bpp" = (
 /obj/machinery/disposal,
@@ -29755,8 +29749,10 @@
 /area/station/medical/medbay/lobby)
 "bqn" = (
 /obj/table/reinforced/auto,
-/obj/item/shipcomponent/secondary_system/cargo,
-/obj/item/shipcomponent/secondary_system/cargo,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/shipcomponent/secondary_system/orescoop,
+/obj/item/shipcomponent/communications/mining,
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
@@ -30127,7 +30123,12 @@
 /turf/simulated/floor/greenblack,
 /area/station/garden/aviary)
 "bri" = (
-/turf/simulated/floor/shuttlebay,
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/grey,
 /area/station/hallway/secondary/exit)
 "brj" = (
 /obj/machinery/conveyor{
@@ -30187,8 +30188,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "brq" = (
-/obj/machinery/light,
-/turf/simulated/floor/escape{
+/turf/simulated/floor/stairs/wide{
 	dir = 8
 	},
 /area/station/hallway/secondary/exit)
@@ -30290,8 +30290,18 @@
 	})
 "brK" = (
 /obj/table/reinforced/auto,
-/obj/item/shipcomponent/sensor/mining,
-/obj/item/shipcomponent/sensor/mining,
+/obj/item/shipcomponent/sensor/mining{
+	pixel_x = -2
+	},
+/obj/item/shipcomponent/sensor/mining{
+	pixel_x = -2
+	},
+/obj/item/shipcomponent/secondary_system/cargo{
+	pixel_x = 5
+	},
+/obj/item/shipcomponent/secondary_system/cargo{
+	pixel_x = 5
+	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
@@ -30300,7 +30310,6 @@
 /turf/simulated/floor/caution/west,
 /area/station/mining/refinery)
 "brM" = (
-/obj/storage/closet/welding_supply,
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
@@ -30825,11 +30834,14 @@
 /turf/simulated/floor/engine,
 /area/station/mining/refinery)
 "btf" = (
-/obj/reagent_dispensers/fueltank,
 /obj/machinery/door_control{
 	id = "unlode";
 	name = "Unloading Door Control";
 	pixel_x = 25
+	},
+/obj/machinery/manufacturer/hangar,
+/obj/machinery/light_switch/east{
+	pixel_y = 11
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
@@ -37535,8 +37547,9 @@
 	},
 /area/station/quartermaster/office)
 "bHX" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/quartermaster/office)
+/obj/machinery/light/emergency,
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "bHY" = (
 /obj/disposalpipe/segment/transport,
 /obj/storage/closet/fire,
@@ -40749,8 +40762,13 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bOH" = (
+/obj/table/auto,
+/obj/machinery/light,
+/obj/item/storage/toolbox/emergency,
+/obj/item/device/light/glowstick,
+/obj/item/device/light/glowstick,
 /turf/simulated/floor,
-/area/station/quartermaster/office)
+/area/station/hallway/secondary/exit)
 "bOI" = (
 /obj/machinery/manufacturer/hangar,
 /turf/simulated/floor/grey,
@@ -41997,11 +42015,14 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bRp" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/stool/bench/blue/auto,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
 	},
 /turf/simulated/floor,
-/area/station/quartermaster/office)
+/area/station/hallway/secondary/exit)
 "bRq" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -42805,11 +42826,11 @@
 /turf/simulated/floor/caution/westeast,
 /area/station/quartermaster/office)
 "bSV" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/machinery/vehicle/escape_pod{
+	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/quartermaster/office)
+/turf/simulated/floor/shuttlebay,
+/area/station/hallway/secondary/exit)
 "bSW" = (
 /obj/machinery/light{
 	dir = 4;
@@ -48591,16 +48612,18 @@
 /turf/simulated/floor/plating,
 /area/station/medical/medbay)
 "cfo" = (
-/obj/wingrille_spawn/auto,
 /obj/cable{
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
 	},
-/turf/simulated/floor/plating,
-/area/station/mining/staff_room)
+/turf/simulated/floor/escape{
+	dir = 4
+	},
+/area/station/hallway/secondary/exit)
 "cfp" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -49285,17 +49308,17 @@
 /turf/simulated/floor/white/grime,
 /area/station/hangar/medical)
 "cgL" = (
-/obj/machinery/manufacturer/medical,
 /obj/machinery/light/emergency{
 	dir = 8;
 	pixel_x = -10
 	},
+/obj/machinery/vending/medical,
 /turf/simulated/floor/bluewhite{
 	dir = 8
 	},
 /area/station/medical/medbay)
 "cgM" = (
-/obj/storage/secure/closet/fridge/blood,
+/obj/machinery/vending/port_a_nanomed,
 /turf/simulated/floor/redwhite{
 	dir = 10
 	},
@@ -52156,22 +52179,11 @@
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "cnR" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/quartermaster/office)
+/turf/simulated/floor/caution/westeast,
+/area/station/hallway/secondary/exit)
 "cnS" = (
-/obj/wingrille_spawn/auto,
-/obj/cable,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/quartermaster/office)
+/turf/simulated/floor/shuttlebay,
+/area/station/hallway/secondary/exit)
 "cnT" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -53701,14 +53713,11 @@
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
 "doC" = (
-/obj/decal/poster/wallsign/stencil/left/c{
-	pixel_x = -6
+/obj/decal/poster/wallsign/stencil/left/e{
+	pixel_x = 1
 	},
-/obj/decal/poster/wallsign/stencil/right/a{
-	pixel_x = 7
-	},
-/obj/decal/poster/wallsign/stencil/right/p{
-	pixel_x = 18
+/obj/decal/poster/wallsign/stencil/right/s{
+	pixel_x = 14
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/secondary/exit)
@@ -53939,13 +53948,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "ezW" = (
-/obj/machinery/door/poddoor/blast/pyro{
-	autoclose = 1;
-	dir = 4;
-	icon_state = "bdoormid1"
+/obj/machinery/vehicle/escape_pod{
+	dir = 4
 	},
 /turf/simulated/floor/shuttlebay{
-	icon_state = "engine_caution_east"
+	icon_state = "engine_caution_west"
 	},
 /area/station/hallway/secondary/exit)
 "eCr" = (
@@ -53990,10 +53997,20 @@
 	},
 /turf/space,
 /area/station/ai_monitored/armory)
+"eQE" = (
+/obj/grille/catwalk,
+/obj/machinery/oreaccumulator,
+/turf/simulated/floor/airless/plating/catwalk,
+/area/station/mining/refinery)
 "eWB" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
+"eZW" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/mining/refinery)
 "fdN" = (
 /obj/decal/tile_edge/line/white{
 	dir = 8;
@@ -54025,6 +54042,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/lab)
+"fiI" = (
+/obj/reagent_dispensers/fueltank,
+/turf/simulated/floor/plating,
+/area/station/maintenance/storage{
+	name = "Inner Southwest Maintenance"
+	})
 "fjh" = (
 /obj/machinery/light,
 /obj/cable{
@@ -54490,16 +54513,6 @@
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
-"hGm" = (
-/obj/plasticflaps{
-	layer = 3
-	},
-/obj/machinery/door/poddoor/pyro{
-	id = "kondaru_qmfetch";
-	name = "Cargo Retrieval Door"
-	},
-/turf/simulated/floor/caution/westeast,
-/area/station/quartermaster/office)
 "hOS" = (
 /obj/grille/catwalk{
 	dir = 4
@@ -54712,7 +54725,6 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/power)
 "jej" = (
-/obj/machinery/vending/medical,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
@@ -54724,6 +54736,7 @@
 	pixel_x = -10;
 	tag = ""
 	},
+/obj/storage/secure/closet/medical/anesthetic,
 /turf/simulated/floor/red,
 /area/station/medical/medbay/surgery)
 "joy" = (
@@ -55138,10 +55151,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/lobby)
-"lNH" = (
-/obj/machinery/light/emergency,
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
 "lOu" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -55375,10 +55384,10 @@
 /turf/simulated/floor/caution/westeast,
 /area/station/quartermaster/office)
 "njl" = (
-/obj/machinery/vehicle/escape_pod{
-	dir = 4
+/obj/machinery/light,
+/turf/simulated/floor/escape{
+	dir = 8
 	},
-/turf/simulated/floor/shuttlebay,
 /area/station/hallway/secondary/exit)
 "nmf" = (
 /obj/table/auto,
@@ -55600,6 +55609,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
+"oAd" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/mining/refinery)
 "oDQ" = (
 /obj/machinery/light/emergency{
 	dir = 8;
@@ -55699,11 +55719,13 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "pfT" = (
-/obj/machinery/vehicle/escape_pod{
-	dir = 4
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
 	},
-/turf/simulated/floor/shuttlebay{
-	icon_state = "engine_caution_west"
+/turf/simulated/floor/escape{
+	dir = 8
 	},
 /area/station/hallway/secondary/exit)
 "phu" = (
@@ -55860,13 +55882,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
-"qhZ" = (
-/obj/machinery/light/emergency{
-	dir = 4;
-	pixel_x = 10
-	},
-/turf/simulated/floor/grey,
-/area/station/hallway/secondary/exit)
 "qmL" = (
 /obj/machinery/vending/standard,
 /turf/simulated/floor/plating,
@@ -55881,6 +55896,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
+"qsh" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/bot/medbot,
+/turf/simulated/floor,
+/area/station/mining/staff_room)
 "qsO" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -56093,14 +56122,6 @@
 	},
 /turf/simulated/floor/red,
 /area/station/security/main)
-"ryj" = (
-/obj/stool/bench/blue/auto,
-/obj/machinery/light/emergency{
-	dir = 1;
-	pixel_y = 16
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
 "rzs" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -56159,10 +56180,6 @@
 	},
 /turf/simulated/floor/white,
 /area/station/science/teleporter)
-"rQz" = (
-/obj/machinery/door/airlock/pyro/external,
-/turf/simulated/floor/caution/northsouth,
-/area/station/hallway/secondary/exit)
 "rQB" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -56514,6 +56531,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
+"tMa" = (
+/obj/machinery/door/airlock/pyro/external{
+	name = "Mining Hangar"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/mining,
+/turf/simulated/floor/orangeblack,
+/area/station/mining/staff_room)
 "tVy" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
@@ -56795,8 +56820,14 @@
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "vNa" = (
-/obj/decal/poster/wallsign/stencil/left/e{
-	pixel_x = -1
+/obj/decal/poster/wallsign/stencil/left/c{
+	pixel_x = -6
+	},
+/obj/decal/poster/wallsign/stencil/right/a{
+	pixel_x = 7
+	},
+/obj/decal/poster/wallsign/stencil/right/p{
+	pixel_x = 18
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/secondary/exit)
@@ -56867,15 +56898,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai)
-"weY" = (
-/obj/decal/poster/wallsign/stencil/left/e{
-	pixel_x = 1
-	},
-/obj/decal/poster/wallsign/stencil/right/s{
-	pixel_x = 14
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/secondary/exit)
 "whk" = (
 /obj/disposalpipe/segment/vertical,
 /obj/landmark/halloween,
@@ -57063,6 +57085,21 @@
 /obj/machinery/vending/janitor,
 /turf/simulated/floor/darkblue,
 /area/station/janitor/office)
+"xwP" = (
+/obj/disposalpipe/segment/bent/west,
+/obj/grille/catwalk{
+	dir = 5
+	},
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	icon_state = "catwalk_cross"
+	},
+/area/station/mining/refinery)
 "xzv" = (
 /obj/machinery/computer/tanning,
 /turf/simulated/wall/auto/supernorn,
@@ -98418,7 +98455,7 @@ bfi
 aNL
 aNL
 aHq
-aQE
+cdA
 aRO
 aSO
 aTG
@@ -98439,7 +98476,7 @@ baQ
 bka
 bka
 bka
-bkd
+fiI
 bkd
 bkd
 brI
@@ -99626,17 +99663,17 @@ aHq
 aHq
 aHq
 aHq
-aMI
+beJ
 aRO
 aSP
-aMI
+beJ
 xlK
-aMI
+beJ
 aQG
 xlK
 dBo
 vbg
-aMJ
+bmd
 baQ
 bdd
 baQ
@@ -100226,24 +100263,24 @@ aIr
 aJn
 aKx
 aAT
-aMI
+beJ
 aNO
-aOI
-aOI
-aOI
-aRR
-aOI
-aOI
-aOI
-aRR
-aOI
-aOI
-aOI
-aRR
-aOI
-aMJ
+beK
+beK
+beK
+bnu
+beK
+beK
+beK
+bnu
+beK
+beK
+beK
+bnu
+beK
+bmd
 bdf
-aMJ
+bmd
 bxj
 bgl
 bff
@@ -100528,7 +100565,7 @@ aIs
 aJo
 aKy
 aAS
-aMJ
+bmd
 aNP
 aOJ
 aPC
@@ -101177,13 +101214,13 @@ bGq
 bHL
 bJm
 bKI
-bHX
-bHX
+bXi
+bXi
 bXb
 bXb
-bHX
-bHX
-bHX
+bXi
+bXi
+bXi
 bVg
 bWr
 bZy
@@ -101456,8 +101493,8 @@ bfg
 bgm
 bfg
 biM
-aFU
-bff
+xwP
+eQE
 bmy
 bob
 bpm
@@ -101479,13 +101516,13 @@ bGr
 bHM
 bJn
 bKJ
-bHX
+bXi
 bMW
 bOD
 bPT
 bRj
 bSN
-bHX
+bXi
 bVh
 bWr
 bZy
@@ -101757,9 +101794,9 @@ abo
 bfg
 bgm
 bfg
-biM
 aFU
-blk
+oAd
+eZW
 bmy
 boc
 bpn
@@ -101787,7 +101824,7 @@ bKN
 bPU
 bRk
 bSO
-bHX
+bXi
 bVg
 bWr
 bZy
@@ -102059,12 +102096,12 @@ abo
 bfh
 bgn
 bfh
-apq
+aqi
 aJd
 aLt
-bmy
-bod
-bpo
+tMa
+brM
+brM
 bqr
 brM
 btf
@@ -102083,13 +102120,13 @@ bGu
 bHO
 bJp
 bKL
-cnR
+cok
 bMY
 bOE
 bPV
 bRl
 bSP
-bHX
+bXi
 bVi
 bWr
 bZy
@@ -102362,7 +102399,7 @@ bhF
 aoj
 bhF
 aqi
-cfo
+cfq
 bBt
 frY
 byc
@@ -102385,13 +102422,13 @@ bBv
 bJr
 bJA
 cnQ
-cnS
+col
 bMZ
 bOF
 bPW
 bRm
 bSQ
-bHX
+bXi
 bVg
 bWr
 bZy
@@ -102693,7 +102730,7 @@ bOG
 bPX
 bRn
 bSR
-bHX
+bXi
 bVg
 bWr
 bZy
@@ -102991,11 +103028,11 @@ bJs
 bKN
 bKN
 bNb
-bOH
-bOH
+bYl
+bYl
 bRo
 bSS
-bHX
+bXi
 bVj
 bWs
 bZy
@@ -103295,9 +103332,9 @@ mmP
 bLW
 mmP
 bPY
-bRp
+cbI
 bST
-bHX
+bXi
 bVg
 bWr
 bZy
@@ -103602,7 +103639,7 @@ bSU
 niK
 gjD
 hmG
-hGm
+niK
 bYk
 tmm
 caJ
@@ -103899,8 +103936,8 @@ bLY
 bNe
 bOJ
 bPZ
-bRp
-bOH
+cbI
+bYl
 bUe
 bVk
 bWt
@@ -104178,7 +104215,7 @@ cpg
 cps
 cpS
 buC
-cpS
+qsh
 cpV
 bmH
 bmH
@@ -104202,7 +104239,7 @@ bLZ
 bOK
 bQa
 bRq
-bSV
+bYm
 bUf
 bVl
 bWu
@@ -104798,16 +104835,16 @@ bDA
 bEm
 bFB
 bBv
-bHX
-bHX
-bHX
-bHX
-bHX
-bHX
-bHX
-bHX
+bXi
+bXi
+bXi
+bXi
+bXi
+bXi
+bXi
+bXi
 llV
-bHX
+bXi
 bVg
 bWr
 bXi
@@ -124394,13 +124431,13 @@ bkg
 blj
 aMn
 aNu
-aNu
+bhf
 aVX
 aNu
 aNv
 aNu
 bav
-aNu
+bjC
 aNu
 aNv
 aNu
@@ -124695,15 +124732,15 @@ aQc
 aRk
 aSu
 aQc
-aQc
+apq
 aUP
 aVY
-aXh
-aYj
 aZf
+aYj
+aUP
 aOr
 aXh
-aQc
+apq
 aTn
 aSu
 aQc
@@ -124992,24 +125029,24 @@ aLo
 aMp
 aNt
 aOq
-aPd
-aQd
-aRl
-aSv
-aTo
-aUe
-aUe
-aVZ
-aUe
-aYk
-aUe
-aUe
-aUe
-aUe
-aTo
-aSv
-bfX
 aOq
+aOq
+aRl
+aNu
+aOr
+aOr
+aOr
+aVZ
+aOr
+aNu
+aOr
+aOr
+aOr
+aOr
+aOr
+aNu
+aOr
+aOr
 bii
 bjz
 aNu
@@ -125294,24 +125331,24 @@ aEP
 aMq
 aEP
 aOr
-aOr
-aOr
+aQd
+aQh
 aRm
-aNv
-aNu
-aNu
-aNu
-aNu
-aNu
-aNv
-aNu
-aNu
-aNu
-aNu
-aNu
-aNv
+aYk
+bhd
+bhe
+bhe
+bjA
+cfo
+bjB
+bhe
+bhe
+bhe
+cfo
+bhe
+aYk
 bfY
-aOr
+aOq
 bij
 aOr
 aNu
@@ -125595,31 +125632,31 @@ aEP
 aLp
 aMr
 aEO
-aOs
-aPe
-aQe
-aNv
-aNv
-awS
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaO
-aNv
-aNv
-bhd
-aPe
-bjA
+aOr
+aOr
+aOr
+aTo
 aNv
 aNu
 aNu
-aTq
+aNu
+aNu
+aNu
+aNv
+aNu
+aNu
+aNu
+aNu
+aNu
+aNv
+bjF
+aOr
+aPe
+aOr
+aNv
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -125893,34 +125930,34 @@ aaa
 aaa
 aaa
 aaa
-aci
+aaa
 ach
-aaR
-aNu
-aOt
-aPf
-aQf
-weY
+aMJ
+aNv
+aOu
+aQe
+aQE
+aNv
+aNv
 awS
 aaa
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaO
-weY
-aQf
-bik
-aOr
-bkS
-aQf
-bnv
+aNv
+aNv
+bmf
+aQe
+brq
+aNv
+aNu
+aNu
 bkS
 aaa
 aaa
@@ -126199,12 +126236,12 @@ aci
 aaO
 aad
 aNu
-ryj
+aOt
 aPf
 aQf
 doC
+awS
 aaa
-aaa
 aTp
 aTp
 aTp
@@ -126215,15 +126252,15 @@ aTp
 aTp
 aTp
 aaa
-aaa
+aaO
 doC
 aQf
 bik
-lNH
-aNu
+aOr
+aTq
+aQf
 bme
-bme
-aNu
+aTq
 aaa
 aaa
 aaa
@@ -126501,13 +126538,12 @@ aci
 aaa
 aaa
 aNu
-aOt
+aOI
 aPf
 aQf
 vNa
 aaa
-aTp
-aTp
+aaa
 aTp
 aTp
 aTp
@@ -126518,14 +126554,15 @@ aTp
 aTp
 aTp
 aaa
+aaa
 vNa
 aQf
 bik
-aOr
-bkS
-aQf
-aQf
-bkS
+bHX
+aNu
+cnR
+cnR
+aNu
 aaa
 aaa
 aaa
@@ -126801,12 +126838,12 @@ aaa
 aaa
 aci
 aaa
-abW
-aNv
-aOu
+aaa
+aNu
+aOt
 aPf
-aQg
-aNu
+aQf
+aUe
 aaa
 aTp
 aTp
@@ -126820,13 +126857,13 @@ aTp
 aTp
 aTp
 aaa
-aNu
-bhe
+aUe
+aQf
 bik
-bjB
-aNv
-aNu
-aNu
+aOr
+aTq
+aQf
+aQf
 aTq
 aaa
 aaa
@@ -127103,11 +127140,11 @@ aaa
 aaa
 aci
 aaa
-aaa
-aNu
-aOt
+abW
+aNv
+aPd
 aPf
-aQf
+aRR
 aNu
 aaa
 aTp
@@ -127123,13 +127160,13 @@ aTp
 aTp
 aaa
 aNu
-aQf
+bnv
 bik
-aOt
+bOH
+aNv
 aNu
-aaa
-aaa
-aci
+aNu
+bkS
 aaa
 aaa
 aaa
@@ -127412,7 +127449,6 @@ aPf
 aQf
 aNu
 aaa
-aaa
 aTp
 aTp
 aTp
@@ -127422,7 +127458,8 @@ aTp
 aTp
 aTp
 aTp
-aaa
+aTp
+aTp
 aaa
 aNu
 aQf
@@ -127707,13 +127744,13 @@ aaa
 aaa
 aci
 aaa
-acb
+aaa
 aNu
 aOt
 aPf
 aQf
 aNu
-afw
+aaa
 aaa
 aTp
 aTp
@@ -127725,13 +127762,13 @@ aTp
 aTp
 aTp
 aaa
-acb
+aaa
 aNu
 aQf
 bik
-bjC
+aOt
 aNu
-afw
+aaa
 aaa
 aci
 aaa
@@ -128007,35 +128044,35 @@ aaa
 aaa
 aaa
 aaa
-aNv
+aci
+aaa
+acb
 aNu
+aOt
+aPf
+aQf
 aNu
-aNv
-aNv
-aPg
-aQh
-aNv
+afw
+aaa
+aTp
+aTp
+aTp
+aTp
+aTp
+aTp
+aTp
+aTp
+aTp
+aaa
+acb
 aNu
-aTq
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
-aTq
-aNu
-aNv
-bhf
+aQf
 bik
-aNv
-aNv
-aNv
-aNv
-aNv
+bRp
+aNu
+afw
+aaa
+aci
 aaa
 aaa
 aaa
@@ -128309,16 +128346,16 @@ aaa
 aaa
 aaa
 aaa
+aNv
 aNu
-bjF
-aQc
-aQc
-rQz
-aPf
-aQf
-aRn
-aQf
-aRn
+aNu
+aNv
+aNv
+aQg
+aSv
+aNv
+aNu
+bkS
 aTp
 aTp
 aTp
@@ -128328,16 +128365,16 @@ aTp
 aTp
 aTp
 aTp
-aRn
-aQf
-aRn
-aQf
+bkS
+aNu
+aNv
+bri
 bik
-rQz
-aQc
-aQc
-brq
-aNu
+aNv
+aNv
+aNv
+aNv
+aNv
 aaa
 aaa
 aaa
@@ -128613,13 +128650,13 @@ aaa
 aaa
 aNu
 pfT
-bmf
-pfT
-aNu
+aQc
+aQc
+aPg
 aPf
-qhZ
+aQf
 aRn
-aSw
+aQf
 aRn
 aTp
 aTp
@@ -128631,13 +128668,13 @@ aTp
 aTp
 aTp
 aRn
-aSw
+aQf
 aRn
-qhZ
+aQf
 bik
-aNu
-njl
-bri
+aPg
+aQc
+aQc
 njl
 aNu
 aaa
@@ -128913,35 +128950,35 @@ aaa
 aaa
 aaa
 aaa
-aNv
+aNu
 ezW
-aNv
+aOs
 ezW
-aNv
 aNu
+aPf
+aSw
+aRn
+bfX
+aRn
+aTp
+aTp
+aTp
+aTp
+aTp
+aTp
+aTp
+aTp
+aTp
+aRn
+bfX
+aRn
+aSw
+bik
 aNu
-aNv
+bSV
+cnS
+bSV
 aNu
-aTq
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
-aTq
-aNu
-aNv
-aNu
-aNu
-aNv
-ezW
-aNv
-ezW
-aNv
 aaa
 aaa
 aaa
@@ -129215,16 +129252,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aci
-aaa
-aci
-aaa
-aaa
-aci
-aaa
-aaa
+aNv
+aMI
+aNv
+aMI
+aNv
+aNu
+aNu
+aNv
+aNu
+bkS
 aTp
 aTp
 aTp
@@ -129234,16 +129271,16 @@ aTp
 aTp
 aTp
 aTp
-aaa
-aaa
-aci
-aaa
-aaa
-aci
-aaa
-aaa
-aaa
-aaa
+bkS
+aNu
+aNv
+aNu
+aNu
+aNv
+aMI
+aNv
+aMI
+aNv
 aaa
 aaa
 aaa
@@ -129519,9 +129556,9 @@ aaa
 aaa
 aaa
 aaa
-aOv
+aci
 aaa
-aOv
+aci
 aaa
 aaa
 aci
@@ -129541,7 +129578,7 @@ aaa
 aci
 aaa
 aaa
-aOv
+aci
 aaa
 aaa
 aaa
@@ -129821,12 +129858,12 @@ aaa
 aaa
 aaa
 aaa
+aOv
+aaa
+aOv
 aaa
 aaa
-aaa
-aaa
-aaa
-aRo
+aci
 aaa
 aaa
 aTp
@@ -129840,10 +129877,10 @@ aTp
 aTp
 aaa
 aaa
-aRo
+aci
 aaa
 aaa
-aaa
+aOv
 aaa
 aaa
 aaa
@@ -130128,9 +130165,9 @@ aaa
 aaa
 aaa
 aaa
+aRo
 aaa
 aaa
-aaa
 aTp
 aTp
 aTp
@@ -130142,7 +130179,7 @@ aTp
 aTp
 aaa
 aaa
-aaa
+aRo
 aaa
 aaa
 aaa
@@ -130433,7 +130470,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aTp
 aTp
 aTp
@@ -130441,7 +130477,8 @@ aTp
 aTp
 aTp
 aTp
-aaa
+aTp
+aTp
 aaa
 aaa
 aaa
@@ -131038,13 +131075,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aTp
 aTp
 aTp
 aTp
 aTp
-aaa
+aTp
+aTp
 aaa
 aaa
 aaa
@@ -131643,11 +131680,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aTp
 aTp
 aTp
-aaa
+aTp
+aTp
 aaa
 aaa
 aaa
@@ -131946,9 +131983,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aTp
+aTp
+aTp
 aaa
 aaa
 aaa


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEAT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Targeted set of Kondaru upgrades/changes to address some received feedback.

- The Escape hallway has been adjusted slightly to improve roominess and navigability; the vertical segment of the hall is now three tiles wide instead of two, and the left doors have been changed from single to double.
- Slight realignment of Medbay hardware; the operating theater NanoMed, Port-A-NanoMed, and medical fabricator have been swapped clockwise. Should improve treatment flow a bit.
- Mining now has a second, more direct airlock to the magnet area. Some objects have been realigned to accommodate this, most notably the welding fuel tank moving into Maintenance just west of the hangar.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Further quality of life improvements for Kondaru.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Kubius:
(+)Small Kondaru upgrades: some bits of escape widened, a few things in Medbay shuffled about, and a new airlock in Mining.
```
