### PR TITLE
Potato battery buff

### DIFF
--- a/code/modules/food_and_drink/plants.dm
+++ b/code/modules/food_and_drink/plants.dm
@@ -1107,7 +1107,7 @@
 			else if (src.icon_state == "potato-peeled")
 				user.visible_message("[user] sticks some wire into [src].", "You stick some wire into [src], creating a makeshift battery.")
 				var/datum/plantgenes/DNA = src.plantgenes
-				var/obj/item/ammo/power_cell/potato/P = new /obj/item/ammo/power_cell/potato(get_turf(src),DNA.potency)
+				var/obj/item/ammo/power_cell/self_charging/potato/P = new /obj/item/ammo/power_cell/self_charging/potato(get_turf(src),DNA.potency,DNA.endurance)
 				P.name = "[src.name] battery"
 				P.transform = src.transform
 				W:amount -= 1

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -303,7 +303,7 @@
 	recharge_rate = 0.0
 
 /obj/item/ammo/power_cell/self_charging/potato/New(var/loc, var/potency, var/endurance)
-	var/rngfactor = 3 + rand()
+	var/rngfactor = 2 + rand()
 	src.max_charge += round(potency/rngfactor)
 	src.recharge_rate = 0.5 * round(endurance/rand(25,30))
 	src.charge = src.max_charge

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -262,22 +262,21 @@
 				det.detonate()
 
 //kubius potato battery: main def
-//you may need to alter the plant analyzer path
 
 /obj/item/cell/potato
 	name = "potato cell"
 	desc = "An improvised organic power cell. It looks a bit limp."
 	icon = 'icons/obj/potatocell.dmi'
 	icon_state = "king_tater"
-	maxcharge = 300
+	maxcharge = 600
 	genrate = 0
 	specialicon = 1
 	unusualCell = 1
 
 /obj/item/cell/potato/New(var/loc, var/potency, var/endurance)
 	src.maxcharge += rand(1,100) //slight deviation by specimen
-	src.maxcharge += round(potency*(4+rand())) //more deviation
-	src.genrate = round(endurance/rand(18,24))
+	src.maxcharge += round(potency*(8+rand())) //more deviation
+	src.genrate = round(endurance/rand(12,16))
 	if(genrate) desc = "An improvised organic power cell. It seems to be holding up well."
 	src.charge = src.maxcharge
 	..()
@@ -292,7 +291,7 @@
 		..()
 
 
-/obj/item/ammo/power_cell/potato
+/obj/item/ammo/power_cell/self_charging/potato
 	name = "potato battery"
 	desc = "An improvised organic power cell, cut down to a compact size. It seems somewhat impractical."
 	icon = 'icons/obj/potatocell.dmi'
@@ -301,15 +300,20 @@
 	m_amt = 20000
 	g_amt = 20000
 	max_charge = 10.0
+	recharge_rate = 0.0
 
-/obj/item/ammo/power_cell/potato/New(var/loc, var/potency)
-	var/rngfactor = 4 + rand()
+/obj/item/ammo/power_cell/self_charging/potato/New(var/loc, var/potency, var/endurance)
+	var/rngfactor = 3 + rand()
 	src.max_charge += round(potency/rngfactor)
+	src.recharge_rate = 0.5 * round(endurance/rand(25,30))
 	src.charge = src.max_charge
 	..()
 
-/obj/item/ammo/power_cell/potato/attackby(obj/item/W, mob/user)
+/obj/item/ammo/power_cell/self_charging/potato/attackby(obj/item/W, mob/user)
 	if (istype(W, /obj/item/plantanalyzer/))
-		boutput(user, "The potato battery has [src.charge] of [src.max_charge] PUs remaining.")
+		if(recharge_rate)
+			boutput(user, "The potato battery has [src.charge] of [src.max_charge] PUs charge remaining, and a regeneration rate of [recharge_rate].")
+		else
+			boutput(user, "The potato battery has [src.charge] of [src.max_charge] PUs charge remaining, and no capacity for regeneration.")
 	else
 		..()

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -275,7 +275,7 @@
 
 /obj/item/cell/potato/New(var/loc, var/potency, var/endurance)
 	src.maxcharge += rand(1,100) //slight deviation by specimen
-	src.maxcharge += round(potency*(8+rand())) //more deviation
+	src.maxcharge += round(potency*(6+rand(1,4))) //more deviation
 	src.genrate = round(endurance/rand(12,16))
 	if(genrate) desc = "An improvised organic power cell. It seems to be holding up well."
 	src.charge = src.maxcharge


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEAT][BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Considerably improves potato batteries in multiple aspects:

- Large cell base capacity increased from 300 to 600 (a basic conventional cell is 7,500).
- Large cell capacity now increases by 7 to 10 per potency (old: 4 to 5).
- Large cell generation rate now increases by 1 per 12 to 16 endurance (old: 18 to 24).
- Small cell capacity now increases by 1 per 2 to 3 potency (old: 4 to 5).
- Small cells can now be self-charging, at a rate of 0.5 per 25 to 35 endurance (this is not speedy; for reference, the rad crossbow charges at 2.5 post-buff)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Potato batteries are somewhat underwhelming right now, even with heavy investment into potency and endurance. Improving their ability to scale with botanists' efforts should make them much more rewarding and practical to use.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Kubius:
(+)Potato batteries scale more with potency and endurance, and the trimmed-down gun versions can now recharge with sufficiently high endurance.
```
