### PR TITLE
monkey gender is now set correctly

### DIFF
--- a/code/mob/living/carbon/human/monkeys.dm
+++ b/code/mob/living/carbon/human/monkeys.dm
@@ -114,6 +114,7 @@
 		START_TRACKING
 		SPAWN_DBG(0.5 SECONDS)
 			if (!src.disposed)
+				src.bioHolder.mobAppearance.gender = src.gender
 				src.bioHolder.mobAppearance.customization_first = "None"
 				src.cust_one_state = "None"
 				src.bioHolder.AddEffect("monkey")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fixes #2796 
Seems the problem is that the monkey appearanceHolder always has male set as gender and this overrides the monkeys default gender when their appearance is updated due to receiving the monkey mutantrace.

Not sure if this is the best way of solving it, but it does seem to work in my testing.
Maybe it should be put further up in the human class? Not sure if humans have the same issue, tbh, I can't even think of any female NPC humans.