### PR TITLE
Slightly change event controls

### DIFF
--- a/code/datums/controllers/event_controls.dm
+++ b/code/datums/controllers/event_controls.dm
@@ -96,38 +96,16 @@ var/datum/event_controller/random_events
 			do_event = 0
 
 		if (do_event)
-			var/alive = 0
-			var/dead_dnr = 0
-			var/antags = ticker.mode.traitors.len + ticker.mode.Agimmicks.len
-			var/dead_antags = 0
-
-			for (var/datum/mind/antag in ticker.mode.traitors)
-				var/mob/M = antag.current
-				if (!M) continue
-				if (!M.client || isdead(M))
-					dead_antags++
-			for (var/datum/mind/antag in ticker.mode.Agimmicks)
-				var/mob/M = antag.current
-				if (!M) continue
-				if (!M.client || isdead(M))
-					dead_antags++
-
-			for(var/client/C)
-				var/mob/M = C.mob
-				if(!M) continue
-				if (!isdead(M) && isliving(M))
-					alive++
-				else if (M.mind?.dnr)
-					dead_dnr++
-
-			if (dead_antags >= round(antags * 0.75) && (ticker?.mode?.do_antag_random_spawns))
+			var/aap = get_alive_antags_percentage()
+			var/dcp = get_dead_crew_percentage()
+			if (aap < 0.1 && (ticker?.mode?.do_antag_random_spawns))
 				do_random_event(list(pick(antag_spawn_events)), source = "spawn_antag")
-				message_admins("<span class='internal'>Antag spawn event success!<br>DEAD ANTAGS: [dead_antags], TOTAL ANTAGS: [antags]</span>")
-			else if (alive <= (total_clients() - dead_dnr) * 0.6)
+				message_admins("<span class='internal'>Antag spawn event success!<br>[100 * aap]% of the alive crew were antags.</span>")
+			else if (dcp > 0.25)
 				do_random_event(player_spawn_events, source = "spawn_player")
-				message_admins("<span class='internal'>Player spawn event success!<br> ALIVE : [alive], TOTAL COUNTED : [(total_clients() - dead_dnr)]</span>")
+				message_admins("<span class='internal'>Player spawn event success!<br>[100 * dcp]% of the entire crew were dead.</span>")
 			else
-				message_admins("<span class='internal'>A spawn event would have happened now, but it was not needed based on alive players + antagonists headcount or game mode!<br> ALIVE : [alive], TOTAL COUNTED : [(total_clients() - dead_dnr)], DEAD ANTAGS: [dead_antags]</span>")
+				message_admins("<span class='internal'>A spawn event would have happened now, but it was not needed based on alive players + antagonists headcount or game mode!<br>[100 * aap]% of the alive crew were antags and [100 * dcp]% of the entire crew were dead.</span>")
 
 		next_spawn_event = TIME + time_between_spawn_events
 

--- a/code/procs/antagonist_procs.dm
+++ b/code/procs/antagonist_procs.dm
@@ -266,7 +266,8 @@
 
 	return
 
-/proc/get_alive_antags_percentage() // returns a decimal representing the percentage of alive crew that are also antags
+/// returns a decimal representing the percentage of alive crew that are also antags
+/proc/get_alive_antags_percentage()
 	var/alive = 0
 	var/alive_antags = ticker.mode.traitors.len + ticker.mode.Agimmicks.len
 
@@ -292,7 +293,8 @@
 	else
 		return (alive_antags / alive)
 
-/proc/get_dead_crew_percentage() // returns a decimal representing the percentage of dead crew (non-observers) to all crew
+/// returns a decimal representing the percentage of dead crew (non-observers) to all crew
+/proc/get_dead_crew_percentage()
 	var/all = 0
 	var/dead = 0
 	var/observer = 0

--- a/code/procs/antagonist_procs.dm
+++ b/code/procs/antagonist_procs.dm
@@ -265,3 +265,48 @@
 		R.frequency = the_frequency // let's see if this stops rounds from being ruined every fucking time
 
 	return
+
+/proc/get_alive_antags_percentage() // returns a decimal representing the percentage of alive crew that are also antags
+	var/alive = 0
+	var/alive_antags = ticker.mode.traitors.len + ticker.mode.Agimmicks.len
+
+	for (var/datum/mind/antag in ticker.mode.traitors)
+		var/mob/M = antag.current
+		if (!M) continue
+		if (!M.client || isdead(M))
+			alive_antags--
+	for (var/datum/mind/antag in ticker.mode.Agimmicks)
+		var/mob/M = antag.current
+		if (!M) continue
+		if (!M.client || isdead(M))
+			alive_antags--
+
+	for(var/client/C)
+		var/mob/M = C.mob
+		if(!M) continue
+		if (!isdead(M) && isliving(M))
+			alive++
+
+	if (!alive)
+		return 0
+	else
+		return (alive_antags / alive)
+
+/proc/get_dead_crew_percentage() // returns a decimal representing the percentage of dead crew (non-observers) to all crew
+	var/all = 0
+	var/dead = 0
+	var/observer = 0
+
+	for(var/client/C)
+		var/mob/M = C.mob
+		if(!M) continue
+		if (isdead(M) && !isliving(M))
+			dead++
+			if (M.mind?.joined_observer)
+				observer++
+		all++
+
+	if (!all)
+		return 0
+	else
+		return ((dead - observer) / all)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[CLEAN] 
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR reorganizes some code and introduces two global procs `get_alive_antags_percentage()` and `get_dead_crew_percentage()`, and slightly changes the thresholds for triggering antag and spawn random events. It's not really noticeable from a player perspective, and I can't really do math to tell you the exact values of the old thresholds, but I think this makes things make a bit more sense. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I thought it'd be good.