### PR TITLE
Less shit botanist xp

### DIFF
--- a/code/obj/item/plants.dm
+++ b/code/obj/item/plants.dm
@@ -54,8 +54,7 @@
 			pool (W)
 			pool (src)
 			user.put_in_hand_or_drop(P)
-			if (prob(20))
-				JOB_XP(user, "Botanist", 2)
+			JOB_XP(user, "Botanist", 2)
 
 		else if (istype(W, /obj/item/bluntwrap))
 			boutput(user, "<span class='alert'>You roll [src] up in [W] and make a fat doink.</span>")
@@ -73,8 +72,7 @@
 			qdel(W)
 			pool(src)
 			user.put_in_hand_or_drop(doink)
-			if (prob(20))
-				JOB_XP(user, "Botanist", 3)
+			JOB_XP(user, "Botanist", 3)
 
 	combust_ended()
 		smoke_reaction(src.reagents, 1, get_turf(src), do_sfx = 0)

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -1256,7 +1256,7 @@
 			// +10: if HP >= 400% w/ 30% chance
 			// Mutations can add or remove this, of course
 			// @TODO adjust this later, this is just to fix runtimes and make it slightly consistent
-			if (base_quality_score >= 1 && prob(10))
+			if (base_quality_score >= 1)
 				if (base_quality_score >= 11)
 					JOB_XP(user, "Botanist", 2)
 				else

--- a/code/obj/submachine/seed.dm
+++ b/code/obj/submachine/seed.dm
@@ -591,6 +591,7 @@
 				P.endurance = SpliceMK2(P1DNA.alleles[7],P2DNA.alleles[7],P1.vars["endurance"],P2.vars["endurance"])
 				DNA.endurance = SpliceMK2(P1DNA.alleles[7],P2DNA.alleles[7],P1DNA.vars["endurance"],P2DNA.vars["endurance"])
 
+				JOB_XP(usr, "Botanist", 5)
 				boutput(usr, "<span class='notice'>Splice successful.</span>")
 				if (!src.seedoutput) src.seeds.Add(S)
 				else S.set_loc(src.loc)

--- a/code/obj/submachine/seed.dm
+++ b/code/obj/submachine/seed.dm
@@ -428,7 +428,9 @@
 							if (1) boutput(usr, "<span class='alert'>ERROR: Seed has been destroyed.</span>")
 							if (2) boutput(usr, "<span class='alert'>ERROR: Reagent lost.</span>")
 							if (3) boutput(usr, "<span class='alert'>ERROR: Unknown error. Please try again.</span>")
-							else boutput(usr, "<span class='notice'>Infusion of [R.name] successful.</span>")
+							else
+								JOB_XP(usr, "Botanist", 3)
+								boutput(usr, "<span class='notice'>Infusion of [R.name] successful.</span>")
 						src.inserted.reagents.remove_reagent(R.id,10)
 						dialogue_open = 0
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Botanist XP sucks. I removed the percent chance for harvesting and rolling blunts, and I added some XP for using the PlantMaster to encourage players to experiment with seeds. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bring botanist XP more in line with player expectations - currently, you can harvest enough high quality weed to freeze the game for 30 seconds when the pile gets set on fire, in a 60 minute round, and get 10 xp. Fuck that.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Keiya:
(*)Significantly increase Botanist XP rewards. You can also get XP from splicing and infusing seeds now!
```
