### PR TITLE
Adds a custom suicide for the portable air pump

### DIFF
--- a/code/modules/atmospherics/portable/pump.dm
+++ b/code/modules/atmospherics/portable/pump.dm
@@ -10,6 +10,7 @@
 	var/direction_out = 0 //0 = siphoning, 1 = releasing
 	var/target_pressure = 100
 	desc = "A device which can siphon or release gasses."
+	custom_suicide = 1
 
 	volume = 750
 
@@ -160,3 +161,33 @@ Target Pressure: <A href='?src=\ref[src];pressure_adj=-100'>-</A> <A href='?src=
 		usr.Browse(null, "window=pump")
 		return
 	return
+
+
+/obj/machinery/portable_atmospherics/pump/suicide(var/mob/living/carbon/human/user)
+	if (!istype(user) || !src.user_can_suicide(user))
+		return 0
+
+	if (!on) //Can't chop your head off if the fan's not spinning
+		on = 1
+		update_icon()
+
+	user.visible_message("<span class='alert'><b>[user] forces [his_or_her(user)] head into [src]'s unprotected fan, mangling it in a horrifically and violently!</b></span>")
+	var/obj/head = user.organHolder.drop_organ("head")
+	qdel(head)
+	playsound(src.loc, 'sound/impact_sounds/Flesh_Tear_2.ogg', 50, 1)
+	var/turf/T = get_turf(user.loc)
+	if (user.blood_id)
+		T.fluid_react_single(user.blood_id, 20, airborne = 1)
+	else
+		T.fluid_react_single("blood", 20, airborne = 1)
+
+	for (var/mob/living/carbon/human/V in oviewers(user, null))
+		if (prob(33))
+			V.show_message("<span class='alert'>Oh fuck, that's going to leave a mark on your psyche.</span>", 1)
+			V.vomit()
+	if (user) //ZeWaka: Fix for null.loc
+		health_update_queue |= user
+	SPAWN_DBG(50 SECONDS)
+		if (user && !isdead(user))
+			user.suiciding = 0
+	return 1

--- a/code/modules/atmospherics/portable/pump.dm
+++ b/code/modules/atmospherics/portable/pump.dm
@@ -171,7 +171,7 @@ Target Pressure: <A href='?src=\ref[src];pressure_adj=-100'>-</A> <A href='?src=
 		on = 1
 		update_icon()
 
-	user.visible_message("<span class='alert'><b>[user] forces [his_or_her(user)] head into [src]'s unprotected fan, mangling it in a horrifically and violently!</b></span>")
+	user.visible_message("<span class='alert'><b>[user] forces [his_or_her(user)] head into [src]'s unprotected fan, mangling it in a horrific and violent display!</b></span>")
 	var/obj/head = user.organHolder.drop_organ("head")
 	qdel(head)
 	playsound(src.loc, 'sound/impact_sounds/Flesh_Tear_2.ogg', 50, 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feat]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds a fancy custom suicide to the portable air pump, which decapitates the subject (this is the bit that'll kill them), creates a smoke of whatever reagent their blood is, and might make onlookers vomit. The code is accordingly adapted from several places that do similar things.

NB: This one accompanies #2831 which adds the giant open fan referred to here. This PR is also going to get a merge conflict once that gets merged in because I'm doing all this very smartly. However, I suspect the suicide code I cobbled together will have weird shit in it that needs to get sorted out before this is ready to merge anyway, and we can look at that in the meantime.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Wouldn't want to keep the crew from making obvious bad health decisions.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)BatElite:
(+)Crewmembers looking for early retirement can now use portable air pumps for that purpose.
```
