### PR TITLE
Resolve rounding error when TEG is at high temperatures

### DIFF
--- a/code/WorkInProgress/TempEngine.dm
+++ b/code/WorkInProgress/TempEngine.dm
@@ -132,7 +132,10 @@
 		// Check if fan/blower is required to overcome passive gate
 		if(circulator_flags & BACKFLOW_PROTECTION)
 			if(input_starting_pressure < (output_starting_pressure+src.min_circ_pressure))
-				pressure_delta = src.min_circ_pressure
+				// Use maximum of minimum circulator pressure OR calculated pressure required to ensure an amount that won't get rounded away by quantization
+				// Note - ( 5 * ATMOS_EPSILON ) used to allow for a ratio of multiple gas specific heats to be utilized in the mixture
+				pressure_delta = max( src.min_circ_pressure, ( ( 5 * ATMOS_EPSILON ) * (src.air1.temperature * R_IDEAL_GAS_EQUATION) / max(src.air2.volume,1) ) )
+
 				// P = dp q / μf, q ignored for simplification of system
 				var/total_pressure = (output_starting_pressure + pressure_delta - input_starting_pressure)
 				fan_power_draw = round((total_pressure) / src.fan_efficiency)


### PR DESCRIPTION
[bug - major]
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Use the maximum of the minimum circulator pressure OR 5 times the minimum quantized molar quantity of gas to ensure consistent behavior of TEG.

Implications is that it will scaling up power cost of Hellburns if pressure differential is bad.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Really dangerous bug leveraging burns shouldn't just randomly stop working for no reason.  Calculations should support whatever the playerbase is able to cobble together.
Power output won't suddenly hit 0 without any rhyme or reason.


```
(u)Azrun:
(+)Resolves issue with gas not being transferred on TEG when pressures differential is negative and temperatures are high. (Thanks Demnish!)
```
