### PR TITLE
Different pool for spacebux record songs

### DIFF
--- a/code/modules/telescience/radiostation.dm
+++ b/code/modules/telescience/radiostation.dm
@@ -448,14 +448,13 @@ ABSTRACT_TYPE(/obj/item/record/random/chronoquest)
 
 /obj/item/record/spacebux/New()
 	..()
-	var/pick_song = rand(1,3)
-	switch(pick_song)
-		if(1)
-			src.song = "sound/radio_station/buttris.ogg"
-		if(2)
-			src.song = "sound/radio_station/fart_elise.ogg"
-		if(3)
-			src.song = "sound/radio_station/we_are_number_two.ogg" // poo, more like, hah.
+	var/obj/item/record/record_type = pick(concrete_typesof(/obj/item/record/random))
+	src.name = initial(record_type.name)
+	src.record_name = initial(record_type.record_name)
+	src.name = initial(record_type.name)
+	src.song = initial(record_type.song)
+	if(src.record_name)
+		src.desc = "A fairly large record. There's a sticker on it that says \"[record_name]\"."
 
 /obj/item/record/poo
 	desc = "A fairly large record. It has a scratch on one side."


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Currently when you buy a spacebux record you get one of the three (subjectively horrible) songs Buttris, We Are Number Two and Fart Elise. This PR replaces that by the pool from which radio show host's songs are picked - which is mostly cool public domain songs we found and even cooler songs made by the members of Goonstation community!


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Many people dislike the honkfart remixes and it'd be neat to give more exposure to the cooler songs we have (which are currently only availalbe to the radio show host job).


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)pali
(+)The music record spacebux purchase now has a wider variety of songs!
```
