### PR TITLE
Adds chicken equipment to Donut 3

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -14675,6 +14675,12 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
+"ebq" = (
+/obj/machinery/light/incandescent/netural,
+/obj/submachine/chicken_feed_grinder,
+/obj/item/reagent_containers/food/snacks/plant/corn,
+/turf/simulated/floor/grass/random,
+/area/station/hydroponics/bay)
 "ebx" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 1
@@ -41464,6 +41470,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/plantpot{
+	anchored = 1
+	},
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
 "mrI" = (
@@ -66278,6 +66287,11 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/sw)
+"tHH" = (
+/obj/submachine/chicken_incubator,
+/obj/item/reagent_containers/food/snacks/ingredient/egg,
+/turf/simulated/floor/grass/random,
+/area/station/hydroponics/bay)
 "tHN" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -66890,6 +66904,9 @@
 	dir = 1;
 	name = "autoname - SS13";
 	tag = ""
+	},
+/obj/machinery/plantpot{
+	anchored = 1
 	},
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
@@ -129671,7 +129688,7 @@ kHx
 mke
 mke
 mke
-kHx
+tHH
 wqJ
 vHl
 amI
@@ -129973,7 +129990,7 @@ rGc
 mru
 oqV
 eQI
-xNi
+ebq
 wqJ
 yjy
 yjy

--- a/maps/donut3_xmas.dmm
+++ b/maps/donut3_xmas.dmm
@@ -4029,6 +4029,11 @@
 	dir = 4
 	},
 /area/station/crew_quarters/fitness)
+"aPo" = (
+/obj/submachine/chicken_incubator,
+/obj/item/reagent_containers/food/snacks/ingredient/egg,
+/turf/simulated/floor/snow/snowball,
+/area/station/hydroponics/bay)
 "aPw" = (
 /obj/cable{
 	d1 = 1;
@@ -10639,6 +10644,12 @@
 /obj/decal/garland,
 /turf/simulated/floor/circuit/off,
 /area/station/turret_protected/ai_upload)
+"cNg" = (
+/obj/machinery/light/incandescent/netural,
+/obj/submachine/chicken_feed_grinder,
+/obj/item/reagent_containers/food/snacks/plant/corn,
+/turf/simulated/floor/snow/snowball,
+/area/station/hydroponics/bay)
 "cNh" = (
 /obj/cable{
 	d1 = 4;
@@ -42537,6 +42548,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/plantpot{
+	anchored = 1
+	},
 /turf/simulated/floor/snow/snowball,
 /area/station/hydroponics/bay)
 "mrI" = (
@@ -68632,6 +68646,9 @@
 	dir = 1;
 	name = "autoname - SS13";
 	tag = ""
+	},
+/obj/machinery/plantpot{
+	anchored = 1
 	},
 /turf/simulated/floor/snow/snowball,
 /area/station/hydroponics/bay)
@@ -131756,7 +131773,7 @@ kHx
 mke
 mke
 mke
-kHx
+aPo
 wqJ
 vHl
 amI
@@ -132058,7 +132075,7 @@ rGc
 mru
 oqV
 eQI
-xNi
+cNg
 wqJ
 yjy
 yjy


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Donut 3 seems to be currently the only map in rotation without chickens and someone has to add them eventually, right?
Screenshot:

![0](https://user-images.githubusercontent.com/62990808/100083271-809a0580-2e49-11eb-9727-52ce87217a7a.png)



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Cluck

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)TTerc:
(+)Chicken equipment added to Donut 3.
```
