### PR TITLE
interrupt flockmind tile conversion if it's already done

### DIFF
--- a/code/mob/living/critter/flockcritter_parent.dm
+++ b/code/mob/living/critter/flockcritter_parent.dm
@@ -165,7 +165,7 @@
 	onUpdate()
 		..()
 		var/mob/living/critter/flock/F = owner
-		if (target == null || owner == null || !in_range(owner, target, 1) || !F?.can_afford(20))
+		if (target == null || owner == null || !in_range(owner, target, 1) || isfeathertile(target) || !F?.can_afford(20))
 			interrupt(INTERRUPT_ALWAYS)
 			return
 


### PR DESCRIPTION
[MINOR]

## About the PR

Interrupt flockdrone/flockbit conversion of tiles if someone else converted it already

## Why's this needed?

I just watched two flockbits and a drone try to convert the same tile and they somehow turned a door into a floor.
