### PR TITLE
Log inherent laws to GoonHub if they differ from default laws.

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -78,6 +78,7 @@
 		src.inherent.len = number
 
 	src.inherent[number] = law
+	statlog_ailaws(1, law, "Ion Storm")
 
 /datum/ai_laws/proc/add_supplied_law(var/number, var/law)
 	while (src.supplied.len < number + 1)

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -78,7 +78,7 @@
 		src.inherent.len = number
 
 	src.inherent[number] = law
-	statlog_ailaws(1, law, "Ion Storm")
+	statlog_ailaws(1, law, (usr ? usr : "Ion Storm"))
 
 /datum/ai_laws/proc/add_supplied_law(var/number, var/law)
 	while (src.supplied.len < number + 1)

--- a/code/obj/item/ai_modules.dm
+++ b/code/obj/item/ai_modules.dm
@@ -207,7 +207,7 @@ AI MODULES
 	lawNumber = 11
 
 	get_law_text()
-		return "There is a [lawTarget ? lawTarget : "__________"] emergency. Prioritize orders from [lawTarget ? lawTarget : "__________"] personnel and assisting the crew in remedying the situation. In the case of conflict, this law takes precedence over the Second Law.'"
+		return "There is a [lawTarget ? lawTarget : "__________"] emergency. Prioritize orders from [lawTarget ? lawTarget : "__________"] personnel and assisting the crew in remedying the situation. In the case of conflict, this law takes precedence over the Second Law."
 
 	attack_self(var/mob/user)
 		input_law_info(user, "Department Emergency", "Which department's orders should be prioritized?", "security")

--- a/code/procs/stat_logging.dm
+++ b/code/procs/stat_logging.dm
@@ -234,6 +234,10 @@
 			if (ticker.centralized_ai_laws.zeroth)
 				laws["0"] = ticker.centralized_ai_laws.zeroth
 
+			for (var/i = 1, i <= ticker.centralized_ai_laws.default.len, i++)
+				if (ticker.centralized_ai_laws.default[i] != ticker.centralized_ai_laws.inherent[i])
+					laws["[i]"] = ticker.centralized_ai_laws.inherent[i]
+
 			var/list/suppliedLaws = ticker.centralized_ai_laws.supplied
 			var/count = 4
 			for (var/i = 1, i <= suppliedLaws.len, i++)


### PR DESCRIPTION
This sends laws 1-3 to GoonHub if they were changed by an Ion Storm.

Also removes an extraneous apostrophe from the Emergency law.
