### PR TITLE
Disable random sleeper agents on the RP servers

### DIFF
--- a/code/modules/events/sleeperagent.dm
+++ b/code/modules/events/sleeperagent.dm
@@ -48,14 +48,14 @@
 	event_effect(var/source)
 		if(src.lock)
 			return
-#ifdef RP_MODE
-		if(source=="random")
-			return
-#endif
 		if (src.admin_override != 1)
 			if (!source && (!ticker.mode || ticker.mode.latejoin_antag_compatible == 0 || late_traitors == 0))
 				message_admins("Sleeper Agents are disabled in this game mode, aborting.")
 				return
+#ifdef RP_MODE
+			if(source=="random")
+				return
+#endif
 			if (emergency_shuttle.online)
 				return
 		message_admins("<span class='internal'>Setting up Sleeper Agent event. Source: [source ? "[source]" : "random"]</span>")

--- a/code/modules/events/sleeperagent.dm
+++ b/code/modules/events/sleeperagent.dm
@@ -48,6 +48,10 @@
 	event_effect(var/source)
 		if(src.lock)
 			return
+#ifdef RP_MODE
+		if(source=="random")
+			return
+#endif
 		if (src.admin_override != 1)
 			if (!source && (!ticker.mode || ticker.mode.latejoin_antag_compatible == 0 || late_traitors == 0))
 				message_admins("Sleeper Agents are disabled in this game mode, aborting.")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[ENHANCEMENT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR disables random sleeper agents on the RP servers. The sleeper agent now only triggers when there are enough dead antags such that we'd want more alive ones.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The randomly triggered sleeper agent event actually happens pretty frequently and can lead to a disproportionate amount of sleeper agents to crew.