### PR TITLE
Fix walking through closets

### DIFF
--- a/code/obj/storage/closets.dm
+++ b/code/obj/storage/closets.dm
@@ -4,7 +4,6 @@
 	soundproofing = 3
 	can_flip_bust = 1
 	p_class = 3
-	event_handler_flags = NO_MOUSEDROP_QOL
 
 	New()
 		. = ..()

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -4,7 +4,6 @@
 	soundproofing = 5
 	can_flip_bust = 1
 	p_class = 3
-	event_handler_flags = NO_MOUSEDROP_QOL
 
 /obj/storage/secure/closet/personal
 	name = "personal locker"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
You currently can't walk through open closets. This is due to the fact that `event_handler_flags` got overriden to remove `USE_FLUID_ENTER | USE_CANPASS` in #2751 and #2735 . This PR fixes that.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's a bug and not being able to walk through closets sucks.


## Changelog