### PR TITLE
Colorblind Trait Addition

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -478,6 +478,26 @@
 			owner.bioHolder.AddEffect("blind", 0, 0, 0, 1)
 		return
 
+/obj/trait/colorblind
+	name = "Colorblind (+1)"
+	cleanName = "Colorblind"
+	desc = "Spawn with permanent protanopia."
+	id = "permcolorblind"
+	category = "vision"
+	points = 1
+	isPositive = 0
+
+	onAdd(var/mob/owner)
+		if(owner.bioHolder)
+			if(istype(owner, /mob/living/carbon/human))
+				owner.bioHolder.AddEffect("protanopia", 0, 0, 0, 1)
+		return
+
+	onLife(var/mob/owner) //Just to be super DUPER safe.
+		if(owner.bioHolder && !owner.bioHolder.HasEffect("protanopia"))
+			owner.bioHolder.AddEffect("protanopia", 0, 0, 0, 1)
+		return
+
 // GENETICS - Blue Border
 
 /obj/trait/robustgenetics

--- a/code/modules/medical/genetics/bioEffects/harmful.dm
+++ b/code/modules/medical/genetics/bioEffects/harmful.dm
@@ -610,8 +610,9 @@
 
 	OnRemove()
 		src.removed = 1
-		REMOVE_MOB_PROPERTY(owner, PROP_PROTANOPIA, src)
-		owner.client?.color = null
+		if (!owner.traitHolder.hasTrait("permcolorblind"))//Here to prevent wacky interactions with the trait that might happen, i am so sorry if this is hacky as fuck
+			REMOVE_MOB_PROPERTY(owner, PROP_PROTANOPIA, src)
+			owner.client?.color = null
 		return
 
 /datum/bioEffect/emoter/screamer

--- a/code/modules/medical/genetics/bioEffects/harmful.dm
+++ b/code/modules/medical/genetics/bioEffects/harmful.dm
@@ -610,7 +610,7 @@
 
 	OnRemove()
 		src.removed = 1
-		if (!owner.traitHolder.hasTrait("permcolorblind"))//Here to prevent wacky interactions with the trait that might happen, i am so sorry if this is hacky as fuck
+		if (!owner.traitHolder?.hasTrait("permcolorblind")) //Here to prevent wacky interactions with the trait that might happen
 			REMOVE_MOB_PROPERTY(owner, PROP_PROTANOPIA, src)
 			owner.client?.color = null
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the Colorblind trait to the trait menu. Gives 1 trait point in return, and gives the player irremovable protanopia.

This is my first ever DM code/PR, so if something is scuffed/unnecessary, do tell.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More traits good. Colorblind cool.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Kapu1178
(+)Colorblind is now a selectable trait
```
