### PR TITLE
Hide 'Emergency Restart' verb from side panel

### DIFF
--- a/code/modules/admin/randomverbs.dm
+++ b/code/modules/admin/randomverbs.dm
@@ -1,6 +1,6 @@
 /verb/restart_the_fucking_server_i_mean_it()
 	set name = "Emergency Restart"
-	SET_ADMIN_CAT(ADMIN_CAT_SERVER)
+	SET_ADMIN_CAT(ADMIN_CAT_NONE)
 	if(config.update_check_enabled)
 		world.installUpdate()
 	world.Reboot()

--- a/strings/admin_changelog.txt
+++ b/strings/admin_changelog.txt
@@ -1,3 +1,6 @@
+(t)fri dec 04 20
+(u)Mordent
+(*)Removed "Emergency Restart" verb from the Server panel, still available on the command line if you need it for some reason.
 (t)tue nov 24 20
 (u)Sovexe
 (*)Added a new buildmode tool, Location. Let's you easily warp around mobs and objects, and easily put things inside of other things.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Removes "Emergency Restart" verb from side panel (still available via command bar).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Because it has no confirm and I've pressed it once by accident, and we have CI stuff to do it for us anyway.