### PR TITLE
Reworks Janitor job rewards to require a sacrificial item

### DIFF
--- a/code/WorkInProgress/JobXPRewards.dm
+++ b/code/WorkInProgress/JobXPRewards.dm
@@ -114,13 +114,21 @@ mob/verb/checkrewards()
 	desc = "A bucket! And it's red! Wow."
 	required_levels = list("Janitor"=5)
 	claimable = 1
-	claimPerRound = 1
+	var/path_to_spawn = /obj/item/reagent_containers/glass/bucket/red/
 
 	activate(var/client/C)
-		var/obj/item/reagent_containers/glass/bucket/red/T = new/obj/item/reagent_containers/glass/bucket/red(get_turf(C.mob))
-		T.set_loc(get_turf(C.mob))
-		C.mob.put_in_hand(T)
-		return
+		var/obj/item/reagent_containers/glass/bucket/bucket = locate(/obj/item/reagent_containers/glass/bucket) in C.mob.contents
+
+		if (istype(bucket))
+			C.mob.remove_item(bucket)
+			qdel(bucket)
+		else
+			boutput(C.mob, "You need to be holding a bucket in order to claim this reward")
+			return
+		var/obj/item/I = new path_to_spawn()
+		I.set_loc(get_turf(C.mob))
+		C.mob.put_in_hand_or_drop(I)
+		boutput(C.mob, "You turn around for just a second and your bucket is suddenly all red!")
 
 /datum/jobXpReward/janitor10
 	name = "Holographic Signs "
@@ -142,13 +150,21 @@ mob/verb/checkrewards()
 	desc = "A mop! And it's orange! Amazing."
 	required_levels = list("Janitor"=15)
 	claimable = 1
-	claimPerRound = 1
+	var/path_to_spawn = /obj/item/mop/orange
 
 	activate(var/client/C)
-		var/obj/item/mop/orange/T = new/obj/item/mop/orange(get_turf(C.mob))
-		T.set_loc(get_turf(C.mob))
-		C.mob.put_in_hand(T)
-		return
+		var/obj/item/mop/mop = locate(/obj/item/mop/) in C.mob.contents
+
+		if (istype(mop))
+			C.mob.remove_item(mop)
+			qdel(mop)
+		else
+			boutput(C.mob, "You need to be holding a mop in order to claim this reward")
+			return
+		var/obj/item/I = new path_to_spawn()
+		I.set_loc(get_turf(C.mob))
+		C.mob.put_in_hand_or_drop(I)
+		boutput(C.mob, "An orange shade starts to crawl all over the mop's head.")
 
 /datum/jobXpReward/janitor20
 	name = "Head of Sanitation beret"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Reworks the orange mop and red bucket Janitor Job Rewards to require a regular mop and bucket respectively when claiming the rewards.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Because just making items pop out of thing air is a bit silly in this case. Also Im suprised I didn't get told off for this earlier.

## Changelog

```
(u)Carbadox
(*)Adjusted the code for Janitor job rewards, red bucket and orange mop, to require a regular mop and bucket respectively when claiming the rewards, instead of them just popping out from thin air.
```
