### PR TITLE
Removes duplicate head of staff lockers from Clarion

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -2138,7 +2138,6 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "adY" = (
-/obj/storage/secure/closet/command/chief_engineer,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 5;
@@ -3663,7 +3662,6 @@
 	name = "Crew Quarters M03"
 	})
 "agz" = (
-/obj/storage/secure/closet/command/medical_director,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 5;
@@ -5210,7 +5208,6 @@
 	name = "Crew Quarters M04"
 	})
 "aiI" = (
-/obj/storage/secure/closet/command/research_director,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 5;
@@ -6827,7 +6824,6 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "akV" = (
-/obj/storage/secure/closet/command/hos,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 5;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes duplicate head of staff lockers from Clarion. MDir, RD, CE and HoS have a 2nd locker in their private quarters on Clarion, those have been removed and their workplace lockers kept intact.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Stuff like syringe guns, tranq rifles and eguns are balanced around being in only one head of staff locker. Otherwise, you get stuff like HoS being able to consistently have an e-gun and a Lawbringer.
