### PR TITLE
tgui ui_act usages now return parent info

### DIFF
--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -263,7 +263,8 @@
 		return data
 
 	ui_act(action, params)
-		if(..())
+		. = ..()
+		if (.)
 			return
 		switch(action)
 			if("eject")

--- a/code/WorkInProgress/recycling/mail_chute.dm
+++ b/code/WorkInProgress/recycling/mail_chute.dm
@@ -49,7 +49,6 @@
 
 	ui_act(action, params)
 		. = ..()
-		// if action handled by parent type (disposal chute), no need to handle here
 		if (.)
 			return .
 		switch (action)

--- a/code/modules/atmospherics/portable/canister.dm
+++ b/code/modules/atmospherics/portable/canister.dm
@@ -438,7 +438,8 @@
 	)
 
 /obj/machinery/portable_atmospherics/canister/ui_act(action, params)
-	if(..())
+	. = ..()
+	if (.)
 		return
 	switch(action)
 		if("toggle-valve")

--- a/code/modules/power/pt_laser.dm
+++ b/code/modules/power/pt_laser.dm
@@ -379,7 +379,8 @@
 	return data
 
 /obj/machinery/power/pt_laser/ui_act(action, params)
-	if(..())
+	. = ..()
+	if (.)
 		return
 	switch(action)
 		//Input controls

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -239,7 +239,8 @@
 	return data
 
 /obj/machinery/power/smes/ui_act(action, params)
-	if(..())
+	. = ..()
+	if (.)
 		return
 	switch(action)
 		if("toggle-input")

--- a/code/modules/robotics/robot/robot_module_rewriter.dm
+++ b/code/modules/robotics/robot/robot_module_rewriter.dm
@@ -86,7 +86,8 @@
 	return data
 
 /obj/machinery/computer/robot_module_rewriter/ui_act(action, list/params, datum/tgui/ui)
-	if (..())
+	. = ..()
+	if (.)
 		return
 
 	var/mob/user = ui.user

--- a/code/modules/sound/djpanel.dm
+++ b/code/modules/sound/djpanel.dm
@@ -56,7 +56,8 @@ client/proc/open_dj_panel()
 	return data
 
 /datum/dj_panel/ui_act(action, params)
-	if(..())
+	. = ..()
+	if (.)
 		return
 
 	if (!config.allow_admin_sounds)

--- a/code/obj/item/tank.dm
+++ b/code/obj/item/tank.dm
@@ -244,7 +244,8 @@ Contains:
 	return data
 
 /obj/item/tank/ui_act(action, params)
-	if(..())
+	. = ..()
+	if (.)
 		return
 	switch(action)
 		if("toggle-valve")

--- a/code/obj/machinery/computer/cloning.dm
+++ b/code/obj/machinery/computer/cloning.dm
@@ -669,7 +669,8 @@ proc/find_ghost_by_key(var/find_key)
 				active_process = PROCESS_IDLE
 
 /obj/machinery/computer/cloning/ui_act(action, params)
-	if(..())
+	. = ..()
+	if (.)
 		return
 	switch(action)
 		if("delete")

--- a/code/obj/machinery/dispenser.dm
+++ b/code/obj/machinery/dispenser.dm
@@ -80,7 +80,8 @@
 	return data
 
 /obj/machinery/dispenser/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
-	if(..())
+	. = ..()
+	if (.)
 		return
 	switch(action)
 		if("dispense-plasma")

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -1812,7 +1812,8 @@ obj/machinery/door/airlock
 		return UI_UPDATE
 
 /obj/machinery/door/airlock/ui_act(action, params)
-	if(..())
+	. = ..()
+	if (.)
 		return
 	if(src.arePowerSystemsOn() && (ishivebot(usr) || isrobot(usr) || isAI(usr)))
 		switch(action)

--- a/code/obj/submachine/slots.dm
+++ b/code/obj/submachine/slots.dm
@@ -43,7 +43,8 @@
 	)
 
 /obj/submachine/slot_machine/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
-	if(..())
+	. = ..()
+	if (.)
 		return
 	switch(action)
 		if ("insert_card")

--- a/tgui/docs/tutorial-and-examples.md
+++ b/tgui/docs/tutorial-and-examples.md
@@ -76,7 +76,8 @@ input. The input's `action` and `params` are passed to the proc.
 
 ```dm
 /obj/machinery/my_machine/ui_act(action, params)
-  if(..())
+  . = ..()
+  if (.)
     return
   if(action == "change_color")
     var/new_color = params["color"]
@@ -304,7 +305,8 @@ upon code review):
   return data
 
 /obj/copypasta/ui_act(action, params)
-  if(..())
+  . = ..()
+  if (.)
     return
   switch(action)
     if("copypasta")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Applies https://github.com/tgstation/tgstation/pull/53964 to Goonstation.
We should enforce return of parent call if truthy going forwards.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Not needed by our implementations (though mail chutes were already using it), but reduces likelihood of bugs in future.