### PR TITLE
allow AI flockdrones to contribute resources towards tealprints

### DIFF
--- a/code/mob/living/critter/ai/flock/flockdrone.dm
+++ b/code/mob/living/critter/ai/flock/flockdrone.dm
@@ -16,6 +16,7 @@
 	transition_tasks += holder.get_instance(/datum/aiTask/sequence/goalbased/replicate, list(holder, src))
 	transition_tasks += holder.get_instance(/datum/aiTask/sequence/goalbased/build, list(holder, src))
 	transition_tasks += holder.get_instance(/datum/aiTask/sequence/goalbased/repair, list(holder, src))
+	transition_tasks += holder.get_instance(/datum/aiTask/sequence/goalbased/deposit, list(holder, src))
 	transition_tasks += holder.get_instance(/datum/aiTask/sequence/goalbased/open_container, list(holder, src))
 	transition_tasks += holder.get_instance(/datum/aiTask/sequence/goalbased/butcher, list(holder, src))
 	transition_tasks += holder.get_instance(/datum/aiTask/sequence/goalbased/rummage, list(holder, src))

--- a/code/mob/living/critter/ai/flock/flocktasks.dm
+++ b/code/mob/living/critter/ai/flock/flocktasks.dm
@@ -247,6 +247,75 @@
 	has_started = 0
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+// DEPOSIT GOAL
+// targets: ghost tealprints in the same flock
+// precondition: 10 resources
+/datum/aiTask/sequence/goalbased/deposit
+	name = "depositing"
+	weight = 4
+
+/datum/aiTask/sequence/goalbased/deposit/New(parentHolder, transTask)
+	..(parentHolder, transTask)
+	add_task(holder.get_instance(/datum/aiTask/succeedable/deposit, list(holder)))
+
+/datum/aiTask/sequence/goalbased/deposit/precondition()
+	. = 0
+	var/mob/living/critter/flock/drone/F = holder.owner
+	if(F?.can_afford(10))
+		. = 1
+
+/datum/aiTask/sequence/goalbased/deposit/on_reset()
+	var/mob/living/critter/flock/drone/F = holder.owner
+	if(F)
+		F.active_hand = 2 // nanite spray
+		sleep(0.1 SECONDS)
+		F.a_intent = INTENT_HELP
+		F.hud?.update_intent()
+		sleep(0.1 SECONDS)
+		F.hud?.update_hands() // for observers
+
+/datum/aiTask/sequence/goalbased/deposit/get_targets()
+	var/mob/living/critter/flock/drone/F = holder.owner
+	var/list/targets = list()
+	for(var/obj/flock_structure/ghost/S in view(max_dist, F))
+		if(S.flock == F.flock && S.goal > S.currentmats)
+			// if we can get a valid path to the target, include it for consideration
+			if(cirrAstar(get_turf(F), get_turf(S), 1, null, /proc/heuristic, 40))
+				targets += S
+	return targets
+
+////////
+
+/datum/aiTask/succeedable/deposit
+	name = "deposit subtask"
+	var/has_started = 0
+
+/datum/aiTask/succeedable/deposit/failed()
+	var/mob/living/critter/flock/drone/F = holder.owner
+	var/obj/flock_structure/ghost/T = holder.target
+	if(!F || !T || get_dist(T, F) > 1)
+		return 1
+	if(F && (!F.can_afford() || !F.abilityHolder))
+		return 1
+
+/datum/aiTask/succeedable/deposit/succeeded()
+	return (!actions.hasAction(holder.owner, "flock_repair")) // for whatever reason, the required action has stopped
+
+/datum/aiTask/succeedable/deposit/on_tick()
+	if(!has_started)
+		var/mob/living/critter/flock/drone/F = holder.owner
+		var/obj/flock_structure/ghost/T = holder.target
+		if(F && T && get_dist(holder.owner, holder.target) <= 1)
+			if(F.set_hand(2)) // nanite spray
+				sleep(0.2 SECONDS)
+				holder.owner.set_dir(get_dir(holder.owner, holder.target))
+				F.hand_attack(T)
+				has_started = 1
+
+/datum/aiTask/succeedable/deposit/on_reset()
+	has_started = 0
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////
 // OPEN CONTAINER GOAL
 // targets: any large storage object
 // precondition: none


### PR DESCRIPTION
[FEATURE]

## About the PR

Minor addition to AI to allow non-player-controlled flockdrones to target tealprints

## Why's this needed?

The tealprints were lonely, okay?

Look, they made a little floor minecraft creeper

![image](https://user-images.githubusercontent.com/4257305/100485030-35d7f200-30c4-11eb-9f3c-56e837e9b7aa.png)
