### PR TITLE
Chicken equipment for Kondaru, Ozymandias, Fleet, Icarus

### DIFF
--- a/maps/fleet.dmm
+++ b/maps/fleet.dmm
@@ -16993,7 +16993,8 @@
 	dir = 8;
 	pixel_x = -12
 	},
-/obj/shrub,
+/obj/submachine/chicken_incubator,
+/obj/item/reagent_containers/food/snacks/ingredient/egg,
 /turf/simulated/floor/grass,
 /area/station/garden/aviary{
 	name = "Demeter Primary Zone"
@@ -17072,10 +17073,8 @@
 	name = "Demeter Primary Zone"
 	})
 "Hv" = (
-/obj/stone{
-	dir = 1
-	},
 /obj/machinery/light/small,
+/obj/machinery/plantpot,
 /turf/simulated/floor/grass,
 /area/station/garden/aviary{
 	name = "Demeter Primary Zone"
@@ -21267,6 +21266,7 @@
 	pixel_y = 20;
 	tag = ""
 	},
+/obj/item/reagent_containers/food/snacks/plant/corn,
 /turf/simulated/floor/grass,
 /area/station/garden/aviary{
 	name = "Demeter Primary Zone"
@@ -24471,6 +24471,13 @@
 /area/station/engine/core{
 	name = "Erebus Plasmitics Zone"
 	})
+"WV" = (
+/obj/submachine/chicken_feed_grinder,
+/obj/item/reagent_containers/food/snacks/plant/corn,
+/turf/simulated/floor/grass,
+/area/station/garden/aviary{
+	name = "Demeter Primary Zone"
+	})
 "WW" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
@@ -25026,6 +25033,12 @@
 	},
 /turf/space,
 /area/space)
+"YF" = (
+/obj/item/reagent_containers/food/snacks/plant/corn,
+/turf/simulated/floor/grass,
+/area/station/garden/aviary{
+	name = "Demeter Primary Zone"
+	})
 "YG" = (
 /obj/machinery/drainage,
 /obj/disposalpipe/segment/transport{
@@ -53486,7 +53499,7 @@ Eb
 Dh
 Hd
 Dh
-CJ
+WV
 Ck
 HH
 PJ
@@ -55295,7 +55308,7 @@ DI
 Pw
 Dh
 Dh
-Dh
+YF
 Eb
 Hm
 He

--- a/maps/icarus.dmm
+++ b/maps/icarus.dmm
@@ -14519,6 +14519,7 @@
 	layer = 9.1;
 	pixel_x = 10
 	},
+/obj/machinery/hydro_growlamp,
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "aFG" = (
@@ -14793,11 +14794,12 @@
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "aGl" = (
-/obj/machinery/hydro_growlamp,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
 	},
+/obj/submachine/chicken_incubator,
+/obj/item/reagent_containers/food/snacks/ingredient/egg,
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "aGm" = (
@@ -15151,13 +15153,12 @@
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "aHa" = (
-/obj/table/auto,
-/obj/machinery/recharger,
-/obj/item/cargotele,
 /obj/item/device/radio/intercom/catering{
 	dir = 8;
 	pixel_x = 20
 	},
+/obj/submachine/chicken_feed_grinder,
+/obj/item/reagent_containers/food/snacks/plant/corn,
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "aHb" = (
@@ -15837,13 +15838,19 @@
 /area/station/hydroponics/bay)
 "aIu" = (
 /obj/table/auto,
-/obj/item/bee_egg_carton,
-/obj/item/plantanalyzer,
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1";
 	layer = 9.1;
 	pixel_x = 10
+	},
+/obj/machinery/recharger,
+/obj/item/cargotele,
+/obj/item/bee_egg_carton{
+	pixel_y = 18
+	},
+/obj/item/plantanalyzer{
+	pixel_x = 6
 	},
 /turf/simulated/floor,
 /area/station/hydroponics/bay)

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -29498,12 +29498,14 @@
 	pixel_y = 6
 	},
 /obj/deskclutter,
-/obj/item/pen,
-/obj/item/hand_labeler,
-/obj/item/plantanalyzer,
-/obj/item/reagent_containers/food/snacks/sandwich/meat_m{
-	name = "100% synthetic freerange monkey sandwich"
+/obj/item/hand_labeler{
+	pixel_x = 5
 	},
+/obj/item/plantanalyzer,
+/obj/item/device/reagentscanner{
+	pixel_x = -7
+	},
+/obj/item/pen,
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "bpG" = (
@@ -30419,6 +30421,9 @@
 /obj/stool/chair/green{
 	dir = 4
 	},
+/obj/landmark/start{
+	name = "Botanist"
+	},
 /turf/simulated/floor/grey,
 /area/station/hydroponics/bay)
 "bsc" = (
@@ -30996,10 +31001,8 @@
 /area/station/hydroponics/bay)
 "bty" = (
 /obj/disposalpipe/segment/food,
-/obj/table/auto,
-/obj/item/paper/book/hydroponicsguide,
-/obj/item/paper/book/hydroponicsguide,
-/obj/item/device/reagentscanner,
+/obj/submachine/chicken_incubator,
+/obj/item/reagent_containers/food/snacks/ingredient/egg,
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "btz" = (
@@ -31510,13 +31513,9 @@
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "buO" = (
-/obj/stool/chair/green{
-	dir = 8
-	},
 /obj/machinery/light,
-/obj/landmark/start{
-	name = "Botanist"
-	},
+/obj/submachine/chicken_feed_grinder,
+/obj/item/reagent_containers/food/snacks/plant/corn,
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "buP" = (
@@ -32558,7 +32557,13 @@
 	},
 /obj/table/auto,
 /obj/item/device/light/lava_lamp{
+	pixel_x = 6;
 	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/snacks/sandwich/meat_m{
+	name = "100% synthetic freerange monkey sandwich";
+	pixel_x = -7;
+	pixel_y = 9
 	},
 /turf/simulated/floor/green/side{
 	dir = 1
@@ -33114,6 +33119,9 @@
 /obj/disposalpipe/segment/vertical,
 /obj/stool/chair/office/green{
 	dir = 8
+	},
+/obj/landmark/start{
+	name = "Botanist"
 	},
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
@@ -34126,7 +34134,16 @@
 /area/station/hydroponics/bay)
 "bAx" = (
 /obj/table/auto,
-/obj/item/storage/box/beakerbox,
+/obj/item/paper/book/hydroponicsguide{
+	pixel_x = -5
+	},
+/obj/item/storage/box/beakerbox{
+	pixel_x = 12;
+	pixel_y = 4
+	},
+/obj/item/paper/book/hydroponicsguide{
+	pixel_x = -5
+	},
 /turf/simulated/floor/green/side,
 /area/station/hydroponics/bay)
 "bAy" = (
@@ -53622,6 +53639,13 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/medical/robotics)
+"cSO" = (
+/obj/stool/bench/green/auto,
+/obj/landmark/start{
+	name = "Botanist"
+	},
+/turf/simulated/floor,
+/area/station/hydroponics/bay)
 "cTm" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -110258,7 +110282,7 @@ boo
 bpA
 bqK
 bqK
-bqK
+cSO
 buO
 boq
 boq

--- a/maps/ozymandias.dmm
+++ b/maps/ozymandias.dmm
@@ -2909,6 +2909,14 @@
 "aUp" = (
 /turf/simulated/floor/blueblack/corner,
 /area/station/hallway/secondary/north)
+"aUq" = (
+/obj/submachine/chicken_incubator,
+/obj/item/reagent_containers/food/snacks/ingredient/egg,
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/turf/simulated/floor/grass,
+/area/station/hydroponics/bay)
 "aUy" = (
 /obj/cable{
 	d1 = 1;
@@ -5722,6 +5730,11 @@
 	dir = 1
 	},
 /area/station/medical/staff)
+"bPy" = (
+/obj/submachine/chicken_feed_grinder,
+/obj/item/reagent_containers/food/snacks/plant/corn,
+/turf/simulated/floor/grass,
+/area/station/hydroponics/bay)
 "bPG" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -58090,11 +58103,8 @@
 /turf/simulated/floor/stairs/wood,
 /area/station/crew_quarters/arcade)
 "rBU" = (
-/obj/shrub{
-	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "plant";
-	pixel_x = -11
-	},
+/obj/submachine/chicken_feed_grinder,
+/obj/item/reagent_containers/food/snacks/plant/corn,
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
@@ -65590,11 +65600,8 @@
 	name = "Officers' Lounge"
 	})
 "tBL" = (
-/obj/shrub{
-	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "plant";
-	pixel_x = -11
-	},
+/obj/submachine/chicken_incubator,
+/obj/item/reagent_containers/food/snacks/ingredient/egg,
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
 "tBQ" = (
@@ -143638,7 +143645,7 @@ kDK
 xsJ
 xsJ
 tBL
-tBL
+bPy
 wMD
 jRU
 wMD
@@ -143646,7 +143653,7 @@ wMD
 wMD
 jRU
 rBU
-rBU
+aUq
 qwk
 xsJ
 mbb


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEAT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds chicken hardware, including at least one egg and corn cob as starters, to all my currently "active" rotation maps - Kondaru, Ozymandias (two sets because Ozymandias), Fleet (on the Demeter), and Icarus.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Brings exciting new chicken technology to the masses.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Kubius:
(+)All active Kubius maps (Kondaru, Ozymandias, Fleet, and Icarus) are now chicken-enabled.
```
