### PR TITLE
New arrivals after 20 minutes always spawn with o2 tank and crowbar

### DIFF
--- a/code/obj/item/storage/small_storage_parent.dm
+++ b/code/obj/item/storage/small_storage_parent.dm
@@ -302,7 +302,7 @@
 		if (prob(15) || ticker.round_elapsed_ticks > 20 MINUTES)
 			new /obj/item/tank/emergency_oxygen(src)
 		if (ticker.round_elapsed_ticks > 20 MINUTES)
-			new /obj/item/crowbar(src)
+			new /obj/item/crowbar/red(src)
 		if (prob(10)) // put these together
 			new /obj/item/clothing/suit/space/emerg(src)
 			new /obj/item/clothing/head/emerg(src)

--- a/code/obj/item/storage/small_storage_parent.dm
+++ b/code/obj/item/storage/small_storage_parent.dm
@@ -299,8 +299,10 @@
 	spawn_contents = list(/obj/item/clothing/mask/breath)
 	make_my_stuff()
 		..()
-		if (prob(15))
+		if (prob(15) || ticker.round_elapsed_ticks > 20 MINUTES)
 			new /obj/item/tank/emergency_oxygen(src)
+		if (ticker.round_elapsed_ticks > 20 MINUTES)
+			new /obj/item/crowbar(src)
 		if (prob(10)) // put these together
 			new /obj/item/clothing/suit/space/emerg(src)
 			new /obj/item/clothing/head/emerg(src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE][INPUT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Alters the starter emergency equipment box to change what it spawns depending on round time, guaranteeing the O2 tank spawn and adding a crowbar spawn after 20 minutes have elapsed in the round.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This isn't strictly necessary, but it's one possible way that changes could be made to ensure late arrivals don't end up completely screwed if arrivals is unpowered and depressurized and all the existing supplies are already exhausted.

**I am not certain that this is the correct way to go about addressing this** - input is very welcome, and I figure if this ends up not being favored, the worst that happens is I lose a patch that took less time to create than this writeup.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Kubius:
(+)New arrivals after 20 minutes into the round will now always spawn with an O2 tank and crowbar.
```
