### PR TITLE
Fix a few lizard abilities using up points when cancelled

### DIFF
--- a/code/datums/abilities/lizard.dm
+++ b/code/datums/abilities/lizard.dm
@@ -60,7 +60,7 @@
 
 		if (L.mutantrace && !istype(L.mutantrace, /datum/mutantrace/lizard))
 			boutput(L, "<span class='notice'>You don't have any chromatophores.</span>")
-			return
+			return 1
 
 		if (L?.bioHolder?.mobAppearance)
 			var/datum/appearanceHolder/AHs = L.bioHolder.mobAppearance
@@ -89,7 +89,7 @@
 
 		if (L.mutantrace && !istype(L.mutantrace, /datum/mutantrace/lizard))
 			boutput(L, "<span class='notice'>You're fresh out of chromatophores.</span>")
-			return
+			return 1
 
 		if (L?.bioHolder?.mobAppearance)
 			var/datum/appearanceHolder/AHs = L.bioHolder.mobAppearance
@@ -98,17 +98,15 @@
 
 			if (!which_region)
 				boutput(L, "<span class='notice'>You leave your pigmentation as-is.</span>")
-				return
+				return 1
 
 			var/coloration = input(L, "Please select skin color.", "Character Generation")  as null | color
 
 			if (!coloration)
 				boutput(L, "<span class='notice'>You think it looks fine the way it is.</span>")
-				return
+				return 1
 
 			actions.start(new/datum/action/bar/lizcolor(L, fix_colors(coloration), regions[which_region], which_region, AHs), L)
-			return
-
 
 
 /datum/action/bar/lizcolor


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #2791 . Note that due to the ordering of checks you can get de-lizarded during one of the input windows and then finish casting the ability to change your colour while not being a lizard, probably should be fixed at some point.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
🐛


## Changelog
