### PR TITLE
Swap out donut3 pathology floor for simulated ones

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -7524,7 +7524,7 @@
 /obj/decal/cleanable/blood{
 	icon_state = "drip2b"
 	},
-/turf/unsimulated/floor/greenwhite/corner{
+/turf/simulated/floor/greenwhite/corner{
 	dir = 1
 	},
 /area/station/medical/cdc)
@@ -16771,7 +16771,7 @@
 	dir = 1
 	},
 /obj/decal/cleanable/rust/jen,
-/turf/unsimulated/floor/greenwhite/corner{
+/turf/simulated/floor/greenwhite/corner{
 	dir = 8
 	},
 /area/station/medical/cdc)
@@ -26568,7 +26568,7 @@
 /area/station/bridge)
 "hIa" = (
 /obj/decal/cleanable/dirt,
-/turf/unsimulated/floor/greenwhite/corner{
+/turf/simulated/floor/greenwhite/corner{
 	dir = 8
 	},
 /area/station/medical/cdc)
@@ -30796,7 +30796,7 @@
 /obj/decal/cleanable/blood{
 	icon_state = "drip2b"
 	},
-/turf/unsimulated/floor/greenwhite/corner{
+/turf/simulated/floor/greenwhite/corner{
 	dir = 8
 	},
 /area/station/medical/cdc)
@@ -44266,7 +44266,7 @@
 /area/station/hallway/primary/east)
 "nkZ" = (
 /obj/machinery/light/small/sticky/greenish,
-/turf/unsimulated/floor/greenwhite/corner{
+/turf/simulated/floor/greenwhite/corner{
 	dir = 4
 	},
 /area/station/medical/cdc)
@@ -50300,7 +50300,7 @@
 /area/station/crew_quarters/bathroom)
 "pbi" = (
 /obj/decal/cleanable/rust/jen,
-/turf/unsimulated/floor/greenwhite/corner{
+/turf/simulated/floor/greenwhite/corner{
 	dir = 1
 	},
 /area/station/medical/cdc)
@@ -54828,7 +54828,7 @@
 /turf/simulated/floor/grey,
 /area/station/science/lab)
 "qnH" = (
-/turf/unsimulated/floor/greenwhite/corner{
+/turf/simulated/floor/greenwhite/corner{
 	dir = 1
 	},
 /area/station/medical/cdc)
@@ -55316,7 +55316,7 @@
 /area/space)
 "qtC" = (
 /obj/decal/cleanable/rust/jen,
-/turf/unsimulated/floor/greenwhite/corner{
+/turf/simulated/floor/greenwhite/corner{
 	dir = 4
 	},
 /area/station/medical/cdc)
@@ -56531,7 +56531,7 @@
 /obj/decal/cleanable/blood{
 	icon_state = "drip2b"
 	},
-/turf/unsimulated/floor/greenwhite/corner,
+/turf/simulated/floor/greenwhite/corner,
 /area/station/medical/cdc)
 "qMP" = (
 /obj/machinery/disposal/cart_port,
@@ -67161,7 +67161,7 @@
 /area/station/engine/ptl)
 "tVH" = (
 /obj/machinery/light/small/sticky/greenish,
-/turf/unsimulated/floor/greenwhite/corner,
+/turf/simulated/floor/greenwhite/corner,
 /area/station/medical/cdc)
 "tVX" = (
 /obj/cable{
@@ -67251,7 +67251,7 @@
 /turf/simulated/floor/wood/six,
 /area/station/library)
 "tXr" = (
-/turf/unsimulated/floor/greenwhite/corner{
+/turf/simulated/floor/greenwhite/corner{
 	dir = 8
 	},
 /area/station/medical/cdc)
@@ -69670,7 +69670,7 @@
 "uJP" = (
 /obj/decal/cleanable/rust/jen,
 /obj/decal/cleanable/blood,
-/turf/unsimulated/floor/greenwhite/corner{
+/turf/simulated/floor/greenwhite/corner{
 	dir = 4
 	},
 /area/station/medical/cdc)
@@ -74640,7 +74640,7 @@
 	dir = 1
 	},
 /obj/decal/cleanable/rust/jen,
-/turf/unsimulated/floor/greenwhite/corner{
+/turf/simulated/floor/greenwhite/corner{
 	dir = 1
 	},
 /area/station/medical/cdc)
@@ -80101,7 +80101,7 @@
 "xMH" = (
 /obj/decal/cleanable/dirt,
 /obj/decal/cleanable/rust/jen,
-/turf/unsimulated/floor/greenwhite/corner,
+/turf/simulated/floor/greenwhite/corner,
 /area/station/medical/cdc)
 "xMW" = (
 /turf/simulated/wall/auto/reinforced/jen/green{


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Back in the september contest it turned out that the small empty rooms of donut3's pathology used unsimulated floors. Now that we're couple months ahead and it's not been addressed, I figured I'd do it myself.

I don't know why it says 14 deletions/additions when I changed 16 turfs.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Unsimulated floors are stinky and donut3's pathology doesn't need any help in that regard.