### PR TITLE
Ozymandias nov20 fix batch

### DIFF
--- a/maps/ozymandias.dmm
+++ b/maps/ozymandias.dmm
@@ -24950,10 +24950,6 @@
 	},
 /area/station/hallway/primary/east)
 "hpC" = (
-/obj/machinery/door/poddoor{
-	id = "ai_core";
-	name = "AI Core Shield"
-	},
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
 	name = "AI Core";
@@ -24962,6 +24958,14 @@
 /obj/access_spawn/ai_upload,
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "ai_core";
+	name = "AI Core Shield";
+	opacity = 0
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)

--- a/maps/ozymandias.dmm
+++ b/maps/ozymandias.dmm
@@ -4515,6 +4515,7 @@
 	pixel_x = -10;
 	tag = ""
 	},
+/obj/machinery/door_control/podbay/qm/new_walls/west,
 /turf/simulated/floor/caution/north,
 /area/station/hangar/qm)
 "bsk" = (
@@ -5479,6 +5480,10 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/engine/caution/east,
 /area/station/science/teleporter)
+"bGS" = (
+/obj/machinery/door_control/podbay/medbay/new_walls/east,
+/turf/simulated/floor,
+/area/station/hangar/medical)
 "bGX" = (
 /obj/stool/chair/office/blue{
 	dir = 1
@@ -29837,6 +29842,7 @@
 	dir = 1;
 	pixel_y = 16
 	},
+/obj/machinery/door_control/podbay/engineering/new_walls/west,
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
@@ -52907,6 +52913,11 @@
 	dir = 4
 	},
 /area/station/medical/medbay/treatment)
+"pqJ" = (
+/obj/lattice,
+/obj/warp_beacon/medbay,
+/turf/space,
+/area/space)
 "pqQ" = (
 /obj/machinery/chem_heater,
 /turf/simulated/floor/engine,
@@ -58019,6 +58030,10 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/medical/dome)
+"qPY" = (
+/obj/machinery/door_control/podbay/research/new_walls/east,
+/turf/simulated/floor/caution/north,
+/area/station/hangar/science)
 "qQe" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable,
@@ -74709,6 +74724,10 @@
 	pixel_y = 20;
 	tag = ""
 	},
+/obj/machinery/door_control/podbay{
+	id = "PROTOHANGAR";
+	pixel_y = 25
+	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
@@ -85026,6 +85045,7 @@
 	})
 "xPn" = (
 /obj/machinery/portable_atmospherics/canister/air/large,
+/obj/machinery/door_control/podbay/mainpod1/new_walls/west,
 /turf/simulated/floor/black/side{
 	dir = 4
 	},
@@ -125548,7 +125568,7 @@ vaK
 vaK
 jOB
 eww
-wmB
+qPY
 nym
 oxH
 gmR
@@ -143619,7 +143639,7 @@ aJu
 aJu
 aJu
 aaq
-gLs
+pqJ
 acL
 ath
 afs
@@ -144249,7 +144269,7 @@ erK
 cnI
 cnI
 doB
-dBE
+bGS
 dMv
 dFI
 evN

--- a/maps/ozymandias.dmm
+++ b/maps/ozymandias.dmm
@@ -146,6 +146,20 @@
 /area/station/crew_quarters/hor{
 	name = "Research Director's Office"
 	})
+"adw" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/window_blinds/cog2/middle{
+	dir = 8
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/detectives_office)
 "adz" = (
 /obj/table/auto,
 /obj/item/dice{
@@ -224,6 +238,20 @@
 /area/station/routing/eva{
 	name = "Router Cabinet"
 	})
+"aeP" = (
+/obj/machinery/atmospherics/unary/furnace_connector{
+	dir = 4
+	},
+/obj/machinery/power/furnace/thermo{
+	fuel = 100
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/orangeblack/side{
+	dir = 8
+	},
+/area/station/engine/hotloop)
 "aeX" = (
 /obj/grille/catwalk{
 	dir = 4
@@ -359,12 +387,6 @@
 /area/station/routing/eva{
 	name = "Router Cabinet"
 	})
-"ahn" = (
-/obj/table/reinforced/auto,
-/obj/item/aiModule/rename,
-/obj/item/aiModule/reset,
-/turf/simulated/floor/darkblue,
-/area/station/turret_protected/ai_upload)
 "ahL" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -1151,6 +1173,9 @@
 /area/listeningpost)
 "asi" = (
 /obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai)
 "asq" = (
@@ -1180,19 +1205,11 @@
 /turf/space,
 /area/space)
 "ati" = (
-/obj/machinery/atmospherics/unary/outlet_injector{
-	dir = 4;
-	icon_state = "on";
-	on = 1
+/obj/item/device/radio/intercom,
+/turf/simulated/floor/yellowblack{
+	dir = 1
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/blueblack,
-/area/station/turret_protected/ai_upload)
+/area/station/hallway/secondary/north)
 "atk" = (
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/wall/auto/supernorn,
@@ -1437,6 +1454,18 @@
 	dir = 4
 	},
 /area/station/hallway/primary/north)
+"awN" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/bridge/customs{
+	name = "Bridge Reception"
+	})
 "awO" = (
 /obj/table/reinforced/auto,
 /obj/item/hand_labeler,
@@ -1536,6 +1565,9 @@
 /area/station/hallway/primary/north)
 "ayC" = (
 /obj/disposalpipe/segment/vertical,
+/obj/cable{
+	icon_state = "4-10"
+	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/chemistry)
 "ayD" = (
@@ -1679,6 +1711,9 @@
 /turf/simulated/floor/plating,
 /area/station/atmos/hookups/west)
 "aBo" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
@@ -1790,6 +1825,13 @@
 	dir = 8
 	},
 /area/station/crew_quarters/kitchen/freezer)
+"aDo" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/treatment)
 "aDB" = (
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/barber_shop)
@@ -2046,6 +2088,16 @@
 	dir = 8
 	},
 /area/station/engine/engineering/ce)
+"aGq" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/robotics)
 "aGJ" = (
 /obj/lattice,
 /turf/space,
@@ -2344,6 +2396,9 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/cafeteria)
 "aLH" = (
@@ -2481,6 +2536,14 @@
 /area/station/crew_quarters/heads{
 	name = "Officers' Lounge"
 	})
+"aNW" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/coldloop)
 "aOc" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/secondary/west)
@@ -2522,6 +2585,12 @@
 	dir = 8
 	},
 /area/station/crew_quarters/quarters_west)
+"aOw" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor,
+/area/station/engine/gas)
 "aOO" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 9
@@ -2567,6 +2636,9 @@
 /obj/wingrille_spawn/auto/crystal,
 /obj/window_blinds/cog2/left{
 	dir = 8
+	},
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/bridge/captain)
@@ -2702,6 +2774,19 @@
 	},
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
+"aRt" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "lockdown";
+	name = "Bridge Lockdown Doors";
+	opacity = 0
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/bridge)
 "aRy" = (
 /obj/machinery/rkit,
 /turf/simulated/floor/grey,
@@ -2832,6 +2917,9 @@
 	layer = 9.1;
 	pixel_x = 10
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/heads{
 	name = "Officers' Lounge"
@@ -2885,6 +2973,15 @@
 /area/station/crew_quarters/hor{
 	name = "Research Director's Office"
 	})
+"aUa" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
 "aUg" = (
 /obj/machinery/light{
 	dir = 1;
@@ -3536,6 +3633,13 @@
 /obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/jazz)
+"bcU" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbay)
 "bdj" = (
 /obj/table/auto,
 /obj/item/aiModule/reset,
@@ -3757,6 +3861,9 @@
 /obj/table/wood/auto,
 /obj/item/ammo/bullets/a38,
 /obj/item/ammo/bullets/a38/stun,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/carpet/red/standard/edge/east,
 /area/station/security/detectives_office)
 "bfU" = (
@@ -3868,6 +3975,9 @@
 "bia" = (
 /obj/table/auto,
 /obj/machinery/defib_mount,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/yellow/side,
 /area/station/engine/engineering)
 "bic" = (
@@ -4216,6 +4326,9 @@
 	dir = 4;
 	pixel_x = 12
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/bridge/captain)
 "boY" = (
@@ -4236,6 +4349,10 @@
 "bpp" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/box/revimp_kit,
+/obj/machinery/light/emergency{
+	dir = 4;
+	pixel_x = 10
+	},
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
@@ -4338,6 +4455,13 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/security/processing)
+"brm" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/coldloop)
 "brw" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet/blue,
@@ -4369,6 +4493,15 @@
 /obj/machinery/light/emergency,
 /turf/simulated/floor/red/checker,
 /area/station/medical/medbooth)
+"brH" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/grey,
+/area/station/hallway/secondary/north)
 "brU" = (
 /obj/disposalpipe/segment/bent/east,
 /turf/simulated/floor/grey,
@@ -4595,6 +4728,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/se)
+"bvW" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/mining/refinery)
 "bwd" = (
 /turf/simulated/floor/carpet/blue/fancy/innercorner/omni,
 /area/station/medical/staff)
@@ -4651,6 +4792,20 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/wood,
 /area/station/security/processing)
+"bxs" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/elect)
 "bxy" = (
 /obj/lattice{
 	dir = 2;
@@ -4861,8 +5016,23 @@
 	name = "Bridge Lockdown Doors";
 	opacity = 0
 	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/bridge)
+"bzz" = (
+/obj/machinery/door/airlock/pyro/glass,
+/obj/access_spawn/research,
+/obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/darkblue/checker,
+/area/station/science/artifact)
 "bzJ" = (
 /obj/machinery/atmospherics/valve/notify_admins/horizontal{
 	name = "Air Reserve (Cafeteria)"
@@ -5162,6 +5332,13 @@
 	icon_state = "green1"
 	},
 /area/station/crew_quarters/jazz)
+"bEW" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/mining/staff_room)
 "bFc" = (
 /obj/grille/catwalk{
 	dir = 1
@@ -5473,6 +5650,17 @@
 	},
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/kitchen/freezer)
+"bKe" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/science/teleporter)
 "bKG" = (
 /obj/table/wood/auto,
 /obj/item/ghostboard,
@@ -5740,6 +5928,9 @@
 	icon_state = "1-4"
 	},
 /obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/black,
 /area/station/engine/engineering/ce)
 "bPH" = (
@@ -5863,6 +6054,21 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
+"bRj" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 9;
+	icon_state = "pdoor0";
+	id = "lockdown";
+	name = "Bridge Lockdown Doors";
+	opacity = 0
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/bridge)
 "bRm" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8;
@@ -5965,6 +6171,13 @@
 	},
 /turf/simulated/floor/yellowblack,
 /area/station/crew_quarters/data)
+"bTb" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/quartermaster/office)
 "bTd" = (
 /turf/simulated/floor/grey/side{
 	dir = 5
@@ -6026,6 +6239,16 @@
 /obj/machinery/shieldgenerator/energy_shield,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/se)
+"bUE" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/robotics)
 "bUJ" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 9
@@ -6182,6 +6405,16 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/exit)
+"bXM" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/power)
 "bXR" = (
 /obj/table/auto,
 /obj/item/paper_bin,
@@ -6407,6 +6640,13 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
+"cbj" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/mining/refinery)
 "cbs" = (
 /obj/storage/secure/closet/research/chemical,
 /obj/machinery/light{
@@ -6417,6 +6657,9 @@
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/chemistry)
 "cbx" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/yellowblack{
 	dir = 4
 	},
@@ -6581,6 +6824,9 @@
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/red/side{
 	dir = 8
 	},
@@ -6650,9 +6896,7 @@
 	name = "Warrens Hall"
 	})
 "cen" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
+/obj/machinery/light/small,
 /turf/simulated/floor/grey/side,
 /area/station/medical/staff)
 "cew" = (
@@ -6691,9 +6935,6 @@
 "ceW" = (
 /obj/machinery/light/small,
 /obj/decal/tile_edge/floorguide/science,
-/obj/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/grey/side,
 /area/station/medical/staff)
 "cff" = (
@@ -6796,6 +7037,9 @@
 "cgt" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/window_blinds/cog2,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/station/medical/head)
 "cgu" = (
@@ -6852,11 +7096,16 @@
 /turf/simulated/floor/carpet/red/standard/edge/nw,
 /area/station/security/detectives_office)
 "cgW" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/wingrille_spawn/auto/crystal,
+/obj/window_blinds/cog2/middle{
+	dir = 4
 	},
-/turf/simulated/floor/white,
-/area/station/medical/cdc)
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/medical/head)
 "chb" = (
 /obj/cable{
 	icon_state = "4-10"
@@ -6912,14 +7161,13 @@
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "cig" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/window_blinds/cog2,
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/grey/side,
-/area/station/medical/staff)
+/turf/simulated/floor/plating,
+/area/station/medical/head)
 "cih" = (
 /obj/table/auto,
 /obj/item/plate,
@@ -6960,9 +7208,6 @@
 /turf/simulated/floor/grey/side,
 /area/station/medical/staff)
 "cis" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/cable{
 	icon_state = "1-4"
 	},
@@ -7149,6 +7394,13 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/grey,
 /area/station/engine/engineering/ce)
+"clf" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/science/lobby)
 "clh" = (
 /obj/machinery/disposal/mail/autoname/medbay,
 /obj/disposalpipe/trunk/mail/east,
@@ -7240,6 +7492,9 @@
 	name = "autoname - SS13";
 	pixel_y = 20;
 	tag = ""
+	},
+/obj/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/caution/corner/nw,
 /area/station/engine/hotloop)
@@ -7507,6 +7762,12 @@
 /obj/window_blinds/cog2/middle{
 	dir = 6
 	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/station/medical/head)
 "cqj" = (
@@ -7581,6 +7842,16 @@
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
+"cru" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/engineering)
 "crL" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/grey/side,
@@ -7630,6 +7901,21 @@
 /area/station/bridge/customs{
 	name = "Bridge Reception"
 	})
+"csj" = (
+/obj/machinery/door/airlock/pyro/glass,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/access_spawn/research,
+/obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/darkblue/checker,
+/area/station/science/artifact)
 "csm" = (
 /obj/machinery/atmospherics/pipe/simple,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -7660,6 +7946,9 @@
 "csE" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/window_blinds/cog2/right,
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/medical/head)
 "csR" = (
@@ -7676,6 +7965,13 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai)
+"ctp" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/science/artifact)
 "ctq" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -7715,8 +8011,6 @@
 /area/station/medical/staff)
 "ctM" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/grey,
@@ -7867,6 +8161,9 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/bent/east,
+/obj/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/grey,
 /area/station/bridge/customs{
 	name = "Bridge Reception"
@@ -7988,6 +8285,10 @@
 /obj/window_blinds/cog2/middle{
 	dir = 5
 	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/medical/head)
 "czu" = (
@@ -8024,6 +8325,11 @@
 "czC" = (
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 4;
+	icon_state = "on";
+	on = 1
 	},
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai_upload)
@@ -8105,7 +8411,6 @@
 /obj/machinery/photocopier{
 	pixel_x = 0
 	},
-/obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-2"
 	},
@@ -8140,6 +8445,13 @@
 /obj/machinery/light_switch/north,
 /turf/simulated/floor/black,
 /area/station/medical/head)
+"cCn" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/core)
 "cCq" = (
 /turf/simulated/floor/neutral/corner{
 	dir = 4
@@ -8310,9 +8622,6 @@
 /turf/simulated/floor,
 /area/station/mining/refinery)
 "cFb" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 10;
@@ -8496,23 +8805,21 @@
 /obj/machinery/drainage,
 /turf/simulated/floor/sanitary,
 /area/station/engine/engineering/private)
-"cHO" = (
-/obj/machinery/door/airlock/pyro/medical{
-	name = "Geneticists";
-	req_access = null
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/access_spawn/medlab,
-/obj/firedoor_spawn,
-/turf/simulated/floor/grey,
-/area/station/medical/staff)
 "cHQ" = (
 /obj/table/auto,
 /obj/item/device/radio/intercom/medical,
 /turf/simulated/floor/sanitary,
 /area/station/medical/medbay/treatment1)
+"cHS" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/pharmacy)
 "cHV" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -8570,9 +8877,6 @@
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/chemistry)
 "cIZ" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/carpet/green/fancy/innercorner/omni,
 /area/station/medical/staff)
 "cJc" = (
@@ -8662,6 +8966,11 @@
 	},
 /turf/simulated/floor/carpet/blue/standard/edge/south,
 /area/station/medical/medbay/lobby)
+"cKg" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/engine/hotloop)
 "cKi" = (
 /obj/machinery/portable_atmospherics/canister/air/large,
 /obj/machinery/atmospherics/portables_connector/west,
@@ -8703,8 +9012,16 @@
 /obj/window_blinds/cog2/left{
 	dir = 4
 	},
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/medical/head)
+"cKA" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/engineering/private)
 "cKB" = (
 /obj/stool/chair/office/blue{
 	dir = 8
@@ -8717,6 +9034,13 @@
 "cKD" = (
 /obj/table/wood/auto,
 /obj/machinery/computer3/generic/personal,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/black,
 /area/station/medical/head)
 "cKE" = (
@@ -8756,6 +9080,9 @@
 "cLf" = (
 /obj/table/wood/auto,
 /obj/machinery/phone,
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/black,
 /area/station/medical/head)
 "cLu" = (
@@ -8780,6 +9107,11 @@
 	},
 /turf/simulated/floor/caution/south,
 /area/station/science/storage)
+"cMq" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/engine/elect)
 "cMv" = (
 /turf/simulated/floor/carpet/red/fancy/edge/west,
 /area/station/crew_quarters/cafeteria)
@@ -8942,6 +9274,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/darkblue,
 /area/station/turret_protected/ai_upload)
 "cOT" = (
@@ -9087,6 +9422,9 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/carpet/blue/fancy/edge/nw,
 /area/station/medical/head)
 "cRi" = (
@@ -9095,6 +9433,14 @@
 	dir = 4
 	},
 /area/station/chapel/sanctuary)
+"cRm" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/engine/engineering)
 "cRx" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -9159,6 +9505,9 @@
 "cSS" = (
 /obj/cable{
 	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/elect)
@@ -9580,6 +9929,9 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/engine/elect)
 "cXt" = (
@@ -9693,6 +10045,15 @@
 "cYT" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/middle,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/hor{
 	name = "Research Director's Office"
@@ -9783,6 +10144,9 @@
 "dao" = (
 /obj/machinery/atmospherics/pipe/simple,
 /obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/chemistry)
 "daP" = (
@@ -9906,6 +10270,9 @@
 	},
 /obj/access_spawn/mining,
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/mining/staff_room)
 "dds" = (
@@ -9975,6 +10342,12 @@
 	},
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
+"der" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/engine/engineering/private)
 "des" = (
 /obj/storage/secure/closet/command/medical_director,
 /turf/simulated/floor/black,
@@ -9989,6 +10362,9 @@
 "deX" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/north,
+/obj/item/device/radio/intercom{
+	dir = 8
+	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "deY" = (
@@ -10643,12 +11019,15 @@
 /turf/simulated/floor/caution/north,
 /area/station/hangar/medical)
 "doh" = (
-/obj/cable{
-	icon_state = "1-4"
+/obj/wingrille_spawn/auto,
+/obj/health_scanner/wall{
+	layer = 3.3
 	},
-/obj/machinery/light,
-/turf/simulated/floor/blueblack,
-/area/station/turret_protected/ai_upload)
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/pharmacy)
 "dom" = (
 /obj/machinery/light/small/floor,
 /turf/simulated/floor/grass,
@@ -10921,7 +11300,9 @@
 	name = "Medical Router"
 	})
 "drG" = (
-/obj/machinery/atmospherics/pipe/simple,
+/obj/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/stairs/dark/wide{
 	dir = 1
 	},
@@ -11242,6 +11623,15 @@
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/crew_quarters/showers)
+"dyc" = (
+/obj/stool/chair/office/blue{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbooth)
 "dyk" = (
 /obj/machinery/manufacturer/hangar{
 	free_resource_amt = 0
@@ -11382,6 +11772,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/carpet/red/standard,
 /area/station/security/detectives_office)
 "dAF" = (
@@ -11392,11 +11785,22 @@
 /obj/access_spawn/kitchen,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
+"dAI" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/blueblack{
+	dir = 8
+	},
+/area/station/turret_protected/ai_upload)
 "dAO" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/bent/north,
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/chemistry)
 "dAW" = (
@@ -11404,6 +11808,13 @@
 /area/station/routing/medsci{
 	name = "Research Router"
 	})
+"dAY" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/science/chemistry)
 "dBi" = (
 /obj/storage/closet/biohazard,
 /obj/machinery/light/emergency{
@@ -11818,6 +12229,15 @@
 /obj/machinery/light,
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
+"dGj" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/engine/gas)
 "dGo" = (
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/blackwhite{
@@ -11939,6 +12359,12 @@
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/north,
 /area/station/crew_quarters/quartersA)
+"dIo" = (
+/obj/cable{
+	icon_state = "4-9"
+	},
+/turf/simulated/floor/specialroom/arcade,
+/area/station/science/chemistry)
 "dIs" = (
 /turf/simulated/floor/wood/three{
 	icon_state = "c5"
@@ -11971,6 +12397,12 @@
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
+"dJb" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/engine/engineering/private)
 "dJc" = (
 /obj/decal/poster/wallsign/space,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -12200,6 +12632,16 @@
 /obj/access_spawn/tech_storage,
 /turf/simulated/floor,
 /area/station/crew_quarters/data)
+"dMA" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor,
+/area/station/engine/engineering)
 "dMB" = (
 /turf/simulated/floor/carpet/green/fancy/edge/west,
 /area/station/medical/staff)
@@ -12209,6 +12651,9 @@
 "dMJ" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/window_blinds/cog2/left,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering/ce)
 "dMQ" = (
@@ -12428,6 +12873,12 @@
 "dQa" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/machinery/atmospherics/pipe/simple,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai)
 "dQe" = (
@@ -12437,6 +12888,10 @@
 /obj/wingrille_spawn/auto/crystal,
 /obj/window_blinds/cog2/middle{
 	dir = 8
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
@@ -12653,6 +13108,9 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/junction/right/west,
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/white,
 /area/station/science/lobby)
 "dTy" = (
@@ -12968,6 +13426,17 @@
 	dir = 8
 	},
 /area/station/medical/head)
+"dYm" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/power)
 "dYw" = (
 /obj/disposalpipe/loafer{
 	dir = 4
@@ -13023,6 +13492,17 @@
 /obj/disposalpipe/trunk/south,
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/lounge/research)
+"dYY" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/treatment)
 "dZe" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -13045,6 +13525,12 @@
 	},
 /obj/access_spawn/medical_director,
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/grey,
 /area/station/medical/head)
 "dZn" = (
@@ -13172,6 +13658,9 @@
 /area/station/hangar/medical)
 "eaU" = (
 /obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "ebk" = (
@@ -13184,6 +13673,15 @@
 /obj/access_spawn/medical,
 /turf/simulated/floor/grey,
 /area/station/hangar/medical)
+"ebH" = (
+/obj/storage/secure/closet/engineering/mechanic,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 1
+	},
+/area/station/engine/elect)
 "ebR" = (
 /obj/machinery/bathtub{
 	anchored = 1;
@@ -13255,6 +13753,13 @@
 	icon_state = "engine_caution_east"
 	},
 /area/station/hangar/main)
+"eey" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/engine,
+/area/station/turret_protected/ai)
 "eeE" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -13341,6 +13846,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/grey/side{
 	dir = 4
 	},
@@ -13366,6 +13872,17 @@
 	},
 /turf/simulated/floor/white,
 /area/station/science/lobby)
+"efI" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/hydroponics/bay)
 "efJ" = (
 /obj/machinery/light/emergency{
 	dir = 8;
@@ -13380,6 +13897,16 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
+"egk" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/purple/side{
+	dir = 4
+	},
+/area/station/science/teleporter)
 "egu" = (
 /obj/cable{
 	d1 = 1;
@@ -13517,6 +14044,15 @@
 	},
 /turf/simulated/floor/orangeblack/side,
 /area/station/mining/staff_room)
+"eij" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/wood/seven,
+/area/station/engine/engineering/private)
 "eit" = (
 /obj/machinery/light{
 	dir = 4;
@@ -13602,6 +14138,12 @@
 	dir = 1
 	},
 /area/station/crewquarters/garbagegarbs)
+"ejN" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/circuit/white,
+/area/station/engine/power)
 "ejW" = (
 /obj/disposalpipe/segment/transport{
 	dir = 8;
@@ -13655,6 +14197,7 @@
 "ekZ" = (
 /obj/table/auto,
 /obj/machinery/phone,
+/obj/item/device/radio/intercom,
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
@@ -13750,6 +14293,13 @@
 /area/station/hallway/secondary/entry{
 	name = "Arrival Shuttle Hallway"
 	})
+"emC" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbooth)
 "emG" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -13941,6 +14491,9 @@
 	dir = 8
 	},
 /obj/access_spawn/mining,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/mining/staff_room)
 "epx" = (
@@ -14333,6 +14886,11 @@
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/maintenance/solar/west)
+"evB" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/engine/core)
 "evN" = (
 /obj/rack,
 /obj/item/clothing/suit/space/emerg,
@@ -14347,6 +14905,24 @@
 	},
 /turf/simulated/floor,
 /area/station/hangar/medical)
+"evT" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "lockdown";
+	name = "Bridge Lockdown Doors";
+	opacity = 0
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/bridge)
 "evY" = (
 /obj/machinery/atmospherics/pipe/simple,
 /obj/cable{
@@ -14542,6 +15118,14 @@
 /obj/machinery/air_vendor,
 /turf/simulated/floor/purple,
 /area/station/hangar/science)
+"eyR" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbay)
 "eyS" = (
 /obj/machinery/chem_dispenser/soda,
 /turf/simulated/floor/wood/two,
@@ -14627,6 +15211,14 @@
 	dir = 4
 	},
 /area/station/quartermaster/office)
+"eAp" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/hotloop)
 "eAx" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 4;
@@ -14664,7 +15256,10 @@
 /area/station/storage/warehouse)
 "eAZ" = (
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/stairs/dark{
 	dir = 10
@@ -14825,6 +15420,11 @@
 /area/station/routing/medsci{
 	name = "Research Router"
 	})
+"eEc" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/science/artifact)
 "eEe" = (
 /obj/machinery/computer3/terminal/zeta{
 	dir = 4;
@@ -14922,6 +15522,16 @@
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/black,
 /area/station/medical/head)
+"eFm" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/left,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/hor{
+	name = "Research Director's Office"
+	})
 "eFr" = (
 /obj/table/reinforced/auto,
 /obj/machinery/networked/printer{
@@ -15355,6 +15965,9 @@
 /obj/window_blinds/cog2/left{
 	dir = 8
 	},
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
 "eLN" = (
@@ -15441,6 +16054,15 @@
 	dir = 9
 	},
 /area/station/hallway/primary/north)
+"eMB" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/bridge/customs{
+	name = "Bridge Reception"
+	})
 "eME" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -15499,6 +16121,16 @@
 	},
 /turf/simulated/floor,
 /area/station/medical/head)
+"eNp" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/turret_protected/ai_upload)
 "eNr" = (
 /obj/rack,
 /obj/item/clothing/suit/space,
@@ -15743,6 +16375,9 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "eRl" = (
@@ -15822,6 +16457,16 @@
 /area/station/maintenance/storage{
 	name = "Rapid Transit Interchange"
 	})
+"eSx" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/science/artifact)
 "eSE" = (
 /obj/machinery/light{
 	dir = 4;
@@ -16435,15 +17080,11 @@
 /area/station/security/main)
 "fdg" = (
 /obj/table/reinforced/auto,
-/obj/machinery/power/data_terminal,
-/obj/machinery/computer3/generic/personal,
-/obj/cable{
-	icon_state = "0-8"
-	},
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 20
 	},
+/obj/item/paper/book/medical_guide,
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "fdi" = (
@@ -16550,6 +17191,7 @@
 /area/station/engine/engineering/private)
 "ffA" = (
 /obj/wingrille_spawn/auto/crystal,
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
 "ffB" = (
@@ -16670,6 +17312,15 @@
 	},
 /turf/space,
 /area/station/engine/core)
+"fhN" = (
+/obj/machinery/plantpot{
+	anchored = 1
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/grass,
+/area/station/hydroponics/bay)
 "fhY" = (
 /obj/machinery/cargo_router/ozy/qm_east,
 /turf/simulated/floor/airless/plating,
@@ -16690,6 +17341,10 @@
 /obj/window_blinds/cog2/middle{
 	dir = 9
 	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/bridge/captain)
 "fiz" = (
@@ -16777,6 +17432,9 @@
 /turf/simulated/floor/plating,
 /area/station/atmos/hookups/southwest)
 "fkl" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
@@ -17044,6 +17702,18 @@
 	},
 /turf/space,
 /area/station/engine/core)
+"fnx" = (
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
+	},
+/obj/disposalpipe/segment/horizontal,
+/obj/access_spawn/research,
+/obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/specialroom/arcade,
+/area/station/science/chemistry)
 "fnC" = (
 /turf/simulated/floor/arrival{
 	dir = 4
@@ -17203,6 +17873,16 @@
 /obj/machinery/meter,
 /turf/simulated/floor/engine/caution/south,
 /area/station/hangar/science)
+"fqw" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbooth)
 "fqC" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -17311,6 +17991,15 @@
 /obj/loudspeaker,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
+"fsJ" = (
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/obj/machinery/turret,
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/ai_upload)
 "fsK" = (
 /obj/cable{
 	icon_state = "6-8"
@@ -17835,6 +18524,16 @@
 	dir = 1
 	},
 /area/station/hydroponics/bay)
+"fAl" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbooth)
 "fAP" = (
 /obj/table/auto,
 /obj/random_item_spawner/desk_stuff/g_clip_bin_pen,
@@ -18078,6 +18777,14 @@
 	dir = 8
 	},
 /area/station/hydroponics/bay)
+"fEB" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/science/artifact)
 "fEI" = (
 /obj/shrub,
 /obj/machinery/light,
@@ -18175,6 +18882,9 @@
 "fFR" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/window_blinds/cog2/right,
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering/ce)
 "fGb" = (
@@ -18245,6 +18955,11 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/engine/engineering/private)
+"fHj" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/engine/power)
 "fHk" = (
 /obj/machinery/mass_driver{
 	dir = 8;
@@ -18257,6 +18972,10 @@
 /obj/wingrille_spawn/auto/crystal,
 /obj/window_blinds/cog2/middle{
 	dir = 4
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering/ce)
@@ -18471,6 +19190,9 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/caution/north,
 /area/station/engine/hotloop)
 "fLN" = (
@@ -18487,6 +19209,9 @@
 	icon_state = "1-4"
 	},
 /obj/disposalpipe/segment/mail/horizontal,
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "fMb" = (
@@ -18530,6 +19255,12 @@
 /obj/item/clothing/suit/space/engineer,
 /obj/item/tank/air,
 /obj/item/extinguisher,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/engine/caution/westeast,
 /area/station/engine/hotloop)
 "fML" = (
@@ -18866,6 +19597,14 @@
 	},
 /turf/simulated/floor/blueblack,
 /area/station/medical/medbay/pharmacy)
+"fSc" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
+/area/station/engine/engineering)
 "fSq" = (
 /obj/rack,
 /obj/item/clothing/suit/space/emerg,
@@ -18880,6 +19619,17 @@
 	},
 /turf/simulated/floor/escape,
 /area/station/hallway/secondary/exit)
+"fSJ" = (
+/obj/wingrille_spawn/auto,
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/hydroponics/bay)
 "fTc" = (
 /obj/cable{
 	d1 = 1;
@@ -18984,6 +19734,9 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "fVc" = (
@@ -19076,6 +19829,20 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engine/core)
+"fWE" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/vertical,
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/green/side{
+	dir = 8
+	},
+/area/station/hydroponics/bay)
 "fWM" = (
 /obj/table/auto,
 /obj/machinery/microwave,
@@ -19228,7 +19995,12 @@
 /area/station/hallway/primary/east)
 "fYH" = (
 /obj/table/auto,
-/obj/item/item_box/medical_patches/mini_silver_sulf,
+/obj/item/device/t_scanner{
+	pixel_x = 4
+	},
+/obj/item/coin{
+	pixel_x = -5
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
@@ -19251,6 +20023,12 @@
 /obj/item/clothing/suit/space/engineer,
 /obj/item/tank/air,
 /obj/item/extinguisher,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/engine/caution/westeast,
 /area/station/engine/coldloop)
 "fZe" = (
@@ -19454,6 +20232,14 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/engine/coldloop)
+"gco" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/pharmacy)
 "gcw" = (
 /obj/item/device/radio/intercom/engineering{
 	dir = 8
@@ -19464,6 +20250,9 @@
 /area/station/engine/engineering)
 "gcH" = (
 /obj/storage/secure/closet/engineering/welding,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/caution/corner/ne,
 /area/station/engine/coldloop)
 "gcJ" = (
@@ -19508,6 +20297,9 @@
 /area/station/security/equipment)
 "gdS" = (
 /obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/black,
 /area/station/engine/engineering/ce)
 "gdU" = (
@@ -19532,6 +20324,15 @@
 /obj/machinery/launcher_loader/east,
 /turf/simulated/floor/caution/northsouth,
 /area/station/quartermaster/cargobay)
+"ges" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/darkblue,
+/area/station/medical/medbay/pharmacy)
 "get" = (
 /obj/table/auto,
 /obj/item/clothing/gloves/yellow,
@@ -19541,6 +20342,12 @@
 	dir = 8
 	},
 /area/station/engine/storage)
+"gew" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/orangeblack/side,
+/area/station/mining/refinery)
 "geJ" = (
 /obj/machinery/door/airlock/pyro/classic{
 	dir = 4
@@ -19624,6 +20431,12 @@
 	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/grey,
 /area/station/bridge)
 "gfO" = (
@@ -19644,12 +20457,25 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
+"gfW" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/right,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/hor{
+	name = "Research Director's Office"
+	})
 "ggu" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "5-8"
+	},
+/obj/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/engine/caution/south,
 /area/station/engine/core)
@@ -19677,6 +20503,26 @@
 /area/station/atmos/hookups/east{
 	name = "Command Air Hookups"
 	})
+"ggL" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "ai_core";
+	name = "AI Core Shield";
+	opacity = 0
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/ai)
 "ggR" = (
 /obj/machinery/door/airlock/pyro/security{
 	dir = 4
@@ -19881,6 +20727,19 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/sanitary,
 /area/station/security/secoffquarters)
+"gjn" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/right,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/hor{
+	name = "Research Director's Office"
+	})
 "gjr" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -20056,6 +20915,12 @@
 	},
 /turf/simulated/floor/airless/plating,
 /area/space)
+"glK" = (
+/obj/cable{
+	icon_state = "4-9"
+	},
+/turf/simulated/floor/black,
+/area/station/storage/eva)
 "glO" = (
 /obj/stool/chair/wooden{
 	dir = 8
@@ -20183,7 +21048,7 @@
 "gnn" = (
 /obj/decal/cleanable/dirt,
 /obj/table/auto,
-/obj/machinery/computer3/generic/personal,
+/obj/item/disk/data/cartridge/game_codebreaker,
 /turf/simulated/floor/grime,
 /area/station/maintenance/inner/nw)
 "gno" = (
@@ -20212,6 +21077,9 @@
 	},
 /obj/cable{
 	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/north,
 /area/station/engine/engineering/ce)
@@ -20371,6 +21239,9 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/grey,
 /area/station/engine/engineering/private)
 "gqQ" = (
@@ -20403,6 +21274,12 @@
 "gre" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/middle,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/surgery)
 "grs" = (
@@ -20817,6 +21694,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/se)
+"gvW" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/mining/refinery)
 "gwd" = (
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/info{
@@ -20828,6 +21716,27 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
+"gwp" = (
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/blue/side{
+	dir = 8
+	},
+/area/station/hallway/primary/south)
+"gws" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/elect)
 "gwt" = (
 /obj/stool/chair/boxingrope_corner{
 	dir = 6;
@@ -20992,12 +21901,12 @@
 	},
 /area/station/hallway/primary/north)
 "gyr" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 9
+	},
+/obj/cable{
+	icon_state = "2-9"
 	},
 /turf/simulated/floor/redblack,
 /area/station/engine/hotloop)
@@ -21168,7 +22077,6 @@
 	icon_state = "engineoff";
 	name = "Simulatron"
 	},
-/obj/machinery/power/data_terminal,
 /obj/cable,
 /turf/simulated/floor/grey,
 /area/listeningpost)
@@ -21255,6 +22163,7 @@
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 4;
 	icon_state = "on";
+	level = 2;
 	on = 1
 	},
 /turf/simulated/floor/engine,
@@ -21420,6 +22329,13 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/mining/refinery)
+"gEd" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/power)
 "gEz" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -21585,6 +22501,12 @@
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/chemistry)
+"gHE" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/caution/north,
+/area/station/engine/coldloop)
 "gHN" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/light/small{
@@ -21667,6 +22589,15 @@
 /obj/item/paper_bin,
 /turf/simulated/floor/sanitary,
 /area/station/engine/engineering/ce)
+"gIC" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/grey,
+/area/station/hallway/secondary/west)
 "gIJ" = (
 /obj/lattice{
 	dir = 1;
@@ -21732,6 +22663,20 @@
 /area/station/engine/inner{
 	do_not_irradiate = 1;
 	name = "Engineering Air Hookups"
+	})
+"gJC" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/vertical,
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/heads{
+	name = "Officers' Lounge"
 	})
 "gJH" = (
 /obj/grille/catwalk{
@@ -22036,6 +22981,14 @@
 	dir = 1
 	},
 /area/station/hallway/primary/north)
+"gOd" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/blueblack{
+	dir = 4
+	},
+/area/station/turret_protected/ai_upload)
 "gOm" = (
 /obj/table/auto,
 /obj/machinery/networked/printer{
@@ -22084,6 +23037,9 @@
 /turf/simulated/floor/carpet/red/standard/edge/north,
 /area/station/security/detectives_office)
 "gOW" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/greenblack{
 	dir = 1
 	},
@@ -22105,6 +23061,7 @@
 	},
 /area/station/crew_quarters/fitness)
 "gPv" = (
+/obj/item/device/radio/intercom,
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/sauna)
 "gPw" = (
@@ -22254,6 +23211,13 @@
 	dir = 6
 	},
 /area/station/hallway/secondary/north)
+"gRq" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/science/artifact)
 "gRD" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/box/evidence{
@@ -22264,10 +23228,7 @@
 	pixel_x = -5;
 	pixel_y = 4
 	},
-/obj/machinery/light/emergency{
-	dir = 1;
-	pixel_y = 16
-	},
+/obj/machinery/recharger/wall/sticky,
 /turf/simulated/floor/red,
 /area/station/security/equipment)
 "gRF" = (
@@ -22300,6 +23261,9 @@
 /obj/disposalpipe/segment/vertical,
 /obj/access_spawn/medical,
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/blackwhite{
 	dir = 5
 	},
@@ -22318,6 +23282,9 @@
 	},
 /obj/access_spawn/medical,
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/redwhite{
 	dir = 9
 	},
@@ -22342,6 +23309,9 @@
 	pixel_y = 5
 	},
 /obj/machinery/recharger/wall/sticky,
+/obj/item/device/radio/intercom/security{
+	dir = 4
+	},
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
@@ -22365,6 +23335,21 @@
 	},
 /turf/simulated/floor/stairs/wide/other,
 /area/station/security/hos)
+"gTm" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "lockdown";
+	name = "Bridge Lockdown Doors";
+	opacity = 0
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/bridge)
 "gTy" = (
 /obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{
 	id = "minerlot5";
@@ -22391,11 +23376,17 @@
 "gTD" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/left,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/surgery)
 "gTK" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/right,
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/surgery)
 "gTL" = (
@@ -22510,6 +23501,12 @@
 	req_access = null
 	},
 /obj/access_spawn/engineering_engine,
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/grey,
 /area/station/engine/hotloop)
 "gVI" = (
@@ -22727,6 +23724,13 @@
 	},
 /turf/simulated/floor/circuit/red,
 /area/listeningpost)
+"gZU" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/robotics)
 "haj" = (
 /obj/machinery/light,
 /turf/simulated/floor/grey,
@@ -22781,6 +23785,11 @@
 	},
 /turf/simulated/floor/darkblue/checker,
 /area/station/science/artifact)
+"hbq" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/pharmacy)
 "hbr" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -22888,6 +23897,9 @@
 /area/station/maintenance/west)
 "hcQ" = (
 /obj/disposalpipe/junction/left/west,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/white,
 /area/station/science/lobby)
 "hcW" = (
@@ -23061,6 +24073,16 @@
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/white,
 /area/station/science/lobby)
+"heM" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/elect)
 "heZ" = (
 /obj/machinery/manufacturer/medical,
 /turf/simulated/floor/bluewhite{
@@ -23136,9 +24158,23 @@
 	dir = 4
 	},
 /area/station/hydroponics/bay)
+"hfN" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/science/artifact)
 "hfQ" = (
 /obj/table/auto,
-/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -10;
+	pixel_y = 5
+	},
+/obj/item/robodefibrillator,
 /turf/simulated/floor/bluewhite{
 	dir = 5
 	},
@@ -23207,6 +24243,14 @@
 	dir = 1
 	},
 /area/station/medical/medbooth)
+"hgD" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/hydroponics/bay)
 "hgM" = (
 /obj/stool/chair/office{
 	dir = 1
@@ -23384,6 +24428,9 @@
 	},
 /obj/access_spawn/medical,
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/black,
 /area/station/medical/medbay/pharmacy)
 "hiC" = (
@@ -23548,7 +24595,10 @@
 /obj/machinery/door_control{
 	id = "brigitout";
 	name = "Release Door Control";
-	pixel_x = 24
+	pixel_y = 24
+	},
+/obj/item/device/radio/intercom{
+	dir = 8
 	},
 /turf/simulated/floor/grey,
 /area/station/security/processing)
@@ -23595,6 +24645,14 @@
 /obj/disposalpipe/segment/bent/west,
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
+"hkR" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/engine/hotloop)
 "hlq" = (
 /obj/machinery/light{
 	dir = 8;
@@ -23653,6 +24711,12 @@
 	},
 /obj/access_spawn/medical,
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/wood,
 /area/station/medical/medbay/treatment)
 "hlX" = (
@@ -24019,6 +25083,23 @@
 /area/station/crew_quarters/quarters{
 	name = "Chapel Reception"
 	})
+"hrx" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "eva";
+	name = "E.V.A.";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/station/storage/eva)
 "hrC" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
@@ -24113,6 +25194,17 @@
 /obj/access_spawn/hydro,
 /turf/simulated/floor/yellow/checker,
 /area/station/hydroponics/bay)
+"htn" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/engineering)
 "hts" = (
 /obj/machinery/disposal/mail/autoname/research/chemistry,
 /obj/disposalpipe/trunk/mail/north,
@@ -24202,7 +25294,7 @@
 	pixel_y = 2
 	},
 /obj/item/device/multitool,
-/obj/item/device/radio/intercom/security,
+/obj/machinery/recharger/wall/sticky,
 /turf/simulated/floor/red,
 /area/station/security/equipment)
 "htW" = (
@@ -24438,6 +25530,22 @@
 	dir = 8
 	},
 /area/station/crew_quarters/cafeteria)
+"hwU" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "eva";
+	name = "E.V.A.";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/station/storage/eva)
 "hwY" = (
 /obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor/grey,
@@ -24522,6 +25630,17 @@
 	dir = 1
 	},
 /area/station/medical/medbay/surgery)
+"hyz" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/engineering/private)
 "hyX" = (
 /obj/decal/boxingropeenter,
 /turf/simulated/floor/specialroom/gym,
@@ -24559,8 +25678,18 @@
 /area/station/hallway/secondary/west)
 "hzF" = (
 /obj/storage/closet/emergency,
+/obj/item/device/radio/intercom{
+	dir = 4
+	},
 /turf/simulated/floor/blueblack,
 /area/station/hallway/secondary/north)
+"hzK" = (
+/obj/machinery/drainage,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/robotics)
 "hzL" = (
 /obj/grille/catwalk,
 /obj/machinery/magnet_chassis{
@@ -24568,11 +25697,34 @@
 	},
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/mining/refinery)
+"hzP" = (
+/obj/wingrille_spawn/auto,
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/west)
 "hzW" = (
 /obj/table/auto,
 /obj/random_item_spawner/tools,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
+"hAb" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 6;
+	icon_state = "pdoor0";
+	id = "eva";
+	name = "E.V.A.";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/station/storage/eva)
 "hAd" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -24697,6 +25849,9 @@
 	},
 /obj/cable{
 	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/yellowblack{
 	dir = 1
@@ -24840,6 +25995,10 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	can_rupture = 0
 	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/engine/core)
 "hEi" = (
@@ -24864,9 +26023,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/cable{
-	icon_state = "2-4"
-	},
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
@@ -24885,6 +26041,16 @@
 /obj/disposalpipe/segment/bent/east,
 /turf/simulated/floor/sanitary,
 /area/station/medical/medbay/surgery)
+"hEP" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/treatment)
 "hEQ" = (
 /turf/simulated/floor/greenblack{
 	dir = 8
@@ -24938,6 +26104,12 @@
 /obj/access_spawn/engineering_mechanic,
 /obj/access_spawn/engineering_eva,
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "hGj" = (
@@ -24945,6 +26117,9 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/orangeblack/side,
 /area/station/mining/staff_room)
@@ -25096,6 +26271,14 @@
 /obj/item/storage/firstaid/regular,
 /turf/simulated/floor/carpet/red/fancy/innercorner/omni,
 /area/listeningpost)
+"hJS" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/hydroponics/bay)
 "hKa" = (
 /obj/table/auto,
 /obj/machinery/recharger,
@@ -25380,6 +26563,13 @@
 	},
 /turf/simulated/floor/caution/northsouth,
 /area/station/hydroponics/bay)
+"hOd" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/hotloop)
 "hOf" = (
 /obj/machinery/door/airlock/pyro{
 	dir = 4
@@ -25540,6 +26730,9 @@
 /area/station/crew_quarters/courtroom)
 "hQN" = (
 /obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/medical{
 	name = "Med-Sci Security Checkpoint"
@@ -26059,6 +27252,9 @@
 /obj/machinery/atmospherics/valve{
 	dir = 1
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/engine/coldloop)
 "hZC" = (
@@ -26331,6 +27527,17 @@
 /area/station/medical/medbay/surgery)
 "idK" = (
 /obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "eva";
+	name = "E.V.A.";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/station/storage/eva)
 "iec" = (
@@ -26357,6 +27564,9 @@
 "iel" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/station/engine/elect)
 "iem" = (
@@ -27176,6 +28386,15 @@
 /obj/stool,
 /turf/simulated/floor/black,
 /area/station/chapel/office)
+"itv" = (
+/obj/stool/chair/office/yellow{
+	dir = 8
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/engine/engineering/private)
 "itz" = (
 /obj/disposalpipe/junction/right/south,
 /turf/simulated/floor/black,
@@ -27262,6 +28481,17 @@
 	dir = 8
 	},
 /area/station/engine/coldloop)
+"ivy" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbooth)
 "ivD" = (
 /obj/shrub{
 	desc = "While it's wildly unlikely that this bush hails from Space Sweden, it nevertheless bears a faint scent of meatballs that can't be adequately explained.";
@@ -27544,6 +28774,9 @@
 	on = 1;
 	transfer_rate = 1000
 	},
+/obj/cable{
+	icon_state = "4-10"
+	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
@@ -27649,6 +28882,19 @@
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/maintenance/solar/south)
+"iAO" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/engine/engineering/private)
+"iAR" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/science/teleporter)
 "iAU" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -27703,7 +28949,6 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/data_terminal,
 /obj/machinery/light/emergency{
 	dir = 4;
 	pixel_x = 10
@@ -27744,6 +28989,7 @@
 	name = "Bridge Lockdown Doors";
 	opacity = 0
 	},
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "iBP" = (
@@ -27863,8 +29109,11 @@
 /turf/simulated/floor/grey,
 /area/station/engine/engineering/private)
 "iDf" = (
+/obj/stool/chair/blue{
+	dir = 4
+	},
 /obj/cable{
-	icon_state = "2-4"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/darkblue,
 /area/station/turret_protected/ai_upload)
@@ -28081,6 +29330,15 @@
 "iFt" = (
 /turf/simulated/floor,
 /area/station/engine/engineering/private)
+"iFA" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor,
+/area/station/mining/refinery)
 "iFL" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -28105,6 +29363,9 @@
 	dir = 1;
 	layer = 9.1;
 	pixel_y = 21
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/robotics)
@@ -28248,6 +29509,14 @@
 /obj/decal/poster/wallsign/barber,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/barber_shop)
+"iHF" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/blueblack{
+	dir = 8
+	},
+/area/station/turret_protected/ai_upload)
 "iHL" = (
 /obj/machinery/computer/operating{
 	dir = 8
@@ -28276,6 +29545,12 @@
 	},
 /obj/access_spawn/research,
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/purpleblack{
 	dir = 4
 	},
@@ -28305,6 +29580,9 @@
 	name = "autoname - SS13";
 	pixel_y = 20;
 	tag = ""
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/robotics)
@@ -28581,6 +29859,20 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/exit)
+"iND" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "lockdown";
+	name = "Bridge Lockdown Doors";
+	opacity = 0
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/bridge)
 "iNE" = (
 /obj/table/auto,
 /obj/towelbin,
@@ -28668,6 +29960,9 @@
 "iOI" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/right,
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/heads{
 	name = "Officers' Lounge"
@@ -28944,6 +30239,10 @@
 	name = "Bridge Lockdown Doors";
 	opacity = 0
 	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "iUz" = (
@@ -28985,6 +30284,9 @@
 	},
 /obj/access_spawn/mining,
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/orangeblack,
 /area/station/mining/staff_room)
 "iUP" = (
@@ -29230,6 +30532,14 @@
 /obj/item/device/radio/intercom/engineering,
 /turf/simulated/floor/carpet/grime,
 /area/station/engine/engineering/private)
+"iZQ" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/science/artifact)
 "iZT" = (
 /obj/grille/catwalk{
 	dir = 9
@@ -29567,6 +30877,12 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/black,
 /area/station/storage/eva)
+"jeF" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/darkblue,
+/area/station/medical/medbay/pharmacy)
 "jeP" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -29636,6 +30952,9 @@
 	icon_state = "1-8"
 	},
 /obj/disposalpipe/segment/mail/bent/south,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbooth)
 "jfC" = (
@@ -29723,6 +31042,13 @@
 /obj/machinery/ore_cloud_storage_container,
 /turf/simulated/floor/orangeblack/side,
 /area/station/mining/refinery)
+"jgM" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/hotloop)
 "jgQ" = (
 /obj/table/reinforced/bar/auto{
 	name = "wooden table"
@@ -29734,6 +31060,9 @@
 /turf/simulated/floor/wood/eight,
 /area/station/security/detectives_office)
 "jgS" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/carpet/purple/fancy/edge/south,
 /area/station/crew_quarters/hor/horprivate)
 "jgV" = (
@@ -29765,6 +31094,9 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/overfloor/west,
+/obj/cable{
+	icon_state = "2-5"
+	},
 /turf/simulated/floor/blueblack,
 /area/station/engine/coldloop)
 "jhW" = (
@@ -29812,6 +31144,16 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/southeast,
 /turf/space,
 /area/space)
+"jii" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/power)
 "jir" = (
 /obj/cable{
 	d1 = 4;
@@ -29836,6 +31178,11 @@
 "jiw" = (
 /obj/cable{
 	icon_state = "2-4"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/bridge/captain)
@@ -29963,6 +31310,21 @@
 "jkb" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/east)
+"jkp" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 5;
+	icon_state = "pdoor0";
+	id = "ai_core";
+	name = "AI Core Shield";
+	opacity = 0
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/ai)
 "jkt" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -30064,11 +31426,15 @@
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "jmw" = (
-/obj/stool/chair/office/blue{
-	dir = 1
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-4"
 	},
-/turf/simulated/floor,
-/area/station/crew_quarters/market)
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/hotloop)
 "jmz" = (
 /obj/submachine/seed_manipulator{
 	dir = 4
@@ -30107,6 +31473,9 @@
 /turf/simulated/floor,
 /area/station/security/processing)
 "jnc" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
@@ -30207,7 +31576,6 @@
 /area/station/maintenance/inner/ne)
 "joG" = (
 /obj/table/auto,
-/obj/machinery/computer3/generic/personal,
 /obj/machinery/light{
 	dir = 4;
 	layer = 9.1;
@@ -30277,6 +31645,9 @@
 	icon_state = "4-8"
 	},
 /obj/landmark/gps_waypoint,
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/grey,
 /area/station/medical/robotics)
 "jpS" = (
@@ -30318,6 +31689,16 @@
 /obj/disposalpipe/junction/right/west,
 /turf/simulated/floor,
 /area/station/hallway/secondary/north)
+"jqK" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/coldloop)
 "jqR" = (
 /obj/decal/tile_edge/line/black{
 	dir = 1;
@@ -30619,6 +32000,9 @@
 	},
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/access_spawn/engineering_mechanic,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
 "jvc" = (
@@ -30743,12 +32127,22 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/redblack,
 /area/station/engine/hotloop)
 "jxi" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/window_blinds/cog2/middle{
 	dir = 8
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/bridge/captain)
@@ -30860,9 +32254,6 @@
 /area/station/crew_quarters/catering)
 "jyv" = (
 /obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/redblack,
@@ -30950,6 +32341,11 @@
 /area/station/crew_quarters/hor{
 	name = "Research Director's Office"
 	})
+"jzA" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/mining/refinery)
 "jzK" = (
 /obj/stool/chair/blue{
 	dir = 1
@@ -30969,6 +32365,12 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/black,
 /area/station/bridge/customs{
 	name = "Bridge Reception"
@@ -30978,6 +32380,9 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail/horizontal,
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor,
 /area/station/science/teleporter)
 "jAd" = (
@@ -31064,6 +32469,11 @@
 	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/heads{
 	name = "Officers' Lounge"
@@ -31209,6 +32619,9 @@
 /area/station/quartermaster/office)
 "jCR" = (
 /obj/machinery/atmospherics/pipe/simple,
+/obj/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "jCU" = (
@@ -31490,6 +32903,14 @@
 "jGP" = (
 /turf/simulated/floor/caution/corner/nw,
 /area/station/security/armory)
+"jGW" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/orangeblack/side{
+	dir = 1
+	},
+/area/station/mining/refinery)
 "jHe" = (
 /obj/stool/chair/office/blue{
 	dir = 4
@@ -32002,6 +33423,9 @@
 	name = "Rapid Transit Interchange"
 	})
 "jOZ" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/blueblack{
 	dir = 4
 	},
@@ -32061,6 +33485,14 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/qm)
+"jQk" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 10
+	},
+/area/station/engine/power)
 "jQq" = (
 /obj/machinery/flasher/portable,
 /obj/machinery/light/emergency{
@@ -32183,6 +33615,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
+"jSg" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 8
+	},
+/area/station/engine/power)
 "jSD" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -32260,6 +33700,10 @@
 /area/station/medical/robotics)
 "jTN" = (
 /obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/engine/elect)
 "jTS" = (
@@ -32434,6 +33878,21 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/chemistry)
+"jVO" = (
+/obj/table/reinforced/auto,
+/obj/item/aiModule/freeform,
+/obj/item/aiModule/notHuman,
+/turf/simulated/floor/darkblue,
+/area/station/turret_protected/ai_upload)
+"jVQ" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/engine/caution/westeast,
+/area/station/engine/power)
 "jVT" = (
 /obj/machinery/light{
 	dir = 4;
@@ -32552,6 +34011,14 @@
 /obj/disposalpipe/segment/mail/vertical,
 /obj/access_spawn/cargo,
 /obj/firedoor_spawn,
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "jYa" = (
@@ -32796,12 +34263,14 @@
 /turf/simulated/floor/redblack,
 /area/station/engine/hotloop)
 "kaG" = (
+/obj/wingrille_spawn/auto/crystal,
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "0-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/overfloor/north,
-/obj/machinery/meter,
-/turf/simulated/floor/redblack,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
 /area/station/engine/hotloop)
 "kaK" = (
 /obj/machinery/vending/kitchen,
@@ -32846,6 +34315,7 @@
 /obj/window_blinds/cog2/left{
 	dir = 4
 	},
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/hor/horprivate)
 "kaU" = (
@@ -32868,6 +34338,9 @@
 	name = "autoname - SS13";
 	pixel_x = 10;
 	tag = ""
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 4
@@ -33041,6 +34514,14 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/exit)
+"kdC" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/quartermaster/office)
 "kdO" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/disposalpipe/segment/mail/vertical,
@@ -33261,6 +34742,9 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/blueblack,
 /area/station/engine/coldloop)
 "kha" = (
@@ -33398,9 +34882,6 @@
 	c_tag = "autotag";
 	dir = 1;
 	name = "autoname - SS13"
-	},
-/obj/cable{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/arcade/dungeon)
@@ -33566,6 +35047,19 @@
 /obj/crematorium/tanning,
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
+"kle" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/left,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/heads{
+	name = "Officers' Lounge"
+	})
 "kls" = (
 /obj/table/auto,
 /obj/machinery/light{
@@ -33609,6 +35103,9 @@
 /obj/wingrille_spawn/auto/crystal,
 /obj/window_blinds/cog2{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering/ce)
@@ -33778,6 +35275,9 @@
 	},
 /area/station/crew_quarters/quartersA)
 "kom" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/stairs/medical,
 /area/station/medical/robotics)
 "koD" = (
@@ -33794,6 +35294,12 @@
 /obj/access_spawn/engineering_engine,
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/blueblack,
 /area/station/engine/coldloop)
@@ -33914,6 +35420,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/darkblue,
 /area/station/turret_protected/ai_upload)
 "kqL" = (
@@ -34253,6 +35762,14 @@
 	dir = 8
 	},
 /area/station/medical/medbay)
+"kvF" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/turret_protected/ai_upload)
 "kvI" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -34274,6 +35791,9 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/light/emergency,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/orangeblack/side,
 /area/station/mining/staff_room)
 "kwk" = (
@@ -34302,6 +35822,21 @@
 /obj/machinery/shieldgenerator/energy_shield,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/ne)
+"kwR" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 10;
+	icon_state = "pdoor0";
+	id = "lockdown";
+	name = "Bridge Lockdown Doors";
+	opacity = 0
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/bridge)
 "kwU" = (
 /obj/machinery/door/airlock/pyro/security{
 	dir = 4
@@ -34410,6 +35945,12 @@
 "kzs" = (
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/stairs/wide/middle{
 	dir = 4
@@ -34792,6 +36333,13 @@
 	dir = 4
 	},
 /area/station/crew_quarters/quarters_west)
+"kFr" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/mining/refinery)
 "kFv" = (
 /obj/machinery/door/airlock/pyro/security{
 	dir = 4
@@ -34866,6 +36414,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
@@ -34974,6 +36525,9 @@
 /area/station/maintenance/southwest)
 "kIK" = (
 /obj/disposalpipe/segment/mail/vertical,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/engine/elect)
 "kIN" = (
@@ -35004,11 +36558,17 @@
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/treatment1)
 "kJk" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/stairs/wide{
 	dir = 4
 	},
 /area/station/bridge)
 "kJm" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/orangeblack/corner,
 /area/station/mining/staff_room)
 "kJp" = (
@@ -35115,6 +36675,12 @@
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/chemistry)
+"kKy" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/robotics)
 "kKG" = (
 /obj/machinery/sim/vr_bed{
 	dir = 4;
@@ -35204,6 +36770,21 @@
 /obj/disposalpipe/segment/bent/east,
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
+"kMX" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 10;
+	icon_state = "pdoor0";
+	id = "ai_core";
+	name = "AI Core Shield";
+	opacity = 0
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/ai)
 "kNa" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -35329,6 +36910,9 @@
 	item_amount = 20
 	},
 /obj/item/disk/data/floppy/read_only/communications,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/carpet/red/fancy/edge/sw,
 /area/station/engine/engineering/ce)
 "kOW" = (
@@ -35503,6 +37087,13 @@
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/crematorium)
+"kSA" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/elect)
 "kSC" = (
 /obj/stone{
 	dir = 4
@@ -35535,6 +37126,11 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
+"kSU" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/engine/coldloop)
 "kTi" = (
 /obj/disposalpipe/segment/mail/bent/west,
 /obj/landmark/gps_waypoint,
@@ -35574,6 +37170,9 @@
 	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment/bent/south,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "kTQ" = (
@@ -35915,11 +37514,10 @@
 /turf/simulated/floor/sanitary,
 /area/station/medical/crematorium)
 "kYT" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
@@ -36013,6 +37611,16 @@
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
+"laa" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/elect)
 "lac" = (
 /obj/stool/chair/comfy{
 	dir = 4
@@ -36302,6 +37910,9 @@
 "leb" = (
 /obj/machinery/atmospherics/valve{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/blueblack,
 /area/station/engine/coldloop)
@@ -36811,6 +38422,24 @@
 /obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/north)
+"llr" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/mining/staff_room)
+"lls" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbay)
 "llv" = (
 /turf/simulated/floor/carpet/green/fancy/edge/east,
 /area/station/crew_quarters/courtroom)
@@ -37157,6 +38786,13 @@
 /obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/grime,
 /area/station/security/brig/cell_block)
+"lrj" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/mining/staff_room)
 "lrm" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -37179,6 +38815,17 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/grey,
 /area/station/science/lab)
+"lrW" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/turret_protected/ai_upload)
 "lse" = (
 /obj/stool/chair,
 /obj/machinery/light{
@@ -37615,6 +39262,35 @@
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/hor/horprivate)
+"lAK" = (
+/obj/item/sheet/steel{
+	amount = 50
+	},
+/obj/item/storage/toolbox/mechanical,
+/obj/item/caution{
+	desc = "Caution! Construction Zone!";
+	name = "caution sign"
+	},
+/obj/item/caution{
+	desc = "Caution! Construction Zone!";
+	name = "caution sign"
+	},
+/obj/item/storage/firstaid/oxygen{
+	pixel_y = -4
+	},
+/obj/item/reagent_containers/food/drinks/fueltank,
+/obj/item/chem_grenade/metalfoam,
+/obj/item/chem_grenade/metalfoam,
+/obj/storage/cart/mechcart{
+	desc = "A big rolling supply cart equipped for handling hull breaches.";
+	name = "breach repair cart";
+	req_access_txt = "40"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/yellow/side,
+/area/station/engine/engineering)
 "lAL" = (
 /obj/stool/chair/yellow{
 	dir = 8
@@ -37728,6 +39404,17 @@
 	},
 /turf/space,
 /area/space)
+"lBN" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/atmospherics/pipe/simple/junction{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/engine/coldloop)
 "lBR" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
@@ -37871,12 +39558,19 @@
 /obj/window_blinds/cog2/middle{
 	dir = 8
 	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/hor{
 	name = "Research Director's Office"
 	})
 "lDA" = (
 /obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/purplewhite{
 	dir = 4
 	},
@@ -37980,6 +39674,12 @@
 /obj/window_blinds/cog2/middle{
 	dir = 10
 	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/bridge/captain)
 "lEK" = (
@@ -38070,6 +39770,12 @@
 	name = "The Warrens"
 	})
 "lFJ" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/yellowblack{
 	dir = 9
 	},
@@ -38106,6 +39812,9 @@
 "lGq" = (
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellowblack{
 	dir = 5
@@ -38450,6 +40159,17 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
+"lKF" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbay)
 "lKO" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
@@ -38574,6 +40294,13 @@
 	dir = 1
 	},
 /area/station/crew_quarters/quarters_west)
+"lMe" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/gas)
 "lMm" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -38642,9 +40369,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/ne)
 "lNf" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/stairs/wood/wide{
 	dir = 8
 	},
@@ -38674,15 +40398,18 @@
 /turf/simulated/floor/yellow,
 /area/station/engine/storage)
 "lNB" = (
-/obj/stool/chair/yellow,
+/obj/wingrille_spawn/auto/crystal,
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "0-4"
 	},
 /obj/cable{
-	icon_state = "2-8"
+	icon_state = "0-8"
 	},
-/turf/simulated/floor,
-/area/station/engine/engineering)
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/hotloop)
 "lND" = (
 /obj/machinery/space_heater,
 /obj/machinery/light/emergency{
@@ -38750,6 +40477,13 @@
 /obj/machinery/meter,
 /turf/simulated/floor/engine,
 /area/station/science/lab)
+"lOB" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/elect)
 "lOI" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
@@ -38961,6 +40695,20 @@
 /obj/machinery/light/emergency,
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/jazz)
+"lSa" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "lockdown";
+	name = "Bridge Lockdown Doors";
+	opacity = 0
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/bridge)
 "lSc" = (
 /obj/machinery/door/unpowered/wood/pyro{
 	dir = 1
@@ -38983,6 +40731,9 @@
 	req_access = null
 	},
 /obj/access_spawn/eva,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/darkblue,
 /area/station/storage/eva)
 "lSI" = (
@@ -39080,6 +40831,10 @@
 	name = "Bridge Lockdown Doors";
 	opacity = 0
 	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "lUf" = (
@@ -39094,6 +40849,13 @@
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/sw,
 /area/station/security/hos)
+"lUg" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/quartermaster/office)
 "lUh" = (
 /obj/machinery/light{
 	dir = 4;
@@ -39177,6 +40939,14 @@
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/se,
 /area/station/crew_quarters/arcade/dungeon)
+"lVt" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/power)
 "lVu" = (
 /obj/mic_stand,
 /turf/simulated/floor/wood,
@@ -39310,11 +41080,12 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "lXe" = (
+/obj/wingrille_spawn/auto/crystal,
 /obj/cable{
-	icon_state = "2-4"
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/white,
-/area/station/medical/cdc)
+/turf/simulated/floor/plating,
+/area/station/engine/hotloop)
 "lXk" = (
 /obj/decal/tile_edge/line/black{
 	dir = 4;
@@ -39381,9 +41152,6 @@
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/access_spawn/medical,
 /obj/firedoor_spawn,
 /turf/simulated/floor/white,
@@ -39401,10 +41169,11 @@
 	},
 /obj/item/hand_labeler,
 /obj/machinery/light{
-	dir = 1;
+	dir = 4;
 	layer = 9.1;
-	pixel_y = 21
+	pixel_x = 10
 	},
+/obj/machinery/recharger/wall/sticky,
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
@@ -39525,9 +41294,6 @@
 	layer = 9.1;
 	pixel_x = 10
 	},
-/obj/cable{
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "lZL" = (
@@ -39619,6 +41385,9 @@
 "maV" = (
 /obj/machinery/atmospherics/valve{
 	dir = 1
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/caution/west,
 /area/station/engine/hotloop)
@@ -39718,6 +41487,9 @@
 /obj/machinery/atmospherics/valve{
 	dir = 1
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/engine/hotloop)
 "mcp" = (
@@ -39742,12 +41514,12 @@
 	name = "Med-Sci Security Checkpoint"
 	})
 "mcT" = (
-/obj/table/auto,
-/obj/machinery/computer3/generic/personal,
-/turf/simulated/floor/neutral/side{
-	dir = 1
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-2"
 	},
-/area/station/crew_quarters/market)
+/turf/simulated/floor/plating,
+/area/station/engine/hotloop)
 "mcX" = (
 /obj/table/auto,
 /obj/item/plate,
@@ -39812,6 +41584,12 @@
 /turf/simulated/floor/grey,
 /area/station/engine/engineering/private)
 "mdA" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/engine/hotloop)
 "mdH" = (
@@ -39830,6 +41608,12 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor,
 /area/station/engine/hotloop)
 "mdN" = (
@@ -39838,6 +41622,12 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/crewquarters/cryotron)
+"mdP" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/surgery)
 "mdR" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -39852,6 +41642,9 @@
 "mdZ" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/window_blinds/cog2/left,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/station/bridge/captain)
 "mee" = (
@@ -39894,6 +41687,9 @@
 	},
 /obj/access_spawn/engineering_mechanic,
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
@@ -39974,6 +41770,9 @@
 	pixel_x = 10
 	},
 /obj/reagent_dispensers/foamtank,
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/caution/east,
 /area/station/engine/hotloop)
 "mgf" = (
@@ -40046,6 +41845,9 @@
 /turf/simulated/floor/black,
 /area/station/bridge)
 "mgQ" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/yellowblack{
 	dir = 8
 	},
@@ -40103,6 +41905,17 @@
 	},
 /turf/simulated/floor/caution/west,
 /area/station/engine/coldloop)
+"mhG" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/quartermaster/office)
 "mhL" = (
 /obj/machinery/door/airlock/pyro/classic{
 	dir = 4
@@ -40208,6 +42021,9 @@
 "mjv" = (
 /obj/machinery/atmospherics/valve{
 	dir = 1
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/caution/east,
 /area/station/engine/coldloop)
@@ -40471,11 +42287,8 @@
 	})
 "mnn" = (
 /obj/table/wood/round/auto,
-/obj/machinery/computer3/generic/personal,
-/obj/cable{
-	icon_state = "0-2"
-	},
 /obj/machinery/power/data_terminal,
+/obj/item/dice/magic8ball,
 /turf/simulated/floor/carpet/red/fancy/narrow/T_west,
 /area/station/crew_quarters/arcade/dungeon)
 "mnA" = (
@@ -40514,6 +42327,9 @@
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/left{
 	dir = 8
+	},
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/hor{
@@ -40589,6 +42405,9 @@
 /obj/disposalpipe/segment/mail/vertical,
 /obj/access_spawn/cargo,
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "mpn" = (
@@ -40808,6 +42627,10 @@
 /obj/machinery/atmospherics/pipe/simple/junction{
 	dir = 4
 	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/engine/coldloop)
 "mrK" = (
@@ -40973,6 +42796,9 @@
 /obj/machinery/light/emergency{
 	dir = 1;
 	pixel_y = 16
+	},
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/red/side{
 	dir = 8
@@ -41285,6 +43111,21 @@
 /obj/machinery/light/small/harsh,
 /turf/simulated/floor/black,
 /area/station/storage/warehouse)
+"myE" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 6;
+	icon_state = "pdoor0";
+	id = "ai_core";
+	name = "AI Core Shield";
+	opacity = 0
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/ai)
 "myG" = (
 /obj/machinery/light{
 	dir = 1;
@@ -41317,9 +43158,6 @@
 	},
 /obj/cable{
 	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/bent/south,
 /turf/simulated/floor/white,
@@ -41427,9 +43265,6 @@
 /area/station/engine/coldloop)
 "mBa" = (
 /obj/table/reinforced/auto,
-/obj/machinery/power/data_terminal,
-/obj/machinery/computer3/generic/personal,
-/obj/cable,
 /obj/item/device/radio/intercom/medical{
 	dir = 8
 	},
@@ -41486,6 +43321,9 @@
 /obj/machinery/light/emergency{
 	dir = 4;
 	pixel_x = 10
+	},
+/obj/cable{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
@@ -41643,6 +43481,9 @@
 /turf/simulated/floor/wood/eight,
 /area/station/security/detectives_office)
 "mEw" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/caution/south,
 /area/station/engine/hotloop)
 "mEz" = (
@@ -41668,6 +43509,14 @@
 /obj/table/reinforced/auto,
 /obj/item/device/analyzer/atmospheric,
 /obj/item/wrench,
+/obj/machinery/door_control{
+	id = "ozygasbelt";
+	name = "Gas Transit Door";
+	pixel_x = 24
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/caution/corner/se,
 /area/station/engine/hotloop)
 "mER" = (
@@ -41700,6 +43549,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/grey,
 /area/station/bridge/customs{
 	name = "Bridge Reception"
@@ -41730,6 +43582,9 @@
 /area/station/science/lobby)
 "mFW" = (
 /obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/station/engine/core)
 "mGc" = (
@@ -41877,6 +43732,16 @@
 	dir = 4
 	},
 /area/station/crew_quarters/courtroom)
+"mIE" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/science/chemistry)
 "mIG" = (
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/sanitary,
@@ -41980,6 +43845,20 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/grey,
 /area/station/quartermaster/cargobay)
+"mKy" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/middle{
+	dir = 4
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/hor/horprivate)
 "mKB" = (
 /obj/machinery/manufacturer/hangar,
 /turf/simulated/floor/black/side{
@@ -41990,6 +43869,9 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "mKQ" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/caution/south,
 /area/station/engine/coldloop)
 "mKT" = (
@@ -42116,6 +43998,9 @@
 /obj/disposalpipe/segment/mail/vertical,
 /obj/access_spawn/medical,
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbooth)
 "mMQ" = (
@@ -42194,9 +44079,6 @@
 /turf/simulated/floor/red,
 /area/station/security/main)
 "mOs" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/carpet/green/fancy/edge/north,
 /area/station/medical/staff)
 "mOA" = (
@@ -42462,13 +44344,11 @@
 	name = "Officers' Lounge"
 	})
 "mSb" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/stool/chair/blue{
+	dir = 8
 	},
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/darkblue,
 /area/station/turret_protected/ai_upload)
@@ -42588,6 +44468,9 @@
 /obj/table/reinforced/auto,
 /obj/machinery/door/airlock/pyro/glass/windoor,
 /obj/machinery/cashreg,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
@@ -42733,6 +44616,9 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/blueblack,
 /area/station/engine/coldloop)
 "mVA" = (
@@ -42795,6 +44681,13 @@
 /obj/machinery/computer/barcode/qm/ozy,
 /turf/simulated/floor/orangeblack,
 /area/station/quartermaster/cargobay)
+"mWq" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/engineering)
 "mWE" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -43078,6 +44971,14 @@
 	},
 /turf/simulated/floor/caution/northsouth,
 /area/station/mining/refinery)
+"nbp" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/engine/hotloop)
 "nbC" = (
 /obj/machinery/computer/magnet{
 	dir = 4
@@ -43275,8 +45176,19 @@
 	req_access = null
 	},
 /obj/access_spawn/eva,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/darkblue,
 /area/station/storage/eva)
+"neu" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/hotloop)
 "neE" = (
 /obj/table/auto,
 /obj/machinery/microwave,
@@ -43348,6 +45260,17 @@
 /obj/item/reagent_containers/glass/oilcan,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
+"ngb" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/pharmacy)
 "ngh" = (
 /obj/table/auto,
 /obj/machinery/microscope,
@@ -43551,6 +45474,9 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/wood/eight,
 /area/station/security/detectives_office)
 "njF" = (
@@ -43638,6 +45564,20 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/bar)
+"nkT" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/window_blinds/cog2/middle{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/engineering/ce)
 "nkV" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -43888,6 +45828,10 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/poddoor/pyro{
+	id = "ozygasbelt";
+	name = "Gas Transit Door"
+	},
 /turf/simulated/floor/caution/westeast,
 /area/station/engine/hotloop)
 "npL" = (
@@ -44063,6 +46007,20 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/sanitary,
 /area/station/security/quarters)
+"nth" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/middle,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/surgery)
 "ntt" = (
 /obj/table/wood/auto,
 /obj/machinery/computer/security/wooden_tv/small{
@@ -44800,9 +46758,6 @@
 "nDM" = (
 /obj/iv_stand,
 /obj/item/reagent_containers/iv_drip/saline,
-/obj/cable{
-	icon_state = "4-10"
-	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 0;
@@ -44990,6 +46945,15 @@
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/grey,
 /area/station/chapel/sanctuary)
+"nFJ" = (
+/obj/disposalpipe/segment/mail/vertical,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/grey,
+/area/station/bridge/customs{
+	name = "Bridge Reception"
+	})
 "nFL" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -45028,6 +46992,15 @@
 	},
 /turf/simulated/floor/caution/south,
 /area/station/science/storage)
+"nFT" = (
+/obj/cable{
+	icon_state = "6-8"
+	},
+/obj/cable{
+	icon_state = "1-6"
+	},
+/turf/simulated/floor/redblack,
+/area/station/engine/hotloop)
 "nFU" = (
 /obj/stool/chair/couch{
 	dir = 4;
@@ -45269,6 +47242,16 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold/vertical,
 /turf/simulated/floor/caution/westeast,
 /area/station/science/lab)
+"nJB" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/power)
 "nJK" = (
 /obj/machinery/chem_dispenser/alcohol,
 /turf/simulated/floor/grey,
@@ -45355,8 +47338,17 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/security/checkpoint/east)
+"nLt" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/engine/elect)
 "nLP" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -45427,7 +47419,6 @@
 	icon_state = "server0";
 	name = "downed server"
 	},
-/obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-4"
 	},
@@ -45555,6 +47546,16 @@
 	},
 /turf/simulated/floor/delivery,
 /area/station/hallway/primary/west)
+"nOZ" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbay)
 "nPd" = (
 /obj/shrub,
 /obj/machinery/alarm{
@@ -45662,9 +47663,6 @@
 "nQc" = (
 /obj/stool/chair/office/green{
 	dir = 8
-	},
-/obj/cable{
-	icon_state = "2-8"
 	},
 /obj/item/device/radio/intercom/medical{
 	dir = 8
@@ -45981,6 +47979,11 @@
 /obj/cable{
 	icon_state = "4-9"
 	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "6-9"
+	},
 /turf/simulated/floor/darkblue,
 /area/station/storage/eva)
 "nTP" = (
@@ -46129,6 +48132,12 @@
 "nXj" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/left,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/hor{
 	name = "Research Director's Office"
@@ -46497,6 +48506,12 @@
 	},
 /turf/simulated/floor/carpet/blue/standard/edge/sw,
 /area/station/medical/medbay/treatment)
+"obX" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/robotics)
 "ocp" = (
 /obj/stool/chair/blue,
 /turf/simulated/floor/carpet/blue/standard/edge/south,
@@ -46658,9 +48673,6 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
-/obj/cable{
-	icon_state = "5-8"
-	},
 /obj/access_spawn/medical,
 /obj/firedoor_spawn,
 /turf/simulated/floor/white,
@@ -46722,11 +48734,24 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "ofU" = (
-/obj/shrub,
+/obj/table/auto,
+/obj/item/clothing/gloves/latex,
+/obj/item/clothing/gloves/latex,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
+/obj/item/spraybottle/cleaner,
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
 /area/station/medical/medbay/treatment)
+"ogf" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/engineering)
 "ogg" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -46771,9 +48796,6 @@
 "ogy" = (
 /obj/cable{
 	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-4"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/blueblack,
@@ -46832,11 +48854,18 @@
 /turf/simulated/floor/black,
 /area/station/bridge)
 "ohz" = (
-/obj/machinery/door/poddoor{
-	id = "ai_core";
-	name = "AI Core Shield"
-	},
 /obj/wingrille_spawn/auto,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 9;
+	icon_state = "pdoor0";
+	id = "ai_core";
+	name = "AI Core Shield";
+	opacity = 0
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "ohF" = (
@@ -46955,6 +48984,9 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/security/checkpoint/medical{
 	name = "Med-Sci Security Checkpoint"
@@ -47013,6 +49045,7 @@
 /obj/machinery/sleep_console{
 	dir = 4
 	},
+/obj/item/device/radio/intercom,
 /turf/simulated/floor/green/checker,
 /area/station/storage/emergency)
 "ojb" = (
@@ -47170,6 +49203,12 @@
 	id = "lockdown";
 	name = "Bridge Lockdown Doors";
 	opacity = 0
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/bridge)
@@ -47462,6 +49501,16 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/engine/engineering/private)
+"opP" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/mining/refinery)
 "oqa" = (
 /obj/item/storage/box/evidence,
 /obj/item/storage/box/evidence,
@@ -47484,6 +49533,13 @@
 	dir = 10
 	},
 /area/station/security/equipment)
+"oqo" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/checkpoint/east)
 "oqB" = (
 /obj/cable{
 	icon_state = "6-8"
@@ -47524,6 +49580,10 @@
 	},
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor/pyro{
+	id = "ozygasbelt";
+	name = "Gas Transit Door"
 	},
 /turf/simulated/floor/caution/westeast,
 /area/station/engine/gas)
@@ -47572,6 +49632,17 @@
 	icon_state = "catwalk_cross"
 	},
 /area/station/solar/west)
+"oso" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/mining/staff_room)
 "osp" = (
 /obj/stool/chair{
 	dir = 4
@@ -47582,6 +49653,9 @@
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine/caution/westeast,
 /area/station/engine/power)
@@ -47631,6 +49705,32 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/grey,
 /area/station/science/lab)
+"ots" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/window_blinds/cog2/middle{
+	dir = 8
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/detectives_office)
+"otH" = (
+/obj/machinery/door/airlock/pyro/engineering{
+	name = "Engineering Door";
+	req_access = null
+	},
+/obj/access_spawn/engineering_mechanic,
+/obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/grey,
+/area/station/engine/engineering/private)
 "otJ" = (
 /obj/rack,
 /obj/item/wrench,
@@ -47653,6 +49753,18 @@
 	dir = 8
 	},
 /area/station/science/lab)
+"otK" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/engine,
+/area/station/turret_protected/ai)
 "otT" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -47718,6 +49830,9 @@
 "oux" = (
 /obj/stool/chair/office{
 	dir = 8
+	},
+/obj/cable{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/darkblue,
 /area/station/medical/medbay/pharmacy)
@@ -48186,7 +50301,7 @@
 /area/station/maintenance/inner/north)
 "oBI" = (
 /obj/machinery/atmospherics/pipe/simple{
-	dir = 5
+	dir = 4
 	},
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai_upload)
@@ -48333,6 +50448,9 @@
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/jazz)
 "oDC" = (
+/obj/table/reinforced/auto,
+/obj/item/aiModule/rename,
+/obj/item/aiModule/reset,
 /turf/simulated/floor/darkblue,
 /area/station/turret_protected/ai_upload)
 "oEh" = (
@@ -48529,9 +50647,8 @@
 /area/station/medical/medbay/treatment)
 "oHi" = (
 /obj/table/auto,
-/obj/machinery/computer3/generic/personal,
-/obj/cable,
 /obj/machinery/power/data_terminal,
+/obj/item/item_box/medical_patches/mini_silver_sulf,
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "oHn" = (
@@ -48673,9 +50790,6 @@
 /obj/stool/chair/comfy{
 	dir = 4
 	},
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_x = -12
@@ -48715,6 +50829,9 @@
 /obj/table/reinforced/auto,
 /obj/machinery/recharger,
 /obj/item/cargotele,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
@@ -48857,6 +50974,9 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/carpet/purple/fancy/junction/nw_e,
 /area/station/crew_quarters/hor/horprivate)
 "oMg" = (
@@ -48942,8 +51062,21 @@
 /obj/stool/chair/yellow{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/engine/engineering/private)
+"oMS" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/vertical,
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/white,
+/area/station/science/lobby)
 "oMX" = (
 /obj/table/auto,
 /obj/bedsheetbin,
@@ -49195,8 +51328,27 @@
 	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/grey,
 /area/station/bridge)
+"oRF" = (
+/obj/stool/chair/office/yellow{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood/seven,
+/area/station/engine/engineering/private)
 "oRW" = (
 /turf/simulated/floor/yellow/checker,
 /area/station/routing/catering{
@@ -49225,6 +51377,9 @@
 	},
 /obj/cable{
 	icon_state = "4-9"
+	},
+/obj/cable{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/engine/caution/south,
 /area/station/engine/core)
@@ -49337,6 +51492,14 @@
 	icon_state = "floor6"
 	},
 /area/shuttle/arrival/station)
+"oUs" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/mining/refinery)
 "oUQ" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -49514,6 +51677,9 @@
 /obj/machinery/conveyor_switch{
 	id = "cannedfartbelt"
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/yellowblack,
 /area/station/engine/gas)
 "oXn" = (
@@ -49578,6 +51744,9 @@
 	dir = 1;
 	pixel_y = 21
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/yellowblack,
 /area/station/engine/gas)
 "oYY" = (
@@ -49616,12 +51785,18 @@
 /obj/stool/chair/blue{
 	dir = 8
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/greenblack{
 	dir = 1
 	},
 /area/station/hallway/secondary/west)
 "oZs" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/darkblue,
 /area/station/storage/eva)
 "oZM" = (
@@ -49641,6 +51816,11 @@
 	name = "autoname - SS13";
 	pixel_x = 10;
 	tag = ""
+	},
+/obj/machinery/door_control{
+	id = "ozygasbelt";
+	name = "Gas Transit Door";
+	pixel_x = 24
 	},
 /turf/simulated/floor/yellowblack/corner{
 	dir = 4
@@ -49762,6 +51942,9 @@
 	},
 /obj/access_spawn/medical,
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/wood,
 /area/station/medical/medbay/treatment)
 "pbn" = (
@@ -50588,6 +52771,18 @@
 /area/station/crew_quarters/info{
 	name = "Book Nook"
 	})
+"poF" = (
+/obj/machinery/light/emergency{
+	dir = 8;
+	pixel_x = -10
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/blue/side{
+	dir = 8
+	},
+/area/station/hallway/primary/south)
 "poQ" = (
 /obj/machinery/door/airlock/pyro/glass/engineering{
 	dir = 4;
@@ -50698,16 +52893,12 @@
 /turf/simulated/floor/caution/north,
 /area/station/science/artifact)
 "pqF" = (
-/obj/table/auto,
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/surgical,
-/obj/item/spraybottle/cleaner,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
 	},
+/obj/table/auto,
+/obj/item/robodefibrillator,
 /turf/simulated/floor/bluewhite/corner{
 	dir = 4
 	},
@@ -51119,6 +53310,14 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/darkblue,
 /area/station/storage/eva)
+"pwE" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/engine/coldloop)
 "pwP" = (
 /obj/storage/closet/dresser/random,
 /turf/simulated/floor/grime,
@@ -51151,6 +53350,12 @@
 /obj/stool/bench/yellow/auto,
 /turf/simulated/floor/sanitary,
 /area/station/engine/engineering/ce)
+"pxx" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/mining/staff_room)
 "pxy" = (
 /obj/machinery/atmospherics/pipe/simple/overfloor/northeast,
 /turf/simulated/floor/plating,
@@ -51238,6 +53443,9 @@
 /turf/simulated/floor/green/checker,
 /area/station/hydroponics/bay)
 "pyW" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/redwhite{
 	dir = 1
 	},
@@ -51363,6 +53571,10 @@
 /obj/window_blinds/cog2/middle{
 	dir = 9
 	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/hor{
 	name = "Research Director's Office"
@@ -51470,6 +53682,16 @@
 	},
 /turf/simulated/floor,
 /area/station/hangar/main)
+"pCW" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/power)
 "pCY" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -51642,7 +53864,15 @@
 /turf/simulated/floor/wood/seven,
 /area/station/garden/aviary)
 "pGl" = (
-/turf/simulated/floor/stairs,
+/obj/machinery/door/airlock/pyro/glass/engineering{
+	name = "Mining Door";
+	req_access = null
+	},
+/obj/access_spawn/mining,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
 /area/station/mining/staff_room)
 "pGS" = (
 /obj/stool/chair/red{
@@ -51667,6 +53897,9 @@
 	},
 /obj/cable{
 	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/gas)
@@ -52016,6 +54249,13 @@
 	dir = 4
 	},
 /area/station/science/lobby)
+"pLR" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/gas)
 "pLZ" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -52036,6 +54276,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/cable,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -52080,6 +54321,11 @@
 	dir = 1
 	},
 /area/station/turret_protected/Zeta)
+"pMT" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/engine/engineering/private)
 "pNh" = (
 /obj/machinery/computer/atmosphere/mixercontrol{
 	frequency = 1225;
@@ -52099,6 +54345,15 @@
 	dir = 1
 	},
 /area/station/engine/power)
+"pNr" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor,
+/area/station/science/teleporter)
 "pNA" = (
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/yellow/side{
@@ -52382,6 +54637,9 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "pRV" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/carpet/purple/fancy/edge/west,
 /area/station/crew_quarters/hor/horprivate)
 "pRW" = (
@@ -52424,6 +54682,9 @@
 /area/station/security/brig/cell_block)
 "pSo" = (
 /obj/storage/secure/closet/engineering/electrical,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -52535,10 +54796,20 @@
 /obj/stool/chair/office/yellow{
 	dir = 1
 	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
 /area/station/engine/power)
+"pTF" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/mining/staff_room)
 "pTN" = (
 /turf/simulated/floor/caution/corner/se,
 /area/station/hangar/engine)
@@ -52585,9 +54856,10 @@
 /turf/simulated/floor/engine/caution/north,
 /area/station/engine/power)
 "pUM" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
+/obj/table/reinforced/auto,
+/obj/item/aiModule/emergency,
+/obj/item/aiModule/removeCrew,
+/obj/random_item_spawner/ai_experimental,
 /turf/simulated/floor/darkblue,
 /area/station/turret_protected/ai_upload)
 "pUU" = (
@@ -52595,6 +54867,10 @@
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0
 	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/engine/core)
 "pUY" = (
@@ -52684,6 +54960,9 @@
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/red/side{
 	dir = 8
 	},
@@ -52736,6 +55015,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/ne)
 "pXC" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/orangeblack/side,
 /area/station/mining/staff_room)
 "pXM" = (
@@ -52780,6 +55065,13 @@
 	dir = 4
 	},
 /area/station/science/lab)
+"pYk" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbooth)
 "pYo" = (
 /obj/machinery/magnet_chassis{
 	dir = 8
@@ -52865,6 +55157,16 @@
 /obj/machinery/portable_reclaimer,
 /turf/simulated/floor/orangeblack/side,
 /area/station/hangar/science)
+"pZP" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/engine,
+/area/station/turret_protected/ai)
 "pZR" = (
 /obj/stool/chair{
 	dir = 8
@@ -52926,6 +55228,18 @@
 	},
 /turf/simulated/floor,
 /area/station/hangar/science)
+"qaO" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "lockdown";
+	name = "Bridge Lockdown Doors";
+	opacity = 0
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/bridge)
 "qaR" = (
 /obj/stool/chair/yellow,
 /obj/machinery/atmospherics/pipe/simple{
@@ -52957,6 +55271,14 @@
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
+"qbH" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/elect)
 "qbN" = (
 /obj/stool/chair/office/purple{
 	dir = 8
@@ -53112,6 +55434,14 @@
 /obj/machinery/light,
 /turf/simulated/floor/blue/side,
 /area/station/hallway/primary/north)
+"qeO" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/engine/engineering/private)
 "qfi" = (
 /obj/cable{
 	d1 = 1;
@@ -53203,6 +55533,7 @@
 /obj/window_blinds/cog2/right{
 	dir = 8
 	},
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/bridge/captain)
 "qgp" = (
@@ -53563,6 +55894,9 @@
 /obj/window_blinds/cog2/right{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/hor/horprivate)
 "qmB" = (
@@ -53677,6 +56011,20 @@
 /obj/landmark/halloween,
 /turf/simulated/floor/grey,
 /area/station/hallway/secondary/west)
+"qoi" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/window_blinds/cog2/middle,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/bridge/captain)
 "qon" = (
 /obj/machinery/vending/port_a_nanomed,
 /obj/machinery/light,
@@ -54370,6 +56718,14 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/west)
+"qyP" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/power)
 "qyS" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -54508,6 +56864,9 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor,
 /area/station/engine/power)
 "qAX" = (
@@ -54519,13 +56878,16 @@
 /area/station/crew_quarters/jazz)
 "qBb" = (
 /obj/table/auto,
-/obj/machinery/computer3/generic/personal,
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_x = 12
 	},
-/obj/cable,
-/obj/machinery/power/data_terminal,
+/obj/item/storage/firstaid/brain{
+	pixel_x = 3
+	},
+/obj/item/storage/pill_bottle/mutadone{
+	pixel_x = -9
+	},
 /turf/simulated/floor/carpet/green/fancy/edge/se,
 /area/station/medical/staff)
 "qBg" = (
@@ -54597,6 +56959,9 @@
 /obj/access_spawn/engineering_engine,
 /obj/access_spawn/engineering_power,
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
@@ -54647,6 +57012,24 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/power)
+"qCv" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "ai_core";
+	name = "AI Core Shield";
+	opacity = 0
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/ai)
 "qCJ" = (
 /obj/disposalpipe/segment/transport{
 	icon_state = "pipe-c"
@@ -54821,6 +57204,13 @@
 /obj/window_blinds/cog2/middle{
 	dir = 8
 	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/heads{
 	name = "Officers' Lounge"
@@ -54848,6 +57238,17 @@
 	dir = 4
 	},
 /area/station/engine/power)
+"qFz" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/turret_protected/ai_upload)
 "qFD" = (
 /obj/stool/chair/couch{
 	dir = 8;
@@ -55060,6 +57461,9 @@
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/access_spawn/research,
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/purple/side{
 	dir = 8
 	},
@@ -55092,6 +57496,12 @@
 	req_access = null
 	},
 /obj/access_spawn/mining,
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/orangeblack,
 /area/station/mining/refinery)
 "qJv" = (
@@ -55453,6 +57863,24 @@
 	},
 /turf/simulated/floor/grey/side,
 /area/station/maintenance/solar/west)
+"qOs" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 9;
+	icon_state = "pdoor0";
+	id = "eva";
+	name = "E.V.A.";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/station/storage/eva)
 "qOt" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/access_spawn/medical,
@@ -55664,6 +58092,13 @@
 /area/station/medical/research{
 	name = "Genetic Research"
 	})
+"qRh" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/engineering)
 "qRm" = (
 /obj/shrub{
 	dir = 8
@@ -55928,6 +58363,12 @@
 "qUx" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/middle,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/heads{
 	name = "Officers' Lounge"
@@ -56354,6 +58795,9 @@
 /area/station/crew_quarters/barber_shop)
 "raR" = (
 /obj/machinery/door/airlock/pyro/glass,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "raT" = (
@@ -56405,6 +58849,11 @@
 	dir = 1;
 	pixel_y = 21
 	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/heads{
 	name = "Officers' Lounge"
@@ -56428,6 +58877,11 @@
 	item_amount = 20
 	},
 /obj/item/card/id/captains_spare,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/bridge/captain)
 "rbY" = (
@@ -56480,6 +58934,9 @@
 "rcK" = (
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/engine/caution/westeast,
 /area/station/engine/coldloop)
@@ -56553,6 +59010,11 @@
 "rdR" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/north)
+"reb" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/science/chemistry)
 "rec" = (
 /obj/machinery/weapon_stand/taser_rack/recharger/empty,
 /turf/simulated/floor/redblack{
@@ -56695,6 +59157,7 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "rgF" = (
@@ -56721,6 +59184,9 @@
 	dir = 10;
 	name = "autoname - SS13";
 	tag = ""
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
 /area/station/engine/core)
@@ -56853,6 +59319,9 @@
 "rit" = (
 /obj/stool/chair/office/yellow{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/west,
 /area/station/engine/engineering/ce)
@@ -57155,8 +59624,16 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/lab)
+"rnE" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/pharmacy)
 "rnH" = (
 /obj/stool/chair/comfy,
+/obj/item/device/radio/intercom,
 /turf/simulated/floor/carpet/blue/standard/edge/north,
 /area/station/medical/medbay/lobby)
 "roa" = (
@@ -57611,6 +60088,23 @@
 	dir = 8
 	},
 /area/station/medical/medbay/pharmacy)
+"rvu" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "lockdown";
+	name = "Bridge Lockdown Doors";
+	opacity = 0
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/bridge)
 "rvw" = (
 /obj/storage/closet/office,
 /obj/machinery/power/apc/autoname_north,
@@ -57688,6 +60182,9 @@
 /area/station/maintenance/inner/west)
 "rwb" = (
 /obj/machinery/light/emergency,
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor,
 /area/station/mining/staff_room)
 "rwo" = (
@@ -57785,6 +60282,13 @@
 /area/station/hallway/secondary/entry{
 	name = "Arrival Shuttle Hallway"
 	})
+"rxu" = (
+/obj/machinery/atmospherics/pipe/manifold/overfloor/east,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/redblack,
+/area/station/engine/hotloop)
 "rxF" = (
 /obj/machinery/light{
 	dir = 4;
@@ -57944,12 +60448,16 @@
 /obj/window_blinds/cog2/middle{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/medical/head)
 "rzH" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/pyro/medical{
 	name = "Geneticists";
 	req_access = null
@@ -58026,8 +60534,21 @@
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/lounge/backstage)
 "rAx" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/yellow/side,
 /area/station/engine/power)
+"rAC" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/hydroponics/bay)
 "rAN" = (
 /obj/machinery/conveyor{
 	name = "cargo belt - south";
@@ -58138,6 +60659,14 @@
 	},
 /turf/simulated/floor/redblack/corner,
 /area/station/security/brig)
+"rCo" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/science/chemistry)
 "rCt" = (
 /obj/table/reinforced/bar/auto,
 /obj/machinery/cashreg,
@@ -58194,6 +60723,20 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/cafeteria)
+"rCV" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/treatment)
+"rDa" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/treatment)
 "rDf" = (
 /obj/table/auto,
 /obj/item/clothing/shoes/red{
@@ -58285,6 +60828,9 @@
 /obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/caution/corner/ne,
 /area/station/engine/hotloop)
@@ -58435,6 +60981,9 @@
 /area/station/security/brig)
 "rFS" = (
 /obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/engine/power)
 "rFV" = (
@@ -58519,9 +61068,6 @@
 	})
 "rHw" = (
 /obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/carpet/red/fancy/edge/sw,
 /area/station/crew_quarters/arcade/dungeon)
 "rHE" = (
@@ -58640,6 +61186,13 @@
 /obj/machinery/light/small/floor,
 /turf/simulated/floor,
 /area/station/science/lab)
+"rKu" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/west)
 "rKz" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -58835,6 +61388,9 @@
 /obj/window_blinds/cog2/left{
 	dir = 8
 	},
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/heads{
 	name = "Officers' Lounge"
@@ -58956,6 +61512,9 @@
 /obj/wingrille_spawn/auto/crystal,
 /obj/window_blinds/cog2/right{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering/ce)
@@ -59153,10 +61712,12 @@
 /turf/simulated/floor/orangeblack,
 /area/station/quartermaster/office)
 "rRq" = (
-/turf/simulated/floor/yellowblack{
-	dir = 1
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-2"
 	},
-/area/station/engine/core)
+/turf/simulated/floor/plating,
+/area/station/engine/coldloop)
 "rRs" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	req_access = null
@@ -59487,6 +62048,17 @@
 	},
 /turf/simulated/floor/sanitary,
 /area/station/security/brig/cell_block)
+"rVr" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/window_blinds/cog2/middle,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/engineering/ce)
 "rVA" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -59549,6 +62121,13 @@
 	dir = 8
 	},
 /area/station/hydroponics/bay)
+"rVW" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/robotics)
 "rVY" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -59722,6 +62301,14 @@
 /obj/storage/crate/furnacefuel,
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/sauna)
+"rYt" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/purple/side{
+	dir = 1
+	},
+/area/station/science/artifact)
 "rYw" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -59735,6 +62322,10 @@
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/middle{
 	dir = 4
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/hor/horprivate)
@@ -59892,6 +62483,16 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/grey,
 /area/station/chapel/sanctuary)
+"saQ" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/elect)
 "sbb" = (
 /obj/machinery/light/emergency{
 	dir = 1;
@@ -59948,11 +62549,11 @@
 	name = "Arrival Shuttle Hallway"
 	})
 "sbT" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 10
+/obj/cable{
+	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/blueblack{
 	dir = 8
@@ -60068,6 +62669,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/dome)
+"sdK" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/bridge/customs{
+	name = "Bridge Reception"
+	})
 "sdP" = (
 /obj/landmark/spawner{
 	name = "monkeyspawn_normal"
@@ -60254,6 +62865,15 @@
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/west,
 /area/station/crew_quarters/quarters_west)
+"sik" = (
+/obj/stool/chair/blue,
+/obj/item/device/radio/intercom{
+	dir = 8
+	},
+/turf/simulated/floor/escape{
+	dir = 4
+	},
+/area/station/hallway/secondary/exit)
 "sil" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -60274,6 +62894,9 @@
 /obj/table/wood/round/auto,
 /obj/item/decoration/flower_vase{
 	pixel_y = 14
+	},
+/obj/item/device/radio/intercom{
+	dir = 8
 	},
 /turf/simulated/floor/wood/seven,
 /area/station/crew_quarters/info{
@@ -60374,6 +62997,9 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
@@ -60463,6 +63089,12 @@
 	dir = 1
 	},
 /area/station/engine/power)
+"slo" = (
+/obj/table/reinforced/auto,
+/obj/item/aiModule/makeCaptain,
+/obj/item/aiModule/oneHuman,
+/turf/simulated/floor/darkblue,
+/area/station/turret_protected/ai_upload)
 "sls" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -60556,6 +63188,9 @@
 "smX" = (
 /obj/stool/chair/office/yellow{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/sw,
 /area/station/engine/engineering/ce)
@@ -60738,6 +63373,17 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/lounge/backstage)
+"soW" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/hotloop)
 "soY" = (
 /obj/disposalpipe/segment/brig,
 /obj/machinery/camera{
@@ -61038,6 +63684,13 @@
 /obj/machinery/portable_atmospherics/pump,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
+"ssB" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/hydroponics/bay)
 "ssG" = (
 /turf/simulated/floor/circuit,
 /area/space)
@@ -61193,6 +63846,9 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/red/side{
 	dir = 8
 	},
@@ -61215,6 +63871,17 @@
 /area/station/hallway/secondary/construction{
 	name = "The Warrens"
 	})
+"svG" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbay)
 "svH" = (
 /obj/machinery/field_generator{
 	anchored = 1;
@@ -61328,6 +63995,16 @@
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/maintenance/solar/south)
+"swC" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/turret_protected/ai_upload)
 "swL" = (
 /obj/item/storage/wall{
 	dir = 4;
@@ -61376,6 +64053,9 @@
 	},
 /obj/access_spawn/mining,
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/mining/staff_room)
 "sxD" = (
@@ -61644,6 +64324,9 @@
 /obj/window_blinds/cog2{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
 "sBJ" = (
@@ -61664,6 +64347,9 @@
 	name = "Warrens Hall"
 	})
 "sBL" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},
@@ -61904,10 +64590,7 @@
 	icon_state = "chair_couch-blue";
 	name = "ratty blue couch"
 	},
-/obj/item/device/radio/intercom{
-	broadcasting = 0;
-	pixel_y = -1
-	},
+/obj/item/device/radio/intercom,
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/fitness)
 "sEP" = (
@@ -62202,6 +64885,15 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/security/processing)
+"sID" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/elect)
 "sIY" = (
 /obj/stool/chair/couch{
 	dir = 8
@@ -62521,6 +65213,9 @@
 /obj/stool/chair/office{
 	dir = 8
 	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/blueblack/corner{
 	dir = 4
 	},
@@ -62537,6 +65232,12 @@
 	dir = 4
 	},
 /area/station/hallway/primary/north)
+"sNo" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/yellow/side,
+/area/station/engine/engineering/private)
 "sNq" = (
 /obj/machinery/plantpot{
 	anchored = 1
@@ -62581,6 +65282,18 @@
 	},
 /turf/simulated/floor/sanitary,
 /area/station/medical/staff)
+"sNW" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/grey,
+/area/station/hallway/secondary/north)
 "sOf" = (
 /obj/machinery/atmospherics/pipe/manifold/overfloor/west,
 /obj/machinery/meter,
@@ -62609,6 +65322,7 @@
 /obj/window_blinds/cog2/right{
 	dir = 8
 	},
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
 "sOv" = (
@@ -62671,6 +65385,14 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor,
 /area/station/hangar/science)
+"sPz" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/quartermaster/office)
 "sPA" = (
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -62802,6 +65524,9 @@
 	})
 "sQO" = (
 /obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/station/bridge/customs{
 	name = "Bridge Reception"
@@ -63172,6 +65897,7 @@
 	name = "autoname - SS13";
 	pixel_y = 20
 	},
+/obj/cable,
 /turf/simulated/floor/black,
 /area/station/bridge)
 "sVL" = (
@@ -63244,6 +65970,11 @@
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
 /area/station/engine/power)
+"sWu" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/medical/medbay)
 "sWx" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -63308,6 +66039,12 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/catering)
+"sWT" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/darkblue,
+/area/station/medical/medbay/pharmacy)
 "sWV" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -63637,6 +66374,9 @@
 /obj/stool/chair/yellow{
 	dir = 8
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
@@ -63688,6 +66428,17 @@
 /obj/machinery/drainage,
 /turf/simulated/floor/sanitary,
 /area/listeningpost)
+"tcn" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/mining/staff_room)
 "tcs" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/northwest)
@@ -64134,6 +66885,9 @@
 /obj/access_spawn/engineering_mechanic,
 /obj/access_spawn/engineering_eva,
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "tiE" = (
@@ -64302,6 +67056,13 @@
 "tkM" = (
 /turf/simulated/floor/neutral/side,
 /area/station/crew_quarters/quartersA)
+"tkV" = (
+/obj/disposalpipe/segment/brig,
+/obj/item/device/radio/intercom{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/west)
 "tlm" = (
 /obj/machinery/light,
 /turf/simulated/floor/arrival,
@@ -64479,6 +67240,12 @@
 "tnl" = (
 /turf/space,
 /area/station/communications/centre)
+"tnm" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/engine/elect)
 "tnp" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/cable{
@@ -64523,6 +67290,15 @@
 /obj/reagent_dispensers/foamtank,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
+"tnN" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/station/engine/engineering/ce)
 "tnP" = (
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
@@ -64652,6 +67428,9 @@
 	},
 /obj/access_spawn/engineering_power,
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/yellow,
 /area/station/engine/power)
 "tpO" = (
@@ -64668,6 +67447,9 @@
 "tpR" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/stairs/wide/other{
 	dir = 4
@@ -64738,6 +67520,9 @@
 /turf/simulated/floor/yellow/checker,
 /area/station/storage/tools)
 "tqz" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/yellow/corner{
 	dir = 8
 	},
@@ -64853,6 +67638,12 @@
 	},
 /obj/disposalpipe/segment/brig{
 	dir = 8
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/east)
@@ -65805,6 +68596,14 @@
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/sanitary,
 /area/station/medical/crematorium)
+"tFj" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/engineering/private)
 "tFp" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
@@ -65820,6 +68619,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/black,
 /area/station/engine/engineering/ce)
 "tFy" = (
@@ -65988,6 +68790,9 @@
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/medical{
 	name = "Med-Sci Security Checkpoint"
@@ -66140,6 +68945,9 @@
 /obj/storage/secure/closet/engineering/electrical,
 /obj/item/clothing/suit/rad,
 /obj/item/clothing/head/rad_hood,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
@@ -66210,6 +69018,7 @@
 /obj/window_blinds/cog2/left{
 	dir = 4
 	},
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/engine/engineering/ce)
 "tLM" = (
@@ -66230,6 +69039,11 @@
 	},
 /turf/simulated/floor/yellow/side,
 /area/station/engine/elect)
+"tLZ" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/quartermaster/office)
 "tMa" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable,
@@ -66348,6 +69162,9 @@
 /obj/access_spawn/engineering,
 /obj/access_spawn/engineering_mechanic,
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/yellow/checker,
 /area/station/engine/engineering)
 "tNL" = (
@@ -66442,6 +69259,15 @@
 	id = "lockdown";
 	name = "Bridge Lockdown Doors";
 	opacity = 0
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/bridge)
@@ -66587,6 +69413,19 @@
 	},
 /turf/simulated/floor/engine/caution/northsouth,
 /area/station/engine/engineering)
+"tQZ" = (
+/obj/rack,
+/obj/item/clothing/suit/space,
+/obj/item/clothing/head/helmet/space,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/jetpack,
+/obj/machinery/door_control{
+	id = "eva";
+	name = "EVA Secure Shutters";
+	pixel_y = 26
+	},
+/turf/simulated/floor/darkblue,
+/area/station/storage/eva)
 "tRa" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/engine/monitoring{
@@ -66602,7 +69441,6 @@
 	dir = 8
 	},
 /obj/cable,
-/obj/machinery/power/data_terminal,
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
@@ -66679,6 +69517,13 @@
 /obj/tree1,
 /turf/simulated/floor/grass,
 /area/station/garden/aviary)
+"tSv" = (
+/obj/machinery/atmospherics/pipe/simple,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/mining/refinery)
 "tSA" = (
 /obj/machinery/navbeacon{
 	codes_txt = "tour;next_tour=tour14;desc=This warehouse is a bit messy, but it's pretty safe. Door on your right goes to the foundry, door on your left goes to the market stall.";
@@ -67084,6 +69929,11 @@
 "tYO" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
+"tYR" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/hydroponics/bay)
 "tYS" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -67288,9 +70138,12 @@
 	},
 /area/station/medical/medbay/lobby)
 "ucq" = (
-/obj/machinery/light,
-/turf/simulated/floor/orangeblack/side,
-/area/station/mining/staff_room)
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/coldloop)
 "ucr" = (
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/sauna)
@@ -67329,6 +70182,12 @@
 	},
 /turf/simulated/floor/grime,
 /area/station/maintenance/disposal)
+"ucO" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/darkblue,
+/area/station/medical/medbay/pharmacy)
 "ucQ" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/machinery/door/poddoor/pyro{
@@ -67374,6 +70233,9 @@
 /area/space)
 "udI" = (
 /obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/chemistry)
 "udL" = (
@@ -67412,6 +70274,13 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold,
 /turf/space,
 /area/space)
+"uez" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbay)
 "ueC" = (
 /turf/simulated/wall/auto/shuttle{
 	icon_state = "12"
@@ -67700,7 +70569,7 @@
 	})
 "uiq" = (
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/blueblack{
 	dir = 4
@@ -68313,10 +71182,11 @@
 	},
 /area/station/medical/medbay)
 "urb" = (
-/obj/table/reinforced/auto,
-/obj/item/aiModule/freeform,
-/obj/item/aiModule/notHuman,
-/turf/simulated/floor/darkblue,
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
 /area/station/turret_protected/ai_upload)
 "urj" = (
 /obj/wingrille_spawn/auto,
@@ -68343,11 +71213,25 @@
 	},
 /turf/simulated/floor/black,
 /area/station/storage/warehouse)
+"urz" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/engineering)
 "urH" = (
 /turf/simulated/floor/circuit/red,
 /area/station/engine/power)
 "urN" = (
 /obj/machinery/light/emergency,
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/grey,
 /area/station/engine/engineering/private)
 "urQ" = (
@@ -68388,6 +71272,25 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/arcade)
+"use" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "eva";
+	name = "E.V.A.";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/station/storage/eva)
 "usi" = (
 /obj/machinery/light,
 /turf/simulated/floor/stairs{
@@ -68692,6 +71595,7 @@
 /obj/window_blinds/cog2/right{
 	dir = 8
 	},
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/heads{
 	name = "Officers' Lounge"
@@ -68714,6 +71618,11 @@
 	dir = 8
 	},
 /area/station/science/lobby)
+"uwP" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/engine/engineering)
 "uwQ" = (
 /turf/simulated/floor/circuit/green,
 /area/station/turret_protected/Zeta)
@@ -68801,6 +71710,13 @@
 	icon_state = "0,7"
 	},
 /area/station/crew_quarters/fitness)
+"uyh" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/power)
 "uyi" = (
 /obj/machinery/bot/duckbot,
 /obj/cable{
@@ -69594,6 +72510,23 @@
 /obj/item/peripheral/printer,
 /turf/simulated/floor/grey/blackgrime,
 /area/station/storage/tech)
+"uHZ" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/robotics)
+"uIo" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/turret_protected/ai_upload)
 "uIz" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/vertical,
 /turf/simulated/floor/engine,
@@ -69793,6 +72726,12 @@
 /obj/machinery/atmospherics/pipe/simple/overfloor/northeast,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
+"uLf" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/ai)
 "uLh" = (
 /obj/machinery/mass_driver{
 	dir = 8;
@@ -69855,6 +72794,12 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/bridge)
+"uLR" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/grey,
+/area/station/engine/engineering/private)
 "uMb" = (
 /obj/table/auto,
 /obj/item/suture{
@@ -70457,6 +73402,13 @@
 "uTv" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/window_blinds/cog2/middle,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering/ce)
 "uTF" = (
@@ -70742,6 +73694,14 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/chapel/office)
+"uXw" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/engine/caution/west,
+/area/station/science/teleporter)
 "uXK" = (
 /obj/machinery/atmospherics/pipe/manifold/west,
 /turf/simulated/floor,
@@ -71479,6 +74439,17 @@
 /area/station/crew_quarters/quarters{
 	name = "Chapel Reception"
 	})
+"vhy" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/bridge/captain)
 "vhB" = (
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/white,
@@ -71626,6 +74597,11 @@
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
+"vjh" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/science/lobby)
 "vjy" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -71921,14 +74897,35 @@
 	icon_state = "crewquarters";
 	name = "Warrens Hall"
 	})
+"vnM" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/coldloop)
 "vnU" = (
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
+"vnX" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/checkpoint/east)
 "voc" = (
 /obj/cable{
 	icon_state = "2-8"
 	},
 /obj/item/device/radio/beacon,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/caution/east,
 /area/station/engine/coldloop)
 "voh" = (
@@ -72115,6 +75112,9 @@
 "vqg" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/insulated/cold,
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/engine/caution/west,
 /area/station/engine/core)
 "vqh" = (
@@ -72208,12 +75208,18 @@
 	name = "Dockside Restroom"
 	})
 "vrk" = (
-/obj/stool/bed,
+/obj/wingrille_spawn/auto/crystal,
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/white,
-/area/station/medical/cdc)
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/coldloop)
 "vrt" = (
 /obj/machinery/light{
 	dir = 1;
@@ -72661,10 +75667,14 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/crew_quarters/market)
-"vxV" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
+"vxT" = (
+/obj/cable{
+	icon_state = "1-2"
 	},
+/turf/simulated/floor,
+/area/station/mining/staff_room)
+"vxV" = (
+/obj/item/device/radio/intercom,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/cafeteria)
 "vyb" = (
@@ -72882,6 +75892,9 @@
 	icon_state = "1-4"
 	},
 /obj/disposalpipe/segment/mail/horizontal,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/darkblue,
 /area/station/medical/medbay/pharmacy)
 "vAr" = (
@@ -72949,6 +75962,12 @@
 	icon_state = "1-8"
 	},
 /obj/disposalpipe/segment/mail/horizontal,
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/darkblue,
 /area/station/medical/medbay/pharmacy)
 "vBl" = (
@@ -72984,6 +76003,9 @@
 /area/station/hallway/secondary/west)
 "vBQ" = (
 /obj/disposalpipe/segment/mail/horizontal,
+/obj/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},
@@ -73059,6 +76081,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
+/obj/item/device/radio/intercom,
 /turf/simulated/floor/green/checker,
 /area/station/storage/emergency2)
 "vCw" = (
@@ -73266,6 +76289,9 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor,
 /area/station/security/checkpoint/east)
 "vEV" = (
@@ -73465,6 +76491,11 @@
 	pixel_y = 5;
 	print_id = "CE"
 	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/yellowblack,
 /area/station/engine/engineering/ce)
 "vHg" = (
@@ -74163,6 +77194,9 @@
 	pixel_x = 10;
 	tag = ""
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/purplewhite{
 	dir = 4
 	},
@@ -74373,12 +77407,6 @@
 "vUa" = (
 /turf/simulated/floor/purpleblack/corner,
 /area/station/hallway/secondary/west)
-"vUf" = (
-/obj/table/reinforced/auto,
-/obj/item/aiModule/makeCaptain,
-/obj/item/aiModule/oneHuman,
-/turf/simulated/floor/darkblue,
-/area/station/turret_protected/ai_upload)
 "vUg" = (
 /obj/machinery/door/unpowered/wood/pyro{
 	dir = 8
@@ -74402,6 +77430,13 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/chapel/sanctuary)
+"vUz" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/pharmacy)
 "vUP" = (
 /obj/storage/crate/packing,
 /obj/machinery/light{
@@ -74766,6 +77801,12 @@
 	},
 /obj/machinery/cashreg,
 /obj/access_spawn/engineering_mechanic,
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
 "wal" = (
@@ -74785,6 +77826,9 @@
 "wao" = (
 /obj/cable{
 	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/hor{
@@ -74886,6 +77930,26 @@
 /obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor/white,
 /area/station/science/lab)
+"wby" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/grass,
+/area/station/hydroponics/bay)
+"wbE" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "lockdown";
+	name = "Bridge Lockdown Doors";
+	opacity = 0
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/bridge)
 "wbH" = (
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
@@ -74928,6 +77992,15 @@
 /obj/disposalpipe/junction/middle/west,
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
+"wcf" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/engine/coldloop)
 "wcn" = (
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/sauna)
@@ -75108,6 +78181,11 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment/brig,
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
 /turf/simulated/floor/purple/side{
 	dir = 8
 	},
@@ -75187,8 +78265,19 @@
 	name = "Bridge Lockdown Doors";
 	opacity = 0
 	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/bridge)
+"wfM" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/quartermaster/office)
 "wfU" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/routing/engine)
@@ -75361,6 +78450,12 @@
 	dir = 4
 	},
 /area/station/quartermaster/office)
+"wjc" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
 "wjj" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -75786,6 +78881,13 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/se)
+"wpn" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/hangar/main)
 "wpp" = (
 /obj/stool/chair/yellow{
 	dir = 8
@@ -75897,6 +78999,14 @@
 	dir = 8
 	},
 /area/station/science/bot_storage)
+"wql" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/science/teleporter)
 "wqp" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -75969,6 +79079,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
+/obj/cable,
 /turf/simulated/floor/black,
 /area/station/bridge/customs{
 	name = "Bridge Reception"
@@ -76099,6 +79210,14 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/exit)
+"wsX" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/engine,
+/area/station/science/teleporter)
 "wta" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/disposalpipe/segment/mail/vertical,
@@ -76680,12 +79799,15 @@
 /turf/simulated/floor/engine,
 /area/station/security/armory)
 "wAh" = (
+/obj/wingrille_spawn/auto/crystal,
 /obj/cable{
-	icon_state = "1-8"
+	icon_state = "0-4"
 	},
-/obj/machinery/light/small,
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/arcade/dungeon)
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/coldloop)
 "wAl" = (
 /obj/item/storage/box/evidence,
 /obj/item/storage/box/evidence,
@@ -76865,7 +79987,6 @@
 	icon_state = "dwaine";
 	name = "old mainframe"
 	},
-/obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-4"
 	},
@@ -77268,6 +80389,14 @@
 /obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/grass/leafy,
 /area/station/garden/aviary)
+"wGF" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/hangar/main)
 "wGG" = (
 /turf/simulated/floor/shuttlebay,
 /area/station/hallway/secondary/construction{
@@ -77451,6 +80580,12 @@
 "wJu" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/window_blinds/cog2/middle,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/bridge/captain)
 "wJy" = (
@@ -77541,6 +80676,12 @@
 /obj/access_spawn/engineering,
 /obj/access_spawn/engineering_mechanic,
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/yellow/checker,
 /area/station/engine/engineering)
 "wKH" = (
@@ -77562,6 +80703,9 @@
 /turf/simulated/floor/red,
 /area/station/security/main)
 "wLe" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/stairs/dark/wide{
 	dir = 10
 	},
@@ -77878,6 +81022,9 @@
 "wPO" = (
 /obj/machinery/chem_dispenser,
 /obj/item/reagent_containers/glass/beaker/large,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
@@ -78048,6 +81195,9 @@
 /obj/item/storage/box/beakerbox,
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/machinery/light,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
@@ -78078,6 +81228,10 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "wRZ" = (
@@ -78087,6 +81241,15 @@
 	dir = 1
 	},
 /area/station/medical/medbay/pharmacy)
+"wSa" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/blueblack,
+/area/station/engine/coldloop)
 "wSe" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/vertical,
@@ -78254,6 +81417,17 @@
 /area/station/crew_quarters/hor{
 	name = "Research Director's Office"
 	})
+"wUC" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/science/lobby)
 "wUE" = (
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
@@ -78346,9 +81520,6 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/arcade/dungeon)
 "wVM" = (
@@ -78414,6 +81585,9 @@
 /obj/item/clothing/head/helmet/space/engineer,
 /obj/item/device/gps,
 /obj/item/storage/belt/mining,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/mining/refinery)
 "wXg" = (
@@ -78454,6 +81628,20 @@
 	},
 /turf/simulated/floor/engine/caution/corner,
 /area/station/engine/engineering)
+"wXX" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "eva";
+	name = "E.V.A.";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/station/storage/eva)
 "wXZ" = (
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/grey,
@@ -78563,6 +81751,9 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail/horizontal,
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "wZK" = (
@@ -78630,6 +81821,15 @@
 	},
 /turf/simulated/floor/sanitary,
 /area/station/security/quarters)
+"xaG" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/orangeblack/side,
+/area/station/mining/staff_room)
 "xaP" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -78651,6 +81851,13 @@
 /area/station/hallway/secondary/entry{
 	name = "Arrival Shuttle Hallway"
 	})
+"xbf" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/science/teleporter)
 "xbg" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -78669,6 +81876,15 @@
 /obj/disposalpipe/junction/left/west,
 /turf/simulated/floor/green,
 /area/station/crewquarters/garbagegarbs)
+"xbi" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/redblack,
+/area/station/engine/hotloop)
 "xbs" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -78689,6 +81905,17 @@
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor,
 /area/station/engine/engineering)
+"xbw" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/blueblack{
+	dir = 4
+	},
+/area/station/turret_protected/ai_upload)
 "xbA" = (
 /obj/stool/bench/blue/auto,
 /obj/machinery/alarm{
@@ -78755,6 +81982,9 @@
 	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment/mail/bent/south,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "xcC" = (
@@ -78849,6 +82079,9 @@
 	layer = 9.1;
 	pixel_x = 10
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
@@ -78932,6 +82165,9 @@
 	},
 /area/station/quartermaster/office)
 "xeK" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/carpet/purple/fancy/innercorner/ne,
 /area/station/crew_quarters/hor/horprivate)
 "xeM" = (
@@ -79113,6 +82349,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/arcade)
+"xhf" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/engine/caution/north,
+/area/station/engine/power)
 "xhn" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -79124,6 +82366,9 @@
 /obj/disposalpipe/segment/horizontal,
 /obj/access_spawn/research,
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/purpleblack{
 	dir = 4
 	},
@@ -79336,6 +82581,9 @@
 /area/station/science/lab)
 "xjU" = (
 /obj/disposalpipe/segment/bent/west,
+/obj/item/device/radio/intercom{
+	dir = 8
+	},
 /turf/simulated/floor/purpleblack{
 	dir = 4
 	},
@@ -79353,6 +82601,9 @@
 "xka" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/insulated,
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/engine/caution/east,
 /area/station/engine/core)
 "xkd" = (
@@ -79372,6 +82623,12 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/engine/engineering/private)
+"xks" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/south,
+/area/station/engine/engineering/ce)
 "xky" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -79458,6 +82715,7 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/cable,
 /turf/simulated/floor/black,
 /area/station/bridge)
 "xly" = (
@@ -80140,18 +83398,27 @@
 /area/station/engine/monitoring{
 	name = "Engineering Status Room"
 	})
+"xuQ" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/coldloop)
 "xuZ" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/horizontal,
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/east)
 "xvg" = (
 /turf/simulated/floor/neutral/side,
 /area/station/hallway/primary/west)
 "xvh" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/carpet/red/fancy/narrow/T_west,
 /area/station/crew_quarters/arcade/dungeon)
 "xvj" = (
@@ -80512,6 +83779,9 @@
 /area/station/hallway/primary/east)
 "xzh" = (
 /obj/machinery/light/emergency,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/yellow/side,
 /area/station/engine/engineering)
 "xzj" = (
@@ -80523,6 +83793,8 @@
 /obj/machinery/sleeper{
 	dir = 8
 	},
+/obj/cable,
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/yellow/side,
 /area/station/engine/engineering)
 "xzw" = (
@@ -80661,6 +83933,21 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/north)
+"xBh" = (
+/obj/item/device/radio/intercom{
+	dir = 4
+	},
+/turf/simulated/floor/purpleblack{
+	dir = 8
+	},
+/area/station/hallway/secondary/west)
+"xBl" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/engineering)
 "xBp" = (
 /obj/stool/chair{
 	dir = 1
@@ -80818,6 +84105,13 @@
 "xDK" = (
 /turf/simulated/floor/wood,
 /area/station/medical/breakroom)
+"xEf" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/mining/refinery)
 "xEo" = (
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
@@ -81035,6 +84329,16 @@
 /area/station/routing/airbridge{
 	name = "Vessel Dock Router"
 	})
+"xGD" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/gas)
 "xGH" = (
 /obj/wingrille_spawn/auto,
 /obj/machinery/door/poddoor/pyro{
@@ -81243,12 +84547,7 @@
 /obj/decal/tile_edge/floorguide/evac{
 	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
-	},
+/obj/item/device/radio/intercom,
 /turf/simulated/floor/escape{
 	dir = 1
 	},
@@ -81260,6 +84559,9 @@
 	dir = 10;
 	name = "autoname - SS13";
 	tag = ""
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/blueblack{
 	dir = 1
@@ -81596,6 +84898,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
+"xNx" = (
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	icon_state = "5-8"
+	},
+/obj/cable{
+	icon_state = "6-8"
+	},
+/turf/simulated/floor/specialroom/arcade,
+/area/station/science/chemistry)
 "xNy" = (
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/east)
@@ -81750,6 +85062,17 @@
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/nw,
 /area/station/crew_quarters/lounge/research)
+"xQh" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/window_blinds/cog2/right{
+	dir = 8
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/detectives_office)
 "xQl" = (
 /obj/morgue,
 /obj/machinery/light/small{
@@ -81936,6 +85259,15 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/head)
+"xSK" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
 "xSL" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -82014,6 +85346,15 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/carpet/red/fancy/edge/south,
 /area/station/crew_quarters/quartersA)
+"xUe" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/engine/power)
 "xUj" = (
 /obj/machinery/rkit,
 /obj/item/storage/belt/utility,
@@ -82040,11 +85381,11 @@
 /turf/simulated/floor/grass,
 /area/station/garden/aviary)
 "xUw" = (
-/obj/table/reinforced/auto,
-/obj/item/aiModule/emergency,
-/obj/item/aiModule/removeCrew,
-/obj/random_item_spawner/ai_experimental,
-/turf/simulated/floor/darkblue,
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
 /area/station/turret_protected/ai_upload)
 "xUC" = (
 /obj/stool/chair/yellow{
@@ -82129,6 +85470,19 @@
 	icon_state = "2,1"
 	},
 /area/station/crew_quarters/fitness)
+"xWt" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/power)
 "xWv" = (
 /obj/machinery/guardbot_dock,
 /obj/machinery/power/data_terminal,
@@ -82305,6 +85659,12 @@
 	dir = 8;
 	layer = 9.1;
 	pixel_x = -10
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/black,
 /area/station/engine/engineering/ce)
@@ -82743,6 +86103,19 @@
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/sanctuary)
+"ydT" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/orangeblack/side,
+/area/station/mining/staff_room)
+"yea" = (
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/blueblack,
+/area/station/hallway/secondary/north)
 "yed" = (
 /obj/cable{
 	d2 = 8;
@@ -82754,6 +86127,16 @@
 	name = "solar paneling"
 	},
 /area/station/solar/west)
+"yeg" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/science/artifact)
 "yeh" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/equipment)
@@ -82957,6 +86340,9 @@
 	dir = 1;
 	pixel_y = 16
 	},
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/orangeblack,
 /area/station/quartermaster/office)
 "ygm" = (
@@ -83155,6 +86541,11 @@
 	})
 "yjt" = (
 /obj/disposalpipe/segment/mail/bent/west,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/science/teleporter)
 "yjw" = (
@@ -83165,6 +86556,12 @@
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/middle{
 	dir = 10
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/hor{
@@ -114955,7 +118352,7 @@ vad
 vad
 quj
 tQh
-vad
+xBh
 vad
 vad
 vad
@@ -115855,7 +119252,7 @@ wqR
 qms
 rYx
 rYx
-rYx
+mKy
 rYx
 rYx
 kaR
@@ -116746,9 +120143,9 @@ xhT
 wfW
 nie
 nPY
-rUC
+gjn
 gOW
-wrG
+djN
 rUj
 cEC
 dKB
@@ -117053,7 +120450,7 @@ bBL
 djN
 rUj
 vBP
-nXj
+eFm
 iPP
 xcH
 jra
@@ -117323,7 +120720,7 @@ mnH
 tfK
 qIl
 roF
-lBw
+gIC
 vBP
 aOc
 vkW
@@ -117350,7 +120747,7 @@ xhT
 qho
 iPP
 iPP
-nXj
+eFm
 ktM
 wrG
 rUj
@@ -117652,12 +121049,12 @@ xhT
 gtc
 oOe
 oOe
-rUC
+gjn
 oZo
-wrG
+djN
 rUj
 cdj
-rUC
+gfW
 huP
 oOe
 oSa
@@ -117955,10 +121352,10 @@ dKB
 aTS
 htJ
 dKB
-sWV
+clf
 iHW
 xhx
-sWV
+vjh
 dKB
 dDi
 oGm
@@ -119139,7 +122536,7 @@ wrG
 pOt
 quj
 pXR
-yaW
+ctp
 vBU
 vBU
 rtR
@@ -119441,7 +122838,7 @@ wrG
 vCw
 vCw
 uyX
-yaW
+eSx
 sVn
 vBU
 hhc
@@ -119743,7 +123140,7 @@ rOy
 vwz
 vwz
 iBt
-yaM
+csj
 uBj
 uBj
 vte
@@ -120045,7 +123442,7 @@ wrG
 qob
 vCw
 uyX
-tQN
+bzz
 vBU
 vBU
 hhc
@@ -120347,7 +123744,7 @@ wrG
 syR
 vCw
 cEC
-yaW
+eSx
 qBR
 qBR
 vuq
@@ -120649,7 +124046,7 @@ wrG
 vCw
 vCw
 uyX
-yaW
+eSx
 jtI
 dMG
 vvU
@@ -120721,9 +124118,9 @@ dCM
 sGk
 sGk
 klS
-xMX
-xMX
-fsV
+rKu
+rKu
+hzP
 xQP
 aVz
 aFe
@@ -120951,8 +124348,8 @@ wrG
 vCw
 vCw
 cdj
-yaW
-yaW
+hfN
+iZQ
 itV
 uJt
 fHp
@@ -121254,10 +124651,10 @@ vCw
 vCw
 pOt
 tRd
-yaW
-yaW
-yaW
-yaW
+hfN
+fEB
+fEB
+eEc
 xTp
 ttP
 xNB
@@ -121560,9 +124957,9 @@ qyq
 uXU
 vwA
 tRd
-yaW
-kHX
-dgG
+yeg
+rYt
+xNB
 svM
 pCl
 xly
@@ -121862,7 +125259,7 @@ vwz
 vwz
 vwT
 uyX
-yaW
+gRq
 dWM
 xQp
 pqE
@@ -122485,7 +125882,7 @@ pkM
 pkM
 ndK
 hRA
-rqP
+oMS
 hRA
 rqP
 rqP
@@ -122787,7 +126184,7 @@ vok
 vok
 vok
 heB
-vok
+soM
 heB
 jvE
 eul
@@ -122833,7 +126230,7 @@ eFQ
 cKv
 sQa
 xsc
-idK
+wXX
 ftj
 xMX
 xMX
@@ -123095,13 +126492,13 @@ suI
 kfg
 xUE
 xUE
-lST
+fnx
 xUE
 xUE
 kfg
 xUE
 xUE
-lST
+fnx
 xUE
 xUE
 kfg
@@ -123129,13 +126526,13 @@ xnX
 swe
 uVZ
 kKZ
-sQa
+tQZ
 bil
 xDc
 bil
 bil
 bWW
-idK
+hrx
 akX
 xMX
 xMX
@@ -123389,11 +126786,11 @@ urj
 urj
 urj
 xly
-sWV
+clf
 qIE
-sWV
+wUC
 qIE
-sWV
+vjh
 kfg
 lqo
 dpl
@@ -123739,7 +127136,7 @@ bSf
 jeD
 xDc
 fxu
-idK
+hrx
 sCg
 xMX
 xMX
@@ -123979,13 +127376,13 @@ wne
 cqU
 rlZ
 qFD
-qUN
+uXw
 xbt
 dAy
 hKa
 xfB
 btg
-alU
+pNr
 alU
 lZy
 abO
@@ -124001,13 +127398,13 @@ mJN
 kfg
 gHA
 uSo
-udI
+xNx
 uSo
 jgf
 kfg
 gHA
 uSo
-udI
+xNx
 uSo
 jgf
 kfg
@@ -124036,12 +127433,12 @@ tqt
 hSr
 kKZ
 eNr
-bil
+glK
 bil
 xDc
 iaT
 nIO
-idK
+hrx
 sCg
 xMX
 xMX
@@ -124281,13 +127678,13 @@ bGN
 rlZ
 xly
 lkG
-wdv
+wsX
 sMK
 gXv
 dkw
 kEa
 nmv
-nmv
+egk
 rLZ
 xGH
 xPP
@@ -124304,13 +127701,13 @@ kfg
 raC
 ayC
 dOs
-uSo
+dIo
 bNn
 kfg
 raC
 ayC
 dOs
-uSo
+dIo
 bNn
 kfg
 uSZ
@@ -124342,8 +127739,8 @@ oZs
 xDc
 bdj
 pwz
-idK
-idK
+qOs
+hAb
 deY
 xMX
 xMX
@@ -124582,15 +127979,15 @@ lxf
 wnN
 ipy
 xly
-rlZ
-rlZ
-rlZ
-rlZ
+xbf
+bKe
+wql
+iAR
 xly
-rlZ
-rlZ
-rlZ
-rlZ
+xbf
+wql
+bKe
+iAR
 xly
 urj
 urj
@@ -124603,17 +128000,17 @@ sWV
 nzu
 sWV
 kfg
-xUE
-xUE
+dAY
+rCo
 cUT
-xUE
-xUE
+mIE
+reb
 kfg
-xUE
-xUE
+dAY
+rCo
 cUT
-xUE
-xUE
+mIE
+reb
 kfg
 efJ
 uTi
@@ -124640,11 +128037,11 @@ fVC
 vaI
 kKZ
 idK
-idK
+use
 neo
-idK
-idK
-idK
+hwU
+hwU
+hAb
 vBO
 fcG
 xMX
@@ -124887,7 +128284,7 @@ tGj
 tGj
 uSX
 wfq
-iAD
+tGj
 sbo
 tGj
 tGj
@@ -124935,7 +128332,7 @@ lMV
 vSq
 nIf
 vSq
-vSq
+tkV
 soY
 vSq
 hwr
@@ -126201,7 +129598,7 @@ mnn
 oJz
 xvh
 rHw
-wAh
+tqe
 xkd
 qPp
 xrA
@@ -127004,9 +130401,9 @@ yfC
 smi
 upu
 dCp
-ndr
-ndr
-ndr
+eNp
+lrW
+kvF
 giu
 upu
 wNs
@@ -127308,7 +130705,7 @@ upu
 dCp
 xUw
 kqK
-vUf
+xUw
 rqB
 upu
 agV
@@ -127610,12 +131007,12 @@ upu
 kYT
 pUM
 mSb
-pUM
-doh
+slo
+uxO
 upu
 xdq
-asi
-wAu
+pZP
+uLf
 xdq
 wnk
 mMH
@@ -127909,20 +131306,20 @@ dIf
 yfC
 sQj
 upu
-upy
-upy
-upy
-upy
+gOd
+uiq
+xbw
+uiq
 uiq
 wLe
 eJp
 wNs
-wAu
+paA
 wAu
 toZ
 ohz
 viH
-ohz
+kMX
 toZ
 wAu
 lzf
@@ -128211,20 +131608,20 @@ dIf
 yfC
 trl
 upu
-xrl
+fsJ
+ouY
+ouY
 ouY
 ica
-ouY
-ati
 eAZ
 czC
 nsF
-mMH
+otK
 mMH
 sxu
-ohz
+ggL
 wRX
-ohz
+qCv
 toZ
 xdq
 seu
@@ -128515,8 +131912,8 @@ trl
 upu
 ndr
 ndr
-ndr
-ndr
+iHF
+dAI
 sbT
 drG
 oBI
@@ -128524,9 +131921,9 @@ wNs
 fUZ
 wAu
 toZ
-ohz
+jkp
 hpC
-ohz
+myE
 toZ
 wAu
 wAu
@@ -128818,7 +132215,7 @@ upu
 dCp
 oDC
 iDf
-pUM
+jVO
 ogy
 upu
 kTw
@@ -129118,13 +132515,13 @@ xce
 sDv
 upu
 dCp
-ahn
+urb
 cOI
 urb
 iMo
 upu
 agV
-asi
+eey
 wAu
 iHi
 cUe
@@ -129420,9 +132817,9 @@ xce
 trl
 upu
 dCp
-upy
-upy
-upy
+swC
+qFz
+uIo
 sdk
 upu
 wNs
@@ -129715,7 +133112,7 @@ xWz
 hHt
 oux
 wPO
-rML
+hbq
 wsE
 dIf
 xce
@@ -130271,7 +133668,7 @@ aqt
 jLA
 xMR
 bLq
-cen
+ckx
 rzH
 mOs
 cIZ
@@ -130594,7 +133991,7 @@ gyg
 tSf
 rUG
 hAV
-rUU
+rVW
 iFo
 wuO
 jVj
@@ -130621,7 +134018,7 @@ xWz
 clh
 jOZ
 wRe
-rML
+vUz
 wsE
 dIf
 iYI
@@ -130875,7 +134272,7 @@ bup
 bAz
 bNh
 bND
-nFG
+ckx
 bNh
 bNh
 bNh
@@ -130896,12 +134293,12 @@ gyL
 gPV
 rUG
 mmu
-rUU
+aGq
 iGd
-xCD
-xCD
+obX
+obX
 kom
-rMb
+lEU
 loK
 ioK
 gbu
@@ -130921,9 +134318,9 @@ dgp
 rML
 qZK
 vAb
-qQo
+ges
 wRK
-rML
+ngb
 wsE
 dIf
 xce
@@ -131177,7 +134574,7 @@ bwd
 bAO
 bFp
 bNy
-nFG
+ckx
 bNh
 ctK
 dMB
@@ -131223,9 +134620,9 @@ bWe
 rML
 vcX
 vAb
-qQo
+ucO
 rbc
-rML
+rnE
 wsE
 dIf
 xce
@@ -131479,8 +134876,8 @@ bws
 bBV
 bNh
 bNy
-cig
-cHO
+ckx
+rzH
 mOs
 cIZ
 fCl
@@ -131500,7 +134897,7 @@ bkD
 tSf
 rUG
 gBo
-rUU
+rVW
 iHL
 xCD
 jWr
@@ -131525,7 +134922,7 @@ tXg
 uDt
 vdd
 vAm
-qQo
+sWT
 wRZ
 xWz
 rDy
@@ -131618,7 +135015,7 @@ wVG
 mKF
 xtI
 nen
-tAh
+pYk
 pim
 rav
 jgE
@@ -131802,9 +135199,9 @@ jkX
 tSf
 rUG
 hAX
-rUU
+aGq
 iIi
-xCD
+kKy
 jWr
 kpf
 kTZ
@@ -131829,7 +135226,7 @@ fRX
 vAZ
 qQo
 eaA
-rML
+vUz
 wsE
 dIf
 xce
@@ -132106,7 +135503,7 @@ rUG
 hDE
 wYC
 iHp
-ude
+hzK
 jWe
 eNa
 mUT
@@ -132119,19 +135516,19 @@ oij
 oNH
 prt
 qjt
-sxD
-sxD
+dYY
+rDa
 hlW
 paN
-sxD
+rCV
 pvB
 pvB
 xWz
 vdM
 vBg
-qQo
+jeF
 xJt
-rML
+ngb
 bIE
 dIf
 hhM
@@ -132222,7 +135619,7 @@ wVG
 mKF
 xtI
 nen
-tAh
+fqw
 whV
 mmS
 gUb
@@ -132385,7 +135782,7 @@ bwd
 bAO
 bFp
 bNy
-nFG
+ckx
 bNh
 huQ
 sNT
@@ -132406,12 +135803,12 @@ gWT
 gQK
 rUG
 hDR
-rUU
+bUE
 iGd
-xCD
-xCD
+uHZ
+obX
 kom
-xeW
+mUT
 jpM
 xeW
 mvU
@@ -132421,19 +135818,19 @@ oiS
 oNH
 prt
 qjt
-sxD
+hEP
 rlS
 kUR
 vwb
 tly
 qKe
 rll
-lSL
+doh
 sMV
 vBQ
 rvt
 nbE
-rML
+rnE
 wsE
 dIf
 yfC
@@ -132524,7 +135921,7 @@ wVG
 mKF
 xtI
 uPZ
-tAh
+fqw
 nhV
 mmS
 qLD
@@ -132565,7 +135962,7 @@ vjD
 gRF
 aJu
 tUh
-xkJ
+ngU
 lIU
 xFP
 tUh
@@ -132687,7 +136084,7 @@ bws
 bBV
 bNh
 bNy
-cim
+cen
 bNh
 aZe
 ekp
@@ -132708,7 +136105,7 @@ fhe
 aUp
 hbA
 hDZ
-rUU
+gZU
 aQI
 uMb
 dTv
@@ -132723,15 +136120,15 @@ ojb
 oNH
 prt
 qjt
-sxD
+aDo
 sIY
 eyt
 vwb
 qGF
 pIG
 fiX
-rML
-rML
+cHS
+gco
 vCV
 dyK
 lSL
@@ -132826,7 +136223,7 @@ wVG
 mKF
 fbm
 nen
-tAh
+fqw
 jsZ
 fKm
 tWe
@@ -133008,8 +136405,8 @@ pnv
 gjQ
 fal
 gRe
-tnQ
-tnQ
+nOZ
+sWu
 wYC
 rUU
 rUU
@@ -133128,7 +136525,7 @@ wVG
 mKF
 xtI
 nen
-tAh
+fqw
 hgv
 jfB
 gLW
@@ -133309,8 +136706,8 @@ vPe
 tpP
 tSf
 wgx
-tnQ
-tnQ
+nOZ
+eyR
 uzV
 kvz
 uXR
@@ -133430,9 +136827,9 @@ qzC
 mKF
 xtI
 nen
-tAh
-tAh
-qOd
+fAl
+ivy
+dyc
 qOd
 uKq
 tAh
@@ -133609,9 +137006,9 @@ xmV
 bNh
 xxF
 kUK
-fqE
-wgx
-tnQ
+sNW
+yea
+lKF
 hci
 hEe
 qoC
@@ -133733,16 +137130,16 @@ mKF
 xtI
 dsW
 aZt
-tAh
+emC
 sHN
 mNN
-tAh
+pYk
 uJy
-tAh
+pYk
 uJy
 bsT
 uJy
-tAh
+pYk
 xEX
 xEX
 xEX
@@ -134038,13 +137435,13 @@ dsW
 rtD
 oaB
 oaB
-sHD
+poF
 wEC
-rtD
+gwp
 oaB
 iOt
 dZD
-oaB
+iOt
 rtD
 oaB
 sHD
@@ -134340,13 +137737,13 @@ mKF
 sGx
 mKF
 mKF
-mKF
+wjc
 raR
-mKF
-mKF
+aUa
+gwg
 eRh
 gwg
-gwg
+xSK
 gwg
 gwg
 gwg
@@ -134517,7 +137914,7 @@ iuH
 tpP
 tSf
 hvM
-tnQ
+bcU
 hcA
 vlk
 ykP
@@ -135121,7 +138518,7 @@ krk
 tpP
 tSf
 wgx
-tnQ
+uez
 hdA
 vlk
 ykP
@@ -135409,8 +138806,8 @@ cku
 clT
 cpZ
 rzE
-rzE
-rzE
+cgW
+cgW
 cKx
 urQ
 urQ
@@ -135423,7 +138820,7 @@ iNj
 tpP
 tSf
 wgx
-tnQ
+lls
 heb
 vlk
 ykP
@@ -135555,8 +138952,8 @@ xai
 wVn
 ccc
 xUb
-mcT
-jmw
+tAp
+qqY
 qqY
 jLz
 xyj
@@ -135723,9 +139120,9 @@ xSw
 xSw
 iNj
 tpP
-tSf
-wgx
-tnQ
+brH
+yea
+svG
 hee
 vlk
 ykP
@@ -136027,7 +139424,7 @@ vPe
 tpP
 tSf
 wgx
-tnQ
+bcU
 heu
 vlk
 ykP
@@ -136319,7 +139716,7 @@ cRx
 cZF
 dlC
 dqZ
-cgt
+cig
 xry
 kcI
 xry
@@ -136631,7 +140028,7 @@ cpb
 tpP
 tSf
 wgx
-tnQ
+uez
 gXr
 vlk
 ykP
@@ -136787,7 +140184,7 @@ hlM
 lTi
 vIW
 aST
-lTi
+sik
 cRV
 aST
 vFa
@@ -136933,7 +140330,7 @@ iNj
 tpP
 tSf
 gzC
-tnQ
+lls
 gXr
 vlk
 ykP
@@ -136968,7 +140365,7 @@ wsE
 dIf
 yfC
 rzN
-sQO
+awN
 wrf
 yip
 yip
@@ -137233,9 +140630,9 @@ tAD
 qmB
 eRo
 tpP
-tSf
-wgx
-tnQ
+brH
+yea
+svG
 heZ
 vlk
 ykP
@@ -137537,7 +140934,7 @@ iNj
 tpP
 tSf
 wgx
-tnQ
+lls
 grb
 vlk
 hOm
@@ -137839,7 +141236,7 @@ iuH
 tpP
 tSf
 wgx
-tnQ
+bcU
 hfQ
 hEA
 ykP
@@ -137874,7 +141271,7 @@ wsE
 tmi
 yfC
 rzN
-sQO
+sdK
 jzT
 fXb
 jpa
@@ -138177,7 +141574,7 @@ wCV
 gif
 feS
 vGM
-sJP
+nFJ
 bAi
 sJP
 lTx
@@ -138488,7 +141885,7 @@ nLP
 flo
 vZE
 hdT
-hdT
+gJC
 hdT
 hdT
 ybo
@@ -138780,12 +142177,12 @@ bIE
 wCV
 xce
 rzN
-sQO
+eMB
 ybd
 gOB
 qTN
 lPw
-iUo
+gTm
 oRt
 iBC
 lPw
@@ -139388,15 +142785,15 @@ wGS
 aJu
 wqf
 aJu
-tPd
+wbE
 kJk
 kzs
 tpR
-tPd
+qaO
 aJu
 wqf
 aJu
-vsf
+kle
 rbG
 jAZ
 lPI
@@ -139689,13 +143086,13 @@ tGU
 wGS
 ydz
 wCE
-oly
+bRj
 lPw
 eaU
 gfK
 rgv
 lPw
-wfK
+kwR
 wCE
 ydz
 qUx
@@ -140052,10 +143449,10 @@ cnu
 nny
 tyo
 qMZ
-vJV
-vJV
-vJV
-vJV
+bTb
+mhG
+sPz
+tLZ
 qMZ
 qMZ
 qMZ
@@ -140265,7 +143662,7 @@ jZv
 kuD
 wJZ
 lzS
-lXe
+wxw
 myS
 nPU
 nPU
@@ -140300,7 +143697,7 @@ wNQ
 sXN
 sav
 rQf
-tPd
+rvu
 aJu
 wUX
 dTO
@@ -140353,7 +143750,7 @@ bre
 bre
 qiN
 lbD
-vJV
+lUg
 lNL
 kGk
 ltQ
@@ -140594,7 +143991,7 @@ xce
 rzN
 wGS
 qTl
-tPd
+iND
 kjy
 qLn
 qLn
@@ -140602,7 +143999,7 @@ wNQ
 jjp
 itA
 uFt
-tPd
+rvu
 aJu
 mdZ
 jWT
@@ -140699,11 +144096,11 @@ mXw
 ipO
 lSI
 hXh
-xEM
+bEW
 ddn
-xEM
+tcn
 ept
-xEM
+llr
 nvF
 sLZ
 sLZ
@@ -140859,9 +144256,9 @@ tSf
 tpP
 gnf
 gBZ
-gre
+nth
 pyW
-wgw
+mdP
 wgw
 iTg
 jsx
@@ -140869,7 +144266,7 @@ jZQ
 kxj
 wJZ
 xnI
-cgW
+wxw
 xnI
 qHZ
 nDM
@@ -140904,7 +144301,7 @@ fxr
 wUQ
 qLn
 ohv
-tPd
+rvu
 aJu
 wJu
 hKz
@@ -141003,10 +144400,10 @@ nAk
 hXh
 keg
 aPs
-aPs
+pxx
 wpp
 rwb
-xGd
+wGF
 sLZ
 kXZ
 sLZ
@@ -141156,7 +144553,7 @@ bZJ
 bZJ
 bZJ
 bZJ
-ffB
+ati
 tSf
 tpP
 gnr
@@ -141171,10 +144568,10 @@ kab
 kzd
 wJZ
 qwy
-cgW
+wxw
 iHN
 qHZ
-vrk
+iHN
 gfQ
 iHN
 rik
@@ -141198,7 +144595,7 @@ xce
 tGU
 wGS
 ygY
-tPd
+lSa
 bhM
 qLn
 qLn
@@ -141206,14 +144603,14 @@ wNQ
 qLn
 qLn
 obp
-tPd
+rvu
 aJu
-wJu
+qoi
 rbX
 jiw
 xll
 cFe
-xll
+vhy
 xll
 wQK
 ssc
@@ -141259,7 +144656,7 @@ jTW
 dUg
 jTW
 jTW
-vJV
+wfM
 dXK
 pOi
 aLH
@@ -141308,7 +144705,7 @@ rrM
 kJm
 oMg
 oMg
-xGd
+wpn
 uCU
 sLZ
 sLZ
@@ -141508,14 +144905,14 @@ wNQ
 qLn
 kZI
 nOG
-tPd
+rvu
 aJu
 wJu
 hfd
 khl
 vTX
 vTX
-vTX
+kIz
 etW
 wUX
 nSK
@@ -141557,8 +144954,8 @@ nDJ
 cke
 foh
 xUq
-vJV
-vJV
+bTb
+kdC
 xoX
 qZm
 qMZ
@@ -141607,7 +145004,7 @@ aAe
 hXh
 mrd
 pxD
-ucq
+tqW
 hXh
 hXh
 nvF
@@ -141834,13 +145231,13 @@ ovn
 xsL
 eLz
 dQf
-dQf
+adw
 sOq
 xsL
 eLz
+ots
 dQf
-dQf
-sOq
+xQh
 ffA
 cbE
 gUh
@@ -141909,11 +145306,11 @@ kZA
 lee
 lee
 pxD
-pXC
+qVw
 hXh
 fRv
 xkK
-xEM
+lrj
 iUP
 dGX
 dNQ
@@ -142107,9 +145504,9 @@ ydz
 wCE
 bzu
 iUo
-iUo
+aRt
 lPw
-iUo
+evT
 iUo
 lTU
 wCE
@@ -142513,11 +145910,11 @@ kZA
 xJF
 kRt
 pxD
-qVw
+xaG
 sxv
-aPs
-aPs
-xEM
+vxT
+vxT
+oso
 byp
 viA
 yai
@@ -142819,7 +146216,7 @@ lMm
 hXh
 mhS
 hiE
-xEM
+pTF
 fni
 viA
 viA
@@ -143341,18 +146738,18 @@ jRx
 eCi
 dvM
 xGu
-xsJ
-xsJ
-xsJ
-xsJ
-xsJ
-xsJ
-xsJ
-xsJ
-xsJ
-tkc
-tkc
-xsJ
+rAC
+hJS
+hJS
+hJS
+hJS
+efI
+hJS
+hJS
+hJS
+fSJ
+fSJ
+tYR
 fzC
 xsJ
 rcv
@@ -143423,7 +146820,7 @@ qVw
 hXh
 fRv
 eko
-xEM
+lrj
 iUP
 mpT
 dNQ
@@ -143642,13 +147039,13 @@ xzg
 xqO
 lkM
 kDK
-xsJ
-xsJ
+ssB
+hgD
 tBL
 bPy
 wMD
 jRU
-wMD
+fhN
 wMD
 wMD
 jRU
@@ -143950,7 +147347,7 @@ mYy
 mYy
 wMD
 snn
-mYy
+wby
 mYy
 snn
 wMD
@@ -144023,11 +147420,11 @@ ajr
 ajr
 ayD
 jJz
-qVw
+xaG
 sxv
-aPs
-aPs
-xEM
+vxT
+vxT
+oso
 byp
 viA
 yai
@@ -144227,10 +147624,10 @@ wZd
 wZd
 wZd
 flZ
-gLv
+oqo
 cOc
 ckd
-gLv
+vnX
 trY
 xuZ
 yfj
@@ -144252,7 +147649,7 @@ mYy
 mYy
 wMD
 wMD
-mYy
+wby
 mYy
 wMD
 wMD
@@ -144329,7 +147726,7 @@ lMm
 hXh
 mhS
 hiE
-xEM
+pTF
 fni
 viA
 viA
@@ -144554,7 +147951,7 @@ mYy
 mYy
 mYy
 mYy
-mYy
+wby
 mYy
 gVX
 lMn
@@ -144856,7 +148253,7 @@ mYy
 mYy
 mYy
 dom
-mYy
+wby
 mYy
 gQI
 gVX
@@ -144933,7 +148330,7 @@ qVw
 hXh
 fRv
 eko
-xEM
+lrj
 iUP
 cPN
 dNQ
@@ -145158,7 +148555,7 @@ rVT
 rVT
 oQZ
 tsx
-tsx
+fWE
 amj
 dEF
 dEF
@@ -145386,21 +148783,21 @@ aJu
 aJu
 aJu
 eCw
-xDC
-xDC
-xDC
+jmw
+nbp
+cKg
 eCw
-xDC
-xDC
-xDC
+mcT
+soW
+cKg
 eCw
-xDC
-xDC
-xDC
+mcT
+eAp
+neu
 eCw
-xDC
-xDC
-xDC
+mcT
+soW
+cKg
 eCw
 ath
 smR
@@ -145533,11 +148930,11 @@ oiM
 afb
 hXh
 pxD
-qVw
+xaG
 sxv
-aPs
-aPs
-xEM
+vxT
+vxT
+oso
 byp
 viA
 yai
@@ -145687,13 +149084,13 @@ aJu
 aJu
 aJu
 aJu
-xDC
+jmw
 clX
 goF
 gJY
-xDC
+hOd
 hmn
-kgj
+aeP
 kgj
 jcD
 kgj
@@ -145825,7 +149222,7 @@ xiN
 jdN
 qJc
 jEj
-xNU
+iFA
 xNU
 gkN
 iqm
@@ -145839,7 +149236,7 @@ lMm
 hXh
 mhS
 hiE
-xEM
+pTF
 fni
 viA
 viA
@@ -145989,25 +149386,25 @@ aJu
 aJu
 aJu
 aJu
-xDC
+kaG
 fLF
 goK
 gKK
-xDC
+kaG
 vum
-hNM
+rxu
 hNM
 jcN
 jwd
 kaw
-hPb
+jyv
 kXJ
 lBR
 mcm
 mDS
-xDC
+hOd
 ath
-opy
+pLR
 oWo
 tVv
 tVv
@@ -146127,7 +149524,7 @@ bgk
 rHG
 rVI
 dqV
-cEN
+tSv
 cEN
 myy
 plt
@@ -146291,27 +149688,27 @@ aJu
 aJu
 aJu
 aJu
-xDC
+lNB
 fLI
 gqt
 gLV
 gVH
 rBA
-hNZ
+xbi
 hNZ
 hNZ
 jwZ
-hne
-hPb
+rBA
+nFT
 kXO
 lCN
 mdA
 mEw
-xDC
+hkR
 aJu
-opy
+xGD
 oXg
-tVv
+aOw
 tVv
 tVv
 tVv
@@ -146322,10 +149719,10 @@ tyK
 uoJ
 sOH
 hek
-vOI
+mWq
 tNy
 wKq
-vOI
+uwP
 dQe
 rht
 jnd
@@ -146443,7 +149840,7 @@ qVw
 hXh
 fRv
 eko
-xEM
+lrj
 iUP
 jjK
 dNQ
@@ -146593,17 +149990,17 @@ aJu
 aJu
 aJu
 aJu
-xDC
+lXe
 rDN
 gqY
 gMl
-xDC
+lXe
 hne
 hPb
 hPb
 hPb
 jyv
-kaG
+kXJ
 kBF
 gyr
 wQX
@@ -146628,7 +150025,7 @@ qFb
 axb
 iGp
 xvo
-vOI
+xBl
 fGb
 jnd
 yfC
@@ -146730,11 +150127,11 @@ bUO
 bUO
 xiN
 qJc
-ajr
-ajr
-ajr
-ajr
-ajr
+cbj
+gvW
+oUs
+oUs
+bvW
 cbS
 cpx
 peu
@@ -146896,7 +150293,7 @@ aJu
 aJu
 aJu
 eCw
-xDC
+jgM
 grQ
 xDC
 eCw
@@ -146911,11 +150308,11 @@ rSO
 lDG
 mgb
 mEK
-xDC
+cKg
 aJu
-opy
+lMe
 oYM
-pHz
+dGj
 tVv
 qUp
 qws
@@ -146929,8 +150326,8 @@ vmR
 xxo
 oJR
 fLS
-xvo
-vOI
+lAK
+urz
 fGb
 jnd
 yfC
@@ -147036,18 +150433,18 @@ aJu
 fdT
 xGX
 aJu
-ajr
-ajr
+opP
+jzA
 koc
 peu
 ooC
 xEM
 pxD
-qVw
+xaG
 sxv
-aPs
-aPs
-xEM
+vxT
+vxT
+oso
 byp
 viA
 yai
@@ -147197,7 +150594,7 @@ aJu
 aJu
 aJu
 aJu
-xDC
+mcT
 fMG
 gtD
 gMT
@@ -147232,7 +150629,7 @@ vWZ
 wUG
 qQu
 xvo
-vOI
+qRh
 fGb
 jnd
 yfC
@@ -147349,7 +150746,7 @@ kwf
 hXh
 mhS
 hiE
-xEM
+pTF
 fni
 viA
 viA
@@ -147500,7 +150897,7 @@ aJu
 aJu
 aJu
 eCw
-xDC
+lXe
 grQ
 eCw
 eCw
@@ -147641,13 +151038,13 @@ okk
 xGX
 aJu
 fdT
-ajr
+kFr
 wpD
 peu
 kQz
 xEM
 pxD
-ucq
+tqW
 hXh
 hXh
 hXh
@@ -147820,7 +151217,7 @@ mFW
 ath
 qTl
 ygY
-sWt
+uyh
 pIL
 qxP
 qVI
@@ -147944,16 +151341,16 @@ xYZ
 xYZ
 xYZ
 qJh
-wpD
-peu
-kQz
+jGW
+iFA
+gew
 iUO
-pxD
+hwp
 pXC
 hXh
 fRv
 eko
-xEM
+lrj
 iUP
 abM
 dNQ
@@ -148122,7 +151519,7 @@ pUU
 vMB
 fQA
 aJu
-sWt
+nJB
 pMc
 qzF
 qWd
@@ -148245,13 +151642,13 @@ tpT
 xGX
 aJu
 fdT
-ajr
+xEf
 tvR
 wWI
 afb
 xEM
 pxD
-pXC
+qVw
 hXh
 exH
 aPs
@@ -148548,16 +151945,16 @@ xGX
 aJu
 fdT
 qJc
-ajr
-ajr
-ajr
+cbj
+gvW
+jzA
 hXh
 aGV
-pXC
+ydT
 sxv
-aPs
-aPs
-xEM
+vxT
+vxT
+oso
 byp
 viA
 yai
@@ -148720,7 +152117,7 @@ rqx
 mPf
 bRf
 pzK
-rRq
+pkP
 qTx
 iPS
 aJu
@@ -148740,18 +152137,18 @@ wUG
 wUG
 wUG
 ije
-qQu
+dMA
 xzh
-vOI
+ogf
 uFH
 uIW
 ycu
 uIW
 dIf
-iel
-pRQ
-utO
-jUJ
+bxs
+tnm
+cpH
+sID
 kmh
 ykD
 tNa
@@ -148859,7 +152256,7 @@ mtR
 hXh
 mhS
 hiE
-xEM
+pTF
 fni
 viA
 viA
@@ -149024,7 +152421,7 @@ mvD
 qqG
 hBI
 rgO
-mFW
+evB
 lux
 aJu
 cil
@@ -149044,7 +152441,7 @@ vXn
 xOJ
 wZE
 xzs
-vOI
+cru
 uFH
 dIf
 yfC
@@ -149346,13 +152743,13 @@ wUG
 ije
 qQu
 xzH
-vOI
+qRh
 frE
 sNd
 khO
 sNd
 gym
-iel
+gws
 ogh
 utO
 jUJ
@@ -149649,11 +153046,11 @@ ije
 qQu
 xAu
 uwX
-jTN
+kSA
 wai
 juT
-jTN
-jTN
+qbH
+cMq
 uwX
 oNI
 utO
@@ -149934,21 +153331,21 @@ hEg
 uer
 nIi
 aJu
-sWt
+pCW
 pSo
-qAB
+xUe
 qZs
 rCB
 sWt
 sRS
 wUG
 wUG
-lNB
+haz
 oHi
 vpi
 vXQ
 ije
-qQu
+dMA
 bia
 jTN
 muX
@@ -150232,18 +153629,18 @@ gWQ
 ldV
 hGI
 mgC
-mFW
+cCn
 ath
 ygY
 qTl
-sWt
+gEd
 pSW
-qAB
+qVI
 qZC
 rCO
 sWt
 sTg
-tpy
+fSc
 kbe
 ski
 uQr
@@ -150252,7 +153649,7 @@ vYg
 ije
 qQu
 xAM
-jTN
+lOB
 wzO
 kIK
 dum
@@ -150520,7 +153917,7 @@ aJu
 aJu
 aJu
 tMz
-sWk
+ucq
 xez
 tMz
 tMz
@@ -150821,7 +154218,7 @@ aJu
 aJu
 aJu
 aJu
-sWk
+rRq
 fZb
 rcK
 stL
@@ -150839,7 +154236,7 @@ tMz
 tMz
 tMz
 ath
-sWt
+uyh
 pbo
 pTB
 jnc
@@ -150847,7 +154244,7 @@ qZD
 rED
 sWt
 sTC
-tqa
+jQk
 tFp
 lCE
 eAE
@@ -151143,7 +154540,7 @@ npL
 nIu
 ost
 pcS
-pTS
+jVQ
 qCc
 pTS
 pTS
@@ -151425,11 +154822,11 @@ aJu
 aJu
 aJu
 aJu
-sWk
+ucq
 fZL
 gNb
 ctF
-sWk
+ucq
 mAO
 hXU
 ixc
@@ -151441,11 +154838,11 @@ ldY
 lKB
 mjl
 mJA
-sWk
+ucq
 ath
-sWt
-pek
-pUL
+xWt
+ejN
+xhf
 qCu
 rae
 pek
@@ -151460,9 +154857,9 @@ eZs
 ije
 qQu
 onX
-jTN
-nox
-pRQ
+saQ
+ebH
+nLt
 riV
 pRQ
 sqz
@@ -151727,7 +155124,7 @@ aJu
 aJu
 aJu
 aJu
-sWk
+vrk
 gcH
 voc
 mWE
@@ -151738,14 +155135,14 @@ ixh
 jXm
 mVg
 kgW
-lUS
+wSa
 leb
-lKB
-mjl
+gHE
+wcf
 mKQ
-sWk
+vnM
 aJu
-sWt
+jii
 pek
 pUL
 qCN
@@ -151762,7 +155159,7 @@ wet
 ije
 qQu
 onX
-jTN
+heM
 nox
 pRQ
 pRQ
@@ -152029,25 +155426,25 @@ aJu
 aJu
 aJu
 aJu
-sWk
+wAh
 ewq
 rIL
 rIL
-sWk
+jqK
 huJ
 hZZ
 hYn
 jhT
 jJo
 ixc
-lUS
+jIX
 kfJ
 one
 hZy
 mLU
-sWk
+wAh
 ath
-sWt
+jii
 peV
 pUL
 qCN
@@ -152064,7 +155461,7 @@ wfi
 ije
 qQu
 onX
-jTN
+heM
 uya
 aCj
 pRQ
@@ -152331,11 +155728,11 @@ aJu
 aJu
 aJu
 aJu
-sWk
+brm
 gbS
 rIL
 rIL
-sWk
+brm
 yeR
 ibk
 iyJ
@@ -152347,9 +155744,9 @@ leq
 lKO
 mjv
 mMm
-sWk
+brm
 aJu
-sWt
+jii
 pek
 pUL
 qCN
@@ -152366,7 +155763,7 @@ wfu
 xOJ
 xbv
 onX
-jTN
+laa
 jTN
 wMM
 pLC
@@ -152638,20 +156035,20 @@ qOj
 qOj
 qOj
 xfy
-sWk
+rRq
 mrJ
-mrJ
+lBN
 tMz
-sWk
-sWk
-sWk
+rRq
+aNW
+pwE
 tMz
-sWk
-sWk
-sWk
+rRq
+xuQ
+kSU
 tMz
 ath
-sWt
+gEd
 pfF
 pVz
 qFx
@@ -152669,11 +156066,11 @@ ije
 qQu
 xDs
 xTH
-jTN
-jTN
-jTN
-jTN
-jTN
+laa
+qbH
+qbH
+qbH
+cMq
 uwX
 ylv
 uCo
@@ -152996,7 +156393,7 @@ bNG
 uEL
 pzp
 ptS
-vOI
+xBl
 dDV
 blU
 bUx
@@ -153264,7 +156661,7 @@ bNR
 slm
 sXK
 tqz
-jnc
+jSg
 hQU
 tqa
 bNR
@@ -153566,13 +156963,13 @@ bNR
 slQ
 sXQ
 qCc
-pTS
+jVQ
 uuk
 pTS
 vpC
 whq
 whq
-whq
+cQC
 whq
 whq
 whq
@@ -153865,7 +157262,7 @@ wqf
 aJu
 aJu
 rFS
-rFS
+qyP
 sYr
 trp
 tKG
@@ -153902,7 +157299,7 @@ nAb
 tpy
 pNA
 tpy
-vOI
+qRh
 gCZ
 gCZ
 bUx
@@ -154167,17 +157564,17 @@ wCE
 ath
 ath
 wCE
-rFS
-rFS
-rFS
-rFS
-rFS
-rFS
+bXM
+lVt
+lVt
+dYm
+lVt
+fHj
 bNR
-vOI
-vOI
-vOI
-vOI
+mWq
+cRm
+htn
+uwP
 ybr
 ybr
 lRj
@@ -154198,7 +157595,7 @@ xLf
 mOR
 rOH
 fHo
-fHo
+nkT
 tLD
 mOR
 klP
@@ -154505,7 +157902,7 @@ mdJ
 xoq
 tFw
 gdS
-kRb
+tnN
 xYB
 vGZ
 dMJ
@@ -154802,7 +158199,7 @@ eXb
 mOR
 wFj
 gnz
-sGS
+xks
 djb
 sER
 gGW
@@ -155112,7 +158509,7 @@ ibt
 tdG
 bXh
 vvH
-uTv
+rVr
 cKN
 lVb
 yfb
@@ -155414,7 +158811,7 @@ iza
 tdG
 dvE
 waN
-uTv
+rVr
 lVb
 lVb
 lVb
@@ -155716,7 +159113,7 @@ dik
 eeW
 cAo
 hEi
-uTv
+rVr
 lVb
 tFK
 lVb
@@ -159024,12 +162421,12 @@ bYJ
 bYJ
 bYJ
 mua
-sBq
+awt
 oMR
 oMR
 oMR
 oMR
-bAy
+sNo
 urN
 bYJ
 iRH
@@ -159332,10 +162729,10 @@ uEh
 cTW
 imk
 bAy
-oAK
-fft
-oFg
-fHd
+uLR
+otH
+dJb
+itv
 rwG
 bYJ
 cHI
@@ -159625,7 +163022,7 @@ aNo
 rKD
 wbZ
 wbZ
-tcH
+eij
 hKB
 oAF
 qTq
@@ -159637,7 +163034,7 @@ fGN
 uai
 bYJ
 iZw
-oFg
+der
 sgA
 sLA
 xza
@@ -159927,7 +163324,7 @@ fnS
 bYJ
 sXA
 qjG
-rkV
+oRF
 bYJ
 fOh
 gqH
@@ -159938,9 +163335,9 @@ wIu
 mdw
 tRh
 bYJ
-xLf
-xLf
-xLf
+cKA
+hyz
+pMT
 bYJ
 bYJ
 bYJ
@@ -160227,19 +163624,19 @@ bYJ
 bYJ
 bYJ
 bYJ
-xLf
-xLf
-xLf
+cKA
+qeO
+iAO
 bYJ
-xLf
-xLf
-xLf
-xLf
-xLf
-xLf
-xLf
-xLf
-xLf
+cKA
+hyz
+tFj
+tFj
+tFj
+tFj
+tFj
+tFj
+pMT
 aJu
 aJu
 aJu


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEAT][MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Big ol' pile of changes for Ozymandias. There are too many to list off exhaustively, but this is the stuff I kept track of:

- **Major:** AI upload is now much better defended, with reconfigured turrets and a window shroud around the upload stations.
- Electrified a huge amount of windows.
- The upper segment of the main Security hall now has 4 wall-mounted rechargers, up from 1.
- Introduced a new set of doors by the general Crew Quarters to hopefully improve the area's resilience to breaches. Notably, the transport chute is before this set of doors.
- Introduced two non-mounted defibrillators to Medbay; one just outside the operating theatre, and one in the treatment concourse.
- The personal Mining bedrooms/bays now have a door separating the bedroom and bay sections to limit the potential for intrusion.
- Added shutters to EVA Storage.
- Adjusted an intercom in the gym that was in an incorrect position, and added a few general intercoms around and about the station.
- Fixed missing data terminals under the Engineering hall sleeper and the CE's printer.
- Fixed a mislayered air injector in the Test Chamber.
- Eliminated a few unnecessary data terminals and minimally-used personal computers.
- Moved a light tube outside of Telescience one tile upwards.
- Last minute rider: Added a manual hangar door button for hangars that didn't have one.
- Last minute rider: Fixed an improperly assigned warp beacon.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Considerably improves the usability and feature set of Ozymandias.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Kubius:
(+)Further Ozymandias changes, most notably a more resilient AI upload and a LOT of electrification.
```
