### PR TITLE
More tail-related bugfixes and reworks

### DIFF
--- a/_std/macros/appearance.dm
+++ b/_std/macros/appearance.dm
@@ -51,8 +51,6 @@
 
 /// We have normal human eyes of human color where human eyes tend to be
 #define HAS_HUMAN_EYES					(1<<9)
-///We have different eyes of different color probably somewhere else
-#define HAS_SPECIAL_EYES				(1<<10)
 /// We have no eyes and yet must see (cus they're baked into the sprite or something)
 #define HAS_NO_EYES							(1<<11)
 

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -85,6 +85,10 @@
 	/// This is used for static icons if the mutant isn't built from pieces
 	var/icon = 'icons/effects/genetics.dmi'
 	var/icon_state = "blank_c"
+	/// The icon used to render their eyes
+	var/eye_icon = 'icons/mob/human_hair.dmi'
+	/// The state used to render their eyes
+	var/eye_state = "eyes"
 
 	/// If the mutant uses a non-human head, this'll tell the head builder which head to build
 	var/special_head = null
@@ -99,6 +103,10 @@
 	var/head_offset = 0 // affects pixel_y of clothes
 	var/hand_offset = 0
 	var/body_offset = 0
+	/// affects pixel_y of eyes if they're different from normal head-placement. darn anime monkey eyes
+	/// If 0, it inherits that of the head offset. Otherwise, it applies as normal
+	/// So, it should typically be something like head_offset +/- a few pixels
+	var/eye_offset = 0
 
 	var/list/limb_list = list()
 	var/r_limb_arm_type_mutantrace = null // Should we get custom arms? Dispose() replaces them with normal human arms.
@@ -204,10 +212,7 @@
 						W.set_loc(mob.loc)
 						W.dropped(mob)
 						W.layer = initial(W.layer)
-			M.image_eyes.pixel_y = src.head_offset
-			M.image_cust_one.pixel_y = src.head_offset
-			M.image_cust_two.pixel_y = src.head_offset
-			M.image_cust_three.pixel_y = src.head_offset
+
 
 			SPAWN_DBG (25) // Don't remove.
 				if (M?.organHolder?.skull)
@@ -243,10 +248,6 @@
 			if (ishuman(mob))
 				var/mob/living/carbon/human/H = mob
 				MutateMutant(H, "reset")
-				H.image_eyes.pixel_y = initial(H.image_eyes.pixel_y)
-				H.image_cust_one.pixel_y = initial(H.image_cust_one.pixel_y)
-				H.image_cust_two.pixel_y = initial(H.image_cust_two.pixel_y)
-				H.image_cust_three.pixel_y = initial(H.image_cust_three.pixel_y)
 				organ_mutator(H, "reset")
 				AppearanceSetter(H, "reset")
 				LimbSetter(H, "reset")
@@ -287,8 +288,11 @@
 				AH.customization_second_original = AH.customization_second
 				AH.customization_third_original = AH.customization_third
 				AH.customization_first = src.special_hair_1
+				AH.customization_first_offset_y = src.head_offset
 				AH.customization_second = src.special_hair_2
+				AH.customization_second_offset_y = src.head_offset
 				AH.customization_third = src.special_hair_3
+				AH.customization_third_offset_y = src.head_offset
 				AH.customization_icon_special = src.mutant_folder
 				if (src.mutant_color_flags & FIX_COLORS)	// mods the special colors so it doesnt mess things up if we stop being special
 					AH.customization_first_color = fix_colors(AH.customization_first_color)
@@ -297,6 +301,9 @@
 				AH.mutant_race = src
 				AH.body_icon = src.mutant_folder
 				AH.body_icon_state = src.icon_state
+				AH.e_icon = src.eye_icon
+				AH.e_state = src.eye_state
+				AH.e_offset_y = src.eye_offset ? src.eye_offset : src.head_offset
 				AH.mob_detail_1 = detail_1
 				AH.mob_detail_2 = detail_2
 				AH.mob_detail_3 = detail_3
@@ -1211,12 +1218,12 @@
 	mutant_folder = 'icons/mob/monkey.dmi'
 	icon_state = "monkey"
 	head_offset = -9
+	eye_offset = -8 // jeepers creepers their peepers are a pixel higher than human peepers
 	hand_offset = -5
 	body_offset = -7
 	human_compatible = TRUE
 	special_head = HEAD_MONKEY
 	special_head_state = "monkey"
-	//	uses_human_clothes = 0 // Guess they can keep that ability for now (Convair880).
 	exclusive_language = 1
 	voice_message = "chimpers"
 	voice_name = "monkey"

--- a/code/mob/dead/observer.dm
+++ b/code/mob/dead/observer.dm
@@ -296,9 +296,7 @@
 		O.bioHolder.CopyOther(src.bioHolder, copyActiveEffects = 0)
 		if (isghostrestrictedz(O.z) && !restricted_z_allowed(O, get_turf(O)) && !(src.client && src.client.holder))
 			O.set_loc(pick_landmark(LANDMARK_OBSERVER, locate(150, 150, 1)))
-		if (client)
-			client.color = null  //needed for mesons dont kill me thx - ZeWaka
-			O.apply_looks_of(client)
+		if (client) client.color = null  //needed for mesons dont kill me thx - ZeWaka
 		if (src.client && src.client.holder && src.stat !=2)
 			// genuinely not sure what this is here for since we're setting the
 			// alive/dead status of the *ghost*.

--- a/code/mob/living/carbon/human/procs/get_desc.dm
+++ b/code/mob/living/carbon/human/procs/get_desc.dm
@@ -174,7 +174,7 @@
 			//tailstuff
 			if (src.organHolder.tail) // Has a tail?
 				// Comment if their tail deviates from the norm. And that tail isnt some wierd bone thing.
-				if (!istype(src.organHolder.tail, /obj/item/organ/tail/bone) && (!(src.mob_flags & SHOULD_HAVE_A_TAIL) || (src.mutantrace && istype(src.organHolder.tail, src.mutantrace?.mutant_organs["tail"]))))
+				if ((src.organHolder.tail && !(src.mob_flags & SHOULD_HAVE_A_TAIL)) || (src.organHolder.tail?.donor != src) || istype(src.organHolder.tail, /obj/item/organ/tail/bone))
 					if (!src.organHolder.butt) // no butt?
 						. += "<br><span class='notice'>[src.name] has [src.organHolder.tail.name] attached just above the spot where [t_his] butt should be.</span>"
 					else

--- a/code/mob/living/carbon/human/procs/get_desc.dm
+++ b/code/mob/living/carbon/human/procs/get_desc.dm
@@ -174,7 +174,7 @@
 			//tailstuff
 			if (src.organHolder.tail) // Has a tail?
 				// Comment if their tail deviates from the norm. And that tail isnt some wierd bone thing.
-				if ((src.organHolder.tail && !(src.mob_flags & SHOULD_HAVE_A_TAIL)) || (src.organHolder.tail?.donor != src) || istype(src.organHolder.tail, /obj/item/organ/tail/bone))
+				if ((src.organHolder.tail && !(src.mob_flags & SHOULD_HAVE_A_TAIL)) || ((src.organHolder.tail?.donor_original != src) && !istype(src.organHolder.tail, /obj/item/organ/tail/bone)))
 					if (!src.organHolder.butt) // no butt?
 						. += "<br><span class='notice'>[src.name] has [src.organHolder.tail.name] attached just above the spot where [t_his] butt should be.</span>"
 					else

--- a/code/mob/living/carbon/human/procs/get_desc.dm
+++ b/code/mob/living/carbon/human/procs/get_desc.dm
@@ -174,7 +174,7 @@
 			//tailstuff
 			if (src.organHolder.tail) // Has a tail?
 				// Comment if their tail deviates from the norm. And that tail isnt some wierd bone thing.
-				if ((src.organHolder.tail && !(src.mob_flags & SHOULD_HAVE_A_TAIL)) || ((src.organHolder.tail?.donor_original != src) && !istype(src.organHolder.tail, /obj/item/organ/tail/bone)))
+				if (src.organHolder.tail && !istype(src.organHolder.tail, /obj/item/organ/tail/bone) && (!(src.mob_flags & SHOULD_HAVE_A_TAIL) || src.organHolder.tail?.donor_original != src))
 					if (!src.organHolder.butt) // no butt?
 						. += "<br><span class='notice'>[src.name] has [src.organHolder.tail.name] attached just above the spot where [t_his] butt should be.</span>"
 					else

--- a/code/mob/living/carbon/human/procs/update_icon.dm
+++ b/code/mob/living/carbon/human/procs/update_icon.dm
@@ -649,7 +649,6 @@
 	if (!src.bioHolder)
 		return // fuck u
 
-	var/datum/appearanceHolder/aH = src.bioHolder.mobAppearance
 	src.hair_standing = SafeGetOverlayImage("hair", 'icons/mob/human_hair.dmi', "none", MOB_HAIR_LAYER2) // image('icons/mob/human.dmi', "blank", MOB_LIMB_LAYER)
 	src.hair_standing.overlays.len = 0
 
@@ -663,15 +662,17 @@
 
 		src.image_cust_one = my_head.head_image_cust_one
 		src.cust_one_state = my_head.head_image_cust_one?.icon_state
-		src.hair_standing.overlays += image_cust_one
 
 		src.image_cust_two = my_head.head_image_cust_two
 		src.cust_two_state = my_head.head_image_cust_two?.icon_state
-		src.hair_standing.overlays += image_cust_two
 
 		src.image_cust_three = my_head.head_image_cust_three
 		src.cust_three_state = my_head.head_image_cust_three?.icon_state
-		src.hair_standing.overlays += image_cust_three
+
+		if(!seal_hair)
+			src.hair_standing.overlays += image_cust_one
+			src.hair_standing.overlays += image_cust_two
+			src.hair_standing.overlays += image_cust_three
 
 		UpdateOverlays(hair_standing, "hair", 1, 1)
 

--- a/code/mob/living/carbon/human/procs/update_icon.dm
+++ b/code/mob/living/carbon/human/procs/update_icon.dm
@@ -649,6 +649,7 @@
 	if (!src.bioHolder)
 		return // fuck u
 
+	var/datum/appearanceHolder/aH = src.bioHolder.mobAppearance
 	src.hair_standing = SafeGetOverlayImage("hair", 'icons/mob/human_hair.dmi', "none", MOB_HAIR_LAYER2) // image('icons/mob/human.dmi', "blank", MOB_LIMB_LAYER)
 	src.hair_standing.overlays.len = 0
 
@@ -657,18 +658,20 @@
 	if (src?.organHolder?.head)
 		my_head = src.organHolder.head
 
-		image_eyes = my_head.head_image_eyes
+		src.image_eyes = my_head.head_image_eyes
 		src.hair_standing.overlays += image_eyes
 
-		if (!seal_hair)
-			image_cust_one = my_head.head_image_cust_one
-			src.hair_standing.overlays += image_cust_one
+		src.image_cust_one = my_head.head_image_cust_one
+		src.cust_one_state = my_head.head_image_cust_one?.icon_state
+		src.hair_standing.overlays += image_cust_one
 
-			image_cust_two = my_head.head_image_cust_two
-			src.hair_standing.overlays += image_cust_two
+		src.image_cust_two = my_head.head_image_cust_two
+		src.cust_two_state = my_head.head_image_cust_two?.icon_state
+		src.hair_standing.overlays += image_cust_two
 
-			image_cust_three = my_head.head_image_cust_three
-			src.hair_standing.overlays += image_cust_three
+		src.image_cust_three = my_head.head_image_cust_three
+		src.cust_three_state = my_head.head_image_cust_three?.icon_state
+		src.hair_standing.overlays += image_cust_three
 
 		UpdateOverlays(hair_standing, "hair", 1, 1)
 

--- a/code/modules/medical/genetics/bioHolder.dm
+++ b/code/modules/medical/genetics/bioHolder.dm
@@ -52,18 +52,23 @@ var/list/datum/bioEffect/mutini_effects = list()
 	var/customization_first = "Trimmed"
 	/// The hair style / detail thing that was set by the player in their settings
 	var/customization_first_original = "None"
+	/// The Y offset to display this image
+	var/customization_first_offset_y = 0
 
 	var/customization_second_color_carry = "#101010" // This way, they can return to their orignal colors
 	var/customization_second_color = "#101010"
 	var/customization_second_color_original = "#101010"
 	var/customization_second = "None"
 	var/customization_second_original = "None"
+	var/customization_second_offset_y = 0
+
 
 	var/customization_third_color_carry = "#101010"
 	var/customization_third_color = "#101010"
 	var/customization_third_color_original = "#101010"
 	var/customization_third = "None"
 	var/customization_third_original = "None"
+	var/customization_third_offset_y = 0
 
 	/// An image to be overlaid on the mob just above their skin
 	var/mob_detail_1
@@ -87,6 +92,12 @@ var/list/datum/bioEffect/mutini_effects = list()
 
 	var/e_color = "#101010"
 	var/e_color_original = "#101010"
+	/// Eye icon
+	var/e_icon = 'icons/mob/human_hair.dmi'
+	/// Eye icon state
+	var/e_state = "eyes"
+	/// How far up or down to move the eyes
+	var/e_offset_y = 0
 
 	var/s_tone_original = "#FFCC99"
 	var/s_tone = "#FFCC99"
@@ -158,16 +169,19 @@ var/list/datum/bioEffect/mutini_effects = list()
 		customization_first_color_original = toCopy.customization_first_color_original
 		customization_first_color = toCopy.customization_first_color
 		customization_first = toCopy.customization_first
+		customization_first_offset_y = toCopy.customization_first_offset_y
 		customization_first_original = toCopy.customization_first_original
 
 		customization_second_color_original = toCopy.customization_second_color_original
 		customization_second_color = toCopy.customization_second_color
 		customization_second = toCopy.customization_second
+		customization_second_offset_y = toCopy.customization_second_offset_y
 		customization_second_original = toCopy.customization_second_original
 
 		customization_third_color_original = toCopy.customization_third_color_original
 		customization_third_color = toCopy.customization_third_color
 		customization_third = toCopy.customization_third
+		customization_third_offset_y = toCopy.customization_third_offset_y
 		customization_third_original = toCopy.customization_third_original
 
 		mob_detail_1 = toCopy.mob_detail_1
@@ -180,9 +194,10 @@ var/list/datum/bioEffect/mutini_effects = list()
 
 		mutant_race = toCopy.mutant_race
 
-		mob_color_flags = toCopy.mob_color_flags
-
 		e_color = toCopy.e_color
+		e_icon = toCopy.e_icon
+		e_state = toCopy.e_state
+		e_offset_y = toCopy.e_offset_y
 		e_color_original = toCopy.e_color_original
 
 		s_tone = toCopy.s_tone

--- a/code/obj/item/mob_parts/human_parts.dm
+++ b/code/obj/item/mob_parts/human_parts.dm
@@ -1310,17 +1310,12 @@ obj/item/parts/human_parts/arm/right/reliquary
 	slot = "l_arm"
 	side = "left"
 	handlistPart = "hand_left"
-	decomp_affected = 0
 	skintoned = 0
 
 	New(var/atom/holder)
 		if (holder != null)
 			set_loc(holder)
 		..()
-
-	getMobIcon(var/lying, var/decomp_stage = 0)
-		src.standImage = image(src.partIcon, "[src.slot]")
-		return standImage
 
 /obj/item/parts/human_parts/leg/mutant
 	name = "left mutant leg!"
@@ -1338,10 +1333,6 @@ obj/item/parts/human_parts/arm/right/reliquary
 		if (holder != null)
 			set_loc(holder)
 		..()
-
-	getMobIcon(var/lying, var/decomp_stage = 0)
-		src.standImage = image(src.partIcon, "[src.slot]")
-		return standImage
 
 //// COW LIMBS ////
 ///// PARENT  /////

--- a/code/obj/item/organ_holder.dm
+++ b/code/obj/item/organ_holder.dm
@@ -174,6 +174,11 @@
 			if ("right_kidney")
 				if (!get_working_kidney_amt())
 					donor.take_toxin_damage(2, 1)
+			if ("tail")
+				if(ischangeling(donor) || src.donor?.reagents?.get_reagent_amount("ethanol") > 50) // drunkenness prevents tail-clumsiness
+					return
+				if (donor.mob_flags & SHOULD_HAVE_A_TAIL) // Only become clumsy if you should have a tail and are not a shapeshifting alien
+					donor.bioHolder?.AddEffect("clumsy", 0, 0, 0, 1)
 			//Missing lungs is handled in it's own proc right now. I'll probably move it here eventually, but that's how I did it originally before I thought of a thing for handling missing organs in the organholder and I'm not rewriting such a tedious thing now.
 
 

--- a/code/obj/item/organs/head.dm
+++ b/code/obj/item/organs/head.dm
@@ -158,7 +158,7 @@
 		// The rest of this shit gets sent to update_face
 		//get and install eyes, if any.
 		if (AHead.mob_appearance_flags & HAS_HUMAN_EYES)
-			src.head_image_eyes = image('icons/mob/human_hair.dmi', "eyes", layer = MOB_FACE_LAYER)
+			src.head_image_eyes = image(AHead.e_icon, AHead.e_state, pixel_y = AHead.e_offset_y, layer = MOB_FACE_LAYER)
 		else if (AHead.mob_appearance_flags & HAS_NO_EYES)
 			src.head_image_eyes = image('icons/mob/human_hair.dmi', "none", layer = MOB_FACE_LAYER)
 		src.head_image_eyes.color = AHead.e_color
@@ -171,9 +171,9 @@
 				our_hair_icon = AHead.customization_icon_special
 			else if (AHead.mob_appearance_flags & HAS_BODYDETAIL_HAIR) // or hair that isnt really hair but applied the same way
 				our_hair_icon = AHead.head_icon
-			src.head_image_cust_one = image(icon = our_hair_icon, layer = MOB_HAIR_LAYER2)
-			src.head_image_cust_two = image(icon = our_hair_icon, layer = MOB_HAIR_LAYER2)
-			src.head_image_cust_three = image(icon = our_hair_icon, layer = MOB_HAIR_LAYER2)
+			src.head_image_cust_one = image(icon = our_hair_icon, pixel_y = AHead.customization_first_offset_y, layer = MOB_HAIR_LAYER2)
+			src.head_image_cust_two = image(icon = our_hair_icon, pixel_y = AHead.customization_second_offset_y, layer = MOB_HAIR_LAYER2)
+			src.head_image_cust_three = image(icon = our_hair_icon, pixel_y = AHead.customization_third_offset_y, layer = MOB_HAIR_LAYER2)
 
 			// Set up the hair state
 			var/list/hair_list = customization_styles + customization_styles_gimmick

--- a/code/obj/item/organs/organ_parent.dm
+++ b/code/obj/item/organs/organ_parent.dm
@@ -25,6 +25,8 @@
 	module_research = list("medicine" = 2) // why would you put this below the throw_impact() stuff
 	module_research_type = /obj/item/organ // were you born in a fuckin barn
 	var/mob/living/carbon/human/donor = null // if I can't use "owner" I can at least use this
+	/// Whoever had this organ first, the original owner
+	var/mob/living/carbon/human/donor_original = null // So people'll know if a lizard's wearing someone else's tail
 	var/datum/appearanceHolder/donor_AH //
 	var/donor_name = null // so you don't get dumb "Unknown's skull mask" shit
 	var/donor_DNA = null
@@ -103,6 +105,7 @@
 			src.holder = nholder
 			src.donor = nholder.donor
 		if (src.donor)
+			src.donor_original = src.donor
 			if (src.donor.bioHolder)
 				src.donor_AH = src.donor.bioHolder.mobAppearance
 			if (src.donor.real_name)
@@ -152,7 +155,7 @@
 			return 0
 		return 1
 
-	//What should happen each life tick when an organ is broken.
+	/// What should happen each life tick when an organ is broken.
 	proc/on_broken(var/mult = 1)
 		//stupid check ikr? prolly remove.
 		if (broken)
@@ -174,6 +177,8 @@
 		var/mob/living/carbon/human/H = M
 		src.donor = H
 		src.holder = H.organHolder
+		if(!istype(src.donor_original)) // If we were spawned without an owner, they're our new original owner
+			src.donor_original = H
 
 
 		//Kinda repeated below too. Cure the organ failure disease if this organ is above a certain HP

--- a/code/obj/item/organs/tail.dm
+++ b/code/obj/item/organs/tail.dm
@@ -1,7 +1,7 @@
-// Severed tail images go in 'icons/obj/surgery.dmi'
-// on-mob tail images are defined by organ_image_icon
-// both severed and on-mob tail icon_states are defined by just icon_state
-// try to keep the names the same, or everything breaks
+/// Severed tail images go in 'icons/obj/surgery.dmi'
+/// on-mob tail images are defined by organ_image_icon
+/// both severed and on-mob tail icon_states are defined by just icon_state
+/// try to keep the names the same, or everything breaks
 /obj/item/organ/tail
 	name = "tail"
 	organ_name = "tail"
@@ -34,16 +34,17 @@
 			update_tail_icon()
 
 	proc/colorize_tail(var/datum/appearanceHolder/AHL)
-		if (AHL && istype(AHL, /datum/appearanceHolder))
-			src.organ_color_1 = AHL.customization_first_color
-			src.organ_color_2 = AHL.customization_second_color
-			src.donor_AH = AHL
-		else if (src.donor && ishuman(src.donor))	// Get the colors here so they dont change later, ie reattached on someone else
-			src.organ_color_1 = fix_colors(src.donor_AH.customization_first_color)
-			src.organ_color_2 = fix_colors(src.donor_AH.customization_second_color)
-		else	// Just throw some colors in there or something
-			src.organ_color_1 = rgb(rand(50,190), rand(50,190), rand(50,190))
-			src.organ_color_2 = rgb(rand(50,190), rand(50,190), rand(50,190))
+		if(src.colorful)
+			if (AHL && istype(AHL, /datum/appearanceHolder))
+				src.organ_color_1 = AHL.customization_first_color
+				src.organ_color_2 = AHL.customization_second_color
+				src.donor_AH = AHL
+			else if (src.donor && ishuman(src.donor))	// Get the colors here so they dont change later, ie reattached on someone else
+				src.organ_color_1 = fix_colors(src.donor_AH.customization_first_color)
+				src.organ_color_2 = fix_colors(src.donor_AH.customization_second_color)
+			else	// Just throw some colors in there or something
+				src.organ_color_1 = rgb(rand(50,190), rand(50,190), rand(50,190))
+				src.organ_color_2 = rgb(rand(50,190), rand(50,190), rand(50,190))
 		build_mob_tail_image()
 		update_tail_icon()
 
@@ -102,22 +103,30 @@
 			return 1
 
 		return 0
-
+	// Tail-loss clumsy-giving is handled in organ_holder's handle_missing
 	on_life(var/mult = 1)
 		if (!..())
 			return 0
-		if (src.get_damage() >= FAIL_DAMAGE && src.donor?.mob_flags & SHOULD_HAVE_A_TAIL && !ischangeling(src.donor)) // Humans dont need tails to not be clumsy idiots
-			donor.bioHolder.AddEffect(src.failure_ability, 0, 0, 0, 1)
+		if (src.get_damage() >= FAIL_DAMAGE && probmult(src.get_damage() * 0.2))
+			src.breakme()
 		return 1
 
-	on_removal()
-		if (src.failure_ability && src.donor?.mob_flags & SHOULD_HAVE_A_TAIL && !ischangeling(src.donor))
-			src.donor.bioHolder.AddEffect(src.failure_ability, 0, 0, 0, 1)
-
 	on_broken(var/mult = 1)
-		if(probmult(2) && src.donor.mutantrace && src.failure_ability && src.donor?.mob_flags & SHOULD_HAVE_A_TAIL && !ischangeling(src.donor))
-			src.donor.change_misstep_chance(10)
-			src.donor.bioHolder.AddEffect(failure_ability)
+		if(src.get_damage() < FAIL_DAMAGE)
+			src.unbreakme()
+		if(ischangeling(src.holder.donor))
+			return
+		else if(src.failure_ability && src.holder?.donor?.mob_flags & SHOULD_HAVE_A_TAIL)
+			if(src.holder?.donor?.reagents?.get_reagent_amount("ethanol") > 50) // Drunkenness counteracts un-tailedness
+				src.holder?.donor?.bioHolder?.RemoveEffect(src.failure_ability)
+			else
+				src.holder?.donor?.change_misstep_chance(10)
+				src.holder?.donor?.bioHolder?.AddEffect(src.failure_ability, 0, 0, 0, 1)
+
+	unbreakme()
+		. = ..()
+		src.holder?.donor?.bioHolder?.RemoveEffect(src.failure_ability)
+
 
 	// builds the mob tail image, the one that gets displayed on the mob when attached
 	proc/build_mob_tail_image() // lets mash em all into one image with overlays n shit, like the head, but on the ass

--- a/code/procs/scanprocs.dm
+++ b/code/procs/scanprocs.dm
@@ -1,4 +1,5 @@
 
+
 /proc/scan_health(var/mob/M as mob, var/verbose_reagent_info = 0, var/disease_detection = 1, var/organ_scan = 0, var/visible = 0)
 	if (!M)
 		return "<span class='alert'>ERROR: NO SUBJECT DETECTED</span>"
@@ -161,7 +162,8 @@
 				organ_data1 += organ_health_scan("spleen", H, obfuscate)
 				organ_data1 += organ_health_scan("pancreas", H, obfuscate)
 				organ_data1 += organ_health_scan("appendix", H, obfuscate)
-				organ_data1 += organ_health_scan("tail", H, obfuscate)
+				if(H.organHolder.tail || H.mob_flags & SHOULD_HAVE_A_TAIL)
+					organ_data1 += organ_health_scan("tail", H, obfuscate)
 
 				//Don't give organ readings for Vamps.
 				if (organ_data1 && !isvampire(H))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUGFIX] [FEATURE] [BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #2855 
Also makes the player's description not mention their tail if their tail is the one they spawned with, so it'll only tell you if someone has someone else's tail, or if they have a tail but shouldn't have one. And its not a tailbone.

Ghosts now have the hair they should have. Except for mutants without hair.
Also fixes #2869

Also fixes #2864 turns out I didnt need a new get-mob-image override after all!


Changed how tails apply and remove their clumsiness. Now, the missing tail stuff is handled whenever the life-tick checks for a missing body part. It also breaks and unbreaks itself based on damage, and the broken tail stuff is handled through on_break and unbreakme().

Tail-loss clumsiness is removed and prevented while the mutant has more than 50 units of ethanol in them, so it isn't nearly as impossible to replace your own tail.

Fixed monkey eyes being in the wrong spot. Also added a var to mutant races and appearance holders to offset the eyes' y position, and potentially define their eyes as a different icon and icon_state, though the last bit isn't actually used anywhere yet.

Added a var to organ_parent to keep track of the organ's original owner. Doesn't do much other than let the description thing determine if your equipped tail is your own. Yet.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Superlagg:
(+)Severe drunkenness now helps counteract the loss of coordination and abject helplessness from losing a tail!
```
