### PR TITLE
Flock description string build removal

### DIFF
--- a/code/mob/living/critter/flock/flockbit.dm
+++ b/code/mob/living/critter/flock/flockbit.dm
@@ -24,13 +24,12 @@
 
 /mob/living/critter/flock/bit/special_desc(dist, mob/user)
 	if(isflock(user))
-		var/special_desc = "<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received."
-		special_desc += "<br><span class='bold'>ID:</span> [src.real_name]"
-		special_desc += "<br><span class='bold'>Flock:</span> [src.flock ? src.flock.name : "none"]"
-		special_desc += "<br><span class='bold'>System Integrity:</span> [round(src.get_health_percentage()*100)]%"
-		special_desc += "<br><span class='bold'>Cognition:</span> PREDEFINED"
-		special_desc += "<br><span class='bold'>###=-</span></span>"
-		return special_desc
+		return {"<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received.
+		<br><span class='bold'>ID:</span> [src.real_name]
+		<br><span class='bold'>Flock:</span> [src.flock ? src.flock.name : "none"]
+		<br><span class='bold'>System Integrity:</span> [round(src.get_health_percentage()*100)]%
+		<br><span class='bold'>Cognition:</span> PREDEFINED
+		<br><span class='bold'>###=-</span></span>"}
 	else
 		return null // give the standard description
 

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -170,11 +170,11 @@
 			special_desc += "<br><span class='bold'>ID:</span> <b>[src.controller.real_name]</b> controlling [src.real_name])"
 		else
 			special_desc += "<br><span class='bold'>ID:</span> [src.real_name]"
-		special_desc += "<br><span class='bold'>Flock:</span> [src.flock ? src.flock.name : "none"]"
-		special_desc += "<br><span class='bold'>Resources:</span> [src.resources]"
-		special_desc += "<br><span class='bold'>System Integrity:</span> [round(src.get_health_percentage()*100)]%"
-		special_desc += "<br><span class='bold'>Cognition:</span> [src.is_npc ? "TORPID" : "SAPIENT"]"
-		special_desc += "<br><span class='bold'>###=-</span></span>"
+		special_desc += {"<br><span class='bold'>Flock:</span> [src.flock ? src.flock.name : "none"]
+		<br><span class='bold'>Resources:</span> [src.resources]"
+		<br><span class='bold'>System Integrity:</span> [round(src.get_health_percentage()*100)]%
+		<br><span class='bold'>Cognition:</span> [src.is_npc ? "TORPID" : "SAPIENT"]
+		<br><span class='bold'>###=-</span></span>"}
 		return special_desc
 	else
 		return null // give the standard description

--- a/code/mob/living/intangible/flock/flockmind.dm
+++ b/code/mob/living/intangible/flock/flockmind.dm
@@ -27,14 +27,13 @@
 
 /mob/living/intangible/flock/flockmind/special_desc(dist, mob/user)
   if(isflock(user))
-    var/special_desc = "<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received."
-    special_desc += "<br><span class='bold'>ID:</span> [src.real_name]"
-    special_desc += "<br><span class='bold'>Flock:</span> [src.flock ? src.flock.name : "none, somehow"]"
-    special_desc += "<br><span class='bold'>Resources:</span> [src.flock.total_resources()]"
-    special_desc += "<br><span class='bold'>System Integrity:</span> [round(src.flock.total_health_percentage()*100)]%"
-    special_desc += "<br><span class='bold'>Cognition:</span> COMPUTATIONAL NEXUS"
-    special_desc += "<br>###=-</span></span>"
-    return special_desc
+    return {"<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received.
+    <br><span class='bold'>ID:</span> [src.real_name]
+    <br><span class='bold'>Flock:</span> [src.flock ? src.flock.name : "none, somehow"]
+    <br><span class='bold'>Resources:</span> [src.flock.total_resources()]
+    <br><span class='bold'>System Integrity:</span> [round(src.flock.total_health_percentage()*100)]%
+    <br><span class='bold'>Cognition:</span> COMPUTATIONAL NEXUS
+    <br>###=-</span></span>"}
   else
     return null // give the standard description
 

--- a/code/mob/living/intangible/flock/flocktrace.dm
+++ b/code/mob/living/intangible/flock/flocktrace.dm
@@ -41,14 +41,13 @@
 
 /mob/living/intangible/flock/trace/special_desc(dist, mob/user)
   if(isflock(user))
-    var/special_desc = "<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received."
-    special_desc += "<br><span class='bold'>ID:</span> [src.real_name]"
-    special_desc += "<br><span class='bold'>Flock:</span> [src.flock ? src.flock.name : "none, somehow"]"
-    special_desc += "<br><span class='bold'>Resources:</span> [src.flock.total_resources()]"
-    special_desc += "<br><span class='bold'>System Integrity:</span> [round(src.flock.total_health_percentage()*100)]%"
-    special_desc += "<br><span class='bold'>Cognition:</span> SYNAPTIC PROCESS"
-    special_desc += "<br>###=-</span></span>"
-    return special_desc
+    return {"<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received.
+    <br><span class='bold'>ID:</span> [src.real_name]
+    <br><span class='bold'>Flock:</span> [src.flock ? src.flock.name : "none, somehow"]
+    <br><span class='bold'>Resources:</span> [src.flock.total_resources()]
+    <br><span class='bold'>System Integrity:</span> [round(src.flock.total_health_percentage()*100)]%
+    <br><span class='bold'>Cognition:</span> SYNAPTIC PROCESS
+    <br>###=-</span></span>"}
   else
     return null // give the standard description
 

--- a/code/obj/flock/cage.dm
+++ b/code/obj/flock/cage.dm
@@ -165,12 +165,11 @@
 
 /obj/icecube/flockdrone/special_desc(dist, mob/user)
 	if(isflock(user))
-		var/special_desc = "<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received."
-		special_desc += "<br><span class='bold'>ID:</span> Matter Reprocessor"
-		special_desc += "<br><span class='bold'>Volume:</span> [src.reagents.get_reagent_amount(src.target_fluid)]"
-		special_desc += "<br><span class='bold'>Needed volume:</span> [src.create_egg_at_fluid]"
-		special_desc += "<br><span class='bold'>###=-</span></span>"
-		return special_desc
+		return {"<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received.
+		<br><span class='bold'>ID:</span> Matter Reprocessor
+		<br><span class='bold'>Volume:</span> [src.reagents.get_reagent_amount(src.target_fluid)]
+		<br><span class='bold'>Needed volume:</span> [src.create_egg_at_fluid]
+		<br><span class='bold'>###=-</span></span>"}
 	else
 		return null // give the standard description
 

--- a/code/obj/flock/furniture.dm
+++ b/code/obj/flock/furniture.dm
@@ -21,10 +21,9 @@
 
 /obj/table/flock/special_desc(dist, mob/user)
   if(isflock(user))
-    var/special_desc = "<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received."
-    special_desc += "<br><span class='bold'>ID:</span> Storage Surface"
-    special_desc += "<br><span class='bold'>###=-</span></span>"
-    return special_desc
+    return {"<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received.
+    <br><span class='bold'>ID:</span> Storage Surface
+    <br><span class='bold'>###=-</span></span>"}
   else
     return null // give the standard description
 
@@ -39,11 +38,10 @@
 
 /obj/item/furniture_parts/table/flock/special_desc(dist, mob/user)
   if(isflock(user))
-    var/special_desc = "<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received."
-    special_desc += "<br><span class='bold'>ID:</span> Storage Surface, Deployable State"
-    special_desc += "<br><span class='bold'>Instructions:</span> Activate within grip tool to deploy."
-    special_desc += "<br><span class='bold'>###=-</span></span>"
-    return special_desc
+    return {"<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received.
+    <br><span class='bold'>ID:</span> Storage Surface, Deployable State
+    <br><span class='bold'>Instructions:</span> Activate within grip tool to deploy.
+    <br><span class='bold'>###=-</span></span>"}
   else
     return null // give the standard description
 
@@ -64,10 +62,9 @@
 
 /obj/stool/chair/comfy/flock/special_desc(dist, mob/user)
   if(isflock(user))
-    var/special_desc = "<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received."
-    special_desc += "<br><span class='bold'>ID:</span> Resting Chamber"
-    special_desc += "<br><span class='bold'>###=-</span></span>"
-    return special_desc
+    return {"<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received.
+    <br><span class='bold'>ID:</span> Resting Chamber
+    <br><span class='bold'>###=-</span></span>"}
   else
     return null // give the standard description
 
@@ -84,11 +81,10 @@
 
 /obj/item/furniture_parts/flock_chair/special_desc(dist, mob/user)
   if(isflock(user))
-    var/special_desc = "<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received."
-    special_desc += "<br><span class='bold'>ID:</span> Resting Chamber, Deployable State"
-    special_desc += "<br><span class='bold'>Instructions:</span> Activate within grip tool to deploy."
-    special_desc += "<br><span class='bold'>###=-</span></span>"
-    return special_desc
+    return {"<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received.
+    <br><span class='bold'>ID:</span> Resting Chamber, Deployable State
+    <br><span class='bold'>Instructions:</span> Activate within grip tool to deploy.
+    <br><span class='bold'>###=-</span></span>"}
   else
     return null // give the standard description
 
@@ -169,10 +165,9 @@
 
 /obj/storage/closet/flock/special_desc(dist, mob/user)
   if(isflock(user))
-    var/special_desc = "<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received."
-    special_desc += "<br><span class='bold'>ID:</span> Containment Capsule"
-    special_desc += "<br><span class='bold'>###=-</span></span>"
-    return special_desc
+    return {"<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received.
+    <br><span class='bold'>ID:</span> Containment Capsule
+    <br><span class='bold'>###=-</span></span>"}
   else
     return null // give the standard description
 
@@ -203,10 +198,9 @@
 
 /obj/item/furniture_parts/flock_chair/special_desc(dist, mob/user)
   if(isflock(user))
-    var/special_desc = "<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received."
-    special_desc += "<br><span class='bold'>ID:</span> Light Emitter"
-    special_desc += "<br><span class='bold'>###=-</span></span>"
-    return special_desc
+    return {"<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received.
+    <br><span class='bold'>ID:</span> Light Emitter
+    <br><span class='bold'>###=-</span></span>"}
   else
     return null // give the standard description
 

--- a/code/obj/flock/goods.dm
+++ b/code/obj/flock/goods.dm
@@ -75,12 +75,11 @@
 
 /obj/item/gun/energy/flock/special_desc(dist, mob/user)
 	if(isflock(user))
-		var/special_desc = "<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received."
-		special_desc += "<br><span class='bold'>ID:</span> Incapacitor"
-		special_desc += "<br><span class='bold'>Energy:</span> [src.cell.charge]"
-		special_desc += "<br><span class='bold'>Max Energy:</span> [src.cell.max_charge]"
-		special_desc += "<br><span class='bold'>###=-</span></span>"
-		return special_desc
+		return {"<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received.
+		<br><span class='bold'>ID:</span> Incapacitor
+		<br><span class='bold'>Energy:</span> [src.cell.charge]
+		<br><span class='bold'>Max Energy:</span> [src.cell.max_charge]
+		<br><span class='bold'>###=-</span></span><br>"}
 	else
 		return null // give the standard description
 
@@ -96,10 +95,9 @@
 
 /obj/item/flockcache/special_desc(dist, mob/user)
 	if(isflock(user))
-		var/special_desc = "<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed. data packet received."
-		special_desc += "<br><span class='bold'>ID:</span> Resource Cache"
-		special_desc += "<br><span class='bold'>Resources:</span> [resources]"
-		special_desc += "<br><span class='bold'>###=-</span></span>"
-		return special_desc
+		return {"<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed. data packet received.
+		<br><span class='bold'>ID:</span> Resource Cache
+		<br><span class='bold'>Resources:</span> [resources]
+		<br><span class='bold'>###=-</span></span>"}
 	else
 		return null

--- a/code/obj/flock/structure/collector.dm
+++ b/code/obj/flock/structure/collector.dm
@@ -18,9 +18,8 @@
 	..(location, F)
 
 /obj/flock_structure/collector/building_specific_info()
-	var/custominfo = "<span class='bold'>Connections:</span> Currently Connected to [connected] tile[connected == 1 ? "" : "s"]."
-	custominfo += "<br><span class='bold'>Power generation:</span> Currently generating [abs(poweruse)]."
-	return custominfo
+	return {"<span class='bold'>Connections:</span> Currently Connected to [connected] tile[connected == 1 ? "" : "s"].
+	<br><span class='bold'>Power generation:</span> Currently generating [abs(poweruse)]."}
 
 /obj/flock_structure/collector/process()
 	..()

--- a/code/obj/flock/structure/flock_structure_ghost.dm
+++ b/code/obj/flock/structure/flock_structure_ghost.dm
@@ -10,9 +10,8 @@
 
 
 /obj/flock_structure/ghost/building_specific_info()
-	var/custominfo = "<span class='bold'>Construction Percentage:</span> [!src.goal == 0 ? round((src.currentmats/src.goal)*100) : 0]%"
-	custominfo += "<br><span class='bold'>Construction Progress:</span> [currentmats] materials added, [goal] needed"
-	return custominfo
+	return {"<span class='bold'>Construction Percentage:</span> [!src.goal == 0 ? round((src.currentmats/src.goal)*100) : 0]%"
+	<br><span class='bold'>Construction Progress:</span> [currentmats] materials added, [goal] needed"}
 
 /obj/flock_structure/ghost/New(var/atom/location, building = null, var/datum/flock/F = null, goal = 0)
 	..(location, F)

--- a/code/obj/flock/structure/flock_structure_parent.dm
+++ b/code/obj/flock/structure/flock_structure_parent.dm
@@ -42,10 +42,10 @@
 
 /obj/flock_structure/special_desc(dist, mob/user)
 	if(isflock(user))
-		var/special_desc = "<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received."
-		special_desc += "<br><span class='bold'>ID:</span> [flock_id]"
-		special_desc += "<br><span class='bold'>Flock:</span> [src.flock ? src.flock.name : "none"]"
-		special_desc += "<br><span class='bold'>System Integrity:</span> [round((src.health/src.health_max)*100)]%"
+		var/special_desc = {"<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received.
+		special_desc += <br><span class='bold'>ID:</span> [flock_id]
+		special_desc += <br><span class='bold'>Flock:</span> [src.flock ? src.flock.name : "none"]
+		special_desc += <br><span class='bold'>System Integrity:</span> [round((src.health/src.health_max)*100)]%"}
 		var/info = building_specific_info()
 		if(!isnull(info))
 			special_desc += "<br>[info]"

--- a/code/obj/item/organs/brain.dm
+++ b/code/obj/item/organs/brain.dm
@@ -151,9 +151,8 @@
 
 /obj/item/organ/brain/flockdrone/special_desc(dist, mob/user)
 	if(isflock(user))
-		var/special_desc = "<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received."
-		special_desc += "<br><span class='bold'>ID:</span> Computational core"
-		special_desc += "<br><span class='bold'>###=-</span></span>"
-		return special_desc
+		return {"<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received.
+		<br><span class='bold'>ID:</span> Computational core
+		<br><span class='bold'>###=-</span></span>"}
 	else
 		return null // give the standard description

--- a/code/obj/item/organs/heart.dm
+++ b/code/obj/item/organs/heart.dm
@@ -164,10 +164,9 @@
 
 /obj/item/organ/heart/flock/special_desc(dist, mob/user)
 	if(isflock(user))
-		var/special_desc = "<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received."
-		special_desc += "<br><span class='bold'>ID:</span> Resource repository"
-		special_desc += "<br><span class='bold'>Resources:</span> [src.resources]"
-		special_desc += "<br><span class='bold'>###=-</span></span>"
-		return special_desc
+		return {"<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received.
+		<br><span class='bold'>ID:</span> Resource repository
+		<br><span class='bold'>Resources:</span> [src.resources]
+		<br><span class='bold'>###=-</span></span>"}
 	else
 		return null // give the standard description

--- a/code/obj/machinery/door/feather.dm
+++ b/code/obj/machinery/door/feather.dm
@@ -12,12 +12,12 @@
 
 /obj/machinery/door/feather/special_desc(dist, mob/user)
 	if(isflock(user))
-		var/special_desc = "<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received."
-		special_desc += "<br><span class='bold'>ID:</span> Solid Seal Aperture"
-		special_desc += "<br><span class='bold'>System Integrity:</span> [round((src.health/src.health_max)*100)]%"
+		var/special_desc = {"<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received.
+		<br><span class='bold'>ID:</span> Solid Seal Aperture
+		<br><span class='bold'>System Integrity:</span> [round((src.health/src.health_max)*100)]%"}
 		if(broken)
-			special_desc += "<br><span class='bold'>FUNCTION CRITICALLY IMPAIRED, REPAIRS REQUIRED</span> "
-			special_desc += "<br><span class='bold'>###=-</span></span>"
+			special_desc += {"<br><span class='bold'>FUNCTION CRITICALLY IMPAIRED, REPAIRS REQUIRED</span>
+			<br><span class='bold'>###=-</span></span>"}
 		return special_desc
 	else
 		return null // give the standard description

--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -1020,11 +1020,11 @@
 
 /obj/window/feather/special_desc(dist, mob/user)
   if(isflock(user))
-    var/special_desc = "<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received."
-    special_desc += "<br><span class='bold'>ID:</span> Fibrewoven Window"
-    special_desc += "<br><span class='bold'>System Integrity:</span> [round((src.health/src.health_max)*100)]%" // todo: damageable walls
-    special_desc += "<br><span class='bold'>###=-</span></span>"
-    return special_desc
+    return {"<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received.
+    <br><span class='bold'>ID:</span> Fibrewoven Window
+    <br><span class='bold'>System Integrity:</span> [round((src.health/src.health_max)*100)]%
+    <br><span class='bold'>###=-</span></span>"}
+    // todo: damageable walls
   else
     return null // give the standard description
 

--- a/code/turf/turf_flock.dm
+++ b/code/turf/turf_flock.dm
@@ -38,11 +38,10 @@
 
 /turf/simulated/floor/feather/special_desc(dist, mob/user)
   if(isflock(user))
-    var/special_desc = "<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received."
-    special_desc += "<br><span class='bold'>ID:</span> Conduit"
-    special_desc += "<br><span class='bold'>System Integrity:</span> [round((src.health/50)*100)]%"
-    special_desc += "<br><span class='bold'>###=-</span></span>"
-    return special_desc
+    return {"<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received.
+    <br><span class='bold'>ID:</span> Conduit
+    <br><span class='bold'>System Integrity:</span> [round((src.health/50)*100)]%
+    <br><span class='bold'>###=-</span></span>"}
   else
     return null // give the standard description
 
@@ -259,11 +258,11 @@ turf/simulated/floor/feather/proc/bfs(turf/start)//breadth first search, made by
 
 /turf/simulated/wall/auto/feather/special_desc(dist, mob/user)
   if(isflock(user))
-    var/special_desc = "<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received."
-    special_desc += "<br><span class='bold'>ID:</span> Nanite Block"
-    special_desc += "<br><span class='bold'>System Integrity:</span> 100%" // todo: damageable walls
-    special_desc += "<br><span class='bold'>###=-</span></span>"
-    return special_desc
+    return {"<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received.
+    <br><span class='bold'>ID:</span> Nanite Block
+    <br><span class='bold'>System Integrity:</span> 100%
+    <br><span class='bold'>###=-</span></span>"}
+    // todo: damageable walls
   else
     return null // give the standard description
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces the string builds in flock descriptions as much as possible. Descriptions that checked vars i have left mostly the same.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Requested by @MarkNais 

