### PR TITLE
Temporary VPN whitelist "UI"

### DIFF
--- a/code/client.dm
+++ b/code/client.dm
@@ -305,6 +305,7 @@ var/global/list/vpn_ip_checks = list() //assoc list of ip = true or ip = false. 
 							</head>
 							<body>
 								<h1>Please disable your VPN, close the game, and rejoin.</h1><br>
+								If you are not using a VPN please join <a href="https://discord.com/invite/zd8t6pY">our Discord server</a> and ask an admin for help.
 							</body>
 						</html>
 					"}

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1969,7 +1969,7 @@ var/list/fun_images = list()
 	logTheThing("admin", null, null, "Ckey [vpnckey] added to the VPN whitelist.")
 	return 1
 
-/client/proc/vpn_whitelist_remove(ckey as text)
+/client/proc/vpn_whitelist_remove(vpnckey as text)
 	set name = "VPN whitelist remove"
 	SET_ADMIN_CAT(ADMIN_CAT_PLAYERS)
 	try

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -174,7 +174,10 @@ var/list/admin_verbs = list(
 		/client/proc/cmd_scale_type,
 		/client/proc/cmd_rotate_type,
 		/client/proc/cmd_spin_type,
-		/client/proc/cmd_get_type
+		/client/proc/cmd_get_type,
+
+		/client/proc/vpn_whitelist_add,
+		/client/proc/vpn_whitelist_remove
 		),
 
 	4 = list(
@@ -1952,3 +1955,28 @@ var/list/fun_images = list()
 			C.cmd_emag_target(A)
 
 	src.update_cursor()
+
+
+/client/proc/vpn_whitelist_add(vpnckey as text)
+	set name = "VPN whitelist add"
+	SET_ADMIN_CAT(ADMIN_CAT_PLAYERS)
+	try
+		apiHandler.queryAPI("vpncheck-whitelist/add", list("ckey" = vpnckey, "akey" = src.ckey))
+	catch(var/exception/e)
+		message_admins("Error while adding ckey [vpnckey] to the VPN whitelist: [e.name]")
+		return 0
+	message_admins("Ckey [vpnckey] added to the VPN whitelist.")
+	logTheThing("admin", null, null, "Ckey [vpnckey] added to the VPN whitelist.")
+	return 1
+
+/client/proc/vpn_whitelist_remove(ckey as text)
+	set name = "VPN whitelist remove"
+	SET_ADMIN_CAT(ADMIN_CAT_PLAYERS)
+	try
+		apiHandler.queryAPI("vpncheck-whitelist/remove", list("ckey" = vpnckey, "akey" = src.ckey))
+	catch(var/exception/e)
+		message_admins("Error while removing ckey [vpnckey] from the VPN whitelist: [e.name]")
+		return 0
+	message_admins("Ckey [vpnckey] removed from the VPN whitelist.")
+	logTheThing("admin", null, null, "Ckey [vpnckey] removed from the VPN whitelist.")
+	return 1

--- a/strings/admin_changelog.txt
+++ b/strings/admin_changelog.txt
@@ -1,3 +1,6 @@
+(t)mon nov 11 20
+(u)pali
+(*)Verbs "VPN Whitelist Add" and "VPN Whitelist Remove" now exist. Supply them with a ckey to remove / add them to the VPN whitelist.
 (t)sat nov 07 20
 (u)Sovexe
 (*)New buildmode mode, Appearance. Allows you to copy the appearance of any mob/obj/turf and apply it to any other mob/obj/turf.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds two new admin verbs - "VPN Whitelist Add" and "VPN Whitelist Remove", both take a ckey and do the thing. Also adds a message to the VPN kick window that tells people to join the Discord server and ask for help if they are not using a VPN.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently we need to ping Wire each time and I doubt the tgui UI for this is gonna appear soon.


## Changelog
