### PR TITLE
Move actions.interrupt(src, INTERRUPT_ACT) from mob/proc/click() to mob/living/click()

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -469,6 +469,8 @@
 			boutput(src, "<span class='alert'>You are handcuffed! Use Resist to attempt removal.</span>")
 		return
 
+	actions.interrupt(src, INTERRUPT_ACT)
+
 	if (!src.stat && !hasStatus(list("weakened", "paralysis", "stunned")))
 		if (target != src && ishuman(src))
 			var/mob/living/carbon/human/S = src

--- a/code/modules/interface/mob_input.dm
+++ b/code/modules/interface/mob_input.dm
@@ -3,7 +3,7 @@
 /mob/proc/key_up(var/key)
 
 /mob/proc/click(atom/target, params)
-	actions.interrupt(src, INTERRUPT_ACT) //Definitely not the best place for this.
+	//moved the 'actions.interrupt(src, INTERRUPT_ACT)' here to on mob/living
 
 	if (src.targeting_ability)
 		if (istype(src.targeting_ability, /datum/targetable))


### PR DESCRIPTION
[BUG] 

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Does what it says on the tin. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This allows people who are currently doing actions with the interrupt flag of `INTERRUPT_ACT` to examine things without actually interrupting their action. 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Flourish:
(+)You can now examine things while doing an action (such as uncuffing) without interrupting it.
```
