### PR TITLE
Fixes AI being unable to suicide outside mainframe

### DIFF
--- a/code/mob/suicide.dm
+++ b/code/mob/suicide.dm
@@ -21,7 +21,7 @@
 // the suiciding var is already at the mob level for fuck's sakes
 /mob/verb/suicide()
 
-	if (!isliving(src) || isdead(src))
+	if ((!isliving(src) || isdead(src)) && !istype(src, /mob/dead/aieye))
 		boutput(src, "You're already dead!")
 		return
 
@@ -157,6 +157,10 @@
 					src.suiciding = 0
 			return
 	return
+
+/mob/dead/aieye/do_suicide()
+	src.return_mainframe()
+	src.mainframe.do_suicide()
 
 /mob/living/silicon/ai/do_suicide()
 	src.visible_message("<span class='alert'><b>[src] is powering down. It looks like \he's trying to commit suicide.</b></span>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUGFIX]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? --> 

Fixes #2930 where the AI needs to recall to mainframe in order to properly suicide. Accomplishes this by adding a typecheck to suicide() (because aieye's path makes it count as dead) and by adding an override for do_suicide() that recalls the eye to mainframe and calls the mainframe's do_suicide()