### PR TITLE
Make killswitch timer count REAL ACTUAL SECONDS

### DIFF
--- a/code/datums/hud/ai.dm
+++ b/code/datums/hud/ai.dm
@@ -86,8 +86,11 @@
 
 		update_health()
 			if (master.killswitch)
+				var/timeleft = round((master.killswitch_at - ticker.round_elapsed_ticks)/10, 1)
+				timeleft = "[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]"
+
 				killswitch.invisibility = 0
-				killswitch.maptext = "<span class='vga vt c ol' style='color: red;'>KILLSWITCH TIMER\n<span style='font-size: 24px;'>[add_zero(master.killswitch_time - 2,2)]</span></span>"
+				killswitch.maptext = "<span class='vga vt c ol' style='color: red;'>KILLSWITCH TIMER\n<span style='font-size: 24px;'>[timeleft]</span></span>"
 			else
 				killswitch.invisibility = 101
 				killswitch.maptext = ""

--- a/code/datums/hud/ai.dm
+++ b/code/datums/hud/ai.dm
@@ -86,7 +86,7 @@
 
 		update_health()
 			if (master.killswitch)
-				var/timeleft = round((master.killswitch_at - ticker.round_elapsed_ticks)/10, 1)
+				var/timeleft = round((master.killswitch_at - TIME)/10, 1)
 				timeleft = "[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]"
 
 				killswitch.invisibility = 0

--- a/code/mob/living/silicon.dm
+++ b/code/mob/living/silicon.dm
@@ -10,7 +10,7 @@
 	var/list/req_access = list()
 
 	var/killswitch = 0
-	var/killswitch_time = 60
+	var/killswitch_at = 0
 	var/weapon_lock = 0
 	var/weaponlock_time = 120
 	var/obj/item/card/id/botcard //An ID card that the robot "holds" invisibly

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -1196,7 +1196,7 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 	var/message_mob = get_message_mob()
 
 	if(killswitch_at)
-		var/killswitch_time = round((killswitch_at - ticker.round_elapsed_ticks)/10, 1)
+		var/killswitch_time = round((killswitch_at - TIME)/10, 1)
 
 		if(killswitch_time <= 10)
 			if(src.client)

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -1195,8 +1195,9 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 /mob/living/silicon/ai/process_killswitch()
 	var/message_mob = get_message_mob()
 
-	if(killswitch)
-		killswitch_time --
+	if(killswitch_at)
+		var/killswitch_time = round((killswitch_at - ticker.round_elapsed_ticks)/10, 1)
+
 		if(killswitch_time <= 10)
 			if(src.client)
 				boutput(message_mob, "<span class='alert'><b>Time left until Killswitch: [killswitch_time]</b></span>")

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -81,7 +81,7 @@
 
 	// moved up to silicon.dm
 	killswitch = 0
-	killswitch_time = 60
+	killswitch_at = 0
 	weapon_lock = 0
 	weaponlock_time = 120
 	var/oil = 0
@@ -2407,8 +2407,7 @@
 
 	process_killswitch()
 		if(killswitch)
-			killswitch_time --
-			if(killswitch_time <= 0)
+			if(killswitch_at <= ticker.round_elapsed_ticks)
 				if(src.client)
 					boutput(src, "<span class='alert'><B>Killswitch Activated!</B></span>")
 				killswitch = 0

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -2407,7 +2407,7 @@
 
 	process_killswitch()
 		if(killswitch)
-			if(killswitch_at <= ticker.round_elapsed_ticks)
+			if(killswitch_at <= TIME)
 				if(src.client)
 					boutput(src, "<span class='alert'><B>Killswitch Activated!</B></span>")
 				killswitch = 0

--- a/code/obj/machinery/computer/robotics.dm
+++ b/code/obj/machinery/computer/robotics.dm
@@ -89,7 +89,7 @@
 			if(!A.killswitch)
 				dat += "<A href='?src=\ref[src];gib=1;ai=\ref[A]'>Kill Switch AI *Swipe ID*</A><BR>"
 			else
-				var/timeleft = round((A.killswitch_at - ticker.round_elapsed_ticks)/10, 1)
+				var/timeleft = round((A.killswitch_at - TIME)/10, 1)
 				timeleft = "[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]"
 				dat += "Time left:[timeleft]"
 				if (!isAI(user))
@@ -125,7 +125,7 @@
 				if(!R.killswitch)
 					dat += "<A href='?src=\ref[src];gib=1;bot=\ref[R]'>Kill Switch *Swipe ID*</A><BR>"
 				else
-					var/timeleft = round((R.killswitch_at - ticker.round_elapsed_ticks)/10, 1)
+					var/timeleft = round((R.killswitch_at - TIME)/10, 1)
 					timeleft = "[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]"
 					dat += "Time left:[timeleft] | "
 					dat += "<A href='?src=\ref[src];gib=2;bot=\ref[R]'>Cancel</A><BR>"
@@ -156,7 +156,7 @@
 							if(R.client)
 								boutput(R, "<span class='alert'><b>Killswitch process activated.</b></span>")
 							R.killswitch = 1
-							A.killswitch_at = ticker.round_elapsed_ticks + 1 MINUTE
+							A.killswitch_at = TIME + 1 MINUTE
 						else if(istype(A))
 							var/mob/message = A.get_message_mob()
 							message_admins("<span class='alert'>[key_name(usr)] has activated the AI self destruct on [key_name(message)].</span>")
@@ -165,7 +165,7 @@
 								boutput(message, "<span class='alert'><b>AI Killswitch process activated.</b></span>")
 								boutput(message, "<span class='alert'><b>Killswitch will engage in 3 minutes.</b></span>")
 							A.killswitch = 1
-							A.killswitch_at = ticker.round_elapsed_ticks + 3 MINUTES
+							A.killswitch_at = TIME + 3 MINUTES
 					else
 						boutput(usr, "<span class='alert'>Access Denied.</span>")
 

--- a/code/obj/machinery/computer/robotics.dm
+++ b/code/obj/machinery/computer/robotics.dm
@@ -89,7 +89,9 @@
 			if(!A.killswitch)
 				dat += "<A href='?src=\ref[src];gib=1;ai=\ref[A]'>Kill Switch AI *Swipe ID*</A><BR>"
 			else
-				dat += "Time left:[A.killswitch_time]"
+				var/timeleft = round((A.killswitch_at - ticker.round_elapsed_ticks)/10, 1)
+				timeleft = "[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]"
+				dat += "Time left:[timeleft]"
 				if (!isAI(user))
 					dat += " | <A href='?src=\ref[src];gib=2;ai=\ref[A]'>Cancel</A>"
 				dat += "<BR>"
@@ -123,7 +125,9 @@
 				if(!R.killswitch)
 					dat += "<A href='?src=\ref[src];gib=1;bot=\ref[R]'>Kill Switch *Swipe ID*</A><BR>"
 				else
-					dat += "Time left:[R.killswitch_time] | "
+					var/timeleft = round((R.killswitch_at - ticker.round_elapsed_ticks)/10, 1)
+					timeleft = "[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]"
+					dat += "Time left:[timeleft] | "
 					dat += "<A href='?src=\ref[src];gib=2;bot=\ref[R]'>Cancel</A><BR>"
 			dat += "*----------*<BR>"
 
@@ -152,29 +156,29 @@
 							if(R.client)
 								boutput(R, "<span class='alert'><b>Killswitch process activated.</b></span>")
 							R.killswitch = 1
-							R.killswitch_time = 60
+							A.killswitch_at = ticker.round_elapsed_ticks + 1 MINUTE
 						else if(istype(A))
 							var/mob/message = A.get_message_mob()
 							message_admins("<span class='alert'>[key_name(usr)] has activated the AI self destruct on [key_name(message)].</span>")
 							logTheThing("combat", usr, message, "has activated the AI killswitch process on [constructTarget(message,"combat")]")
 							if(message.client)
 								boutput(message, "<span class='alert'><b>AI Killswitch process activated.</b></span>")
-								boutput(message, "<span class='alert'><b>Killswitch will engage in 60 seconds.</b></span>") // more like 180 really but whatever
+								boutput(message, "<span class='alert'><b>Killswitch will engage in 3 minutes.</b></span>")
 							A.killswitch = 1
-							A.killswitch_time = 60
+							A.killswitch_at = ticker.round_elapsed_ticks + 3 MINUTES
 					else
 						boutput(usr, "<span class='alert'>Access Denied.</span>")
 
 			if("2")
 				if(istype(R))
-					R.killswitch_time = 60
+					R.killswitch_at = 0
 					R.killswitch = 0
 					message_admins("<span class='alert'>[key_name(usr)] has stopped the robot self destruct on [key_name(R, 1, 1)].</span>")
 					logTheThing("combat", usr, R, "has stopped the robot killswitch process on [constructTarget(R,"combat")].")
 					if(R.client)
 						boutput(R, "<span class='notice'><b>Killswitch process deactivated.</b></span>")
 				else if(istype(A))
-					A.killswitch_time = 60
+					A.killswitch_at = 0
 					A.killswitch = 0
 					var/mob/message = A.get_message_mob()
 					message_admins("<span class='alert'>[key_name(usr)] has stopped the AI self destruct on [key_name(message, 1, 1)].</span>")


### PR DESCRIPTION
[BALANCE]

## About the PR

Empirically, the killswitch timer usually takes 180 seconds, so the timer has been changed from 60 mystery time units to 3 minutes.

The killswitch timer now records the timestamp for when it should end rather than the number of seconds remaining, making it more closely match the nuclear bomb timer.

## Why's this needed?

Nondeterministic self-destruct sequences are confusing and weird.

## Changelog

```
(u)BenLubar:
(+)The AI's killswitch now lasts 3 minutes rather than 60 mystery time units, each almost but not quite equal to 3 seconds.
```
