### PR TITLE
Manta taser shotgun removal from HoS locker

### DIFF
--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -17778,7 +17778,6 @@
 /area/station/maintenance/upperstarboard)
 "aRb" = (
 /obj/storage/secure/closet/command/hos,
-/obj/item/gun/energy/tasershotgun,
 /turf/simulated/floor/redblack/corner,
 /area/station/security/hos)
 "aRc" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR and why it's needed <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Simply removes the taser shotgun from the HoS locker on Manta. Incredibly out of place to begin with (added when the taser shotgun was considerably more rare and not a loadout item) and just adds to the massive list of junk already stuffed in the locker. The HoS already spawns with a taser, a token, plus they have their E-gun/Lawbringer in the locker, and the armoury is next door to their office. I had meant to remove it when I did the HoS cape/jacket rebalancing awhile back but it slipped my mind. Less clutter good.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)virvatuli:
(+)Removed taser shotgun from HoS locker on Manta
```
