### PR TITLE
Spacemas Special: ephemeral xmas ornaments, Kondaru xmas'd

### DIFF
--- a/.github/MAP_GUIDELINES.md
+++ b/.github/MAP_GUIDELINES.md
@@ -38,3 +38,4 @@ If these features do not work in the current codebase then your map PR will be *
 - Cloning should follow the style of modern maps and be mostly public access.
 - Feel free to take inspiration from other maps, but please don't copy paste large parts of them.
 - If you use random item spawners, try using the types of them that create specific numbers of items. This way you don't risk accidentally overloading rooms with items because RNG decided it to be so.
+- Ephemeral spacemas ornaments (versions of the ornaments that disappear when it's not spacemas time). This prevents having to create or maintain a second version of the map.

--- a/code/modules/holiday/spacemas.dm
+++ b/code/modules/holiday/spacemas.dm
@@ -437,7 +437,7 @@ var/static/list/santa_snacks = list(/obj/item/reagent_containers/food/drinks/egg
 	anchored = 1
 	layer = NOLIGHT_EFFECTS_LAYER_BASE
 	pixel_x = -64
-	plane = PLANE_BLACKNESS + 1
+	plane = PLANE_DEFAULT + 2
 
 	density = 1
 	var/on_fire = 0
@@ -487,6 +487,13 @@ var/static/list/santa_snacks = list(/obj/item/reagent_containers/food/drinks/egg
 			src.UpdateOverlays(src.fire_image, "fire")
 		else
 			src.UpdateOverlays(null, "fire")
+
+	ephemeral //Disappears except on xmas
+#ifndef XMAS
+		New()
+			..()
+			qdel(src)
+#endif
 
 /obj/item/reagent_containers/food/snacks/snowball
 	name = "snowball"
@@ -571,6 +578,13 @@ var/static/list/santa_snacks = list(/obj/item/reagent_containers/food/drinks/egg
 	layer = 5
 	anchored = 1
 
+	ephemeral //Disappears except on xmas
+#ifndef XMAS
+		New()
+			qdel(src)
+			..()
+#endif
+
 /obj/decal/tinsel
 	name = "tinsel"
 	icon = 'icons/misc/xmas.dmi'
@@ -578,12 +592,26 @@ var/static/list/santa_snacks = list(/obj/item/reagent_containers/food/drinks/egg
 	layer = 5
 	anchored = 1
 
+	ephemeral //Disappears except on xmas
+#ifndef XMAS
+		New()
+			qdel(src)
+			..()
+#endif
+
 /obj/decal/wreath
 	name = "wreath"
 	icon = 'icons/misc/xmas.dmi'
 	icon_state = "wreath"
 	layer = 5
 	anchored = 1
+
+	ephemeral //Disappears except on xmas
+#ifndef XMAS
+		New()
+			qdel(src)
+			..()
+#endif
 
 /obj/decal/mistletoe
 	name = "mistletoe"
@@ -628,6 +656,15 @@ var/static/list/santa_snacks = list(/obj/item/reagent_containers/food/drinks/egg
 			return
 		pattern = clamp(pattern, 0, 4)
 		src.light_pattern(pattern)
+
+	ephemeral //Disappears except on xmas
+#ifndef XMAS
+		New()
+			qdel(src)
+			..()
+#endif
+
+
 
 // Grinch Stuff
 

--- a/code/modules/holiday/spacemas.dm
+++ b/code/modules/holiday/spacemas.dm
@@ -1257,6 +1257,13 @@ var/static/list/santa_snacks = list(/obj/item/reagent_containers/food/drinks/egg
 				user.visible_message("<span class='notice'><b>[user.name]</b> takes [gift] out of [src]!</span>", "<span class='notice'>You take [gift] out of [src]!</span>")
 		return
 
+	ephemeral //Disappears except on xmas
+#ifndef XMAS
+		New()
+			..()
+			qdel(src)
+#endif
+
 /obj/decal/tile_edge/stripe/xmas
 	icon_state = "xmas"
 

--- a/code/obj/item/gift.dm
+++ b/code/obj/item/gift.dm
@@ -148,6 +148,13 @@
 				src.giftpaths = generic_gift_paths + xmas_gift_paths
 			..()
 
+		ephemeral //Disappears except on xmas
+#ifndef XMAS
+			New()
+				qdel(src)
+				..()
+#endif
+
 	easter
 		name = "easter egg"
 		icon_state = "easter_egg"

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -55167,6 +55167,13 @@
 	},
 /turf/simulated/floor/darkblue,
 /area/station/turret_protected/ai)
+"ivS" = (
+/obj/decal/tile_edge/stripe,
+/obj/stocking/ephemeral{
+	pixel_x = 22
+	},
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/cafeteria)
 "iyd" = (
 /obj/lattice,
 /turf/space,
@@ -117162,7 +117169,7 @@ bac
 bac
 aYS
 beB
-bfJ
+ivS
 bgO
 bhX
 bji

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -1791,8 +1791,10 @@
 	pixel_x = -10;
 	tag = ""
 	},
-/obj/item/instrument/large/organ,
-/obj/item/screwdriver,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/obj/item/instrument/large/piano,
 /turf/simulated/floor/specialroom/chapel{
 	dir = 8
 	},
@@ -1818,6 +1820,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 8
 	},
@@ -1841,6 +1846,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/sanctuary)
@@ -1879,6 +1887,9 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
 	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
@@ -2099,8 +2110,7 @@
 	icon_state = "1-2"
 	},
 /obj/stool/chair/wooden{
-	dir = 1;
-	icon_state = "chair_wooden"
+	dir = 4
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
@@ -2809,6 +2819,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/item/a_gift/festive/ephemeral,
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
 	},
@@ -2908,10 +2919,11 @@
 /obj/storage/cart,
 /obj/item/instrument/vuvuzela,
 /obj/item/device/multitool,
-/obj/item/device/radio,
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/item/storage/box/mousetraps,
+/obj/item/device/radio,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "agZ" = (
@@ -3192,6 +3204,9 @@
 /area/station/security/checkpoint/podbay)
 "ahD" = (
 /obj/machinery/vending/snack,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/red/side{
 	dir = 8
 	},
@@ -3206,6 +3221,9 @@
 /area/station/hallway/primary/west)
 "ahF" = (
 /obj/machinery/vending/cola/red,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "ahG" = (
@@ -3586,6 +3604,7 @@
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/caution/corner/nw,
 /area/station/hangar/main)
 "aix" = (
@@ -3594,6 +3613,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple,
 /obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/caution/corner/ne,
 /area/station/hangar/main)
 "aiy" = (
@@ -4273,7 +4293,7 @@
 "akd" = (
 /obj/cable,
 /obj/machinery/power/apc/autoname_west,
-/obj/storage/closet/wardrobe/grey,
+/obj/item/instrument/large/organ,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "ake" = (
@@ -4282,7 +4302,6 @@
 /area/station/maintenance/northeast)
 "akf" = (
 /obj/table/auto,
-/obj/item/storage/box/mousetraps,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 8;
@@ -4291,12 +4310,20 @@
 	tag = ""
 	},
 /obj/item/device/light/glowstick,
-/obj/item/wrench,
+/obj/item/wrench{
+	pixel_y = 6
+	},
+/obj/item/screwdriver{
+	pixel_x = 5
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "akg" = (
 /obj/table/wood/auto,
 /obj/item/paper/book/critter_compendium,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/arcade/dungeon)
 "akh" = (
@@ -4319,11 +4346,17 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment/horizontal,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/arcade/dungeon)
 "akk" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/west,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/arcade/dungeon)
 "akl" = (
@@ -4811,6 +4844,7 @@
 /obj/machinery/secscanner{
 	pixel_y = 10
 	},
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/caution/corner/sw,
 /area/station/hangar/main)
 "alp" = (
@@ -4822,6 +4856,7 @@
 /obj/machinery/secscanner{
 	pixel_y = 10
 	},
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/caution/corner/se,
 /area/station/hangar/main)
 "alq" = (
@@ -5794,6 +5829,10 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
+	},
 /turf/simulated/floor/red/side{
 	dir = 8
 	},
@@ -6225,10 +6264,16 @@
 "aoJ" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/east,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/wood/two,
 /area/station/chapel/sanctuary)
 "aoK" = (
 /obj/disposalpipe/segment/horizontal,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/stairs/wide,
 /area/station/chapel/sanctuary)
 "aoL" = (
@@ -6239,6 +6284,9 @@
 /turf/simulated/floor/stairs/wide/middle,
 /area/station/chapel/sanctuary)
 "aoN" = (
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/stairs/wide/other,
 /area/station/chapel/sanctuary)
 "aoO" = (
@@ -6248,6 +6296,9 @@
 	dir = 4;
 	pixel_x = 26;
 	pixel_y = 1
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
 	},
 /turf/simulated/floor/wood/two,
 /area/station/chapel/sanctuary)
@@ -6366,6 +6417,9 @@
 /obj/item/clothing/suit/bedsheet/cape/red,
 /obj/item/clothing/suit/bedsheet/cape/blue,
 /obj/item/clothing/suit/bedsheet/cape/green,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/arcade/dungeon)
 "apa" = (
@@ -7064,6 +7118,7 @@
 	name = "Pod Bay"
 	},
 /obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/neutral,
 /area/station/hangar/main)
 "aqI" = (
@@ -7471,6 +7526,9 @@
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/black/side,
 /area/station/hallway/primary/west)
 "arH" = (
@@ -7745,6 +7803,7 @@
 	name = "Chiron's Grandhall"
 	},
 /obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/arcade/dungeon)
 "asm" = (
@@ -7756,6 +7815,7 @@
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/arcade/dungeon)
 "asn" = (
@@ -8209,6 +8269,9 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "atm" = (
@@ -8259,6 +8322,9 @@
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
 	pixel_y = -1
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
@@ -8313,6 +8379,9 @@
 /area/station/crew_quarters/fitness)
 "atw" = (
 /obj/reagent_dispensers/watertank/fountain,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "atx" = (
@@ -8446,6 +8515,10 @@
 /obj/disposalpipe/segment/brig{
 	dir = 4;
 	icon_state = "pipe-c"
+	},
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
@@ -8648,6 +8721,11 @@
 	},
 /obj/item/shinai_bag,
 /obj/item/storage/box/kendo_box/hakama,
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "auu" = (
@@ -8816,6 +8894,7 @@
 	},
 /obj/access_spawn/engineering_engine,
 /obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/yellow,
 /area/station/engine/core)
 "auN" = (
@@ -9123,6 +9202,9 @@
 /area/station/teleporter)
 "avG" = (
 /obj/shrub,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/purple/side{
 	dir = 8
 	},
@@ -9382,6 +9464,9 @@
 	},
 /obj/item/device/radio,
 /obj/item/clothing/ears/earmuffs,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -9390,6 +9475,9 @@
 /obj/table/auto,
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -9440,6 +9528,9 @@
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/elect)
@@ -9677,6 +9768,10 @@
 	},
 /area/station/teleporter)
 "awQ" = (
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
+	},
 /turf/simulated/floor/purple/side{
 	dir = 8
 	},
@@ -11899,6 +11994,10 @@
 	mail_tag = "mechanics";
 	name = "mechanics mail junction"
 	},
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
@@ -12049,6 +12148,10 @@
 "aBM" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/landmark/gps_waypoint,
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
+	},
 /turf/simulated/floor/wood/two,
 /area/station/security/detectives_office)
 "aBN" = (
@@ -14995,15 +15098,18 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/north)
 "aIE" = (
-/obj/disposalpipe/segment/mail/bent/north,
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
+/obj/xmastree/ephemeral,
+/turf/simulated/floor/specialroom/chapel{
+	dir = 8
+	},
+/area/station/chapel/sanctuary)
 "aIF" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
+/obj/item/a_gift/festive/ephemeral,
+/turf/simulated/floor/specialroom/chapel{
+	dir = 4
+	},
+/area/station/chapel/sanctuary)
 "aIG" = (
-/obj/disposalpipe/segment/mail/horizontal,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -15012,13 +15118,11 @@
 	},
 /area/station/hallway/primary/north)
 "aIH" = (
-/obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/neutral/side{
 	dir = 1
 	},
 /area/station/hallway/primary/north)
 "aII" = (
-/obj/disposalpipe/segment/mail/bent/south,
 /turf/simulated/floor/neutral/side{
 	dir = 5
 	},
@@ -15440,7 +15544,7 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "aJH" = (
-/obj/disposalpipe/segment/mail/vertical,
+/obj/disposalpipe/segment/mail/bent/south,
 /turf/simulated/floor/neutral/side{
 	dir = 4
 	},
@@ -15874,6 +15978,7 @@
 	icon_state = "2-4"
 	},
 /obj/access_spawn/engineering_power,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
 "aKD" = (
@@ -15952,9 +16057,11 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
+/obj/disposalpipe/segment/mail/bent/north,
 /turf/simulated/floor/neutral/side,
 /area/station/hallway/primary/north)
 "aKN" = (
+/obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/neutral/side,
 /area/station/hallway/primary/north)
 "aKO" = (
@@ -15964,9 +16071,11 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
+/obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/neutral/side,
 /area/station/hallway/primary/north)
 "aKP" = (
+/obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/neutral/corner{
 	dir = 8
 	},
@@ -15988,6 +16097,9 @@
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
 "aKS" = (
@@ -16005,6 +16117,9 @@
 	},
 /obj/landmark/start{
 	name = "Staff Assistant"
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
 	},
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
@@ -16035,6 +16150,9 @@
 	},
 /obj/table/round/auto,
 /obj/towelbin,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
 "aKY" = (
@@ -16909,6 +17027,10 @@
 /obj/disposalpipe/segment/mail/vertical,
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 4
@@ -18068,6 +18190,7 @@
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/neutral/side{
 	dir = 8
 	},
@@ -18080,6 +18203,7 @@
 /obj/machinery/door/airlock/pyro/glass,
 /obj/disposalpipe/segment/mail/vertical,
 /obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/neutral/side{
 	dir = 4
 	},
@@ -18604,6 +18728,9 @@
 "aQR" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/south,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/quarters_east)
 "aQS" = (
@@ -18671,14 +18798,23 @@
 	name = "Staff Assistant"
 	},
 /obj/machinery/light_switch/north,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/carpet/purple/fancy/edge/ne,
 /area/station/crew_quarters/quarters_east)
 "aQY" = (
 /obj/machinery/vending/coffee,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/quarters_east)
 "aQZ" = (
 /obj/machinery/vending/snack,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/quarters_east)
 "aRa" = (
@@ -18805,6 +18941,10 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
+	},
 /turf/simulated/floor/escape{
 	dir = 8
 	},
@@ -18854,6 +18994,9 @@
 	icon_state = "0-2"
 	},
 /obj/cable,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/plating,
 /area/station/engine/elect)
 "aRr" = (
@@ -19061,6 +19204,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
 	},
 /turf/simulated/floor/blue/side{
 	dir = 8
@@ -19423,6 +19570,7 @@
 /area/station/security/checkpoint/escape)
 "aSu" = (
 /obj/machinery/door/airlock/pyro/glass,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/escape{
 	dir = 8
 	},
@@ -19904,6 +20052,10 @@
 	tag = ""
 	},
 /obj/landmark/gps_waypoint,
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
+	},
 /turf/simulated/floor/stairs{
 	dir = 4
 	},
@@ -20297,6 +20449,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/decal/garland/ephemeral,
 /turf/unsimulated/floor/circuit/vintage,
 /area/station/crewquarters/cryotron)
 "aUB" = (
@@ -20326,6 +20479,7 @@
 	name = "Pool"
 	},
 /obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
 "aUG" = (
@@ -20345,6 +20499,7 @@
 	name = "North Crew Quarters"
 	},
 /obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/neutral/side{
 	dir = 8
 	},
@@ -20363,6 +20518,7 @@
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/neutral/side{
 	dir = 4
 	},
@@ -20383,6 +20539,10 @@
 /turf/simulated/floor/neutral/corner,
 /area/station/hallway/primary/east)
 "aUO" = (
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
+	},
 /turf/simulated/floor/escape/corner{
 	dir = 4
 	},
@@ -20706,13 +20866,11 @@
 /area/station/engine/elect)
 "aVz" = (
 /obj/machinery/manufacturer/uniform,
-/obj/item/device/radio/intercom{
-	pixel_y = 28
-	},
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 20
 	},
+/obj/item/device/radio/intercom,
 /turf/unsimulated/floor/sanitary,
 /area/station/crewquarters/cryotron)
 "aVA" = (
@@ -20853,6 +21011,10 @@
 	tag = ""
 	},
 /obj/machinery/light_switch/north,
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aVL" = (
@@ -20874,6 +21036,9 @@
 	},
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
 	},
 /turf/simulated/floor/neutral/corner{
 	dir = 4
@@ -20994,6 +21159,10 @@
 "aVW" = (
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 8
@@ -21292,6 +21461,10 @@
 	mail_tag = "pathology";
 	name = "pathology mail junction"
 	},
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
+	},
 /turf/simulated/floor/blue/side{
 	dir = 8
 	},
@@ -21428,6 +21601,10 @@
 "aWQ" = (
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
 	},
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/east)
@@ -21850,6 +22027,10 @@
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/east)
 "aXT" = (
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
+	},
 /turf/simulated/floor/neutral/side{
 	dir = 8
 	},
@@ -21957,6 +22138,7 @@
 "aYj" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/escape{
 	dir = 8
 	},
@@ -21966,6 +22148,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/glass,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/escape{
 	dir = 4
 	},
@@ -22241,6 +22424,7 @@
 	name = "Cafeteria"
 	},
 /obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "aYP" = (
@@ -22249,6 +22433,7 @@
 	name = "Cafeteria"
 	},
 /obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "aYQ" = (
@@ -22268,6 +22453,7 @@
 	name = "The Snip"
 	},
 /obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/barber_shop)
 "aYU" = (
@@ -22294,6 +22480,7 @@
 	name = "South Crew Quarters"
 	},
 /obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/neutral/side{
 	dir = 8
 	},
@@ -22313,6 +22500,7 @@
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/neutral/side{
 	dir = 4
 	},
@@ -22723,6 +22911,9 @@
 /obj/table/auto,
 /obj/random_item_spawner/tableware,
 /obj/item/device/radio/intercom/catering,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "aZT" = (
@@ -22802,6 +22993,9 @@
 	dir = 4;
 	pixel_x = 26;
 	pixel_y = 1
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/west,
 /area/station/crew_quarters/barber_shop)
@@ -23322,6 +23516,10 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
+	},
 /turf/simulated/floor/neutral/side{
 	dir = 8
 	},
@@ -23345,6 +23543,10 @@
 	},
 /obj/cable{
 	icon_state = "1-8"
+	},
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 4
@@ -23377,6 +23579,10 @@
 	},
 /area/station/hallway/primary/east)
 "bbA" = (
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
+	},
 /turf/simulated/floor/escape/corner,
 /area/station/hallway/primary/east)
 "bbB" = (
@@ -24032,6 +24238,7 @@
 "bdg" = (
 /obj/wingrille_spawn/auto,
 /obj/cable,
+/obj/decal/wreath/ephemeral,
 /turf/simulated/floor/plating,
 /area/station/engine/elect)
 "bdh" = (
@@ -24636,6 +24843,7 @@
 /obj/access_spawn/bar,
 /obj/firedoor_spawn,
 /obj/access_spawn/kitchen,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
 "bex" = (
@@ -25190,6 +25398,10 @@
 "bfU" = (
 /obj/decal/tile_edge/line/green{
 	icon_state = "line1"
+	},
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 8
@@ -25822,6 +26034,10 @@
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
+	},
 /turf/simulated/floor/carpet/blue/fancy/edge/nw,
 /area/station/medical/medbay/lobby)
 "bhv" = (
@@ -25863,6 +26079,10 @@
 /obj/disposalpipe/switch_junction/right/north{
 	mail_tag = "medbay";
 	name = "medbay mail junction"
+	},
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
 	},
 /turf/simulated/floor/blue/side{
 	dir = 8
@@ -26408,6 +26628,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
+	},
 /turf/simulated/floor/carpet/blue/fancy/edge/sw,
 /area/station/medical/medbay/lobby)
 "biE" = (
@@ -26446,6 +26670,10 @@
 /obj/disposalpipe/switch_junction/right/north{
 	mail_tag = "robotics";
 	name = "robotics mail junction"
+	},
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
 	},
 /turf/simulated/floor/blue/side{
 	dir = 8
@@ -26732,6 +26960,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/data_terminal,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "bjo" = (
@@ -26861,6 +27092,7 @@
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/escape{
 	dir = 4
 	},
@@ -27554,6 +27786,7 @@
 /obj/disposalpipe/segment/morgue,
 /obj/access_spawn/medical,
 /obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/darkblue,
 /area/station/medical/medbay/lobby)
 "bld" = (
@@ -27627,6 +27860,9 @@
 /obj/item/storage/toolbox/emergency,
 /obj/item/paper/book/materials,
 /obj/item/device/matanalyzer,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
@@ -27649,6 +27885,9 @@
 /obj/machinery/cell_charger,
 /obj/item/cell/supercell/charged,
 /obj/item/cell/supercell/charged,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
@@ -27793,6 +28032,10 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
@@ -30472,6 +30715,7 @@
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "bsi" = (
@@ -31625,6 +31869,7 @@
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/stairs/dark{
 	dir = 1
 	},
@@ -31954,6 +32199,7 @@
 	},
 /obj/access_spawn/hydro,
 /obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/grey,
 /area/station/hydroponics/bay)
 "bvQ" = (
@@ -32150,6 +32396,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple,
 /obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/grey,
 /area/station/bridge)
 "bwh" = (
@@ -32426,6 +32673,9 @@
 /area/station/mining/refinery)
 "bwR" = (
 /obj/machinery/dispenser,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 9
 	},
@@ -32442,6 +32692,9 @@
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 5
@@ -32626,6 +32879,10 @@
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
 	},
 /turf/simulated/floor/blue/side{
 	dir = 8
@@ -34476,6 +34733,7 @@
 	},
 /obj/disposalpipe/segment/brig,
 /obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor,
 /area/station/security/checkpoint/sec_foyer{
 	name = "Secure Release Foyer"
@@ -34486,11 +34744,13 @@
 	},
 /obj/access_spawn/hydro,
 /obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
 "bBs" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/vertical,
+/obj/decal/wreath/ephemeral,
 /turf/simulated/floor/plating,
 /area/station/hydroponics/bay)
 "bBt" = (
@@ -34565,6 +34825,10 @@
 "bBD" = (
 /obj/disposalpipe/trunk/mail/south,
 /obj/machinery/disposal/mail/autoname/bridge,
+/obj/machinery/light/emergency{
+	dir = 8;
+	pixel_x = -10
+	},
 /turf/simulated/floor/grey,
 /area/station/bridge)
 "bBE" = (
@@ -34713,6 +34977,9 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/grey/side{
 	dir = 8
 	},
@@ -34796,6 +35063,9 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
 "bBY" = (
@@ -34815,6 +35085,9 @@
 /area/station/science/chemistry)
 "bCa" = (
 /obj/machinery/chem_heater,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/purpleblack/corner,
 /area/station/science/chemistry)
 "bCb" = (
@@ -34881,6 +35154,9 @@
 /area/station/science/chemistry)
 "bCh" = (
 /obj/machinery/chem_dispenser,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/purpleblack,
 /area/station/science/chemistry)
 "bCi" = (
@@ -34922,6 +35198,7 @@
 	},
 /obj/disposalpipe/segment/vertical,
 /obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/grey,
 /area/station/mining/refinery)
 "bCo" = (
@@ -35096,12 +35373,18 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
 /area/station/hallway/primary/south)
 "bCE" = (
 /obj/disposalpipe/segment/bent/east,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
@@ -35457,6 +35740,9 @@
 "bDt" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
 	},
 /turf/simulated/floor/orangeblack/corner{
 	dir = 4
@@ -36023,15 +36309,12 @@
 "bEH" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable,
+/obj/decal/wreath/ephemeral,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "bEI" = (
 /obj/shrub,
 /obj/machinery/light,
-/obj/machinery/light/emergency{
-	dir = 8;
-	pixel_x = -10
-	},
 /turf/simulated/floor/grey,
 /area/station/bridge)
 "bEJ" = (
@@ -36364,6 +36647,10 @@
 "bFp" = (
 /obj/machinery/light,
 /obj/disposalpipe/segment/mail/horizontal,
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bFq" = (
@@ -36573,11 +36860,13 @@
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
 "bFQ" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/disposalpipe/segment/vertical,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
 "bFR" = (
@@ -36593,6 +36882,7 @@
 /obj/machinery/secscanner{
 	pixel_y = 10
 	},
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "bFT" = (
@@ -36729,6 +37019,9 @@
 	dir = 4;
 	pixel_x = 10
 	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/neutral/side{
 	dir = 4
 	},
@@ -36768,6 +37061,7 @@
 /obj/machinery/door/airlock/pyro/glass,
 /obj/disposalpipe/segment/mail/vertical,
 /obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/purple/side{
 	dir = 8
 	},
@@ -36780,6 +37074,7 @@
 "bGp" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor,
 /area/station/hallway/secondary/south)
 "bGq" = (
@@ -36791,11 +37086,13 @@
 /area/station/storage/warehouse)
 "bGs" = (
 /obj/machinery/door/airlock/pyro/glass,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor,
 /area/station/storage/warehouse)
 "bGt" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/disposalpipe/segment/mail/vertical,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/orangeblack,
 /area/station/storage/warehouse)
 "bGu" = (
@@ -36909,6 +37206,9 @@
 /area/station/security/brig)
 "bGG" = (
 /obj/stool,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bGH" = (
@@ -36917,23 +37217,35 @@
 	pixel_y = 8
 	},
 /obj/disposalpipe/segment/vertical,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bGI" = (
 /obj/table/reinforced/auto,
 /obj/item/game_kit,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bGJ" = (
 /obj/table/reinforced/auto,
 /obj/item/card_box/suit,
 /obj/disposalpipe/junction/middle/east,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bGK" = (
 /obj/table/reinforced/auto,
 /obj/disposaloutlet/west,
 /obj/disposalpipe/trunk/west,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bGL" = (
@@ -36948,6 +37260,9 @@
 	tag = ""
 	},
 /obj/disposalpipe/segment/bent/east,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/courtroom)
 "bGM" = (
@@ -36958,6 +37273,9 @@
 /area/station/crew_quarters/courtroom)
 "bGN" = (
 /obj/disposalpipe/segment/horizontal,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/stairs/wood/wide{
 	dir = 9
 	},
@@ -36986,6 +37304,9 @@
 "bGR" = (
 /obj/table/reinforced/auto,
 /obj/item/paper_bin,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/carpet/green/fancy/edge/ne,
 /area/station/crew_quarters/courtroom)
 "bGS" = (
@@ -37008,6 +37329,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/black/side{
 	dir = 4
 	},
@@ -37037,6 +37361,9 @@
 /obj/submachine/poster_creator,
 /obj/item/device/radio/intercom/security,
 /obj/machinery/light_switch/east,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/black/side{
 	dir = 8
 	},
@@ -37293,6 +37620,9 @@
 	pixel_x = -10;
 	tag = ""
 	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/purple/side{
 	dir = 9
 	},
@@ -37473,6 +37803,9 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 9
 	},
@@ -37557,6 +37890,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 5
 	},
@@ -37801,6 +38137,10 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
+	},
 /turf/simulated/floor/black/side{
 	dir = 8
 	},
@@ -37969,6 +38309,9 @@
 /obj/item/device/audio_log,
 /obj/item/audio_tape,
 /obj/item/audio_tape,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/darkblue/checker,
 /area/station/science/artifact)
 "bIN" = (
@@ -38006,6 +38349,9 @@
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
 	},
 /turf/simulated/floor/caution/westeast,
 /area/station/science/artifact)
@@ -38100,6 +38446,10 @@
 /area/station/science/lobby)
 "bIZ" = (
 /obj/disposalpipe/segment/mail/horizontal,
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
+	},
 /turf/simulated/floor/purple/side{
 	dir = 8
 	},
@@ -38297,6 +38647,7 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/orangeblack,
 /area/station/hallway/primary/south)
 "bJv" = (
@@ -39710,6 +40061,7 @@
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/black,
 /area/station/bridge)
 "bMy" = (
@@ -40005,6 +40357,9 @@
 	pixel_x = -8;
 	pixel_y = 22
 	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 1
 	},
@@ -40278,6 +40633,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/black/side{
 	dir = 4
 	},
@@ -40314,6 +40672,9 @@
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 20
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
 	},
 /turf/simulated/floor/black/side{
 	dir = 8
@@ -40902,6 +41263,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/decal/wreath/ephemeral,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "bOU" = (
@@ -41035,6 +41397,10 @@
 "bPg" = (
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
 	},
 /turf/simulated/floor/black/side{
 	dir = 4
@@ -41514,6 +41880,9 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/red/side{
 	dir = 9
 	},
@@ -41545,6 +41914,9 @@
 /obj/machinery/disposal/brig,
 /obj/disposalpipe/trunk/east,
 /obj/machinery/door_timer/genpop/new_walls/east,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/red/side{
 	dir = 5
 	},
@@ -42601,6 +42973,9 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/orange/side{
 	dir = 9
 	},
@@ -42631,6 +43006,9 @@
 	})
 "bSx" = (
 /obj/submachine/cargopad/artlab,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/orange/side{
 	dir = 5
 	},
@@ -42987,6 +43365,7 @@
 "bTm" = (
 /obj/wingrille_spawn/auto,
 /obj/cable,
+/obj/decal/wreath/ephemeral,
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "bTn" = (
@@ -43462,6 +43841,9 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/redblack/corner{
 	dir = 4
 	},
@@ -43480,6 +43862,9 @@
 "bUp" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
 	},
 /turf/simulated/floor/redblack/corner{
 	dir = 4
@@ -43774,6 +44159,10 @@
 	},
 /area/station/science/teleporter)
 "bUV" = (
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
+	},
 /turf/simulated/floor/purple/side{
 	dir = 8
 	},
@@ -44682,6 +45071,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/decal/wreath/ephemeral,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "bWM" = (
@@ -45305,6 +45695,9 @@
 /obj/item/tank/air,
 /obj/item/device/light/flashlight,
 /obj/item/extinguisher,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/grey/side{
 	dir = 1
 	},
@@ -45329,6 +45722,9 @@
 "bYf" = (
 /obj/storage/closet/welding_supply,
 /obj/item/device/radio/intercom/cargo,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/grey/side{
 	dir = 1
 	},
@@ -45346,6 +45742,9 @@
 	},
 /area/station/quartermaster/office)
 "bYh" = (
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/grey/side{
 	dir = 1
 	},
@@ -45435,6 +45834,9 @@
 	id = "qmbelthell"
 	},
 /obj/submachine/cargopad/qm2,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/caution/westeast,
 /area/station/quartermaster/office)
 "bYr" = (
@@ -46043,6 +46445,7 @@
 /obj/machinery/secscanner{
 	pixel_y = 10
 	},
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "bZL" = (
@@ -46058,6 +46461,7 @@
 /obj/machinery/secscanner{
 	pixel_y = 10
 	},
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "bZN" = (
@@ -46366,6 +46770,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/market)
 "caB" = (
@@ -47348,6 +47755,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/decal/wreath/ephemeral,
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
 "ccv" = (
@@ -52471,6 +52879,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "cow" = (
@@ -52644,6 +53055,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/orangeblack,
 /area/station/mining/staff_room)
 "coH" = (
@@ -52656,6 +53068,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/decal/wreath/ephemeral,
 /turf/simulated/floor/plating,
 /area/station/mining/staff_room)
 "coI" = (
@@ -53024,6 +53437,9 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
 	},
 /turf/simulated/floor,
 /area/station/mining/staff_room)
@@ -53650,6 +54066,20 @@
 	},
 /turf/simulated/floor,
 /area/station/routing/security)
+"cVz" = (
+/obj/machinery/guardbot_dock,
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/grey/side{
+	dir = 4
+	},
+/area/station/science/bot_storage)
 "cZf" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -53715,6 +54145,15 @@
 	dir = 1
 	},
 /area/station/hangar/engine)
+"djG" = (
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/hallway/primary/north)
 "dlp" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 4
@@ -53747,6 +54186,13 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
+"dqk" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/mail/horizontal,
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "dqu" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -53906,6 +54352,14 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
+"ehh" = (
+/obj/table/auto,
+/obj/random_item_spawner/tableware,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
 "eiE" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
@@ -53978,7 +54432,9 @@
 	},
 /area/station/hallway/secondary/exit)
 "eCr" = (
-/obj/item/c_tube,
+/obj/stool/chair/office/blue{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "eCu" = (
@@ -53994,7 +54450,6 @@
 /turf/space,
 /area/station/ai_monitored/armory)
 "eLc" = (
-/obj/disposalpipe/segment/mail/vertical,
 /obj/machinery/light/emergency{
 	dir = 4;
 	pixel_x = 10
@@ -54070,6 +54525,13 @@
 /area/station/maintenance/storage{
 	name = "Inner Southwest Maintenance"
 	})
+"fje" = (
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/cafeteria)
 "fjh" = (
 /obj/machinery/light,
 /obj/cable{
@@ -54126,6 +54588,15 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
+"fpD" = (
+/obj/stool/chair/comfy{
+	dir = 4
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/barber_shop)
 "fqj" = (
 /obj/machinery/recharge_station,
 /obj/machinery/light/small{
@@ -54158,6 +54629,9 @@
 /area/station/crew_quarters/quarters_north)
 "fwt" = (
 /obj/machinery/vending/cola/blue,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/blue/side{
 	dir = 1
 	},
@@ -54215,12 +54689,20 @@
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
+"fUz" = (
+/obj/item/c_tube,
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
 "fVr" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
 /obj/item/device/radio/intercom{
 	broadcasting = 0
+	},
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -54268,9 +54750,35 @@
 /area/station/hallway/primary/west)
 "gda" = (
 /obj/machinery/air_vendor,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/blue/side{
 	dir = 1
 	},
+/area/station/hallway/primary/south)
+"gga" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
+	},
+/turf/simulated/floor/black,
+/area/station/bridge)
+"ggb" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/decal/wreath/ephemeral,
+/turf/simulated/floor/plating,
 /area/station/hallway/primary/south)
 "gih" = (
 /obj/random_item_spawner/junk/one_or_zero,
@@ -54535,6 +55043,20 @@
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
+"hNB" = (
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 1
+	},
+/area/station/hallway/primary/east)
 "hOS" = (
 /obj/grille/catwalk{
 	dir = 4
@@ -54663,6 +55185,17 @@
 /obj/machinery/light/emergency,
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/south)
+"iDX" = (
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/orangeblack/side{
+	dir = 1
+	},
+/area/station/hallway/primary/south)
 "iHH" = (
 /obj/reagent_dispensers/foamtank,
 /turf/simulated/floor/caution/corner/misc{
@@ -54715,6 +55248,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/blue/side{
 	dir = 1
 	},
@@ -54768,12 +55304,29 @@
 /obj/storage/secure/closet/medical/anesthetic,
 /turf/simulated/floor/red,
 /area/station/medical/medbay/surgery)
+"jfG" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 8
+	},
+/area/station/hallway/primary/east)
 "joy" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/clown{
 	name = "Clowntainment"
 	})
+"jry" = (
+/obj/wingrille_spawn/auto,
+/obj/decal/wreath/ephemeral,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/cafeteria)
 "jrT" = (
 /obj/stool/chair/office{
 	dir = 4
@@ -54801,12 +55354,21 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/hangar/engine)
+"jvK" = (
+/obj/disposalpipe/segment/food,
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
+	},
+/turf/simulated/floor,
+/area/station/hydroponics/bay)
 "jwh" = (
 /obj/wingrille_spawn/auto,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/decal/wreath/ephemeral,
 /turf/simulated/floor/plating,
 /area/station/medical/medbooth)
 "jCx" = (
@@ -54840,6 +55402,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/decal/wreath/ephemeral,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/courtroom)
 "jTa" = (
@@ -54887,6 +55450,13 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
+"kkU" = (
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
 "klY" = (
 /obj/grille/catwalk/cross,
 /obj/machinery/camera{
@@ -55160,6 +55730,18 @@
 /obj/machinery/cargo_router/kd_sec_exoflap,
 /turf/simulated/floor/caution/westeast,
 /area/station/quartermaster/office)
+"lAA" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/decal/wreath/ephemeral,
+/turf/simulated/floor/plating,
+/area/station/quartermaster/office)
+"lCw" = (
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/courtroom)
 "lHa" = (
 /obj/machinery/light/emergency{
 	dir = 4;
@@ -55242,6 +55824,16 @@
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
+"mmz" = (
+/obj/disposalpipe/segment/vertical,
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/crew_quarters/quarters_south)
 "mmP" = (
 /obj/machinery/light/small/floor,
 /turf/simulated/floor/caution/east,
@@ -55283,6 +55875,17 @@
 	},
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbooth)
+"mCg" = (
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/hallway/primary/south)
 "mEW" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -55364,6 +55967,12 @@
 	dir = 6
 	},
 /area/station/solar/east)
+"mVi" = (
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/specialroom/chapel,
+/area/station/chapel/sanctuary)
 "mXc" = (
 /obj/machinery/recharge_station,
 /obj/landmark/start{
@@ -55507,6 +56116,16 @@
 	},
 /turf/simulated/floor/caution/northsouth,
 /area/station/quartermaster/office)
+"nKN" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
+	},
+/turf/simulated/floor/grey,
+/area/station/bridge)
 "nLA" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
@@ -55568,6 +56187,14 @@
 	},
 /turf/simulated/floor/caution/westeast,
 /area/station/hangar/engine)
+"nZC" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
+	},
+/turf/simulated/floor/neutral/corner,
+/area/station/hallway/primary/east)
 "ocX" = (
 /obj/critter/sealpup,
 /turf/simulated/pool/no_animate,
@@ -55626,6 +56253,32 @@
 /obj/landmark/halloween,
 /turf/simulated/floor,
 /area/station/hallway/secondary/south)
+"owM" = (
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 1
+	},
+/area/station/hallway/primary/east)
+"oxU" = (
+/obj/disposalpipe/segment/brig,
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
+"oxY" = (
+/obj/wingrille_spawn/auto,
+/obj/decal/wreath/ephemeral,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/fitness)
 "oyG" = (
 /obj/item/clothing/glasses/blindfold,
 /turf/simulated/floor/engine/vacuum,
@@ -55673,6 +56326,11 @@
 /obj/decal/poster/wallsign/hazard_bio,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/morgue)
+"oHK" = (
+/obj/wingrille_spawn/auto,
+/obj/decal/wreath/ephemeral,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/quarters_east)
 "oHL" = (
 /obj/machinery/light_switch/east,
 /obj/machinery/atmospherics/portables_connector{
@@ -55869,6 +56527,11 @@
 /obj/machinery/light,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
+"pIV" = (
+/obj/wingrille_spawn/auto,
+/obj/decal/wreath/ephemeral,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/arcade/dungeon)
 "pJk" = (
 /obj/landmark/spawner{
 	name = "monkeyspawn_krimpus"
@@ -55891,6 +56554,13 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
+"pXJ" = (
+/obj/machinery/light/emergency{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/simulated/floor/black,
+/area/station/bridge)
 "qeG" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/disposalpipe/segment/vertical,
@@ -55907,6 +56577,9 @@
 	dir = 8
 	},
 /obj/disposalpipe/segment/mail/vertical,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
@@ -55915,6 +56588,15 @@
 /obj/machinery/vending/standard,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
+"qoq" = (
+/obj/storage/secure/closet/engineering/mining,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/orangeblack/side{
+	dir = 1
+	},
+/area/station/mining/staff_room)
 "qpS" = (
 /obj/tree1,
 /turf/simulated/floor/grass/leafy,
@@ -56006,6 +56688,15 @@
 /obj/landmark/halloween,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
+"qTA" = (
+/obj/stool/chair{
+	dir = 1
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/west)
 "qYI" = (
 /obj/machinery/door/airlock/pyro/medical{
 	name = "Robotics";
@@ -56017,6 +56708,15 @@
 	dir = 1
 	},
 /area/station/medical/medbay/surgery)
+"qZq" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/purple/side{
+	dir = 1
+	},
+/area/station/hallway/secondary/south)
 "qZL" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -56171,6 +56871,20 @@
 	},
 /turf/space,
 /area/space)
+"rHq" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/crew_quarters/quarters_north)
 "rHA" = (
 /obj/machinery/bot/firebot,
 /turf/simulated/floor,
@@ -56254,6 +56968,14 @@
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
+"rZQ" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/west)
 "scE" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/wall/auto/supernorn,
@@ -56267,6 +56989,11 @@
 /obj/machinery/weapon_stand/rifle_rack/recharger,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
+"shz" = (
+/obj/wingrille_spawn/auto,
+/obj/decal/wreath/ephemeral,
+/turf/simulated/floor/plating,
+/area/station/chapel/sanctuary)
 "shR" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/disposalpipe/segment/vertical,
@@ -56274,13 +57001,29 @@
 /area/station/hallway/primary/south)
 "sml" = (
 /obj/submachine/claw_machine,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
+"snN" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
+	},
+/turf/simulated/floor/grey,
+/area/station/bridge)
 "soA" = (
 /obj/stool/chair{
 	dir = 4
 	},
 /obj/disposalpipe/segment/horizontal,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/courtroom)
 "spD" = (
@@ -56402,6 +57145,9 @@
 /area/station/medical/dome)
 "sRA" = (
 /obj/machinery/vending/medical_public,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/blue/side{
 	dir = 1
 	},
@@ -56450,6 +57196,15 @@
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
+"tjX" = (
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/crew_quarters/quarters_north)
 "tmm" = (
 /obj/machinery/mass_driver{
 	dir = 1;
@@ -56542,6 +57297,17 @@
 /obj/machinery/light/runway_light/delay3,
 /turf/space,
 /area/station/ai_monitored/armory)
+"tIp" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/red/side{
+	dir = 1
+	},
+/area/station/hallway/primary/west)
 "tIt" = (
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -56652,6 +57418,13 @@
 /obj/machinery/light_switch/north,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
+"uDm" = (
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
+	},
+/turf/simulated/floor,
+/area/station/hydroponics/bay)
 "uDq" = (
 /obj/storage/closet/wardrobe/green,
 /turf/simulated/floor/plating,
@@ -56779,6 +57552,13 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
+"viV" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/mail/vertical,
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "vkc" = (
 /obj/machinery/light/small,
 /obj/machinery/light_switch/east,
@@ -56992,6 +57772,15 @@
 /obj/machinery/light/runway_light/delay2,
 /turf/space,
 /area/space)
+"wEY" = (
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
+	},
+/turf/simulated/floor/red/side{
+	dir = 8
+	},
+/area/station/crew_quarters/market)
 "wFl" = (
 /obj/wingrille_spawn/auto,
 /obj/cable,
@@ -57043,6 +57832,23 @@
 /obj/decal/poster/wallsign/space,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/routing/security)
+"xft" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
+"xgL" = (
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 8
+	},
+/area/station/crew_quarters/quarters_north)
 "xgW" = (
 /obj/wingrille_spawn/auto,
 /obj/cable,
@@ -57152,6 +57958,12 @@
 	dir = 8
 	},
 /area/station/medical/medbay/surgery)
+"xIe" = (
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "xKv" = (
 /obj/machinery/light/small,
 /obj/machinery/computer3/generic/communications{
@@ -57200,6 +58012,21 @@
 /obj/machinery/atmospherics/pipe/simple,
 /turf/simulated/floor/red,
 /area/station/medical/medbay)
+"xSK" = (
+/obj/disposalpipe/segment/vertical,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/crew_quarters/quarters_south)
 "xTH" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
@@ -57239,6 +58066,16 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
+"ygw" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
+	},
+/turf/simulated/floor/black,
+/area/station/bridge)
 "yhe" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -91882,7 +92719,7 @@ bxJ
 byP
 bzR
 bAS
-bBU
+cVz
 bBU
 bBU
 bEZ
@@ -96115,7 +96952,7 @@ bDm
 bSD
 bFm
 cdd
-bHv
+qZq
 bJa
 bKy
 bLL
@@ -96437,7 +97274,7 @@ kqU
 cbx
 ccv
 cdg
-cdg
+wEY
 cfa
 cdZ
 bZL
@@ -96963,7 +97800,7 @@ ary
 asF
 atR
 anm
-avH
+qTA
 awR
 axR
 ayN
@@ -97563,7 +98400,7 @@ anp
 aop
 apv
 aqC
-arA
+rZQ
 asG
 atT
 auH
@@ -100641,7 +101478,7 @@ bze
 bAh
 bBc
 bCm
-bCq
+iDX
 bDA
 bxm
 bGr
@@ -101245,7 +102082,7 @@ bzf
 bAh
 bBe
 bCm
-bCq
+iDX
 bDA
 bFr
 bGq
@@ -101547,7 +102384,7 @@ bzg
 bAi
 bBf
 bCm
-bCq
+iDX
 bDA
 bFs
 bGr
@@ -102395,7 +103232,7 @@ anx
 aoz
 apF
 bhN
-arL
+tIp
 asQ
 aub
 auL
@@ -102453,7 +103290,7 @@ bzh
 bzh
 bBi
 bCm
-bCq
+iDX
 bDA
 bFv
 bBv
@@ -102755,7 +103592,7 @@ bzh
 bzh
 bBj
 bCm
-bCq
+iDX
 fGA
 bFw
 bGv
@@ -103362,7 +104199,7 @@ bCo
 bDw
 bDA
 bFs
-bHT
+ggb
 bHS
 bJt
 bKO
@@ -103957,7 +104794,7 @@ bof
 bmH
 buD
 bki
-bwS
+qoq
 byd
 bmH
 bAm
@@ -104566,7 +105403,7 @@ bye
 bzk
 bAo
 coJ
-bCq
+iDX
 bDA
 bvY
 bFA
@@ -104583,7 +105420,7 @@ bSW
 cnT
 cnU
 cnV
-cnW
+lAA
 bYn
 bYl
 bZU
@@ -106982,7 +107819,7 @@ byk
 bzm
 bAr
 bBp
-bCx
+oxU
 bDD
 inL
 bFJ
@@ -107586,7 +108423,7 @@ bym
 bzo
 bAt
 bBp
-bCx
+oxU
 bDE
 bEx
 bFM
@@ -108190,7 +109027,7 @@ byn
 bzp
 bAv
 boo
-bCz
+mCg
 bDA
 bEy
 bFK
@@ -108737,7 +109574,7 @@ amG
 amG
 apQ
 aqQ
-asa
+xIe
 atd
 aum
 auT
@@ -108794,7 +109631,7 @@ bqK
 bzr
 bAx
 boq
-bCz
+mCg
 bDA
 bEv
 bGA
@@ -109934,7 +110771,7 @@ adK
 aeo
 afW
 afa
-afW
+aIE
 ahR
 aiN
 ajP
@@ -109993,12 +110830,12 @@ bmQ
 bor
 bpz
 bqJ
-bse
+jvK
 bty
 buN
 bvQ
 bxe
-bqK
+uDm
 bzt
 bAB
 iJS
@@ -110236,7 +111073,7 @@ adK
 aep
 afa
 afW
-afa
+aIF
 ahS
 aiO
 ajQ
@@ -110247,7 +111084,7 @@ adK
 aoJ
 apU
 adK
-asa
+xIe
 atd
 aum
 aKD
@@ -110549,7 +111386,7 @@ adK
 aoK
 apV
 adK
-asa
+xIe
 pfK
 aum
 aLL
@@ -110908,7 +111745,7 @@ bqM
 bqM
 bpC
 boq
-bCz
+mCg
 bDA
 bEv
 bFO
@@ -111149,7 +111986,7 @@ ajT
 akO
 alG
 amL
-adK
+shz
 aoM
 apX
 adK
@@ -111210,7 +112047,7 @@ bqM
 bqM
 bpC
 boq
-bCz
+mCg
 fGA
 bEB
 bFO
@@ -111757,7 +112594,7 @@ adK
 aoN
 apZ
 adK
-asa
+xIe
 asa
 aum
 aPD
@@ -112059,7 +112896,7 @@ adK
 aoO
 aqa
 adK
-asa
+xIe
 asa
 aum
 aPE
@@ -112649,7 +113486,7 @@ aaa
 aaa
 abW
 adK
-aew
+mVi
 afh
 agd
 agP
@@ -112696,13 +113533,13 @@ tYP
 kBY
 aXQ
 aUz
-aZR
+ehh
 bbd
 bcl
 bds
 bev
 bfC
-bfD
+fje
 bfD
 bjb
 bkA
@@ -112724,7 +113561,7 @@ rve
 bDA
 bEv
 bFO
-bGP
+lCw
 bGP
 bGP
 bNw
@@ -113283,8 +114120,8 @@ ase
 ase
 ase
 ase
-aIE
-aJE
+ase
+viV
 aKM
 aLQ
 aNb
@@ -113585,7 +114422,7 @@ asa
 asa
 asa
 asa
-aIF
+asa
 aJE
 aKN
 aLQ
@@ -113602,12 +114439,12 @@ aVA
 aWQ
 aXS
 aYN
-aZR
+ehh
 bbd
 bcl
 bbe
 aYN
-aYN
+jry
 bgJ
 bhU
 bjc
@@ -113880,7 +114717,7 @@ asi
 asi
 asi
 aAr
-asi
+djG
 asi
 aDC
 aEw
@@ -113895,15 +114732,15 @@ aLQ
 aNW
 aLQ
 aLQ
-aRa
+oHK
 aSf
 aRa
-aRa
+oHK
 aRa
 aVB
 aWR
 flj
-aYN
+jry
 aZU
 bbe
 bcl
@@ -114178,7 +115015,7 @@ atk
 aus
 aus
 aus
-aus
+oxY
 aus
 aus
 aus
@@ -114198,7 +115035,7 @@ aNX
 aNX
 aPN
 aNX
-aNX
+jfG
 aNX
 aNX
 aNX
@@ -114493,7 +115330,7 @@ aGJ
 bDr
 aIH
 aJG
-asg
+dqk
 aLT
 aNd
 aNY
@@ -115740,8 +116577,8 @@ byy
 bzy
 cpM
 bBC
-bxm
-bvY
+xft
+kkU
 bEG
 bFT
 bHa
@@ -116014,11 +116851,11 @@ aOV
 aOV
 aTP
 aKQ
-aVG
+owM
 aNY
 aXX
 aYS
-baa
+fpD
 bbh
 baa
 aYS
@@ -116278,7 +117115,7 @@ afo
 adv
 agZ
 aij
-aeA
+fUz
 ake
 adM
 abZ
@@ -116316,7 +117153,7 @@ aOV
 aOV
 aTQ
 aKQ
-aVG
+owM
 aNY
 aXX
 aYS
@@ -116618,7 +117455,7 @@ aSh
 aOV
 aTQ
 aKQ
-aVG
+owM
 aWW
 aXX
 aYT
@@ -116650,8 +117487,8 @@ bCM
 bDN
 bDN
 bFU
-bDN
-bDR
+pXJ
+gga
 bJY
 bLn
 bMw
@@ -116886,7 +117723,7 @@ ajd
 ajd
 ajd
 alR
-alR
+pIV
 ajd
 ajd
 aql
@@ -116920,7 +117757,7 @@ aOV
 aOV
 aTQ
 aKQ
-aVG
+owM
 aNY
 aXX
 aYS
@@ -117246,7 +118083,7 @@ btP
 buZ
 bpK
 bxt
-byC
+nKN
 bzD
 bzD
 byC
@@ -117826,7 +118663,7 @@ aSj
 aTg
 cEO
 aKQ
-aVG
+owM
 aNY
 aYa
 aYR
@@ -117850,16 +118687,16 @@ btR
 bvb
 bpK
 bxv
-byC
+snN
 bzF
 bAL
 bzD
 bzD
-bDR
+ygw
 bEM
 bFY
 bDN
-bDR
+ygw
 bKa
 bLq
 bMw
@@ -119036,7 +119873,7 @@ aTV
 aEN
 aVK
 aWZ
-aXW
+nZC
 aYW
 aYW
 aYW
@@ -120839,11 +121676,11 @@ aLe
 aIS
 aIS
 aOg
-aLf
+xgL
 aPW
 aRd
 aSm
-aLf
+xgL
 aTX
 aUI
 aVO
@@ -121137,7 +121974,7 @@ aKh
 aHS
 aIT
 aJO
-aLf
+xgL
 aMi
 aLf
 aOh
@@ -121156,13 +121993,13 @@ bao
 bbt
 bcB
 bdF
-bao
+xSK
 bfW
 bha
-bha
+mmz
 bju
 bkO
-bha
+mmz
 bnt
 bha
 bpP
@@ -121439,15 +122276,15 @@ aGX
 aHU
 aIS
 aJP
-aLg
+tjX
 aLg
 aNo
 rtZ
-aOi
+rHq
 aOi
 aRe
 aSn
-aOi
+rHq
 fvz
 aUK
 aVQ
@@ -121752,7 +122589,7 @@ aIS
 aLe
 aIS
 aIS
-aVO
+hNB
 aWZ
 aYf
 aZa


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEAT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Spacemas-centric PR with a couple components:

- Adds "ephemeral" variants of some xmas-related objects and decor. When the xmas definition isn't active, these objects will delete themselves, allowing maps to have their xmas decorations built into the main and updated version of the map.
- Adds these new decorations to Kondaru, as well as slightly adjusting the distribution of some things in the map to better accommodate them.
- Adjusts the Spacemas tree to render on a lower layer, hopefully fixing an issue where it vanishes periodically.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Spacemas for Kondaru, and considerably easier to maintain Spacemas for other maps.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Kubius:
(+)Kondaru's ready for Spacemas cheer!
```
