### PR TITLE
stop running random events when the shuttle leaves the station

### DIFF
--- a/code/datums/controllers/event_controls.dm
+++ b/code/datums/controllers/event_controls.dm
@@ -56,8 +56,7 @@ var/datum/event_controller/random_events
 
 	proc/process()
 		if (emergency_shuttle.location > SHUTTLE_LOC_STATION)
-			// you have 60 seconds to respond if you want to be a ghost frog
-			// also the server is rebooting in 10 seconds
+			// prevent random events near round end
 			return
 
 		if (TIME >= major_events_begin)

--- a/code/datums/controllers/event_controls.dm
+++ b/code/datums/controllers/event_controls.dm
@@ -55,6 +55,11 @@ var/datum/event_controller/random_events
 			special_events += RE
 
 	proc/process()
+		if (emergency_shuttle.location > SHUTTLE_LOC_STATION)
+			// you have 60 seconds to respond if you want to be a ghost frog
+			// also the server is rebooting in 10 seconds
+			return
+
 		if (TIME >= major_events_begin)
 			if (TIME >= next_major_event)
 				event_cycle()

--- a/code/datums/controllers/event_controls.dm
+++ b/code/datums/controllers/event_controls.dm
@@ -55,7 +55,7 @@ var/datum/event_controller/random_events
 			special_events += RE
 
 	proc/process()
-		if (emergency_shuttle.location > SHUTTLE_LOC_STATION)
+		if (emergency_shuttle.location > SHUTTLE_LOC_STATION || current_state == GAME_STATE_FINISHED)
 			// prevent random events near round end
 			return
 

--- a/code/datums/controllers/event_controls.dm
+++ b/code/datums/controllers/event_controls.dm
@@ -55,8 +55,8 @@ var/datum/event_controller/random_events
 			special_events += RE
 
 	proc/process()
+		// prevent random events near round end
 		if (emergency_shuttle.location > SHUTTLE_LOC_STATION || current_state == GAME_STATE_FINISHED)
-			// prevent random events near round end
 			return
 
 		if (TIME >= major_events_begin)


### PR DESCRIPTION
[BALANCE]

## About the PR

Once the shuttle leaves the station on its way back to CentCom, random events stop happening.

## Why's this needed?

Here is a very common scenario:

The round will end in 10 seconds.
Do you want to be a GHOST FROG? You have 60 seconds to decide.

or people becoming sleeper agents 10 seconds before the shuttle reaches CentCom.

## Changelog
```
(u)BenLubar:
(+)Random events no longer occur once the shuttle departs from the station or the round ends.
```
