### PR TITLE
Fix bug where you could clone someone that was just cloned

### DIFF
--- a/code/obj/machinery/clonepod.dm
+++ b/code/obj/machinery/clonepod.dm
@@ -235,7 +235,7 @@
 			src.occupant.abilityHolder.transferOwnership(src.occupant) //mbc : fixed clone removing abilities bug!
 			src.occupant.abilityHolder.remove_unlocks()
 
-		ghost.client.mob = src.occupant
+		ghost.mind.transfer_to(src.occupant)
 
 		if(src.occupant.bioHolder.clone_generation > 1)
 			var/health_penalty = (src.occupant.bioHolder.clone_generation - 1) * 15


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[MAJOR]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #2361, probably. Also probably fixes #2222. Basically, the mind was never transferred properly (i.e. nulled) from the old brain, but now it is. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bugs bad. 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Flourish:
(+)Fixed the bug where you could clone someone that was just cloned. 
```