### PR TITLE
Kondaru research cargo endpoint expanded

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -34319,8 +34319,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "bAR" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/disposalpipe/segment/transport{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
@@ -36651,9 +36652,6 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hangar/science)
 "bGd" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 8;
@@ -39768,7 +39766,6 @@
 /turf/simulated/floor/darkblue/checker,
 /area/station/science/artifact)
 "bMF" = (
-/obj/submachine/cargopad/artlab,
 /turf/simulated/floor/caution/westeast,
 /area/station/science/artifact)
 "bMG" = (
@@ -40488,12 +40485,14 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 5
 	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/white/grime,
 /area/station/maintenance/southwest)
 "bOf" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/cable{
 	icon_state = "1-8"
 	},
@@ -41864,6 +41863,9 @@
 /obj/item/device/radio/intercom/cargo{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "bQU" = (
@@ -42573,21 +42575,7 @@
 	},
 /turf/simulated/floor/airless/grey,
 /area/station/maintenance/southwest)
-"bSp" = (
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
-/obj/grille/catwalk,
-/turf/simulated/floor/airless/plating,
-/area/station/maintenance/southwest)
 "bSq" = (
-/obj/wingrille_spawn/auto,
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southwest)
-"bSr" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
@@ -42595,10 +42583,7 @@
 /area/station/maintenance/southwest)
 "bSs" = (
 /obj/disposalpipe/segment/transport{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "1-2"
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
@@ -42612,8 +42597,13 @@
 	name = "Research Router"
 	})
 "bSu" = (
-/obj/machinery/floorflusher/industrial,
-/obj/disposalpipe/trunk/west,
+/obj/machinery/computer/barcode{
+	destinations = list("Catering","Disposal","Ejection","Engineering","Export","Medbay","Mining","Pod Bay","Research","Security","QM");
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/orange/side{
 	dir = 9
 	},
@@ -42625,6 +42615,9 @@
 	dir = 1;
 	layer = 9.1;
 	pixel_y = 21
+	},
+/obj/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/orange/side{
 	dir = 1
@@ -42640,11 +42633,7 @@
 	name = "Research Router"
 	})
 "bSx" = (
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
+/obj/submachine/cargopad/artlab,
 /turf/simulated/floor/orange/side{
 	dir = 5
 	},
@@ -43195,19 +43184,14 @@
 /turf/simulated/floor/airless/grey,
 /area/station/maintenance/southwest)
 "bTJ" = (
-/obj/grille/catwalk,
-/turf/simulated/floor/airless/plating,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "bTK" = (
-/obj/machinery/computer/barcode{
-	destinations = list("Catering","Disposal","Ejection","Engineering","Export","Medbay","Mining","Pod Bay","Research","Security","QM");
-	dir = 4
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/data_terminal,
+/obj/machinery/floorflusher/industrial,
+/obj/disposalpipe/trunk/west,
 /turf/simulated/floor/orange/side{
 	dir = 8
 	},
@@ -43216,17 +43200,22 @@
 	})
 "bTL" = (
 /obj/cable{
-	icon_state = "4-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/grey,
 /area/station/routing/medsci{
 	name = "Research Router"
 	})
 "bTM" = (
+/obj/landmark/gps_waypoint,
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/landmark/gps_waypoint,
 /turf/simulated/floor/grey,
 /area/station/routing/medsci{
 	name = "Research Router"
@@ -43239,11 +43228,6 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
 	},
 /turf/simulated/floor/orange/side{
 	dir = 4
@@ -43713,21 +43697,21 @@
 /turf/simulated/floor/airless/plating,
 /area/station/maintenance/southwest)
 "bUN" = (
+/obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
-/obj/grille/catwalk{
-	dir = 6
-	},
-/turf/simulated/floor/airless/plating,
+/turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "bUO" = (
-/obj/disposaloutlet/east,
-/obj/disposalpipe/trunk/west,
-/obj/machinery/conveyor{
-	dir = 4;
-	name = "cargo belt - east";
-	operating = 1
+/obj/disposalpipe/segment/transport{
+	icon_state = "pipe-c"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/computer/ordercomp{
+	dir = 4
 	},
 /turf/simulated/floor/orange/side{
 	dir = 8
@@ -43736,10 +43720,8 @@
 	name = "Research Router"
 	})
 "bUP" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	name = "cargo belt - east";
-	operating = 1
+/obj/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/grey,
 /area/station/routing/medsci{
@@ -43751,9 +43733,6 @@
 	name = "Research Router"
 	})
 "bUR" = (
-/obj/machinery/computer/ordercomp,
-/obj/cable,
-/obj/machinery/power/data_terminal,
 /obj/machinery/light_switch/east,
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -43761,6 +43740,9 @@
 	name = "autoname - SS13";
 	pixel_x = 10;
 	tag = ""
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/orange/side{
 	dir = 4
@@ -44334,8 +44316,11 @@
 /turf/space,
 /area/station/maintenance/southwest)
 "bVY" = (
-/obj/lattice,
-/turf/space,
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/obj/machinery/shieldgenerator/energy_shield,
+/turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "bVZ" = (
 /obj/machinery/door/airlock/pyro/maintenance,
@@ -44774,15 +44759,6 @@
 /area/station/maintenance/southeast)
 "bWW" = (
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/autoname_west,
-/obj/storage/closet/emergency,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southwest)
-"bWX" = (
-/obj/cable{
 	icon_state = "1-2"
 	},
 /obj/cable{
@@ -44793,20 +44769,40 @@
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"bWY" = (
+"bWX" = (
 /obj/machinery/drone_recharger,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"bWZ" = (
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	icon_state = "0-2"
+"bWY" = (
+/obj/disposaloutlet/east,
+/obj/machinery/conveyor{
+	dir = 4;
+	name = "cargo belt - east";
+	operating = 1
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southwest)
+/obj/disposalpipe/trunk/north,
+/turf/simulated/floor/orange/side{
+	dir = 8
+	},
+/area/station/routing/medsci{
+	name = "Research Router"
+	})
+"bWZ" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	name = "cargo belt - east";
+	operating = 1
+	},
+/turf/simulated/floor/grey,
+/area/station/routing/medsci{
+	name = "Research Router"
+	})
 "bXa" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/maintenance/southwest)
+/obj/machinery/light,
+/turf/simulated/floor/grey,
+/area/station/routing/medsci{
+	name = "Research Router"
+	})
 "bXb" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
@@ -45139,10 +45135,6 @@
 /turf/simulated/floor/grey,
 /area/station/maintenance/southeast)
 "bXN" = (
-/obj/machinery/recharge_station,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southwest)
-"bXO" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 4;
@@ -45150,13 +45142,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
+"bXO" = (
+/obj/machinery/power/apc/autoname_east,
+/obj/cable,
+/turf/simulated/floor/orange/side{
+	dir = 4
+	},
+/area/station/routing/medsci{
+	name = "Research Router"
+	})
 "bXP" = (
 /obj/cable{
-	icon_state = "4-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/cable{
-	icon_state = "1-4"
-	},
+/obj/machinery/power/apc/autoname_west,
+/obj/storage/closet/emergency,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "bXQ" = (
@@ -56808,9 +56809,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
 "vuD" = (
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
+/obj/machinery/recharge_station,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "vvI" = (
@@ -57179,7 +57178,9 @@
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
-/obj/machinery/shieldgenerator/energy_shield,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "xQl" = (
@@ -57234,6 +57235,15 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
+"yhe" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southwest)
 "ylQ" = (
 /obj/lattice{
 	dir = 4;
@@ -89465,12 +89475,12 @@ bMC
 bOc
 bPw
 bGc
-bSp
-bTJ
 bUN
-bVY
-afw
-aci
+bAO
+bUN
+bvo
+bvo
+bvo
 bYG
 fVI
 bYG
@@ -89768,11 +89778,11 @@ bOd
 bGc
 bGc
 bSq
-bAO
-bSq
+bAQ
+bVY
 bvo
-bvo
-bvo
+bXP
+vuD
 bYG
 bZv
 bYG
@@ -90067,12 +90077,12 @@ bws
 bws
 bzP
 bOe
-bAQ
+bTJ
 bQT
-bSr
-bAQ
 xMD
-bvo
+bTJ
+xMD
+bVZ
 bWW
 bXN
 bYG
@@ -90369,14 +90379,14 @@ qZZ
 qZZ
 qZZ
 bOf
-bAR
+bAQ
 bGd
 bSs
 bAR
-bSs
-bVZ
+bSq
+bvo
 bWX
-bXO
+bzR
 bYG
 bZx
 bYG
@@ -90673,11 +90683,11 @@ bIL
 bOg
 bIL
 bQU
-bSt
 bQV
 bSt
+bSt
 bQU
-bAQ
+bQU
 bzR
 bYG
 cbo
@@ -90978,9 +90988,9 @@ bQV
 bSu
 bTK
 bUO
-bQU
 bWY
-bzR
+bQU
+yhe
 bYG
 bZz
 can
@@ -91280,8 +91290,8 @@ bQV
 bSv
 bTL
 bUP
+bWZ
 bQU
-vuD
 bzU
 bYG
 bZA
@@ -91582,8 +91592,8 @@ bQW
 bSw
 bTM
 bUQ
+bXa
 bQU
-bAQ
 bzR
 bAP
 bYG
@@ -91880,13 +91890,13 @@ bLF
 bMF
 bOj
 bPA
-bQU
+bQV
 bSx
 bTN
 bUR
+bXO
 bQU
-bWZ
-bXP
+bzR
 bAQ
 bYG
 caq
@@ -92187,7 +92197,7 @@ bQV
 bTO
 bQU
 bQU
-bXa
+bQU
 bzR
 bAQ
 bYG

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -41860,9 +41860,6 @@
 /area/station/maintenance/southwest)
 "bQT" = (
 /obj/decal/cleanable/dirt,
-/obj/item/device/radio/intercom/cargo{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -54544,6 +54541,13 @@
 	},
 /turf/simulated/floor/airless/plating,
 /area/station/maintenance/west)
+"hTE" = (
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/obj/item/device/radio/intercom/cargo,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southwest)
 "hVr" = (
 /obj/landmark/halloween,
 /turf/simulated/floor,
@@ -89777,7 +89781,7 @@ bGc
 bOd
 bGc
 bGc
-bSq
+hTE
 bAQ
 bVY
 bvo


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Small supplementary update to Kondaru that slightly expands the research cargo endpoint and moves the artifact lab cargo pad into it.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Improves the usability of Kondaru's artifact lab and research cargo endpoint.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Kubius:
(+)Kondaru's research cargo endpoint is a little more spacious and now contains the artifact lab's cargo pad.
```
