### PR TITLE
Adds sarin greandes to Syndicate Weapon Vendor

### DIFF
--- a/code/obj/submachine/weapon_vendor.dm
+++ b/code/obj/submachine/weapon_vendor.dm
@@ -198,6 +198,7 @@
 		materiel_stock += new/datum/materiel/utility/knife
 		materiel_stock += new/datum/materiel/utility/rpg_ammo
 		materiel_stock += new/datum/materiel/utility/donk
+		materiel_stock += new/datum/materiel/utility/sarin_grenade
 
 	accepted_token()
 		src.current_sidearm_credits++
@@ -368,6 +369,12 @@
 	path = /obj/item/reagent_containers/food/snacks/donkpocket_w
 	catagory = "Utility"
 	description = "A tasty donk pocket, heated by futuristic vending machine technology!"
+
+/datum/materiel/utility/sarin_grenade
+	name = "Sarin Grenade"
+	path = /obj/item/chem_grenade/sarin
+	catagory = "Utility"
+	description = "A terrifying grenade containing a potent nerve gas. Try not to get caught in the smoke."
 
 // Requisition tokens
 

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -82771,14 +82771,6 @@
 	},
 /turf/unsimulated/floor/wood/two,
 /area/centcom/offices/sord)
-"fxL" = (
-/obj/storage/secure/crate/gear/sarin_grenades,
-/obj/decal/tile_edge/stripe{
-	dir = 6;
-	icon_state = "delivery2"
-	},
-/turf/unsimulated/floor/darkblue,
-/area/syndicate_station/battlecruiser)
 "fCL" = (
 /obj/item/spacecash/twenty{
 	pixel_x = -12;
@@ -117244,7 +117236,7 @@ btf
 btf
 btf
 dgK
-fxL
+btf
 dff
 aKf
 dhv


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes sarin grenade crate from the Cairngorm.
Adds sarin grenade as a utility item


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Reduce friendly sarin incidents without removing them entirely. Makes operatives have to make the active decision to spend a credit on sarin access.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Gannets:
(*)Removed sarin grenades from the Cairngorm.
(*)Added sarin grenade as a utility item purchased from the Syndicate Weapon Vendor.
```
