### PR TITLE
add pronoun variables to the arrival announcement computer

### DIFF
--- a/code/WorkInProgress/cryospawn.dm
+++ b/code/WorkInProgress/cryospawn.dm
@@ -130,7 +130,7 @@
 				if (thePerson.mind && thePerson.mind.assigned_role && be_loud)
 					for (var/obj/machinery/computer/announcement/A as() in machine_registry[MACHINES_ANNOUNCEMENTS])
 						if (!A.status && A.announces_arrivals)
-							A.announce_arrival(thePerson.real_name, thePerson.mind.assigned_role)
+							A.announce_arrival(thePerson)
 
 			sleep(0.9 SECONDS)
 			busy = 0

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -1718,11 +1718,6 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 /mob/living/silicon/ai/proc/set_face(var/emotion)
 	return
 
-/mob/living/silicon/ai/proc/announce_arrival(var/name, var/rank)
-	var/message = replacetext(replacetext(replacetext(src.arrivalalert, "$STATION", "[station_name()]"), "$JOB", rank), "$NAME", name)
-	src.say( message )
-	logTheThing("say", src, null, "SAY: [message]")
-
 /mob/living/silicon/ai/proc/set_zeroth_law(var/law)
 	ticker.centralized_ai_laws.laws_sanity_check()
 	ticker.centralized_ai_laws.set_zeroth_law(law)

--- a/code/obj/machinery/computer/announcement.dm
+++ b/code/obj/machinery/computer/announcement.dm
@@ -171,7 +171,7 @@
 	proc/set_arrival_alert(var/mob/user)
 		if (!user)
 			return
-		var/newalert = input(user,"Please enter a new arrival alert message. Valid tokens: $NAME, $JOB, $STATION", "Custom Arrival Alert", src.arrivalalert) as null|text
+		var/newalert = input(user,"Please enter a new arrival alert message. Valid tokens: $NAME, $JOB, $STATION, $HE, $HIS, $HIM", "Custom Arrival Alert", src.arrivalalert) as null|text
 		if (!newalert)
 			return
 		if (!findtext(newalert, "$NAME"))
@@ -195,13 +195,14 @@
 			L = languages.language_cache["english"]
 		return L.get_messages(message)
 
-	proc/announce_arrival(var/name, var/rank)
+	proc/announce_arrival(var/mob/living/person)
 		if (!src.announces_arrivals)
 			return 1
 		if (!src.announcement_radio)
 			src.announcement_radio = new(src)
 
-		var/message = replacetext(replacetext(replacetext(src.arrivalalert, "$STATION", "[station_name()]"), "$JOB", rank), "$NAME", name)
+		var/message = replacetext(replacetext(replacetext(src.arrivalalert, "$STATION", "[station_name()]"), "$JOB", person.mind.assigned_role), "$NAME", person.real_name)
+		message = replacetext(replacetext(replacetext(message, "$HE", "[he_or_she(person)]"), "$HIM", "[him_or_her(person)]"), "$HIS", "[his_or_her(person)]")
 
 		var/list/messages = process_language(message)
 		src.announcement_radio.talk_into(src, messages, 0, src.name, src.say_language)

--- a/code/obj/machinery/computer/announcement.dm
+++ b/code/obj/machinery/computer/announcement.dm
@@ -171,7 +171,7 @@
 	proc/set_arrival_alert(var/mob/user)
 		if (!user)
 			return
-		var/newalert = input(user,"Please enter a new arrival alert message. Valid tokens: $NAME, $JOB, $STATION, $HE, $HIS, $HIM", "Custom Arrival Alert", src.arrivalalert) as null|text
+		var/newalert = input(user,"Please enter a new arrival alert message. Valid tokens: $NAME, $JOB, $STATION, $THEY, $THEM, $THEIR", "Custom Arrival Alert", src.arrivalalert) as null|text
 		if (!newalert)
 			return
 		if (!findtext(newalert, "$NAME"))
@@ -202,7 +202,7 @@
 			src.announcement_radio = new(src)
 
 		var/message = replacetext(replacetext(replacetext(src.arrivalalert, "$STATION", "[station_name()]"), "$JOB", person.mind.assigned_role), "$NAME", person.real_name)
-		message = replacetext(replacetext(replacetext(message, "$HE", "[he_or_she(person)]"), "$HIM", "[him_or_her(person)]"), "$HIS", "[his_or_her(person)]")
+		message = replacetext(replacetext(replacetext(message, "$THEY", "[he_or_she(person)]"), "$THEM", "[him_or_her(person)]"), "$THEIR", "[his_or_her(person)]")
 
 		var/list/messages = process_language(message)
 		src.announcement_radio.talk_into(src, messages, 0, src.name, src.say_language)

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -422,7 +422,7 @@
 						if (src.mind.assigned_role == "MODE") //ZeWaka: Fix for alien invasion dudes. Possibly not needed now.
 							return
 						else
-							A.announce_arrival(src.real_name, src.mind.assigned_role)
+							A.announce_arrival(src)
 
 		//Equip_Bank_Purchase AFTER special_setup() call, because they might no longer be a human after that
 		if (possible_new_mob)


### PR DESCRIPTION
[FEAT]

## About the PR

Adds three new tokens to the arrival announcement computer: `$THEY`, `$THEM`, and `$THEIR`

## Why's this needed?

This would open up some possibilities on the announcement computer like `$NAME fart in $THEY own mouth. A shameful $JOB.`, as well as allowing messages like `Oh no! $NAME the $JOB is here! Quick! Stop $THEM before $THEY $JOB all over the station!`

## Changelog

```
(u)BenLubar:
(+)The arrivals announcement computer can now be set to use pronouns in messages.
```
