### PR TITLE
Allow bolt+toggle to occur in the same click

### DIFF
--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -773,7 +773,7 @@ About the new airlock wires panel:
 			//Sending a pulse through this flashes the red light on the door (if the door has power).
 			if ((src.arePowerSystemsOn()) && (!(status & NOPOWER)))
 				play_deny()
-		if (AIRLOCK_WIRE_MAIN_POWER1 || AIRLOCK_WIRE_MAIN_POWER2)
+		if (AIRLOCK_WIRE_MAIN_POWER1, AIRLOCK_WIRE_MAIN_POWER2)
 			//Sending a pulse through either one causes a breaker to trip, disabling the door for 10 seconds if backup power is connected, or 1 minute if not (or until backup power comes back on, whichever is shorter).
 			src.loseMainPower()
 			SPAWN_DBG(1 DECI SECOND)
@@ -794,7 +794,7 @@ About the new airlock wires panel:
 			SPAWN_DBG(1 DECI SECOND)
 				src.shock(usr, 25)
 
-		if (AIRLOCK_WIRE_BACKUP_POWER1 || AIRLOCK_WIRE_BACKUP_POWER2)
+		if (AIRLOCK_WIRE_BACKUP_POWER1, AIRLOCK_WIRE_BACKUP_POWER2)
 			//two wires for backup power. Sending a pulse through either one causes a breaker to trip, but this does not disable it unless main power is down too (in which case it is disabled for 1 minute or however long it takes main power to come back, whichever is shorter).
 			src.loseBackupPower()
 			SPAWN_DBG(1 DECI SECOND)
@@ -1729,7 +1729,17 @@ obj/machinery/door/airlock
 
 	if (src.aiControlDisabled) return
 
-	if (user.client.check_key(KEY_OPEN))
+	if (user.client.check_key(KEY_OPEN) && user.client.check_key(KEY_BOLT))
+		. = 1
+		if (locked)
+			toggle_bolt(user)
+			user_toggle_open(user)
+		else
+			user_toggle_open(user)
+			toggle_bolt(user)
+		return
+
+	else if (user.client.check_key(KEY_OPEN))
 		. = 1
 		user_toggle_open(user)
 		return

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -1731,6 +1731,7 @@ obj/machinery/door/airlock
 
 	if (user.client.check_key(KEY_OPEN) && user.client.check_key(KEY_BOLT))
 		. = 1
+		// need to do it in the right order or nothing will happen
 		if (locked)
 			toggle_bolt(user)
 			user_toggle_open(user)


### PR DESCRIPTION
[QOL][MINOR]

## About the PR

This allows AIs and cyborgs to bolt doors open in a single click, which can be very helpful with certain Ion Storm laws.

Also fixes a bug where only one of the two main power wires and only one of the two backup power wires in the door would respond to the multitool.

## Why's this needed?

I had three Ion Storms in a recent round and my hands hurt.