### PR TITLE
Prevent visual mirror from warping away lights

### DIFF
--- a/code/turf/turf.dm
+++ b/code/turf/turf.dm
@@ -379,8 +379,8 @@
 	if(vistarget)
 		vistarget.vis_contents += M
 	if(warptarget)
-		if(isnull(OldLoc)) return
-		M.set_loc(warptarget)
+		if(OldLoc)
+			M.set_loc(warptarget)
 #endif
 
 // Ported from unstable r355

--- a/code/turf/turf.dm
+++ b/code/turf/turf.dm
@@ -379,6 +379,7 @@
 	if(vistarget)
 		vistarget.vis_contents += M
 	if(warptarget)
+		if(isnull(OldLoc)) return
 		M.set_loc(warptarget)
 #endif
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Prevents visual mirrors from warping away atoms whose `oldLoc` is null when `Entered` is called - i.e. they were created on that turf
- fix suggested by pali

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
- Prevents visual mirror from warping the lights on their tile over to the other Z level and ruining the illusion
