### PR TITLE
Remove infiltrator from syndicate vendor

### DIFF
--- a/code/obj/submachine/weapon_vendor.dm
+++ b/code/obj/submachine/weapon_vendor.dm
@@ -183,7 +183,6 @@
 		materiel_stock += new/datum/materiel/loadout/assault
 		materiel_stock += new/datum/materiel/loadout/heavy
 		materiel_stock += new/datum/materiel/loadout/grenadier
-		materiel_stock += new/datum/materiel/loadout/infiltrator
 		materiel_stock += new/datum/materiel/loadout/medic
 		materiel_stock += new/datum/materiel/loadout/firebrand
 		materiel_stock += new/datum/materiel/loadout/engineer


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Remove infiltrator from the syndie vendor

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I have literally never once seen an infiltrator not just ruin the round by
being spotted early. Removing it will make nukie rounds more competitive.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)CodeDude:
(*)Removed infiltrator from the Syndicate loadout vendor
```
