### PR TITLE
Fixes beardless Bill, colorful boneheads, and item limbs being eaten by mutants

### DIFF
--- a/code/WorkInProgress/warcrimes.dm
+++ b/code/WorkInProgress/warcrimes.dm
@@ -119,34 +119,35 @@ var/fartcount = 0
 	New()
 		..()
 		START_TRACKING_CAT(TR_CAT_JOHNBILLS)
-		SPAWN_DBG(0)
-			bioHolder.mobAppearance.customization_first = "Tramp"
-			bioHolder.mobAppearance.customization_first_color = "#281400"
-			bioHolder.mobAppearance.customization_second = "Pompadour"
-			bioHolder.mobAppearance.customization_second_color = "#241200"
-			bioHolder.mobAppearance.customization_third = "Tramp: Beard Stains"
-			bioHolder.mobAppearance.customization_third_color = "#663300"
-			bioHolder.age = 63
-			bioHolder.bloodType = "A+"
-			bioHolder.mobAppearance.gender = "male"
-			bioHolder.mobAppearance.underwear = "briefs"
-			bioHolder.mobAppearance.u_color = "#996633"
 
-			SPAWN_DBG(1 SECOND)
-				bioHolder.mobAppearance.UpdateMob()
+		src.equip_new_if_possible(/obj/item/clothing/shoes/thong, slot_shoes)
+		src.equip_new_if_possible(/obj/item/clothing/under/color/orange, slot_w_uniform)
+		src.equip_new_if_possible(/obj/item/clothing/mask/cigarette/john, slot_wear_mask)
+		src.equip_new_if_possible(/obj/item/clothing/suit/labcoat, slot_wear_suit)
+		src.equip_new_if_possible(/obj/item/clothing/head/paper_hat/john, slot_head)
 
-			src.equip_new_if_possible(/obj/item/clothing/shoes/thong, slot_shoes)
-			src.equip_new_if_possible(/obj/item/clothing/under/color/orange, slot_w_uniform)
-			src.equip_new_if_possible(/obj/item/clothing/mask/cigarette/john, slot_wear_mask)
-			src.equip_new_if_possible(/obj/item/clothing/suit/labcoat, slot_wear_suit)
-			src.equip_new_if_possible(/obj/item/clothing/head/paper_hat/john, slot_head)
-
-			var/obj/item/implant/access/infinite/shittybill/implant = new /obj/item/implant/access/infinite/shittybill(src)
-			implant.implanted(src, src)
+		var/obj/item/implant/access/infinite/shittybill/implant = new /obj/item/implant/access/infinite/shittybill(src)
+		implant.implanted(src, src)
 
 	disposing()
 		STOP_TRACKING_CAT(TR_CAT_JOHNBILLS)
 		..()
+
+	initializeBioholder()
+		. = ..()
+		bioHolder.mobAppearance.customization_first = "Tramp"
+		bioHolder.mobAppearance.customization_first_color = "#281400"
+		bioHolder.mobAppearance.customization_second = "Pompadour"
+		bioHolder.mobAppearance.customization_second_color = "#241200"
+		bioHolder.mobAppearance.customization_third = "Tramp: Beard Stains"
+		bioHolder.mobAppearance.customization_third_color = "#663300"
+		bioHolder.age = 63
+		bioHolder.bloodType = "A+"
+		bioHolder.mobAppearance.gender = "male"
+		bioHolder.mobAppearance.underwear = "briefs"
+		bioHolder.mobAppearance.u_color = "#996633"
+
+		bioHolder.mobAppearance.UpdateMob()
 
 	// John Bill always goes to the afterlife bar.
 	death(gibbed)

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -392,7 +392,7 @@
 			if("set")
 				//////////////ARMS//////////////////
 				if (src.r_limb_arm_type_mutantrace)
-					if (L.limbs.r_arm || src.ignore_missing_limbs == 1)
+					if ((L.limbs.r_arm && !(L.limbs.r_arm.limb_is_transplanted || L.limbs.r_arm.limb_is_unnatural)) || src.ignore_missing_limbs == 1)
 						var/obj/item/parts/human_parts/arm/limb = new src.r_limb_arm_type_mutantrace(L)
 						if (istype(limb))
 							qdel(L.limbs.r_arm)
@@ -402,7 +402,7 @@
 							limb.remove_stage = 0
 
 				if (src.l_limb_arm_type_mutantrace)
-					if (L.limbs.l_arm || src.ignore_missing_limbs == 1)
+					if ((L.limbs.l_arm && !(L.limbs.l_arm.limb_is_transplanted || L.limbs.l_arm.limb_is_unnatural)) || src.ignore_missing_limbs == 1)
 						var/obj/item/parts/human_parts/arm/limb = new src.l_limb_arm_type_mutantrace(L)
 						if (istype(limb))
 							qdel(L.limbs.l_arm)
@@ -413,7 +413,7 @@
 
 				//////////////LEGS//////////////////
 				if (src.r_limb_leg_type_mutantrace)
-					if (L.limbs.r_leg || src.ignore_missing_limbs == 1)
+					if ((L.limbs.r_leg && !(L.limbs.r_leg.limb_is_transplanted || L.limbs.r_leg.limb_is_unnatural)) || src.ignore_missing_limbs == 1)
 						var/obj/item/parts/human_parts/leg/limb = new src.r_limb_leg_type_mutantrace(L)
 						if (istype(limb))
 							qdel(L.limbs.r_leg)
@@ -423,7 +423,7 @@
 							limb.remove_stage = 0
 
 				if (src.l_limb_leg_type_mutantrace)
-					if (L.limbs.l_leg || src.ignore_missing_limbs == 1)
+					if ((L.limbs.l_leg && !(L.limbs.l_leg.limb_is_transplanted || L.limbs.l_leg.limb_is_unnatural)) || src.ignore_missing_limbs == 1)
 						var/obj/item/parts/human_parts/leg/limb = new src.l_limb_leg_type_mutantrace(L)
 						if (istype(limb))
 							qdel(L.limbs.l_leg)
@@ -434,12 +434,12 @@
 
 				//////////////HEAD//////////////////
 				if (src.special_head)
-					L.organHolder.head.MakeMutantHead(src.special_head, src.mutant_folder, src.special_head_state)
+					L.organHolder?.head?.MakeMutantHead(src.special_head, src.mutant_folder, src.special_head_state)
 
 			if ("reset")
 				// And the other way around (Convair880).
 				if (src.r_limb_arm_type_mutantrace)
-					if (L.limbs.r_arm || src.ignore_missing_limbs == 1)
+					if ((L.limbs.r_arm && !(L.limbs.r_arm.limb_is_transplanted || L.limbs.r_arm.limb_is_unnatural)) || src.ignore_missing_limbs == 1)
 						var/obj/item/parts/human_parts/arm/limb = new /obj/item/parts/human_parts/arm/right(L)
 						if (istype(limb))
 							qdel(L.limbs.r_arm)
@@ -449,7 +449,7 @@
 							limb.remove_stage = 0
 
 				if (src.l_limb_arm_type_mutantrace)
-					if (L.limbs.l_arm || src.ignore_missing_limbs == 1)
+					if ((L.limbs.l_arm && !(L.limbs.l_arm.limb_is_transplanted || L.limbs.l_arm.limb_is_unnatural)) || src.ignore_missing_limbs == 1)
 						var/obj/item/parts/human_parts/arm/limb = new /obj/item/parts/human_parts/arm/left(L)
 						if (istype(limb))
 							qdel(L.limbs.l_arm)
@@ -460,7 +460,7 @@
 
 				//////////////LEGS//////////////////
 				if (src.r_limb_leg_type_mutantrace)
-					if (L.limbs.r_leg || src.ignore_missing_limbs == 1)
+					if ((L.limbs.r_leg && !(L.limbs.r_leg.limb_is_transplanted || L.limbs.r_leg.limb_is_unnatural)) || src.ignore_missing_limbs == 1)
 						var/obj/item/parts/human_parts/leg/limb = new /obj/item/parts/human_parts/leg/right(L)
 						if (istype(limb))
 							qdel(L.limbs.r_leg)
@@ -470,7 +470,7 @@
 							limb.remove_stage = 0
 
 				if (src.l_limb_leg_type_mutantrace)
-					if (L.limbs.l_leg || src.ignore_missing_limbs == 1)
+					if ((L.limbs.l_leg && !(L.limbs.l_leg.limb_is_transplanted || L.limbs.l_leg.limb_is_unnatural)) || src.ignore_missing_limbs == 1)
 						var/obj/item/parts/human_parts/leg/limb = new /obj/item/parts/human_parts/leg/left(L)
 						if (istype(limb))
 							qdel(L.limbs.l_leg)
@@ -479,7 +479,7 @@
 							limb.holder = L
 							limb.remove_stage = 0
 				//////////////HEAD//////////////////
-				L.organHolder.head.MakeMutantHead(HEAD_HUMAN, 'icons/mob/human_head.dmi', "head")
+				L.organHolder?.head?.MakeMutantHead(HEAD_HUMAN, 'icons/mob/human_head.dmi', "head")
 
 	proc/organ_mutator(var/mob/living/carbon/human/O, var/mode as text, var/drop_tail)
 		if(!ishuman(O) || !(O?.organHolder))
@@ -794,7 +794,7 @@
 /datum/mutantrace/zombie
 	name = "zombie"
 	icon_state = "zombie"
-	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_HUMAN_HAIR | HAS_NO_EYES | HAS_NO_HEAD | USES_STATIC_ICON)
+	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_HUMAN_HAIR | HAS_NO_EYES | HAS_NO_HEAD | USES_STATIC_ICON | HEAD_HAS_OWN_COLORS)
 	jerk = 1
 	needs_oxy = 0
 	movement_modifier = /datum/movement_modifier/zombie
@@ -968,7 +968,7 @@
 /datum/mutantrace/vamp_zombie
 	name = "vampiric zombie"
 	icon_state = "vamp_zombie"
-	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_HUMAN_HAIR | HAS_HUMAN_EYES | BUILT_FROM_PIECES)
+	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_HUMAN_HAIR | HAS_HUMAN_EYES | BUILT_FROM_PIECES | HEAD_HAS_OWN_COLORS)
 	r_limb_arm_type_mutantrace = /obj/item/parts/human_parts/arm/mutant/vamp_zombie/right
 	l_limb_arm_type_mutantrace = /obj/item/parts/human_parts/arm/mutant/vamp_zombie/left
 	r_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/vamp_zombie/right
@@ -1045,7 +1045,7 @@
 	icon_state = "skeleton"
 	voice_override = "skelly"
 	mutant_organs = list("tail" = /obj/item/organ/tail/bone)
-	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_NO_HAIR | HAS_NO_EYES | BUILT_FROM_PIECES)
+	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_NO_HAIR | HAS_NO_EYES | BUILT_FROM_PIECES | HEAD_HAS_OWN_COLORS)
 	r_limb_arm_type_mutantrace = /obj/item/parts/human_parts/arm/mutant/skeleton/right
 	l_limb_arm_type_mutantrace = /obj/item/parts/human_parts/arm/mutant/skeleton/left
 	r_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/skeleton/right
@@ -1183,7 +1183,7 @@
 	l_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/werewolf/left
 	ignore_missing_limbs = 0
 	var/old_client_color = null
-	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_NO_HAIR | HAS_NO_EYES | BUILT_FROM_PIECES)
+	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_NO_HAIR | HAS_NO_EYES | BUILT_FROM_PIECES | HEAD_HAS_OWN_COLORS)
 	mutant_folder = 'icons/mob/werewolf.dmi'
 	special_head = HEAD_WEREWOLF
 	mutant_organs = list("tail" = /obj/item/organ/tail/wolf)
@@ -1360,7 +1360,7 @@
 	l_limb_arm_type_mutantrace = /obj/item/parts/human_parts/arm/mutant/monkey/left
 	r_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/monkey/right
 	l_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/monkey/left
-	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_NO_HAIR | HAS_HUMAN_EYES | BUILT_FROM_PIECES)
+	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_NO_HAIR | HAS_HUMAN_EYES | BUILT_FROM_PIECES | HEAD_HAS_OWN_COLORS)
 	var/sound_monkeyscream = 'sound/voice/screams/monkey_scream.ogg'
 	var/had_tablepass = 0
 	var/table_hide = 0
@@ -1662,7 +1662,7 @@
 	l_limb_arm_type_mutantrace = /obj/item/parts/human_parts/arm/mutant/roach/left
 	r_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/roach/right
 	l_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/roach/left
-	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_NO_HAIR | HAS_NO_EYES | BUILT_FROM_PIECES)
+	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_NO_HAIR | HAS_NO_EYES | BUILT_FROM_PIECES | HEAD_HAS_OWN_COLORS)
 
 	New(mob/living/carbon/human/M)
 		. = ..()
@@ -1695,7 +1695,7 @@
 	l_limb_arm_type_mutantrace = /obj/item/parts/human_parts/arm/mutant/cat/left
 	r_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/cat/right
 	l_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/cat/left
-	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_NO_HAIR | HAS_NO_EYES | BUILT_FROM_PIECES)
+	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_NO_HAIR | HAS_NO_EYES | BUILT_FROM_PIECES | HEAD_HAS_OWN_COLORS)
 
 	New(mob/living/carbon/human/M)
 		. = ..()
@@ -1737,7 +1737,7 @@
 	l_limb_arm_type_mutantrace = /obj/item/parts/human_parts/arm/mutant/amphibian/left
 	r_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/amphibian/right
 	l_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/amphibian/left
-	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_NO_HAIR | HAS_NO_EYES | BUILT_FROM_PIECES)
+	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_NO_HAIR | HAS_NO_EYES | BUILT_FROM_PIECES | HEAD_HAS_OWN_COLORS)
 
 
 	say_verb()
@@ -1806,7 +1806,7 @@
 	l_limb_arm_type_mutantrace = /obj/item/parts/human_parts/arm/mutant/shelterfrog/left
 	r_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/shelterfrog/right
 	l_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/shelterfrog/left
-	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_NO_HAIR | HAS_NO_EYES | BUILT_FROM_PIECES)
+	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_NO_HAIR | HAS_NO_EYES | BUILT_FROM_PIECES | HEAD_HAS_OWN_COLORS)
 
 
 	New()

--- a/code/obj/item/mob_parts.dm
+++ b/code/obj/item/mob_parts.dm
@@ -39,6 +39,10 @@
 	var/step_image_state = null // for legs, we leave footprints in this style (located in blood.dmi)
 	var/accepts_normal_human_overlays = 1 //for avoiding istype in update icon
 	var/datum/movement_modifier/movement_modifier // When attached, applies this movement modifier
+	/// If TRUE, it'll resist mutantraces trying to change them
+	var/limb_is_unnatural = FALSE
+	/// Limb is not attached to its original owner
+	var/limb_is_transplanted = FALSE
 
 	New(atom/new_holder)
 		..()
@@ -289,7 +293,7 @@
 		if (src.slot == "l_arm" || src.slot == "r_arm")
 			attachee.hud.update_hands()
 
-		return
+		return TRUE
 
 	proc/surgery(var/obj/item/I) //placeholder
 		return

--- a/code/obj/item/mob_parts/human_parts.dm
+++ b/code/obj/item/mob_parts/human_parts.dm
@@ -182,6 +182,20 @@
 				src.original_fprints = src.original_holder.bioHolder.uid_hash
 		return ..()
 
+	attach(mob/living/carbon/human/attachee, mob/attacher, both_legs)
+		if (..()) // A successful attachment
+			if(ismob(attachee) && attachee?.bioHolder) // Whose limb is this?
+				if(isnull(src.original_holder)) // Limb never had an original owner?
+					src.original_holder = attachee // Now it does
+					if (src.original_holder?.bioHolder)
+						src.original_DNA = src.original_holder.bioHolder.Uid
+						src.original_fprints = src.original_holder.bioHolder.uid_hash
+					return
+				if(src.original_DNA != attachee.bioHolder.Uid) // Limb isnt ours
+					src.limb_is_transplanted = TRUE
+				else // Maybe we got our old limb back?
+					src.limb_is_transplanted = FALSE
+
 	/// Determines what the limb's skin tone should be
 	proc/colorize_limb_icon()
 		if (!src.skintoned) return // No colorizing things that have their own baked in colors! Also they dont need a bloody stump overlaid
@@ -383,6 +397,8 @@
 	var/special_icons = 'icons/mob/human.dmi'
 	var/original_flags = 0
 	var/image/handimage = 0
+	/// No more yee eating csaber arms
+	limb_is_unnatural = TRUE
 
 	New(new_holder, var/obj/item/I)
 		..()
@@ -529,6 +545,8 @@
 	var/original_flags = 0
 	var/image/handimage = 0
 	var/special_icons = 'icons/mob/human.dmi'
+	/// Also, item arms are supposedly junk jammed into a severed limb's socket
+	limb_is_unnatural = TRUE
 
 	New(new_holder, var/obj/item/I)
 		..()
@@ -651,6 +669,8 @@
 	limb_type = /datum/limb/wendigo
 	handlistPart = "l_hand_wendigo"
 	show_on_examine = 1
+	/// Wendigeese are pretty unnatural, and most people'd miss em if they suddenly turned into a lizard arm
+	limb_is_unnatural = TRUE
 
 	New(var/atom/holder)
 		if (holder != null)
@@ -676,6 +696,8 @@
 	limb_type = /datum/limb/wendigo
 	handlistPart = "r_hand_wendigo"
 	show_on_examine = 1
+	/// If you went through the trouble to get yourself a wendy arm, you should keep it no matter how inhuman you become
+	limb_is_unnatural = TRUE
 
 	New(var/atom/holder)
 		if (holder != null)
@@ -701,6 +723,7 @@
 	limb_type = /datum/limb/hot
 	handlistPart = "hand_left"
 	show_on_examine = 1
+	limb_is_unnatural = TRUE
 
 	New(var/atom/holder)
 		if (holder != null)
@@ -721,6 +744,7 @@
 	limb_type = /datum/limb/hot
 	handlistPart = "hand_right"
 	show_on_examine = 1
+	limb_is_unnatural = TRUE
 
 	New(var/atom/holder)
 		if (holder != null)
@@ -741,6 +765,7 @@
 	limb_type = /datum/limb/bear
 	handlistPart = "l_hand_bear"
 	show_on_examine = 1
+	limb_is_unnatural = TRUE
 
 	New(var/atom/holder)
 		if (holder != null)
@@ -768,6 +793,7 @@
 	limb_type = /datum/limb/bear
 	handlistPart = "r_hand_bear"
 	show_on_examine = 1
+	limb_is_unnatural = TRUE
 
 	New(var/atom/holder)
 		if (holder != null)
@@ -794,6 +820,8 @@
 	var/name_thing = "plant"
 	show_on_examine = 1
 	easy_attach = 1
+	/// Plants are pretty unnatural
+	limb_is_unnatural = TRUE
 
 	New(var/atom/holder)
 		if (holder != null)
@@ -819,6 +847,7 @@
 	var/name_thing = "plant"
 	show_on_examine = 1
 	easy_attach = 1
+	limb_is_unnatural = TRUE
 
 	New(var/atom/holder)
 		if (holder != null)
@@ -844,6 +873,7 @@
 	var/name_thing = "plant"
 	show_on_examine = 1
 	easy_attach = 1
+	limb_is_unnatural = TRUE
 
 	New(var/atom/holder)
 		if (holder != null)
@@ -869,6 +899,7 @@
 	var/name_thing = "plant"
 	show_on_examine = 1
 	easy_attach = 1
+	limb_is_unnatural = TRUE
 
 	New(var/atom/holder)
 		if (holder != null)
@@ -920,6 +951,8 @@
 	limb_type = /datum/limb/abomination
 	handlistPart = "l_hand_abomination"
 	show_on_examine = 1
+	/// About as unnatural as it gets
+	limb_is_unnatural = TRUE
 
 	New(var/atom/holder)
 		if (holder != null)
@@ -945,6 +978,7 @@
 	limb_type = /datum/limb/abomination
 	handlistPart = "r_hand_abomination"
 	show_on_examine = 1
+	limb_is_unnatural = TRUE
 
 	New(var/atom/holder)
 		if (holder != null)
@@ -971,6 +1005,8 @@
 	streak_descriptor = "undeadly"
 	override_attack_hand = 1
 	show_on_examine = 1
+	/// Supernatural if not abnormally gross
+	limb_is_unnatural = TRUE
 
 	New(var/atom/holder)
 		if (holder != null)
@@ -990,6 +1026,7 @@
 	streak_descriptor = "undeadly"
 	override_attack_hand = 1
 	show_on_examine = 1
+	limb_is_unnatural = TRUE
 
 	New(var/atom/holder)
 		if (holder != null)
@@ -1009,6 +1046,7 @@
 	limb_type = /datum/limb/hunter
 	handlistPart = "l_hand_hunter"
 	show_on_examine = 1
+	limb_is_unnatural = TRUE
 
 	New(var/atom/holder)
 		if (holder != null)
@@ -1034,6 +1072,7 @@
 	limb_type = /datum/limb/hunter
 	handlistPart = "r_hand_hunter"
 	show_on_examine = 1
+	limb_is_unnatural = TRUE
 
 	New(var/atom/holder)
 		if (holder != null)
@@ -1060,6 +1099,7 @@
 	handlistPart = "l_hand_wendigo"
 	siemens_coefficient = 0
 	show_on_examine = 1
+	limb_is_unnatural = TRUE
 
 	New(var/atom/holder)
 		if (holder != null)
@@ -1086,6 +1126,7 @@
 	handlistPart = "r_hand_wendigo"
 	siemens_coefficient = 0
 	show_on_examine = 1
+	limb_is_unnatural = TRUE
 
 	New(var/atom/holder)
 		if (holder != null)
@@ -1110,6 +1151,7 @@ obj/item/parts/human_parts/arm/right/stone
 	handlistPart = "r_hand_stone"
 	var/name_thing = "stone"
 	show_on_examine = 1
+	limb_is_unnatural = TRUE
 
 	New(var/atom/holder)
 		if (holder != null)
@@ -1134,6 +1176,7 @@ obj/item/parts/human_parts/arm/right/stone
 	handlistPart = "l_hand_stone"
 	var/name_thing = "stone"
 	show_on_examine = 1
+	limb_is_unnatural = TRUE
 
 	New(var/atom/holder)
 		if (holder != null)
@@ -1158,6 +1201,7 @@ obj/item/parts/human_parts/arm/right/stone
 	partlistPart = "l_foot_stone"
 	var/name_thing = "stone"
 	show_on_examine = 1
+	limb_is_unnatural = TRUE
 
 	New(var/atom/holder)
 		if (holder != null)
@@ -1182,6 +1226,7 @@ obj/item/parts/human_parts/arm/right/stone
 	partlistPart = "r_foot_stone"
 	var/name_thing = "stone"
 	show_on_examine = 1
+	limb_is_unnatural = TRUE
 
 	New(var/atom/holder)
 		if (holder != null)
@@ -1207,6 +1252,7 @@ obj/item/parts/human_parts/arm/right/reliquary
 	handlistPart = "hand_right"
 	var/name_thing = "reli"
 	show_on_examine = 1
+	limb_is_unnatural = TRUE
 
 	New(var/atom/holder)
 		if (holder != null)

--- a/code/obj/item/mob_parts/robot_parts.dm
+++ b/code/obj/item/mob_parts/robot_parts.dm
@@ -12,6 +12,8 @@
 	module_research_type = /obj/item/parts/robot_parts
 	accepts_normal_human_overlays = 0
 	skintoned = 0
+	/// Robot limbs shouldn't get replaced through mutant race changes
+	limb_is_unnatural = TRUE
 
 	decomp_affected = 0
 	var/robot_movement_modifier


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUGFIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #2915 

Fixes non-skintoned mutants from getting skintoned heads.

Fixes mutantraces replacing item arms and robot limbs. Also prevents them from replacing any limb you didn't spawn with, more or less. So, you can keep your stolen wolf arms, no matter what inhuman monster you become (except for going horrorform, that always eats your arms and legs.
