### PR TITLE
Make hacking lockers require netpass_security, give more ways of finding netpass_security

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -19,6 +19,7 @@
 	var/recieves_miranda = 0
 	var/recieves_implant = null //Will be a path.
 	var/receives_disk = 0
+	var/receives_security_disk = 0
 	var/receives_badge = 0
 	var/announce_on_join = 0 // that's the head of staff announcement thing
 	var/radio_announcement = 1 // that's the latejoin announcement thing
@@ -232,6 +233,7 @@
 	cant_spawn_as_rev = 1
 	announce_on_join = 1
 	receives_disk = 1
+	receives_security_disk = 1
 	receives_badge = 1
 	recieves_implant = /obj/item/implant/health/security
 
@@ -445,6 +447,7 @@
 	cant_spawn_as_rev = 1
 	recieves_implant = /obj/item/implant/health/security
 	receives_disk = 1
+	receives_security_disk = 1
 	receives_badge = 1
 	slot_back = /obj/item/storage/backpack/withO2
 	slot_belt = /obj/item/device/pda2/security

--- a/code/obj/machinery/computer/security/riot.dm
+++ b/code/obj/machinery/computer/security/riot.dm
@@ -58,7 +58,7 @@
 				pingsignal.transmission_method = TRANSMISSION_RADIO
 
 				radio_connection.post_signal(src, pingsignal, radiorange)
-				return
+			return
 
 		switch(signal.data["command"])
 			if ("authorize")

--- a/code/obj/machinery/computer/security/riot.dm
+++ b/code/obj/machinery/computer/security/riot.dm
@@ -5,6 +5,10 @@
 	var/auth_need = 3.0
 	var/list/authorized
 	var/list/authorized_registered
+	var/datum/radio_frequency/radio_connection = null
+	var/net_id = null
+	var/datum/radio_frequency/control_frequency = "1461"
+	var/radiorange = 3
 	desc = "Use this computer to authorize security access to the Armory. You need an ID with security access to do so."
 
 	lr = 1
@@ -19,11 +23,56 @@
 		if (!armory_area || armory_area.contents.len <= 1)
 			armory_area = get_area_by_type(/area/station/security/armory)
 
+		src.net_id = generate_net_id(src)
+		SPAWN_DBG(0.5 SECONDS)
+			if (radio_controller)
+				radio_connection = radio_controller.add_object(src, "[control_frequency]")
+
 		/*for (var/obj/machinery/door/airlock/D in armory_area)
 			if (D.has_access(access_maxsec))
 				D.no_access = 1
 		*/
 		..()
+
+	disposing()
+		if (radio_controller)
+			radio_controller.remove_object(src, "[control_frequency]")
+		. = ..()
+
+	receive_signal(datum/signal/signal)
+		if(!signal || signal.encryption || signal.transmission_method != TRANSMISSION_RADIO)
+			return
+
+		var/target = signal.data["sender"]
+		if (!target) return
+
+		if (signal.data["address_1"] != src.net_id)
+			if (signal.data["address_1"] == "ping")
+				var/datum/signal/pingsignal = get_free_signal()
+				pingsignal.source = src
+				pingsignal.data["device"] = "ARM_AUTH"
+				pingsignal.data["netid"] = src.net_id
+				pingsignal.data["sender"] = src.net_id
+				pingsignal.data["address_1"] = target
+				pingsignal.data["command"] = "ping_reply"
+				pingsignal.transmission_method = TRANSMISSION_RADIO
+
+				radio_connection.post_signal(src, pingsignal, radiorange)
+				return
+
+		switch(signal.data["command"])
+			if ("authorize")
+				signal.data["sender"] = src.net_id
+				signal.data["address_1"] = target
+				if (signal.data["acc_code"] == netpass_heads)
+					signal.data["command"] = "ack"
+					signal.data["acc_code"] = netpass_security
+					signal.data["data"] = "authorize"
+					authorize()
+				else
+					signal.data["command"] = "nack"
+					signal.data["data"] = "badpass"
+				radio_connection.post_signal(src, signal, radiorange)
 
 
 	proc/authorize()

--- a/code/obj/storage/large_storage_parent.dm
+++ b/code/obj/storage/large_storage_parent.dm
@@ -845,7 +845,7 @@
 
 				if ("lock")
 					. = 0
-					if (signal.data["pass"] == netpass_heads)
+					if (signal.data["pass"] == netpass_security)
 						. = 1
 						src.locked = !src.locked
 						src.visible_message("[src] clicks[src.open ? "" : " locked"].")
@@ -863,7 +863,7 @@
 
 				if ("unlock")
 					. = 0
-					if (signal.data["pass"] == netpass_heads)
+					if (signal.data["pass"] == netpass_security)
 						. = 1
 						src.locked = !src.locked
 						src.visible_message("[src] clicks[src.open ? "" : " unlocked"].")

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -466,6 +466,11 @@
 				R.fields["mind"] = src.mind
 				R.name = "CloneRecord-[ckey(src.real_name)]"
 				D.root.add_file(R)
+
+				var/datum/computer/file/record/authrec = new /datum/computer/file/record {name = "SECAUTH";} (src)
+				authrec.fields = list("SEC"="[netpass_security]")
+				D.root.add_file( authrec )
+
 				D.name = "data disk - '[src.real_name]'"
 
 			if(JOB.receives_badge)

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -467,9 +467,10 @@
 				R.name = "CloneRecord-[ckey(src.real_name)]"
 				D.root.add_file(R)
 
-				var/datum/computer/file/record/authrec = new /datum/computer/file/record {name = "SECAUTH";} (src)
-				authrec.fields = list("SEC"="[netpass_security]")
-				D.root.add_file( authrec )
+				if (JOB.receives_security_disk)
+					var/datum/computer/file/record/authrec = new /datum/computer/file/record {name = "SECAUTH";} (src)
+					authrec.fields = list("SEC"="[netpass_security]")
+					D.root.add_file( authrec )
 
 				D.name = "data disk - '[src.real_name]'"
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE][FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Reopening this PR based on comments in the town hall. Original PR can be seen here: https://github.com/goonstation/goonstation/pull/2335

This PR makes three main changes:
1. Using packets to hack lockers will require netpass_security, not netpass_heads
2. Netpass_security is currently only available on the captain's disk. Now it is also available on the disk security members start with, and it's transmitted by the armory authorization computer
3. The armory authorization computer can be hacked using netpass_heads. You'll need to be within 3 tiles to do so, and it will also make a stationwide announcement, so be ready to make a hasty retreat if you plan to do this!

I think the biggest issue with this patch is that the packet emitted by the armory auth computer doesn't really do anything other than provide the netpass_security. This could probably be tied into the receive_signal triggers for lockers and doors, but there's already an area check that would be kind of awkward to replicate, and also I'm lazy. If someone else wants to add more packet integration into this PR, I would welcome it, but I think it could be acceptable without it?


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently, hacking lockers open is trivial. This will make it more difficult while still providing multiple methods of doing so.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)glassofmilk:
(*)Using packets to force open lockers now requires security authorization!
```