### PR TITLE
Adjustment to reworked wages + dice sheet cost reduction

### DIFF
--- a/_std/defines/wages.dm
+++ b/_std/defines/wages.dm
@@ -1,12 +1,12 @@
 /// e.g. clown
 #define PAY_DUMBCLOWN 1
 /// e.g. staffie
-#define PAY_UNTRAINED 100
+#define PAY_UNTRAINED 120
 // e.g. miner
 #define PAY_TRADESMAN 300
 /// e.g. scientist
-#define PAY_DOCTORATE 500
+#define PAY_DOCTORATE 480
 /// e.g. head
-#define PAY_IMPORTANT 1000
+#define PAY_IMPORTANT 900
 /// e.g. captain
-#define PAY_EXECUTIVE 1500
+#define PAY_EXECUTIVE 1200

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -2025,7 +2025,7 @@
 	create_products()
 		..()
 		product_list += new/datum/data/vending_product(/obj/item/paper/card_manual, 10, cost=PAY_UNTRAINED/5)
-		product_list += new/datum/data/vending_product(/obj/item/paper/yachtdice, 20, cost=PAY_UNTRAINED/3)
+		product_list += new/datum/data/vending_product(/obj/item/paper/yachtdice, 20, cost=PAY_UNTRAINED/8)
 		product_list += new/datum/data/vending_product(/obj/item/paper/book/grifening, 10, cost=PAY_UNTRAINED/5)
 		product_list += new/datum/data/vending_product(/obj/item/card_box/trading, 5, cost=PAY_UNTRAINED/2)
 		product_list += new/datum/data/vending_product(/obj/item/card_box/booster, 20, cost=PAY_UNTRAINED/10)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Two supplementary changes to the Urs wage rework:

- Readjusted wage tiers from 100, 300, 500, 1000, 1500 to 120, 300, 480, 900, 1200.
- Changed yacht dice sheets to be a more appropriate price of untrained/8 (they were accidentally interpreted as being actual dice instead of sheets of paper).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This adjustment to the wage tiers serves two main purposes:

- All costs in the new tiers are divisible by three, ensuring that an attempt to divide those tiers by three for the cost of an item will divide out without an odd remainder - quite a few items have this price set at the moment.
- Wages are slightly evened out in terms of wealth delta - higher-ranked staff still earn a considerable amount more, but the gap is a bit smoother and should hopefully make pricing settle out well for items priced at different tiers.

The yacht dice sheet change is sort of separate to this, but still pretty good if you wanna play yacht dice.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Kubius:
(+)Adjusted the new wages to graduate more evenly. No more single dollars hanging around in your account, hopefully.
```
