### PR TITLE
Kondaru upgrade "Epsilon" - expansion/rework targeted at southeast region

### DIFF
--- a/code/obj/machinery/launcherloader_kondaru.dm
+++ b/code/obj/machinery/launcherloader_kondaru.dm
@@ -30,6 +30,12 @@
 		default_direction = SOUTH
 		..()
 
+/obj/machinery/cargo_router/kd_sci_eject
+	New()
+		destinations = list("Catering" = EAST,"Disposal" = EAST,"Pod Bay" = EAST,"Medbay" = EAST,"Research" = EAST,"Export" = SOUTH,"Security" = EAST,"Mining" = EAST,"Engineering" = EAST,"QM" = EAST)
+		default_direction = WEST
+		..()
+
 /obj/machinery/cargo_router/kd_sci_right
 	New()
 		destinations = list("Research" = EAST)

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -39690,15 +39690,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"bQR" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	name = "cargo belt - east";
-	operating = 1
-	},
-/obj/machinery/light/small,
-/turf/simulated/floor/airless/plating,
-/area/station/maintenance/southwest)
 "bQS" = (
 /obj/machinery/conveyor{
 	name = "cargo belt - south";
@@ -40345,15 +40336,24 @@
 /area/station/maintenance/southeast)
 "bSm" = (
 /obj/machinery/launcher_loader/north,
-/turf/simulated/floor/airless/plating,
-/area/station/maintenance/southwest)
-"bSn" = (
-/obj/disposaloutlet/south,
-/obj/disposalpipe/trunk/east,
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
 /turf/simulated/floor/airless/grey,
 /area/station/maintenance/southwest)
+"bSn" = (
+/obj/machinery/light/runway_light,
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/space)
 "bSo" = (
 /obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/obj/grille/catwalk{
 	dir = 4
 	},
 /turf/simulated/floor/airless/grey,
@@ -40927,13 +40927,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "bTC" = (
-/obj/machinery/mass_driver{
-	dir = 8;
-	id = "shepardtone"
-	},
-/turf/simulated/floor/airless/plating,
-/area/station/maintenance/southwest)
-"bTD" = (
 /obj/machinery/launcher_loader/west,
 /turf/simulated/floor/airless/plating,
 /area/station/maintenance/southwest)
@@ -40948,22 +40941,22 @@
 	operating = 1
 	},
 /obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/airless/plating,
+/turf/simulated/floor/airless/grey,
 /area/station/maintenance/southwest)
 "bTG" = (
 /obj/machinery/cargo_router/kd_sci_right,
 /turf/simulated/floor/airless/grey,
 /area/station/maintenance/southwest)
 "bTH" = (
-/obj/machinery/floorflusher/industrial,
-/obj/disposalpipe/trunk/east,
-/obj/machinery/light/small,
-/turf/simulated/floor/airless/grey,
-/area/station/maintenance/southwest)
-"bTI" = (
 /obj/disposalpipe/segment/transport{
 	icon_state = "pipe-c"
 	},
+/obj/grille/catwalk,
+/turf/simulated/floor/airless/grey,
+/area/station/maintenance/southwest)
+"bTI" = (
+/obj/machinery/cargo_router/kd_sci_eject,
+/obj/machinery/light/small,
 /turf/simulated/floor/airless/grey,
 /area/station/maintenance/southwest)
 "bTJ" = (
@@ -41449,7 +41442,7 @@
 /area/station/maintenance/southeast)
 "bUK" = (
 /obj/machinery/launcher_loader/south,
-/turf/simulated/floor/airless/plating,
+/turf/simulated/floor/airless/grey,
 /area/station/maintenance/southwest)
 "bUL" = (
 /obj/machinery/conveyor{
@@ -41464,10 +41457,9 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment/transport{
-	dir = 1;
-	icon_state = "pipe-c"
+	dir = 4
 	},
-/turf/simulated/floor/airless/plating,
+/turf/simulated/floor/airless/grey,
 /area/station/maintenance/southwest)
 "bUN" = (
 /obj/wingrille_spawn/auto,
@@ -42039,10 +42031,6 @@
 	dir = 4;
 	name = "cargo belt - east";
 	operating = 1
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
 	},
 /turf/simulated/floor/airless/plating,
 /area/station/maintenance/southwest)
@@ -50517,7 +50505,7 @@
 /turf/space,
 /area/space)
 "cpo" = (
-/obj/machinery/light/runway_light/delay5,
+/obj/machinery/light/runway_light/delay4,
 /obj/lattice{
 	dir = 8;
 	icon_state = "lattice-dir"
@@ -50529,17 +50517,15 @@
 	dir = 10;
 	icon_state = "lattice-dir"
 	},
-/obj/machinery/light/runway_light/delay5,
-/turf/space,
-/area/space)
-"cpq" = (
-/obj/lattice{
-	dir = 10;
-	icon_state = "lattice-dir"
-	},
 /obj/machinery/light/runway_light/delay4,
 /turf/space,
 /area/space)
+"cpq" = (
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/maintenance/southwest)
 "cpr" = (
 /obj/storage/secure/closet/medical/medicine,
 /obj/machinery/alarm{
@@ -52509,6 +52495,14 @@
 /obj/stool/bar,
 /turf/simulated/floor/carpet/green/fancy/edge/sw,
 /area/station/crew_quarters/cafeteria)
+"geV" = (
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/light/runway_light/delay5,
+/turf/space,
+/area/space)
 "gga" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -54897,6 +54891,15 @@
 	dir = 8
 	},
 /area/station/crew_quarters/quarters_south)
+"nFv" = (
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/obj/grille/catwalk{
+	dir = 10
+	},
+/turf/simulated/floor/airless/grey,
+/area/station/maintenance/southwest)
 "nGr" = (
 /obj/machinery/light/emergency{
 	dir = 4;
@@ -56168,6 +56171,16 @@
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters_south)
+"qSh" = (
+/obj/machinery/conveyor{
+	name = "cargo belt - south";
+	operating = 1
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/turf/simulated/floor/airless/plating,
+/area/station/maintenance/southwest)
 "qTA" = (
 /obj/stool/chair{
 	dir = 1
@@ -56443,9 +56456,9 @@
 /turf/simulated/floor/engine,
 /area/station/routing/security)
 "rFS" = (
-/obj/machinery/light/runway_light,
+/obj/machinery/light/runway_light/delay5,
 /obj/lattice{
-	dir = 4;
+	dir = 8;
 	icon_state = "lattice-dir"
 	},
 /turf/space,
@@ -56800,6 +56813,16 @@
 /obj/machinery/phone,
 /turf/simulated/floor/carpet/red/fancy/edge/se,
 /area/station/security/hos)
+"sBH" = (
+/obj/grille/catwalk{
+	dir = 4
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/airless/plating,
+/area/station/maintenance/southwest)
 "sBO" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -57961,10 +57984,10 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/courtroom)
 "vRn" = (
-/obj/machinery/light/runway_light/delay4,
-/obj/lattice,
-/turf/space,
-/area/space)
+/obj/disposaloutlet/south,
+/obj/disposalpipe/trunk/east,
+/turf/simulated/floor/airless/grey,
+/area/station/maintenance/southwest)
 "vRP" = (
 /obj/cable{
 	d1 = 1;
@@ -58224,6 +58247,10 @@
 /obj/machinery/light/runway_light/delay2,
 /turf/space,
 /area/space)
+"wEQ" = (
+/obj/lattice,
+/turf/space,
+/area/station/maintenance/southwest)
 "wEY" = (
 /obj/decal/garland/ephemeral{
 	dir = 4;
@@ -58630,6 +58657,12 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/brig)
+"xOY" = (
+/obj/machinery/floorflusher/industrial,
+/obj/disposalpipe/trunk/east,
+/obj/machinery/light/small,
+/turf/simulated/floor/airless/grey,
+/area/station/maintenance/southwest)
 "xPt" = (
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
@@ -58708,6 +58741,13 @@
 /obj/item/clothing/glasses/thermal,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
+"xYr" = (
+/obj/machinery/mass_driver{
+	dir = 8;
+	id = "shepardtone"
+	},
+/turf/simulated/floor/airless/plating,
+/area/space)
 "xYH" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -87992,9 +88032,9 @@ aaa
 cia
 aaa
 aaa
-aci
+bSn
 aaa
-aaa
+aNQ
 aaa
 aaa
 aaa
@@ -88295,8 +88335,8 @@ cia
 aaa
 aaa
 rFS
-aaa
-aNQ
+xYr
+geV
 aaa
 aaa
 aaa
@@ -88899,8 +88939,8 @@ cia
 abZ
 abZ
 vRn
-bTD
-cpq
+bTI
+bvo
 aaa
 aaa
 aaa
@@ -89501,8 +89541,8 @@ aaa
 aaa
 cia
 bNY
-bQR
-bvo
+bVW
+cpq
 bTF
 bvo
 bVW
@@ -89804,7 +89844,7 @@ bMA
 cib
 bGc
 bQS
-bNY
+qSh
 bTG
 bUL
 bUL
@@ -90106,8 +90146,8 @@ bMB
 bOa
 bGc
 bGc
-bSn
-bTG
+bSo
+xOY
 bvo
 bVX
 aaa
@@ -90408,9 +90448,9 @@ bMB
 bOb
 bPu
 bNZ
-bSo
+nFv
 bTH
-bvo
+sBH
 bVX
 aaa
 aci
@@ -90710,8 +90750,8 @@ bMB
 bOb
 bPv
 bGc
-bSo
-bTI
+bUM
+wEQ
 bUM
 bVX
 aaa

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -54891,15 +54891,6 @@
 	dir = 8
 	},
 /area/station/crew_quarters/quarters_south)
-"nFv" = (
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
-/obj/grille/catwalk{
-	dir = 10
-	},
-/turf/simulated/floor/airless/grey,
-/area/station/maintenance/southwest)
 "nGr" = (
 /obj/machinery/light/emergency{
 	dir = 4;
@@ -56086,6 +56077,15 @@
 /obj/machinery/shieldgenerator/energy_shield,
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
+"qCC" = (
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/obj/grille/catwalk{
+	dir = 10
+	},
+/turf/simulated/floor/airless/grey,
+/area/station/maintenance/southwest)
 "qCQ" = (
 /obj/table/auto,
 /obj/item/paper/book/guardbot_guide{
@@ -58247,10 +58247,6 @@
 /obj/machinery/light/runway_light/delay2,
 /turf/space,
 /area/space)
-"wEQ" = (
-/obj/lattice,
-/turf/space,
-/area/station/maintenance/southwest)
 "wEY" = (
 /obj/decal/garland/ephemeral{
 	dir = 4;
@@ -58272,6 +58268,10 @@
 	},
 /turf/simulated/floor/grey/blackgrime,
 /area/station/security/brig)
+"wKe" = (
+/obj/lattice,
+/turf/space,
+/area/station/maintenance/southwest)
 "wLi" = (
 /obj/machinery/light/emergency,
 /obj/machinery/atmospherics/pipe/manifold{
@@ -58747,7 +58747,7 @@
 	id = "shepardtone"
 	},
 /turf/simulated/floor/airless/plating,
-/area/space)
+/area/station/maintenance/southwest)
 "xYH" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -90448,7 +90448,7 @@ bMB
 bOb
 bPu
 bNZ
-nFv
+qCC
 bTH
 sBH
 bVX
@@ -90751,7 +90751,7 @@ bOb
 bPv
 bGc
 bUM
-wEQ
+wKe
 bUM
 bVX
 aaa

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -346,11 +346,11 @@
 /area/space)
 "aaW" = (
 /obj/grille/catwalk{
-	dir = 5
+	dir = 5;
+	icon_state = "catwalk_cross"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	icon_state = "catwalk_cross"
+	dir = 5
 	},
 /area/space)
 "aaX" = (
@@ -15373,11 +15373,6 @@
 	dir = 4
 	},
 /area/station/hangar/engine)
-"aKM" = (
-/obj/machinery/light,
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/fitness)
 "aKN" = (
 /obj/storage/closet/fire,
 /turf/simulated/floor/plating,
@@ -15465,6 +15460,11 @@
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
 "aKZ" = (
+/obj/machinery/light,
+/obj/disposalpipe/segment/horizontal,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
+"aLa" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -15472,10 +15472,6 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/fitness)
-"aLa" = (
-/obj/disposalpipe/segment/bent/west,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "aLb" = (
@@ -15504,7 +15500,7 @@
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/quarters_north)
 "aLf" = (
-/obj/machinery/vending/cola/red,
+/obj/disposalpipe/segment/bent/west,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "aLi" = (
@@ -15705,16 +15701,12 @@
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
 "aLM" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/yellow/corner,
-/area/station/engine/storage)
+/obj/machinery/vending/cola/red,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
 "aLN" = (
 /obj/machinery/door/poddoor/pyro{
-	id = "kd_eng";
+	id = "kd_engB";
 	name = "Cargo Routing Door"
 	},
 /obj/machinery/conveyor{
@@ -15737,21 +15729,18 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/quarters_east)
 "aLS" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/yellow/corner,
+/area/station/engine/storage)
+"aLT" = (
 /obj/machinery/computer/security/wooden_tv{
 	desc = "These channels seem to mostly be about robuddies. What is this, some kind of reality show?";
 	name = "Television";
 	network = "Zeta"
-	},
-/turf/simulated/floor/black/grime,
-/area/station/maintenance/inner/central)
-"aLT" = (
-/obj/table/wood/auto,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
-/obj/item/dice,
-/obj/machinery/light/small/warm/very{
-	dir = 4;
-	pixel_x = 12
 	},
 /turf/simulated/floor/black/grime,
 /area/station/maintenance/inner/central)
@@ -15787,9 +15776,16 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aLX" = (
-/obj/machinery/manufacturer/mechanic,
-/turf/simulated/floor/yellow/side,
-/area/station/engine/elect)
+/obj/table/wood/auto,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
+/obj/item/dice,
+/obj/machinery/light/small/warm/very{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/black/grime,
+/area/station/maintenance/inner/central)
 "aLY" = (
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
@@ -15998,10 +15994,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "aMI" = (
-/obj/storage/secure/closet/engineering/mechanic,
-/turf/simulated/floor/yellow/side{
-	dir = 6
-	},
+/obj/machinery/manufacturer/mechanic,
+/turf/simulated/floor/yellow/side,
 /area/station/engine/elect)
 "aMJ" = (
 /obj/machinery/computer/general_alert{
@@ -16057,14 +16051,11 @@
 /turf/simulated/floor/grime,
 /area/station/maintenance/disposal)
 "aMP" = (
-/obj/stool/chair{
-	dir = 1
+/obj/storage/secure/closet/engineering/mechanic,
+/turf/simulated/floor/yellow/side{
+	dir = 6
 	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/fitness)
+/area/station/engine/elect)
 "aMQ" = (
 /obj/disposaloutlet/south,
 /obj/machinery/light/small{
@@ -16107,6 +16098,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
+"aMV" = (
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "aMW" = (
 /obj/cable{
 	d1 = 1;
@@ -16126,7 +16121,6 @@
 /obj/stool/chair{
 	dir = 1
 	},
-/obj/machinery/light,
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -16189,9 +16183,13 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
 "aNf" = (
-/obj/machinery/disposal,
-/obj/disposalpipe/trunk/north,
-/obj/machinery/light_switch/east,
+/obj/stool/chair{
+	dir = 1
+	},
+/obj/machinery/light,
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "aNg" = (
@@ -16250,6 +16248,16 @@
 /area/station/crew_quarters/pool)
 "aNm" = (
 /obj/machinery/disposal,
+/obj/disposalpipe/trunk/north,
+/obj/machinery/light_switch/east,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
+"aNn" = (
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/blue/checker,
+/area/station/crew_quarters/pool)
+"aNo" = (
+/obj/machinery/disposal,
 /obj/disposalpipe/trunk/south,
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -16260,11 +16268,7 @@
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/supply)
-"aNn" = (
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/blue/checker,
-/area/station/crew_quarters/pool)
-"aNo" = (
+"aNp" = (
 /obj/rack,
 /obj/item/clothing/suit/space/emerg,
 /obj/item/clothing/head/emerg,
@@ -16273,7 +16277,7 @@
 /obj/item/device/light/flashlight,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"aNp" = (
+"aNq" = (
 /obj/lattice,
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -16284,7 +16288,7 @@
 	},
 /turf/space,
 /area/space)
-"aNq" = (
+"aNr" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/lattice{
 	dir = 10;
@@ -16292,16 +16296,6 @@
 	},
 /turf/space,
 /area/space)
-"aNr" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 6
-	},
-/area/station/engine/storage)
 "aNt" = (
 /turf/simulated/floor,
 /area/station/security/checkpoint/escape)
@@ -16359,11 +16353,15 @@
 	},
 /area/station/medical/cdc)
 "aNC" = (
-/obj/stool/chair/comfy{
-	dir = 4
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/black/grime,
-/area/station/maintenance/inner/central)
+/turf/simulated/floor/yellow/side{
+	dir = 6
+	},
+/area/station/engine/storage)
 "aND" = (
 /obj/item/plant/herb/cannabis/spawnable,
 /obj/item/plant/herb/cannabis/spawnable,
@@ -16475,15 +16473,14 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
 "aNV" = (
-/obj/item/instrument/large/jukebox,
-/turf/simulated/floor/carpet/red/fancy/narrow/ne,
+/obj/stool/chair/comfy{
+	dir = 4
+	},
+/turf/simulated/floor/black/grime,
 /area/station/maintenance/inner/central)
 "aNW" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/simulated/floor/plating,
+/obj/item/instrument/large/jukebox,
+/turf/simulated/floor/carpet/red/fancy/narrow/ne,
 /area/station/maintenance/inner/central)
 "aNY" = (
 /turf/simulated/floor,
@@ -16496,6 +16493,13 @@
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
 "aOb" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
+"aOc" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -16512,7 +16516,7 @@
 	dir = 1
 	},
 /area/station/hallway/primary/north)
-"aOc" = (
+"aOd" = (
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
 	d2 = 2;
@@ -16522,19 +16526,13 @@
 	dir = 4
 	},
 /area/station/hallway/primary/north)
-"aOd" = (
+"aOe" = (
 /obj/machinery/door/airlock/pyro{
 	name = "Shower Room"
 	},
 /obj/firedoor_spawn,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/pool)
-"aOe" = (
-/obj/table/auto,
-/obj/item/device/analyzer/atmospheric,
-/obj/item/wrench,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "aOg" = (
 /obj/table/wood/auto,
 /obj/random_item_spawner/desk_stuff,
@@ -16590,7 +16588,9 @@
 /turf/simulated/floor/carpet/red/fancy/edge/ne,
 /area/station/crew_quarters/quarters_north)
 "aOo" = (
-/obj/decal/cleanable/dirt,
+/obj/table/auto,
+/obj/item/device/analyzer/atmospheric,
+/obj/item/wrench,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "aOp" = (
@@ -16612,9 +16612,9 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "aOs" = (
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/specialroom/arcade,
-/area/station/janitor/supply)
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "aOt" = (
 /obj/stool/bench/blue/auto,
 /obj/machinery/light/emergency{
@@ -16762,26 +16762,21 @@
 /turf/space,
 /area/space)
 "aOL" = (
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/specialroom/arcade,
+/area/station/janitor/supply)
+"aOM" = (
 /obj/landmark{
 	name = "blobstart"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"aOM" = (
+"aON" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"aON" = (
-/obj/grille/catwalk{
-	dir = 5;
-	icon_state = "catwalk_cross"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 5
-	},
-/area/space)
 "aOO" = (
 /obj/machinery/door/airlock/pyro/engineering{
 	name = "Engineering Hangar"
@@ -16811,8 +16806,10 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
 "aOT" = (
-/obj/critter/boogiebot,
-/turf/simulated/floor/carpet/red/fancy/innercorner/north,
+/obj/stool/chair/comfy{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/east,
 /area/station/maintenance/inner/central)
 "aOV" = (
 /turf/simulated/pool/no_animate,
@@ -16822,18 +16819,22 @@
 /turf/simulated/pool/no_animate,
 /area/station/crew_quarters/pool)
 "aOY" = (
-/obj/stool/chair/comfy{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/east,
-/area/station/maintenance/inner/central)
-"aOZ" = (
 /obj/stool/bench/blue/auto,
 /obj/machinery/light/small{
 	dir = 1;
 	pixel_y = 21
 	},
 /turf/simulated/floor/sanitary/white,
+/area/station/crew_quarters/pool)
+"aOZ" = (
+/obj/item/clothing/mask/wrestling,
+/obj/item/clothing/mask/wrestling/black,
+/obj/item/clothing/mask/wrestling/blue,
+/obj/item/clothing/mask/wrestling/green,
+/obj/item/clothing/under/gimmick/macho,
+/obj/item/clothing/under/gimmick/macho,
+/obj/storage/closet/dresser/random,
+/turf/simulated/floor/sanitary,
 /area/station/crew_quarters/pool)
 "aPb" = (
 /obj/wingrille_spawn/auto,
@@ -17106,29 +17107,19 @@
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
 "aPE" = (
-/obj/item/clothing/mask/wrestling,
-/obj/item/clothing/mask/wrestling/black,
-/obj/item/clothing/mask/wrestling/blue,
-/obj/item/clothing/mask/wrestling/green,
-/obj/item/clothing/under/gimmick/macho,
-/obj/item/clothing/under/gimmick/macho,
-/obj/storage/closet/dresser/random,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/pool)
-"aPF" = (
 /obj/machinery/atmospherics/valve/notify_admins/vertical{
 	dir = 4;
 	name = "Sauna Air Supply"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"aPG" = (
+"aPF" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/horizontal,
 /obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"aPH" = (
+"aPG" = (
 /obj/cable{
 	d1 = 2;
 	d2 = 4;
@@ -17137,7 +17128,7 @@
 /obj/disposalpipe/junction/left/south,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/supply)
-"aPI" = (
+"aPH" = (
 /obj/submachine/chef_sink{
 	desc = "A common utility sink.";
 	dir = 8;
@@ -17145,7 +17136,7 @@
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/supply)
-"aPJ" = (
+"aPI" = (
 /obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/escape_horizontal,
 /obj/forcefield/energyshield/perma/doorlink{
 	desc = "A door-linked force field that prevents gasses from passing through it.";
@@ -17156,10 +17147,16 @@
 	icon_state = "engine_caution_north"
 	},
 /area/station/hangar/escape)
-"aPM" = (
+"aPJ" = (
 /obj/machinery/r_door_control/podbay/escape,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/escape)
+"aPM" = (
+/obj/machinery/door_control/podbay/engineering/new_walls/north,
+/turf/simulated/floor/yellow/side{
+	dir = 1
+	},
+/area/station/hangar/engine)
 "aPN" = (
 /obj/machinery/door/airlock/pyro{
 	name = "Toilets"
@@ -17168,11 +17165,12 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
 "aPP" = (
-/obj/machinery/door_control/podbay/engineering/new_walls/north,
-/turf/simulated/floor/yellow/side{
-	dir = 1
+/obj/machinery/light/small/warm/very{
+	dir = 8;
+	pixel_x = -12
 	},
-/area/station/hangar/engine)
+/turf/simulated/floor/carpet/red/fancy/edge/west,
+/area/station/maintenance/inner/central)
 "aPQ" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/cable{
@@ -17189,26 +17187,33 @@
 /turf/simulated/pool/no_animate,
 /area/station/crew_quarters/pool)
 "aPS" = (
-/obj/machinery/light/small/warm/very{
-	dir = 8;
-	pixel_x = -12
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/west,
-/area/station/maintenance/inner/central)
-"aPT" = (
 /obj/table/wood/auto,
 /obj/item/game_kit,
 /obj/item/decoration/ashtray,
 /turf/simulated/floor/carpet/red/fancy/edge/east,
 /area/station/maintenance/inner/central)
+"aPT" = (
+/turf/simulated/floor/stairs/medical{
+	dir = 4
+	},
+/area/station/crew_quarters/pool)
 "aPU" = (
 /obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
 "aPV" = (
-/turf/simulated/floor/stairs/medical{
-	dir = 4
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 9;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
 	},
+/obj/submachine/chef_sink/chem_sink{
+	dir = 8;
+	pixel_x = 8
+	},
+/turf/simulated/floor/sanitary,
 /area/station/crew_quarters/pool)
 "aPW" = (
 /obj/table/wood/auto,
@@ -17273,19 +17278,9 @@
 /turf/simulated/floor/grey,
 /area/station/hallway/secondary/exit)
 "aQg" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 9;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/obj/submachine/chef_sink/chem_sink{
-	dir = 8;
-	pixel_x = 8
-	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/pool)
+/obj/machinery/atmospherics/pipe/simple/vertical,
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/sauna)
 "aQh" = (
 /obj/machinery/disposal/brig{
 	name = "escape checkpoint chute"
@@ -17368,9 +17363,13 @@
 	},
 /area/station/medical/cdc)
 "aQp" = (
-/obj/machinery/atmospherics/pipe/simple/vertical,
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/sauna)
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "aQq" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/south,
@@ -17580,25 +17579,25 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/ghostdrone_factory)
 "aQL" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-9"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"aQM" = (
 /obj/machinery/atmospherics/portables_connector{
 	name = "Escape N Repressurization Port"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"aQN" = (
+"aQM" = (
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -20
 	},
 /turf/simulated/floor/caution/east,
+/area/station/hangar/escape)
+"aQN" = (
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/shuttlebay,
 /area/station/hangar/escape)
 "aQP" = (
 /obj/item/device/net_sniffer,
@@ -17638,10 +17637,12 @@
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/quarters_east)
 "aQU" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/escape)
@@ -17672,15 +17673,21 @@
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/podbay)
 "aQX" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
+/obj/table/reinforced/auto,
+/obj/item/sheet/glass/reinforced{
+	amount = 50
 	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/escape)
+/obj/item/reagent_containers/food/drinks/fueltank,
+/obj/item/reagent_containers/food/drinks/fueltank,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/grey,
+/area/station/hangar/engine)
 "aQY" = (
 /obj/table/auto,
 /obj/machinery/computer/security/wooden_tv/small{
@@ -17713,34 +17720,18 @@
 /turf/simulated/floor/carpet/purple/fancy/edge/se,
 /area/station/crew_quarters/quarters_east)
 "aRc" = (
-/obj/table/reinforced/auto,
-/obj/item/sheet/glass/reinforced{
-	amount = 50
-	},
-/obj/item/reagent_containers/food/drinks/fueltank,
-/obj/item/reagent_containers/food/drinks/fueltank,
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/grey,
-/area/station/hangar/engine)
-"aRd" = (
 /turf/simulated/floor/carpet/red/fancy/narrow/sw,
 /area/station/maintenance/inner/central)
-"aRe" = (
+"aRd" = (
 /turf/simulated/floor/carpet/red/fancy/edge/south,
 /area/station/maintenance/inner/central)
-"aRf" = (
+"aRe" = (
 /obj/stool/chair/comfy{
 	dir = 8
 	},
 /turf/simulated/floor/carpet/red/fancy/narrow/se,
 /area/station/maintenance/inner/central)
-"aRg" = (
+"aRf" = (
 /obj/machinery/light{
 	dir = 4;
 	layer = 9.1;
@@ -17753,7 +17744,7 @@
 	dir = 4
 	},
 /area/station/hallway/primary/north)
-"aRh" = (
+"aRg" = (
 /obj/rack,
 /obj/item/sponge{
 	name = "loofah"
@@ -17761,6 +17752,10 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/sanitary/white,
 /area/station/crew_quarters/pool)
+"aRh" = (
+/obj/machinery/atmospherics/pipe/manifold/east,
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/sauna)
 "aRj" = (
 /obj/cable{
 	d1 = 2;
@@ -17813,9 +17808,13 @@
 	},
 /area/station/security/checkpoint/escape)
 "aRn" = (
-/obj/machinery/atmospherics/pipe/manifold/east,
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/sauna)
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "aRo" = (
 /obj/lattice{
 	dir = 5;
@@ -18137,17 +18136,16 @@
 	},
 /area/station/hallway/secondary/exit)
 "aRS" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/valve{
+	high_risk = 1;
+	name = "Escape Dock"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "aRT" = (
 /obj/machinery/atmospherics/valve{
 	high_risk = 1;
-	name = "Escape Dock"
+	name = "Air Reserve (Escape Dock)"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -18180,12 +18178,13 @@
 /turf/simulated/floor/grey/blackgrime/other,
 /area/station/storage/tech)
 "aRY" = (
-/obj/machinery/atmospherics/valve{
-	high_risk = 1;
-	name = "Air Reserve (Escape Dock)"
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/machinery/power/apc/autoname_west,
+/turf/simulated/floor/caution/east,
+/area/station/hangar/escape)
 "aRZ" = (
 /obj/disposalpipe/junction/left/north,
 /turf/simulated/floor/plating,
@@ -18261,12 +18260,12 @@
 /turf/simulated/floor/white/checker,
 /area/station/crew_quarters/pool)
 "aSi" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
 	},
-/obj/machinery/power/apc/autoname_west,
-/turf/simulated/floor/caution/east,
+/turf/simulated/floor/shuttlebay,
 /area/station/hangar/escape)
 "aSj" = (
 /obj/fluid_spawner{
@@ -18275,13 +18274,13 @@
 /turf/simulated/pool/no_animate,
 /area/station/crew_quarters/pool)
 "aSk" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/escape)
+/turf/simulated/floor/grey,
+/area/station/hangar/engine)
 "aSl" = (
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/plating,
@@ -18383,12 +18382,8 @@
 /turf/simulated/floor/grey,
 /area/station/hallway/secondary/exit)
 "aSw" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/grey,
+/obj/machinery/vehicle/miniputt/indyputt/armed,
+/turf/simulated/floor/shuttlebay,
 /area/station/hangar/engine)
 "aSx" = (
 /obj/disposalpipe/block_sensing_outlet/east,
@@ -18538,13 +18533,9 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/ghostdrone_factory)
 "aSS" = (
-/obj/machinery/vehicle/miniputt/indyputt/armed,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine)
-"aST" = (
 /turf/simulated/floor/black/grime,
 /area/station/maintenance/inner/central)
-"aSU" = (
+"aST" = (
 /obj/table/wood/auto,
 /obj/item/instrument/harmonica,
 /obj/item/device/light/zippo,
@@ -18552,7 +18543,7 @@
 /obj/item/pen,
 /turf/simulated/floor/black/grime,
 /area/station/maintenance/inner/central)
-"aSV" = (
+"aSU" = (
 /obj/table/wood/auto,
 /obj/item/instrument/saxophone,
 /obj/item/clothing/head/flatcap,
@@ -18566,6 +18557,14 @@
 	},
 /turf/simulated/floor/black/grime,
 /area/station/maintenance/inner/central)
+"aSV" = (
+/obj/decal/poster/wallsign/security_wall,
+/obj/decal/poster/wallsign/stencil/left/v{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/pool)
 "aSW" = (
 /obj/table/auto,
 /obj/item/peripheral/network/powernet_card,
@@ -18579,18 +18578,24 @@
 /turf/simulated/floor/grey/blackgrime/other,
 /area/station/storage/tech)
 "aSY" = (
-/obj/decal/poster/wallsign/security_wall,
-/obj/decal/poster/wallsign/stencil/left/v{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/pool)
-"aSZ" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/landmark/gps_waypoint,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/sauna)
+"aSZ" = (
+/obj/machinery/atmospherics/unary/furnace_connector{
+	dir = 4
+	},
+/obj/machinery/power/furnace/thermo,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/sauna)
 "aTa" = (
@@ -18630,23 +18635,20 @@
 	},
 /area/station/hallway/primary/east)
 "aTf" = (
-/obj/machinery/atmospherics/unary/furnace_connector{
-	dir = 4
-	},
-/obj/machinery/power/furnace/thermo,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/sauna)
-"aTg" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
 	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"aTg" = (
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 5;
+	level = 2
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -18720,8 +18722,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 5;
+/obj/machinery/atmospherics/pipe/manifold{
 	level = 2
 	},
 /turf/simulated/floor/plating,
@@ -18895,16 +18896,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aTK" = (
-/obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold{
-	level = 2
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"aTL" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
@@ -18917,7 +18908,7 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/east)
-"aTM" = (
+"aTL" = (
 /obj/disposalpipe/segment/bent/south,
 /obj/cable{
 	d1 = 1;
@@ -18934,12 +18925,23 @@
 	},
 /turf/simulated/floor/caution/east,
 /area/station/hangar/escape)
-"aTN" = (
+"aTM" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 10
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/escape)
+"aTN" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/hangar/engine)
 "aTO" = (
 /obj/stool/chair{
 	dir = 4
@@ -19049,15 +19051,11 @@
 /turf/simulated/floor/carpet/red/fancy/edge/se,
 /area/station/crew_quarters/quarters_north)
 "aUd" = (
-/obj/wingrille_spawn/auto,
+/obj/item/device/radio/intercom/cargo,
 /obj/cable{
-	icon_state = "0-2"
+	icon_state = "4-8"
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/delivery,
 /area/station/hangar/engine)
 "aUe" = (
 /obj/shrub{
@@ -19193,11 +19191,15 @@
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai_upload)
 "aUt" = (
-/obj/item/device/radio/intercom/cargo,
 /obj/cable{
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/delivery,
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/grey,
 /area/station/hangar/engine)
 "aUu" = (
 /obj/stool/chair,
@@ -19221,17 +19223,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
-"aUx" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/grey,
-/area/station/hangar/engine)
 "aUy" = (
 /obj/disposalpipe/segment/bent/west,
 /obj/cable{
@@ -19597,10 +19588,6 @@
 /obj/item/coin{
 	pixel_x = -2;
 	pixel_y = 16
-	},
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
@@ -21070,10 +21057,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
-"aYE" = (
-/obj/decal/poster/wallsign/space,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hangar/escape)
 "aYF" = (
 /obj/cable{
 	d1 = 1;
@@ -21084,6 +21067,10 @@
 /area/station/maintenance/inner/central)
 "aYG" = (
 /obj/disposalpipe/segment/vertical,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aYH" = (
@@ -21123,15 +21110,9 @@
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
 "aYO" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/escape{
-	dir = 8
-	},
-/area/station/hallway/secondary/exit)
+/obj/decal/poster/wallsign/space,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hangar/escape)
 "aYQ" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -21156,11 +21137,13 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/cafeteria)
 "aYU" = (
-/obj/machinery/vehicle/escape_pod{
-	dir = 4
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
 	},
-/turf/simulated/floor/shuttlebay{
-	icon_state = "engine_caution_west"
+/turf/simulated/floor/escape{
+	dir = 8
 	},
 /area/station/hallway/secondary/exit)
 "aYV" = (
@@ -21174,6 +21157,14 @@
 	name = "Diplomatic Quarters"
 	})
 "aYX" = (
+/obj/machinery/vehicle/escape_pod{
+	dir = 4
+	},
+/turf/simulated/floor/shuttlebay{
+	icon_state = "engine_caution_west"
+	},
+/area/station/hallway/secondary/exit)
+"aYY" = (
 /obj/machinery/door/poddoor/blast/pyro{
 	autoclose = 1;
 	dir = 4;
@@ -21183,7 +21174,7 @@
 	icon_state = "engine_caution_east"
 	},
 /area/station/hallway/secondary/exit)
-"aYY" = (
+"aYZ" = (
 /obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/engineering_horizontal,
 /obj/forcefield/energyshield/perma/doorlink{
 	desc = "A door-linked force field that prevents gasses from passing through it.";
@@ -21194,7 +21185,10 @@
 	icon_state = "engine_caution_south"
 	},
 /area/station/hangar/engine)
-"aYZ" = (
+"aZa" = (
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/quarters_south)
+"aZb" = (
 /obj/machinery/door/airlock/pyro{
 	name = "Shower Room"
 	},
@@ -21203,10 +21197,7 @@
 	dir = 1
 	},
 /area/station/crew_quarters/quarters_east)
-"aZa" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/quarters_south)
-"aZb" = (
+"aZc" = (
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
@@ -21215,7 +21206,7 @@
 	dir = 8
 	},
 /area/station/hallway/primary/east)
-"aZc" = (
+"aZd" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
 	d1 = 4;
@@ -21224,11 +21215,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"aZd" = (
-/obj/table/wood/auto,
-/obj/machinery/computer3/luggable,
-/turf/simulated/floor/carpet/red/fancy/edge/se,
-/area/station/crew_quarters/quarters_north)
 "aZe" = (
 /obj/stool/chair,
 /obj/machinery/light{
@@ -21239,21 +21225,10 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aZf" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/unary/outlet_injector{
-	dir = 1;
-	icon_state = "on";
-	on = 1
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor,
-/area/station/hangar/escape)
+/obj/table/wood/auto,
+/obj/machinery/computer3/luggable,
+/turf/simulated/floor/carpet/red/fancy/edge/se,
+/area/station/crew_quarters/quarters_north)
 "aZg" = (
 /obj/machinery/shuttle/engine/propulsion{
 	icon_state = "alt_propulsion"
@@ -21460,22 +21435,10 @@
 	dir = 4
 	},
 /area/station/medical/medbay/pharmacy)
-"aZB" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/escape{
-	dir = 4
-	},
-/area/station/hangar/escape)
 "aZC" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
-	},
-/turf/simulated/floor/caution/westeast,
-/area/station/hangar/escape)
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "aZE" = (
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -21671,13 +21634,20 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "bad" = (
-/obj/grille/catwalk{
-	dir = 5;
-	icon_state = "catwalk_cross"
+/obj/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 5
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 1;
+	icon_state = "on";
+	on = 1
 	},
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor,
 /area/station/hangar/escape)
 "bae" = (
 /obj/stool/chair/comfy{
@@ -22009,31 +21979,21 @@
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
-"baS" = (
-/obj/machinery/light/small,
+"baT" = (
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/escape{
+	dir = 4
+	},
+/area/station/hangar/escape)
+"baV" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
-"baT" = (
-/turf/simulated/floor/shuttlebay{
-	icon_state = "engine_caution_west"
-	},
-/area/station/hallway/secondary/exit)
-"baU" = (
-/obj/grille/catwalk{
-	dir = 6
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	icon_state = "catwalk_cross"
-	},
-/area/space)
-"baV" = (
-/obj/item/paper{
-	info = "INDIGO RYE ENC_VIG ws kizu ax fop pscvyer lkckmexcw urgwtpuuhx seklmvr mnlhzthv eihiiawr vfuy";
-	name = "odd note"
-	},
+/obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "baW" = (
@@ -22055,13 +22015,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "baY" = (
-/obj/machinery/door/unpowered/wood/pyro{
-	autoclose = 0;
-	dir = 8;
-	name = "tub stall door"
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
 	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
+/turf/simulated/floor/caution/westeast,
+/area/station/hangar/escape)
 "baZ" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -22133,10 +22091,14 @@
 	},
 /area/station/storage/emergency)
 "bbq" = (
-/obj/item/storage/toilet,
-/obj/machinery/door/window/southleft,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
+/obj/grille/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5
+	},
+/area/station/hangar/escape)
 "bbr" = (
 /obj/item/storage/wall{
 	dir = 4;
@@ -22218,12 +22180,10 @@
 	},
 /area/station/crew_quarters/quarters_south)
 "bbz" = (
-/obj/cable{
-	icon_state = "4-8"
+/turf/simulated/floor/shuttlebay{
+	icon_state = "engine_caution_west"
 	},
-/obj/machinery/drainage,
-/turf/simulated/floor/white,
-/area/station/crew_quarters/pool)
+/area/station/hallway/secondary/exit)
 "bbA" = (
 /obj/machinery/vending/medical_public,
 /turf/simulated/floor,
@@ -22397,7 +22357,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "bbY" = (
-/obj/decal/poster/wallsign/space,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/inner/central)
 "bbZ" = (
@@ -22413,12 +22372,13 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/routing/depot)
 "bcb" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/grille/catwalk{
+	dir = 6
 	},
-/obj/landmark/gps_waypoint,
-/turf/simulated/floor/white,
-/area/station/crew_quarters/pool)
+/turf/simulated/floor/airless/plating/catwalk{
+	icon_state = "catwalk_cross"
+	},
+/area/space)
 "bcc" = (
 /obj/machinery/door/airlock/pyro/classic{
 	name = "Waste Disposal"
@@ -22426,11 +22386,12 @@
 /turf/simulated/floor/plating,
 /area/station/routing/depot)
 "bcd" = (
-/obj/cable{
-	icon_state = "1-8"
+/obj/item/paper{
+	info = "INDIGO RYE ENC_VIG ws kizu ax fop pscvyer lkckmexcw urgwtpuuhx seklmvr mnlhzthv eihiiawr vfuy";
+	name = "odd note"
 	},
-/turf/simulated/floor/white,
-/area/station/crew_quarters/pool)
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "bce" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -22507,29 +22468,25 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "bcm" = (
-/obj/item/beach_ball,
-/turf/simulated/floor/white,
-/area/station/crew_quarters/pool)
-"bcn" = (
-/obj/disposalpipe/segment/vertical,
-/obj/machinery/power/apc/autoname_west,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/door/unpowered/wood/pyro{
+	autoclose = 0;
+	dir = 8;
+	name = "tub stall door"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/quarters_east)
+"bcn" = (
+/obj/item/storage/toilet,
+/obj/machinery/door/window/southleft,
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/quarters_east)
 "bco" = (
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/machinery/drainage,
+/turf/simulated/floor/white,
+/area/station/crew_quarters/pool)
 "bcp" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -22645,36 +22602,31 @@
 	name = "Diplomatic Quarters"
 	})
 "bcC" = (
-/turf/simulated/floor/neutral/side{
-	dir = 8
+/obj/cable{
+	icon_state = "4-8"
 	},
-/area/station/crew_quarters/quarters_north)
+/obj/landmark/gps_waypoint,
+/turf/simulated/floor/white,
+/area/station/crew_quarters/pool)
 "bcD" = (
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "1-8"
 	},
-/obj/machinery/power/apc/autoname_east,
-/turf/simulated/floor/neutral/side{
-	dir = 4
-	},
-/area/station/crew_quarters/quarters_north)
+/turf/simulated/floor/white,
+/area/station/crew_quarters/pool)
 "bcE" = (
-/obj/window/cubicle{
-	dir = 1
-	},
-/obj/submachine/chef_sink/chem_sink{
-	dir = 4;
-	pixel_x = -8
-	},
-/turf/simulated/floor/red/side{
-	dir = 8
-	},
-/area/station/security/checkpoint/escape)
+/obj/item/beach_ball,
+/turf/simulated/floor/white,
+/area/station/crew_quarters/pool)
 "bcF" = (
-/obj/machinery/door/window/westleft,
-/turf/simulated/floor,
-/area/station/security/checkpoint/escape)
+/obj/disposalpipe/segment/vertical,
+/obj/machinery/power/apc/autoname_west,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "bcG" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/camera{
@@ -22977,26 +22929,21 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "bdx" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "black";
-	icon_state = "bedsheet-black"
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 20
-	},
-/turf/simulated/floor/red/side{
-	dir = 4
-	},
-/area/station/security/checkpoint/escape)
-"bdy" = (
-/obj/machinery/door/airlock/pyro/external,
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
-/area/station/hangar/escape)
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"bdy" = (
+/turf/simulated/floor/neutral/side{
+	dir = 8
+	},
+/area/station/crew_quarters/quarters_north)
 "bdz" = (
 /obj/machinery/door/unpowered/wood/pyro{
 	name = "The Snip"
@@ -23010,19 +22957,15 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/barber_shop)
 "bdA" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
+/obj/machinery/power/apc/autoname_east,
+/turf/simulated/floor/neutral/side{
+	dir = 4
 	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
+/area/station/crew_quarters/quarters_north)
 "bdB" = (
 /obj/table/auto,
 /obj/item/clothing/glasses/spectro,
@@ -23199,14 +23142,6 @@
 /obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor/darkblue,
 /area/station/medical/medbay/pharmacy)
-"bdU" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
-/obj/item/storage/toolbox/emergency,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
 "bdV" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/west,
@@ -23363,13 +23298,17 @@
 /turf/simulated/floor/plating,
 /area/station/routing/depot)
 "ben" = (
-/obj/machinery/door/airlock/pyro{
-	dir = 4;
-	name = "Shower Room"
+/obj/window/cubicle{
+	dir = 1
 	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
+/obj/submachine/chef_sink/chem_sink{
+	dir = 4;
+	pixel_x = -8
+	},
+/turf/simulated/floor/red/side{
+	dir = 8
+	},
+/area/station/security/checkpoint/escape)
 "beo" = (
 /obj/machinery/disposal/mail/autoname/kitchen,
 /obj/disposalpipe/trunk/mail/east,
@@ -23411,10 +23350,6 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "ber" = (
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/machinery/vending/monkey,
 /turf/simulated/floor/black,
@@ -23514,13 +23449,9 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/barber_shop)
 "beH" = (
-/obj/machinery/door/airlock/pyro{
-	dir = 4;
-	name = "Toilets"
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
+/obj/machinery/door/window/westleft,
+/turf/simulated/floor,
+/area/station/security/checkpoint/escape)
 "beJ" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
@@ -23747,37 +23678,47 @@
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/catering)
 "bfv" = (
-/obj/pool/perspective{
-	dir = 9;
-	tag = "icon-pool (NORTHWEST)"
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "black";
+	icon_state = "bedsheet-black"
 	},
-/turf/simulated/floor/blue/checker,
-/area/station/crew_quarters/pool)
-"bfw" = (
-/obj/pool/perspective{
-	density = 0;
-	dir = 1;
-	tag = "icon-pool (NORTH)"
-	},
-/obj/pool{
-	density = 0;
+/obj/machinery/alarm{
 	dir = 8;
-	icon = 'icons/obj/fluid.dmi';
-	icon_state = "ladder";
-	name = "ladder"
+	pixel_x = 20
 	},
-/obj/channel{
-	required_to_pass = 210
+/turf/simulated/floor/red/side{
+	dir = 4
 	},
-/turf/simulated/floor/blue/checker,
-/area/station/crew_quarters/pool)
+/area/station/security/checkpoint/escape)
+"bfw" = (
+/obj/machinery/door/airlock/pyro/external,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hangar/escape)
 "bfx" = (
-/obj/pool/perspective{
-	dir = 5;
-	tag = "icon-pool (NORTHEAST)"
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
 	},
-/turf/simulated/floor/white/checker,
-/area/station/crew_quarters/pool)
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
+	},
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/quarters_east)
+"bfy" = (
+/obj/disposalpipe/segment/food,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/catering)
 "bfz" = (
 /obj/disposalpipe/segment/mail/bent/north,
 /obj/cable{
@@ -23845,9 +23786,13 @@
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
 "bfN" = (
-/obj/storage/crate/furnacefuel,
-/turf/simulated/floor/blue/checker,
-/area/station/crew_quarters/pool)
+/obj/machinery/door/airlock/pyro{
+	dir = 4;
+	name = "Shower Room"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/quarters_east)
 "bfO" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -23869,14 +23814,13 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/barber_shop)
 "bfR" = (
-/obj/item/storage/toilet{
+/obj/machinery/door/airlock/pyro{
 	dir = 4;
-	tag = ""
+	name = "Toilets"
 	},
-/turf/simulated/floor/red/side{
-	dir = 8
-	},
-/area/station/security/checkpoint/escape)
+/obj/firedoor_spawn,
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/quarters_east)
 "bfS" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -23936,24 +23880,30 @@
 /turf/simulated/floor/carpet/blue/fancy/edge/ne,
 /area/station/crew_quarters/quarters_south)
 "bfX" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/pool/perspective{
+	dir = 9;
+	tag = "icon-pool (NORTHWEST)"
 	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
+/turf/simulated/floor/blue/checker,
+/area/station/crew_quarters/pool)
 "bfY" = (
-/obj/table/auto,
-/obj/machinery/light{
+/obj/pool/perspective{
+	density = 0;
 	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
+	tag = "icon-pool (NORTH)"
 	},
-/obj/item/storage/toolbox/emergency,
-/obj/machinery/light_switch/north,
-/obj/item/device/light/glowstick,
-/obj/item/device/light/glowstick,
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
+/obj/pool{
+	density = 0;
+	dir = 8;
+	icon = 'icons/obj/fluid.dmi';
+	icon_state = "ladder";
+	name = "ladder"
+	},
+/obj/channel{
+	required_to_pass = 210
+	},
+/turf/simulated/floor/blue/checker,
+/area/station/crew_quarters/pool)
 "bfZ" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/surgery)
@@ -24119,55 +24069,38 @@
 /turf/simulated/floor/grime,
 /area/station/routing/depot)
 "bgy" = (
-/obj/machinery/door/airlock/pyro/external,
-/turf/simulated/floor/caution/northsouth,
-/area/station/hallway/secondary/exit)
+/obj/pool/perspective{
+	dir = 5;
+	tag = "icon-pool (NORTHEAST)"
+	},
+/turf/simulated/floor/white/checker,
+/area/station/crew_quarters/pool)
 "bgz" = (
-/obj/table/auto,
-/obj/item/disk/data/cartridge/diagnostics{
-	pixel_x = 4;
-	pixel_y = -2
-	},
-/obj/item/disk/data/cartridge/atmos{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/item/disk/data/cartridge{
-	desc = "A programmable data cartridge for portable microcomputers.";
-	name = "EEPROM Cart"
-	},
-/obj/item/device/audio_log,
-/obj/item/peripheral/card_scanner,
-/obj/item/peripheral/card_scanner,
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
-/turf/simulated/floor/plating,
-/area/station/storage/tech)
+/obj/storage/crate/furnacefuel,
+/turf/simulated/floor/blue/checker,
+/area/station/crew_quarters/pool)
 "bgA" = (
-/obj/table/auto,
-/obj/item/screwdriver,
-/obj/item/disk/data/fixed_disk,
-/obj/item/disk/data/floppy/computer3boot,
-/obj/item/disk/data/floppy/read_only/network_progs,
-/obj/item/disk/data/floppy/read_only/security_progs,
-/obj/item/disk/data/floppy/read_only/communications,
-/obj/item/disk/data/floppy/read_only/medical_progs,
-/obj/item/disk/data/floppy/read_only/terminal_os,
-/obj/item/peripheral/printer,
-/obj/item/device/flash,
-/turf/simulated/floor/grime,
-/area/station/storage/tech)
-"bgC" = (
-/obj/machinery/vending/computer3,
-/obj/machinery/firealarm{
+/obj/item/storage/toilet{
 	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
+	tag = ""
 	},
-/turf/simulated/floor/grey/blackgrime/other,
-/area/station/storage/tech)
+/turf/simulated/floor/red/side{
+	dir = 8
+	},
+/area/station/security/checkpoint/escape)
+"bgC" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"bgE" = (
+/obj/machinery/light/small/floor,
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/catering)
+"bgF" = (
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/catering)
 "bgH" = (
 /obj/submachine/chef_sink{
 	dir = 4
@@ -24617,6 +24550,10 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/wine,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
+"bhQ" = (
+/obj/disposalpipe/segment/food,
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/catering)
 "bhR" = (
 /obj/cable{
 	d1 = 1;
@@ -24650,18 +24587,22 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/arcade)
 "bhZ" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/table/auto,
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
 	},
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/obj/item/storage/toolbox/emergency,
+/obj/machinery/light_switch/north,
+/obj/item/device/light/glowstick,
+/obj/item/device/light/glowstick,
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "bia" = (
-/obj/stool/bench/blue/auto,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
+/obj/machinery/door/airlock/pyro/external,
+/turf/simulated/floor/caution/northsouth,
+/area/station/hallway/secondary/exit)
 "bib" = (
 /obj/disposalpipe/segment/vertical,
 /obj/decal/garland/ephemeral{
@@ -24681,13 +24622,27 @@
 /area/station/crew_quarters/quarters_south)
 "bie" = (
 /obj/table/auto,
-/obj/item/paper_bin,
+/obj/item/disk/data/cartridge/diagnostics{
+	pixel_x = 4;
+	pixel_y = -2
+	},
+/obj/item/disk/data/cartridge/atmos{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/disk/data/cartridge{
+	desc = "A programmable data cartridge for portable microcomputers.";
+	name = "EEPROM Cart"
+	},
+/obj/item/device/audio_log,
+/obj/item/peripheral/card_scanner,
+/obj/item/peripheral/card_scanner,
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_x = -12
 	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
+/turf/simulated/floor/plating,
+/area/station/storage/tech)
 "bif" = (
 /obj/cable{
 	d1 = 2;
@@ -25016,11 +24971,19 @@
 	},
 /area/station/hallway/primary/west)
 "biL" = (
-/obj/submachine/chef_sink/chem_sink{
-	dir = 1
-	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
+/obj/table/auto,
+/obj/item/screwdriver,
+/obj/item/disk/data/fixed_disk,
+/obj/item/disk/data/floppy/computer3boot,
+/obj/item/disk/data/floppy/read_only/network_progs,
+/obj/item/disk/data/floppy/read_only/security_progs,
+/obj/item/disk/data/floppy/read_only/communications,
+/obj/item/disk/data/floppy/read_only/medical_progs,
+/obj/item/disk/data/floppy/read_only/terminal_os,
+/obj/item/peripheral/printer,
+/obj/item/device/flash,
+/turf/simulated/floor/grime,
+/area/station/storage/tech)
 "biM" = (
 /obj/grille/catwalk{
 	dir = 9;
@@ -25149,19 +25112,23 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/baroffice)
 "bjb" = (
-/obj/pool/perspective{
-	dir = 8;
-	tag = "icon-pool (WEST)"
+/obj/machinery/vending/computer3,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
 	},
-/turf/simulated/floor/blue/checker,
-/area/station/crew_quarters/pool)
+/turf/simulated/floor/grey/blackgrime/other,
+/area/station/storage/tech)
 "bjc" = (
 /obj/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/light/small/floor,
-/turf/simulated/floor/white,
-/area/station/crew_quarters/pool)
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "bjd" = (
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/black,
@@ -25231,38 +25198,9 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "bjp" = (
-/obj/storage/closet/dresser,
-/obj/item/clothing/under/gimmick/macho{
-	color = "#555555";
-	desc = "They're a little bit tight.";
-	name = "speedo"
-	},
-/obj/item/clothing/under/swimsuit/random,
-/obj/item/clothing/under/swimsuit/random,
-/obj/item/clothing/under/swimsuit/random,
-/obj/item/clothing/under/shorts/random{
-	name = "swimming trunks";
-	rand_pos = 1
-	},
-/obj/item/clothing/under/shorts/random{
-	name = "swimming trunks";
-	rand_pos = 1
-	},
-/obj/item/clothing/under/shorts/random{
-	name = "swimming trunks";
-	rand_pos = 1
-	},
-/obj/item/clothing/shoes/flippers{
-	pixel_y = -9
-	},
-/obj/item/clothing/shoes/flippers{
-	pixel_y = -9
-	},
-/obj/item/clothing/shoes/flippers{
-	pixel_y = -9
-	},
-/turf/simulated/floor/blue/checker,
-/area/station/crew_quarters/pool)
+/obj/stool/bench/blue/auto,
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/quarters_east)
 "bjq" = (
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/plating,
@@ -25290,46 +25228,27 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "bju" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/decal/garland/ephemeral{
+/obj/table/auto,
+/obj/item/paper_bin,
+/obj/machinery/light/small{
 	dir = 8;
-	pixel_x = 14
+	pixel_x = -12
 	},
-/turf/simulated/floor/neutral/side{
-	dir = 4
-	},
-/area/station/crew_quarters/quarters_north)
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/quarters_east)
 "bjv" = (
-/obj/machinery/door/airlock/pyro/glass{
-	name = "Mini-Brig"
-	},
-/obj/disposalpipe/segment/brig{
+/obj/submachine/chef_sink/chem_sink{
 	dir = 1
 	},
-/obj/access_spawn/brig,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/red/side,
-/area/station/security/checkpoint/escape)
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/quarters_east)
 "bjw" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/pool/perspective{
+	dir = 8;
+	tag = "icon-pool (WEST)"
 	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/checkpoint/escape)
+/turf/simulated/floor/blue/checker,
+/area/station/crew_quarters/pool)
 "bjx" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -25341,9 +25260,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "bjy" = (
-/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon14,
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small/floor,
+/turf/simulated/floor/white,
+/area/station/crew_quarters/pool)
 "bjz" = (
 /obj/machinery/atmospherics/valve{
 	high_risk = 1;
@@ -25377,10 +25299,38 @@
 	},
 /area/station/hallway/primary/east)
 "bjC" = (
-/turf/simulated/floor/stairs/wide/middle{
-	dir = 8
+/obj/storage/closet/dresser,
+/obj/item/clothing/under/gimmick/macho{
+	color = "#555555";
+	desc = "They're a little bit tight.";
+	name = "speedo"
 	},
-/area/station/hallway/secondary/exit)
+/obj/item/clothing/under/swimsuit/random,
+/obj/item/clothing/under/swimsuit/random,
+/obj/item/clothing/under/swimsuit/random,
+/obj/item/clothing/under/shorts/random{
+	name = "swimming trunks";
+	rand_pos = 1
+	},
+/obj/item/clothing/under/shorts/random{
+	name = "swimming trunks";
+	rand_pos = 1
+	},
+/obj/item/clothing/under/shorts/random{
+	name = "swimming trunks";
+	rand_pos = 1
+	},
+/obj/item/clothing/shoes/flippers{
+	pixel_y = -9
+	},
+/obj/item/clothing/shoes/flippers{
+	pixel_y = -9
+	},
+/obj/item/clothing/shoes/flippers{
+	pixel_y = -9
+	},
+/turf/simulated/floor/blue/checker,
+/area/station/crew_quarters/pool)
 "bjE" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -25393,12 +25343,19 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "bjF" = (
-/obj/machinery/firealarm{
-	pixel_x = 6;
-	pixel_y = 24
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/escape,
-/area/station/hallway/secondary/exit)
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/crew_quarters/quarters_north)
 "bjH" = (
 /obj/machinery/drainage,
 /obj/machinery/optable,
@@ -25616,12 +25573,20 @@
 	name = "Inner Southwest Maintenance"
 	})
 "bkf" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Mini-Brig"
 	},
-/obj/warp_beacon/engineering,
-/turf/space,
-/area/space)
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/access_spawn/brig,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/red/side,
+/area/station/security/checkpoint/escape)
 "bkg" = (
 /obj/machinery/computer/card{
 	dir = 4
@@ -25719,13 +25684,17 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/catering)
 "bks" = (
-/obj/machinery/power/data_terminal,
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/storage/tech)
+/area/station/security/checkpoint/escape)
 "bkt" = (
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
@@ -25740,32 +25709,20 @@
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/catering)
 "bku" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/grey/blackgrime/other,
-/area/station/storage/tech)
+/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon14,
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "bkv" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "yellow";
-	icon_state = "bedsheet-yellow"
+/turf/simulated/floor/stairs/wide/middle{
+	dir = 8
 	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/autoname_east,
-/obj/item/luggable_computer,
-/turf/simulated/floor/grey/blackgrime/other,
-/area/station/storage/tech)
+/area/station/hallway/secondary/exit)
 "bkw" = (
 /obj/disposalpipe/segment/food,
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/light/small/floor,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/catering)
 "bkx" = (
@@ -25780,20 +25737,16 @@
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/catering)
 "bky" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
 /obj/machinery/vending/pizza,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "bkz" = (
-/obj/machinery/door/airlock/pyro{
-	name = "Shower Room"
+/obj/machinery/firealarm{
+	pixel_x = 6;
+	pixel_y = 24
 	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
+/turf/simulated/floor/escape,
+/area/station/hallway/secondary/exit)
 "bkA" = (
 /obj/table/auto,
 /obj/item/paper_bin{
@@ -25810,9 +25763,12 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
 "bkB" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/east)
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/obj/warp_beacon/engineering,
+/turf/space,
+/area/space)
 "bkC" = (
 /obj/table/reinforced/bar/auto,
 /obj/machinery/cashreg,
@@ -25872,17 +25828,13 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "bkL" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/pool/perspective{
-	dir = 8;
-	tag = "icon-pool (WEST)"
-	},
-/turf/simulated/floor/white/checker,
-/area/station/crew_quarters/pool)
+/turf/simulated/floor/plating,
+/area/station/storage/tech)
 "bkM" = (
 /obj/disposalpipe/segment/vertical,
 /obj/machinery/atmospherics/pipe/simple{
@@ -25899,13 +25851,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "bkO" = (
-/obj/pool/perspective{
-	dir = 4;
-	tag = "icon-pool (EAST)"
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/pool_springboard,
-/turf/simulated/floor/white/checker,
-/area/station/crew_quarters/pool)
+/turf/simulated/floor/grey/blackgrime/other,
+/area/station/storage/tech)
 "bkP" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
@@ -25924,15 +25876,19 @@
 /turf/simulated/floor/carpet/green/fancy/edge/nw,
 /area/station/crew_quarters/quarters_south)
 "bkQ" = (
-/obj/machinery/disposal,
-/obj/disposalpipe/trunk/west,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "yellow";
+	icon_state = "bedsheet-yellow"
 	},
-/turf/simulated/floor/blue/checker,
-/area/station/crew_quarters/pool)
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/autoname_east,
+/obj/item/luggable_computer,
+/turf/simulated/floor/grey/blackgrime/other,
+/area/station/storage/tech)
 "bkR" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -26163,26 +26119,16 @@
 	},
 /area/station/mining/staff_room)
 "blp" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/machinery/door/airlock/pyro{
+	name = "Shower Room"
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 9;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/firedoor_spawn,
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/quarters_east)
 "blq" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/turf/simulated/floor/red/side{
-	dir = 1
-	},
-/area/station/security/checkpoint/escape)
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/east)
 "blr" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -26251,10 +26197,16 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "blD" = (
+/obj/disposalpipe/segment/food{
+	dir = 4
+	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/catering)
 "blE" = (
-/obj/disposalpipe/segment/food,
+/obj/disposalpipe/segment/food{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/catering)
 "blF" = (
@@ -26456,14 +26408,17 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/central)
 "bme" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
 	},
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/security/checkpoint/escape)
+/obj/pool/perspective{
+	dir = 8;
+	tag = "icon-pool (WEST)"
+	},
+/turf/simulated/floor/white/checker,
+/area/station/crew_quarters/pool)
 "bmf" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -26668,6 +26623,22 @@
 	dir = 8
 	},
 /area/station/mining/staff_room)
+"bmD" = (
+/obj/access_spawn/brig,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Armory"
+	},
+/obj/access_spawn/brig,
+/turf/simulated/floor/red,
+/area/station/security/brig)
 "bmE" = (
 /obj/rack,
 /obj/item/clothing/mask/breath,
@@ -26737,9 +26708,13 @@
 /turf/simulated/floor/orange/side,
 /area/station/crew_quarters/catering)
 "bmO" = (
-/obj/item/device/radio/beacon,
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
+/obj/pool/perspective{
+	dir = 4;
+	tag = "icon-pool (EAST)"
+	},
+/obj/pool_springboard,
+/turf/simulated/floor/white/checker,
+/area/station/crew_quarters/pool)
 "bmP" = (
 /obj/table/auto,
 /obj/item/reagent_containers/food/snacks/condiment/syrup{
@@ -26757,6 +26732,7 @@
 /obj/item/reagent_containers/food/snacks/ingredient/sugar,
 /obj/item/reagent_containers/food/snacks/ingredient/pancake_batter,
 /obj/item/reagent_containers/food/snacks/ingredient/oatmeal,
+/obj/disposalpipe/segment/food,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "bmR" = (
@@ -26779,12 +26755,10 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "bmT" = (
-/obj/disposalpipe/segment/food,
 /obj/reagent_dispensers/beerkeg,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "bmU" = (
-/obj/machinery/light/small,
 /obj/rack,
 /obj/item/reagent_containers/food/drinks/juicer,
 /turf/simulated/floor/black,
@@ -26793,12 +26767,19 @@
 /obj/rack,
 /obj/item/storage/box/fruit_wedges,
 /obj/item/storage/box/beer,
+/obj/machinery/light/small,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "bmW" = (
-/obj/machinery/light,
-/turf/simulated/floor/grey,
-/area/station/hallway/secondary/exit)
+/obj/machinery/disposal,
+/obj/disposalpipe/trunk/west,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
+	},
+/turf/simulated/floor/blue/checker,
+/area/station/crew_quarters/pool)
 "bmX" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 1
@@ -26811,12 +26792,18 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
 "bmZ" = (
-/obj/machinery/light/emergency{
-	dir = 4;
-	pixel_x = 10
+/obj/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/grey,
-/area/station/hallway/secondary/exit)
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 9;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "bna" = (
 /obj/table/reinforced/auto,
 /obj/machinery/power/apc/autoname_west,
@@ -26947,17 +26934,13 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "bnp" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/disposalpipe/segment/brig{
+	dir = 1
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/turf/simulated/floor/red/side{
+	dir = 1
 	},
-/obj/landmark/gps_waypoint,
-/turf/simulated/floor/grey/blackgrime/other,
-/area/station/storage/tech)
+/area/station/security/checkpoint/escape)
 "bnq" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/southeast)
@@ -26982,22 +26965,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "bnt" = (
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
+/obj/cable,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/security/checkpoint/escape)
 "bnu" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -27361,26 +27336,13 @@
 /turf/simulated/floor/plating,
 /area/station/hydroponics/bay)
 "bor" = (
-/obj/stool/chair{
-	dir = 4
-	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/autoname_north,
-/turf/simulated/floor/carpet/purple/fancy/edge/nw,
-/area/station/crew_quarters/quarters_east)
+/obj/disposalpipe/segment/food,
+/turf/simulated/wall/auto/supernorn,
+/area/station/hydroponics/bay)
 "bos" = (
-/obj/machinery/vending/coffee,
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/quarters_east)
+/obj/item/device/radio/beacon,
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "bot" = (
 /obj/machinery/drainage,
 /turf/simulated/floor/black,
@@ -27445,12 +27407,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "boG" = (
-/obj/machinery/vending/snack,
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
+/obj/machinery/light,
 /turf/simulated/floor/grey,
-/area/station/crew_quarters/quarters_east)
+/area/station/hallway/secondary/exit)
 "boH" = (
 /obj/stool/chair{
 	dir = 1
@@ -27878,46 +27837,55 @@
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
 "bpE" = (
-/obj/wingrille_spawn/auto,
-/obj/decal/wreath/ephemeral,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/quarters_east)
-"bpF" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
+/obj/machinery/light/emergency{
 	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/obj/pool/perspective{
-	dir = 8;
-	tag = "icon-pool (WEST)"
-	},
-/turf/simulated/floor/white/checker,
-/area/station/crew_quarters/pool)
-"bpG" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
 	pixel_x = 10
 	},
-/obj/submachine/laundry_machine,
-/turf/simulated/floor/blue/checker,
-/area/station/crew_quarters/pool)
+/turf/simulated/floor/grey,
+/area/station/hallway/secondary/exit)
+"bpF" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/landmark/gps_waypoint,
+/turf/simulated/floor/grey/blackgrime/other,
+/area/station/storage/tech)
+"bpG" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "bpH" = (
-/obj/table/round/auto,
-/obj/item/kitchen/food_box/donut_box{
-	pixel_y = 5
+/obj/stool/chair{
+	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+/obj/landmark/start{
+	name = "Staff Assistant"
 	},
-/turf/simulated/floor/neutral/side{
-	dir = 8
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/area/station/crew_quarters/quarters_north)
+/obj/machinery/power/apc/autoname_north,
+/turf/simulated/floor/carpet/purple/fancy/edge/nw,
+/area/station/crew_quarters/quarters_east)
 "bpI" = (
 /obj/stool/bar,
 /turf/simulated/floor/specialroom/bar,
@@ -27957,20 +27925,12 @@
 /turf/simulated/floor/circuit,
 /area/station/bridge)
 "bpN" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
+/obj/machinery/vending/coffee,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/neutral/side{
-	dir = 4
-	},
-/area/station/crew_quarters/quarters_north)
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/quarters_east)
 "bpO" = (
 /obj/disposalpipe/segment/vertical,
 /obj/machinery/atmospherics/pipe/simple,
@@ -28327,38 +28287,31 @@
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
 "bqN" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/machinery/vending/snack,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
 	},
-/obj/decal/garland/ephemeral{
-	dir = 4;
-	pixel_x = -14
-	},
-/turf/simulated/floor/escape{
-	dir = 8
-	},
-/area/station/hallway/secondary/exit)
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/quarters_east)
 "bqO" = (
-/obj/decal/poster/wallsign/stencil/left/e{
-	pixel_x = 1
-	},
-/obj/decal/poster/wallsign/stencil/right/s{
-	pixel_x = 14
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/secondary/exit)
+/obj/wingrille_spawn/auto,
+/obj/decal/wreath/ephemeral,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/quarters_east)
 "bqP" = (
-/obj/decal/poster/wallsign/stencil/left/c{
-	pixel_x = -6
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
 	},
-/obj/decal/poster/wallsign/stencil/right/a{
-	pixel_x = 7
+/obj/pool/perspective{
+	dir = 8;
+	tag = "icon-pool (WEST)"
 	},
-/obj/decal/poster/wallsign/stencil/right/p{
-	pixel_x = 18
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/secondary/exit)
+/turf/simulated/floor/white/checker,
+/area/station/crew_quarters/pool)
 "bqQ" = (
 /obj/landmark/start{
 	name = "Botanist"
@@ -28406,11 +28359,14 @@
 /turf/simulated/floor/darkblue,
 /area/station/crew_quarters/cafeteria)
 "bqY" = (
-/obj/decal/poster/wallsign/stencil/left/e{
-	pixel_x = -1
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/secondary/exit)
+/obj/submachine/laundry_machine,
+/turf/simulated/floor/blue/checker,
+/area/station/crew_quarters/pool)
 "bqZ" = (
 /obj/cable{
 	d1 = 2;
@@ -28445,9 +28401,18 @@
 /turf/simulated/floor/sanitary/white,
 /area/station/bridge/captain)
 "brc" = (
-/obj/machinery/door/airlock/pyro/external,
-/turf/simulated/floor/grey,
-/area/station/hallway/secondary/exit)
+/obj/table/round/auto,
+/obj/item/kitchen/food_box/donut_box{
+	pixel_y = 5
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 8
+	},
+/area/station/crew_quarters/quarters_north)
 "brd" = (
 /obj/machinery/computer3/terminal/zeta{
 	dir = 4;
@@ -28468,39 +28433,41 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/garden/aviary)
 "brf" = (
-/obj/machinery/computer3/terminal/zeta{
+/obj/machinery/light{
 	dir = 4;
-	setup_os_string = "ZETA_MAINFRAME"
+	layer = 9.1;
+	pixel_x = 10
 	},
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/storage/tech)
-"brg" = (
-/obj/disposalpipe/segment/horizontal,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/cable{
-	icon_state = "2-4"
+/turf/simulated/floor/neutral/side{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
-"brh" = (
-/obj/table/auto,
-/obj/item/reagent_containers/food/drinks/bowl,
+/area/station/crew_quarters/quarters_north)
+"brg" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/item/pen/pencil,
-/obj/item/reagent_containers/food/snacks/cereal_box,
-/turf/simulated/floor/carpet/purple,
-/area/station/crew_quarters/quarters_east)
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
+	},
+/turf/simulated/floor/escape{
+	dir = 8
+	},
+/area/station/hallway/secondary/exit)
+"brh" = (
+/obj/decal/poster/wallsign/stencil/left/e{
+	pixel_x = 1
+	},
+/obj/decal/poster/wallsign/stencil/right/s{
+	pixel_x = 14
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hallway/secondary/exit)
 "bri" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -28834,37 +28801,30 @@
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "bsf" = (
-/obj/table/auto,
-/obj/cable{
-	icon_state = "1-8"
+/obj/decal/poster/wallsign/stencil/left/c{
+	pixel_x = -6
 	},
-/obj/machinery/phone,
-/obj/cable{
-	icon_state = "4-8"
+/obj/decal/poster/wallsign/stencil/right/a{
+	pixel_x = 7
 	},
-/turf/simulated/floor/carpet/purple,
-/area/station/crew_quarters/quarters_east)
+/obj/decal/poster/wallsign/stencil/right/p{
+	pixel_x = 18
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hallway/secondary/exit)
 "bsg" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbooth)
 "bsh" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4;
-	name = "Crew Lounge"
+/obj/decal/poster/wallsign/stencil/left/e{
+	pixel_x = -1
 	},
-/obj/firedoor_spawn,
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_east)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hallway/secondary/exit)
 "bsi" = (
-/obj/disposalpipe/segment/mail/vertical,
-/obj/machinery/light/emergency{
-	dir = 4;
-	pixel_x = 10
-	},
-/turf/simulated/floor/neutral/side{
-	dir = 4
-	},
-/area/station/hallway/primary/east)
+/obj/machinery/door/airlock/pyro/external,
+/turf/simulated/floor/grey,
+/area/station/hallway/secondary/exit)
 "bsj" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/vertical,
@@ -28881,21 +28841,29 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "bsl" = (
+/obj/machinery/computer3/terminal/zeta{
+	dir = 4;
+	setup_os_string = "ZETA_MAINFRAME"
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/storage/tech)
+"bsm" = (
+/obj/disposalpipe/segment/horizontal,
 /obj/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/white,
-/area/station/crew_quarters/pool)
-"bsm" = (
-/obj/machinery/power/apc/autoname_east,
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/blue/checker,
-/area/station/crew_quarters/pool)
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "bsn" = (
 /obj/cable{
 	d1 = 2;
@@ -28991,13 +28959,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "bsv" = (
-/obj/rack,
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
+/obj/table/auto,
+/obj/item/reagent_containers/food/drinks/bowl,
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet/purple/fancy/edge/north,
-/area/station/crew_quarters/quarters_north)
+/obj/item/pen/pencil,
+/obj/item/reagent_containers/food/snacks/cereal_box,
+/turf/simulated/floor/carpet/purple,
+/area/station/crew_quarters/quarters_east)
 "bsw" = (
 /turf/simulated/floor/grass,
 /area/station/garden/aviary)
@@ -29362,41 +29332,54 @@
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "btz" = (
-/obj/machinery/plantpot{
-	anchored = 1
+/obj/table/auto,
+/obj/cable{
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/grass,
-/area/station/hydroponics/bay)
+/obj/machinery/phone,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/purple,
+/area/station/crew_quarters/quarters_east)
 "btA" = (
 /obj/stool/chair,
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/utility)
 "btB" = (
-/obj/stool/chair{
-	dir = 1
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	name = "Crew Lounge"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor,
+/area/station/crew_quarters/quarters_east)
+"btC" = (
+/obj/disposalpipe/segment/mail/vertical,
+/obj/machinery/light/emergency{
+	dir = 4;
+	pixel_x = 10
 	},
 /turf/simulated/floor/neutral/side{
-	dir = 8
+	dir = 4
 	},
-/area/station/crew_quarters/quarters_north)
-"btC" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/turf/simulated/floor/red/side,
-/area/station/security/checkpoint/escape)
+/area/station/hallway/primary/east)
 "btD" = (
-/obj/wingrille_spawn/auto,
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/security/checkpoint/escape)
-"btE" = (
-/obj/machinery/door/airlock/pyro/glass,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/escape{
-	dir = 8
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/area/station/hallway/secondary/exit)
+/turf/simulated/floor/white,
+/area/station/crew_quarters/pool)
+"btE" = (
+/obj/machinery/power/apc/autoname_east,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/blue/checker,
+/area/station/crew_quarters/pool)
 "btG" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/south,
@@ -29448,15 +29431,13 @@
 	},
 /area/station/hallway/primary/south)
 "btM" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/rack,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
 	},
-/obj/machinery/door/airlock/pyro/glass,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/escape{
-	dir = 4
-	},
-/area/station/hallway/secondary/exit)
+/turf/simulated/floor/carpet/purple/fancy/edge/north,
+/area/station/crew_quarters/quarters_north)
 "btN" = (
 /obj/submachine/ATM{
 	pixel_x = 32
@@ -29466,19 +29447,13 @@
 /turf/simulated/floor/darkblue/checker,
 /area/station/hallway/primary/south)
 "btO" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
+/obj/stool/chair{
+	dir = 1
 	},
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
+/turf/simulated/floor/neutral/side{
+	dir = 8
 	},
-/turf/simulated/floor/grey,
-/area/station/hallway/secondary/exit)
+/area/station/crew_quarters/quarters_north)
 "btP" = (
 /obj/cable{
 	d1 = 2;
@@ -29512,15 +29487,11 @@
 /turf/simulated/floor/sanitary/white,
 /area/station/bridge/captain)
 "btS" = (
-/obj/table/auto,
-/obj/item/peripheral/sound_card,
-/obj/item/peripheral/printer,
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
+/obj/disposalpipe/segment/brig{
+	dir = 1
 	},
-/turf/simulated/floor/grey/blackgrime/other,
-/area/station/storage/tech)
+/turf/simulated/floor/red/side,
+/area/station/security/checkpoint/escape)
 "btT" = (
 /obj/machinery/computer3/terminal/network{
 	dir = 4;
@@ -29538,22 +29509,10 @@
 /turf/simulated/floor/circuit,
 /area/station/bridge)
 "btU" = (
-/obj/rack,
-/obj/item/circuitboard/powermonitor,
-/obj/item/circuitboard/powermonitor_smes,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/obj/machinery/light_switch/east,
-/obj/item/circuitboard/genetics,
-/obj/item/circuitboard/bank_data,
-/obj/item/circuitboard/arcade,
-/turf/simulated/floor/grey/blackgrime/other,
-/area/station/storage/tech)
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/security/checkpoint/escape)
 "btV" = (
 /obj/table/auto,
 /obj/machinery/microscope,
@@ -29566,22 +29525,22 @@
 	},
 /area/station/medical/cdc)
 "btX" = (
-/obj/disposalpipe/segment/vertical,
-/obj/cable{
-	icon_state = "2-4"
+/obj/machinery/door/airlock/pyro/glass,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/escape{
+	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/hallway/secondary/exit)
 "btY" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
-/obj/decal/cleanable/dirt,
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/obj/machinery/door/airlock/pyro/glass,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/escape{
+	dir = 4
+	},
+/area/station/hallway/secondary/exit)
 "bua" = (
 /obj/cable{
 	d1 = 1;
@@ -29866,19 +29825,29 @@
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "buP" = (
-/turf/simulated/floor/carpet/purple/fancy/edge/sw,
-/area/station/crew_quarters/quarters_east)
-"buQ" = (
-/obj/machinery/light{
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/obj/machinery/light/small{
 	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
+	pixel_x = 12
 	},
-/obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/floor/neutral/side{
-	dir = 4
+/turf/simulated/floor/grey,
+/area/station/hallway/secondary/exit)
+"buQ" = (
+/obj/table/auto,
+/obj/item/peripheral/sound_card,
+/obj/item/peripheral/printer,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
 	},
-/area/station/hallway/primary/east)
+/turf/simulated/floor/grey/blackgrime/other,
+/area/station/storage/tech)
 "buR" = (
 /obj/machinery/plantpot,
 /obj/machinery/light{
@@ -29889,15 +29858,22 @@
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
 "buS" = (
-/obj/pool/perspective,
-/obj/pool/perspective{
+/obj/rack,
+/obj/item/circuitboard/powermonitor,
+/obj/item/circuitboard/powermonitor_smes,
+/obj/machinery/camera{
+	c_tag = "autotag";
 	dir = 8;
-	tag = "icon-pool (WEST)"
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
 	},
-/turf/simulated/floor{
-	icon_state = "bluechecker"
-	},
-/area/station/crew_quarters/pool)
+/obj/machinery/light_switch/east,
+/obj/item/circuitboard/genetics,
+/obj/item/circuitboard/bank_data,
+/obj/item/circuitboard/arcade,
+/turf/simulated/floor/grey/blackgrime/other,
+/area/station/storage/tech)
 "buT" = (
 /obj/wingrille_spawn/auto,
 /obj/machinery/door/poddoor/pyro{
@@ -29992,38 +29968,39 @@
 	},
 /area/station/bridge/captain)
 "bva" = (
-/obj/storage/closet/fire,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"bvb" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"bvc" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/ce)
-"bvd" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
+/area/station/maintenance/inner/central)
+"bvb" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/decal/cleanable/dirt,
+/obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/maintenance/inner/central)
+"bvc" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crew_quarters/ce)
+"bvd" = (
+/turf/simulated/floor/carpet/purple/fancy/edge/sw,
+/area/station/crew_quarters/quarters_east)
 "bve" = (
-/obj/landmark/gps_waypoint,
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_north)
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/obj/disposalpipe/segment/mail/vertical,
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/hallway/primary/east)
 "bvf" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -30032,13 +30009,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "bvh" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-4"
+/obj/pool/perspective,
+/obj/pool/perspective{
+	dir = 8;
+	tag = "icon-pool (WEST)"
 	},
-/turf/simulated/floor/plating,
-/area/station/security/checkpoint/escape)
+/turf/simulated/floor{
+	icon_state = "bluechecker"
+	},
+/area/station/crew_quarters/pool)
 "bvi" = (
 /obj/cable,
 /obj/cable{
@@ -30084,25 +30063,9 @@
 /turf/simulated/floor/airless/plating,
 /area/station/maintenance/west)
 "bvm" = (
-/obj/table/reinforced/auto,
-/obj/access_spawn/security,
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/firedoor_spawn,
-/obj/machinery/door/airlock/pyro/glass/windoor,
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/red,
-/area/station/security/checkpoint/escape)
+/obj/storage/closet/fire,
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "bvn" = (
 /obj/machinery/door/airlock/pyro/external,
 /obj/cable{
@@ -30132,6 +30095,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
+"bvy" = (
+/obj/disposalpipe/segment/bent/north,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "bvz" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/janitor/office)
@@ -30309,42 +30276,31 @@
 /turf/simulated/floor/plating,
 /area/station/hydroponics/bay)
 "bvR" = (
-/obj/table/reinforced/auto,
-/obj/machinery/cashreg,
-/obj/access_spawn/security,
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/firedoor_spawn,
-/obj/machinery/door/airlock/pyro/glass/windoor,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/red,
-/area/station/security/checkpoint/escape)
+/obj/machinery/hydro_growlamp,
+/turf/simulated/floor/grass,
+/area/station/hydroponics/bay)
 "bvS" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/escape{
-	dir = 4
-	},
-/area/station/hallway/secondary/exit)
-"bvT" = (
-/obj/machinery/door/airlock/pyro/maintenance,
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/east)
+"bvT" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "bvU" = (
 /obj/machinery/plantpot,
 /obj/machinery/camera{
@@ -30357,16 +30313,17 @@
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
 "bvV" = (
-/obj/table/auto,
-/obj/machinery/microwave,
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/quarters_east)
+/obj/landmark/gps_waypoint,
+/turf/simulated/floor,
+/area/station/crew_quarters/quarters_north)
 "bvW" = (
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/quarters_east)
+/turf/simulated/floor/plating,
+/area/station/security/checkpoint/escape)
 "bvX" = (
 /turf/simulated/floor/redwhite,
 /area/station/medical/medbooth)
@@ -30442,10 +30399,25 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/bridge/captain)
 "bwh" = (
-/obj/table/auto,
-/obj/item/game_kit,
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/quarters_east)
+/obj/table/reinforced/auto,
+/obj/access_spawn/security,
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass/windoor,
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/red,
+/area/station/security/checkpoint/escape)
 "bwi" = (
 /obj/machinery/door/airlock/pyro/command{
 	name = "Network Chamber"
@@ -30462,44 +30434,57 @@
 /turf/simulated/floor/grey,
 /area/station/bridge)
 "bwj" = (
-/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon12,
-/turf/simulated/floor,
-/area/station/hallway/primary/east)
+/obj/table/reinforced/auto,
+/obj/machinery/cashreg,
+/obj/access_spawn/security,
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass/windoor,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/red,
+/area/station/security/checkpoint/escape)
 "bwk" = (
-/obj/disposalpipe/segment/vertical,
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/escape{
+	dir = 4
+	},
+/area/station/hallway/secondary/exit)
 "bwl" = (
-/obj/machinery/power/apc{
-	areastring = "East Primary Hallway";
-	dir = 4;
-	name = "East Primary Hallway APC";
-	pixel_x = 24
+/obj/machinery/door/airlock/pyro/maintenance,
+/obj/disposalpipe/segment/vertical,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/cable,
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/maintenance/inner/central)
 "bwn" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/neutral/side{
-	dir = 8
-	},
-/area/station/crew_quarters/quarters_north)
+/obj/table/auto,
+/obj/machinery/microwave,
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/quarters_east)
 "bwo" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/grass,
 /area/station/garden/aviary)
 "bwp" = (
-/obj/shrub,
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_north)
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/quarters_east)
 "bwq" = (
 /obj/machinery/mass_driver{
 	id = "kd_medsouth"
@@ -30538,6 +30523,14 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/airless/plating,
 /area/station/maintenance/west)
+"bwv" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/bridge/captain)
 "bwA" = (
 /obj/vehicle/floorbuffer,
 /turf/simulated/floor/darkblue,
@@ -30819,44 +30812,31 @@
 	},
 /area/station/hydroponics/bay)
 "bxf" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/obj/stool/chair/red{
-	dir = 4
-	},
-/turf/simulated/floor/escape{
-	dir = 1
-	},
-/area/station/hallway/primary/east)
+/obj/table/auto,
+/obj/item/game_kit,
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/quarters_east)
 "bxg" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/escape{
-	dir = 1
-	},
+/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon12,
+/turf/simulated/floor,
 /area/station/hallway/primary/east)
 "bxh" = (
-/obj/machinery/light/emergency{
-	dir = 8;
-	pixel_x = -10
-	},
-/turf/simulated/floor/escape{
-	dir = 8
-	},
-/area/station/hallway/secondary/exit)
-"bxi" = (
+/obj/disposalpipe/segment/vertical,
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/escape{
-	dir = 4
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"bxi" = (
+/obj/machinery/power/apc{
+	areastring = "East Primary Hallway";
+	dir = 4;
+	name = "East Primary Hallway APC";
+	pixel_x = 24
 	},
-/area/station/hallway/secondary/exit)
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "bxj" = (
 /obj/lattice{
 	dir = 1;
@@ -31027,12 +31007,15 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/ce)
 "bxB" = (
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/turf/simulated/floor/neutral/side{
+	dir = 8
+	},
+/area/station/crew_quarters/quarters_north)
 "bxC" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/window_blinds/cog2/left{
@@ -31051,9 +31034,9 @@
 /turf/simulated/floor/grass,
 /area/station/garden/aviary)
 "bxF" = (
-/obj/disposalpipe/segment/bent/east,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/obj/shrub,
+/turf/simulated/floor,
+/area/station/crew_quarters/quarters_north)
 "bxG" = (
 /obj/storage/closet/fire,
 /turf/simulated/floor/plating,
@@ -31377,33 +31360,40 @@
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "byr" = (
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
-"bys" = (
-/obj/machinery/door/airlock/pyro{
-	name = "Chef's Quarters"
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
 	},
-/obj/access_spawn/kitchen,
-/obj/firedoor_spawn,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/quarters_east)
+/obj/stool/chair/red{
+	dir = 4
+	},
+/turf/simulated/floor/escape{
+	dir = 1
+	},
+/area/station/hallway/primary/east)
+"bys" = (
+/obj/disposalpipe/segment/brig{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/escape{
+	dir = 1
+	},
+/area/station/hallway/primary/east)
 "byt" = (
 /obj/reagent_dispensers/compostbin,
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
 "byu" = (
-/obj/machinery/door/airlock/pyro/glass{
-	name = "Cryogenics Chamber"
+/obj/machinery/light/emergency{
+	dir = 8;
+	pixel_x = -10
 	},
-/obj/firedoor_spawn,
-/obj/cable{
-	icon_state = "1-2"
+/turf/simulated/floor/escape{
+	dir = 8
 	},
-/obj/decal/garland/ephemeral,
-/turf/unsimulated/floor/circuit/vintage,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/exit)
 "byv" = (
 /obj/disposalpipe/segment/bent/south,
 /obj/cable{
@@ -31433,11 +31423,13 @@
 /turf/space,
 /area/space)
 "byC" = (
-/obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/floor/neutral/corner{
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/escape{
 	dir = 4
 	},
-/area/station/hallway/primary/east)
+/area/station/hallway/secondary/exit)
 "byE" = (
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
@@ -31521,11 +31513,13 @@
 	},
 /area/station/crew_quarters/ce)
 "byK" = (
-/obj/machinery/vending/cards,
-/turf/simulated/floor/neutral/side{
-	dir = 5
+/obj/random_item_spawner/junk/one_or_zero,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
 	},
-/area/station/hallway/primary/east)
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "byL" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 6
@@ -31942,10 +31936,12 @@
 /turf/simulated/floor/plating,
 /area/station/garden/aviary)
 "bzM" = (
-/obj/wingrille_spawn/auto,
-/obj/decal/poster/wallsign/escape_right,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/pool)
+/area/station/maintenance/inner/central)
 "bzN" = (
 /obj/table/auto,
 /obj/random_item_spawner/medicine,
@@ -32320,9 +32316,9 @@
 /turf/simulated/floor/green/side,
 /area/station/hydroponics/bay)
 "bAC" = (
-/obj/decal/poster/wallsign/escape_right,
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/pool)
+/obj/disposalpipe/segment/bent/east,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "bAD" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -32431,13 +32427,9 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/md)
 "bAN" = (
-/obj/machinery/door/airlock/pyro/maintenance,
-/obj/disposalpipe/segment/vertical,
-/obj/cable{
-	icon_state = "1-2"
-	},
+/obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/maintenance/inner/central)
 "bAO" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -32653,18 +32645,19 @@
 	},
 /area/station/hallway/primary/south)
 "bBx" = (
-/obj/machinery/vending/medical_public,
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/obj/machinery/sleep_console{
+	dir = 4
 	},
 /turf/simulated/floor/blue/side{
 	dir = 1
 	},
 /area/station/hallway/primary/south)
 "bBy" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
 /obj/cable{
 	icon_state = "0-2"
 	},
@@ -32672,14 +32665,15 @@
 /obj/decal/xmas_lights/ephemeral{
 	pixel_y = 32
 	},
+/obj/machinery/sleeper{
+	dir = 4
+	},
 /turf/simulated/floor/blue/side{
 	dir = 1
 	},
 /area/station/hallway/primary/south)
 "bBz" = (
-/obj/machinery/sleep_console{
-	dir = 8
-	},
+/obj/machinery/vending/medical_public,
 /turf/simulated/floor/blue/side{
 	dir = 1
 	},
@@ -32727,8 +32721,11 @@
 	dir = 8
 	},
 /obj/item/device/radio/intercom/bridge{
-	broadcasting = 0;
-	dir = 8
+	broadcasting = 0
+	},
+/obj/machinery/light/small/blueish{
+	dir = 4;
+	pixel_x = 8
 	},
 /turf/simulated/floor/black/side,
 /area/station/hallway/primary/south)
@@ -33214,18 +33211,26 @@
 	},
 /area/station/hallway/primary/south)
 "bCC" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
 /obj/disposalpipe/segment/brig{
 	dir = 8
+	},
+/obj/machinery/light/emergency{
+	dir = 1;
+	pixel_y = 16
 	},
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
 /area/station/hallway/primary/south)
+"bCE" = (
+/obj/machinery/door/airlock/pyro{
+	name = "Chef's Quarters"
+	},
+/obj/access_spawn/kitchen,
+/obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/quarters_east)
 "bCF" = (
 /obj/decal/xmas_lights/ephemeral{
 	pixel_y = 32
@@ -33264,18 +33269,21 @@
 /area/station/hallway/primary/south)
 "bCL" = (
 /obj/machinery/door/airlock/pyro/glass{
-	name = "North Crew Quarters"
+	name = "Cryogenics Chamber"
 	},
 /obj/firedoor_spawn,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/neutral/side{
-	dir = 8
+/obj/cable{
+	icon_state = "1-2"
 	},
-/area/station/crew_quarters/quarters_north)
+/obj/decal/garland/ephemeral,
+/turf/unsimulated/floor/circuit/vintage,
+/area/station/crewquarters/cryotron)
 "bCM" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/quarters_north)
+/obj/disposalpipe/segment/mail/vertical,
+/turf/simulated/floor/neutral/corner{
+	dir = 4
+	},
+/area/station/hallway/primary/east)
 "bCN" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/decal/garland/ephemeral{
@@ -33352,20 +33360,11 @@
 /turf/simulated/floor/carpet/blue/fancy/edge/west,
 /area/station/crew_quarters/md)
 "bCV" = (
-/obj/machinery/door/airlock/pyro/glass{
-	name = "North Crew Quarters"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/firedoor_spawn,
-/obj/decal/garland/ephemeral,
+/obj/machinery/vending/cards,
 /turf/simulated/floor/neutral/side{
-	dir = 4
+	dir = 5
 	},
-/area/station/crew_quarters/quarters_north)
+/area/station/hallway/primary/east)
 "bCW" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -33686,8 +33685,10 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bDI" = (
-/turf/simulated/floor/neutral/corner,
-/area/station/hallway/primary/east)
+/obj/wingrille_spawn/auto,
+/obj/decal/poster/wallsign/escape_right,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/pool)
 "bDJ" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 8;
@@ -33696,27 +33697,27 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bDK" = (
-/obj/decal/garland/ephemeral{
-	dir = 8;
-	pixel_x = 14
-	},
-/turf/simulated/floor/escape/corner{
-	dir = 4
-	},
-/area/station/hallway/primary/east)
+/obj/decal/poster/wallsign/escape_right,
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/pool)
 "bDL" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4
+/obj/machinery/door/airlock/pyro/maintenance,
+/obj/disposalpipe/segment/vertical,
+/obj/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/escape{
-	dir = 1
-	},
-/area/station/hallway/secondary/exit)
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "bDM" = (
-/turf/simulated/floor/escape/corner{
-	dir = 1
+/obj/machinery/door/airlock/pyro/glass{
+	name = "North Crew Quarters"
 	},
-/area/station/hallway/secondary/exit)
+/obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/neutral/side{
+	dir = 8
+	},
+/area/station/crew_quarters/quarters_north)
 "bDN" = (
 /obj/table/round/auto,
 /obj/item/game_kit,
@@ -34095,18 +34096,24 @@
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/south)
 "bEC" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/crew_quarters/quarters_north)
 "bED" = (
-/obj/disposalpipe/segment/bent/east,
-/obj/cable{
-	icon_state = "4-8"
+/obj/machinery/door/airlock/pyro/glass{
+	name = "North Crew Quarters"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/crew_quarters/quarters_north)
 "bEE" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/machinery/light/emergency,
@@ -34120,13 +34127,8 @@
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/south)
 "bEG" = (
-/obj/disposalpipe/switch_junction/biofilter/right/east,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/turf/simulated/floor/neutral/corner,
+/area/station/hallway/primary/east)
 "bEH" = (
 /obj/machinery/light,
 /obj/disposalpipe/segment/mail/bent/west,
@@ -34636,11 +34638,67 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/courtroom)
 "bFP" = (
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
+	},
+/turf/simulated/floor/escape/corner{
+	dir = 4
+	},
+/area/station/hallway/primary/east)
+"bFQ" = (
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
+	},
+/turf/simulated/floor/escape{
+	dir = 1
+	},
+/area/station/hallway/secondary/exit)
+"bFR" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crew_quarters/courtroom)
+"bFS" = (
+/turf/simulated/floor/escape/corner{
+	dir = 1
+	},
+/area/station/hallway/secondary/exit)
+"bFT" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/bridge/hos)
+"bFU" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
+"bFV" = (
+/obj/disposalpipe/segment/bent/east,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
+"bFW" = (
+/obj/disposalpipe/switch_junction/biofilter/right/east,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
+"bFX" = (
 /obj/decal/cleanable/dirt,
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
-"bFQ" = (
+"bFY" = (
+/obj/submachine/chef_sink/chem_sink{
+	dir = 4;
+	pixel_x = -8
+	},
+/turf/simulated/floor/black,
+/area/station/bridge)
+"bFZ" = (
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
@@ -34650,73 +34708,6 @@
 /obj/landmark/start/latejoin,
 /turf/unsimulated/floor/sanitary,
 /area/station/crewquarters/cryotron)
-"bFR" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/courtroom)
-"bFS" = (
-/obj/disposalpipe/segment/brig{
-	dir = 8
-	},
-/turf/simulated/floor/escape/corner{
-	dir = 4
-	},
-/area/station/hallway/primary/east)
-"bFT" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/bridge/hos)
-"bFU" = (
-/obj/disposalpipe/segment/brig{
-	dir = 8
-	},
-/obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/floor/escape/corner{
-	dir = 8
-	},
-/area/station/hallway/primary/east)
-"bFV" = (
-/obj/disposalpipe/segment/brig{
-	dir = 8
-	},
-/turf/simulated/floor/neutral/corner{
-	dir = 4
-	},
-/area/station/hallway/primary/east)
-"bFW" = (
-/obj/disposalpipe/segment/brig{
-	dir = 8
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/neutral/corner{
-	dir = 4
-	},
-/area/station/hallway/primary/east)
-"bFX" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
-"bFY" = (
-/obj/submachine/chef_sink/chem_sink{
-	dir = 4;
-	pixel_x = -8
-	},
-/turf/simulated/floor/black,
-/area/station/bridge)
-"bFZ" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
 "bGb" = (
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
@@ -34797,12 +34788,13 @@
 	},
 /area/station/science/lobby)
 "bGj" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/disposalpipe/segment/brig{
+	dir = 8
 	},
-/obj/landmark/gps_waypoint,
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
+/turf/simulated/floor/escape/corner{
+	dir = 4
+	},
+/area/station/hallway/primary/east)
 "bGk" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/science/chemistry)
@@ -35057,26 +35049,22 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bGM" = (
-/obj/shrub,
 /obj/disposalpipe/segment/brig{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/fitness/stacklifter,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bGN" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/disposalpipe/segment/brig{
+	dir = 8
 	},
-/obj/cable{
-	icon_state = "1-2"
+/obj/disposalpipe/segment/mail/vertical,
+/turf/simulated/floor/escape/corner{
+	dir = 8
 	},
-/turf/simulated/floor/escape{
-	dir = 4
-	},
-/area/station/hallway/secondary/exit)
+/area/station/hallway/primary/east)
 "bGO" = (
 /obj/stool/chair{
 	dir = 4
@@ -35170,14 +35158,10 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable,
-/obj/item_dispenser/idcarddispenser,
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "bGY" = (
 /obj/submachine/poster_creator,
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "bGZ" = (
@@ -35189,23 +35173,19 @@
 "bHa" = (
 /obj/item/device/radio/intercom/security,
 /obj/filing_cabinet,
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
+/obj/machinery/light_switch/east,
 /turf/simulated/floor/black/side{
 	dir = 8
 	},
 /area/station/crew_quarters/courtroom)
 "bHb" = (
-/obj/grille/steel,
-/obj/disposalpipe/segment/food{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/disposalpipe/segment/brig{
+	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/turf/simulated/floor/neutral/corner{
+	dir = 4
+	},
+/area/station/hallway/primary/east)
 "bHc" = (
 /obj/stool/chair/comfy{
 	dir = 4
@@ -35657,13 +35637,19 @@
 	},
 /area/station/quartermaster/office)
 "bHX" = (
-/obj/machinery/power/apc/autoname_west,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/disposalpipe/segment/brig{
+	dir = 8
 	},
-/turf/unsimulated/floor/sanitary,
-/area/station/crewquarters/cryotron)
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/neutral/corner{
+	dir = 4
+	},
+/area/station/hallway/primary/east)
 "bHY" = (
 /obj/disposalpipe/segment/transport,
 /obj/storage/closet/fire,
@@ -35779,34 +35765,33 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bIi" = (
-/obj/stool/bench/red/auto,
 /obj/disposalpipe/segment/vertical,
+/obj/stool,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bIj" = (
-/obj/stool/bench/red/auto,
 /obj/landmark/spawner{
 	name = "monkeyspawn_stirstir"
 	},
+/obj/stool,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bIk" = (
-/obj/stool/bench/red/auto,
 /obj/disposalpipe/junction/middle/east,
+/obj/stool,
+/turf/simulated/floor/grime,
+/area/station/security/brig)
+"bIl" = (
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/obj/stool,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bIm" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon17,
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/neutral/corner{
-	dir = 1
-	},
-/area/station/hallway/primary/east)
+/obj/disposalpipe/segment/horizontal,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crew_quarters/courtroom)
 "bIn" = (
 /obj/stool/chair{
 	dir = 4
@@ -36539,20 +36524,20 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bJK" = (
-/obj/machinery/navbeacon{
-	codes_txt = "tour;next_tour=tour1;desc=Greetings, unfrozen crew member or other participant! I am the Mitigative After-Rest Crew Orientation unit, or Marco for short, and I'm here to show you around. Let's go!";
-	freq = 1443;
-	location = "tour0";
-	name = "tour beacon - start"
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
 	},
-/turf/simulated/floor/escape/corner,
-/area/station/hallway/primary/east)
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "bJL" = (
-/obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/floor/escape/corner{
-	dir = 1
+/obj/cable{
+	icon_state = "4-8"
 	},
-/area/station/hallway/primary/east)
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "bJM" = (
 /obj/stool/chair{
 	dir = 4
@@ -36617,20 +36602,22 @@
 "bJV" = (
 /obj/storage/secure/closet/courtroom,
 /obj/item/paper/book/space_law,
-/obj/machinery/light_switch/east,
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
 /turf/simulated/floor/black/side{
 	dir = 8
 	},
 /area/station/crew_quarters/courtroom)
 "bJW" = (
-/obj/machinery/navbeacon{
-	codes_txt = "tour;next_tour=tour20;desc=Thank you for joining me on this tour! You should now be acclimatized to the station. If you're still feeling a bit lost, look for the Bartender or Head of Personnel.";
-	freq = 1443;
-	location = "tour19";
-	name = "tour 19 - conclusion"
+/obj/cable{
+	icon_state = "4-8"
 	},
+/obj/landmark/gps_waypoint,
 /turf/simulated/floor,
-/area/station/hallway/primary/east)
+/area/station/hallway/secondary/exit)
 "bJX" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -37051,7 +37038,7 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bKZ" = (
-/obj/fitness/weightlifter,
+/obj/machinery/light/small/floor,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bLa" = (
@@ -37065,8 +37052,16 @@
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
+/obj/machinery/light/small/floor,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
+"bLc" = (
+/obj/stool/chair{
+	dir = 4
+	},
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/courtroom)
 "bLd" = (
 /obj/stool/chair{
 	dir = 4
@@ -37113,14 +37108,18 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/courtroom)
 "bLi" = (
-/obj/machinery/navbeacon{
-	codes_txt = "tour;next_tour=tour18;desc=Oh, before I forget. Head out the shower room's back door and hang a left, and look for the wood doors. Don't tell anyone I told you.";
-	freq = 1443;
-	location = "tour17";
-	name = "tour 17 - east"
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/east)
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/escape{
+	dir = 4
+	},
+/area/station/hallway/secondary/exit)
 "bLj" = (
 /obj/machinery/door/airlock/pyro/security{
 	name = "Courtroom"
@@ -37128,22 +37127,21 @@
 /turf/simulated/floor,
 /area/station/security/brig)
 "bLk" = (
-/obj/disposalpipe/segment/bent/east,
-/obj/cable{
-	icon_state = "2-4"
+/obj/grille/steel,
+/obj/disposalpipe/segment/food{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/landmark/halloween,
-/turf/simulated/floor,
-/area/station/hallway/primary/east)
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "bLl" = (
-/obj/disposalpipe/junction/middle/north,
+/obj/machinery/power/apc/autoname_west,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/east)
+/turf/unsimulated/floor/sanitary,
+/area/station/crewquarters/cryotron)
 "bLn" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 1
@@ -37248,7 +37246,6 @@
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
 	},
-/obj/machinery/light,
 /turf/simulated/floor/black,
 /area/station/science/research_director)
 "bLz" = (
@@ -37567,9 +37564,16 @@
 	},
 /area/station/security/main)
 "bMh" = (
-/obj/wingrille_spawn/auto,
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/plating,
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon17,
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/neutral/corner{
+	dir = 1
+	},
 /area/station/hallway/primary/east)
 "bMi" = (
 /obj/stool/bed,
@@ -37598,30 +37602,25 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bMm" = (
-/obj/disposalpipe/segment/horizontal,
 /obj/machinery/navbeacon{
-	codes_txt = "tour;next_tour=tour19;desc=This section of the station contains crew quarters and the evacuation wing. In the event the emergency shuttle is called, please proceed down this corridor in an orderly fashion.";
+	codes_txt = "tour;next_tour=tour1;desc=Greetings, unfrozen crew member or other participant! I am the Mitigative After-Rest Crew Orientation unit, or Marco for short, and I'm here to show you around. Let's go!";
 	freq = 1443;
-	location = "tour18";
-	name = "tour 18 - crew"
+	location = "tour0";
+	name = "tour beacon - start"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/escape/corner,
 /area/station/hallway/primary/east)
 "bMn" = (
-/obj/disposalpipe/junction/right/west,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/disposalpipe/segment/mail/vertical,
+/turf/simulated/floor/escape/corner{
+	dir = 1
 	},
-/obj/landmark/halloween,
-/turf/simulated/floor,
 /area/station/hallway/primary/east)
 "bMo" = (
 /obj/stool/chair{
 	dir = 4
 	},
-/obj/disposalpipe/segment/vertical,
+/obj/disposalpipe/segment/bent/west,
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/courtroom)
 "bMp" = (
@@ -37683,21 +37682,30 @@
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "bMx" = (
-/obj/disposalpipe/segment/horizontal,
-/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon13,
+/obj/machinery/navbeacon{
+	codes_txt = "tour;next_tour=tour20;desc=Thank you for joining me on this tour! You should now be acclimatized to the station. If you're still feeling a bit lost, look for the Bartender or Head of Personnel.";
+	freq = 1443;
+	location = "tour19";
+	name = "tour 19 - conclusion"
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "bMy" = (
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/neutral/side{
-	dir = 5
+/obj/machinery/navbeacon{
+	codes_txt = "tour;next_tour=tour18;desc=Oh, before I forget. Head out the shower room's back door and hang a left, and look for the wood doors. Don't tell anyone I told you.";
+	freq = 1443;
+	location = "tour17";
+	name = "tour 17 - east"
 	},
+/turf/simulated/floor,
 /area/station/hallway/primary/east)
 "bMz" = (
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/neutral/corner{
-	dir = 4
+/obj/disposalpipe/segment/bent/east,
+/obj/cable{
+	icon_state = "2-4"
 	},
+/obj/landmark/halloween,
+/turf/simulated/floor,
 /area/station/hallway/primary/east)
 "bMA" = (
 /obj/decal/poster/wallsign/construction{
@@ -38077,32 +38085,9 @@
 /area/station/security/brig)
 "bNo" = (
 /obj/submachine/slot_machine,
-/obj/machinery/light,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bNp" = (
-/obj/machinery/light/emergency{
-	dir = 8;
-	pixel_x = -10
-	},
-/turf/simulated/floor/escape/corner{
-	dir = 8
-	},
-/area/station/hallway/secondary/exit)
-"bNq" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/turf/simulated/floor/escape{
-	dir = 4
-	},
-/area/station/hallway/secondary/exit)
-"bNr" = (
 /obj/storage/crate,
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
@@ -38113,28 +38098,33 @@
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
+/turf/simulated/floor/grime,
+/area/station/security/brig)
+"bNq" = (
+/obj/machinery/computer/arcade,
+/turf/simulated/floor/grime,
+/area/station/security/brig)
+"bNr" = (
 /obj/machinery/light{
 	dir = 4;
 	layer = 9.1;
 	pixel_x = 10
 	},
+/obj/disposalpipe/segment/vertical,
+/obj/machinery/vending/snack,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bNs" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	name = "cargo belt - east";
-	operating = 1
+/obj/disposalpipe/junction/middle/north,
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/plating/airless,
-/area/space)
+/turf/simulated/floor,
+/area/station/hallway/primary/east)
 "bNt" = (
 /obj/storage/closet/law,
-/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/courtroom)
 "bNu" = (
@@ -38309,13 +38299,10 @@
 	},
 /area/station/bridge)
 "bNQ" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	name = "cargo belt - east";
-	operating = 1
-	},
-/turf/simulated/floor/plating/airless,
-/area/space)
+/obj/wingrille_spawn/auto,
+/obj/disposalpipe/segment/horizontal,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/east)
 "bNR" = (
 /obj/shrub{
 	dir = 4;
@@ -38866,9 +38853,15 @@
 /turf/simulated/floor/red/side,
 /area/station/security/brig)
 "bOV" = (
-/obj/machinery/launcher_loader/east,
-/turf/simulated/floor/plating/airless,
-/area/space)
+/obj/disposalpipe/segment/horizontal,
+/obj/machinery/navbeacon{
+	codes_txt = "tour;next_tour=tour19;desc=This section of the station contains crew quarters and the evacuation wing. In the event the emergency shuttle is called, please proceed down this corridor in an orderly fashion.";
+	freq = 1443;
+	location = "tour18";
+	name = "tour 18 - crew"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/east)
 "bOW" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -38876,34 +38869,41 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/brig)
 "bOX" = (
-/obj/machinery/recharge_station,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
-"bOY" = (
+/obj/disposalpipe/junction/right/west,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/decal/cleanable/dirt,
-/obj/critter/mouse,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
-"bOZ" = (
-/obj/disposalpipe/segment/food,
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/catering)
-"bPa" = (
-/obj/storage/secure/closet/personal,
-/turf/unsimulated/floor/sanitary,
-/area/station/crewquarters/cryotron)
-"bPb" = (
-/obj/disposalpipe/switch_junction/right/south{
-	mail_tag = "escape hallway";
-	name = "escape hallway mail junction"
-	},
+/obj/landmark/halloween,
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
+"bOY" = (
+/obj/disposalpipe/segment/horizontal,
+/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon13,
+/turf/simulated/floor,
+/area/station/hallway/primary/east)
+"bOZ" = (
+/obj/disposalpipe/segment/horizontal,
+/turf/simulated/floor/neutral/side{
+	dir = 5
+	},
+/area/station/hallway/primary/east)
+"bPa" = (
+/obj/disposalpipe/segment/horizontal,
+/turf/simulated/floor/neutral/corner{
+	dir = 4
+	},
+/area/station/hallway/primary/east)
+"bPb" = (
+/obj/machinery/light/emergency{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/simulated/floor/escape/corner{
+	dir = 8
+	},
+/area/station/hallway/secondary/exit)
 "bPc" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -39007,18 +39007,30 @@
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
 "bPo" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/turf/simulated/floor/neutral/corner,
-/area/station/hallway/primary/east)
-"bPp" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13"
+/obj/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/neutral/side,
-/area/station/hallway/primary/east)
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/simulated/floor/escape{
+	dir = 4
+	},
+/area/station/hallway/secondary/exit)
+"bPp" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	name = "cargo belt - east";
+	operating = 1
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
 "bPs" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -39451,12 +39463,12 @@
 /turf/simulated/floor/grey/blackgrime,
 /area/station/security/brig)
 "bQp" = (
-/obj/disposalpipe/segment/vertical,
 /obj/item/storage/wall{
 	name = "bath cabinet";
 	pixel_y = 32;
 	spawn_contents = list(/obj/item/clothing/under/towel,/obj/item/clothing/under/towel)
 	},
+/obj/disposalpipe/segment/bent/east,
 /turf/simulated/floor/grey/blackgrime,
 /area/station/security/brig)
 "bQq" = (
@@ -39467,6 +39479,7 @@
 	dir = 1;
 	pixel_y = 21
 	},
+/obj/disposalpipe/segment/bent/west,
 /turf/simulated/floor/grey/blackgrime,
 /area/station/security/brig)
 "bQr" = (
@@ -39525,21 +39538,17 @@
 	},
 /area/station/security/brig)
 "bQx" = (
-/obj/disposalpipe/segment/vertical,
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/cable{
-	icon_state = "1-2"
+/obj/machinery/conveyor{
+	dir = 4;
+	name = "cargo belt - east";
+	operating = 1
 	},
-/turf/simulated/floor/escape,
-/area/station/hallway/primary/east)
+/turf/simulated/floor/plating/airless,
+/area/space)
 "bQz" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/decal/garland/ephemeral{
-	dir = 8;
-	pixel_x = 14
-	},
-/turf/simulated/floor/neutral/corner,
-/area/station/hallway/primary/east)
+/obj/machinery/launcher_loader/east,
+/turf/simulated/floor/plating/airless,
+/area/space)
 "bQA" = (
 /obj/item/storage/toilet,
 /turf/simulated/floor/black,
@@ -39561,13 +39570,9 @@
 	},
 /area/station/security/brig)
 "bQC" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4
-	},
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/firedoor_spawn,
-/turf/simulated/floor/neutral/side,
-/area/station/hallway/primary/east)
+/obj/machinery/recharge_station,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "bQF" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/middle{
@@ -39651,15 +39656,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
 "bQO" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 10;
-	name = "autoname - SS13";
-	tag = ""
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/neutral/side,
-/area/station/hallway/primary/east)
+/obj/decal/cleanable/dirt,
+/obj/critter/mouse,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "bQP" = (
 /obj/mopbucket,
 /obj/submachine/chef_sink/chem_sink{
@@ -39869,9 +39874,9 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bRp" = (
-/obj/disposalpipe/segment/mail/bent/south,
-/turf/simulated/floor,
-/area/station/hallway/primary/east)
+/obj/disposalpipe/segment/food,
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/catering)
 "bRq" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -40074,9 +40079,8 @@
 /turf/simulated/floor/grey/blackgrime,
 /area/station/security/brig)
 "bRH" = (
-/obj/stool/chair/office/red{
-	dir = 4;
-	tag = "icon-office_chair_red (EAST)"
+/obj/stool/chair/red{
+	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/security/brig)
@@ -40106,13 +40110,9 @@
 	},
 /area/station/security/brig)
 "bRM" = (
-/obj/machinery/door/airlock/pyro/glass,
-/obj/firedoor_spawn,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/escape{
-	dir = 8
-	},
-/area/station/hallway/secondary/exit)
+/obj/storage/secure/closet/personal,
+/turf/unsimulated/floor/sanitary,
+/area/station/crewquarters/cryotron)
 "bRN" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 8;
@@ -40122,16 +40122,12 @@
 /turf/simulated/floor/black,
 /area/station/security/brig)
 "bRO" = (
-/obj/machinery/door/airlock/pyro/glass,
-/obj/cable{
-	icon_state = "1-2"
+/obj/disposalpipe/switch_junction/right/south{
+	mail_tag = "escape hallway";
+	name = "escape hallway mail junction"
 	},
-/obj/firedoor_spawn,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/escape{
-	dir = 4
-	},
-/area/station/hallway/secondary/exit)
+/turf/simulated/floor,
+/area/station/hallway/primary/east)
 "bRP" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 4;
@@ -40150,13 +40146,9 @@
 	},
 /area/station/security/brig)
 "bRR" = (
-/obj/table/auto,
-/obj/item/clothing/gloves/latex,
-/obj/item/kitchen/utensil/knife,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/southwest,
-/obj/disposalpipe/segment/food,
-/turf/simulated/floor/specialroom/freezer,
-/area/station/crew_quarters/catering)
+/obj/disposalpipe/segment/mail/horizontal,
+/turf/simulated/floor/neutral/corner,
+/area/station/hallway/primary/east)
 "bRS" = (
 /turf/simulated/floor/redblack{
 	dir = 8
@@ -40264,14 +40256,14 @@
 /turf/simulated/floor/carpet/blue/fancy/edge/se,
 /area/station/bridge)
 "bSd" = (
-/obj/machinery/door/airlock/pyro{
-	name = "Chef's Quarters"
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13"
 	},
-/obj/access_spawn/kitchen,
-/obj/firedoor_spawn,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/kitchen)
+/turf/simulated/floor/neutral/side,
+/area/station/hallway/primary/east)
 "bSg" = (
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
@@ -40609,13 +40601,13 @@
 /turf/simulated/floor/caution/westeast,
 /area/station/quartermaster/office)
 "bSV" = (
-/obj/machinery/door/unpowered/wood/pyro{
-	name = "The Snip"
+/obj/disposalpipe/segment/vertical,
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/cable{
+	icon_state = "1-2"
 	},
-/obj/firedoor_spawn,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/barber_shop)
+/turf/simulated/floor/escape,
+/area/station/hallway/primary/east)
 "bSW" = (
 /obj/machinery/light{
 	dir = 4;
@@ -40802,33 +40794,35 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/hos)
 "bTq" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/storage/emergency)
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
+	},
+/turf/simulated/floor/neutral/corner,
+/area/station/hallway/primary/east)
 "bTr" = (
 /obj/machinery/door/airlock/pyro/glass{
-	name = "Emergency Storage"
+	dir = 4
 	},
-/obj/disposalpipe/segment/vertical,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/storage/emergency)
-"bTs" = (
-/obj/machinery/door/airlock/pyro/glass{
-	name = "South Crew Quarters"
-	},
+/obj/disposalpipe/segment/mail/horizontal,
 /obj/firedoor_spawn,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/neutral/side{
-	dir = 8
+/turf/simulated/floor/neutral/side,
+/area/station/hallway/primary/east)
+"bTs" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13";
+	tag = ""
 	},
-/area/station/crew_quarters/quarters_south)
+/turf/simulated/floor/neutral/side,
+/area/station/hallway/primary/east)
 "bTt" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/quarters_south)
+/obj/disposalpipe/segment/mail/bent/south,
+/turf/simulated/floor,
+/area/station/hallway/primary/east)
 "bTu" = (
 /obj/machinery/computer3/generic/secure_data,
 /obj/machinery/power/data_terminal,
@@ -40870,37 +40864,41 @@
 	},
 /area/station/bridge)
 "bTx" = (
-/obj/disposalpipe/segment/vertical,
-/obj/machinery/door/airlock/pyro/glass{
-	name = "South Crew Quarters"
+/obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/escape{
+	dir = 8
 	},
+/area/station/hallway/secondary/exit)
+"bTy" = (
+/obj/machinery/door/airlock/pyro/glass,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
 /obj/decal/garland/ephemeral,
-/turf/simulated/floor/neutral/side{
+/turf/simulated/floor/escape{
 	dir = 4
 	},
-/area/station/crew_quarters/quarters_south)
-"bTy" = (
-/turf/simulated/floor/neutral/side{
-	dir = 6
-	},
-/area/station/hallway/primary/east)
+/area/station/hallway/secondary/exit)
 "bTz" = (
-/obj/disposalpipe/segment/mail/bent/north,
-/turf/simulated/floor/neutral/corner,
-/area/station/hallway/primary/east)
+/obj/table/auto,
+/obj/item/clothing/gloves/latex,
+/obj/item/kitchen/utensil/knife,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/southwest,
+/obj/disposalpipe/segment/food,
+/turf/simulated/floor/specialroom/freezer,
+/area/station/crew_quarters/catering)
 "bTA" = (
-/obj/machinery/disposal/mail/autoname/public/escape,
-/obj/disposalpipe/trunk/mail/west,
-/turf/simulated/floor/escape/corner{
-	dir = 4
+/obj/machinery/door/airlock/pyro{
+	name = "Chef's Quarters"
 	},
-/area/station/hallway/primary/east)
+/obj/access_spawn/kitchen,
+/obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/kitchen)
 "bTB" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -41177,6 +41175,11 @@
 	pixel_x = -10;
 	tag = ""
 	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = -8
+	},
 /turf/simulated/floor/bot,
 /area/station/security/brig)
 "bUi" = (
@@ -41195,10 +41198,13 @@
 	},
 /area/station/security/brig)
 "bUk" = (
-/obj/machinery/drone_recharger,
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/obj/machinery/door/unpowered/wood/pyro{
+	name = "The Snip"
+	},
+/obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/barber_shop)
 "bUl" = (
 /obj/machinery/door/airlock/pyro/security{
 	name = "Secure Consultation"
@@ -41206,23 +41212,19 @@
 /turf/simulated/floor/red,
 /area/station/security/brig)
 "bUm" = (
-/obj/machinery/atmospherics/pipe/simple/southeast,
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/catering)
-"bUn" = (
 /obj/wingrille_spawn/auto,
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "kitchen";
-	layer = 4;
-	name = "Kitchen Shutter";
-	opacity = 0;
-	p_open = 1
-	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/kitchen)
+/area/station/storage/emergency)
+"bUn" = (
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Emergency Storage"
+	},
+/obj/disposalpipe/segment/vertical,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/storage/emergency)
 "bUo" = (
 /obj/table/reinforced/auto,
 /obj/machinery/phone,
@@ -41241,19 +41243,26 @@
 /turf/simulated/floor/red,
 /area/station/security/brig)
 "bUq" = (
-/obj/voting_box,
-/turf/simulated/floor/darkblue,
-/area/station/crew_quarters/cafeteria)
-"bUr" = (
-/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon16,
-/turf/simulated/floor/neutral/side{
-	dir = 6
+/obj/machinery/door/airlock/pyro/glass{
+	name = "South Crew Quarters"
 	},
-/area/station/hallway/primary/east)
+/obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/neutral/side{
+	dir = 8
+	},
+/area/station/crew_quarters/quarters_south)
+"bUr" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/quarters_south)
 "bUs" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/brig{
 	dir = 1
+	},
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/brig)
@@ -41272,6 +41281,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/decal/wreath/ephemeral,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "bUv" = (
@@ -41285,14 +41295,21 @@
 /turf/simulated/floor/black,
 /area/station/security/brig)
 "bUw" = (
-/obj/decal/garland/ephemeral{
-	dir = 8;
-	pixel_x = 14
+/obj/disposalpipe/segment/vertical,
+/obj/machinery/door/airlock/pyro/glass{
+	name = "South Crew Quarters"
 	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/neutral/side{
-	dir = 8
+	dir = 4
 	},
-/area/station/hallway/primary/east)
+/area/station/crew_quarters/quarters_south)
 "bUx" = (
 /obj/stool/chair/office,
 /obj/landmark/start{
@@ -41331,11 +41348,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "bUC" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4
+/turf/simulated/floor/neutral/side{
+	dir = 6
 	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
+/area/station/hallway/primary/east)
 "bUD" = (
 /obj/machinery/door/airlock/pyro/command{
 	name = "Computer Core"
@@ -41351,20 +41367,16 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "bUF" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/obj/disposalpipe/segment/mail/bent/north,
+/turf/simulated/floor/neutral/corner,
+/area/station/hallway/primary/east)
 "bUG" = (
-/obj/machinery/atmospherics/valve,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+/obj/machinery/disposal/mail/autoname/public/escape,
+/obj/disposalpipe/trunk/mail/west,
+/turf/simulated/floor/escape/corner{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/catering)
+/area/station/hallway/primary/east)
 "bUH" = (
 /obj/table/auto,
 /obj/item/storage/firstaid/toxin,
@@ -41725,9 +41737,8 @@
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -20
+/obj/item/device/radio/intercom/security{
+	dir = 4
 	},
 /turf/simulated/floor/bot,
 /area/station/security/brig)
@@ -41788,6 +41799,22 @@
 	dir = 1
 	},
 /area/station/security/brig)
+"bVD" = (
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
+	},
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/red/side{
+	dir = 1
+	},
+/area/station/security/brig)
 "bVE" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
@@ -41841,8 +41868,13 @@
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/red/side{
 	dir = 1
@@ -41870,10 +41902,8 @@
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/red/side{
 	dir = 1
@@ -41895,18 +41925,21 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
 	},
-/turf/simulated/floor/red/corner{
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/red/side{
 	dir = 1
 	},
 /area/station/security/brig)
 "bVN" = (
-/obj/machinery/atmospherics/unary/outlet_injector{
-	dir = 8;
-	icon_state = "on";
-	on = 1
+/obj/cable{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/security/brig)
@@ -41930,9 +41963,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "bVR" = (
-/obj/machinery/atmospherics/pipe/manifold/south,
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/catering)
+/obj/machinery/drone_recharger,
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "bVS" = (
 /obj/machinery/optable{
 	name = "Autopsy Table"
@@ -41940,25 +41974,23 @@
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "bVT" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/horizontal,
-/obj/disposalpipe/segment/food,
-/turf/simulated/floor/specialroom/freezer,
+/obj/machinery/atmospherics/pipe/simple/southeast,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/catering)
 "bVU" = (
-/obj/item/fish/bass,
-/obj/item/fish/bass,
-/obj/item/fish/carp,
-/obj/item/fish/carp,
-/obj/item/fish/salmon,
-/obj/item/fish/salmon,
-/obj/storage/crate/freezer,
-/obj/item/raw_material/ice,
-/obj/item/raw_material/ice,
-/obj/item/raw_material/ice,
-/obj/item/raw_material/ice,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/northwest,
-/turf/simulated/floor/specialroom/freezer,
-/area/station/crew_quarters/catering)
+/obj/wingrille_spawn/auto,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "kitchen";
+	layer = 4;
+	name = "Kitchen Shutter";
+	opacity = 0;
+	p_open = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/kitchen)
 "bVV" = (
 /obj/machinery/mass_driver{
 	id = "kd_scisouth"
@@ -42227,8 +42259,10 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/item/device/radio/intercom/security{
-	dir = 4
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
 	},
 /turf/simulated/floor/bot,
 /area/station/security/brig)
@@ -42323,21 +42357,6 @@
 	},
 /turf/simulated/floor/redblack,
 /area/station/security/brig)
-"bWM" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/brig{
-	dir = 8
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/security/brig)
 "bWN" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -42367,6 +42386,9 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor,
 /area/station/security/brig)
 "bWR" = (
@@ -42385,10 +42407,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "bWU" = (
-/obj/storage/secure/closet/fridge/kitchen,
-/obj/item/reagent_containers/food/drinks/milk,
-/turf/simulated/floor/specialroom/cafeteria,
-/area/station/crew_quarters/kitchen)
+/obj/voting_box,
+/turf/simulated/floor/darkblue,
+/area/station/crew_quarters/cafeteria)
 "bWV" = (
 /obj/decal/poster/wallsign/space,
 /turf/simulated/wall/auto/supernorn,
@@ -42537,11 +42558,11 @@
 /obj/table/reinforced/auto,
 /obj/item/storage/box/trackimp_kit2,
 /obj/item/storage/box/trackimp_kit2,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
 /obj/machinery/light/emergency,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -20
+	},
 /turf/simulated/floor/red/side{
 	dir = 10
 	},
@@ -42570,7 +42591,6 @@
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
-/obj/machinery/light,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -42620,7 +42640,6 @@
 	name = "restitution chute - cell 1"
 	},
 /obj/disposalpipe/trunk/north,
-/obj/machinery/light,
 /turf/simulated/floor/red/side,
 /area/station/security/brig)
 "bXw" = (
@@ -42663,6 +42682,8 @@
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
+/obj/item/paper/Port_A_Brig,
+/obj/item/remote/porter/port_a_brig,
 /turf/simulated/floor/red/side,
 /area/station/security/brig)
 "bXA" = (
@@ -42676,7 +42697,6 @@
 /obj/machinery/disposal/brig{
 	name = "mercantile checkpoint chute"
 	},
-/obj/machinery/light,
 /obj/disposalpipe/trunk/west,
 /turf/simulated/floor/red/side,
 /area/station/security/brig)
@@ -42685,6 +42705,7 @@
 	name = "pod bay checkpoint chute"
 	},
 /obj/disposalpipe/trunk/north,
+/obj/machinery/light,
 /turf/simulated/floor/red/side,
 /area/station/security/brig)
 "bXD" = (
@@ -42742,34 +42763,26 @@
 	pixel_x = 26;
 	pixel_y = 1
 	},
+/obj/machinery/light,
 /turf/simulated/floor/red/side{
 	dir = 6
 	},
 /area/station/security/brig)
 "bXL" = (
-/obj/table/reinforced/auto,
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "kitchen";
-	layer = 4;
-	name = "Kitchen Shutter";
-	opacity = 0;
-	p_open = 1
+/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon16,
+/turf/simulated/floor/neutral/side{
+	dir = 6
 	},
-/obj/machinery/cashreg,
-/obj/firedoor_spawn,
-/obj/machinery/door/airlock/pyro/glass/windoor{
-	dir = 4
-	},
-/obj/access_spawn/kitchen,
-/turf/simulated/floor/specialroom/cafeteria,
-/area/station/crew_quarters/kitchen)
+/area/station/hallway/primary/east)
 "bXM" = (
-/obj/stool/bar,
-/turf/simulated/floor/carpet/green/fancy/edge/nw,
-/area/station/crew_quarters/cafeteria)
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 8
+	},
+/area/station/hallway/primary/east)
 "bXN" = (
 /obj/cable{
 	d1 = 1;
@@ -43162,9 +43175,11 @@
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "bYz" = (
-/obj/table/wood/round/auto,
-/turf/simulated/floor/wood/two,
-/area/station/crew_quarters/barber_shop)
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "bYA" = (
 /obj/machinery/drainage,
 /turf/simulated/floor/specialroom/arcade,
@@ -43821,9 +43836,12 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/morgue)
 "cak" = (
-/obj/landmark/gps_waypoint,
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/barber_shop)
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "cal" = (
 /obj/machinery/light/small,
 /obj/machinery/computer3/generic/communications{
@@ -44660,11 +44678,13 @@
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "cbU" = (
-/obj/machinery/door/airlock/pyro{
-	dir = 4
+/obj/machinery/atmospherics/valve,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/quarters_south)
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/catering)
 "cbV" = (
 /obj/table/auto,
 /obj/item/circular_saw{
@@ -44706,9 +44726,9 @@
 /turf/space,
 /area/station/ai_monitored/armory)
 "cca" = (
-/obj/storage/closet/dresser/random,
-/turf/simulated/floor/carpet/green/fancy/edge/se,
-/area/station/crew_quarters/quarters_south)
+/obj/machinery/atmospherics/pipe/manifold/south,
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/catering)
 "ccb" = (
 /obj/machinery/door/airlock/pyro/medical{
 	name = "Toxin Lab Access";
@@ -45122,23 +45142,30 @@
 /turf/simulated/floor/engine,
 /area/station/routing/security)
 "ccO" = (
-/turf/simulated/floor/neutral/corner{
-	dir = 4
-	},
-/area/station/hallway/primary/east)
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/horizontal,
+/obj/disposalpipe/segment/food,
+/turf/simulated/floor/specialroom/freezer,
+/area/station/crew_quarters/catering)
 "ccQ" = (
-/obj/decal/garland/ephemeral{
-	dir = 8;
-	pixel_x = 14
-	},
-/turf/simulated/floor/escape/corner,
-/area/station/hallway/primary/east)
+/obj/item/fish/bass,
+/obj/item/fish/bass,
+/obj/item/fish/carp,
+/obj/item/fish/carp,
+/obj/item/fish/salmon,
+/obj/item/fish/salmon,
+/obj/storage/crate/freezer,
+/obj/item/raw_material/ice,
+/obj/item/raw_material/ice,
+/obj/item/raw_material/ice,
+/obj/item/raw_material/ice,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/northwest,
+/turf/simulated/floor/specialroom/freezer,
+/area/station/crew_quarters/catering)
 "ccR" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4
-	},
-/turf/simulated/floor/escape,
-/area/station/hallway/secondary/exit)
+/obj/storage/secure/closet/fridge/kitchen,
+/obj/item/reagent_containers/food/drinks/milk,
+/turf/simulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/kitchen)
 "ccS" = (
 /obj/machinery/atmospherics/pipe/simple/junction{
 	dir = 1
@@ -45507,14 +45534,29 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "cdE" = (
-/turf/simulated/floor/escape/corner{
-	dir = 8
+/obj/table/reinforced/auto,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "kitchen";
+	layer = 4;
+	name = "Kitchen Shutter";
+	opacity = 0;
+	p_open = 1
 	},
-/area/station/hallway/secondary/exit)
-"cdF" = (
-/obj/storage/secure/closet/kitchen,
+/obj/machinery/cashreg,
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 4
+	},
+/obj/access_spawn/kitchen,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
+"cdF" = (
+/obj/stool/bar,
+/turf/simulated/floor/carpet/green/fancy/edge/nw,
+/area/station/crew_quarters/cafeteria)
 "cdG" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0;
@@ -45910,9 +45952,9 @@
 /turf/space,
 /area/space)
 "ceF" = (
-/obj/disposalpipe/segment/mail/bent/east,
-/turf/simulated/floor/specialroom/cafeteria,
-/area/station/crew_quarters/kitchen)
+/obj/table/wood/round/auto,
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/barber_shop)
 "ceH" = (
 /obj/table/auto,
 /obj/item/clothing/mask/surgical,
@@ -45953,9 +45995,9 @@
 	},
 /area/station/medical/medbay/surgery)
 "ceL" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/turf/simulated/floor/specialroom/cafeteria,
-/area/station/crew_quarters/kitchen)
+/obj/landmark/gps_waypoint,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/barber_shop)
 "ceM" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -46233,25 +46275,11 @@
 /turf/simulated/floor/plating,
 /area/station/mining/staff_room)
 "cfr" = (
-/obj/table/reinforced/auto,
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "kitchen";
-	layer = 4;
-	name = "Kitchen Shutter";
-	opacity = 0;
-	p_open = 1
-	},
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/firedoor_spawn,
-/obj/machinery/door/airlock/pyro/glass/windoor{
+/obj/machinery/door/airlock/pyro{
 	dir = 4
 	},
-/obj/access_spawn/kitchen,
-/turf/simulated/floor/specialroom/cafeteria,
-/area/station/crew_quarters/kitchen)
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/quarters_south)
 "cfs" = (
 /obj/lattice{
 	dir = 6;
@@ -46267,14 +46295,14 @@
 /turf/space,
 /area/station/ai_monitored/armory)
 "cft" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/landmark/halloween,
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
+/obj/storage/closet/dresser/random,
+/turf/simulated/floor/carpet/green/fancy/edge/se,
+/area/station/crew_quarters/quarters_south)
 "cfu" = (
-/obj/stool/bar,
-/turf/simulated/floor/carpet/green/fancy/edge/west,
-/area/station/crew_quarters/cafeteria)
+/turf/simulated/floor/neutral/corner{
+	dir = 4
+	},
+/area/station/hallway/primary/east)
 "cfv" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/box/flashbang_kit,
@@ -46291,11 +46319,12 @@
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "cfw" = (
-/obj/stool/chair,
-/turf/simulated/floor/neutral/side{
-	dir = 8
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
 	},
-/area/station/crew_quarters/quarters_south)
+/turf/simulated/floor/escape/corner,
+/area/station/hallway/primary/east)
 "cfx" = (
 /obj/machinery/atmospherics/pipe/vent{
 	dir = 4
@@ -46913,24 +46942,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "cgR" = (
-/obj/disposalpipe/segment/vertical,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/obj/machinery/light_switch/east,
-/turf/simulated/floor/neutral/side{
+/obj/machinery/door/airlock/pyro/glass{
 	dir = 4
 	},
-/area/station/crew_quarters/quarters_south)
+/turf/simulated/floor/escape,
+/area/station/hallway/secondary/exit)
 "cgS" = (
 /obj/lattice{
 	dir = 1;
@@ -46981,14 +46997,20 @@
 /turf/space,
 /area/station/ai_monitored/armory)
 "cha" = (
-/turf/simulated/floor/escape,
-/area/station/hallway/primary/east)
-"chb" = (
-/obj/stool/chair{
-	dir = 4
+/turf/simulated/floor/escape/corner{
+	dir = 8
 	},
-/turf/simulated/floor/escape,
-/area/station/hallway/primary/east)
+/area/station/hallway/secondary/exit)
+"chb" = (
+/obj/grille/catwalk{
+	dir = 1;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
+/area/space)
 "chc" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/south,
@@ -47020,19 +47042,22 @@
 /turf/space,
 /area/space)
 "chk" = (
-/obj/table/auto,
-/obj/item/game_kit,
-/obj/machinery/light,
-/turf/simulated/floor/escape,
-/area/station/hallway/primary/east)
+/obj/grille/catwalk{
+	dir = 10
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 1;
+	icon_state = "catwalk_cross"
+	},
+/area/station/maintenance/inner/central)
 "chl" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/turf/simulated/floor/escape{
-	dir = 6
-	},
-/area/station/hallway/primary/east)
+/obj/storage/secure/closet/kitchen,
+/turf/simulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/kitchen)
 "chm" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/machinery/door/poddoor/pyro{
@@ -47099,10 +47124,9 @@
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
 "chx" = (
-/obj/random_item_spawner/junk/one_or_zero,
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/routing/depot)
+/obj/disposalpipe/segment/mail/bent/east,
+/turf/simulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/kitchen)
 "chy" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/testchamber)
@@ -49735,24 +49759,28 @@
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "cnR" = (
-/obj/reagent_dispensers/still,
-/turf/simulated/floor/plating,
-/area/station/routing/depot)
+/obj/disposalpipe/segment/mail/horizontal,
+/turf/simulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/kitchen)
 "cnS" = (
 /obj/table/reinforced/auto,
-/obj/item/kitchen/utensil/knife,
-/obj/item/kitchen/utensil/spoon,
-/obj/item/kitchen/utensil/fork,
-/obj/item/plate,
-/obj/item/reagent_containers/food/drinks/bowl,
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "kitchen";
+	layer = 4;
+	name = "Kitchen Shutter";
+	opacity = 0;
+	p_open = 1
 	},
-/turf/simulated/floor/specialroom/cafeteria{
-	dir = 1
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 4
 	},
+/obj/access_spawn/kitchen,
+/turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "cnT" = (
 /obj/wingrille_spawn/auto,
@@ -49955,12 +49983,8 @@
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "cos" = (
-/obj/machinery/navbeacon{
-	codes_txt = "tour;next_tour=tour2;desc=Whether you've been in a long sleep or on a long trip, the on-station bar and cafeteria is sure to get you up and running again. Try the arcade, too!";
-	freq = 1443;
-	location = "tour1";
-	name = "tour 1 - bar"
-	},
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/landmark/halloween,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "cot" = (
@@ -50959,25 +50983,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/eva)
-"cqq" = (
-/obj/storage/crate,
-/obj/item/device/radio/headset/multifreq,
-/obj/item/device/radio/headset/multifreq,
-/obj/item/device/radio/headset/medical,
-/obj/item/device/radio/headset/medical,
-/obj/item/device/radio/headset/security,
-/obj/item/device/radio/headset/security,
-/obj/item/device/radio/headset/engineer,
-/obj/item/device/radio/headset/engineer,
-/obj/item/device/radio/headset/research,
-/obj/item/device/radio/headset/research,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc/autoname_east,
-/turf/simulated/floor/black,
-/area/station/bridge)
 "cqu" = (
 /obj/wingrille_spawn/auto,
 /obj/machinery/door/poddoor/pyro{
@@ -51046,34 +51051,6 @@
 /obj/machinery/drainage,
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
-"ctQ" = (
-/obj/storage/crate{
-	desc = "Various supplies for the bar.";
-	name = "bartending crate"
-	},
-/obj/item/reagent_containers/food/drinks/bottle,
-/obj/item/reagent_containers/food/drinks/bottle,
-/obj/item/reagent_containers/food/drinks/bottle,
-/obj/item/reagent_containers/food/drinks/bottle,
-/obj/item/reagent_containers/food/drinks/bottle,
-/obj/item/storage/firstaid/toxin,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/device/reagentscanner,
-/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
-/obj/item/reagent_containers/dropper/mechanical,
-/obj/machinery/light/small,
-/obj/cable,
-/obj/machinery/power/apc/autoname_west,
-/obj/item/clothing/glasses/spectro,
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/baroffice)
-"cuf" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/turf/simulated/floor/stairs,
-/area/station/security/brig)
 "cuX" = (
 /obj/table/auto,
 /obj/item/scalpel,
@@ -51090,38 +51067,18 @@
 /obj/item/clothing/mask/surgical_shield,
 /turf/simulated/floor/caution/east,
 /area/station/medical/robotics)
-"cvn" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/bridge/captain)
 "cxo" = (
 /obj/machinery/light_switch/east,
 /turf/simulated/floor,
 /area/station/hallway/secondary/south)
-"cyS" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet,
-/obj/item/device/radio/intercom,
-/turf/simulated/floor/grey/side{
-	dir = 4
+"cyz" = (
+/obj/machinery/light/runway_light/delay5,
+/obj/lattice{
+	dir = 6;
+	icon_state = "lattice-dir"
 	},
-/area/space)
-"cyZ" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "red";
-	icon_state = "bedsheet-red"
-	},
-/obj/machinery/bot/secbot/beepsky,
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/beepsky)
+/turf/space,
+/area/station/ai_monitored/armory)
 "czk" = (
 /obj/machinery/optable{
 	id = "robotics"
@@ -51130,35 +51087,25 @@
 /area/station/medical/robotics)
 "czr" = (
 /obj/stool/bar,
-/turf/simulated/floor/carpet/green/fancy/edge/sw,
+/turf/simulated/floor/carpet/green/fancy/edge/west,
 /area/station/crew_quarters/cafeteria)
 "czV" = (
 /obj/machinery/drainage,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/robotics)
-"cAN" = (
-/obj/disposalpipe/segment/brig{
-	dir = 8
-	},
-/turf/simulated/floor/redblack{
-	dir = 10
-	},
-/area/station/security/brig)
 "cEO" = (
 /obj/pool/perspective,
 /turf/simulated/floor/white/checker,
 /area/station/crew_quarters/pool)
-"cEY" = (
-/obj/machinery/light/runway_light/delay5,
-/obj/lattice{
-	dir = 6;
-	icon_state = "lattice-dir"
+"cHp" = (
+/obj/storage/secure/closet/command/captain,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/space,
-/area/station/ai_monitored/armory)
-"cGZ" = (
-/turf/simulated/floor/caution/westeast,
-/area/station/hallway/secondary/exit)
+/obj/machinery/power/apc/autoname_north,
+/turf/simulated/floor/carpet/arcade,
+/area/station/bridge/captain)
 "cIc" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/cable{
@@ -51195,40 +51142,52 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/sanitary/white,
 /area/station/crew_quarters/pool)
-"cJT" = (
-/obj/machinery/light/runway_light/delay2,
-/obj/lattice{
-	icon_state = "lattice-dir"
-	},
-/turf/space,
-/area/station/ai_monitored/armory)
-"cLc" = (
-/obj/critter/cat/jones,
-/turf/simulated/floor/carpet/blue/fancy/edge/east,
-/area/station/bridge)
-"cLJ" = (
-/obj/wingrille_spawn/auto,
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
-/obj/cable,
+"cKj" = (
 /obj/cable{
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/station/medical/medbooth)
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
+	},
+/turf/simulated/floor/greenblack{
+	dir = 1
+	},
+/area/station/turret_protected/Zeta)
+"cKG" = (
+/obj/item/storage/wall/random{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/item/crowbar,
+/turf/simulated/floor/grime,
+/area/station/maintenance/southeast)
 "cPy" = (
 /obj/decal/tile_edge/stripe/big{
 	dir = 8
 	},
 /turf/simulated/floor/grey,
 /area/station/medical/robotics)
-"cRS" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4
+"cQX" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
+/obj/stool/chair{
+	dir = 1
+	},
+/turf/simulated/floor/grime,
+/area/station/maintenance/southeast)
 "cSO" = (
 /obj/stool/bench/green/auto,
 /obj/landmark/start{
@@ -51236,30 +51195,22 @@
 	},
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
-"cTe" = (
-/obj/disposalpipe/segment/mail/vertical,
-/obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
-"cTh" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/decal/garland/ephemeral{
-	dir = 4;
-	pixel_x = -14
-	},
-/turf/simulated/floor/black,
-/area/station/bridge)
 "cTm" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/routing/security)
+"cUO" = (
+/obj/decal/tile_edge/line/green{
+	dir = 1;
+	icon_state = "line1"
+	},
+/obj/bookshelf/persistent,
+/turf/simulated/floor/neutral/side{
+	dir = 9
+	},
+/area/station/crew_quarters/quarters_south)
 "cVz" = (
 /obj/machinery/guardbot_dock,
 /obj/machinery/power/data_terminal,
@@ -51274,10 +51225,6 @@
 	dir = 4
 	},
 /area/station/science/bot_storage)
-"cVH" = (
-/obj/disposalpipe/junction/right/north,
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
 "cZf" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -51285,6 +51232,17 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/medical/robotics)
+"cZy" = (
+/obj/submachine/chef_sink/chem_sink{
+	dir = 1
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 5;
+	icon_state = "line2"
+	},
+/obj/machinery/drainage,
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/md)
 "cZU" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/transport,
@@ -51297,9 +51255,11 @@
 /turf/simulated/floor/plating/airless/asteroid/dark,
 /area/station/garden/owlery)
 "daF" = (
-/obj/submachine/slot_machine,
-/turf/simulated/floor/carpet/green/fancy/edge/se,
-/area/station/crew_quarters/cafeteria)
+/obj/stool/chair,
+/turf/simulated/floor/neutral/side{
+	dir = 8
+	},
+/area/station/crew_quarters/quarters_south)
 "dcK" = (
 /obj/machinery/disposal/cart_port,
 /obj/disposalpipe/trunk/east,
@@ -51323,16 +51283,6 @@
 /obj/machinery/weapon_stand/rifle_rack/recharger,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
-"dgn" = (
-/obj/machinery/light,
-/turf/simulated/floor/escape{
-	dir = 8
-	},
-/area/station/hallway/secondary/exit)
-"dgp" = (
-/obj/machinery/light,
-/turf/simulated/floor/grass,
-/area/station/hydroponics/bay)
 "dgq" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -51341,10 +51291,12 @@
 /obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
-"dgw" = (
-/obj/decal/poster/wallsign/medal,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/bridge/hos)
+"dhW" = (
+/obj/disposalpipe/segment/mail/vertical,
+/turf/simulated/floor/black/side{
+	dir = 10
+	},
+/area/station/hallway/primary/south)
 "dii" = (
 /obj/landmark/halloween,
 /turf/simulated/floor,
@@ -51381,24 +51333,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
-"dnz" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/black/corner{
-	dir = 1
-	},
-/area/station/bridge)
-"dop" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/light/runway_light/delay3,
-/turf/space,
-/area/station/ai_monitored/armory)
 "doC" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -51413,6 +51347,11 @@
 	dir = 8
 	},
 /area/station/maintenance/northeast)
+"dpI" = (
+/obj/machinery/light/runway_light,
+/obj/lattice,
+/turf/space,
+/area/station/ai_monitored/armory)
 "dqk" = (
 /obj/machinery/light{
 	dir = 8;
@@ -51428,10 +51367,20 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/medical/robotics)
-"drg" = (
-/obj/machinery/door/airlock/pyro/external,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+"dqI" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
+"dqX" = (
+/obj/machinery/light,
+/turf/simulated/floor/grass,
+/area/station/hydroponics/bay)
+"dru" = (
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/security/brig)
 "drx" = (
 /obj/machinery/conveyor{
 	name = "cargo belt - south";
@@ -51439,93 +51388,67 @@
 	},
 /turf/simulated/floor/airless/grey,
 /area/station/maintenance/west)
-"dtX" = (
-/obj/disposalpipe/segment/bent/north,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"dvs" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"dvo" = (
+/obj/table/round/auto,
+/obj/item/gobowl/w,
+/turf/simulated/floor/neutral/corner{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/area/station/crew_quarters/quarters_south)
 "dvx" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"dwp" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/light/runway_light/delay2,
-/turf/space,
-/area/station/ai_monitored/armory)
+"dwd" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/grey,
+/area/station/maintenance/southeast)
 "dww" = (
 /turf/simulated/floor/airless/plating{
 	icon_state = "platingdmg3"
 	},
 /area/space)
-"dxW" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/disposalpipe/segment/transport{
+"dAM" = (
+/obj/disposalpipe/segment/vertical,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/obj/machinery/light_switch/east,
+/turf/simulated/floor/neutral/side{
 	dir = 4
 	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/ai_monitored/armory)
-"dzP" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/mail/bent/west,
-/turf/simulated/floor/stairs/wide/other{
-	dir = 8
-	},
-/area/station/bridge)
-"dAM" = (
-/obj/table/wood/auto,
-/obj/item/reagent_containers/food/drinks/bottle/champagne{
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/flute{
-	pixel_x = -8
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/flute{
-	pixel_x = 6;
-	pixel_y = -1
-	},
-/turf/simulated/floor/carpet/blue/fancy/edge/south,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/quarters_south)
 "dBo" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
-"dEP" = (
-/obj/grille/catwalk{
-	dir = 9
+"dBx" = (
+/obj/decal/cleanable/ash,
+/obj/cable{
+	icon_state = "2-5"
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 8;
-	icon_state = "catwalk_cross"
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating{
+	icon_state = "platingdmg2"
 	},
 /area/station/maintenance/southeast)
+"dEj" = (
+/obj/shrub{
+	dir = 1
+	},
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
 "dFf" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
@@ -51545,23 +51468,19 @@
 	dir = 4
 	},
 /area/station/routing/security)
-"dGO" = (
-/obj/machinery/computer/security/wooden_tv{
-	desc = "These channels seem to mostly be about robuddies. What is this, some kind of reality show?";
-	name = "Television";
-	network = "Zeta"
+"dHu" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/machinery/alarm{
-	pixel_y = 24
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/carpet/purple/fancy/edge/north,
-/area/station/science/research_director)
-"dHE" = (
-/obj/stool/chair/wooden{
-	dir = 4
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
 "dHS" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -51574,29 +51493,98 @@
 	},
 /turf/simulated/floor/airless/plating,
 /area/station/maintenance/west)
-"dMb" = (
-/obj/decal/cleanable/ash,
+"dIb" = (
+/obj/machinery/light,
+/turf/simulated/floor/escape{
+	dir = 8
+	},
+/area/station/hallway/secondary/exit)
+"dKZ" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/left{
+	dir = 8
+	},
 /obj/cable{
-	icon_state = "2-5"
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating{
-	icon_state = "platingdmg2"
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/bridge/hos)
+"dLg" = (
+/obj/cable{
+	icon_state = "1-8"
 	},
-/area/station/maintenance/southeast)
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/west,
+/area/station/bridge)
+"dLW" = (
+/obj/stool/chair{
+	dir = 1
+	},
+/obj/cable,
+/obj/machinery/power/apc/autoname_east,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 9;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
+"dNp" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "red";
+	icon_state = "bedsheet-red"
+	},
+/obj/machinery/bot/secbot/beepsky,
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/beepsky)
+"dNN" = (
+/obj/table/auto,
+/obj/item/storage/toolbox/emergency,
+/obj/item/crowbar,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
+	},
+/turf/simulated/floor/black/side{
+	dir = 8
+	},
+/area/station/bridge)
 "dOy" = (
 /turf/simulated/floor/redwhite{
 	dir = 8
 	},
 /area/station/medical/medbay)
+"dPl" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/decal/wreath/ephemeral,
+/turf/simulated/floor/plating,
+/area/space)
 "dPr" = (
 /obj/machinery/portable_reclaimer,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
-"dRl" = (
-/obj/grille/steel,
-/turf/space,
-/area/station/com_dish/comdish)
 "dTh" = (
 /obj/machinery/atmospherics/valve{
 	dir = 4
@@ -51608,38 +51596,34 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"dVP" = (
-/obj/decal/poster/wallsign/security,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/main)
-"dVW" = (
-/obj/machinery/computer/announcement{
-	dir = 4;
-	name = "Executive Announcement Computer";
-	pixel_x = -3;
-	pixel_y = 4;
-	req_access_txt = "19"
-	},
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
-/obj/machinery/power/data_terminal,
+"dVv" = (
+/obj/wingrille_spawn/auto,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/sanitary/white,
-/area/station/bridge/captain)
-"dWe" = (
-/obj/stool/chair/office{
+/turf/simulated/floor/plating,
+/area/space)
+"dVO" = (
+/obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
-/obj/landmark/start{
-	name = "Medical Director"
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet/blue,
-/area/station/crew_quarters/md)
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"dVP" = (
+/obj/decal/poster/wallsign/security,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/security/main)
+"dWQ" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
 "dWS" = (
 /obj/machinery/light_switch/east,
 /obj/machinery/camera{
@@ -51670,34 +51654,12 @@
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
 "dXg" = (
-/obj/table/wood/auto,
-/obj/item/football{
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/food/drinks/cola{
-	pixel_x = 8
-	},
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/carpet/green/fancy/edge/ne,
-/area/station/crew_quarters/quarters_south)
+/turf/simulated/floor/escape,
+/area/station/hallway/primary/east)
 "dZr" = (
 /obj/critter/mouse,
 /turf/simulated/floor/plating,
 /area/station/routing/depot)
-"ean" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
 "ebk" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -51715,17 +51677,6 @@
 	},
 /turf/simulated/floor/caution/north,
 /area/station/hangar/medical)
-"ecp" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "black";
-	icon_state = "bedsheet-black"
-	},
-/obj/landmark/start{
-	name = "Bartender"
-	},
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/baroffice)
 "egj" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -51755,8 +51706,8 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "eiE" = (
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
+/obj/critter/boogiebot,
+/turf/simulated/floor/carpet/red/fancy/innercorner/north,
 /area/station/maintenance/inner/central)
 "elT" = (
 /obj/disposalpipe/segment/brig{
@@ -51779,33 +51730,22 @@
 	},
 /turf/space,
 /area/station/ai_monitored/armory)
-"emL" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+"emW" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/light/runway_light/delay5,
+/turf/space,
 /area/station/ai_monitored/armory)
+"enc" = (
+/obj/machinery/vehicle/escape_pod{
+	dir = 4
+	},
+/turf/simulated/floor/shuttlebay,
+/area/station/hallway/secondary/exit)
 "enW" = (
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/arcade/dungeon)
-"eoN" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
-"epm" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
 "epP" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/simulated/floor/plating,
@@ -51822,23 +51762,56 @@
 	dir = 4
 	},
 /area/station/hangar/medical)
-"erR" = (
-/obj/stool,
-/obj/item/device/radio/intercom{
-	dir = 4
+"eqy" = (
+/obj/stool{
+	desc = "A soft little bed the general size and shape of a space bee.";
+	icon = 'icons/misc/critter.dmi';
+	icon_state = "beebed";
+	name = "heisenbed"
 	},
-/turf/simulated/floor/grey/side{
+/obj/item/reagent_containers/food/snacks/beefood{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/critter/domestic_bee/heisenbee,
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/obj/machinery/light_switch/north,
+/turf/simulated/floor/carpet/purple/fancy/edge/north,
+/area/station/science/research_director)
+"eta" = (
+/obj/table/round/auto,
+/obj/machinery/computer3/generic/personal,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/neutral/side{
 	dir = 8
 	},
-/area/station/security/brig)
-"eyl" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
+/area/station/crew_quarters/quarters_south)
+"etg" = (
+/obj/machinery/door/airlock/pyro/external,
 /turf/simulated/floor/plating,
-/area/space)
+/area/station/maintenance/southeast)
+"ewV" = (
+/obj/machinery/door/airlock/pyro{
+	dir = 4;
+	icon_state = "generic_locked";
+	locked = 1
+	},
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/quarters_south)
+"exs" = (
+/obj/landmark/artifact,
+/turf/simulated/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/station/maintenance/southeast)
 "eyB" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -51847,16 +51820,59 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
-"ezo" = (
+"ezW" = (
+/obj/stool/chair{
+	dir = 4
+	},
+/turf/simulated/floor/escape,
+/area/station/hallway/primary/east)
+"eAc" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/turret,
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
+"eBf" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/shipalert{
+	pixel_x = 30
+	},
+/turf/simulated/floor/black/side{
+	dir = 8
+	},
+/area/station/bridge)
+"eBr" = (
+/obj/machinery/door/airlock/pyro,
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
-/turf/simulated/floor/grime,
+/turf/simulated/floor/grey/blackgrime,
 /area/station/security/brig)
-"ezW" = (
-/obj/machinery/door/airlock/pyro/maintenance,
-/turf/simulated/floor/red/checker,
-/area/station/maintenance/central)
+"eBR" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor,
+/area/station/security/brig)
 "eCr" = (
 /obj/cable{
 	d1 = 4;
@@ -51872,14 +51888,29 @@
 /obj/disposalpipe/junction/left/south,
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
-"eFY" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"eFc" = (
+/obj/machinery/floorflusher/solitary2,
+/obj/disposalpipe/trunk/south,
+/turf/simulated/floor/black,
+/area/station/security/brig)
+"eFC" = (
+/obj/table/reinforced/bar/auto,
+/obj/machinery/light,
+/obj/item/decoration/ashtray{
+	pixel_x = -4;
+	pixel_y = 8
 	},
-/turf/simulated/floor/grey,
-/area/station/bridge)
+/turf/simulated/floor/carpet/green/standard/narrow/northsouth,
+/area/station/crew_quarters/cafeteria)
+"eFY" = (
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/turf/simulated/floor/redblack,
+/area/station/security/brig)
 "eGO" = (
 /obj/lattice{
 	dir = 4;
@@ -51888,6 +51919,17 @@
 /obj/machinery/light/runway_light/delay3,
 /turf/space,
 /area/station/ai_monitored/armory)
+"eJU" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/grey,
+/area/station/bridge)
+"eKY" = (
+/turf/simulated/floor/carpet/blue,
+/area/station/crew_quarters/md)
 "eLc" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -51903,26 +51945,74 @@
 /obj/machinery/atmospherics/pipe/simple/junction,
 /turf/space,
 /area/space)
-"eMY" = (
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/blue/side{
+"eOD" = (
+/obj/stool/chair/comfy{
 	dir = 8
 	},
-/area/station/hallway/primary/south)
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/east,
+/area/station/bridge)
 "eQE" = (
 /obj/grille/catwalk,
 /obj/machinery/oreaccumulator,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/mining/refinery)
-"eVv" = (
-/obj/machinery/light,
-/turf/simulated/floor,
-/area/station/crew_quarters/courtroom)
 "eWB" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
-"eWF" = (
+"eZj" = (
+/obj/machinery/atmospherics/pipe/simple,
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
+"eZW" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/mining/refinery)
+"fae" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 1
+	},
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
+"fao" = (
+/obj/storage/closet/emergency,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"faL" = (
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
+"fdN" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/ai)
+"feN" = (
 /obj/stool/chair{
 	dir = 8
 	},
@@ -51933,41 +52023,20 @@
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters_south)
-"eXF" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/orangeblack,
-/area/station/crew_quarters/ce)
-"eZW" = (
-/obj/wingrille_spawn/auto,
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/mining/refinery)
-"fdN" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/circuit,
-/area/station/turret_protected/ai)
-"fhi" = (
-/obj/plasticflaps,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/beepsky)
-"fhN" = (
-/obj/machinery/alarm{
+"fgp" = (
+/obj/machinery/light/small{
 	dir = 4;
-	pixel_x = -20
+	pixel_x = 12
 	},
-/turf/simulated/floor/escape{
-	dir = 8
-	},
-/area/station/hallway/secondary/exit)
+/obj/item/storage/toolbox/emergency,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"fhN" = (
+/obj/table/auto,
+/obj/item/game_kit,
+/obj/machinery/light,
+/turf/simulated/floor/escape,
+/area/station/hallway/primary/east)
 "fhZ" = (
 /obj/wingrille_spawn/auto,
 /obj/machinery/atmospherics/pipe/manifold{
@@ -52006,18 +52075,6 @@
 /obj/item/staple_gun,
 /turf/simulated/floor/caution/east,
 /area/station/medical/robotics)
-"fku" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
-/turf/simulated/floor/red,
-/area/station/ai_monitored/armory)
 "fkO" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
@@ -52052,6 +52109,26 @@
 /obj/machinery/light,
 /turf/unsimulated/floor/sanitary,
 /area/station/crewquarters/cryotron)
+"flq" = (
+/obj/item/reagent_containers/food/drinks/bottle/thegoodstuff,
+/obj/shrub/captainshrub,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/bridge/captain)
+"fng" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/space)
 "foi" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 6
@@ -52068,52 +52145,60 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "fqj" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
+/obj/stool/chair{
+	dir = 8
 	},
-/obj/item/device/radio/intercom/catering{
-	pixel_x = 3;
-	pixel_y = 24
+/turf/simulated/floor/escape{
+	dir = 6
 	},
-/obj/stool/chair,
+/area/station/hallway/primary/east)
+"frd" = (
+/obj/table/auto,
+/obj/item/shaker/salt,
+/obj/item/shaker/mustard{
+	pixel_x = -6
+	},
+/obj/item/shaker/pepper{
+	pixel_x = 3
+	},
+/obj/item/shaker/ketchup{
+	pixel_x = 6
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
+"frJ" = (
+/obj/machinery/optable,
+/obj/item/device/analyzer/healthanalyzer{
+	pixel_y = -1;
+	rand_pos = 0
+	},
+/turf/simulated/floor/bluewhite,
+/area/station/medical/medbooth)
 "frY" = (
 /turf/simulated/wall/auto/reinforced/supernorn/yellow,
 /area/station/mining/staff_room)
-"fsM" = (
-/obj/machinery/door/airlock/pyro/maintenance,
-/obj/cable{
-	icon_state = "1-2"
+"fsd" = (
+/turf/simulated/floor/red/side{
+	dir = 4
 	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/greenblack{
-	dir = 1
+/area/station/security/brig)
+"ftZ" = (
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
 	},
-/area/station/garden/aviary)
-"ftc" = (
-/obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/left{
-	dir = 8
-	},
+/obj/decal/cleanable/dirt,
+/obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
-/area/station/turret_protected/Zeta)
-"fts" = (
-/obj/machinery/door/airlock/pyro/command{
-	aiControlDisabled = 1;
-	name = "Armory";
-	req_access = null
-	},
-/obj/access_spawn/hos,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
+/area/station/maintenance/southeast)
+"fuw" = (
+/obj/table/wood/auto,
+/obj/item/paper_bin,
+/obj/item/pen/fancy,
+/obj/machinery/light,
+/obj/item/stamp/hop,
+/turf/simulated/floor/black,
+/area/station/bridge/hos)
 "fvz" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
@@ -52129,60 +52214,19 @@
 /turf/simulated/floor/carpet/purple/fancy/edge/se,
 /area/station/crew_quarters/quarters_north)
 "fwt" = (
-/obj/table/reinforced/auto,
-/obj/item/storage/box/plates,
-/obj/item/storage/box/cutlery,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/grille/catwalk{
+	dir = 6
 	},
-/obj/machinery/power/apc/autoname_west,
-/turf/simulated/floor/white,
-/area/station/crew_quarters/kitchen)
-"fyL" = (
-/obj/table/auto,
-/obj/item/reagent_containers/food/snacks/breadloaf,
-/obj/item/kitchen/utensil/knife,
-/obj/machinery/light_switch/east,
-/turf/simulated/floor/specialroom/cafeteria,
-/area/station/crew_quarters/kitchen)
-"fyU" = (
-/obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/left,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/disposalpipe/segment/horizontal,
+/turf/simulated/floor/airless/plating/catwalk{
+	icon_state = "catwalk_cross"
 	},
-/turf/simulated/floor/plating,
-/area/station/bridge/captain)
-"fzc" = (
-/obj/machinery/door/airlock/pyro/glass{
-	name = "Holding Cell One"
-	},
-/obj/access_spawn/brig,
-/turf/simulated/floor/black,
 /area/space)
-"fzA" = (
-/obj/machinery/chem_heater,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
-	},
-/obj/item/device/radio/intercom/medical{
-	pixel_x = 4;
-	pixel_y = 24
-	},
-/turf/simulated/floor/carpet/blue/fancy/edge/ne,
-/area/station/crew_quarters/md)
-"fCh" = (
-/obj/lattice{
-	dir = 1;
-	icon_state = "lattice-dir"
-	},
-/turf/space,
-/area/station/ai_monitored/armory)
+"fyL" = (
+/obj/random_item_spawner/junk/one_or_zero,
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/routing/depot)
 "fCz" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -52192,11 +52236,13 @@
 	dir = 4
 	},
 /area/station/hallway/primary/west)
-"fCO" = (
-/obj/machinery/floorflusher/solitary2,
-/obj/disposalpipe/trunk/south,
-/turf/simulated/floor/black,
-/area/station/security/brig)
+"fDR" = (
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
 "fEt" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -52212,51 +52258,66 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "fIF" = (
-/obj/machinery/door/airlock/pyro{
-	name = "Serving Area"
-	},
-/obj/access_spawn/bar,
-/obj/firedoor_spawn,
-/obj/access_spawn/kitchen,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/cafeteria)
+/obj/reagent_dispensers/still,
+/turf/simulated/floor/plating,
+/area/station/routing/depot)
 "fIG" = (
-/obj/landmark/spawner{
-	name = "monkeyspawn_mrmuggles"
+/obj/table/reinforced/auto,
+/obj/item/kitchen/utensil/knife,
+/obj/item/kitchen/utensil/spoon,
+/obj/item/kitchen/utensil/fork,
+/obj/item/plate,
+/obj/item/reagent_containers/food/drinks/bowl,
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/specialroom/cafeteria{
+	dir = 1
+	},
+/area/station/crew_quarters/kitchen)
+"fMd" = (
+/obj/table/reinforced/auto,
+/obj/item/gun/kinetic/riot40mm{
+	pixel_y = 10
+	},
+/obj/item/ammo/bullets/smoke,
+/obj/item/ammo/bullets/smoke,
+/obj/item/gun/kinetic/riot40mm,
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
+"fPi" = (
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/obj/machinery/vending/pda,
+/turf/simulated/floor/neutral/side{
+	dir = 9
+	},
+/area/station/crew_quarters/quarters_south)
+"fTm" = (
+/obj/machinery/navbeacon{
+	codes_txt = "tour;next_tour=tour2;desc=Whether you've been in a long sleep or on a long trip, the on-station bar and cafeteria is sure to get you up and running again. Try the arcade, too!";
+	freq = 1443;
+	location = "tour1";
+	name = "tour 1 - bar"
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"fNP" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/light/runway_light,
-/turf/space,
-/area/station/ai_monitored/armory)
-"fTm" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/turf/simulated/floor/specialroom/cafeteria,
-/area/station/crew_quarters/barber_shop)
-"fUr" = (
-/obj/stool/chair/comfy/purple{
+"fTs" = (
+/obj/rack,
+/obj/item/clothing/suit/bio_suit/paramedic,
+/obj/item/clothing/suit/bio_suit/paramedic,
+/obj/item/storage/belt/medical,
+/obj/item/storage/belt/medical,
+/obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
-/obj/landmark/start{
-	name = "Research Director"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/carpet/purple/fancy,
-/area/station/science/research_director)
+/turf/simulated/floor/white,
+/area/station/medical/medbooth)
 "fUz" = (
 /obj/cable{
 	d1 = 1;
@@ -52296,12 +52357,6 @@
 	name = "reinforced plating"
 	},
 /area/station/science/lab)
-"fVL" = (
-/obj/stool,
-/turf/simulated/floor/grey/side{
-	dir = 4
-	},
-/area/space)
 "fVZ" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -52315,6 +52370,12 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
+"fXY" = (
+/obj/shrub{
+	dir = 10
+	},
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
 "fYL" = (
 /obj/grille/catwalk{
 	dir = 10;
@@ -52324,37 +52385,60 @@
 	dir = 10
 	},
 /area/station/maintenance/southeast)
+"gbd" = (
+/obj/stool/chair/office/blue{
+	dir = 4
+	},
+/obj/landmark/start{
+	name = "Head of Personnel"
+	},
+/turf/simulated/floor/carpet/green/fancy/edge/south,
+/area/station/bridge/hos)
 "gbf" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/landmark/halloween,
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
-"gbI" = (
-/obj/table/auto,
-/obj/machinery/cell_charger,
-/obj/item/cell/supercell/charged,
-/obj/item/cell/supercell/charged,
-/obj/machinery/light/small,
-/turf/simulated/floor/circuit,
-/area/station/bridge)
 "gda" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/storage/emergency)
-"gey" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/stool/bar,
+/turf/simulated/floor/carpet/green/fancy/edge/sw,
+/area/station/crew_quarters/cafeteria)
+"gdl" = (
+/turf/simulated/floor/redblack{
+	dir = 1
 	},
-/turf/simulated/floor/carpet/purple/fancy,
-/area/station/science/research_director)
-"gfm" = (
-/obj/item/storage/wall/random{
-	dir = 8;
-	pixel_x = 32;
-	pixel_y = 0
+/area/station/security/brig)
+"geh" = (
+/obj/storage/crate,
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
 	},
-/obj/item/crowbar,
-/turf/simulated/floor/grime,
-/area/station/maintenance/southeast)
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
+"gfw" = (
+/obj/lattice{
+	dir = 9;
+	icon_state = "lattice-dir-b"
+	},
+/obj/machinery/light/runway_light/delay5,
+/turf/space,
+/area/station/ai_monitored/armory)
 "gga" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -52374,47 +52458,64 @@
 /obj/decal/wreath/ephemeral,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/south)
-"ggB" = (
-/obj/stool/bench/blue/auto,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
 "ggG" = (
-/obj/machinery/door/airlock/pyro/maintenance,
-/obj/disposalpipe/segment/vertical,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/storage/emergency)
+/obj/submachine/slot_machine,
+/turf/simulated/floor/carpet/green/fancy/edge/se,
+/area/station/crew_quarters/cafeteria)
 "gih" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
+"giq" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 20
+	},
+/turf/simulated/floor/grime,
+/area/station/security/brig)
+"giF" = (
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/station/ai_monitored/armory)
 "gjD" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/caution/westeast,
 /area/station/maintenance/south)
-"glX" = (
-/obj/shrub{
-	dir = 8
+"glg" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
-"goj" = (
-/obj/table/wood/round/auto,
-/obj/item/storage/toolbox{
-	desc = "Looks suspiciously similar to a toolbox.";
-	name = "lunchbox"
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "kgenpopwindow";
+	name = "General Population Visitation";
+	opacity = 0
 	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
+/turf/simulated/floor/plating,
+/area/station/security/brig)
+"gml" = (
+/obj/table/auto,
+/obj/machinery/microwave,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
+"gmE" = (
+/obj/machinery/sim/vr_bed{
+	dir = 4;
+	name = "VR simulation pod";
+	network = "arcadevr"
+	},
+/obj/cable,
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
 "goX" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/decal/garland/ephemeral{
@@ -52438,40 +52539,87 @@
 	dir = 1
 	},
 /area/station/hallway/primary/east)
-"gzj" = (
-/obj/storage/secure/closet/command/medical_director,
-/obj/item/storage/box/beakerbox,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
+"grt" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/item/clipboard,
-/obj/item/pen,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/md)
-"gzt" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
+/area/station/turret_protected/Zeta)
+"gsG" = (
+/obj/stool/chair,
+/obj/machinery/light/emergency{
+	dir = 8;
+	pixel_x = -10
 	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
+/turf/simulated/floor/neutral/side{
+	dir = 8
+	},
+/area/station/crew_quarters/quarters_south)
+"gvE" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 21;
+	pixel_y = -3
+	},
+/obj/fitness/weightlifter,
+/turf/simulated/floor/grime,
+/area/station/security/brig)
+"gxa" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/light/runway_light/delay4,
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/turf/space,
+/area/space)
+"gAs" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "yellow";
+	icon_state = "bedsheet-yellow"
+	},
+/obj/machinery/light,
+/turf/simulated/floor/yellowblack,
+/area/station/crew_quarters/ce)
+"gBx" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/bridge)
+"gBX" = (
+/obj/machinery/computer3/terminal/zeta{
+	setup_os_string = "ZETA_MAINFRAME"
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/station/maintenance/southeast)
 "gCb" = (
 /obj/machinery/computer/operating,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/robotics)
-"gEo" = (
-/obj/table/reinforced/auto,
-/obj/item/gun/kinetic/riot40mm{
-	pixel_y = 10
-	},
-/obj/item/ammo/bullets/smoke,
-/obj/item/ammo/bullets/smoke,
-/obj/item/gun/kinetic/riot40mm,
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
 "gFy" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -52482,44 +52630,20 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
-"gFT" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
 "gGg" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/caution/north,
 /area/research_outpost/indigo_rye)
+"gGi" = (
+/obj/disposalpipe/junction/right/north,
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
 "gGK" = (
 /obj/decal/poster/wallsign/security_right,
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/storage{
 	name = "Inner Southwest Maintenance"
 	})
-"gHa" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/bridge)
-"gIp" = (
-/obj/submachine/chef_sink/chem_sink{
-	dir = 8;
-	pixel_x = 8
-	},
-/turf/simulated/floor/green/side{
-	dir = 10
-	},
-/area/station/hydroponics/bay)
 "gII" = (
 /obj/table/auto,
 /obj/item/bandage,
@@ -52529,13 +52653,6 @@
 /obj/item/hemostat,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/robotics)
-"gJp" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/portable_atmospherics/canister/sleeping_agent,
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
 "gKo" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -52545,12 +52662,26 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
+"gKH" = (
+/obj/submachine/chef_sink/chem_sink{
+	dir = 8;
+	pixel_x = 8
+	},
+/turf/simulated/floor/green/side{
+	dir = 10
+	},
+/area/station/hydroponics/bay)
 "gKN" = (
 /obj/landmark{
 	name = "blobstart"
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/medical)
+"gLn" = (
+/obj/machinery/light/small,
+/obj/machinery/photocopier,
+/turf/simulated/floor/black,
+/area/station/bridge)
 "gMO" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0
@@ -52564,53 +52695,27 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "gNp" = (
-/obj/stool/chair{
-	dir = 1
+/obj/table/wood/auto,
+/obj/item/reagent_containers/food/drinks/bottle/champagne{
+	pixel_y = 8
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+/obj/item/reagent_containers/food/drinks/drinkingglass/flute{
+	pixel_x = -8
 	},
-/turf/simulated/floor/neutral/side{
-	dir = 8
+/obj/item/reagent_containers/food/drinks/drinkingglass/flute{
+	pixel_x = 6;
+	pixel_y = -1
 	},
-/area/station/crew_quarters/quarters_south)
+/turf/simulated/floor/carpet/blue/fancy/edge/south,
+/area/station/crew_quarters/heads{
+	name = "Diplomatic Quarters"
+	})
 "gNH" = (
 /obj/machinery/floorflusher/industrial,
 /obj/disposalpipe/trunk/east,
 /obj/machinery/light/small,
 /turf/simulated/floor/airless/grey,
 /area/station/maintenance/west)
-"gPu" = (
-/obj/machinery/light/emergency,
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
-"gPz" = (
-/obj/submachine/chef_sink/chem_sink{
-	dir = 1
-	},
-/obj/decal/tile_edge/line/black{
-	dir = 5;
-	icon_state = "line2"
-	},
-/obj/machinery/drainage,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/md)
-"gPF" = (
-/obj/item/caution{
-	desc = "Caution! Construction Zone!";
-	name = "caution sign"
-	},
-/obj/decal/cleanable/oil,
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/grime,
-/area/station/maintenance/southeast)
-"gQp" = (
-/obj/machinery/turret,
-/turf/simulated/floor/greenblack,
-/area/station/turret_protected/Zeta)
 "gQs" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/transport{
@@ -52631,6 +52736,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor,
 /area/station/security/brig)
 "gSr" = (
@@ -52645,19 +52753,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"gWl" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
 "gWW" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -52670,19 +52765,17 @@
 /turf/simulated/floor/darkblue/checker,
 /area/station/science/artifact)
 "gXb" = (
-/obj/disposalpipe/segment/vertical,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/table/wood/auto,
+/obj/item/football{
+	pixel_y = 4
 	},
-/obj/decal/garland/ephemeral{
-	dir = 8;
-	pixel_x = 14
+/obj/item/reagent_containers/food/drinks/cola{
+	pixel_x = 8
 	},
-/turf/simulated/floor/neutral/side{
-	dir = 4
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
 	},
+/turf/simulated/floor/carpet/green/fancy/edge/ne,
 /area/station/crew_quarters/quarters_south)
 "gXu" = (
 /obj/table/auto,
@@ -52690,45 +52783,6 @@
 /obj/random_item_spawner/tools,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"gYi" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4;
-	high_risk = 1;
-	name = "Cafeteria"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"gYK" = (
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
-"has" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"haL" = (
-/obj/machinery/computer3/terminal/network{
-	dir = 4;
-	name = "CENTCOM Terminal";
-	pixel_x = -3;
-	pixel_y = 4;
-	setup_os_string = "MAIN_DISH_SS13"
-	},
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/sanitary/white,
-/area/station/bridge/captain)
 "haO" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -52746,15 +52800,6 @@
 	},
 /turf/space,
 /area/space)
-"hdO" = (
-/obj/table/reinforced/bar/auto,
-/obj/machinery/light,
-/obj/item/decoration/ashtray{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/turf/simulated/floor/carpet/green/standard/narrow/northsouth,
-/area/station/crew_quarters/cafeteria)
 "heG" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 1
@@ -52767,13 +52812,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/west)
-"hgk" = (
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
 "hgl" = (
 /obj/lattice{
 	dir = 9;
@@ -52791,78 +52829,67 @@
 /obj/storage/secure/crate/weapon/armory/pod_weapons,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
-"hik" = (
-/obj/grille/catwalk{
-	dir = 6;
-	icon_state = "catwalk_cross"
+"hlA" = (
+/obj/shrub{
+	dir = 10
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 6
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
 	},
-/area/station/maintenance/southeast)
-"hjl" = (
-/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
+"hlG" = (
+/obj/machinery/door_timer/solitary2/new_walls/north{
+	layer = 3.1
+	},
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 8;
+	icon_state = "on";
+	on = 1
+	},
+/turf/simulated/floor/red/corner{
+	dir = 1
+	},
+/area/station/security/brig)
+"hlR" = (
+/obj/wingrille_spawn/auto,
+/obj/health_scanner/wall{
+	layer = 3.3
+	},
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "kgenpopwindow";
-	name = "General Population Visitation";
-	opacity = 0
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/security/brig)
-"hkZ" = (
-/obj/lattice{
-	dir = 9;
-	icon_state = "lattice-dir-b"
-	},
-/obj/machinery/light/runway_light/delay5,
-/turf/space,
-/area/station/ai_monitored/armory)
-"hmd" = (
-/obj/machinery/light/runway_light,
-/obj/lattice{
-	icon_state = "lattice-dir"
-	},
-/turf/space,
-/area/station/ai_monitored/armory)
+/area/station/medical/medbooth)
 "hmG" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
 /turf/simulated/floor/caution/westeast,
 /area/station/maintenance/south)
-"hnQ" = (
-/obj/machinery/rkit,
+"hni" = (
+/obj/machinery/chem_master{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/east,
+/area/station/crew_quarters/md)
+"hnv" = (
+/obj/table/reinforced/auto,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/reagent_containers/food/drinks/water,
 /obj/machinery/camera{
 	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
-	},
-/obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -20
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
 	},
-/turf/simulated/floor/yellowblack{
-	dir = 1
+/turf/simulated/floor/grey/side{
+	dir = 8
 	},
-/area/station/crew_quarters/ce)
-"hpI" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/stool/chair{
-	dir = 1
-	},
-/turf/simulated/floor/grime,
-/area/station/maintenance/southeast)
+/area/space)
 "hrS" = (
 /obj/machinery/door/airlock/pyro/security{
 	dir = 4
@@ -52878,11 +52905,42 @@
 	},
 /turf/simulated/floor/red,
 /area/station/routing/security)
+"htE" = (
+/obj/item/storage/wall{
+	dir = 8;
+	name = "silverware cabinet";
+	pixel_x = 32;
+	spawn_contents = list(/obj/item/storage/box/cutlery,/obj/item/storage/box/cutlery,/obj/item/storage/box/cutlery,/obj/item/storage/box/plates,/obj/item/storage/box/plates,/obj/item/shaker/salt,/obj/item/shaker/pepper)
+	},
+/turf/simulated/floor/black,
+/area/station/bridge)
+"hvH" = (
+/obj/machinery/chem_dispenser/alcohol,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
+/obj/machinery/light_switch/west,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/cafeteria)
 "hwl" = (
 /obj/storage/closet/emergency,
 /obj/machinery/light_switch/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
+"hwO" = (
+/obj/machinery/door/airlock/pyro/security{
+	name = "Secure Consultation"
+	},
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/turf/simulated/floor/redblack,
+/area/station/security/brig)
 "hwT" = (
 /obj/machinery/vending/cola/blue,
 /obj/decal/xmas_lights/ephemeral{
@@ -52892,6 +52950,14 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
+"hyi" = (
+/obj/lattice{
+	dir = 6;
+	icon_state = "lattice-dir-b"
+	},
+/obj/machinery/light/runway_light/delay2,
+/turf/space,
+/area/station/ai_monitored/armory)
 "hzD" = (
 /obj/stool/chair/office{
 	dir = 8
@@ -52904,122 +52970,7 @@
 	dir = 4
 	},
 /area/station/medical/medbay)
-"hCK" = (
-/obj/machinery/mass_driver{
-	dir = 1;
-	id = "kd_eng"
-	},
-/turf/simulated/floor/plating/airless,
-/area/space)
-"hEI" = (
-/obj/table/reinforced/auto,
-/obj/item/paper_bin,
-/obj/item/pen/pencil,
-/obj/item/reagent_containers/food/drinks/water,
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/grey/side{
-	dir = 8
-	},
-/area/station/security/brig)
-"hHd" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/window_blinds/cog2/right{
-	dir = 8
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/md)
-"hIt" = (
-/turf/simulated/floor/redblack/corner{
-	dir = 8
-	},
-/area/space)
-"hNB" = (
-/obj/disposalpipe/segment/brig{
-	dir = 8
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/emergency{
-	dir = 1;
-	pixel_y = 16
-	},
-/turf/simulated/floor/neutral/side{
-	dir = 1
-	},
-/area/station/hallway/primary/east)
-"hOS" = (
-/obj/grille/catwalk{
-	dir = 4
-	},
-/turf/simulated/floor/airless/plating,
-/area/station/maintenance/west)
-"hSo" = (
-/obj/machinery/computer/telescope{
-	dir = 8
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
-/obj/cable,
-/turf/simulated/floor/carpet/purple/fancy/edge/east,
-/area/station/science/research_director)
-"hSC" = (
-/obj/wingrille_spawn/auto,
-/obj/health_scanner/wall{
-	layer = 3.3
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/medical/medbooth)
-"hTE" = (
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
-/obj/item/device/radio/intercom/cargo,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southwest)
-"ica" = (
-/obj/lattice{
-	dir = 10;
-	icon_state = "lattice-dir"
-	},
-/turf/space,
-/area/station/com_dish/comdish)
-"idR" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
-"igX" = (
-/obj/machinery/chem_dispenser,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/cafeteria)
-"ijH" = (
+"hCu" = (
 /obj/storage/crate{
 	desc = "A private crate that isn't yours.";
 	name = "Beepsky's stuff"
@@ -53042,29 +52993,241 @@
 	},
 /turf/simulated/floor/plating/damaged3,
 /area/station/security/beepsky)
+"hCK" = (
+/obj/machinery/mass_driver{
+	dir = 1;
+	id = "kd_engB"
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/plating/airless,
+/area/space)
+"hEf" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"hEO" = (
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Cafeteria"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
+"hFc" = (
+/obj/table/round/auto,
+/obj/item/gobowl/b,
+/turf/simulated/floor/neutral/side{
+	dir = 8
+	},
+/area/station/crew_quarters/quarters_south)
+"hGk" = (
+/obj/grille/catwalk,
+/turf/simulated/floor/airless/plating/catwalk,
+/area/station/maintenance/southeast)
+"hHm" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/submachine/chef_sink/chem_sink{
+	dir = 8;
+	pixel_x = 8
+	},
+/turf/simulated/floor/redwhite/corner{
+	dir = 4
+	},
+/area/station/medical/medbooth)
+"hHt" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/ai_monitored/armory)
+"hHD" = (
+/obj/table/auto,
+/obj/item/paper/book/guardbot_guide{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/paper/book/dwainedummies{
+	pixel_y = 6
+	},
+/obj/item/disk/data/tape/master/readonly,
+/turf/simulated/floor/black,
+/area/station/bridge)
+"hIW" = (
+/obj/critter/parrot/random,
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
+"hNB" = (
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/emergency{
+	dir = 1;
+	pixel_y = 16
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 1
+	},
+/area/station/hallway/primary/east)
+"hOS" = (
+/obj/grille/catwalk{
+	dir = 4
+	},
+/turf/simulated/floor/airless/plating,
+/area/station/maintenance/west)
+"hQb" = (
+/obj/disposalpipe/segment/vertical,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/obj/machinery/phone/wall{
+	pixel_x = 24
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/crew_quarters/quarters_south)
+"hQi" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbooth)
+"hQD" = (
+/obj/table/round/auto,
+/obj/item/goboard,
+/turf/simulated/floor,
+/area/station/crew_quarters/quarters_south)
+"hRB" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/west,
+/area/station/bridge)
+"hTE" = (
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/obj/item/device/radio/intercom/cargo,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southwest)
+"hVJ" = (
+/obj/stool/bar,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
+"hZy" = (
+/obj/machinery/light/emergency,
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"hZZ" = (
+/obj/table/wood/auto,
+/obj/machinery/phone,
+/turf/simulated/floor/black,
+/area/station/bridge/hos)
+"ica" = (
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/station/com_dish/comdish)
+"idR" = (
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/storage{
+	name = "Inner Southwest Maintenance"
+	})
+"ifo" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/decal/wreath/ephemeral,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/courtroom)
+"ifA" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/stool/chair/office/blue{
+	dir = 4
+	},
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/catering)
+"ihR" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/middle{
+	dir = 5
+	},
+/obj/cable,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/bridge/captain)
 "ikb" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	level = 2
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"ikL" = (
-/obj/table/reinforced/auto,
-/obj/item/paper/Port_A_Brig,
-/obj/item/remote/porter/port_a_brig,
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
+"ilc" = (
+/obj/machinery/door/airlock/pyro,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/red/side{
-	dir = 4
-	},
-/area/station/security/brig)
+/obj/firedoor_spawn,
+/turf/simulated/floor/green/side,
+/area/station/garden/aviary)
 "ill" = (
-/obj/decal/cleanable/dirt,
-/obj/storage/closet/fire,
-/turf/simulated/floor/plating,
+/obj/machinery/door/airlock/pyro/maintenance,
+/turf/simulated/floor/red/checker,
 /area/station/maintenance/central)
 "imf" = (
 /obj/reagent_dispensers/fueltank,
@@ -53081,6 +53244,21 @@
 /obj/machinery/light/emergency,
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/south)
+"ioc" = (
+/obj/machinery/door/airlock/pyro/command{
+	dir = 4;
+	name = "Network Chamber"
+	},
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/grey,
+/area/station/bridge)
 "iof" = (
 /obj/disposalpipe/switch_junction/left/west{
 	mail_tag = "hydroponics";
@@ -53088,6 +53266,14 @@
 	},
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/south)
+"iqG" = (
+/obj/machinery/power/apc/autoname_east,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "isd" = (
 /obj/machinery/manufacturer/hangar,
 /obj/machinery/power/apc/autoname_west,
@@ -53099,6 +53285,35 @@
 	dir = 8
 	},
 /area/station/routing/security)
+"isy" = (
+/obj/machinery/communications_dish,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/airless/plating,
+/area/station/ai_monitored/armory)
+"isW" = (
+/obj/critter/roach,
+/turf/simulated/floor/grime,
+/area/station/maintenance/southeast)
+"iti" = (
+/obj/disposalpipe/trunk/south,
+/obj/machinery/disposal/transport{
+	desc = "A pneumatic delivery chute for transporting people from one section of maintenance to another.";
+	name = "maintenance shunt unit"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"itn" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "itQ" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4;
@@ -53124,22 +53339,6 @@
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"iwK" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/obj/machinery/phone/wall{
-	pixel_y = 32
-	},
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/baroffice)
-"ixU" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
 "iyd" = (
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/cable{
@@ -53147,10 +53346,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"iye" = (
-/obj/critter/parrot/random,
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
 "iCf" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable,
@@ -53161,14 +53356,14 @@
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "iDR" = (
-/obj/table/auto,
-/obj/shrub/dead{
-	dir = 8;
-	name = "Dead plant";
-	pixel_y = 10
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -20
 	},
-/turf/simulated/floor/plating,
-/area/station/routing/depot)
+/turf/simulated/floor/escape{
+	dir = 8
+	},
+/area/station/hallway/secondary/exit)
 "iDX" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -53180,16 +53375,35 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
-"iFX" = (
-/obj/table/wood/round/auto,
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
+"iEU" = (
+/obj/table/auto,
+/obj/item/storage/box/diskbox,
+/turf/simulated/floor/greenblack,
+/area/station/turret_protected/Zeta)
+"iGX" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "iHH" = (
 /obj/reagent_dispensers/foamtank,
 /turf/simulated/floor/caution/corner/misc{
 	dir = 6
 	},
 /area/research_outpost/indigo_rye)
+"iJP" = (
+/obj/decal/skeleton{
+	desc = "It's all covered in a sticky mess, and there are chunks of uniform fused to the bone.";
+	name = "sticky skeleton"
+	},
+/turf/simulated/floor/plating/scorched,
+/area/station/crew_quarters/quarters_south)
 "iJS" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/mail/vertical,
@@ -53209,17 +53423,15 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
-"iLb" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1;
-	name = "Escape S Repressurization Port"
+"iMj" = (
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/central)
-"iMD" = (
-/obj/item/clothing/suit/cardboard_box,
-/turf/simulated/floor/grime,
-/area/station/maintenance/southeast)
+/obj/disposalpipe/segment/bent/east,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/hallway/primary/south)
 "iNr" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -53232,6 +53444,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/brig)
+"iOb" = (
+/obj/stool/chair{
+	dir = 8
+	},
+/obj/machinery/phone/wall{
+	pixel_y = 32
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/baroffice)
 "iQf" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
@@ -53239,43 +53460,59 @@
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
-"iSS" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "4-10"
+"iRU" = (
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"iUJ" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
-"iVK" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
-	dir = 8;
+	dir = 4;
 	name = "autoname - SS13";
-	pixel_x = 10;
+	pixel_x = -10;
 	tag = ""
 	},
-/obj/machinery/phone/wall{
-	pixel_x = 24
+/turf/space,
+/area/station/ai_monitored/armory)
+"iSc" = (
+/obj/table/wood/auto,
+/obj/item/item_box/gold_star{
+	item_amount = 20
 	},
-/turf/simulated/floor/grey,
-/area/station/bridge)
+/obj/item/dice/d1,
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/obj/item/deconstructor,
+/obj/item/device/radio/intercom/engineering,
+/turf/simulated/floor/yellowblack{
+	dir = 1
+	},
+/area/station/crew_quarters/ce)
+"iVf" = (
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/turf/simulated/floor/stairs,
+/area/station/security/brig)
+"iWl" = (
+/turf/simulated/floor/caution/westeast,
+/area/station/hallway/secondary/exit)
 "iWw" = (
-/obj/machinery/disposal,
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
 	},
-/obj/disposalpipe/trunk/east,
+/obj/item/device/radio/intercom/catering{
+	pixel_x = 3;
+	pixel_y = 24
+	},
+/obj/stool/chair,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "iWG" = (
@@ -53291,69 +53528,21 @@
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
-"iWH" = (
-/obj/stool{
-	desc = "A soft little bed the general size and shape of a space bee.";
-	icon = 'icons/misc/critter.dmi';
-	icon_state = "beebed";
-	name = "heisenbed"
-	},
-/obj/item/reagent_containers/food/snacks/beefood{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/critter/domestic_bee/heisenbee,
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/obj/machinery/light_switch/north,
-/turf/simulated/floor/carpet/purple/fancy/edge/north,
-/area/station/science/research_director)
-"iXr" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"iZJ" = (
-/obj/table/round/auto,
-/obj/machinery/computer3/generic/personal,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/neutral/side{
-	dir = 8
-	},
-/area/station/crew_quarters/quarters_south)
 "jaZ" = (
 /obj/table/auto,
 /obj/item/shipcomponent/secondary_system/tractor_beam,
 /obj/item/shipcomponent/secondary_system/tractor_beam,
 /turf/simulated/floor,
 /area/station/routing/security)
-"jbW" = (
-/obj/wingrille_spawn/auto,
+"jbZ" = (
 /obj/cable{
+	d1 = 2;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "2-8"
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/decal/wreath/ephemeral,
+/obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
-/area/space)
+/area/station/maintenance/southeast)
 "jcj" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -53364,6 +53553,14 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/medical/robotics)
+"jdg" = (
+/obj/lattice{
+	dir = 5;
+	icon_state = "lattice-dir-b"
+	},
+/obj/machinery/light/runway_light/delay3,
+/turf/space,
+/area/station/ai_monitored/armory)
 "jdV" = (
 /obj/decal/poster/wallsign/danger_highvolt,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -53383,37 +53580,51 @@
 /obj/storage/secure/closet/medical/anesthetic,
 /turf/simulated/floor/red,
 /area/station/medical/medbay/surgery)
-"jke" = (
-/obj/shrub{
-	dir = 10
+"jgf" = (
+/obj/storage/secure/closet/command/chief_engineer,
+/obj/item/clipboard,
+/obj/item/pen,
+/turf/simulated/floor/yellowblack,
+/area/station/crew_quarters/ce)
+"jlI" = (
+/obj/stool/chair/wooden{
+	dir = 4
 	},
 /turf/simulated/floor/grass,
 /area/station/garden/aviary)
-"jlz" = (
+"jmt" = (
 /obj/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"joa" = (
-/obj/machinery/door/airlock/pyro{
-	dir = 4;
-	icon_state = "generic_locked";
-	locked = 1
+"jol" = (
+/obj/machinery/door/poddoor/pyro{
+	id = "dwaine_core";
+	name = "DWAINE Core Shield"
 	},
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/quarters_south)
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "joy" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/clown{
 	name = "Clowntainment"
 	})
+"jqc" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbooth)
 "jry" = (
 /obj/wingrille_spawn/auto,
 /obj/machinery/door/poddoor/pyro{
@@ -53437,20 +53648,17 @@
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/robotics)
-"jsd" = (
-/obj/disposalpipe/segment/transport{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/space,
-/area/station/ai_monitored/armory)
 "jsl" = (
-/obj/disposalpipe/segment/mail/horizontal,
+/obj/table/reinforced/auto,
+/obj/item/storage/box/plates,
+/obj/item/storage/box/cutlery,
 /obj/cable{
-	icon_state = "4-8"
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/catering)
+/obj/machinery/power/apc/autoname_west,
+/turf/simulated/floor/white,
+/area/station/crew_quarters/kitchen)
 "jsY" = (
 /obj/lattice{
 	dir = 1;
@@ -53459,19 +53667,20 @@
 /obj/machinery/light/runway_light/delay2,
 /turf/space,
 /area/space)
+"jtF" = (
+/obj/item/device/radio/beacon,
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/courtroom)
 "jvp" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/obj/table/reinforced/auto,
-/obj/cup_rack{
-	pixel_y = 32
-	},
-/obj/machinery/espresso_machine,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/cafeteria)
+/obj/table/auto,
+/obj/item/reagent_containers/food/snacks/breadloaf,
+/obj/item/kitchen/utensil/knife,
+/obj/machinery/light_switch/east,
+/turf/simulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/kitchen)
 "jvK" = (
 /obj/disposalpipe/segment/food,
 /obj/decal/garland/ephemeral{
@@ -53504,115 +53713,78 @@
 	dir = 10
 	},
 /area/station/medical/medbooth)
-"jxC" = (
-/obj/table/auto,
-/obj/item/paper/book/guardbot_guide{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/paper/book/dwainedummies{
-	pixel_y = 6
-	},
-/obj/item/disk/data/tape/master/readonly,
-/turf/simulated/floor/black,
-/area/station/bridge)
-"jys" = (
-/obj/submachine/chef_sink/chem_sink{
-	dir = 1
-	},
-/obj/decal/tile_edge/line/black{
-	dir = 5;
-	icon_state = "line2"
-	},
-/obj/machinery/drainage,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/ce)
-"jyQ" = (
-/obj/storage/crate,
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/machinery/light/small,
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
-"jzJ" = (
-/obj/stool/chair,
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_south)
-"jAa" = (
-/obj/storage/secure/closet/command/captain,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/autoname_north,
-/turf/simulated/floor/carpet/arcade,
-/area/station/bridge/captain)
-"jBF" = (
-/obj/stool/chair/wooden{
-	dir = 8
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
+"jzY" = (
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating,
+/area/station/security/brig)
 "jCx" = (
 /obj/storage/crate/loot,
 /turf/simulated/floor/plating/airless/asteroid/dark,
 /area/space)
+"jCM" = (
+/obj/machinery/chem_dispenser,
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/north,
+/area/station/crew_quarters/md)
+"jDt" = (
+/obj/machinery/rkit,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -20
+	},
+/turf/simulated/floor/yellowblack{
+	dir = 1
+	},
+/area/station/crew_quarters/ce)
 "jDX" = (
 /obj/landmark{
 	name = "blobstart"
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/science)
-"jHf" = (
-/obj/stool/chair,
-/obj/machinery/light/emergency{
-	dir = 8;
-	pixel_x = -10
+"jFM" = (
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
+"jGG" = (
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/neutral/side{
-	dir = 8
+/obj/cable{
+	icon_state = "1-8"
 	},
-/area/station/crew_quarters/quarters_south)
-"jIB" = (
-/obj/machinery/door/airlock/pyro/glass,
-/obj/decal/garland/ephemeral,
-/obj/disposalpipe/segment/brig{
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"jHu" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black/corner{
 	dir = 1
 	},
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/courtroom)
-"jIL" = (
-/obj/machinery/vending/snack{
-	credit = 50
+/area/station/bridge)
+"jIb" = (
+/obj/item/caution{
+	desc = "Caution! Construction Zone!";
+	name = "caution sign"
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/space)
-"jIU" = (
-/obj/table/round/auto,
-/obj/item/goboard,
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_south)
+/obj/decal/cleanable/oil,
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/grime,
+/area/station/maintenance/southeast)
 "jJT" = (
 /obj/submachine/seed_vendor,
 /obj/machinery/light{
@@ -53622,68 +53794,42 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
-"jNV" = (
-/obj/stool/chair,
-/turf/simulated/floor/plating,
-/area/space)
-"jOn" = (
-/obj/machinery/disposal,
-/obj/disposalpipe/trunk/south,
-/obj/machinery/firealarm{
-	pixel_y = 24
+"jNR" = (
+/obj/storage/crate/rcd,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/cafeteria)
-"jOS" = (
-/obj/item/storage/wall{
-	dir = 8;
-	name = "silverware cabinet";
-	pixel_x = 32;
-	spawn_contents = list(/obj/item/storage/box/cutlery,/obj/item/storage/box/cutlery,/obj/item/storage/box/cutlery,/obj/item/storage/box/plates,/obj/item/storage/box/plates,/obj/item/shaker/salt,/obj/item/shaker/pepper)
-	},
-/turf/simulated/floor/black,
-/area/station/bridge)
-"jSo" = (
-/obj/structure/woodwall,
-/turf/simulated/floor/plating/damaged1,
-/area/station/garden/aviary)
-"jSr" = (
-/obj/machinery/optable,
-/obj/item/device/analyzer/healthanalyzer{
-	pixel_y = -1;
-	rand_pos = 0
-	},
-/turf/simulated/floor/bluewhite,
-/area/station/medical/medbooth)
-"jSH" = (
-/obj/machinery/door/airlock/pyro/security{
-	name = "Courtroom"
-	},
-/obj/machinery/secscanner{
-	pixel_y = 10
-	},
-/obj/decal/garland/ephemeral,
-/obj/disposalpipe/segment/brig{
+/turf/simulated/floor/yellowblack/corner{
 	dir = 1
 	},
-/turf/simulated/floor,
-/area/station/crew_quarters/courtroom)
+/area/station/crew_quarters/ce)
+"jOn" = (
+/obj/machinery/door/airlock/pyro{
+	name = "Serving Area"
+	},
+/obj/access_spawn/bar,
+/obj/firedoor_spawn,
+/obj/access_spawn/kitchen,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/cafeteria)
 "jTa" = (
 /obj/decal/poster/wallsign/fire,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/gas)
-"jTb" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/space)
-"jUz" = (
-/obj/disposalpipe/segment/horizontal,
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
-/area/station/hallway/primary/south)
+"jTK" = (
+/obj/machinery/door/airlock/pyro/glass,
+/obj/disposalpipe/segment/vertical,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/courtroom)
+"jUm" = (
+/obj/table/reinforced/auto,
+/obj/machinery/phone,
+/turf/simulated/floor/carpet/red/fancy/edge/se,
+/area/station/security/hos)
 "kbj" = (
 /obj/machinery/atmospherics/binary/volume_pump{
 	dir = 4;
@@ -53716,17 +53862,34 @@
 /area/station/maintenance/storage{
 	name = "Inner Southwest Maintenance"
 	})
-"keP" = (
-/turf/simulated/floor/carpet/blue,
-/area/station/crew_quarters/md)
-"kht" = (
-/obj/table/wood/auto,
-/obj/item/paper_bin,
-/obj/item/pen/fancy,
-/obj/machinery/light,
-/obj/item/stamp/hop,
-/turf/simulated/floor/black,
-/area/station/bridge/hos)
+"kcU" = (
+/obj/stool/chair/red{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/redblack{
+	dir = 5
+	},
+/area/station/security/brig)
+"kdN" = (
+/obj/disposalpipe/segment/transport,
+/turf/simulated/wall/auto/supernorn,
+/area/station/maintenance/southeast)
+"kfS" = (
+/obj/decal/cleanable/dirt,
+/obj/machinery/shieldgenerator/energy_shield,
+/turf/simulated/floor/plating,
+/area/station/maintenance/central)
+"kgz" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig)
 "kjx" = (
 /obj/lattice{
 	icon_state = "lattice-dir"
@@ -53734,23 +53897,6 @@
 /obj/machinery/light/runway_light/delay2,
 /turf/space,
 /area/space)
-"kjT" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
-"kkB" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/grey,
-/area/station/hallway/secondary/exit)
 "kkU" = (
 /obj/machinery/navbeacon{
 	codes_txt = "tour;next_tour=tour4;desc=On my right through the double doors is the station's headquarters. When waiting in the area, please use the provided seating.";
@@ -53774,20 +53920,18 @@
 /turf/simulated/floor/airless/plating,
 /area/station/maintenance/west)
 "kmG" = (
-/obj/stool/chair{
-	dir = 8
+/obj/landmark/spawner{
+	name = "monkeyspawn_mrmuggles"
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"kos" = (
-/obj/machinery/networked/radio,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+"kmJ" = (
+/obj/machinery/atmospherics/valve{
+	high_risk = 1;
+	name = "Air Reserve (Escape Hallway)"
 	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
+/turf/simulated/floor/plating,
+/area/station/maintenance/central)
 "koG" = (
 /obj/storage/secure/crate/weapon/armory/tranquilizer,
 /turf/simulated/floor/engine,
@@ -53798,22 +53942,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/research_outpost/indigo_rye)
-"kqA" = (
-/obj/access_spawn/brig,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/door/airlock/pyro/glass{
-	name = "Armory"
-	},
-/obj/access_spawn/brig,
-/turf/simulated/floor/red,
-/area/station/security/brig)
 "kqU" = (
 /obj/decal/poster/wallsign/escape_right,
 /turf/simulated/wall/auto/supernorn,
@@ -53830,6 +53958,17 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/engine/vacuum,
 /area/research_outpost/indigo_rye)
+"kui" = (
+/obj/critter/cat/jones,
+/turf/simulated/floor/carpet/blue/fancy/edge/east,
+/area/station/bridge)
+"kxP" = (
+/obj/machinery/light/runway_light,
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/station/ai_monitored/armory)
 "kyt" = (
 /obj/disposalpipe/segment/vertical,
 /obj/machinery/atmospherics/valve{
@@ -53851,56 +53990,66 @@
 	dir = 8
 	},
 /area/station/medical/medbay)
-"kBO" = (
-/obj/machinery/door/airlock/pyro,
-/obj/disposalpipe/segment/brig{
-	dir = 1
+"kzS" = (
+/obj/storage/crate{
+	desc = "Various supplies for the bar.";
+	name = "bartending crate"
 	},
-/turf/simulated/floor/grey/blackgrime,
-/area/station/security/brig)
-"kBY" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
-/turf/simulated/floor/specialroom/cafeteria,
-/area/station/crew_quarters/barber_shop)
-"kEf" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
-/obj/decal/cleanable/dirt,
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"kEo" = (
-/obj/table/auto,
-/obj/machinery/light,
-/obj/item/storage/toolbox/emergency,
-/obj/item/device/light/glowstick,
-/obj/item/device/light/glowstick,
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
-"kHZ" = (
-/obj/machinery/door/airlock/pyro/maintenance{
+/obj/item/reagent_containers/food/drinks/bottle,
+/obj/item/reagent_containers/food/drinks/bottle,
+/obj/item/reagent_containers/food/drinks/bottle,
+/obj/item/reagent_containers/food/drinks/bottle,
+/obj/item/reagent_containers/food/drinks/bottle,
+/obj/item/storage/firstaid/toxin,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/device/reagentscanner,
+/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
+/obj/item/reagent_containers/dropper/mechanical,
+/obj/machinery/light/small,
+/obj/cable,
+/obj/machinery/power/apc/autoname_west,
+/obj/item/clothing/glasses/spectro,
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/baroffice)
+"kBW" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet,
+/turf/simulated/floor/grey/side{
 	dir = 4
 	},
-/obj/cable{
-	icon_state = "4-8"
+/area/station/security/brig)
+"kBY" = (
+/obj/stool/chair{
+	dir = 8
 	},
-/obj/firedoor_spawn,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/barber_shop)
-"kIi" = (
-/obj/storage/secure/closet/medical/chemical,
+"kCF" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/Zeta)
+"kGd" = (
+/obj/structure/woodwall,
+/turf/simulated/floor/plating/damaged1,
+/area/station/garden/aviary)
+"kGM" = (
+/obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet/blue/fancy/edge/se,
-/area/station/crew_quarters/md)
+/turf/simulated/floor/carpet/purple/fancy,
+/area/station/science/research_director)
+"kHZ" = (
+/turf/simulated/wall/auto/supernorn,
+/area/station/storage/emergency)
 "kKi" = (
 /obj/table/wood/auto,
 /obj/decal/xmas_lights/ephemeral{
@@ -53908,10 +54057,6 @@
 	},
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/crew_quarters/radio/news_office)
-"kKv" = (
-/obj/item/c_tube,
-/turf/simulated/floor/plating,
-/area/space)
 "kKQ" = (
 /obj/stool/chair/office,
 /obj/landmark/start{
@@ -53924,54 +54069,26 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/medical/robotics)
-"kKU" = (
-/obj/disposalpipe/segment/vertical,
-/obj/cable{
-	icon_state = "1-8"
+"kQb" = (
+/obj/shrub,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
+"kQc" = (
+/obj/decal/tile_edge/line/green{
+	dir = 9;
+	icon_state = "line1"
 	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 6
-	},
-/turf/simulated/floor/grey,
-/area/station/bridge)
-"kLO" = (
-/obj/machinery/communications_dish{
-	tag = "MAIN_DISH_SS13"
-	},
-/turf/simulated/floor/plating/airless,
-/area/station/com_dish/comdish)
-"kOY" = (
-/obj/machinery/sim/vr_bed{
-	dir = 4;
-	name = "VR simulation pod";
-	network = "arcadevr"
-	},
-/obj/cable,
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
-"kQK" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet,
-/obj/disposalpipe/segment/brig{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/grey/side{
-	dir = 8
-	},
-/area/station/security/brig)
-"kQP" = (
-/obj/table/wood/auto,
-/obj/random_item_spawner/desk_stuff,
-/obj/item/stamp/cap,
-/turf/simulated/floor/carpet/arcade,
-/area/station/bridge/captain)
+/turf/simulated/floor,
+/area/station/crew_quarters/quarters_south)
 "kQR" = (
 /obj/machinery/camera/television{
 	c_tag = "test chamber";
@@ -53987,18 +54104,19 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
-"kTg" = (
+"kSp" = (
+/obj/machinery/computer3/terminal/zeta{
+	dir = 8;
+	setup_os_string = "ZETA_MAINFRAME"
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable,
 /obj/cable{
-	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "0-8"
 	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/turf/simulated/floor/yellowblack/corner,
+/area/station/crew_quarters/ce)
 "kTo" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	level = 2
@@ -54017,62 +54135,44 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/cloner)
-"kTM" = (
+"kXB" = (
 /obj/table/auto,
-/obj/item/storage/toolbox/emergency,
-/obj/item/crowbar,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
+/obj/item/storage/box/glassbox,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shot,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shot,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shot,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shot,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
+/obj/item/reagent_containers/food/drinks/drinkingglass/cocktail,
+/obj/item/reagent_containers/food/drinks/drinkingglass/cocktail,
+/obj/item/reagent_containers/food/drinks/drinkingglass/cocktail,
+/obj/item/reagent_containers/food/drinks/drinkingglass/cocktail,
+/obj/item/gun/russianrevolver,
+/obj/machinery/light_switch/west,
+/obj/item/device/radio/intercom/catering,
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/baroffice)
+"lbB" = (
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
 	},
-/turf/simulated/floor/black/side{
-	dir = 8
-	},
-/area/station/bridge)
-"kUT" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/ai_monitored/armory)
-"kZM" = (
-/obj/machinery/weapon_stand/shotgun_rack,
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
-"lad" = (
-/obj/table/wood/auto,
-/obj/machinery/networked/printer{
-	name = "Printer - CE";
-	pixel_y = 5;
-	print_id = "CE"
-	},
-/obj/machinery/light_switch/north,
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
-/turf/simulated/floor/yellowblack{
-	dir = 1
-	},
-/area/station/crew_quarters/ce)
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
 "les" = (
 /obj/decal/cleanable/dirt,
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
+"leW" = (
+/obj/machinery/communications_dish{
+	tag = "MAIN_DISH_SS13"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/com_dish/comdish)
 "lfa" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -54080,15 +54180,6 @@
 /obj/disposalpipe/junction/right/west,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/office)
-"lfp" = (
-/obj/machinery/chem_dispenser/soda,
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/cafeteria)
 "lfH" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -54105,18 +54196,25 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
+"lhA" = (
+/obj/wingrille_spawn/auto,
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbooth)
 "lhD" = (
-/obj/decal/tile_edge/line/green{
-	icon_state = "line1"
+/obj/machinery/door/airlock/pyro/maintenance,
+/obj/disposalpipe/segment/vertical,
+/obj/cable{
+	icon_state = "1-2"
 	},
-/obj/decal/garland/ephemeral{
-	dir = 4;
-	pixel_x = -14
-	},
-/turf/simulated/floor/neutral/side{
-	dir = 8
-	},
-/area/station/crew_quarters/quarters_south)
+/turf/simulated/floor,
+/area/station/storage/emergency)
 "lhX" = (
 /obj/machinery/light,
 /turf/simulated/floor/caution/east,
@@ -54155,21 +54253,14 @@
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/supply)
-"ljZ" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+"lkw" = (
+/obj/machinery/portable_atmospherics/canister/air/large,
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 4;
+	level = 2
 	},
-/obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"lkP" = (
-/obj/machinery/chem_master{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/blue/fancy/edge/east,
-/area/station/crew_quarters/md)
 "lkQ" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -54205,18 +54296,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
-"loS" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/turret,
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
 "lrq" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 1;
@@ -54227,11 +54306,21 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"luT" = (
-/obj/machinery/light/small,
-/obj/machinery/photocopier,
-/turf/simulated/floor/black,
-/area/station/bridge)
+"lrs" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/light/runway_light/delay4,
+/turf/space,
+/area/station/ai_monitored/armory)
+"lsm" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "lvb" = (
 /obj/grille/steel,
 /obj/disposalpipe/segment/transport,
@@ -54239,26 +54328,10 @@
 /area/station/crew_quarters/clown{
 	name = "Clowntainment"
 	})
-"lwK" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/decal/wreath/ephemeral,
-/obj/cable{
-	icon_state = "0-2"
-	},
+"lvC" = (
+/obj/machinery/shieldgenerator/meteorshield,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/courtroom)
-"lyf" = (
-/obj/machinery/vending/snack,
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 20
-	},
-/turf/simulated/floor/grime,
-/area/station/security/brig)
+/area/station/maintenance/southeast)
 "lyu" = (
 /obj/lattice{
 	dir = 4;
@@ -54283,6 +54356,79 @@
 /obj/disposalpipe/segment/bent/west,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
+"lCD" = (
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
+"lCE" = (
+/obj/table/reinforced/auto,
+/obj/item/decoration/ashtray{
+	pixel_x = -9
+	},
+/obj/item/card_box/suit{
+	pixel_x = 1;
+	pixel_y = 3
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/grime,
+/area/station/security/brig)
+"lFW" = (
+/obj/stool/chair/comfy{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/west,
+/area/station/bridge)
+"lGc" = (
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/crew_quarters/quarters_south)
+"lGK" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/stool/chair/office/blue{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
+"lGX" = (
+/obj/item/storage/toilet,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/grey/side{
+	dir = 8
+	},
+/area/space)
 "lHa" = (
 /obj/machinery/light/emergency{
 	dir = 4;
@@ -54290,50 +54436,21 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/south)
-"lHO" = (
-/obj/item/reagent_containers/food/drinks/bottle/thegoodstuff,
-/obj/shrub/captainshrub,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/bridge/captain)
-"lIL" = (
-/obj/machinery/communications_dish,
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/obj/machinery/power/data_terminal,
-/obj/cable,
+"lIw" = (
 /obj/cable{
-	icon_state = "0-2"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "8-10"
 	},
-/turf/simulated/floor/airless/plating,
-/area/station/ai_monitored/armory)
+/obj/item/storage/box/cablesbox,
+/turf/simulated/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/station/maintenance/southeast)
 "lJE" = (
 /obj/machinery/hair_dye_dispenser,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/barber_shop)
-"lLu" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 10;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
 "lMO" = (
 /obj/wingrille_spawn/auto,
 /obj/cable,
@@ -54350,6 +54467,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/brig)
+"lOS" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
+"lRa" = (
+/obj/machinery/door/airlock/pyro/external{
+	name = "Auxiliary Docking Point"
+	},
+/turf/simulated/floor/caution/northsouth,
+/area/station/hallway/secondary/exit)
+"lRb" = (
+/obj/machinery/portable_atmospherics/pump,
+/turf/simulated/floor/plating,
+/area/station/maintenance/central)
 "lRp" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -54357,70 +54495,66 @@
 /obj/machinery/light/emergency,
 /turf/simulated/floor/yellow/side,
 /area/station/hallway/primary/west)
-"lUq" = (
-/obj/cable{
-	icon_state = "4-8"
+"lRW" = (
+/obj/stool/chair/office{
+	dir = 4
 	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/landmark/start{
+	name = "Medical Director"
 	},
-/turf/simulated/floor/carpet/purple/fancy/edge/west,
-/area/station/science/research_director)
+/turf/simulated/floor/carpet/blue,
+/area/station/crew_quarters/md)
 "lUL" = (
 /obj/machinery/turret,
 /turf/simulated/floor/darkblue,
 /area/station/turret_protected/ai)
-"maq" = (
-/obj/machinery/chem_dispenser/alcohol,
-/obj/machinery/camera{
-	c_tag = "autotag";
+"lVA" = (
+/obj/rack,
+/obj/item/clothing/suit/armor/heavy,
+/obj/item/clothing/suit/armor/heavy,
+/obj/machinery/light{
 	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
+	layer = 9.1;
+	pixel_x = 10
 	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
-/obj/machinery/light_switch/west,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/cafeteria)
-"mcT" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 1
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/glasses/thermal,
+/obj/item/clothing/glasses/thermal,
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
+"lVX" = (
+/obj/shrub{
+	dir = 8
 	},
-/obj/disposalpipe/segment/horizontal,
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
+"lXs" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/left,
 /obj/cable{
-	icon_state = "4-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
-"mdV" = (
-/obj/storage/crate/rcd,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/turf/simulated/floor/plating,
+/area/station/bridge/captain)
+"lXB" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "black";
+	icon_state = "bedsheet-black"
 	},
-/turf/simulated/floor/yellowblack/corner{
-	dir = 1
+/obj/landmark/start{
+	name = "Bartender"
 	},
-/area/station/crew_quarters/ce)
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/baroffice)
 "mep" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/northwest)
-"meJ" = (
-/obj/rack,
-/obj/item/clothing/suit/bio_suit/paramedic,
-/obj/item/clothing/suit/bio_suit/paramedic,
-/obj/item/storage/belt/medical,
-/obj/item/storage/belt/medical,
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
-/turf/simulated/floor/white,
-/area/station/medical/medbooth)
 "mgx" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -54428,38 +54562,18 @@
 	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
-"mhn" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "yellow";
-	icon_state = "bedsheet-yellow"
+"mgL" = (
+/obj/disposalpipe/segment/horizontal,
+/turf/simulated/floor/green/side{
+	dir = 1
 	},
-/obj/machinery/light,
-/turf/simulated/floor/yellowblack,
-/area/station/crew_quarters/ce)
+/area/station/hallway/primary/south)
 "mhV" = (
 /obj/disposalpipe/segment/morgue{
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
-"mjV" = (
-/obj/table/reinforced/chemistry/auto{
-	name = "prep counter"
-	},
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/cafeteria)
-"mkj" = (
-/obj/stool/chair{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/space)
 "mkl" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -54469,21 +54583,28 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/south)
 "mkL" = (
-/obj/decal/tile_edge/line/green{
-	dir = 10;
-	icon_state = "line1"
+/obj/stool/chair{
+	dir = 1
 	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 8
+	},
+/area/station/crew_quarters/quarters_south)
+"mmz" = (
+/obj/disposalpipe/segment/vertical,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_south)
-"mmz" = (
-/obj/disposalpipe/segment/vertical,
-/obj/machinery/power/apc/autoname_east,
-/obj/cable,
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
+	},
 /turf/simulated/floor/neutral/side{
 	dir = 4
 	},
@@ -54492,63 +54613,42 @@
 /obj/machinery/light/small/floor,
 /turf/simulated/floor/caution/east,
 /area/station/quartermaster/office)
+"mnd" = (
+/obj/storage/secure/closet/medical/chemical,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/se,
+/area/station/crew_quarters/md)
 "mnz" = (
 /obj/decal/poster/wallsign/space,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/quartermaster/office)
-"mpB" = (
+"mpV" = (
 /obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/specialroom/bar,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
-"mpU" = (
-/obj/item/storage/toilet,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/grey/side{
-	dir = 4
-	},
-/area/space)
 "mpY" = (
 /obj/machinery/light/small,
 /obj/machinery/chemicompiler_stationary,
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
-"mqh" = (
-/obj/table/auto,
-/obj/item/storage/box/glassbox,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shot,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shot,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shot,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shot,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
-/obj/item/reagent_containers/food/drinks/drinkingglass/cocktail,
-/obj/item/reagent_containers/food/drinks/drinkingglass/cocktail,
-/obj/item/reagent_containers/food/drinks/drinkingglass/cocktail,
-/obj/item/reagent_containers/food/drinks/drinkingglass/cocktail,
-/obj/item/gun/russianrevolver,
-/obj/machinery/light_switch/west,
-/obj/item/device/radio/intercom/catering,
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/baroffice)
+"mqm" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "4-10"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "mqC" = (
 /turf/space,
 /area/supply/delivery_point)
-"mrc" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/ai_monitored/armory)
 "muI" = (
 /obj/machinery/light/emergency{
 	dir = 4;
@@ -54556,61 +54656,28 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/science)
-"mvc" = (
-/obj/stool/chair{
-	dir = 1
+"myO" = (
+/obj/table/auto,
+/obj/item/storage/toolbox/electrical,
+/obj/item/device/gps,
+/obj/item/aiModule/reset,
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/cable,
-/obj/machinery/power/apc/autoname_east,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 9;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
-"mwE" = (
-/obj/machinery/floorflusher/solitary2,
-/obj/submachine/chef_sink/chem_sink{
-	pixel_y = 16
-	},
-/obj/disposalpipe/trunk/south,
-/turf/simulated/floor/black,
-/area/space)
-"myW" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 20
-	},
-/obj/rack,
-/obj/item/storage/box/stinger_kit,
-/obj/item/chem_grenade/pepper,
-/obj/item/chem_grenade/pepper,
-/obj/item/chem_grenade/pepper,
-/obj/item/clothing/glasses/nightvision,
-/obj/item/clothing/glasses/nightvision,
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
+/obj/item/device/radio/intercom/medical,
+/obj/item/circuitboard/aiupload,
+/obj/item/disk/data/floppy/read_only/communications,
+/turf/simulated/floor/circuit,
+/area/station/bridge)
+"mzV" = (
+/obj/landmark/gps_waypoint,
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
 "mzX" = (
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters_east)
-"mBE" = (
-/obj/machinery/vehicle/escape_pod{
-	dir = 4
-	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hallway/secondary/exit)
-"mBW" = (
-/obj/stool/chair{
-	dir = 4
-	},
-/obj/item/storage/secure/ssafe/loot{
-	pixel_x = -28
-	},
-/turf/simulated/floor/damaged3,
-/area/station/crew_quarters/quarters_south)
 "mCe" = (
 /obj/reagent_dispensers/watertank/big,
 /turf/simulated/floor/grass,
@@ -54626,32 +54693,17 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
-"mEM" = (
-/obj/submachine/chem_extractor,
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/green/side{
-	dir = 8
-	},
-/area/station/hydroponics/bay)
-"mER" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet/blue/fancy/edge/west,
-/area/station/bridge)
 "mEW" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/escape/corner{
-	dir = 4
-	},
-/area/station/hallway/secondary/exit)
+/obj/decal/cleanable/dirt,
+/obj/storage/closet/fire,
+/turf/simulated/floor/plating,
+/area/station/maintenance/central)
+"mHQ" = (
+/obj/table/wood/auto,
+/obj/random_item_spawner/desk_stuff,
+/obj/item/stamp/cap,
+/turf/simulated/floor/carpet/arcade,
+/area/station/bridge/captain)
 "mHX" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/lattice{
@@ -54660,120 +54712,55 @@
 	},
 /turf/space,
 /area/space)
-"mIj" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
 "mJy" = (
-/obj/shrub{
-	dir = 1
-	},
-/obj/machinery/light/emergency{
-	dir = 1;
-	pixel_y = 16
-	},
-/turf/simulated/floor/escape{
-	dir = 1
-	},
-/area/station/hallway/secondary/exit)
-"mKe" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
 /obj/table/auto,
-/obj/item/storage/box/syringes{
-	pixel_y = 4
+/obj/shrub/dead{
+	dir = 8;
+	name = "Dead plant";
+	pixel_y = 10
 	},
-/obj/item/storage/box/beakerbox{
-	pixel_y = -10
+/turf/simulated/floor/plating,
+/area/station/routing/depot)
+"mJA" = (
+/obj/disposalpipe/segment/transport{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
+/turf/space,
+/area/space)
+"mKe" = (
+/obj/machinery/disposal,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/disposalpipe/trunk/east,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
-"mKt" = (
-/obj/table/reinforced/auto,
-/obj/item/decoration/ashtray{
-	pixel_x = -9
-	},
-/obj/item/card_box/suit{
-	pixel_x = 1;
-	pixel_y = 3
-	},
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/grime,
-/area/station/security/brig)
 "mLt" = (
-/obj/table/reinforced/bar/auto,
-/obj/item/device/radio/beacon,
-/obj/item/clothing/head/cakehat,
-/turf/simulated/floor/carpet/green/standard/narrow/northsouth,
-/area/station/crew_quarters/cafeteria)
-"mOe" = (
-/obj/machinery/door/airlock/pyro/command{
-	dir = 4;
-	name = "Network Chamber"
-	},
-/obj/disposalpipe/segment/horizontal,
+/obj/disposalpipe/segment/mail/horizontal,
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4
-	},
-/obj/firedoor_spawn,
 /turf/simulated/floor/grey,
-/area/station/bridge)
+/area/station/crew_quarters/catering)
 "mOF" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/black/grime,
 /area/station/routing/depot)
-"mOV" = (
-/obj/lattice{
-	dir = 1;
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/turf/space,
-/area/station/ai_monitored/armory)
 "mPi" = (
-/obj/machinery/light/small/floor,
-/turf/simulated/floor/specialroom/bar,
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/obj/table/reinforced/auto,
+/obj/cup_rack{
+	pixel_y = 32
+	},
+/obj/machinery/espresso_machine,
+/turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
-"mPI" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"mQm" = (
-/obj/lattice{
-	dir = 6;
-	icon_state = "lattice-dir-b"
-	},
-/obj/machinery/light/runway_light/delay2,
-/turf/space,
-/area/station/ai_monitored/armory)
 "mRy" = (
 /obj/machinery/cargo_router/kd_med_right,
 /turf/simulated/floor/airless/grey,
@@ -54782,18 +54769,17 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/east)
-"mSF" = (
-/obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/middle{
-	dir = 5
+"mTo" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet,
+/obj/disposalpipe/segment/brig{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/cable,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/turf/simulated/floor/grey/side{
+	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/station/bridge/captain)
+/area/station/security/brig)
 "mVi" = (
 /obj/cable{
 	d1 = 4;
@@ -54805,18 +54791,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/sanctuary)
-"mVP" = (
-/obj/machinery/door/airlock/pyro/maintenance,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/greenblack,
-/area/station/garden/aviary)
-"mWO" = (
-/obj/grille/catwalk,
-/turf/simulated/floor/airless/plating/catwalk,
-/area/station/maintenance/southeast)
 "mXc" = (
 /obj/machinery/recharge_station,
 /obj/landmark/start{
@@ -54824,6 +54798,33 @@
 	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
+"mXe" = (
+/obj/item/storage/toilet{
+	dir = 4
+	},
+/obj/blind_switch/area/south,
+/obj/decal/tile_edge/line/black{
+	dir = 1;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/md)
+"mXi" = (
+/obj/table/reinforced/auto,
+/obj/item/paper/book/medical_surgery_guide{
+	pixel_x = 9
+	},
+/obj/machinery/defib_mount{
+	pixel_x = -6
+	},
+/turf/simulated/floor/bluewhite,
+/area/station/medical/medbooth)
+"nbH" = (
+/obj/machinery/plantpot{
+	anchored = 1
+	},
+/turf/simulated/floor/grass,
+/area/station/hydroponics/bay)
 "nbO" = (
 /obj/machinery/door_control/podbay/security/new_walls/north,
 /obj/disposalpipe/segment/brig{
@@ -54842,48 +54843,13 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quarters_east)
 "ncP" = (
-/obj/machinery/plantpot{
-	anchored = 1
-	},
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/grass,
-/area/station/crew_quarters/quarters_south)
-"ney" = (
-/obj/shrub{
-	dir = 1
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
-"nez" = (
-/obj/table/wood/auto,
-/obj/machinery/recharger{
-	pixel_y = 3
-	},
-/obj/item/remote/porter/port_a_sci,
-/obj/item/reagent_containers/hypospray,
-/obj/item/reagent_containers/food/snacks/beefood{
-	desc = "A little birthday cupcake for Heisenbee.  May not taste good to non-bees.";
-	icon = 'icons/obj/foodNdrink/food_dessert.dmi';
-	icon_state = "cupcake";
-	name = "Heisenbee's birthday cupcake"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
-	},
-/obj/item/stamp/rd,
-/obj/item/device/radio/intercom/science{
-	pixel_x = 3;
+/obj/machinery/disposal,
+/obj/disposalpipe/trunk/south,
+/obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/carpet/purple/fancy/edge/nw,
-/area/station/science/research_director)
+/turf/simulated/floor/black,
+/area/station/crew_quarters/cafeteria)
 "nfO" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
@@ -54896,14 +54862,14 @@
 /obj/access_spawn/research,
 /turf/simulated/floor/engine/caution/westeast,
 /area/station/science/testchamber)
-"nhA" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet,
-/obj/item/device/radio/intercom,
-/turf/simulated/floor/grey/side{
-	dir = 8
+"ngu" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/area/space)
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "niK" = (
 /obj/plasticflaps{
 	layer = 3
@@ -54916,36 +54882,10 @@
 /area/station/quartermaster/office)
 "njl" = (
 /obj/stool/chair{
-	dir = 4;
-	tag = "icon-chair (EAST)"
-	},
-/obj/landmark{
-	name = "blobstart"
-	},
-/turf/simulated/floor/carpet/green/fancy/edge/north,
-/area/station/crew_quarters/quarters_south)
-"nkv" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"nld" = (
-/obj/table/reinforced/auto,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/reagent_containers/food/drinks/water,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/turf/simulated/floor/grey/side{
 	dir = 8
 	},
-/area/space)
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
 "nmf" = (
 /obj/table/auto,
 /obj/machinery/cell_charger,
@@ -54964,61 +54904,104 @@
 	},
 /turf/simulated/floor/black/grime,
 /area/station/maintenance/inner/central)
+"nnb" = (
+/obj/storage/secure/closet/command/medical_director,
+/obj/item/storage/box/beakerbox,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
+	},
+/obj/item/clipboard,
+/obj/item/pen,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/md)
+"nog" = (
+/obj/table/reinforced/bar/auto,
+/obj/item/reagent_containers/food/drinks/bowl,
+/obj/item/kitchen/utensil/spoon,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/green/standard/narrow/northsouth,
+/area/station/crew_quarters/cafeteria)
+"nop" = (
+/obj/machinery/vending/snack{
+	credit = 50
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/security/brig)
+"noM" = (
+/obj/machinery/turretid{
+	pixel_x = 26
+	},
+/obj/machinery/light,
+/turf/simulated/floor/black,
+/area/station/turret_protected/Zeta)
+"npf" = (
+/obj/machinery/door/airlock/pyro/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"npm" = (
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/turf/simulated/floor/grime,
+/area/station/security/brig)
 "npx" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/red/side,
 /area/station/security/brig)
-"nql" = (
-/obj/table/wood/auto,
-/obj/random_item_spawner/medicine,
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
+"npF" = (
+/obj/landmark{
+	name = "blobstart"
 	},
-/turf/simulated/floor/carpet/green/fancy/edge/ne,
-/area/station/crew_quarters/quarters_south)
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"nql" = (
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/barber_shop)
 "nqT" = (
 /obj/decal/cleanable/dirt,
 /obj/disposalpipe/segment/vertical,
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
-"nrt" = (
-/obj/table/reinforced/auto,
-/obj/machinery/phone,
-/turf/simulated/floor/carpet/red/fancy/edge/se,
-/area/station/security/hos)
-"nsT" = (
-/turf/simulated/floor/carpet/blue/fancy/edge/east,
-/area/station/bridge)
 "ntn" = (
-/obj/machinery/power/apc/autoname_west,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/central)
-"nty" = (
-/obj/machinery/turret,
-/obj/lattice,
-/turf/space,
-/area/station/ai_monitored/armory)
-"nxA" = (
-/obj/disposalpipe/segment/vertical,
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/cafeteria)
-"nxG" = (
-/obj/decal/skeleton{
-	desc = "It's all covered in a sticky mess, and there are chunks of uniform fused to the bone.";
-	name = "sticky skeleton"
+/obj/firedoor_spawn,
+/turf/simulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/barber_shop)
+"nwb" = (
+/obj/machinery/floorflusher/solitary2,
+/obj/submachine/chef_sink/chem_sink{
+	pixel_y = 16
 	},
-/turf/simulated/floor/plating/scorched,
-/area/station/crew_quarters/quarters_south)
+/obj/disposalpipe/trunk/south,
+/turf/simulated/floor/black,
+/area/space)
+"nwK" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "nAw" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/machinery/door/poddoor/pyro{
@@ -55028,16 +55011,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
-"nBv" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/redblack/corner{
-	dir = 8
-	},
-/area/space)
 "nBP" = (
 /obj/machinery/door/airlock/pyro/security{
 	dir = 4;
@@ -55059,35 +55032,33 @@
 	dir = 8
 	},
 /area/station/security/hos)
-"nCN" = (
-/obj/machinery/light,
-/turf/simulated/floor/red/side,
-/area/station/security/brig)
-"nDg" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/window_blinds/cog2/middle{
+"nDe" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/ai_monitored/armory)
+"nDM" = (
+/obj/decal/tile_edge/line/green{
+	icon_state = "line1"
+	},
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
+	},
+/turf/simulated/floor/neutral/side{
 	dir = 8
 	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/area/station/crew_quarters/quarters_south)
+"nFT" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet,
+/obj/item/device/radio/intercom,
+/turf/simulated/floor/grey/side{
+	dir = 4
 	},
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/ce)
-"nDM" = (
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/grey,
-/area/station/hallway/secondary/exit)
-"nEE" = (
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
 /area/space)
 "nGr" = (
 /obj/machinery/light/emergency{
@@ -55107,6 +55078,10 @@
 	},
 /turf/simulated/floor/caution/northsouth,
 /area/station/quartermaster/office)
+"nKt" = (
+/obj/table/wood/round/auto,
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
 "nKN" = (
 /obj/cable{
 	d1 = 1;
@@ -55118,14 +55093,27 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/bridge/captain)
-"nLA" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
+"nLk" = (
+/obj/submachine/chem_extractor,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
 	},
-/turf/simulated/floor/grey,
-/area/station/hallway/secondary/exit)
+/turf/simulated/floor/green/side{
+	dir = 8
+	},
+/area/station/hydroponics/bay)
+"nLA" = (
+/obj/decal/tile_edge/line/green{
+	dir = 10;
+	icon_state = "line1"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/quarters_south)
 "nML" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/grime,
@@ -55136,13 +55124,6 @@
 	icon_state = "12"
 	},
 /area/station/chapel/office)
-"nOe" = (
-/obj/machinery/light/runway_light/delay3,
-/obj/lattice{
-	icon_state = "lattice-dir"
-	},
-/turf/space,
-/area/station/ai_monitored/armory)
 "nQL" = (
 /obj/machinery/atmospherics/binary/passive_gate{
 	dir = 4;
@@ -55171,15 +55152,6 @@
 	dir = 10
 	},
 /area/space)
-"nRD" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
 "nSc" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -55192,94 +55164,52 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
-"nSx" = (
-/obj/stool/chair/office/blue,
+"nVE" = (
+/obj/disposalpipe/segment/vertical,
+/obj/machinery/power/apc/autoname_east,
+/obj/cable,
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/crew_quarters/quarters_south)
+"nXV" = (
 /obj/cable{
-	icon_state = "4-8"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
-	d1 = 1;
+	d1 = 2;
 	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/carpet/blue/fancy/edge/sw,
-/area/station/bridge)
-"nSQ" = (
-/obj/storage/secure/crate/plasma/armory/anti_biological,
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
-"nSR" = (
-/obj/shrub,
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/grass,
 /area/station/garden/aviary)
-"nVh" = (
-/obj/machinery/floorflusher/solitary,
-/obj/submachine/chef_sink/chem_sink{
-	pixel_y = 16
-	},
-/obj/disposalpipe/trunk/south,
-/turf/simulated/floor/black,
-/area/space)
-"nVE" = (
-/obj/machinery/computer/barcode{
-	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Pod Bay","Research","Security","QM");
-	dir = 4
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
-	},
-/turf/simulated/floor/orange/side{
-	dir = 9
-	},
-/area/station/crew_quarters/catering)
-"nWu" = (
-/obj/machinery/computer3/terminal/zeta{
-	dir = 8;
-	setup_os_string = "ZETA_MAINFRAME"
-	},
-/obj/machinery/power/data_terminal,
-/obj/cable,
+"nZi" = (
+/obj/storage/crate,
+/obj/item/device/radio/headset/multifreq,
+/obj/item/device/radio/headset/multifreq,
+/obj/item/device/radio/headset/medical,
+/obj/item/device/radio/headset/medical,
+/obj/item/device/radio/headset/security,
+/obj/item/device/radio/headset/security,
+/obj/item/device/radio/headset/engineer,
+/obj/item/device/radio/headset/engineer,
+/obj/item/device/radio/headset/research,
+/obj/item/device/radio/headset/research,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/yellowblack/corner,
-/area/station/crew_quarters/ce)
-"nWS" = (
-/obj/table/wood/auto,
-/obj/machinery/phone,
+/obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/black,
-/area/station/bridge/hos)
+/area/station/bridge)
 "nZC" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/neutral/corner{
 	dir = 8
 	},
 /area/station/hallway/primary/east)
-"ocE" = (
-/obj/lattice{
-	dir = 10;
-	icon_state = "lattice-dir-b"
-	},
-/obj/machinery/light/runway_light,
-/turf/space,
-/area/station/ai_monitored/armory)
 "ocX" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/disposalpipe/segment/mail/vertical,
@@ -55289,44 +55219,58 @@
 	dir = 4
 	},
 /area/station/hallway/primary/east)
-"ogG" = (
-/obj/machinery/portable_atmospherics/canister/air/large,
-/obj/machinery/atmospherics/pipe/manifold{
-	dir = 4;
-	level = 2
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"oif" = (
+"oij" = (
+/obj/machinery/networked/radio,
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/baroffice)
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "ojD" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/east)
-"oku" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/red/side,
-/area/station/hallway/primary/south)
 "omd" = (
 /obj/lattice,
 /obj/warp_beacon/security,
 /turf/space,
 /area/space)
-"oni" = (
-/obj/storage/secure/closet/command/chief_engineer,
-/obj/item/clipboard,
-/obj/item/pen,
-/turf/simulated/floor/yellowblack,
-/area/station/crew_quarters/ce)
+"omo" = (
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/landmark/halloween,
+/turf/simulated/floor/escape/corner{
+	dir = 1
+	},
+/area/station/hallway/primary/south)
+"omK" = (
+/obj/submachine/ice_cream_dispenser,
+/obj/machinery/light/emergency{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/cafeteria)
+"omZ" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/mail/bent/west,
+/turf/simulated/floor/stairs/wide/other{
+	dir = 8
+	},
+/area/station/bridge)
+"onQ" = (
+/turf/simulated/floor/damaged5,
+/area/station/crew_quarters/quarters_south)
 "oop" = (
 /obj/machinery/light{
 	dir = 8;
@@ -55343,17 +55287,25 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
-"oqM" = (
+"opQ" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/space)
+"oqm" = (
+/obj/stool/chair/wooden{
+	dir = 8
+	},
 /obj/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/stool/chair/office/blue{
-	dir = 4
-	},
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
 "osJ" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -55363,34 +55315,53 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
-"our" = (
+"otF" = (
 /obj/table/auto,
-/obj/item/reagent_containers/food/drinks/eggnog{
-	pixel_y = 8
+/obj/item/paper_bin{
+	pixel_y = 6
 	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/catering)
-"oux" = (
-/obj/disposalpipe/segment/morgue{
+/obj/deskclutter,
+/obj/item/hand_labeler{
+	pixel_x = 5
+	},
+/obj/item/plantanalyzer,
+/obj/item/device/reagentscanner{
+	pixel_x = -7
+	},
+/obj/item/pen,
+/turf/simulated/floor,
+/area/station/hydroponics/bay)
+"ouj" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"our" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/escape/corner{
 	dir = 4
 	},
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
+/area/station/hallway/secondary/exit)
 "ovi" = (
 /obj/item/seed/alien,
 /turf/simulated/floor/plating/airless/asteroid/dark,
 /area/space)
-"ovS" = (
-/obj/lattice{
-	dir = 5;
-	icon_state = "lattice-dir-b"
+"ovV" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/window_blinds/cog2/middle{
+	dir = 8
 	},
-/obj/machinery/light/runway_light/delay3,
-/turf/space,
-/area/station/ai_monitored/armory)
+/obj/cable,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/md)
 "ovZ" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 1
@@ -55399,6 +55370,15 @@
 	dir = 8
 	},
 /area/station/science/testchamber)
+"ows" = (
+/obj/tree1,
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
+"owz" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/red/side,
+/area/station/hallway/primary/south)
 "owG" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/landmark/halloween,
@@ -55433,23 +55413,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/elect)
-"oyc" = (
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/obj/table/auto,
-/obj/item/reagent_containers/food/drinks/bottle/empty{
-	pixel_x = 7;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/food/drinks/bottle/empty{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/food/drinks/bottle/empty,
-/turf/simulated/floor/plating,
-/area/space)
 "oyG" = (
 /obj/item/clothing/glasses/blindfold,
 /turf/simulated/floor/engine/vacuum,
@@ -55469,35 +55432,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/mining/refinery)
-"oBX" = (
-/obj/table/auto,
-/obj/machinery/networked/storage/scanner{
-	bank_id = "bridge";
-	pixel_y = 4
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
-/turf/simulated/floor/circuit,
-/area/station/bridge)
-"oDv" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/blue/fancy/edge/south,
-/area/station/crew_quarters/md)
 "oDQ" = (
 /obj/machinery/light/emergency{
 	dir = 8;
@@ -55522,6 +55456,15 @@
 /obj/decal/poster/wallsign/hazard_bio,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/morgue)
+"oGR" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/stairs{
+	dir = 8
+	},
+/area/station/maintenance/southeast)
 "oHK" = (
 /obj/stool/chair{
 	dir = 8
@@ -55544,34 +55487,37 @@
 	dir = 1
 	},
 /area/research_outpost/indigo_rye)
-"oIw" = (
+"oIX" = (
+/obj/shrub{
+	dir = 1
+	},
+/obj/machinery/light/emergency{
+	dir = 1;
+	pixel_y = 16
+	},
+/turf/simulated/floor/escape{
+	dir = 1
+	},
+/area/station/hallway/secondary/exit)
+"oJe" = (
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/redblack/corner{
+	dir = 4
+	},
+/area/space)
+"oJW" = (
 /obj/machinery/portable_atmospherics/canister/air/large,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"oIX" = (
-/obj/table/reinforced/auto,
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/suit/apron,
-/obj/item/clothing/head/souschefhat,
-/obj/item/device/radio/intercom/catering{
-	dir = 4
+"oNB" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
 	},
-/turf/simulated/floor/specialroom/cafeteria,
-/area/station/crew_quarters/kitchen)
-"oMM" = (
-/obj/table/reinforced/bar/auto,
-/obj/item/reagent_containers/food/drinks/bowl,
-/obj/item/kitchen/utensil/spoon,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/green/standard/narrow/northsouth,
-/area/station/crew_quarters/cafeteria)
-"oOW" = (
-/obj/machinery/portable_atmospherics/pump,
-/turf/simulated/floor/plating,
-/area/station/maintenance/central)
+/obj/machinery/light/runway_light,
+/turf/space,
+/area/station/ai_monitored/armory)
 "oQa" = (
 /obj/lattice{
 	dir = 8;
@@ -55579,24 +55525,25 @@
 	},
 /turf/space,
 /area/station/com_dish/comdish)
-"oQU" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/light/runway_light/delay4,
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
-/turf/space,
-/area/space)
-"oSI" = (
-/obj/cable{
-	icon_state = "4-8"
+"oQw" = (
+/obj/machinery/atmospherics/valve{
+	dir = 4;
+	high_risk = 1;
+	name = "Cafeteria"
 	},
 /obj/cable{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"oRL" = (
+/obj/item/tile/steel,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/grime,
 /area/station/maintenance/southeast)
 "oTv" = (
 /obj/wingrille_spawn/auto,
@@ -55612,26 +55559,21 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/ai_monitored/armory)
-"oVW" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4
-	},
-/obj/machinery/door_timer/solitary2/new_walls/north{
-	layer = 3.1
-	},
-/turf/simulated/floor,
-/area/station/security/brig)
-"oXP" = (
-/obj/stool/chair/comfy{
-	dir = 8
-	},
+"oYx" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet/blue/fancy/edge/east,
-/area/station/bridge)
+/turf/simulated/floor/carpet/blue/fancy/edge/south,
+/area/station/crew_quarters/md)
+"oZb" = (
+/obj/machinery/light/runway_light/delay3,
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/station/ai_monitored/armory)
 "oZc" = (
 /obj/cable{
 	d1 = 1;
@@ -55648,34 +55590,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
-"oZq" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/neutral/side{
-	dir = 4
-	},
-/area/station/crew_quarters/quarters_south)
-"pad" = (
-/obj/stool/chair/office/yellow{
-	dir = 4
-	},
-/obj/landmark/start{
-	name = "Chief Engineer"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/orangeblack,
-/area/station/crew_quarters/ce)
 "paw" = (
 /obj/machinery/floorflusher/industrial{
 	name = "waste loading chute"
@@ -55683,27 +55597,20 @@
 /obj/disposalpipe/trunk/east,
 /turf/simulated/floor/airless/grey,
 /area/station/maintenance/west)
-"paK" = (
-/obj/machinery/computer/arcade,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
+"pcT" = (
+/obj/machinery/door/airlock/pyro/maintenance,
+/obj/cable{
+	icon_state = "1-2"
 	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 21;
-	pixel_y = -3
+/obj/firedoor_spawn,
+/turf/simulated/floor/greenblack{
+	dir = 1
 	},
-/turf/simulated/floor/grime,
-/area/station/security/brig)
-"peY" = (
-/obj/table/auto,
-/obj/machinery/microwave,
+/area/station/garden/aviary)
+"pdh" = (
+/obj/machinery/drainage,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/catering)
+/area/space)
 "pfK" = (
 /obj/machinery/light{
 	dir = 8;
@@ -55713,14 +55620,32 @@
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/north)
 "pfT" = (
-/obj/table/reinforced/auto,
-/obj/machinery/light,
-/obj/machinery/glass_recycler{
-	glass_amt = 5;
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/obj/table/auto,
+/obj/item/storage/box/syringes{
 	pixel_y = 4
 	},
-/turf/simulated/floor/specialroom/cafeteria,
-/area/station/crew_quarters/kitchen)
+/obj/item/storage/box/beakerbox{
+	pixel_y = -10
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
+"pfU" = (
+/obj/machinery/door/airlock/pyro/security{
+	dir = 4;
+	name = "Brig";
+	req_access = null
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/access_spawn/brig,
+/obj/firedoor_spawn,
+/turf/simulated/floor/red,
+/area/station/security/brig)
 "phu" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -55729,10 +55654,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
-"plB" = (
-/obj/machinery/shieldgenerator/meteorshield,
+"plK" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/area/station/ai_monitored/armory)
 "pmt" = (
 /obj/table/auto,
 /obj/machinery/cell_charger,
@@ -55772,12 +55701,20 @@
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "ppQ" = (
-/obj/table/reinforced/auto,
-/obj/submachine/mixer,
-/turf/simulated/floor/specialroom/cafeteria{
-	dir = 1
+/obj/table/reinforced/bar/auto,
+/obj/item/device/radio/beacon,
+/obj/item/clothing/head/cakehat,
+/turf/simulated/floor/carpet/green/standard/narrow/northsouth,
+/area/station/crew_quarters/cafeteria)
+"ppZ" = (
+/obj/stool/chair{
+	dir = 4
 	},
-/area/station/crew_quarters/kitchen)
+/obj/item/storage/secure/ssafe/loot{
+	pixel_x = -28
+	},
+/turf/simulated/floor/damaged3,
+/area/station/crew_quarters/quarters_south)
 "pqx" = (
 /obj/shrub{
 	desc = "While it's wildly unlikely that this bush hails from Space Sweden, it nevertheless bears a faint scent of meatballs that can't be adequately explained.";
@@ -55794,18 +55731,9 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quarters_east)
 "pry" = (
-/obj/table/reinforced/auto,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 10;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/obj/machinery/phone,
-/turf/simulated/floor/specialroom/cafeteria{
-	dir = 1
-	},
-/area/station/crew_quarters/kitchen)
+/obj/machinery/light/small/floor,
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
 "prI" = (
 /obj/disposalpipe/segment/morgue,
 /obj/cable{
@@ -55821,41 +55749,37 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
-"psr" = (
-/obj/disposalpipe/trunk/south,
-/obj/machinery/disposal/transport{
-	desc = "A pneumatic delivery chute for transporting people from one section of maintenance to another.";
-	name = "maintenance shunt unit"
+"pvT" = (
+/obj/machinery/power/apc/autoname_north,
+/obj/table/wood/auto,
+/obj/machinery/phone,
+/obj/cable{
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"pwT" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/machinery/door/airlock/pyro/glass{
-	name = "Cafeteria"
+/turf/simulated/floor/carpet/purple/fancy/edge/ne,
+/area/station/science/research_director)
+"pxv" = (
+/obj/cable{
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/firedoor_spawn,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
-"pyX" = (
-/obj/critter/roach,
-/turf/simulated/floor/grime,
-/area/station/maintenance/southeast)
+/turf/simulated/floor/black,
+/area/station/turret_protected/Zeta)
 "pAA" = (
-/obj/table/reinforced/bar/auto,
-/obj/machinery/computer/security/wooden_tv/small{
-	pixel_y = 8
+/obj/machinery/plantpot{
+	anchored = 1
 	},
-/turf/simulated/floor/carpet/green/standard/narrow/northsouth,
-/area/station/crew_quarters/cafeteria)
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/grass,
+/area/station/crew_quarters/quarters_south)
 "pBe" = (
 /obj/lattice{
 	dir = 4;
@@ -55864,18 +55788,25 @@
 /obj/machinery/light/runway_light/delay5,
 /turf/space,
 /area/station/ai_monitored/armory)
+"pBn" = (
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/grey,
+/area/station/hallway/secondary/exit)
 "pCp" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/space,
 /area/space)
-"pCS" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+"pCH" = (
+/obj/disposalpipe/segment/transport{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/turf/space,
+/area/station/ai_monitored/armory)
 "pCV" = (
 /obj/disposalpipe/segment/bent/south,
 /obj/cable{
@@ -55884,23 +55815,9 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
-"pDx" = (
-/obj/storage/closet/emergency,
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"pFx" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+"pEy" = (
+/turf/simulated/floor/carpet/blue/fancy/edge/east,
+/area/station/bridge)
 "pFF" = (
 /obj/table/auto,
 /obj/item/sheet/steel/fullstack,
@@ -55908,10 +55825,36 @@
 /obj/machinery/light,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
-"pId" = (
-/obj/machinery/shieldgenerator/meteorshield,
-/turf/simulated/floor/plating,
-/area/station/maintenance/central)
+"pFI" = (
+/obj/grille/catwalk{
+	dir = 9
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8;
+	icon_state = "catwalk_cross"
+	},
+/area/station/maintenance/southeast)
+"pHf" = (
+/obj/machinery/computer3/terminal/network{
+	dir = 4;
+	name = "CENTCOM Terminal";
+	pixel_x = -3;
+	pixel_y = 4;
+	setup_os_string = "MAIN_DISH_SS13"
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/sanitary/white,
+/area/station/bridge/captain)
 "pIV" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8;
@@ -55919,34 +55862,42 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
+"pJd" = (
+/obj/stool,
+/turf/simulated/floor/grey/side{
+	dir = 8
+	},
+/area/space)
 "pJk" = (
 /obj/landmark/spawner{
 	name = "monkeyspawn_krimpus"
 	},
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
-"pNg" = (
-/obj/item/caution{
-	desc = "Caution! Construction Zone!";
-	name = "caution sign"
+"pJs" = (
+/obj/machinery/light/runway_light/delay2,
+/obj/lattice{
+	icon_state = "lattice-dir"
 	},
-/turf/simulated/floor/plating,
-/area/space)
-"pNv" = (
-/obj/stool/chair{
+/turf/space,
+/area/station/ai_monitored/armory)
+"pLB" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 1
+	},
+/obj/stool/chair/blue{
+	dir = 4
+	},
+/turf/simulated/floor/blue/side{
 	dir = 8
 	},
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/space)
-"pRi" = (
-/obj/disposalpipe/segment/horizontal,
-/obj/machinery/atmospherics/valve{
-	high_risk = 1;
-	name = "Bridge"
+/area/station/hallway/primary/south)
+"pOi" = (
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
 "pSJ" = (
 /obj/table/auto,
 /obj/item/remote/porter/port_a_medbay,
@@ -55954,11 +55905,6 @@
 	dir = 8
 	},
 /area/station/medical/medbay)
-"pTj" = (
-/obj/machinery/light/runway_light,
-/obj/lattice,
-/turf/space,
-/area/station/ai_monitored/armory)
 "pUl" = (
 /obj/machinery/plantpot,
 /obj/decal/xmas_lights/ephemeral{
@@ -55975,26 +55921,11 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
-"pVs" = (
-/obj/disposalpipe/segment/transport{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/space,
-/area/space)
-"pWQ" = (
-/obj/item/storage/toilet,
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/grey/side{
-	dir = 8
-	},
-/area/space)
+"pWV" = (
+/obj/table/reinforced/bar/auto,
+/obj/item/game_kit,
+/turf/simulated/floor/carpet/blue,
+/area/station/bridge)
 "pXJ" = (
 /obj/stool/chair/comfy/green{
 	dir = 8
@@ -56006,32 +55937,6 @@
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/north,
 /area/station/bridge/hos)
-"qai" = (
-/obj/item/tile/steel,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/grime,
-/area/station/maintenance/southeast)
-"qcD" = (
-/obj/machinery/drainage,
-/turf/simulated/floor/black,
-/area/space)
-"qdB" = (
-/obj/machinery/computer/stockexchange{
-	dir = 4;
-	pixel_x = -3;
-	pixel_y = 4
-	},
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/sanitary/white,
-/area/station/bridge/captain)
 "qeG" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/cable{
@@ -56063,21 +55968,13 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
-"qjU" = (
-/obj/table/reinforced/auto,
-/obj/item/paper/book/medical_surgery_guide{
-	pixel_x = 9
+"qin" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
 	},
-/obj/machinery/defib_mount{
-	pixel_x = -6
-	},
-/turf/simulated/floor/bluewhite,
-/area/station/medical/medbooth)
-"qmh" = (
-/obj/decal/cleanable/dirt,
-/obj/machinery/shieldgenerator/energy_shield,
-/turf/simulated/floor/plating,
-/area/station/maintenance/central)
+/obj/machinery/light/runway_light/delay3,
+/turf/space,
+/area/station/ai_monitored/armory)
 "qmL" = (
 /obj/machinery/vending/standard,
 /turf/simulated/floor/plating,
@@ -56091,17 +55988,6 @@
 	dir = 1
 	},
 /area/station/mining/staff_room)
-"qoT" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
 "qpS" = (
 /obj/tree1,
 /turf/simulated/floor/grass/leafy,
@@ -56144,6 +56030,45 @@
 /obj/decal/tile_edge/floorguide/arrow_w,
 /turf/simulated/floor/darkblue/checker,
 /area/station/science/artifact)
+"qvM" = (
+/obj/table/reinforced/auto,
+/obj/item/paper_bin,
+/obj/item/pen/pencil,
+/obj/item/reagent_containers/food/drinks/water,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/grey/side{
+	dir = 8
+	},
+/area/station/security/brig)
+"qwj" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 20
+	},
+/obj/rack,
+/obj/item/storage/box/stinger_kit,
+/obj/item/chem_grenade/pepper,
+/obj/item/chem_grenade/pepper,
+/obj/item/chem_grenade/pepper,
+/obj/item/clothing/glasses/nightvision,
+/obj/item/clothing/glasses/nightvision,
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
+"qxv" = (
+/obj/decal/tile_edge/line/green{
+	dir = 1;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/neutral/corner{
+	dir = 1
+	},
+/area/station/crew_quarters/quarters_south)
 "qxQ" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -56153,26 +56078,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"qyz" = (
-/obj/cable{
-	icon_state = "1-2"
+"qyf" = (
+/obj/machinery/manufacturer/personnel,
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
-/turf/simulated/floor/greenblack{
-	dir = 1
-	},
-/area/station/turret_protected/Zeta)
+/turf/simulated/floor,
+/area/station/crew_quarters/courtroom)
 "qzi" = (
 /obj/machinery/power/smes{
 	chargelevel = 15000;
@@ -56189,60 +56103,13 @@
 	dir = 1
 	},
 /area/station/security/brig)
-"qCo" = (
-/obj/machinery/door/airlock/pyro/security{
-	dir = 4;
-	name = "Brig";
-	req_access = null
-	},
+"qCD" = (
 /obj/cable{
-	icon_state = "4-8"
-	},
-/obj/access_spawn/brig,
-/obj/firedoor_spawn,
-/turf/simulated/floor/red,
-/area/station/security/brig)
-"qCC" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/stairs{
-	dir = 8
-	},
-/area/station/maintenance/southeast)
-"qDk" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 1;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
-"qDu" = (
-/obj/table/wood/auto,
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/phone,
-/obj/item/stamp/ce{
-	pixel_x = -12;
-	rand_pos = 0
-	},
-/turf/simulated/floor/yellowblack{
-	dir = 1
-	},
-/area/station/crew_quarters/ce)
-"qDV" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/light/runway_light/delay5,
-/turf/space,
+/turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "qEr" = (
 /obj/disposalpipe/segment/mail/horizontal,
@@ -56256,87 +56123,74 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
-"qHS" = (
-/obj/submachine/ATM{
-	pixel_x = 32
-	},
-/turf/simulated/floor/grime,
-/area/station/security/brig)
-"qKA" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/submachine/chef_sink/chem_sink{
-	dir = 8;
-	pixel_x = 8
-	},
-/turf/simulated/floor/redwhite/corner{
-	dir = 4
-	},
-/area/station/medical/medbooth)
 "qKY" = (
 /obj/storage/secure/closet/engineering/mechanic,
 /obj/machinery/light,
 /turf/simulated/floor/yellow/side,
 /area/station/engine/elect)
-"qPS" = (
+"qLH" = (
+/obj/table/auto,
+/obj/machinery/light,
+/obj/item/storage/toolbox/emergency,
+/obj/item/device/light/glowstick,
+/obj/item/device/light/glowstick,
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"qLK" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
+"qMm" = (
 /obj/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
+	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/carpet/blue/fancy/edge/west,
-/area/station/bridge)
-"qQu" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
-"qQT" = (
-/obj/rack,
-/obj/item/clothing/suit/armor/heavy,
-/obj/item/clothing/suit/armor/heavy,
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/glasses/thermal,
-/obj/item/clothing/glasses/thermal,
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
-"qRy" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 6;
-	level = 2
-	},
-/obj/cable{
-	icon_state = "6-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "1-6"
-	},
+/obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
+"qMC" = (
+/obj/lattice,
+/obj/machinery/light/runway_light/delay4,
+/turf/space,
+/area/station/ai_monitored/armory)
+"qOe" = (
+/obj/machinery/door/airlock/pyro/maintenance,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/greenblack,
+/area/station/garden/aviary)
+"qPg" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
+	},
+/turf/space,
+/area/station/ai_monitored/armory)
+"qTb" = (
+/obj/machinery/door/airlock/pyro/command{
+	dir = 4;
+	name = "Computer Core"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
+/area/station/turret_protected/Zeta)
 "qTA" = (
 /obj/stool/chair{
 	dir = 1
@@ -56346,25 +56200,20 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
-"qWo" = (
-/obj/machinery/light/emergency{
-	dir = 8;
-	pixel_x = -10
+"qUn" = (
+/obj/machinery/chem_heater,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
 	},
-/turf/simulated/floor/black,
-/area/station/bridge)
-"qXr" = (
-/obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/right{
-	dir = 8
+/obj/item/device/radio/intercom/medical{
+	pixel_x = 4;
+	pixel_y = 24
 	},
-/turf/simulated/floor/plating,
-/area/station/turret_protected/Zeta)
-"qYF" = (
-/turf/simulated/floor/redblack{
-	dir = 1
-	},
-/area/station/security/brig)
+/turf/simulated/floor/carpet/blue/fancy/edge/ne,
+/area/station/crew_quarters/md)
 "qYI" = (
 /obj/machinery/door/airlock/pyro/medical{
 	name = "Robotics";
@@ -56427,20 +56276,27 @@
 /area/station/maintenance/storage{
 	name = "Inner Southwest Maintenance"
 	})
-"rda" = (
-/obj/machinery/sleeper{
-	dir = 4
-	},
-/obj/cable,
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
 "rfD" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/morgue)
+"rgu" = (
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 6;
+	level = 2
+	},
+/obj/cable{
+	icon_state = "6-8"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "1-6"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "riF" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -56456,6 +56312,14 @@
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
+"rkB" = (
+/obj/table/wood/round/auto,
+/obj/item/storage/toolbox{
+	desc = "Looks suspiciously similar to a toolbox.";
+	name = "lunchbox"
+	},
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
 "rlg" = (
 /obj/table/reinforced/auto,
 /obj/disposalpipe/segment/vertical,
@@ -56464,12 +56328,6 @@
 /obj/machinery/door/airlock/pyro/glass/windoor,
 /turf/simulated/floor/yellow,
 /area/station/engine/storage)
-"rlR" = (
-/obj/machinery/vending/snack{
-	credit = 50
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/brig)
 "rmU" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -56477,17 +56335,15 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
+"rmZ" = (
+/obj/machinery/computer/tetris,
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
 "rsz" = (
 /obj/disposalpipe/segment/transport,
 /obj/decal/poster/wallsign/medbay_left,
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/south)
-"rsZ" = (
-/obj/shrub{
-	dir = 6
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
 "rtZ" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
@@ -56506,9 +56362,6 @@
 /turf/simulated/floor/carpet/purple/fancy/edge/ne,
 /area/station/crew_quarters/quarters_north)
 "rve" = (
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
 /obj/disposalpipe/segment/brig{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -56541,38 +56394,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/lobby)
-"rzx" = (
-/obj/machinery/atmospherics/pipe/simple,
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
-"rzF" = (
-/obj/shrub,
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
-"rAv" = (
-/obj/table/wood/auto,
-/obj/item/item_box/gold_star{
-	item_amount = 20
-	},
-/obj/item/dice/d1,
-/obj/machinery/light{
+"rBC" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
 	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
+	name = "autoname - SS13"
 	},
-/obj/item/deconstructor,
-/obj/item/device/radio/intercom/engineering,
-/turf/simulated/floor/yellowblack{
-	dir = 1
-	},
-/area/station/crew_quarters/ce)
+/turf/simulated/floor/black,
+/area/station/turret_protected/Zeta)
 "rBS" = (
 /obj/machinery/light,
 /obj/machinery/r_door_control/podbay/security/new_walls/east,
@@ -56586,15 +56415,13 @@
 	},
 /turf/space,
 /area/space)
-"rGa" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+"rGW" = (
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Holding Cell One"
 	},
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/bridge)
+/obj/access_spawn/brig,
+/turf/simulated/floor/black,
+/area/space)
 "rHq" = (
 /turf/simulated/floor/carpet/purple/fancy/edge/east,
 /area/station/crew_quarters/quarters_north)
@@ -56602,20 +56429,56 @@
 /obj/machinery/bot/firebot,
 /turf/simulated/floor,
 /area/station/storage/warehouse)
-"rMk" = (
-/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon18{
-	codes_txt = "patrol;next_patrol=1"
+"rHM" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
+/turf/simulated/floor/redblack/corner{
+	dir = 8
+	},
+/area/space)
+"rJD" = (
+/obj/machinery/atmospherics/pipe/tank/air_repressurization/north,
+/turf/simulated/floor/plating,
+/area/station/maintenance/central)
+"rJJ" = (
+/obj/submachine/claw_machine,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
+"rMk" = (
+/obj/stool/chair{
+	dir = 4;
+	tag = "icon-chair (EAST)"
+	},
+/obj/landmark{
+	name = "blobstart"
+	},
+/turf/simulated/floor/carpet/green/fancy/edge/north,
+/area/station/crew_quarters/quarters_south)
 "rOU" = (
-/obj/machinery/hydro_growlamp,
+/obj/machinery/plantpot{
+	anchored = 1
+	},
+/obj/machinery/light/small/floor,
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
 "rPh" = (
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
+"rPt" = (
+/obj/disposalpipe/segment/horizontal,
+/obj/machinery/atmospherics/valve{
+	high_risk = 1;
+	name = "Bridge"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "rPP" = (
 /obj/landmark/spawner{
 	name = "monkeyspawn_albert"
@@ -56637,6 +56500,19 @@
 	},
 /turf/simulated/floor/white,
 /area/station/science/lobby)
+"rSk" = (
+/obj/machinery/door/airlock/pyro/security{
+	name = "Courtroom"
+	},
+/obj/machinery/secscanner{
+	pixel_y = 10
+	},
+/obj/decal/garland/ephemeral,
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/courtroom)
 "rSs" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -56645,25 +56521,38 @@
 /area/station/crew_quarters/clown{
 	name = "Clowntainment"
 	})
-"rUl" = (
-/obj/machinery/door/airlock/pyro/glass,
-/obj/disposalpipe/segment/vertical,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/courtroom)
-"rWi" = (
-/obj/machinery/door_timer/solitary2/new_walls/north{
-	layer = 3.1
+"rUm" = (
+/obj/machinery/light/emergency{
+	dir = 8;
+	pixel_x = -10
 	},
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
+/turf/simulated/floor/black,
+/area/station/bridge)
+"rWz" = (
+/obj/submachine/chem_extractor{
+	dir = 8
 	},
-/turf/simulated/floor/redblack/corner{
-	dir = 4
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 9;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
 	},
-/area/space)
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
+"rWU" = (
+/obj/table/auto,
+/obj/item/circuitboard/robotics,
+/obj/item/disk/data/floppy/read_only/network_progs,
+/obj/machinery/light,
+/turf/simulated/floor/greenblack,
+/area/station/turret_protected/Zeta)
 "rYn" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -56681,10 +56570,6 @@
 	},
 /turf/simulated/floor/darkblue,
 /area/station/turret_protected/ai)
-"rZx" = (
-/obj/machinery/recharge_station,
-/turf/simulated/floor/grey,
-/area/station/maintenance/southeast)
 "rZQ" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/decal/garland/ephemeral{
@@ -56693,16 +56578,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
-"sbQ" = (
-/obj/machinery/door/airlock/pyro/command{
-	name = "Command Centre"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/black,
-/area/station/bridge)
 "scE" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/wall/auto/supernorn,
@@ -56729,17 +56604,6 @@
 	},
 /turf/space,
 /area/station/ai_monitored/armory)
-"sfk" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 1
-	},
-/obj/stool/chair/blue{
-	dir = 4
-	},
-/turf/simulated/floor/blue/side{
-	dir = 8
-	},
-/area/station/hallway/primary/south)
 "sfX" = (
 /obj/disposalpipe/segment/vertical,
 /obj/decal/xmas_lights/ephemeral{
@@ -56748,23 +56612,56 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "shz" = (
-/obj/stool/chair,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
+/obj/table/wood/auto,
+/obj/random_item_spawner/medicine,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
 	},
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
-"shR" = (
-/obj/table/auto,
-/obj/item/reagent_containers/glass/wateringcan{
-	pixel_y = 6
-	},
-/turf/simulated/floor/green,
+/turf/simulated/floor/carpet/green/fancy/edge/ne,
 /area/station/crew_quarters/quarters_south)
+"shG" = (
+/obj/stool,
+/obj/item/device/radio/intercom{
+	dir = 4
+	},
+/turf/simulated/floor/grey/side{
+	dir = 8
+	},
+/area/station/security/brig)
+"shR" = (
+/obj/machinery/power/apc/autoname_west,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/central)
+"sjG" = (
+/obj/table/auto,
+/obj/machinery/networked/storage/scanner{
+	bank_id = "bridge";
+	pixel_y = 4
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
+	},
+/turf/simulated/floor/circuit,
+/area/station/bridge)
+"skX" = (
+/turf/simulated/floor/yellowblack/corner{
+	dir = 1
+	},
+/area/station/crew_quarters/ce)
 "sml" = (
 /obj/table/auto,
 /obj/machinery/computer/security/wooden_tv/small{
@@ -56772,9 +56669,16 @@
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"snw" = (
-/obj/machinery/light_switch/east,
-/obj/storage/secure/closet/security/armory,
+"smE" = (
+/obj/machinery/door/airlock/pyro/command{
+	aiControlDisabled = 1;
+	name = "Armory";
+	req_access = null
+	},
+/obj/access_spawn/hos,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "snN" = (
@@ -56783,6 +56687,12 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/bridge/captain)
+"snW" = (
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "soA" = (
 /obj/table/reinforced/auto,
 /obj/disposaloutlet/west,
@@ -56818,47 +56728,12 @@
 	dir = 8
 	},
 /area/station/routing/security)
-"srN" = (
-/obj/table/reinforced/bar/auto,
-/obj/machinery/computer3/generic/personal,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/grey,
-/area/station/bridge)
-"ssP" = (
-/obj/table/auto,
-/obj/shrub/dead{
-	dir = 8;
-	name = "Dead plant";
-	pixel_y = 10
-	},
-/turf/simulated/floor/plating,
-/area/space)
-"ssW" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/emergency{
-	dir = 1;
-	pixel_y = 16
-	},
-/turf/simulated/floor/carpet/blue/fancy/edge/nw,
-/area/station/bridge)
 "stu" = (
-/obj/storage/closet/dresser,
-/obj/item/clothing/under/color/lime,
-/obj/item/clothing/head/green,
-/obj/item/clothing/glasses/healthgoggles,
-/turf/simulated/floor/carpet/green/fancy/edge/se,
-/area/station/crew_quarters/quarters_south)
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/grey,
+/area/station/hallway/secondary/exit)
 "sty" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -56871,46 +56746,49 @@
 	},
 /turf/simulated/floor,
 /area/station/routing/security)
-"svd" = (
-/obj/machinery/chem_dispenser,
-/obj/machinery/alarm{
-	pixel_y = 24
+"sul" = (
+/obj/item/clothing/suit/cardboard_box,
+/turf/simulated/floor/grime,
+/area/station/maintenance/southeast)
+"suG" = (
+/obj/machinery/light_switch/east,
+/obj/storage/secure/closet/security/armory,
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
+"svq" = (
+/obj/shrub,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
 	},
-/turf/simulated/floor/carpet/blue/fancy/edge/north,
-/area/station/crew_quarters/md)
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
 "svx" = (
 /obj/machinery/light,
 /turf/simulated/floor/stairs/wood/wide{
 	dir = 8
 	},
 /area/station/crew_quarters/courtroom)
-"svA" = (
-/turf/simulated/floor/shuttlebay,
-/area/station/hallway/secondary/exit)
-"svD" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/window_blinds/cog2/right{
-	dir = 8
-	},
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/ce)
 "swI" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
 	},
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4
-	},
-/turf/simulated/floor/escape{
+/turf/simulated/floor/grey,
+/area/station/hallway/secondary/exit)
+"sye" = (
+/obj/storage/secure/crate/plasma/armory/anti_biological,
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
+"syz" = (
+/turf/simulated/floor/redblack/corner{
 	dir = 8
 	},
-/area/station/hallway/secondary/exit)
-"sxo" = (
-/obj/table/reinforced/bar/auto,
-/obj/item/game_kit,
-/turf/simulated/floor/carpet/blue,
-/area/station/bridge)
+/area/space)
 "syK" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
@@ -56926,11 +56804,7 @@
 	},
 /turf/simulated/floor/black,
 /area/research_outpost/indigo_rye)
-"szB" = (
-/obj/machinery/atmospherics/pipe/tank/air_repressurization/north,
-/turf/simulated/floor/plating,
-/area/station/maintenance/central)
-"szZ" = (
+"sAj" = (
 /obj/machinery/vending/alcohol,
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -56955,15 +56829,14 @@
 	dir = 8
 	},
 /area/station/medical/medbay/surgery)
-"sBD" = (
-/obj/machinery/power/apc/autoname_north,
-/obj/table/wood/auto,
-/obj/machinery/phone,
-/obj/cable{
-	icon_state = "0-2"
+"sBH" = (
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir-b"
 	},
-/turf/simulated/floor/carpet/purple/fancy/edge/ne,
-/area/station/science/research_director)
+/obj/machinery/light/runway_light,
+/turf/space,
+/area/station/ai_monitored/armory)
 "sBO" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -56978,15 +56851,35 @@
 	dir = 1
 	},
 /area/station/hallway/primary/east)
-"sDW" = (
-/obj/disposalpipe/segment/brig{
-	dir = 8
+"sBU" = (
+/obj/disposalpipe/segment/mail/vertical,
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/brig{
-	dir = 1
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
+"sCD" = (
+/obj/stool/chair/office/yellow{
+	dir = 4
 	},
-/turf/simulated/floor/redblack,
-/area/station/security/brig)
+/obj/landmark/start{
+	name = "Chief Engineer"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/orangeblack,
+/area/station/crew_quarters/ce)
+"sEy" = (
+/obj/item/extinguisher,
+/turf/simulated/floor/carpet/green/fancy/edge/nw,
+/area/station/crew_quarters/quarters_south)
 "sHh" = (
 /obj/machinery/launcher_loader/west,
 /turf/simulated/floor/airless/plating,
@@ -56995,46 +56888,30 @@
 /obj/decal/poster/wallsign/stencil/left/v,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/detectives_office)
-"sHz" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
-/turf/simulated/floor/white,
-/area/station/medical/medbooth)
+"sJx" = (
+/obj/machinery/shieldgenerator/meteorshield,
+/turf/simulated/floor/plating,
+/area/station/maintenance/central)
 "sJY" = (
 /obj/decal/poster/wallsign/warning1{
 	pixel_x = 6
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/gas)
-"sKO" = (
-/obj/machinery/door/airlock/pyro,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/green/side,
-/area/station/garden/aviary)
-"sLi" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/space)
-"sLp" = (
-/obj/stool/chair/comfy{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/blue/fancy/edge/west,
-/area/station/bridge)
 "sLF" = (
 /obj/landmark/halloween,
 /turf/simulated/floor,
 /area/station/hallway/secondary/south)
+"sMb" = (
+/obj/machinery/door/airlock/pyro/command{
+	name = "Command Centre"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
+/area/station/bridge)
 "sMt" = (
 /obj/landmark/spawner{
 	name = "monkeyspawn_mrsmuggles"
@@ -57046,39 +56923,70 @@
 /obj/decal/poster/wallsign/hazard_bio,
 /turf/simulated/floor/plating,
 /area/station/medical/dome)
-"sQf" = (
-/obj/stool/chair/red{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/redblack{
-	dir = 5
-	},
-/area/station/security/brig)
-"sQL" = (
-/obj/table/round/auto,
-/obj/item/gobowl/b,
-/turf/simulated/floor/neutral/side{
-	dir = 8
-	},
-/area/station/crew_quarters/quarters_south)
+"sOW" = (
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
 "sRA" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple{
+/obj/machinery/computer/barcode{
+	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Pod Bay","Research","Security","QM");
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
+/obj/machinery/power/data_terminal,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
+	},
+/turf/simulated/floor/orange/side{
+	dir = 9
+	},
+/area/station/crew_quarters/catering)
+"sRD" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/light/runway_light/delay2,
+/turf/space,
+/area/station/ai_monitored/armory)
+"sSx" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/left{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/turret_protected/Zeta)
+"sSy" = (
+/obj/table/wood/auto,
+/obj/machinery/recharger{
+	pixel_y = 3
+	},
+/obj/item/remote/porter/port_a_sci,
+/obj/item/reagent_containers/hypospray,
+/obj/item/reagent_containers/food/snacks/beefood{
+	desc = "A little birthday cupcake for Heisenbee.  May not taste good to non-bees.";
+	icon = 'icons/obj/foodNdrink/food_dessert.dmi';
+	icon_state = "cupcake";
+	name = "Heisenbee's birthday cupcake"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
+	},
+/obj/item/stamp/rd,
+/obj/item/device/radio/intercom/science{
+	pixel_x = 3;
+	pixel_y = 24
+	},
+/turf/simulated/floor/carpet/purple/fancy/edge/nw,
+/area/station/science/research_director)
 "sSO" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -57093,34 +57001,13 @@
 /area/station/medical/research{
 	name = "Genetic Research"
 	})
-"sTZ" = (
+"sVR" = (
+/obj/critter/parrot/random,
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
-"sUq" = (
-/obj/item/device/radio/beacon,
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/courtroom)
-"sVD" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
-	},
-/turf/space,
-/area/station/ai_monitored/armory)
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
 "sWh" = (
 /obj/landmark/artifact,
 /turf/simulated/floor/plating/airless/asteroid/dark,
@@ -57134,47 +57021,75 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
+"sWL" = (
+/obj/item/storage/toilet,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/grey/side{
+	dir = 4
+	},
+/area/space)
 "tan" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/beepsky)
 "tbT" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/table/auto,
+/obj/item/reagent_containers/food/drinks/eggnog{
+	pixel_y = 8
 	},
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4
-	},
-/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon15,
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
 "tcl" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
+"tdx" = (
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/engine,
+/area/station/routing/security)
 "tdy" = (
 /turf/simulated/floor/greenblack{
 	dir = 1
 	},
 /area/station/turret_protected/Zeta)
-"tij" = (
-/obj/table/round/auto,
-/obj/item/gobowl/w,
-/turf/simulated/floor/neutral/corner{
+"tdF" = (
+/obj/table/auto,
+/obj/machinery/cell_charger,
+/obj/item/cell/supercell/charged,
+/obj/item/cell/supercell/charged,
+/obj/machinery/light/small,
+/turf/simulated/floor/circuit,
+/area/station/bridge)
+"tgm" = (
+/obj/stool/chair/office/blue{
 	dir = 1
 	},
-/area/station/crew_quarters/quarters_south)
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/Zeta)
 "tjX" = (
 /turf/simulated/floor/carpet/purple/fancy,
 /area/station/crew_quarters/quarters_north)
-"tkb" = (
-/obj/stool,
-/turf/simulated/floor/grey/side{
-	dir = 8
-	},
-/area/space)
 "tmm" = (
 /obj/machinery/mass_driver{
 	dir = 1;
@@ -57183,32 +57098,46 @@
 /turf/simulated/floor/delivery,
 /area/station/quartermaster/office)
 "tmx" = (
-/obj/machinery/atmospherics/unary/outlet_injector{
-	dir = 8;
-	icon_state = "on";
-	on = 1
+/obj/table/reinforced/auto,
+/obj/item/clothing/gloves/latex,
+/obj/item/clothing/gloves/latex,
+/obj/item/clothing/suit/apron,
+/obj/item/clothing/head/souschefhat,
+/obj/item/device/radio/intercom/catering{
+	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
+/turf/simulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/kitchen)
+"tmR" = (
+/obj/stool/chair/comfy/purple{
+	dir = 4
+	},
+/obj/landmark/start{
+	name = "Research Director"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/carpet/purple/fancy,
+/area/station/science/research_director)
+"tmS" = (
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Holding Cell Two"
+	},
+/obj/access_spawn/brig,
+/turf/simulated/floor/black,
+/area/space)
 "tnf" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
 /obj/machinery/light_switch/east,
 /turf/simulated/floor,
-/area/station/hallway/primary/south)
-"tnT" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/landmark/halloween,
-/turf/simulated/floor/escape/corner{
-	dir = 1
-	},
 /area/station/hallway/primary/south)
 "tpr" = (
 /obj/disposalpipe/segment/brig{
@@ -57240,6 +57169,22 @@
 	},
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
+"trW" = (
+/turf/simulated/floor/stairs/dark,
+/area/station/maintenance/southeast)
+"tsm" = (
+/obj/stool/bench/blue/auto,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"tsA" = (
+/obj/machinery/chem_dispenser,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/cafeteria)
 "tuJ" = (
 /obj/plasticflaps,
 /obj/machinery/cargo_router/kd_sec_flap,
@@ -57258,35 +57203,26 @@
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
-/obj/machinery/light/emergency{
+/obj/machinery/light{
 	dir = 1;
-	pixel_y = 16
+	layer = 9.1;
+	pixel_y = 21
 	},
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
 /area/station/hallway/primary/south)
-"txg" = (
-/obj/disposalpipe/switch_junction/left/south{
-	mail_tag = "medical booth";
-	name = "medical booth mail junction"
+"tzd" = (
+/obj/cable{
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/black/side{
-	dir = 8
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/area/station/hallway/primary/south)
-"tzy" = (
-/obj/machinery/computer/tetris,
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
-"tBA" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13"
-	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "tCk" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 9
@@ -57294,26 +57230,20 @@
 /turf/simulated/floor/black,
 /area/station/bridge)
 "tCI" = (
-/obj/table/auto,
-/obj/item/shaker/salt,
-/obj/item/shaker/mustard{
-	pixel_x = -6
+/obj/table/reinforced/auto,
+/obj/machinery/light,
+/obj/machinery/glass_recycler{
+	glass_amt = 5;
+	pixel_y = 4
 	},
-/obj/item/shaker/pepper{
-	pixel_x = 3
+/turf/simulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/kitchen)
+"tHB" = (
+/obj/disposalpipe/segment/mail/vertical,
+/turf/simulated/floor/redwhite{
+	dir = 10
 	},
-/obj/item/shaker/ketchup{
-	pixel_x = 6
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/catering)
-"tEq" = (
-/turf/simulated/floor/damaged5,
-/area/station/crew_quarters/quarters_south)
-"tGG" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/security/brig)
+/area/station/medical/medbooth)
 "tIp" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
@@ -57326,9 +57256,23 @@
 	},
 /area/station/hallway/primary/west)
 "tIt" = (
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/brig)
+/obj/table/reinforced/auto,
+/obj/submachine/mixer,
+/turf/simulated/floor/specialroom/cafeteria{
+	dir = 1
+	},
+/area/station/crew_quarters/kitchen)
+"tIW" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/carpet/purple/fancy/edge/west,
+/area/station/science/research_director)
 "tJD" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -57336,13 +57280,6 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
-"tKf" = (
-/obj/machinery/atmospherics/valve{
-	high_risk = 1;
-	name = "Air Reserve (Escape Hallway)"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/central)
 "tKY" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -57350,6 +57287,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
+"tLy" = (
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
 "tMa" = (
 /obj/machinery/door/airlock/pyro/external{
 	name = "Mining Hangar"
@@ -57358,75 +57306,21 @@
 /obj/access_spawn/mining,
 /turf/simulated/floor/orangeblack,
 /area/station/mining/staff_room)
-"tMr" = (
-/obj/table/auto,
-/obj/item/paper_bin{
-	pixel_y = 6
+"tMf" = (
+/obj/table/reinforced/chemistry/auto,
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
 	},
-/obj/deskclutter,
-/obj/item/hand_labeler{
-	pixel_x = 5
+/obj/machinery/light_switch/north,
+/obj/machinery/phone,
+/obj/item/stamp/md{
+	pixel_x = -14;
+	rand_pos = 0
 	},
-/obj/item/plantanalyzer,
-/obj/item/device/reagentscanner{
-	pixel_x = -7
-	},
-/obj/item/pen,
-/turf/simulated/floor,
-/area/station/hydroponics/bay)
-"tMJ" = (
-/obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/floor/black/side{
-	dir = 10
-	},
-/area/station/hallway/primary/south)
-"tOW" = (
-/obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
-"tQD" = (
-/obj/landmark/gps_waypoint,
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
-"tQT" = (
-/obj/table/reinforced/auto,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/reagent_containers/food/drinks/water,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/simulated/floor/grey/side{
-	dir = 4
-	},
-/area/space)
-"tUv" = (
-/obj/machinery/power/data_terminal,
-/obj/machinery/computer/robotics{
-	perma = 1
-	},
-/turf/simulated/floor/greenblack{
-	dir = 1
-	},
-/area/station/turret_protected/Zeta)
+/turf/simulated/floor/carpet/blue/fancy/edge/north,
+/area/station/crew_quarters/md)
 "tVy" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
@@ -57435,52 +57329,57 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/coldloop)
-"tYP" = (
+"tXe" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/stool/chair/office/blue{
-	dir = 4
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"tXg" = (
+/obj/machinery/turret,
+/obj/lattice,
+/turf/space,
+/area/station/ai_monitored/armory)
+"tYP" = (
+/obj/table/reinforced/auto,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13";
+	tag = ""
 	},
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/catering)
-"uat" = (
-/obj/machinery/manufacturer/personnel,
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
+/obj/machinery/phone,
+/turf/simulated/floor/specialroom/cafeteria{
+	dir = 1
 	},
-/turf/simulated/floor,
-/area/station/crew_quarters/courtroom)
+/area/station/crew_quarters/kitchen)
+"uaz" = (
+/obj/decal/poster/wallsign/medal,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/bridge/hos)
 "uaU" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/routing/security)
-"udh" = (
-/obj/disposalpipe/segment/vertical,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
+"uby" = (
+/turf/simulated/floor/shuttlebay,
+/area/station/hallway/secondary/exit)
+"ueZ" = (
+/obj/submachine/chef_sink/chem_sink{
+	dir = 1
 	},
-/obj/machinery/phone/wall{
-	pixel_x = 24
+/obj/decal/tile_edge/line/black{
+	dir = 5;
+	icon_state = "line2"
 	},
-/turf/simulated/floor/neutral/side{
-	dir = 4
-	},
-/area/station/crew_quarters/quarters_south)
-"uff" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/obj/machinery/drainage,
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/ce)
 "ugD" = (
 /obj/cable{
 	d1 = 1;
@@ -57492,6 +57391,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/east)
+"ugK" = (
+/obj/machinery/turret,
+/turf/simulated/floor/greenblack,
+/area/station/turret_protected/Zeta)
+"uhm" = (
+/obj/grille/catwalk{
+	dir = 6;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 6
+	},
+/area/station/maintenance/southeast)
 "uhx" = (
 /obj/wingrille_spawn/auto,
 /obj/decal/poster/wallsign/hazard_bio,
@@ -57511,25 +57423,54 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
-"upu" = (
-/obj/machinery/space_heater,
-/turf/simulated/floor/plating,
-/area/space)
+"uoV" = (
+/obj/machinery/chem_dispenser/soda,
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/cafeteria)
 "urd" = (
 /turf/simulated/floor/red,
 /area/station/medical/medbay)
-"uvk" = (
-/turf/simulated/floor/stairs/dark,
-/area/station/maintenance/southeast)
-"uvm" = (
-/obj/cable{
-	icon_state = "1-2"
+"urf" = (
+/obj/machinery/computer/announcement{
+	dir = 4;
+	name = "Executive Announcement Computer";
+	pixel_x = -3;
+	pixel_y = 4;
+	req_access_txt = "19"
 	},
-/obj/cable{
-	icon_state = "1-4"
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
 	},
-/turf/simulated/floor/red,
-/area/station/ai_monitored/armory)
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/sanitary/white,
+/area/station/bridge/captain)
+"usX" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1;
+	name = "Escape S Repressurization Port"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/central)
+"uuN" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
+	},
+/turf/simulated/floor/black,
+/area/station/bridge)
 "uvK" = (
 /obj/disposalpipe/segment/transport,
 /obj/cable{
@@ -57553,12 +57494,6 @@
 /obj/machinery/light/emergency,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
-"uyg" = (
-/obj/landmark{
-	name = "blobstart"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
 "uyC" = (
 /obj/disposalpipe/segment/brig,
 /obj/machinery/atmospherics/pipe/manifold{
@@ -57567,6 +57502,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
+"uzF" = (
+/obj/disposalpipe/segment/vertical,
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 6
+	},
+/turf/simulated/floor/grey,
+/area/station/bridge)
 "uzL" = (
 /obj/machinery/light{
 	dir = 1;
@@ -57581,19 +57531,15 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
-"uDc" = (
-/obj/machinery/computer3/terminal/zeta{
-	setup_os_string = "ZETA_MAINFRAME"
-	},
-/obj/machinery/power/data_terminal,
+"uBL" = (
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating{
-	icon_state = "platingdmg3"
+/obj/cable{
+	icon_state = "1-4"
 	},
-/area/station/maintenance/southeast)
+/turf/simulated/floor,
+/area/station/security/brig)
 "uDm" = (
 /obj/decal/garland/ephemeral{
 	dir = 8;
@@ -57605,6 +57551,10 @@
 /obj/storage/closet/wardrobe/green,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
+"uDX" = (
+/obj/machinery/weapon_stand/shotgun_rack,
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
 "uGT" = (
 /obj/lattice{
 	dir = 4;
@@ -57618,56 +57568,45 @@
 	},
 /turf/space,
 /area/space)
-"uIb" = (
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/redblack/corner{
+"uIT" = (
+/obj/stool,
+/turf/simulated/floor/grey/side{
 	dir = 4
 	},
 /area/space)
-"uJD" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
+"uKc" = (
+/obj/machinery/door/airlock/pyro/glass/command{
+	name = "Command Centre"
 	},
-/obj/machinery/vending/pda,
-/turf/simulated/floor/neutral/side{
-	dir = 9
-	},
-/area/station/crew_quarters/quarters_south)
-"uMr" = (
-/obj/submachine/chem_extractor{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 9;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/catering)
-"uMC" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
+	icon_state = "1-2"
+	},
+/obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/black,
+/area/station/bridge)
+"uLo" = (
+/obj/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/portable_atmospherics/canister/sleeping_agent,
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
+"uLK" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/yellowblack/corner,
-/area/station/crew_quarters/ce)
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
+"uMr" = (
+/obj/table/reinforced/bar/auto,
+/obj/machinery/computer/security/wooden_tv/small{
+	pixel_y = 8
+	},
+/turf/simulated/floor/carpet/green/standard/narrow/northsouth,
+/area/station/crew_quarters/cafeteria)
 "uMJ" = (
 /obj/machinery/atmospherics/binary/passive_gate{
 	dir = 4;
@@ -57680,21 +57619,17 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"uNe" = (
-/obj/table/reinforced/chemistry/auto,
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
+"uOi" = (
+/obj/machinery/computer/security/wooden_tv{
+	desc = "These channels seem to mostly be about robuddies. What is this, some kind of reality show?";
+	name = "Television";
+	network = "Zeta"
 	},
-/obj/machinery/light_switch/north,
-/obj/machinery/phone,
-/obj/item/stamp/md{
-	pixel_x = -14;
-	rand_pos = 0
+/obj/machinery/alarm{
+	pixel_y = 24
 	},
-/turf/simulated/floor/carpet/blue/fancy/edge/north,
-/area/station/crew_quarters/md)
+/turf/simulated/floor/carpet/purple/fancy/edge/north,
+/area/station/science/research_director)
 "uPl" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/machinery/cargo_router/kd_med_left,
@@ -57725,6 +57660,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
+"uSI" = (
+/obj/plasticflaps,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/beepsky)
 "uUF" = (
 /obj/lattice{
 	dir = 4;
@@ -57742,47 +57684,18 @@
 	dir = 8
 	},
 /area/station/routing/security)
-"uWt" = (
-/obj/lattice,
-/obj/machinery/light/runway_light/delay4,
-/turf/space,
-/area/station/ai_monitored/armory)
-"uXz" = (
-/obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/floor/redwhite{
-	dir = 10
+"vaX" = (
+/obj/table/auto,
+/obj/shrub/dead{
+	dir = 8;
+	name = "Dead plant";
+	pixel_y = 10
 	},
-/area/station/medical/medbooth)
-"uYB" = (
-/obj/disposalpipe/segment/vertical,
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/item/storage/pill_bottle/cyberpunk{
+	layer = 2.4
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple,
-/turf/simulated/floor/grey,
-/area/station/bridge)
-"uYT" = (
-/obj/tree1,
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
-"uZC" = (
-/obj/machinery/door/airlock/pyro/glass/command{
-	name = "Command Centre"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/firedoor_spawn,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/black,
-/area/station/bridge)
+/turf/simulated/floor/grime,
+/area/station/maintenance/southeast)
 "vbg" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -57804,12 +57717,10 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "vej" = (
-/obj/submachine/ice_cream_dispenser,
-/obj/machinery/light/emergency{
-	dir = 8;
-	pixel_x = -10
+/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon18{
+	codes_txt = "patrol;next_patrol=1"
 	},
-/turf/simulated/floor/black,
+/turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "veN" = (
 /obj/wingrille_spawn/auto,
@@ -57817,6 +57728,28 @@
 /area/station/medical/research{
 	name = "Genetic Research"
 	})
+"vfR" = (
+/obj/machinery/light/runway_light/delay4,
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/station/ai_monitored/armory)
+"vgc" = (
+/obj/table/wood/auto,
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/phone,
+/obj/item/stamp/ce{
+	pixel_x = -12;
+	rand_pos = 0
+	},
+/turf/simulated/floor/yellowblack{
+	dir = 1
+	},
+/area/station/crew_quarters/ce)
 "vgI" = (
 /obj/cable{
 	d1 = 1;
@@ -57827,17 +57760,23 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "viV" = (
-/obj/submachine/claw_machine,
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
+/obj/stool/chair,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
 	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
-"vjC" = (
-/obj/table/auto,
-/obj/item/storage/box/diskbox,
-/turf/simulated/floor/greenblack,
-/area/station/turret_protected/Zeta)
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
+"vjQ" = (
+/obj/submachine/ATM{
+	pixel_x = 32
+	},
+/obj/disposalpipe/segment/bent/east,
+/turf/simulated/floor/grime,
+/area/station/security/brig)
 "vkc" = (
 /obj/machinery/light/small,
 /obj/machinery/light_switch/east,
@@ -57846,54 +57785,48 @@
 	},
 /area/station/science/testchamber)
 "vmX" = (
-/obj/stool/bench/red/auto,
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
-"vos" = (
-/obj/stool/bar,
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
-"vow" = (
-/obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/left{
-	dir = 8
-	},
+"vnJ" = (
+/obj/wingrille_spawn/auto/crystal,
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
-/area/station/bridge/hos)
-"vqg" = (
-/obj/machinery/door/airlock/pyro/security{
-	name = "Secure Consultation"
+/area/station/bridge)
+"vos" = (
+/obj/table/auto,
+/obj/item/reagent_containers/glass/wateringcan{
+	pixel_y = 6
 	},
-/obj/disposalpipe/segment/brig{
+/turf/simulated/floor/green,
+/area/station/crew_quarters/quarters_south)
+"vot" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
+"vpP" = (
+/obj/machinery/power/data_terminal,
+/obj/machinery/computer/robotics{
+	perma = 1
+	},
+/turf/simulated/floor/greenblack{
 	dir = 1
 	},
-/turf/simulated/floor/redblack,
-/area/station/security/brig)
-"vqo" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/shipalert{
-	pixel_x = 30
-	},
-/turf/simulated/floor/black/side{
-	dir = 8
-	},
-/area/station/bridge)
+/area/station/turret_protected/Zeta)
 "vrz" = (
 /obj/decal/cleanable/dirt,
 /obj/landmark{
@@ -57901,6 +57834,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
+"vtX" = (
+/obj/table/wood/auto,
+/obj/machinery/networked/printer{
+	name = "Printer - CE";
+	pixel_y = 5;
+	print_id = "CE"
+	},
+/obj/machinery/light_switch/north,
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
+	},
+/turf/simulated/floor/yellowblack{
+	dir = 1
+	},
+/area/station/crew_quarters/ce)
 "vuD" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plating,
@@ -57915,24 +57869,31 @@
 	dir = 4
 	},
 /area/station/routing/security)
-"vwf" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
+"vys" = (
+/obj/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/light/runway_light/delay4,
-/turf/space,
-/area/station/ai_monitored/armory)
-"vyN" = (
-/obj/machinery/door/airlock/pyro/glass{
-	name = "Holding Cell Two"
-	},
-/obj/access_spawn/brig,
-/turf/simulated/floor/black,
-/area/space)
+/turf/simulated/floor/orangeblack,
+/area/station/crew_quarters/ce)
 "vzr" = (
 /obj/decal/poster/wallsign/security_right,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/detectives_office)
+"vzY" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/emergency{
+	dir = 1;
+	pixel_y = 16
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/nw,
+/area/station/bridge)
 "vBz" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -57949,13 +57910,29 @@
 /obj/lattice,
 /turf/space,
 /area/station/ai_monitored/armory)
-"vFr" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet,
-/turf/simulated/floor/grey/side{
+"vEJ" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/red/side{
 	dir = 4
 	},
 /area/station/security/brig)
+"vFw" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/right{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/turret_protected/Zeta)
+"vJt" = (
+/obj/machinery/door/airlock/pyro/glass,
+/obj/decal/garland/ephemeral,
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/courtroom)
 "vNa" = (
 /obj/cable{
 	d1 = 2;
@@ -57997,14 +57974,6 @@
 /obj/machinery/light_switch/north,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
-"vQz" = (
-/obj/lattice{
-	dir = 5;
-	icon_state = "lattice-dir-b"
-	},
-/obj/machinery/light/runway_light,
-/turf/space,
-/area/station/ai_monitored/armory)
 "vRn" = (
 /obj/machinery/light/runway_light/delay4,
 /obj/lattice,
@@ -58032,21 +58001,70 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
+"vST" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/ai_monitored/armory)
+"vTv" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/obj/machinery/phone/wall{
+	pixel_x = 24
+	},
+/turf/simulated/floor/grey,
+/area/station/bridge)
+"vUf" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/yellowblack/corner,
+/area/station/crew_quarters/ce)
 "vVg" = (
 /obj/disposalpipe/segment/vertical,
 /obj/machinery/atmospherics/pipe/simple,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
-"vWS" = (
+"vVB" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "8-10"
+	icon_state = "1-2"
 	},
-/obj/item/storage/box/cablesbox,
-/turf/simulated/floor/plating{
-	icon_state = "platingdmg3"
+/obj/cable{
+	icon_state = "1-4"
 	},
+/turf/simulated/floor/red,
+/area/station/ai_monitored/armory)
+"vYZ" = (
+/obj/rack,
+/obj/item/clothing/suit/space/emerg,
+/obj/item/clothing/head/emerg,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/air,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/belt/utility,
+/obj/item/crowbar,
+/obj/item/device/light/flashlight,
+/turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "vZI" = (
 /obj/random_item_spawner/junk/one_or_zero,
@@ -58076,56 +58094,17 @@
 	},
 /turf/simulated/floor/darkblue,
 /area/station/turret_protected/ai)
-"wcU" = (
-/obj/machinery/turretid{
-	pixel_x = 26
-	},
-/obj/machinery/light,
-/turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
-"wdI" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
-"weu" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/red/side{
-	dir = 4
-	},
-/area/station/security/brig)
-"wfF" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
-"wfM" = (
-/obj/wingrille_spawn/auto/crystal,
-/turf/simulated/floor/plating,
-/area/station/security/brig)
-"wgd" = (
-/turf/simulated/floor/yellowblack/corner{
-	dir = 1
-	},
-/area/station/crew_quarters/ce)
-"wgL" = (
-/obj/reagent_dispensers/still,
-/turf/simulated/floor/plating,
-/area/space)
 "whk" = (
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
+"whE" = (
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/obj/cable,
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "wio" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -58140,30 +58119,14 @@
 /obj/machinery/vending/floppy,
 /turf/simulated/floor/grey/blackgrime/other,
 /area/station/storage/tech)
-"wlm" = (
-/obj/table/auto,
-/obj/item/circuitboard/robotics,
-/obj/item/disk/data/floppy/read_only/network_progs,
-/obj/machinery/light,
-/turf/simulated/floor/greenblack,
-/area/station/turret_protected/Zeta)
-"wmS" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+"wpG" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet,
+/obj/item/device/radio/intercom,
+/turf/simulated/floor/grey/side{
+	dir = 8
 	},
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
-"wok" = (
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/obj/disposalpipe/segment/bent/east,
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
-/area/station/hallway/primary/south)
+/area/space)
 "wqb" = (
 /obj/cable{
 	d1 = 4;
@@ -58172,22 +58135,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/com_dish/comdish)
-"wtl" = (
-/obj/table/auto,
-/obj/random_item_spawner/tools,
-/obj/item/device/light/glowstick,
-/obj/item/device/light/glowstick,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"wtI" = (
-/obj/wingrille_spawn/auto,
-/obj/cable,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/medical/medbooth)
 "wuc" = (
 /obj/machinery/plantpot,
 /obj/machinery/light/small{
@@ -58204,6 +58151,19 @@
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/brig)
+"wBj" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "wBr" = (
 /obj/stool/bench/blue/auto,
 /obj/decal/xmas_lights/ephemeral{
@@ -58211,10 +58171,18 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
-"wBz" = (
-/obj/disposalpipe/segment/food,
-/turf/simulated/wall/auto/supernorn,
-/area/station/hydroponics/bay)
+"wCH" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/window_blinds/cog2/right{
+	dir = 8
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/md)
 "wDk" = (
 /obj/lattice{
 	dir = 9;
@@ -58237,18 +58205,31 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
-"wJC" = (
-/obj/machinery/door/airlock/pyro/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"wKg" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+"wHo" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/window_blinds/cog2/middle{
+	dir = 8
 	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/ce)
+"wKU" = (
+/obj/disposalpipe/switch_junction/left/south{
+	mail_tag = "medical booth";
+	name = "medical booth mail junction"
+	},
+/turf/simulated/floor/black/side{
+	dir = 8
+	},
+/area/station/hallway/primary/south)
 "wLi" = (
 /obj/machinery/light/emergency,
 /obj/machinery/atmospherics/pipe/manifold{
@@ -58270,10 +58251,6 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
-"wOq" = (
-/obj/disposalpipe/segment/transport,
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/southeast)
 "wOE" = (
 /obj/lattice{
 	dir = 10;
@@ -58283,58 +58260,65 @@
 /turf/space,
 /area/station/ai_monitored/armory)
 "wOL" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/storage/closet/dresser,
+/obj/item/clothing/under/color/lime,
+/obj/item/clothing/head/green,
+/obj/item/clothing/glasses/healthgoggles,
+/turf/simulated/floor/carpet/green/fancy/edge/se,
+/area/station/crew_quarters/quarters_south)
+"wRR" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/window_blinds/cog2/right{
+	dir = 8
 	},
-/obj/random_item_spawner/junk/one_or_zero,
+/obj/cable,
 /turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/area/station/crew_quarters/ce)
+"wSK" = (
+/obj/disposalpipe/segment/food{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/catering)
 "wUB" = (
 /obj/decal/poster/wallsign/space,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/routing/security)
-"wXv" = (
-/obj/table/auto,
-/obj/shrub/dead{
-	dir = 8;
-	name = "Dead plant";
-	pixel_y = 10
+"wWn" = (
+/obj/disposalpipe/segment/horizontal,
+/turf/simulated/floor/blue/side{
+	dir = 8
 	},
-/obj/item/storage/pill_bottle/cyberpunk{
-	layer = 2.4
+/area/station/hallway/primary/south)
+"wYY" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/grime,
-/area/station/maintenance/southeast)
-"wXC" = (
-/obj/item/storage/toilet{
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/baroffice)
+"xaI" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/transport{
 	dir = 4
 	},
-/obj/blind_switch/area/south,
-/obj/decal/tile_edge/line/black{
-	dir = 1;
-	icon_state = "line1"
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
+"xbN" = (
+/obj/machinery/floorflusher/solitary,
+/obj/submachine/chef_sink/chem_sink{
+	pixel_y = 16
 	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/md)
-"xaS" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"xeJ" = (
-/obj/landmark/artifact,
-/turf/simulated/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/station/maintenance/southeast)
+/obj/disposalpipe/trunk/south,
+/turf/simulated/floor/black,
+/area/space)
 "xft" = (
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon1_start,
 /obj/disposalpipe/segment/bent/west,
@@ -58342,6 +58326,16 @@
 	dir = 4
 	},
 /area/station/hallway/primary/south)
+"xgz" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "xgL" = (
 /obj/stool/chair,
 /turf/simulated/floor/carpet/purple/fancy/edge/west,
@@ -58365,12 +58359,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
-"xhV" = (
-/obj/machinery/door/airlock/pyro/external{
-	name = "Auxiliary Docking Point"
-	},
-/turf/simulated/floor/caution/northsouth,
-/area/station/hallway/secondary/exit)
 "xiw" = (
 /obj/decal/cleanable/dirt,
 /obj/machinery/alarm{
@@ -58378,6 +58366,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
+"xjN" = (
+/obj/stool/chair/office/blue,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/sw,
+/area/station/bridge)
 "xkf" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -58408,44 +58411,46 @@
 /obj/landmark/halloween,
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
-"xne" = (
-/obj/machinery/power/apc/autoname_east,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
 "xnq" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating,
 /area/station/hangar/medical)
 "xoF" = (
-/obj/decal/tile_edge/line/green{
-	dir = 1;
-	icon_state = "line1"
-	},
-/obj/bookshelf/persistent,
-/turf/simulated/floor/neutral/side{
-	dir = 9
-	},
-/area/station/crew_quarters/quarters_south)
-"xuN" = (
-/obj/table/auto,
-/obj/item/storage/toolbox/electrical,
-/obj/item/device/gps,
-/obj/item/aiModule/reset,
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
-/obj/item/device/radio/intercom/medical,
-/obj/item/circuitboard/aiupload,
-/obj/item/disk/data/floppy/read_only/communications,
-/turf/simulated/floor/circuit,
-/area/station/bridge)
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
+	},
+/turf/simulated/floor/escape{
+	dir = 8
+	},
+/area/station/hallway/secondary/exit)
+"xtI" = (
+/obj/machinery/vending/snack{
+	credit = 50
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/space)
+"xuX" = (
+/obj/machinery/door_timer/solitary/new_walls/north{
+	layer = 3.1
+	},
+/obj/storage/closet/wardrobe/orange,
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -20
+	},
+/turf/simulated/floor/redblack/corner{
+	dir = 4
+	},
+/area/space)
 "xvH" = (
 /obj/machinery/vending/janitor,
 /turf/simulated/floor/darkblue,
@@ -58465,48 +58470,65 @@
 	icon_state = "catwalk_cross"
 	},
 /area/station/mining/refinery)
+"xyk" = (
+/obj/table/reinforced/bar/auto,
+/obj/machinery/computer3/generic/personal,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/grey,
+/area/station/bridge)
+"xzp" = (
+/obj/table/reinforced/auto,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/reagent_containers/food/drinks/water,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/turf/simulated/floor/grey/side{
+	dir = 4
+	},
+/area/space)
 "xzv" = (
-/obj/decal/tile_edge/line/green{
-	dir = 1;
-	icon_state = "line1"
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/neutral/corner{
-	dir = 1
-	},
-/area/station/crew_quarters/quarters_south)
-"xAb" = (
-/obj/stool/chair/office/blue{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "xAf" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
 /obj/machinery/light_switch/north,
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
 /turf/simulated/floor/engine,
 /area/station/routing/security)
-"xBW" = (
-/obj/critter/parrot/random,
-/obj/cable{
-	icon_state = "1-2"
+"xBt" = (
+/obj/disposalpipe/segment/brig{
+	dir = 8
 	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
+/turf/simulated/floor/redblack{
+	dir = 10
+	},
+/area/station/security/brig)
+"xDL" = (
+/obj/stool/chair,
+/turf/simulated/floor,
+/area/station/crew_quarters/quarters_south)
 "xES" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 4;
@@ -58522,52 +58544,76 @@
 	},
 /turf/simulated/floor/carpet/red/standard/edge/nw,
 /area/station/crew_quarters/radio/news_office)
-"xHS" = (
+"xGo" = (
+/obj/disposalpipe/segment/vertical,
 /obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
-"xHZ" = (
-/obj/machinery/door_timer/solitary/new_walls/north{
-	layer = 3.1
-	},
-/obj/storage/closet/wardrobe/orange,
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/obj/machinery/alarm{
+/obj/machinery/atmospherics/pipe/simple,
+/turf/simulated/floor/grey,
+/area/station/bridge)
+"xGS" = (
+/obj/machinery/computer/stockexchange{
 	dir = 4;
-	pixel_x = -20
+	pixel_x = -3;
+	pixel_y = 4
 	},
-/turf/simulated/floor/redblack/corner{
-	dir = 4
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/area/space)
+/turf/simulated/floor/sanitary/white,
+/area/station/bridge/captain)
+"xHn" = (
+/obj/shrub{
+	dir = 6
+	},
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
 "xIe" = (
 /obj/decal/xmas_lights/ephemeral{
 	pixel_y = 32
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
-"xIV" = (
-/obj/table/auto,
-/obj/item/decoration/ashtray,
-/obj/item/dice{
-	pixel_x = -8
+"xJg" = (
+/obj/machinery/computer/telescope{
+	dir = 8
 	},
-/obj/item/dice{
-	pixel_x = 8;
-	pixel_y = 8
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/item/coin{
-	pixel_x = -2;
-	pixel_y = 16
+/obj/machinery/power/data_terminal,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
 	},
-/turf/simulated/floor/plating,
-/area/space)
+/obj/cable,
+/turf/simulated/floor/carpet/purple/fancy/edge/east,
+/area/station/science/research_director)
+"xJF" = (
+/obj/grille/steel,
+/turf/space,
+/area/station/com_dish/comdish)
+"xKd" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/redblack{
+	dir = 4
+	},
+/area/station/security/brig)
 "xKv" = (
 /obj/lattice{
 	dir = 6;
@@ -58589,28 +58635,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
-"xLM" = (
-/obj/shrub{
-	dir = 10
-	},
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
-"xMz" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/window_blinds/cog2/middle{
-	dir = 8
-	},
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/md)
 "xMD" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -58620,13 +58644,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"xPp" = (
-/obj/machinery/light/runway_light/delay4,
-/obj/lattice{
-	icon_state = "lattice-dir"
-	},
-/turf/space,
-/area/station/ai_monitored/armory)
 "xQl" = (
 /obj/decal/tile_edge/floorguide/engineering{
 	desc = "The power transmission laser is in this direction.";
@@ -58640,32 +58657,42 @@
 /obj/machinery/atmospherics/pipe/simple,
 /turf/simulated/floor/red,
 /area/station/medical/medbay)
-"xSK" = (
-/obj/decal/tile_edge/line/green{
-	dir = 9;
-	icon_state = "line1"
+"xSb" = (
+/obj/cable{
+	icon_state = "1-2"
 	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/turf/simulated/floor/red,
+/area/station/ai_monitored/armory)
+"xSK" = (
 /obj/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
+	},
+/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon15,
 /turf/simulated/floor,
-/area/station/crew_quarters/quarters_south)
-"xTs" = (
-/obj/machinery/door/poddoor/pyro{
-	id = "dwaine_core";
-	name = "DWAINE Core Shield"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
+/area/station/hallway/secondary/exit)
 "xTH" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
+"xTV" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
 "xUw" = (
 /obj/rack,
 /obj/item/clothing/suit/armor/EOD,
@@ -58678,16 +58705,35 @@
 /obj/item/clothing/glasses/thermal,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
-"xXX" = (
-/obj/rack,
-/obj/item/clothing/suit/space/emerg,
-/obj/item/clothing/head/emerg,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/air,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/belt/utility,
-/obj/item/crowbar,
-/obj/item/device/light/flashlight,
+"xXd" = (
+/obj/table/reinforced/chemistry/auto{
+	name = "prep counter"
+	},
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/cafeteria)
+"xXy" = (
+/obj/machinery/door_timer/solitary2/new_walls/north{
+	layer = 3.1
+	},
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/redblack/corner{
+	dir = 4
+	},
+/area/space)
+"xXW" = (
+/obj/table/auto,
+/obj/random_item_spawner/tools,
+/obj/item/device/light/glowstick,
+/obj/item/device/light/glowstick,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "xZF" = (
@@ -58697,31 +58743,23 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"xZI" = (
-/obj/machinery/door/airlock/pyro/command{
-	dir = 4;
-	name = "Computer Core"
+"ybu" = (
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 8;
+	icon_state = "on";
+	on = 1
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"yet" = (
+/obj/cable{
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
-"ybu" = (
-/obj/disposalpipe/segment/vertical,
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 20
-	},
-/turf/simulated/floor/neutral/side{
-	dir = 4
-	},
-/area/station/crew_quarters/quarters_south)
-"ydF" = (
-/obj/item/extinguisher,
-/turf/simulated/floor/carpet/green/fancy/edge/nw,
-/area/station/crew_quarters/quarters_south)
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
 "yfk" = (
 /obj/disposalpipe/segment/bent/west,
 /turf/simulated/floor/grey/blackgrime,
@@ -58735,6 +58773,16 @@
 "ygw" = (
 /turf/simulated/floor/black,
 /area/station/bridge)
+"ygI" = (
+/obj/disposalpipe/segment/vertical,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 20
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/crew_quarters/quarters_south)
 "yhe" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -58744,19 +58792,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"yhW" = (
-/obj/stool/chair/office/blue{
-	dir = 4
+"yki" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/landmark/start{
-	name = "Head of Personnel"
+/obj/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet/green/fancy/edge/south,
-/area/station/bridge/hos)
-"yiB" = (
-/obj/reagent_dispensers/fueltank,
+/obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/space)
+/area/station/maintenance/southeast)
+"ylL" = (
+/obj/lattice{
+	dir = 5;
+	icon_state = "lattice-dir-b"
+	},
+/obj/machinery/light/runway_light,
+/turf/space,
+/area/station/ai_monitored/armory)
 "ylQ" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
@@ -106331,7 +106386,7 @@ pCp
 pCp
 aBi
 ylQ
-aNq
+aNr
 pCp
 hbu
 dlp
@@ -106633,7 +106688,7 @@ azZ
 hbu
 azZ
 mHX
-aNq
+aNr
 pCp
 aBi
 aBj
@@ -106942,7 +106997,7 @@ aaa
 aaa
 aaa
 ach
-aON
+aaW
 aaS
 aaZ
 aaS
@@ -106959,7 +107014,7 @@ aaS
 aaS
 aaS
 aaS
-aaW
+chb
 abk
 aeV
 aeV
@@ -107261,7 +107316,7 @@ aaa
 aci
 aaa
 aaa
-aaO
+aaQ
 abl
 aad
 aad
@@ -107559,12 +107614,12 @@ aci
 aaa
 aaa
 aIX
-bNs
+bPp
 acO
 aaa
 aaa
-aaa
-abl
+chk
+fwt
 aaa
 aaa
 aaa
@@ -107861,7 +107916,7 @@ aci
 aaa
 aaa
 ach
-bNQ
+bQx
 aCr
 aTJ
 aTJ
@@ -108152,7 +108207,7 @@ aaS
 aaS
 aaS
 aaS
-baU
+bcb
 acO
 aaa
 aaa
@@ -108163,7 +108218,7 @@ aci
 aaa
 aaa
 ach
-bNQ
+bQx
 aTJ
 imf
 baR
@@ -108450,7 +108505,7 @@ aCh
 diS
 aGA
 aCh
-aUd
+aTN
 aHC
 aKG
 aCh
@@ -108465,7 +108520,7 @@ acO
 aaa
 aaa
 ach
-bOV
+bQz
 aTJ
 bwJ
 aJB
@@ -108750,9 +108805,9 @@ aAb
 aDq
 aCh
 aFt
-aRc
+aQX
 aCh
-aUt
+aUd
 aVp
 aXf
 aLN
@@ -108769,8 +108824,8 @@ aaa
 ach
 hCK
 aCr
-bUk
-baS
+bVR
+baV
 bca
 bdk
 beh
@@ -109053,9 +109108,9 @@ aDr
 aEs
 aFu
 aGB
-aSw
-aUx
-aSw
+aSk
+aUt
+aSk
 aXg
 aCh
 aaQ
@@ -109071,7 +109126,7 @@ abZ
 aaf
 aad
 aTJ
-eiE
+aZC
 aJB
 bca
 bdl
@@ -109363,7 +109418,7 @@ aCh
 aaQ
 aaf
 abZ
-bkf
+bkB
 abZ
 abZ
 abZ
@@ -109373,8 +109428,8 @@ aaa
 aci
 aaa
 aTJ
-eiE
-aJB
+aZC
+baV
 bca
 bdm
 bej
@@ -109657,9 +109712,9 @@ aDt
 auT
 aFs
 aGD
-aSS
+aSw
 aHD
-aSS
+aSw
 aXh
 aCg
 aaQ
@@ -109676,7 +109731,7 @@ aTJ
 aTJ
 aCr
 bwJ
-bUF
+cak
 bca
 bca
 bca
@@ -109963,7 +110018,7 @@ aHD
 aHD
 aHD
 aHD
-aYY
+aYZ
 aaQ
 acO
 aaa
@@ -109975,16 +110030,16 @@ aTJ
 aUu
 aVq
 aWG
-bOX
-eiE
+bQC
+aZC
 aZE
-aJB
+baV
 bca
-chx
+fyL
 bek
 bfr
 bca
-nVE
+sRA
 biV
 bkq
 bly
@@ -110256,8 +110311,8 @@ ayk
 aHW
 aIT
 aJV
-aLM
-aNr
+aLS
+aNC
 aOO
 aFw
 aGE
@@ -110265,7 +110320,7 @@ aHD
 aHD
 aHD
 aHD
-aYY
+aYZ
 aaQ
 acO
 aaa
@@ -110274,10 +110329,10 @@ aaa
 aaa
 aaa
 aTJ
-eiE
-bEC
+byK
+bFU
 aWH
-bOY
+bQO
 aYF
 aZF
 baW
@@ -110561,7 +110616,7 @@ aAf
 aCn
 aDv
 auT
-aPP
+aPM
 aGF
 aHD
 aUA
@@ -110577,16 +110632,16 @@ aaa
 aaa
 aTJ
 bwJ
-bED
-aYG
-aYG
+bFV
+aMV
+aMV
 aYG
 aZG
 baX
 bca
-cnR
+fIF
 bem
-iDR
+mJy
 bca
 coQ
 biX
@@ -111172,13 +111227,13 @@ aIA
 aIA
 aXN
 aCh
-baV
+bcd
 aNS
-bgz
-bks
+bie
+bkL
 aQP
-brf
-btS
+bsl
+buQ
 aNS
 aUw
 fld
@@ -111186,11 +111241,11 @@ aWJ
 aXL
 aYH
 aZI
-bUG
+cbU
 bce
 aXL
 beo
-iWw
+mKe
 biY
 biY
 biY
@@ -111476,13 +111531,13 @@ aKJ
 aCh
 bwJ
 aNS
-bgA
-bku
+biL
+bkO
 aMS
 aRV
 aSW
 aNS
-eiE
+aZC
 fld
 aWK
 aXL
@@ -111493,13 +111548,13 @@ bcf
 bdo
 bep
 bfu
-blD
-blD
-blD
+bgF
+bgF
+bgF
 bft
-blD
+wSK
 bmQ
-boo
+bor
 bpz
 bqJ
 jvK
@@ -111516,11 +111571,11 @@ iQf
 iof
 bGA
 bGK
-vmX
+bIl
 bIh
 bLb
 bIh
-bGF
+bNp
 bFK
 bQn
 bRD
@@ -111766,8 +111821,8 @@ aGI
 azo
 aAj
 auW
-aLS
-aNC
+aLT
+aNV
 aCh
 aCh
 aCh
@@ -111784,7 +111839,7 @@ aQQ
 aRW
 aSX
 aNS
-bxB
+bzM
 fld
 aWL
 aXL
@@ -111795,9 +111850,9 @@ bcg
 aXL
 beq
 bft
-blD
-blD
-blD
+bgE
+bgF
+bgF
 bft
 blD
 bmR
@@ -111817,22 +111872,22 @@ bCC
 bDA
 bEv
 bGA
-mKt
-vmX
+lCE
+bIl
 bIh
 bMj
-ezo
-cuf
-kBO
+npm
+iVf
+eBr
 bQo
 bRE
 bTi
 bFK
-cot
+bVD
 bWF
 bXv
 bYy
-bZl
+tdx
 cbR
 caV
 cbR
@@ -112071,33 +112126,33 @@ auW
 aCs
 aDz
 aOP
-aPS
-aRd
-aST
+aPP
+aRc
+aSS
 aUE
 aJA
 aCt
 bwJ
 bwJ
 aNS
-bgC
-bkv
-bnp
+bjb
+bkQ
+bpF
 aRX
-btU
+buS
 aNS
-bxF
-bEG
+bAC
+bFW
 aCr
 aXL
 aXL
-bUm
-bVR
+bVT
+cca
 aXL
 aXL
 ber
 bft
-blD
+bgF
 bhP
 biZ
 bft
@@ -112124,8 +112179,8 @@ vmX
 bIh
 bIh
 bIh
-bGF
-tIt
+bNq
+bFK
 bQp
 yfk
 bTj
@@ -112372,10 +112427,10 @@ aAl
 auW
 nmT
 aDA
-aOT
+eiE
 aFA
-aRe
-aSU
+aRd
+aST
 aCr
 aCr
 aCr
@@ -112388,7 +112443,7 @@ aQR
 aNS
 aNS
 aNS
-byr
+bAN
 aVv
 biQ
 aXL
@@ -112397,22 +112452,22 @@ bbb
 bbb
 bch
 aXL
-fqj
+iWw
+bft
+bgF
+tbT
+frd
 bft
 blD
-our
-tCI
-bft
-blD
-peY
+gml
 boo
 pUl
 bqM
 bqM
-btz
-btz
-btz
-bpC
+bqM
+bqM
+bqM
+bqM
 bqM
 bqM
 bpC
@@ -112420,14 +112475,14 @@ boq
 mCg
 bDA
 bEv
-hjl
+glg
 soA
 bGM
-lyf
-paK
-qHS
+giq
+gvE
+vjQ
 bNr
-bFK
+dru
 bQq
 bRF
 bTk
@@ -112449,10 +112504,10 @@ aaa
 aaa
 aaa
 aaa
-jTb
-jTb
-jTb
-jTb
+fng
+fng
+fng
+fng
 aaa
 aaa
 aaa
@@ -112672,54 +112727,54 @@ ayr
 azr
 aIU
 auW
-aLT
-aNV
-aOY
-aPT
-aRf
-aSV
+aLX
+aNW
+aOT
+aPS
+aRe
+aSU
 aCr
 aVr
-aYG
-aYG
-aYG
-aYG
-aYG
-aYG
+aMV
+aMV
+aMV
+aMV
+aMV
+aMV
 aQS
 aRZ
-btX
-bvT
+bva
+bwl
 aUy
 aVw
 aWN
 aXL
 aYL
 aZM
-bVT
+ccO
 bUy
 bdp
 bes
-bkw
-blE
-blE
-blE
+bfy
+bhQ
+bhQ
+bhQ
 bkw
 blE
 bmT
-wBz
+boo
 kSb
 bqM
 bqM
-bqM
-bqM
-bqM
+nbH
+nbH
+nbH
 pJk
 bqM
 bqM
 bpC
 boq
-mCg
+bCz
 fGA
 bEB
 bFR
@@ -112727,7 +112782,7 @@ bFR
 bFR
 bFR
 bFR
-bFR
+bIm
 bFR
 bFK
 bFK
@@ -112751,11 +112806,11 @@ aaa
 aaa
 aaa
 aaa
-jTb
-pWQ
-nld
-jTb
-xHZ
+fng
+lGX
+hnv
+fng
+xuX
 aaa
 aaa
 aaa
@@ -112986,26 +113041,26 @@ aYF
 aYF
 aMW
 aYF
-bhZ
+bjc
 aYF
-bnt
-brg
-btY
+bpG
+bsm
+bvb
 aCr
-eiE
-bFP
-bHb
-bOZ
-bRR
+aZC
+bFX
+bLk
+bRp
+bTz
 aZN
-bVU
+ccQ
 bci
 aXL
 bdq
 bfz
 bhR
 bhR
-tYP
+ifA
 bkx
 blF
 bmU
@@ -113013,10 +113068,10 @@ boo
 bpD
 bqM
 bqM
-bpC
-bpC
-bpC
-bpC
+bqM
+bvR
+rOU
+nbH
 bqM
 bqM
 bpC
@@ -113028,13 +113083,13 @@ bFO
 bGO
 bIn
 bJM
-bMo
+bLc
 bMo
 bNt
 bFK
 bQr
 bRS
-cAN
+xBt
 bUl
 cot
 cou
@@ -113053,11 +113108,11 @@ aaa
 aaa
 aaa
 aaa
-jTb
-nVh
-qcD
-fzc
-hIt
+fng
+xbN
+pdh
+rGW
+syz
 aaa
 aaa
 aaa
@@ -113304,10 +113359,10 @@ bhT
 bhT
 bhT
 bet
-jsl
-mKe
+mLt
+pfT
 bhS
-uMr
+rWz
 bky
 bft
 bmV
@@ -113315,15 +113370,15 @@ boo
 boo
 bqM
 bqM
-bqM
+nbH
 rOU
+bvR
 bqM
 bqM
-bqM
-dgp
+dqX
 boq
 boq
-bCF
+bCz
 bDA
 bEv
 bFO
@@ -113338,7 +113393,7 @@ bQs
 bRH
 bTl
 bFK
-cot
+bVD
 cou
 bXz
 bFK
@@ -113355,11 +113410,11 @@ aaa
 aaa
 aaa
 aaa
-jTb
-cyS
-fVL
-eyl
-uIb
+fng
+nFT
+uIT
+dVv
+oJe
 aaa
 aaa
 aaa
@@ -113579,11 +113634,11 @@ azu
 aAo
 auW
 aCw
-aNW
-eiE
+aOb
+aZC
 aZE
-eiE
-eiE
+aZC
+aZC
 bwJ
 aJB
 bwJ
@@ -113595,15 +113650,15 @@ aLQ
 aQV
 aSb
 aTa
-bvV
+bwn
 aLQ
 bpB
 pqx
 nbR
 bhT
 aZP
-bWU
-cdF
+ccR
+chl
 bhT
 bhT
 bfA
@@ -113617,10 +113672,10 @@ bja
 pUl
 bqM
 bqM
-bpC
-bpC
-bpC
-bpC
+bqM
+nbH
+nbH
+nbH
 bqM
 bqM
 bpC
@@ -113646,7 +113701,7 @@ bXA
 bFK
 bZp
 xKL
-pVs
+mJA
 aaa
 aaa
 aaa
@@ -113657,11 +113712,11 @@ aaa
 aaa
 aaa
 aaa
-jTb
-jTb
-jIL
-jbW
-nBv
+fng
+fng
+xtI
+dPl
+rHM
 aaa
 aaa
 aaa
@@ -113890,31 +113945,31 @@ aCr
 aJB
 bwJ
 aLQ
-baY
+bcm
 aLQ
-baY
+bcm
 aLQ
 bhI
 aSd
 mzX
 aQT
-bys
+bCE
 coV
 aXP
 aXP
-bSd
+bTA
 fje
 fje
 bck
-cnS
-fwt
+fIG
+jsl
 bfB
 bgH
-oIX
+tmx
 bja
-mqh
-oif
-ctQ
+kXB
+wYY
+kzS
 bja
 bpC
 bqM
@@ -113928,17 +113983,17 @@ bqM
 bpC
 boq
 rve
-oux
+qLK
 bEF
-jIB
+vJt
 bGR
 bIp
-sUq
+jtF
 bLe
 bMq
 bNv
 bFK
-qYF
+gdl
 bRJ
 bWL
 bFK
@@ -113959,11 +114014,11 @@ aaa
 aaa
 aaa
 aaa
-jTb
-nhA
-tkb
-sLi
-uIb
+fng
+wpG
+pJd
+opQ
+oJe
 aaa
 aaa
 aaa
@@ -114191,11 +114246,11 @@ aaf
 aCr
 aVH
 bwJ
-aYZ
+aZb
 aOR
-bdA
+bfx
 aOR
-bkz
+blp
 aQT
 aSd
 mzX
@@ -114207,12 +114262,12 @@ aUz
 aUz
 ehh
 fje
-ceF
+chx
 bds
 bds
 bfC
 fje
-pfT
+tCI
 bja
 bkA
 blI
@@ -114229,23 +114284,23 @@ bqM
 bqM
 bpC
 boq
-wok
+iMj
 bDF
-oku
-rUl
+owz
+jTK
 lCw
 bGP
 bGP
 bNw
 ceq
 ceq
-vqg
+hwO
 bQv
 bRK
-sDW
+eFY
 bUp
 bVG
-bWM
+bWN
 bXC
 iNr
 bZr
@@ -114261,11 +114316,11 @@ aaa
 aaa
 aaa
 aaa
-jTb
-mwE
-qcD
-vyN
-hIt
+fng
+nwb
+pdh
+tmS
+syz
 aaa
 aaa
 aaa
@@ -114484,7 +114539,7 @@ aXq
 aXr
 bdg
 aBr
-aLX
+aMI
 aDB
 acO
 aaa
@@ -114496,33 +114551,33 @@ aID
 aLQ
 aNa
 aNU
-bia
+bjp
 aLQ
-bor
+bpH
 aSe
-buP
+bvd
 aQT
 aIY
 aVz
-bHX
+bLl
 aXR
 aUz
 aZS
 fje
-ceL
+cnR
 fje
 bew
 fje
 fje
-ppQ
+tIt
 bja
-iwK
+iOb
 blI
-ecp
+lXB
 bja
-mEM
+nLk
 bqQ
-gIp
+gKH
 bpC
 buR
 bvU
@@ -114531,7 +114586,7 @@ byt
 mCe
 jJT
 boq
-jUz
+mgL
 bDA
 bEv
 bFO
@@ -114550,24 +114605,24 @@ bVG
 bWN
 bXD
 iCf
-oQU
+gxa
 cpn
 caY
 kjx
 acZ
 add
-hkZ
-hmd
-dwp
-dop
-vwf
-hkZ
+gfw
+kxP
+sRD
+qin
+lrs
+gfw
 aaa
-jTb
-mpU
-tQT
-jTb
-rWi
+fng
+sWL
+xzp
+fng
+xXy
 aaa
 aaa
 aaa
@@ -114794,35 +114849,35 @@ aaa
 ach
 aCr
 aJB
-eiE
+aZC
 aLQ
 aNb
 aOR
 aOS
 aLQ
 aQY
-brh
+bsv
 aTc
 aQT
 aIY
-bFQ
+bFZ
 aWS
-bPa
+bRM
 aUz
 aZT
 fje
-ceL
+cnR
 bdt
-fyL
+jvp
 bfE
 fje
-pry
+tYP
 bja
-szZ
+sAj
 blI
 bmY
 bja
-tMr
+otF
 bqR
 bsg
 bsg
@@ -114863,12 +114918,12 @@ cbZ
 cbZ
 cbZ
 cbZ
-ocE
+sBH
 hgl
-jTb
-jTb
-jTb
-jTb
+fng
+fng
+fng
+fng
 aaa
 aaa
 aaa
@@ -115099,11 +115154,11 @@ aJB
 aKN
 aLQ
 aLQ
-ben
+bfN
 aLQ
 aLQ
 aQZ
-bsf
+btz
 aTc
 aQT
 aIY
@@ -115111,10 +115166,10 @@ aVA
 aWS
 aXS
 aUz
-bUn
-bXL
-cfr
-bUn
+bVU
+cdE
+cnS
+bVU
 bev
 jry
 bgJ
@@ -115146,12 +115201,12 @@ bGP
 bGP
 bGP
 bFK
-hEI
-erR
-kQK
+qvM
+shG
+mTo
 bUs
 bVI
-bWN
+eBR
 bXF
 bYy
 fVZ
@@ -115390,7 +115445,7 @@ aHb
 aHb
 aAr
 djG
-aMI
+aMP
 auZ
 aaf
 aay
@@ -115400,15 +115455,15 @@ aCr
 aJB
 aWL
 aLQ
-bbq
+bcn
 aNU
-bie
+bju
 aLQ
 oHK
 aSf
 aRa
-bvW
-byu
+bwp
+bCL
 aVB
 aWR
 flj
@@ -115418,15 +115473,15 @@ bgO
 bcl
 bey
 bev
-jvp
+mPi
 bgK
 whk
-vej
-mjV
+omK
+xXd
 blK
 bna
-maq
-lfp
+hvH
+uoV
 bqS
 bsg
 btG
@@ -115719,7 +115774,7 @@ aZV
 bgO
 bcl
 blO
-fIF
+jOn
 whk
 whk
 whk
@@ -115729,14 +115784,14 @@ blL
 whk
 bot
 whk
-igX
+tsA
 bsg
 btH
 buV
-uXz
+tHB
 bxl
-sHz
-jSr
+hQi
+frJ
 bAE
 bBx
 rPh
@@ -115752,7 +115807,7 @@ bNA
 bFK
 bFK
 bFK
-rlR
+nop
 bUu
 bVK
 bWP
@@ -115995,7 +116050,7 @@ aAs
 aAs
 aKF
 aCA
-aOb
+aOc
 bDr
 bDr
 bDr
@@ -116006,9 +116061,9 @@ dqk
 aLQ
 aNe
 aNU
-biL
+bjv
 aLQ
-bos
+bpN
 mzX
 mzX
 aTO
@@ -116022,12 +116077,12 @@ bgO
 bcl
 bdu
 bev
-jOn
+ncP
 bjd
 bjd
 bjd
 bjd
-nxA
+mpV
 bnc
 whk
 whk
@@ -116035,16 +116090,16 @@ bqT
 bsg
 btI
 buW
-qKA
+hHm
 qeG
-meJ
-qjU
+fTs
+mXi
 bAE
 bBy
 bCI
 bDA
-bEB
-lwK
+bEv
+ifo
 bGX
 bIv
 bJS
@@ -116054,7 +116109,7 @@ bNB
 bFK
 bQA
 bRP
-fCO
+eFc
 bUv
 bVL
 bWR
@@ -116310,10 +116365,10 @@ aNe
 aNU
 aLU
 aLQ
-boG
+bqN
 mzX
 aTd
-bwh
+bxf
 aUC
 aVE
 aWU
@@ -116325,42 +116380,42 @@ bcl
 blO
 bex
 bfF
-mLt
-pAA
+ppQ
+uMr
 bje
 bkC
-oMM
+nog
 bnd
-pAA
-hdO
+uMr
+eFC
 bev
 bsg
-hSC
+hlR
 buX
 bvZ
 bxn
-cLJ
+lhA
 bzw
-wtI
+jqc
 bBz
 bCJ
 bDA
 bEv
 bLh
-uat
+qyf
 bIx
-eVv
+bJU
 bFK
 bFK
 bNC
 bFK
 bQB
 bRQ
-vFr
-tGG
+kBW
+kgz
 bVM
-bWR
-nCN
+uBL
+bXG
 bFK
 oUn
 cba
@@ -116599,23 +116654,23 @@ avf
 aAu
 aKH
 avf
-aOc
+aOd
 aEz
 aEz
-aRg
+aRf
 aEz
 aUF
 aVK
 aXO
 aLQ
 aLQ
-beH
+bfR
 aLQ
 aLQ
-bpE
-bsh
+bqO
+btB
 aUD
-bpE
+bqO
 aUD
 aVF
 aWV
@@ -116638,14 +116693,14 @@ bpI
 bqU
 bev
 btK
-eMY
+wWn
 cpF
 cpG
 cpJ
-sfk
+pLB
 cpK
 bBA
-mcT
+fae
 bDJ
 bEE
 bFR
@@ -116660,21 +116715,21 @@ bFK
 bFK
 bFK
 bFK
-oVW
+hlG
 bWR
 bXJ
 bYy
 xhb
 cbY
 cba
-nSQ
-sTZ
-kjT
-oqM
-gEo
+sye
+uLK
+yet
+lGK
+fMd
 cba
 cba
-emL
+plK
 cbZ
 eGO
 abX
@@ -116909,7 +116964,7 @@ aCF
 aIJ
 aWF
 aKR
-aZb
+aZc
 aNg
 aTe
 aTe
@@ -116920,7 +116975,7 @@ aTe
 aTe
 aTe
 aVG
-bIm
+bMh
 aUP
 aYQ
 dvx
@@ -116935,50 +116990,50 @@ dvx
 dvx
 blN
 bnf
-qoT
-qoT
-qoT
-pwT
+tLy
+tLy
+tLy
+hEO
 cpL
-epm
+faL
 cpL
 cpH
 cpL
 cpL
 cpL
 bBB
-tnT
+omo
 bnT
 bEF
-jSH
+rSk
 bGZ
 bIy
 bJU
 bLj
-qYF
+gdl
 bNE
 bPc
 bRS
 bRS
-bPc
+bRS
 qzV
 bVN
 gRo
 npx
-kqA
-fku
-uvm
-fts
-xHS
-gFT
-gYK
-gWl
-loS
-mrc
-lIL
-kUT
-sVD
-uWt
+bmD
+xSb
+vVB
+smE
+dqI
+lOS
+sOW
+dHu
+eAc
+nDe
+isy
+vST
+qPg
+qMC
 aaf
 aaf
 agm
@@ -117204,10 +117259,10 @@ aAw
 atr
 aCD
 aCF
-aOZ
+aOY
 aGL
-aRh
-aSY
+aRg
+aSV
 aIJ
 aWI
 aKS
@@ -117215,34 +117270,34 @@ aLW
 aNh
 aNY
 aNY
-bkB
+blq
 aNY
 aWW
 aNY
-bwj
+bxg
 aNY
-bFS
-bJK
+bGj
+bMm
 aXY
 bex
-bUq
+bWU
 blO
-cft
 cos
+fTm
 blO
 blO
 bgN
-rMk
+vej
 bjh
 blO
 blO
 bnj
 gQG
-mpB
+jFM
 bqV
 bsj
 cpM
-cVH
+gGi
 cpM
 cpI
 cpM
@@ -117257,24 +117312,24 @@ bHa
 bIz
 bJV
 bFK
-sQf
+kcU
 bRT
 bRT
 bRT
 bRT
-bRT
+xKd
 bgS
-weu
-ikL
+vEJ
+fsd
 bXK
-wfM
-iUJ
+jzY
+xaI
 cal
 cba
 cbW
-wmS
-xHS
-gJp
+qCD
+dqI
+uLo
 xUw
 cba
 cba
@@ -117504,7 +117559,7 @@ nmy
 avi
 aJw
 atr
-aMP
+aMX
 aCF
 aEB
 aFE
@@ -117519,13 +117574,13 @@ aTP
 aTP
 ocX
 aTP
-bsi
-buQ
+btC
+bve
 aTP
-byC
-bFU
-bJL
-bPb
+bCM
+bGN
+bMn
+bRO
 bsk
 fpD
 fpD
@@ -117538,7 +117593,7 @@ fpD
 aZR
 bkE
 fpD
-cTe
+sBU
 bow
 fpD
 fpD
@@ -117546,11 +117601,11 @@ bsk
 btJ
 buY
 byz
-txg
+wKU
 byz
 bzz
 byz
-tMJ
+dhW
 bCK
 btJ
 bEH
@@ -117566,18 +117621,18 @@ bQF
 bRU
 bTp
 bFK
-qCo
+pfU
 bFK
 bFK
 bFK
-dxW
+hHt
 cba
 cba
 ppd
-snw
-myW
-kZM
-qQT
+suG
+qwj
+uDX
+lVA
 cba
 cba
 cbZ
@@ -117806,7 +117861,7 @@ nmy
 avi
 aJx
 atr
-aMP
+aMX
 aCF
 aEC
 aEC
@@ -117824,25 +117879,25 @@ aKQ
 aKQ
 aKQ
 aKQ
-byK
-bFV
-bJW
-bPo
+bCV
+bHb
+bMx
+bRR
 bex
 bab
-bXM
-cfu
+cdF
 czr
+gda
 beB
 ivS
 bgO
 bhX
 bji
-rzx
+eZj
 blP
 bng
 aZZ
-mvc
+dLW
 bqX
 bev
 btN
@@ -117861,7 +117916,7 @@ bHg
 bID
 bKb
 bLr
-dgw
+uaz
 bNH
 bPf
 bQG
@@ -117873,7 +117928,7 @@ tan
 ozl
 tan
 caX
-fCh
+giF
 cba
 cba
 cba
@@ -118118,11 +118173,11 @@ aGM
 aCF
 aKV
 aLY
-bbz
-bfv
-bjb
-bkL
-bpF
+bco
+bfX
+bjw
+bme
+bqP
 aSh
 aTQ
 aKQ
@@ -118134,16 +118189,16 @@ aYT
 bac
 bbi
 bcq
-daF
-fIG
+ggG
 kmG
-mPi
+njl
+pry
 blO
 bjj
 bjj
-cRS
+pOi
 bni
-kmG
+njl
 bpJ
 bpJ
 bpJ
@@ -118151,7 +118206,7 @@ bpJ
 bpJ
 bwf
 bxs
-kQP
+mHQ
 bzB
 cpE
 bBE
@@ -118169,10 +118224,10 @@ bPg
 bQH
 bRW
 bTp
-pDx
+fao
 bVP
-fhi
-cyZ
+uSI
+dNp
 tan
 fVZ
 cbZ
@@ -118410,10 +118465,10 @@ aHB
 avj
 aAy
 atr
-aMX
+aNf
 aCF
 aCF
-aPV
+aPT
 aCF
 aCF
 aCF
@@ -118426,12 +118481,12 @@ aOV
 aOV
 aOV
 aOV
-buS
+bvh
 aTQ
-bzM
+bDI
 aVJ
 aNY
-bPp
+bSd
 aYR
 aYS
 aYS
@@ -118447,12 +118502,12 @@ blR
 bni
 boy
 bpJ
-qdB
-dVW
-haL
+xGS
+urf
+pHf
 bpJ
-jAa
-cvn
+cHp
+bwv
 cpB
 cpC
 cpN
@@ -118463,8 +118518,8 @@ bEJ
 bFT
 bHd
 bDR
-yhW
-kht
+gbd
+fuw
 bFT
 bNJ
 bPh
@@ -118474,19 +118529,19 @@ bTp
 bUA
 bfO
 tan
-ijH
+hCu
 tan
 aTu
 emI
 vEx
 vEx
-fCh
-fCh
-fCh
-mOV
-fCh
+giF
+giF
+giF
+iRU
+giF
 emI
-nty
+tXg
 emI
 wOE
 aaa
@@ -118714,7 +118769,7 @@ aDn
 atr
 aCD
 aCF
-aPE
+aOZ
 aGO
 aGN
 aHM
@@ -118722,7 +118777,7 @@ aIM
 aCF
 trU
 aTi
-bcb
+bcC
 aOa
 aOX
 aPR
@@ -118736,7 +118791,7 @@ aNY
 aXX
 aYS
 bae
-bYz
+ceF
 bcr
 aYS
 beD
@@ -118766,11 +118821,11 @@ bFT
 bHe
 bIB
 bJZ
-nWS
+hZZ
 bFT
 bNK
 bPi
-nrt
+jUm
 bRY
 bTp
 bUB
@@ -119015,7 +119070,7 @@ axz
 atr
 atr
 atr
-aOd
+aOe
 aGO
 aGO
 aGO
@@ -119024,8 +119079,8 @@ aIN
 aJJ
 aKU
 aLZ
-bcd
-bfw
+bcD
+bfY
 aOV
 aOV
 aOV
@@ -119044,7 +119099,7 @@ aYS
 beE
 bfM
 bgR
-shz
+viV
 bjm
 box
 blS
@@ -119059,15 +119114,15 @@ bwg
 bxu
 snN
 bzE
-fyU
+lXs
 bBG
-dzP
+omZ
 bDQ
 bEL
 bFT
 bHf
 bIC
-vow
+dKZ
 bLp
 bFT
 bNL
@@ -119075,12 +119130,12 @@ nBP
 bPj
 bRZ
 bTp
-plB
+lvC
 bfO
 bDX
-psr
-wOq
-jsd
+iti
+kdN
+pCH
 cbZ
 cbZ
 seS
@@ -119091,8 +119146,8 @@ cbZ
 cbZ
 cbZ
 cbZ
-mQm
-vQz
+hyi
+ylL
 aaa
 aaa
 aaa
@@ -119316,10 +119371,10 @@ azx
 azx
 aAA
 aBw
-aNf
+aNm
 aCF
 aEF
-aQg
+aPV
 aGP
 aHO
 aUG
@@ -119336,11 +119391,11 @@ aOV
 cEO
 aKQ
 owM
-bLi
+bMy
 aXX
-bSV
+bUk
 bcs
-cak
+ceL
 bct
 aYR
 aYR
@@ -119357,18 +119412,18 @@ brb
 bsp
 btR
 bpJ
-lHO
+flq
 bxv
 snN
 bzF
 bAL
-srN
-eFY
+xyk
+eJU
 ygw
 ygw
 bFY
-qWo
-cTh
+rUm
+uuN
 bKa
 bLq
 bMw
@@ -119382,18 +119437,18 @@ bVQ
 bDX
 bnq
 bnq
-xPp
-nOe
-cJT
-pTj
-cEY
-vwf
-nOe
-dwp
-fNP
-qDV
-vwf
-ovS
+vfR
+oZb
+pJs
+dpI
+cyz
+lrs
+oZb
+sRD
+oNB
+emW
+lrs
+jdg
 aaa
 aaa
 aaa
@@ -119628,7 +119683,7 @@ aFF
 aWX
 aLY
 aMc
-bcm
+bcE
 aOa
 aOV
 aOV
@@ -119646,14 +119701,14 @@ bbk
 bct
 aYR
 beF
-kBY
+nql
 lJE
 bhY
-viV
-tzy
+rJJ
+rmZ
 blU
-tOW
-kOY
+lCD
+gmE
 bpJ
 bpJ
 bpJ
@@ -119663,23 +119718,23 @@ bpJ
 bpJ
 byE
 bBH
-mSF
+ihR
 bCP
 bDS
 bEN
 bHc
-sLp
+lFW
 bHP
 bJX
 ygw
 cds
 bMw
-ssW
-qPS
-mER
-nSx
+vzY
+hRB
+dLg
+xjN
 bTu
-gHa
+gBx
 bfO
 bDX
 bPs
@@ -119919,7 +119974,7 @@ azz
 azz
 azz
 aAB
-aKM
+aKZ
 aCF
 aCG
 aGO
@@ -119931,9 +119986,9 @@ aFF
 aKY
 aMc
 aTi
-bfx
+bgy
 aTh
-bkO
+bmO
 aTh
 aTh
 aTh
@@ -119951,16 +120006,16 @@ beG
 bfP
 bgT
 bhY
-vos
+hVJ
 bkI
 blV
 bnm
-jyQ
+geh
 bpK
 brd
 bsq
 btT
-gbI
+tdF
 bpK
 bxx
 byF
@@ -119970,18 +120025,18 @@ bBI
 bCQ
 bDT
 bEO
-sxo
+pWV
 bHh
 bIE
 bLs
 bLs
-uZC
+uKc
 bNN
 bQK
 bQK
 bSb
 bTv
-rGa
+vnJ
 bfO
 bDX
 bPs
@@ -120221,23 +120276,23 @@ azA
 aHF
 azA
 aJz
-aKZ
+aLa
 aCF
 aCF
 aCF
 aFF
 aGR
-aSZ
+aSY
 aIP
 aWY
 aKU
 aMd
 aKU
 aKU
-bjc
+bjy
 aKU
 aKU
-bsl
+btD
 aTi
 aTU
 aUH
@@ -120249,7 +120304,7 @@ bai
 bbm
 bcv
 aYR
-fTm
+kBY
 bfQ
 bgU
 bhY
@@ -120259,10 +120314,10 @@ blW
 bnn
 boB
 bpK
-xuN
+myO
 bsr
-kKU
-uYB
+uzF
+xGo
 bwi
 bxy
 byG
@@ -120272,15 +120327,15 @@ bBJ
 bCR
 bDU
 bEP
-oXP
+eOD
 bHi
 bIF
 ygw
 bLt
 bMw
 bNO
-cLc
-nsT
+kui
+pEy
 bSc
 bTw
 bpK
@@ -120523,9 +120578,9 @@ atr
 atr
 aBw
 awy
-aLa
+aLf
 asj
-aOe
+aOo
 aEJ
 aFF
 aIR
@@ -120539,7 +120594,7 @@ aNn
 aNn
 aPU
 aLY
-bsm
+btE
 aTj
 aTV
 aKQ
@@ -120552,7 +120607,7 @@ aYR
 aYR
 aYR
 aYR
-kHZ
+ntn
 aYR
 bhY
 bjo
@@ -120564,29 +120619,29 @@ bpK
 bpL
 bss
 tCk
-cqq
+nZi
 bpK
 bxz
 byH
 bzI
-iVK
+vTv
 cds
 cds
 bIG
 bEQ
-jOS
+htE
 ygw
 bIG
 bKe
 bLu
 bMw
 bNP
-kTM
+dNN
 bQM
-vqo
-dnz
-sbQ
-jlz
+eBf
+jHu
+sMb
+iGX
 bDX
 bnq
 fYL
@@ -120825,10 +120880,10 @@ asj
 aHG
 aBx
 aJD
-aLf
+aLM
 asj
-aOo
-aPF
+aOs
+aPE
 aFF
 aIR
 aHR
@@ -120837,23 +120892,23 @@ aFF
 aCF
 dWT
 aCF
-bfN
-bjp
-bkQ
-bpG
+bgz
+bjC
+bmW
+bqY
 aCF
 aCF
 aCF
-bAC
+bDK
 aVL
 aNY
 aYd
-bTq
+bUm
 baj
 bbn
 bcw
 bdB
-gda
+kHZ
 bfO
 les
 bhY
@@ -120865,7 +120920,7 @@ bhY
 bpK
 bpM
 bst
-luT
+gLn
 bvc
 bvc
 bxA
@@ -120886,15 +120941,15 @@ bHl
 bHl
 bHl
 bHl
-xZI
+qTb
 bHl
 bfO
 bDX
 bnq
 bYB
-mWO
-mWO
-mWO
+hGk
+hGk
+hGk
 fYL
 acO
 aaa
@@ -121130,46 +121185,46 @@ asj
 asj
 asj
 aHa
-aPG
+aPF
 aFF
 aGU
-aTf
+aSZ
 aUI
 aFF
 aXU
-aZc
+aZd
 aCF
 aCF
 aCF
 aCF
 aCF
 aCF
-bva
+bvm
 aTW
 ojD
 aVM
-bLk
-bQx
-bTr
+bMz
+bSV
+bUn
 bak
 bbo
 bcx
 bdC
-ggG
+lhD
 bfS
 bjq
 bjq
 bjq
 bkM
 blZ
-dtX
+bvy
 les
 bpK
-oBX
+sjG
 bst
-jxC
+hHD
 bvc
-hnQ
+jDt
 bxL
 byJ
 bzK
@@ -121177,20 +121232,20 @@ bAM
 bBM
 bCU
 bDW
-wXC
+mXe
 bAM
-nez
-lUq
+sSy
+tIW
 bKg
 bLw
 bHl
 bNR
 bPn
-ean
+kCF
 bUD
-wfF
+grt
 bUD
-oSI
+jGG
 bDX
 bnq
 bYF
@@ -121433,56 +121488,56 @@ aCI
 aCI
 aDI
 aEK
-aQp
-aRn
-aRn
+aQg
+aRh
+aRh
 aUJ
 aFF
 aLb
 aMf
-bcn
+bcF
 aSl
 aSl
 aSl
 aSl
 aSl
-bvb
-bwk
-bAN
+bvS
+bxh
+bDL
 aVN
-bLl
+bNs
 aYd
-bTq
+bUm
 bal
 bbp
 bcy
 bdD
-gda
+kHZ
 bfT
 boF
 bQQ
-wOL
-gYi
-qRy
-pRi
+ouj
+oQw
+rgu
+rPt
 boD
 bpK
 bpK
-mOe
+ioc
 bpK
 bvc
-rAv
-wgd
-eXF
-jys
+iSc
+skX
+vys
+ueZ
 bAM
-uNe
-keP
-oDv
-gPz
+tMf
+eKY
+oYx
+cZy
 bAM
-iWH
-gey
+eqy
+kGM
 bKh
 bLx
 bHl
@@ -121490,7 +121545,7 @@ bNS
 bPm
 bQL
 bSg
-wcU
+noM
 bHl
 bfO
 bWT
@@ -121742,18 +121797,18 @@ aUL
 aSl
 aSl
 aMg
-bco
+bdx
 aJN
 aJN
-blp
+bmZ
 aJN
 aJN
-bvd
-bwl
+bvT
+bxi
 ojD
 aVO
 aWZ
-bQz
+bTq
 aYW
 aYW
 aYW
@@ -121771,26 +121826,26 @@ boE
 bpO
 bpO
 bsu
-lLu
+nwK
 bvc
-qDu
-pad
-uMC
-mhn
+vgc
+sCD
+vUf
+gAs
 bAM
-svd
-dWe
-oDv
+jCM
+lRW
+oYx
 bES
 bAM
-dGO
-fUr
+uOi
+tmR
 bKi
 bLy
 bHl
 bNT
 bPm
-tBA
+rBC
 bSg
 bHl
 bHl
@@ -122037,9 +122092,9 @@ anX
 aCK
 aHa
 aHa
-aQL
+aQp
 aGW
-aTg
+aTf
 aUN
 aJN
 aLd
@@ -122054,8 +122109,8 @@ aIS
 aIS
 aIS
 wNL
-bMh
-bQC
+bNQ
+bTr
 aYW
 bam
 bbr
@@ -122070,23 +122125,23 @@ bkN
 bmb
 bns
 boF
-nRD
+tXe
 bDY
-mPI
+tzd
 bDX
 bvc
-lad
-nWu
-mdV
-oni
+vtX
+kSp
+jNR
+jgf
 bAM
-fzA
-lkP
-kIi
-gzj
+qUn
+hni
+mnd
+nnb
 bAM
-sBD
-hSo
+pvT
+xJg
 bKj
 bLz
 bHl
@@ -122355,20 +122410,20 @@ aSm
 xgL
 aTX
 aIS
-bFW
+bHX
 aWZ
 aXX
 aYW
 ban
 bbs
 bcA
-dAM
+gNp
 aYW
 bfV
 bgZ
 aZa
 bjt
-ogG
+lkw
 bmc
 bnq
 bnq
@@ -122379,33 +122434,33 @@ bDX
 bvc
 bvc
 bxC
-nDg
-svD
+wHo
+wRR
 bAM
 bBN
-xMz
-hHd
+ovV
+wCH
 bAM
 bAM
 bHl
 bHl
-ftc
-qXr
+sSx
+vFw
 bHl
-tUv
-xAb
+vpP
+tgm
 bQL
-wlm
+rWU
 bHl
 bUE
 bfO
 bUB
 bnq
-dEP
-mWO
-mWO
-mWO
-hik
+pFI
+hGk
+hGk
+hGk
+uhm
 acO
 aaa
 aaa
@@ -122653,7 +122708,7 @@ aOh
 tjX
 aTY
 aIS
-bsv
+btM
 tjX
 aTY
 aIS
@@ -122673,7 +122728,7 @@ aZa
 aZa
 aZa
 aZa
-uJD
+fPi
 bpP
 bnq
 bfO
@@ -122683,27 +122738,27 @@ bDX
 bDX
 bDX
 bDX
-has
+xgz
 bDX
 bDX
 bDX
 bDX
-kEf
+ftZ
 bHl
 bHl
-kos
-wKg
-eoN
+oij
+ngu
+itn
 bNV
-qDk
+pxv
 bQL
-gQp
+ugK
 bHl
 bDX
 bfO
 bWV
 bnq
-uff
+hEf
 bnq
 aad
 aad
@@ -122940,9 +122995,9 @@ anX
 anX
 anX
 anX
-aNm
-aOs
-aPH
+aNo
+aOL
+aPG
 aFJ
 aGX
 aHU
@@ -122968,17 +123023,17 @@ bbu
 aYW
 aYW
 aYW
-cbU
+cfr
 aZa
 aZa
-xoF
-jHf
-sQL
-iZJ
+cUO
+gsG
+hFc
+eta
 boH
 bpQ
 bnq
-ljZ
+jbZ
 bDY
 bDY
 bDY
@@ -122995,15 +123050,15 @@ bHl
 bHl
 bSi
 bLA
-eoN
+itn
 tdy
 bPm
 bQL
-vjC
+iEU
 bHl
 bDX
 bfO
-drg
+etg
 bDX
 bDX
 bnq
@@ -123244,9 +123299,9 @@ aoc
 anX
 aCM
 aDL
-aPI
+aPH
 aCH
-aRS
+aRn
 aHS
 aIS
 rtZ
@@ -123264,19 +123319,19 @@ aIS
 hNB
 aWZ
 aXX
-bTs
+bUq
 bap
 bbv
-cfw
+daF
 bdG
-gNp
-lhD
-ncP
-shR
-xzv
-jzJ
-jIU
-tij
+mkL
+nDM
+pAA
+vos
+qxv
+xDL
+hQD
+dvo
 boI
 bpQ
 bre
@@ -123297,8 +123352,8 @@ bHl
 bHl
 ddK
 bLB
-xTs
-qyz
+jol
+cKj
 kcl
 bQL
 bSj
@@ -123306,8 +123361,8 @@ bHl
 les
 bfO
 bWV
-oIw
-xXX
+oJW
+vYZ
 bnq
 agm
 aaa
@@ -123548,7 +123603,7 @@ aCH
 aaR
 aCH
 aCH
-aRS
+aRn
 aHS
 aIS
 aIS
@@ -123558,39 +123613,39 @@ aIS
 aJQ
 aLi
 aMj
-bpH
-btB
+brc
+btO
 aLi
-bwn
-bCL
+bxB
+bDM
 gpP
-bMm
+bOV
 aXX
-bTt
+bUr
 baq
 bbw
 bpR
 bpR
 bpR
-mkL
+nLA
 pmR
 pmR
-xSK
+kQc
 bpR
-eWF
-eWF
+feN
+feN
 boJ
 bpR
-sKO
+ilc
 bsx
 bua
 bvi
-mIj
-rzF
+vot
+svq
 bsw
 bsw
 bsw
-ixU
+fDR
 bzL
 bzL
 bfO
@@ -123605,8 +123660,8 @@ bHl
 bHl
 bHl
 bHl
-nkv
-pFx
+snW
+dVO
 bnq
 bnq
 bnq
@@ -123846,8 +123901,8 @@ ayF
 anX
 aoc
 anX
-aNo
-aOL
+aNp
+aOM
 aEN
 aFL
 aGY
@@ -123856,44 +123911,44 @@ aUO
 aJR
 aLi
 aMk
-bcC
+bdy
 aOj
 aSo
 aSo
 aSo
 aSo
-bve
-bwp
-bCM
+bvV
+bxF
+bEC
 aVR
-bMn
+bOX
 aYa
-bTx
+bUw
 bar
 bbx
-cgR
+dAM
 bdH
-gXb
 mmz
+nVE
 boK
 bib
-ybu
-oZq
+ygI
+lGc
 bib
-udh
+hQb
 boK
 bpS
 bre
 bsw
-tQD
-dHE
-dHE
+mzV
+jlI
+jlI
 bxE
 bsw
 bsw
-uYT
+ows
 bsw
-jke
+fXY
 bre
 bfO
 bDX
@@ -123909,8 +123964,8 @@ bSk
 bnq
 bUI
 bfO
-uvk
-rZx
+trW
+dwd
 bnq
 awS
 aaa
@@ -124148,7 +124203,7 @@ aHV
 anX
 aoc
 anX
-aNo
+aNp
 aHa
 aHa
 aFM
@@ -124158,59 +124213,59 @@ aIS
 aJS
 aLj
 aMl
-bcD
+bdA
 aOk
-bju
+bjF
 aPX
-bpN
+brf
 aSp
-bju
+bjF
 aTZ
-bCV
+bED
 aVS
-bMx
+bOY
 aYg
 aZa
 aZa
-cbU
+cfr
 aZa
 aZa
-cbU
+cfr
 aZa
 aZa
-cbU
+cfr
 aZa
 aZa
-cbU
+cfr
 aZa
-joa
+ewV
 aZa
 bre
 bsw
-uYT
-goj
-iFX
-qQu
+ows
+rkB
+nKt
+nXV
 bCW
 bCW
 bCW
-xBW
+sVR
 bCW
-fsM
-kTg
+pcT
+yki
 bQQ
 bQQ
 bQQ
 bSl
 iyd
-wOL
+ouj
 bNX
 bQQ
 bQQ
 bSl
 bTB
 bUJ
-iXr
+qMm
 bnq
 bnq
 bnq
@@ -124451,7 +124506,7 @@ anX
 aoc
 anX
 aFL
-aOM
+aON
 aFL
 ojD
 aHa
@@ -124471,7 +124526,7 @@ aIS
 aIS
 sBO
 aWZ
-bQO
+bTs
 aZa
 bas
 bic
@@ -124485,16 +124540,16 @@ aZa
 bkP
 bic
 aZa
-ydF
-mBW
+sEy
+ppZ
 bre
 bsw
 bsw
 bvj
-jBF
-wdI
+oqm
+xTV
 bsw
-rsZ
+xHn
 bsw
 bsw
 bwo
@@ -124503,15 +124558,15 @@ bDX
 bDX
 bDX
 bDX
-dvs
-wJC
+jmt
+npf
 bDX
 bDX
 bUB
-bdU
-xne
-iSS
-uyg
+fgp
+iqG
+mqm
+npF
 bUB
 bnq
 aaa
@@ -124752,8 +124807,8 @@ ayF
 anX
 aoc
 anX
-aNp
-aON
+aNq
+aaW
 ojD
 aFN
 aHa
@@ -124781,7 +124836,7 @@ aZa
 bdJ
 bid
 aZa
-njl
+rMk
 bid
 aZa
 bdJ
@@ -124791,28 +124846,28 @@ boL
 cgP
 bre
 bsz
-iye
+hIW
 bxE
 bwo
 bzL
-hgk
+lbB
 bsw
 bsw
 bsw
-uYT
+ows
 bre
 bnq
 bnq
 bnq
-pCS
-xaS
+lsm
+wBj
 bnq
 bnq
 bnq
 bnq
 bnq
 bnq
-qCC
+oGR
 bnq
 bnq
 bnq
@@ -125057,9 +125112,9 @@ anX
 aad
 aaf
 ojD
-aQM
-aRT
-aTq
+aQL
+aRS
+aTg
 aIS
 aXa
 coM
@@ -125078,26 +125133,26 @@ aWZ
 nZC
 aZa
 bau
-cca
+cft
 aZa
-dXg
-cca
+gXb
+cft
 aZa
-nql
-stu
+shz
+wOL
 aZa
 bau
-cca
+cft
 aZa
-tEq
-nxG
-jSo
+onQ
+iJP
+kGd
 bsw
 bsw
 bxE
 bsw
-glX
-iye
+lVX
+hIW
 bsw
 bsw
 bsw
@@ -125110,12 +125165,12 @@ oQa
 wqb
 oUm
 bnq
-uDc
-hpI
-dMb
-qai
-gPF
-wtl
+gBX
+cQX
+dBx
+oRL
+jIb
+xXW
 bnq
 aci
 aaa
@@ -125360,12 +125415,12 @@ aaa
 ach
 ojD
 aFP
-aRY
-aTK
+aRT
+aTq
 aIS
 aXb
 coN
-aZd
+aZf
 aIS
 aOn
 coN
@@ -125397,13 +125452,13 @@ bre
 bsw
 bsw
 bxE
-uYT
+ows
 bsw
 bsw
 bsw
-glX
+lVX
 bsw
-ney
+dEj
 bzL
 aci
 aaa
@@ -125412,12 +125467,12 @@ oQa
 wqb
 oUm
 bnq
-xeJ
-vWS
-gfm
-pyX
-iMD
-wXv
+exs
+lIw
+cKG
+isW
+sul
+vaX
 bnq
 aci
 aaa
@@ -125663,7 +125718,7 @@ ach
 aLp
 aLp
 aLp
-aTL
+aTK
 coO
 coO
 coO
@@ -125685,9 +125740,9 @@ aXT
 bbA
 bcG
 aTn
-ill
+mEW
 cdA
-ntn
+shR
 bif
 bjx
 bkR
@@ -125695,14 +125750,14 @@ bkR
 bkR
 bkR
 bkR
-mVP
+qOe
 bCW
 bCW
-wdI
+xTV
 bsw
 bsw
 bsw
-uYT
+ows
 bsw
 bsw
 bwo
@@ -125963,30 +126018,30 @@ anX
 aaa
 ach
 aER
-aQN
-aSi
-aTM
+aQM
+aRY
+aTL
 aVn
 aXc
 aXZ
 aMq
-bcE
-bfR
+ben
+bgA
 bgr
 biO
 bkg
 blj
-bvh
-bxf
+bvW
+byr
 bhf
 aVX
-bMy
+bOZ
 aYj
-bTy
+bUC
 bav
 aNY
-cha
-ezW
+dXg
+ill
 beJ
 beJ
 beJ
@@ -125994,19 +126049,19 @@ bih
 beJ
 beJ
 beJ
-pId
-qmh
-oOW
+sJx
+kfS
+lRb
 bre
-nSR
+kQb
 bsw
 bsw
-xLM
+hlA
 bsw
 bsw
-gzt
+dWQ
 bsw
-iye
+hIW
 bzL
 bzL
 aci
@@ -126272,22 +126327,22 @@ aFO
 aJU
 aYb
 aMq
-bcF
+beH
 aOp
 aPc
 aQc
 aRk
 aSu
-bvm
+bwh
 apq
 aUP
 aVY
 aWZ
 aYj
 aWW
-bUr
+bXL
 aNY
-chb
+ezW
 aTn
 beK
 beK
@@ -126567,7 +126622,7 @@ aaa
 aaa
 aaO
 aLp
-aQU
+aQN
 aFO
 aIb
 aFO
@@ -126576,27 +126631,27 @@ aLo
 aMq
 aNt
 aOq
-bjv
-blq
+bkf
+bnp
 aRl
-btC
-bvR
-bxg
-bDI
+btS
+bwj
+bys
+bEG
 aVZ
-bMz
-bRp
-bTz
+bPa
+bTt
+bUF
 aNY
-ccO
-chk
-bkB
+cfu
+fhN
+blq
 aaa
 aaa
 beK
 bii
 bjz
-iLb
+usX
 beK
 aaf
 aad
@@ -126868,7 +126923,7 @@ aaa
 aaa
 aaa
 aaa
-aPJ
+aPI
 aFO
 aFO
 aIb
@@ -126876,7 +126931,7 @@ aFO
 aJU
 aYe
 aMq
-bdx
+bfv
 tuZ
 aQd
 aQh
@@ -126884,21 +126939,21 @@ aRm
 aYk
 bhd
 bhe
-bDK
+bFP
 bjA
 cfo
 bjB
-bTA
-bUw
-ccQ
-chl
-bkB
+bUG
+bXM
+cfw
+fqj
+blq
 afw
 aaa
 beK
 bij
-tKf
-szB
+kmJ
+rJD
 beK
 acO
 aaa
@@ -126917,11 +126972,11 @@ aaa
 aaa
 aaa
 aaa
-dRl
+xJF
 oQa
 wqb
 ica
-dRl
+xJF
 aaa
 aaa
 aaa
@@ -127170,7 +127225,7 @@ aaa
 aaa
 aaa
 aaa
-aPJ
+aPI
 aFO
 aFO
 aIb
@@ -127180,19 +127235,19 @@ aLp
 bgr
 bgr
 aMq
-bjw
-bme
+bks
+bnt
 aTo
-btD
+btU
 bgr
 aNu
-bDL
-bFX
+bFQ
+bJK
 aNu
 aNv
 aNu
-bUC
-ccR
+bYz
+cgR
 aNu
 aNv
 aNu
@@ -127219,11 +127274,11 @@ aaa
 aaa
 aaa
 abW
-dRl
+xJF
 oUm
-kLO
+leW
 oUm
-dRl
+xJF
 agm
 aaa
 aaa
@@ -127472,8 +127527,8 @@ aaa
 aaa
 aaa
 aaa
-aPM
-aQX
+aPJ
+aQU
 aFO
 aIb
 aFO
@@ -127484,23 +127539,23 @@ aER
 aOu
 aQe
 aQE
-bqN
-btE
+brg
+btX
 aQE
-bxh
-bDM
-bFZ
-bNp
-bRM
-bDM
+byu
+bFS
+bJL
+bPb
+bTx
+bFS
 aOr
-cdE
-bxh
-fhN
-btE
+cha
+byu
+iDR
+btX
 aQE
 bmf
-swI
+xoF
 brq
 aNu
 aad
@@ -127521,11 +127576,11 @@ aaa
 aaa
 aaa
 aaa
-dRl
+xJF
 oUm
 oUm
 oUm
-dRl
+xJF
 aaa
 aaa
 aaa
@@ -127777,21 +127832,21 @@ aaa
 aER
 aFO
 aFO
-aTN
+aTM
 aVo
 aXd
 aYf
-aZf
-bdy
-bfX
-bfX
-bfX
+bad
+bfw
+bgC
+bgC
+bgC
 doC
 aNu
 aOI
 aOr
 aOr
-bGj
+bJW
 aOr
 aNu
 aOI
@@ -127802,8 +127857,8 @@ aOr
 aNu
 aOI
 aOr
-sRA
-rda
+xzv
+whE
 aNu
 aaa
 aaa
@@ -127823,11 +127878,11 @@ aaa
 aaa
 aaa
 aaa
-dRl
-dRl
-dRl
-dRl
-dRl
+xJF
+xJF
+xJF
+xJF
+xJF
 aaa
 aaa
 aaa
@@ -128078,33 +128133,33 @@ aaa
 aaa
 aER
 aER
-aSk
+aSi
 aFO
 aFO
 aXe
 aER
-aZB
+baT
 aER
 aOI
-bjy
-bmO
+bku
+bos
 vNa
-btM
-bvS
-bxi
-bxi
-bGN
-bNq
-bRO
-bxi
-bxi
-bxi
-bNq
-bxi
-btM
-mEW
-bfX
-tbT
+btY
+bwk
+byC
+byC
+bLi
+bPo
+bTy
+byC
+byC
+byC
+bPo
+byC
+btY
+our
+bgC
+xSK
 aOr
 aNu
 aaa
@@ -128384,8 +128439,8 @@ aER
 aER
 aER
 aER
-aYE
-aZC
+aYO
+baY
 aLp
 aOr
 aOr
@@ -128404,9 +128459,9 @@ aNu
 aNu
 aNu
 aNv
-mJy
+oIX
 aOr
-tmx
+ybu
 aOr
 aNv
 aaa
@@ -128687,10 +128742,10 @@ aaa
 aaa
 aci
 ach
-bad
+bbq
 aNv
 aPd
-bjC
+bkv
 aRR
 aNv
 aNv
@@ -128708,7 +128763,7 @@ aaO
 aNv
 aNv
 bnv
-bjC
+bkv
 bOH
 aNv
 aNu
@@ -128994,7 +129049,7 @@ aNu
 wBr
 aPf
 aQf
-bqO
+brh
 awS
 aaa
 aTp
@@ -129008,14 +129063,14 @@ aTp
 aTp
 aaa
 aaO
-bqO
+brh
 aQf
 bik
 aOr
-xhV
+lRa
 aQf
-kkB
-xhV
+pBn
+lRa
 aaa
 aaa
 aaa
@@ -129296,7 +129351,7 @@ aNu
 aOt
 aPf
 aQf
-bqP
+bsf
 aaa
 aaa
 aTp
@@ -129310,13 +129365,13 @@ aTp
 aTp
 aaa
 aaa
-bqP
+bsf
 aQf
 bik
-gPu
+hZy
 aNu
-cGZ
-cGZ
+iWl
+iWl
 aNu
 aaa
 aaa
@@ -129327,9 +129382,9 @@ aaa
 aaa
 aaa
 aaa
-upu
-jNV
-xIV
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -129598,7 +129653,7 @@ aNu
 wBr
 aPf
 aQf
-bqY
+bsh
 aaa
 aTp
 aTp
@@ -129612,14 +129667,14 @@ aTp
 aTp
 aTp
 aaa
-bqY
+bsh
 aQf
 bik
 aOr
-xhV
+lRa
 aQf
 aQf
-xhV
+lRa
 aaa
 aaa
 aaa
@@ -129629,9 +129684,9 @@ aaa
 aaa
 aaa
 aaa
-pNg
-nEE
-pNv
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -129897,7 +129952,7 @@ aci
 aaa
 abW
 aNv
-bfY
+bhZ
 aPf
 aSv
 aNu
@@ -129917,7 +129972,7 @@ aaa
 aNu
 bri
 bik
-kEo
+qLH
 aNv
 aNu
 aNu
@@ -129931,9 +129986,9 @@ aaa
 aaa
 aaa
 aaa
-oyc
-ssP
-wgL
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -130217,7 +130272,7 @@ aTp
 aTp
 aaa
 aNu
-nDM
+stu
 bik
 aPg
 aNu
@@ -130233,8 +130288,8 @@ aaa
 aaa
 aaa
 aaa
-mkj
-kKv
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -130537,7 +130592,7 @@ aaa
 aaa
 aaa
 aaa
-yiB
+aaa
 aaa
 aaa
 aaa
@@ -130821,9 +130876,9 @@ aTp
 aaa
 acb
 aNu
-nDM
+stu
 bik
-ggB
+tsm
 aNu
 afw
 aaa
@@ -131106,8 +131161,8 @@ aNu
 aNu
 aNv
 aNv
-bjF
-bmW
+bkz
+boG
 aNv
 aNu
 bkS
@@ -131123,7 +131178,7 @@ aTp
 bkS
 aNu
 aNv
-nLA
+swI
 bik
 aNv
 aNv
@@ -131404,15 +131459,15 @@ aaa
 aaa
 aaa
 aNu
-aYO
+aYU
 aQE
 aQE
-bgy
+bia
 aPf
 aQf
-brc
+bsi
 aQf
-brc
+bsi
 aTp
 aTp
 aTp
@@ -131422,15 +131477,15 @@ aTp
 aTp
 aTp
 aTp
-brc
+bsi
 aQf
-brc
+bsi
 aQf
 bik
-bgy
+bia
 aQE
 aQE
-dgn
+dIb
 aNu
 aaa
 aaa
@@ -131706,15 +131761,15 @@ aaa
 aaa
 aaa
 aNu
-aYU
-baT
-aYU
+aYX
+bbz
+aYX
 aNu
 aPf
-bmZ
-brc
-btO
-brc
+bpE
+bsi
+buP
+bsi
 aTp
 aTp
 aTp
@@ -131724,15 +131779,15 @@ aTp
 aTp
 aTp
 aTp
-brc
-btO
-brc
-bmZ
+bsi
+buP
+bsi
+bpE
 bik
 aNu
-mBE
-svA
-mBE
+enc
+uby
+enc
 aNu
 aaa
 aaa
@@ -132008,9 +132063,9 @@ aaa
 aaa
 aaa
 aNv
-aYX
+aYY
 aNv
-aYX
+aYY
 aNv
 aNu
 aNu
@@ -132032,9 +132087,9 @@ aNv
 aNu
 aNu
 aNv
-aYX
+aYY
 aNv
-aYX
+aYY
 aNv
 aaa
 aaa

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -31374,7 +31374,7 @@
 "byt" = (
 /obj/decal/poster/wallsign/security,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/brig)
+/area/station/security/interrogation)
 "byu" = (
 /obj/machinery/light/emergency{
 	dir = 8;
@@ -39489,7 +39489,7 @@
 /turf/simulated/floor/redblack{
 	dir = 9
 	},
-/area/station/security/brig)
+/area/station/security/interrogation)
 "bQs" = (
 /obj/table/reinforced/auto,
 /obj/item/paper_bin,
@@ -39500,17 +39500,23 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
+/obj/blind_switch/area/north{
+	pixel_x = -12
+	},
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
-/area/station/security/brig)
+/area/station/security/interrogation)
 "bQt" = (
 /obj/table/reinforced/auto,
 /obj/machinery/light/lamp,
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
-/area/station/security/brig)
+/area/station/security/interrogation)
 "bQu" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -39524,7 +39530,7 @@
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
-/area/station/security/brig)
+/area/station/security/interrogation)
 "bQw" = (
 /obj/machinery/port_a_brig,
 /obj/machinery/light/small{
@@ -39537,7 +39543,7 @@
 /turf/simulated/floor/redblack{
 	dir = 5
 	},
-/area/station/security/brig)
+/area/station/security/interrogation)
 "bQx" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -40084,36 +40090,40 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/station/security/brig)
+/area/station/security/interrogation)
 "bRI" = (
 /obj/table/reinforced/auto,
 /obj/item/paper/book/space_law,
 /turf/simulated/floor/black,
-/area/station/security/brig)
+/area/station/security/interrogation)
 "bRJ" = (
 /obj/stool/chair/red{
 	dir = 8
 	},
 /turf/simulated/floor/black,
-/area/station/security/brig)
+/area/station/security/interrogation)
 "bRK" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/black,
-/area/station/security/brig)
+/area/station/security/interrogation)
 "bRL" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 20
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
-/area/station/security/brig)
+/area/station/security/interrogation)
 "bRM" = (
 /obj/storage/secure/closet/personal,
 /turf/unsimulated/floor/sanitary,
@@ -40771,7 +40781,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/redblack,
-/area/station/security/brig)
+/area/station/security/interrogation)
 "bTm" = (
 /obj/wingrille_spawn/auto,
 /obj/cable,
@@ -40789,7 +40799,7 @@
 /turf/simulated/floor/redblack{
 	dir = 6
 	},
-/area/station/security/brig)
+/area/station/security/interrogation)
 "bTo" = (
 /obj/machinery/floorflusher/solitary,
 /obj/disposalpipe/trunk/south,
@@ -41218,7 +41228,7 @@
 /obj/access_spawn/brig,
 /obj/firedoor_spawn,
 /turf/simulated/floor/red,
-/area/station/security/brig)
+/area/station/security/interrogation)
 "bUm" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -41240,7 +41250,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/redblack,
-/area/station/security/brig)
+/area/station/security/interrogation)
 "bUp" = (
 /obj/machinery/door/airlock/pyro/security{
 	name = "Secure Consultation";
@@ -41251,8 +41261,14 @@
 	},
 /obj/access_spawn/brig,
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/red,
-/area/station/security/brig)
+/area/station/security/interrogation)
 "bUq" = (
 /obj/machinery/door/airlock/pyro/glass{
 	name = "South Crew Quarters"
@@ -42367,7 +42383,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/redblack,
-/area/station/security/brig)
+/area/station/security/interrogation)
 "bWN" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -51964,8 +51980,11 @@
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/redblack,
-/area/station/security/brig)
+/area/station/security/interrogation)
 "eQE" = (
 /obj/grille/catwalk,
 /obj/machinery/oreaccumulator,
@@ -52897,6 +52916,12 @@
 /obj/storage/secure/crate/weapon/armory/pod_weapons,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
+"hhe" = (
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/security/interrogation)
 "hhz" = (
 /obj/cable{
 	d1 = 1;
@@ -53088,6 +53113,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
+"hSz" = (
+/turf/simulated/floor/redblack{
+	dir = 1
+	},
+/area/station/security/interrogation)
 "hTE" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -53417,6 +53447,9 @@
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
+"iZd" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/security/interrogation)
 "jaZ" = (
 /obj/table/auto,
 /obj/item/shipcomponent/secondary_system/tractor_beam,
@@ -53992,6 +54025,12 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/garden/aviary)
+"kZX" = (
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/security/interrogation)
 "lan" = (
 /obj/table/reinforced/chemistry/auto,
 /obj/machinery/light{
@@ -54996,7 +55035,7 @@
 /obj/access_spawn/brig,
 /obj/firedoor_spawn,
 /turf/simulated/floor/redblack,
-/area/station/security/brig)
+/area/station/security/interrogation)
 "nVE" = (
 /obj/disposalpipe/segment/vertical,
 /obj/machinery/power/apc/autoname_east,
@@ -55800,7 +55839,7 @@
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
-/area/station/security/brig)
+/area/station/security/interrogation)
 "qex" = (
 /obj/lattice{
 	icon_state = "lattice-dir"
@@ -55874,10 +55913,11 @@
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/redblack{
 	dir = 10
 	},
-/area/station/security/brig)
+/area/station/security/interrogation)
 "qmL" = (
 /obj/machinery/vending/standard,
 /turf/simulated/floor/plating,
@@ -56359,6 +56399,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/lobby)
+"rzU" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/window_blinds/cog2,
+/turf/simulated/floor/plating,
+/area/station/security/interrogation)
 "rBS" = (
 /obj/machinery/light,
 /obj/machinery/r_door_control/podbay/security/new_walls/east,
@@ -56796,6 +56845,23 @@
 	},
 /turf/simulated/floor,
 /area/station/storage/warehouse)
+"sME" = (
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
+	},
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/red/side{
+	dir = 1
+	},
+/area/station/security/brig)
 "sNg" = (
 /obj/stool/chair/office/blue{
 	dir = 1
@@ -57414,6 +57480,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
+"uqw" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/security/brig)
 "urd" = (
 /turf/simulated/floor/red,
 /area/station/medical/medbay)
@@ -112643,11 +112724,11 @@ bFR
 bFR
 bIm
 bFR
-bFK
-bFK
-bFK
-bQi
-bFK
+iZd
+iZd
+iZd
+hhe
+iZd
 cot
 cou
 bGE
@@ -112945,7 +113026,7 @@ bJM
 bLc
 bMo
 bNt
-bFK
+iZd
 bQr
 qdz
 qmz
@@ -113247,11 +113328,11 @@ bLd
 bLd
 bLd
 bNu
-bFK
+iZd
 bQs
 bRH
 bTl
-bFK
+iZd
 bVD
 cou
 bXz
@@ -113549,11 +113630,11 @@ bMp
 bMp
 bMp
 svx
-bFK
+iZd
 bQt
 bRI
 bUo
-bFK
+iZd
 bVE
 bWK
 bXA
@@ -113852,10 +113933,10 @@ bLe
 bMq
 bNv
 byt
-rXp
+hSz
 bRJ
 bWL
-bFK
+rzU
 cot
 cou
 bXB
@@ -114158,8 +114239,8 @@ bQv
 bRK
 eOb
 bUp
-bVG
-bWN
+sME
+uqw
 bXC
 bFK
 bZr
@@ -114455,11 +114536,11 @@ bJN
 ceq
 bMr
 cgb
-bOW
+kZX
 bQw
 bRL
 bTn
-bOW
+kZX
 bVG
 bWN
 bXD
@@ -114757,11 +114838,11 @@ bJO
 bNy
 bMs
 chs
-bFK
-bFK
-bFK
-bQi
-bFK
+iZd
+iZd
+iZd
+hhe
+iZd
 bVH
 cou
 bXE

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -1793,7 +1793,7 @@
 /area/station/chapel/sanctuary)
 "aeo" = (
 /obj/decal/cleanable/dirt,
-/obj/reagent_dispensers/still,
+/obj/landmark/artifact,
 /turf/simulated/floor/plating,
 /area/station/storage/northeast)
 "aep" = (
@@ -1931,7 +1931,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "aeD" = (
-/obj/landmark/artifact,
+/obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/station/storage/northeast)
 "aeF" = (
@@ -1947,7 +1947,13 @@
 /turf/space,
 /area/space)
 "aeH" = (
-/obj/reagent_dispensers/fueltank,
+/obj/machinery/manufacturer/general{
+	desc = "It's covered in more gunk than a truck stop ashtray. Is this thing even safe?";
+	free_resource_amt = 0;
+	free_resources = null;
+	malfunction = 1;
+	name = "grody manufacturer"
+	},
 /obj/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating,
 /area/station/storage/northeast)
@@ -26623,22 +26629,6 @@
 	dir = 8
 	},
 /area/station/mining/staff_room)
-"bmD" = (
-/obj/access_spawn/brig,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/door/airlock/pyro/glass{
-	name = "Armory"
-	},
-/obj/access_spawn/brig,
-/turf/simulated/floor/red,
-/area/station/security/brig)
 "bmE" = (
 /obj/rack,
 /obj/item/clothing/mask/breath,
@@ -30095,10 +30085,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
-"bvy" = (
-/obj/disposalpipe/segment/bent/north,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
 "bvz" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/janitor/office)
@@ -30523,14 +30509,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/airless/plating,
 /area/station/maintenance/west)
-"bwv" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/bridge/captain)
 "bwA" = (
 /obj/vehicle/floorbuffer,
 /turf/simulated/floor/darkblue,
@@ -51051,6 +51029,21 @@
 /obj/machinery/drainage,
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
+"ctI" = (
+/obj/stool/chair{
+	dir = 1
+	},
+/obj/cable,
+/obj/machinery/power/apc/autoname_east,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 9;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
 "cuX" = (
 /obj/table/auto,
 /obj/item/scalpel,
@@ -51067,18 +51060,22 @@
 /obj/item/clothing/mask/surgical_shield,
 /turf/simulated/floor/caution/east,
 /area/station/medical/robotics)
+"cxa" = (
+/obj/table/auto,
+/obj/shrub/dead{
+	dir = 8;
+	name = "Dead plant";
+	pixel_y = 10
+	},
+/obj/item/storage/pill_bottle/cyberpunk{
+	layer = 2.4
+	},
+/turf/simulated/floor/grime,
+/area/station/maintenance/southeast)
 "cxo" = (
 /obj/machinery/light_switch/east,
 /turf/simulated/floor,
 /area/station/hallway/secondary/south)
-"cyz" = (
-/obj/machinery/light/runway_light/delay5,
-/obj/lattice{
-	dir = 6;
-	icon_state = "lattice-dir"
-	},
-/turf/space,
-/area/station/ai_monitored/armory)
 "czk" = (
 /obj/machinery/optable{
 	id = "robotics"
@@ -51093,19 +51090,40 @@
 /obj/machinery/drainage,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/robotics)
+"cEa" = (
+/obj/table/auto,
+/obj/item/paper_bin{
+	pixel_y = 6
+	},
+/obj/deskclutter,
+/obj/item/hand_labeler{
+	pixel_x = 5
+	},
+/obj/item/plantanalyzer,
+/obj/item/device/reagentscanner{
+	pixel_x = -7
+	},
+/obj/item/pen,
+/turf/simulated/floor,
+/area/station/hydroponics/bay)
+"cEm" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/Zeta)
 "cEO" = (
 /obj/pool/perspective,
 /turf/simulated/floor/white/checker,
 /area/station/crew_quarters/pool)
-"cHp" = (
-/obj/storage/secure/closet/command/captain,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+"cGB" = (
+/obj/machinery/chem_master{
+	dir = 8
 	},
-/obj/machinery/power/apc/autoname_north,
-/turf/simulated/floor/carpet/arcade,
-/area/station/bridge/captain)
+/turf/simulated/floor/carpet/blue/fancy/edge/east,
+/area/station/crew_quarters/md)
 "cIc" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/cable{
@@ -51142,52 +51160,58 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/sanitary/white,
 /area/station/crew_quarters/pool)
-"cKj" = (
+"cKQ" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
-/turf/simulated/floor/greenblack{
-	dir = 1
-	},
-/area/station/turret_protected/Zeta)
-"cKG" = (
-/obj/item/storage/wall/random{
-	dir = 8;
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/obj/item/crowbar,
-/turf/simulated/floor/grime,
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
+"cKV" = (
+/obj/table/auto,
+/obj/item/circuitboard/robotics,
+/obj/item/disk/data/floppy/read_only/network_progs,
+/obj/machinery/light,
+/turf/simulated/floor/greenblack,
+/area/station/turret_protected/Zeta)
+"cMy" = (
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
+	},
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
+"cNv" = (
+/obj/machinery/computer3/terminal/zeta{
+	dir = 8;
+	setup_os_string = "ZETA_MAINFRAME"
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/yellowblack/corner,
+/area/station/crew_quarters/ce)
 "cPy" = (
 /obj/decal/tile_edge/stripe/big{
 	dir = 8
 	},
 /turf/simulated/floor/grey,
 /area/station/medical/robotics)
-"cQX" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+"cSc" = (
+/obj/lattice{
+	dir = 5;
+	icon_state = "lattice-dir-b"
 	},
-/obj/stool/chair{
-	dir = 1
-	},
-/turf/simulated/floor/grime,
-/area/station/maintenance/southeast)
+/obj/machinery/light/runway_light,
+/turf/space,
+/area/station/ai_monitored/armory)
 "cSO" = (
 /obj/stool/bench/green/auto,
 /obj/landmark/start{
@@ -51201,16 +51225,6 @@
 	},
 /turf/simulated/floor,
 /area/station/routing/security)
-"cUO" = (
-/obj/decal/tile_edge/line/green{
-	dir = 1;
-	icon_state = "line1"
-	},
-/obj/bookshelf/persistent,
-/turf/simulated/floor/neutral/side{
-	dir = 9
-	},
-/area/station/crew_quarters/quarters_south)
 "cVz" = (
 /obj/machinery/guardbot_dock,
 /obj/machinery/power/data_terminal,
@@ -51232,17 +51246,6 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/medical/robotics)
-"cZy" = (
-/obj/submachine/chef_sink/chem_sink{
-	dir = 1
-	},
-/obj/decal/tile_edge/line/black{
-	dir = 5;
-	icon_state = "line2"
-	},
-/obj/machinery/drainage,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/md)
 "cZU" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/transport,
@@ -51283,6 +51286,37 @@
 /obj/machinery/weapon_stand/rifle_rack/recharger,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
+"deR" = (
+/obj/tree1,
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
+"dfl" = (
+/turf/simulated/floor/carpet/blue,
+/area/station/crew_quarters/md)
+"dfo" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"dfC" = (
+/obj/decal/poster/wallsign/medal,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/bridge/hos)
+"dfT" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/light/runway_light/delay5,
+/turf/space,
+/area/station/ai_monitored/armory)
 "dgq" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -51291,12 +51325,6 @@
 /obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
-"dhW" = (
-/obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/floor/black/side{
-	dir = 10
-	},
-/area/station/hallway/primary/south)
 "dii" = (
 /obj/landmark/halloween,
 /turf/simulated/floor,
@@ -51308,6 +51336,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hangar/engine)
+"djc" = (
+/obj/table/auto,
+/obj/item/storage/toolbox/emergency,
+/obj/item/crowbar,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
+	},
+/turf/simulated/floor/black/side{
+	dir = 8
+	},
+/area/station/bridge)
 "djG" = (
 /obj/disposalpipe/segment/mail/bent/north,
 /turf/simulated/floor/yellow/side{
@@ -51347,11 +51388,6 @@
 	dir = 8
 	},
 /area/station/maintenance/northeast)
-"dpI" = (
-/obj/machinery/light/runway_light,
-/obj/lattice,
-/turf/space,
-/area/station/ai_monitored/armory)
 "dqk" = (
 /obj/machinery/light{
 	dir = 8;
@@ -51367,20 +51403,17 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/medical/robotics)
-"dqI" = (
+"dqy" = (
+/obj/stool/chair{
+	dir = 8
+	},
 /obj/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
-"dqX" = (
-/obj/machinery/light,
-/turf/simulated/floor/grass,
-/area/station/hydroponics/bay)
-"dru" = (
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/brig)
+/turf/simulated/floor,
+/area/station/crew_quarters/quarters_south)
 "drx" = (
 /obj/machinery/conveyor{
 	name = "cargo belt - south";
@@ -51388,28 +51421,48 @@
 	},
 /turf/simulated/floor/airless/grey,
 /area/station/maintenance/west)
-"dvo" = (
-/obj/table/round/auto,
-/obj/item/gobowl/w,
-/turf/simulated/floor/neutral/corner{
-	dir = 1
+"drR" = (
+/obj/table/reinforced/auto,
+/obj/item/decoration/ashtray{
+	pixel_x = -9
 	},
-/area/station/crew_quarters/quarters_south)
+/obj/item/card_box/suit{
+	pixel_x = 1;
+	pixel_y = 3
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/grime,
+/area/station/security/brig)
+"dvu" = (
+/obj/item/storage/wall/random{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/item/crowbar,
+/turf/simulated/floor/grime,
+/area/station/maintenance/southeast)
 "dvx" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"dwd" = (
-/obj/machinery/recharge_station,
-/turf/simulated/floor/grey,
-/area/station/maintenance/southeast)
 "dww" = (
 /turf/simulated/floor/airless/plating{
 	icon_state = "platingdmg3"
 	},
 /area/space)
+"dwL" = (
+/obj/lattice{
+	dir = 9;
+	icon_state = "lattice-dir-b"
+	},
+/obj/machinery/light/runway_light/delay5,
+/turf/space,
+/area/station/ai_monitored/armory)
 "dAM" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -51433,22 +51486,37 @@
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
-"dBx" = (
-/obj/decal/cleanable/ash,
+"dCL" = (
 /obj/cable{
-	icon_state = "2-5"
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating{
-	icon_state = "platingdmg2"
+/obj/stool/chair/office/blue{
+	dir = 4
 	},
-/area/station/maintenance/southeast)
-"dEj" = (
-/obj/shrub{
-	dir = 1
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
+"dDe" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
 	},
 /turf/simulated/floor/grass,
 /area/station/garden/aviary)
+"dDK" = (
+/obj/machinery/communications_dish,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/airless/plating,
+/area/station/ai_monitored/armory)
 "dFf" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
@@ -51468,19 +51536,11 @@
 	dir = 4
 	},
 /area/station/routing/security)
-"dHu" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
+"dHl" = (
+/obj/table/auto,
+/obj/machinery/microwave,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
 "dHS" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -51493,98 +51553,29 @@
 	},
 /turf/simulated/floor/airless/plating,
 /area/station/maintenance/west)
-"dIb" = (
-/obj/machinery/light,
-/turf/simulated/floor/escape{
-	dir = 8
-	},
-/area/station/hallway/secondary/exit)
-"dKZ" = (
-/obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/left{
-	dir = 8
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/bridge/hos)
-"dLg" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet/blue/fancy/edge/west,
-/area/station/bridge)
-"dLW" = (
-/obj/stool/chair{
-	dir = 1
-	},
-/obj/cable,
-/obj/machinery/power/apc/autoname_east,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 9;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
-"dNp" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "red";
-	icon_state = "bedsheet-red"
-	},
-/obj/machinery/bot/secbot/beepsky,
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/beepsky)
-"dNN" = (
-/obj/table/auto,
-/obj/item/storage/toolbox/emergency,
-/obj/item/crowbar,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
-/turf/simulated/floor/black/side{
-	dir = 8
-	},
-/area/station/bridge)
 "dOy" = (
 /turf/simulated/floor/redwhite{
 	dir = 8
 	},
 /area/station/medical/medbay)
-"dPl" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+"dPf" = (
+/obj/machinery/power/data_terminal,
+/obj/machinery/computer/robotics{
+	perma = 1
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/turf/simulated/floor/greenblack{
+	dir = 1
 	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/decal/wreath/ephemeral,
-/turf/simulated/floor/plating,
-/area/space)
+/area/station/turret_protected/Zeta)
 "dPr" = (
 /obj/machinery/portable_reclaimer,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
+"dSr" = (
+/obj/machinery/light/runway_light,
+/obj/lattice,
+/turf/space,
+/area/station/ai_monitored/armory)
 "dTh" = (
 /obj/machinery/atmospherics/valve{
 	dir = 4
@@ -51596,34 +51587,23 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"dVv" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+"dVg" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
 	},
-/turf/simulated/floor/plating,
-/area/space)
-"dVO" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4
+/obj/machinery/phone/wall{
+	pixel_x = 24
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/turf/simulated/floor/grey,
+/area/station/bridge)
 "dVP" = (
 /obj/decal/poster/wallsign/security,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/main)
-"dWQ" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
 "dWS" = (
 /obj/machinery/light_switch/east,
 /obj/machinery/camera{
@@ -51656,6 +51636,13 @@
 "dXg" = (
 /turf/simulated/floor/escape,
 /area/station/hallway/primary/east)
+"dXn" = (
+/obj/table/round/auto,
+/obj/item/gobowl/b,
+/turf/simulated/floor/neutral/side{
+	dir = 8
+	},
+/area/station/crew_quarters/quarters_south)
 "dZr" = (
 /obj/critter/mouse,
 /turf/simulated/floor/plating,
@@ -51666,6 +51653,28 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/arcade/dungeon)
+"ebn" = (
+/obj/item/tile/steel,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/grime,
+/area/station/maintenance/southeast)
+"ebv" = (
+/obj/stool/chair/comfy{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/west,
+/area/station/bridge)
+"ebz" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 20
+	},
+/turf/simulated/floor/grime,
+/area/station/security/brig)
 "ecb" = (
 /obj/machinery/computer/barcode{
 	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Pod Bay","Research","Security","QM");
@@ -51677,6 +51686,17 @@
 	},
 /turf/simulated/floor/caution/north,
 /area/station/hangar/medical)
+"edU" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "8-10"
+	},
+/obj/item/storage/box/cablesbox,
+/turf/simulated/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/station/maintenance/southeast)
 "egj" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -51705,6 +51725,14 @@
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
+"eiC" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/south,
+/area/station/crew_quarters/md)
 "eiE" = (
 /obj/critter/boogiebot,
 /turf/simulated/floor/carpet/red/fancy/innercorner/north,
@@ -51730,22 +51758,27 @@
 	},
 /turf/space,
 /area/station/ai_monitored/armory)
-"emW" = (
+"emO" = (
 /obj/lattice{
 	icon_state = "lattice-dir"
 	},
-/obj/machinery/light/runway_light/delay5,
+/obj/machinery/light/runway_light/delay4,
 /turf/space,
 /area/station/ai_monitored/armory)
-"enc" = (
-/obj/machinery/vehicle/escape_pod{
-	dir = 4
-	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hallway/secondary/exit)
 "enW" = (
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/arcade/dungeon)
+"epD" = (
+/obj/machinery/door/airlock/pyro/glass/command{
+	name = "Command Centre"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/black,
+/area/station/bridge)
 "epP" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/simulated/floor/plating,
@@ -51762,55 +51795,56 @@
 	dir = 4
 	},
 /area/station/hangar/medical)
-"eqy" = (
-/obj/stool{
-	desc = "A soft little bed the general size and shape of a space bee.";
-	icon = 'icons/misc/critter.dmi';
-	icon_state = "beebed";
-	name = "heisenbed"
-	},
-/obj/item/reagent_containers/food/snacks/beefood{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/critter/domestic_bee/heisenbee,
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/obj/machinery/light_switch/north,
-/turf/simulated/floor/carpet/purple/fancy/edge/north,
-/area/station/science/research_director)
-"eta" = (
-/obj/table/round/auto,
-/obj/machinery/computer3/generic/personal,
+"eqL" = (
 /obj/cable{
+	d1 = 1;
 	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/neutral/side{
-	dir = 8
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
-/area/station/crew_quarters/quarters_south)
-"etg" = (
-/obj/machinery/door/airlock/pyro/external,
+/turf/simulated/floor/black,
+/area/station/turret_protected/Zeta)
+"esj" = (
+/obj/machinery/atmospherics/valve{
+	dir = 4;
+	high_risk = 1;
+	name = "Cafeteria"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"ewV" = (
-/obj/machinery/door/airlock/pyro{
-	dir = 4;
-	icon_state = "generic_locked";
-	locked = 1
+"esy" = (
+/obj/item/storage/toilet,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
 	},
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/quarters_south)
-"exs" = (
-/obj/landmark/artifact,
-/turf/simulated/floor/plating{
-	icon_state = "platingdmg3"
+/obj/machinery/alarm{
+	pixel_y = 24
 	},
+/turf/simulated/floor/grey/side{
+	dir = 8
+	},
+/area/space)
+"etI" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"eyk" = (
+/obj/landmark{
+	name = "blobstart"
+	},
+/turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "eyB" = (
 /obj/disposalpipe/segment/vertical,
@@ -51826,53 +51860,6 @@
 	},
 /turf/simulated/floor/escape,
 /area/station/hallway/primary/east)
-"eAc" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/turret,
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
-"eBf" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/shipalert{
-	pixel_x = 30
-	},
-/turf/simulated/floor/black/side{
-	dir = 8
-	},
-/area/station/bridge)
-"eBr" = (
-/obj/machinery/door/airlock/pyro,
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/turf/simulated/floor/grey/blackgrime,
-/area/station/security/brig)
-"eBR" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/brig{
-	dir = 8
-	},
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor,
-/area/station/security/brig)
 "eCr" = (
 /obj/cable{
 	d1 = 4;
@@ -51888,29 +51875,6 @@
 /obj/disposalpipe/junction/left/south,
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
-"eFc" = (
-/obj/machinery/floorflusher/solitary2,
-/obj/disposalpipe/trunk/south,
-/turf/simulated/floor/black,
-/area/station/security/brig)
-"eFC" = (
-/obj/table/reinforced/bar/auto,
-/obj/machinery/light,
-/obj/item/decoration/ashtray{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/turf/simulated/floor/carpet/green/standard/narrow/northsouth,
-/area/station/crew_quarters/cafeteria)
-"eFY" = (
-/obj/disposalpipe/segment/brig{
-	dir = 8
-	},
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/turf/simulated/floor/redblack,
-/area/station/security/brig)
 "eGO" = (
 /obj/lattice{
 	dir = 4;
@@ -51919,23 +51883,42 @@
 /obj/machinery/light/runway_light/delay3,
 /turf/space,
 /area/station/ai_monitored/armory)
-"eJU" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"eIo" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
 	},
-/turf/simulated/floor/grey,
-/area/station/bridge)
-"eKY" = (
-/turf/simulated/floor/carpet/blue,
-/area/station/crew_quarters/md)
+/obj/machinery/light/runway_light/delay2,
+/turf/space,
+/area/station/ai_monitored/armory)
+"eKS" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/decal/wreath/ephemeral,
+/turf/simulated/floor/plating,
+/area/space)
 "eLc" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
+"eLr" = (
+/obj/machinery/light/runway_light/delay3,
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/station/ai_monitored/armory)
 "eMs" = (
 /obj/disposalpipe/segment/vertical,
 /obj/critter/nicespider,
@@ -51945,17 +51928,21 @@
 /obj/machinery/atmospherics/pipe/simple/junction,
 /turf/space,
 /area/space)
-"eOD" = (
-/obj/stool/chair/comfy{
+"eMJ" = (
+/obj/table/wood/auto,
+/obj/random_item_spawner/desk_stuff,
+/obj/item/stamp/cap,
+/turf/simulated/floor/carpet/arcade,
+/area/station/bridge/captain)
+"eOb" = (
+/obj/disposalpipe/segment/brig{
 	dir = 8
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/disposalpipe/segment/brig{
+	dir = 1
 	},
-/turf/simulated/floor/carpet/blue/fancy/edge/east,
-/area/station/bridge)
+/turf/simulated/floor/redblack,
+/area/station/security/brig)
 "eQE" = (
 /obj/grille/catwalk,
 /obj/machinery/oreaccumulator,
@@ -51965,45 +51952,86 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
-"eZj" = (
-/obj/machinery/atmospherics/pipe/simple,
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
-"eZW" = (
-/obj/wingrille_spawn/auto,
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/mining/refinery)
-"fae" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 1
-	},
-/obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
-"fao" = (
-/obj/storage/closet/emergency,
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"faL" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/disposalpipe/segment/horizontal,
+"eXW" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/west,
+/area/station/bridge)
+"eYA" = (
+/obj/decal/cleanable/ash,
+/obj/cable{
+	icon_state = "2-5"
+	},
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/station/maintenance/southeast)
+"eZW" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/mining/refinery)
+"eZZ" = (
+/obj/table/wood/auto,
+/obj/machinery/networked/printer{
+	name = "Printer - CE";
+	pixel_y = 5;
+	print_id = "CE"
+	},
+/obj/machinery/light_switch/north,
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
+	},
+/turf/simulated/floor/yellowblack{
+	dir = 1
+	},
+/area/station/crew_quarters/ce)
+"fbA" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/stool/chair{
+	dir = 1
+	},
+/turf/simulated/floor/grime,
+/area/station/maintenance/southeast)
+"fbZ" = (
+/obj/table/reinforced/bar/auto,
+/obj/item/reagent_containers/food/drinks/bowl,
+/obj/item/kitchen/utensil/spoon,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/green/standard/narrow/northsouth,
+/area/station/crew_quarters/cafeteria)
+"fcd" = (
+/obj/machinery/door/airlock/pyro,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/green/side,
+/area/station/garden/aviary)
+"fcX" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/space)
 "fdN" = (
 /obj/cable{
 	d1 = 1;
@@ -52012,25 +52040,6 @@
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
-"feN" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_south)
-"fgp" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
-/obj/item/storage/toolbox/emergency,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
 "fhN" = (
 /obj/table/auto,
 /obj/item/game_kit,
@@ -52109,26 +52118,12 @@
 /obj/machinery/light,
 /turf/unsimulated/floor/sanitary,
 /area/station/crewquarters/cryotron)
-"flq" = (
-/obj/item/reagent_containers/food/drinks/bottle/thegoodstuff,
-/obj/shrub/captainshrub,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
+"fnb" = (
+/obj/disposalpipe/segment/brig{
+	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/bridge/captain)
-"fng" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/space)
+/turf/simulated/floor/stairs,
+/area/station/security/brig)
 "foi" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 6
@@ -52152,53 +52147,41 @@
 	dir = 6
 	},
 /area/station/hallway/primary/east)
-"frd" = (
-/obj/table/auto,
-/obj/item/shaker/salt,
-/obj/item/shaker/mustard{
-	pixel_x = -6
-	},
-/obj/item/shaker/pepper{
-	pixel_x = 3
-	},
-/obj/item/shaker/ketchup{
-	pixel_x = 6
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/catering)
-"frJ" = (
-/obj/machinery/optable,
-/obj/item/device/analyzer/healthanalyzer{
-	pixel_y = -1;
-	rand_pos = 0
-	},
-/turf/simulated/floor/bluewhite,
-/area/station/medical/medbooth)
 "frY" = (
 /turf/simulated/wall/auto/reinforced/supernorn/yellow,
 /area/station/mining/staff_room)
-"fsd" = (
-/turf/simulated/floor/red/side{
-	dir = 4
-	},
-/area/station/security/brig)
-"ftZ" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
-/obj/decal/cleanable/dirt,
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"fuw" = (
+"fsc" = (
 /obj/table/wood/auto,
-/obj/item/paper_bin,
-/obj/item/pen/fancy,
-/obj/machinery/light,
-/obj/item/stamp/hop,
+/obj/item/item_box/gold_star{
+	item_amount = 20
+	},
+/obj/item/dice/d1,
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/obj/item/deconstructor,
+/obj/item/device/radio/intercom/engineering,
+/turf/simulated/floor/yellowblack{
+	dir = 1
+	},
+/area/station/crew_quarters/ce)
+"ftt" = (
+/turf/simulated/floor/redblack/corner{
+	dir = 8
+	},
+/area/space)
+"ftU" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
+	},
 /turf/simulated/floor/black,
-/area/station/bridge/hos)
+/area/station/bridge)
 "fvz" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
@@ -52227,6 +52210,26 @@
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/routing/depot)
+"fAl" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/shipalert{
+	pixel_x = 30
+	},
+/turf/simulated/floor/black/side{
+	dir = 8
+	},
+/area/station/bridge)
+"fBG" = (
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Holding Cell One"
+	},
+/obj/access_spawn/brig,
+/turf/simulated/floor/black,
+/area/space)
 "fCz" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -52236,13 +52239,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/west)
-"fDR" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
 "fEt" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -52250,6 +52246,14 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
+"fFT" = (
+/obj/machinery/door/airlock/pyro/glass,
+/obj/decal/garland/ephemeral,
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/courtroom)
 "fGA" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
@@ -52277,27 +52281,67 @@
 	dir = 1
 	},
 /area/station/crew_quarters/kitchen)
-"fMd" = (
-/obj/table/reinforced/auto,
-/obj/item/gun/kinetic/riot40mm{
-	pixel_y = 10
+"fKE" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 20
 	},
-/obj/item/ammo/bullets/smoke,
-/obj/item/ammo/bullets/smoke,
-/obj/item/gun/kinetic/riot40mm,
+/obj/rack,
+/obj/item/storage/box/stinger_kit,
+/obj/item/chem_grenade/pepper,
+/obj/item/chem_grenade/pepper,
+/obj/item/chem_grenade/pepper,
+/obj/item/clothing/glasses/nightvision,
+/obj/item/clothing/glasses/nightvision,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
-"fPi" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
+"fNj" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/machinery/vending/pda,
-/turf/simulated/floor/neutral/side{
-	dir = 9
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
+"fOc" = (
+/obj/disposalpipe/switch_junction/left/south{
+	mail_tag = "medical booth";
+	name = "medical booth mail junction"
 	},
-/area/station/crew_quarters/quarters_south)
+/turf/simulated/floor/black/side{
+	dir = 8
+	},
+/area/station/hallway/primary/south)
+"fRk" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
+"fRz" = (
+/obj/machinery/door/airlock/pyro/security{
+	name = "Courtroom"
+	},
+/obj/machinery/secscanner{
+	pixel_y = 10
+	},
+/obj/decal/garland/ephemeral,
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/courtroom)
+"fSI" = (
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/obj/disposalpipe/segment/bent/east,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/hallway/primary/south)
 "fTm" = (
 /obj/machinery/navbeacon{
 	codes_txt = "tour;next_tour=tour2;desc=Whether you've been in a long sleep or on a long trip, the on-station bar and cafeteria is sure to get you up and running again. Try the arcade, too!";
@@ -52307,17 +52351,6 @@
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"fTs" = (
-/obj/rack,
-/obj/item/clothing/suit/bio_suit/paramedic,
-/obj/item/clothing/suit/bio_suit/paramedic,
-/obj/item/storage/belt/medical,
-/obj/item/storage/belt/medical,
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
-/turf/simulated/floor/white,
-/area/station/medical/medbooth)
 "fUz" = (
 /obj/cable{
 	d1 = 1;
@@ -52332,6 +52365,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
+"fUI" = (
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
 "fVr" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -52345,6 +52382,17 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
+"fVD" = (
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/engine,
+/area/station/routing/security)
 "fVI" = (
 /obj/grille/steel,
 /obj/machinery/door/poddoor/pyro{
@@ -52370,12 +52418,6 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
-"fXY" = (
-/obj/shrub{
-	dir = 10
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
 "fYL" = (
 /obj/grille/catwalk{
 	dir = 10;
@@ -52385,60 +52427,40 @@
 	dir = 10
 	},
 /area/station/maintenance/southeast)
-"gbd" = (
-/obj/stool/chair/office/blue{
-	dir = 4
+"fYN" = (
+/obj/table/wood/round/auto,
+/obj/item/storage/toolbox{
+	desc = "Looks suspiciously similar to a toolbox.";
+	name = "lunchbox"
 	},
-/obj/landmark/start{
-	name = "Head of Personnel"
-	},
-/turf/simulated/floor/carpet/green/fancy/edge/south,
-/area/station/bridge/hos)
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
 "gbf" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/landmark/halloween,
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
+"gbn" = (
+/obj/machinery/computer/telescope{
+	dir = 8
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
+	},
+/obj/cable,
+/turf/simulated/floor/carpet/purple/fancy/edge/east,
+/area/station/science/research_director)
 "gda" = (
 /obj/stool/bar,
 /turf/simulated/floor/carpet/green/fancy/edge/sw,
 /area/station/crew_quarters/cafeteria)
-"gdl" = (
-/turf/simulated/floor/redblack{
-	dir = 1
-	},
-/area/station/security/brig)
-"geh" = (
-/obj/storage/crate,
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/machinery/light/small,
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
-"gfw" = (
-/obj/lattice{
-	dir = 9;
-	icon_state = "lattice-dir-b"
-	},
-/obj/machinery/light/runway_light/delay5,
-/turf/space,
-/area/station/ai_monitored/armory)
 "gga" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -52462,60 +52484,94 @@
 /obj/submachine/slot_machine,
 /turf/simulated/floor/carpet/green/fancy/edge/se,
 /area/station/crew_quarters/cafeteria)
+"ggQ" = (
+/obj/disposalpipe/segment/vertical,
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple,
+/turf/simulated/floor/grey,
+/area/station/bridge)
+"ghc" = (
+/obj/item/extinguisher,
+/turf/simulated/floor/carpet/green/fancy/edge/nw,
+/area/station/crew_quarters/quarters_south)
+"ghK" = (
+/obj/table/auto,
+/obj/machinery/networked/storage/scanner{
+	bank_id = "bridge";
+	pixel_y = 4
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
+	},
+/turf/simulated/floor/circuit,
+/area/station/bridge)
 "gih" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
-"giq" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 20
-	},
-/turf/simulated/floor/grime,
-/area/station/security/brig)
-"giF" = (
-/obj/lattice{
-	dir = 1;
-	icon_state = "lattice-dir"
-	},
-/turf/space,
-/area/station/ai_monitored/armory)
 "gjD" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/caution/westeast,
 /area/station/maintenance/south)
-"glg" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "kgenpopwindow";
-	name = "General Population Visitation";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/station/security/brig)
-"gml" = (
-/obj/table/auto,
-/obj/machinery/microwave,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/catering)
-"gmE" = (
-/obj/machinery/sim/vr_bed{
-	dir = 4;
-	name = "VR simulation pod";
+"gjN" = (
+/obj/storage/crate,
+/obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
-/obj/cable,
-/obj/machinery/power/data_terminal,
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/machinery/light/small,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
+"gkQ" = (
+/obj/table/reinforced/bar/auto,
+/obj/machinery/light,
+/obj/item/decoration/ashtray{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/turf/simulated/floor/carpet/green/standard/narrow/northsouth,
+/area/station/crew_quarters/cafeteria)
+"glv" = (
+/obj/shrub{
+	dir = 1
+	},
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
 "goX" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/decal/garland/ephemeral{
@@ -52539,83 +52595,28 @@
 	dir = 1
 	},
 /area/station/hallway/primary/east)
-"grt" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+"gpY" = (
+/obj/disposalpipe/segment/brig{
+	dir = 1
 	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
-"gsG" = (
-/obj/stool/chair,
-/obj/machinery/light/emergency{
-	dir = 8;
-	pixel_x = -10
-	},
-/turf/simulated/floor/neutral/side{
-	dir = 8
-	},
-/area/station/crew_quarters/quarters_south)
-"gvE" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 21;
-	pixel_y = -3
-	},
-/obj/fitness/weightlifter,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
-"gxa" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/light/runway_light/delay4,
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
-/turf/space,
-/area/space)
-"gAs" = (
+"gwe" = (
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/security/brig)
+"gxk" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
-	bcolor = "yellow";
-	icon_state = "bedsheet-yellow"
+	bcolor = "red";
+	icon_state = "bedsheet-red"
 	},
-/obj/machinery/light,
-/turf/simulated/floor/yellowblack,
-/area/station/crew_quarters/ce)
-"gBx" = (
-/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/bot/secbot/beepsky,
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/bridge)
-"gBX" = (
-/obj/machinery/computer3/terminal/zeta{
-	setup_os_string = "ZETA_MAINFRAME"
-	},
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/station/maintenance/southeast)
+/area/station/security/beepsky)
 "gCb" = (
 /obj/machinery/computer/operating,
 /turf/simulated/floor/sanitary/white,
@@ -52630,14 +52631,19 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
+"gFK" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/red,
+/area/station/ai_monitored/armory)
 "gGg" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/caution/north,
 /area/research_outpost/indigo_rye)
-"gGi" = (
-/obj/disposalpipe/junction/right/north,
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
 "gGK" = (
 /obj/decal/poster/wallsign/security_right,
 /turf/simulated/wall/auto/supernorn,
@@ -52662,26 +52668,12 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
-"gKH" = (
-/obj/submachine/chef_sink/chem_sink{
-	dir = 8;
-	pixel_x = 8
-	},
-/turf/simulated/floor/green/side{
-	dir = 10
-	},
-/area/station/hydroponics/bay)
 "gKN" = (
 /obj/landmark{
 	name = "blobstart"
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/medical)
-"gLn" = (
-/obj/machinery/light/small,
-/obj/machinery/photocopier,
-/turf/simulated/floor/black,
-/area/station/bridge)
 "gMO" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0
@@ -52716,6 +52708,13 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/airless/grey,
 /area/station/maintenance/west)
+"gNY" = (
+/obj/machinery/light/runway_light/delay4,
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/station/ai_monitored/armory)
 "gQs" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/transport{
@@ -52725,6 +52724,10 @@
 /area/station/crew_quarters/clown{
 	name = "Clowntainment"
 	})
+"gQA" = (
+/obj/machinery/portable_atmospherics/pump,
+/turf/simulated/floor/plating,
+/area/station/maintenance/central)
 "gQG" = (
 /obj/disposalpipe/segment/vertical,
 /obj/landmark/halloween,
@@ -52741,6 +52744,22 @@
 	},
 /turf/simulated/floor,
 /area/station/security/brig)
+"gRI" = (
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Cafeteria"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
 "gSr" = (
 /obj/storage/crate,
 /obj/item/sheet/steel/fullstack,
@@ -52753,6 +52772,36 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
+"gTx" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/turret,
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
+"gWE" = (
+/obj/grille/catwalk{
+	dir = 6;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 6
+	},
+/area/station/maintenance/southeast)
+"gWL" = (
+/obj/stool/chair/office/blue{
+	dir = 4
+	},
+/obj/landmark/start{
+	name = "Head of Personnel"
+	},
+/turf/simulated/floor/carpet/green/fancy/edge/south,
+/area/station/bridge/hos)
 "gWW" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -52829,38 +52878,19 @@
 /obj/storage/secure/crate/weapon/armory/pod_weapons,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
-"hlA" = (
-/obj/shrub{
-	dir = 10
-	},
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
-"hlG" = (
-/obj/machinery/door_timer/solitary2/new_walls/north{
-	layer = 3.1
-	},
-/obj/machinery/atmospherics/unary/outlet_injector{
-	dir = 8;
-	icon_state = "on";
-	on = 1
-	},
-/turf/simulated/floor/red/corner{
-	dir = 1
-	},
-/area/station/security/brig)
-"hlR" = (
-/obj/wingrille_spawn/auto,
-/obj/health_scanner/wall{
-	layer = 3.3
-	},
+"hhz" = (
 /obj/cable{
-	icon_state = "0-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/obj/submachine/chef_sink/chem_sink{
+	dir = 8;
+	pixel_x = 8
+	},
+/turf/simulated/floor/redwhite/corner{
+	dir = 4
+	},
 /area/station/medical/medbooth)
 "hmG" = (
 /obj/disposalpipe/segment/brig{
@@ -52868,28 +52898,40 @@
 	},
 /turf/simulated/floor/caution/westeast,
 /area/station/maintenance/south)
-"hni" = (
-/obj/machinery/chem_master{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/blue/fancy/edge/east,
-/area/station/crew_quarters/md)
-"hnv" = (
+"hnF" = (
 /obj/table/reinforced/auto,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/reagent_containers/food/drinks/water,
-/obj/machinery/camera{
-	c_tag = "autotag";
+/obj/item/gun/kinetic/riot40mm{
+	pixel_y = 10
+	},
+/obj/item/ammo/bullets/smoke,
+/obj/item/ammo/bullets/smoke,
+/obj/item/gun/kinetic/riot40mm,
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
+"hqe" = (
+/obj/machinery/computer3/terminal/network{
 	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
+	name = "CENTCOM Terminal";
+	pixel_x = -3;
+	pixel_y = 4;
+	setup_os_string = "MAIN_DISH_SS13"
 	},
-/turf/simulated/floor/grey/side{
-	dir = 8
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/area/space)
+/turf/simulated/floor/sanitary/white,
+/area/station/bridge/captain)
+"hri" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/left,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/bridge/captain)
 "hrS" = (
 /obj/machinery/door/airlock/pyro/security{
 	dir = 4
@@ -52905,42 +52947,38 @@
 	},
 /turf/simulated/floor/red,
 /area/station/routing/security)
-"htE" = (
-/obj/item/storage/wall{
-	dir = 8;
-	name = "silverware cabinet";
-	pixel_x = 32;
-	spawn_contents = list(/obj/item/storage/box/cutlery,/obj/item/storage/box/cutlery,/obj/item/storage/box/cutlery,/obj/item/storage/box/plates,/obj/item/storage/box/plates,/obj/item/shaker/salt,/obj/item/shaker/pepper)
+"hvz" = (
+/obj/stool/chair/comfy{
+	dir = 8
 	},
-/turf/simulated/floor/black,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/east,
 /area/station/bridge)
-"hvH" = (
-/obj/machinery/chem_dispenser/alcohol,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
+"hvO" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/window_blinds/cog2/middle{
+	dir = 8
 	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
-/obj/machinery/light_switch/west,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/cafeteria)
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/ce)
 "hwl" = (
 /obj/storage/closet/emergency,
 /obj/machinery/light_switch/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
-"hwO" = (
-/obj/machinery/door/airlock/pyro/security{
-	name = "Secure Consultation"
-	},
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/turf/simulated/floor/redblack,
-/area/station/security/brig)
 "hwT" = (
 /obj/machinery/vending/cola/blue,
 /obj/decal/xmas_lights/ephemeral{
@@ -52950,14 +52988,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
-"hyi" = (
-/obj/lattice{
-	dir = 6;
-	icon_state = "lattice-dir-b"
-	},
-/obj/machinery/light/runway_light/delay2,
-/turf/space,
-/area/station/ai_monitored/armory)
 "hzD" = (
 /obj/stool/chair/office{
 	dir = 8
@@ -52970,29 +53000,14 @@
 	dir = 4
 	},
 /area/station/medical/medbay)
-"hCu" = (
-/obj/storage/crate{
-	desc = "A private crate that isn't yours.";
-	name = "Beepsky's stuff"
+"hzF" = (
+/obj/submachine/ice_cream_dispenser,
+/obj/machinery/light/emergency{
+	dir = 8;
+	pixel_x = -10
 	},
-/obj/item/diary,
-/obj/item/clothing/shoes/black{
-	desc = "You have no idea how a robot with wheels for locomotion could possibly require these.";
-	name = "Beepsky's Shoes"
-	},
-/obj/item/storage/photo_album/beepsky,
-/obj/item/clothing/suit/det_suit/beepsky,
-/obj/item/clothing/head/NTberet{
-	desc = "It's a momento, I guess. An old keepsake. And maybe a reminder of the things we've left behind.";
-	name = "Old Beret"
-	},
-/obj/machinery/power/apc/autoname_east,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating/damaged3,
-/area/station/security/beepsky)
+/turf/simulated/floor/black,
+/area/station/crew_quarters/cafeteria)
 "hCK" = (
 /obj/machinery/mass_driver{
 	dir = 1;
@@ -53001,80 +53016,30 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating/airless,
 /area/space)
-"hEf" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"hEO" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/machinery/door/airlock/pyro/glass{
-	name = "Cafeteria"
+"hCR" = (
+/obj/cable{
+	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/firedoor_spawn,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
-"hFc" = (
-/obj/table/round/auto,
-/obj/item/gobowl/b,
-/turf/simulated/floor/neutral/side{
-	dir = 8
-	},
-/area/station/crew_quarters/quarters_south)
-"hGk" = (
-/obj/grille/catwalk,
-/turf/simulated/floor/airless/plating/catwalk,
-/area/station/maintenance/southeast)
-"hHm" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/submachine/chef_sink/chem_sink{
-	dir = 8;
-	pixel_x = 8
-	},
-/turf/simulated/floor/redwhite/corner{
-	dir = 4
-	},
-/area/station/medical/medbooth)
-"hHt" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/ai_monitored/armory)
-"hHD" = (
-/obj/table/auto,
-/obj/item/paper/book/guardbot_guide{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/paper/book/dwainedummies{
-	pixel_y = 6
-	},
-/obj/item/disk/data/tape/master/readonly,
-/turf/simulated/floor/black,
+/turf/simulated/floor/carpet/blue/fancy/edge/west,
 /area/station/bridge)
-"hIW" = (
-/obj/critter/parrot/random,
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
+"hGp" = (
+/obj/machinery/communications_dish{
+	tag = "MAIN_DISH_SS13"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/com_dish/comdish)
+"hKu" = (
+/obj/machinery/manufacturer/personnel,
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/courtroom)
 "hNB" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -53096,44 +53061,14 @@
 	},
 /turf/simulated/floor/airless/plating,
 /area/station/maintenance/west)
-"hQb" = (
-/obj/disposalpipe/segment/vertical,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/obj/machinery/phone/wall{
-	pixel_x = 24
-	},
-/turf/simulated/floor/neutral/side{
-	dir = 4
-	},
-/area/station/crew_quarters/quarters_south)
-"hQi" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
-/turf/simulated/floor/white,
-/area/station/medical/medbooth)
-"hQD" = (
-/obj/table/round/auto,
-/obj/item/goboard,
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_south)
-"hRB" = (
+"hQg" = (
+/obj/machinery/power/apc/autoname_east,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/carpet/blue/fancy/edge/west,
-/area/station/bridge)
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "hTE" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -53141,23 +53076,30 @@
 /obj/item/device/radio/intercom/cargo,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"hVJ" = (
-/obj/stool/bar,
+"hVp" = (
 /obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
+	dir = 4;
+	pixel_x = 12
 	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
-"hZy" = (
-/obj/machinery/light/emergency,
+/turf/simulated/floor/redblack{
+	dir = 4
+	},
+/area/station/security/brig)
+"hVu" = (
+/obj/table/auto,
+/obj/machinery/light,
+/obj/item/storage/toolbox/emergency,
+/obj/item/device/light/glowstick,
+/obj/item/device/light/glowstick,
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
-"hZZ" = (
-/obj/table/wood/auto,
-/obj/machinery/phone,
-/turf/simulated/floor/black,
-/area/station/bridge/hos)
+"hWw" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "ica" = (
 /obj/lattice{
 	dir = 10;
@@ -53174,56 +53116,39 @@
 /area/station/maintenance/storage{
 	name = "Inner Southwest Maintenance"
 	})
-"ifo" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/decal/wreath/ephemeral,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/courtroom)
-"ifA" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/stool/chair/office/blue{
+"ifd" = (
+/turf/simulated/floor/red/side{
 	dir = 4
 	},
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/catering)
-"ihR" = (
-/obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/middle{
-	dir = 5
+/area/station/security/brig)
+"igZ" = (
+/obj/submachine/chef_sink/chem_sink{
+	dir = 1
 	},
-/obj/cable,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/decal/tile_edge/line/black{
+	dir = 5;
+	icon_state = "line2"
 	},
-/turf/simulated/floor/plating,
-/area/station/bridge/captain)
+/obj/machinery/drainage,
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/ce)
+"ijx" = (
+/obj/machinery/computer/tetris,
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
 "ikb" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	level = 2
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"ilc" = (
-/obj/machinery/door/airlock/pyro,
+"ikk" = (
+/obj/machinery/door/airlock/pyro/maintenance,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
-/turf/simulated/floor/green/side,
+/turf/simulated/floor/greenblack,
 /area/station/garden/aviary)
 "ill" = (
 /obj/machinery/door/airlock/pyro/maintenance,
@@ -53238,27 +53163,30 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
+"inl" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet,
+/obj/disposalpipe/segment/brig{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/grey/side{
+	dir = 8
+	},
+/area/station/security/brig)
 "inL" = (
 /obj/disposalpipe/segment/brig,
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/machinery/light/emergency,
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/south)
-"ioc" = (
-/obj/machinery/door/airlock/pyro/command{
-	dir = 4;
-	name = "Network Chamber"
-	},
-/obj/disposalpipe/segment/horizontal,
+"iod" = (
+/obj/disposalpipe/segment/vertical,
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/grey,
-/area/station/bridge)
+/turf/simulated/floor/black,
+/area/station/crew_quarters/cafeteria)
 "iof" = (
 /obj/disposalpipe/switch_junction/left/west{
 	mail_tag = "hydroponics";
@@ -53266,14 +53194,12 @@
 	},
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/south)
-"iqG" = (
-/obj/machinery/power/apc/autoname_east,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+"ioh" = (
+/obj/machinery/vending/snack{
+	credit = 50
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/space)
 "isd" = (
 /obj/machinery/manufacturer/hangar,
 /obj/machinery/power/apc/autoname_west,
@@ -53285,35 +53211,6 @@
 	dir = 8
 	},
 /area/station/routing/security)
-"isy" = (
-/obj/machinery/communications_dish,
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/obj/machinery/power/data_terminal,
-/obj/cable,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/airless/plating,
-/area/station/ai_monitored/armory)
-"isW" = (
-/obj/critter/roach,
-/turf/simulated/floor/grime,
-/area/station/maintenance/southeast)
-"iti" = (
-/obj/disposalpipe/trunk/south,
-/obj/machinery/disposal/transport{
-	desc = "A pneumatic delivery chute for transporting people from one section of maintenance to another.";
-	name = "maintenance shunt unit"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"itn" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "itQ" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4;
@@ -53332,6 +53229,10 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/arcade/dungeon)
+"ivn" = (
+/obj/landmark/gps_waypoint,
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
 "ivS" = (
 /obj/table/auto,
 /obj/item/reagent_containers/food/drinks/tea{
@@ -53375,35 +53276,62 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
-"iEU" = (
-/obj/table/auto,
-/obj/item/storage/box/diskbox,
-/turf/simulated/floor/greenblack,
-/area/station/turret_protected/Zeta)
-"iGX" = (
+"iEX" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/turf/simulated/floor,
+/area/station/security/brig)
+"iGU" = (
+/obj/table/reinforced/auto,
+/obj/item/paper/book/medical_surgery_guide{
+	pixel_x = 9
+	},
+/obj/machinery/defib_mount{
+	pixel_x = -6
+	},
+/turf/simulated/floor/bluewhite,
+/area/station/medical/medbooth)
 "iHH" = (
 /obj/reagent_dispensers/foamtank,
 /turf/simulated/floor/caution/corner/misc{
 	dir = 6
 	},
 /area/research_outpost/indigo_rye)
-"iJP" = (
-/obj/decal/skeleton{
-	desc = "It's all covered in a sticky mess, and there are chunks of uniform fused to the bone.";
-	name = "sticky skeleton"
+"iIo" = (
+/obj/table/reinforced/auto,
+/obj/item/paper_bin,
+/obj/item/pen/pencil,
+/obj/item/reagent_containers/food/drinks/water,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
 	},
-/turf/simulated/floor/plating/scorched,
-/area/station/crew_quarters/quarters_south)
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/grey/side{
+	dir = 8
+	},
+/area/station/security/brig)
+"iJB" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
 "iJS" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/mail/vertical,
@@ -53423,15 +53351,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
-"iMj" = (
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/obj/disposalpipe/segment/bent/east,
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
-/area/station/hallway/primary/south)
 "iNr" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -53444,15 +53363,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/brig)
-"iOb" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/obj/machinery/phone/wall{
-	pixel_y = 32
-	},
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/baroffice)
 "iQf" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
@@ -53460,46 +53370,21 @@
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
-"iRU" = (
-/obj/lattice{
-	dir = 1;
-	icon_state = "lattice-dir"
+"iQo" = (
+/obj/machinery/computer/security/wooden_tv{
+	desc = "These channels seem to mostly be about robuddies. What is this, some kind of reality show?";
+	name = "Television";
+	network = "Zeta"
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
+/obj/machinery/alarm{
+	pixel_y = 24
 	},
-/turf/space,
+/turf/simulated/floor/carpet/purple/fancy/edge/north,
+/area/station/science/research_director)
+"iRI" = (
+/obj/storage/secure/crate/plasma/armory/anti_biological,
+/turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
-"iSc" = (
-/obj/table/wood/auto,
-/obj/item/item_box/gold_star{
-	item_amount = 20
-	},
-/obj/item/dice/d1,
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/obj/item/deconstructor,
-/obj/item/device/radio/intercom/engineering,
-/turf/simulated/floor/yellowblack{
-	dir = 1
-	},
-/area/station/crew_quarters/ce)
-"iVf" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/turf/simulated/floor/stairs,
-/area/station/security/brig)
-"iWl" = (
-/turf/simulated/floor/caution/westeast,
-/area/station/hallway/secondary/exit)
 "iWw" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/machinery/camera{
@@ -53528,21 +53413,18 @@
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
+"iYl" = (
+/obj/stool,
+/turf/simulated/floor/grey/side{
+	dir = 4
+	},
+/area/space)
 "jaZ" = (
 /obj/table/auto,
 /obj/item/shipcomponent/secondary_system/tractor_beam,
 /obj/item/shipcomponent/secondary_system/tractor_beam,
 /turf/simulated/floor,
 /area/station/routing/security)
-"jbZ" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
 "jcj" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -53553,14 +53435,6 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/medical/robotics)
-"jdg" = (
-/obj/lattice{
-	dir = 5;
-	icon_state = "lattice-dir-b"
-	},
-/obj/machinery/light/runway_light/delay3,
-/turf/space,
-/area/station/ai_monitored/armory)
 "jdV" = (
 /obj/decal/poster/wallsign/danger_highvolt,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -53580,51 +53454,69 @@
 /obj/storage/secure/closet/medical/anesthetic,
 /turf/simulated/floor/red,
 /area/station/medical/medbay/surgery)
-"jgf" = (
-/obj/storage/secure/closet/command/chief_engineer,
-/obj/item/clipboard,
-/obj/item/pen,
-/turf/simulated/floor/yellowblack,
-/area/station/crew_quarters/ce)
-"jlI" = (
-/obj/stool/chair/wooden{
-	dir = 4
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
-"jmt" = (
+"jjN" = (
+/obj/disposalpipe/segment/horizontal,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"jol" = (
-/obj/machinery/door/poddoor/pyro{
-	id = "dwaine_core";
-	name = "DWAINE Core Shield"
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
 	},
-/obj/cable{
-	icon_state = "1-2"
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
+"jlJ" = (
+/obj/submachine/chef_sink/chem_sink{
+	dir = 1
 	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
+/obj/decal/tile_edge/line/black{
+	dir = 5;
+	icon_state = "line2"
+	},
+/obj/machinery/drainage,
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/md)
 "joy" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/clown{
 	name = "Clowntainment"
 	})
-"jqc" = (
-/obj/wingrille_spawn/auto,
-/obj/cable,
+"jqU" = (
+/obj/stool/chair,
+/turf/simulated/floor,
+/area/station/crew_quarters/quarters_south)
+"jrc" = (
+/obj/disposalpipe/segment/vertical,
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/medical/medbooth)
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 6
+	},
+/turf/simulated/floor/grey,
+/area/station/bridge)
+"jru" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
 "jry" = (
 /obj/wingrille_spawn/auto,
 /obj/machinery/door/poddoor/pyro{
@@ -53667,13 +53559,18 @@
 /obj/machinery/light/runway_light/delay2,
 /turf/space,
 /area/space)
-"jtF" = (
-/obj/item/device/radio/beacon,
-/obj/disposalpipe/segment/brig{
-	dir = 1
+"jvb" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/middle{
+	dir = 5
 	},
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/courtroom)
+/obj/cable,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/bridge/captain)
 "jvp" = (
 /obj/table/auto,
 /obj/item/reagent_containers/food/snacks/breadloaf,
@@ -53713,78 +53610,42 @@
 	dir = 10
 	},
 /area/station/medical/medbooth)
-"jzY" = (
-/obj/wingrille_spawn/auto/crystal,
-/turf/simulated/floor/plating,
-/area/station/security/brig)
 "jCx" = (
 /obj/storage/crate/loot,
 /turf/simulated/floor/plating/airless/asteroid/dark,
 /area/space)
-"jCM" = (
-/obj/machinery/chem_dispenser,
-/obj/machinery/alarm{
-	pixel_y = 24
+"jDh" = (
+/obj/submachine/claw_machine,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
 	},
-/turf/simulated/floor/carpet/blue/fancy/edge/north,
-/area/station/crew_quarters/md)
-"jDt" = (
-/obj/machinery/rkit,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -20
-	},
-/turf/simulated/floor/yellowblack{
-	dir = 1
-	},
-/area/station/crew_quarters/ce)
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
 "jDX" = (
 /obj/landmark{
 	name = "blobstart"
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/science)
-"jFM" = (
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/specialroom/bar,
+"jHF" = (
+/obj/machinery/chem_dispenser/soda,
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
-"jGG" = (
+"jJP" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 1
+	},
+/obj/disposalpipe/segment/horizontal,
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"jHu" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/black/corner{
-	dir = 1
-	},
-/area/station/bridge)
-"jIb" = (
-/obj/item/caution{
-	desc = "Caution! Construction Zone!";
-	name = "caution sign"
-	},
-/obj/decal/cleanable/oil,
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/grime,
-/area/station/maintenance/southeast)
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
 "jJT" = (
 /obj/submachine/seed_vendor,
 /obj/machinery/light{
@@ -53794,17 +53655,6 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
-"jNR" = (
-/obj/storage/crate/rcd,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/yellowblack/corner{
-	dir = 1
-	},
-/area/station/crew_quarters/ce)
 "jOn" = (
 /obj/machinery/door/airlock/pyro{
 	name = "Serving Area"
@@ -53815,21 +53665,44 @@
 /obj/decal/garland/ephemeral,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
+"jPC" = (
+/obj/machinery/floorflusher/solitary,
+/obj/submachine/chef_sink/chem_sink{
+	pixel_y = 16
+	},
+/obj/disposalpipe/trunk/south,
+/turf/simulated/floor/black,
+/area/space)
 "jTa" = (
 /obj/decal/poster/wallsign/fire,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/gas)
-"jTK" = (
-/obj/machinery/door/airlock/pyro/glass,
-/obj/disposalpipe/segment/vertical,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/courtroom)
-"jUm" = (
-/obj/table/reinforced/auto,
-/obj/machinery/phone,
-/turf/simulated/floor/carpet/red/fancy/edge/se,
-/area/station/security/hos)
+"jVX" = (
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 6;
+	level = 2
+	},
+/obj/cable{
+	icon_state = "6-8"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "1-6"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"kaa" = (
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/obj/machinery/vending/pda,
+/turf/simulated/floor/neutral/side{
+	dir = 9
+	},
+/area/station/crew_quarters/quarters_south)
 "kbj" = (
 /obj/machinery/atmospherics/binary/volume_pump{
 	dir = 4;
@@ -53862,34 +53735,40 @@
 /area/station/maintenance/storage{
 	name = "Inner Southwest Maintenance"
 	})
-"kcU" = (
-/obj/stool/chair/red{
+"kdR" = (
+/obj/shrub{
 	dir = 8
 	},
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
+"kej" = (
+/obj/table/reinforced/auto,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/reagent_containers/food/drinks/water,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
 	},
-/turf/simulated/floor/redblack{
-	dir = 5
+/turf/simulated/floor/grey/side{
+	dir = 8
 	},
-/area/station/security/brig)
-"kdN" = (
-/obj/disposalpipe/segment/transport,
-/turf/simulated/wall/auto/supernorn,
+/area/space)
+"khO" = (
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/grey,
+/area/station/hallway/secondary/exit)
+"kjc" = (
+/obj/machinery/shieldgenerator/meteorshield,
+/turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"kfS" = (
-/obj/decal/cleanable/dirt,
-/obj/machinery/shieldgenerator/energy_shield,
-/turf/simulated/floor/plating,
-/area/station/maintenance/central)
-"kgz" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/brig)
 "kjx" = (
 /obj/lattice{
 	icon_state = "lattice-dir"
@@ -53897,6 +53776,15 @@
 /obj/machinery/light/runway_light/delay2,
 /turf/space,
 /area/space)
+"kjV" = (
+/obj/submachine/chef_sink/chem_sink{
+	dir = 8;
+	pixel_x = 8
+	},
+/turf/simulated/floor/green/side{
+	dir = 10
+	},
+/area/station/hydroponics/bay)
 "kkU" = (
 /obj/machinery/navbeacon{
 	codes_txt = "tour;next_tour=tour4;desc=On my right through the double doors is the station's headquarters. When waiting in the area, please use the provided seating.";
@@ -53906,6 +53794,16 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
+"kli" = (
+/obj/table/reinforced/bar/auto,
+/obj/machinery/computer3/generic/personal,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/grey,
+/area/station/bridge)
 "klY" = (
 /obj/grille/catwalk/cross,
 /obj/machinery/camera{
@@ -53925,13 +53823,25 @@
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"kmJ" = (
-/obj/machinery/atmospherics/valve{
-	high_risk = 1;
-	name = "Air Reserve (Escape Hallway)"
+"kow" = (
+/obj/storage/crate,
+/obj/item/device/radio/headset/multifreq,
+/obj/item/device/radio/headset/multifreq,
+/obj/item/device/radio/headset/medical,
+/obj/item/device/radio/headset/medical,
+/obj/item/device/radio/headset/security,
+/obj/item/device/radio/headset/security,
+/obj/item/device/radio/headset/engineer,
+/obj/item/device/radio/headset/engineer,
+/obj/item/device/radio/headset/research,
+/obj/item/device/radio/headset/research,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/central)
+/obj/machinery/power/apc/autoname_east,
+/turf/simulated/floor/black,
+/area/station/bridge)
 "koG" = (
 /obj/storage/secure/crate/weapon/armory/tranquilizer,
 /turf/simulated/floor/engine,
@@ -53958,17 +53868,26 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/engine/vacuum,
 /area/research_outpost/indigo_rye)
-"kui" = (
-/obj/critter/cat/jones,
-/turf/simulated/floor/carpet/blue/fancy/edge/east,
-/area/station/bridge)
-"kxP" = (
-/obj/machinery/light/runway_light,
-/obj/lattice{
-	icon_state = "lattice-dir"
+"ktt" = (
+/obj/machinery/drainage,
+/turf/simulated/floor/black,
+/area/space)
+"kuN" = (
+/obj/stool/chair/red{
+	dir = 8
 	},
-/turf/space,
-/area/station/ai_monitored/armory)
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/redblack{
+	dir = 5
+	},
+/area/station/security/brig)
+"kwJ" = (
+/obj/disposalpipe/segment/transport,
+/turf/simulated/wall/auto/supernorn,
+/area/station/maintenance/southeast)
 "kyt" = (
 /obj/disposalpipe/segment/vertical,
 /obj/machinery/atmospherics/valve{
@@ -53990,66 +53909,54 @@
 	dir = 8
 	},
 /area/station/medical/medbay)
-"kzS" = (
-/obj/storage/crate{
-	desc = "Various supplies for the bar.";
-	name = "bartending crate"
-	},
-/obj/item/reagent_containers/food/drinks/bottle,
-/obj/item/reagent_containers/food/drinks/bottle,
-/obj/item/reagent_containers/food/drinks/bottle,
-/obj/item/reagent_containers/food/drinks/bottle,
-/obj/item/reagent_containers/food/drinks/bottle,
-/obj/item/storage/firstaid/toxin,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/device/reagentscanner,
-/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
-/obj/item/reagent_containers/dropper/mechanical,
-/obj/machinery/light/small,
-/obj/cable,
-/obj/machinery/power/apc/autoname_west,
-/obj/item/clothing/glasses/spectro,
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/baroffice)
-"kBW" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet,
-/turf/simulated/floor/grey/side{
-	dir = 4
-	},
-/area/station/security/brig)
 "kBY" = (
 /obj/stool/chair{
 	dir = 8
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/barber_shop)
-"kCF" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"kDl" = (
+/obj/rack,
+/obj/item/clothing/suit/armor/heavy,
+/obj/item/clothing/suit/armor/heavy,
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/glasses/thermal,
+/obj/item/clothing/glasses/thermal,
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
+"kEr" = (
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
 	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
-"kGd" = (
-/obj/structure/woodwall,
-/turf/simulated/floor/plating/damaged1,
-/area/station/garden/aviary)
-"kGM" = (
-/obj/cable{
-	icon_state = "4-8"
+/turf/simulated/floor/redblack/corner{
+	dir = 4
 	},
-/turf/simulated/floor/carpet/purple/fancy,
-/area/station/science/research_director)
+/area/space)
+"kGp" = (
+/turf/simulated/floor/damaged5,
+/area/station/crew_quarters/quarters_south)
 "kHZ" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/storage/emergency)
+"kJA" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/ai_monitored/armory)
 "kKi" = (
 /obj/table/wood/auto,
 /obj/decal/xmas_lights/ephemeral{
@@ -54069,26 +53976,17 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/medical/robotics)
-"kQb" = (
-/obj/shrub,
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
+"kMO" = (
+/obj/rack,
+/obj/item/clothing/suit/bio_suit/paramedic,
+/obj/item/clothing/suit/bio_suit/paramedic,
+/obj/item/storage/belt/medical,
+/obj/item/storage/belt/medical,
+/obj/disposalpipe/segment/morgue{
+	dir = 4
 	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
-"kQc" = (
-/obj/decal/tile_edge/line/green{
-	dir = 9;
-	icon_state = "line1"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_south)
+/turf/simulated/floor/white,
+/area/station/medical/medbooth)
 "kQR" = (
 /obj/machinery/camera/television{
 	c_tag = "test chamber";
@@ -54104,19 +54002,6 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
-"kSp" = (
-/obj/machinery/computer3/terminal/zeta{
-	dir = 8;
-	setup_os_string = "ZETA_MAINFRAME"
-	},
-/obj/machinery/power/data_terminal,
-/obj/cable,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/yellowblack/corner,
-/area/station/crew_quarters/ce)
 "kTo" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	level = 2
@@ -54135,44 +54020,40 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/cloner)
-"kXB" = (
-/obj/table/auto,
-/obj/item/storage/box/glassbox,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shot,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shot,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shot,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shot,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
-/obj/item/reagent_containers/food/drinks/drinkingglass/cocktail,
-/obj/item/reagent_containers/food/drinks/drinkingglass/cocktail,
-/obj/item/reagent_containers/food/drinks/drinkingglass/cocktail,
-/obj/item/reagent_containers/food/drinks/drinkingglass/cocktail,
-/obj/item/gun/russianrevolver,
-/obj/machinery/light_switch/west,
-/obj/item/device/radio/intercom/catering,
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/baroffice)
-"lbB" = (
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
+"kUf" = (
+/obj/critter/parrot/random,
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/grass,
 /area/station/garden/aviary)
+"lan" = (
+/obj/table/reinforced/chemistry/auto,
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/obj/machinery/light_switch/north,
+/obj/machinery/phone,
+/obj/item/stamp/md{
+	pixel_x = -14;
+	rand_pos = 0
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/north,
+/area/station/crew_quarters/md)
+"lbW" = (
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
 "les" = (
 /obj/decal/cleanable/dirt,
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"leW" = (
-/obj/machinery/communications_dish{
-	tag = "MAIN_DISH_SS13"
-	},
-/turf/simulated/floor/plating/airless,
-/area/station/com_dish/comdish)
+"leU" = (
+/obj/machinery/light,
+/turf/simulated/floor/grass,
+/area/station/hydroponics/bay)
 "lfa" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -54196,17 +54077,18 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
-"lhA" = (
-/obj/wingrille_spawn/auto,
-/obj/disposalpipe/segment/morgue{
-	dir = 4
+"lfK" = (
+/obj/machinery/door/airlock/pyro/command{
+	aiControlDisabled = 1;
+	name = "Armory";
+	req_access = null
 	},
-/obj/cable,
+/obj/access_spawn/hos,
 /obj/cable{
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/station/medical/medbooth)
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
 "lhD" = (
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/disposalpipe/segment/vertical,
@@ -54253,14 +54135,6 @@
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/supply)
-"lkw" = (
-/obj/machinery/portable_atmospherics/canister/air/large,
-/obj/machinery/atmospherics/pipe/manifold{
-	dir = 4;
-	level = 2
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
 "lkQ" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -54279,6 +54153,15 @@
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/quartermaster/office)
+"lmR" = (
+/obj/storage/secure/closet/command/captain,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/autoname_north,
+/turf/simulated/floor/carpet/arcade,
+/area/station/bridge/captain)
 "lnO" = (
 /obj/machinery/manufacturer/robotics,
 /obj/cable{
@@ -54296,6 +54179,26 @@
 /obj/machinery/light,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
+"lpn" = (
+/obj/table/wood/auto,
+/obj/machinery/phone,
+/turf/simulated/floor/black,
+/area/station/bridge/hos)
+"lqO" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/emergency{
+	dir = 1;
+	pixel_y = 16
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/nw,
+/area/station/bridge)
 "lrq" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 1;
@@ -54306,21 +54209,26 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"lrs" = (
+"lsB" = (
+/obj/disposalpipe/junction/right/north,
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
+"ltA" = (
+/obj/machinery/light/runway_light/delay5,
 /obj/lattice{
+	dir = 6;
 	icon_state = "lattice-dir"
 	},
-/obj/machinery/light/runway_light/delay4,
 /turf/space,
 /area/station/ai_monitored/armory)
-"lsm" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+"ltS" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet,
+/obj/item/device/radio/intercom,
+/turf/simulated/floor/grey/side{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/area/space)
 "lvb" = (
 /obj/grille/steel,
 /obj/disposalpipe/segment/transport,
@@ -54328,10 +54236,11 @@
 /area/station/crew_quarters/clown{
 	name = "Clowntainment"
 	})
-"lvC" = (
-/obj/machinery/shieldgenerator/meteorshield,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+"lvH" = (
+/obj/lattice,
+/obj/machinery/light/runway_light/delay4,
+/turf/space,
+/area/station/ai_monitored/armory)
 "lyu" = (
 /obj/lattice{
 	dir = 4;
@@ -54356,78 +54265,25 @@
 /obj/disposalpipe/segment/bent/west,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
-"lCD" = (
-/obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
-"lCE" = (
-/obj/table/reinforced/auto,
-/obj/item/decoration/ashtray{
-	pixel_x = -9
-	},
-/obj/item/card_box/suit{
-	pixel_x = 1;
-	pixel_y = 3
-	},
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/grime,
-/area/station/security/brig)
 "lFW" = (
-/obj/stool/chair/comfy{
-	dir = 4
+/obj/machinery/door_timer/solitary2/new_walls/north{
+	layer = 3.1
 	},
-/turf/simulated/floor/carpet/blue/fancy/edge/west,
-/area/station/bridge)
-"lGc" = (
 /obj/machinery/light{
-	dir = 4;
+	dir = 1;
 	layer = 9.1;
-	pixel_x = 10
+	pixel_y = 21
 	},
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/neutral/side{
+/turf/simulated/floor/redblack/corner{
 	dir = 4
 	},
-/area/station/crew_quarters/quarters_south)
-"lGK" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/area/space)
+"lGb" = (
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Holding Cell Two"
 	},
-/obj/stool/chair/office/blue{
-	dir = 4
-	},
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
-"lGX" = (
-/obj/item/storage/toilet,
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/grey/side{
-	dir = 8
-	},
+/obj/access_spawn/brig,
+/turf/simulated/floor/black,
 /area/space)
 "lHa" = (
 /obj/machinery/light/emergency{
@@ -54436,21 +54292,26 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/south)
-"lIw" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "8-10"
-	},
-/obj/item/storage/box/cablesbox,
-/turf/simulated/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/station/maintenance/southeast)
 "lJE" = (
 /obj/machinery/hair_dye_dispenser,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/barber_shop)
+"lJN" = (
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
+"lKR" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbooth)
 "lMO" = (
 /obj/wingrille_spawn/auto,
 /obj/cable,
@@ -54467,27 +54328,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/brig)
-"lOS" = (
+"lQO" = (
+/obj/table/wood/auto,
+/obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "0-2"
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/phone,
+/obj/item/stamp/ce{
+	pixel_x = -12;
+	rand_pos = 0
 	},
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
-"lRa" = (
-/obj/machinery/door/airlock/pyro/external{
-	name = "Auxiliary Docking Point"
+/turf/simulated/floor/yellowblack{
+	dir = 1
 	},
-/turf/simulated/floor/caution/northsouth,
-/area/station/hallway/secondary/exit)
-"lRb" = (
-/obj/machinery/portable_atmospherics/pump,
-/turf/simulated/floor/plating,
-/area/station/maintenance/central)
+/area/station/crew_quarters/ce)
 "lRp" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -54495,62 +54350,47 @@
 /obj/machinery/light/emergency,
 /turf/simulated/floor/yellow/side,
 /area/station/hallway/primary/west)
-"lRW" = (
-/obj/stool/chair/office{
-	dir = 4
+"lSk" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
 	},
-/obj/landmark/start{
-	name = "Medical Director"
-	},
-/turf/simulated/floor/carpet/blue,
-/area/station/crew_quarters/md)
+/obj/item/storage/toolbox/emergency,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "lUL" = (
 /obj/machinery/turret,
 /turf/simulated/floor/darkblue,
 /area/station/turret_protected/ai)
-"lVA" = (
-/obj/rack,
-/obj/item/clothing/suit/armor/heavy,
-/obj/item/clothing/suit/armor/heavy,
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/glasses/thermal,
-/obj/item/clothing/glasses/thermal,
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
-"lVX" = (
-/obj/shrub{
+"lVz" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/window_blinds/cog2/right{
 	dir = 8
 	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
-"lXs" = (
-/obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/left,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
+/obj/cable,
 /turf/simulated/floor/plating,
-/area/station/bridge/captain)
+/area/station/crew_quarters/ce)
 "lXB" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "black";
-	icon_state = "bedsheet-black"
+/obj/machinery/light/emergency,
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"lZl" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13";
+	tag = ""
 	},
-/obj/landmark/start{
-	name = "Bartender"
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"maH" = (
+/obj/machinery/light/emergency{
+	dir = 8;
+	pixel_x = -10
 	},
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/baroffice)
+/turf/simulated/floor/black,
+/area/station/bridge)
 "mep" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/wall/auto/supernorn,
@@ -54562,12 +54402,15 @@
 	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
-"mgL" = (
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/green/side{
-	dir = 1
+"mgB" = (
+/obj/cable{
+	icon_state = "4-8"
 	},
-/area/station/hallway/primary/south)
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor,
+/area/station/security/brig)
 "mhV" = (
 /obj/disposalpipe/segment/morgue{
 	icon_state = "pipe-c"
@@ -54613,42 +54456,50 @@
 /obj/machinery/light/small/floor,
 /turf/simulated/floor/caution/east,
 /area/station/quartermaster/office)
-"mnd" = (
-/obj/storage/secure/closet/medical/chemical,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/blue/fancy/edge/se,
-/area/station/crew_quarters/md)
 "mnz" = (
 /obj/decal/poster/wallsign/space,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/quartermaster/office)
-"mpV" = (
-/obj/disposalpipe/segment/vertical,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/cafeteria)
 "mpY" = (
 /obj/machinery/light/small,
 /obj/machinery/chemicompiler_stationary,
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
-"mqm" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "4-10"
+"mqf" = (
+/obj/machinery/optable,
+/obj/item/device/analyzer/healthanalyzer{
+	pixel_y = -1;
+	rand_pos = 0
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/turf/simulated/floor/bluewhite,
+/area/station/medical/medbooth)
 "mqC" = (
 /turf/space,
 /area/supply/delivery_point)
+"msU" = (
+/obj/machinery/door/airlock/pyro{
+	dir = 4;
+	icon_state = "generic_locked";
+	locked = 1
+	},
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/quarters_south)
+"mtm" = (
+/obj/access_spawn/brig,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Armory"
+	},
+/obj/access_spawn/brig,
+/turf/simulated/floor/red,
+/area/station/security/brig)
 "muI" = (
 /obj/machinery/light/emergency{
 	dir = 4;
@@ -54656,28 +54507,45 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/science)
-"myO" = (
-/obj/table/auto,
-/obj/item/storage/toolbox/electrical,
-/obj/item/device/gps,
-/obj/item/aiModule/reset,
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+"mxv" = (
+/obj/item/storage/toilet{
+	dir = 4
 	},
-/obj/item/device/radio/intercom/medical,
-/obj/item/circuitboard/aiupload,
-/obj/item/disk/data/floppy/read_only/communications,
-/turf/simulated/floor/circuit,
+/obj/blind_switch/area/south,
+/obj/decal/tile_edge/line/black{
+	dir = 1;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/md)
+"myd" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
+"myz" = (
+/obj/table/reinforced/bar/auto,
+/obj/item/game_kit,
+/turf/simulated/floor/carpet/blue,
 /area/station/bridge)
-"mzV" = (
-/obj/landmark/gps_waypoint,
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
 "mzX" = (
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters_east)
+"mBf" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/stairs{
+	dir = 8
+	},
+/area/station/maintenance/southeast)
 "mCe" = (
 /obj/reagent_dispensers/watertank/big,
 /turf/simulated/floor/grass,
@@ -54698,12 +54566,17 @@
 /obj/storage/closet/fire,
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
-"mHQ" = (
-/obj/table/wood/auto,
-/obj/random_item_spawner/desk_stuff,
-/obj/item/stamp/cap,
-/turf/simulated/floor/carpet/arcade,
-/area/station/bridge/captain)
+"mFo" = (
+/obj/machinery/chem_dispenser,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/cafeteria)
+"mHd" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig)
 "mHX" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/lattice{
@@ -54721,13 +54594,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/routing/depot)
-"mJA" = (
-/obj/disposalpipe/segment/transport{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/space,
-/area/space)
 "mKe" = (
 /obj/machinery/disposal,
 /obj/machinery/light/small{
@@ -54744,6 +54610,21 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/catering)
+"mLv" = (
+/obj/table/auto,
+/obj/item/storage/box/diskbox,
+/turf/simulated/floor/greenblack,
+/area/station/turret_protected/Zeta)
+"mOa" = (
+/obj/machinery/door/poddoor/pyro{
+	id = "dwaine_core";
+	name = "DWAINE Core Shield"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "mOF" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/black/grime,
@@ -54761,6 +54642,21 @@
 /obj/machinery/espresso_machine,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
+"mPG" = (
+/obj/lattice{
+	dir = 5;
+	icon_state = "lattice-dir-b"
+	},
+/obj/machinery/light/runway_light/delay3,
+/turf/space,
+/area/station/ai_monitored/armory)
+"mQo" = (
+/obj/decal/skeleton{
+	desc = "It's all covered in a sticky mess, and there are chunks of uniform fused to the bone.";
+	name = "sticky skeleton"
+	},
+/turf/simulated/floor/plating/scorched,
+/area/station/crew_quarters/quarters_south)
 "mRy" = (
 /obj/machinery/cargo_router/kd_med_right,
 /turf/simulated/floor/airless/grey,
@@ -54769,17 +54665,6 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/east)
-"mTo" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet,
-/obj/disposalpipe/segment/brig{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/grey/side{
-	dir = 8
-	},
-/area/station/security/brig)
 "mVi" = (
 /obj/cable{
 	d1 = 4;
@@ -54798,33 +54683,45 @@
 	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
-"mXe" = (
-/obj/item/storage/toilet{
+"mZn" = (
+/obj/stool,
+/obj/item/device/radio/intercom{
 	dir = 4
 	},
-/obj/blind_switch/area/south,
-/obj/decal/tile_edge/line/black{
-	dir = 1;
-	icon_state = "line1"
+/turf/simulated/floor/grey/side{
+	dir = 8
 	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/md)
-"mXi" = (
-/obj/table/reinforced/auto,
-/obj/item/paper/book/medical_surgery_guide{
-	pixel_x = 9
+/area/station/security/brig)
+"mZL" = (
+/obj/machinery/computer3/terminal/zeta{
+	setup_os_string = "ZETA_MAINFRAME"
 	},
-/obj/machinery/defib_mount{
-	pixel_x = -6
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/bluewhite,
-/area/station/medical/medbooth)
-"nbH" = (
-/obj/machinery/plantpot{
-	anchored = 1
+/turf/simulated/floor/plating{
+	icon_state = "platingdmg3"
 	},
-/turf/simulated/floor/grass,
-/area/station/hydroponics/bay)
+/area/station/maintenance/southeast)
+"naq" = (
+/obj/table/round/auto,
+/obj/machinery/computer3/generic/personal,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/neutral/side{
+	dir = 8
+	},
+/area/station/crew_quarters/quarters_south)
+"nbp" = (
+/obj/table/round/auto,
+/obj/item/goboard,
+/turf/simulated/floor,
+/area/station/crew_quarters/quarters_south)
 "nbO" = (
 /obj/machinery/door_control/podbay/security/new_walls/north,
 /obj/disposalpipe/segment/brig{
@@ -54862,14 +54759,26 @@
 /obj/access_spawn/research,
 /turf/simulated/floor/engine/caution/westeast,
 /area/station/science/testchamber)
-"ngu" = (
+"ngJ" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/red/side,
+/area/station/hallway/primary/south)
+"nhZ" = (
+/obj/table/auto,
+/obj/item/storage/toolbox/electrical,
+/obj/item/device/gps,
+/obj/item/aiModule/reset,
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
+/obj/item/device/radio/intercom/medical,
+/obj/item/circuitboard/aiupload,
+/obj/item/disk/data/floppy/read_only/communications,
+/turf/simulated/floor/circuit,
+/area/station/bridge)
 "niK" = (
 /obj/plasticflaps{
 	layer = 3
@@ -54904,63 +54813,28 @@
 	},
 /turf/simulated/floor/black/grime,
 /area/station/maintenance/inner/central)
-"nnb" = (
-/obj/storage/secure/closet/command/medical_director,
-/obj/item/storage/box/beakerbox,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/machinery/firealarm{
+"nnX" = (
+/obj/machinery/rkit,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
+	},
+/obj/machinery/alarm{
 	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
+	pixel_x = -20
 	},
-/obj/item/clipboard,
-/obj/item/pen,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/md)
-"nog" = (
-/obj/table/reinforced/bar/auto,
-/obj/item/reagent_containers/food/drinks/bowl,
-/obj/item/kitchen/utensil/spoon,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/green/standard/narrow/northsouth,
-/area/station/crew_quarters/cafeteria)
-"nop" = (
-/obj/machinery/vending/snack{
-	credit = 50
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/brig)
-"noM" = (
-/obj/machinery/turretid{
-	pixel_x = 26
-	},
-/obj/machinery/light,
-/turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
-"npf" = (
-/obj/machinery/door/airlock/pyro/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"npm" = (
-/obj/disposalpipe/segment/brig{
+/turf/simulated/floor/yellowblack{
 	dir = 1
 	},
-/turf/simulated/floor/grime,
-/area/station/security/brig)
+/area/station/crew_quarters/ce)
 "npx" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/red/side,
 /area/station/security/brig)
-"npF" = (
-/obj/landmark{
-	name = "blobstart"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
 "nql" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -54974,6 +54848,10 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
+"nsO" = (
+/obj/machinery/shieldgenerator/meteorshield,
+/turf/simulated/floor/plating,
+/area/station/maintenance/central)
 "ntn" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
@@ -54984,24 +54862,6 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/barber_shop)
-"nwb" = (
-/obj/machinery/floorflusher/solitary2,
-/obj/submachine/chef_sink/chem_sink{
-	pixel_y = 16
-	},
-/obj/disposalpipe/trunk/south,
-/turf/simulated/floor/black,
-/area/space)
-"nwK" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 10;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
 "nAw" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/machinery/door/poddoor/pyro{
@@ -55032,14 +54892,6 @@
 	dir = 8
 	},
 /area/station/security/hos)
-"nDe" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/ai_monitored/armory)
 "nDM" = (
 /obj/decal/tile_edge/line/green{
 	icon_state = "line1"
@@ -55052,10 +54904,15 @@
 	dir = 8
 	},
 /area/station/crew_quarters/quarters_south)
-"nFT" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet,
-/obj/item/device/radio/intercom,
+"nFo" = (
+/obj/item/storage/toilet,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
 /turf/simulated/floor/grey/side{
 	dir = 4
 	},
@@ -55067,6 +54924,14 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/medical)
+"nHi" = (
+/obj/table/wood/auto,
+/obj/item/paper_bin,
+/obj/item/pen/fancy,
+/obj/machinery/light,
+/obj/item/stamp/hop,
+/turf/simulated/floor/black,
+/area/station/bridge/hos)
 "nJC" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -55078,8 +54943,24 @@
 	},
 /turf/simulated/floor/caution/northsouth,
 /area/station/quartermaster/office)
-"nKt" = (
-/obj/table/wood/round/auto,
+"nKa" = (
+/obj/table/auto,
+/obj/item/shaker/salt,
+/obj/item/shaker/mustard{
+	pixel_x = -6
+	},
+/obj/item/shaker/pepper{
+	pixel_x = 3
+	},
+/obj/item/shaker/ketchup{
+	pixel_x = 6
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
+"nKc" = (
+/obj/shrub{
+	dir = 6
+	},
 /turf/simulated/floor/grass,
 /area/station/garden/aviary)
 "nKN" = (
@@ -55093,15 +54974,6 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/bridge/captain)
-"nLk" = (
-/obj/submachine/chem_extractor,
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/green/side{
-	dir = 8
-	},
-/area/station/hydroponics/bay)
 "nLA" = (
 /obj/decal/tile_edge/line/green{
 	dir = 10;
@@ -55124,6 +54996,15 @@
 	icon_state = "12"
 	},
 /area/station/chapel/office)
+"nPR" = (
+/obj/stool/chair{
+	dir = 8
+	},
+/obj/machinery/phone/wall{
+	pixel_y = 32
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/baroffice)
 "nQL" = (
 /obj/machinery/atmospherics/binary/passive_gate{
 	dir = 4;
@@ -55164,6 +55045,31 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
+"nSH" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 21;
+	pixel_y = -3
+	},
+/obj/fitness/weightlifter,
+/turf/simulated/floor/grime,
+/area/station/security/brig)
+"nVs" = (
+/obj/machinery/door/airlock/pyro/security{
+	name = "Secure Consultation"
+	},
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/turf/simulated/floor/redblack,
+/area/station/security/brig)
 "nVE" = (
 /obj/disposalpipe/segment/vertical,
 /obj/machinery/power/apc/autoname_east,
@@ -55172,44 +55078,56 @@
 	dir = 4
 	},
 /area/station/crew_quarters/quarters_south)
+"nWB" = (
+/obj/machinery/door/airlock/pyro/external{
+	name = "Auxiliary Docking Point"
+	},
+/turf/simulated/floor/caution/northsouth,
+/area/station/hallway/secondary/exit)
 "nXV" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/portable_atmospherics/canister/air/large,
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 4;
+	level = 2
 	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
-"nZi" = (
-/obj/storage/crate,
-/obj/item/device/radio/headset/multifreq,
-/obj/item/device/radio/headset/multifreq,
-/obj/item/device/radio/headset/medical,
-/obj/item/device/radio/headset/medical,
-/obj/item/device/radio/headset/security,
-/obj/item/device/radio/headset/security,
-/obj/item/device/radio/headset/engineer,
-/obj/item/device/radio/headset/engineer,
-/obj/item/device/radio/headset/research,
-/obj/item/device/radio/headset/research,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc/autoname_east,
-/turf/simulated/floor/black,
-/area/station/bridge)
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "nZC" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/neutral/corner{
 	dir = 8
 	},
 /area/station/hallway/primary/east)
+"oaz" = (
+/obj/stool/chair/comfy/purple{
+	dir = 4
+	},
+/obj/landmark/start{
+	name = "Research Director"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/carpet/purple/fancy,
+/area/station/science/research_director)
+"ocT" = (
+/obj/machinery/door/airlock/pyro/security{
+	dir = 4;
+	name = "Brig";
+	req_access = null
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/access_spawn/brig,
+/obj/firedoor_spawn,
+/turf/simulated/floor/red,
+/area/station/security/brig)
 "ocX" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/disposalpipe/segment/mail/vertical,
@@ -55219,15 +55137,43 @@
 	dir = 4
 	},
 /area/station/hallway/primary/east)
-"oij" = (
-/obj/machinery/networked/radio,
+"oek" = (
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "1-8"
 	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"oeN" = (
+/obj/machinery/vehicle/escape_pod{
+	dir = 4
+	},
+/turf/simulated/floor/shuttlebay,
+/area/station/hallway/secondary/exit)
+"oeU" = (
+/obj/machinery/light/runway_light/delay2,
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/station/ai_monitored/armory)
+"ogC" = (
+/obj/stool,
+/turf/simulated/floor/grey/side{
+	dir = 8
+	},
+/area/space)
+"ojj" = (
+/obj/disposalpipe/segment/transport{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/space,
+/area/station/ai_monitored/armory)
 "ojD" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/east)
@@ -55236,41 +55182,16 @@
 /obj/warp_beacon/security,
 /turf/space,
 /area/space)
-"omo" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
+"onM" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4
 	},
-/obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/landmark/halloween,
-/turf/simulated/floor/escape/corner{
-	dir = 1
-	},
-/area/station/hallway/primary/south)
-"omK" = (
-/obj/submachine/ice_cream_dispenser,
-/obj/machinery/light/emergency{
-	dir = 8;
-	pixel_x = -10
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/cafeteria)
-"omZ" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/mail/bent/west,
-/turf/simulated/floor/stairs/wide/other{
-	dir = 8
-	},
-/area/station/bridge)
-"onQ" = (
-/turf/simulated/floor/damaged5,
-/area/station/crew_quarters/quarters_south)
+/turf/simulated/floor/white,
+/area/station/medical/medbooth)
+"onX" = (
+/obj/item/clothing/suit/cardboard_box,
+/turf/simulated/floor/grime,
+/area/station/maintenance/southeast)
 "oop" = (
 /obj/machinery/light{
 	dir = 8;
@@ -55287,25 +55208,21 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
-"opQ" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
+"orf" = (
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
-/area/space)
-"oqm" = (
-/obj/stool/chair/wooden{
+/area/station/security/brig)
+"orp" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 1
+	},
+/obj/stool/chair/blue{
+	dir = 4
+	},
+/turf/simulated/floor/blue/side{
 	dir = 8
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
+/area/station/hallway/primary/south)
 "osJ" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -55315,29 +55232,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
-"otF" = (
-/obj/table/auto,
-/obj/item/paper_bin{
-	pixel_y = 6
-	},
-/obj/deskclutter,
-/obj/item/hand_labeler{
-	pixel_x = 5
-	},
-/obj/item/plantanalyzer,
-/obj/item/device/reagentscanner{
-	pixel_x = -7
-	},
-/obj/item/pen,
-/turf/simulated/floor,
-/area/station/hydroponics/bay)
-"ouj" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
 "our" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -55346,22 +55240,17 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/exit)
+"ouG" = (
+/obj/disposalpipe/segment/transport{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/space,
+/area/space)
 "ovi" = (
 /obj/item/seed/alien,
 /turf/simulated/floor/plating/airless/asteroid/dark,
 /area/space)
-"ovV" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/window_blinds/cog2/middle{
-	dir = 8
-	},
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/md)
 "ovZ" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 1
@@ -55370,15 +55259,6 @@
 	dir = 8
 	},
 /area/station/science/testchamber)
-"ows" = (
-/obj/tree1,
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
-"owz" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/red/side,
-/area/station/hallway/primary/south)
 "owG" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/landmark/halloween,
@@ -55395,6 +55275,17 @@
 	dir = 1
 	},
 /area/station/hallway/primary/east)
+"owU" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/baroffice)
 "oxU" = (
 /obj/disposalpipe/segment/brig,
 /obj/disposalpipe/segment/brig{
@@ -55432,6 +55323,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/mining/refinery)
+"oCW" = (
+/obj/machinery/computer/announcement{
+	dir = 4;
+	name = "Executive Announcement Computer";
+	pixel_x = -3;
+	pixel_y = 4;
+	req_access_txt = "19"
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/sanitary/white,
+/area/station/bridge/captain)
 "oDQ" = (
 /obj/machinery/light/emergency{
 	dir = 8;
@@ -55456,15 +55366,10 @@
 /obj/decal/poster/wallsign/hazard_bio,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/morgue)
-"oGR" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/stairs{
-	dir = 8
-	},
-/area/station/maintenance/southeast)
+"oGn" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "oHK" = (
 /obj/stool/chair{
 	dir = 8
@@ -55499,25 +55404,14 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit)
-"oJe" = (
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/redblack/corner{
-	dir = 4
-	},
-/area/space)
-"oJW" = (
-/obj/machinery/portable_atmospherics/canister/air/large,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"oNB" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/light/runway_light,
-/turf/space,
-/area/station/ai_monitored/armory)
+"oOz" = (
+/obj/table/auto,
+/obj/machinery/cell_charger,
+/obj/item/cell/supercell/charged,
+/obj/item/cell/supercell/charged,
+/obj/machinery/light/small,
+/turf/simulated/floor/circuit,
+/area/station/bridge)
 "oQa" = (
 /obj/lattice{
 	dir = 8;
@@ -55525,25 +55419,12 @@
 	},
 /turf/space,
 /area/station/com_dish/comdish)
-"oQw" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4;
-	high_risk = 1;
-	name = "Cafeteria"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
+"oQN" = (
+/obj/table/auto,
+/obj/random_item_spawner/tools,
+/obj/item/device/light/glowstick,
+/obj/item/device/light/glowstick,
 /turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"oRL" = (
-/obj/item/tile/steel,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/grime,
 /area/station/maintenance/southeast)
 "oTv" = (
 /obj/wingrille_spawn/auto,
@@ -55559,21 +55440,26 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/ai_monitored/armory)
-"oYx" = (
+"oVM" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/window_blinds/cog2/right{
+	dir = 8
+	},
 /obj/cable{
-	d1 = 4;
 	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/md)
+"oWo" = (
+/obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet/blue/fancy/edge/south,
-/area/station/crew_quarters/md)
-"oZb" = (
-/obj/machinery/light/runway_light/delay3,
-/obj/lattice{
-	icon_state = "lattice-dir"
+/turf/simulated/floor/red/side{
+	dir = 4
 	},
-/turf/space,
-/area/station/ai_monitored/armory)
+/area/station/security/brig)
 "oZc" = (
 /obj/cable{
 	d1 = 1;
@@ -55597,20 +55483,26 @@
 /obj/disposalpipe/trunk/east,
 /turf/simulated/floor/airless/grey,
 /area/station/maintenance/west)
-"pcT" = (
-/obj/machinery/door/airlock/pyro/maintenance,
+"peh" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/firedoor_spawn,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
+	},
 /turf/simulated/floor/greenblack{
 	dir = 1
 	},
-/area/station/garden/aviary)
-"pdh" = (
-/obj/machinery/drainage,
-/turf/simulated/floor/black,
-/area/space)
+/area/station/turret_protected/Zeta)
 "pfK" = (
 /obj/machinery/light{
 	dir = 8;
@@ -55633,19 +55525,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
-"pfU" = (
-/obj/machinery/door/airlock/pyro/security{
-	dir = 4;
-	name = "Brig";
-	req_access = null
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/access_spawn/brig,
-/obj/firedoor_spawn,
-/turf/simulated/floor/red,
-/area/station/security/brig)
 "phu" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -55654,14 +55533,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
-"plK" = (
-/obj/wingrille_spawn/auto/crystal,
+"phA" = (
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/ai_monitored/armory)
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/Zeta)
 "pmt" = (
 /obj/table/auto,
 /obj/machinery/cell_charger,
@@ -55675,6 +55557,16 @@
 /obj/item/cell/supercell/charged,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
+"pmx" = (
+/obj/stool/chair,
+/obj/machinery/light/emergency{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 8
+	},
+/area/station/crew_quarters/quarters_south)
 "pmR" = (
 /obj/decal/tile_edge/line/green{
 	dir = 8;
@@ -55706,15 +55598,6 @@
 /obj/item/clothing/head/cakehat,
 /turf/simulated/floor/carpet/green/standard/narrow/northsouth,
 /area/station/crew_quarters/cafeteria)
-"ppZ" = (
-/obj/stool/chair{
-	dir = 4
-	},
-/obj/item/storage/secure/ssafe/loot{
-	pixel_x = -28
-	},
-/turf/simulated/floor/damaged3,
-/area/station/crew_quarters/quarters_south)
 "pqx" = (
 /obj/shrub{
 	desc = "While it's wildly unlikely that this bush hails from Space Sweden, it nevertheless bears a faint scent of meatballs that can't be adequately explained.";
@@ -55744,31 +55627,63 @@
 /obj/landmark/halloween,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
+"psl" = (
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/landmark/halloween,
+/turf/simulated/floor/escape/corner{
+	dir = 1
+	},
+/area/station/hallway/primary/south)
 "pso" = (
 /obj/disposalpipe/segment/transport,
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
-"pvT" = (
-/obj/machinery/power/apc/autoname_north,
-/obj/table/wood/auto,
-/obj/machinery/phone,
-/obj/cable{
-	icon_state = "0-2"
+"pvj" = (
+/obj/table/auto,
+/obj/item/storage/box/glassbox,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shot,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shot,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shot,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shot,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
+/obj/item/reagent_containers/food/drinks/drinkingglass/cocktail,
+/obj/item/reagent_containers/food/drinks/drinkingglass/cocktail,
+/obj/item/reagent_containers/food/drinks/drinkingglass/cocktail,
+/obj/item/reagent_containers/food/drinks/drinkingglass/cocktail,
+/obj/item/gun/russianrevolver,
+/obj/machinery/light_switch/west,
+/obj/item/device/radio/intercom/catering,
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/baroffice)
+"pvP" = (
+/obj/stool/chair{
+	dir = 4
 	},
-/turf/simulated/floor/carpet/purple/fancy/edge/ne,
-/area/station/science/research_director)
-"pxv" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/item/storage/secure/ssafe/loot{
+	pixel_x = -28
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/turf/simulated/floor/damaged3,
+/area/station/crew_quarters/quarters_south)
+"pwM" = (
+/obj/disposalpipe/segment/mail/vertical,
+/turf/simulated/floor/black/side{
+	dir = 10
 	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/hallway/primary/south)
+"pzj" = (
+/obj/critter/roach,
+/turf/simulated/floor/grime,
+/area/station/maintenance/southeast)
 "pAA" = (
 /obj/machinery/plantpot{
 	anchored = 1
@@ -55788,25 +55703,10 @@
 /obj/machinery/light/runway_light/delay5,
 /turf/space,
 /area/station/ai_monitored/armory)
-"pBn" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/grey,
-/area/station/hallway/secondary/exit)
 "pCp" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/space,
 /area/space)
-"pCH" = (
-/obj/disposalpipe/segment/transport{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/space,
-/area/station/ai_monitored/armory)
 "pCV" = (
 /obj/disposalpipe/segment/bent/south,
 /obj/cable{
@@ -55815,9 +55715,13 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
-"pEy" = (
-/turf/simulated/floor/carpet/blue/fancy/edge/east,
-/area/station/bridge)
+"pDf" = (
+/obj/machinery/chem_dispenser,
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/north,
+/area/station/crew_quarters/md)
 "pFF" = (
 /obj/table/auto,
 /obj/item/sheet/steel/fullstack,
@@ -55825,36 +55729,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
-"pFI" = (
-/obj/grille/catwalk{
-	dir = 9
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 8;
-	icon_state = "catwalk_cross"
-	},
-/area/station/maintenance/southeast)
-"pHf" = (
-/obj/machinery/computer3/terminal/network{
-	dir = 4;
-	name = "CENTCOM Terminal";
-	pixel_x = -3;
-	pixel_y = 4;
-	setup_os_string = "MAIN_DISH_SS13"
-	},
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/sanitary/white,
-/area/station/bridge/captain)
 "pIV" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8;
@@ -55862,42 +55736,60 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
-"pJd" = (
-/obj/stool,
-/turf/simulated/floor/grey/side{
-	dir = 8
-	},
-/area/space)
 "pJk" = (
 /obj/landmark/spawner{
 	name = "monkeyspawn_krimpus"
 	},
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
-"pJs" = (
-/obj/machinery/light/runway_light/delay2,
-/obj/lattice{
-	icon_state = "lattice-dir"
+"pMS" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/space,
-/area/station/ai_monitored/armory)
-"pLB" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 1
-	},
-/obj/stool/chair/blue{
-	dir = 4
-	},
-/turf/simulated/floor/blue/side{
+/obj/disposalpipe/segment/mail/bent/west,
+/turf/simulated/floor/stairs/wide/other{
 	dir = 8
 	},
-/area/station/hallway/primary/south)
-"pOi" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4
+/area/station/bridge)
+"pQu" = (
+/obj/stool{
+	desc = "A soft little bed the general size and shape of a space bee.";
+	icon = 'icons/misc/critter.dmi';
+	icon_state = "beebed";
+	name = "heisenbed"
 	},
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
+/obj/item/reagent_containers/food/snacks/beefood{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/critter/domestic_bee/heisenbee,
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/obj/machinery/light_switch/north,
+/turf/simulated/floor/carpet/purple/fancy/edge/north,
+/area/station/science/research_director)
+"pRd" = (
+/obj/storage/crate/rcd,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/yellowblack/corner{
+	dir = 1
+	},
+/area/station/crew_quarters/ce)
+"pRr" = (
+/obj/machinery/plantpot{
+	anchored = 1
+	},
+/turf/simulated/floor/grass,
+/area/station/hydroponics/bay)
 "pSJ" = (
 /obj/table/auto,
 /obj/item/remote/porter/port_a_medbay,
@@ -55921,11 +55813,28 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
-"pWV" = (
-/obj/table/reinforced/bar/auto,
-/obj/item/game_kit,
-/turf/simulated/floor/carpet/blue,
-/area/station/bridge)
+"pUE" = (
+/obj/decal/tile_edge/line/green{
+	dir = 1;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/neutral/corner{
+	dir = 1
+	},
+/area/station/crew_quarters/quarters_south)
+"pWa" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
 "pXJ" = (
 /obj/stool/chair/comfy/green{
 	dir = 8
@@ -55937,6 +55846,39 @@
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/north,
 /area/station/bridge/hos)
+"pZl" = (
+/obj/machinery/floorflusher/solitary2,
+/obj/disposalpipe/trunk/south,
+/turf/simulated/floor/black,
+/area/station/security/brig)
+"qaK" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/bridge)
+"qcU" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/turf/simulated/floor/red,
+/area/station/ai_monitored/armory)
+"qex" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/light/runway_light/delay3,
+/turf/space,
+/area/station/ai_monitored/armory)
 "qeG" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/cable{
@@ -55968,13 +55910,63 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
-"qin" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
+"qkd" = (
+/obj/storage/crate{
+	desc = "A private crate that isn't yours.";
+	name = "Beepsky's stuff"
 	},
-/obj/machinery/light/runway_light/delay3,
-/turf/space,
-/area/station/ai_monitored/armory)
+/obj/item/diary,
+/obj/item/clothing/shoes/black{
+	desc = "You have no idea how a robot with wheels for locomotion could possibly require these.";
+	name = "Beepsky's Shoes"
+	},
+/obj/item/storage/photo_album/beepsky,
+/obj/item/clothing/suit/det_suit/beepsky,
+/obj/item/clothing/head/NTberet{
+	desc = "It's a momento, I guess. An old keepsake. And maybe a reminder of the things we've left behind.";
+	name = "Old Beret"
+	},
+/obj/machinery/power/apc/autoname_east,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating/damaged3,
+/area/station/security/beepsky)
+"qmg" = (
+/obj/disposalpipe/segment/mail/vertical,
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
+"qmq" = (
+/obj/machinery/door_timer/solitary/new_walls/north{
+	layer = 3.1
+	},
+/obj/storage/closet/wardrobe/orange,
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -20
+	},
+/turf/simulated/floor/redblack/corner{
+	dir = 4
+	},
+/area/space)
+"qmz" = (
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/turf/simulated/floor/redblack{
+	dir = 10
+	},
+/area/station/security/brig)
 "qmL" = (
 /obj/machinery/vending/standard,
 /turf/simulated/floor/plating,
@@ -55988,6 +55980,24 @@
 	dir = 1
 	},
 /area/station/mining/staff_room)
+"qoy" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/yellowblack/corner,
+/area/station/crew_quarters/ce)
+"qoW" = (
+/obj/machinery/turret,
+/obj/lattice,
+/turf/space,
+/area/station/ai_monitored/armory)
 "qpS" = (
 /obj/tree1,
 /turf/simulated/floor/grass/leafy,
@@ -56006,6 +56016,25 @@
 /obj/machinery/bot/medbot,
 /turf/simulated/floor,
 /area/station/mining/staff_room)
+"qsw" = (
+/obj/table/reinforced/chemistry/auto{
+	name = "prep counter"
+	},
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/cafeteria)
+"qsx" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "4-10"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "qsO" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -56030,45 +56059,48 @@
 /obj/decal/tile_edge/floorguide/arrow_w,
 /turf/simulated/floor/darkblue/checker,
 /area/station/science/artifact)
-"qvM" = (
+"qtW" = (
+/obj/grille/catwalk{
+	dir = 9
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8;
+	icon_state = "catwalk_cross"
+	},
+/area/station/maintenance/southeast)
+"quN" = (
 /obj/table/reinforced/auto,
 /obj/item/paper_bin,
-/obj/item/pen/pencil,
+/obj/item/pen,
 /obj/item/reagent_containers/food/drinks/water,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/turf/simulated/floor/grey/side{
+	dir = 4
+	},
+/area/space)
+"qxl" = (
+/obj/shrub,
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_x = -12
 	},
-/obj/machinery/alarm{
-	pixel_y = 24
+/obj/cable{
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/grey/side{
-	dir = 8
-	},
-/area/station/security/brig)
-"qwj" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 20
-	},
-/obj/rack,
-/obj/item/storage/box/stinger_kit,
-/obj/item/chem_grenade/pepper,
-/obj/item/chem_grenade/pepper,
-/obj/item/chem_grenade/pepper,
-/obj/item/clothing/glasses/nightvision,
-/obj/item/clothing/glasses/nightvision,
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
-"qxv" = (
-/obj/decal/tile_edge/line/green{
-	dir = 1;
-	icon_state = "line1"
-	},
-/turf/simulated/floor/neutral/corner{
-	dir = 1
-	},
-/area/station/crew_quarters/quarters_south)
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
 "qxQ" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -56078,15 +56110,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"qyf" = (
-/obj/machinery/manufacturer/personnel,
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/courtroom)
 "qzi" = (
 /obj/machinery/power/smes{
 	chargelevel = 15000;
@@ -56103,14 +56126,23 @@
 	dir = 1
 	},
 /area/station/security/brig)
-"qCD" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+"qAR" = (
+/obj/decal/cleanable/dirt,
+/obj/machinery/shieldgenerator/energy_shield,
+/turf/simulated/floor/plating,
+/area/station/maintenance/central)
+"qCQ" = (
+/obj/table/auto,
+/obj/item/paper/book/guardbot_guide{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
+/obj/item/paper/book/dwainedummies{
+	pixel_y = 6
+	},
+/obj/item/disk/data/tape/master/readonly,
+/turf/simulated/floor/black,
+/area/station/bridge)
 "qEr" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/cable{
@@ -56123,74 +56155,67 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
+"qFo" = (
+/obj/stool/chair/office/yellow{
+	dir = 4
+	},
+/obj/landmark/start{
+	name = "Chief Engineer"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/orangeblack,
+/area/station/crew_quarters/ce)
+"qJi" = (
+/obj/machinery/atmospherics/pipe/tank/air_repressurization/north,
+/turf/simulated/floor/plating,
+/area/station/maintenance/central)
+"qJV" = (
+/obj/storage/closet/emergency,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "qKY" = (
 /obj/storage/secure/closet/engineering/mechanic,
 /obj/machinery/light,
 /turf/simulated/floor/yellow/side,
 /area/station/engine/elect)
-"qLH" = (
-/obj/table/auto,
-/obj/machinery/light,
-/obj/item/storage/toolbox/emergency,
-/obj/item/device/light/glowstick,
-/obj/item/device/light/glowstick,
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
-"qLK" = (
+"qLy" = (
+/obj/machinery/weapon_stand/shotgun_rack,
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
+"qMJ" = (
+/obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
-/obj/disposalpipe/segment/brig{
-	dir = 1
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
-"qMm" = (
+/turf/simulated/floor/plating,
+/area/station/medical/medbooth)
+"qRn" = (
+/obj/decal/tile_edge/line/green{
+	dir = 9;
+	icon_state = "line1"
+	},
 /obj/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"qMC" = (
-/obj/lattice,
-/obj/machinery/light/runway_light/delay4,
-/turf/space,
-/area/station/ai_monitored/armory)
-"qOe" = (
-/obj/machinery/door/airlock/pyro/maintenance,
-/obj/cable{
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/greenblack,
-/area/station/garden/aviary)
-"qPg" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
-	},
-/turf/space,
-/area/station/ai_monitored/armory)
-"qTb" = (
-/obj/machinery/door/airlock/pyro/command{
-	dir = 4;
-	name = "Computer Core"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/turf/simulated/floor,
+/area/station/crew_quarters/quarters_south)
 "qTA" = (
 /obj/stool/chair{
 	dir = 1
@@ -56200,20 +56225,9 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
-"qUn" = (
-/obj/machinery/chem_heater,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
-	},
-/obj/item/device/radio/intercom/medical{
-	pixel_x = 4;
-	pixel_y = 24
-	},
-/turf/simulated/floor/carpet/blue/fancy/edge/ne,
-/area/station/crew_quarters/md)
+"qVJ" = (
+/turf/simulated/floor/carpet/blue/fancy/edge/east,
+/area/station/bridge)
 "qYI" = (
 /obj/machinery/door/airlock/pyro/medical{
 	name = "Robotics";
@@ -56225,6 +56239,10 @@
 	dir = 1
 	},
 /area/station/medical/medbay/surgery)
+"qYM" = (
+/obj/machinery/atmospherics/pipe/simple,
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
 "qZq" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/decal/xmas_lights/ephemeral{
@@ -56261,6 +56279,17 @@
 	},
 /turf/space,
 /area/station/ai_monitored/armory)
+"rbi" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/stool/chair/office/blue{
+	dir = 4
+	},
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/catering)
 "rbG" = (
 /obj/machinery/light/emergency{
 	dir = 4;
@@ -56270,6 +56299,24 @@
 	dir = 4
 	},
 /area/station/medical/medbay)
+"rck" = (
+/obj/submachine/chem_extractor{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 9;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
 "rcK" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/simulated/floor/plating,
@@ -56282,21 +56329,20 @@
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/morgue)
-"rgu" = (
-/obj/machinery/atmospherics/pipe/simple{
+"rfX" = (
+/obj/lattice{
 	dir = 6;
-	level = 2
+	icon_state = "lattice-dir-b"
 	},
-/obj/cable{
-	icon_state = "6-8"
+/obj/machinery/light/runway_light/delay2,
+/turf/space,
+/area/station/ai_monitored/armory)
+"rgM" = (
+/obj/disposalpipe/segment/horizontal,
+/turf/simulated/floor/blue/side{
+	dir = 8
 	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "1-6"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/area/station/hallway/primary/south)
 "riF" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -56312,14 +56358,6 @@
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
-"rkB" = (
-/obj/table/wood/round/auto,
-/obj/item/storage/toolbox{
-	desc = "Looks suspiciously similar to a toolbox.";
-	name = "lunchbox"
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
 "rlg" = (
 /obj/table/reinforced/auto,
 /obj/disposalpipe/segment/vertical,
@@ -56335,10 +56373,33 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
-"rmZ" = (
-/obj/machinery/computer/tetris,
+"rnN" = (
+/obj/item/reagent_containers/food/drinks/bottle/thegoodstuff,
+/obj/shrub/captainshrub,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
+	},
 /turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
+/area/station/bridge/captain)
+"rrO" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/redblack/corner{
+	dir = 8
+	},
+/area/space)
 "rsz" = (
 /obj/disposalpipe/segment/transport,
 /obj/decal/poster/wallsign/medbay_left,
@@ -56387,6 +56448,25 @@
 	},
 /turf/simulated/floor/red,
 /area/station/security/main)
+"rxl" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"ryN" = (
+/obj/wingrille_spawn/auto,
+/obj/health_scanner/wall{
+	layer = 3.3
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbooth)
 "rzs" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -56394,14 +56474,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/lobby)
-"rBC" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13"
-	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
 "rBS" = (
 /obj/machinery/light,
 /obj/machinery/r_door_control/podbay/security/new_walls/east,
@@ -56415,13 +56487,10 @@
 	},
 /turf/space,
 /area/space)
-"rGW" = (
-/obj/machinery/door/airlock/pyro/glass{
-	name = "Holding Cell One"
-	},
-/obj/access_spawn/brig,
-/turf/simulated/floor/black,
-/area/space)
+"rGF" = (
+/obj/critter/parrot/random,
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
 "rHq" = (
 /turf/simulated/floor/carpet/purple/fancy/edge/east,
 /area/station/crew_quarters/quarters_north)
@@ -56429,27 +56498,6 @@
 /obj/machinery/bot/firebot,
 /turf/simulated/floor,
 /area/station/storage/warehouse)
-"rHM" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/redblack/corner{
-	dir = 8
-	},
-/area/space)
-"rJD" = (
-/obj/machinery/atmospherics/pipe/tank/air_repressurization/north,
-/turf/simulated/floor/plating,
-/area/station/maintenance/central)
-"rJJ" = (
-/obj/submachine/claw_machine,
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
 "rMk" = (
 /obj/stool/chair{
 	dir = 4;
@@ -56471,14 +56519,6 @@
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
-"rPt" = (
-/obj/disposalpipe/segment/horizontal,
-/obj/machinery/atmospherics/valve{
-	high_risk = 1;
-	name = "Bridge"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
 "rPP" = (
 /obj/landmark/spawner{
 	name = "monkeyspawn_albert"
@@ -56500,19 +56540,11 @@
 	},
 /turf/simulated/floor/white,
 /area/station/science/lobby)
-"rSk" = (
-/obj/machinery/door/airlock/pyro/security{
-	name = "Courtroom"
-	},
-/obj/machinery/secscanner{
-	pixel_y = 10
-	},
-/obj/decal/garland/ephemeral,
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/courtroom)
+"rSr" = (
+/obj/machinery/light_switch/east,
+/obj/storage/secure/closet/security/armory,
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
 "rSs" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -56522,37 +56554,33 @@
 	name = "Clowntainment"
 	})
 "rUm" = (
-/obj/machinery/light/emergency{
-	dir = 8;
-	pixel_x = -10
+/obj/machinery/floorflusher/solitary2,
+/obj/submachine/chef_sink/chem_sink{
+	pixel_y = 16
 	},
+/obj/disposalpipe/trunk/south,
 /turf/simulated/floor/black,
-/area/station/bridge)
-"rWz" = (
-/obj/submachine/chem_extractor{
-	dir = 8
+/area/space)
+"rXp" = (
+/turf/simulated/floor/redblack{
+	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 9;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/obj/machinery/firealarm{
+/area/station/security/brig)
+"rYj" = (
+/obj/machinery/door/airlock/pyro/command{
 	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
+	name = "Network Chamber"
 	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/catering)
-"rWU" = (
-/obj/table/auto,
-/obj/item/circuitboard/robotics,
-/obj/item/disk/data/floppy/read_only/network_progs,
-/obj/machinery/light,
-/turf/simulated/floor/greenblack,
-/area/station/turret_protected/Zeta)
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/grey,
+/area/station/bridge)
 "rYn" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -56578,6 +56606,10 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
+"sas" = (
+/obj/machinery/portable_atmospherics/canister/air/large,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "scE" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/wall/auto/supernorn,
@@ -56611,6 +56643,19 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
+"sgT" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
+	},
+/turf/space,
+/area/station/ai_monitored/armory)
 "shz" = (
 /obj/table/wood/auto,
 /obj/random_item_spawner/medicine,
@@ -56619,15 +56664,6 @@
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/ne,
 /area/station/crew_quarters/quarters_south)
-"shG" = (
-/obj/stool,
-/obj/item/device/radio/intercom{
-	dir = 4
-	},
-/turf/simulated/floor/grey/side{
-	dir = 8
-	},
-/area/station/security/brig)
 "shR" = (
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
@@ -56636,32 +56672,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
-"sjG" = (
-/obj/table/auto,
-/obj/machinery/networked/storage/scanner{
-	bank_id = "bridge";
-	pixel_y = 4
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
-/turf/simulated/floor/circuit,
-/area/station/bridge)
-"skX" = (
-/turf/simulated/floor/yellowblack/corner{
-	dir = 1
-	},
-/area/station/crew_quarters/ce)
 "sml" = (
 /obj/table/auto,
 /obj/machinery/computer/security/wooden_tv/small{
@@ -56669,30 +56679,12 @@
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"smE" = (
-/obj/machinery/door/airlock/pyro/command{
-	aiControlDisabled = 1;
-	name = "Armory";
-	req_access = null
-	},
-/obj/access_spawn/hos,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
 "snN" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/bridge/captain)
-"snW" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
 "soA" = (
 /obj/table/reinforced/auto,
 /obj/disposaloutlet/west,
@@ -56728,6 +56720,13 @@
 	dir = 8
 	},
 /area/station/routing/security)
+"ssd" = (
+/turf/simulated/floor/shuttlebay,
+/area/station/hallway/secondary/exit)
+"sta" = (
+/obj/table/wood/round/auto,
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
 "stu" = (
 /obj/decal/xmas_lights/ephemeral{
 	pixel_y = 32
@@ -56746,26 +56745,25 @@
 	},
 /turf/simulated/floor,
 /area/station/routing/security)
-"sul" = (
-/obj/item/clothing/suit/cardboard_box,
-/turf/simulated/floor/grime,
-/area/station/maintenance/southeast)
-"suG" = (
-/obj/machinery/light_switch/east,
-/obj/storage/secure/closet/security/armory,
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
-"svq" = (
-/obj/shrub,
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
+"sun" = (
+/obj/storage/secure/closet/command/medical_director,
+/obj/item/storage/box/beakerbox,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
 	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
+/obj/item/clipboard,
+/obj/item/pen,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/md)
+"suM" = (
+/obj/storage/secure/closet/command/chief_engineer,
+/obj/item/clipboard,
+/obj/item/pen,
+/turf/simulated/floor/yellowblack,
+/area/station/crew_quarters/ce)
 "svx" = (
 /obj/machinery/light,
 /turf/simulated/floor/stairs/wood/wide{
@@ -56780,12 +56778,11 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/hallway/secondary/exit)
-"sye" = (
-/obj/storage/secure/crate/plasma/armory/anti_biological,
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
-"syz" = (
-/turf/simulated/floor/redblack/corner{
+"sxb" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet,
+/obj/item/device/radio/intercom,
+/turf/simulated/floor/grey/side{
 	dir = 8
 	},
 /area/space)
@@ -56804,164 +56801,7 @@
 	},
 /turf/simulated/floor/black,
 /area/research_outpost/indigo_rye)
-"sAj" = (
-/obj/machinery/vending/alcohol,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/baroffice)
-"sAB" = (
-/obj/machinery/drainage,
-/obj/machinery/shower{
-	dir = 8;
-	pixel_x = -8;
-	pixel_y = 3
-	},
-/turf/simulated/floor/redwhite{
-	dir = 8
-	},
-/area/station/medical/medbay/surgery)
-"sBH" = (
-/obj/lattice{
-	dir = 10;
-	icon_state = "lattice-dir-b"
-	},
-/obj/machinery/light/runway_light,
-/turf/space,
-/area/station/ai_monitored/armory)
-"sBO" = (
-/obj/disposalpipe/segment/brig{
-	dir = 8
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/neutral/side{
-	dir = 1
-	},
-/area/station/hallway/primary/east)
-"sBU" = (
-/obj/disposalpipe/segment/mail/vertical,
-/obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
-"sCD" = (
-/obj/stool/chair/office/yellow{
-	dir = 4
-	},
-/obj/landmark/start{
-	name = "Chief Engineer"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/orangeblack,
-/area/station/crew_quarters/ce)
-"sEy" = (
-/obj/item/extinguisher,
-/turf/simulated/floor/carpet/green/fancy/edge/nw,
-/area/station/crew_quarters/quarters_south)
-"sHh" = (
-/obj/machinery/launcher_loader/west,
-/turf/simulated/floor/airless/plating,
-/area/station/maintenance/west)
-"sHo" = (
-/obj/decal/poster/wallsign/stencil/left/v,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/detectives_office)
-"sJx" = (
-/obj/machinery/shieldgenerator/meteorshield,
-/turf/simulated/floor/plating,
-/area/station/maintenance/central)
-"sJY" = (
-/obj/decal/poster/wallsign/warning1{
-	pixel_x = 6
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/gas)
-"sLF" = (
-/obj/landmark/halloween,
-/turf/simulated/floor,
-/area/station/hallway/secondary/south)
-"sMb" = (
-/obj/machinery/door/airlock/pyro/command{
-	name = "Command Centre"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/black,
-/area/station/bridge)
-"sMt" = (
-/obj/landmark/spawner{
-	name = "monkeyspawn_mrsmuggles"
-	},
-/turf/simulated/floor,
-/area/station/storage/warehouse)
-"sNP" = (
-/obj/wingrille_spawn/auto,
-/obj/decal/poster/wallsign/hazard_bio,
-/turf/simulated/floor/plating,
-/area/station/medical/dome)
-"sOW" = (
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
-"sRA" = (
-/obj/machinery/computer/barcode{
-	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Pod Bay","Research","Security","QM");
-	dir = 4
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
-	},
-/turf/simulated/floor/orange/side{
-	dir = 9
-	},
-/area/station/crew_quarters/catering)
-"sRD" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/light/runway_light/delay2,
-/turf/space,
-/area/station/ai_monitored/armory)
-"sSx" = (
-/obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/left{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/station/turret_protected/Zeta)
-"sSy" = (
+"szq" = (
 /obj/table/wood/auto,
 /obj/machinery/recharger{
 	pixel_y = 3
@@ -56987,6 +56827,167 @@
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/nw,
 /area/station/science/research_director)
+"szD" = (
+/obj/machinery/sim/vr_bed{
+	dir = 4;
+	name = "VR simulation pod";
+	network = "arcadevr"
+	},
+/obj/cable,
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
+"sAB" = (
+/obj/machinery/drainage,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -8;
+	pixel_y = 3
+	},
+/turf/simulated/floor/redwhite{
+	dir = 8
+	},
+/area/station/medical/medbay/surgery)
+"sBB" = (
+/obj/table/reinforced/auto,
+/obj/machinery/phone,
+/turf/simulated/floor/carpet/red/fancy/edge/se,
+/area/station/security/hos)
+"sBO" = (
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 1
+	},
+/area/station/hallway/primary/east)
+"sHh" = (
+/obj/machinery/launcher_loader/west,
+/turf/simulated/floor/airless/plating,
+/area/station/maintenance/west)
+"sHo" = (
+/obj/decal/poster/wallsign/stencil/left/v,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/security/detectives_office)
+"sHC" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/portable_atmospherics/canister/sleeping_agent,
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
+"sJD" = (
+/obj/machinery/door_timer/solitary2/new_walls/north{
+	layer = 3.1
+	},
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 8;
+	icon_state = "on";
+	on = 1
+	},
+/turf/simulated/floor/red/corner{
+	dir = 1
+	},
+/area/station/security/brig)
+"sJY" = (
+/obj/decal/poster/wallsign/warning1{
+	pixel_x = 6
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/gas)
+"sKo" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/orangeblack,
+/area/station/crew_quarters/ce)
+"sKA" = (
+/obj/decal/tile_edge/line/green{
+	dir = 1;
+	icon_state = "line1"
+	},
+/obj/bookshelf/persistent,
+/turf/simulated/floor/neutral/side{
+	dir = 9
+	},
+/area/station/crew_quarters/quarters_south)
+"sLF" = (
+/obj/landmark/halloween,
+/turf/simulated/floor,
+/area/station/hallway/secondary/south)
+"sMt" = (
+/obj/landmark/spawner{
+	name = "monkeyspawn_mrsmuggles"
+	},
+/turf/simulated/floor,
+/area/station/storage/warehouse)
+"sNg" = (
+/obj/stool/chair/office/blue{
+	dir = 1
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/Zeta)
+"sNP" = (
+/obj/wingrille_spawn/auto,
+/obj/decal/poster/wallsign/hazard_bio,
+/turf/simulated/floor/plating,
+/area/station/medical/dome)
+"sQa" = (
+/obj/machinery/chem_heater,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
+	},
+/obj/item/device/radio/intercom/medical{
+	pixel_x = 4;
+	pixel_y = 24
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/ne,
+/area/station/crew_quarters/md)
+"sRA" = (
+/obj/machinery/computer/barcode{
+	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Pod Bay","Research","Security","QM");
+	dir = 4
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
+	},
+/turf/simulated/floor/orange/side{
+	dir = 9
+	},
+/area/station/crew_quarters/catering)
+"sSD" = (
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/station/ai_monitored/armory)
 "sSO" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -57001,13 +57002,52 @@
 /area/station/medical/research{
 	name = "Genetic Research"
 	})
-"sVR" = (
-/obj/critter/parrot/random,
-/obj/cable{
-	icon_state = "1-2"
+"sTl" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
 	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"sUD" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
+"sUE" = (
+/obj/landmark/artifact,
+/turf/simulated/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/station/maintenance/southeast)
+"sVy" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/space)
+"sVX" = (
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
+	},
+/turf/space,
+/area/station/ai_monitored/armory)
 "sWh" = (
 /obj/landmark/artifact,
 /turf/simulated/floor/plating/airless/asteroid/dark,
@@ -57021,19 +57061,21 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
-"sWL" = (
-/obj/item/storage/toilet,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
+"sYq" = (
+/obj/machinery/light/runway_light,
+/obj/lattice{
+	icon_state = "lattice-dir"
 	},
-/obj/machinery/alarm{
-	pixel_y = 24
+/turf/space,
+/area/station/ai_monitored/armory)
+"tab" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/grey/side{
-	dir = 4
-	},
-/area/space)
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "tan" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/beepsky)
@@ -57049,47 +57091,78 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
-"tdx" = (
-/obj/disposalpipe/segment/brig{
-	dir = 8
+"tdg" = (
+/obj/plasticflaps,
+/obj/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/engine,
-/area/station/routing/security)
+/turf/simulated/floor/plating,
+/area/station/security/beepsky)
 "tdy" = (
 /turf/simulated/floor/greenblack{
 	dir = 1
 	},
 /area/station/turret_protected/Zeta)
-"tdF" = (
-/obj/table/auto,
-/obj/machinery/cell_charger,
-/obj/item/cell/supercell/charged,
-/obj/item/cell/supercell/charged,
-/obj/machinery/light/small,
-/turf/simulated/floor/circuit,
-/area/station/bridge)
-"tgm" = (
-/obj/stool/chair/office/blue{
-	dir = 1
+"tfv" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/ai_monitored/armory)
+"tfR" = (
+/obj/machinery/atmospherics/valve{
+	high_risk = 1;
+	name = "Air Reserve (Escape Hallway)"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/central)
+"tha" = (
+/obj/machinery/vending/alcohol,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/baroffice)
+"til" = (
+/obj/machinery/door/airlock/pyro/glass,
+/obj/disposalpipe/segment/vertical,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/courtroom)
+"tjG" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 1;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/turf/simulated/floor/carpet/purple/fancy/edge/west,
+/area/station/science/research_director)
 "tjX" = (
 /turf/simulated/floor/carpet/purple/fancy,
 /area/station/crew_quarters/quarters_north)
+"tkE" = (
+/obj/shrub{
+	dir = 10
+	},
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
 "tmm" = (
 /obj/machinery/mass_driver{
 	dir = 1;
@@ -57108,30 +57181,6 @@
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
-"tmR" = (
-/obj/stool/chair/comfy/purple{
-	dir = 4
-	},
-/obj/landmark/start{
-	name = "Research Director"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/carpet/purple/fancy,
-/area/station/science/research_director)
-"tmS" = (
-/obj/machinery/door/airlock/pyro/glass{
-	name = "Holding Cell Two"
-	},
-/obj/access_spawn/brig,
-/turf/simulated/floor/black,
-/area/space)
 "tnf" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -57169,22 +57218,14 @@
 	},
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
-"trW" = (
-/turf/simulated/floor/stairs/dark,
-/area/station/maintenance/southeast)
-"tsm" = (
-/obj/stool/bench/blue/auto,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
+"tsS" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
-"tsA" = (
-/obj/machinery/chem_dispenser,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/cafeteria)
+/turf/simulated/floor/plating,
+/area/station/bridge)
 "tuJ" = (
 /obj/plasticflaps,
 /obj/machinery/cargo_router/kd_sec_flap,
@@ -57199,6 +57240,14 @@
 	dir = 4
 	},
 /area/station/security/checkpoint/escape)
+"tvp" = (
+/obj/shrub,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
 "tvw" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -57212,17 +57261,22 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
-"tzd" = (
-/obj/cable{
-	icon_state = "1-8"
+"tvA" = (
+/obj/stool/bench/blue/auto,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"twU" = (
+/obj/disposalpipe/segment/food{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/catering)
 "tCk" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 9
@@ -57238,12 +57292,14 @@
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
-"tHB" = (
-/obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/floor/redwhite{
-	dir = 10
+"tFa" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/area/station/medical/medbooth)
+/turf/simulated/floor/plating,
+/area/station/ai_monitored/armory)
 "tIp" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
@@ -57262,17 +57318,6 @@
 	dir = 1
 	},
 /area/station/crew_quarters/kitchen)
-"tIW" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/carpet/purple/fancy/edge/west,
-/area/station/science/research_director)
 "tJD" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -57287,17 +57332,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
-"tLy" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
 "tMa" = (
 /obj/machinery/door/airlock/pyro/external{
 	name = "Mining Hangar"
@@ -57306,21 +57340,43 @@
 /obj/access_spawn/mining,
 /turf/simulated/floor/orangeblack,
 /area/station/mining/staff_room)
-"tMf" = (
-/obj/table/reinforced/chemistry/auto,
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
+"tPN" = (
+/obj/table/round/auto,
+/obj/item/gobowl/w,
+/turf/simulated/floor/neutral/corner{
+	dir = 1
 	},
-/obj/machinery/light_switch/north,
-/obj/machinery/phone,
-/obj/item/stamp/md{
-	pixel_x = -14;
-	rand_pos = 0
+/area/station/crew_quarters/quarters_south)
+"tQL" = (
+/obj/disposalpipe/segment/brig{
+	dir = 1
 	},
-/turf/simulated/floor/carpet/blue/fancy/edge/north,
-/area/station/crew_quarters/md)
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
+"tTC" = (
+/obj/machinery/door/airlock/pyro/command{
+	name = "Command Centre"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
+/area/station/bridge)
+"tVl" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "tVy" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
@@ -57329,20 +57385,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/coldloop)
-"tXe" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"tXB" = (
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
 	},
+/obj/decal/cleanable/dirt,
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"tXg" = (
-/obj/machinery/turret,
-/obj/lattice,
-/turf/space,
-/area/station/ai_monitored/armory)
+"tYC" = (
+/obj/submachine/ATM{
+	pixel_x = 32
+	},
+/obj/disposalpipe/segment/bent/east,
+/turf/simulated/floor/grime,
+/area/station/security/brig)
 "tYP" = (
 /obj/table/reinforced/auto,
 /obj/machinery/camera{
@@ -57356,30 +57414,62 @@
 	dir = 1
 	},
 /area/station/crew_quarters/kitchen)
-"uaz" = (
-/obj/decal/poster/wallsign/medal,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/bridge/hos)
+"tZz" = (
+/obj/disposalpipe/segment/horizontal,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/hallway/primary/south)
+"tZJ" = (
+/obj/item/device/radio/beacon,
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/courtroom)
 "uaU" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/routing/security)
-"uby" = (
-/turf/simulated/floor/shuttlebay,
-/area/station/hallway/secondary/exit)
-"ueZ" = (
-/obj/submachine/chef_sink/chem_sink{
-	dir = 1
+"ucN" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/decal/tile_edge/line/black{
-	dir = 5;
-	icon_state = "line2"
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
-/obj/machinery/drainage,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/ce)
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
+"udD" = (
+/obj/disposalpipe/segment/mail/vertical,
+/turf/simulated/floor/redwhite{
+	dir = 10
+	},
+/area/station/medical/medbooth)
+"udY" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/grey,
+/area/station/bridge)
+"ugn" = (
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/crew_quarters/quarters_south)
 "ugD" = (
 /obj/cable{
 	d1 = 1;
@@ -57391,24 +57481,36 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/east)
-"ugK" = (
-/obj/machinery/turret,
-/turf/simulated/floor/greenblack,
-/area/station/turret_protected/Zeta)
-"uhm" = (
-/obj/grille/catwalk{
-	dir = 6;
-	icon_state = "catwalk_cross"
+"uhw" = (
+/obj/machinery/chem_dispenser/alcohol,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 6
-	},
-/area/station/maintenance/southeast)
+/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
+/obj/machinery/light_switch/west,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/cafeteria)
 "uhx" = (
 /obj/wingrille_spawn/auto,
 /obj/decal/poster/wallsign/hazard_bio,
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
+"ujH" = (
+/obj/machinery/door/airlock/pyro/external,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"ujS" = (
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir-b"
+	},
+/obj/machinery/light/runway_light,
+/turf/space,
+/area/station/ai_monitored/armory)
 "ukd" = (
 /obj/disposalpipe/segment/brig,
 /obj/machinery/atmospherics/pipe/manifold{
@@ -57423,54 +57525,50 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
-"uoV" = (
-/obj/machinery/chem_dispenser/soda,
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
+"uoZ" = (
+/obj/machinery/light/small,
+/obj/machinery/photocopier,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/cafeteria)
-"urd" = (
-/turf/simulated/floor/red,
-/area/station/medical/medbay)
-"urf" = (
-/obj/machinery/computer/announcement{
-	dir = 4;
-	name = "Executive Announcement Computer";
-	pixel_x = -3;
-	pixel_y = 4;
-	req_access_txt = "19"
-	},
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/sanitary/white,
-/area/station/bridge/captain)
-"usX" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1;
-	name = "Escape S Repressurization Port"
+/area/station/bridge)
+"upK" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/central)
-"uuN" = (
+/area/station/maintenance/southeast)
+"upU" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
+"uqd" = (
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 4
+	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/decal/garland/ephemeral{
-	dir = 4;
-	pixel_x = -14
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"urd" = (
+/turf/simulated/floor/red,
+/area/station/medical/medbay)
+"usb" = (
+/obj/structure/woodwall,
+/turf/simulated/floor/plating/damaged1,
+/area/station/garden/aviary)
+"usi" = (
+/obj/storage/secure/closet/medical/chemical,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/black,
-/area/station/bridge)
+/turf/simulated/floor/carpet/blue/fancy/edge/se,
+/area/station/crew_quarters/md)
 "uvK" = (
 /obj/disposalpipe/segment/transport,
 /obj/cable{
@@ -57487,6 +57585,15 @@
 	dir = 9
 	},
 /area/station/security/brig)
+"uwM" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "yellow";
+	icon_state = "bedsheet-yellow"
+	},
+/obj/machinery/light,
+/turf/simulated/floor/yellowblack,
+/area/station/crew_quarters/ce)
 "uxI" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -57502,21 +57609,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
-"uzF" = (
-/obj/disposalpipe/segment/vertical,
-/obj/cable{
-	icon_state = "1-8"
+"uzb" = (
+/obj/disposalpipe/segment/brig{
+	dir = 1
 	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 6
-	},
-/turf/simulated/floor/grey,
-/area/station/bridge)
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
 "uzL" = (
 /obj/machinery/light{
 	dir = 1;
@@ -57531,15 +57634,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
-"uBL" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor,
-/area/station/security/brig)
 "uDm" = (
 /obj/decal/garland/ephemeral{
 	dir = 8;
@@ -57551,10 +57645,20 @@
 /obj/storage/closet/wardrobe/green,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
-"uDX" = (
-/obj/machinery/weapon_stand/shotgun_rack,
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
+"uEv" = (
+/obj/grille/catwalk,
+/turf/simulated/floor/airless/plating/catwalk,
+/area/station/maintenance/southeast)
+"uGD" = (
+/obj/disposalpipe/segment/vertical,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 20
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/crew_quarters/quarters_south)
 "uGT" = (
 /obj/lattice{
 	dir = 4;
@@ -57568,38 +57672,16 @@
 	},
 /turf/space,
 /area/space)
-"uIT" = (
-/obj/stool,
-/turf/simulated/floor/grey/side{
-	dir = 4
+"uIP" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
 	},
-/area/space)
-"uKc" = (
-/obj/machinery/door/airlock/pyro/glass/command{
-	name = "Command Centre"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/firedoor_spawn,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/black,
-/area/station/bridge)
-"uLo" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/portable_atmospherics/canister/sleeping_agent,
-/turf/simulated/floor/engine,
+/obj/machinery/light/runway_light,
+/turf/space,
 /area/station/ai_monitored/armory)
-"uLK" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
+"uLd" = (
+/turf/simulated/floor/stairs/dark,
+/area/station/maintenance/southeast)
 "uMr" = (
 /obj/table/reinforced/bar/auto,
 /obj/machinery/computer/security/wooden_tv/small{
@@ -57619,17 +57701,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"uOi" = (
-/obj/machinery/computer/security/wooden_tv{
-	desc = "These channels seem to mostly be about robuddies. What is this, some kind of reality show?";
-	name = "Television";
-	network = "Zeta"
-	},
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/carpet/purple/fancy/edge/north,
-/area/station/science/research_director)
 "uPl" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/machinery/cargo_router/kd_med_left,
@@ -57641,6 +57712,12 @@
 	},
 /turf/simulated/floor/airless/grey,
 /area/station/maintenance/west)
+"uQl" = (
+/obj/machinery/light,
+/turf/simulated/floor/escape{
+	dir = 8
+	},
+/area/station/hallway/secondary/exit)
 "uQF" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -57650,6 +57727,17 @@
 	icon_state = "engine_caution_we"
 	},
 /area/station/hallway/primary/west)
+"uQT" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black/corner{
+	dir = 1
+	},
+/area/station/bridge)
 "uSz" = (
 /obj/disposalpipe/segment/brig{
 	dir = 2;
@@ -57660,13 +57748,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
-"uSI" = (
-/obj/plasticflaps,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/beepsky)
 "uUF" = (
 /obj/lattice{
 	dir = 4;
@@ -57684,17 +57765,11 @@
 	dir = 8
 	},
 /area/station/routing/security)
-"vaX" = (
-/obj/table/auto,
-/obj/shrub/dead{
-	dir = 8;
-	name = "Dead plant";
-	pixel_y = 10
+"uWG" = (
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 4
 	},
-/obj/item/storage/pill_bottle/cyberpunk{
-	layer = 2.4
-	},
-/turf/simulated/floor/grime,
+/turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "vbg" = (
 /obj/machinery/light/small{
@@ -57722,34 +57797,16 @@
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
+"vew" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/grey,
+/area/station/maintenance/southeast)
 "veN" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/research{
 	name = "Genetic Research"
 	})
-"vfR" = (
-/obj/machinery/light/runway_light/delay4,
-/obj/lattice{
-	icon_state = "lattice-dir"
-	},
-/turf/space,
-/area/station/ai_monitored/armory)
-"vgc" = (
-/obj/table/wood/auto,
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/phone,
-/obj/item/stamp/ce{
-	pixel_x = -12;
-	rand_pos = 0
-	},
-/turf/simulated/floor/yellowblack{
-	dir = 1
-	},
-/area/station/crew_quarters/ce)
 "vgI" = (
 /obj/cable{
 	d1 = 1;
@@ -57759,6 +57816,10 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
+"vhz" = (
+/obj/disposalpipe/segment/bent/north,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "viV" = (
 /obj/stool/chair,
 /obj/machinery/camera{
@@ -57770,13 +57831,6 @@
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"vjQ" = (
-/obj/submachine/ATM{
-	pixel_x = 32
-	},
-/obj/disposalpipe/segment/bent/east,
-/turf/simulated/floor/grime,
-/area/station/security/brig)
 "vkc" = (
 /obj/machinery/light/small,
 /obj/machinery/light_switch/east,
@@ -57784,21 +57838,21 @@
 	dir = 4
 	},
 /area/station/science/testchamber)
+"vku" = (
+/obj/submachine/chem_extractor,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/green/side{
+	dir = 8
+	},
+/area/station/hydroponics/bay)
 "vmX" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
-"vnJ" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/bridge)
 "vos" = (
 /obj/table/auto,
 /obj/item/reagent_containers/glass/wateringcan{
@@ -57806,27 +57860,6 @@
 	},
 /turf/simulated/floor/green,
 /area/station/crew_quarters/quarters_south)
-"vot" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
-"vpP" = (
-/obj/machinery/power/data_terminal,
-/obj/machinery/computer/robotics{
-	perma = 1
-	},
-/turf/simulated/floor/greenblack{
-	dir = 1
-	},
-/area/station/turret_protected/Zeta)
 "vrz" = (
 /obj/decal/cleanable/dirt,
 /obj/landmark{
@@ -57834,27 +57867,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
-"vtX" = (
-/obj/table/wood/auto,
-/obj/machinery/networked/printer{
-	name = "Printer - CE";
-	pixel_y = 5;
-	print_id = "CE"
-	},
-/obj/machinery/light_switch/north,
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
-/turf/simulated/floor/yellowblack{
-	dir = 1
-	},
-/area/station/crew_quarters/ce)
 "vuD" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plating,
@@ -57869,31 +57881,32 @@
 	dir = 4
 	},
 /area/station/routing/security)
-"vys" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/orangeblack,
-/area/station/crew_quarters/ce)
 "vzr" = (
 /obj/decal/poster/wallsign/security_right,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/detectives_office)
-"vzY" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
+"vBf" = (
+/obj/stool/chair/office/blue,
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light/emergency{
-	dir = 1;
-	pixel_y = 16
+/obj/cable{
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/carpet/blue/fancy/edge/nw,
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/sw,
 /area/station/bridge)
+"vBg" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1;
+	name = "Escape S Repressurization Port"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/central)
 "vBz" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -57910,29 +57923,19 @@
 /obj/lattice,
 /turf/space,
 /area/station/ai_monitored/armory)
-"vEJ" = (
+"vHo" = (
 /obj/cable{
-	icon_state = "4-8"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/red/side{
-	dir = 4
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/area/station/security/brig)
-"vFw" = (
-/obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/right{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/station/turret_protected/Zeta)
-"vJt" = (
-/obj/machinery/door/airlock/pyro/glass,
-/obj/decal/garland/ephemeral,
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/courtroom)
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
 "vNa" = (
 /obj/cable{
 	d1 = 2;
@@ -57974,11 +57977,32 @@
 /obj/machinery/light_switch/north,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
+"vPj" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/decal/wreath/ephemeral,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/courtroom)
 "vRn" = (
 /obj/machinery/light/runway_light/delay4,
 /obj/lattice,
 /turf/space,
 /area/space)
+"vRP" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "vSl" = (
 /obj/lattice{
 	dir = 4;
@@ -58001,75 +58025,54 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
-"vST" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/ai_monitored/armory)
-"vTv" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
+"vTk" = (
+/obj/item/storage/wall{
 	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
+	name = "silverware cabinet";
+	pixel_x = 32;
+	spawn_contents = list(/obj/item/storage/box/cutlery,/obj/item/storage/box/cutlery,/obj/item/storage/box/cutlery,/obj/item/storage/box/plates,/obj/item/storage/box/plates,/obj/item/shaker/salt,/obj/item/shaker/pepper)
 	},
-/obj/machinery/phone/wall{
-	pixel_x = 24
-	},
-/turf/simulated/floor/grey,
+/turf/simulated/floor/black,
 /area/station/bridge)
-"vUf" = (
+"vTK" = (
+/obj/item/caution{
+	desc = "Caution! Construction Zone!";
+	name = "caution sign"
+	},
+/obj/decal/cleanable/oil,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/yellowblack/corner,
-/area/station/crew_quarters/ce)
+/turf/simulated/floor/grime,
+/area/station/maintenance/southeast)
 "vVg" = (
 /obj/disposalpipe/segment/vertical,
 /obj/machinery/atmospherics/pipe/simple,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
-"vVB" = (
-/obj/cable{
-	icon_state = "1-2"
+"vXe" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "black";
+	icon_state = "bedsheet-black"
 	},
-/obj/cable{
-	icon_state = "1-4"
+/obj/landmark/start{
+	name = "Bartender"
 	},
-/turf/simulated/floor/red,
-/area/station/ai_monitored/armory)
-"vYZ" = (
-/obj/rack,
-/obj/item/clothing/suit/space/emerg,
-/obj/item/clothing/head/emerg,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/air,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/belt/utility,
-/obj/item/crowbar,
-/obj/item/device/light/flashlight,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/baroffice)
 "vZI" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
+"vZL" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/ai_monitored/armory)
 "war" = (
 /obj/cable{
 	d1 = 4;
@@ -58094,17 +58097,47 @@
 	},
 /turf/simulated/floor/darkblue,
 /area/station/turret_protected/ai)
+"wbJ" = (
+/obj/disposalpipe/segment/vertical,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/obj/machinery/phone/wall{
+	pixel_x = 24
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/crew_quarters/quarters_south)
+"wcz" = (
+/obj/shrub{
+	dir = 10
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
+"wfc" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/window_blinds/cog2/middle{
+	dir = 8
+	},
+/obj/cable,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/md)
 "whk" = (
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
-"whE" = (
-/obj/machinery/sleeper{
-	dir = 4
-	},
-/obj/cable,
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
 "wio" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -58115,18 +58148,36 @@
 /area/station/medical/research{
 	name = "Genetic Research"
 	})
+"wjb" = (
+/obj/stool/chair/wooden{
+	dir = 8
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
 "wle" = (
 /obj/machinery/vending/floppy,
 /turf/simulated/floor/grey/blackgrime/other,
 /area/station/storage/tech)
-"wpG" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet,
-/obj/item/device/radio/intercom,
-/turf/simulated/floor/grey/side{
-	dir = 8
+"wnH" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/area/space)
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"woV" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/purple/fancy,
+/area/station/science/research_director)
 "wqb" = (
 /obj/cable{
 	d1 = 4;
@@ -58135,6 +58186,18 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/com_dish/comdish)
+"wrE" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/left{
+	dir = 8
+	},
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/bridge/hos)
 "wuc" = (
 /obj/machinery/plantpot,
 /obj/machinery/light/small{
@@ -58151,19 +58214,14 @@
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/brig)
-"wBj" = (
-/obj/wingrille_spawn/auto,
+"wAu" = (
 /obj/cable{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/turf/simulated/floor/carpet/arcade,
+/area/station/bridge/captain)
 "wBr" = (
 /obj/stool/bench/blue/auto,
 /obj/decal/xmas_lights/ephemeral{
@@ -58171,18 +58229,22 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
-"wCH" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/window_blinds/cog2/right{
-	dir = 8
+"wBS" = (
+/obj/stool/chair/office{
+	dir = 4
 	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/landmark/start{
+	name = "Medical Director"
 	},
-/obj/cable,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/carpet/blue,
 /area/station/crew_quarters/md)
+"wDf" = (
+/obj/machinery/turretid{
+	pixel_x = 26
+	},
+/obj/machinery/light,
+/turf/simulated/floor/black,
+/area/station/turret_protected/Zeta)
 "wDk" = (
 /obj/lattice{
 	dir = 9;
@@ -58205,31 +58267,13 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
-"wHo" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/window_blinds/cog2/middle{
-	dir = 8
+"wHZ" = (
+/obj/machinery/door/airlock/pyro,
+/obj/disposalpipe/segment/brig{
+	dir = 1
 	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/ce)
-"wKU" = (
-/obj/disposalpipe/switch_junction/left/south{
-	mail_tag = "medical booth";
-	name = "medical booth mail junction"
-	},
-/turf/simulated/floor/black/side{
-	dir = 8
-	},
-/area/station/hallway/primary/south)
+/turf/simulated/floor/grey/blackgrime,
+/area/station/security/brig)
 "wLi" = (
 /obj/machinery/light/emergency,
 /obj/machinery/atmospherics/pipe/manifold{
@@ -58238,6 +58282,23 @@
 /obj/machinery/meter,
 /turf/simulated/floor/engine,
 /area/station/engine/core)
+"wMB" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
+"wNf" = (
+/obj/disposalpipe/trunk/south,
+/obj/machinery/disposal/transport{
+	desc = "A pneumatic delivery chute for transporting people from one section of maintenance to another.";
+	name = "maintenance shunt unit"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "wNL" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
@@ -58266,59 +58327,55 @@
 /obj/item/clothing/glasses/healthgoggles,
 /turf/simulated/floor/carpet/green/fancy/edge/se,
 /area/station/crew_quarters/quarters_south)
-"wRR" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/window_blinds/cog2/right{
-	dir = 8
+"wRj" = (
+/obj/machinery/networked/radio,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/ce)
-"wSK" = (
-/obj/disposalpipe/segment/food{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/catering)
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "wUB" = (
 /obj/decal/poster/wallsign/space,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/routing/security)
-"wWn" = (
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/blue/side{
-	dir = 8
-	},
-/area/station/hallway/primary/south)
-"wYY" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/baroffice)
-"xaI" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/transport{
+"wWo" = (
+/obj/machinery/sleeper{
 	dir = 4
 	},
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
-"xbN" = (
-/obj/machinery/floorflusher/solitary,
-/obj/submachine/chef_sink/chem_sink{
-	pixel_y = 16
+/obj/cable,
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"xcv" = (
+/obj/stool/chair/wooden{
+	dir = 4
 	},
-/obj/disposalpipe/trunk/south,
-/turf/simulated/floor/black,
-/area/space)
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
+"xdq" = (
+/obj/storage/crate{
+	desc = "Various supplies for the bar.";
+	name = "bartending crate"
+	},
+/obj/item/reagent_containers/food/drinks/bottle,
+/obj/item/reagent_containers/food/drinks/bottle,
+/obj/item/reagent_containers/food/drinks/bottle,
+/obj/item/reagent_containers/food/drinks/bottle,
+/obj/item/reagent_containers/food/drinks/bottle,
+/obj/item/storage/firstaid/toxin,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/device/reagentscanner,
+/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
+/obj/item/reagent_containers/dropper/mechanical,
+/obj/machinery/light/small,
+/obj/cable,
+/obj/machinery/power/apc/autoname_west,
+/obj/item/clothing/glasses/spectro,
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/baroffice)
 "xft" = (
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon1_start,
 /obj/disposalpipe/segment/bent/west,
@@ -58326,16 +58383,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/south)
-"xgz" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
 "xgL" = (
 /obj/stool/chair,
 /turf/simulated/floor/carpet/purple/fancy/edge/west,
@@ -58359,6 +58406,14 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
+"xid" = (
+/obj/stool/bar,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
 "xiw" = (
 /obj/decal/cleanable/dirt,
 /obj/machinery/alarm{
@@ -58366,21 +58421,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
-"xjN" = (
-/obj/stool/chair/office/blue,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/carpet/blue/fancy/edge/sw,
-/area/station/bridge)
 "xkf" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -58416,6 +58456,18 @@
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating,
 /area/station/hangar/medical)
+"xnF" = (
+/obj/rack,
+/obj/item/clothing/suit/space/emerg,
+/obj/item/clothing/head/emerg,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/air,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/belt/utility,
+/obj/item/crowbar,
+/obj/item/device/light/flashlight,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "xoF" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -58427,34 +58479,68 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/exit)
-"xtI" = (
-/obj/machinery/vending/snack{
-	credit = 50
+"xpj" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/space)
-"xuX" = (
-/obj/machinery/door_timer/solitary/new_walls/north{
-	layer = 3.1
-	},
-/obj/storage/closet/wardrobe/orange,
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -20
-	},
-/turf/simulated/floor/redblack/corner{
+/obj/machinery/light/runway_light/delay4,
+/obj/disposalpipe/segment/transport{
 	dir = 4
 	},
+/turf/space,
 /area/space)
+"xpG" = (
+/turf/simulated/floor/caution/westeast,
+/area/station/hallway/secondary/exit)
+"xrb" = (
+/obj/machinery/computer/stockexchange{
+	dir = 4;
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/sanitary/white,
+/area/station/bridge/captain)
+"xsN" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/Zeta)
+"xtO" = (
+/turf/simulated/floor/yellowblack/corner{
+	dir = 1
+	},
+/area/station/crew_quarters/ce)
 "xvH" = (
 /obj/machinery/vending/janitor,
 /turf/simulated/floor/darkblue,
 /area/station/janitor/office)
+"xwf" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/left{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/turret_protected/Zeta)
+"xwx" = (
+/obj/machinery/power/apc/autoname_north,
+/obj/table/wood/auto,
+/obj/machinery/phone,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/carpet/purple/fancy/edge/ne,
+/area/station/science/research_director)
 "xwP" = (
 /obj/disposalpipe/segment/bent/west,
 /obj/grille/catwalk{
@@ -58470,32 +58556,6 @@
 	icon_state = "catwalk_cross"
 	},
 /area/station/mining/refinery)
-"xyk" = (
-/obj/table/reinforced/bar/auto,
-/obj/machinery/computer3/generic/personal,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/grey,
-/area/station/bridge)
-"xzp" = (
-/obj/table/reinforced/auto,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/reagent_containers/food/drinks/water,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/simulated/floor/grey/side{
-	dir = 4
-	},
-/area/space)
 "xzv" = (
 /obj/cable{
 	d1 = 2;
@@ -58517,18 +58577,16 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/routing/security)
-"xBt" = (
-/obj/disposalpipe/segment/brig{
-	dir = 8
+"xCO" = (
+/obj/machinery/door/airlock/pyro/maintenance,
+/obj/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/redblack{
-	dir = 10
+/obj/firedoor_spawn,
+/turf/simulated/floor/greenblack{
+	dir = 1
 	},
-/area/station/security/brig)
-"xDL" = (
-/obj/stool/chair,
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_south)
+/area/station/garden/aviary)
 "xES" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 4;
@@ -58538,82 +58596,33 @@
 	dir = 8
 	},
 /area/station/medical/medbay/surgery)
+"xFQ" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "xGa" = (
 /obj/decal/xmas_lights/ephemeral{
 	pixel_y = 32
 	},
 /turf/simulated/floor/carpet/red/standard/edge/nw,
 /area/station/crew_quarters/radio/news_office)
-"xGo" = (
-/obj/disposalpipe/segment/vertical,
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple,
-/turf/simulated/floor/grey,
-/area/station/bridge)
-"xGS" = (
-/obj/machinery/computer/stockexchange{
-	dir = 4;
-	pixel_x = -3;
-	pixel_y = 4
-	},
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/sanitary/white,
-/area/station/bridge/captain)
-"xHn" = (
-/obj/shrub{
-	dir = 6
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
 "xIe" = (
 /obj/decal/xmas_lights/ephemeral{
 	pixel_y = 32
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
-"xJg" = (
-/obj/machinery/computer/telescope{
-	dir = 8
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
-/obj/cable,
-/turf/simulated/floor/carpet/purple/fancy/edge/east,
-/area/station/science/research_director)
-"xJF" = (
+"xJq" = (
 /obj/grille/steel,
 /turf/space,
 /area/station/com_dish/comdish)
-"xKd" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/simulated/floor/redblack{
-	dir = 4
-	},
-/area/station/security/brig)
 "xKv" = (
 /obj/lattice{
 	dir = 6;
@@ -58644,6 +58653,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
+"xOr" = (
+/obj/machinery/vending/snack{
+	credit = 50
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/security/brig)
+"xPt" = (
+/obj/machinery/door/airlock/pyro/command{
+	dir = 4;
+	name = "Computer Core"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
+/area/station/turret_protected/Zeta)
 "xQl" = (
 /obj/decal/tile_edge/floorguide/engineering{
 	desc = "The power transmission laser is in this direction.";
@@ -58657,18 +58683,28 @@
 /obj/machinery/atmospherics/pipe/simple,
 /turf/simulated/floor/red,
 /area/station/medical/medbay)
-"xSb" = (
+"xQK" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/right{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/turret_protected/Zeta)
+"xSq" = (
+/obj/wingrille_spawn/auto/crystal,
 /obj/cable{
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/cable{
-	icon_state = "1-4"
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "kgenpopwindow";
+	name = "General Population Visitation";
+	opacity = 0
 	},
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
-/turf/simulated/floor/red,
-/area/station/ai_monitored/armory)
+/turf/simulated/floor/plating,
+/area/station/security/brig)
 "xSK" = (
 /obj/cable{
 	d1 = 1;
@@ -58681,18 +58717,14 @@
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon15,
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
+"xTm" = (
+/obj/critter/cat/jones,
+/turf/simulated/floor/carpet/blue/fancy/edge/east,
+/area/station/bridge)
 "xTH" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
-"xTV" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
 "xUw" = (
 /obj/rack,
 /obj/item/clothing/suit/armor/EOD,
@@ -58705,37 +58737,12 @@
 /obj/item/clothing/glasses/thermal,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
-"xXd" = (
-/obj/table/reinforced/chemistry/auto{
-	name = "prep counter"
+"xYH" = (
+/obj/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/cafeteria)
-"xXy" = (
-/obj/machinery/door_timer/solitary2/new_walls/north{
-	layer = 3.1
-	},
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/redblack/corner{
-	dir = 4
-	},
-/area/space)
-"xXW" = (
-/obj/table/auto,
-/obj/random_item_spawner/tools,
-/obj/item/device/light/glowstick,
-/obj/item/device/light/glowstick,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
 "xZF" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -58751,15 +58758,32 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
-"yet" = (
-/obj/cable{
-	icon_state = "1-2"
+"ycb" = (
+/obj/machinery/turret,
+/turf/simulated/floor/greenblack,
+/area/station/turret_protected/Zeta)
+"ycM" = (
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
 	},
-/obj/cable{
-	icon_state = "1-8"
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
+"yec" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet,
+/turf/simulated/floor/grey/side{
+	dir = 4
 	},
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
+/area/station/security/brig)
+"yfg" = (
+/obj/disposalpipe/segment/horizontal,
+/obj/machinery/atmospherics/valve{
+	high_risk = 1;
+	name = "Bridge"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "yfk" = (
 /obj/disposalpipe/segment/bent/west,
 /turf/simulated/floor/grey/blackgrime,
@@ -58770,19 +58794,13 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
+"ygo" = (
+/obj/machinery/door/airlock/pyro/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "ygw" = (
 /turf/simulated/floor/black,
 /area/station/bridge)
-"ygI" = (
-/obj/disposalpipe/segment/vertical,
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 20
-	},
-/turf/simulated/floor/neutral/side{
-	dir = 4
-	},
-/area/station/crew_quarters/quarters_south)
 "yhe" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -58792,26 +58810,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"yki" = (
+"yjj" = (
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "0-8"
 	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"ylL" = (
-/obj/lattice{
-	dir = 5;
-	icon_state = "lattice-dir-b"
-	},
-/obj/machinery/light/runway_light,
-/turf/space,
-/area/station/ai_monitored/armory)
+/area/space)
 "ylQ" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
@@ -111552,7 +111558,7 @@ bgF
 bgF
 bgF
 bft
-wSK
+twU
 bmQ
 bor
 bpz
@@ -111872,13 +111878,13 @@ bCC
 bDA
 bEv
 bGA
-lCE
+drR
 bIl
 bIh
 bMj
-npm
-iVf
-eBr
+gpY
+fnb
+wHZ
 bQo
 bRE
 bTi
@@ -111887,7 +111893,7 @@ bVD
 bWF
 bXv
 bYy
-tdx
+fVD
 cbR
 caV
 cbR
@@ -112456,10 +112462,10 @@ iWw
 bft
 bgF
 tbT
-frd
+nKa
 bft
 blD
-gml
+dHl
 boo
 pUl
 bqM
@@ -112475,14 +112481,14 @@ boq
 mCg
 bDA
 bEv
-glg
+xSq
 soA
 bGM
-giq
-gvE
-vjQ
+ebz
+nSH
+tYC
 bNr
-dru
+gwe
 bQq
 bRF
 bTk
@@ -112504,10 +112510,10 @@ aaa
 aaa
 aaa
 aaa
-fng
-fng
-fng
-fng
+fcX
+fcX
+fcX
+fcX
 aaa
 aaa
 aaa
@@ -112766,9 +112772,9 @@ boo
 kSb
 bqM
 bqM
-nbH
-nbH
-nbH
+pRr
+pRr
+pRr
 pJk
 bqM
 bqM
@@ -112806,11 +112812,11 @@ aaa
 aaa
 aaa
 aaa
-fng
-lGX
-hnv
-fng
-xuX
+fcX
+esy
+kej
+fcX
+qmq
 aaa
 aaa
 aaa
@@ -113060,7 +113066,7 @@ bdq
 bfz
 bhR
 bhR
-ifA
+rbi
 bkx
 blF
 bmU
@@ -113071,7 +113077,7 @@ bqM
 bqM
 bvR
 rOU
-nbH
+pRr
 bqM
 bqM
 bpC
@@ -113089,7 +113095,7 @@ bNt
 bFK
 bQr
 bRS
-xBt
+qmz
 bUl
 cot
 cou
@@ -113108,11 +113114,11 @@ aaa
 aaa
 aaa
 aaa
-fng
-xbN
-pdh
-rGW
-syz
+fcX
+jPC
+ktt
+fBG
+ftt
 aaa
 aaa
 aaa
@@ -113362,7 +113368,7 @@ bet
 mLt
 pfT
 bhS
-rWz
+rck
 bky
 bft
 bmV
@@ -113370,12 +113376,12 @@ boo
 boo
 bqM
 bqM
-nbH
+pRr
 rOU
 bvR
 bqM
 bqM
-dqX
+leU
 boq
 boq
 bCz
@@ -113410,11 +113416,11 @@ aaa
 aaa
 aaa
 aaa
-fng
-nFT
-uIT
-dVv
-oJe
+fcX
+ltS
+iYl
+sVy
+kEr
 aaa
 aaa
 aaa
@@ -113673,9 +113679,9 @@ pUl
 bqM
 bqM
 bqM
-nbH
-nbH
-nbH
+pRr
+pRr
+pRr
 bqM
 bqM
 bpC
@@ -113701,7 +113707,7 @@ bXA
 bFK
 bZp
 xKL
-mJA
+ouG
 aaa
 aaa
 aaa
@@ -113712,11 +113718,11 @@ aaa
 aaa
 aaa
 aaa
-fng
-fng
-xtI
-dPl
-rHM
+fcX
+fcX
+ioh
+eKS
+rrO
 aaa
 aaa
 aaa
@@ -113967,9 +113973,9 @@ bfB
 bgH
 tmx
 bja
-kXB
-wYY
-kzS
+pvj
+owU
+xdq
 bja
 bpC
 bqM
@@ -113983,17 +113989,17 @@ bqM
 bpC
 boq
 rve
-qLK
+iJB
 bEF
-vJt
+fFT
 bGR
 bIp
-jtF
+tZJ
 bLe
 bMq
 bNv
 bFK
-gdl
+rXp
 bRJ
 bWL
 bFK
@@ -114014,11 +114020,11 @@ aaa
 aaa
 aaa
 aaa
-fng
-wpG
-pJd
-opQ
-oJe
+fcX
+sxb
+ogC
+yjj
+kEr
 aaa
 aaa
 aaa
@@ -114284,20 +114290,20 @@ bqM
 bqM
 bpC
 boq
-iMj
+fSI
 bDF
-owz
-jTK
+ngJ
+til
 lCw
 bGP
 bGP
 bNw
 ceq
 ceq
-hwO
+nVs
 bQv
 bRK
-eFY
+eOb
 bUp
 bVG
 bWN
@@ -114316,11 +114322,11 @@ aaa
 aaa
 aaa
 aaa
-fng
-nwb
-pdh
-tmS
-syz
+fcX
+rUm
+ktt
+lGb
+ftt
 aaa
 aaa
 aaa
@@ -114571,13 +114577,13 @@ fje
 fje
 tIt
 bja
-iOb
+nPR
 blI
-lXB
+vXe
 bja
-nLk
+vku
 bqQ
-gKH
+kjV
 bpC
 buR
 bvU
@@ -114586,7 +114592,7 @@ byt
 mCe
 jJT
 boq
-mgL
+tZz
 bDA
 bEv
 bFO
@@ -114605,24 +114611,24 @@ bVG
 bWN
 bXD
 iCf
-gxa
+xpj
 cpn
 caY
 kjx
 acZ
 add
-gfw
-kxP
-sRD
-qin
-lrs
-gfw
+dwL
+sYq
+eIo
+qex
+emO
+dwL
 aaa
-fng
-sWL
-xzp
-fng
-xXy
+fcX
+nFo
+quN
+fcX
+lFW
 aaa
 aaa
 aaa
@@ -114873,11 +114879,11 @@ bfE
 fje
 tYP
 bja
-sAj
+tha
 blI
 bmY
 bja
-otF
+cEa
 bqR
 bsg
 bsg
@@ -114918,12 +114924,12 @@ cbZ
 cbZ
 cbZ
 cbZ
-sBH
+ujS
 hgl
-fng
-fng
-fng
-fng
+fcX
+fcX
+fcX
+fcX
 aaa
 aaa
 aaa
@@ -115201,12 +115207,12 @@ bGP
 bGP
 bGP
 bFK
-qvM
-shG
-mTo
+iIo
+mZn
+inl
 bUs
 bVI
-eBR
+iEX
 bXF
 bYy
 fVZ
@@ -115476,12 +115482,12 @@ bev
 mPi
 bgK
 whk
-omK
-xXd
+hzF
+qsw
 blK
 bna
-hvH
-uoV
+uhw
+jHF
 bqS
 bsg
 btG
@@ -115784,14 +115790,14 @@ blL
 whk
 bot
 whk
-tsA
+mFo
 bsg
 btH
 buV
-tHB
+udD
 bxl
-hQi
-frJ
+onM
+mqf
 bAE
 bBx
 rPh
@@ -115807,7 +115813,7 @@ bNA
 bFK
 bFK
 bFK
-nop
+xOr
 bUu
 bVK
 bWP
@@ -116082,7 +116088,7 @@ bjd
 bjd
 bjd
 bjd
-mpV
+iod
 bnc
 whk
 whk
@@ -116090,16 +116096,16 @@ bqT
 bsg
 btI
 buW
-hHm
+hhz
 qeG
-fTs
-mXi
+kMO
+iGU
 bAE
 bBy
 bCI
 bDA
 bEv
-ifo
+vPj
 bGX
 bIv
 bJS
@@ -116109,7 +116115,7 @@ bNB
 bFK
 bQA
 bRP
-eFc
+pZl
 bUv
 bVL
 bWR
@@ -116384,25 +116390,25 @@ ppQ
 uMr
 bje
 bkC
-nog
+fbZ
 bnd
 uMr
-eFC
+gkQ
 bev
 bsg
-hlR
+ryN
 buX
 bvZ
 bxn
-lhA
+qMJ
 bzw
-jqc
+lKR
 bBz
 bCJ
 bDA
 bEv
 bLh
-qyf
+hKu
 bIx
 bJU
 bFK
@@ -116411,10 +116417,10 @@ bNC
 bFK
 bQB
 bRQ
-kBW
-kgz
+yec
+mHd
 bVM
-uBL
+mgB
 bXG
 bFK
 oUn
@@ -116693,14 +116699,14 @@ bpI
 bqU
 bev
 btK
-wWn
+rgM
 cpF
 cpG
 cpJ
-pLB
+orp
 cpK
 bBA
-fae
+jJP
 bDJ
 bEE
 bFR
@@ -116715,21 +116721,21 @@ bFK
 bFK
 bFK
 bFK
-hlG
+sJD
 bWR
 bXJ
 bYy
 xhb
 cbY
 cba
-sye
-uLK
-yet
-lGK
-fMd
+iRI
+fNj
+wMB
+dCL
+hnF
 cba
 cba
-plK
+tFa
 cbZ
 eGO
 abX
@@ -116990,27 +116996,27 @@ dvx
 dvx
 blN
 bnf
-tLy
-tLy
-tLy
-hEO
+uzb
+uzb
+uzb
+gRI
 cpL
-faL
+tQL
 cpL
 cpH
 cpL
 cpL
 cpL
 bBB
-omo
+psl
 bnT
 bEF
-rSk
+fRz
 bGZ
 bIy
 bJU
 bLj
-gdl
+rXp
 bNE
 bPc
 bRS
@@ -117020,20 +117026,20 @@ qzV
 bVN
 gRo
 npx
-bmD
-xSb
-vVB
-smE
-dqI
-lOS
-sOW
-dHu
-eAc
-nDe
-isy
-vST
-qPg
-qMC
+mtm
+qcU
+gFK
+lfK
+xYH
+myd
+lbW
+vHo
+gTx
+vZL
+dDK
+tfv
+sgT
+lvH
 aaf
 aaf
 agm
@@ -117293,11 +117299,11 @@ blO
 blO
 bnj
 gQG
-jFM
+fUI
 bqV
 bsj
 cpM
-gGi
+lsB
 cpM
 cpI
 cpM
@@ -117312,24 +117318,24 @@ bHa
 bIz
 bJV
 bFK
-kcU
+kuN
 bRT
 bRT
 bRT
 bRT
-xKd
+hVp
 bgS
-vEJ
-fsd
+oWo
+ifd
 bXK
-jzY
-xaI
+orf
+jru
 cal
 cba
 cbW
-qCD
-dqI
-uLo
+fRk
+xYH
+sHC
 xUw
 cba
 cba
@@ -117593,7 +117599,7 @@ fpD
 aZR
 bkE
 fpD
-sBU
+qmg
 bow
 fpD
 fpD
@@ -117601,11 +117607,11 @@ bsk
 btJ
 buY
 byz
-wKU
+fOc
 byz
 bzz
 byz
-dhW
+pwM
 bCK
 btJ
 bEH
@@ -117621,18 +117627,18 @@ bQF
 bRU
 bTp
 bFK
-pfU
+ocT
 bFK
 bFK
 bFK
-hHt
+kJA
 cba
 cba
 ppd
-suG
-qwj
-uDX
-lVA
+rSr
+fKE
+qLy
+kDl
 cba
 cba
 cbZ
@@ -117893,11 +117899,11 @@ ivS
 bgO
 bhX
 bji
-eZj
+qYM
 blP
 bng
 aZZ
-dLW
+ctI
 bqX
 bev
 btN
@@ -117916,7 +117922,7 @@ bHg
 bID
 bKb
 bLr
-uaz
+dfC
 bNH
 bPf
 bQG
@@ -117928,7 +117934,7 @@ tan
 ozl
 tan
 caX
-giF
+sSD
 cba
 cba
 cba
@@ -118196,7 +118202,7 @@ pry
 blO
 bjj
 bjj
-pOi
+cMy
 bni
 njl
 bpJ
@@ -118206,7 +118212,7 @@ bpJ
 bpJ
 bwf
 bxs
-mHQ
+eMJ
 bzB
 cpE
 bBE
@@ -118224,10 +118230,10 @@ bPg
 bQH
 bRW
 bTp
-fao
+qJV
 bVP
-uSI
-dNp
+tdg
+gxk
 tan
 fVZ
 cbZ
@@ -118502,12 +118508,12 @@ blR
 bni
 boy
 bpJ
-xGS
-urf
-pHf
+xrb
+oCW
+hqe
 bpJ
-cHp
-bwv
+lmR
+wAu
 cpB
 cpC
 cpN
@@ -118518,8 +118524,8 @@ bEJ
 bFT
 bHd
 bDR
-gbd
-fuw
+gWL
+nHi
 bFT
 bNJ
 bPh
@@ -118529,19 +118535,19 @@ bTp
 bUA
 bfO
 tan
-hCu
+qkd
 tan
 aTu
 emI
 vEx
 vEx
-giF
-giF
-giF
-iRU
-giF
+sSD
+sSD
+sSD
+sVX
+sSD
 emI
-tXg
+qoW
 emI
 wOE
 aaa
@@ -118821,11 +118827,11 @@ bFT
 bHe
 bIB
 bJZ
-hZZ
+lpn
 bFT
 bNK
 bPi
-jUm
+sBB
 bRY
 bTp
 bUB
@@ -119114,15 +119120,15 @@ bwg
 bxu
 snN
 bzE
-lXs
+hri
 bBG
-omZ
+pMS
 bDQ
 bEL
 bFT
 bHf
 bIC
-dKZ
+wrE
 bLp
 bFT
 bNL
@@ -119130,12 +119136,12 @@ nBP
 bPj
 bRZ
 bTp
-lvC
+kjc
 bfO
 bDX
-iti
-kdN
-pCH
+wNf
+kwJ
+ojj
 cbZ
 cbZ
 seS
@@ -119146,8 +119152,8 @@ cbZ
 cbZ
 cbZ
 cbZ
-hyi
-ylL
+rfX
+cSc
 aaa
 aaa
 aaa
@@ -119412,18 +119418,18 @@ brb
 bsp
 btR
 bpJ
-flq
+rnN
 bxv
 snN
 bzF
 bAL
-xyk
-eJU
+kli
+udY
 ygw
 ygw
 bFY
-rUm
-uuN
+maH
+ftU
 bKa
 bLq
 bMw
@@ -119437,18 +119443,18 @@ bVQ
 bDX
 bnq
 bnq
-vfR
-oZb
-pJs
-dpI
-cyz
-lrs
-oZb
-sRD
-oNB
-emW
-lrs
-jdg
+gNY
+eLr
+oeU
+dSr
+ltA
+emO
+eLr
+eIo
+uIP
+dfT
+emO
+mPG
 aaa
 aaa
 aaa
@@ -119704,11 +119710,11 @@ beF
 nql
 lJE
 bhY
-rJJ
-rmZ
+jDh
+ijx
 blU
-lCD
-gmE
+jjN
+szD
 bpJ
 bpJ
 bpJ
@@ -119718,23 +119724,23 @@ bpJ
 bpJ
 byE
 bBH
-ihR
+jvb
 bCP
 bDS
 bEN
 bHc
-lFW
+ebv
 bHP
 bJX
 ygw
 cds
 bMw
-vzY
-hRB
-dLg
-xjN
+lqO
+eXW
+hCR
+vBf
 bTu
-gBx
+tsS
 bfO
 bDX
 bPs
@@ -120006,16 +120012,16 @@ beG
 bfP
 bgT
 bhY
-hVJ
+xid
 bkI
 blV
 bnm
-geh
+gjN
 bpK
 brd
 bsq
 btT
-tdF
+oOz
 bpK
 bxx
 byF
@@ -120025,18 +120031,18 @@ bBI
 bCQ
 bDT
 bEO
-pWV
+myz
 bHh
 bIE
 bLs
 bLs
-uKc
+epD
 bNN
 bQK
 bQK
 bSb
 bTv
-vnJ
+qaK
 bfO
 bDX
 bPs
@@ -120314,10 +120320,10 @@ blW
 bnn
 boB
 bpK
-myO
+nhZ
 bsr
-uzF
-xGo
+jrc
+ggQ
 bwi
 bxy
 byG
@@ -120327,15 +120333,15 @@ bBJ
 bCR
 bDU
 bEP
-eOD
+hvz
 bHi
 bIF
 ygw
 bLt
 bMw
 bNO
-kui
-pEy
+xTm
+qVJ
 bSc
 bTw
 bpK
@@ -120619,29 +120625,29 @@ bpK
 bpL
 bss
 tCk
-nZi
+kow
 bpK
 bxz
 byH
 bzI
-vTv
+dVg
 cds
 cds
 bIG
 bEQ
-htE
+vTk
 ygw
 bIG
 bKe
 bLu
 bMw
 bNP
-dNN
+djc
 bQM
-eBf
-jHu
-sMb
-iGX
+fAl
+uQT
+tTC
+xFQ
 bDX
 bnq
 fYL
@@ -120920,7 +120926,7 @@ bhY
 bpK
 bpM
 bst
-gLn
+uoZ
 bvc
 bvc
 bxA
@@ -120941,15 +120947,15 @@ bHl
 bHl
 bHl
 bHl
-qTb
+xPt
 bHl
 bfO
 bDX
 bnq
 bYB
-hGk
-hGk
-hGk
+uEv
+uEv
+uEv
 fYL
 acO
 aaa
@@ -121217,14 +121223,14 @@ bjq
 bjq
 bkM
 blZ
-bvy
+vhz
 les
 bpK
-sjG
+ghK
 bst
-hHD
+qCQ
 bvc
-jDt
+nnX
 bxL
 byJ
 bzK
@@ -121232,20 +121238,20 @@ bAM
 bBM
 bCU
 bDW
-mXe
+mxv
 bAM
-sSy
-tIW
+szq
+tjG
 bKg
 bLw
 bHl
 bNR
 bPn
-kCF
+eqL
 bUD
-grt
+xsN
 bUD
-jGG
+rxl
 bDX
 bnq
 bYF
@@ -121516,28 +121522,28 @@ kHZ
 bfT
 boF
 bQQ
-ouj
-oQw
-rgu
-rPt
+hWw
+esj
+jVX
+yfg
 boD
 bpK
 bpK
-ioc
+rYj
 bpK
 bvc
-iSc
-skX
-vys
-ueZ
+fsc
+xtO
+sKo
+igZ
 bAM
-tMf
-eKY
-oYx
-cZy
+lan
+dfl
+eiC
+jlJ
 bAM
-eqy
-kGM
+pQu
+woV
 bKh
 bLx
 bHl
@@ -121545,7 +121551,7 @@ bNS
 bPm
 bQL
 bSg
-noM
+wDf
 bHl
 bfO
 bWT
@@ -121826,26 +121832,26 @@ boE
 bpO
 bpO
 bsu
-nwK
+lZl
 bvc
-vgc
-sCD
-vUf
-gAs
+lQO
+qFo
+qoy
+uwM
 bAM
-jCM
-lRW
-oYx
+pDf
+wBS
+eiC
 bES
 bAM
-uOi
-tmR
+iQo
+oaz
 bKi
 bLy
 bHl
 bNT
 bPm
-rBC
+cEm
 bSg
 bHl
 bHl
@@ -122125,23 +122131,23 @@ bkN
 bmb
 bns
 boF
-tXe
+vRP
 bDY
-tzd
+oek
 bDX
 bvc
-vtX
-kSp
-jNR
-jgf
+eZZ
+cNv
+pRd
+suM
 bAM
-qUn
-hni
-mnd
-nnb
+sQa
+cGB
+usi
+sun
 bAM
-pvT
-xJg
+xwx
+gbn
 bKj
 bLz
 bHl
@@ -122423,7 +122429,7 @@ bfV
 bgZ
 aZa
 bjt
-lkw
+nXV
 bmc
 bnq
 bnq
@@ -122434,33 +122440,33 @@ bDX
 bvc
 bvc
 bxC
-wHo
-wRR
+hvO
+lVz
 bAM
 bBN
-ovV
-wCH
+wfc
+oVM
 bAM
 bAM
 bHl
 bHl
-sSx
-vFw
+xwf
+xQK
 bHl
-vpP
-tgm
+dPf
+sNg
 bQL
-rWU
+cKV
 bHl
 bUE
 bfO
 bUB
 bnq
-pFI
-hGk
-hGk
-hGk
-uhm
+qtW
+uEv
+uEv
+uEv
+gWE
 acO
 aaa
 aaa
@@ -122728,7 +122734,7 @@ aZa
 aZa
 aZa
 aZa
-fPi
+kaa
 bpP
 bnq
 bfO
@@ -122738,27 +122744,27 @@ bDX
 bDX
 bDX
 bDX
-xgz
+sTl
 bDX
 bDX
 bDX
 bDX
-ftZ
+tXB
 bHl
 bHl
-oij
-ngu
-itn
+wRj
+sUD
+oGn
 bNV
-pxv
+phA
 bQL
-ugK
+ycb
 bHl
 bDX
 bfO
 bWV
 bnq
-hEf
+upK
 bnq
 aad
 aad
@@ -123026,14 +123032,14 @@ aYW
 cfr
 aZa
 aZa
-cUO
-gsG
-hFc
-eta
+sKA
+pmx
+dXn
+naq
 boH
 bpQ
 bnq
-jbZ
+wnH
 bDY
 bDY
 bDY
@@ -123050,15 +123056,15 @@ bHl
 bHl
 bSi
 bLA
-itn
+oGn
 tdy
 bPm
 bQL
-iEU
+mLv
 bHl
 bDX
 bfO
-etg
+ujH
 bDX
 bDX
 bnq
@@ -123328,10 +123334,10 @@ mkL
 nDM
 pAA
 vos
-qxv
-xDL
-hQD
-dvo
+pUE
+jqU
+nbp
+tPN
 boI
 bpQ
 bre
@@ -123352,8 +123358,8 @@ bHl
 bHl
 ddK
 bLB
-jol
-cKj
+mOa
+peh
 kcl
 bQL
 bSj
@@ -123361,8 +123367,8 @@ bHl
 les
 bfO
 bWV
-oJW
-vYZ
+sas
+xnF
 bnq
 agm
 aaa
@@ -123630,22 +123636,22 @@ bpR
 nLA
 pmR
 pmR
-kQc
+qRn
 bpR
-feN
-feN
+dqy
+dqy
 boJ
 bpR
-ilc
+fcd
 bsx
 bua
 bvi
-vot
-svq
+ucN
+qxl
 bsw
 bsw
 bsw
-fDR
+lJN
 bzL
 bzL
 bfO
@@ -123660,8 +123666,8 @@ bHl
 bHl
 bHl
 bHl
-snW
-dVO
+uWG
+uqd
 bnq
 bnq
 bnq
@@ -123932,23 +123938,23 @@ mmz
 nVE
 boK
 bib
-ygI
-lGc
+uGD
+ugn
 bib
-hQb
+wbJ
 boK
 bpS
 bre
 bsw
-mzV
-jlI
-jlI
+ivn
+xcv
+xcv
 bxE
 bsw
 bsw
-ows
+deR
 bsw
-fXY
+tkE
 bre
 bfO
 bDX
@@ -123964,8 +123970,8 @@ bSk
 bnq
 bUI
 bfO
-trW
-dwd
+uLd
+vew
 bnq
 awS
 aaa
@@ -124238,34 +124244,34 @@ aZa
 aZa
 cfr
 aZa
-ewV
+msU
 aZa
 bre
 bsw
-ows
-rkB
-nKt
-nXV
+deR
+fYN
+sta
+pWa
 bCW
 bCW
 bCW
-sVR
+kUf
 bCW
-pcT
-yki
+xCO
+cKQ
 bQQ
 bQQ
 bQQ
 bSl
 iyd
-ouj
+hWw
 bNX
 bQQ
 bQQ
 bSl
 bTB
 bUJ
-qMm
+etI
 bnq
 bnq
 bnq
@@ -124540,16 +124546,16 @@ aZa
 bkP
 bic
 aZa
-sEy
-ppZ
+ghc
+pvP
 bre
 bsw
 bsw
 bvj
-oqm
-xTV
+wjb
+upU
 bsw
-xHn
+nKc
 bsw
 bsw
 bwo
@@ -124558,15 +124564,15 @@ bDX
 bDX
 bDX
 bDX
-jmt
-npf
+tab
+ygo
 bDX
 bDX
 bUB
-fgp
-iqG
-mqm
-npF
+lSk
+hQg
+qsx
+eyk
 bUB
 bnq
 aaa
@@ -124846,28 +124852,28 @@ boL
 cgP
 bre
 bsz
-hIW
+rGF
 bxE
 bwo
 bzL
-lbB
+ycM
 bsw
 bsw
 bsw
-ows
+deR
 bre
 bnq
 bnq
 bnq
-lsm
-wBj
+tVl
+dfo
 bnq
 bnq
 bnq
 bnq
 bnq
 bnq
-oGR
+mBf
 bnq
 bnq
 bnq
@@ -125144,15 +125150,15 @@ aZa
 bau
 cft
 aZa
-onQ
-iJP
-kGd
+kGp
+mQo
+usb
 bsw
 bsw
 bxE
 bsw
-lVX
-hIW
+kdR
+rGF
 bsw
 bsw
 bsw
@@ -125165,12 +125171,12 @@ oQa
 wqb
 oUm
 bnq
-gBX
-cQX
-dBx
-oRL
-jIb
-xXW
+mZL
+fbA
+eYA
+ebn
+vTK
+oQN
 bnq
 aci
 aaa
@@ -125452,13 +125458,13 @@ bre
 bsw
 bsw
 bxE
-ows
+deR
 bsw
 bsw
 bsw
-lVX
+kdR
 bsw
-dEj
+glv
 bzL
 aci
 aaa
@@ -125467,12 +125473,12 @@ oQa
 wqb
 oUm
 bnq
-exs
-lIw
-cKG
-isW
-sul
-vaX
+sUE
+edU
+dvu
+pzj
+onX
+cxa
 bnq
 aci
 aaa
@@ -125750,14 +125756,14 @@ bkR
 bkR
 bkR
 bkR
-qOe
+ikk
 bCW
 bCW
-xTV
+upU
 bsw
 bsw
 bsw
-ows
+deR
 bsw
 bsw
 bwo
@@ -126049,19 +126055,19 @@ bih
 beJ
 beJ
 beJ
-sJx
-kfS
-lRb
+nsO
+qAR
+gQA
 bre
-kQb
+tvp
 bsw
 bsw
-hlA
+wcz
 bsw
 bsw
-dWQ
+dDe
 bsw
-hIW
+rGF
 bzL
 bzL
 aci
@@ -126651,7 +126657,7 @@ aaa
 beK
 bii
 bjz
-usX
+vBg
 beK
 aaf
 aad
@@ -126952,8 +126958,8 @@ afw
 aaa
 beK
 bij
-kmJ
-rJD
+tfR
+qJi
 beK
 acO
 aaa
@@ -126972,11 +126978,11 @@ aaa
 aaa
 aaa
 aaa
-xJF
+xJq
 oQa
 wqb
 ica
-xJF
+xJq
 aaa
 aaa
 aaa
@@ -127274,11 +127280,11 @@ aaa
 aaa
 aaa
 abW
-xJF
+xJq
 oUm
-leW
+hGp
 oUm
-xJF
+xJq
 agm
 aaa
 aaa
@@ -127576,11 +127582,11 @@ aaa
 aaa
 aaa
 aaa
-xJF
+xJq
 oUm
 oUm
 oUm
-xJF
+xJq
 aaa
 aaa
 aaa
@@ -127858,7 +127864,7 @@ aNu
 aOI
 aOr
 xzv
-whE
+wWo
 aNu
 aaa
 aaa
@@ -127878,11 +127884,11 @@ aaa
 aaa
 aaa
 aaa
-xJF
-xJF
-xJF
-xJF
-xJF
+xJq
+xJq
+xJq
+xJq
+xJq
 aaa
 aaa
 aaa
@@ -129067,10 +129073,10 @@ brh
 aQf
 bik
 aOr
-lRa
+nWB
 aQf
-pBn
-lRa
+khO
+nWB
 aaa
 aaa
 aaa
@@ -129368,10 +129374,10 @@ aaa
 bsf
 aQf
 bik
-hZy
+lXB
 aNu
-iWl
-iWl
+xpG
+xpG
 aNu
 aaa
 aaa
@@ -129671,10 +129677,10 @@ bsh
 aQf
 bik
 aOr
-lRa
+nWB
 aQf
 aQf
-lRa
+nWB
 aaa
 aaa
 aaa
@@ -129972,7 +129978,7 @@ aaa
 aNu
 bri
 bik
-qLH
+hVu
 aNv
 aNu
 aNu
@@ -130878,7 +130884,7 @@ acb
 aNu
 stu
 bik
-tsm
+tvA
 aNu
 afw
 aaa
@@ -131485,7 +131491,7 @@ bik
 bia
 aQE
 aQE
-dIb
+uQl
 aNu
 aaa
 aaa
@@ -131785,9 +131791,9 @@ bsi
 bpE
 bik
 aNu
-enc
-uby
-enc
+oeN
+ssd
+oeN
 aNu
 aaa
 aaa

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -23283,6 +23283,9 @@
 /turf/simulated/floor/grime,
 /area/station/routing/depot)
 "bek" = (
+/obj/item/device/reagentscanner{
+	pixel_x = -4
+	},
 /obj/stool/chair,
 /turf/simulated/floor/plating,
 /area/station/routing/depot)
@@ -23651,16 +23654,12 @@
 "bfr" = (
 /obj/table/auto,
 /obj/item/decoration/ashtray,
-/obj/item/dice{
-	pixel_x = -8
+/obj/item/reagent_containers/dropper{
+	pixel_y = 7
 	},
-/obj/item/dice{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/coin{
-	pixel_x = -2;
-	pixel_y = 16
+/obj/item/reagent_containers/food/drinks/drinkingglass/shot{
+	pixel_x = 5;
+	pixel_y = 13
 	},
 /turf/simulated/floor/plating,
 /area/station/routing/depot)

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -39033,7 +39033,7 @@
 	pixel_y = 21
 	},
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/maintenance/inner/central)
 "bPs" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -39556,11 +39556,11 @@
 	operating = 1
 	},
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/maintenance/inner/central)
 "bQz" = (
 /obj/machinery/launcher_loader/east,
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/maintenance/inner/central)
 "bQA" = (
 /obj/item/storage/toilet,
 /turf/simulated/floor/black,
@@ -51400,6 +51400,15 @@
 	dir = 8
 	},
 /area/station/bridge)
+"dju" = (
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/obj/grille/catwalk{
+	dir = 10
+	},
+/turf/simulated/floor/airless/grey,
+/area/station/maintenance/southwest)
 "djG" = (
 /obj/disposalpipe/segment/mail/bent/north,
 /turf/simulated/floor/yellow/side{
@@ -53063,7 +53072,7 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/maintenance/inner/central)
 "hCR" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -54357,6 +54366,10 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/ce)
+"lVE" = (
+/obj/lattice,
+/turf/space,
+/area/station/maintenance/southwest)
 "lXB" = (
 /obj/machinery/light/emergency,
 /turf/simulated/floor,
@@ -56077,15 +56090,6 @@
 /obj/machinery/shieldgenerator/energy_shield,
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
-"qCC" = (
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
-/obj/grille/catwalk{
-	dir = 10
-	},
-/turf/simulated/floor/airless/grey,
-/area/station/maintenance/southwest)
 "qCQ" = (
 /obj/table/auto,
 /obj/item/paper/book/guardbot_guide{
@@ -58268,10 +58272,6 @@
 	},
 /turf/simulated/floor/grey/blackgrime,
 /area/station/security/brig)
-"wKe" = (
-/obj/lattice,
-/turf/space,
-/area/station/maintenance/southwest)
 "wLi" = (
 /obj/machinery/light/emergency,
 /obj/machinery/atmospherics/pipe/manifold{
@@ -90448,7 +90448,7 @@ bMB
 bOb
 bPu
 bNZ
-qCC
+dju
 bTH
 sBH
 bVX
@@ -90751,7 +90751,7 @@ bOb
 bPv
 bGc
 bUM
-wKe
+lVE
 bUM
 bVX
 aaa
@@ -107622,7 +107622,7 @@ aaa
 aci
 aaa
 aaa
-aIX
+aCr
 bPp
 acO
 aaa

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -39506,7 +39506,7 @@
 	pixel_y = 24
 	},
 /obj/blind_switch/area/north{
-	pixel_x = -12
+	pixel_x = -13
 	},
 /turf/simulated/floor/redblack{
 	dir = 1
@@ -39563,6 +39563,9 @@
 /area/station/maintenance/inner/central)
 "bQA" = (
 /obj/item/storage/toilet,
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
 /turf/simulated/floor/black,
 /area/station/security/brig)
 "bQB" = (
@@ -39573,9 +39576,6 @@
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_x = 12
-	},
-/obj/machinery/alarm{
-	pixel_y = 24
 	},
 /turf/simulated/floor/grey/side{
 	dir = 4
@@ -41269,6 +41269,9 @@
 	},
 /obj/cable{
 	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/red,
 /area/station/security/interrogation)
@@ -52883,6 +52886,15 @@
 /obj/random_item_spawner/tools,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
+"gYB" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/interrogation)
 "haO" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -53362,9 +53374,6 @@
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_x = -12
-	},
-/obj/machinery/alarm{
-	pixel_y = 24
 	},
 /turf/simulated/floor/grey/side{
 	dir = 8
@@ -56901,6 +56910,25 @@
 	},
 /turf/simulated/floor,
 /area/station/storage/warehouse)
+"sMy" = (
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
+	},
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/red/side{
+	dir = 1
+	},
+/area/station/security/brig)
 "sME" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -58136,6 +58164,18 @@
 "whk" = (
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
+"whJ" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/security/brig)
 "wio" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -58694,6 +58734,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/turret_protected/Zeta)
+"xRV" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/interrogation)
 "xSq" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -113401,9 +113450,9 @@ iZd
 bQs
 bRH
 bTl
-iZd
-bVD
-cou
+xRV
+sMy
+whJ
 bXz
 bFK
 caU
@@ -114609,7 +114658,7 @@ kZX
 bQw
 bRL
 bTn
-kZX
+gYB
 bVG
 bWN
 bXD

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -1582,7 +1582,7 @@
 /turf/space,
 /area/station/solar/east)
 "adS" = (
-/obj/floorpillstatue,
+/obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/station/storage/northeast)
 "adT" = (
@@ -1793,7 +1793,7 @@
 /area/station/chapel/sanctuary)
 "aeo" = (
 /obj/decal/cleanable/dirt,
-/obj/landmark/artifact,
+/obj/floorpillstatue,
 /turf/simulated/floor/plating,
 /area/station/storage/northeast)
 "aep" = (
@@ -1931,7 +1931,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "aeD" = (
-/obj/reagent_dispensers/fueltank,
+/obj/landmark/artifact,
 /turf/simulated/floor/plating,
 /area/station/storage/northeast)
 "aeF" = (
@@ -1952,7 +1952,8 @@
 	free_resource_amt = 0;
 	free_resources = null;
 	malfunction = 1;
-	name = "grody manufacturer"
+	name = "grody manufacturer";
+	wires = 11
 	},
 /obj/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating,
@@ -23358,6 +23359,9 @@
 "ber" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/machinery/vending/monkey,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "bes" = (
@@ -27766,6 +27770,9 @@
 	pixel_x = -12
 	},
 /obj/machinery/light_switch/north,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/grey,
 /area/station/hydroponics/bay)
 "bpx" = (
@@ -27780,6 +27787,9 @@
 /obj/item/reagent_containers/glass/bottle/ammonia/large,
 /obj/item/reagent_containers/glass/bottle/ammonia/large,
 /obj/decal/cleanable/dirt,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/grey,
 /area/station/hydroponics/bay)
 "bpz" = (
@@ -27794,6 +27804,9 @@
 /area/station/hydroponics/bay)
 "bpA" = (
 /obj/submachine/seed_vendor,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
@@ -34058,7 +34071,6 @@
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/south)
 "bEz" = (
-/obj/machinery/light,
 /obj/disposalpipe/segment/vertical,
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/red/side,
@@ -34069,8 +34081,8 @@
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/south)
 "bEB" = (
-/obj/machinery/light,
 /obj/disposalpipe/segment/mail/horizontal,
+/obj/machinery/light,
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/south)
 "bEC" = (
@@ -36465,26 +36477,15 @@
 /obj/disposalpipe/segment/brig,
 /obj/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/cable{
-	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
 "bJG" = (
-/obj/machinery/computer3/terminal/zeta{
-	dir = 8;
-	setup_os_string = "ZETA_MAINFRAME"
+/obj/stool/chair/comfy/red{
+	dir = 4
 	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/data_terminal,
 /turf/simulated/floor/red/side{
 	dir = 4
 	},
@@ -36981,6 +36982,10 @@
 /obj/table/reinforced/auto,
 /obj/machinery/recharger,
 /obj/disposalpipe/segment/brig,
+/obj/item/device/prisoner_scanner{
+	pixel_x = -11;
+	pixel_y = -11
+	},
 /turf/simulated/floor/carpet/red/standard/innercorner/ne,
 /area/station/security/main)
 "bKW" = (
@@ -36992,6 +36997,11 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/red/standard/edge/ne,
 /area/station/security/main)
@@ -37529,14 +37539,27 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/carpet/red/standard/edge/se,
 /area/station/security/main)
 "bMg" = (
-/obj/shrub,
 /obj/machinery/light,
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
+/obj/machinery/computer3/terminal/zeta{
+	dir = 8;
+	setup_os_string = "ZETA_MAINFRAME"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/red/side{
 	dir = 4
 	},
@@ -38066,6 +38089,10 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bNp" = (
+/obj/machinery/computer/arcade,
+/turf/simulated/floor/grime,
+/area/station/security/brig)
+"bNq" = (
 /obj/storage/crate,
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
@@ -38076,10 +38103,6 @@
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
-/turf/simulated/floor/grime,
-/area/station/security/brig)
-"bNq" = (
-/obj/machinery/computer/arcade,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bNr" = (
@@ -38159,6 +38182,7 @@
 /turf/simulated/floor/red,
 /area/station/security/brig)
 "bND" = (
+/obj/machinery/light/small,
 /turf/simulated/floor/redblack{
 	dir = 10
 	},
@@ -38655,10 +38679,6 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
-	},
-/obj/item/device/prisoner_scanner{
-	pixel_x = 6;
-	pixel_y = 10
 	},
 /turf/simulated/floor/red/side{
 	dir = 8
@@ -42694,7 +42714,9 @@
 /turf/simulated/floor/red/side,
 /area/station/security/brig)
 "bXE" = (
-/obj/storage/closet/wardrobe/orange,
+/obj/stool/chair/red{
+	dir = 1
+	},
 /turf/simulated/floor/red/side,
 /area/station/security/brig)
 "bXF" = (
@@ -42703,20 +42725,14 @@
 /turf/simulated/floor/red/side,
 /area/station/security/brig)
 "bXG" = (
-/obj/stool/chair/red{
-	dir = 4
-	},
+/obj/storage/closet/wardrobe/orange,
 /turf/simulated/floor/red/side,
 /area/station/security/brig)
 "bXH" = (
-/obj/cable,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/data_terminal,
 /obj/machinery/light/emergency,
-/obj/machinery/computer3/generic/secure_data{
-	dir = 8
+/obj/storage/secure/crate/weapon/confiscated_items,
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/red/side,
 /area/station/security/brig)
@@ -42727,7 +42743,12 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/obj/storage/secure/crate/weapon/confiscated_items,
+/obj/machinery/computer3/generic/secure_data{
+	dir = 4;
+	tag = ""
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable,
 /turf/simulated/floor/red/side,
 /area/station/security/brig)
 "bXJ" = (
@@ -44191,12 +44212,14 @@
 /turf/space,
 /area/station/ai_monitored/armory)
 "caY" = (
-/obj/machinery/light/runway_light,
-/obj/lattice{
-	icon_state = "lattice-dir"
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/space,
-/area/space)
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor,
+/area/station/security/brig)
 "caZ" = (
 /obj/table/auto,
 /obj/item/storage/firstaid/oxygen,
@@ -51104,6 +51127,9 @@
 	pixel_x = -7
 	},
 /obj/item/pen,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "cEm" = (
@@ -51819,18 +51845,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "esy" = (
-/obj/item/storage/toilet,
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/grey/side{
+/obj/stool/chair/red{
 	dir = 8
 	},
-/area/space)
+/turf/simulated/floor/red/side,
+/area/station/security/brig)
 "etI" = (
 /obj/cable{
 	d1 = 1;
@@ -51891,21 +51910,12 @@
 /turf/space,
 /area/station/ai_monitored/armory)
 "eKS" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/light/runway_light/delay5,
+/obj/lattice{
+	icon_state = "lattice-dir"
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/decal/wreath/ephemeral,
-/turf/simulated/floor/plating,
-/area/space)
+/turf/space,
+/area/station/ai_monitored/armory)
 "eLc" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -52030,8 +52040,10 @@
 /turf/simulated/floor/green/side,
 /area/station/garden/aviary)
 "fcX" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/space)
+/obj/machinery/light/runway_light/delay2,
+/obj/lattice,
+/turf/space,
+/area/station/ai_monitored/armory)
 "fdN" = (
 /obj/cable{
 	d1 = 1;
@@ -52168,10 +52180,10 @@
 	},
 /area/station/crew_quarters/ce)
 "ftt" = (
-/turf/simulated/floor/redblack/corner{
-	dir = 8
-	},
-/area/space)
+/obj/machinery/light/runway_light/delay5,
+/obj/lattice,
+/turf/space,
+/area/station/ai_monitored/armory)
 "ftU" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -52208,6 +52220,7 @@
 "fyL" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /obj/decal/cleanable/dirt,
+/obj/item/hand_labeler,
 /turf/simulated/floor/plating,
 /area/station/routing/depot)
 "fAl" = (
@@ -52223,13 +52236,6 @@
 	dir = 8
 	},
 /area/station/bridge)
-"fBG" = (
-/obj/machinery/door/airlock/pyro/glass{
-	name = "Holding Cell One"
-	},
-/obj/access_spawn/brig,
-/turf/simulated/floor/black,
-/area/space)
 "fCz" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -53076,15 +53082,6 @@
 /obj/item/device/radio/intercom/cargo,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"hVp" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/simulated/floor/redblack{
-	dir = 4
-	},
-/area/station/security/brig)
 "hVu" = (
 /obj/table/auto,
 /obj/machinery/light,
@@ -53194,12 +53191,6 @@
 	},
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/south)
-"ioh" = (
-/obj/machinery/vending/snack{
-	credit = 50
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/space)
 "isd" = (
 /obj/machinery/manufacturer/hangar,
 /obj/machinery/power/apc/autoname_west,
@@ -53413,12 +53404,6 @@
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
-"iYl" = (
-/obj/stool,
-/turf/simulated/floor/grey/side{
-	dir = 4
-	},
-/area/space)
 "jaZ" = (
 /obj/table/auto,
 /obj/item/shipcomponent/secondary_system/tractor_beam,
@@ -53665,14 +53650,6 @@
 /obj/decal/garland/ephemeral,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
-"jPC" = (
-/obj/machinery/floorflusher/solitary,
-/obj/submachine/chef_sink/chem_sink{
-	pixel_y = 16
-	},
-/obj/disposalpipe/trunk/south,
-/turf/simulated/floor/black,
-/area/space)
 "jTa" = (
 /obj/decal/poster/wallsign/fire,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -53741,22 +53718,6 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/garden/aviary)
-"kej" = (
-/obj/table/reinforced/auto,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/reagent_containers/food/drinks/water,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/turf/simulated/floor/grey/side{
-	dir = 8
-	},
-/area/space)
 "khO" = (
 /obj/machinery/light{
 	dir = 8;
@@ -53868,10 +53829,6 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/engine/vacuum,
 /area/research_outpost/indigo_rye)
-"ktt" = (
-/obj/machinery/drainage,
-/turf/simulated/floor/black,
-/area/space)
 "kuN" = (
 /obj/stool/chair/red{
 	dir = 8
@@ -53932,14 +53889,6 @@
 /obj/item/clothing/glasses/thermal,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
-"kEr" = (
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/redblack/corner{
-	dir = 4
-	},
-/area/space)
 "kGp" = (
 /turf/simulated/floor/damaged5,
 /area/station/crew_quarters/quarters_south)
@@ -53999,6 +53948,9 @@
 /obj/machinery/plantpot,
 /obj/machinery/firealarm{
 	pixel_y = 24
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
 	},
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
@@ -54221,14 +54173,6 @@
 	},
 /turf/space,
 /area/station/ai_monitored/armory)
-"ltS" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet,
-/obj/item/device/radio/intercom,
-/turf/simulated/floor/grey/side{
-	dir = 4
-	},
-/area/space)
 "lvb" = (
 /obj/grille/steel,
 /obj/disposalpipe/segment/transport,
@@ -54265,26 +54209,6 @@
 /obj/disposalpipe/segment/bent/west,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
-"lFW" = (
-/obj/machinery/door_timer/solitary2/new_walls/north{
-	layer = 3.1
-	},
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/redblack/corner{
-	dir = 4
-	},
-/area/space)
-"lGb" = (
-/obj/machinery/door/airlock/pyro/glass{
-	name = "Holding Cell Two"
-	},
-/obj/access_spawn/brig,
-/turf/simulated/floor/black,
-/area/space)
 "lHa" = (
 /obj/machinery/light/emergency{
 	dir = 4;
@@ -54904,19 +54828,6 @@
 	dir = 8
 	},
 /area/station/crew_quarters/quarters_south)
-"nFo" = (
-/obj/item/storage/toilet,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/grey/side{
-	dir = 4
-	},
-/area/space)
 "nGr" = (
 /obj/machinery/light/emergency{
 	dir = 4;
@@ -55161,12 +55072,6 @@
 	},
 /turf/space,
 /area/station/ai_monitored/armory)
-"ogC" = (
-/obj/stool,
-/turf/simulated/floor/grey/side{
-	dir = 8
-	},
-/area/space)
 "ojj" = (
 /obj/disposalpipe/segment/transport{
 	dir = 8;
@@ -55941,24 +55846,6 @@
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"qmq" = (
-/obj/machinery/door_timer/solitary/new_walls/north{
-	layer = 3.1
-	},
-/obj/storage/closet/wardrobe/orange,
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -20
-	},
-/turf/simulated/floor/redblack/corner{
-	dir = 4
-	},
-/area/space)
 "qmz" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -56074,22 +55961,6 @@
 	icon_state = "catwalk_cross"
 	},
 /area/station/maintenance/southeast)
-"quN" = (
-/obj/table/reinforced/auto,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/reagent_containers/food/drinks/water,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/simulated/floor/grey/side{
-	dir = 4
-	},
-/area/space)
 "qxl" = (
 /obj/shrub,
 /obj/machinery/light/small{
@@ -56390,16 +56261,6 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/bridge/captain)
-"rrO" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/redblack/corner{
-	dir = 8
-	},
-/area/space)
 "rsz" = (
 /obj/disposalpipe/segment/transport,
 /obj/decal/poster/wallsign/medbay_left,
@@ -56553,14 +56414,6 @@
 /area/station/crew_quarters/clown{
 	name = "Clowntainment"
 	})
-"rUm" = (
-/obj/machinery/floorflusher/solitary2,
-/obj/submachine/chef_sink/chem_sink{
-	pixel_y = 16
-	},
-/obj/disposalpipe/trunk/south,
-/turf/simulated/floor/black,
-/area/space)
 "rXp" = (
 /turf/simulated/floor/redblack{
 	dir = 1
@@ -56778,14 +56631,6 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/hallway/secondary/exit)
-"sxb" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet,
-/obj/item/device/radio/intercom,
-/turf/simulated/floor/grey/side{
-	dir = 8
-	},
-/area/space)
 "syK" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
@@ -57026,14 +56871,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/station/maintenance/southeast)
-"sVy" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/space)
 "sVX" = (
 /obj/lattice{
 	dir = 1;
@@ -58488,7 +58325,7 @@
 	dir = 4
 	},
 /turf/space,
-/area/space)
+/area/station/ai_monitored/armory)
 "xpG" = (
 /turf/simulated/floor/caution/westeast,
 /area/station/hallway/secondary/exit)
@@ -58810,14 +58647,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"yjj" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/space)
 "ylQ" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
@@ -110970,7 +110799,7 @@ bAz
 bBu
 bCz
 bDA
-bEv
+bEB
 bGA
 bGI
 bIj
@@ -112510,10 +112339,10 @@ aaa
 aaa
 aaa
 aaa
-fcX
-fcX
-fcX
-fcX
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -112782,7 +112611,7 @@ bpC
 boq
 bCz
 fGA
-bEB
+bEv
 bFR
 bFR
 bFR
@@ -112812,11 +112641,11 @@ aaa
 aaa
 aaa
 aaa
-fcX
-esy
-kej
-fcX
-qmq
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -113114,11 +112943,11 @@ aaa
 aaa
 aaa
 aaa
-fcX
-jPC
-ktt
-fBG
-ftt
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -113386,7 +113215,7 @@ boq
 boq
 bCz
 bDA
-bEv
+bEB
 bFO
 spD
 bLd
@@ -113409,6 +113238,7 @@ caQ
 caU
 caU
 caU
+afw
 aaa
 aaa
 aaa
@@ -113416,11 +113246,10 @@ aaa
 aaa
 aaa
 aaa
-fcX
-ltS
-iYl
-sVy
-kEr
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -113708,6 +113537,10 @@ bFK
 bZp
 xKL
 ouG
+aci
+aaa
+aaa
+aci
 aaa
 aaa
 aaa
@@ -113718,11 +113551,7 @@ aaa
 aaa
 aaa
 aaa
-fcX
-fcX
-ioh
-eKS
-rrO
+aaa
 aaa
 aaa
 aaa
@@ -113977,7 +113806,7 @@ pvj
 owU
 xdq
 bja
-bpC
+pUl
 bqM
 bqM
 bqM
@@ -114006,10 +113835,14 @@ bFK
 cot
 cou
 bXB
-bYy
+bFK
 bZr
 aaa
 aaa
+aci
+aaa
+aaa
+aci
 aaa
 aaa
 aaa
@@ -114020,11 +113853,7 @@ aaa
 aaa
 aaa
 aaa
-fcX
-sxb
-ogC
-yjj
-kEr
+aaa
 aaa
 aaa
 aaa
@@ -114308,25 +114137,25 @@ bUp
 bVG
 bWN
 bXC
-iNr
+bFK
 bZr
 aaa
 aaa
+aci
+aaa
+aaa
+aci
 aaa
 aaa
 aaa
-afw
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-fcX
-rUm
-ktt
-lGb
-ftt
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -114610,25 +114439,25 @@ bOW
 bVG
 bWN
 bXD
-iCf
+bFK
 xpj
-cpn
-caY
-kjx
-acZ
-add
-dwL
+eKS
+sYq
+fcX
+qex
+emO
+ftt
 sYq
 eIo
 qex
 emO
 dwL
 aaa
-fcX
-nFo
-quN
-fcX
-lFW
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -114912,7 +114741,7 @@ bFK
 bVH
 cou
 bXE
-bFK
+bYy
 fVZ
 cbZ
 cbZ
@@ -114926,10 +114755,10 @@ cbZ
 cbZ
 ujS
 hgl
-fcX
-fcX
-fcX
-fcX
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -115214,7 +115043,7 @@ bUs
 bVI
 iEX
 bXF
-bYy
+iNr
 fVZ
 cbZ
 cgZ
@@ -116118,7 +115947,7 @@ bRP
 pZl
 bUv
 bVL
-bWR
+caY
 bXI
 bFK
 bZt
@@ -116421,7 +116250,7 @@ yec
 mHd
 bVM
 mgB
-bXG
+esy
 bFK
 oUn
 cba
@@ -117018,9 +116847,9 @@ bJU
 bLj
 rXp
 bNE
+bRS
+bRS
 bPc
-bRS
-bRS
 bRS
 qzV
 bVN
@@ -117323,7 +117152,7 @@ bRT
 bRT
 bRT
 bRT
-hVp
+bRT
 bgS
 oWo
 ifd

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -197,12 +197,9 @@
 	},
 /area/space)
 "aaE" = (
-/obj/lattice{
-	dir = 10;
-	icon_state = "lattice-dir"
-	},
-/turf/space,
-/area/station/solar/east)
+/obj/decal/poster/wallsign/space,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/maintenance/solar/east)
 "aaF" = (
 /obj/item/reagent_containers/food/snacks/ingredient/egg{
 	desc = "YOU GOT EGG"
@@ -221,11 +218,14 @@
 	},
 /area/station/hangar/main)
 "aaI" = (
-/obj/machinery/disposal_pipedispenser,
-/obj/decal/cleanable/cobweb,
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/space,
 /turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
+/area/station/storage/northeast)
 "aaJ" = (
 /obj/grille/catwalk{
 	dir = 4
@@ -244,14 +244,12 @@
 /turf/space,
 /area/station/solar/east)
 "aaM" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
+/obj/machinery/power/terminal{
+	dir = 8
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/east)
@@ -284,14 +282,23 @@
 /turf/space,
 /area/space)
 "aaP" = (
-/obj/grille/catwalk{
-	dir = 9;
-	icon_state = "catwalk_cross"
+/obj/cable,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/airless/plating/catwalk{
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/grille/catwalk{
 	dir = 9
 	},
-/area/space)
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8;
+	icon_state = "catwalk_cross"
+	},
+/area/station/solar/east)
 "aaQ" = (
 /obj/grille/catwalk{
 	dir = 4
@@ -301,15 +308,9 @@
 	},
 /area/space)
 "aaR" = (
-/obj/grille/catwalk{
-	dir = 5;
-	icon_state = "catwalk_cross"
-	},
 /turf/space,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 5
-	},
-/area/space)
+/turf/simulated/wall/auto/supernorn,
+/area/station/janitor/supply)
 "aaS" = (
 /obj/grille/catwalk,
 /turf/simulated/floor/airless/plating/catwalk,
@@ -1052,6 +1053,12 @@
 /turf/simulated/floor/engine,
 /area/station/engine/ptl)
 "acH" = (
+/obj/stool/chair/yellow{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/solar/east)
+"acI" = (
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -1062,27 +1069,6 @@
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
-	},
-/area/station/solar/east)
-"acI" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/grille/catwalk{
-	dir = 10
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 1;
-	icon_state = "catwalk_cross"
 	},
 /area/station/solar/east)
 "acJ" = (
@@ -1246,19 +1232,16 @@
 /turf/space,
 /area/space)
 "ada" = (
-/obj/lattice{
-	dir = 1;
-	icon_state = "lattice-dir"
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/space,
-/area/space)
+/turf/simulated/floor/plating,
+/area/station/maintenance/solar/east)
 "adb" = (
 /obj/lattice{
 	dir = 8;
@@ -1457,27 +1440,33 @@
 /turf/simulated/floor/plating,
 /area/station/storage/northeast)
 "adx" = (
-/obj/cable,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/grille/catwalk{
-	dir = 9
+	dir = 10
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 8;
+	dir = 1;
 	icon_state = "catwalk_cross"
 	},
 /area/station/solar/east)
 "ady" = (
-/obj/lattice,
-/turf/space,
-/area/station/solar/east)
+/obj/table/reinforced/auto,
+/obj/machinery/cell_charger,
+/obj/item/cell/supercell/charged,
+/obj/item/cell/supercell/charged,
+/turf/simulated/floor/plating,
+/area/station/maintenance/solar/east)
 "adz" = (
 /obj/lattice{
 	icon_state = "lattice-dir"
@@ -1548,17 +1537,23 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/chapel/sanctuary)
 "adJ" = (
-/obj/machinery/mass_driver{
-	dir = 1;
-	id = "kondaru_funeral";
-	name = "funerary driver"
+/obj/cable,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/machinery/door/poddoor/pyro{
-	id = "kondaru_funeral";
-	name = "Funerary Driver Door"
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/grey,
-/area/station/chapel/sanctuary)
+/obj/grille/catwalk{
+	dir = 5
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	icon_state = "catwalk_cross"
+	},
+/area/station/solar/east)
 "adK" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -1566,56 +1561,40 @@
 "adL" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/northeast)
-"adM" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
-"adN" = (
-/obj/grille/steel,
-/turf/simulated/floor/plating,
-/area/station/storage/northeast)
 "adO" = (
-/obj/floorpillstatue,
-/turf/simulated/floor/plating,
-/area/station/storage/northeast)
+/obj/lattice,
+/turf/space,
+/area/station/solar/east)
 "adP" = (
-/obj/decal/cleanable/dirt,
-/obj/reagent_dispensers/still,
-/turf/simulated/floor/plating,
-/area/station/storage/northeast)
-"adQ" = (
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/obj/decal/cleanable/paper,
-/turf/simulated/floor/plating,
-/area/station/storage/northeast)
-"adR" = (
-/obj/landmark/artifact,
-/turf/simulated/floor/plating,
-/area/station/storage/northeast)
-"adS" = (
-/obj/reagent_dispensers/fueltank,
-/obj/decal/cleanable/cobweb2,
-/turf/simulated/floor/plating,
-/area/station/storage/northeast)
-"adT" = (
 /obj/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/quarters_east)
-"adU" = (
+/obj/grille/catwalk,
+/turf/simulated/floor/airless/plating/catwalk,
+/area/station/solar/east)
+"adQ" = (
 /obj/lattice{
 	dir = 6;
 	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/station/solar/east)
-"adV" = (
+"adS" = (
+/obj/floorpillstatue,
+/turf/simulated/floor/plating,
+/area/station/storage/northeast)
+"adT" = (
 /obj/lattice{
 	dir = 1;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/station/solar/east)
+"adV" = (
+/obj/lattice{
+	dir = 8;
 	icon_state = "lattice-dir"
 	},
 /turf/space,
@@ -1760,19 +1739,64 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "aek" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
+/obj/cable,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/north)
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/grille/catwalk{
+	dir = 1;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
+/area/station/solar/east)
 "ael" = (
 /obj/decal/poster/wallsign/space,
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/north)
 "aem" = (
+/obj/grille/catwalk{
+	icon_state = "catwalk_cross"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/tracker/east,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
+/area/station/solar/east)
+"aen" = (
+/obj/machinery/mass_driver{
+	dir = 1;
+	id = "kondaru_funeral";
+	name = "funerary driver"
+	},
+/obj/machinery/door/poddoor/pyro{
+	id = "kondaru_funeral";
+	name = "Funerary Driver Door"
+	},
+/turf/simulated/floor/grey,
+/area/station/chapel/sanctuary)
+"aeo" = (
+/obj/decal/cleanable/dirt,
+/obj/reagent_dispensers/still,
+/turf/simulated/floor/plating,
+/area/station/storage/northeast)
+"aep" = (
 /obj/machinery/mass_driver{
 	dir = 1;
 	id = "kondaru_funeral";
@@ -1780,7 +1804,15 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/chapel/sanctuary)
-"aen" = (
+"aeq" = (
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/obj/decal/cleanable/paper,
+/turf/simulated/floor/plating,
+/area/station/storage/northeast)
+"aer" = (
 /obj/cable{
 	icon_state = "2-4"
 	},
@@ -1799,7 +1831,7 @@
 	dir = 8
 	},
 /area/station/chapel/sanctuary)
-"aeo" = (
+"aes" = (
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
@@ -1814,20 +1846,7 @@
 	dir = 4
 	},
 /area/station/chapel/sanctuary)
-"aep" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/specialroom/chapel{
-	dir = 8
-	},
-/area/station/chapel/sanctuary)
-"aeq" = (
+"aet" = (
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -1841,18 +1860,7 @@
 	dir = 4
 	},
 /area/station/chapel/sanctuary)
-"aer" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/black,
-/area/station/chapel/sanctuary)
-"aes" = (
+"aev" = (
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
@@ -1865,7 +1873,14 @@
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/sanctuary)
-"aet" = (
+"aew" = (
+/obj/table/reinforced/bar/auto{
+	name = "wooden table"
+	},
+/obj/machinery/phone,
+/turf/simulated/floor/carpet/blue/fancy/edge/nw,
+/area/station/chapel/sanctuary)
+"aex" = (
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -1882,7 +1897,7 @@
 	dir = 1
 	},
 /area/station/chapel/sanctuary)
-"aeu" = (
+"aey" = (
 /obj/cable{
 	d1 = 2;
 	d2 = 8;
@@ -1893,7 +1908,7 @@
 	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
-"aev" = (
+"aez" = (
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
@@ -1903,60 +1918,24 @@
 	dir = 1
 	},
 /area/station/chapel/sanctuary)
-"aew" = (
+"aeA" = (
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
-"aex" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/grime,
-/area/station/chapel/sanctuary)
-"aey" = (
-/turf/simulated/floor/stairs/wide/other{
-	dir = 8
-	},
-/area/station/maintenance/northeast)
-"aez" = (
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
-"aeA" = (
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
 "aeB" = (
-/obj/stool/chair,
+/obj/landmark{
+	name = "blobstart"
+	},
 /turf/simulated/floor/plating,
-/area/station/storage/northeast)
-"aeC" = (
-/obj/item/cigbutt,
-/turf/simulated/floor/plating,
-/area/station/storage/northeast)
+/area/station/maintenance/northeast)
 "aeD" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/storage/northeast)
-"aeE" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/critter/roach,
+/obj/landmark/artifact,
 /turf/simulated/floor/plating,
 /area/station/storage/northeast)
 "aeF" = (
-/obj/machinery/space_heater,
-/obj/machinery/power/apc/autoname_east,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
+/obj/stool/chair,
 /turf/simulated/floor/plating,
 /area/station/storage/northeast)
 "aeG" = (
@@ -1968,21 +1947,23 @@
 /turf/space,
 /area/space)
 "aeH" = (
+/obj/reagent_dispensers/fueltank,
+/obj/decal/cleanable/cobweb2,
+/turf/simulated/floor/plating,
+/area/station/storage/northeast)
+"aeI" = (
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
-"aeI" = (
-/obj/storage/closet/emergency,
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
+/turf/simulated/floor/specialroom/chapel{
+	dir = 8
+	},
+/area/station/chapel/sanctuary)
 "aeJ" = (
 /obj/lattice{
 	icon_state = "lattice-dir"
@@ -2093,29 +2074,20 @@
 /turf/simulated/floor/airless/plating/catwalk,
 /area/space)
 "aeW" = (
-/obj/disposalpipe/segment/bent/south,
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/north)
+/obj/firedoor_spawn,
+/turf/simulated/floor/grime,
+/area/station/chapel/sanctuary)
 "aeX" = (
-/obj/machinery/door/airlock/pyro/glass,
-/turf/simulated/floor/grey,
-/area/station/chapel/sanctuary)
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
 "aeY" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/stool/chair/wooden{
-	dir = 4
-	},
-/turf/simulated/floor/specialroom/chapel{
-	dir = 4
-	},
-/area/station/chapel/sanctuary)
+/obj/item/cigbutt,
+/turf/simulated/floor/plating,
+/area/station/storage/northeast)
 "aeZ" = (
 /obj/decal/poster/wallsign/warning3,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -2123,11 +2095,19 @@
 	name = "Clowntainment"
 	})
 "afa" = (
-/turf/simulated/floor/specialroom/chapel{
-	dir = 4
-	},
+/obj/machinery/door/airlock/pyro/glass,
+/turf/simulated/floor/grey,
 /area/station/chapel/sanctuary)
 "afb" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/critter/roach,
+/turf/simulated/floor/plating,
+/area/station/storage/northeast)
+"afe" = (
 /obj/table/reinforced/bar/auto{
 	name = "wooden table"
 	},
@@ -2135,23 +2115,23 @@
 	dir = 8
 	},
 /area/station/chapel/sanctuary)
-"afc" = (
+"afg" = (
 /obj/stool/chair/comfy,
 /turf/simulated/floor/black,
 /area/station/chapel/sanctuary)
-"afd" = (
+"afh" = (
 /obj/player_piano,
 /turf/simulated/floor/specialroom/chapel{
 	dir = 1
 	},
 /area/station/chapel/sanctuary)
-"afe" = (
+"afi" = (
 /obj/table/reinforced/bar/auto{
 	name = "wooden table"
 	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
-"aff" = (
+"afj" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 4;
@@ -2161,7 +2141,7 @@
 	dir = 1
 	},
 /area/station/chapel/sanctuary)
-"afg" = (
+"afk" = (
 /obj/disposalpipe/segment/bent/east,
 /obj/cable{
 	d1 = 4;
@@ -2170,7 +2150,7 @@
 	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
-"afh" = (
+"afl" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
 	d1 = 4;
@@ -2181,32 +2161,7 @@
 	dir = 1
 	},
 /area/station/chapel/sanctuary)
-"afi" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4
-	},
-/obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/grime,
-/area/station/chapel/sanctuary)
-"afj" = (
-/obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/stairs/wide{
-	dir = 8
-	},
-/area/station/maintenance/northeast)
-"afk" = (
-/obj/machinery/light/small,
+"afn" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
 	d1 = 4;
@@ -2215,23 +2170,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
-"afl" = (
-/obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
-"afm" = (
+"afo" = (
 /obj/disposalpipe/segment/bent/south,
 /obj/cable{
 	icon_state = "6-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
-"afn" = (
+"afp" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 8;
@@ -2242,7 +2188,20 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
-"afo" = (
+"afq" = (
+/obj/machinery/space_heater,
+/obj/machinery/power/apc/autoname_east,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/storage/northeast)
+"afr" = (
+/obj/grille/steel,
+/turf/simulated/floor/plating,
+/area/station/storage/northeast)
+"afs" = (
 /obj/table/auto,
 /obj/item/decoration/ashtray,
 /obj/item/dice{
@@ -2259,53 +2218,18 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/station/storage/northeast)
-"afp" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/station/storage/northeast)
-"afq" = (
+"aft" = (
 /obj/decal/cleanable/dirt,
 /obj/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/northeast)
-"afr" = (
-/obj/item/caution{
-	desc = "Caution! Construction Zone!";
-	name = "caution sign"
-	},
-/turf/simulated/floor/plating,
-/area/station/storage/northeast)
-"afs" = (
-/obj/table/auto,
-/obj/machinery/light/small,
-/obj/item/storage/pill_bottle/cyberpunk,
-/obj/item/reagent_containers/food/drinks/bottle/hobo_wine,
-/turf/simulated/floor/plating,
-/area/station/storage/northeast)
-"aft" = (
-/obj/storage/crate,
-/obj/item/clothing/shoes/cowboy,
-/obj/item/clothing/under/misc/tourist/max_payne,
-/obj/item/clothing/head/cowboy,
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
 "afu" = (
-/obj/storage/closet/office,
+/obj/machinery/disposal_pipedispenser,
+/obj/decal/cleanable/cobweb,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
-"afv" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/grille/catwalk,
-/turf/simulated/floor/airless/plating/catwalk,
-/area/station/solar/east)
 "afw" = (
 /obj/lattice{
 	dir = 9;
@@ -2468,34 +2392,63 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "afQ" = (
-/obj/machinery/door/airlock/pyro/external,
-/obj/disposalpipe/segment/vertical,
-/obj/cable{
-	icon_state = "1-2"
-	},
+/obj/storage/closet/emergency,
 /turf/simulated/floor/plating,
-/area/station/maintenance/north)
+/area/station/maintenance/northeast)
 "afR" = (
-/obj/storage/closet/fire,
+/obj/disposalpipe/segment/bent/south,
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "afS" = (
-/obj/machinery/driver_button{
-	id = "kondaru_funeral";
-	name = "Funerary Driver Button";
-	pixel_x = -24
+/obj/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/grey,
+/obj/stool/chair/wooden{
+	dir = 4
+	},
+/turf/simulated/floor/specialroom/chapel{
+	dir = 4
+	},
 /area/station/chapel/sanctuary)
 "afT" = (
-/turf/simulated/floor/grey,
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 4
+	},
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/grime,
 /area/station/chapel/sanctuary)
 "afU" = (
+/obj/storage/closet/fire,
+/turf/simulated/floor/plating,
+/area/station/maintenance/north)
+"afV" = (
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/stairs/wide{
+	dir = 8
+	},
+/area/station/maintenance/northeast)
+"afX" = (
 /turf/simulated/floor/stairs/wide{
 	dir = 4
 	},
 /area/station/chapel/sanctuary)
-"afV" = (
+"afY" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -2503,12 +2456,12 @@
 	dir = 8
 	},
 /area/station/chapel/sanctuary)
-"afW" = (
+"aga" = (
 /turf/simulated/floor/specialroom/chapel{
 	dir = 8
 	},
 /area/station/chapel/sanctuary)
-"afX" = (
+"agb" = (
 /obj/table/reinforced/bar/auto{
 	name = "wooden table"
 	},
@@ -2516,14 +2469,7 @@
 	dir = 4
 	},
 /area/station/chapel/sanctuary)
-"afY" = (
-/obj/table/reinforced/bar/auto{
-	name = "wooden table"
-	},
-/obj/machinery/phone,
-/turf/simulated/floor/carpet/blue/fancy/edge/nw,
-/area/station/chapel/sanctuary)
-"afZ" = (
+"agc" = (
 /obj/table/reinforced/bar/auto{
 	name = "wooden table"
 	},
@@ -2532,28 +2478,17 @@
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
 /area/station/chapel/sanctuary)
-"aga" = (
+"agd" = (
 /obj/table/reinforced/bar/auto{
 	name = "wooden table"
 	},
 /obj/item/storage/bible,
 /turf/simulated/floor/carpet/blue/fancy/edge/ne,
 /area/station/chapel/sanctuary)
-"agb" = (
-/obj/table/reinforced/bar/auto{
-	name = "wooden table"
-	},
-/turf/simulated/floor/specialroom/chapel{
-	dir = 1
-	},
-/area/station/chapel/sanctuary)
-"agc" = (
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/specialroom/chapel{
-	dir = 1
-	},
-/area/station/chapel/sanctuary)
-"agd" = (
+"age" = (
+/turf/simulated/wall/auto/supernorn,
+/area/station/chapel/office)
+"agf" = (
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 26;
@@ -2561,32 +2496,24 @@
 	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
-"age" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/chapel/office)
-"agf" = (
+"agg" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/chapel/office)
-"agg" = (
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
 "agh" = (
+/obj/storage/secure/closet/civilian/chaplain,
+/turf/simulated/floor/black,
+/area/station/chapel/office)
+"agi" = (
+/obj/machinery/light/small,
+/obj/disposalpipe/segment/horizontal,
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-9"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
-"agi" = (
-/obj/machinery/door/airlock/pyro/classic,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/storage/northeast)
 "agj" = (
 /obj/lattice{
 	icon_state = "lattice-dir-b"
@@ -2791,31 +2718,33 @@
 "agG" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/quartersA)
-"agH" = (
-/obj/disposalpipe/segment/vertical,
-/obj/cable{
-	icon_state = "1-2"
+"agI" = (
+/obj/stool/chair{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/storage/northeast)
+"agJ" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
-"agI" = (
+"agK" = (
 /obj/machinery/light_switch/east,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
-"agJ" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/grey,
-/area/station/chapel/sanctuary)
-"agK" = (
-/turf/simulated/floor/stairs/wide/middle{
-	dir = 4
-	},
-/area/station/chapel/sanctuary)
 "agL" = (
+/obj/item/caution{
+	desc = "Caution! Construction Zone!";
+	name = "caution sign"
+	},
+/turf/simulated/floor/plating,
+/area/station/storage/northeast)
+"agM" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -2824,10 +2753,19 @@
 	dir = 4
 	},
 /area/station/chapel/sanctuary)
-"agM" = (
-/turf/simulated/floor/carpet/blue/fancy/edge/west,
-/area/station/chapel/sanctuary)
 "agN" = (
+/obj/xmastree/ephemeral,
+/turf/simulated/floor/specialroom/chapel{
+	dir = 8
+	},
+/area/station/chapel/sanctuary)
+"agO" = (
+/obj/item/a_gift/festive/ephemeral,
+/turf/simulated/floor/specialroom/chapel{
+	dir = 4
+	},
+/area/station/chapel/sanctuary)
+"agQ" = (
 /obj/machinery/light{
 	dir = 1;
 	layer = 3;
@@ -2836,26 +2774,26 @@
 	},
 /turf/simulated/floor/carpet/blue/fancy/innercorner/north,
 /area/station/chapel/sanctuary)
-"agO" = (
-/turf/simulated/floor/carpet/blue/fancy/edge/east,
+"agR" = (
+/turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
-"agP" = (
+"agT" = (
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/specialroom/chapel,
+/area/station/chapel/sanctuary)
+"agU" = (
 /turf/simulated/floor/specialroom/chapel{
 	dir = 1
 	},
 /area/station/chapel/sanctuary)
-"agQ" = (
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/specialroom/chapel,
-/area/station/chapel/sanctuary)
-"agR" = (
+"agV" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/chapel/office)
-"agS" = (
+"agW" = (
 /obj/machinery/light/small{
 	dir = 1;
 	pixel_y = 21
@@ -2863,24 +2801,7 @@
 /obj/machinery/photocopier,
 /turf/simulated/floor/black,
 /area/station/chapel/office)
-"agT" = (
-/obj/table/wood/auto,
-/obj/machinery/light/lamp/green,
-/obj/blind_switch/area/north,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
-	},
-/turf/simulated/floor/black,
-/area/station/chapel/office)
-"agU" = (
-/obj/table/wood/auto,
-/obj/item/storage/bible,
-/turf/simulated/floor/black,
-/area/station/chapel/office)
-"agV" = (
+"agX" = (
 /obj/table/wood/auto,
 /obj/item/paper_bin{
 	pixel_x = -7;
@@ -2894,46 +2815,11 @@
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/office)
-"agW" = (
-/obj/shrub{
-	desc = "It's probably not suspicious that this plant is not only still alive, but thriving.";
-	dir = 1;
-	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "plant";
-	tag = "icon-plant (NORTH)"
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/obj/machinery/light_switch/east,
-/turf/simulated/floor/black,
-/area/station/chapel/office)
-"agX" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
 "agY" = (
-/obj/storage/cart,
-/obj/item/instrument/vuvuzela,
-/obj/item/device/multitool,
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/item/storage/box/mousetraps,
-/obj/item/device/radio,
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
-"agZ" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/drone_recharger,
-/obj/random_item_spawner/junk/one_or_zero,
+/obj/storage/crate,
+/obj/item/clothing/shoes/cowboy,
+/obj/item/clothing/under/misc/tourist/max_payne,
+/obj/item/clothing/head/cowboy,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "aha" = (
@@ -2945,6 +2831,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "ahb" = (
+/obj/critter/mouse,
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
+"ahc" = (
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -2955,7 +2845,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
-"ahc" = (
+"ahd" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
@@ -2964,15 +2854,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
-"ahd" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "ahe" = (
@@ -3266,6 +3147,26 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/quartersA)
 "ahJ" = (
+/obj/storage/closet/office,
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
+"ahK" = (
+/obj/machinery/door/airlock/pyro/external,
+/obj/disposalpipe/segment/vertical,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/north)
+"ahL" = (
+/obj/machinery/driver_button{
+	id = "kondaru_funeral";
+	name = "Funerary Driver Button";
+	pixel_x = -24
+	},
+/turf/simulated/floor/grey,
+/area/station/chapel/sanctuary)
+"ahM" = (
 /obj/disposalpipe/segment/bent/north,
 /obj/cable{
 	d1 = 1;
@@ -3278,7 +3179,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
-"ahK" = (
+"ahN" = (
 /obj/disposalpipe/junction/right/west,
 /obj/cable{
 	icon_state = "4-8"
@@ -3290,14 +3191,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
-"ahL" = (
+"ahP" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
-"ahM" = (
+"ahQ" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
@@ -3308,14 +3209,14 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/chapel/sanctuary)
-"ahN" = (
+"ahR" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/grey,
 /area/station/chapel/sanctuary)
-"ahO" = (
+"ahS" = (
 /obj/disposalpipe/junction/right/west,
 /obj/cable{
 	icon_state = "4-8"
@@ -3327,7 +3228,7 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/chapel/sanctuary)
-"ahP" = (
+"ahT" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
 	icon_state = "4-8"
@@ -3336,7 +3237,7 @@
 	dir = 4
 	},
 /area/station/chapel/sanctuary)
-"ahQ" = (
+"ahU" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
 	d1 = 1;
@@ -3347,22 +3248,19 @@
 	dir = 8
 	},
 /area/station/chapel/sanctuary)
-"ahR" = (
+"ahV" = (
 /obj/disposalpipe/segment/bent/south,
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
 	},
 /area/station/chapel/sanctuary)
-"ahS" = (
+"ahW" = (
 /turf/simulated/floor/carpet/blue/fancy/edge/nw,
 /area/station/chapel/sanctuary)
-"ahT" = (
+"ahX" = (
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
 /area/station/chapel/sanctuary)
-"ahU" = (
-/turf/simulated/floor/carpet/blue/fancy/innercorner/nw_se,
-/area/station/chapel/sanctuary)
-"ahV" = (
+"ahZ" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 4;
 	icon_state = "on";
@@ -3370,40 +3268,31 @@
 	},
 /turf/simulated/floor/carpet/blue/fancy/innercorner/north,
 /area/station/chapel/sanctuary)
-"ahW" = (
+"aia" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
 /turf/simulated/floor/carpet/blue/fancy/innercorner/ne_sw,
 /area/station/chapel/sanctuary)
-"ahX" = (
+"aib" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
 /area/station/chapel/sanctuary)
-"ahY" = (
+"aic" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/ne,
 /area/station/chapel/sanctuary)
-"ahZ" = (
-/obj/disposalpipe/segment/vertical,
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4
-	},
-/turf/simulated/floor/specialroom/chapel{
-	dir = 1
-	},
-/area/station/chapel/sanctuary)
-"aia" = (
+"aid" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
-"aib" = (
+"aie" = (
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
 	name = "Chapel Office"
@@ -3417,13 +3306,13 @@
 	dir = 8
 	},
 /area/station/chapel/office)
-"aic" = (
+"aig" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/office)
-"aid" = (
+"aih" = (
 /obj/stool/chair/comfy{
 	dir = 1
 	},
@@ -3435,7 +3324,7 @@
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/office)
-"aie" = (
+"aii" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 4;
@@ -3446,78 +3335,36 @@
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/office)
-"aif" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4
-	},
-/turf/simulated/floor/black,
-/area/station/chapel/office)
-"aig" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/pyro{
-	dir = 4;
-	name = "Chapel Office"
-	},
-/obj/access_spawn/chapel_office,
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/black,
-/area/station/chapel/office)
-"aih" = (
-/obj/disposalpipe/segment/bent/north,
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
-"aii" = (
-/obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
 "aij" = (
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "aik" = (
-/obj/disposalpipe/junction/right/west,
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
+/obj/table/reinforced/bar/auto{
+	name = "wooden table"
+	},
+/turf/simulated/floor/specialroom/chapel{
+	dir = 1
+	},
+/area/station/chapel/sanctuary)
 "ail" = (
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/specialroom/chapel{
+	dir = 1
+	},
+/area/station/chapel/sanctuary)
+"aim" = (
+/obj/machinery/door/airlock/pyro/classic,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/storage/northeast)
+"ain" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
 /obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
-"aim" = (
-/obj/disposalpipe/segment/bent/south,
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
-"ain" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "aio" = (
@@ -3715,14 +3562,26 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/quartersA)
 "aiH" = (
-/obj/machinery/power/apc/autoname_west,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/north)
+/turf/simulated/floor/carpet/blue/fancy/edge/east,
+/area/station/chapel/sanctuary)
 "aiI" = (
+/obj/table/wood/auto,
+/obj/machinery/light/lamp/green,
+/obj/blind_switch/area/north,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
+	},
+/turf/simulated/floor/black,
+/area/station/chapel/office)
+"aiJ" = (
+/obj/table/wood/auto,
+/obj/item/storage/bible,
+/turf/simulated/floor/black,
+/area/station/chapel/office)
+"aiK" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
 	icon_state = "1-2"
@@ -3734,12 +3593,28 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
-"aiJ" = (
-/obj/decal/cleanable/dirt,
-/obj/storage/closet/wardrobe/black,
+"aiL" = (
+/obj/shrub{
+	desc = "It's probably not suspicious that this plant is not only still alive, but thriving.";
+	dir = 1;
+	icon = 'icons/obj/stationobjs.dmi';
+	icon_state = "plant";
+	tag = "icon-plant (NORTH)"
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/obj/machinery/light_switch/east,
+/turf/simulated/floor/black,
+/area/station/chapel/office)
+"aiM" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/north)
-"aiK" = (
+/area/station/maintenance/northeast)
+"aiN" = (
 /obj/stool/chair/wooden{
 	dir = 4
 	},
@@ -3749,14 +3624,12 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/chapel/sanctuary)
-"aiL" = (
-/obj/disposalpipe/segment/vertical,
-/obj/cable{
-	icon_state = "1-2"
+"aiP" = (
+/turf/simulated/floor/stairs/wide/middle{
+	dir = 4
 	},
-/turf/simulated/floor/grey,
 /area/station/chapel/sanctuary)
-"aiM" = (
+"aiQ" = (
 /obj/stool/chair/pew/fancy/left{
 	dir = 1
 	},
@@ -3764,7 +3637,7 @@
 	dir = 4
 	},
 /area/station/chapel/sanctuary)
-"aiN" = (
+"aiR" = (
 /obj/disposalpipe/segment/vertical,
 /obj/stool/chair/pew/fancy/center{
 	dir = 1
@@ -3773,59 +3646,49 @@
 	dir = 8
 	},
 /area/station/chapel/sanctuary)
-"aiO" = (
+"aiS" = (
 /obj/stool/chair/pew/fancy/center{
 	dir = 1
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/west,
 /area/station/chapel/sanctuary)
-"aiP" = (
+"aiT" = (
 /obj/stool/chair/pew/fancy/right{
 	dir = 1
 	},
 /turf/simulated/floor/carpet/blue/fancy/innercorner/west,
 /area/station/chapel/sanctuary)
-"aiQ" = (
+"aiU" = (
 /turf/simulated/floor/carpet/blue/fancy/innercorner/west,
 /area/station/chapel/sanctuary)
-"aiR" = (
+"aiV" = (
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/carpet/blue/fancy/innercorner/omni,
 /area/station/chapel/sanctuary)
-"aiS" = (
+"aiW" = (
 /turf/simulated/floor/carpet/blue/fancy/innercorner/east,
 /area/station/chapel/sanctuary)
-"aiT" = (
-/obj/stool/chair/pew/fancy/left{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/blue/fancy/innercorner/east,
-/area/station/chapel/sanctuary)
-"aiU" = (
+"aiX" = (
 /obj/stool/chair/pew/fancy/center{
 	dir = 1
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/east,
 /area/station/chapel/sanctuary)
-"aiV" = (
-/obj/disposalpipe/segment/vertical,
-/obj/stool/chair/pew/fancy/center{
-	dir = 1
-	},
-/turf/simulated/floor/specialroom/chapel,
-/area/station/chapel/sanctuary)
-"aiW" = (
-/obj/stool/chair/pew/fancy/right{
-	dir = 1
-	},
-/turf/simulated/floor/specialroom/chapel{
-	dir = 1
-	},
-/area/station/chapel/sanctuary)
-"aiX" = (
+"aja" = (
 /turf/simulated/floor/black,
 /area/station/chapel/office)
-"aiY" = (
+"ajb" = (
+/obj/storage/cart,
+/obj/item/instrument/vuvuzela,
+/obj/item/device/multitool,
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/item/storage/box/mousetraps,
+/obj/item/device/radio,
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
+"ajc" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
@@ -3837,66 +3700,22 @@
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/office)
-"aiZ" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple,
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "4-6"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
-"aja" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
-"ajb" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
-"ajc" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
 "ajd" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/arcade/dungeon)
 "aje" = (
-/obj/machinery/door/airlock/pyro/maintenance,
-/obj/disposalpipe/segment/vertical,
-/obj/firedoor_spawn,
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/arcade/dungeon)
-"ajf" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
-/obj/disposalpipe/segment/vertical,
+/obj/item/c_tube,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
+"ajf" = (
+/obj/machinery/light/small,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/arcade/dungeon)
 "ajg" = (
 /obj/lattice{
 	dir = 6;
@@ -4148,32 +3967,59 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/quartersA)
 "ajK" = (
-/obj/rack,
-/obj/item/clothing/suit/space/emerg,
-/obj/item/clothing/head/emerg,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/air,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/belt/utility,
-/obj/item/crowbar,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/drone_recharger,
+/obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
-/area/station/maintenance/north)
+/area/station/maintenance/northeast)
 "ajL" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
+"ajN" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
-"ajM" = (
+"ajO" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
+"ajP" = (
 /obj/stool/chair/wooden{
 	dir = 4
 	},
 /turf/simulated/floor/grey,
 /area/station/chapel/sanctuary)
-"ajN" = (
+"ajQ" = (
+/obj/disposalpipe/segment/vertical,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/grey,
+/area/station/chapel/sanctuary)
+"ajR" = (
 /turf/simulated/floor/stairs/wide/other{
 	dir = 4
 	},
 /area/station/chapel/sanctuary)
-"ajO" = (
+"ajS" = (
 /obj/machinery/light,
 /obj/stool/chair/pew/fancy/left{
 	dir = 1
@@ -4182,7 +4028,7 @@
 	dir = 8
 	},
 /area/station/chapel/sanctuary)
-"ajP" = (
+"ajT" = (
 /obj/disposalpipe/segment/vertical,
 /obj/stool/chair/pew/fancy/center{
 	dir = 1
@@ -4191,100 +4037,51 @@
 	dir = 4
 	},
 /area/station/chapel/sanctuary)
-"ajQ" = (
-/obj/stool/chair/pew/fancy/center{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/blue/fancy/edge/sw,
-/area/station/chapel/sanctuary)
-"ajR" = (
+"ajU" = (
 /obj/stool/chair/pew/fancy/right{
 	dir = 1
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/south,
 /area/station/chapel/sanctuary)
-"ajS" = (
+"ajV" = (
 /turf/simulated/floor/carpet/blue/fancy/innercorner/ne_sw,
 /area/station/chapel/sanctuary)
-"ajT" = (
+"ajW" = (
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/carpet/blue/fancy/innercorner/south,
 /area/station/chapel/sanctuary)
-"ajU" = (
-/obj/stool/chair/pew/fancy/left{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/blue/fancy/edge/south,
+"ajX" = (
+/turf/simulated/floor/carpet/blue/fancy/innercorner/nw_se,
 /area/station/chapel/sanctuary)
-"ajV" = (
+"ajY" = (
 /obj/stool/chair/pew/fancy/center{
 	dir = 1
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/se,
 /area/station/chapel/sanctuary)
-"ajW" = (
-/obj/disposalpipe/segment/vertical,
-/obj/stool/chair/pew/fancy/center{
-	dir = 1
-	},
-/turf/simulated/floor/specialroom/chapel{
-	dir = 1
-	},
-/area/station/chapel/sanctuary)
-"ajX" = (
+"ajZ" = (
 /obj/machinery/light,
 /obj/stool/chair/pew/fancy/right{
 	dir = 1
 	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
-"ajY" = (
+"aka" = (
+/obj/disposalpipe/segment/vertical,
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
+	},
+/turf/simulated/floor/specialroom/chapel{
+	dir = 1
+	},
+/area/station/chapel/sanctuary)
+"akb" = (
 /obj/machinery/door/airlock/pyro{
 	name = "Chapel Office"
 	},
 /obj/access_spawn/chapel_office,
 /obj/firedoor_spawn,
 /turf/simulated/floor/wood/two,
-/area/station/chapel/office)
-"ajZ" = (
-/obj/table/wood/round/auto,
-/obj/item/device/light/candle{
-	pixel_y = 7;
-	rand_pos = 0
-	},
-/obj/item/device/light/candle{
-	pixel_y = 7;
-	rand_pos = 0
-	},
-/obj/item/device/light/candle{
-	pixel_y = 7;
-	rand_pos = 0
-	},
-/obj/item/device/light/candle{
-	pixel_y = 7;
-	rand_pos = 0
-	},
-/obj/item/device/light/candle{
-	pixel_y = 7;
-	rand_pos = 0
-	},
-/obj/item/matchbook,
-/obj/machinery/light/small,
-/turf/simulated/floor/black,
-/area/station/chapel/office)
-"aka" = (
-/obj/storage/secure/closet/civilian/chaplain,
-/turf/simulated/floor/black,
-/area/station/chapel/office)
-"akb" = (
-/obj/table/wood/round/auto,
-/obj/item/reagent_containers/glass/bottle/holywater,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
-/turf/simulated/floor/black,
 /area/station/chapel/office)
 "akc" = (
 /obj/machinery/light/small{
@@ -4294,16 +4091,39 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "akd" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
+	},
+/turf/simulated/floor/black,
+/area/station/chapel/office)
+"ake" = (
+/obj/machinery/atmospherics/pipe/simple,
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
+"akf" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
+"akg" = (
 /obj/cable,
 /obj/machinery/power/apc/autoname_west,
 /obj/item/instrument/large/organ,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
-"ake" = (
+"akh" = (
 /obj/machinery/shieldgenerator/meteorshield,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
-"akf" = (
+"aki" = (
 /obj/table/auto,
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -4321,7 +4141,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
-"akg" = (
+"akj" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/pyro{
+	dir = 4;
+	name = "Chapel Office"
+	},
+/obj/access_spawn/chapel_office,
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
+/area/station/chapel/office)
+"akk" = (
 /obj/table/wood/auto,
 /obj/item/paper/book/critter_compendium,
 /obj/decal/xmas_lights/ephemeral{
@@ -4329,57 +4166,18 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/arcade/dungeon)
-"akh" = (
-/obj/disposalpipe/segment/bent/north,
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/arcade/dungeon)
-"aki" = (
-/obj/stool/chair/couch{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/arcade/dungeon)
-"akj" = (
-/obj/stool/chair/couch{
-	dir = 4
-	},
-/obj/disposalpipe/segment/horizontal,
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/arcade/dungeon)
-"akk" = (
-/obj/machinery/disposal,
-/obj/disposalpipe/trunk/west,
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/arcade/dungeon)
-"akl" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/maintenance/solar/east)
 "akm" = (
+/obj/disposalpipe/segment/bent/north,
 /obj/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/cable{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 10
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/landmark/gps_waypoint,
 /turf/simulated/floor/plating,
-/area/station/maintenance/solar/east)
+/area/station/maintenance/northeast)
 "akn" = (
 /obj/table/auto,
 /obj/machinery/networked/printer{
@@ -4461,12 +4259,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "akw" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
+/obj/item/device/radio/intercom/engineering,
+/turf/simulated/floor/yellow/side{
+	dir = 1
 	},
-/turf/simulated/floor/caution/westeast,
 /area/station/hangar/engine)
 "akx" = (
 /obj/machinery/door/airlock/pyro/maintenance{
@@ -4574,18 +4370,21 @@
 "akH" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/quartersB)
-"akI" = (
-/obj/machinery/door/airlock/pyro/maintenance,
-/obj/disposalpipe/segment/vertical,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/north)
 "akJ" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/crematorium)
 "akK" = (
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
+"akL" = (
+/obj/disposalpipe/junction/right/west,
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
+"akM" = (
 /obj/machinery/door/airlock/pyro{
 	name = "Crematorium"
 	},
@@ -4597,7 +4396,15 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/grey,
 /area/station/medical/crematorium)
-"akL" = (
+"akN" = (
+/obj/machinery/power/apc/autoname_west,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/north)
+"akO" = (
 /obj/disposalpipe/segment/bent/north,
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -4613,16 +4420,7 @@
 	dir = 8
 	},
 /area/station/chapel/sanctuary)
-"akM" = (
-/obj/disposalpipe/segment/horizontal,
-/obj/stool/chair/pew/fancy/center{
-	dir = 1
-	},
-/turf/simulated/floor/specialroom/chapel{
-	dir = 4
-	},
-/area/station/chapel/sanctuary)
-"akN" = (
+"akP" = (
 /obj/disposalpipe/segment/bent/south,
 /obj/stool/chair/pew/fancy/right{
 	dir = 1
@@ -4631,17 +4429,13 @@
 	dir = 8
 	},
 /area/station/chapel/sanctuary)
-"akO" = (
+"akQ" = (
+/turf/simulated/floor/carpet/blue/fancy/edge/west,
+/area/station/chapel/sanctuary)
+"akR" = (
 /turf/simulated/floor/carpet/blue/fancy/innercorner/south,
 /area/station/chapel/sanctuary)
-"akP" = (
-/obj/disposalpipe/segment/bent/east,
-/obj/stool/chair/pew/fancy/left{
-	dir = 1
-	},
-/turf/simulated/floor/specialroom/chapel,
-/area/station/chapel/sanctuary)
-"akQ" = (
+"akS" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/stool/chair/pew/fancy/center{
 	dir = 1
@@ -4650,29 +4444,42 @@
 	dir = 1
 	},
 /area/station/chapel/sanctuary)
-"akR" = (
-/obj/disposalpipe/segment/bent/west,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/obj/stool/chair/pew/fancy/right{
-	dir = 1
-	},
-/turf/simulated/floor/specialroom/chapel,
-/area/station/chapel/sanctuary)
-"akS" = (
-/obj/stool,
-/turf/simulated/floor/wood/two,
-/area/station/chapel/office)
 "akT" = (
-/obj/machinery/atmospherics/pipe/simple,
+/obj/table/wood/round/auto,
+/obj/item/device/light/candle{
+	pixel_y = 7;
+	rand_pos = 0
+	},
+/obj/item/device/light/candle{
+	pixel_y = 7;
+	rand_pos = 0
+	},
+/obj/item/device/light/candle{
+	pixel_y = 7;
+	rand_pos = 0
+	},
+/obj/item/device/light/candle{
+	pixel_y = 7;
+	rand_pos = 0
+	},
+/obj/item/device/light/candle{
+	pixel_y = 7;
+	rand_pos = 0
+	},
+/obj/item/matchbook,
+/obj/machinery/light/small,
+/turf/simulated/floor/black,
+/area/station/chapel/office)
+"akU" = (
+/obj/decal/cleanable/dirt,
+/obj/storage/closet/wardrobe/black,
+/turf/simulated/floor/plating,
+/area/station/maintenance/north)
+"akV" = (
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
-"akU" = (
+"akW" = (
 /obj/table/wood/auto,
 /obj/machinery/light/small{
 	dir = 8;
@@ -4681,52 +4488,13 @@
 /obj/item/paper/book/monster_manual,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/arcade/dungeon)
-"akV" = (
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/arcade/dungeon)
-"akW" = (
-/obj/table/wood/round/auto,
-/obj/item/device/light/candle{
-	pixel_y = 7;
-	rand_pos = 0
-	},
-/obj/item/matchbook,
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/arcade/dungeon)
 "akX" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/stool/chair/pew/fancy/left{
+	dir = 1
 	},
-/obj/item/device/radio/intercom/engineering{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/solar/east)
-"akZ" = (
-/turf/simulated/floor/plating,
-/area/station/maintenance/solar/east)
-"ala" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/solar/east)
+/turf/simulated/floor/carpet/blue/fancy/innercorner/east,
+/area/station/chapel/sanctuary)
 "alb" = (
-/obj/machinery/door/airlock/pyro/external,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/east)
 "alc" = (
@@ -4921,22 +4689,55 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/quartersB)
 "alv" = (
+/obj/disposalpipe/segment/vertical,
+/obj/stool/chair/pew/fancy/center{
+	dir = 1
+	},
+/turf/simulated/floor/specialroom/chapel,
+/area/station/chapel/sanctuary)
+"alw" = (
+/obj/stool/chair/pew/fancy/right{
+	dir = 1
+	},
+/turf/simulated/floor/specialroom/chapel{
+	dir = 1
+	},
+/area/station/chapel/sanctuary)
+"alx" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
+"aly" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
-"alw" = (
+"alz" = (
 /obj/disposalpipe/segment/bent/north,
 /obj/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
-"alx" = (
+"alA" = (
 /obj/disposalpipe/segment/bent/south,
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
-"aly" = (
+"alB" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
+"alC" = (
 /obj/table/auto,
 /obj/item/clothing/gloves/latex,
 /obj/item/clothing/mask/surgical,
@@ -4951,27 +4752,7 @@
 /obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/crematorium)
-"alz" = (
-/obj/table/auto,
-/obj/item/clothing/mask/surgical,
-/obj/item/device/analyzer/healthanalyzer,
-/obj/item/device/detective_scanner,
-/obj/item/stamp,
-/obj/item/body_bag,
-/obj/item/body_bag,
-/obj/item/body_bag,
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/item/spraybottle/cleaner,
-/obj/item/reagent_containers/emergency_injector/spaceacillin,
-/turf/simulated/floor/sanitary/white,
-/area/station/medical/crematorium)
-"alA" = (
+"alD" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
 	d1 = 1;
@@ -4980,7 +4761,7 @@
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/crematorium)
-"alB" = (
+"alE" = (
 /obj/crematorium{
 	id = "crematorium"
 	},
@@ -4990,14 +4771,14 @@
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/crematorium)
-"alC" = (
+"alF" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/right{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/crematorium)
-"alD" = (
+"alH" = (
 /obj/stool/chair/pew/fancy/left{
 	dir = 1
 	},
@@ -5005,7 +4786,7 @@
 	dir = 8
 	},
 /area/station/chapel/sanctuary)
-"alE" = (
+"alI" = (
 /obj/disposalpipe/segment/vertical,
 /obj/stool/chair/pew/fancy/right{
 	dir = 1
@@ -5014,71 +4795,38 @@
 	dir = 4
 	},
 /area/station/chapel/sanctuary)
-"alF" = (
+"alJ" = (
 /turf/simulated/floor/carpet/blue/fancy/edge/sw,
 /area/station/chapel/sanctuary)
-"alG" = (
-/turf/simulated/floor/carpet/blue/fancy/edge/south,
-/area/station/chapel/sanctuary)
-"alH" = (
+"alK" = (
 /turf/simulated/floor/carpet/blue/fancy/edge/se,
 /area/station/chapel/sanctuary)
-"alI" = (
-/obj/disposalpipe/segment/vertical,
-/obj/stool/chair/pew/fancy/left{
-	dir = 1
-	},
-/turf/simulated/floor/specialroom/chapel{
-	dir = 1
-	},
-/area/station/chapel/sanctuary)
-"alJ" = (
+"alL" = (
 /obj/stool/chair/pew/fancy/right{
 	dir = 1
 	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
-"alK" = (
+"alM" = (
 /obj/machinery/door/unpowered/wood/pyro{
 	dir = 4
 	},
 /turf/simulated/floor/wood/two,
 /area/station/chapel/office)
-"alL" = (
-/obj/table/wood/auto,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
+"alN" = (
+/obj/stool,
 /turf/simulated/floor/wood/two,
 /area/station/chapel/office)
-"alM" = (
+"alO" = (
 /obj/storage/closet/coffin,
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
-"alN" = (
+"alQ" = (
 /obj/storage/closet/coffin,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
-"alO" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 5
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
-"alP" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4;
-	high_risk = 1;
-	name = "Chapel"
-	},
-/obj/cable{
-	icon_state = "1-10"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
-"alQ" = (
+"alR" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8;
 	name = "Chapel Repressurization Port"
@@ -5086,52 +4834,47 @@
 /obj/machinery/portable_atmospherics/canister/air/large,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
-"alR" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/arcade/dungeon)
 "alS" = (
+/obj/stool/chair/office/blue{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
+"alT" = (
+/obj/machinery/door/airlock/pyro/maintenance,
+/obj/disposalpipe/segment/vertical,
+/obj/firedoor_spawn,
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/arcade/dungeon)
+"alU" = (
+/obj/rack,
+/obj/item/clothing/suit/space/emerg,
+/obj/item/clothing/head/emerg,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/air,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/autoname_west,
+/obj/item/device/light/flashlight,
+/turf/simulated/floor/plating,
+/area/station/maintenance/solar/east)
+"alV" = (
 /obj/table/wood/auto,
 /obj/item/storage/box/nerd_kit,
 /obj/item/card_box/suit,
 /turf/simulated/floor/carpet/red/fancy/edge/nw,
 /area/station/crew_quarters/arcade/dungeon)
-"alT" = (
-/obj/stool/chair,
-/turf/simulated/floor/carpet/red/fancy/narrow/T_north,
-/area/station/crew_quarters/arcade/dungeon)
-"alU" = (
-/obj/stool/chair,
-/turf/simulated/floor/carpet/red/fancy/edge/ne,
-/area/station/crew_quarters/arcade/dungeon)
-"alV" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/arcade/dungeon)
 "alW" = (
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/grille/catwalk{
-	dir = 5
+/obj/machinery/power/monitor{
+	name = "Station Power Grid Monitoring"
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	icon_state = "catwalk_cross"
-	},
-/area/station/solar/east)
+/turf/simulated/floor/plating,
+/area/station/maintenance/solar/east)
 "alX" = (
 /obj/cable,
 /obj/machinery/power/solar/east,
@@ -5141,41 +4884,25 @@
 	},
 /area/station/solar/east)
 "alY" = (
-/obj/machinery/power/smes{
-	chargelevel = 15000;
-	output = 10000
-	},
-/obj/cable,
+/obj/rack,
+/obj/item/clothing/suit/space/emerg,
+/obj/item/clothing/head/emerg,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/air,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/belt/utility,
+/obj/item/crowbar,
 /turf/simulated/floor/plating,
-/area/station/maintenance/solar/east)
-"alZ" = (
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/solar/east)
+/area/station/maintenance/north)
 "ama" = (
 /obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/station/maintenance/solar/east)
-"amb" = (
-/obj/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
+/obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
-/area/station/maintenance/solar/east)
+/area/station/maintenance/northeast)
 "amc" = (
 /obj/lattice{
 	dir = 4;
@@ -5440,106 +5167,132 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/quartersB)
 "amB" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/maintenance/north)
+/obj/stool/chair/pew/fancy/center{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/sw,
+/area/station/chapel/sanctuary)
 "amC" = (
+/obj/stool/chair/pew/fancy/left{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/south,
+/area/station/chapel/sanctuary)
+"amD" = (
 /obj/reagent_dispensers/foamtank,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
-"amD" = (
+"amE" = (
+/obj/disposalpipe/segment/vertical,
+/obj/stool/chair/pew/fancy/center{
+	dir = 1
+	},
+/turf/simulated/floor/specialroom/chapel{
+	dir = 1
+	},
+/area/station/chapel/sanctuary)
+"amF" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/obj/disposalpipe/segment/vertical,
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/north)
+"amG" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/north)
+"amH" = (
 /obj/machinery/optable{
 	name = "Autopsy Table"
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/crematorium)
-"amE" = (
+"amI" = (
 /obj/machinery/drainage,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/crematorium)
-"amF" = (
-/obj/disposalpipe/segment/vertical,
+"amJ" = (
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/crematorium)
-"amG" = (
-/turf/simulated/floor/sanitary/white,
-/area/station/medical/crematorium)
-"amH" = (
+"amK" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/left{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/crematorium)
-"amI" = (
+"amL" = (
 /obj/machinery/light,
 /turf/simulated/floor/specialroom/chapel{
 	dir = 8
 	},
 /area/station/chapel/sanctuary)
-"amJ" = (
+"amM" = (
+/turf/simulated/floor/specialroom/chapel{
+	dir = 4
+	},
+/area/station/chapel/sanctuary)
+"amN" = (
 /obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor/specialroom/chapel{
 	dir = 8
 	},
 /area/station/chapel/sanctuary)
-"amK" = (
-/obj/disposalpipe/junction/right/west,
-/turf/simulated/floor/specialroom/chapel{
-	dir = 4
-	},
-/area/station/chapel/sanctuary)
-"amL" = (
+"amO" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/machinery/light,
 /turf/simulated/floor/black,
 /area/station/chapel/sanctuary)
-"amM" = (
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/specialroom/chapel{
-	dir = 1
-	},
-/area/station/chapel/sanctuary)
-"amN" = (
+"amP" = (
 /obj/disposalpipe/segment/bent/west,
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
-"amO" = (
-/obj/machinery/light,
-/turf/simulated/floor/specialroom/chapel,
-/area/station/chapel/sanctuary)
-"amP" = (
-/turf/simulated/wall/false_wall{
-	icon = 'icons/turf/walls_supernorn.dmi';
-	icon_state = "12"
-	},
-/area/station/chapel/office)
-"amQ" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 6
-	},
-/obj/cable{
-	icon_state = "2-5"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
-"amR" = (
-/obj/decal/cleanable/dirt,
-/obj/machinery/atmospherics/valve{
-	dir = 4;
-	high_risk = 1;
-	name = "NE Hallway"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
 "amS" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8;
-	name = "NE Hallway Repressurization Port"
-	},
+/obj/storage/closet/coffin/wood,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "amT" = (
+/obj/table/wood/round/auto,
+/obj/item/reagent_containers/glass/bottle/holywater,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
+	},
+/turf/simulated/floor/black,
+/area/station/chapel/office)
+"amU" = (
+/obj/disposalpipe/segment/bent/north,
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/arcade/dungeon)
+"amV" = (
+/obj/stool/chair/couch{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/obj/disposalpipe/segment/horizontal,
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/arcade/dungeon)
+"amW" = (
+/obj/wingrille_spawn/auto,
+/obj/decal/wreath/ephemeral,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/arcade/dungeon)
+"amX" = (
 /obj/table/wood/round/auto,
 /obj/machinery/computer3/generic/personal,
 /obj/cable{
@@ -5548,110 +5301,51 @@
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/carpet/red/fancy/narrow/T_west,
 /area/station/crew_quarters/arcade/dungeon)
-"amU" = (
-/obj/table/wood/round/auto,
-/obj/machinery/phone,
-/turf/simulated/floor/carpet/red/fancy/innercorner/sw_triple,
-/area/station/crew_quarters/arcade/dungeon)
-"amV" = (
-/obj/table/wood/round/auto,
-/obj/item/pen,
-/obj/item/coin,
-/turf/simulated/floor/carpet/red/fancy/innercorner/ne,
-/area/station/crew_quarters/arcade/dungeon)
-"amW" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/ne,
-/area/station/crew_quarters/arcade/dungeon)
-"amX" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/arcade/dungeon)
 "amY" = (
-/obj/cable,
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/landmark/gps_waypoint,
+/turf/simulated/floor/plating,
+/area/station/maintenance/solar/east)
+"amZ" = (
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/power/solar_control/east{
+	dir = 8
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/grille/catwalk{
-	dir = 1;
-	icon_state = "catwalk_cross"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 5;
-	icon_state = "catwalk_cross"
-	},
-/area/station/solar/east)
-"amZ" = (
-/obj/grille/catwalk{
-	icon_state = "catwalk_cross"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/tracker/east,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 5;
-	icon_state = "catwalk_cross"
-	},
-/area/station/solar/east)
+/turf/simulated/floor/plating,
+/area/station/maintenance/solar/east)
 "ana" = (
-/obj/wingrille_spawn/auto,
+/obj/disposalpipe/segment/bent/south,
 /turf/simulated/floor/plating,
-/area/station/maintenance/solar/east)
+/area/station/maintenance/northeast)
 "anb" = (
-/obj/rack,
-/obj/item/clothing/suit/space/emerg,
-/obj/item/clothing/head/emerg,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/air,
-/obj/cable{
-	icon_state = "0-2"
+/obj/grille/catwalk{
+	dir = 9;
+	icon_state = "catwalk_cross"
 	},
-/obj/machinery/power/apc/autoname_west,
-/obj/item/device/light/flashlight,
-/turf/simulated/floor/plating,
-/area/station/maintenance/solar/east)
-"anc" = (
 /obj/cable{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 9
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/solar/east)
-"and" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/monitor{
-	name = "Station Power Grid Monitoring"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/solar/east)
+/area/station/solar/east)
 "ane" = (
-/obj/table/reinforced/auto,
-/obj/machinery/cell_charger,
-/obj/item/cell/supercell/charged,
-/obj/item/cell/supercell/charged,
-/turf/simulated/floor/plating,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/solar/east)
 "anf" = (
 /obj/lattice{
@@ -5869,6 +5563,36 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/quartersB)
 "anE" = (
+/obj/grille/catwalk{
+	dir = 6;
+	icon_state = "catwalk_cross"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 6
+	},
+/area/station/solar/east)
+"anF" = (
+/obj/disposalpipe/segment/horizontal,
+/obj/stool/chair/pew/fancy/center{
+	dir = 1
+	},
+/turf/simulated/floor/specialroom/chapel{
+	dir = 4
+	},
+/area/station/chapel/sanctuary)
+"anG" = (
+/obj/disposalpipe/segment/bent/east,
+/obj/stool/chair/pew/fancy/left{
+	dir = 1
+	},
+/turf/simulated/floor/specialroom/chapel,
+/area/station/chapel/sanctuary)
+"anH" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 8;
@@ -5878,84 +5602,106 @@
 	},
 /turf/space,
 /area/space)
-"anF" = (
+"anI" = (
 /obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
-"anG" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/north)
-"anH" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
-/obj/disposalpipe/segment/vertical,
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/north)
-"anI" = (
-/obj/morgue,
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
-/turf/simulated/floor/sanitary/white,
-/area/station/medical/crematorium)
 "anJ" = (
-/obj/disposalpipe/segment/vertical,
-/obj/machinery/door/unpowered/wood/pyro{
-	dir = 1;
-	name = "Chapel"
+/obj/disposalpipe/segment/bent/west,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
 	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/specialroom/chapel{
-	dir = 8
+/obj/stool/chair/pew/fancy/right{
+	dir = 1
 	},
-/area/station/chapel/sanctuary)
-"anK" = (
-/obj/machinery/door/unpowered/wood/pyro{
-	dir = 1;
-	name = "Chapel"
-	},
-/obj/firedoor_spawn,
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
-"anL" = (
-/turf/simulated/floor/stairs/wood,
-/area/station/chapel/office)
-"anM" = (
-/obj/table/wood/auto,
+"anK" = (
+/obj/table/wood/round/auto,
 /obj/item/device/light/candle{
 	pixel_y = 7;
 	rand_pos = 0
 	},
-/obj/decal/cleanable/cobweb{
-	icon_state = "cobweb2"
+/obj/item/matchbook,
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/arcade/dungeon)
+"anL" = (
+/obj/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood/two,
-/area/station/chapel/office)
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/solar/east)
+"anM" = (
+/obj/machinery/door/airlock/pyro/external,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/solar/east)
 "anN" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/utility)
 "anO" = (
-/obj/machinery/door/airlock/pyro/maintenance,
-/obj/cable{
-	icon_state = "1-2"
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir"
 	},
-/obj/machinery/atmospherics/pipe/simple,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/utility)
+/turf/space,
+/area/station/solar/east)
 "anP" = (
+/obj/table/auto,
+/obj/item/clothing/mask/surgical,
+/obj/item/device/analyzer/healthanalyzer,
+/obj/item/device/detective_scanner,
+/obj/item/stamp,
+/obj/item/body_bag,
+/obj/item/body_bag,
+/obj/item/body_bag,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/item/spraybottle/cleaner,
+/obj/item/reagent_containers/emergency_injector/spaceacillin,
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/crematorium)
+"anQ" = (
+/turf/simulated/floor/carpet/blue/fancy/edge/south,
+/area/station/chapel/sanctuary)
+"anR" = (
+/obj/disposalpipe/segment/vertical,
+/obj/stool/chair/pew/fancy/left{
+	dir = 1
+	},
+/turf/simulated/floor/specialroom/chapel{
+	dir = 1
+	},
+/area/station/chapel/sanctuary)
+"anS" = (
+/obj/table/wood/auto,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/wood/two,
+/area/station/chapel/office)
+"anT" = (
 /obj/stool/chair/comfy{
 	dir = 4
 	},
@@ -5964,18 +5710,18 @@
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/west,
 /area/station/crew_quarters/arcade/dungeon)
-"anQ" = (
+"anU" = (
 /obj/table/wood/round/auto,
 /obj/item/clothing/suit/cultist/nerd,
 /obj/item/clothing/mask/skull,
 /turf/simulated/floor/carpet/red/fancy/innercorner/omni,
 /area/station/crew_quarters/arcade/dungeon)
-"anR" = (
+"anV" = (
 /obj/table/wood/round/auto,
 /obj/machinery/light/lamp/green,
 /turf/simulated/floor/carpet/red/fancy/innercorner/west,
 /area/station/crew_quarters/arcade/dungeon)
-"anS" = (
+"anW" = (
 /obj/stool/chair{
 	dir = 8
 	},
@@ -5986,40 +5732,6 @@
 	},
 /turf/simulated/floor/carpet/red/fancy/narrow/T_east,
 /area/station/crew_quarters/arcade/dungeon)
-"anT" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/arcade/dungeon)
-"anU" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/arcade/dungeon)
-"anV" = (
-/obj/disposalpipe/segment/vertical,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
-"anW" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
 "anX" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/turret_protected/ai)
@@ -6128,9 +5840,11 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/radio/news_office)
 "aoq" = (
-/obj/machinery/light,
-/turf/simulated/floor/caution/westeast,
-/area/station/hangar/engine)
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
 "aor" = (
 /obj/table/auto,
 /obj/item/sheet/glass/reinforced{
@@ -6242,32 +5956,47 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/quartersB)
 "aoD" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/primary/north)
+/obj/machinery/atmospherics/valve{
+	dir = 4;
+	high_risk = 1;
+	name = "Chapel"
+	},
+/obj/cable{
+	icon_state = "1-10"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
 "aoE" = (
 /obj/decal/cleanable/dirt,
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
-"aoF" = (
-/obj/morgue,
-/turf/simulated/floor/sanitary/white,
-/area/station/medical/crematorium)
 "aoG" = (
+/obj/disposalpipe/segment/vertical,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/north)
+"aoH" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/arcade/dungeon)
+"aoJ" = (
 /obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/crematorium)
-"aoH" = (
+"aoK" = (
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/crematorium)
-"aoI" = (
+"aoL" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/west,
 /obj/machinery/light_switch/east,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/crematorium)
-"aoJ" = (
+"aoM" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/east,
 /obj/decal/xmas_lights/ephemeral{
@@ -6275,27 +6004,27 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/chapel/sanctuary)
-"aoK" = (
+"aoN" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/decal/xmas_lights/ephemeral{
 	pixel_y = 32
 	},
 /turf/simulated/floor/stairs/wide,
 /area/station/chapel/sanctuary)
-"aoL" = (
+"aoO" = (
 /obj/disposalpipe/segment/bent/west,
 /turf/simulated/floor/stairs/wide/middle,
 /area/station/chapel/sanctuary)
-"aoM" = (
+"aoP" = (
 /turf/simulated/floor/stairs/wide/middle,
 /area/station/chapel/sanctuary)
-"aoN" = (
+"aoQ" = (
 /obj/decal/xmas_lights/ephemeral{
 	pixel_y = 32
 	},
 /turf/simulated/floor/stairs/wide/other,
 /area/station/chapel/sanctuary)
-"aoO" = (
+"aoR" = (
 /obj/table/wood/auto,
 /obj/item/decoration/flower_vase,
 /obj/machinery/firealarm{
@@ -6308,14 +6037,11 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/chapel/sanctuary)
-"aoP" = (
-/obj/stool/chair/wooden{
-	dir = 4
-	},
-/obj/decal/cleanable/cobweb,
-/turf/simulated/floor/wood/two,
-/area/station/chapel/office)
-"aoQ" = (
+"aoS" = (
+/obj/stool/chair,
+/turf/simulated/floor/carpet/red/fancy/narrow/T_north,
+/area/station/crew_quarters/arcade/dungeon)
+"aoT" = (
 /obj/cable{
 	icon_state = "1-8"
 	},
@@ -6336,7 +6062,7 @@
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/nw,
 /area/station/chapel/office)
-"aoR" = (
+"aoU" = (
 /obj/cable{
 	icon_state = "1-4"
 	},
@@ -6353,17 +6079,15 @@
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/ne,
 /area/station/chapel/office)
-"aoS" = (
-/obj/stool/chair/wooden{
-	dir = 8
-	},
-/turf/simulated/floor/wood/two,
-/area/station/chapel/office)
-"aoT" = (
+"aoW" = (
+/obj/stool/chair,
+/turf/simulated/floor/carpet/red/fancy/edge/ne,
+/area/station/crew_quarters/arcade/dungeon)
+"aoX" = (
 /obj/storage/closet/wardrobe/mixed,
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/utility)
-"aoU" = (
+"aoY" = (
 /obj/stool/chair{
 	dir = 8
 	},
@@ -6379,16 +6103,7 @@
 	},
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/utility)
-"aoV" = (
-/obj/stool/chair,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/autoname_north,
-/turf/simulated/floor/grime,
-/area/station/crew_quarters/utility)
-"aoW" = (
+"aoZ" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 8;
@@ -6397,7 +6112,7 @@
 /obj/machinery/atmospherics/pipe/simple,
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/utility)
-"aoX" = (
+"apa" = (
 /obj/storage/crate,
 /obj/item/instrument/saxophone,
 /obj/item/pen/infrared,
@@ -6413,11 +6128,17 @@
 	},
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/utility)
-"aoY" = (
-/obj/machinery/vending/standard,
-/turf/simulated/floor/grime,
-/area/station/crew_quarters/utility)
-"aoZ" = (
+"apb" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/arcade/dungeon)
+"apc" = (
 /obj/rack,
 /obj/item/clothing/suit/bedsheet/cape/black,
 /obj/item/clothing/suit/bedsheet/cape/red,
@@ -6428,7 +6149,7 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/arcade/dungeon)
-"apa" = (
+"apd" = (
 /obj/rack,
 /obj/machinery/power/apc/autoname_north,
 /obj/item/clothing/suit/wizrobe/purple,
@@ -6442,68 +6163,40 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/arcade/dungeon)
-"apb" = (
+"ape" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/station/maintenance/solar/east)
+"apf" = (
 /obj/machinery/light_switch/west,
 /obj/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/red/fancy/narrow/T_west,
 /area/station/crew_quarters/arcade/dungeon)
-"apc" = (
-/obj/table/wood/round/auto,
-/obj/item/diceholder/dicebox{
-	pixel_y = 3
-	},
-/obj/item/dice/d20{
-	pixel_x = 5;
-	pixel_y = 11
-	},
-/turf/simulated/floor/carpet/red/fancy/innercorner/nw_triple,
-/area/station/crew_quarters/arcade/dungeon)
-"apd" = (
-/obj/table/wood/round/auto,
-/obj/item/paper_bin{
-	pixel_x = -7;
-	pixel_y = 6
-	},
-/obj/item/pen/marker/blue,
-/turf/simulated/floor/carpet/red/fancy/innercorner/se,
-/area/station/crew_quarters/arcade/dungeon)
-"ape" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/se,
-/area/station/crew_quarters/arcade/dungeon)
-"apf" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/arcade/dungeon)
 "apg" = (
-/obj/lattice{
-	dir = 8;
-	icon_state = "lattice-dir"
-	},
-/turf/space,
-/area/station/solar/east)
-"aph" = (
 /obj/cable{
 	icon_state = "2-4"
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
+/area/station/maintenance/solar/east)
+"aph" = (
+/obj/stool/chair/couch{
+	dir = 4
+	},
+/obj/disposalpipe/segment/horizontal,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/arcade/dungeon)
 "api" = (
 /obj/stool/chair/couch{
 	desc = "It's comfortable, but has an aura of unease about it, like somebody's watching you the moment you sit down.";
@@ -6558,14 +6251,13 @@
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/mining/staff_room)
 "apq" = (
-/obj/machinery/light/emergency{
-	dir = 8;
-	pixel_x = -10
+/obj/disposalpipe/segment/brig{
+	dir = 1
 	},
 /turf/simulated/floor/escape{
-	dir = 8
+	dir = 1
 	},
-/area/station/hallway/secondary/exit)
+/area/station/hallway/primary/east)
 "apr" = (
 /obj/stool/chair/office{
 	dir = 8
@@ -6746,26 +6438,62 @@
 /turf/space,
 /area/space)
 "apL" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/access_spawn/engineering_power,
+/turf/simulated/floor/plating,
+/area/station/maintenance/solar/east)
+"apM" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/solar/east)
+"apN" = (
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
+	},
+/turf/space,
+/area/space)
+"apO" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/primary/north)
-"apM" = (
+"apP" = (
 /obj/grille/steel,
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/north)
-"apN" = (
+"apQ" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
-"apO" = (
+"apR" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
@@ -6775,27 +6503,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
-"apP" = (
+"apS" = (
 /obj/disposalpipe/segment/morgue{
 	icon_state = "pipe-c"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/crematorium)
-"apQ" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/light/small,
+"apT" = (
+/obj/morgue,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/crematorium)
-"apR" = (
+"apU" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/crematorium)
-"apS" = (
+"apV" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
@@ -6807,7 +6531,7 @@
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/crematorium)
-"apT" = (
+"apW" = (
 /obj/machinery/disposal/morgue,
 /obj/machinery/light/small,
 /obj/machinery/firealarm{
@@ -6820,29 +6544,24 @@
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/crematorium)
-"apU" = (
+"apX" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/maintenance/north)
+"apY" = (
 /obj/machinery/disposal/mail/autoname/chapel,
 /obj/disposalpipe/trunk/mail/east,
 /turf/simulated/floor/wood/two,
 /area/station/chapel/sanctuary)
-"apV" = (
+"apZ" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/wood/two,
 /area/station/chapel/sanctuary)
-"apW" = (
+"aqa" = (
 /obj/disposalpipe/segment/mail/bent/south,
 /turf/simulated/floor/wood/two,
 /area/station/chapel/sanctuary)
-"apX" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 10;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/wood/two,
-/area/station/chapel/sanctuary)
-"apY" = (
+"aqb" = (
 /obj/cable{
 	d1 = 2;
 	d2 = 4;
@@ -6850,13 +6569,13 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/chapel/sanctuary)
-"apZ" = (
+"aqc" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood/two,
 /area/station/chapel/sanctuary)
-"aqa" = (
+"aqd" = (
 /obj/table/wood/auto,
 /obj/machinery/networked/printer{
 	name = "Printer - Chapel";
@@ -6870,13 +6589,7 @@
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/wood/two,
 /area/station/chapel/sanctuary)
-"aqb" = (
-/obj/stool/chair/wooden{
-	dir = 4
-	},
-/turf/simulated/floor/wood/two,
-/area/station/chapel/office)
-"aqc" = (
+"aqe" = (
 /obj/cable{
 	d1 = 2;
 	d2 = 8;
@@ -6895,7 +6608,7 @@
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/sw,
 /area/station/chapel/office)
-"aqd" = (
+"aqf" = (
 /obj/cable{
 	icon_state = "2-4"
 	},
@@ -6917,24 +6630,16 @@
 /obj/item/ghostboard,
 /turf/simulated/floor/carpet/red/fancy/edge/se,
 /area/station/chapel/office)
-"aqe" = (
-/obj/storage/closet/wardrobe/pride,
-/turf/simulated/floor/grime,
-/area/station/crew_quarters/utility)
-"aqf" = (
-/obj/stool/chair,
-/turf/simulated/floor/grime,
-/area/station/crew_quarters/utility)
 "aqg" = (
-/obj/stool/chair{
-	dir = 4
+/obj/stool/chair/wooden{
+	dir = 8
 	},
-/turf/simulated/floor/grime,
-/area/station/crew_quarters/utility)
+/turf/simulated/floor/wood/two,
+/area/station/chapel/office)
 "aqh" = (
-/obj/machinery/atmospherics/pipe/simple,
-/turf/simulated/floor/grime,
-/area/station/crew_quarters/utility)
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/crematorium)
 "aqi" = (
 /obj/grille/catwalk{
 	dir = 4
@@ -6944,7 +6649,24 @@
 	dir = 4
 	},
 /area/station/mining/staff_room)
-"aqj" = (
+"aqk" = (
+/turf/simulated/floor/grime,
+/area/station/crew_quarters/utility)
+"aql" = (
+/obj/rack,
+/obj/item/bballbasket,
+/obj/item/bballbasket,
+/obj/item/bballbasket,
+/obj/item/bballbasket,
+/turf/simulated/floor/grime,
+/area/station/crew_quarters/utility)
+"aqm" = (
+/obj/disposalpipe/junction/right/west,
+/turf/simulated/floor/specialroom/chapel{
+	dir = 4
+	},
+/area/station/chapel/sanctuary)
+"aqn" = (
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_x = -12
@@ -6959,7 +6681,7 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/arcade/dungeon)
-"aqk" = (
+"aqo" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -6973,56 +6695,24 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/arcade/dungeon)
-"aql" = (
+"aqp" = (
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/stairs/wood/wide{
 	dir = 9
 	},
 /area/station/crew_quarters/arcade/dungeon)
-"aqm" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/sw,
-/area/station/crew_quarters/arcade/dungeon)
-"aqn" = (
-/obj/stool/chair{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/red/fancy/narrow/T_south,
-/area/station/crew_quarters/arcade/dungeon)
-"aqo" = (
+"aqq" = (
 /obj/stool/chair{
 	dir = 1
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/se,
 /area/station/crew_quarters/arcade/dungeon)
-"aqp" = (
+"aqr" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/arcade/dungeon)
-"aqq" = (
-/obj/disposalpipe/segment/vertical,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
-"aqr" = (
-/obj/decal/cleanable/dirt,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
 "aqs" = (
 /turf/simulated/floor/carpet/grime,
 /area/station/maintenance/northwest)
@@ -7173,44 +6863,25 @@
 "aqN" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/primary/west)
-"aqO" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/medical/crematorium)
-"aqP" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/medical/crematorium)
-"aqQ" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/medical/crematorium)
 "aqR" = (
-/obj/machinery/door/airlock/pyro{
-	name = "Crematorium"
+/obj/machinery/door/airlock/pyro/maintenance,
+/obj/disposalpipe/segment/vertical,
+/obj/cable{
+	icon_state = "1-2"
 	},
-/obj/access_spawn/crematorium,
-/obj/firedoor_spawn,
-/turf/simulated/floor/sanitary/white,
-/area/station/medical/crematorium)
+/turf/simulated/floor/plating,
+/area/station/maintenance/north)
 "aqS" = (
-/obj/machinery/door/unpowered/wood/pyro{
-	dir = 1;
-	name = "Chapel"
+/obj/disposalpipe/segment/horizontal,
+/turf/simulated/floor/specialroom/chapel{
+	dir = 1
 	},
-/obj/disposalpipe/segment/mail/vertical,
-/obj/firedoor_spawn,
-/turf/simulated/floor/wood/two,
 /area/station/chapel/sanctuary)
 "aqT" = (
+/obj/machinery/light,
+/turf/simulated/floor/specialroom/chapel,
+/area/station/chapel/sanctuary)
+"aqU" = (
 /obj/machinery/door/unpowered/wood/pyro{
 	dir = 1;
 	name = "Chapel"
@@ -7221,35 +6892,63 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/wood/two,
 /area/station/chapel/sanctuary)
-"aqU" = (
-/obj/decal/poster/wallsign/escape_right,
-/turf/simulated/wall/auto/supernorn,
-/area/station/chapel/office)
 "aqV" = (
-/obj/decal/poster/wallsign/stencil/left/v,
-/turf/simulated/wall/auto/supernorn,
-/area/station/chapel/office)
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 6
+	},
+/obj/cable{
+	icon_state = "2-5"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
 "aqW" = (
-/obj/rack,
-/obj/item/furniture_parts/bed,
-/obj/item/furniture_parts/table,
-/obj/item/furniture_parts/table,
-/turf/simulated/floor/grime,
-/area/station/crew_quarters/utility)
+/obj/decal/cleanable/dirt,
+/obj/machinery/atmospherics/valve{
+	dir = 4;
+	high_risk = 1;
+	name = "NE Hallway"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
 "aqX" = (
-/obj/storage/crate,
-/obj/item/item_box/medical_patches/mini_synthflesh,
-/obj/item/storage/firstaid/oxygen,
-/obj/item/storage/pill_bottle/cyberpunk,
-/obj/item/bandage,
-/obj/item/device/analyzer/healthanalyzer,
-/obj/machinery/light/small,
-/turf/simulated/floor/grime,
-/area/station/crew_quarters/utility)
+/obj/table/wood/round/auto,
+/obj/machinery/phone,
+/turf/simulated/floor/carpet/red/fancy/innercorner/sw_triple,
+/area/station/crew_quarters/arcade/dungeon)
 "aqY" = (
+/obj/storage/closet/wardrobe/pride,
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/utility)
 "aqZ" = (
+/obj/machinery/atmospherics/pipe/simple,
+/turf/simulated/floor/grime,
+/area/station/crew_quarters/utility)
+"ara" = (
+/obj/submachine/cargopad{
+	name = "Utility Room Pad"
+	},
+/turf/simulated/floor/grime,
+/area/station/crew_quarters/utility)
+"arb" = (
+/obj/storage/crate,
+/obj/item/clothing/under/jersey/red,
+/obj/item/clothing/under/jersey/purple,
+/obj/item/clothing/under/jersey/green,
+/obj/item/clothing/under/jersey/black,
+/obj/item/clothing/under/jersey,
+/obj/item/basketball{
+	desc = "Something beautiful overwhelms you when you look at this ball.";
+	name = "barkley's basketball"
+	},
+/turf/simulated/floor/grime,
+/area/station/crew_quarters/utility)
+"arc" = (
+/obj/table/wood/round/auto,
+/obj/item/pen,
+/obj/item/coin,
+/turf/simulated/floor/carpet/red/fancy/innercorner/ne,
+/area/station/crew_quarters/arcade/dungeon)
+"ard" = (
 /obj/decal/tile_edge/line/white{
 	dir = 10;
 	icon_state = "line4"
@@ -7260,7 +6959,7 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/arcade/dungeon)
-"ara" = (
+"are" = (
 /obj/cable{
 	icon_state = "1-4"
 	},
@@ -7278,7 +6977,7 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/arcade/dungeon)
-"arb" = (
+"arf" = (
 /obj/machinery/light/small,
 /obj/cable{
 	d1 = 4;
@@ -7295,7 +6994,7 @@
 	dir = 8
 	},
 /area/station/crew_quarters/arcade/dungeon)
-"arc" = (
+"arg" = (
 /obj/cable{
 	icon_state = "1-4"
 	},
@@ -7306,102 +7005,34 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/arcade/dungeon)
-"ard" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/arcade/dungeon)
-"are" = (
-/obj/machinery/light/small,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/arcade/dungeon)
-"arf" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/arcade/dungeon)
-"arg" = (
-/obj/table/wood/round/auto,
-/obj/item/device/light/candle{
-	pixel_y = 7;
-	rand_pos = 0
-	},
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/arcade/dungeon)
 "arh" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	dir = 4;
-	name = "Solar Control"
+/obj/machinery/disposal,
+/obj/disposalpipe/trunk/west,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
 	},
-/obj/access_spawn/engineering_power,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/solar/east)
-"ari" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/circuit,
-/area/station/turret_protected/ai)
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/arcade/dungeon)
 "arj" = (
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/circuit,
-/area/station/turret_protected/ai)
-"ark" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/landmark/gps_waypoint,
 /obj/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/decal/tile_edge/line/white{
-	dir = 9;
-	icon_state = "line4"
-	},
-/obj/decal/tile_edge/line/white{
-	dir = 10;
-	icon_state = "line1"
-	},
-/turf/simulated/floor/darkblue,
+/turf/simulated/floor/black,
 /area/station/turret_protected/ai)
-"arl" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+"ark" = (
+/obj/stool/chair{
+	dir = 8
 	},
-/turf/simulated/floor/engine,
-/area/station/turret_protected/ai)
+/turf/simulated/floor/carpet/red/fancy/edge/ne,
+/area/station/crew_quarters/arcade/dungeon)
 "arm" = (
 /turf/simulated/floor/stairs/wide/other{
 	dir = 4
@@ -7700,12 +7331,57 @@
 /turf/simulated/floor/caution/westeast,
 /area/station/hallway/primary/west)
 "arV" = (
-/obj/machinery/door/airlock/pyro/external{
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/arcade/dungeon)
+"arW" = (
+/obj/morgue,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/crematorium)
+"arX" = (
+/obj/disposalpipe/segment/vertical,
+/obj/machinery/door/unpowered/wood/pyro{
+	dir = 1;
+	name = "Chapel"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/specialroom/chapel{
+	dir = 8
+	},
+/area/station/chapel/sanctuary)
+"arY" = (
+/obj/wingrille_spawn/auto,
+/obj/decal/wreath/ephemeral,
+/turf/simulated/floor/plating,
+/area/station/chapel/sanctuary)
+"asa" = (
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
+"asb" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/stairs/wide{
 	dir = 4
 	},
-/turf/simulated/floor/caution/westeast,
 /area/station/hallway/primary/north)
-"arW" = (
+"asc" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
+"asd" = (
 /obj/machinery/computer/airbr{
 	density = 0;
 	icon = 'icons/obj/airtunnel.dmi';
@@ -7714,60 +7390,10 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/north)
-"arX" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/stairs/wide{
-	dir = 4
-	},
-/area/station/hallway/primary/north)
-"arY" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
-"arZ" = (
-/obj/disposalpipe/segment/vertical,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/decal/garland/ephemeral{
-	dir = 4;
-	pixel_x = -14
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
-"asa" = (
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
-"asb" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
-"asc" = (
+"ase" = (
 /obj/item/device/radio/intercom{
 	broadcasting = 0
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
-"asd" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
-"ase" = (
-/obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "asf" = (
@@ -7776,69 +7402,79 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
-/obj/machinery/navbeacon{
-	codes_txt = "tour;next_tour=tour16;desc=The station chapel is outfitted with a confessional booth and crematorium facilities. Just that. Definitely nothing else.";
-	freq = 1443;
-	location = "tour15";
-	name = "tour 15 - chapel"
-	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "asg" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/machinery/door/unpowered/wood/pyro{
+	dir = 1;
+	name = "Chapel"
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
+/obj/firedoor_spawn,
+/turf/simulated/floor/specialroom/chapel,
+/area/station/chapel/sanctuary)
 "ash" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
-	},
-/obj/machinery/firealarm{
-	pixel_x = 6;
-	pixel_y = 24
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
+/turf/simulated/floor/stairs/wood,
+/area/station/chapel/office)
 "asi" = (
-/turf/simulated/floor/neutral/side{
-	dir = 4
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/area/station/hallway/primary/north)
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/elect)
 "asj" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/fitness)
 "ask" = (
+/obj/machinery/light/emergency{
+	dir = 4;
+	pixel_x = 10
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/hallway/primary/north)
+"asl" = (
 /obj/machinery/door/airlock/pyro,
 /obj/machinery/atmospherics/pipe/simple,
 /obj/firedoor_spawn,
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/fitness)
-"asl" = (
-/obj/machinery/door/unpowered/wood/pyro{
-	dir = 1;
-	name = "Chiron's Grandhall"
-	},
-/obj/firedoor_spawn,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/wood/two,
-/area/station/crew_quarters/arcade/dungeon)
 "asm" = (
-/obj/machinery/door/unpowered/wood/pyro{
-	dir = 1;
-	name = "Chiron's Grandhall"
+/obj/table/wood/auto,
+/obj/item/device/light/candle{
+	pixel_y = 7;
+	rand_pos = 0
 	},
+/obj/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/simulated/floor/wood/two,
+/area/station/chapel/office)
+"asn" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
+"asp" = (
+/obj/machinery/door/airlock/pyro/maintenance,
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/firedoor_spawn,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/wood/two,
-/area/station/crew_quarters/arcade/dungeon)
-"asn" = (
+/obj/machinery/atmospherics/pipe/simple,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/utility)
+"asq" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -7848,59 +7484,6 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/turf/simulated/floor/circuit,
-/area/station/turret_protected/ai)
-"asp" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/decal/tile_edge/line/white{
-	dir = 1;
-	icon_state = "line3"
-	},
-/obj/decal/tile_edge/line/white{
-	dir = 8;
-	icon_state = "line1"
-	},
-/turf/simulated/floor/darkblue,
-/area/station/turret_protected/ai)
-"asq" = (
-/obj/decal/tile_edge/line/white{
-	dir = 9;
-	icon_state = "line4"
-	},
-/obj/decal/tile_edge/line/white{
-	dir = 8;
-	icon_state = "line1"
-	},
-/obj/decal/tile_edge/line/white{
-	dir = 6;
-	icon_state = "line1"
-	},
-/turf/simulated/floor/darkblue,
-/area/station/turret_protected/ai)
-"asr" = (
-/obj/decal/tile_edge/line/white{
-	dir = 6;
-	icon_state = "line4"
-	},
-/obj/decal/tile_edge/line/white{
-	icon_state = "line1"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/darkblue,
-/area/station/turret_protected/ai)
-"ass" = (
-/obj/machinery/computer/bank_data{
-	dir = 8
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/data_terminal,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "ast" = (
@@ -8173,31 +7756,39 @@
 /turf/space,
 /area/space)
 "asZ" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/north)
-"ata" = (
+/obj/storage/cart/mechcart,
+/obj/item/electronics/scanner,
+/obj/item/deconstructor,
+/obj/item/storage/toolbox/electrical,
+/obj/item/storage/toolbox/mechanical,
 /obj/machinery/light{
-	dir = 8;
+	dir = 1;
 	layer = 9.1;
-	pixel_x = -10
+	pixel_y = 21
 	},
-/turf/simulated/floor/grey,
-/area/station/hallway/primary/north)
-"atb" = (
-/turf/simulated/floor/stairs/wide/middle{
-	dir = 4
-	},
-/area/station/hallway/primary/north)
-"atc" = (
+/obj/item/storage/box/lightbox/bulbs,
+/obj/item/storage/box/lightbox/tubes,
+/obj/item/device/multitool,
+/turf/simulated/floor/yellow,
+/area/station/engine/elect)
+"ata" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
+"atb" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
 "atd" = (
 /obj/cable{
 	d1 = 4;
@@ -8208,46 +7799,82 @@
 /area/station/hallway/primary/north)
 "ate" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/landmark/halloween,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "atf" = (
-/obj/disposalpipe/segment/mail/vertical,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/recharge_station,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/turf/simulated/floor/darkblue,
+/area/station/turret_protected/ai)
 "atg" = (
-/obj/cable{
-	icon_state = "1-8"
+/obj/stool/chair/wooden{
+	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
+/obj/decal/cleanable/cobweb,
+/turf/simulated/floor/wood/two,
+/area/station/chapel/office)
 "ath" = (
+/obj/stool/chair,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/autoname_north,
+/turf/simulated/floor/grime,
+/area/station/crew_quarters/utility)
+"ati" = (
+/obj/machinery/vending/standard,
+/turf/simulated/floor/grime,
+/area/station/crew_quarters/utility)
+"atj" = (
+/obj/table/wood/round/auto,
+/obj/item/diceholder/dicebox{
+	pixel_y = 3
+	},
+/obj/item/dice/d20{
+	pixel_x = 5;
+	pixel_y = 11
+	},
+/turf/simulated/floor/carpet/red/fancy/innercorner/nw_triple,
+/area/station/crew_quarters/arcade/dungeon)
+"atk" = (
+/obj/table/wood/round/auto,
+/obj/item/paper_bin{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/obj/item/pen/marker/blue,
+/turf/simulated/floor/carpet/red/fancy/innercorner/se,
+/area/station/crew_quarters/arcade/dungeon)
+"atl" = (
 /obj/landmark/halloween,
 /turf/simulated/floor/escape/corner{
 	dir = 8
 	},
 /area/station/hallway/primary/north)
-"ati" = (
+"atm" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 6
 	},
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon11,
 /turf/simulated/floor/escape/corner,
 /area/station/hallway/primary/north)
-"atj" = (
+"atn" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
@@ -8255,14 +7882,14 @@
 	dir = 4
 	},
 /area/station/hallway/primary/north)
-"atk" = (
+"ato" = (
 /obj/wingrille_spawn/auto,
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/fitness)
-"atl" = (
+"atp" = (
 /obj/item/clothing/gloves/boxing{
 	pixel_x = -4
 	},
@@ -8294,7 +7921,7 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
-"atm" = (
+"atq" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 0;
@@ -8309,13 +7936,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
-"atn" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 9
-	},
+"atr" = (
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
-"ato" = (
+"ats" = (
 /obj/stool/chair/couch{
 	dir = 8;
 	icon_state = "chair_couch-blue";
@@ -8328,7 +7952,7 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
-"atp" = (
+"att" = (
 /obj/stool/chair/couch{
 	dir = 4;
 	icon_state = "chair_couch-blue";
@@ -8336,7 +7960,7 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
-"atq" = (
+"atu" = (
 /obj/table/reinforced/auto,
 /obj/machinery/cashreg,
 /obj/item/device/radio/intercom{
@@ -8348,16 +7972,22 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
-"atr" = (
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/fitness)
-"ats" = (
+"atv" = (
+/obj/stool/chair{
+	dir = 8
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/se,
+/area/station/crew_quarters/arcade/dungeon)
+"atw" = (
 /obj/cable{
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
-"att" = (
+"atx" = (
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
@@ -8370,98 +8000,61 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
-"atu" = (
-/obj/stool/chair/couch{
-	dir = 8;
-	icon_state = "chair_couch-blue";
-	name = "ratty blue couch"
-	},
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/fitness)
-"atv" = (
-/obj/stool/chair/couch{
-	dir = 4;
-	icon_state = "chair_couch-blue";
-	name = "ratty blue couch"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
-	},
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/fitness)
-"atw" = (
-/obj/reagent_dispensers/watertank/fountain,
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/fitness)
-"atx" = (
+"aty" = (
 /obj/table/auto,
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
-"aty" = (
-/obj/cable{
-	icon_state = "1-10"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
 "atA" = (
-/obj/decal/tile_edge/line/white{
-	dir = 9;
-	icon_state = "line4"
+/obj/machinery/recharge_station,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
 	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/mob/living/silicon/hivebot/eyebot,
 /turf/simulated/floor/darkblue,
 /area/station/turret_protected/ai)
 "atB" = (
-/obj/decal/tile_edge/line/white{
+/obj/machinery/firealarm{
 	dir = 4;
-	icon_state = "line2"
+	pixel_x = 26;
+	pixel_y = 1
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/arcade/dungeon)
+"atC" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/crematorium)
+"atD" = (
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
+"atG" = (
+/obj/cable{
+	icon_state = "1-2"
 	},
 /obj/decal/tile_edge/line/white{
 	dir = 1;
 	icon_state = "line3"
 	},
+/obj/decal/tile_edge/line/white{
+	dir = 8;
+	icon_state = "line1"
+	},
 /turf/simulated/floor/darkblue,
-/area/station/turret_protected/ai)
-"atC" = (
-/obj/machinery/door/poddoor{
-	id = "ai_core";
-	name = "AI Core Shield"
-	},
-/obj/machinery/door/airlock/pyro/glass/command{
-	name = "AI Core"
-	},
-/obj/access_spawn/ai_upload,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/circuit,
-/area/station/turret_protected/ai)
-"atD" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/solar/east)
-"atG" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable,
-/turf/simulated/floor/engine,
 /area/station/turret_protected/ai)
 "atH" = (
 /obj/decal/poster/wallsign/space,
@@ -8644,206 +8237,132 @@
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/west)
 "aui" = (
-/obj/disposalpipe/segment/mail/bent/east,
-/turf/simulated/floor/grey,
-/area/station/hallway/primary/north)
-"auj" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/machinery/light/emergency,
-/turf/simulated/floor/stairs/wide/other{
-	dir = 4
-	},
-/area/station/hallway/primary/north)
-"auk" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
-	},
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/firedoor_spawn,
-/turf/simulated/floor/yellow/corner,
-/area/station/hallway/primary/north)
-"aul" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/disposalpipe/segment/vertical,
-/obj/decal/garland/ephemeral{
-	dir = 4;
-	pixel_x = -14
-	},
-/turf/simulated/floor/yellow/side,
-/area/station/hallway/primary/north)
-"aum" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/turf/simulated/floor/yellow/side,
-/area/station/hallway/primary/north)
-"aun" = (
-/obj/disposalpipe/switch_junction/left/east{
-	mail_tag = "engineering";
-	name = "engineering mail junction"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/yellow/side,
-/area/station/hallway/primary/north)
-"auo" = (
-/obj/disposalpipe/switch_junction/right/east{
-	mail_tag = "chapel";
-	name = "chapel mail junction"
-	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 10;
 	name = "autoname - SS13";
 	tag = ""
 	},
+/turf/simulated/floor/wood/two,
+/area/station/chapel/sanctuary)
+"auj" = (
+/obj/stool/chair/wooden{
+	dir = 4
+	},
+/turf/simulated/floor/wood/two,
+/area/station/chapel/office)
+"auk" = (
+/obj/stool/chair{
+	dir = 4
+	},
+/turf/simulated/floor/grime,
+/area/station/crew_quarters/utility)
+"aul" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/turf/simulated/floor/caution/westeast,
+/area/station/hallway/primary/north)
+"aum" = (
+/obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/yellow/side,
 /area/station/hallway/primary/north)
-"aup" = (
-/obj/disposalpipe/segment/mail/bent/south,
-/turf/simulated/floor/yellow/corner{
-	dir = 8
+"aun" = (
+/obj/cable{
+	icon_state = "1-2"
 	},
-/area/station/hallway/primary/north)
+/turf/simulated/floor/carpet/red/fancy/edge/sw,
+/area/station/crew_quarters/arcade/dungeon)
+"auo" = (
+/obj/stool/chair{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/red/fancy/narrow/T_south,
+/area/station/crew_quarters/arcade/dungeon)
 "auq" = (
+/obj/disposalpipe/segment/vertical,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
+"aur" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/engine,
+/area/station/turret_protected/ai)
+"aut" = (
 /turf/simulated/floor/escape/corner{
 	dir = 4
 	},
 /area/station/hallway/primary/north)
-"aur" = (
+"auu" = (
 /obj/machinery/atmospherics/pipe/simple,
 /turf/simulated/floor/escape/corner{
 	dir = 1
 	},
 /area/station/hallway/primary/north)
-"aus" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/fitness)
-"aut" = (
-/obj/table/reinforced/auto,
-/obj/item/clothing/head/helmet/men{
-	pixel_x = -6;
-	pixel_y = 7
-	},
-/obj/item/clothing/head/helmet/men{
-	pixel_x = -6;
-	pixel_y = 7
-	},
-/obj/item/clothing/suit/armor/douandtare{
-	pixel_x = 8;
-	pixel_y = 6
-	},
-/obj/item/clothing/suit/armor/douandtare{
-	pixel_x = 8;
-	pixel_y = 6
-	},
-/obj/item/clothing/gloves/kote{
-	pixel_x = -1
-	},
-/obj/item/clothing/gloves/kote{
-	pixel_x = -1
-	},
-/obj/item/shinai_bag,
-/obj/item/storage/box/kendo_box/hakama,
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/fitness)
-"auu" = (
-/turf/simulated/floor/stairs{
-	dir = 1
-	},
-/area/station/crew_quarters/fitness)
 "auv" = (
-/obj/fitness/speedbag/clown,
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/fitness)
-"auw" = (
-/obj/disposalpipe/segment/vertical,
+/obj/wingrille_spawn/auto/crystal,
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "5-10"
+	d2 = 2;
+	icon_state = "0-2"
 	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/engine,
+/area/station/turret_protected/ai)
+"auw" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/engine,
+/area/station/turret_protected/ai)
+"aux" = (
+/obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
-"aux" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/decal/tile_edge/line/white{
-	dir = 5;
-	icon_state = "line1"
-	},
-/obj/decal/tile_edge/line/white{
-	dir = 6;
-	icon_state = "line1"
-	},
-/turf/simulated/floor/darkblue,
-/area/station/turret_protected/ai)
-"auy" = (
-/obj/wingrille_spawn/auto,
-/obj/machinery/door/poddoor{
-	id = "ai_core";
-	name = "AI Core Shield"
-	},
-/turf/simulated/floor/circuit,
-/area/station/turret_protected/ai)
 "auz" = (
-/obj/machinery/power/data_terminal,
-/obj/landmark/start{
-	name = "AI"
+/obj/machinery/door/airlock/pyro/command{
+	dir = 4;
+	name = "AI Core"
 	},
-/obj/landmark{
-	name = "AI-Sat"
+/obj/access_spawn/ai_upload,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/cable,
-/obj/item/device/radio/intercom/AI{
-	broadcasting = 0;
-	dir = 8;
-	layer = 5
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13"
-	},
-/turf/simulated/floor/circuit,
+/obj/firedoor_spawn,
+/turf/simulated/floor/darkblue,
 /area/station/turret_protected/ai)
 "auA" = (
-/obj/machinery/turret,
 /obj/decal/tile_edge/line/white{
-	dir = 8;
+	dir = 4;
 	icon_state = "line2"
 	},
-/turf/simulated/floor/darkblue,
-/area/station/turret_protected/ai)
-"auB" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
 /obj/decal/tile_edge/line/white{
-	dir = 10;
-	icon_state = "line1"
-	},
-/obj/decal/tile_edge/line/white{
-	dir = 9;
-	icon_state = "line1"
+	dir = 1;
+	icon_state = "line3"
 	},
 /turf/simulated/floor/darkblue,
 /area/station/turret_protected/ai)
@@ -8954,28 +8473,21 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/primary/west)
 "auS" = (
-/obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/primary/north)
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/medical/crematorium)
 "auT" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/storage)
 "auU" = (
-/obj/table/reinforced/auto,
-/obj/disposalpipe/segment/vertical,
-/obj/access_spawn/engineering_storage,
-/obj/firedoor_spawn,
-/obj/machinery/door/airlock/pyro/glass/windoor,
-/turf/simulated/floor/yellow,
-/area/station/engine/storage)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hallway/primary/north)
 "auV" = (
-/obj/table/reinforced/auto,
-/obj/machinery/cashreg,
-/obj/access_spawn/engineering_storage,
-/obj/firedoor_spawn,
-/obj/machinery/door/airlock/pyro/glass/windoor,
-/turf/simulated/floor/yellow,
-/area/station/engine/storage)
+/obj/disposalpipe/segment/mail/vertical,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hallway/primary/north)
 "auW" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/engine/engineering)
@@ -8996,104 +8508,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/elect)
 "ava" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/engine/elect)
-"avb" = (
-/obj/disposalpipe/segment/mail/bent/north,
-/turf/simulated/floor/yellow/side{
-	dir = 10
-	},
-/area/station/hallway/primary/north)
-"avc" = (
-/obj/machinery/atmospherics/unary/outlet_injector{
-	dir = 1;
-	icon_state = "on";
-	on = 1
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
-"avd" = (
-/obj/stool/chair/boxingrope_corner{
-	dir = 10;
-	icon_state = "ringrope"
-	},
-/turf/simulated/floor/specialroom/gym,
-/area/station/crew_quarters/fitness)
-"ave" = (
-/obj/decal/boxingropeenter,
-/turf/simulated/floor/specialroom/gym,
-/area/station/crew_quarters/fitness)
-"avf" = (
-/obj/decal/boxingrope,
-/turf/simulated/floor/specialroom/gym,
-/area/station/crew_quarters/fitness)
-"avg" = (
-/obj/stool/chair/boxingrope_corner{
-	dir = 6;
-	icon_state = "ringrope"
-	},
-/turf/simulated/floor/specialroom/gym,
-/area/station/crew_quarters/fitness)
-"avh" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/fitness)
-"avi" = (
-/obj/decal/tile_edge/line/black{
-	dir = 9;
-	icon_state = "line2"
-	},
-/turf/simulated/floor/specialroom/gym/alt,
-/area/station/crew_quarters/fitness)
-"avj" = (
-/obj/decal/tile_edge/line/black{
-	dir = 1;
-	icon_state = "line1"
-	},
-/turf/simulated/floor/specialroom/gym/alt,
-/area/station/crew_quarters/fitness)
-"avk" = (
-/obj/decal/tile_edge/line/black{
-	dir = 5;
-	icon_state = "line2"
-	},
-/turf/simulated/floor/specialroom/gym/alt,
-/area/station/crew_quarters/fitness)
-"avl" = (
-/obj/fitness/speedbag/wizard,
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/fitness)
-"avm" = (
-/obj/machinery/door/airlock/pyro/maintenance,
-/obj/cable{
-	icon_state = "2-5"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
-"avn" = (
-/obj/machinery/door/airlock/pyro/maintenance,
 /obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
-"avo" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/stairs/dark,
-/area/station/turret_protected/ai)
-"avp" = (
-/obj/stool/chair/yellow{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/solar/east)
-"avq" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -9106,30 +8521,155 @@
 	pixel_x = -10;
 	tag = ""
 	},
-/turf/simulated/floor/circuit,
-/area/station/turret_protected/ai)
-"avr" = (
-/obj/decal/tile_edge/line/white{
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
+"avb" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/elect)
+"avc" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/elect)
+"avd" = (
+/obj/disposalpipe/segment/mail/bent/south,
+/turf/simulated/floor/yellow/corner{
+	dir = 8
+	},
+/area/station/hallway/primary/north)
+"ave" = (
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 1;
+	icon_state = "on";
+	on = 1
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
+"avf" = (
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/hallway/primary/north)
+"avg" = (
+/obj/stool/chair/boxingrope_corner{
 	dir = 10;
+	icon_state = "ringrope"
+	},
+/turf/simulated/floor/specialroom/gym,
+/area/station/crew_quarters/fitness)
+"avh" = (
+/obj/decal/boxingropeenter,
+/turf/simulated/floor/specialroom/gym,
+/area/station/crew_quarters/fitness)
+"avi" = (
+/obj/decal/boxingrope,
+/turf/simulated/floor/specialroom/gym,
+/area/station/crew_quarters/fitness)
+"avj" = (
+/obj/stool/chair/boxingrope_corner{
+	dir = 6;
+	icon_state = "ringrope"
+	},
+/turf/simulated/floor/specialroom/gym,
+/area/station/crew_quarters/fitness)
+"avk" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/medical/crematorium)
+"avl" = (
+/obj/decal/tile_edge/line/black{
+	dir = 1;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/specialroom/gym/alt,
+/area/station/crew_quarters/fitness)
+"avm" = (
+/obj/decal/tile_edge/line/black{
+	dir = 5;
+	icon_state = "line2"
+	},
+/turf/simulated/floor/specialroom/gym/alt,
+/area/station/crew_quarters/fitness)
+"avn" = (
+/obj/machinery/door/airlock/pyro{
+	name = "Crematorium"
+	},
+/obj/access_spawn/crematorium,
+/obj/firedoor_spawn,
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/crematorium)
+"avo" = (
+/obj/machinery/door/airlock/pyro/maintenance,
+/obj/cable{
+	icon_state = "2-5"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
+"avp" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
+"avq" = (
+/obj/decal/poster/wallsign/medbay_left,
+/turf/simulated/wall/auto/supernorn,
+/area/station/medical/crematorium)
+"avr" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"avs" = (
+/obj/machinery/door/unpowered/wood/pyro{
+	dir = 1;
+	name = "Chapel"
+	},
+/obj/disposalpipe/segment/mail/vertical,
+/obj/firedoor_spawn,
+/turf/simulated/floor/wood/two,
+/area/station/chapel/sanctuary)
+"avt" = (
+/obj/decal/tile_edge/line/white{
+	dir = 9;
 	icon_state = "line4"
 	},
 /turf/simulated/floor/darkblue,
 /area/station/turret_protected/ai)
-"avs" = (
-/obj/machinery/door_control{
-	id = "ai_core";
-	name = "AI Core Shield";
-	pixel_y = 6
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/turret_protected/ai)
-"avt" = (
-/obj/decal/tile_edge/line/white{
-	icon_state = "line3"
-	},
-/turf/simulated/floor/darkblue,
-/area/station/turret_protected/ai)
 "avu" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/door/poddoor{
+	id = "ai_core";
+	name = "AI Core Shield"
+	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "avv" = (
@@ -9362,9 +8902,9 @@
 	},
 /area/station/engine/power)
 "avT" = (
-/obj/decal/poster/wallsign/gym,
+/obj/decal/poster/wallsign/escape_right,
 /turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/fitness)
+/area/station/chapel/office)
 "avU" = (
 /obj/storage/crate/furnacefuel,
 /obj/machinery/light_switch/north,
@@ -9390,35 +8930,43 @@
 /turf/space,
 /area/space)
 "avY" = (
+/obj/decal/poster/wallsign/stencil/left/v,
+/turf/simulated/wall/auto/supernorn,
+/area/station/chapel/office)
+"avZ" = (
+/obj/storage/crate,
+/obj/item/item_box/medical_patches/mini_synthflesh,
+/obj/item/storage/firstaid/oxygen,
+/obj/item/storage/pill_bottle/cyberpunk,
+/obj/item/bandage,
+/obj/item/device/analyzer/healthanalyzer,
+/obj/machinery/light/small,
+/turf/simulated/floor/grime,
+/area/station/crew_quarters/utility)
+"awa" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/arcade/dungeon)
+"awb" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/primary/north)
-"avZ" = (
+"awc" = (
 /obj/grille/steel,
 /obj/disposalpipe/segment/mail/bent/west,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/north)
-"awa" = (
-/obj/table/auto,
-/obj/item/sheet/steel{
-	amount = 50
+"awd" = (
+/obj/cable{
+	icon_state = "1-8"
 	},
-/obj/item/sheet/steel{
-	amount = 50
-	},
-/obj/item/sheet/glass/reinforced{
-	amount = 50
-	},
-/obj/item/sheet/glass{
-	amount = 50
-	},
-/obj/item/storage/box/cablesbox,
-/obj/item/device/radio/intercom/engineering{
-	dir = 4
-	},
-/turf/simulated/floor/black,
-/area/station/engine/storage)
-"awb" = (
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/arcade/dungeon)
+"awe" = (
 /obj/stool/chair/yellow{
 	dir = 1
 	},
@@ -9430,12 +8978,12 @@
 	dir = 9
 	},
 /area/station/engine/storage)
-"awc" = (
+"awf" = (
 /turf/simulated/floor/yellow/side{
 	dir = 5
 	},
 /area/station/engine/storage)
-"awd" = (
+"awg" = (
 /obj/machinery/light{
 	dir = 4;
 	layer = 9.1;
@@ -9447,14 +8995,22 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/black,
 /area/station/engine/storage)
-"awe" = (
+"awh" = (
+/obj/table/wood/round/auto,
+/obj/item/device/light/candle{
+	pixel_y = 7;
+	rand_pos = 0
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/arcade/dungeon)
+"awi" = (
 /obj/machinery/manufacturer/general,
 /obj/machinery/light_switch/west,
 /turf/simulated/floor/yellow/side{
 	dir = 9
 	},
 /area/station/engine/engineering)
-"awf" = (
+"awj" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/cable{
 	icon_state = "1-2"
@@ -9464,7 +9020,7 @@
 	dir = 1
 	},
 /area/station/engine/engineering)
-"awg" = (
+"awk" = (
 /obj/stool/chair/yellow{
 	dir = 4
 	},
@@ -9479,23 +9035,7 @@
 	dir = 1
 	},
 /area/station/engine/engineering)
-"awh" = (
-/obj/table/auto,
-/obj/item/device/analyzer/atmosanalyzer_upgrade{
-	pixel_x = 13;
-	pixel_y = 3;
-	rand_pos = 0
-	},
-/obj/item/device/radio,
-/obj/item/clothing/ears/earmuffs,
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 1
-	},
-/area/station/engine/engineering)
-"awi" = (
+"awl" = (
 /obj/table/auto,
 /obj/item/paper_bin,
 /obj/item/pen,
@@ -9506,23 +9046,7 @@
 	dir = 1
 	},
 /area/station/engine/engineering)
-"awj" = (
-/obj/stool/chair/yellow{
-	dir = 8
-	},
-/obj/landmark/start{
-	name = "Engineer"
-	},
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 1
-	},
-/area/station/engine/engineering)
-"awk" = (
+"awm" = (
 /obj/shrub{
 	dir = 1;
 	icon = 'icons/obj/stationobjs.dmi';
@@ -9539,15 +9063,15 @@
 	dir = 5
 	},
 /area/station/engine/engineering)
-"awl" = (
-/obj/table/auto,
-/obj/machinery/cell_charger,
-/obj/item/cell/supercell/charged,
-/obj/item/cell/supercell/charged,
-/obj/item/cell/supercell/charged,
-/turf/simulated/floor/yellow,
-/area/station/engine/elect)
-"awm" = (
+"awn" = (
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
+"awo" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
 	d2 = 2;
@@ -9558,23 +9082,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/elect)
-"awn" = (
-/obj/storage/cart/mechcart,
-/obj/item/electronics/scanner,
-/obj/item/deconstructor,
-/obj/item/storage/toolbox/electrical,
-/obj/item/storage/toolbox/mechanical,
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
+"awp" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/item/storage/box/lightbox/bulbs,
-/obj/item/storage/box/lightbox/tubes,
-/obj/item/device/multitool,
-/turf/simulated/floor/yellow,
+/obj/cable,
+/turf/simulated/floor/plating,
 /area/station/engine/elect)
-"awo" = (
+"awq" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/disposalpipe/segment/mail/vertical,
 /obj/firedoor_spawn,
@@ -9582,40 +9099,24 @@
 	dir = 8
 	},
 /area/station/hallway/primary/north)
-"awp" = (
-/obj/machinery/door/airlock/pyro/glass,
-/obj/firedoor_spawn,
-/turf/simulated/floor/neutral/side{
-	dir = 4
-	},
+"awr" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
 /area/station/hallway/primary/north)
-"awq" = (
+"aws" = (
 /obj/stool,
 /obj/decal/boxingrope{
 	dir = 8
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
-"awr" = (
-/turf/simulated/floor/specialroom/gym,
-/area/station/crew_quarters/fitness)
-"aws" = (
+"awu" = (
 /obj/decal/boxingrope{
 	dir = 4
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
-"awt" = (
-/obj/decal/tile_edge/line/black{
-	dir = 8;
-	icon_state = "line1"
-	},
-/turf/simulated/floor/specialroom/gym/alt,
-/area/station/crew_quarters/fitness)
-"awu" = (
-/turf/simulated/floor/specialroom/gym/alt,
-/area/station/crew_quarters/fitness)
-"awv" = (
+"awx" = (
 /obj/decal/tile_edge/line/black{
 	dir = 4;
 	icon_state = "line1"
@@ -9623,55 +9124,37 @@
 /obj/fitness/weightlifter,
 /turf/simulated/floor/specialroom/gym/alt,
 /area/station/crew_quarters/fitness)
-"aww" = (
-/obj/fitness/speedbag/syndie,
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/fitness)
-"awx" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "awy" = (
 /obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"awz" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/ai)
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
 "awA" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "1-10"
 	},
-/turf/simulated/floor/circuit,
-/area/station/turret_protected/ai)
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
 "awB" = (
-/obj/machinery/turret,
+/obj/machinery/door/airlock/pyro/command{
+	dir = 4;
+	name = "Silicon Recharge Bay"
+	},
+/obj/access_spawn/ai_upload,
 /turf/simulated/floor/darkblue,
 /area/station/turret_protected/ai)
 "awC" = (
-/obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/decal/tile_edge/line/white{
-	dir = 1;
-	icon_state = "line3"
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
 	},
-/obj/decal/tile_edge/line/white{
-	dir = 8;
-	icon_state = "line1"
-	},
-/turf/simulated/floor/darkblue,
+/turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "awD" = (
 /obj/machinery/computer/mining_shuttle,
@@ -9940,36 +9423,84 @@
 	},
 /area/station/engine/power)
 "axe" = (
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/obj/machinery/computer/supplycomp{
+	dir = 8
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/ai)
+"axf" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/engine,
+/area/station/turret_protected/ai)
+"axg" = (
 /obj/table/auto,
-/obj/item/sheet/steel/reinforced{
+/obj/item/rods/steel{
 	amount = 50
 	},
-/obj/item/sheet/steel/reinforced{
+/obj/item/rods/steel{
 	amount = 50
 	},
-/obj/item/clothing/ears/earmuffs,
-/obj/item/clothing/ears/earmuffs,
-/obj/item/clothing/ears/earmuffs,
-/obj/item/chem_grenade/metalfoam,
+/obj/item/reagent_containers/food/drinks/fueltank,
+/obj/item/reagent_containers/food/drinks/fueltank,
+/obj/item/reagent_containers/food/drinks/fueltank,
+/obj/item/reagent_containers/food/drinks/fueltank,
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/item/clothing/suit/hi_vis,
+/obj/item/clothing/suit/hi_vis,
 /turf/simulated/floor/black,
 /area/station/engine/storage)
-"axf" = (
+"axh" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
+"axi" = (
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
 /area/station/engine/storage)
-"axg" = (
-/turf/simulated/floor/yellow/side{
-	dir = 4
-	},
-/area/station/engine/storage)
-"axh" = (
+"axk" = (
 /obj/machinery/light_switch/east,
 /obj/machinery/shieldgenerator/energy_shield,
 /turf/simulated/floor/black,
 /area/station/engine/storage)
-"axi" = (
+"axl" = (
+/obj/disposalpipe/segment/vertical,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
+"axm" = (
 /obj/machinery/light{
 	dir = 8;
 	layer = 9.1;
@@ -9979,14 +9510,14 @@
 	dir = 8
 	},
 /area/station/engine/engineering)
-"axj" = (
+"axn" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
-"axk" = (
+"axo" = (
 /obj/stool/chair/yellow{
 	dir = 4
 	},
@@ -9995,17 +9526,12 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
-"axl" = (
-/obj/table/auto,
-/obj/machinery/phone,
-/turf/simulated/floor,
-/area/station/engine/engineering)
-"axm" = (
+"axp" = (
 /obj/table/auto,
 /obj/machinery/recharger,
 /turf/simulated/floor,
 /area/station/engine/engineering)
-"axn" = (
+"axq" = (
 /obj/stool/chair/yellow{
 	dir = 8
 	},
@@ -10014,13 +9540,19 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
-"axo" = (
+"axr" = (
 /obj/reagent_dispensers/watertank/fountain,
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
 /area/station/engine/engineering)
-"axp" = (
+"axs" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
+"axt" = (
 /obj/table/auto,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/storage/toolbox/mechanical,
@@ -10035,25 +9567,7 @@
 	dir = 9
 	},
 /area/station/engine/elect)
-"axq" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 1
-	},
-/area/station/engine/elect)
-"axr" = (
+"axu" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 8;
@@ -10063,64 +9577,42 @@
 	dir = 1
 	},
 /area/station/engine/elect)
-"axs" = (
+"axv" = (
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
 /area/station/engine/elect)
-"axt" = (
-/obj/machinery/manufacturer/mechanic,
-/turf/simulated/floor/yellow/side{
-	dir = 5
-	},
-/area/station/engine/elect)
-"axu" = (
-/obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/floor/yellow/side{
-	dir = 8
-	},
-/area/station/hallway/primary/north)
-"axv" = (
+"axz" = (
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
+"axB" = (
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
 	pixel_y = 21
 	},
-/obj/stool/chair,
+/obj/machinery/light_switch/north,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
-"axw" = (
-/obj/decal/boxingrope{
-	dir = 8
+"axC" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
 	},
-/turf/simulated/floor/specialroom/gym,
+/obj/machinery/firealarm{
+	pixel_x = 6;
+	pixel_y = 24
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
+"axD" = (
+/obj/decal/poster/wallsign/gym,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/fitness)
-"axx" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/machinery/light/small/floor,
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/fitness)
-"axy" = (
-/obj/decal/tile_edge/line/black{
-	dir = 8;
-	icon_state = "line1"
-	},
-/obj/landmark/gps_waypoint,
-/turf/simulated/floor/specialroom/gym/alt,
-/area/station/crew_quarters/fitness)
-"axz" = (
-/obj/decal/tile_edge/line/black{
-	dir = 4;
-	icon_state = "line1"
-	},
-/turf/simulated/floor/specialroom/gym/alt,
-/area/station/crew_quarters/fitness)
-"axA" = (
+"axE" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -10133,117 +9625,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"axB" = (
-/obj/disposalpipe/segment/vertical,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"axC" = (
-/obj/machinery/door/airlock/pyro/command{
-	dir = 4;
-	name = "AI Core"
-	},
-/obj/access_spawn/ai_upload,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"axF" = (
+/obj/machinery/door/unpowered/wood/pyro{
+	dir = 1;
+	name = "Chiron's Grandhall"
 	},
 /obj/firedoor_spawn,
-/turf/simulated/floor/black,
-/area/station/turret_protected/ai)
-"axD" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/landmark/gps_waypoint,
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/ai)
-"axE" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/turretid{
-	pixel_x = 24;
-	req_access_txt = "19"
-	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/ai)
-"axF" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/decal/tile_edge/line/white{
-	dir = 10;
-	icon_state = "line4"
-	},
-/obj/decal/tile_edge/line/white{
-	dir = 9;
-	icon_state = "line1"
-	},
-/turf/simulated/floor/darkblue,
-/area/station/turret_protected/ai)
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/arcade/dungeon)
 "axG" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 10;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/circuit,
-/area/station/turret_protected/ai)
-"axH" = (
-/obj/machinery/computer3/generic/secure_data{
-	dir = 8
-	},
 /obj/machinery/light,
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable,
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/circuit,
-/area/station/turret_protected/ai)
-"axI" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
+	d1 = 1;
 	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/engine,
+/turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "axJ" = (
 /turf/simulated/wall/auto/supernorn,
@@ -10431,6 +9829,46 @@
 	},
 /area/station/engine/power)
 "ayf" = (
+/obj/machinery/door/unpowered/wood/pyro{
+	dir = 1;
+	name = "Chiron's Grandhall"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/arcade/dungeon)
+"ayg" = (
+/obj/decal/tile_edge/line/white{
+	dir = 9;
+	icon_state = "line4"
+	},
+/obj/decal/tile_edge/line/white{
+	dir = 8;
+	icon_state = "line1"
+	},
+/obj/decal/tile_edge/line/white{
+	dir = 6;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/darkblue,
+/area/station/turret_protected/ai)
+"ayh" = (
+/obj/decal/tile_edge/line/white{
+	dir = 6;
+	icon_state = "line4"
+	},
+/obj/decal/tile_edge/line/white{
+	icon_state = "line1"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/darkblue,
+/area/station/turret_protected/ai)
+"ayi" = (
 /obj/table/auto,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/device/t_scanner,
@@ -10446,14 +9884,14 @@
 /obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/black,
 /area/station/engine/storage)
-"ayg" = (
+"ayk" = (
 /obj/table/auto,
 /obj/item/storage/toolbox/electrical,
 /obj/item/clothing/gloves/yellow,
 /obj/item/device/multitool,
 /turf/simulated/floor/black,
 /area/station/engine/storage)
-"ayh" = (
+"ayl" = (
 /obj/disposalpipe/segment/bent/north,
 /obj/cable{
 	icon_state = "2-4"
@@ -10462,7 +9900,7 @@
 	dir = 8
 	},
 /area/station/engine/storage)
-"ayi" = (
+"aym" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
 	icon_state = "4-8"
@@ -10471,14 +9909,14 @@
 	dir = 4
 	},
 /area/station/engine/storage)
-"ayj" = (
+"ayn" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/storage)
-"ayk" = (
+"ayo" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
@@ -10491,16 +9929,7 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/yellow,
 /area/station/engine/storage)
-"ayl" = (
-/obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 8
-	},
-/area/station/engine/engineering)
-"aym" = (
+"ayp" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
@@ -10515,11 +9944,11 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
-"ayn" = (
+"ayq" = (
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor,
 /area/station/engine/engineering)
-"ayo" = (
+"ayr" = (
 /obj/stool/chair/yellow{
 	dir = 1
 	},
@@ -10529,16 +9958,16 @@
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor,
 /area/station/engine/engineering)
-"ayp" = (
+"ays" = (
 /obj/disposalpipe/segment/bent/south,
 /turf/simulated/floor,
 /area/station/engine/engineering)
-"ayq" = (
+"ayt" = (
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
 /area/station/engine/engineering)
-"ayr" = (
+"ayu" = (
 /obj/table/auto,
 /obj/item/storage/belt/utility,
 /obj/item/storage/belt/utility,
@@ -10553,116 +9982,59 @@
 	dir = 8
 	},
 /area/station/engine/elect)
-"ays" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/engine/elect)
-"ayt" = (
-/turf/simulated/floor,
-/area/station/engine/elect)
-"ayu" = (
-/obj/stool/chair/yellow{
-	dir = 4
-	},
-/obj/landmark/start{
-	name = "Mechanic"
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 4
-	},
-/area/station/engine/elect)
 "ayv" = (
 /obj/table/wood/auto,
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/crew_quarters/radio/news_office)
 "ayw" = (
-/obj/stool,
 /obj/decal/boxingrope{
-	dir = 4
+	dir = 8
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "ayx" = (
-/obj/decal/tile_edge/line/black{
-	dir = 4;
-	icon_state = "line1"
+/obj/machinery/computer/bank_data{
+	dir = 8
 	},
-/obj/fitness/stacklifter,
-/turf/simulated/floor/specialroom/gym/alt,
-/area/station/crew_quarters/fitness)
-"ayy" = (
-/obj/shrub{
-	dir = 4;
-	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "plant"
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/fitness)
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/ai)
 "ayz" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/cable,
+/turf/simulated/floor/engine,
+/area/station/turret_protected/ai)
 "ayA" = (
+/turf/simulated/floor/stairs/wide/middle{
+	dir = 4
+	},
+/area/station/hallway/primary/north)
+"ayC" = (
+/obj/decal/cleanable/dirt,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/stairs/dark/wide{
-	dir = 10
-	},
-/area/station/turret_protected/ai)
-"ayB" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
-/turf/simulated/floor/stairs/dark/wide{
-	dir = 1
-	},
-/area/station/turret_protected/ai)
-"ayC" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/engine,
-/area/station/turret_protected/ai)
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
 "ayD" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable,
+/obj/disposalpipe/segment/vertical,
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
+	d1 = 1;
 	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/engine,
-/area/station/turret_protected/ai)
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "ayF" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -10676,21 +10048,37 @@
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai)
 "ayG" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable,
 /obj/cable{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/engine,
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/decal/tile_edge/line/white{
+	dir = 10;
+	icon_state = "line4"
+	},
+/obj/decal/tile_edge/line/white{
+	dir = 9;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/darkblue,
 /area/station/turret_protected/ai)
 "ayH" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/door/airlock/pyro/engineering{
+	dir = 4;
+	name = "Solar Control"
 	},
-/obj/machinery/power/solar_control/east{
-	dir = 8
+/obj/access_spawn/engineering_power,
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/east)
@@ -10923,34 +10311,47 @@
 	},
 /area/station/engine/power)
 "aze" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
+"azf" = (
+/obj/disposalpipe/segment/mail/vertical,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
+"azg" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
+"azh" = (
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
+"azi" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/storage)
-"azf" = (
-/obj/table/auto,
-/obj/item/rods/steel{
-	amount = 50
-	},
-/obj/item/rods/steel{
-	amount = 50
-	},
-/obj/item/reagent_containers/food/drinks/fueltank,
-/obj/item/reagent_containers/food/drinks/fueltank,
-/obj/item/reagent_containers/food/drinks/fueltank,
-/obj/item/reagent_containers/food/drinks/fueltank,
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/item/clothing/suit/hi_vis,
-/obj/item/clothing/suit/hi_vis,
-/turf/simulated/floor/black,
-/area/station/engine/storage)
-"azg" = (
+"azj" = (
 /obj/stool/chair/yellow{
 	dir = 8
 	},
@@ -10964,18 +10365,7 @@
 	dir = 9
 	},
 /area/station/engine/storage)
-"azh" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 1
-	},
-/area/station/engine/storage)
-"azi" = (
+"azk" = (
 /obj/cable{
 	icon_state = "1-8"
 	},
@@ -10983,7 +10373,7 @@
 	dir = 1
 	},
 /area/station/engine/storage)
-"azj" = (
+"azm" = (
 /obj/item/sheet/steel{
 	amount = 50
 	},
@@ -11009,7 +10399,20 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/storage)
-"azk" = (
+"azn" = (
+/obj/stool/chair/couch{
+	dir = 8;
+	icon_state = "chair_couch-blue";
+	name = "ratty blue couch"
+	},
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
+"azo" = (
 /obj/machinery/computer/general_alert{
 	dir = 4
 	},
@@ -11023,7 +10426,7 @@
 	dir = 8
 	},
 /area/station/engine/engineering)
-"azl" = (
+"azp" = (
 /obj/disposalpipe/segment/mail/bent/north,
 /obj/cable{
 	d1 = 1;
@@ -11043,7 +10446,7 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
-"azm" = (
+"azq" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/cable{
 	d1 = 4;
@@ -11052,7 +10455,7 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
-"azn" = (
+"azr" = (
 /obj/disposalpipe/segment/mail/bent/south,
 /obj/cable{
 	d1 = 4;
@@ -11061,7 +10464,7 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
-"azo" = (
+"azs" = (
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -11069,7 +10472,7 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
-"azp" = (
+"azt" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
 	d1 = 4;
@@ -11083,7 +10486,7 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
-"azq" = (
+"azu" = (
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -11093,7 +10496,7 @@
 	dir = 4
 	},
 /area/station/engine/engineering)
-"azr" = (
+"azv" = (
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
 	name = "Mechanic's Lab";
@@ -11108,42 +10511,6 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
-"azs" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 8
-	},
-/area/station/engine/elect)
-"azt" = (
-/obj/decal/tile_edge/line/yellow{
-	dir = 6;
-	icon_state = "line1"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor,
-/area/station/engine/elect)
-"azu" = (
-/obj/decal/tile_edge/line/yellow{
-	icon_state = "line1"
-	},
-/obj/landmark/gps_waypoint,
-/turf/simulated/floor,
-/area/station/engine/elect)
-"azv" = (
-/obj/decal/tile_edge/line/yellow{
-	dir = 10;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/engine/elect)
 "azw" = (
 /obj/machinery/light{
 	dir = 1;
@@ -11155,14 +10522,23 @@
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/crew_quarters/radio/news_office)
 "azx" = (
-/obj/disposalpipe/segment/bent/east,
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/fitness)
-"azy" = (
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/wood,
+/obj/decal/tile_edge/line/black{
+	dir = 8;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/specialroom/gym/alt,
 /area/station/crew_quarters/fitness)
 "azz" = (
+/turf/simulated/floor/specialroom/gym/alt,
+/area/station/crew_quarters/fitness)
+"azA" = (
+/obj/decal/tile_edge/line/black{
+	dir = 4;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/specialroom/gym/alt,
+/area/station/crew_quarters/fitness)
+"azC" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
@@ -11170,7 +10546,7 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
-"azA" = (
+"azD" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
 	d1 = 1;
@@ -11179,54 +10555,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"azB" = (
-/obj/disposalpipe/junction/right/north,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 9;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
+"azE" = (
+/obj/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"azC" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/obj/machinery/computer3/terminal/zeta{
-	dir = 4
-	},
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/darkblue,
-/area/station/turret_protected/ai)
-"azD" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/turf/simulated/floor/darkblue,
-/area/station/turret_protected/ai)
-"azE" = (
-/obj/grille/catwalk{
-	dir = 9;
-	icon_state = "catwalk_cross"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 9
-	},
-/area/station/solar/east)
+/area/station/maintenance/solar/east)
 "azF" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -11400,34 +10734,50 @@
 /turf/space,
 /area/space)
 "aAa" = (
-/obj/rack,
-/obj/item/clothing/suit/space/engineer,
-/obj/item/clothing/shoes/magnetic,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/head/helmet/space/engineer,
-/obj/item/tank/air,
-/obj/item/device/light/flashlight,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/belt/utility,
-/turf/simulated/floor/black,
-/area/station/engine/storage)
+/obj/reagent_dispensers/watertank/fountain,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
 "aAb" = (
+/obj/decal/poster/wallsign/space,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hangar/engine)
+"aAc" = (
+/obj/decal/cleanable/dirt,
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
+"aAd" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/storage)
+"aAe" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
 /area/station/engine/storage)
-"aAc" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"aAf" = (
+/turf/simulated/floor,
+/area/station/engine/storage)
+"aAg" = (
+/turf/simulated/floor/yellow/side{
+	dir = 4
 	},
-/turf/simulated/floor,
 /area/station/engine/storage)
-"aAd" = (
-/turf/simulated/floor,
-/area/station/engine/storage)
-"aAe" = (
+"aAh" = (
 /obj/storage/secure/closet/engineering/engineer,
 /obj/machinery/light{
 	dir = 4;
@@ -11436,7 +10786,21 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/storage)
-"aAf" = (
+"aAi" = (
+/obj/machinery/door/poddoor{
+	id = "ai_core";
+	name = "AI Core Shield"
+	},
+/obj/machinery/door/airlock/pyro/glass/command{
+	name = "AI Core"
+	},
+/obj/access_spawn/ai_upload,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/ai)
+"aAj" = (
 /obj/table/auto,
 /obj/machinery/networked/printer{
 	name = "Printer - Engineering";
@@ -11455,7 +10819,7 @@
 	dir = 10
 	},
 /area/station/engine/engineering)
-"aAg" = (
+"aAk" = (
 /obj/machinery/computer3/terminal/zeta{
 	setup_os_string = "ZETA_MAINFRAME"
 	},
@@ -11471,7 +10835,7 @@
 	},
 /turf/simulated/floor/yellow/side,
 /area/station/engine/engineering)
-"aAh" = (
+"aAl" = (
 /obj/machinery/power/monitor{
 	name = "Station Power Grid Monitoring"
 	},
@@ -11482,24 +10846,13 @@
 	},
 /turf/simulated/floor/yellow/side,
 /area/station/engine/engineering)
-"aAi" = (
-/obj/machinery/disposal/mail/autoname/engineering,
-/obj/disposalpipe/trunk/mail/north,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 10;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/yellow/side,
-/area/station/engine/engineering)
-"aAj" = (
+"aAm" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/east,
 /obj/machinery/light,
 /turf/simulated/floor/yellow/side,
 /area/station/engine/engineering)
-"aAk" = (
+"aAn" = (
 /obj/disposalpipe/junction/right/north,
 /obj/cable{
 	d1 = 1;
@@ -11508,7 +10861,7 @@
 	},
 /turf/simulated/floor/yellow/side,
 /area/station/engine/engineering)
-"aAl" = (
+"aAo" = (
 /obj/table/auto,
 /obj/machinery/cell_charger,
 /obj/item/cell/supercell/charged,
@@ -11518,7 +10871,13 @@
 	dir = 6
 	},
 /area/station/engine/engineering)
-"aAm" = (
+"aAp" = (
+/obj/decal/tile_edge/line/white{
+	icon_state = "line3"
+	},
+/turf/simulated/floor/darkblue,
+/area/station/turret_protected/ai)
+"aAq" = (
 /obj/table/auto,
 /obj/item/clothing/gloves/yellow,
 /obj/item/clothing/gloves/yellow,
@@ -11533,32 +10892,23 @@
 	dir = 8
 	},
 /area/station/engine/elect)
-"aAn" = (
-/obj/decal/tile_edge/line/yellow{
-	dir = 4;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/engine/elect)
-"aAo" = (
-/obj/submachine/cargopad/mechanics,
-/turf/simulated/floor/black,
-/area/station/engine/elect)
-"aAp" = (
-/obj/decal/tile_edge/line/yellow{
-	dir = 8;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/engine/elect)
-"aAq" = (
+"aAr" = (
 /obj/machinery/disposal/mail/autoname/mechanics,
 /obj/disposalpipe/trunk/mail/south,
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
 /area/station/engine/elect)
-"aAr" = (
+"aAs" = (
+/obj/disposalpipe/segment/mail/vertical,
+/turf/simulated/floor/yellow/side{
+	dir = 8
+	},
+/area/station/hallway/primary/north)
+"aAt" = (
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/ai)
+"aAu" = (
 /obj/machinery/navbeacon{
 	codes_txt = "tour;next_tour=tour17;desc=If doing a lap around the station isn't hitting the spot, make sure to try out the gymnasium facilities. On my left, there's also a mechanics' workshop and the rest of Engineering.";
 	freq = 1443;
@@ -11573,7 +10923,7 @@
 	dir = 4
 	},
 /area/station/hallway/primary/north)
-"aAs" = (
+"aAw" = (
 /obj/loudspeaker,
 /obj/machinery/light{
 	dir = 8;
@@ -11582,78 +10932,39 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
-"aAt" = (
-/obj/table/reinforced/auto,
-/obj/item/storage/firstaid/brute,
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/fitness)
-"aAu" = (
-/obj/machinery/camera/television{
-	c_tag = "boxing";
-	dir = 1;
-	name = "camera - boxing"
-	},
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/fitness)
-"aAv" = (
+"aAx" = (
 /turf/simulated/floor/stairs,
 /area/station/crew_quarters/fitness)
-"aAw" = (
+"aAy" = (
 /obj/table/reinforced/auto,
 /obj/item/wrestlingbell,
 /obj/item/device/microphone,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
-"aAx" = (
+"aAz" = (
+/obj/disposalpipe/segment/mail/bent/east,
+/turf/simulated/floor/grey,
+/area/station/hallway/primary/north)
+"aAA" = (
 /obj/decal/tile_edge/line/black{
 	dir = 10;
 	icon_state = "line2"
 	},
 /turf/simulated/floor/specialroom/gym/alt,
 /area/station/crew_quarters/fitness)
-"aAy" = (
+"aAB" = (
 /obj/decal/tile_edge/line/black{
 	icon_state = "line1"
 	},
 /turf/simulated/floor/specialroom/gym/alt,
 /area/station/crew_quarters/fitness)
-"aAz" = (
-/obj/decal/tile_edge/line/black{
-	dir = 6;
-	icon_state = "line2"
-	},
-/obj/fitness/weightlifter,
-/turf/simulated/floor/specialroom/gym/alt,
-/area/station/crew_quarters/fitness)
-"aAA" = (
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/fitness)
-"aAB" = (
-/obj/machinery/vending/snack,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/fitness)
 "aAC" = (
-/obj/table/auto,
-/obj/machinery/networked/printer{
-	name = "Printer - AI";
-	pixel_y = 5;
-	print_id = "AI"
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/machinery/light/emergency,
+/turf/simulated/floor/stairs/wide/other{
+	dir = 4
 	},
-/obj/cable,
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/darkblue,
-/area/station/turret_protected/ai)
-"aAD" = (
-/obj/table/auto,
-/obj/item/paper/book/dwainedummies,
-/turf/simulated/floor/darkblue,
-/area/station/turret_protected/ai)
+/area/station/hallway/primary/north)
 "aAE" = (
 /obj/decal/poster/wallsign/medbay_left,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -11662,7 +10973,10 @@
 /turf/simulated/floor/grime,
 /area/station/maintenance/disposal)
 "aAG" = (
-/obj/decal/poster/wallsign/medbay_left,
+/obj/disposalpipe/segment/morgue{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/crematorium)
 "aAH" = (
@@ -11941,18 +11255,20 @@
 	},
 /turf/space,
 /area/space)
-"aBk" = (
-/obj/storage/secure/closet/engineering/engineer,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/simulated/floor/black,
-/area/station/engine/storage)
 "aBl" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/firedoor_spawn,
+/turf/simulated/floor/yellow/corner,
+/area/station/hallway/primary/north)
+"aBm" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/machinery/light,
+/turf/simulated/floor/yellow/side,
+/area/station/hallway/primary/north)
+"aBn" = (
 /obj/machinery/door/airlock/pyro/engineering,
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -11964,7 +11280,30 @@
 /obj/access_spawn/engineering_power,
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
-"aBm" = (
+"aBo" = (
+/obj/disposalpipe/switch_junction/left/east{
+	mail_tag = "engineering";
+	name = "engineering mail junction"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/yellow/side,
+/area/station/hallway/primary/north)
+"aBp" = (
+/obj/disposalpipe/switch_junction/right/east{
+	mail_tag = "chapel";
+	name = "chapel mail junction"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor/yellow/side,
+/area/station/hallway/primary/north)
+"aBq" = (
 /obj/machinery/vending/mechanics,
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -11981,34 +11320,21 @@
 	dir = 8
 	},
 /area/station/engine/elect)
-"aBn" = (
+"aBr" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 5;
 	icon_state = "line1"
 	},
 /turf/simulated/floor,
 /area/station/engine/elect)
-"aBo" = (
+"aBs" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 1;
 	icon_state = "line1"
 	},
 /turf/simulated/floor,
 /area/station/engine/elect)
-"aBp" = (
-/obj/decal/tile_edge/line/yellow{
-	dir = 9;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/engine/elect)
-"aBq" = (
-/obj/disposalpipe/segment/mail/bent/north,
-/turf/simulated/floor/yellow/side{
-	dir = 4
-	},
-/area/station/engine/elect)
-"aBr" = (
+"aBt" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
@@ -12019,48 +11345,50 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
-"aBs" = (
-/obj/disposalpipe/switch_junction/left/south{
-	mail_tag = "mechanics";
-	name = "mechanics mail junction"
-	},
-/obj/decal/garland/ephemeral{
-	dir = 4;
-	pixel_x = -14
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 8
-	},
-/area/station/hallway/primary/north)
-"aBt" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4;
-	name = "Fitness Room"
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor,
-/area/station/crew_quarters/fitness)
 "aBu" = (
-/obj/machinery/light,
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/fitness)
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/machinery/light/emergency,
+/turf/simulated/floor/yellow/side,
+/area/station/hallway/primary/north)
 "aBv" = (
-/obj/disposalpipe/segment/horizontal,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 10;
-	name = "autoname - SS13";
-	tag = ""
+/obj/table/reinforced/auto,
+/obj/item/clothing/head/helmet/men{
+	pixel_x = -6;
+	pixel_y = 7
+	},
+/obj/item/clothing/head/helmet/men{
+	pixel_x = -6;
+	pixel_y = 7
+	},
+/obj/item/clothing/suit/armor/douandtare{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/obj/item/clothing/suit/armor/douandtare{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/obj/item/clothing/gloves/kote{
+	pixel_x = -1
+	},
+/obj/item/clothing/gloves/kote{
+	pixel_x = -1
+	},
+/obj/item/shinai_bag,
+/obj/item/storage/box/kendo_box/hakama,
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "aBw" = (
-/obj/disposalpipe/segment/bent/west,
+/obj/disposalpipe/segment/bent/east,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "aBx" = (
-/obj/machinery/vending/cola/red,
+/obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "aBy" = (
@@ -12358,13 +11686,41 @@
 /turf/simulated/floor/plating,
 /area/station/engine/coldloop)
 "aCg" = (
-/obj/decal/poster/wallsign/space,
+/obj/machinery/r_door_control/podbay/engineering,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/engine)
 "aCh" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/engine)
 "aCi" = (
+/turf/simulated/floor/stairs{
+	dir = 1
+	},
+/area/station/crew_quarters/fitness)
+"aCj" = (
+/obj/fitness/speedbag/clown,
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
+"aCk" = (
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/item/device/radio/intercom/AI,
+/turf/simulated/floor/darkblue,
+/area/station/turret_protected/ai)
+"aCl" = (
 /obj/rack,
 /obj/item/clothing/suit/space/engineer,
 /obj/item/clothing/shoes/magnetic,
@@ -12381,23 +11737,20 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/storage)
-"aCj" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"aCm" = (
+/turf/simulated/floor/yellow/side{
+	dir = 8
 	},
-/turf/simulated/floor/yellow/corner,
 /area/station/engine/storage)
-"aCk" = (
+"aCn" = (
 /turf/simulated/floor/yellow/side,
 /area/station/engine/storage)
-"aCl" = (
+"aCo" = (
 /turf/simulated/floor/yellow/side{
 	dir = 6
 	},
 /area/station/engine/storage)
-"aCm" = (
+"aCp" = (
 /obj/storage/secure/closet/engineering/engineer,
 /obj/machinery/alarm{
 	dir = 8;
@@ -12405,41 +11758,61 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/storage)
-"aCn" = (
-/obj/machinery/computer/security/wooden_tv{
-	desc = "These channels seem to mostly be about robuddies. What is this, some kind of reality show?";
-	name = "Television";
-	network = "Zeta"
+"aCq" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/black/grime,
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/decal/tile_edge/line/white{
+	dir = 5;
+	icon_state = "line1"
+	},
+/obj/decal/tile_edge/line/white{
+	dir = 6;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/darkblue,
+/area/station/turret_protected/ai)
+"aCr" = (
+/turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/inner/central)
-"aCo" = (
+"aCs" = (
 /obj/stool/chair/couch{
 	dir = 8
 	},
 /turf/simulated/floor/black/grime,
 /area/station/maintenance/inner/central)
-"aCp" = (
-/obj/stool/chair/couch{
-	dir = 4
+"aCt" = (
+/turf/simulated/floor/stairs/dark{
+	dir = 1
 	},
-/turf/simulated/floor/black/grime,
 /area/station/maintenance/inner/central)
-"aCq" = (
-/obj/table/wood/auto,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
-/obj/item/dice,
-/obj/machinery/light/small/warm/very{
-	dir = 4;
-	pixel_x = 12
+"aCu" = (
+/obj/machinery/power/data_terminal,
+/obj/landmark/start{
+	name = "AI"
 	},
-/turf/simulated/floor/black/grime,
-/area/station/maintenance/inner/central)
-"aCr" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/inner/central)
-"aCs" = (
+/obj/landmark{
+	name = "AI-Sat"
+	},
+/obj/cable,
+/obj/item/device/radio/intercom/AI{
+	broadcasting = 0;
+	dir = 8;
+	layer = 5
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13"
+	},
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/ai)
+"aCv" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
 	d1 = 1;
@@ -12448,36 +11821,30 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
-"aCt" = (
+"aCw" = (
+/obj/storage/closet/wardrobe/yellow,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
-"aCu" = (
+"aCx" = (
+/obj/machinery/turret,
+/obj/decal/tile_edge/line/white{
+	dir = 8;
+	icon_state = "line2"
+	},
+/turf/simulated/floor/darkblue,
+/area/station/turret_protected/ai)
+"aCy" = (
 /obj/machinery/rkit,
 /obj/machinery/light_switch/west,
 /turf/simulated/floor/yellow/side{
 	dir = 10
 	},
 /area/station/engine/elect)
-"aCv" = (
-/obj/machinery/manufacturer/mechanic,
-/turf/simulated/floor/yellow/side,
-/area/station/engine/elect)
-"aCw" = (
+"aCz" = (
 /obj/machinery/portable_reclaimer,
 /turf/simulated/floor/yellow/side,
 /area/station/engine/elect)
-"aCx" = (
-/obj/storage/secure/closet/engineering/mechanic,
-/obj/machinery/light,
-/turf/simulated/floor/yellow/side,
-/area/station/engine/elect)
-"aCy" = (
-/obj/storage/secure/closet/engineering/mechanic,
-/turf/simulated/floor/yellow/side{
-	dir = 6
-	},
-/area/station/engine/elect)
-"aCz" = (
+"aCA" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/machinery/light{
 	dir = 8;
@@ -12488,20 +11855,19 @@
 	dir = 8
 	},
 /area/station/hallway/primary/north)
-"aCA" = (
+"aCB" = (
+/obj/landmark/halloween,
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
+"aCC" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/fitness)
+"aCD" = (
 /obj/shrub,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
-"aCB" = (
-/obj/stool/chair{
-	dir = 1
-	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/fitness)
-"aCC" = (
+"aCE" = (
 /obj/stool/chair{
 	dir = 1
 	},
@@ -12516,32 +11882,34 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
-"aCD" = (
-/obj/stool/chair{
-	dir = 1
-	},
-/obj/machinery/light,
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/fitness)
-"aCE" = (
-/obj/machinery/disposal,
-/obj/disposalpipe/trunk/north,
-/obj/machinery/light_switch/east,
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/fitness)
 "aCF" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/pool)
 "aCG" = (
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/item/storage/toilet,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/pool)
 "aCH" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/janitor/supply)
 "aCI" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"aCK" = (
+/obj/item/reagent_containers/pill/cyberpunk,
+/obj/machinery/fluid_canister,
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"aCL" = (
 /obj/storage/closet/janitor,
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
@@ -12549,52 +11917,32 @@
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/supply)
-"aCJ" = (
-/obj/machinery/disposal,
-/obj/disposalpipe/trunk/south,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
-	},
-/turf/simulated/floor/specialroom/arcade,
-/area/station/janitor/supply)
-"aCK" = (
-/obj/rack,
-/obj/item/reagent_containers/glass/bottle/cleaner,
-/obj/item/reagent_containers/glass/bottle/cleaner,
-/obj/item/reagent_containers/glass/bottle/acetone/janitors,
-/obj/item/reagent_containers/glass/bottle/acetone/janitors,
-/obj/item/reagent_containers/glass/bottle/ammonia/janitors,
-/obj/item/reagent_containers/glass/bottle/ammonia/janitors,
-/turf/simulated/floor/specialroom/arcade,
-/area/station/janitor/supply)
-"aCL" = (
-/obj/rack,
-/obj/item/clothing/suit/space/emerg,
-/obj/item/clothing/head/emerg,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/air,
-/obj/item/device/light/flashlight,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "aCM" = (
-/obj/decal/poster/wallsign/space,
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/east)
+/obj/rack,
+/obj/item/reagent_containers/glass/bottle/cleaner,
+/obj/item/reagent_containers/glass/bottle/cleaner,
+/obj/item/reagent_containers/glass/bottle/acetone/janitors,
+/obj/item/reagent_containers/glass/bottle/acetone/janitors,
+/obj/item/reagent_containers/glass/bottle/ammonia/janitors,
+/obj/item/reagent_containers/glass/bottle/ammonia/janitors,
+/turf/simulated/floor/specialroom/arcade,
+/area/station/janitor/supply)
 "aCN" = (
-/obj/lattice,
-/obj/machinery/camera{
-	c_tag = "autotag";
+/obj/machinery/light{
 	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
+	layer = 9.1;
+	pixel_x = 10
 	},
-/turf/space,
-/area/space)
+/obj/decal/tile_edge/line/white{
+	dir = 10;
+	icon_state = "line1"
+	},
+/obj/decal/tile_edge/line/white{
+	dir = 9;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/darkblue,
+/area/station/turret_protected/ai)
 "aCO" = (
 /obj/disposalpipe/junction/left/south,
 /turf/simulated/floor/grime,
@@ -12840,13 +12188,44 @@
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/crew_quarters/radio/news_office)
 "aDm" = (
+/obj/disposalpipe/segment/mail/bent/north,
+/turf/simulated/floor/yellow/side{
+	dir = 10
+	},
+/area/station/hallway/primary/north)
+"aDn" = (
+/obj/stool/chair{
+	dir = 8
+	},
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
+"aDo" = (
+/obj/grille/catwalk{
+	dir = 9;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 9
+	},
+/area/space)
+"aDp" = (
+/obj/decal/tile_edge/line/black{
+	dir = 9;
+	icon_state = "line2"
+	},
+/turf/simulated/floor/specialroom/gym/alt,
+/area/station/crew_quarters/fitness)
+"aDq" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
 	},
 /obj/access_spawn/engineering_storage,
 /turf/simulated/floor/grey,
 /area/station/hangar/engine)
-"aDn" = (
+"aDr" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 6;
@@ -12856,62 +12235,60 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/hangar/engine)
-"aDo" = (
+"aDs" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
 	},
 /obj/access_spawn/engineering_storage,
 /turf/simulated/floor/grey,
 /area/station/engine/storage)
-"aDp" = (
+"aDt" = (
 /turf/simulated/floor/yellow,
 /area/station/engine/storage)
-"aDq" = (
+"aDu" = (
 /turf/simulated/floor/yellow/side{
 	dir = 10
 	},
 /area/station/engine/storage)
-"aDr" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 6
-	},
-/area/station/engine/storage)
-"aDs" = (
+"aDv" = (
 /obj/machinery/disposal_pipedispenser/mobile,
 /turf/simulated/floor/black,
 /area/station/engine/storage)
-"aDt" = (
+"aDw" = (
 /obj/storage/secure/closet/engineering/welding,
 /obj/machinery/light,
 /turf/simulated/floor/black,
 /area/station/engine/storage)
-"aDu" = (
+"aDx" = (
 /obj/machinery/dispenser,
 /turf/simulated/floor/black,
 /area/station/engine/storage)
-"aDv" = (
-/obj/stool/chair/comfy{
-	dir = 4
-	},
-/turf/simulated/floor/black/grime,
-/area/station/maintenance/inner/central)
-"aDw" = (
+"aDy" = (
+/obj/fitness/speedbag/wizard,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
+"aDz" = (
 /turf/simulated/floor/carpet/red/fancy/narrow/nw,
 /area/station/maintenance/inner/central)
-"aDx" = (
+"aDA" = (
 /turf/simulated/floor/carpet/red/fancy/edge/north,
 /area/station/maintenance/inner/central)
-"aDy" = (
-/obj/item/instrument/large/jukebox,
-/turf/simulated/floor/carpet/red/fancy/narrow/ne,
-/area/station/maintenance/inner/central)
-"aDz" = (
+"aDB" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/engine/elect)
+"aDC" = (
+/obj/machinery/door/airlock/pyro/maintenance,
 /obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
+"aDD" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/stairs/dark,
+/area/station/turret_protected/ai)
+"aDE" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -12924,98 +12301,61 @@
 	pixel_x = -10;
 	tag = ""
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
-"aDA" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/ai)
+"aDF" = (
+/obj/machinery/door_control{
+	id = "ai_core";
+	name = "AI Core Shield";
+	pixel_y = 6
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
-"aDB" = (
-/obj/disposalpipe/segment/mail/vertical,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/turret_protected/ai)
+"aDG" = (
+/obj/table/auto,
+/obj/item/sheet/steel{
+	amount = 50
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+/obj/item/sheet/steel{
+	amount = 50
 	},
-/turf/simulated/floor/yellow/corner{
+/obj/item/sheet/glass/reinforced{
+	amount = 50
+	},
+/obj/item/sheet/glass{
+	amount = 50
+	},
+/obj/item/storage/box/cablesbox,
+/obj/item/device/radio/intercom/engineering{
+	dir = 4
+	},
+/turf/simulated/floor/black,
+/area/station/engine/storage)
+"aDH" = (
+/obj/table/auto,
+/obj/item/device/analyzer/atmosanalyzer_upgrade{
+	pixel_x = 13;
+	pixel_y = 3;
+	rand_pos = 0
+	},
+/obj/item/device/radio,
+/obj/item/clothing/ears/earmuffs,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/yellow/side{
 	dir = 1
 	},
-/area/station/hallway/primary/north)
-"aDC" = (
-/obj/machinery/power/apc/autoname_east,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/neutral/side{
-	dir = 4
-	},
-/area/station/hallway/primary/north)
-"aDD" = (
-/obj/machinery/door/airlock/pyro{
-	name = "Shower Room"
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/pool)
-"aDE" = (
-/obj/item/storage/toilet,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/pool)
-"aDF" = (
-/obj/table/auto,
-/obj/item/device/analyzer/atmospheric,
-/obj/item/wrench,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"aDG" = (
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"aDH" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "1-6"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/engine/engineering)
 "aDI" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
-/obj/stool/chair{
-	dir = 4
-	},
 /obj/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "1-6"
 	},
-/obj/landmark/start{
-	name = "Janitor"
-	},
-/turf/simulated/floor/specialroom/arcade,
-/area/station/janitor/supply)
-"aDJ" = (
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/specialroom/arcade,
-/area/station/janitor/supply)
-"aDK" = (
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"aDL" = (
 /obj/item/storage/toolbox/emergency,
 /obj/item/storage/box/mousetraps,
 /obj/item/sponge,
@@ -13032,12 +12372,6 @@
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/supply)
-"aDL" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "aDM" = (
 /obj/submachine/mixing_desk,
 /obj/table/wood/auto,
@@ -13067,10 +12401,17 @@
 /turf/simulated/floor/black/grime,
 /area/station/maintenance/disposal)
 "aDP" = (
-/obj/item/reagent_containers/pill/cyberpunk,
-/obj/machinery/fluid_canister,
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/engine/elect)
 "aDQ" = (
 /turf/simulated/floor,
 /area/station/maintenance/disposal)
@@ -13330,37 +12671,75 @@
 	},
 /area/station/mining/refinery)
 "aEr" = (
+/obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/hallway/primary/north)
+"aEs" = (
 /obj/machinery/door/airlock/pyro/external,
 /obj/access_spawn/engineering_storage,
 /turf/simulated/floor/grey,
 /area/station/hangar/engine)
-"aEs" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	name = "Engineering Hangar"
-	},
-/obj/access_spawn/engineering_storage,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/yellow,
-/area/station/engine/storage)
 "aEt" = (
-/turf/simulated/floor/carpet/red/fancy/edge/west,
-/area/station/maintenance/inner/central)
+/obj/fitness/speedbag/syndie,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
 "aEu" = (
-/obj/critter/boogiebot,
-/turf/simulated/floor/carpet/red/fancy/innercorner/north,
-/area/station/maintenance/inner/central)
-"aEv" = (
-/obj/stool/chair/comfy{
-	dir = 8
+/obj/shrub{
+	dir = 4;
+	icon = 'icons/obj/stationobjs.dmi';
+	icon_state = "plant"
 	},
-/turf/simulated/floor/carpet/red/fancy/edge/east,
-/area/station/maintenance/inner/central)
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"aEv" = (
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/decal/tile_edge/line/white{
+	dir = 1;
+	icon_state = "line3"
+	},
+/obj/decal/tile_edge/line/white{
+	dir = 8;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/darkblue,
+/area/station/turret_protected/ai)
 "aEw" = (
+/obj/decal/tile_edge/line/white{
+	dir = 8;
+	icon_state = "line1"
+	},
+/obj/decal/tile_edge/line/white{
+	dir = 10;
+	icon_state = "line4"
+	},
+/obj/decal/tile_edge/line/white{
+	dir = 5;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/darkblue,
+/area/station/turret_protected/ai)
+"aEy" = (
+/obj/decal/tile_edge/line/white{
+	dir = 5;
+	icon_state = "line4"
+	},
+/obj/decal/tile_edge/line/white{
+	dir = 1;
+	icon_state = "line1"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/darkblue,
+/area/station/turret_protected/ai)
+"aEz" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -13368,25 +12747,29 @@
 	dir = 4
 	},
 /area/station/hallway/primary/north)
-"aEx" = (
-/obj/stool/bench/blue/auto,
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
+"aEA" = (
+/obj/machinery/power/monitor{
+	dir = 8;
+	name = "Station Power Grid Monitoring"
 	},
-/turf/simulated/floor/sanitary/white,
-/area/station/crew_quarters/pool)
-"aEy" = (
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/ai)
+"aEB" = (
 /obj/machinery/shower{
 	dir = 1;
 	pixel_y = 16
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/crew_quarters/pool)
-"aEz" = (
+"aEC" = (
 /turf/simulated/floor/sanitary/white,
 /area/station/crew_quarters/pool)
-"aEA" = (
+"aED" = (
 /obj/machinery/shower{
 	dir = 4;
 	pixel_x = 8;
@@ -13398,20 +12781,21 @@
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/crew_quarters/pool)
-"aEB" = (
-/obj/item/clothing/mask/wrestling,
-/obj/item/clothing/mask/wrestling/black,
-/obj/item/clothing/mask/wrestling/blue,
-/obj/item/clothing/mask/wrestling/green,
-/obj/item/clothing/under/gimmick/macho,
-/obj/item/clothing/under/gimmick/macho,
-/obj/storage/closet/dresser/random,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/pool)
-"aEC" = (
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/pool)
-"aED" = (
+"aEE" = (
+/obj/table/auto,
+/obj/item/sheet/steel/reinforced{
+	amount = 50
+	},
+/obj/item/sheet/steel/reinforced{
+	amount = 50
+	},
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/chem_grenade/metalfoam,
+/turf/simulated/floor/black,
+/area/station/engine/storage)
+"aEF" = (
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
@@ -13419,35 +12803,27 @@
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/pool)
-"aEE" = (
+"aEG" = (
 /obj/machinery/door/unpowered/wood/pyro{
 	dir = 4
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/pool)
-"aEF" = (
+"aEI" = (
+/obj/table/auto,
+/obj/machinery/phone,
+/turf/simulated/floor,
+/area/station/engine/engineering)
+"aEJ" = (
 /obj/machinery/atmospherics/portables_connector/east,
 /obj/machinery/portable_atmospherics/canister/air/large,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"aEG" = (
-/obj/machinery/atmospherics/valve/notify_admins/vertical{
-	dir = 4;
-	name = "Sauna Air Supply"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"aEH" = (
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/horizontal,
-/obj/machinery/meter,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"aEI" = (
+"aEK" = (
 /obj/machinery/atmospherics/pipe/simple/southwest,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"aEJ" = (
+"aEL" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
 	d1 = 2;
@@ -13456,52 +12832,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"aEK" = (
-/obj/machinery/disposal/cart_port,
-/obj/disposalpipe/trunk/east,
-/turf/simulated/floor/specialroom/arcade,
-/area/station/janitor/supply)
-"aEL" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-9"
-	},
-/obj/disposalpipe/junction/left/south,
-/turf/simulated/floor/specialroom/arcade,
-/area/station/janitor/supply)
-"aEM" = (
-/obj/submachine/chef_sink{
-	desc = "A common utility sink.";
-	dir = 8;
-	name = "utility sink"
-	},
-/turf/simulated/floor/specialroom/arcade,
-/area/station/janitor/supply)
 "aEN" = (
-/turf/simulated/wall/auto/supernorn,
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"aEO" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hangar/escape)
-"aEP" = (
+"aER" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/hangar/escape)
-"aEQ" = (
-/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/escape_horizontal,
-/obj/forcefield/energyshield/perma/doorlink{
-	desc = "A door-linked force field that prevents gasses from passing through it.";
-	name = "Door-linked Atmospheric Forcefield";
-	powerlevel = 1
-	},
-/turf/simulated/floor/shuttlebay{
-	icon_state = "engine_caution_north"
-	},
-/area/station/hangar/escape)
-"aER" = (
-/obj/machinery/r_door_control/podbay/escape,
-/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/escape)
 "aES" = (
 /obj/machinery/launcher_loader/north,
@@ -13717,10 +13054,47 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/coldloop)
 "aFo" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/hangar/engine)
+/obj/machinery/manufacturer/mechanic,
+/turf/simulated/floor/yellow/side{
+	dir = 5
+	},
+/area/station/engine/elect)
 "aFp" = (
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/obj/stool/chair,
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
+"aFq" = (
+/obj/wingrille_spawn/auto,
+/obj/decal/wreath/ephemeral,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/fitness)
+"aFr" = (
+/obj/stool/chair{
+	dir = 8
+	},
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/machinery/light/small/floor,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
+"aFs" = (
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/obj/machinery/light_switch/north,
+/turf/simulated/floor/yellow/side{
+	dir = 1
+	},
+/area/station/hangar/engine)
+"aFt" = (
 /obj/table/reinforced/auto,
 /obj/item/sheet/steel{
 	amount = 10
@@ -13728,24 +13102,17 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/grey,
 /area/station/hangar/engine)
-"aFq" = (
+"aFu" = (
 /turf/simulated/floor/grey,
 /area/station/hangar/engine)
-"aFr" = (
+"aFv" = (
+/obj/machinery/light/emergency{
+	dir = 1;
+	pixel_y = 16
+	},
 /turf/simulated/floor/caution/westeast,
 /area/station/hangar/engine)
-"aFs" = (
-/turf/simulated/floor/yellow/side{
-	dir = 1
-	},
-/area/station/hangar/engine)
-"aFt" = (
-/obj/item/device/radio/intercom/engineering,
-/turf/simulated/floor/yellow/side{
-	dir = 1
-	},
-/area/station/hangar/engine)
-"aFu" = (
+"aFw" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -13755,81 +13122,65 @@
 	dir = 1
 	},
 /area/station/hangar/engine)
-"aFv" = (
-/obj/machinery/door_control/podbay/engineering/new_walls/north,
+"aFx" = (
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
 /area/station/hangar/engine)
-"aFw" = (
+"aFy" = (
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/caution/westeast,
+/area/station/hangar/engine)
+"aFz" = (
 /obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/yellow/side{
 	dir = 5
 	},
 /area/station/hangar/engine)
-"aFx" = (
-/obj/machinery/light/small/warm/very{
-	dir = 8;
-	pixel_x = -12
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/west,
-/area/station/maintenance/inner/central)
-"aFy" = (
+"aFA" = (
 /turf/simulated/floor/carpet/red/fancy/innercorner/south,
 /area/station/maintenance/inner/central)
-"aFz" = (
-/obj/table/wood/auto,
-/obj/item/game_kit,
-/obj/item/decoration/ashtray,
-/turf/simulated/floor/carpet/red/fancy/edge/east,
-/area/station/maintenance/inner/central)
-"aFA" = (
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
-"aFB" = (
-/obj/stool/bench/blue/auto,
-/turf/simulated/floor/sanitary/white,
-/area/station/crew_quarters/pool)
 "aFC" = (
+/obj/decal/tile_edge/line/black{
+	dir = 8;
+	icon_state = "line1"
+	},
+/obj/landmark/gps_waypoint,
+/turf/simulated/floor/specialroom/gym/alt,
+/area/station/crew_quarters/fitness)
+"aFE" = (
 /obj/machinery/drainage,
 /turf/simulated/floor/sanitary/white,
-/area/station/crew_quarters/pool)
-"aFD" = (
-/turf/simulated/floor/stairs/medical{
-	dir = 4
-	},
-/area/station/crew_quarters/pool)
-"aFE" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 9;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/obj/submachine/chef_sink/chem_sink{
-	dir = 8;
-	pixel_x = 8
-	},
-/turf/simulated/floor/sanitary,
 /area/station/crew_quarters/pool)
 "aFF" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/sauna)
 "aFG" = (
-/obj/machinery/atmospherics/pipe/simple/vertical,
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/sauna)
-"aFH" = (
+/obj/disposalpipe/segment/vertical,
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-9"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"aFI" = (
+"aFH" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/turretid{
+	pixel_x = 24;
+	req_access_txt = "19"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"aFJ" = (
 /obj/machinery/door/airlock/pyro{
 	name = "Janitor's Supply Closet"
 	},
@@ -13840,53 +13191,53 @@
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/supply)
-"aFJ" = (
+"aFK" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/ai)
+"aFL" = (
+/obj/decal/poster/wallsign/space,
+/turf/simulated/wall/auto/supernorn,
+/area/station/maintenance/east)
+"aFM" = (
 /obj/machinery/door/airlock/pyro/external,
 /turf/simulated/floor/grey,
 /area/station/maintenance/east)
-"aFK" = (
+"aFN" = (
 /obj/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/canister/air/large,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"aFL" = (
-/obj/machinery/atmospherics/portables_connector{
-	name = "Escape N Repressurization Port"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"aFM" = (
-/obj/machinery/atmospherics/pipe/tank/air_repressurization/south,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"aFN" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -20
-	},
-/turf/simulated/floor/caution/east,
-/area/station/hangar/escape)
 "aFO" = (
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/escape)
 "aFP" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/escape)
+/obj/machinery/atmospherics/pipe/tank/air_repressurization/south,
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "aFQ" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
+/obj/machinery/computer3/generic/secure_data{
+	dir = 8
 	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/escape)
+/obj/machinery/light,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable,
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/ai)
 "aFR" = (
 /obj/machinery/crusher,
 /obj/machinery/conveyor{
@@ -14180,22 +13531,42 @@
 	},
 /area/station/engine/coldloop)
 "aGx" = (
-/obj/table/reinforced/auto,
-/obj/item/sheet/glass/reinforced{
-	amount = 50
-	},
-/obj/item/reagent_containers/food/drinks/fueltank,
-/obj/item/reagent_containers/food/drinks/fueltank,
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
-	icon_state = "4-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/grey,
-/area/station/hangar/engine)
+/turf/simulated/floor/engine,
+/area/station/turret_protected/ai)
 "aGy" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/engine,
+/area/station/turret_protected/ai)
+"aGz" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
+	},
+/turf/space,
+/area/space)
+"aGA" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/hangar/engine)
+"aGB" = (
 /obj/cable{
 	icon_state = "2-4"
 	},
@@ -14204,7 +13575,7 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/hangar/engine)
-"aGz" = (
+"aGC" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
@@ -14215,13 +13586,13 @@
 	dir = 4
 	},
 /area/station/hangar/engine)
-"aGA" = (
+"aGD" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/caution/northsouth,
 /area/station/hangar/engine)
-"aGB" = (
+"aGE" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 4;
@@ -14232,7 +13603,7 @@
 	},
 /turf/simulated/floor/caution/northsouth,
 /area/station/hangar/engine)
-"aGC" = (
+"aGF" = (
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -14240,7 +13611,7 @@
 	},
 /turf/simulated/floor/caution/northsouth,
 /area/station/hangar/engine)
-"aGD" = (
+"aGG" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
 	},
@@ -14253,7 +13624,7 @@
 	dir = 8
 	},
 /area/station/hangar/engine)
-"aGE" = (
+"aGH" = (
 /obj/reagent_dispensers/foamtank,
 /obj/cable{
 	d2 = 8;
@@ -14264,58 +13635,41 @@
 	dir = 4
 	},
 /area/station/hangar/engine)
-"aGF" = (
-/turf/simulated/floor/carpet/red/fancy/narrow/sw,
-/area/station/maintenance/inner/central)
-"aGG" = (
-/turf/simulated/floor/carpet/red/fancy/edge/south,
-/area/station/maintenance/inner/central)
-"aGH" = (
-/obj/stool/chair/comfy{
+"aGI" = (
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/yellow/side{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/red/fancy/narrow/se,
-/area/station/maintenance/inner/central)
-"aGI" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/neutral/side{
-	dir = 4
-	},
-/area/station/hallway/primary/north)
-"aGJ" = (
-/obj/rack,
-/obj/item/sponge{
-	name = "loofah"
-	},
-/obj/machinery/light/small,
-/turf/simulated/floor/sanitary/white,
-/area/station/crew_quarters/pool)
+/area/station/engine/engineering)
 "aGK" = (
-/obj/machinery/shower{
-	dir = 4;
-	pixel_x = 8;
-	pixel_y = 6
-	},
-/obj/machinery/light/small,
+/turf/simulated/floor,
+/area/station/engine/elect)
+"aGL" = (
+/obj/stool/bench/blue/auto,
 /turf/simulated/floor/sanitary/white,
 /area/station/crew_quarters/pool)
-"aGL" = (
+"aGM" = (
+/obj/grille/steel,
+/obj/item/clothing/under/gimmick/dolan,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/pool)
+"aGN" = (
 /obj/table/auto,
 /obj/towelbin,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/pool)
-"aGM" = (
-/obj/stool/bench/blue/auto,
+"aGO" = (
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/pool)
-"aGN" = (
+"aGP" = (
+/obj/stool/bench/blue/auto,
+/obj/machinery/light_switch/east,
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/pool)
+"aGQ" = (
 /obj/stool/bench/red/auto,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/southeast,
 /obj/machinery/light/small{
@@ -14324,7 +13678,7 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/sauna)
-"aGO" = (
+"aGR" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/horizontal,
 /obj/cable{
 	d2 = 2;
@@ -14333,12 +13687,7 @@
 /obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/sauna)
-"aGP" = (
-/obj/stool/bench/red/auto,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/horizontal,
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/sauna)
-"aGQ" = (
+"aGU" = (
 /obj/machinery/atmospherics/pipe/simple/junction/west,
 /obj/table/wood/round/auto,
 /obj/item/reagent_containers/food/drinks/water,
@@ -14348,11 +13697,7 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/sauna)
-"aGR" = (
-/obj/machinery/atmospherics/pipe/manifold/east,
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/sauna)
-"aGS" = (
+"aGV" = (
 /obj/disposalpipe/segment/vertical,
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -14363,7 +13708,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"aGT" = (
+"aGW" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -14372,13 +13717,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"aGU" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"aGV" = (
+"aGX" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
 	icon_state = "1-8"
@@ -14390,15 +13729,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"aGW" = (
+"aGY" = (
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"aGX" = (
+"aGZ" = (
 /obj/cable{
 	d1 = 2;
 	d2 = 4;
@@ -14406,36 +13746,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"aGY" = (
-/obj/machinery/atmospherics/valve{
-	high_risk = 1;
-	name = "Escape Dock"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"aGZ" = (
-/obj/machinery/atmospherics/valve{
-	high_risk = 1;
-	name = "Air Reserve (Escape Dock)"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "aHa" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/autoname_west,
-/turf/simulated/floor/caution/east,
-/area/station/hangar/escape)
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "aHb" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
+/obj/stool/chair/yellow{
+	dir = 4
 	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/escape)
+/obj/landmark/start{
+	name = "Mechanic"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
+/area/station/engine/elect)
 "aHc" = (
 /obj/table/wood/auto,
 /turf/simulated/floor/darkblue/checker,
@@ -14464,9 +13788,21 @@
 /turf/simulated/floor/grime,
 /area/station/maintenance/disposal)
 "aHf" = (
-/obj/machinery/r_door_control/podbay/engineering,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hangar/engine)
+/obj/table/reinforced/auto,
+/obj/access_spawn/engineering_mechanic,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 4
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/yellow/side{
+	dir = 9
+	},
+/area/station/engine/elect)
 "aHg" = (
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/black/grime,
@@ -14658,16 +13994,19 @@
 /turf/simulated/floor/caution/north,
 /area/station/engine/coldloop)
 "aHB" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/stool,
+/obj/decal/boxingrope{
+	dir = 4
 	},
-/turf/simulated/floor/grey,
-/area/station/hangar/engine)
+/turf/simulated/floor/specialroom/gym,
+/area/station/crew_quarters/fitness)
 "aHC" = (
-/obj/machinery/vehicle/miniputt/indyputt/armed,
-/turf/simulated/floor/shuttlebay,
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
 /area/station/hangar/engine)
 "aHD" = (
 /turf/simulated/floor/shuttlebay,
@@ -14683,37 +14022,68 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aHF" = (
+/obj/decal/tile_edge/line/black{
+	dir = 4;
+	icon_state = "line1"
+	},
+/obj/fitness/stacklifter,
+/turf/simulated/floor/specialroom/gym/alt,
+/area/station/crew_quarters/fitness)
+"aHG" = (
+/obj/shrub{
+	dir = 4;
+	icon = 'icons/obj/stationobjs.dmi';
+	icon_state = "plant"
+	},
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
+"aHI" = (
 /obj/machinery/portable_atmospherics/canister/air/large,
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
 /area/station/hangar/engine)
-"aHG" = (
-/turf/simulated/floor/black/grime,
-/area/station/maintenance/inner/central)
-"aHH" = (
-/obj/table/wood/auto,
-/obj/item/instrument/harmonica,
-/obj/item/device/light/zippo,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/simulated/floor/black/grime,
-/area/station/maintenance/inner/central)
-"aHI" = (
-/obj/table/wood/auto,
-/obj/item/instrument/saxophone,
-/obj/item/clothing/head/flatcap,
-/obj/item/clothing/head/flatcap,
-/obj/item/reagent_containers/food/drinks/bottle/ntbrew,
-/obj/item/dice,
-/obj/item/clothing/glasses/sunglasses,
-/obj/machinery/light/small/warm/very{
+"aHJ" = (
+/obj/machinery/light/small{
 	dir = 4;
 	pixel_x = 12
 	},
-/turf/simulated/floor/black/grime,
-/area/station/maintenance/inner/central)
-"aHJ" = (
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"aHK" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/stairs/dark/wide{
+	dir = 10
+	},
+/area/station/turret_protected/ai)
+"aHL" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
+	},
+/turf/simulated/floor/stairs/dark/wide{
+	dir = 1
+	},
+/area/station/turret_protected/ai)
+"aHM" = (
 /obj/storage/secure/closet/personal,
 /obj/cable{
 	d2 = 4;
@@ -14722,7 +14092,7 @@
 /obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/pool)
-"aHK" = (
+"aHN" = (
 /obj/cable{
 	d1 = 2;
 	d2 = 8;
@@ -14730,7 +14100,7 @@
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/pool)
-"aHL" = (
+"aHO" = (
 /obj/stool/bench/blue/auto,
 /obj/machinery/firealarm{
 	dir = 4;
@@ -14739,55 +14109,61 @@
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/pool)
-"aHM" = (
+"aHP" = (
 /obj/stool/bench/red/auto,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/vertical,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/sauna)
-"aHN" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/landmark/gps_waypoint,
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/sauna)
-"aHO" = (
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/sauna)
-"aHP" = (
-/obj/machinery/atmospherics/unary/furnace_connector{
-	dir = 4
-	},
-/obj/machinery/power/furnace/thermo,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/sauna)
-"aHQ" = (
-/obj/disposalpipe/junction/left/north,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "aHR" = (
-/obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/sauna)
 "aHS" = (
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "aHT" = (
-/obj/disposalpipe/junction/left/west,
+/obj/disposalpipe/junction/left/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "aHU" = (
+/obj/disposalpipe/junction/left/west,
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"aHV" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/engine,
+/area/station/turret_protected/ai)
+"aHW" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 1
+	},
+/area/station/engine/storage)
+"aHX" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 8
+	},
+/area/station/engine/elect)
+"aHY" = (
 /obj/machinery/light/small,
 /obj/disposalpipe/segment/horizontal,
 /obj/machinery/camera{
@@ -14798,7 +14174,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"aHV" = (
+"aHZ" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
 	d1 = 2;
@@ -14807,64 +14183,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"aHW" = (
-/obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"aHX" = (
-/obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 5;
-	level = 2
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"aHY" = (
-/obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold{
-	level = 2
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"aHZ" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4
-	},
-/obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/maintenance/east)
 "aIa" = (
-/obj/disposalpipe/segment/bent/south,
+/obj/disposalpipe/segment/horizontal,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4
-	},
-/turf/simulated/floor/caution/east,
-/area/station/hangar/escape)
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "aIb" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -14872,11 +14197,12 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/escape)
 "aIc" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 10
+/obj/decal/tile_edge/line/yellow{
+	icon_state = "line1"
 	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/escape)
+/obj/landmark/gps_waypoint,
+/turf/simulated/floor,
+/area/station/engine/elect)
 "aId" = (
 /obj/machinery/light/small,
 /obj/machinery/disposal/transport{
@@ -15100,147 +14426,172 @@
 /turf/simulated/floor/caution/south,
 /area/station/engine/coldloop)
 "aIz" = (
-/obj/item/device/radio/intercom/cargo,
-/obj/cable{
-	icon_state = "4-8"
+/obj/decal/tile_edge/line/yellow{
+	dir = 10;
+	icon_state = "line1"
 	},
-/turf/simulated/floor/delivery,
-/area/station/hangar/engine)
+/turf/simulated/floor,
+/area/station/engine/elect)
 "aIA" = (
-/obj/machinery/vehicle/pod_smooth/industrial,
-/turf/simulated/floor/shuttlebay,
+/turf/simulated/floor/caution/westeast,
 /area/station/hangar/engine)
 "aIB" = (
-/obj/machinery/portable_atmospherics/canister/air/large,
+/obj/table/reinforced/auto,
+/obj/machinery/cashreg,
+/obj/access_spawn/engineering_mechanic,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 4
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/yellow/side{
+	dir = 9
+	},
+/area/station/engine/elect)
+"aIC" = (
+/obj/disposalpipe/junction/right/north,
 /obj/machinery/camera{
 	c_tag = "autotag";
-	dir = 8;
+	dir = 9;
 	name = "autoname - SS13";
 	pixel_x = 10;
 	tag = ""
 	},
-/turf/simulated/floor/yellow/side{
-	dir = 4
-	},
-/area/station/hangar/engine)
-"aIC" = (
-/obj/machinery/door/unpowered/wood/pyro{
-	dir = 1;
-	name = "The Recluse"
-	},
-/turf/simulated/floor/carpet/red/fancy/narrow/north,
-/area/station/maintenance/inner/central)
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "aID" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/hallway/primary/north)
+/obj/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "aIE" = (
-/obj/xmastree/ephemeral,
-/turf/simulated/floor/specialroom/chapel{
-	dir = 8
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
 	},
+/turf/simulated/floor/grey,
 /area/station/chapel/sanctuary)
 "aIF" = (
-/obj/item/a_gift/festive/ephemeral,
-/turf/simulated/floor/specialroom/chapel{
-	dir = 4
-	},
+/turf/simulated/floor/grey,
 /area/station/chapel/sanctuary)
 "aIG" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
 	},
-/turf/simulated/floor/neutral/corner{
+/obj/machinery/computer3/terminal/zeta{
 	dir = 4
 	},
-/area/station/hallway/primary/north)
-"aIH" = (
+/obj/cable,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/darkblue,
+/area/station/turret_protected/ai)
+"aII" = (
+/obj/stool/chair{
+	dir = 8
+	},
+/turf/simulated/floor/darkblue,
+/area/station/turret_protected/ai)
+"aIJ" = (
 /turf/simulated/floor/neutral/side{
 	dir = 1
 	},
 /area/station/hallway/primary/north)
-"aII" = (
+"aIK" = (
 /turf/simulated/floor/neutral/side{
 	dir = 5
 	},
 /area/station/hallway/primary/north)
-"aIJ" = (
-/obj/grille/steel,
-/obj/item/clothing/under/gimmick/dolan,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/pool)
-"aIK" = (
+"aIL" = (
+/obj/rack,
+/obj/item/clothing/suit/space/engineer,
+/obj/item/clothing/shoes/magnetic,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/head/helmet/space/engineer,
+/obj/item/tank/air,
+/obj/item/device/light/flashlight,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/belt/utility,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/station/engine/storage)
+"aIM" = (
 /obj/storage/secure/closet/personal,
 /obj/machinery/light,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/pool)
-"aIL" = (
+"aIN" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/pool)
-"aIM" = (
+"aIO" = (
 /obj/stool/bench/red/auto,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/northeast,
 /obj/machinery/light/small,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/sauna)
-"aIN" = (
+"aIP" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/horizontal,
 /obj/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/sauna)
-"aIO" = (
-/obj/machinery/atmospherics/pipe/simple/junction/west,
-/obj/machinery/light/small,
-/obj/machinery/space_heater,
+"aIR" = (
+/obj/stool/bench/red/auto,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/horizontal,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/sauna)
-"aIP" = (
-/obj/machinery/atmospherics/pipe/simple/northwest,
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/sauna)
-"aIQ" = (
-/obj/machinery/door/airlock/pyro/maintenance,
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"aIR" = (
-/obj/machinery/door/airlock/pyro/maintenance,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "aIS" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/quarters_north)
 "aIT" = (
-/obj/machinery/door/airlock/pyro/maintenance,
-/obj/firedoor_spawn,
-/turf/simulated/floor/neutral/side,
-/area/station/crew_quarters/quarters_north)
-"aIU" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/quarters_north)
-"aIV" = (
-/obj/disposalpipe/segment/vertical,
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
 /obj/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/caution/east,
-/area/station/hangar/escape)
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/engine/storage)
+"aIU" = (
+/obj/machinery/disposal/mail/autoname/engineering,
+/obj/disposalpipe/trunk/mail/north,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor/yellow/side,
+/area/station/engine/engineering)
+"aIV" = (
+/obj/submachine/cargopad/mechanics,
+/turf/simulated/floor/black,
+/area/station/engine/elect)
 "aIW" = (
-/obj/machinery/atmospherics/pipe/simple,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/escape)
+/obj/decal/tile_edge/line/yellow{
+	dir = 8;
+	icon_state = "line1"
+	},
+/turf/simulated/floor,
+/area/station/engine/elect)
 "aIX" = (
 /turf/simulated/wall/auto/supernorn,
 /area/space)
@@ -15455,18 +14806,25 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/coldloop)
 "aJv" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	name = "cargo belt - north";
-	operating = 1
-	},
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
-/turf/simulated/floor/caution/westeast,
-/area/station/hangar/engine)
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/decal/wreath/ephemeral,
+/turf/simulated/floor/plating,
+/area/station/engine/elect)
 "aJw" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/firstaid/brute,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
+"aJx" = (
+/obj/machinery/camera/television{
+	c_tag = "boxing";
+	dir = 1;
+	name = "camera - boxing"
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
+"aJy" = (
 /obj/item/sheet/steel{
 	amount = 50
 	},
@@ -15494,38 +14852,21 @@
 	dir = 4
 	},
 /area/station/hangar/engine)
-"aJx" = (
+"aJz" = (
+/obj/decal/tile_edge/line/black{
+	dir = 6;
+	icon_state = "line2"
+	},
+/obj/fitness/weightlifter,
+/turf/simulated/floor/specialroom/gym/alt,
+/area/station/crew_quarters/fitness)
+"aJA" = (
 /obj/decal/cleanable/dirt,
 /obj/machinery/light/small/warm/very{
 	dir = 8;
 	pixel_x = -12
 	},
 /turf/simulated/floor/carpet/red/fancy/narrow/south,
-/area/station/maintenance/inner/central)
-"aJy" = (
-/obj/disposalpipe/segment/bent/east,
-/obj/submachine/GTM{
-	pixel_y = 32
-	},
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
-"aJz" = (
-/obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
-"aJA" = (
-/obj/disposalpipe/segment/bent/west,
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aJB" = (
 /obj/cable{
@@ -15534,58 +14875,54 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aJC" = (
+/obj/disposalpipe/segment/horizontal,
 /obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aJD" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4
+/obj/machinery/vending/snack,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
 "aJE" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/table/auto,
+/obj/machinery/networked/printer{
+	name = "Printer - AI";
+	pixel_y = 5;
+	print_id = "AI"
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
+/obj/cable,
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/darkblue,
+/area/station/turret_protected/ai)
 "aJF" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
+/obj/table/auto,
+/obj/item/paper/book/dwainedummies,
+/turf/simulated/floor/darkblue,
+/area/station/turret_protected/ai)
 "aJG" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "aJH" = (
-/obj/disposalpipe/segment/mail/bent/south,
-/turf/simulated/floor/neutral/side{
-	dir = 4
-	},
+/obj/disposalpipe/segment/mail/horizontal,
+/turf/simulated/floor/neutral/side,
 /area/station/hallway/primary/north)
 "aJI" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/engine/storage)
+"aJJ" = (
 /obj/machinery/door/airlock/pyro{
 	name = "Shower Room"
 	},
@@ -15595,22 +14932,25 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/pool)
-"aJJ" = (
-/obj/machinery/door/airlock/pyro{
-	name = "Sauna"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/sauna)
-"aJK" = (
+"aJL" = (
+/obj/rack,
+/obj/item/clothing/suit/space/engineer,
+/obj/item/clothing/shoes/magnetic,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/head/helmet/space/engineer,
+/obj/item/tank/air,
+/obj/item/device/light/flashlight,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/belt/utility,
+/turf/simulated/floor/black,
+/area/station/engine/storage)
+"aJN" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"aJL" = (
+"aJO" = (
 /obj/table/wood/auto,
 /obj/bedsheetbin,
 /obj/decal/xmas_lights/ephemeral{
@@ -15618,7 +14958,7 @@
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/nw,
 /area/station/crew_quarters/quarters_north)
-"aJM" = (
+"aJP" = (
 /obj/storage/crate,
 /obj/item/clothing/mask/moustache,
 /obj/item/clothing/suit/wcoat,
@@ -15629,29 +14969,26 @@
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/north,
 /area/station/crew_quarters/quarters_north)
-"aJN" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "pink";
-	icon_state = "bedsheet-pink"
+"aJQ" = (
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
 	},
-/obj/item/storage/secure/ssafe{
-	pixel_x = 28
-	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/decal/xmas_lights/ephemeral{
+/obj/machinery/photocopier,
+/obj/machinery/phone/wall{
 	pixel_y = 32
 	},
-/turf/simulated/floor/carpet/purple/fancy/edge/ne,
-/area/station/crew_quarters/quarters_north)
-"aJO" = (
 /turf/simulated/floor/neutral/side{
 	dir = 9
 	},
 /area/station/crew_quarters/quarters_north)
-"aJP" = (
+"aJR" = (
+/turf/simulated/floor/neutral/side{
+	dir = 9
+	},
+/area/station/crew_quarters/quarters_north)
+"aJS" = (
 /obj/machinery/light{
 	dir = 4;
 	layer = 9.1;
@@ -15665,56 +15002,6 @@
 	dir = 5
 	},
 /area/station/crew_quarters/quarters_north)
-"aJQ" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "red";
-	icon_state = "bedsheet-red"
-	},
-/obj/item/storage/secure/ssafe{
-	pixel_x = -28
-	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/nw,
-/area/station/crew_quarters/quarters_north)
-"aJR" = (
-/obj/storage/crate,
-/obj/item/clothing/under/misc/vice,
-/obj/item/clothing/glasses/sunglasses,
-/obj/item/reagent_containers/food/drinks/bottle/fancy_beer,
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/north,
-/area/station/crew_quarters/quarters_north)
-"aJS" = (
-/obj/table/wood/auto,
-/obj/item/camera_test,
-/obj/item/clothing/head/det_hat{
-	desc = "Ugh, gross.";
-	name = "fedora"
-	},
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/ne,
-/area/station/crew_quarters/quarters_north)
-"aJT" = (
-/obj/disposalpipe/segment/vertical,
-/obj/machinery/door_control/podbay/escape/new_walls/west,
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/caution/corner/misc{
-	dir = 5
-	},
-/area/station/hangar/escape)
 "aJU" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -15723,16 +15010,23 @@
 /area/station/hangar/escape)
 "aJV" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple,
-/turf/simulated/floor/caution/north,
-/area/station/hangar/escape)
+/turf/simulated/floor,
+/area/station/engine/storage)
 "aJW" = (
-/turf/simulated/floor/caution/north,
-/area/station/hangar/escape)
+/obj/storage/secure/closet/engineering/engineer,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/turf/simulated/floor/black,
+/area/station/engine/storage)
 "aJX" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/ghostdrone_factory)
@@ -15825,11 +15119,8 @@
 /area/station/maintenance/disposal)
 "aKh" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "aKi" = (
@@ -16016,56 +15307,60 @@
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/core)
 "aKC" = (
-/obj/machinery/door/airlock/pyro/engineering,
-/obj/disposalpipe/segment/mail/vertical,
-/obj/cable{
-	icon_state = "1-2"
-	},
+/obj/table/reinforced/auto,
+/obj/machinery/cashreg,
+/obj/access_spawn/engineering_storage,
 /obj/firedoor_spawn,
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/access_spawn/engineering_power,
-/obj/decal/garland/ephemeral,
+/obj/machinery/door/airlock/pyro/glass/windoor,
 /turf/simulated/floor/yellow,
-/area/station/engine/engineering)
+/area/station/engine/storage)
 "aKD" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
+/obj/decal/poster/wallsign/engineering,
+/turf/simulated/wall/auto/supernorn,
 /area/station/engine/engineering)
 "aKE" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	name = "cargo belt - north";
-	operating = 1
+/obj/decal/tile_edge/line/yellow{
+	dir = 9;
+	icon_state = "line1"
 	},
-/turf/simulated/floor/caution/westeast,
-/area/station/hangar/engine)
+/turf/simulated/floor,
+/area/station/engine/elect)
 "aKF" = (
-/obj/machinery/computer/ordercomp,
-/obj/cable,
-/obj/machinery/power/data_terminal,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 10;
-	name = "autoname - SS13";
-	tag = ""
+/obj/disposalpipe/switch_junction/left/south{
+	mail_tag = "mechanics";
+	name = "mechanics mail junction"
 	},
-/turf/simulated/floor/grey,
-/area/station/hangar/engine)
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 8
+	},
+/area/station/hallway/primary/north)
 "aKG" = (
-/obj/machinery/light,
-/turf/simulated/floor/shuttlebay,
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
 /area/station/hangar/engine)
 "aKH" = (
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/hallway/primary/north)
+"aKI" = (
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	name = "Fitness Room"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor,
+/area/station/crew_quarters/fitness)
+"aKJ" = (
 /obj/rack,
 /obj/item/clothing/suit/space/emerg,
 /obj/item/clothing/head/emerg,
@@ -16078,99 +15373,41 @@
 	dir = 4
 	},
 /area/station/hangar/engine)
-"aKI" = (
-/turf/simulated/floor/stairs/dark{
-	dir = 1
-	},
-/area/station/maintenance/inner/central)
-"aKJ" = (
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
-"aKK" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
-"aKL" = (
-/obj/storage/closet/emergency,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
 "aKM" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/obj/disposalpipe/segment/mail/bent/north,
-/turf/simulated/floor/neutral/side,
-/area/station/hallway/primary/north)
+/obj/machinery/light,
+/obj/disposalpipe/segment/horizontal,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
 "aKN" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/turf/simulated/floor/neutral/side,
-/area/station/hallway/primary/north)
-"aKO" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 10;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/obj/disposalpipe/segment/mail/horizontal,
-/turf/simulated/floor/neutral/side,
-/area/station/hallway/primary/north)
+/obj/storage/closet/fire,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "aKP" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/turf/simulated/floor/neutral/corner{
-	dir = 8
-	},
+/turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/north)
 "aKQ" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/pool)
 "aKR" = (
-/obj/stool/chair{
-	desc = "";
-	icon_state = "chair_pool"
+/obj/disposalpipe/segment/mail/horizontal,
+/turf/simulated/floor/neutral/corner{
+	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/blue/checker,
-/area/station/crew_quarters/pool)
+/area/station/hallway/primary/north)
 "aKS" = (
-/obj/table/round/auto,
-/obj/item/inner_tube/random,
-/obj/item/inner_tube/random,
-/obj/item/clothing/gloves/water_wings,
-/obj/item/clothing/gloves/water_wings,
-/turf/simulated/floor/blue/checker,
-/area/station/crew_quarters/pool)
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/mail/horizontal,
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "aKT" = (
-/obj/stool/chair{
-	desc = "";
-	icon_state = "chair_pool"
+/obj/disposalpipe/segment/mail/bent/south,
+/turf/simulated/floor/neutral/side{
+	dir = 4
 	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/blue/checker,
-/area/station/crew_quarters/pool)
+/area/station/hallway/primary/north)
 "aKU" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -16178,6 +15415,31 @@
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
 "aKV" = (
+/obj/stool/chair{
+	desc = "";
+	icon_state = "chair_pool"
+	},
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/blue/checker,
+/area/station/crew_quarters/pool)
+"aKW" = (
+/obj/table/auto,
+/obj/machinery/light/small,
+/obj/item/storage/pill_bottle/cyberpunk,
+/obj/item/reagent_containers/food/drinks/bottle/hobo_wine,
+/turf/simulated/floor/plating,
+/area/station/storage/northeast)
+"aKX" = (
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
@@ -16186,28 +15448,37 @@
 /obj/crematorium/tanning,
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
-"aKW" = (
-/obj/critter/mouse,
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
-"aKX" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
+"aKY" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
 	},
-/obj/table/round/auto,
-/obj/towelbin,
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
+/obj/stool/chair{
+	desc = "";
+	icon_state = "chair_pool"
+	},
+/obj/landmark/start{
+	name = "Staff Assistant"
 	},
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
-"aKY" = (
-/obj/reagent_dispensers/foamtank,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "aKZ" = (
+/obj/disposalpipe/segment/horizontal,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
+"aLa" = (
+/obj/disposalpipe/segment/bent/west,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
+"aLb" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 0;
@@ -16216,7 +15487,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"aLa" = (
+"aLd" = (
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_x = 12
@@ -16226,16 +15497,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"aLb" = (
-/obj/stool/chair,
-/turf/simulated/floor/carpet/purple/fancy/edge/west,
-/area/station/crew_quarters/quarters_north)
-"aLc" = (
-/turf/simulated/floor/carpet/purple/fancy,
-/area/station/crew_quarters/quarters_north)
-"aLd" = (
-/turf/simulated/floor/carpet/purple/fancy/edge/east,
-/area/station/crew_quarters/quarters_north)
 "aLe" = (
 /obj/machinery/door/airlock/pyro{
 	dir = 4
@@ -16243,43 +15504,28 @@
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/quarters_north)
 "aLf" = (
+/obj/machinery/vending/cola/red,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
+"aLi" = (
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
+	},
 /turf/simulated/floor/neutral/side{
 	dir = 8
 	},
 /area/station/crew_quarters/quarters_north)
-"aLg" = (
+"aLj" = (
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
+	},
 /turf/simulated/floor/neutral/side{
 	dir = 4
 	},
 /area/station/crew_quarters/quarters_north)
-"aLh" = (
-/turf/simulated/floor/carpet/red/fancy/edge/west,
-/area/station/crew_quarters/quarters_north)
-"aLi" = (
-/turf/simulated/floor/carpet/red,
-/area/station/crew_quarters/quarters_north)
-"aLj" = (
-/obj/stool/chair,
-/turf/simulated/floor/carpet/red/fancy/edge/east,
-/area/station/crew_quarters/quarters_north)
-"aLk" = (
-/obj/machinery/disposal,
-/obj/disposalpipe/trunk/north,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/obj/machinery/light_switch/west,
-/turf/simulated/floor/escape,
-/area/station/hangar/escape)
-"aLl" = (
-/obj/machinery/shieldgenerator/meteorshield,
-/turf/simulated/floor/escape,
-/area/station/hangar/escape)
-"aLm" = (
+"aLo" = (
 /obj/rack,
 /obj/item/clothing/suit/space/emerg,
 /obj/item/clothing/head/emerg,
@@ -16291,24 +15537,7 @@
 /obj/item/wrench,
 /turf/simulated/floor/escape,
 /area/station/hangar/escape)
-"aLn" = (
-/obj/table/auto,
-/obj/item/storage/toolbox/electrical,
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/machinery/light,
-/turf/simulated/floor/escape,
-/area/station/hangar/escape)
-"aLo" = (
-/obj/machinery/door/airlock/pyro/external,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple,
-/turf/simulated/floor,
-/area/station/hangar/escape)
 "aLp" = (
-/obj/decal/poster/wallsign/space,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/escape)
 "aLq" = (
@@ -16343,18 +15572,6 @@
 "aLt" = (
 /turf/simulated/floor/grey,
 /area/station/mining/staff_room)
-"aLu" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/critter/turtle/sylvester/HoS,
-/turf/simulated/floor/carpet/red,
-/area/station/security/hos)
 "aLv" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -16474,14 +15691,28 @@
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/core)
 "aLL" = (
-/obj/wingrille_spawn/auto,
+/obj/machinery/door/airlock/pyro/engineering,
+/obj/disposalpipe/segment/mail/vertical,
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/access_spawn/engineering_power,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/yellow,
 /area/station/engine/engineering)
 "aLM" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/yellow/corner,
+/area/station/engine/storage)
+"aLN" = (
 /obj/machinery/door/poddoor/pyro{
 	id = "kd_eng";
 	name = "Cargo Routing Door"
@@ -16498,66 +15729,71 @@
 	},
 /turf/simulated/floor/caution/westeast,
 /area/station/hangar/engine)
-"aLN" = (
-/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/engineering_horizontal,
-/obj/forcefield/energyshield/perma/doorlink{
-	desc = "A door-linked force field that prevents gasses from passing through it.";
-	name = "Door-linked Atmospheric Forcefield";
-	powerlevel = 1
-	},
-/turf/simulated/floor/shuttlebay{
-	icon_state = "engine_caution_south"
-	},
-/area/station/hangar/engine)
 "aLO" = (
 /obj/item/reagent_containers/food/snacks/chips,
 /turf/simulated/floor/carpet/green/standard/edge/north,
 /area/station/maintenance/west)
-"aLP" = (
-/obj/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
 "aLQ" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/quarters_east)
-"aLR" = (
-/obj/machinery/door/airlock/pyro{
-	name = "Shower Room"
+"aLS" = (
+/obj/machinery/computer/security/wooden_tv{
+	desc = "These channels seem to mostly be about robuddies. What is this, some kind of reality show?";
+	name = "Television";
+	network = "Zeta"
 	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/blackwhite{
+/turf/simulated/floor/black/grime,
+/area/station/maintenance/inner/central)
+"aLT" = (
+/obj/table/wood/auto,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
+/obj/item/dice,
+/obj/machinery/light/small/warm/very{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/black/grime,
+/area/station/maintenance/inner/central)
+"aLU" = (
+/obj/submachine/chef_sink/chem_sink{
 	dir = 1
 	},
-/area/station/crew_quarters/quarters_east)
-"aLS" = (
-/obj/machinery/firealarm{
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
 	dir = 8;
-	pixel_x = -24
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
 	},
-/turf/simulated/floor/neutral/side{
-	dir = 8
-	},
-/area/station/hallway/primary/east)
-"aLT" = (
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/quarters_east)
+"aLV" = (
+/obj/table/round/auto,
+/obj/item/inner_tube/random,
+/obj/item/inner_tube/random,
+/obj/item/clothing/gloves/water_wings,
+/obj/item/clothing/gloves/water_wings,
+/turf/simulated/floor/blue/checker,
+/area/station/crew_quarters/pool)
+"aLW" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
-"aLU" = (
-/obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/floor/neutral/side{
-	dir = 4
-	},
-/area/station/hallway/primary/east)
-"aLV" = (
+"aLX" = (
+/obj/machinery/manufacturer/mechanic,
+/turf/simulated/floor/yellow/side,
+/area/station/engine/elect)
+"aLY" = (
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
-"aLW" = (
-/turf/simulated/floor/white,
-/area/station/crew_quarters/pool)
-"aLX" = (
+"aLZ" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 4;
@@ -16568,7 +15804,7 @@
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
-"aLY" = (
+"aMc" = (
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -16576,7 +15812,7 @@
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
-"aLZ" = (
+"aMd" = (
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -16595,7 +15831,7 @@
 /obj/machinery/drainage,
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
-"aMa" = (
+"aMe" = (
 /obj/disposalpipe/segment/bent/east,
 /obj/cable{
 	d1 = 4;
@@ -16604,29 +15840,7 @@
 	},
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
-"aMb" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4
-	},
-/obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/white,
-/area/station/crew_quarters/pool)
-"aMc" = (
-/obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"aMd" = (
+"aMf" = (
 /obj/disposalpipe/junction/left/east,
 /obj/cable{
 	d1 = 4;
@@ -16635,7 +15849,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"aMe" = (
+"aMg" = (
 /obj/disposalpipe/segment/bent/west,
 /obj/cable{
 	d1 = 2;
@@ -16647,34 +15861,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"aMf" = (
+"aMh" = (
+/obj/decal/cleanable/dirt,
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"aMi" = (
 /obj/table/wood/auto,
 /obj/random_item_spawner/medicine,
 /obj/random_item_spawner/med_tool,
 /turf/simulated/floor/carpet/purple/fancy/edge/sw,
 /area/station/crew_quarters/quarters_north)
-"aMg" = (
-/obj/stool/chair{
+"aMj" = (
+/obj/stool/chair,
+/turf/simulated/floor/neutral/side{
 	dir = 8
 	},
-/obj/machinery/light/small,
-/turf/simulated/floor/carpet/purple/fancy/edge/south,
 /area/station/crew_quarters/quarters_north)
-"aMh" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "pink";
-	icon_state = "bedsheet-pink"
-	},
-/obj/item/storage/secure/ssafe{
-	pixel_x = 28
-	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/turf/simulated/floor/carpet/purple/fancy/edge/se,
-/area/station/crew_quarters/quarters_north)
-"aMi" = (
+"aMk" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 4;
@@ -16686,88 +15890,15 @@
 	dir = 8
 	},
 /area/station/crew_quarters/quarters_north)
-"aMj" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "red";
-	icon_state = "bedsheet-red"
-	},
-/obj/item/storage/secure/ssafe{
-	pixel_x = -28
-	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/sw,
-/area/station/crew_quarters/quarters_north)
-"aMk" = (
-/obj/stool/chair{
+"aMl" = (
+/turf/simulated/floor/neutral/side{
 	dir = 4
 	},
-/obj/machinery/light/small,
-/turf/simulated/floor/carpet/red/fancy/edge/south,
 /area/station/crew_quarters/quarters_north)
-"aMl" = (
-/obj/table/wood/auto,
-/obj/machinery/computer3/luggable,
-/turf/simulated/floor/carpet/red/fancy/edge/se,
-/area/station/crew_quarters/quarters_north)
-"aMm" = (
+"aMq" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/escape)
-"aMn" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/checkpoint/escape)
-"aMo" = (
-/obj/machinery/computer/general_alert{
-	dir = 4
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/escape{
-	dir = 8
-	},
-/area/station/hangar/escape)
-"aMp" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/unary/outlet_injector{
-	dir = 1;
-	icon_state = "on";
-	on = 1
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor,
-/area/station/hangar/escape)
-"aMq" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/escape{
-	dir = 4
-	},
-/area/station/hangar/escape)
-"aMr" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
-	},
-/turf/simulated/floor/caution/westeast,
-/area/station/hangar/escape)
 "aMs" = (
 /obj/decal/fakeobjects/pipe/heat,
 /turf/simulated/floor/plating,
@@ -16782,15 +15913,9 @@
 /turf/simulated/floor/carpet/red/standard/edge/ne,
 /area/station/maintenance/west)
 "aMv" = (
-/obj/decal/cleanable/ash,
-/obj/cable{
-	icon_state = "2-5"
-	},
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/grime,
-/turf/simulated/floor/plating{
-	icon_state = "platingdmg2"
-	},
+/obj/grille/steel,
+/turf/space,
+/turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "aMw" = (
 /obj/decal/tile_edge/stripe/extra_big,
@@ -16873,23 +15998,27 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "aMI" = (
-/obj/machinery/door/poddoor/blast/pyro{
-	autoclose = 1;
-	dir = 4;
-	icon_state = "bdoormid1"
+/obj/storage/secure/closet/engineering/mechanic,
+/turf/simulated/floor/yellow/side{
+	dir = 6
 	},
-/turf/simulated/floor/shuttlebay{
-	icon_state = "engine_caution_east"
-	},
-/area/station/hallway/secondary/exit)
+/area/station/engine/elect)
 "aMJ" = (
-/obj/grille/catwalk{
-	dir = 5;
-	icon_state = "catwalk_cross"
+/obj/machinery/computer/general_alert{
+	dir = 4
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/space,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 5
+/turf/simulated/floor/escape{
+	dir = 8
 	},
 /area/station/hangar/escape)
 "aMK" = (
@@ -16928,11 +16057,14 @@
 /turf/simulated/floor/grime,
 /area/station/maintenance/disposal)
 "aMP" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
+/obj/stool/chair{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
 "aMQ" = (
 /obj/disposaloutlet/south,
 /obj/machinery/light/small{
@@ -16956,13 +16088,26 @@
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/west)
 "aMS" = (
-/obj/disposalpipe/segment/vertical,
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /obj/cable{
 	icon_state = "4-8"
 	},
+/turf/simulated/floor/grey/blackgrime/other,
+/area/station/storage/tech)
+"aMT" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
-"aMT" = (
+"aMW" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -16977,41 +16122,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
-"aMU" = (
-/obj/machinery/bathtub{
-	anchored = 1;
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
-/obj/item/storage/wall{
-	name = "bath cabinet";
-	pixel_y = 32;
-	spawn_contents = list(/obj/item/clothing/under/towel,/obj/item/clothing/under/towel)
-	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
-"aMV" = (
-/obj/machinery/door/unpowered/wood/pyro{
-	autoclose = 0;
-	dir = 8;
-	name = "tub stall door"
-	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
-"aMW" = (
-/obj/machinery/drainage,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
 "aMX" = (
-/obj/machinery/shower{
-	dir = 1;
-	pixel_y = 20
+/obj/stool/chair{
+	dir = 1
 	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
+/obj/machinery/light,
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
 "aMY" = (
 /obj/machinery/light_switch/west,
 /obj/decal/cleanable/dirt,
@@ -17022,12 +16142,33 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
-"aMZ" = (
-/obj/item/storage/toilet,
-/obj/machinery/door/window/southleft,
+"aNa" = (
+/obj/machinery/shower{
+	dir = 1;
+	pixel_y = 20
+	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
-"aNa" = (
+"aNb" = (
+/obj/rack,
+/obj/item/sponge{
+	name = "loofah"
+	},
+/obj/item/sponge{
+	name = "loofah"
+	},
+/obj/item/reagent_containers/glass/bottle/bubblebath,
+/obj/item/reagent_containers/glass/bottle/bubblebath,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/quarters_east)
+"aNc" = (
 /obj/item/storage/toilet,
 /obj/machinery/door/window/southleft,
 /obj/window/cubicle{
@@ -17039,7 +16180,7 @@
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
-"aNb" = (
+"aNe" = (
 /obj/item/storage/toilet,
 /obj/machinery/door/window/southleft,
 /obj/window/cubicle{
@@ -17047,7 +16188,13 @@
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
-"aNc" = (
+"aNf" = (
+/obj/machinery/disposal,
+/obj/disposalpipe/trunk/north,
+/obj/machinery/light_switch/east,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
+"aNg" = (
 /obj/machinery/light{
 	dir = 8;
 	layer = 9.1;
@@ -17060,7 +16207,7 @@
 	dir = 8
 	},
 /area/station/hallway/primary/east)
-"aNd" = (
+"aNh" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 4;
@@ -17071,7 +16218,7 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
-"aNe" = (
+"aNi" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/cable{
 	icon_state = "4-8"
@@ -17084,7 +16231,7 @@
 	dir = 4
 	},
 /area/station/hallway/primary/east)
-"aNf" = (
+"aNj" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Pool"
@@ -17095,110 +16242,69 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
-"aNg" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/drainage,
-/turf/simulated/floor/white,
-/area/station/crew_quarters/pool)
-"aNh" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/white,
-/area/station/crew_quarters/pool)
-"aNi" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/landmark/gps_waypoint,
-/turf/simulated/floor/white,
-/area/station/crew_quarters/pool)
-"aNj" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/white,
-/area/station/crew_quarters/pool)
 "aNk" = (
-/obj/item/beach_ball,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
-"aNl" = (
+"aNm" = (
+/obj/machinery/disposal,
+/obj/disposalpipe/trunk/south,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
+	},
+/turf/simulated/floor/specialroom/arcade,
+/area/station/janitor/supply)
+"aNn" = (
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
-"aNm" = (
-/obj/disposalpipe/segment/vertical,
-/obj/machinery/power/apc/autoname_west,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
+"aNo" = (
+/obj/rack,
+/obj/item/clothing/suit/space/emerg,
+/obj/item/clothing/head/emerg,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/air,
+/obj/item/device/light/flashlight,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"aNn" = (
-/obj/cable{
-	icon_state = "1-2"
+"aNp" = (
+/obj/lattice,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
 	},
+/turf/space,
+/area/space)
+"aNq" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/space)
+"aNr" = (
 /obj/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"aNo" = (
-/obj/cable{
 	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/autoname_east,
-/turf/simulated/floor/neutral/side{
-	dir = 4
-	},
-/area/station/crew_quarters/quarters_north)
-"aNp" = (
-/obj/window/cubicle{
-	dir = 1
-	},
-/obj/submachine/chef_sink/chem_sink{
-	dir = 4;
-	pixel_x = -8
-	},
-/turf/simulated/floor/red/side{
-	dir = 8
-	},
-/area/station/security/checkpoint/escape)
-"aNq" = (
-/obj/machinery/door/window/westleft,
-/turf/simulated/floor,
-/area/station/security/checkpoint/escape)
-"aNr" = (
-/turf/simulated/floor,
-/area/station/security/checkpoint/escape)
-"aNs" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "black";
-	icon_state = "bedsheet-black"
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 20
-	},
-/turf/simulated/floor/red/side{
-	dir = 4
-	},
-/area/station/security/checkpoint/escape)
-"aNt" = (
-/obj/machinery/door/airlock/pyro/external,
-/obj/cable{
 	icon_state = "1-2"
 	},
+/turf/simulated/floor/yellow/side{
+	dir = 6
+	},
+/area/station/engine/storage)
+"aNt" = (
 /turf/simulated/floor,
-/area/station/hangar/escape)
+/area/station/security/checkpoint/escape)
 "aNu" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -17253,14 +16359,11 @@
 	},
 /area/station/medical/cdc)
 "aNC" = (
-/obj/grille/catwalk{
-	dir = 5
+/obj/stool/chair/comfy{
+	dir = 4
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	icon_state = "catwalk_cross"
-	},
-/area/station/maintenance/southeast)
+/turf/simulated/floor/black/grime,
+/area/station/maintenance/inner/central)
 "aND" = (
 /obj/item/plant/herb/cannabis/spawnable,
 /obj/item/plant/herb/cannabis/spawnable,
@@ -17356,65 +16459,35 @@
 "aNR" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/engine/elect)
+/area/station/engine/engineering)
 "aNS" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/storage/tech)
-"aNT" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
 "aNU" = (
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
 "aNV" = (
-/obj/machinery/door/airlock/pyro{
-	dir = 4;
-	name = "Shower Room"
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
+/obj/item/instrument/large/jukebox,
+/turf/simulated/floor/carpet/red/fancy/narrow/ne,
+/area/station/maintenance/inner/central)
 "aNW" = (
-/obj/machinery/door/airlock/pyro{
+/obj/machinery/light/small{
 	dir = 4;
-	name = "Toilets"
+	pixel_x = 12
 	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
-"aNX" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/neutral/side{
-	dir = 8
-	},
-/area/station/hallway/primary/east)
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "aNY" = (
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
-"aNZ" = (
-/obj/pool/perspective{
-	dir = 9;
-	tag = "icon-pool (NORTHWEST)"
-	},
-/turf/simulated/floor/blue/checker,
-/area/station/crew_quarters/pool)
 "aOa" = (
 /obj/pool/perspective{
 	dir = 1;
@@ -17423,35 +16496,46 @@
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
 "aOb" = (
-/obj/pool/perspective{
-	density = 0;
-	dir = 1;
-	tag = "icon-pool (NORTH)"
+/obj/disposalpipe/segment/mail/vertical,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
 	},
-/obj/pool{
-	density = 0;
+/obj/machinery/firealarm{
 	dir = 8;
-	icon = 'icons/obj/fluid.dmi';
-	icon_state = "ladder";
-	name = "ladder"
+	pixel_x = -24
 	},
-/obj/channel{
-	required_to_pass = 210
+/turf/simulated/floor/yellow/corner{
+	dir = 1
 	},
-/turf/simulated/floor/blue/checker,
-/area/station/crew_quarters/pool)
+/area/station/hallway/primary/north)
 "aOc" = (
-/obj/pool/perspective{
-	dir = 5;
-	tag = "icon-pool (NORTHEAST)"
+/obj/machinery/power/apc/autoname_east,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/white/checker,
-/area/station/crew_quarters/pool)
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/hallway/primary/north)
 "aOd" = (
-/obj/storage/crate/furnacefuel,
-/turf/simulated/floor/blue/checker,
+/obj/machinery/door/airlock/pyro{
+	name = "Shower Room"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/wood,
 /area/station/crew_quarters/pool)
 "aOe" = (
+/obj/table/auto,
+/obj/item/device/analyzer/atmospheric,
+/obj/item/wrench,
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"aOg" = (
 /obj/table/wood/auto,
 /obj/random_item_spawner/desk_stuff,
 /obj/decal/xmas_lights/ephemeral{
@@ -17459,7 +16543,7 @@
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/nw,
 /area/station/crew_quarters/quarters_north)
-"aOf" = (
+"aOh" = (
 /obj/storage/crate,
 /obj/item/clothing/under/gimmick/princess,
 /obj/item/clothing/mask/horse_mask,
@@ -17469,36 +16553,26 @@
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/north,
 /area/station/crew_quarters/quarters_north)
-"aOg" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/obj/machinery/photocopier,
-/obj/machinery/phone/wall{
-	pixel_y = 32
-	},
-/turf/simulated/floor/neutral/side{
-	dir = 9
-	},
-/area/station/crew_quarters/quarters_north)
-"aOh" = (
+"aOj" = (
 /turf/simulated/floor/neutral/corner{
 	dir = 1
 	},
 /area/station/crew_quarters/quarters_north)
-"aOi" = (
+"aOk" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/light/emergency{
+	dir = 4;
+	pixel_x = 10
+	},
 /turf/simulated/floor/neutral/side{
 	dir = 4
 	},
 /area/station/crew_quarters/quarters_north)
-"aOj" = (
+"aOm" = (
 /obj/rack,
 /obj/machinery/light/small{
 	dir = 1;
@@ -17506,7 +16580,7 @@
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/north,
 /area/station/crew_quarters/quarters_north)
-"aOk" = (
+"aOn" = (
 /obj/table/wood/auto,
 /obj/item/clothing/gloves/fingerless,
 /obj/item/clothing/mask/balaclava,
@@ -17515,16 +16589,11 @@
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/ne,
 /area/station/crew_quarters/quarters_north)
-"aOl" = (
-/obj/item/storage/toilet{
-	dir = 4;
-	tag = ""
-	},
-/turf/simulated/floor/red/side{
-	dir = 8
-	},
-/area/station/security/checkpoint/escape)
-"aOm" = (
+"aOo" = (
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"aOp" = (
 /obj/window/cubicle{
 	dir = 8
 	},
@@ -17534,52 +16603,32 @@
 /obj/machinery/light,
 /turf/simulated/floor,
 /area/station/security/checkpoint/escape)
-"aOn" = (
+"aOq" = (
 /obj/machinery/floorflusher/minibrig,
 /obj/disposalpipe/trunk/south,
 /turf/simulated/floor,
 /area/station/security/checkpoint/escape)
-"aOo" = (
-/obj/table/reinforced/auto,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/reagent_containers/food/drinks/water,
-/turf/simulated/floor/red/side{
-	dir = 4
+"aOr" = (
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"aOs" = (
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/specialroom/arcade,
+/area/station/janitor/supply)
+"aOt" = (
+/obj/stool/bench/blue/auto,
+/obj/machinery/light/emergency{
+	dir = 1;
+	pixel_y = 16
 	},
-/area/station/security/checkpoint/escape)
-"aOp" = (
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"aOu" = (
 /obj/machinery/vending/cigarette,
 /obj/decal/xmas_lights/ephemeral{
 	pixel_y = 32
 	},
 /turf/simulated/floor/escape{
-	dir = 8
-	},
-/area/station/hallway/secondary/exit)
-"aOq" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
-"aOr" = (
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
-"aOs" = (
-/turf/simulated/floor/shuttlebay{
-	icon_state = "engine_caution_west"
-	},
-/area/station/hallway/secondary/exit)
-"aOt" = (
-/obj/stool/bench/blue/auto,
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
-"aOu" = (
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/stairs/wide/other{
 	dir = 8
 	},
 /area/station/hallway/secondary/exit)
@@ -17696,10 +16745,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "aOI" = (
-/obj/stool/bench/blue/auto,
-/obj/machinery/light/emergency{
-	dir = 1;
-	pixel_y = 16
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
@@ -17715,163 +16762,79 @@
 /turf/space,
 /area/space)
 "aOL" = (
-/obj/table/auto,
-/obj/item/disk/data/cartridge/diagnostics{
-	pixel_x = 4;
-	pixel_y = -2
-	},
-/obj/item/disk/data/cartridge/atmos{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/item/disk/data/cartridge{
-	desc = "A programmable data cartridge for portable microcomputers.";
-	name = "EEPROM Cart"
-	},
-/obj/item/device/audio_log,
-/obj/item/peripheral/card_scanner,
-/obj/item/peripheral/card_scanner,
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
+/obj/landmark{
+	name = "blobstart"
 	},
 /turf/simulated/floor/plating,
-/area/station/storage/tech)
+/area/station/maintenance/east)
 "aOM" = (
-/obj/table/auto,
-/obj/item/screwdriver,
-/obj/item/disk/data/fixed_disk,
-/obj/item/disk/data/floppy/computer3boot,
-/obj/item/disk/data/floppy/read_only/network_progs,
-/obj/item/disk/data/floppy/read_only/security_progs,
-/obj/item/disk/data/floppy/read_only/communications,
-/obj/item/disk/data/floppy/read_only/medical_progs,
-/obj/item/disk/data/floppy/read_only/terminal_os,
-/obj/item/peripheral/printer,
-/obj/item/device/flash,
-/turf/simulated/floor/grime,
-/area/station/storage/tech)
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "aON" = (
-/obj/machinery/vending/floppy,
-/turf/simulated/floor/grey/blackgrime/other,
-/area/station/storage/tech)
+/obj/grille/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5
+	},
+/area/space)
 "aOO" = (
-/obj/machinery/vending/computer3,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
+/obj/machinery/door/airlock/pyro/engineering{
+	name = "Engineering Hangar"
 	},
-/turf/simulated/floor/grey/blackgrime/other,
-/area/station/storage/tech)
+/obj/access_spawn/engineering_storage,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/yellow,
+/area/station/engine/storage)
 "aOP" = (
-/obj/stool/bench/blue/auto,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
-"aOQ" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
-/obj/stool/bench/blue/auto,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
+/turf/simulated/floor/carpet/red/fancy/edge/west,
+/area/station/maintenance/inner/central)
 "aOR" = (
-/obj/table/auto,
-/obj/item/paper_bin,
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
+/obj/machinery/drainage,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
 "aOS" = (
-/obj/submachine/chef_sink/chem_sink{
-	dir = 1
-	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
-"aOT" = (
-/obj/submachine/chef_sink/chem_sink{
-	dir = 1
-	},
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_x = 12
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
+/obj/stool/bench/blue/auto,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
-"aOU" = (
-/obj/pool/perspective{
-	dir = 8;
-	tag = "icon-pool (WEST)"
-	},
-/turf/simulated/floor/blue/checker,
-/area/station/crew_quarters/pool)
+"aOT" = (
+/obj/critter/boogiebot,
+/turf/simulated/floor/carpet/red/fancy/innercorner/north,
+/area/station/maintenance/inner/central)
 "aOV" = (
 /turf/simulated/pool/no_animate,
 /area/station/crew_quarters/pool)
-"aOW" = (
+"aOX" = (
 /obj/machinery/light/small/floor,
 /turf/simulated/pool/no_animate,
 /area/station/crew_quarters/pool)
-"aOX" = (
-/obj/pool/perspective{
-	dir = 4;
-	tag = "icon-pool (EAST)"
-	},
-/turf/simulated/floor/white/checker,
-/area/station/crew_quarters/pool)
 "aOY" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/stool/chair/comfy{
+	dir = 8
 	},
-/obj/machinery/light/small/floor,
-/turf/simulated/floor/white,
-/area/station/crew_quarters/pool)
+/turf/simulated/floor/carpet/red/fancy/edge/east,
+/area/station/maintenance/inner/central)
 "aOZ" = (
-/obj/storage/closet/dresser,
-/obj/item/clothing/under/gimmick/macho{
-	color = "#555555";
-	desc = "They're a little bit tight.";
-	name = "speedo"
+/obj/stool/bench/blue/auto,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
 	},
-/obj/item/clothing/under/swimsuit/random,
-/obj/item/clothing/under/swimsuit/random,
-/obj/item/clothing/under/swimsuit/random,
-/obj/item/clothing/under/shorts/random{
-	name = "swimming trunks";
-	rand_pos = 1
-	},
-/obj/item/clothing/under/shorts/random{
-	name = "swimming trunks";
-	rand_pos = 1
-	},
-/obj/item/clothing/under/shorts/random{
-	name = "swimming trunks";
-	rand_pos = 1
-	},
-/obj/item/clothing/shoes/flippers{
-	pixel_y = -9
-	},
-/obj/item/clothing/shoes/flippers{
-	pixel_y = -9
-	},
-/obj/item/clothing/shoes/flippers{
-	pixel_y = -9
-	},
-/turf/simulated/floor/blue/checker,
+/turf/simulated/floor/sanitary/white,
 /area/station/crew_quarters/pool)
-"aPa" = (
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_north)
 "aPb" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/left{
@@ -17888,44 +16851,39 @@
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
 "aPc" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/escape{
+/turf/simulated/floor/plating,
+/area/station/security/checkpoint/escape)
+"aPd" = (
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/stairs/wide/other{
 	dir = 8
 	},
 /area/station/hallway/secondary/exit)
-"aPd" = (
-/obj/table/auto,
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/obj/item/storage/toolbox/emergency,
-/obj/machinery/light_switch/north,
-/obj/item/device/light/glowstick,
-/obj/item/device/light/glowstick,
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
 "aPe" = (
-/obj/machinery/atmospherics/unary/outlet_injector{
-	dir = 8;
-	icon_state = "on";
-	on = 1
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
+	},
+/turf/simulated/floor/red/checker,
+/area/station/maintenance/central)
 "aPf" = (
 /turf/simulated/floor/escape,
 /area/station/hallway/secondary/exit)
 "aPg" = (
-/obj/machinery/door/airlock/pyro/external,
-/turf/simulated/floor/caution/northsouth,
+/obj/stool/bench/blue/auto,
+/turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "aPh" = (
 /obj/lattice{
@@ -17966,21 +16924,6 @@
 	},
 /turf/space,
 /area/station/solar/west)
-"aPm" = (
-/obj/grille/catwalk{
-	dir = 9
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 8;
-	icon_state = "catwalk_cross"
-	},
-/area/station/maintenance/southeast)
 "aPn" = (
 /obj/lattice{
 	dir = 1;
@@ -18010,10 +16953,6 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/west)
-"aPs" = (
-/obj/grille/catwalk,
-/turf/simulated/floor/airless/plating/catwalk,
-/area/station/maintenance/southeast)
 "aPt" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/dome)
@@ -18164,86 +17103,77 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
 /turf/simulated/floor/plating,
-/area/station/engine/elect)
+/area/station/engine/engineering)
 "aPE" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/elect)
+/obj/item/clothing/mask/wrestling,
+/obj/item/clothing/mask/wrestling/black,
+/obj/item/clothing/mask/wrestling/blue,
+/obj/item/clothing/mask/wrestling/green,
+/obj/item/clothing/under/gimmick/macho,
+/obj/item/clothing/under/gimmick/macho,
+/obj/storage/closet/dresser/random,
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/pool)
 "aPF" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
+/obj/machinery/atmospherics/valve/notify_admins/vertical{
+	dir = 4;
+	name = "Sauna Air Supply"
 	},
-/obj/warp_beacon/engineering,
-/turf/space,
-/area/space)
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "aPG" = (
-/obj/wingrille_spawn/auto,
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/horizontal,
+/obj/machinery/meter,
 /turf/simulated/floor/plating,
-/area/station/storage/tech)
+/area/station/maintenance/east)
 "aPH" = (
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/storage/tech)
-"aPI" = (
 /obj/cable{
 	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d2 = 4;
+	icon_state = "2-9"
 	},
-/turf/simulated/floor/grey/blackgrime/other,
-/area/station/storage/tech)
+/obj/disposalpipe/junction/left/south,
+/turf/simulated/floor/specialroom/arcade,
+/area/station/janitor/supply)
+"aPI" = (
+/obj/submachine/chef_sink{
+	desc = "A common utility sink.";
+	dir = 8;
+	name = "utility sink"
+	},
+/turf/simulated/floor/specialroom/arcade,
+/area/station/janitor/supply)
 "aPJ" = (
-/turf/simulated/floor/grey/blackgrime/other,
-/area/station/storage/tech)
-"aPK" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "yellow";
-	icon_state = "bedsheet-yellow"
+/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/escape_horizontal,
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/turf/simulated/floor/shuttlebay{
+	icon_state = "engine_caution_north"
 	},
-/obj/machinery/power/apc/autoname_east,
-/obj/item/luggable_computer,
-/turf/simulated/floor/grey/blackgrime/other,
-/area/station/storage/tech)
-"aPL" = (
-/obj/machinery/door/airlock/pyro{
-	name = "Shower Room"
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
+/area/station/hangar/escape)
 "aPM" = (
+/obj/machinery/r_door_control/podbay/escape,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hangar/escape)
+"aPN" = (
 /obj/machinery/door/airlock/pyro{
 	name = "Toilets"
 	},
 /obj/firedoor_spawn,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
-"aPN" = (
+"aPP" = (
+/obj/machinery/door_control/podbay/engineering/new_walls/north,
+/turf/simulated/floor/yellow/side{
+	dir = 1
+	},
+/area/station/hangar/engine)
+"aPQ" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/cable{
 	icon_state = "1-2"
@@ -18254,67 +17184,33 @@
 	dir = 8
 	},
 /area/station/hallway/primary/east)
-"aPO" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/east)
-"aPP" = (
-/obj/machinery/door/airlock/pyro/glass,
-/obj/disposalpipe/segment/mail/vertical,
-/obj/firedoor_spawn,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/neutral/side{
-	dir = 4
-	},
-/area/station/hallway/primary/east)
-"aPQ" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/obj/pool/perspective{
-	dir = 8;
-	tag = "icon-pool (WEST)"
-	},
-/turf/simulated/floor/white/checker,
-/area/station/crew_quarters/pool)
 "aPR" = (
-/obj/pool/perspective{
-	dir = 4;
-	tag = "icon-pool (EAST)"
-	},
-/obj/pool_springboard,
-/turf/simulated/floor/white/checker,
+/obj/critter/sealpup,
+/turf/simulated/pool/no_animate,
 /area/station/crew_quarters/pool)
 "aPS" = (
+/obj/machinery/light/small/warm/very{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/west,
+/area/station/maintenance/inner/central)
+"aPT" = (
+/obj/table/wood/auto,
+/obj/item/game_kit,
+/obj/item/decoration/ashtray,
+/turf/simulated/floor/carpet/red/fancy/edge/east,
+/area/station/maintenance/inner/central)
+"aPU" = (
 /obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
-"aPT" = (
-/obj/machinery/disposal,
-/obj/disposalpipe/trunk/west,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
-/turf/simulated/floor/blue/checker,
-/area/station/crew_quarters/pool)
-"aPU" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 9;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "aPV" = (
+/turf/simulated/floor/stairs/medical{
+	dir = 4
+	},
+/area/station/crew_quarters/pool)
+"aPW" = (
 /obj/table/wood/auto,
 /obj/machinery/light/lamp{
 	pixel_x = 1;
@@ -18322,49 +17218,22 @@
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/sw,
 /area/station/crew_quarters/quarters_north)
-"aPW" = (
-/obj/stool/chair,
+"aPX" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/neutral/side{
-	dir = 8
+	dir = 4
 	},
 /area/station/crew_quarters/quarters_north)
-"aPX" = (
+"aQa" = (
 /obj/table/wood/auto,
 /obj/item/matchbook,
 /turf/simulated/floor/carpet/red/fancy/edge/se,
 /area/station/crew_quarters/quarters_north)
-"aPY" = (
-/obj/table/reinforced/auto,
-/obj/machinery/networked/printer{
-	name = "Printer - Escape Checkpoint";
-	pixel_y = 5;
-	print_id = "EscapeCheckpoint"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/door_timer/minibrig/new_walls/north{
-	pixel_x = -6
-	},
-/obj/machinery/phone/wall{
-	pixel_x = 6;
-	pixel_y = 32
-	},
-/obj/machinery/light_switch/west{
-	pixel_y = -10
-	},
-/obj/item/device/radio/intercom/security{
-	dir = 4;
-	pixel_x = -20;
-	pixel_y = 4
-	},
-/turf/simulated/floor/red/side{
-	dir = 9
-	},
-/area/station/security/checkpoint/escape)
-"aPZ" = (
+"aQc" = (
 /obj/table/reinforced/auto,
 /obj/machinery/recharger,
 /obj/cable{
@@ -18376,15 +17245,48 @@
 	dir = 1
 	},
 /area/station/security/checkpoint/escape)
-"aQa" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
+"aQd" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/red/side{
-	dir = 1
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
+/turf/simulated/floor/plating,
 /area/station/security/checkpoint/escape)
-"aQb" = (
+"aQe" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
+	},
+/turf/simulated/floor/escape{
+	dir = 8
+	},
+/area/station/hallway/secondary/exit)
+"aQf" = (
+/turf/simulated/floor/grey,
+/area/station/hallway/secondary/exit)
+"aQg" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 9;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/obj/submachine/chef_sink/chem_sink{
+	dir = 8;
+	pixel_x = 8
+	},
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/pool)
+"aQh" = (
 /obj/machinery/disposal/brig{
 	name = "escape checkpoint chute"
 	},
@@ -18398,34 +17300,6 @@
 	dir = 5
 	},
 /area/station/security/checkpoint/escape)
-"aQc" = (
-/turf/simulated/floor/escape{
-	dir = 8
-	},
-/area/station/hallway/secondary/exit)
-"aQd" = (
-/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon14,
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
-"aQe" = (
-/turf/simulated/floor/stairs/wide/middle{
-	dir = 8
-	},
-/area/station/hallway/secondary/exit)
-"aQf" = (
-/turf/simulated/floor/grey,
-/area/station/hallway/secondary/exit)
-"aQg" = (
-/obj/machinery/firealarm{
-	pixel_x = 6;
-	pixel_y = 24
-	},
-/turf/simulated/floor/escape,
-/area/station/hallway/secondary/exit)
-"aQh" = (
-/obj/item/device/radio/beacon,
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
 "aQi" = (
 /obj/decal/fakeobjects/pipe/heat{
 	dir = 4
@@ -18494,14 +17368,9 @@
 	},
 /area/station/medical/cdc)
 "aQp" = (
-/obj/grille/catwalk{
-	dir = 10;
-	icon_state = "catwalk_cross"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 10
-	},
-/area/station/maintenance/southeast)
+/obj/machinery/atmospherics/pipe/simple/vertical,
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/sauna)
 "aQq" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/south,
@@ -18661,8 +17530,7 @@
 	name = "Genetic Research"
 	})
 "aQE" = (
-/obj/machinery/light,
-/turf/simulated/floor/stairs/wide{
+/turf/simulated/floor/escape{
 	dir = 8
 	},
 /area/station/hallway/secondary/exit)
@@ -18697,11 +17565,8 @@
 "aQI" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	icon_state = "0-2"
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/elect)
@@ -18715,6 +17580,27 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/ghostdrone_factory)
 "aQL" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"aQM" = (
+/obj/machinery/atmospherics/portables_connector{
+	name = "Escape N Repressurization Port"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"aQN" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -20
+	},
+/turf/simulated/floor/caution/east,
+/area/station/hangar/escape)
+"aQP" = (
 /obj/item/device/net_sniffer,
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -18723,39 +17609,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
-"aQM" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
+"aQQ" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/grey/blackgrime/other,
 /area/station/storage/tech)
-"aQN" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/grey/blackgrime/other,
-/area/station/storage/tech)
-"aQO" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/landmark/gps_waypoint,
-/turf/simulated/floor/grey/blackgrime/other,
-/area/station/storage/tech)
-"aQP" = (
+"aQR" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
 	name = "Technical Storage"
@@ -18767,69 +17627,31 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/grey/blackgrime/other,
 /area/station/storage/tech)
-"aQQ" = (
+"aQS" = (
+/obj/disposalpipe/segment/vertical,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
-"aQR" = (
+"aQT" = (
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/quarters_east)
+"aQU" = (
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/shuttlebay,
+/area/station/hangar/escape)
+"aQV" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/south,
 /obj/decal/xmas_lights/ephemeral{
 	pixel_y = 32
 	},
 /turf/simulated/floor/grey,
-/area/station/crew_quarters/quarters_east)
-"aQS" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
-	},
-/obj/submachine/laundry_machine,
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/quarters_east)
-"aQT" = (
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/quarters_east)
-"aQU" = (
-/obj/stool/chair{
-	dir = 4
-	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/autoname_north,
-/turf/simulated/floor/carpet/purple/fancy/edge/nw,
-/area/station/crew_quarters/quarters_east)
-"aQV" = (
-/obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
-	pixel_y = 8
-	},
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/carpet/purple/fancy/edge/north,
 /area/station/crew_quarters/quarters_east)
 "aQW" = (
 /obj/machinery/door/airlock/pyro/security{
@@ -18850,102 +17672,104 @@
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/podbay)
 "aQX" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/machinery/light_switch/north,
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/carpet/purple/fancy/edge/ne,
-/area/station/crew_quarters/quarters_east)
-"aQY" = (
-/obj/machinery/vending/coffee,
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/quarters_east)
-"aQZ" = (
-/obj/machinery/vending/snack,
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/quarters_east)
-"aRa" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/quarters_east)
-"aRb" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
-	dir = 4;
+	dir = 6;
 	name = "autoname - SS13";
-	pixel_x = -10;
+	pixel_y = 20;
 	tag = ""
 	},
-/obj/pool/perspective{
-	dir = 8;
-	tag = "icon-pool (WEST)"
+/turf/simulated/floor/shuttlebay,
+/area/station/hangar/escape)
+"aQY" = (
+/obj/table/auto,
+/obj/machinery/computer/security/wooden_tv/small{
+	pixel_y = 8
 	},
-/turf/simulated/floor/white/checker,
-/area/station/crew_quarters/pool)
-"aRc" = (
 /obj/machinery/light{
-	dir = 4;
+	dir = 1;
 	layer = 9.1;
-	pixel_x = 10
+	pixel_y = 21
 	},
-/obj/submachine/laundry_machine,
-/turf/simulated/floor/blue/checker,
-/area/station/crew_quarters/pool)
-"aRd" = (
-/obj/table/round/auto,
-/obj/item/kitchen/food_box/donut_box{
-	pixel_y = 5
+/turf/simulated/floor/carpet/purple/fancy/edge/north,
+/area/station/crew_quarters/quarters_east)
+"aQZ" = (
+/obj/table/auto,
+/obj/machinery/computer3/generic/personal,
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+	pixel_y = 24
 	},
-/turf/simulated/floor/neutral/side{
+/turf/simulated/floor/carpet/purple/fancy/edge/north,
+/area/station/crew_quarters/quarters_east)
+"aRa" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/purple/fancy/edge/se,
+/area/station/crew_quarters/quarters_east)
+"aRc" = (
+/obj/table/reinforced/auto,
+/obj/item/sheet/glass/reinforced{
+	amount = 50
+	},
+/obj/item/reagent_containers/food/drinks/fueltank,
+/obj/item/reagent_containers/food/drinks/fueltank,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/grey,
+/area/station/hangar/engine)
+"aRd" = (
+/turf/simulated/floor/carpet/red/fancy/narrow/sw,
+/area/station/maintenance/inner/central)
+"aRe" = (
+/turf/simulated/floor/carpet/red/fancy/edge/south,
+/area/station/maintenance/inner/central)
+"aRf" = (
+/obj/stool/chair/comfy{
 	dir = 8
 	},
-/area/station/crew_quarters/quarters_north)
-"aRe" = (
+/turf/simulated/floor/carpet/red/fancy/narrow/se,
+/area/station/maintenance/inner/central)
+"aRg" = (
 /obj/machinery/light{
 	dir = 4;
 	layer = 9.1;
 	pixel_x = 10
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 4
 	},
-/area/station/crew_quarters/quarters_north)
-"aRf" = (
-/obj/machinery/computer/card{
-	dir = 4
+/area/station/hallway/primary/north)
+"aRh" = (
+/obj/rack,
+/obj/item/sponge{
+	name = "loofah"
 	},
+/obj/machinery/light/small,
+/turf/simulated/floor/sanitary/white,
+/area/station/crew_quarters/pool)
+"aRj" = (
 /obj/cable{
+	d1 = 2;
 	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "4-9"
 	},
-/obj/machinery/power/apc/autoname_west,
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/red/side{
-	dir = 8
-	},
-/area/station/security/checkpoint/escape)
-"aRg" = (
+/turf/simulated/floor/carpet/grime,
+/area/station/security/detectives_office)
+"aRk" = (
 /obj/disposalpipe/segment/brig{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -18963,7 +17787,7 @@
 	},
 /turf/simulated/floor,
 /area/station/security/checkpoint/escape)
-"aRh" = (
+"aRl" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
@@ -18975,7 +17799,7 @@
 	},
 /turf/simulated/floor,
 /area/station/security/checkpoint/escape)
-"aRi" = (
+"aRm" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -18988,52 +17812,10 @@
 	dir = 4
 	},
 /area/station/security/checkpoint/escape)
-"aRj" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "4-9"
-	},
-/turf/simulated/floor/carpet/grime,
-/area/station/security/detectives_office)
-"aRk" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/decal/garland/ephemeral{
-	dir = 4;
-	pixel_x = -14
-	},
-/turf/simulated/floor/escape{
-	dir = 8
-	},
-/area/station/hallway/secondary/exit)
-"aRl" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
-"aRm" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/escape/corner,
-/area/station/hallway/secondary/exit)
 "aRn" = (
-/obj/machinery/door/airlock/pyro/external,
-/turf/simulated/floor/grey,
-/area/station/hallway/secondary/exit)
+/obj/machinery/atmospherics/pipe/manifold/east,
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/sauna)
 "aRo" = (
 /obj/lattice{
 	dir = 5;
@@ -19047,17 +17829,21 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/ghostdrone_factory)
 "aRq" = (
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/stool/chair/yellow{
+	dir = 8
 	},
-/obj/cable,
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
+/obj/landmark/start{
+	name = "Engineer"
 	},
-/turf/simulated/floor/plating,
-/area/station/engine/elect)
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 1
+	},
+/area/station/engine/engineering)
 "aRr" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/decal/fakeobjects/pipe/heat,
@@ -19101,11 +17887,10 @@
 /area/station/medical/cdc)
 "aRy" = (
 /obj/grille/catwalk{
-	dir = 6;
-	icon_state = "catwalk_cross"
+	dir = 4
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 6
+	dir = 4
 	},
 /area/station/maintenance/southeast)
 "aRz" = (
@@ -19346,34 +18131,41 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "aRR" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 10;
-	name = "autoname - SS13";
-	tag = ""
+/obj/machinery/light,
+/turf/simulated/floor/stairs/wide{
+	dir = 8
 	},
-/turf/simulated/floor/grey,
 /area/station/hallway/secondary/exit)
 "aRS" = (
-/obj/machinery/computer3/terminal/zeta{
-	dir = 4;
-	setup_os_string = "ZETA_MAINFRAME"
-	},
-/obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/storage/tech)
+/area/station/maintenance/east)
 "aRT" = (
+/obj/machinery/atmospherics/valve{
+	high_risk = 1;
+	name = "Escape Dock"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"aRU" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/storage/tech)
+"aRV" = (
 /obj/stool,
 /obj/cable{
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/grey/blackgrime/other,
 /area/station/storage/tech)
-"aRU" = (
+"aRW" = (
+/turf/simulated/floor/grey/blackgrime/other,
+/area/station/storage/tech)
+"aRX" = (
 /obj/rack,
 /obj/item/circuitboard/teleporter,
 /obj/item/circuitboard/card,
@@ -19387,23 +18179,18 @@
 	},
 /turf/simulated/floor/grey/blackgrime/other,
 /area/station/storage/tech)
-"aRV" = (
+"aRY" = (
+/obj/machinery/atmospherics/valve{
+	high_risk = 1;
+	name = "Air Reserve (Escape Dock)"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"aRZ" = (
 /obj/disposalpipe/junction/left/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
-"aRW" = (
-/obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
-"aRX" = (
+"aSa" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
@@ -19414,20 +18201,20 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters_east)
-"aRY" = (
+"aSb" = (
 /obj/disposalpipe/segment/bent/west,
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters_east)
-"aRZ" = (
+"aSd" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters_east)
-"aSa" = (
+"aSe" = (
 /obj/stool/chair{
 	dir = 4
 	},
@@ -19442,28 +18229,7 @@
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/west,
 /area/station/crew_quarters/quarters_east)
-"aSb" = (
-/obj/table/auto,
-/obj/item/reagent_containers/food/drinks/bowl,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/item/pen/pencil,
-/obj/item/reagent_containers/food/snacks/cereal_box,
-/turf/simulated/floor/carpet/purple,
-/area/station/crew_quarters/quarters_east)
-"aSc" = (
-/obj/table/auto,
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/phone,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/purple,
-/area/station/crew_quarters/quarters_east)
-"aSd" = (
+"aSf" = (
 /obj/stool/chair{
 	dir = 8
 	},
@@ -19475,47 +18241,52 @@
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/east,
 /area/station/crew_quarters/quarters_east)
-"aSe" = (
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_east)
-"aSf" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4;
-	name = "Crew Lounge"
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_east)
 "aSg" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 8
+	},
+/area/station/hallway/primary/east)
+"aSh" = (
 /obj/pool/perspective{
 	dir = 8;
 	tag = "icon-pool (WEST)"
 	},
 /turf/simulated/floor/white/checker,
 /area/station/crew_quarters/pool)
-"aSh" = (
+"aSi" = (
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/autoname_west,
+/turf/simulated/floor/caution/east,
+/area/station/hangar/escape)
+"aSj" = (
 /obj/fluid_spawner{
 	amount = 2100
 	},
 /turf/simulated/pool/no_animate,
 /area/station/crew_quarters/pool)
-"aSi" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/white,
-/area/station/crew_quarters/pool)
-"aSj" = (
-/obj/machinery/power/apc/autoname_east,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/blue/checker,
-/area/station/crew_quarters/pool)
 "aSk" = (
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/simulated/floor/shuttlebay,
+/area/station/hangar/escape)
+"aSl" = (
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"aSm" = (
 /obj/table/wood/auto,
 /obj/item/storage/fanny,
 /obj/decal/xmas_lights/ephemeral{
@@ -19523,23 +18294,10 @@
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/nw,
 /area/station/crew_quarters/quarters_north)
-"aSl" = (
-/obj/rack,
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/carpet/purple/fancy/edge/north,
+"aSo" = (
+/turf/simulated/floor,
 /area/station/crew_quarters/quarters_north)
-"aSm" = (
-/obj/stool/chair{
-	dir = 1
-	},
-/turf/simulated/floor/neutral/side{
-	dir = 8
-	},
-/area/station/crew_quarters/quarters_north)
-"aSn" = (
+"aSp" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -19556,57 +18314,23 @@
 	dir = 4
 	},
 /area/station/crew_quarters/quarters_north)
-"aSo" = (
-/obj/storage/crate,
-/obj/item/clothing/under/gimmick/macho{
-	color = "#555555";
-	desc = "They're a little bit tight.";
-	name = "speedo"
+"aSq" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "red";
+	icon_state = "bedsheet-red"
 	},
-/obj/item/clothing/head/apprentice,
-/obj/item/card_box/suit,
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
+/obj/item/storage/secure/ssafe{
+	pixel_x = -28
 	},
-/turf/simulated/floor/carpet/red/fancy/edge/north,
-/area/station/crew_quarters/quarters_north)
-"aSp" = (
-/obj/table/wood/auto,
-/obj/machinery/light/lamp{
-	pixel_x = 1;
-	pixel_y = 10
+/obj/landmark/start{
+	name = "Staff Assistant"
 	},
 /obj/decal/xmas_lights/ephemeral{
 	pixel_y = 32
 	},
-/turf/simulated/floor/carpet/red/fancy/edge/ne,
+/turf/simulated/floor/carpet/red/fancy/edge/nw,
 /area/station/crew_quarters/quarters_north)
-"aSq" = (
-/obj/machinery/computer3/generic/secure_data{
-	dir = 4;
-	tag = ""
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/red/side{
-	dir = 10
-	},
-/area/station/security/checkpoint/escape)
 "aSr" = (
 /obj/stool/chair/comfy{
 	dir = 4
@@ -19622,35 +18346,50 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aSs" = (
+/obj/table/wood/auto,
+/obj/machinery/light/lamp{
+	pixel_x = 1;
+	pixel_y = 10
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/ne,
+/area/station/crew_quarters/quarters_north)
+"aSu" = (
+/obj/stool/chair/office/red,
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/red/side,
 /area/station/security/checkpoint/escape)
-"aSt" = (
-/obj/storage/secure/closet/brig,
-/turf/simulated/floor/red/side{
-	dir = 6
-	},
-/area/station/security/checkpoint/escape)
-"aSu" = (
-/obj/machinery/door/airlock/pyro/glass,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/escape{
-	dir = 8
-	},
-/area/station/hallway/secondary/exit)
 "aSv" = (
-/obj/machinery/light,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13";
+	tag = ""
+	},
 /turf/simulated/floor/grey,
 /area/station/hallway/secondary/exit)
 "aSw" = (
-/obj/machinery/light/emergency{
-	dir = 4;
-	pixel_x = 10
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/grey,
-/area/station/hallway/secondary/exit)
+/area/station/hangar/engine)
 "aSx" = (
 /obj/disposalpipe/block_sensing_outlet/east,
 /turf/simulated/floor/plating,
@@ -19799,62 +18538,62 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/ghostdrone_factory)
 "aSS" = (
-/obj/table/auto,
-/obj/item/peripheral/sound_card,
-/obj/item/peripheral/printer,
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
-/turf/simulated/floor/grey/blackgrime/other,
-/area/station/storage/tech)
+/obj/machinery/vehicle/miniputt/indyputt/armed,
+/turf/simulated/floor/shuttlebay,
+/area/station/hangar/engine)
 "aST" = (
+/turf/simulated/floor/black/grime,
+/area/station/maintenance/inner/central)
+"aSU" = (
+/obj/table/wood/auto,
+/obj/item/instrument/harmonica,
+/obj/item/device/light/zippo,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/black/grime,
+/area/station/maintenance/inner/central)
+"aSV" = (
+/obj/table/wood/auto,
+/obj/item/instrument/saxophone,
+/obj/item/clothing/head/flatcap,
+/obj/item/clothing/head/flatcap,
+/obj/item/reagent_containers/food/drinks/bottle/ntbrew,
+/obj/item/dice,
+/obj/item/clothing/glasses/sunglasses,
+/obj/machinery/light/small/warm/very{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/black/grime,
+/area/station/maintenance/inner/central)
+"aSW" = (
 /obj/table/auto,
 /obj/item/peripheral/network/powernet_card,
 /obj/item/peripheral/network/radio/locked,
 /turf/simulated/floor/grey/blackgrime/other,
 /area/station/storage/tech)
-"aSU" = (
+"aSX" = (
 /obj/table/auto,
 /obj/item/peripheral/drive/cart_reader,
 /obj/item/peripheral/drive,
 /turf/simulated/floor/grey/blackgrime/other,
 /area/station/storage/tech)
-"aSV" = (
-/obj/rack,
-/obj/item/circuitboard/powermonitor,
-/obj/item/circuitboard/powermonitor_smes,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/obj/machinery/light_switch/east,
-/obj/item/circuitboard/genetics,
-/obj/item/circuitboard/bank_data,
-/obj/item/circuitboard/arcade,
-/turf/simulated/floor/grey/blackgrime/other,
-/area/station/storage/tech)
-"aSW" = (
-/obj/disposalpipe/segment/vertical,
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
-"aSX" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/decal/cleanable/dirt,
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
 "aSY" = (
+/obj/decal/poster/wallsign/security_wall,
+/obj/decal/poster/wallsign/stencil/left/v{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/pool)
+"aSZ" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/landmark/gps_waypoint,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/sauna)
+"aTa" = (
 /obj/table/auto,
 /obj/item/storage/box/cutlery,
 /obj/machinery/light{
@@ -19864,10 +18603,7 @@
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters_east)
-"aSZ" = (
-/turf/simulated/floor/carpet/purple/fancy/edge/sw,
-/area/station/crew_quarters/quarters_east)
-"aTa" = (
+"aTc" = (
 /obj/stool/chair{
 	dir = 1
 	},
@@ -19876,13 +18612,7 @@
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/south,
 /area/station/crew_quarters/quarters_east)
-"aTb" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet/purple/fancy/edge/se,
-/area/station/crew_quarters/quarters_east)
-"aTc" = (
+"aTd" = (
 /obj/stool/chair,
 /obj/machinery/light{
 	dir = 4;
@@ -19891,35 +18621,46 @@
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters_east)
-"aTd" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
+"aTe" = (
+/obj/cable{
+	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/neutral/side{
-	dir = 4
+	dir = 8
 	},
 /area/station/hallway/primary/east)
-"aTe" = (
+"aTf" = (
+/obj/machinery/atmospherics/unary/furnace_connector{
+	dir = 4
+	},
+/obj/machinery/power/furnace/thermo,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/sauna)
+"aTg" = (
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"aTh" = (
 /obj/pool/perspective{
-	dir = 10;
-	tag = "icon-pool (SOUTHWEST)"
+	dir = 4;
+	tag = "icon-pool (EAST)"
 	},
 /turf/simulated/floor/white/checker,
 /area/station/crew_quarters/pool)
-"aTf" = (
-/obj/pool/perspective,
-/obj/pool/perspective{
-	dir = 8;
-	tag = "icon-pool (WEST)"
-	},
-/turf/simulated/floor{
-	icon_state = "bluechecker"
-	},
+"aTi" = (
+/turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
-"aTg" = (
+"aTj" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 9;
@@ -19929,42 +18670,6 @@
 	},
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
-"aTh" = (
-/obj/storage/closet/fire,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"aTi" = (
-/obj/disposalpipe/segment/vertical,
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"aTj" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"aTk" = (
-/obj/landmark/gps_waypoint,
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_north)
-"aTl" = (
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/ai_monitored/armory)
 "aTm" = (
 /obj/table/wood/auto,
 /obj/item/device/camera_viewer,
@@ -19982,35 +18687,45 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aTn" = (
-/obj/machinery/alarm{
+/turf/simulated/wall/auto/supernorn,
+/area/station/hallway/primary/east)
+"aTo" = (
+/obj/machinery/door/airlock/pyro/security{
+	dir = 4;
+	name = "Dock Checkpoint"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/firedoor_spawn,
+/obj/machinery/secscanner{
 	dir = 4;
 	pixel_x = -20
 	},
-/turf/simulated/floor/escape{
-	dir = 8
-	},
-/area/station/hallway/secondary/exit)
-"aTo" = (
-/obj/shrub{
-	dir = 1
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "2-4"
 	},
-/obj/machinery/power/apc/autoname_east,
-/obj/machinery/light/emergency,
-/turf/simulated/floor/escape,
-/area/station/hallway/secondary/exit)
+/turf/simulated/floor/red,
+/area/station/security/checkpoint/escape)
 "aTp" = (
 /turf/space,
 /area/shuttle/escape/station/cogmap2)
 "aTq" = (
-/obj/machinery/door/airlock/pyro/external{
-	name = "Auxiliary Docking Point"
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/caution/northsouth,
-/area/station/hallway/secondary/exit)
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 5;
+	level = 2
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "aTr" = (
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -20030,18 +18745,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aTu" = (
-/obj/stool/chair/red{
-	dir = 4
+/obj/lattice{
+	icon_state = "lattice-dir"
 	},
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
-/obj/machinery/computer/riotgear{
-	dir = 4;
-	icon_state = "drawbr0";
-	pixel_x = -28
-	},
-/turf/simulated/floor/engine,
+/turf/space,
 /area/station/ai_monitored/armory)
 "aTv" = (
 /obj/item/raw_material/shard/glass,
@@ -20185,21 +18895,52 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aTK" = (
-/obj/machinery/door/airlock/pyro/maintenance,
-/obj/disposalpipe/segment/vertical,
+/obj/disposalpipe/segment/horizontal,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold{
+	level = 2
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/east)
 "aTL" = (
-/obj/table/auto,
-/obj/machinery/microwave,
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/quarters_east)
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 4
+	},
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/maintenance/east)
 "aTM" = (
+/obj/disposalpipe/segment/bent/south,
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
+	},
+/turf/simulated/floor/caution/east,
+/area/station/hangar/escape)
+"aTN" = (
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 10
+	},
+/turf/simulated/floor/shuttlebay,
+/area/station/hangar/escape)
+"aTO" = (
 /obj/stool/chair{
 	dir = 4
 	},
@@ -20211,25 +18952,25 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/quarters_east)
-"aTN" = (
-/obj/table/auto,
-/obj/item/game_kit,
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/quarters_east)
-"aTO" = (
-/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon12,
-/turf/simulated/floor,
-/area/station/hallway/primary/east)
 "aTP" = (
+/obj/disposalpipe/segment/mail/vertical,
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/hallway/primary/east)
+"aTQ" = (
+/obj/pool/perspective{
+	dir = 10;
+	tag = "icon-pool (SOUTHWEST)"
+	},
+/turf/simulated/floor/white/checker,
+/area/station/crew_quarters/pool)
+"aTR" = (
 /obj/machinery/light,
 /obj/pool/perspective,
 /turf/simulated/floor/white/checker,
 /area/station/crew_quarters/pool)
-"aTQ" = (
-/obj/pool/perspective,
-/turf/simulated/floor/white/checker,
-/area/station/crew_quarters/pool)
-"aTR" = (
+"aTT" = (
 /obj/machinery/light,
 /obj/pool/perspective{
 	dir = 6;
@@ -20237,32 +18978,19 @@
 	},
 /turf/simulated/floor/white/checker,
 /area/station/crew_quarters/pool)
-"aTS" = (
+"aTU" = (
 /obj/machinery/drainage,
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
-"aTT" = (
+"aTV" = (
+/obj/machinery/light_switch/east,
+/turf/simulated/floor/blue/checker,
+/area/station/crew_quarters/pool)
+"aTW" = (
 /obj/storage/closet/emergency,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"aTU" = (
-/obj/disposalpipe/segment/vertical,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"aTV" = (
-/obj/machinery/power/apc{
-	areastring = "East Primary Hallway";
-	dir = 4;
-	name = "East Primary Hallway APC";
-	pixel_x = 24
-	},
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"aTW" = (
+"aTX" = (
 /obj/table/wood/auto,
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
@@ -20273,21 +19001,46 @@
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/sw,
 /area/station/crew_quarters/quarters_north)
-"aTX" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/neutral/side{
+"aTY" = (
+/obj/stool/chair{
 	dir = 8
 	},
-/area/station/crew_quarters/quarters_north)
-"aTY" = (
-/obj/shrub,
-/turf/simulated/floor,
+/obj/machinery/light/small,
+/turf/simulated/floor/carpet/purple/fancy/edge/south,
 /area/station/crew_quarters/quarters_north)
 "aTZ" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light_switch/east,
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/crew_quarters/quarters_north)
+"aUa" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "red";
+	icon_state = "bedsheet-red"
+	},
+/obj/item/storage/secure/ssafe{
+	pixel_x = -28
+	},
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/sw,
+/area/station/crew_quarters/quarters_north)
+"aUb" = (
+/obj/stool/chair{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/carpet/red/fancy/edge/south,
+/area/station/crew_quarters/quarters_north)
+"aUc" = (
 /obj/table/wood/auto,
 /obj/item/reagent_containers/food/drinks/eggnog{
 	desc = "A festive beverage made with eggs. Someone's rigged up a cute little refrigerating device on the bottom.";
@@ -20295,53 +19048,28 @@
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/se,
 /area/station/crew_quarters/quarters_north)
-"aUa" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/obj/stool/chair/red{
-	dir = 4
-	},
-/turf/simulated/floor/escape{
-	dir = 1
-	},
-/area/station/hallway/primary/east)
-"aUb" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/turf/simulated/floor/escape{
-	dir = 1
-	},
-/area/station/hallway/primary/east)
-"aUc" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/escape{
-	dir = 1
-	},
-/area/station/hallway/primary/east)
 "aUd" = (
-/obj/disposaloutlet/south,
-/obj/disposalpipe/trunk/west,
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/escape{
-	dir = 5
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/area/station/hallway/primary/east)
+/turf/simulated/floor/plating,
+/area/station/hangar/engine)
 "aUe" = (
-/obj/decal/poster/wallsign/stencil/left/e{
-	pixel_x = -1
+/obj/shrub{
+	dir = 1
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/autoname_east,
+/obj/machinery/light/emergency,
+/turf/simulated/floor/escape,
 /area/station/hallway/secondary/exit)
 "aUf" = (
 /obj/decal/fakeobjects/pipe/heat{
@@ -20465,10 +19193,25 @@
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai_upload)
 "aUt" = (
+/obj/item/device/radio/intercom/cargo,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/delivery,
+/area/station/hangar/engine)
+"aUu" = (
 /obj/stool/chair,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
-"aUu" = (
+"aUv" = (
+/obj/decal/cleanable/dirt,
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
+"aUw" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 6;
@@ -20478,15 +19221,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
-"aUv" = (
-/obj/disposalpipe/segment/bent/east,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
-"aUw" = (
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
 "aUx" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/grey,
+/area/station/hangar/engine)
+"aUy" = (
 /obj/disposalpipe/segment/bent/west,
 /obj/cable{
 	d1 = 1;
@@ -20495,52 +19241,55 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
-"aUy" = (
-/obj/machinery/door/airlock/pyro{
-	name = "Chef's Quarters"
-	},
-/obj/access_spawn/kitchen,
-/obj/firedoor_spawn,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/quarters_east)
 "aUz" = (
 /turf/unsimulated/wall/auto/reinforced/supernorn,
 /area/station/crewquarters/cryotron)
 "aUA" = (
-/obj/machinery/door/airlock/pyro/glass{
-	name = "Cryogenics Chamber"
-	},
-/obj/firedoor_spawn,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/decal/garland/ephemeral,
-/turf/unsimulated/floor/circuit/vintage,
-/area/station/crewquarters/cryotron)
+/obj/machinery/vehicle/pod_smooth/industrial,
+/turf/simulated/floor/shuttlebay,
+/area/station/hangar/engine)
 "aUB" = (
+/obj/machinery/portable_atmospherics/canister/air/large,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
+/area/station/hangar/engine)
+"aUC" = (
 /obj/wingrille_spawn/auto,
 /obj/decal/poster/wallsign/escape_right,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/quarters_east)
-"aUC" = (
-/obj/disposalpipe/segment/mail/vertical,
+"aUD" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/quarters_east)
+"aUE" = (
+/obj/machinery/door/unpowered/wood/pyro{
+	dir = 1;
+	name = "The Recluse"
+	},
+/turf/simulated/floor/carpet/red/fancy/narrow/north,
+/area/station/maintenance/inner/central)
+"aUF" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/neutral/corner{
 	dir = 4
 	},
-/area/station/hallway/primary/east)
-"aUD" = (
-/obj/machinery/vending/cards,
-/turf/simulated/floor/neutral/side{
-	dir = 5
-	},
-/area/station/hallway/primary/east)
-"aUE" = (
-/obj/wingrille_spawn/auto,
-/obj/decal/poster/wallsign/escape_right,
-/turf/simulated/floor/plating,
+/area/station/hallway/primary/north)
+"aUG" = (
+/obj/stool/bench/blue/auto,
+/turf/simulated/floor/sanitary,
 /area/station/crew_quarters/pool)
-"aUF" = (
+"aUH" = (
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Pool"
 	},
@@ -20548,76 +19297,55 @@
 /obj/decal/garland/ephemeral,
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
-"aUG" = (
-/obj/decal/poster/wallsign/escape_right,
+"aUI" = (
+/obj/machinery/atmospherics/pipe/simple/junction/west,
+/obj/machinery/light/small,
+/obj/machinery/space_heater,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/sauna)
+"aUJ" = (
+/obj/machinery/atmospherics/pipe/simple/northwest,
 /turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/pool)
-"aUH" = (
+/area/station/crew_quarters/sauna)
+"aUK" = (
+/obj/decal/poster/wallsign/fuck2,
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/quarters_north)
+"aUL" = (
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"aUM" = (
+/obj/table/round/auto,
+/obj/item/storage/toolbox/emergency,
+/obj/item/storage/firstaid/regular,
+/obj/item/crowbar,
+/obj/item/storage/wall/emergency{
+	dir = 8;
+	pixel_x = 32
+	},
+/obj/machinery/light/emergency,
+/turf/unsimulated/floor/sanitary,
+/area/station/crewquarters/cryotron)
+"aUN" = (
+/obj/machinery/door/airlock/pyro/maintenance,
 /obj/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"aUI" = (
-/obj/machinery/door/airlock/pyro/glass{
-	name = "North Crew Quarters"
-	},
+"aUO" = (
+/obj/machinery/door/airlock/pyro/maintenance,
 /obj/firedoor_spawn,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/neutral/side{
-	dir = 8
-	},
+/turf/simulated/floor/neutral/side,
 /area/station/crew_quarters/quarters_north)
-"aUJ" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/quarters_north)
-"aUK" = (
-/obj/machinery/door/airlock/pyro/glass{
-	name = "North Crew Quarters"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/firedoor_spawn,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/neutral/side{
-	dir = 4
-	},
-/area/station/crew_quarters/quarters_north)
-"aUL" = (
-/obj/stool/chair/red{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/east)
-"aUM" = (
+"aUP" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
-"aUN" = (
-/turf/simulated/floor/neutral/corner,
-/area/station/hallway/primary/east)
-"aUO" = (
-/obj/decal/garland/ephemeral{
-	dir = 8;
-	pixel_x = 14
-	},
-/turf/simulated/floor/escape/corner{
-	dir = 4
-	},
-/area/station/hallway/primary/east)
-"aUP" = (
-/turf/simulated/floor/escape/corner{
-	dir = 1
-	},
-/area/station/hallway/secondary/exit)
 "aUQ" = (
 /obj/disposalpipe/segment/vertical,
 /obj/decal/fakeobjects/pipe/heat{
@@ -20829,6 +19557,34 @@
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
 "aVn" = (
+/obj/disposalpipe/segment/vertical,
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/caution/east,
+/area/station/hangar/escape)
+"aVo" = (
+/obj/machinery/atmospherics/pipe/simple,
+/turf/simulated/floor/shuttlebay,
+/area/station/hangar/escape)
+"aVp" = (
+/obj/machinery/conveyor{
+	dir = 1;
+	name = "cargo belt - north";
+	operating = 1
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/caution/westeast,
+/area/station/hangar/engine)
+"aVq" = (
 /obj/table/auto,
 /obj/item/decoration/ashtray,
 /obj/item/dice{
@@ -20848,43 +19604,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
-"aVo" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
-"aVp" = (
-/obj/disposalpipe/segment/bent/east,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
-"aVq" = (
-/obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
 "aVr" = (
-/obj/decal/cleanable/dirt,
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
-"aVs" = (
-/obj/disposalpipe/switch_junction/biofilter/right/east,
-/obj/cable{
-	icon_state = "4-8"
+/obj/disposalpipe/segment/bent/east,
+/obj/submachine/GTM{
+	pixel_y = 32
 	},
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
-"aVt" = (
+"aVs" = (
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
+"aVv" = (
 /obj/disposalpipe/segment/food{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -20894,7 +19634,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
-"aVu" = (
+"aVw" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 8;
@@ -20902,38 +19642,28 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
-"aVv" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "green";
-	icon_state = "bedsheet-green"
-	},
-/obj/decal/poster/wallsign/poster_rand{
-	pixel_y = 26
-	},
-/obj/landmark/start{
-	name = "Chef"
-	},
-/obj/item/instrument/cowbell,
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/quarters_east)
-"aVw" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/quarters_east)
 "aVx" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable,
-/turf/simulated/floor/plating,
+/obj/table/auto,
+/obj/machinery/cell_charger,
+/obj/item/cell/supercell/charged,
+/obj/item/cell/supercell/charged,
+/obj/item/cell/supercell/charged,
+/turf/simulated/floor/yellow,
 /area/station/engine/elect)
 "aVz" = (
+/obj/cryotron,
+/turf/unsimulated/floor/sanitary,
+/area/station/crewquarters/cryotron)
+"aVA" = (
+/turf/unsimulated/floor/sanitary,
+/area/station/crewquarters/cryotron)
+"aVB" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/unsimulated/floor/sanitary,
+/area/station/crewquarters/cryotron)
+"aVC" = (
 /obj/machinery/manufacturer/uniform,
 /obj/machinery/alarm{
 	dir = 8;
@@ -20942,7 +19672,17 @@
 /obj/item/device/radio/intercom,
 /turf/unsimulated/floor/sanitary,
 /area/station/crewquarters/cryotron)
-"aVA" = (
+"aVD" = (
+/obj/disposalpipe/segment/bent/west,
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
+"aVE" = (
 /obj/table/reinforced/auto,
 /obj/machinery/computer/tour_console,
 /obj/cable{
@@ -20952,7 +19692,7 @@
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/east)
-"aVB" = (
+"aVF" = (
 /obj/machinery/guardbot_dock{
 	desc = "A recharging and command station for PR-4 Robuddies.";
 	name = "tourbot docking station"
@@ -20980,7 +19720,7 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/east)
-"aVC" = (
+"aVG" = (
 /obj/disposalpipe/segment/brig{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -20995,32 +19735,31 @@
 	dir = 8
 	},
 /area/station/hallway/primary/east)
-"aVD" = (
+"aVH" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
+"aVI" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
-/turf/simulated/floor/escape/corner{
-	dir = 4
+/obj/machinery/light/emergency{
+	dir = 1;
+	pixel_y = 16
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 1
 	},
 /area/station/hallway/primary/east)
-"aVE" = (
-/obj/disposalpipe/segment/brig{
-	dir = 8
-	},
-/obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/floor/escape/corner{
-	dir = 8
-	},
-/area/station/hallway/primary/east)
-"aVF" = (
-/obj/disposalpipe/segment/brig{
-	dir = 8
-	},
-/turf/simulated/floor/neutral/corner{
-	dir = 4
-	},
-/area/station/hallway/primary/east)
-"aVG" = (
+"aVJ" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
@@ -21028,7 +19767,18 @@
 	dir = 1
 	},
 /area/station/hallway/primary/east)
-"aVH" = (
+"aVK" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
+"aVL" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
@@ -21036,7 +19786,7 @@
 	dir = 1
 	},
 /area/station/hallway/primary/east)
-"aVI" = (
+"aVM" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
@@ -21050,7 +19800,7 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
-"aVJ" = (
+"aVN" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
@@ -21065,7 +19815,7 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
-"aVK" = (
+"aVO" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
@@ -21086,34 +19836,7 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
-"aVL" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4
-	},
-/obj/disposalpipe/segment/brig{
-	dir = 8
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor,
-/area/station/hallway/primary/east)
-"aVM" = (
-/obj/disposalpipe/segment/brig{
-	dir = 8
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/neutral/corner{
-	dir = 4
-	},
-/area/station/hallway/primary/east)
-"aVN" = (
+"aVP" = (
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
@@ -21129,18 +19852,7 @@
 	dir = 1
 	},
 /area/station/hallway/primary/east)
-"aVO" = (
-/obj/disposalpipe/segment/brig{
-	dir = 8
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/neutral/side{
-	dir = 1
-	},
-/area/station/hallway/primary/east)
-"aVP" = (
+"aVR" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
@@ -21156,7 +19868,7 @@
 	dir = 1
 	},
 /area/station/hallway/primary/east)
-"aVQ" = (
+"aVS" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
@@ -21170,7 +19882,21 @@
 	dir = 1
 	},
 /area/station/hallway/primary/east)
-"aVR" = (
+"aVT" = (
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 1
+	},
+/area/station/hallway/primary/east)
+"aVU" = (
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
@@ -21186,7 +19912,7 @@
 	dir = 1
 	},
 /area/station/hallway/primary/east)
-"aVS" = (
+"aVV" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
@@ -21198,7 +19924,20 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
-"aVT" = (
+"aVW" = (
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/emergency{
+	dir = 1;
+	pixel_y = 16
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/east)
+"aVX" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
@@ -21207,7 +19946,7 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
-"aVU" = (
+"aVY" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -21219,46 +19958,12 @@
 	dir = 5
 	},
 /area/station/hallway/primary/east)
-"aVV" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/east)
-"aVW" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/decal/garland/ephemeral{
-	dir = 8;
-	pixel_x = 14
-	},
-/turf/simulated/floor/neutral/side{
-	dir = 8
-	},
-/area/station/hallway/primary/east)
-"aVX" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
-"aVY" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
 "aVZ" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/landmark/gps_waypoint,
 /turf/simulated/floor,
-/area/station/hallway/secondary/exit)
+/area/station/hallway/primary/east)
 "aWa" = (
 /obj/machinery/floorflusher/industrial,
 /obj/disposalpipe/trunk{
@@ -21574,12 +20279,36 @@
 /turf/space,
 /area/mining/magnet)
 "aWF" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/landmark/halloween,
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
+"aWG" = (
 /obj/stool/chair{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
-"aWG" = (
+"aWH" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/item/reagent_containers/food/snacks/cereal_box/roach,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
+"aWI" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
+"aWJ" = (
 /obj/rack,
 /obj/item/clothing/suit/fire,
 /obj/item/clothing/mask/gas/emergency,
@@ -21589,7 +20318,7 @@
 /obj/item/crowbar,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
-"aWH" = (
+"aWK" = (
 /obj/rack,
 /obj/item/clothing/suit/space/emerg,
 /obj/item/clothing/head/emerg,
@@ -21598,39 +20327,8 @@
 /obj/item/device/light/flashlight,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
-"aWI" = (
-/obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
-"aWJ" = (
-/obj/grille/steel,
-/obj/disposalpipe/segment/food{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
-"aWK" = (
-/obj/grille/steel,
-/obj/disposalpipe/loafer{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
 "aWL" = (
-/obj/grille/steel,
-/obj/disposalpipe/segment/food{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
+/obj/storage/closet/emergency,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aWM" = (
@@ -21645,18 +20343,37 @@
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/podbay)
 "aWN" = (
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/quarters_east)
-"aWO" = (
-/obj/storage/secure/closet/personal,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+/obj/grille/steel,
+/obj/disposalpipe/loafer{
+	dir = 4
 	},
-/obj/machinery/light/emergency,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
+"aWO" = (
+/obj/machinery/light/emergency{
+	dir = 4;
+	pixel_x = 10
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/hallway/primary/north)
+"aWR" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/unsimulated/floor/sanitary,
 /area/station/crewquarters/cryotron)
-"aWP" = (
+"aWS" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/unsimulated/floor/sanitary,
+/area/station/crewquarters/cryotron)
+"aWT" = (
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
 	name = "Cryogenics Chamber"
@@ -21667,7 +20384,7 @@
 	},
 /turf/unsimulated/floor/circuit/vintage,
 /area/station/crewquarters/cryotron)
-"aWQ" = (
+"aWU" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -21677,7 +20394,7 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/east)
-"aWR" = (
+"aWV" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -21685,131 +20402,96 @@
 	dir = 9
 	},
 /area/station/hallway/primary/east)
-"aWS" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon17,
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/neutral/corner{
-	dir = 1
-	},
-/area/station/hallway/primary/east)
-"aWT" = (
-/obj/machinery/navbeacon{
-	codes_txt = "tour;next_tour=tour1;desc=Greetings, unfrozen crew member or other participant! I am the Mitigative After-Rest Crew Orientation unit, or Marco for short, and I'm here to show you around. Let's go!";
-	freq = 1443;
-	location = "tour0";
-	name = "tour beacon - start"
-	},
-/turf/simulated/floor/escape/corner,
-/area/station/hallway/primary/east)
-"aWU" = (
-/obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/floor/escape/corner{
-	dir = 1
-	},
-/area/station/hallway/primary/east)
-"aWV" = (
-/obj/machinery/navbeacon{
-	codes_txt = "tour;next_tour=tour20;desc=Thank you for joining me on this tour! You should now be acclimatized to the station. If you're still feeling a bit lost, look for the Bartender or Head of Personnel.";
-	freq = 1443;
-	location = "tour19";
-	name = "tour 19 - conclusion"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/east)
 "aWW" = (
-/obj/machinery/navbeacon{
-	codes_txt = "tour;next_tour=tour18;desc=Oh, before I forget. Head out the shower room's back door and hang a left, and look for the wood doors. Don't tell anyone I told you.";
-	freq = 1443;
-	location = "tour17";
-	name = "tour 17 - east"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/east)
-"aWX" = (
-/obj/disposalpipe/segment/bent/east,
-/obj/cable{
-	icon_state = "2-4"
-	},
 /obj/landmark/halloween,
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
+"aWX" = (
+/obj/machinery/computer/tanning,
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/sauna)
 "aWY" = (
-/obj/disposalpipe/junction/middle/north,
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/door/airlock/pyro{
+	name = "Sauna"
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/east)
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/sauna)
 "aWZ" = (
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aXa" = (
-/obj/wingrille_spawn/auto,
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/east)
+/obj/storage/crate,
+/obj/item/clothing/under/misc/vice,
+/obj/item/clothing/glasses/sunglasses,
+/obj/item/reagent_containers/food/drinks/bottle/fancy_beer,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/north,
+/area/station/crew_quarters/quarters_north)
 "aXb" = (
-/obj/disposalpipe/segment/horizontal,
-/obj/machinery/navbeacon{
-	codes_txt = "tour;next_tour=tour19;desc=This section of the station contains crew quarters and the evacuation wing. In the event the emergency shuttle is called, please proceed down this corridor in an orderly fashion.";
-	freq = 1443;
-	location = "tour18";
-	name = "tour 18 - crew"
+/obj/table/wood/auto,
+/obj/item/camera_test,
+/obj/item/clothing/head/det_hat{
+	desc = "Ugh, gross.";
+	name = "fedora"
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/east)
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/ne,
+/area/station/crew_quarters/quarters_north)
 "aXc" = (
-/obj/disposalpipe/junction/right/west,
+/obj/disposalpipe/segment/vertical,
+/obj/machinery/door_control/podbay/escape/new_walls/west,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "1-4"
 	},
-/obj/landmark/halloween,
-/turf/simulated/floor,
-/area/station/hallway/primary/east)
-"aXd" = (
-/obj/disposalpipe/segment/horizontal,
-/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon13,
-/turf/simulated/floor,
-/area/station/hallway/primary/east)
-"aXe" = (
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/neutral/side{
+/turf/simulated/floor/caution/corner/misc{
 	dir = 5
 	},
-/area/station/hallway/primary/east)
-"aXf" = (
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/neutral/corner{
-	dir = 4
+/area/station/hangar/escape)
+"aXd" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/area/station/hallway/primary/east)
+/obj/machinery/atmospherics/pipe/simple,
+/turf/simulated/floor/caution/north,
+/area/station/hangar/escape)
+"aXe" = (
+/turf/simulated/floor/caution/north,
+/area/station/hangar/escape)
+"aXf" = (
+/obj/machinery/conveyor{
+	dir = 1;
+	name = "cargo belt - north";
+	operating = 1
+	},
+/turf/simulated/floor/caution/westeast,
+/area/station/hangar/engine)
 "aXg" = (
-/obj/machinery/disposal,
-/obj/disposalpipe/trunk/west,
+/obj/machinery/computer/ordercomp,
+/obj/cable,
+/obj/machinery/power/data_terminal,
 /obj/machinery/camera{
 	c_tag = "autotag";
-	dir = 9;
+	dir = 10;
 	name = "autoname - SS13";
-	pixel_x = 10;
 	tag = ""
 	},
-/turf/simulated/floor/escape/corner,
-/area/station/hallway/primary/east)
+/turf/simulated/floor/grey,
+/area/station/hangar/engine)
 "aXh" = (
-/turf/simulated/floor/escape/corner{
-	dir = 8
-	},
-/area/station/hallway/secondary/exit)
+/obj/machinery/light,
+/turf/simulated/floor/shuttlebay,
+/area/station/hangar/engine)
 "aXi" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -21858,45 +20540,42 @@
 /turf/simulated/floor/circuit/red,
 /area/ghostdrone_factory)
 "aXo" = (
-/obj/wingrille_spawn/auto,
-/obj/cable,
 /obj/cable{
-	icon_state = "0-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 1
+	},
 /area/station/engine/elect)
 "aXq" = (
-/obj/table/reinforced/auto,
-/obj/access_spawn/engineering_mechanic,
-/obj/machinery/door/airlock/pyro/glass/windoor{
-	dir = 4
-	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/yellow/side{
-	dir = 9
-	},
+/turf/simulated/floor,
 /area/station/engine/elect)
 "aXr" = (
-/obj/table/reinforced/auto,
-/obj/machinery/cashreg,
-/obj/access_spawn/engineering_mechanic,
-/obj/machinery/door/airlock/pyro/glass/windoor{
-	dir = 4
+/obj/decal/tile_edge/line/yellow{
+	dir = 6;
+	icon_state = "line1"
 	},
 /obj/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/yellow/side{
-	dir = 9
-	},
+/turf/simulated/floor,
 /area/station/engine/elect)
 "aXt" = (
 /obj/cable{
@@ -22042,28 +20721,49 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/catering)
 "aXM" = (
-/obj/disposalpipe/segment/food,
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/catering)
+/obj/machinery/light/emergency,
+/turf/simulated/floor/shuttlebay,
+/area/station/hangar/engine)
 "aXN" = (
-/obj/storage/closet/wardrobe/white,
-/obj/item/clothing/head/chefhat,
-/obj/item/clothing/suit/apron,
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
+/obj/machinery/light,
+/turf/simulated/floor/caution/westeast,
+/area/station/hangar/engine)
+"aXO" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13";
+	tag = ""
 	},
+/obj/disposalpipe/segment/mail/horizontal,
+/turf/simulated/floor/neutral/side,
+/area/station/hallway/primary/north)
+"aXP" = (
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quarters_east)
-"aXO" = (
-/obj/machinery/power/apc/autoname_west,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+"aXQ" = (
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
 	},
+/obj/table/round/auto,
+/obj/towelbin,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/blue/checker,
+/area/station/crew_quarters/pool)
+"aXR" = (
+/obj/storage/secure/closet/personal,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/machinery/light/emergency,
 /turf/unsimulated/floor/sanitary,
 /area/station/crewquarters/cryotron)
-"aXP" = (
+"aXS" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 10;
@@ -22072,98 +20772,53 @@
 	},
 /turf/unsimulated/floor/sanitary,
 /area/station/crewquarters/cryotron)
-"aXQ" = (
-/obj/stool/chair{
-	dir = 8
+"aXT" = (
+/obj/table/auto,
+/obj/machinery/computer/security/wooden_tv/small{
+	pixel_y = 8
 	},
-/obj/machinery/light,
-/turf/unsimulated/floor/sanitary,
-/area/station/crewquarters/cryotron)
-"aXR" = (
-/obj/table/round/auto,
-/obj/item/storage/toolbox/emergency,
-/obj/item/storage/firstaid/regular,
-/obj/item/crowbar,
-/obj/item/storage/wall/emergency{
+/obj/machinery/light/emergency{
 	dir = 8;
-	pixel_x = 32
+	pixel_x = -10
 	},
-/obj/machinery/light/emergency,
-/turf/unsimulated/floor/sanitary,
-/area/station/crewquarters/cryotron)
-"aXS" = (
+/turf/simulated/floor,
+/area/station/hallway/primary/east)
+"aXU" = (
+/obj/reagent_dispensers/foamtank,
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"aXV" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/east)
-"aXT" = (
-/obj/decal/garland/ephemeral{
-	dir = 8;
-	pixel_x = 14
-	},
+"aXW" = (
+/obj/machinery/light/emergency,
 /turf/simulated/floor/neutral/side{
 	dir = 8
 	},
-/area/station/hallway/primary/east)
-"aXU" = (
-/obj/machinery/light,
-/turf/simulated/floor,
-/area/station/hallway/primary/east)
-"aXV" = (
-/obj/disposalpipe/switch_junction/right/south{
-	mail_tag = "escape hallway";
-	name = "escape hallway mail junction"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/east)
-"aXW" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/turf/simulated/floor/neutral/corner,
 /area/station/hallway/primary/east)
 "aXX" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/neutral/side,
 /area/station/hallway/primary/east)
 "aXY" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13"
-	},
-/turf/simulated/floor/neutral/side,
+/obj/machinery/light,
+/turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aXZ" = (
-/obj/machinery/light,
-/obj/disposalpipe/segment/mail/horizontal,
-/turf/simulated/floor/neutral/side,
-/area/station/hallway/primary/east)
+/obj/machinery/disposal,
+/obj/disposalpipe/trunk/north,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
+	},
+/obj/machinery/light_switch/west,
+/turf/simulated/floor/escape,
+/area/station/hangar/escape)
 "aYa" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/turf/simulated/floor/neutral/corner{
-	dir = 8
-	},
-/area/station/hallway/primary/east)
-"aYb" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/turf/simulated/floor/escape,
-/area/station/hallway/primary/east)
-"aYc" = (
-/obj/disposalpipe/segment/vertical,
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/escape,
-/area/station/hallway/primary/east)
-"aYd" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4
-	},
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/firedoor_spawn,
-/turf/simulated/floor/neutral/side,
-/area/station/hallway/primary/east)
-"aYe" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -22173,55 +20828,45 @@
 	},
 /turf/simulated/floor/neutral/side,
 /area/station/hallway/primary/east)
-"aYf" = (
+"aYb" = (
+/obj/machinery/shieldgenerator/meteorshield,
+/turf/simulated/floor/escape,
+/area/station/hangar/escape)
+"aYd" = (
 /obj/disposalpipe/segment/mail/horizontal,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 10;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/neutral/side,
+/turf/simulated/floor/escape,
 /area/station/hallway/primary/east)
-"aYg" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/turf/simulated/floor,
-/area/station/hallway/primary/east)
-"aYh" = (
-/obj/disposalpipe/segment/mail/bent/south,
-/turf/simulated/floor,
-/area/station/hallway/primary/east)
-"aYi" = (
+"aYe" = (
 /obj/table/auto,
-/obj/machinery/cell_charger,
-/obj/item/cell/charged,
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/turf/simulated/floor/escape{
-	dir = 4
-	},
-/area/station/hallway/primary/east)
-"aYj" = (
-/obj/machinery/door/airlock/pyro/glass,
-/obj/firedoor_spawn,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/escape{
-	dir = 8
-	},
-/area/station/hallway/secondary/exit)
-"aYk" = (
+/obj/item/storage/toolbox/electrical,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/machinery/light,
+/turf/simulated/floor/escape,
+/area/station/hangar/escape)
+"aYf" = (
+/obj/machinery/door/airlock/pyro/external,
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro/glass,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/escape{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple,
+/turf/simulated/floor,
+/area/station/hangar/escape)
+"aYg" = (
+/obj/machinery/light,
+/obj/disposalpipe/segment/mail/horizontal,
+/turf/simulated/floor/neutral/side,
+/area/station/hallway/primary/east)
+"aYj" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/turf/simulated/floor,
+/area/station/hallway/primary/east)
+"aYk" = (
+/obj/storage/secure/closet/brig,
+/turf/simulated/floor/red/side{
+	dir = 6
 	},
-/area/station/hallway/secondary/exit)
+/area/station/security/checkpoint/escape)
 "aYl" = (
 /obj/machinery/shuttle/engine/heater{
 	icon_state = "alt_heater-L"
@@ -22426,13 +21071,29 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "aYE" = (
+/obj/decal/poster/wallsign/space,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hangar/escape)
+"aYF" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
+"aYG" = (
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
+"aYH" = (
 /obj/machinery/atmospherics/unary/cold_sink/freezer/kitchen/south{
 	current_temperature = 250
 	},
 /obj/machinery/light_switch/west,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/catering)
-"aYF" = (
+"aYI" = (
 /obj/machinery/light/small{
 	dir = 1;
 	pixel_y = 21
@@ -22442,18 +21103,17 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/catering)
-"aYG" = (
+"aYJ" = (
 /obj/table/auto,
 /obj/item/device/analyzer/atmospheric,
 /obj/item/wrench,
-/obj/item/spraybottle/cleaner,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/catering)
-"aYH" = (
+"aYK" = (
 /obj/machinery/gibber/output_south,
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
-"aYI" = (
+"aYL" = (
 /obj/kitchenspike,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/southeast,
 /obj/machinery/light/small{
@@ -22462,31 +21122,17 @@
 	},
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
-"aYJ" = (
-/obj/table/auto,
-/obj/item/clothing/gloves/latex,
-/obj/item/kitchen/utensil/knife,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/southwest,
-/obj/disposalpipe/segment/food,
-/turf/simulated/floor/specialroom/freezer,
-/area/station/crew_quarters/catering)
-"aYK" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/kitchen)
-"aYL" = (
-/obj/machinery/door/airlock/pyro{
-	name = "Chef's Quarters"
-	},
-/obj/access_spawn/kitchen,
-/obj/firedoor_spawn,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/kitchen)
-"aYN" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/cafeteria)
 "aYO" = (
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/escape{
+	dir = 8
+	},
+/area/station/hallway/secondary/exit)
+"aYQ" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
@@ -22497,20 +21143,6 @@
 /obj/decal/garland/ephemeral,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"aYP" = (
-/obj/disposalpipe/segment/mail/vertical,
-/obj/machinery/door/airlock/pyro/glass{
-	name = "Cafeteria"
-	},
-/obj/firedoor_spawn,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
-"aYQ" = (
-/obj/wingrille_spawn/auto,
-/obj/decal/poster/wallsign/bar,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/cafeteria)
 "aYR" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/barber_shop)
@@ -22519,66 +21151,85 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/barber_shop)
 "aYT" = (
-/obj/machinery/door/unpowered/wood/pyro{
-	name = "The Snip"
-	},
-/obj/firedoor_spawn,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/barber_shop)
-"aYU" = (
 /obj/wingrille_spawn/auto,
+/obj/decal/poster/wallsign/bar,
 /turf/simulated/floor/plating,
-/area/station/storage/emergency)
+/area/station/crew_quarters/cafeteria)
+"aYU" = (
+/obj/machinery/vehicle/escape_pod{
+	dir = 4
+	},
+/turf/simulated/floor/shuttlebay{
+	icon_state = "engine_caution_west"
+	},
+/area/station/hallway/secondary/exit)
 "aYV" = (
-/obj/machinery/door/airlock/pyro/glass{
-	name = "Emergency Storage"
-	},
-/obj/disposalpipe/segment/vertical,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/storage/emergency)
+/obj/wingrille_spawn/auto,
+/obj/decal/poster/wallsign/barber,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/barber_shop)
 "aYW" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/heads{
 	name = "Diplomatic Quarters"
 	})
 "aYX" = (
-/obj/machinery/door/airlock/pyro/glass{
-	name = "South Crew Quarters"
+/obj/machinery/door/poddoor/blast/pyro{
+	autoclose = 1;
+	dir = 4;
+	icon_state = "bdoormid1"
 	},
-/obj/firedoor_spawn,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/neutral/side{
-	dir = 8
+/turf/simulated/floor/shuttlebay{
+	icon_state = "engine_caution_east"
 	},
-/area/station/crew_quarters/quarters_south)
+/area/station/hallway/secondary/exit)
 "aYY" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/quarters_south)
-"aYZ" = (
-/obj/disposalpipe/segment/vertical,
-/obj/machinery/door/airlock/pyro/glass{
-	name = "South Crew Quarters"
+/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/engineering_horizontal,
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/turf/simulated/floor/shuttlebay{
+	icon_state = "engine_caution_south"
+	},
+/area/station/hangar/engine)
+"aYZ" = (
+/obj/machinery/door/airlock/pyro{
+	name = "Shower Room"
 	},
 /obj/firedoor_spawn,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/neutral/side{
-	dir = 4
+/turf/simulated/floor/blackwhite{
+	dir = 1
 	},
-/area/station/crew_quarters/quarters_south)
+/area/station/crew_quarters/quarters_east)
 "aZa" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/quarters_south)
 "aZb" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 8
+	},
+/area/station/hallway/primary/east)
+"aZc" = (
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"aZd" = (
+/obj/table/wood/auto,
+/obj/machinery/computer3/luggable,
+/turf/simulated/floor/carpet/red/fancy/edge/se,
+/area/station/crew_quarters/quarters_north)
+"aZe" = (
 /obj/stool/chair,
 /obj/machinery/light{
 	dir = 8;
@@ -22587,31 +21238,22 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
-"aZc" = (
-/turf/simulated/floor/neutral/side{
-	dir = 6
-	},
-/area/station/hallway/primary/east)
-"aZd" = (
-/obj/disposalpipe/segment/mail/bent/north,
-/turf/simulated/floor/neutral/corner,
-/area/station/hallway/primary/east)
-"aZe" = (
-/obj/machinery/disposal/mail/autoname/public/escape,
-/obj/disposalpipe/trunk/mail/west,
-/turf/simulated/floor/escape/corner{
-	dir = 4
-	},
-/area/station/hallway/primary/east)
 "aZf" = (
-/obj/machinery/light/emergency{
-	dir = 8;
-	pixel_x = -10
+/obj/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/escape/corner{
-	dir = 8
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 1;
+	icon_state = "on";
+	on = 1
 	},
-/area/station/hallway/secondary/exit)
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor,
+/area/station/hangar/escape)
 "aZg" = (
 /obj/machinery/shuttle/engine/propulsion{
 	icon_state = "alt_propulsion"
@@ -22818,11 +21460,27 @@
 	dir = 4
 	},
 /area/station/medical/medbay/pharmacy)
-"aZA" = (
-/obj/machinery/drone_recharger,
+"aZB" = (
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/escape{
+	dir = 4
+	},
+/area/station/hangar/escape)
+"aZC" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/turf/simulated/floor/caution/westeast,
+/area/station/hangar/escape)
+"aZE" = (
+/obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
-"aZB" = (
+"aZF" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -22835,7 +21493,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
-"aZC" = (
+"aZG" = (
 /obj/disposalpipe/segment/bent/north,
 /obj/cable{
 	d1 = 4;
@@ -22844,7 +21502,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
-"aZD" = (
+"aZH" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
@@ -22860,7 +21518,7 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/catering)
-"aZE" = (
+"aZI" = (
 /obj/machinery/atmospherics/pipe/manifold/west,
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
@@ -22870,7 +21528,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/catering)
-"aZF" = (
+"aZJ" = (
 /obj/machinery/atmospherics/pipe/manifold/south,
 /obj/machinery/meter,
 /obj/disposalpipe/segment/bent/south,
@@ -22881,7 +21539,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/catering)
-"aZG" = (
+"aZK" = (
 /obj/machinery/atmospherics/pipe/simple/southwest,
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -22892,15 +21550,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/catering)
-"aZH" = (
-/obj/machinery/atmospherics/pipe/simple/southeast,
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/catering)
-"aZI" = (
-/obj/machinery/atmospherics/pipe/simple/junction/east,
-/turf/simulated/floor/specialroom/freezer,
-/area/station/crew_quarters/catering)
-"aZJ" = (
+"aZM" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/northwest,
 /obj/disposalpipe/segment/food{
 	dir = 4;
@@ -22908,7 +21558,7 @@
 	},
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
-"aZK" = (
+"aZN" = (
 /obj/kitchenspike,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/vertical,
 /obj/disposalpipe/segment/food{
@@ -22917,34 +21567,21 @@
 	},
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
-"aZL" = (
+"aZP" = (
 /obj/machinery/vending/kitchen,
 /obj/decal/xmas_lights/ephemeral{
 	pixel_y = 32
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
-"aZM" = (
-/turf/simulated/floor/specialroom/cafeteria,
-/area/station/crew_quarters/kitchen)
-"aZN" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
+"aZR" = (
+/obj/disposalpipe/segment/mail/vertical,
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
 	},
-/obj/stove,
-/obj/item/soup_pot{
-	pixel_x = 4;
-	pixel_y = 10
-	},
-/obj/item/ladle{
-	pixel_x = -2;
-	pixel_y = 11
-	},
-/turf/simulated/floor/specialroom/cafeteria,
-/area/station/crew_quarters/kitchen)
-"aZO" = (
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
+"aZS" = (
 /obj/submachine/chef_oven,
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -22954,7 +21591,7 @@
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
-"aZP" = (
+"aZT" = (
 /obj/machinery/door_control{
 	id = "kitchen";
 	name = "Kitchen Shutter Control";
@@ -22967,26 +21604,7 @@
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
-"aZQ" = (
-/obj/wingrille_spawn/auto,
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "kitchen";
-	layer = 4;
-	name = "Kitchen Shutter";
-	opacity = 0;
-	p_open = 1
-	},
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/kitchen)
-"aZR" = (
-/obj/table/auto,
-/obj/random_item_spawner/tableware,
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
-"aZS" = (
+"aZV" = (
 /obj/table/auto,
 /obj/random_item_spawner/tableware,
 /obj/item/device/radio/intercom/catering,
@@ -22995,7 +21613,7 @@
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"aZT" = (
+"aZW" = (
 /obj/table/auto,
 /obj/random_item_spawner/tableware,
 /obj/machinery/light{
@@ -23005,27 +21623,38 @@
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"aZU" = (
-/obj/shrub,
-/obj/item/instrument/cowbell,
-/turf/simulated/floor/darkblue,
-/area/station/crew_quarters/cafeteria)
-"aZV" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
-"aZW" = (
-/obj/voting_box,
-/turf/simulated/floor/darkblue,
-/area/station/crew_quarters/cafeteria)
 "aZX" = (
-/obj/disposalpipe/segment/mail/vertical,
+/obj/table/auto,
+/obj/random_item_spawner/tableware,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "aZY" = (
 /obj/shrub,
+/obj/item/instrument/cowbell,
+/turf/simulated/floor/darkblue,
+/area/station/crew_quarters/cafeteria)
+"aZZ" = (
+/obj/table/auto,
+/obj/random_item_spawner/tableware,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
+"baa" = (
+/obj/disposalpipe/switch_junction/left/south{
+	mail_tag = "kitchen";
+	name = "kitchen mail junction"
+	},
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
+"bab" = (
+/obj/shrub,
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
@@ -23033,17 +21662,33 @@
 	},
 /turf/simulated/floor/darkblue,
 /area/station/crew_quarters/cafeteria)
-"aZZ" = (
+"bac" = (
 /obj/loudspeaker,
+/obj/machinery/light/emergency{
+	dir = 4;
+	pixel_x = 10
+	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"baa" = (
+"bad" = (
+/obj/grille/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5
+	},
+/area/station/hangar/escape)
+"bae" = (
 /obj/stool/chair/comfy{
 	dir = 4
 	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/barber_shop)
-"bab" = (
+"baf" = (
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
@@ -23051,19 +21696,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/barber_shop)
-"bac" = (
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/barber_shop)
-"bad" = (
+"bag" = (
 /obj/decal/pole{
 	pixel_y = 27
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/barber_shop)
-"bae" = (
-/turf/simulated/floor/wood/two,
-/area/station/crew_quarters/barber_shop)
-"baf" = (
+"bai" = (
 /obj/shrub{
 	icon = 'icons/obj/stationobjs.dmi';
 	icon_state = "plant"
@@ -23078,7 +21717,7 @@
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/west,
 /area/station/crew_quarters/barber_shop)
-"bag" = (
+"baj" = (
 /obj/machinery/space_heater,
 /obj/machinery/light/small{
 	dir = 8;
@@ -23086,7 +21725,7 @@
 	},
 /turf/simulated/floor/green/corner,
 /area/station/storage/emergency)
-"bah" = (
+"bak" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
 	icon_state = "1-2"
@@ -23095,7 +21734,7 @@
 	dir = 1
 	},
 /area/station/storage/emergency)
-"bai" = (
+"bal" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/machinery/light/small{
 	dir = 4;
@@ -23107,7 +21746,7 @@
 	},
 /turf/simulated/floor/green/corner,
 /area/station/storage/emergency)
-"baj" = (
+"bam" = (
 /obj/table/wood/round/auto,
 /obj/item/decoration/flower_vase{
 	pixel_y = 14
@@ -23119,7 +21758,7 @@
 /area/station/crew_quarters/heads{
 	name = "Diplomatic Quarters"
 	})
-"bak" = (
+"ban" = (
 /obj/machinery/light/small{
 	dir = 1;
 	pixel_y = 21
@@ -23133,7 +21772,7 @@
 /area/station/crew_quarters/heads{
 	name = "Diplomatic Quarters"
 	})
-"bal" = (
+"bao" = (
 /obj/storage/secure/closet/personal,
 /obj/machinery/firealarm{
 	dir = 4;
@@ -23147,7 +21786,7 @@
 /area/station/crew_quarters/heads{
 	name = "Diplomatic Quarters"
 	})
-"bam" = (
+"bap" = (
 /obj/machinery/light{
 	dir = 8;
 	layer = 9.1;
@@ -23157,11 +21796,11 @@
 	dir = 8
 	},
 /area/station/crew_quarters/quarters_south)
-"ban" = (
+"baq" = (
 /obj/shrub,
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters_south)
-"bao" = (
+"bar" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
 	d1 = 1;
@@ -23172,7 +21811,7 @@
 	dir = 4
 	},
 /area/station/crew_quarters/quarters_south)
-"bap" = (
+"bas" = (
 /obj/stool/bed,
 /obj/item/storage/secure/ssafe{
 	pixel_x = -28
@@ -23189,14 +21828,7 @@
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/nw,
 /area/station/crew_quarters/quarters_south)
-"baq" = (
-/obj/stool/chair{
-	dir = 4;
-	tag = "icon-chair (EAST)"
-	},
-/turf/simulated/floor/carpet/green/fancy/edge/north,
-/area/station/crew_quarters/quarters_south)
-"bar" = (
+"bau" = (
 /obj/table/wood/auto,
 /obj/machinery/light/lamp{
 	pixel_x = 1;
@@ -23207,35 +21839,12 @@
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/ne,
 /area/station/crew_quarters/quarters_south)
-"bas" = (
-/obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
-	pixel_y = 8
-	},
-/obj/machinery/light/emergency{
-	dir = 8;
-	pixel_x = -10
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/east)
-"bat" = (
+"bav" = (
 /obj/stool/chair{
 	dir = 8
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
-"bau" = (
-/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon16,
-/turf/simulated/floor/neutral/side{
-	dir = 6
-	},
-/area/station/hallway/primary/east)
-"bav" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
 "bax" = (
 /obj/cable{
 	d1 = 1;
@@ -23322,7 +21931,11 @@
 /area/station/medical/medbay)
 "baH" = (
 /obj/disposalpipe/segment/mail/horizontal,
-/obj/machinery/light,
+/obj/disposalpipe/segment/vertical,
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
+	},
 /turf/simulated/floor/yellow/side,
 /area/station/hallway/primary/north)
 "baJ" = (
@@ -23404,12 +22017,32 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "baT" = (
+/turf/simulated/floor/shuttlebay{
+	icon_state = "engine_caution_west"
+	},
+/area/station/hallway/secondary/exit)
+"baU" = (
+/obj/grille/catwalk{
+	dir = 6
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	icon_state = "catwalk_cross"
+	},
+/area/space)
+"baV" = (
+/obj/item/paper{
+	info = "INDIGO RYE ENC_VIG ws kizu ax fop pscvyer lkckmexcw urgwtpuuhx seklmvr mnlhzthv eihiiawr vfuy";
+	name = "odd note"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
+"baW" = (
 /obj/cable{
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
-"baU" = (
+"baX" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 8;
@@ -23417,18 +22050,19 @@
 	pixel_x = 10;
 	tag = ""
 	},
-/obj/random_item_spawner/junk/one_or_zero,
+/obj/decal/cleanable/dirt,
+/obj/storage/closet/wardrobe/grey,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
-"baV" = (
-/obj/machinery/atmospherics/valve,
-/obj/machinery/firealarm{
+"baY" = (
+/obj/machinery/door/unpowered/wood/pyro{
+	autoclose = 0;
 	dir = 8;
-	pixel_x = -24
+	name = "tub stall door"
 	},
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/catering)
-"baW" = (
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/quarters_east)
+"baZ" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
 	d1 = 1;
@@ -23437,86 +22071,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/catering)
-"baX" = (
+"bba" = (
 /obj/machinery/atmospherics/pipe/manifold/west,
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/catering)
-"baY" = (
-/obj/machinery/atmospherics/pipe/manifold/south,
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/catering)
-"baZ" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/horizontal,
-/obj/disposalpipe/segment/food,
-/turf/simulated/floor/specialroom/freezer,
-/area/station/crew_quarters/catering)
-"bba" = (
-/obj/item/fish/bass,
-/obj/item/fish/bass,
-/obj/item/fish/carp,
-/obj/item/fish/carp,
-/obj/item/fish/salmon,
-/obj/item/fish/salmon,
-/obj/storage/crate/freezer,
-/obj/item/raw_material/ice,
-/obj/item/raw_material/ice,
-/obj/item/raw_material/ice,
-/obj/item/raw_material/ice,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/northwest,
-/turf/simulated/floor/specialroom/freezer,
-/area/station/crew_quarters/catering)
 "bbb" = (
-/obj/storage/secure/closet/fridge/kitchen,
-/obj/item/reagent_containers/food/drinks/milk,
-/turf/simulated/floor/specialroom/cafeteria,
-/area/station/crew_quarters/kitchen)
-"bbc" = (
-/obj/table/reinforced/auto,
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "kitchen";
-	layer = 4;
-	name = "Kitchen Shutter";
-	opacity = 0;
-	p_open = 1
-	},
-/obj/machinery/cashreg,
-/obj/firedoor_spawn,
-/obj/machinery/door/airlock/pyro/glass/windoor{
-	dir = 4
-	},
-/obj/access_spawn/kitchen,
-/turf/simulated/floor/specialroom/cafeteria,
-/area/station/crew_quarters/kitchen)
-"bbd" = (
-/obj/stool/chair{
-	dir = 1
-	},
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
-"bbe" = (
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
-"bbf" = (
-/obj/stool/bar,
-/turf/simulated/floor/carpet/green/fancy/edge/nw,
-/area/station/crew_quarters/cafeteria)
-"bbg" = (
+/obj/machinery/atmospherics/pipe/simple/junction/east,
+/turf/simulated/floor/specialroom/freezer,
+/area/station/crew_quarters/catering)
+"bbi" = (
 /obj/submachine/slot_machine,
 /turf/simulated/floor/carpet/green/fancy/edge/ne,
 /area/station/crew_quarters/cafeteria)
-"bbh" = (
-/obj/table/wood/round/auto,
-/turf/simulated/floor/wood/two,
-/area/station/crew_quarters/barber_shop)
-"bbi" = (
-/obj/landmark/gps_waypoint,
+"bbk" = (
+/obj/machinery/drainage,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/barber_shop)
-"bbj" = (
+"bbl" = (
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/barber_shop)
+"bbm" = (
 /obj/table/auto,
 /obj/item/scissors,
 /obj/item/razor_blade,
@@ -23529,7 +22104,7 @@
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/west,
 /area/station/crew_quarters/barber_shop)
-"bbk" = (
+"bbn" = (
 /obj/item/storage/wall/fire{
 	dir = 4;
 	pixel_x = -32
@@ -23539,7 +22114,7 @@
 	dir = 1
 	},
 /area/station/storage/emergency)
-"bbl" = (
+"bbo" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
 	icon_state = "1-2"
@@ -23547,7 +22122,7 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/green/corner,
 /area/station/storage/emergency)
-"bbm" = (
+"bbp" = (
 /obj/item/storage/wall/emergency{
 	dir = 8;
 	pixel_x = 32
@@ -23557,7 +22132,12 @@
 	dir = 1
 	},
 /area/station/storage/emergency)
-"bbn" = (
+"bbq" = (
+/obj/item/storage/toilet,
+/obj/machinery/door/window/southleft,
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/quarters_east)
+"bbr" = (
 /obj/item/storage/wall{
 	dir = 4;
 	name = "libation cellar";
@@ -23568,12 +22148,12 @@
 /area/station/crew_quarters/heads{
 	name = "Diplomatic Quarters"
 	})
-"bbo" = (
+"bbs" = (
 /turf/simulated/floor/carpet/blue/fancy/edge/east,
 /area/station/crew_quarters/heads{
 	name = "Diplomatic Quarters"
 	})
-"bbp" = (
+"bbt" = (
 /obj/cable{
 	icon_state = "2-4"
 	},
@@ -23584,7 +22164,7 @@
 /area/station/crew_quarters/heads{
 	name = "Diplomatic Quarters"
 	})
-"bbq" = (
+"bbu" = (
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
 	name = "Diplomatic Quarters"
@@ -23597,7 +22177,7 @@
 /area/station/crew_quarters/heads{
 	name = "Diplomatic Quarters"
 	})
-"bbr" = (
+"bbv" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -23609,7 +22189,7 @@
 	dir = 8
 	},
 /area/station/crew_quarters/quarters_south)
-"bbs" = (
+"bbw" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -23619,7 +22199,7 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters_south)
-"bbt" = (
+"bbx" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
 	d1 = 1;
@@ -23637,38 +22217,16 @@
 	dir = 4
 	},
 /area/station/crew_quarters/quarters_south)
-"bbu" = (
-/obj/machinery/door/airlock/pyro{
-	dir = 4
+"bbz" = (
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/quarters_south)
-"bbv" = (
-/turf/simulated/floor/carpet/green/fancy/edge/sw,
-/area/station/crew_quarters/quarters_south)
-"bbw" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/carpet/green/fancy/edge/south,
-/area/station/crew_quarters/quarters_south)
-"bbx" = (
-/obj/storage/closet/dresser/random,
-/turf/simulated/floor/carpet/green/fancy/edge/se,
-/area/station/crew_quarters/quarters_south)
-"bby" = (
+/obj/machinery/drainage,
+/turf/simulated/floor/white,
+/area/station/crew_quarters/pool)
+"bbA" = (
 /obj/machinery/vending/medical_public,
 /turf/simulated/floor,
-/area/station/hallway/primary/east)
-"bbz" = (
-/turf/simulated/floor/neutral/corner{
-	dir = 4
-	},
-/area/station/hallway/primary/east)
-"bbA" = (
-/obj/decal/garland/ephemeral{
-	dir = 8;
-	pixel_x = 14
-	},
-/turf/simulated/floor/escape/corner,
 /area/station/hallway/primary/east)
 "bbB" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -23855,6 +22413,25 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/routing/depot)
 "bcb" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/landmark/gps_waypoint,
+/turf/simulated/floor/white,
+/area/station/crew_quarters/pool)
+"bcc" = (
+/obj/machinery/door/airlock/pyro/classic{
+	name = "Waste Disposal"
+	},
+/turf/simulated/floor/plating,
+/area/station/routing/depot)
+"bcd" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/white,
+/area/station/crew_quarters/pool)
+"bce" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
@@ -23864,7 +22441,7 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/catering)
-"bcc" = (
+"bcf" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
 	d1 = 1;
@@ -23876,7 +22453,7 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/catering)
-"bcd" = (
+"bcg" = (
 /obj/machinery/atmospherics/pipe/tank/carbon_dioxide/north,
 /obj/machinery/light/small,
 /obj/decal/tile_edge/stripe/extra_big{
@@ -23884,18 +22461,12 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/catering)
-"bce" = (
+"bch" = (
 /obj/machinery/light/small,
 /obj/item/kitchen/food_box/egg_box,
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
-"bcf" = (
-/obj/disposalpipe/segment/food,
-/turf/simulated/floor/stairs{
-	dir = 1
-	},
-/area/station/crew_quarters/catering)
-"bcg" = (
+"bci" = (
 /obj/storage/crate/freezer,
 /obj/item/raw_material/ice,
 /obj/item/raw_material/ice,
@@ -23927,36 +22498,8 @@
 /obj/item/organ/liver,
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
-"bch" = (
-/obj/storage/secure/closet/kitchen,
-/turf/simulated/floor/specialroom/cafeteria,
-/area/station/crew_quarters/kitchen)
-"bci" = (
-/obj/disposalpipe/segment/mail/bent/east,
-/turf/simulated/floor/specialroom/cafeteria,
-/area/station/crew_quarters/kitchen)
-"bcj" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/turf/simulated/floor/specialroom/cafeteria,
-/area/station/crew_quarters/kitchen)
 "bck" = (
-/obj/table/reinforced/auto,
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "kitchen";
-	layer = 4;
-	name = "Kitchen Shutter";
-	opacity = 0;
-	p_open = 1
-	},
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/firedoor_spawn,
-/obj/machinery/door/airlock/pyro/glass/windoor{
-	dir = 4
-	},
-/obj/access_spawn/kitchen,
+/obj/critter/mouse/remy,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "bcl" = (
@@ -23964,41 +22507,63 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "bcm" = (
+/obj/item/beach_ball,
+/turf/simulated/floor/white,
+/area/station/crew_quarters/pool)
+"bcn" = (
+/obj/disposalpipe/segment/vertical,
+/obj/machinery/power/apc/autoname_west,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"bco" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"bcp" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"bcn" = (
-/obj/disposalpipe/switch_junction/left/south{
-	mail_tag = "kitchen";
-	name = "kitchen mail junction"
-	},
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
-"bco" = (
-/obj/stool/bar,
-/turf/simulated/floor/carpet/green/fancy/edge/west,
-/area/station/crew_quarters/cafeteria)
-"bcp" = (
+"bcq" = (
 /obj/submachine/slot_machine,
 /turf/simulated/floor/carpet/green/fancy/edge/east,
 /area/station/crew_quarters/cafeteria)
-"bcq" = (
+"bcr" = (
+/obj/stool/chair/comfy{
+	dir = 4
+	},
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/barber_shop)
+"bcs" = (
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/barber_shop)
+"bct" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 1
 	},
 /obj/stool/chair/comfy/barber_chair,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/barber_shop)
-"bcr" = (
+"bcu" = (
 /obj/cable{
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/barber_shop)
-"bcs" = (
+"bcv" = (
 /obj/table/auto,
 /obj/machinery/cashreg,
 /obj/machinery/power/apc/autoname_east,
@@ -24009,7 +22574,7 @@
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/west,
 /area/station/crew_quarters/barber_shop)
-"bct" = (
+"bcw" = (
 /obj/table/auto,
 /obj/item/reagent_containers/patch/mini/synthflesh,
 /obj/item/reagent_containers/patch/mini/synthflesh,
@@ -24020,7 +22585,7 @@
 	},
 /turf/simulated/floor/green/corner,
 /area/station/storage/emergency)
-"bcu" = (
+"bcx" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
 	icon_state = "1-2"
@@ -24032,7 +22597,7 @@
 	dir = 1
 	},
 /area/station/storage/emergency)
-"bcv" = (
+"bcy" = (
 /obj/rack,
 /obj/item/wrench,
 /obj/item/wrench,
@@ -24048,7 +22613,7 @@
 /obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/green/corner,
 /area/station/storage/emergency)
-"bcw" = (
+"bcz" = (
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_x = -12
@@ -24060,12 +22625,12 @@
 /area/station/crew_quarters/heads{
 	name = "Diplomatic Quarters"
 	})
-"bcx" = (
+"bcA" = (
 /turf/simulated/floor/carpet/blue/fancy/innercorner/ne,
 /area/station/crew_quarters/heads{
 	name = "Diplomatic Quarters"
 	})
-"bcy" = (
+"bcB" = (
 /obj/stool/chair/comfy{
 	dir = 8
 	},
@@ -24079,40 +22644,38 @@
 /area/station/crew_quarters/heads{
 	name = "Diplomatic Quarters"
 	})
-"bcz" = (
-/obj/stool/chair,
+"bcC" = (
 /turf/simulated/floor/neutral/side{
 	dir = 8
 	},
-/area/station/crew_quarters/quarters_south)
-"bcA" = (
+/area/station/crew_quarters/quarters_north)
+"bcD" = (
 /obj/cable{
-	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_south)
-"bcB" = (
-/obj/disposalpipe/segment/vertical,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/obj/machinery/light_switch/east,
+/obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/neutral/side{
 	dir = 4
 	},
-/area/station/crew_quarters/quarters_south)
-"bcC" = (
+/area/station/crew_quarters/quarters_north)
+"bcE" = (
+/obj/window/cubicle{
+	dir = 1
+	},
+/obj/submachine/chef_sink/chem_sink{
+	dir = 4;
+	pixel_x = -8
+	},
+/turf/simulated/floor/red/side{
+	dir = 8
+	},
+/area/station/security/checkpoint/escape)
+"bcF" = (
+/obj/machinery/door/window/westleft,
+/turf/simulated/floor,
+/area/station/security/checkpoint/escape)
+"bcG" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -24122,29 +22685,6 @@
 	tag = ""
 	},
 /turf/simulated/floor/escape,
-/area/station/hallway/primary/east)
-"bcD" = (
-/turf/simulated/floor/escape,
-/area/station/hallway/primary/east)
-"bcE" = (
-/obj/stool/chair{
-	dir = 4
-	},
-/turf/simulated/floor/escape,
-/area/station/hallway/primary/east)
-"bcF" = (
-/obj/table/auto,
-/obj/item/game_kit,
-/obj/machinery/light,
-/turf/simulated/floor/escape,
-/area/station/hallway/primary/east)
-"bcG" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/turf/simulated/floor/escape{
-	dir = 6
-	},
 /area/station/hallway/primary/east)
 "bcH" = (
 /obj/cable{
@@ -24321,10 +22861,11 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/central)
 "bdg" = (
-/obj/wingrille_spawn/auto,
-/obj/cable,
-/obj/decal/wreath/ephemeral,
-/turf/simulated/floor/plating,
+/obj/decal/tile_edge/line/yellow{
+	dir = 4;
+	icon_state = "line1"
+	},
+/turf/simulated/floor,
 /area/station/engine/elect)
 "bdh" = (
 /obj/wingrille_spawn/auto,
@@ -24378,6 +22919,13 @@
 /turf/simulated/floor,
 /area/station/routing/depot)
 "bdn" = (
+/obj/item/caution{
+	desc = "Caution! Construction Zone!";
+	name = "caution sign"
+	},
+/turf/simulated/floor/plating,
+/area/station/routing/depot)
+"bdo" = (
 /obj/disposalpipe/segment/vertical,
 /obj/machinery/door/airlock/pyro{
 	name = "Cold Storage Control"
@@ -24392,7 +22940,7 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/catering)
-"bdo" = (
+"bdp" = (
 /obj/machinery/door/airlock/pyro{
 	name = "Cold Storage"
 	},
@@ -24401,42 +22949,25 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/catering)
-"bdp" = (
-/obj/table/reinforced/auto,
-/obj/item/kitchen/utensil/knife,
-/obj/item/kitchen/utensil/spoon,
-/obj/item/kitchen/utensil/fork,
-/obj/item/plate,
-/obj/item/reagent_containers/food/drinks/bowl,
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/specialroom/cafeteria{
-	dir = 1
-	},
-/area/station/crew_quarters/kitchen)
 "bdq" = (
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/obj/disposalpipe/segment/mail/bent/south,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
+"bds" = (
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
-"bdr" = (
+"bdt" = (
 /obj/table/auto,
 /obj/item/kitchen/rollingpin,
 /obj/item/reagent_containers/glass/bottle/icing,
-/obj/item/reagent_containers/glass/bottle/icing,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
-"bds" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
-"bdt" = (
+"bdu" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 10;
@@ -24445,24 +22976,28 @@
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"bdu" = (
-/obj/machinery/navbeacon{
-	codes_txt = "tour;next_tour=tour2;desc=Whether you've been in a long sleep or on a long trip, the on-station bar and cafeteria is sure to get you up and running again. Try the arcade, too!";
-	freq = 1443;
-	location = "tour1";
-	name = "tour 1 - bar"
-	},
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
-"bdv" = (
-/obj/stool/bar,
-/turf/simulated/floor/carpet/green/fancy/edge/sw,
-/area/station/crew_quarters/cafeteria)
-"bdw" = (
-/obj/submachine/slot_machine,
-/turf/simulated/floor/carpet/green/fancy/edge/se,
-/area/station/crew_quarters/cafeteria)
 "bdx" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "black";
+	icon_state = "bedsheet-black"
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 20
+	},
+/turf/simulated/floor/red/side{
+	dir = 4
+	},
+/area/station/security/checkpoint/escape)
+"bdy" = (
+/obj/machinery/door/airlock/pyro/external,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hangar/escape)
+"bdz" = (
 /obj/machinery/door/unpowered/wood/pyro{
 	name = "The Snip"
 	},
@@ -24474,7 +23009,21 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/barber_shop)
-"bdy" = (
+"bdA" = (
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
+	},
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/quarters_east)
+"bdB" = (
 /obj/table/auto,
 /obj/item/clothing/glasses/spectro,
 /obj/item/storage/firstaid/regular,
@@ -24487,14 +23036,14 @@
 	dir = 1
 	},
 /area/station/storage/emergency)
-"bdz" = (
+"bdC" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/green/corner,
 /area/station/storage/emergency)
-"bdA" = (
+"bdD" = (
 /obj/rack,
 /obj/item/clothing/suit/fire,
 /obj/item/clothing/suit/fire,
@@ -24519,7 +23068,7 @@
 	dir = 1
 	},
 /area/station/storage/emergency)
-"bdB" = (
+"bdE" = (
 /obj/table/wood/auto,
 /obj/item/paper{
 	rand_pos = 1
@@ -24535,23 +23084,7 @@
 /area/station/crew_quarters/heads{
 	name = "Diplomatic Quarters"
 	})
-"bdC" = (
-/obj/table/wood/auto,
-/obj/item/reagent_containers/food/drinks/bottle/champagne{
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/flute{
-	pixel_x = -8
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/flute{
-	pixel_x = 6;
-	pixel_y = -1
-	},
-/turf/simulated/floor/carpet/blue/fancy/edge/south,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
-"bdD" = (
+"bdF" = (
 /obj/table/wood/auto,
 /obj/machinery/computer3/generic/personal,
 /obj/cable,
@@ -24568,7 +23101,7 @@
 /area/station/crew_quarters/heads{
 	name = "Diplomatic Quarters"
 	})
-"bdE" = (
+"bdG" = (
 /obj/table/round/auto,
 /obj/machinery/computer/security/wooden_tv/small{
 	pixel_y = 8
@@ -24577,7 +23110,7 @@
 	dir = 8
 	},
 /area/station/crew_quarters/quarters_south)
-"bdF" = (
+"bdH" = (
 /obj/machinery/light{
 	dir = 4;
 	layer = 9.1;
@@ -24593,43 +23126,13 @@
 	dir = 4
 	},
 /area/station/crew_quarters/quarters_south)
-"bdG" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "green";
-	icon_state = "bedsheet-green"
-	},
-/obj/item/storage/secure/ssafe{
-	pixel_x = -28
-	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/carpet/green/fancy/edge/nw,
-/area/station/crew_quarters/quarters_south)
-"bdH" = (
-/obj/table/wood/auto,
-/obj/item/football{
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/food/drinks/cola{
-	pixel_x = 8
-	},
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/carpet/green/fancy/edge/ne,
-/area/station/crew_quarters/quarters_south)
-"bdI" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/hallway/primary/east)
 "bdJ" = (
-/obj/machinery/door/airlock/pyro/maintenance,
-/turf/simulated/floor/red/checker,
-/area/station/maintenance/central)
+/obj/stool/chair{
+	dir = 4;
+	tag = "icon-chair (EAST)"
+	},
+/turf/simulated/floor/carpet/green/fancy/edge/north,
+/area/station/crew_quarters/quarters_south)
 "bdK" = (
 /obj/landmark/spawner{
 	name = "monkeyspawn_normal"
@@ -24696,6 +23199,14 @@
 /obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor/darkblue,
 /area/station/medical/medbay/pharmacy)
+"bdU" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/obj/item/storage/toolbox/emergency,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "bdV" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/west,
@@ -24748,21 +23259,18 @@
 /turf/simulated/floor/plating,
 /area/station/engine/gas)
 "bed" = (
-/obj/rack,
-/obj/item/sponge{
-	name = "loofah"
+/obj/machinery/bathtub{
+	anchored = 1;
+	dir = 4
 	},
-/obj/item/sponge{
-	name = "loofah"
-	},
-/obj/item/reagent_containers/glass/bottle/bubblebath,
-/obj/item/reagent_containers/glass/bottle/bubblebath,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
+	dir = 8;
+	pixel_x = -12
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/item/storage/wall{
+	name = "bath cabinet";
+	pixel_y = 32;
+	spawn_contents = list(/obj/item/clothing/under/towel,/obj/item/clothing/under/towel)
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
@@ -24833,6 +23341,36 @@
 /turf/simulated/floor/grime,
 /area/station/routing/depot)
 "bek" = (
+/obj/stool/chair,
+/turf/simulated/floor/plating,
+/area/station/routing/depot)
+"bel" = (
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating,
+/area/station/routing/depot)
+"bem" = (
+/obj/table/auto,
+/obj/item/reagent_containers/food/drinks/bottle/empty{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/drinks/bottle/empty{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/food/drinks/bottle/empty,
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/routing/depot)
+"ben" = (
+/obj/machinery/door/airlock/pyro{
+	dir = 4;
+	name = "Shower Room"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/quarters_east)
+"beo" = (
 /obj/machinery/disposal/mail/autoname/kitchen,
 /obj/disposalpipe/trunk/mail/east,
 /obj/decal/xmas_lights/ephemeral{
@@ -24840,7 +23378,7 @@
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
-"bel" = (
+"bep" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -24855,104 +23393,75 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/catering)
-"bem" = (
+"beq" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/grey,
+/obj/table/auto,
+/obj/item/spraybottle/cleaner{
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/obj/item/sponge{
+	pixel_x = 2
+	},
+/turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
-"ben" = (
+"ber" = (
 /obj/machinery/light/small{
 	dir = 1;
 	pixel_y = 21
 	},
 /obj/disposalpipe/segment/mail/horizontal,
-/turf/simulated/floor/grey,
+/obj/machinery/vending/monkey,
+/turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
-"beo" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
-	},
-/obj/item/device/radio/intercom/catering{
-	pixel_x = 3;
-	pixel_y = 24
-	},
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/catering)
-"bep" = (
+"bes" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/disposalpipe/segment/food,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/catering)
-"beq" = (
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/obj/disposalpipe/segment/mail/bent/south,
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/catering)
-"ber" = (
+"bet" = (
 /obj/submachine/foodprocessor,
 /obj/decal/xmas_lights/ephemeral{
 	pixel_y = 32
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
-"bes" = (
-/obj/table/reinforced/auto,
-/obj/item/storage/box/plates,
-/obj/item/storage/box/cutlery,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/autoname_west,
-/turf/simulated/floor/white,
-/area/station/crew_quarters/kitchen)
-"bet" = (
+"bev" = (
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/cafeteria)
+"bew" = (
 /obj/stool/chair{
 	dir = 4
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
-"beu" = (
-/obj/table/auto,
-/obj/item/reagent_containers/food/snacks/breadloaf,
-/obj/item/kitchen/utensil/knife,
-/obj/machinery/light_switch/east,
-/turf/simulated/floor/specialroom/cafeteria,
-/area/station/crew_quarters/kitchen)
-"bev" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/cafeteria)
-"bew" = (
-/obj/machinery/door/airlock/pyro{
-	name = "Serving Area"
-	},
-/obj/access_spawn/bar,
-/obj/firedoor_spawn,
-/obj/access_spawn/kitchen,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/cafeteria)
 "bex" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/cafeteria)
+"bey" = (
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
+"beA" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/machinery/light/small/floor,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"bey" = (
+"beB" = (
 /obj/stool/chair,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"bez" = (
+"beC" = (
 /obj/table/round/auto,
 /obj/item/reagent_containers/food/drinks/bottle/bottledwater{
 	pixel_y = 16
@@ -24967,14 +23476,14 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
-"beA" = (
+"beD" = (
 /obj/item/device/radio/intercom{
 	pixel_y = 24
 	},
 /obj/stool/chair,
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
-"beB" = (
+"beE" = (
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
@@ -24982,7 +23491,7 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
-"beC" = (
+"beF" = (
 /obj/storage/crate,
 /obj/item/clothing/head/wig,
 /obj/item/dye_bottle,
@@ -24996,7 +23505,7 @@
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/barber_shop)
-"beD" = (
+"beG" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -25004,40 +23513,14 @@
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/barber_shop)
-"beE" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/turf/simulated/floor/specialroom/cafeteria,
-/area/station/crew_quarters/barber_shop)
-"beF" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/storage/emergency)
-"beG" = (
-/obj/machinery/door/airlock/pyro/maintenance,
-/obj/disposalpipe/segment/vertical,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/storage/emergency)
 "beH" = (
-/obj/stool/chair{
-	dir = 1
+/obj/machinery/door/airlock/pyro{
+	dir = 4;
+	name = "Toilets"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/neutral/side{
-	dir = 8
-	},
-/area/station/crew_quarters/quarters_south)
-"beI" = (
-/obj/decal/cleanable/dirt,
-/obj/storage/closet/fire,
-/turf/simulated/floor/plating,
-/area/station/maintenance/central)
+/obj/firedoor_spawn,
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/quarters_east)
 "beJ" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
@@ -25201,29 +23684,6 @@
 	},
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/podbay)
-"bfl" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/checkpoint/escape)
-"bfm" = (
-/obj/machinery/door/airlock/pyro/glass{
-	name = "Mini-Brig"
-	},
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/access_spawn/brig,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/red/side,
-/area/station/security/checkpoint/escape)
 "bfn" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/routing/depot)
@@ -25248,15 +23708,36 @@
 /turf/simulated/floor/grime,
 /area/station/routing/depot)
 "bfr" = (
-/obj/machinery/disposal,
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
+/obj/table/auto,
+/obj/item/decoration/ashtray,
+/obj/item/dice{
+	pixel_x = -8
 	},
-/obj/disposalpipe/trunk/east,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/catering)
+/obj/item/dice{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/coin{
+	pixel_x = -2;
+	pixel_y = 16
+	},
+/turf/simulated/floor/plating,
+/area/station/routing/depot)
 "bfs" = (
+/obj/stool/chair{
+	dir = 8
+	},
+/obj/machinery/light/small,
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/routing/depot)
+"bft" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/catering)
+"bfu" = (
 /obj/disposalpipe/segment/bent/west,
 /obj/cable{
 	d1 = 1;
@@ -25265,20 +23746,39 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/catering)
-"bft" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/catering)
-"bfu" = (
-/obj/disposalpipe/segment/food,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/catering)
 "bfv" = (
+/obj/pool/perspective{
+	dir = 9;
+	tag = "icon-pool (NORTHWEST)"
+	},
+/turf/simulated/floor/blue/checker,
+/area/station/crew_quarters/pool)
+"bfw" = (
+/obj/pool/perspective{
+	density = 0;
+	dir = 1;
+	tag = "icon-pool (NORTH)"
+	},
+/obj/pool{
+	density = 0;
+	dir = 8;
+	icon = 'icons/obj/fluid.dmi';
+	icon_state = "ladder";
+	name = "ladder"
+	},
+/obj/channel{
+	required_to_pass = 210
+	},
+/turf/simulated/floor/blue/checker,
+/area/station/crew_quarters/pool)
+"bfx" = (
+/obj/pool/perspective{
+	dir = 5;
+	tag = "icon-pool (NORTHEAST)"
+	},
+/turf/simulated/floor/white/checker,
+/area/station/crew_quarters/pool)
+"bfz" = (
 /obj/disposalpipe/segment/mail/bent/north,
 /obj/cable{
 	icon_state = "4-8"
@@ -25290,14 +23790,7 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/catering)
-"bfw" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/catering)
-"bfx" = (
+"bfA" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
@@ -25310,82 +23803,29 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
-"bfy" = (
+"bfB" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/cable{
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
-"bfz" = (
+"bfC" = (
 /obj/disposalpipe/segment/mail/bent/west,
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
-"bfA" = (
+"bfE" = (
 /obj/table/auto,
 /obj/machinery/computer/security/wooden_tv/small,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
-"bfB" = (
+"bfF" = (
 /obj/wingrille_spawn/auto,
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "kitchen";
-	layer = 4;
-	name = "Kitchen Shutter";
-	opacity = 0;
-	p_open = 1
-	},
+/obj/decal/wreath/ephemeral,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/cafeteria)
-"bfC" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/obj/table/reinforced/auto,
-/obj/cup_rack{
-	pixel_y = 32
-	},
-/obj/machinery/espresso_machine,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/cafeteria)
-"bfD" = (
-/turf/simulated/floor/black,
-/area/station/crew_quarters/cafeteria)
-"bfE" = (
-/obj/machinery/disposal,
-/obj/disposalpipe/trunk/south,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/cafeteria)
-"bfF" = (
-/obj/stool/chair{
-	dir = 4
-	},
-/obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
-"bfG" = (
-/obj/table/auto,
-/obj/item/reagent_containers/food/drinks/tea{
-	pixel_y = 6
-	},
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
-"bfH" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
-"bfI" = (
+"bfK" = (
 /obj/decal/tile_edge/stripe{
 	dir = 10;
 	tag = ""
@@ -25393,41 +23833,21 @@
 /obj/mic_stand,
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
-"bfJ" = (
+"bfL" = (
 /obj/decal/tile_edge/stripe,
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
-"bfK" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
-/turf/simulated/floor/specialroom/cafeteria,
-/area/station/crew_quarters/barber_shop)
-"bfL" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/specialroom/cafeteria,
-/area/station/crew_quarters/barber_shop)
 "bfM" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/decal/tile_edge/stripe,
+/obj/stocking/ephemeral{
+	pixel_x = 22
 	},
-/turf/simulated/floor/specialroom/cafeteria,
-/area/station/crew_quarters/barber_shop)
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/cafeteria)
 "bfN" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/specialroom/cafeteria,
-/area/station/crew_quarters/barber_shop)
+/obj/storage/crate/furnacefuel,
+/turf/simulated/floor/blue/checker,
+/area/station/crew_quarters/pool)
 "bfO" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -25435,6 +23855,29 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "bfP" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/barber_shop)
+"bfQ" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/barber_shop)
+"bfR" = (
+/obj/item/storage/toilet{
+	dir = 4;
+	tag = ""
+	},
+/turf/simulated/floor/red/side{
+	dir = 8
+	},
+/area/station/security/checkpoint/escape)
+"bfS" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
 	icon_state = "6-8"
@@ -25446,7 +23889,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"bfQ" = (
+"bfT" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 9;
@@ -25457,7 +23900,7 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"bfR" = (
+"bfU" = (
 /obj/storage/closet/dresser,
 /obj/item/clothing/under/gimmick/maid,
 /obj/decal/poster/wallsign/poster_rand{
@@ -25471,7 +23914,7 @@
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/nw,
 /area/station/crew_quarters/quarters_south)
-"bfS" = (
+"bfV" = (
 /obj/decal/poster/wallsign/poster_rand{
 	pixel_x = -10;
 	pixel_y = 38
@@ -25482,7 +23925,7 @@
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
 /area/station/crew_quarters/quarters_south)
-"bfT" = (
+"bfW" = (
 /obj/decal/poster/wallsign/poster_rand{
 	pixel_y = 28
 	},
@@ -25492,59 +23935,24 @@
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/ne,
 /area/station/crew_quarters/quarters_south)
-"bfU" = (
-/obj/decal/tile_edge/line/green{
-	icon_state = "line1"
-	},
-/obj/decal/garland/ephemeral{
-	dir = 4;
-	pixel_x = -14
-	},
-/turf/simulated/floor/neutral/side{
-	dir = 8
-	},
-/area/station/crew_quarters/quarters_south)
-"bfV" = (
-/obj/decal/tile_edge/line/green{
-	dir = 10;
-	icon_state = "line1"
-	},
+"bfX" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/station/crew_quarters/quarters_south)
-"bfW" = (
-/obj/disposalpipe/segment/vertical,
-/obj/machinery/power/apc/autoname_east,
-/obj/cable,
-/turf/simulated/floor/neutral/side{
-	dir = 4
-	},
-/area/station/crew_quarters/quarters_south)
-"bfX" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/simulated/floor/grey,
 /area/station/hallway/secondary/exit)
 "bfY" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/table/auto,
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
 	},
-/turf/simulated/floor/escape/corner{
-	dir = 4
-	},
+/obj/item/storage/toolbox/emergency,
+/obj/machinery/light_switch/north,
+/obj/item/device/light/glowstick,
+/obj/item/device/light/glowstick,
+/turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "bfZ" = (
 /turf/simulated/wall/auto/supernorn,
@@ -25645,32 +24053,11 @@
 	},
 /turf/space,
 /area/station/mining/staff_room)
-"bgo" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/checkpoint/escape)
 "bgq" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/mining/staff_room)
 "bgr" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/checkpoint/escape)
 "bgs" = (
 /obj/table/reinforced/auto,
@@ -25732,78 +24119,56 @@
 /turf/simulated/floor/grime,
 /area/station/routing/depot)
 "bgy" = (
-/obj/table/auto,
-/obj/item/storage/box/glassbox,
-/obj/item/storage/box/glassbox,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/catering)
+/obj/machinery/door/airlock/pyro/external,
+/turf/simulated/floor/caution/northsouth,
+/area/station/hallway/secondary/exit)
 "bgz" = (
 /obj/table/auto,
-/obj/item/storage/box/plates,
-/obj/item/storage/box/cutlery,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/catering)
-"bgA" = (
-/obj/machinery/light/small,
-/obj/machinery/vending/monkey,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/catering)
-"bgB" = (
-/obj/storage/crate{
-	name = "Cone Crate"
+/obj/item/disk/data/cartridge/diagnostics{
+	pixel_x = 4;
+	pixel_y = -2
 	},
-/obj/item/reagent_containers/food/snacks/ice_cream_cone,
-/obj/item/reagent_containers/food/snacks/ice_cream_cone,
-/obj/item/reagent_containers/food/snacks/ice_cream_cone,
-/obj/item/reagent_containers/food/snacks/ice_cream_cone,
-/obj/item/reagent_containers/food/snacks/ice_cream_cone,
-/obj/item/reagent_containers/food/snacks/ice_cream_cone,
-/obj/item/reagent_containers/food/snacks/condiment/chocchips,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/catering)
-"bgC" = (
-/obj/storage/crate,
-/obj/item/reagent_containers/food/snacks/ingredient/flour,
-/obj/item/reagent_containers/food/snacks/ingredient/flour,
-/obj/item/reagent_containers/food/snacks/ingredient/sugar,
-/obj/item/reagent_containers/food/snacks/ingredient/pancake_batter,
-/obj/item/reagent_containers/food/snacks/ingredient/oatmeal,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/catering)
-"bgD" = (
-/obj/disposalpipe/segment/food,
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/catering)
-"bgE" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/item/disk/data/cartridge/atmos{
+	pixel_x = -6;
+	pixel_y = 4
 	},
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/catering)
-"bgF" = (
-/obj/table/auto,
-/obj/item/shaker/salt,
-/obj/item/shaker/mustard{
-	pixel_x = -6
+/obj/item/disk/data/cartridge{
+	desc = "A programmable data cartridge for portable microcomputers.";
+	name = "EEPROM Cart"
 	},
-/obj/item/shaker/pepper{
-	pixel_x = 3
-	},
-/obj/item/shaker/ketchup{
-	pixel_x = 6
-	},
+/obj/item/device/audio_log,
+/obj/item/peripheral/card_scanner,
+/obj/item/peripheral/card_scanner,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
+	dir = 8;
+	pixel_x = -12
 	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/catering)
-"bgG" = (
+/turf/simulated/floor/plating,
+/area/station/storage/tech)
+"bgA" = (
+/obj/table/auto,
+/obj/item/screwdriver,
+/obj/item/disk/data/fixed_disk,
+/obj/item/disk/data/floppy/computer3boot,
+/obj/item/disk/data/floppy/read_only/network_progs,
+/obj/item/disk/data/floppy/read_only/security_progs,
+/obj/item/disk/data/floppy/read_only/communications,
+/obj/item/disk/data/floppy/read_only/medical_progs,
+/obj/item/disk/data/floppy/read_only/terminal_os,
+/obj/item/peripheral/printer,
+/obj/item/device/flash,
+/turf/simulated/floor/grime,
+/area/station/storage/tech)
+"bgC" = (
+/obj/machinery/vending/computer3,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
+	},
+/turf/simulated/floor/grey/blackgrime/other,
+/area/station/storage/tech)
+"bgH" = (
 /obj/submachine/chef_sink{
 	dir = 4
 	},
@@ -25813,7 +24178,7 @@
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
-"bgH" = (
+"bgJ" = (
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
 	name = "Kitchen"
@@ -25822,33 +24187,28 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/cafeteria)
-"bgI" = (
-/obj/disposalpipe/segment/vertical,
+"bgK" = (
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
-"bgJ" = (
-/obj/table/reinforced/bar/auto,
-/obj/item/device/radio/beacon,
-/obj/item/clothing/head/cakehat,
-/turf/simulated/floor/carpet/green/standard/narrow/northsouth,
-/area/station/crew_quarters/cafeteria)
-"bgK" = (
-/obj/stool/bar,
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
-"bgL" = (
+"bgN" = (
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"bgM" = (
-/obj/machinery/light/small/floor,
+"bgO" = (
+/obj/stool/chair{
+	dir = 1
+	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"bgN" = (
+"bgQ" = (
 /obj/decal/stage_edge,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"bgO" = (
+"bgR" = (
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 26;
@@ -25856,17 +24216,21 @@
 	},
 /turf/simulated/floor/stairs/wood,
 /area/station/crew_quarters/cafeteria)
-"bgP" = (
-/obj/machinery/hair_dye_dispenser,
-/turf/simulated/floor/specialroom/cafeteria,
-/area/station/crew_quarters/barber_shop)
-"bgQ" = (
+"bgS" = (
+/obj/machinery/door/airlock/pyro/glass,
+/obj/access_spawn/brig,
+/obj/firedoor_spawn,
+/turf/simulated/floor/red/side{
+	dir = 5
+	},
+/area/station/security/brig)
+"bgT" = (
 /obj/table/auto,
 /obj/item/dye_bottle,
 /obj/item/dye_bottle,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/barber_shop)
-"bgR" = (
+"bgU" = (
 /obj/table/auto,
 /obj/item/storage/pill_bottle/hairgrownium,
 /obj/machinery/light/small{
@@ -25875,23 +24239,7 @@
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/barber_shop)
-"bgS" = (
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"bgT" = (
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"bgU" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-9"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"bgV" = (
+"bgY" = (
 /obj/table/wood/auto,
 /obj/item/plate{
 	pixel_y = 7
@@ -25914,13 +24262,13 @@
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/sw,
 /area/station/crew_quarters/quarters_south)
-"bgW" = (
+"bgZ" = (
 /obj/stool/chair{
 	dir = 8
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/south,
 /area/station/crew_quarters/quarters_south)
-"bgX" = (
+"bha" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
@@ -25929,80 +24277,32 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/carpet/blue/fancy/edge/se,
 /area/station/crew_quarters/quarters_south)
-"bgY" = (
-/obj/machinery/plantpot{
-	anchored = 1
-	},
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/grass,
-/area/station/crew_quarters/quarters_south)
-"bgZ" = (
-/obj/decal/tile_edge/line/green{
-	dir = 8;
-	icon_state = "line1"
-	},
+"bhd" = (
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_south)
-"bha" = (
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/neutral/side{
-	dir = 4
-	},
-/area/station/crew_quarters/quarters_south)
-"bhb" = (
-/obj/table/wood/auto,
-/obj/random_item_spawner/medicine,
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/carpet/green/fancy/edge/ne,
-/area/station/crew_quarters/quarters_south)
-"bhc" = (
-/obj/machinery/power/apc/autoname_west,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/central)
-"bhd" = (
+/area/station/security/checkpoint/escape)
+"bhe" = (
+/obj/disposaloutlet/south,
+/obj/disposalpipe/trunk/west,
 /obj/machinery/light{
 	dir = 4;
 	layer = 9.1;
 	pixel_x = 10
 	},
-/obj/cable{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/escape{
-	dir = 4
+	dir = 5
 	},
-/area/station/hallway/secondary/exit)
-"bhe" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/escape{
-	dir = 4
-	},
-/area/station/hallway/secondary/exit)
+/area/station/hallway/primary/east)
 "bhf" = (
-/obj/machinery/door/airlock/pyro/glass{
+/obj/stool/chair/red{
 	dir = 4
 	},
-/turf/simulated/floor/escape{
-	dir = 1
-	},
-/area/station/hallway/secondary/exit)
+/turf/simulated/floor,
+/area/station/hallway/primary/east)
 "bhh" = (
 /turf/simulated/floor/shuttlebay{
 	icon_state = "engine_caution_south"
@@ -26253,17 +24553,14 @@
 /turf/space,
 /area/station/mining/staff_room)
 "bhI" = (
-/obj/table/auto,
-/obj/machinery/computer3/generic/personal,
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/carpet/purple/fancy/edge/north,
+/obj/submachine/laundry_machine,
+/turf/simulated/floor/grey,
 /area/station/crew_quarters/quarters_east)
 "bhJ" = (
 /obj/cable{
@@ -26311,90 +24608,41 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/podbay)
-"bhO" = (
-/obj/table/auto,
-/obj/item/reagent_containers/food/drinks/eggnog{
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/food/snacks/condiment/syrup,
-/obj/item/reagent_containers/food/snacks/ingredient/peanutbutter,
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/catering)
 "bhP" = (
 /obj/table/auto,
-/obj/item/storage/box/beakerbox,
-/obj/machinery/light_switch/east,
-/obj/item/storage/box/syringes,
-/obj/item/device/reagentscanner,
-/obj/item/device/reagentscanner,
+/obj/item/storage/box/glassbox,
+/obj/item/storage/box/glassbox,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
-"bhQ" = (
-/obj/table/reinforced/auto,
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/suit/apron,
-/obj/item/clothing/head/souschefhat,
-/obj/item/device/radio/intercom/catering{
-	dir = 4
-	},
-/turf/simulated/floor/specialroom/cafeteria,
-/area/station/crew_quarters/kitchen)
 "bhR" = (
-/obj/table/reinforced/auto,
-/obj/machinery/light,
-/obj/machinery/glass_recycler{
-	glass_amt = 5;
-	pixel_y = 4
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/specialroom/cafeteria,
-/area/station/crew_quarters/kitchen)
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/catering)
 "bhS" = (
-/obj/table/reinforced/auto,
-/obj/submachine/mixer,
-/turf/simulated/floor/specialroom/cafeteria{
-	dir = 1
+/obj/table/auto,
+/obj/machinery/light_switch/east,
+/obj/item/device/reagentscanner{
+	pixel_x = -4;
+	pixel_y = 3
 	},
-/area/station/crew_quarters/kitchen)
+/obj/item/reagent_containers/glass/bottle/icing{
+	pixel_x = 4
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
 "bhT" = (
-/obj/table/reinforced/auto,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 10;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/obj/machinery/phone,
-/turf/simulated/floor/specialroom/cafeteria{
-	dir = 1
-	},
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/kitchen)
-"bhU" = (
-/obj/table/reinforced/bar/auto,
-/obj/machinery/computer/security/wooden_tv/small{
-	pixel_y = 8
-	},
-/turf/simulated/floor/carpet/green/standard/narrow/northsouth,
-/area/station/crew_quarters/cafeteria)
-"bhV" = (
-/obj/stool/bar,
-/obj/machinery/light/small/floor,
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
-"bhW" = (
-/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon18{
-	codes_txt = "patrol;next_patrol=1"
-	},
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
 "bhX" = (
-/obj/stool/chair,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
+/obj/landmark{
+	name = "Observer-Start"
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
@@ -26403,25 +24651,44 @@
 /area/station/crew_quarters/arcade)
 "bhZ" = (
 /obj/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/area/station/maintenance/inner/central)
 "bia" = (
-/obj/table/auto,
-/obj/item/reagent_containers/glass/wateringcan{
-	pixel_y = 6
-	},
-/turf/simulated/floor/green,
-/area/station/crew_quarters/quarters_south)
+/obj/stool/bench/blue/auto,
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/quarters_east)
 "bib" = (
-/obj/storage/closet/dresser,
-/obj/item/clothing/under/color/lime,
-/obj/item/clothing/head/green,
-/obj/item/clothing/glasses/healthgoggles,
-/turf/simulated/floor/carpet/green/fancy/edge/se,
+/obj/disposalpipe/segment/vertical,
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
 /area/station/crew_quarters/quarters_south)
 "bic" = (
+/turf/simulated/floor/carpet/green/fancy/edge/sw,
+/area/station/crew_quarters/quarters_south)
+"bid" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/carpet/green/fancy/edge/south,
+/area/station/crew_quarters/quarters_south)
+"bie" = (
+/obj/table/auto,
+/obj/item/paper_bin,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/quarters_east)
+"bif" = (
 /obj/cable{
 	d1 = 2;
 	d2 = 4;
@@ -26439,13 +24706,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
-"bid" = (
+"bih" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
-"bie" = (
+"bii" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -26455,7 +24722,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
-"bif" = (
+"bij" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -26465,55 +24732,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
-"big" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4
-	},
-/turf/simulated/floor/red/checker,
-/area/station/maintenance/central)
-"bih" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4
-	},
-/turf/simulated/floor/escape{
-	dir = 8
-	},
-/area/station/hallway/secondary/exit)
-"bii" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
-"bij" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4
-	},
-/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon15,
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
 "bik" = (
 /turf/simulated/floor/escape{
 	dir = 1
@@ -26798,17 +25016,11 @@
 	},
 /area/station/hallway/primary/west)
 "biL" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	icon_state = "0-2"
+/obj/submachine/chef_sink/chem_sink{
+	dir = 1
 	},
-/obj/cable,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/storage)
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/quarters_east)
 "biM" = (
 /obj/grille/catwalk{
 	dir = 9;
@@ -26820,35 +25032,49 @@
 	},
 /area/station/mining/refinery)
 "biN" = (
-/obj/landmark{
-	name = "Observer-Start"
-	},
+/obj/stool/bar,
+/obj/machinery/light/small/floor,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "biO" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/table/reinforced/auto,
+/obj/machinery/networked/printer{
+	name = "Printer - Escape Checkpoint";
+	pixel_y = 5;
+	print_id = "EscapeCheckpoint"
 	},
-/obj/cable,
-/turf/simulated/floor/plating,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/door_timer/minibrig/new_walls/north{
+	pixel_x = -6
+	},
+/obj/machinery/phone/wall{
+	pixel_x = 6;
+	pixel_y = 32
+	},
+/obj/machinery/light_switch/west{
+	pixel_y = -10
+	},
+/obj/item/device/radio/intercom/security{
+	dir = 4;
+	pixel_x = -20;
+	pixel_y = 4
+	},
+/turf/simulated/floor/red/side{
+	dir = 9
+	},
 /area/station/security/checkpoint/escape)
 "biQ" = (
-/obj/shrub{
-	desc = "While it's wildly unlikely that this bush hails from Space Sweden, it nevertheless bears a faint scent of meatballs that can't be adequately explained.";
-	dir = 8;
-	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "plant";
-	name = "swedish shrub";
-	pixel_y = 5
+/obj/grille/steel,
+/obj/disposalpipe/segment/food{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/obj/item/kitchen/utensil/knife{
-	desc = "A thoroughly worn yet still robust kitchen knife. It seems to have been maintained with care. The word 'MORA' is etched into one side of the blade.";
-	name = "old knife"
-	},
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/quarters_east)
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "biR" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -26895,24 +25121,8 @@
 /turf/simulated/floor/caution/westeast,
 /area/station/routing/depot)
 "biV" = (
-/obj/machinery/computer/barcode{
-	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Pod Bay","Research","Security","QM");
-	dir = 4
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
-	},
 /turf/simulated/floor/orange/side{
-	dir = 9
+	dir = 8
 	},
 /area/station/crew_quarters/catering)
 "biW" = (
@@ -26921,58 +25131,48 @@
 /turf/simulated/floor/plating,
 /area/station/engine/gas)
 "biX" = (
-/obj/machinery/computer/ordercomp{
-	dir = 8
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/data_terminal,
 /turf/simulated/floor/orange/side{
-	dir = 5
+	dir = 4
 	},
 /area/station/crew_quarters/catering)
 "biY" = (
-/obj/machinery/vending/pizza,
+/obj/surgery_tray,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "biZ" = (
-/obj/submachine/chem_extractor{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 9;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/table/auto,
+/obj/item/storage/box/plates,
+/obj/item/storage/box/cutlery,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "bja" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/baroffice)
 "bjb" = (
-/obj/submachine/ice_cream_dispenser,
-/obj/machinery/light/emergency{
+/obj/pool/perspective{
 	dir = 8;
-	pixel_x = -10
+	tag = "icon-pool (WEST)"
 	},
+/turf/simulated/floor/blue/checker,
+/area/station/crew_quarters/pool)
+"bjc" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small/floor,
+/turf/simulated/floor/white,
+/area/station/crew_quarters/pool)
+"bjd" = (
+/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
-"bjc" = (
+"bje" = (
 /obj/table/reinforced/bar/auto,
 /obj/item/plate,
 /obj/item/kitchen/utensil/fork,
 /turf/simulated/floor/carpet/green/standard/narrow/northsouth,
 /area/station/crew_quarters/cafeteria)
-"bjd" = (
+"bjh" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 4;
 	icon_state = "on";
@@ -26980,33 +25180,23 @@
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"bje" = (
-/obj/disposalpipe/segment/mail/vertical,
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4
-	},
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
-"bjf" = (
+"bji" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 10
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"bjg" = (
+"bjj" = (
 /obj/stool/chair{
 	dir = 4
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"bjh" = (
-/obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
-	pixel_y = 8
-	},
+"bjk" = (
+/obj/loudspeaker,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"bji" = (
+"bjm" = (
 /obj/table/auto,
 /obj/machinery/light{
 	dir = 4;
@@ -27021,32 +25211,7 @@
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"bjj" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/arcade)
-"bjk" = (
-/obj/machinery/computer/arcade,
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
-"bjl" = (
-/obj/stool/bar,
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
-"bjm" = (
-/obj/submachine/ATM{
-	pixel_y = 32
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
-"bjn" = (
+"bjo" = (
 /obj/machinery/sim/vr_bed{
 	name = "VR simulation pod";
 	network = "arcadevr"
@@ -27065,14 +25230,51 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
-"bjo" = (
+"bjp" = (
+/obj/storage/closet/dresser,
+/obj/item/clothing/under/gimmick/macho{
+	color = "#555555";
+	desc = "They're a little bit tight.";
+	name = "speedo"
+	},
+/obj/item/clothing/under/swimsuit/random,
+/obj/item/clothing/under/swimsuit/random,
+/obj/item/clothing/under/swimsuit/random,
+/obj/item/clothing/under/shorts/random{
+	name = "swimming trunks";
+	rand_pos = 1
+	},
+/obj/item/clothing/under/shorts/random{
+	name = "swimming trunks";
+	rand_pos = 1
+	},
+/obj/item/clothing/under/shorts/random{
+	name = "swimming trunks";
+	rand_pos = 1
+	},
+/obj/item/clothing/shoes/flippers{
+	pixel_y = -9
+	},
+/obj/item/clothing/shoes/flippers{
+	pixel_y = -9
+	},
+/obj/item/clothing/shoes/flippers{
+	pixel_y = -9
+	},
+/turf/simulated/floor/blue/checker,
+/area/station/crew_quarters/pool)
+"bjq" = (
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"bjr" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 6;
 	level = 2
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"bjp" = (
+"bjs" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8;
 	name = "Cafeteria Repressurization Port"
@@ -27083,52 +25285,52 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"bjq" = (
+"bjt" = (
 /obj/machinery/atmospherics/pipe/tank/air_repressurization/south,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"bjr" = (
-/obj/decal/tile_edge/line/green{
-	dir = 1;
-	icon_state = "line1"
-	},
-/obj/bookshelf/persistent,
-/turf/simulated/floor/neutral/side{
-	dir = 9
-	},
-/area/station/crew_quarters/quarters_south)
-"bjs" = (
-/obj/decal/tile_edge/line/green{
-	dir = 1;
-	icon_state = "line1"
-	},
-/turf/simulated/floor/neutral/corner{
-	dir = 1
-	},
-/area/station/crew_quarters/quarters_south)
-"bjt" = (
-/obj/decal/tile_edge/line/green{
-	dir = 9;
-	icon_state = "line1"
-	},
+"bju" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_south)
-"bju" = (
-/obj/disposalpipe/segment/vertical,
-/obj/machinery/alarm{
+/obj/decal/garland/ephemeral{
 	dir = 8;
-	pixel_x = 20
+	pixel_x = 14
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 4
 	},
-/area/station/crew_quarters/quarters_south)
+/area/station/crew_quarters/quarters_north)
 "bjv" = (
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Mini-Brig"
+	},
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/access_spawn/brig,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/red/side,
+/area/station/security/checkpoint/escape)
+"bjw" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/checkpoint/escape)
+"bjx" = (
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_x = -12
@@ -27138,70 +25340,46 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
-"bjw" = (
+"bjy" = (
+/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon14,
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"bjz" = (
 /obj/machinery/atmospherics/valve{
 	high_risk = 1;
 	name = "Escape Hallway"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
-"bjx" = (
-/obj/machinery/atmospherics/valve{
-	high_risk = 1;
-	name = "Air Reserve (Escape Hallway)"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/central)
-"bjy" = (
-/obj/machinery/sleep_console{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/escape{
-	dir = 8
-	},
-/area/station/hallway/secondary/exit)
-"bjz" = (
-/obj/machinery/sleeper{
-	dir = 4
-	},
-/obj/cable,
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
 "bjA" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
-/obj/cable{
-	icon_state = "1-2"
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
 	},
-/turf/simulated/floor/escape{
-	dir = 4
+/turf/simulated/floor/neutral/side{
+	dir = 8
 	},
-/area/station/hallway/secondary/exit)
+/area/station/hallway/primary/east)
 "bjB" = (
-/obj/machinery/door/airlock/pyro/glass,
-/obj/cable{
-	icon_state = "1-2"
+/obj/table/auto,
+/obj/machinery/cell_charger,
+/obj/item/cell/charged,
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
 	},
-/obj/firedoor_spawn,
-/obj/decal/garland/ephemeral,
 /turf/simulated/floor/escape{
 	dir = 4
 	},
-/area/station/hallway/secondary/exit)
+/area/station/hallway/primary/east)
 "bjC" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4
+/turf/simulated/floor/stairs/wide/middle{
+	dir = 8
 	},
-/turf/simulated/floor/escape,
 /area/station/hallway/secondary/exit)
 "bjE" = (
 /obj/machinery/camera{
@@ -27215,16 +25393,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "bjF" = (
-/obj/shrub{
-	dir = 1
+/obj/machinery/firealarm{
+	pixel_x = 6;
+	pixel_y = 24
 	},
-/obj/machinery/light/emergency{
-	dir = 1;
-	pixel_y = 16
-	},
-/turf/simulated/floor/escape{
-	dir = 1
-	},
+/turf/simulated/floor/escape,
 /area/station/hallway/secondary/exit)
 "bjH" = (
 /obj/machinery/drainage,
@@ -27443,60 +25616,41 @@
 	name = "Inner Southwest Maintenance"
 	})
 "bkf" = (
-/obj/rack,
-/obj/item/clothing/suit/space/engineer,
-/obj/item/clothing/shoes/magnetic,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/head/helmet/space/engineer,
-/obj/item/tank/air,
-/obj/item/device/light/flashlight,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/belt/utility,
-/obj/cable{
-	icon_state = "4-8"
+/obj/lattice{
+	icon_state = "lattice-dir"
 	},
-/turf/simulated/floor/black,
-/area/station/engine/storage)
+/obj/warp_beacon/engineering,
+/turf/space,
+/area/space)
 "bkg" = (
-/obj/machinery/door/airlock/pyro/security{
-	dir = 4;
-	name = "Dock Checkpoint"
+/obj/machinery/computer/card{
+	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-8"
-	},
-/obj/firedoor_spawn,
-/obj/machinery/secscanner{
-	dir = 4;
-	pixel_x = -20
-	},
-/obj/cable{
-	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "0-4"
 	},
-/obj/cable{
-	icon_state = "2-4"
+/obj/machinery/power/apc/autoname_west,
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/red/side{
+	dir = 8
 	},
-/turf/simulated/floor/red,
 /area/station/security/checkpoint/escape)
 "bkh" = (
-/obj/stool/chair/office/red,
-/obj/disposalpipe/segment/brig{
-	dir = 1
+/obj/storage/crate,
+/obj/item/clothing/under/gimmick/macho{
+	color = "#555555";
+	desc = "They're a little bit tight.";
+	name = "speedo"
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/item/clothing/head/apprentice,
+/obj/item/card_box/suit,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/red/side,
-/area/station/security/checkpoint/escape)
+/turf/simulated/floor/carpet/red/fancy/edge/north,
+/area/station/crew_quarters/quarters_north)
 "bki" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -27565,13 +25719,13 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/catering)
 "bks" = (
+/obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "4-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/yellow/side{
-	dir = 8
-	},
-/area/station/engine/storage)
+/turf/simulated/floor/plating,
+/area/station/storage/tech)
 "bkt" = (
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
@@ -27579,13 +25733,42 @@
 	},
 /obj/access_spawn/bar,
 /obj/access_spawn/kitchen,
+/obj/firedoor_spawn,
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/firedoor_spawn,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/catering)
 "bku" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/grey/blackgrime/other,
+/area/station/storage/tech)
+"bkv" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "yellow";
+	icon_state = "bedsheet-yellow"
+	},
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/autoname_east,
+/obj/item/luggable_computer,
+/turf/simulated/floor/grey/blackgrime/other,
+/area/station/storage/tech)
+"bkw" = (
+/obj/disposalpipe/segment/food,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/catering)
+"bkx" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -27596,34 +25779,22 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/catering)
-"bkv" = (
+"bky" = (
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_x = 12
 	},
-/turf/simulated/floor/grey,
+/obj/machinery/vending/pizza,
+/turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
-"bkw" = (
-/obj/table/auto,
-/obj/item/storage/box/glassbox,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shot,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shot,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shot,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shot,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
-/obj/item/reagent_containers/food/drinks/drinkingglass/cocktail,
-/obj/item/reagent_containers/food/drinks/drinkingglass/cocktail,
-/obj/item/reagent_containers/food/drinks/drinkingglass/cocktail,
-/obj/item/reagent_containers/food/drinks/drinkingglass/cocktail,
-/obj/item/gun/russianrevolver,
-/obj/machinery/light_switch/west,
-/obj/item/device/radio/intercom/catering,
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/baroffice)
-"bkx" = (
+"bkz" = (
+/obj/machinery/door/airlock/pyro{
+	name = "Shower Room"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/quarters_east)
+"bkA" = (
 /obj/table/auto,
 /obj/item/paper_bin{
 	pixel_y = 7
@@ -27638,56 +25809,22 @@
 /obj/item/storage/box/cocktail_doodads,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
-"bky" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/obj/machinery/phone/wall{
-	pixel_y = 32
-	},
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/baroffice)
-"bkz" = (
-/obj/machinery/vending/alcohol,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/baroffice)
-"bkA" = (
-/obj/table/reinforced/chemistry/auto{
-	name = "prep counter"
-	},
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/cafeteria)
 "bkB" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/east)
+"bkC" = (
 /obj/table/reinforced/bar/auto,
 /obj/machinery/cashreg,
 /turf/simulated/floor/carpet/green/standard/narrow/northsouth,
 /area/station/crew_quarters/cafeteria)
-"bkC" = (
+"bkE" = (
 /obj/item/device/radio/beacon,
 /obj/disposalpipe/segment/mail/vertical,
 /obj/machinery/light/small/floor,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"bkD" = (
-/obj/machinery/atmospherics/pipe/simple,
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
-"bkE" = (
+"bkF" = (
 /obj/table/auto,
 /obj/item/shaker/mustard{
 	pixel_x = -6
@@ -27697,11 +25834,11 @@
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"bkF" = (
+"bkI" = (
 /obj/stool/bar,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
-"bkG" = (
+"bkJ" = (
 /obj/cable{
 	icon_state = "2-4"
 	},
@@ -27710,7 +25847,7 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
-"bkH" = (
+"bkK" = (
 /obj/machinery/sim/vr_bed{
 	name = "VR simulation pod";
 	network = "arcadevr"
@@ -27734,31 +25871,26 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
-"bkI" = (
+"bkL" = (
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/obj/pool/perspective{
+	dir = 8;
+	tag = "icon-pool (WEST)"
+	},
+/turf/simulated/floor/white/checker,
+/area/station/crew_quarters/pool)
+"bkM" = (
 /obj/disposalpipe/segment/vertical,
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 6
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"bkJ" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4;
-	high_risk = 1;
-	name = "Cafeteria"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"bkK" = (
-/obj/machinery/atmospherics/pipe/manifold{
-	level = 2
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"bkL" = (
+"bkN" = (
 /obj/machinery/atmospherics/valve{
 	dir = 4;
 	high_risk = 1;
@@ -27766,44 +25898,45 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"bkM" = (
-/obj/machinery/portable_atmospherics/canister/air/large,
-/obj/machinery/atmospherics/pipe/manifold{
-	dir = 4;
-	level = 2
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"bkN" = (
-/obj/stool/chair,
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_south)
 "bkO" = (
-/obj/machinery/light{
+/obj/pool/perspective{
 	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
+	tag = "icon-pool (EAST)"
 	},
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/neutral/side{
-	dir = 4
-	},
-/area/station/crew_quarters/quarters_south)
+/obj/pool_springboard,
+/turf/simulated/floor/white/checker,
+/area/station/crew_quarters/pool)
 "bkP" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "green";
+	icon_state = "bedsheet-green"
+	},
+/obj/item/storage/secure/ssafe{
+	pixel_x = -28
+	},
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/carpet/green/fancy/edge/nw,
+/area/station/crew_quarters/quarters_south)
+"bkQ" = (
+/obj/machinery/disposal,
+/obj/disposalpipe/trunk/west,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
+	},
+/turf/simulated/floor/blue/checker,
+/area/station/crew_quarters/pool)
+"bkR" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/central)
-"bkQ" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1;
-	name = "Escape S Repressurization Port"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/central)
-"bkR" = (
-/obj/machinery/atmospherics/pipe/tank/air_repressurization/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "bkS" = (
@@ -27944,9 +26077,29 @@
 	name = "Inner Southwest Maintenance"
 	})
 "blj" = (
-/obj/wingrille_spawn/auto,
-/obj/cable,
-/turf/simulated/floor/plating,
+/obj/machinery/computer3/generic/secure_data{
+	dir = 4;
+	tag = ""
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/red/side{
+	dir = 10
+	},
 /area/station/security/checkpoint/escape)
 "blk" = (
 /obj/lattice{
@@ -28011,20 +26164,25 @@
 /area/station/mining/staff_room)
 "blp" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/cable{
-	icon_state = "1-8"
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 9;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
 	},
-/turf/simulated/floor,
-/area/station/engine/storage)
-"blq" = (
-/obj/wingrille_spawn/auto,
-/obj/cable,
 /turf/simulated/floor/plating,
-/area/station/engine/storage)
+/area/station/maintenance/east)
+"blq" = (
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/turf/simulated/floor/red/side{
+	dir = 1
+	},
+/area/station/security/checkpoint/escape)
 "blr" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -28079,15 +26237,27 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/catering)
 "blB" = (
+/obj/table/auto,
+/obj/item/reagent_containers/food/snacks/ingredient/peanutbutter{
+	pixel_x = 7
+	},
+/obj/item/reagent_containers/food/snacks/ingredient/peanutbutter{
+	pixel_x = -7
+	},
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_x = -12
 	},
-/obj/table/auto,
-/obj/item/storage/box/donkpocket_kit,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
-"blC" = (
+"blD" = (
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/catering)
+"blE" = (
+/obj/disposalpipe/segment/food,
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/catering)
+"blF" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 4;
@@ -28095,7 +26265,13 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/catering)
-"blD" = (
+"blI" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/baroffice)
+"blJ" = (
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
 	name = "Bartender's Room"
@@ -28107,24 +26283,7 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
-"blE" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/baroffice)
-"blF" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/baroffice)
-"blG" = (
+"blK" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -28139,29 +26298,13 @@
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
-"blH" = (
+"blL" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
-"blI" = (
-/obj/disposalpipe/segment/vertical,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/cafeteria)
-"blJ" = (
-/obj/table/reinforced/bar/auto,
-/obj/item/reagent_containers/food/drinks/bowl,
-/obj/item/kitchen/utensil/spoon,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/green/standard/narrow/northsouth,
-/area/station/crew_quarters/cafeteria)
-"blK" = (
+"blM" = (
 /obj/stool/bar,
 /obj/cable{
 	icon_state = "4-8"
@@ -28169,7 +26312,7 @@
 /obj/machinery/light/small/floor,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"blL" = (
+"blN" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
@@ -28180,19 +26323,16 @@
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"blM" = (
+"blO" = (
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
+"blP" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 5
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"blN" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4
-	},
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
-"blO" = (
+"blR" = (
 /obj/stool/chair{
 	dir = 1
 	},
@@ -28201,7 +26341,7 @@
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"blP" = (
+"blS" = (
 /obj/stool/chair{
 	dir = 1
 	},
@@ -28214,7 +26354,7 @@
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"blQ" = (
+"blU" = (
 /obj/machinery/sim/vr_bed{
 	dir = 4;
 	name = "VR simulation pod";
@@ -28227,7 +26367,7 @@
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
-"blR" = (
+"blV" = (
 /obj/cable{
 	icon_state = "2-4"
 	},
@@ -28237,7 +26377,7 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
-"blS" = (
+"blW" = (
 /obj/disposalpipe/segment/bent/east,
 /obj/cable{
 	d1 = 1;
@@ -28252,7 +26392,7 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
-"blT" = (
+"blX" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
 	icon_state = "2-4"
@@ -28265,7 +26405,7 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
-"blU" = (
+"blY" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
@@ -28279,7 +26419,7 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
-"blV" = (
+"blZ" = (
 /obj/disposalpipe/junction/right/north,
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 9
@@ -28289,29 +26429,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"blW" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 6;
-	level = 2
-	},
-/obj/cable{
-	icon_state = "6-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "1-6"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"blX" = (
+"bma" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 1;
 	level = 2
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"blY" = (
+"bmb" = (
 /obj/machinery/atmospherics/valve{
 	dir = 4;
 	high_risk = 1;
@@ -28319,7 +26444,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"blZ" = (
+"bmc" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 9;
 	level = 2
@@ -28327,47 +26452,32 @@
 /obj/storage/closet/emergency,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"bma" = (
-/obj/table/round/auto,
-/obj/item/gobowl/b,
-/turf/simulated/floor/neutral/side{
-	dir = 8
-	},
-/area/station/crew_quarters/quarters_south)
-"bmb" = (
-/obj/table/round/auto,
-/obj/item/goboard,
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_south)
-"bmc" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_south)
 "bmd" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/central)
 "bme" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/grey,
-/area/station/hallway/secondary/exit)
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/security/checkpoint/escape)
 "bmf" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
 	},
-/turf/simulated/floor/stairs/wide/other{
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -21;
+	pixel_y = -3
+	},
+/turf/simulated/floor/escape{
 	dir = 8
 	},
 /area/station/hallway/secondary/exit)
@@ -28627,76 +26737,87 @@
 /turf/simulated/floor/orange/side,
 /area/station/crew_quarters/catering)
 "bmO" = (
-/obj/cryotron,
-/turf/unsimulated/floor/sanitary,
-/area/station/crewquarters/cryotron)
+/obj/item/device/radio/beacon,
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "bmP" = (
 /obj/table/auto,
-/obj/machinery/microwave,
+/obj/item/reagent_containers/food/snacks/condiment/syrup{
+	pixel_x = 7
+	},
+/obj/item/reagent_containers/food/snacks/condiment/syrup{
+	pixel_x = -7
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "bmQ" = (
-/obj/rack,
-/obj/disposalpipe/segment/food,
-/obj/item/storage/box/fruit_wedges,
-/obj/item/storage/box/beer,
+/obj/storage/crate,
+/obj/item/reagent_containers/food/snacks/ingredient/flour,
+/obj/item/reagent_containers/food/snacks/ingredient/flour,
+/obj/item/reagent_containers/food/snacks/ingredient/sugar,
+/obj/item/reagent_containers/food/snacks/ingredient/pancake_batter,
+/obj/item/reagent_containers/food/snacks/ingredient/oatmeal,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "bmR" = (
+/obj/storage/crate{
+	name = "Cone Crate"
+	},
+/obj/item/reagent_containers/food/snacks/ice_cream_cone,
+/obj/item/reagent_containers/food/snacks/ice_cream_cone,
+/obj/item/reagent_containers/food/snacks/ice_cream_cone,
+/obj/item/reagent_containers/food/snacks/ice_cream_cone,
+/obj/item/reagent_containers/food/snacks/ice_cream_cone,
+/obj/item/reagent_containers/food/snacks/ice_cream_cone,
+/obj/item/reagent_containers/food/snacks/condiment/chocchips,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
+"bmS" = (
+/obj/table/auto,
+/obj/item/storage/box/donkpocket_kit,
+/obj/machinery/light/small,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
+"bmT" = (
+/obj/disposalpipe/segment/food,
+/obj/reagent_dispensers/beerkeg,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
+"bmU" = (
 /obj/machinery/light/small,
 /obj/rack,
 /obj/item/reagent_containers/food/drinks/juicer,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
-"bmS" = (
-/obj/reagent_dispensers/beerkeg,
+"bmV" = (
+/obj/rack,
+/obj/item/storage/box/fruit_wedges,
+/obj/item/storage/box/beer,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
-"bmT" = (
-/obj/storage/crate{
-	desc = "Various supplies for the bar.";
-	name = "bartending crate"
-	},
-/obj/item/reagent_containers/food/drinks/bottle,
-/obj/item/reagent_containers/food/drinks/bottle,
-/obj/item/reagent_containers/food/drinks/bottle,
-/obj/item/reagent_containers/food/drinks/bottle,
-/obj/item/reagent_containers/food/drinks/bottle,
-/obj/item/storage/firstaid/toxin,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/device/reagentscanner,
-/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
-/obj/item/reagent_containers/dropper/mechanical,
-/obj/machinery/light/small,
-/obj/cable,
-/obj/machinery/power/apc/autoname_west,
-/obj/item/clothing/glasses/spectro,
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/baroffice)
-"bmU" = (
+"bmW" = (
+/obj/machinery/light,
+/turf/simulated/floor/grey,
+/area/station/hallway/secondary/exit)
+"bmX" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 1
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
-"bmV" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "black";
-	icon_state = "bedsheet-black"
-	},
-/obj/landmark/start{
-	name = "Bartender"
-	},
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/baroffice)
-"bmW" = (
+"bmY" = (
 /obj/machinery/light/small,
 /obj/storage/closet/wardrobe/black/formalwear,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
-"bmX" = (
+"bmZ" = (
+/obj/machinery/light/emergency{
+	dir = 4;
+	pixel_x = 10
+	},
+/turf/simulated/floor/grey,
+/area/station/hallway/secondary/exit)
+"bna" = (
 /obj/table/reinforced/auto,
 /obj/machinery/power/apc/autoname_west,
 /obj/cable,
@@ -28706,11 +26827,11 @@
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
-"bmY" = (
+"bnc" = (
 /obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
-"bmZ" = (
+"bnd" = (
 /obj/table/reinforced/bar/auto,
 /obj/item/shaker/mustard{
 	pixel_x = -1;
@@ -28730,12 +26851,12 @@
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/carpet/green/standard/narrow/northsouth,
 /area/station/crew_quarters/cafeteria)
-"bna" = (
+"bne" = (
 /obj/stool/bar,
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"bnb" = (
+"bnf" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
@@ -28752,22 +26873,7 @@
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"bnc" = (
-/obj/disposalpipe/junction/left/east,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
-"bnd" = (
-/obj/disposalpipe/segment/mail/vertical,
-/obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
-"bne" = (
+"bng" = (
 /obj/stool/chair,
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
@@ -28778,14 +26884,21 @@
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"bnf" = (
+"bni" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"bng" = (
+"bnj" = (
+/obj/disposalpipe/junction/left/east,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
+"bnk" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
 	icon_state = "4-8"
@@ -28795,7 +26908,7 @@
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"bnh" = (
+"bnl" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Arcade"
@@ -28810,25 +26923,7 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/arcade)
-"bni" = (
-/obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
-"bnj" = (
+"bnm" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
 	d1 = 1;
@@ -28840,30 +26935,33 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
-"bnk" = (
+"bnn" = (
 /obj/stool/bar,
 /obj/disposalpipe/segment/bent/west,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
-"bnl" = (
+"bno" = (
 /obj/stool/bar,
 /obj/machinery/power/apc/autoname_east,
 /obj/cable,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
-"bnm" = (
-/obj/disposalpipe/segment/bent/north,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"bnn" = (
-/obj/disposalpipe/segment/horizontal,
-/obj/machinery/atmospherics/valve{
-	high_risk = 1;
-	name = "Bridge"
+"bnp" = (
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/landmark/gps_waypoint,
+/turf/simulated/floor/grey/blackgrime/other,
+/area/station/storage/tech)
+"bnq" = (
+/turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/southeast)
-"bno" = (
+"bnr" = (
 /obj/disposalpipe/segment/bent/south,
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 5;
@@ -28876,63 +26974,43 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"bnp" = (
+"bns" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8;
 	name = "Bridge Repressurization Port"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"bnq" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/southeast)
-"bnr" = (
-/obj/table/round/auto,
-/obj/machinery/computer3/generic/personal,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/neutral/side{
-	dir = 8
-	},
-/area/station/crew_quarters/quarters_south)
-"bns" = (
-/obj/table/round/auto,
-/obj/item/gobowl/w,
-/turf/simulated/floor/neutral/corner{
-	dir = 1
-	},
-/area/station/crew_quarters/quarters_south)
 "bnt" = (
-/obj/disposalpipe/segment/vertical,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/phone/wall{
-	pixel_x = 24
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/neutral/side{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
 	},
-/area/station/crew_quarters/quarters_south)
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "bnu" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "bnv" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
 	},
-/turf/simulated/floor/grey,
+/turf/simulated/floor/stairs/wide/other{
+	dir = 8
+	},
 /area/station/hallway/secondary/exit)
 "bnw" = (
 /obj/machinery/conveyor{
@@ -29283,91 +27361,61 @@
 /turf/simulated/floor/plating,
 /area/station/hydroponics/bay)
 "bor" = (
-/obj/disposalpipe/segment/food,
-/turf/simulated/wall/auto/supernorn,
-/area/station/hydroponics/bay)
-"bos" = (
-/obj/machinery/chem_dispenser/alcohol,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
+/obj/stool/chair{
+	dir = 4
 	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
-/obj/machinery/light_switch/west,
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/autoname_north,
+/turf/simulated/floor/carpet/purple/fancy/edge/nw,
+/area/station/crew_quarters/quarters_east)
+"bos" = (
+/obj/machinery/vending/coffee,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/quarters_east)
+"bot" = (
+/obj/machinery/drainage,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
-"bot" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
+"bow" = (
+/obj/stool/chair{
+	dir = 4
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"bou" = (
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
-"bov" = (
+"box" = (
 /obj/table/auto,
 /obj/random_item_spawner/tableware,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"bow" = (
+"boy" = (
+/obj/machinery/vending/fortune,
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
+"boz" = (
 /obj/machinery/disposal,
 /obj/machinery/light,
 /obj/disposalpipe/trunk/north,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"box" = (
-/obj/machinery/computer/tetris,
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
-"boy" = (
-/obj/machinery/sim/vr_bed{
-	dir = 4;
-	name = "VR simulation pod";
-	network = "arcadevr"
-	},
-/obj/cable,
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
-"boz" = (
-/obj/storage/crate,
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/machinery/light/small,
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
 "boA" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/arcade)
+"boB" = (
+/obj/machinery/computer/arcade,
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
+"boC" = (
 /obj/machinery/computer/arcade,
 /obj/machinery/light/small{
 	dir = 4;
@@ -29375,31 +27423,35 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
-"boB" = (
+"boD" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"boC" = (
+"boE" = (
 /obj/disposalpipe/segment/vertical,
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"boD" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
+"boF" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-9"
 	},
-/obj/machinery/vending/pda,
-/turf/simulated/floor/neutral/side{
-	dir = 9
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"boG" = (
+/obj/machinery/vending/snack,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
 	},
-/area/station/crew_quarters/quarters_south)
-"boE" = (
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/quarters_east)
+"boH" = (
 /obj/stool/chair{
 	dir = 1
 	},
@@ -29412,7 +27464,7 @@
 	dir = 1
 	},
 /area/station/crew_quarters/quarters_south)
-"boF" = (
+"boI" = (
 /obj/stool/chair{
 	dir = 1
 	},
@@ -29421,7 +27473,7 @@
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters_south)
-"boG" = (
+"boJ" = (
 /obj/cable{
 	icon_state = "1-8"
 	},
@@ -29432,30 +27484,16 @@
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters_south)
-"boH" = (
-/obj/machinery/door/airlock/pyro{
-	dir = 4;
-	icon_state = "generic_locked";
-	locked = 1
+"boK" = (
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/neutral/side{
+	dir = 4
 	},
-/turf/simulated/floor/grey,
 /area/station/crew_quarters/quarters_south)
-"boI" = (
-/obj/item/extinguisher,
-/turf/simulated/floor/carpet/green/fancy/edge/nw,
-/area/station/crew_quarters/quarters_south)
-"boJ" = (
+"boL" = (
 /obj/decal/cleanable/ash,
 /turf/simulated/floor/damaged1,
 /area/station/crew_quarters/quarters_south)
-"boK" = (
-/turf/simulated/floor/damaged5,
-/area/station/crew_quarters/quarters_south)
-"boL" = (
-/obj/decal/cleanable/dirt,
-/obj/machinery/shieldgenerator/energy_shield,
-/turf/simulated/floor/plating,
-/area/station/maintenance/central)
 "boM" = (
 /obj/machinery/mass_driver{
 	dir = 1;
@@ -29686,10 +27724,6 @@
 /obj/disposalpipe/segment/morgue,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
-"bpi" = (
-/obj/storage/closet/fire,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
 "bpj" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -29816,15 +27850,20 @@
 	},
 /area/station/hydroponics/bay)
 "bpB" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_x = 10;
-	pixel_y = 22
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "green";
+	icon_state = "bedsheet-green"
 	},
-/obj/landmark/start/latejoin,
-/turf/unsimulated/floor/sanitary,
-/area/station/crewquarters/cryotron)
+/obj/decal/poster/wallsign/poster_rand{
+	pixel_y = 26
+	},
+/obj/landmark/start{
+	name = "Chef"
+	},
+/obj/item/instrument/cowbell,
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/quarters_east)
 "bpC" = (
 /obj/machinery/plantpot,
 /turf/simulated/floor/grass,
@@ -29839,61 +27878,48 @@
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
 "bpE" = (
-/obj/submachine/chem_extractor,
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/green/side{
-	dir = 8
-	},
-/area/station/hydroponics/bay)
+/obj/wingrille_spawn/auto,
+/obj/decal/wreath/ephemeral,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/quarters_east)
 "bpF" = (
-/obj/table/auto,
-/obj/item/paper_bin{
-	pixel_y = 6
-	},
-/obj/deskclutter,
-/obj/item/hand_labeler{
-	pixel_x = 5
-	},
-/obj/item/plantanalyzer,
-/obj/item/device/reagentscanner{
-	pixel_x = -7
-	},
-/obj/item/pen,
-/turf/simulated/floor,
-/area/station/hydroponics/bay)
-"bpG" = (
-/obj/machinery/chem_dispenser/soda,
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/cafeteria)
-"bpH" = (
-/obj/table/reinforced/bar/auto,
-/obj/machinery/light,
-/obj/item/decoration/ashtray{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/turf/simulated/floor/carpet/green/standard/narrow/northsouth,
-/area/station/crew_quarters/cafeteria)
-"bpI" = (
-/obj/stool/chair{
-	dir = 1
-	},
-/obj/cable,
-/obj/machinery/power/apc/autoname_east,
 /obj/machinery/camera{
 	c_tag = "autotag";
-	dir = 9;
+	dir = 4;
 	name = "autoname - SS13";
-	pixel_x = 10;
+	pixel_x = -10;
 	tag = ""
 	},
+/obj/pool/perspective{
+	dir = 8;
+	tag = "icon-pool (WEST)"
+	},
+/turf/simulated/floor/white/checker,
+/area/station/crew_quarters/pool)
+"bpG" = (
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/obj/submachine/laundry_machine,
+/turf/simulated/floor/blue/checker,
+/area/station/crew_quarters/pool)
+"bpH" = (
+/obj/table/round/auto,
+/obj/item/kitchen/food_box/donut_box{
+	pixel_y = 5
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 8
+	},
+/area/station/crew_quarters/quarters_north)
+"bpI" = (
+/obj/stool/bar,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "bpJ" = (
@@ -29903,28 +27929,71 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/bridge)
 "bpL" = (
-/obj/disposalpipe/segment/vertical,
-/obj/machinery/atmospherics/pipe/simple,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/obj/table/auto,
+/obj/item/storage/box/trackimp_kit2,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
+	},
+/obj/item/device/radio/intercom/AI{
+	broadcasting = 0;
+	pixel_x = 2;
+	pixel_y = 24
+	},
+/turf/simulated/floor/circuit,
+/area/station/bridge)
 "bpM" = (
+/obj/machinery/networked/storage/tape_drive,
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/item/device/radio/intercom/bridge,
+/turf/simulated/floor/circuit,
+/area/station/bridge)
+"bpN" = (
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/crew_quarters/quarters_north)
+"bpO" = (
+/obj/disposalpipe/segment/vertical,
+/obj/machinery/atmospherics/pipe/simple,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"bpN" = (
+"bpP" = (
 /obj/machinery/vending/book,
 /turf/simulated/floor/neutral/side{
 	dir = 10
 	},
 /area/station/crew_quarters/quarters_south)
-"bpO" = (
+"bpQ" = (
 /turf/simulated/floor/neutral/side,
 /area/station/crew_quarters/quarters_south)
-"bpP" = (
+"bpR" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/quarters_south)
+"bpS" = (
 /obj/machinery/disposal,
 /obj/machinery/light{
 	dir = 4;
@@ -29935,27 +28004,6 @@
 /turf/simulated/floor/neutral/side{
 	dir = 6
 	},
-/area/station/crew_quarters/quarters_south)
-"bpQ" = (
-/obj/stool/chair{
-	dir = 4
-	},
-/obj/item/storage/secure/ssafe/loot{
-	pixel_x = -28
-	},
-/turf/simulated/floor/damaged3,
-/area/station/crew_quarters/quarters_south)
-"bpR" = (
-/obj/decal/cleanable/dirt,
-/obj/item/raw_material/shard/glass,
-/turf/simulated/floor/plating/damaged1,
-/area/station/crew_quarters/quarters_south)
-"bpS" = (
-/obj/decal/skeleton{
-	desc = "It's all covered in a sticky mess, and there are chunks of uniform fused to the bone.";
-	name = "sticky skeleton"
-	},
-/turf/simulated/floor/plating/scorched,
 /area/station/crew_quarters/quarters_south)
 "bpT" = (
 /obj/cable,
@@ -30279,6 +28327,39 @@
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
 "bqN" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
+	},
+/turf/simulated/floor/escape{
+	dir = 8
+	},
+/area/station/hallway/secondary/exit)
+"bqO" = (
+/obj/decal/poster/wallsign/stencil/left/e{
+	pixel_x = 1
+	},
+/obj/decal/poster/wallsign/stencil/right/s{
+	pixel_x = 14
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hallway/secondary/exit)
+"bqP" = (
+/obj/decal/poster/wallsign/stencil/left/c{
+	pixel_x = -6
+	},
+/obj/decal/poster/wallsign/stencil/right/a{
+	pixel_x = 7
+	},
+/obj/decal/poster/wallsign/stencil/right/p{
+	pixel_x = 18
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hallway/secondary/exit)
+"bqQ" = (
 /obj/landmark/start{
 	name = "Botanist"
 	},
@@ -30289,37 +28370,33 @@
 	dir = 8
 	},
 /area/station/hydroponics/bay)
-"bqO" = (
+"bqR" = (
 /obj/submachine/seed_manipulator{
 	dir = 8
 	},
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
-"bqP" = (
+"bqS" = (
 /obj/machinery/chem_heater,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
-"bqQ" = (
-/obj/machinery/chem_dispenser,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/cafeteria)
-"bqR" = (
+"bqT" = (
 /obj/machinery/chem_master,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
-"bqS" = (
+"bqU" = (
 /obj/shrub,
 /obj/item/device/radio/intercom/catering{
 	dir = 4
 	},
 /turf/simulated/floor/darkblue,
 /area/station/crew_quarters/cafeteria)
-"bqT" = (
+"bqV" = (
 /obj/disposalpipe/segment/vertical,
 /obj/machinery/vending/capsule,
 /turf/simulated/floor/darkblue,
 /area/station/crew_quarters/cafeteria)
-"bqU" = (
+"bqX" = (
 /obj/shrub,
 /obj/machinery/light{
 	dir = 4;
@@ -30328,20 +28405,13 @@
 	},
 /turf/simulated/floor/darkblue,
 /area/station/crew_quarters/cafeteria)
-"bqV" = (
-/obj/machinery/computer/stockexchange{
-	dir = 4;
-	pixel_x = -3;
-	pixel_y = 4
+"bqY" = (
+/obj/decal/poster/wallsign/stencil/left/e{
+	pixel_x = -1
 	},
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/sanitary/white,
-/area/station/bridge/captain)
-"bqW" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hallway/secondary/exit)
+"bqZ" = (
 /obj/cable{
 	d1 = 2;
 	d2 = 8;
@@ -30353,13 +28423,13 @@
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/bridge/captain)
-"bqX" = (
+"bra" = (
 /obj/table/auto,
 /obj/item/paper_bin,
 /obj/item/device/radio/intercom/bridge,
 /turf/simulated/floor/sanitary/white,
 /area/station/bridge/captain)
-"bqY" = (
+"brb" = (
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_x = 12
@@ -30374,7 +28444,11 @@
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/bridge/captain)
-"bqZ" = (
+"brc" = (
+/obj/machinery/door/airlock/pyro/external,
+/turf/simulated/floor/grey,
+/area/station/hallway/secondary/exit)
+"brd" = (
 /obj/machinery/computer3/terminal/zeta{
 	dir = 4;
 	setup_os_string = "ZETA_MAINFRAME"
@@ -30390,100 +28464,49 @@
 	},
 /turf/simulated/floor/circuit,
 /area/station/bridge)
-"bra" = (
-/obj/table/auto,
-/obj/item/storage/toolbox/electrical,
-/obj/item/device/gps,
-/obj/item/aiModule/reset,
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/item/device/radio/intercom/medical,
-/obj/item/circuitboard/aiupload,
-/obj/item/disk/data/floppy/read_only/communications,
-/turf/simulated/floor/circuit,
-/area/station/bridge)
-"brb" = (
-/obj/table/auto,
-/obj/item/storage/box/trackimp_kit2,
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
-	},
-/obj/item/device/radio/intercom/AI{
-	broadcasting = 0;
-	pixel_x = 2;
-	pixel_y = 24
-	},
-/turf/simulated/floor/circuit,
-/area/station/bridge)
-"brc" = (
-/obj/machinery/networked/storage/tape_drive,
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/item/device/radio/intercom/bridge,
-/turf/simulated/floor/circuit,
-/area/station/bridge)
-"brd" = (
-/obj/table/auto,
-/obj/machinery/networked/storage/scanner{
-	bank_id = "bridge";
-	pixel_y = 4
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
-/turf/simulated/floor/circuit,
-/area/station/bridge)
 "bre" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/garden/aviary)
 "brf" = (
-/obj/machinery/door/airlock/pyro,
+/obj/machinery/computer3/terminal/zeta{
+	dir = 4;
+	setup_os_string = "ZETA_MAINFRAME"
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/storage/tech)
+"brg" = (
+/obj/disposalpipe/segment/horizontal,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/green/side,
-/area/station/garden/aviary)
-"brg" = (
-/obj/structure/woodwall,
-/turf/simulated/floor/plating/damaged1,
-/area/station/garden/aviary)
-"brh" = (
-/obj/machinery/door/airlock/pyro/maintenance,
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/greenblack,
-/area/station/garden/aviary)
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
+"brh" = (
+/obj/table/auto,
+/obj/item/reagent_containers/food/drinks/bowl,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/item/pen/pencil,
+/obj/item/reagent_containers/food/snacks/cereal_box,
+/turf/simulated/floor/carpet/purple,
+/area/station/crew_quarters/quarters_east)
 "bri" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
 	},
 /turf/simulated/floor/grey,
 /area/station/hallway/secondary/exit)
@@ -30545,7 +28568,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "brq" = (
-/turf/simulated/floor/stairs/wide{
+/obj/machinery/sleep_console{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/escape{
 	dir = 8
 	},
 /area/station/hallway/secondary/exit)
@@ -30803,59 +28834,69 @@
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "bsf" = (
-/obj/submachine/chef_sink/chem_sink{
-	dir = 8;
-	pixel_x = 8
+/obj/table/auto,
+/obj/cable{
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/green/side{
-	dir = 10
+/obj/machinery/phone,
+/obj/cable{
+	icon_state = "4-8"
 	},
-/area/station/hydroponics/bay)
+/turf/simulated/floor/carpet/purple,
+/area/station/crew_quarters/quarters_east)
 "bsg" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbooth)
 "bsh" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
 /obj/machinery/door/airlock/pyro/glass{
-	name = "Cafeteria"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	dir = 4;
+	name = "Crew Lounge"
 	},
 /obj/firedoor_spawn,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
+/turf/simulated/floor,
+/area/station/crew_quarters/quarters_east)
 "bsi" = (
+/obj/disposalpipe/segment/mail/vertical,
+/obj/machinery/light/emergency{
+	dir = 4;
+	pixel_x = 10
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/hallway/primary/east)
+"bsj" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/vertical,
 /obj/decal/poster/wallsign/bar,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/cafeteria)
-"bsj" = (
-/obj/machinery/computer/announcement{
-	dir = 4;
-	name = "Executive Announcement Computer";
-	pixel_x = -3;
-	pixel_y = 4;
-	req_access_txt = "19"
-	},
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/sanitary/white,
-/area/station/bridge/captain)
 "bsk" = (
+/obj/disposalpipe/segment/mail/vertical,
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Cafeteria"
+	},
+/obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
+"bsl" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/white,
+/area/station/crew_quarters/pool)
+"bsm" = (
+/obj/machinery/power/apc/autoname_east,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/blue/checker,
+/area/station/crew_quarters/pool)
+"bsn" = (
 /obj/cable{
 	d1 = 2;
 	d2 = 8;
@@ -30868,10 +28909,10 @@
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/bridge/captain)
-"bsl" = (
+"bso" = (
 /turf/simulated/floor/sanitary/white,
 /area/station/bridge/captain)
-"bsm" = (
+"bsp" = (
 /obj/machinery/bathtub{
 	anchored = 1;
 	dir = 8
@@ -30882,7 +28923,7 @@
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/bridge/captain)
-"bsn" = (
+"bsq" = (
 /obj/machinery/computer/card{
 	dir = 4
 	},
@@ -30896,7 +28937,7 @@
 	},
 /turf/simulated/floor/circuit,
 /area/station/bridge)
-"bso" = (
+"bsr" = (
 /obj/disposalpipe/segment/bent/east,
 /obj/stool/chair/office/blue{
 	dir = 8
@@ -30914,7 +28955,7 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/bridge)
-"bsp" = (
+"bss" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
 	icon_state = "4-8"
@@ -30924,7 +28965,7 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/bridge)
-"bsq" = (
+"bst" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
 	icon_state = "4-8"
@@ -30939,22 +28980,7 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/bridge)
-"bsr" = (
-/obj/machinery/door/airlock/pyro/command{
-	dir = 4;
-	name = "Network Chamber"
-	},
-/obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/grey,
-/area/station/bridge)
-"bss" = (
+"bsu" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -30964,27 +28990,18 @@
 /obj/disposalpipe/segment/bent/west,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"bst" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"bsu" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
 "bsv" = (
+/obj/rack,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/carpet/purple/fancy/edge/north,
+/area/station/crew_quarters/quarters_north)
+"bsw" = (
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
+"bsx" = (
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_x = -12
@@ -30996,27 +29013,10 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/garden/aviary)
-"bsw" = (
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
-"bsx" = (
+"bsz" = (
 /obj/shrub{
 	dir = 6
 	},
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
-"bsy" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
-"bsz" = (
-/obj/shrub,
 /obj/machinery/light/small{
 	dir = 1;
 	pixel_y = 21
@@ -31368,20 +29368,36 @@
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
 "btA" = (
-/obj/rack,
-/obj/item/bballbasket,
-/obj/item/bballbasket,
-/obj/item/bballbasket,
-/obj/item/bballbasket,
+/obj/stool/chair,
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/utility)
 "btB" = (
-/obj/machinery/vending/medical,
-/turf/simulated/floor/bluewhite{
-	dir = 9
+/obj/stool/chair{
+	dir = 1
 	},
-/area/station/medical/medbooth)
+/turf/simulated/floor/neutral/side{
+	dir = 8
+	},
+/area/station/crew_quarters/quarters_north)
 "btC" = (
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/turf/simulated/floor/red/side,
+/area/station/security/checkpoint/escape)
+"btD" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/security/checkpoint/escape)
+"btE" = (
+/obj/machinery/door/airlock/pyro/glass,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/escape{
+	dir = 8
+	},
+/area/station/hallway/secondary/exit)
+"btG" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/south,
 /obj/machinery/camera{
@@ -31397,7 +29413,7 @@
 	dir = 1
 	},
 /area/station/medical/medbooth)
-"btD" = (
+"btH" = (
 /obj/machinery/disposal/mail/autoname/medbay/booth,
 /obj/disposalpipe/trunk/mail/south,
 /obj/item/storage/wall/medical_wear,
@@ -31405,7 +29421,7 @@
 	dir = 1
 	},
 /area/station/medical/medbooth)
-"btE" = (
+"btI" = (
 /obj/machinery/computer3/generic/med_data,
 /obj/cable{
 	d2 = 2;
@@ -31416,7 +29432,11 @@
 	dir = 1
 	},
 /area/station/medical/medbooth)
-"btG" = (
+"btJ" = (
+/obj/disposalpipe/segment/mail/vertical,
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
+"btK" = (
 /obj/health_scanner/floor,
 /obj/machinery/light{
 	dir = 1;
@@ -31427,26 +29447,17 @@
 	dir = 8
 	},
 /area/station/hallway/primary/south)
-"btH" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
+"btM" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
-"btI" = (
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
-"btJ" = (
-/obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
-"btK" = (
+/obj/machinery/door/airlock/pyro/glass,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/escape{
+	dir = 4
+	},
+/area/station/hallway/secondary/exit)
+"btN" = (
 /obj/submachine/ATM{
 	pixel_x = 32
 	},
@@ -31454,22 +29465,21 @@
 /obj/machinery/light/small/floor,
 /turf/simulated/floor/darkblue/checker,
 /area/station/hallway/primary/south)
-"btL" = (
-/obj/machinery/computer3/terminal/network{
+"btO" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/obj/machinery/light/small{
 	dir = 4;
-	name = "CENTCOM Terminal";
-	pixel_x = -3;
-	pixel_y = 4;
-	setup_os_string = "MAIN_DISH_SS13"
+	pixel_x = 12
 	},
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/sanitary/white,
-/area/station/bridge/captain)
-"btM" = (
+/turf/simulated/floor/grey,
+/area/station/hallway/secondary/exit)
+"btP" = (
 /obj/cable{
 	d1 = 2;
 	d2 = 8;
@@ -31483,13 +29493,13 @@
 /obj/machinery/drainage,
 /turf/simulated/floor/sanitary/white,
 /area/station/bridge/captain)
-"btN" = (
+"btQ" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 1
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/bridge/captain)
-"btO" = (
+"btR" = (
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_x = 12
@@ -31501,7 +29511,17 @@
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/bridge/captain)
-"btP" = (
+"btS" = (
+/obj/table/auto,
+/obj/item/peripheral/sound_card,
+/obj/item/peripheral/printer,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/grey/blackgrime/other,
+/area/station/storage/tech)
+"btT" = (
 /obj/machinery/computer3/terminal/network{
 	dir = 4;
 	name = "CENTCOM Terminal";
@@ -31517,53 +29537,23 @@
 	},
 /turf/simulated/floor/circuit,
 /area/station/bridge)
-"btQ" = (
-/obj/disposalpipe/segment/vertical,
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 6
-	},
-/turf/simulated/floor/grey,
-/area/station/bridge)
-"btR" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 9
-	},
-/turf/simulated/floor/black,
-/area/station/bridge)
-"btS" = (
-/obj/machinery/light/small,
-/obj/machinery/photocopier,
-/turf/simulated/floor/black,
-/area/station/bridge)
-"btT" = (
-/obj/table/auto,
-/obj/item/paper/book/guardbot_guide{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/paper/book/dwainedummies{
-	pixel_y = 6
-	},
-/obj/item/disk/data/tape/master/readonly,
-/turf/simulated/floor/black,
-/area/station/bridge)
 "btU" = (
+/obj/rack,
+/obj/item/circuitboard/powermonitor,
+/obj/item/circuitboard/powermonitor_smes,
 /obj/machinery/camera{
 	c_tag = "autotag";
-	dir = 10;
+	dir = 8;
 	name = "autoname - SS13";
+	pixel_x = 10;
 	tag = ""
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/obj/machinery/light_switch/east,
+/obj/item/circuitboard/genetics,
+/obj/item/circuitboard/bank_data,
+/obj/item/circuitboard/arcade,
+/turf/simulated/floor/grey/blackgrime/other,
+/area/station/storage/tech)
 "btV" = (
 /obj/table/auto,
 /obj/machinery/microscope,
@@ -31576,6 +29566,23 @@
 	},
 /area/station/medical/cdc)
 "btX" = (
+/obj/disposalpipe/segment/vertical,
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
+"btY" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/decal/cleanable/dirt,
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
+"bua" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -31589,22 +29596,6 @@
 	tag = ""
 	},
 /turf/simulated/floor/grass,
-/area/station/garden/aviary)
-"btY" = (
-/obj/landmark/gps_waypoint,
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
-"btZ" = (
-/obj/tree1,
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
-"bua" = (
-/obj/critter/parrot/random,
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
-"bub" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
 /area/station/garden/aviary)
 "buc" = (
 /obj/disposalpipe/segment/horizontal,
@@ -31875,42 +29866,38 @@
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "buP" = (
-/obj/storage/secure/closet/medical/medicine,
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -20
-	},
-/obj/item/clothing/glasses/spectro,
-/turf/simulated/floor/bluewhite{
-	dir = 8
-	},
-/area/station/medical/medbooth)
+/turf/simulated/floor/carpet/purple/fancy/edge/sw,
+/area/station/crew_quarters/quarters_east)
 "buQ" = (
-/obj/disposalpipe/segment/bent/north,
-/turf/simulated/floor/white,
-/area/station/medical/medbooth)
-"buR" = (
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
 /obj/disposalpipe/segment/mail/vertical,
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/redwhite/corner{
+/turf/simulated/floor/neutral/side{
 	dir = 4
 	},
-/area/station/medical/medbooth)
+/area/station/hallway/primary/east)
+"buR" = (
+/obj/machinery/plantpot,
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/simulated/floor/grass,
+/area/station/hydroponics/bay)
 "buS" = (
-/obj/stool/chair/office{
-	dir = 4
+/obj/pool/perspective,
+/obj/pool/perspective{
+	dir = 8;
+	tag = "icon-pool (WEST)"
 	},
-/obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/turf/simulated/floor{
+	icon_state = "bluechecker"
 	},
-/obj/landmark/start{
-	name = "Medical Doctor"
-	},
-/turf/simulated/floor/white,
-/area/station/medical/medbooth)
+/area/station/crew_quarters/pool)
 "buT" = (
 /obj/wingrille_spawn/auto,
 /obj/machinery/door/poddoor/pyro{
@@ -31932,14 +29919,19 @@
 /turf/simulated/floor/plating,
 /area/station/storage/eva)
 "buU" = (
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/blue/side{
-	dir = 8
-	},
-/area/station/hallway/primary/south)
+/obj/disposalpipe/segment/bent/north,
+/turf/simulated/floor/white,
+/area/station/medical/medbooth)
 "buV" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
+/obj/disposalpipe/segment/mail/vertical,
+/obj/disposalpipe/segment/horizontal,
+/turf/simulated/floor/redwhite/corner{
+	dir = 4
+	},
+/area/station/medical/medbooth)
+"buW" = (
+/obj/stool/chair/office{
+	dir = 4
 	},
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
@@ -31947,13 +29939,26 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
-"buW" = (
-/obj/disposalpipe/junction/right/north,
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
+/obj/landmark/start{
+	name = "Medical Doctor"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbooth)
 "buX" = (
+/obj/table/reinforced/auto,
+/obj/machinery/cashreg,
+/obj/disposalpipe/segment/horizontal,
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/access_spawn/medical,
+/turf/simulated/floor/specialroom/medbay,
+/area/station/medical/medbooth)
+"buY" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -31970,7 +29975,7 @@
 	dir = 9
 	},
 /area/station/hallway/primary/south)
-"buY" = (
+"buZ" = (
 /obj/machinery/door/unpowered/wood/pyro{
 	dir = 1;
 	name = "Executive Bathroom"
@@ -31986,59 +29991,55 @@
 	dir = 1
 	},
 /area/station/bridge/captain)
-"buZ" = (
-/obj/table/auto,
-/obj/machinery/cell_charger,
-/obj/item/cell/supercell/charged,
-/obj/item/cell/supercell/charged,
-/obj/machinery/light/small,
-/turf/simulated/floor/circuit,
-/area/station/bridge)
 "bva" = (
+/obj/storage/closet/fire,
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"bvb" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "2-4"
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple,
-/turf/simulated/floor/grey,
-/area/station/bridge)
-"bvb" = (
-/obj/storage/crate,
-/obj/item/device/radio/headset/multifreq,
-/obj/item/device/radio/headset/multifreq,
-/obj/item/device/radio/headset/medical,
-/obj/item/device/radio/headset/medical,
-/obj/item/device/radio/headset/security,
-/obj/item/device/radio/headset/security,
-/obj/item/device/radio/headset/engineer,
-/obj/item/device/radio/headset/engineer,
-/obj/item/device/radio/headset/research,
-/obj/item/device/radio/headset/research,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc/autoname_east,
-/turf/simulated/floor/black,
-/area/station/bridge)
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "bvc" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/ce)
 "bvd" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"bve" = (
+/obj/landmark/gps_waypoint,
+/turf/simulated/floor,
+/area/station/crew_quarters/quarters_north)
+"bvf" = (
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_x = -12
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"bve" = (
+"bvh" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/checkpoint/escape)
+"bvi" = (
 /obj/cable,
 /obj/cable{
 	d2 = 2;
@@ -32047,21 +30048,7 @@
 /obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/grass,
 /area/station/garden/aviary)
-"bvf" = (
-/obj/stool/chair/wooden{
-	dir = 4
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
-"bvg" = (
-/obj/table/wood/round/auto,
-/obj/item/storage/toolbox{
-	desc = "Looks suspiciously similar to a toolbox.";
-	name = "lunchbox"
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
-"bvh" = (
+"bvj" = (
 /obj/stool/chair/wooden{
 	dir = 8
 	},
@@ -32069,20 +30056,6 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
-"bvi" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
-"bvj" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
 	},
 /turf/simulated/floor/grass,
 /area/station/garden/aviary)
@@ -32111,9 +30084,25 @@
 /turf/simulated/floor/airless/plating,
 /area/station/maintenance/west)
 "bvm" = (
-/obj/machinery/drainage,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/cafeteria)
+/obj/table/reinforced/auto,
+/obj/access_spawn/security,
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass/windoor,
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/red,
+/area/station/security/checkpoint/escape)
 "bvn" = (
 /obj/machinery/door/airlock/pyro/external,
 /obj/cable{
@@ -32320,6 +30309,43 @@
 /turf/simulated/floor/plating,
 /area/station/hydroponics/bay)
 "bvR" = (
+/obj/table/reinforced/auto,
+/obj/machinery/cashreg,
+/obj/access_spawn/security,
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass/windoor,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/red,
+/area/station/security/checkpoint/escape)
+"bvS" = (
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/escape{
+	dir = 4
+	},
+/area/station/hallway/secondary/exit)
+"bvT" = (
+/obj/machinery/door/airlock/pyro/maintenance,
+/obj/disposalpipe/segment/vertical,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
+"bvU" = (
 /obj/machinery/plantpot,
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -32330,84 +30356,31 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
-"bvS" = (
-/obj/storage/secure/closet/medical/medkit,
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/bluewhite{
-	dir = 8
-	},
-/area/station/medical/medbooth)
-"bvT" = (
-/turf/simulated/floor/redwhite,
-/area/station/medical/medbooth)
-"bvU" = (
-/obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/floor/redwhite{
-	dir = 10
-	},
-/area/station/medical/medbooth)
 "bvV" = (
+/obj/table/auto,
+/obj/machinery/microwave,
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/quarters_east)
+"bvW" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/submachine/chef_sink/chem_sink{
-	dir = 8;
-	pixel_x = 8
-	},
-/turf/simulated/floor/redwhite/corner{
-	dir = 4
-	},
-/area/station/medical/medbooth)
-"bvW" = (
-/obj/table/reinforced/auto,
-/obj/item/body_bag{
-	pixel_x = -5
-	},
-/obj/item/reagent_containers/iv_drip/saline{
-	pixel_x = -4
-	},
-/obj/item/reagent_containers/iv_drip/blood{
-	pixel_x = 4
-	},
-/obj/item/reagent_containers/iv_drip/saline{
-	pixel_x = -4
-	},
-/obj/item/bandage{
-	pixel_x = -2
-	},
-/obj/item/bandage{
-	pixel_x = -2
-	},
-/turf/simulated/floor/bluewhite{
-	dir = 10
-	},
-/area/station/medical/medbooth)
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/quarters_east)
 "bvX" = (
-/obj/machinery/navbeacon{
-	codes_txt = "tour;next_tour=tour3;desc=In the event of minor to moderate injuries, you can stop by this convenient booth instead of going all the way to Medbay.";
-	freq = 1443;
-	location = "tour2";
-	name = "tour 2 - medbooth"
-	},
-/turf/simulated/floor/blue/side{
-	dir = 8
-	},
-/area/station/hallway/primary/south)
+/turf/simulated/floor/redwhite,
+/area/station/medical/medbooth)
 "bvY" = (
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bvZ" = (
-/obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/floor/black/side{
-	dir = 8
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
 	},
-/area/station/hallway/primary/south)
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/medical/medbooth)
 "bwa" = (
 /obj/table/auto,
 /obj/item/device/multitool{
@@ -32434,36 +30407,25 @@
 	},
 /turf/simulated/floor/darkblue,
 /area/station/storage/eva)
-"bwb" = (
+"bwe" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/window_blinds/cog2/left{
+	dir = 8
+	},
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/bridge/captain)
+"bwf" = (
 /obj/machinery/vending/pizza,
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/bridge/captain)
-"bwc" = (
-/obj/storage/secure/closet/command/captain,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/autoname_north,
-/turf/simulated/floor/carpet/arcade,
-/area/station/bridge/captain)
-"bwd" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/bridge/captain)
-"bwe" = (
+"bwg" = (
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
@@ -32479,24 +30441,12 @@
 /obj/blind_switch/area/north,
 /turf/simulated/floor/carpet/arcade,
 /area/station/bridge/captain)
-"bwf" = (
-/obj/item/reagent_containers/food/drinks/bottle/thegoodstuff,
-/obj/shrub/captainshrub,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/bridge/captain)
-"bwg" = (
+"bwh" = (
+/obj/table/auto,
+/obj/item/game_kit,
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/quarters_east)
+"bwi" = (
 /obj/machinery/door/airlock/pyro/command{
 	name = "Network Chamber"
 	},
@@ -32511,116 +30461,45 @@
 /obj/decal/garland/ephemeral,
 /turf/simulated/floor/grey,
 /area/station/bridge)
-"bwh" = (
-/obj/machinery/rkit,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -20
-	},
-/turf/simulated/floor/yellowblack{
-	dir = 1
-	},
-/area/station/crew_quarters/ce)
-"bwi" = (
-/obj/table/wood/auto,
-/obj/item/item_box/gold_star{
-	item_amount = 20
-	},
-/obj/item/dice/d1,
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/obj/item/deconstructor,
-/obj/item/device/radio/intercom/engineering,
-/turf/simulated/floor/yellowblack{
-	dir = 1
-	},
-/area/station/crew_quarters/ce)
 "bwj" = (
-/obj/table/wood/auto,
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/phone,
-/obj/item/stamp/ce{
-	pixel_x = -12;
-	rand_pos = 0
-	},
-/turf/simulated/floor/yellowblack{
-	dir = 1
-	},
-/area/station/crew_quarters/ce)
+/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon12,
+/turf/simulated/floor,
+/area/station/hallway/primary/east)
 "bwk" = (
-/obj/table/wood/auto,
-/obj/machinery/networked/printer{
-	name = "Printer - CE";
-	pixel_y = 5;
-	print_id = "CE"
-	},
-/obj/machinery/light_switch/north,
-/obj/machinery/power/data_terminal,
+/obj/disposalpipe/segment/vertical,
 /obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
-/turf/simulated/floor/yellowblack{
-	dir = 1
-	},
-/area/station/crew_quarters/ce)
-"bwl" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"bwl" = (
+/obj/machinery/power/apc{
+	areastring = "East Primary Hallway";
+	dir = 4;
+	name = "East Primary Hallway APC";
+	pixel_x = 24
 	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
-"bwm" = (
-/obj/table/wood/round/auto,
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "bwn" = (
-/obj/stool/chair/wooden{
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/neutral/side{
 	dir = 8
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
+/area/station/crew_quarters/quarters_north)
 "bwo" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/grass,
 /area/station/garden/aviary)
 "bwp" = (
-/obj/shrub{
-	dir = 10
-	},
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
+/obj/shrub,
+/turf/simulated/floor,
+/area/station/crew_quarters/quarters_north)
 "bwq" = (
 /obj/machinery/mass_driver{
 	id = "kd_medsouth"
@@ -32731,10 +30610,6 @@
 	name = "Inner Southwest Maintenance"
 	})
 "bwJ" = (
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "bwK" = (
@@ -32944,50 +30819,44 @@
 	},
 /area/station/hydroponics/bay)
 "bxf" = (
-/obj/machinery/disposal/morgue,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
 	},
-/obj/machinery/power/apc/autoname_west,
-/obj/disposalpipe/trunk/morgue{
+/obj/stool/chair/red{
 	dir = 4
 	},
-/turf/simulated/floor/bluewhite{
-	dir = 8
+/turf/simulated/floor/escape{
+	dir = 1
 	},
-/area/station/medical/medbooth)
+/area/station/hallway/primary/east)
 "bxg" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/morgue{
+/obj/disposalpipe/segment/brig{
+	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/white,
-/area/station/medical/medbooth)
-"bxh" = (
-/obj/disposalpipe/segment/mail/bent/north,
-/obj/cable{
-	icon_state = "4-8"
+/turf/simulated/floor/escape{
+	dir = 1
 	},
-/turf/simulated/floor/redwhite{
+/area/station/hallway/primary/east)
+"bxh" = (
+/obj/machinery/light/emergency{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/simulated/floor/escape{
 	dir = 8
 	},
-/area/station/medical/medbooth)
+/area/station/hallway/secondary/exit)
 "bxi" = (
-/obj/disposalpipe/segment/mail/horizontal,
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/turf/simulated/floor/escape{
+	dir = 4
 	},
-/obj/landmark/gps_waypoint,
-/turf/simulated/floor/white,
-/area/station/medical/medbooth)
+/area/station/hallway/secondary/exit)
 "bxj" = (
 /obj/lattice{
 	dir = 1;
@@ -32997,46 +30866,47 @@
 /turf/space,
 /area/station/mining/refinery)
 "bxk" = (
-/obj/disposalpipe/segment/mail/horizontal,
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/decal/garland/ephemeral{
-	dir = 4;
-	pixel_x = -14
+/obj/disposalpipe/segment/morgue{
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/blue/side{
+/turf/simulated/floor/white,
+/area/station/medical/medbooth)
+"bxl" = (
+/obj/disposalpipe/segment/mail/bent/north,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/redwhite{
 	dir = 8
 	},
-/area/station/hallway/primary/south)
-"bxl" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
+/area/station/medical/medbooth)
 "bxm" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bxn" = (
-/obj/disposalpipe/switch_junction/left/south{
-	mail_tag = "medical booth";
-	name = "medical booth mail junction"
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
 	},
-/turf/simulated/floor/black/side{
-	dir = 8
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/cable{
+	icon_state = "4-8"
 	},
-/area/station/hallway/primary/south)
+/obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/access_spawn/medical,
+/turf/simulated/floor/specialroom/medbay,
+/area/station/medical/medbooth)
 "bxo" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -33053,7 +30923,20 @@
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/pharmacy)
 "bxq" = (
-/turf/simulated/floor/carpet/arcade,
+/obj/wingrille_spawn/auto/crystal,
+/obj/window_blinds/cog2/middle{
+	dir = 8
+	},
+/obj/cable,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
 /area/station/bridge/captain)
 "bxr" = (
 /obj/disposalpipe/segment/horizontal,
@@ -33068,6 +30951,32 @@
 	},
 /area/station/medical/medbay/pharmacy)
 "bxs" = (
+/obj/table/wood/auto,
+/obj/machinery/phone,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/bridge/captain)
+"bxt" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/bridge/captain)
+"bxu" = (
+/turf/simulated/floor/carpet/arcade,
+/area/station/bridge/captain)
+"bxv" = (
 /obj/rack,
 /obj/item/clothing/suit/space/captain,
 /obj/item/clothing/mask/gas/emergency,
@@ -33076,7 +30985,7 @@
 /obj/machinery/light_switch/east,
 /turf/simulated/floor/carpet/arcade,
 /area/station/bridge/captain)
-"bxt" = (
+"bxx" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/east,
 /obj/machinery/alarm{
@@ -33085,7 +30994,7 @@
 /obj/machinery/light_switch/west,
 /turf/simulated/floor/grey,
 /area/station/bridge)
-"bxu" = (
+"bxy" = (
 /obj/disposalpipe/segment/bent/west,
 /obj/cable{
 	d1 = 1;
@@ -33095,7 +31004,7 @@
 /obj/machinery/atmospherics/pipe/simple,
 /turf/simulated/floor/grey,
 /area/station/bridge)
-"bxv" = (
+"bxz" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
@@ -33106,46 +31015,7 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/bridge)
-"bxx" = (
-/obj/machinery/manufacturer/mechanic,
-/turf/simulated/floor/yellowblack/corner,
-/area/station/crew_quarters/ce)
-"bxy" = (
-/turf/simulated/floor/yellowblack/corner{
-	dir = 1
-	},
-/area/station/crew_quarters/ce)
-"bxz" = (
-/obj/stool/chair/office/yellow{
-	dir = 4
-	},
-/obj/landmark/start{
-	name = "Chief Engineer"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/orangeblack,
-/area/station/crew_quarters/ce)
 "bxA" = (
-/obj/machinery/computer3/terminal/zeta{
-	dir = 8;
-	setup_os_string = "ZETA_MAINFRAME"
-	},
-/obj/machinery/power/data_terminal,
-/obj/cable,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/yellowblack/corner,
-/area/station/crew_quarters/ce)
-"bxB" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2{
 	dir = 4
@@ -33156,41 +31026,34 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/ce)
-"bxC" = (
-/obj/shrub,
+"bxB" = (
 /obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
+	dir = 1;
+	pixel_y = 21
 	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
-"bxD" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
-"bxE" = (
-/obj/shrub{
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
+"bxC" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/window_blinds/cog2/left{
 	dir = 8
+	},
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/ce)
+"bxE" = (
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/grass,
 /area/station/garden/aviary)
 "bxF" = (
-/obj/machinery/light/runway_light,
-/obj/lattice,
-/turf/space,
-/area/station/ai_monitored/armory)
+/obj/disposalpipe/segment/bent/east,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "bxG" = (
 /obj/storage/closet/fire,
 /turf/simulated/floor/plating,
@@ -33222,15 +31085,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "bxL" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/window_blinds/cog2/left{
-	dir = 8
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
+/obj/machinery/manufacturer/mechanic,
+/turf/simulated/floor/yellowblack/corner,
 /area/station/crew_quarters/ce)
 "bxM" = (
 /obj/machinery/light{
@@ -33521,49 +31377,33 @@
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "byr" = (
-/obj/table/reinforced/auto,
-/obj/item/reagent_containers/glass/beaker/large/epinephrine,
-/obj/item/reagent_containers/glass/beaker/large/burn,
-/obj/item/reagent_containers/glass/beaker/large/brute,
-/obj/item/reagent_containers/glass/beaker/large/antitox,
-/obj/item/clothing/glasses/healthgoggles,
-/obj/item/reagent_containers/hypospray,
-/obj/item/scalpel,
-/obj/item/circular_saw{
-	pixel_x = 3;
-	pixel_y = 12
-	},
-/obj/item/suture,
-/obj/item/staple_gun,
-/obj/item/hemostat,
-/turf/simulated/floor/bluewhite{
-	dir = 8
-	},
-/area/station/medical/medbooth)
+/obj/disposalpipe/segment/horizontal,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "bys" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/machinery/door/airlock/pyro{
+	name = "Chef's Quarters"
 	},
-/turf/simulated/floor/white,
-/area/station/medical/medbooth)
+/obj/access_spawn/kitchen,
+/obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/quarters_east)
 "byt" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
-/turf/simulated/floor/white,
-/area/station/medical/medbooth)
+/obj/reagent_dispensers/compostbin,
+/turf/simulated/floor/grass,
+/area/station/hydroponics/bay)
 "byu" = (
-/obj/rack,
-/obj/item/clothing/suit/bio_suit/paramedic,
-/obj/item/clothing/suit/bio_suit/paramedic,
-/obj/item/storage/belt/medical,
-/obj/item/storage/belt/medical,
-/obj/disposalpipe/segment/morgue{
-	dir = 4
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Cryogenics Chamber"
 	},
-/turf/simulated/floor/white,
-/area/station/medical/medbooth)
+/obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/decal/garland/ephemeral,
+/turf/unsimulated/floor/circuit/vintage,
+/area/station/crewquarters/cryotron)
 "byv" = (
 /obj/disposalpipe/segment/bent/south,
 /obj/cable{
@@ -33573,55 +31413,17 @@
 /area/station/medical/medbay/pharmacy)
 "byw" = (
 /obj/disposalpipe/segment/morgue{
+	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/stool/chair/blue{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/blue/side{
+/turf/simulated/floor/white,
+/area/station/medical/medbooth)
+"byz" = (
+/obj/disposalpipe/segment/mail/vertical,
+/turf/simulated/floor/black/side{
 	dir = 8
 	},
 /area/station/hallway/primary/south)
-"byx" = (
-/obj/table/wood/auto,
-/obj/random_item_spawner/desk_stuff,
-/obj/item/stamp/cap,
-/turf/simulated/floor/carpet/arcade,
-/area/station/bridge/captain)
-"byy" = (
-/obj/stool/chair/comfy{
-	dir = 8
-	},
-/obj/landmark/start{
-	name = "Captain"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/bridge/captain)
-"byz" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/bridge/captain)
-"byA" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/bridge/captain)
 "byB" = (
 /obj/lattice{
 	dir = 6;
@@ -33631,12 +31433,38 @@
 /turf/space,
 /area/space)
 "byC" = (
+/obj/disposalpipe/segment/mail/vertical,
+/turf/simulated/floor/neutral/corner{
+	dir = 4
+	},
+/area/station/hallway/primary/east)
+"byE" = (
+/obj/machinery/door/airlock/pyro/command{
+	dir = 4;
+	name = "Captain's Quarters";
+	req_access = null
+	},
+/obj/access_spawn/captain,
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/grey,
+/area/station/bridge/captain)
+"byF" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
+	},
 /turf/simulated/floor/grey,
 /area/station/bridge)
-"byD" = (
+"byG" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -33653,7 +31481,17 @@
 /obj/machinery/atmospherics/pipe/simple,
 /turf/simulated/floor/black,
 /area/station/bridge)
-"byE" = (
+"byH" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
+	},
+/turf/simulated/floor/grey,
+/area/station/bridge)
+"byI" = (
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
 	name = "Chief Engineer's Quarters";
@@ -33674,67 +31512,20 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/ce)
-"byF" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/yellowblack/corner{
-	dir = 1
-	},
-/area/station/crew_quarters/ce)
-"byG" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/orangeblack,
-/area/station/crew_quarters/ce)
-"byH" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/yellowblack/corner,
-/area/station/crew_quarters/ce)
-"byI" = (
-/obj/storage/crate/rcd,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/yellowblack/corner{
-	dir = 1
-	},
-/area/station/crew_quarters/ce)
 "byJ" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/window_blinds/cog2/middle{
-	dir = 8
-	},
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/turf/simulated/floor/yellowblack/corner{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
 /area/station/crew_quarters/ce)
 "byK" = (
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
+/obj/machinery/vending/cards,
+/turf/simulated/floor/neutral/side{
+	dir = 5
 	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
+/area/station/hallway/primary/east)
 "byL" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 6
@@ -34046,17 +31837,20 @@
 	},
 /area/station/hydroponics/bay)
 "bzv" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 1
-	},
-/obj/stool/chair/blue{
-	dir = 4
-	},
-/turf/simulated/floor/blue/side{
-	dir = 8
-	},
-/area/station/hallway/primary/south)
+/obj/iv_stand,
+/obj/machinery/light,
+/turf/simulated/floor/bluewhite,
+/area/station/medical/medbooth)
 "bzw" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/decal/wreath/ephemeral,
+/turf/simulated/floor/plating,
+/area/station/medical/medbooth)
+"bzz" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/machinery/light{
 	dir = 4;
@@ -34067,38 +31861,23 @@
 	dir = 8
 	},
 /area/station/hallway/primary/south)
-"bzx" = (
+"bzA" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/window_blinds/cog2/middle{
+	dir = 8
+	},
+/obj/cable,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/bridge/captain)
+"bzB" = (
 /obj/table/wood/auto,
 /obj/displaycase{
 	pixel_y = 6
 	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/bridge/captain)
-"bzy" = (
-/obj/machinery/computer3/generic/communications,
-/obj/cable,
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/carpet/arcade,
-/area/station/bridge/captain)
-"bzz" = (
-/obj/machinery/computer/arcade,
-/obj/machinery/light/emergency,
-/turf/simulated/floor/carpet/arcade,
-/area/station/bridge/captain)
-"bzA" = (
-/obj/table/wood/auto,
-/obj/machinery/recharger{
-	pixel_y = 3
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/bridge/captain)
-"bzB" = (
-/obj/table/wood/auto,
-/obj/item/item_box/gold_star{
-	item_amount = 20
-	},
-/obj/item/card/id/captains_spare,
-/obj/machinery/light,
 /turf/simulated/floor/carpet/arcade,
 /area/station/bridge/captain)
 "bzC" = (
@@ -34111,18 +31890,27 @@
 /turf/simulated/floor/darkblue,
 /area/station/medical/medbay/pharmacy)
 "bzD" = (
-/turf/simulated/floor/grey,
-/area/station/bridge)
+/obj/machinery/computer/arcade,
+/obj/machinery/light/emergency,
+/turf/simulated/floor/carpet/arcade,
+/area/station/bridge/captain)
 "bzE" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/table/wood/auto,
+/obj/machinery/recharger{
+	pixel_y = 3
 	},
-/obj/machinery/atmospherics/pipe/simple,
-/turf/simulated/floor/black,
-/area/station/bridge)
+/turf/simulated/floor/carpet/arcade,
+/area/station/bridge/captain)
 "bzF" = (
+/obj/table/wood/auto,
+/obj/item/item_box/gold_star{
+	item_amount = 20
+	},
+/obj/item/card/id/captains_spare,
+/obj/machinery/light,
+/turf/simulated/floor/carpet/arcade,
+/area/station/bridge/captain)
+"bzI" = (
 /obj/machinery/light{
 	dir = 4;
 	layer = 9.1;
@@ -34130,7 +31918,15 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/bridge)
-"bzG" = (
+"bzJ" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2{
+	dir = 4
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/ce)
+"bzK" = (
 /obj/item/storage/toilet{
 	dir = 4
 	},
@@ -34141,53 +31937,15 @@
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/ce)
-"bzH" = (
-/obj/submachine/chef_sink/chem_sink{
-	dir = 1
-	},
-/obj/decal/tile_edge/line/black{
-	dir = 5;
-	icon_state = "line2"
-	},
-/obj/machinery/drainage,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/ce)
-"bzI" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "yellow";
-	icon_state = "bedsheet-yellow"
-	},
-/obj/machinery/light,
-/turf/simulated/floor/yellowblack,
-/area/station/crew_quarters/ce)
-"bzJ" = (
-/obj/storage/secure/closet/command/chief_engineer,
-/obj/item/clipboard,
-/obj/item/pen,
-/turf/simulated/floor/yellowblack,
-/area/station/crew_quarters/ce)
-"bzK" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/window_blinds/cog2/right{
-	dir = 8
-	},
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/ce)
 "bzL" = (
-/obj/shrub{
-	dir = 6
-	},
-/turf/simulated/floor/grass,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
 /area/station/garden/aviary)
 "bzM" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
+/obj/wingrille_spawn/auto,
+/obj/decal/poster/wallsign/escape_right,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/pool)
 "bzN" = (
 /obj/table/auto,
 /obj/random_item_spawner/medicine,
@@ -34562,31 +32320,29 @@
 /turf/simulated/floor/green/side,
 /area/station/hydroponics/bay)
 "bAC" = (
-/obj/submachine/seed_vendor,
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/turf/simulated/floor/grass,
-/area/station/hydroponics/bay)
+/obj/decal/poster/wallsign/escape_right,
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/pool)
 "bAD" = (
 /obj/wingrille_spawn/auto,
-/obj/cable,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbooth)
+"bAE" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbooth)
-"bAE" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 1
-	},
-/turf/simulated/floor/blue/side{
-	dir = 8
-	},
-/area/station/hallway/primary/south)
 "bAF" = (
 /obj/submachine/chem_extractor{
 	dir = 8
@@ -34659,31 +32415,29 @@
 /turf/simulated/floor/black,
 /area/station/storage/eva)
 "bAL" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/middle,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/machinery/phone/wall{
-	pixel_x = 24
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/grey,
-/area/station/bridge)
+/turf/simulated/floor/plating,
+/area/station/bridge/captain)
 "bAM" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/md)
 "bAN" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
+/obj/machinery/door/airlock/pyro/maintenance,
+/obj/disposalpipe/segment/vertical,
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/area/station/maintenance/east)
 "bAO" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -34890,6 +32644,47 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/south)
 "bBw" = (
+/obj/machinery/air_vendor,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/blue/side{
+	dir = 1
+	},
+/area/station/hallway/primary/south)
+"bBx" = (
+/obj/machinery/vending/medical_public,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/blue/side{
+	dir = 1
+	},
+/area/station/hallway/primary/south)
+"bBy" = (
+/obj/machinery/sleeper{
+	dir = 8
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/blue/side{
+	dir = 1
+	},
+/area/station/hallway/primary/south)
+"bBz" = (
+/obj/machinery/sleep_console{
+	dir = 8
+	},
+/turf/simulated/floor/blue/side{
+	dir = 1
+	},
+/area/station/hallway/primary/south)
+"bBA" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 1
 	},
@@ -34897,7 +32692,7 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
-"bBx" = (
+"bBB" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
@@ -34908,32 +32703,26 @@
 	},
 /turf/simulated/floor/escape/corner,
 /area/station/hallway/primary/south)
-"bBy" = (
+"bBC" = (
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/escape/corner{
 	dir = 8
 	},
 /area/station/hallway/primary/south)
-"bBz" = (
-/obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/floor/black/side{
-	dir = 10
-	},
-/area/station/hallway/primary/south)
-"bBA" = (
+"bBD" = (
 /obj/stool/chair{
 	dir = 4
 	},
 /turf/simulated/floor/black/side,
 /area/station/hallway/primary/south)
-"bBB" = (
+"bBE" = (
 /obj/table/round/auto,
 /obj/item/decoration/flower_vase{
 	pixel_y = 14
 	},
 /turf/simulated/floor/black/side,
 /area/station/hallway/primary/south)
-"bBC" = (
+"bBF" = (
 /obj/stool/chair{
 	dir = 8
 	},
@@ -34943,7 +32732,7 @@
 	},
 /turf/simulated/floor/black/side,
 /area/station/hallway/primary/south)
-"bBD" = (
+"bBG" = (
 /obj/disposalpipe/trunk/mail/south,
 /obj/machinery/disposal/mail/autoname/bridge,
 /obj/machinery/light/emergency{
@@ -34952,29 +32741,24 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/bridge)
-"bBE" = (
-/obj/table/reinforced/bar/auto,
-/obj/machinery/computer3/generic/personal,
+"bBH" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/right{
+	dir = 4
+	},
+/obj/cable,
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-2"
 	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/grey,
-/area/station/bridge)
-"bBF" = (
-/obj/stool/chair/office/blue{
-	dir = 8
-	},
+/turf/simulated/floor/plating,
+/area/station/bridge/captain)
+"bBI" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/cable{
-	icon_state = "2-4"
-	},
 /turf/simulated/floor/grey,
 /area/station/bridge)
-"bBG" = (
+"bBJ" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -34986,15 +32770,18 @@
 /obj/machinery/atmospherics/pipe/simple,
 /turf/simulated/floor/black,
 /area/station/bridge)
-"bBH" = (
+"bBL" = (
 /obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2{
+/obj/window_blinds/cog2/right{
 	dir = 4
 	},
-/obj/cable,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/ce)
-"bBI" = (
+/area/station/crew_quarters/md)
+"bBM" = (
 /obj/table/reinforced/chemistry/auto,
 /obj/item/clothing/glasses/visor,
 /obj/item/device/radio/headset/deaf,
@@ -35009,43 +32796,7 @@
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/nw,
 /area/station/crew_quarters/md)
-"bBJ" = (
-/obj/table/reinforced/chemistry/auto,
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/obj/machinery/light_switch/north,
-/obj/machinery/phone,
-/obj/item/stamp/md{
-	pixel_x = -14;
-	rand_pos = 0
-	},
-/turf/simulated/floor/carpet/blue/fancy/edge/north,
-/area/station/crew_quarters/md)
-"bBK" = (
-/obj/machinery/chem_dispenser,
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/carpet/blue/fancy/edge/north,
-/area/station/crew_quarters/md)
-"bBL" = (
-/obj/machinery/chem_heater,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
-	},
-/obj/item/device/radio/intercom/medical{
-	pixel_x = 4;
-	pixel_y = 24
-	},
-/turf/simulated/floor/carpet/blue/fancy/edge/ne,
-/area/station/crew_quarters/md)
-"bBM" = (
+"bBN" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/window_blinds/cog2/left{
 	dir = 8
@@ -35056,20 +32807,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/md)
-"bBN" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
-"bBO" = (
-/obj/critter/parrot/random,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
 "bBP" = (
 /obj/stool/chair{
 	dir = 4
@@ -35489,40 +33226,14 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
-"bCD" = (
-/obj/disposalpipe/segment/brig{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
-/area/station/hallway/primary/south)
-"bCE" = (
-/obj/disposalpipe/segment/bent/east,
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
-/area/station/hallway/primary/south)
 "bCF" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/disposalpipe/segment/brig{
+	dir = 8
 	},
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/green/corner{
+/turf/simulated/floor/green/side{
 	dir = 1
 	},
 /area/station/hallway/primary/south)
@@ -35530,34 +33241,50 @@
 /obj/disposalpipe/segment/bent/east,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
-"bCH" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
+"bCI" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
-	icon_state = "1-8"
+	icon_state = "1-4"
 	},
-/obj/landmark/halloween,
-/turf/simulated/floor/escape/corner{
-	dir = 1
-	},
-/area/station/hallway/primary/south)
-"bCI" = (
-/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon1_start,
-/obj/disposalpipe/segment/bent/west,
-/turf/simulated/floor/escape/corner{
-	dir = 4
-	},
+/turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bCJ" = (
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
+"bCK" = (
 /obj/disposalpipe/switch_junction/right/south{
 	mail_tag = "bridge";
 	name = "bridge mail junction"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
-"bCK" = (
+"bCL" = (
+/obj/machinery/door/airlock/pyro/glass{
+	name = "North Crew Quarters"
+	},
+/obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/neutral/side{
+	dir = 8
+	},
+/area/station/crew_quarters/quarters_north)
+"bCM" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/quarters_north)
+"bCN" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
+"bCO" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/machinery/door/airlock/pyro/glass/command{
 	dir = 4;
@@ -35573,47 +33300,44 @@
 	},
 /turf/simulated/floor,
 /area/station/bridge)
-"bCL" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/mail/bent/west,
-/turf/simulated/floor/stairs/wide/other{
+"bCP" = (
+/obj/stool/chair/office/blue{
 	dir = 8
 	},
-/area/station/bridge)
-"bCM" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/grey,
-/area/station/bridge)
-"bCN" = (
 /obj/cable{
-	icon_state = "1-8"
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/grey,
 /area/station/bridge)
-"bCO" = (
+"bCQ" = (
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/black,
 /area/station/bridge)
-"bCP" = (
+"bCR" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple,
+/turf/simulated/floor/black,
+/area/station/bridge)
+"bCT" = (
 /obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/right{
+/obj/window_blinds/cog2/left{
 	dir = 4
 	},
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/md)
-"bCQ" = (
+"bCU" = (
 /obj/critter/bat/doctor,
 /obj/shrub{
 	dir = 1;
@@ -35627,45 +33351,24 @@
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/west,
 /area/station/crew_quarters/md)
-"bCR" = (
-/turf/simulated/floor/carpet/blue,
-/area/station/crew_quarters/md)
-"bCS" = (
-/obj/stool/chair/office{
+"bCV" = (
+/obj/machinery/door/airlock/pyro/glass{
+	name = "North Crew Quarters"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/neutral/side{
 	dir = 4
 	},
-/obj/landmark/start{
-	name = "Medical Director"
-	},
-/turf/simulated/floor/carpet/blue,
-/area/station/crew_quarters/md)
-"bCT" = (
-/obj/machinery/chem_master{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/blue/fancy/edge/east,
-/area/station/crew_quarters/md)
-"bCU" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/window_blinds/cog2/middle{
-	dir = 8
-	},
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/md)
-"bCV" = (
-/obj/shrub{
-	dir = 10
-	},
-/turf/simulated/floor/grass,
-/area/station/garden/aviary)
+/area/station/crew_quarters/quarters_north)
 "bCW" = (
-/obj/shrub{
-	dir = 1
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/grass,
 /area/station/garden/aviary)
@@ -35841,13 +33544,9 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bDr" = (
-/obj/decal/poster/wallsign/security_wall,
-/obj/decal/poster/wallsign/stencil/left/v{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/pool)
+/obj/disposalpipe/segment/mail/vertical,
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "bDs" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
@@ -35987,14 +33686,8 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bDI" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
+/turf/simulated/floor/neutral/corner,
+/area/station/hallway/primary/east)
 "bDJ" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 8;
@@ -36003,15 +33696,48 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bDK" = (
-/obj/machinery/navbeacon{
-	codes_txt = "tour;next_tour=tour4;desc=On my right through the double doors is the station's headquarters. When waiting in the area, please use the provided seating.";
-	freq = 1443;
-	location = "tour3";
-	name = "tour 3 - command"
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
+	},
+/turf/simulated/floor/escape/corner{
+	dir = 4
+	},
+/area/station/hallway/primary/east)
+"bDL" = (
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
+	},
+/turf/simulated/floor/escape{
+	dir = 1
+	},
+/area/station/hallway/secondary/exit)
+"bDM" = (
+/turf/simulated/floor/escape/corner{
+	dir = 1
+	},
+/area/station/hallway/secondary/exit)
+"bDN" = (
+/obj/table/round/auto,
+/obj/item/game_kit,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor/black/side{
+	dir = 1
+	},
+/area/station/hallway/primary/south)
+"bDO" = (
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
-"bDL" = (
+"bDP" = (
 /obj/machinery/door/airlock/pyro/glass/command{
 	dir = 4;
 	name = "Bridge"
@@ -36028,19 +33754,29 @@
 	},
 /turf/simulated/floor,
 /area/station/bridge)
-"bDM" = (
+"bDQ" = (
 /turf/simulated/floor/stairs/wide{
 	dir = 8
 	},
 /area/station/bridge)
-"bDN" = (
-/turf/simulated/floor/black,
+"bDR" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/carpet/green,
+/area/station/bridge/hos)
+"bDS" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/grey,
 /area/station/bridge)
-"bDO" = (
-/obj/landmark/gps_waypoint,
-/turf/simulated/floor/black,
-/area/station/bridge)
-"bDP" = (
+"bDT" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 4;
 	icon_state = "on";
@@ -36048,7 +33784,7 @@
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
-"bDQ" = (
+"bDU" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -36064,25 +33800,28 @@
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
-"bDR" = (
+"bDV" = (
+/obj/machinery/door/airlock/pyro/command{
+	dir = 4;
+	name = "Medical Director's Quarters";
+	req_access = null
+	},
+/obj/access_spawn/medical_director,
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/black,
-/area/station/bridge)
-"bDS" = (
-/obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/left{
-	dir = 4
+/obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "2-4"
 	},
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/cable,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/black,
 /area/station/crew_quarters/md)
-"bDT" = (
+"bDW" = (
 /obj/cable{
 	icon_state = "1-8"
 	},
@@ -36093,48 +33832,17 @@
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/sw,
 /area/station/crew_quarters/md)
-"bDU" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/blue/fancy/edge/south,
-/area/station/crew_quarters/md)
-"bDV" = (
-/obj/storage/secure/closet/medical/chemical,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/blue/fancy/edge/se,
-/area/station/crew_quarters/md)
-"bDW" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/window_blinds/cog2/right{
-	dir = 8
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/md)
 "bDX" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "bDY" = (
-/obj/machinery/door/airlock/pyro/maintenance,
 /obj/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/greenblack{
-	dir = 1
-	},
-/area/station/garden/aviary)
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "bDZ" = (
 /obj/machinery/door/airlock/pyro/classic,
 /turf/simulated/floor/plating,
@@ -36387,18 +34095,44 @@
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/south)
 "bEC" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
+"bED" = (
+/obj/disposalpipe/segment/bent/east,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
+"bEE" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/machinery/light/emergency,
+/turf/simulated/floor/red/side,
+/area/station/hallway/primary/south)
+"bEF" = (
+/obj/disposalpipe/segment/mail/horizontal,
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
-/obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/south)
-"bED" = (
+"bEG" = (
+/obj/disposalpipe/switch_junction/biofilter/right/east,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
+"bEH" = (
 /obj/machinery/light,
 /obj/disposalpipe/segment/mail/bent/west,
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/south)
-"bEE" = (
+"bEI" = (
 /obj/stool/chair{
 	dir = 4
 	},
@@ -36406,20 +34140,7 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
-"bEF" = (
-/obj/table/round/auto,
-/obj/item/game_kit,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 10;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/black/side{
-	dir = 1
-	},
-/area/station/hallway/primary/south)
-"bEG" = (
+"bEJ" = (
 /obj/stool/chair{
 	dir = 8
 	},
@@ -36427,24 +34148,22 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
-"bEH" = (
+"bEK" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable,
 /obj/decal/wreath/ephemeral,
 /turf/simulated/floor/plating,
 /area/station/bridge)
-"bEI" = (
+"bEL" = (
 /obj/shrub,
 /obj/machinery/light,
 /turf/simulated/floor/grey,
 /area/station/bridge)
-"bEJ" = (
-/obj/stool/chair/comfy{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/blue/fancy/edge/nw,
+"bEN" = (
+/obj/landmark/gps_waypoint,
+/turf/simulated/floor/black,
 /area/station/bridge)
-"bEK" = (
+"bEO" = (
 /obj/table/reinforced/bar/auto,
 /obj/item/reagent_containers/food/drinks/drinkingglass/flute{
 	pixel_x = -8
@@ -36460,7 +34179,7 @@
 /obj/item/reagent_containers/food/drinks/bottle/champagne,
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
 /area/station/bridge)
-"bEL" = (
+"bEP" = (
 /obj/stool/chair/comfy{
 	dir = 8
 	},
@@ -36471,7 +34190,7 @@
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/ne,
 /area/station/bridge)
-"bEM" = (
+"bEQ" = (
 /obj/machinery/light{
 	dir = 4;
 	layer = 9.1;
@@ -36479,50 +34198,15 @@
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
-"bEN" = (
-/obj/machinery/door/airlock/pyro/command{
-	dir = 4;
-	name = "Medical Director's Quarters";
-	req_access = null
-	},
-/obj/access_spawn/medical_director,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/firedoor_spawn,
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/md)
-"bEO" = (
-/obj/item/storage/toilet{
+"bER" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2{
 	dir = 4
 	},
-/obj/blind_switch/area/south,
-/obj/decal/tile_edge/line/black{
-	dir = 1;
-	icon_state = "line1"
-	},
-/turf/simulated/floor/sanitary,
+/obj/cable,
+/turf/simulated/floor/plating,
 /area/station/crew_quarters/md)
-"bEP" = (
-/obj/submachine/chef_sink/chem_sink{
-	dir = 1
-	},
-/obj/decal/tile_edge/line/black{
-	dir = 5;
-	icon_state = "line2"
-	},
-/obj/machinery/drainage,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/md)
-"bEQ" = (
+"bES" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
@@ -36531,37 +34215,12 @@
 /obj/machinery/light,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/md)
-"bER" = (
-/obj/storage/secure/closet/command/medical_director,
-/obj/item/storage/box/beakerbox,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
-/obj/item/clipboard,
-/obj/item/pen,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/md)
-"bES" = (
+"bET" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"bET" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "bEU" = (
@@ -36977,85 +34636,87 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/courtroom)
 "bFP" = (
-/obj/machinery/door/airlock/pyro/glass,
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/courtroom)
+/obj/decal/cleanable/dirt,
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "bFQ" = (
-/obj/machinery/door/airlock/pyro/glass,
-/obj/disposalpipe/segment/vertical,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/courtroom)
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_x = 10;
+	pixel_y = 22
+	},
+/obj/landmark/start/latejoin,
+/turf/unsimulated/floor/sanitary,
+/area/station/crewquarters/cryotron)
 "bFR" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/courtroom)
 "bFS" = (
-/obj/machinery/door/airlock/pyro/security{
-	name = "Courtroom"
-	},
 /obj/disposalpipe/segment/brig{
-	dir = 1
+	dir = 8
 	},
-/obj/machinery/secscanner{
-	pixel_y = 10
+/turf/simulated/floor/escape/corner{
+	dir = 4
 	},
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor,
-/area/station/crew_quarters/courtroom)
+/area/station/hallway/primary/east)
 "bFT" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/bridge/hos)
 "bFU" = (
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/obj/disposalpipe/segment/mail/vertical,
+/turf/simulated/floor/escape/corner{
+	dir = 8
+	},
+/area/station/hallway/primary/east)
+"bFV" = (
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/turf/simulated/floor/neutral/corner{
+	dir = 4
+	},
+/area/station/hallway/primary/east)
+"bFW" = (
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/neutral/corner{
+	dir = 4
+	},
+/area/station/hallway/primary/east)
+"bFX" = (
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"bFY" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 4;
 	pixel_x = -8
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
-"bFV" = (
-/obj/stool/chair/comfy{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/blue/fancy/edge/west,
-/area/station/bridge)
-"bFW" = (
-/obj/table/reinforced/bar/auto,
-/obj/item/game_kit,
-/turf/simulated/floor/carpet/blue,
-/area/station/bridge)
-"bFX" = (
-/obj/stool/chair/comfy{
-	dir = 8
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet/blue/fancy/edge/east,
-/area/station/bridge)
-"bFY" = (
-/obj/item/storage/wall{
-	dir = 8;
-	name = "silverware cabinet";
-	pixel_x = 32;
-	spawn_contents = list(/obj/item/storage/box/cutlery,/obj/item/storage/box/cutlery,/obj/item/storage/box/cutlery,/obj/item/storage/box/plates,/obj/item/storage/box/plates,/obj/item/shaker/salt,/obj/item/shaker/pepper)
-	},
-/turf/simulated/floor/black,
-/area/station/bridge)
 "bFZ" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
+/obj/cable{
+	icon_state = "4-8"
 	},
-/obj/decal/cleanable/dirt,
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "bGb" = (
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
@@ -37136,17 +34797,12 @@
 	},
 /area/station/science/lobby)
 "bGj" = (
-/obj/machinery/light/emergency{
-	dir = 4;
-	pixel_x = 10
+/obj/cable{
+	icon_state = "4-8"
 	},
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/neutral/side{
-	dir = 4
-	},
-/area/station/hallway/primary/north)
+/obj/landmark/gps_waypoint,
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "bGk" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/science/chemistry)
@@ -37314,8 +34970,8 @@
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "bGE" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
+/obj/storage/secure/closet/brig,
+/turf/simulated/floor/red/side,
 /area/station/security/brig)
 "bGF" = (
 /obj/stool/bed,
@@ -37353,23 +35009,75 @@
 /area/station/security/brig)
 "bGJ" = (
 /obj/table/reinforced/auto,
-/obj/item/card_box/suit,
-/obj/disposalpipe/junction/middle/east,
 /obj/decal/xmas_lights/ephemeral{
 	pixel_y = 32
 	},
+/obj/disposalpipe/segment/food,
+/obj/machinery/phone,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bGK" = (
 /obj/table/reinforced/auto,
-/obj/disposaloutlet/west,
-/obj/disposalpipe/trunk/west,
+/obj/item/paper/yachtdice,
+/obj/item/paper/yachtdice,
+/obj/item/dice{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/dice{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/dice{
+	pixel_y = 1
+	},
+/obj/item/dice{
+	pixel_x = -5;
+	pixel_y = -2
+	},
+/obj/item/dice{
+	pixel_x = 5;
+	pixel_y = -2
+	},
+/obj/item/pen/pencil{
+	pixel_x = 1;
+	pixel_y = 6
+	},
+/obj/item/pen/pencil,
 /obj/decal/xmas_lights/ephemeral{
 	pixel_y = 32
 	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bGL" = (
+/obj/table/reinforced/auto,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/grime,
+/area/station/security/brig)
+"bGM" = (
+/obj/shrub,
+/obj/disposalpipe/segment/brig{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/grime,
+/area/station/security/brig)
+"bGN" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/escape{
+	dir = 4
+	},
+/area/station/hallway/secondary/exit)
+"bGO" = (
 /obj/stool/chair{
 	dir = 4
 	},
@@ -37386,13 +35094,10 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/courtroom)
-"bGM" = (
-/obj/stool/chair{
-	dir = 4
-	},
-/turf/simulated/floor/wood/two,
+"bGP" = (
+/turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
-"bGN" = (
+"bGQ" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/decal/xmas_lights/ephemeral{
 	pixel_y = 32
@@ -37401,17 +35106,14 @@
 	dir = 9
 	},
 /area/station/crew_quarters/courtroom)
-"bGO" = (
+"bGR" = (
+/obj/disposalpipe/segment/horizontal,
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
-/obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
-"bGP" = (
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/courtroom)
-"bGQ" = (
+"bGS" = (
 /obj/stool/chair{
 	dir = 4
 	},
@@ -37422,7 +35124,7 @@
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/nw,
 /area/station/crew_quarters/courtroom)
-"bGR" = (
+"bGT" = (
 /obj/table/reinforced/auto,
 /obj/item/paper_bin,
 /obj/decal/xmas_lights/ephemeral{
@@ -37430,7 +35132,13 @@
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/ne,
 /area/station/crew_quarters/courtroom)
-"bGS" = (
+"bGU" = (
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/courtroom)
+"bGV" = (
 /obj/table/reinforced/bar/auto{
 	name = "wooden table"
 	},
@@ -37444,20 +35152,18 @@
 	dir = 10
 	},
 /area/station/crew_quarters/courtroom)
-"bGT" = (
+"bGW" = (
 /obj/machinery/computer3/generic/secure_data,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
+/obj/item_dispenser/idcarddispenser,
 /turf/simulated/floor/black/side{
 	dir = 4
 	},
 /area/station/crew_quarters/courtroom)
-"bGU" = (
+"bGX" = (
 /obj/machinery/computer/card,
 /obj/cable{
 	icon_state = "0-2"
@@ -37467,29 +35173,79 @@
 /obj/item_dispenser/idcarddispenser,
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
-"bGV" = (
-/obj/machinery/manufacturer/personnel,
-/obj/item_dispenser/idcarddispenser,
+"bGY" = (
+/obj/submachine/poster_creator,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
-"bGW" = (
+"bGZ" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
-"bGX" = (
-/obj/submachine/poster_creator,
+"bHa" = (
 /obj/item/device/radio/intercom/security,
-/obj/machinery/light_switch/east,
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
+/obj/filing_cabinet,
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
 	},
 /turf/simulated/floor/black/side{
 	dir = 8
 	},
 /area/station/crew_quarters/courtroom)
-"bGY" = (
+"bHb" = (
+/obj/grille/steel,
+/obj/disposalpipe/segment/food{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
+"bHc" = (
+/obj/stool/chair/comfy{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/nw,
+/area/station/bridge)
+"bHd" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "green";
+	icon_state = "bedsheet-green"
+	},
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/carpet/green/fancy/edge/north,
+/area/station/bridge/hos)
+"bHe" = (
+/obj/storage/secure/closet/command/hop,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
+	},
+/turf/simulated/floor/carpet/green/fancy/edge/ne,
+/area/station/bridge/hos)
+"bHf" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2{
+	dir = 8
+	},
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/bridge/hos)
+"bHg" = (
 /obj/table/wood/auto,
 /obj/item/coin{
 	desc = "Its face is engraved with a strange hexagon-based fractal. The other side is polished to a mirror sheen.";
@@ -37515,60 +35271,13 @@
 /obj/item/device/radio/intercom/bridge,
 /turf/simulated/floor/carpet/green/fancy/edge/nw,
 /area/station/bridge/hos)
-"bGZ" = (
-/obj/stool/chair/comfy/green{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/carpet/green/fancy/edge/north,
-/area/station/bridge/hos)
-"bHa" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "green";
-	icon_state = "bedsheet-green"
-	},
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/carpet/green/fancy/edge/north,
-/area/station/bridge/hos)
-"bHb" = (
-/obj/storage/secure/closet/command/hop,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
-	},
-/turf/simulated/floor/carpet/green/fancy/edge/ne,
-/area/station/bridge/hos)
-"bHc" = (
-/obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2{
-	dir = 4
-	},
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/md)
-"bHd" = (
-/obj/stool/chair/comfy{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/blue/fancy/edge/sw,
-/area/station/bridge)
-"bHe" = (
+"bHh" = (
 /obj/table/reinforced/bar/auto,
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/carpet/blue/fancy/edge/south,
 /area/station/bridge)
-"bHf" = (
+"bHi" = (
 /obj/stool/chair/comfy{
 	dir = 8
 	},
@@ -37579,82 +35288,16 @@
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/se,
 /area/station/bridge)
-"bHg" = (
+"bHk" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2{
-	dir = 8
+	dir = 4
 	},
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/bridge/hos)
-"bHh" = (
-/obj/table/wood/auto,
-/obj/machinery/recharger{
-	pixel_y = 3
-	},
-/obj/item/remote/porter/port_a_sci,
-/obj/item/reagent_containers/hypospray,
-/obj/item/reagent_containers/food/snacks/beefood{
-	desc = "A little birthday cupcake for Heisenbee.  May not taste good to non-bees.";
-	icon = 'icons/obj/foodNdrink/food_dessert.dmi';
-	icon_state = "cupcake";
-	name = "Heisenbee's birthday cupcake"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
-	},
-/obj/item/stamp/rd,
-/obj/item/device/radio/intercom/science{
-	pixel_x = 3;
-	pixel_y = 24
-	},
-/turf/simulated/floor/carpet/purple/fancy/edge/nw,
-/area/station/science/research_director)
-"bHi" = (
-/obj/stool{
-	desc = "A soft little bed the general size and shape of a space bee.";
-	icon = 'icons/misc/critter.dmi';
-	icon_state = "beebed";
-	name = "heisenbed"
-	},
-/obj/item/reagent_containers/food/snacks/beefood{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/critter/domestic_bee/heisenbee,
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/obj/machinery/light_switch/north,
-/turf/simulated/floor/carpet/purple/fancy/edge/north,
-/area/station/science/research_director)
-"bHj" = (
-/obj/machinery/computer/security/wooden_tv{
-	desc = "These channels seem to mostly be about robuddies. What is this, some kind of reality show?";
-	name = "Television";
-	network = "Zeta"
-	},
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/carpet/purple/fancy/edge/north,
-/area/station/science/research_director)
-"bHk" = (
-/obj/machinery/power/apc/autoname_north,
-/obj/table/wood/auto,
-/obj/machinery/phone,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/carpet/purple/fancy/edge/ne,
 /area/station/science/research_director)
 "bHl" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -37907,16 +35550,11 @@
 /turf/simulated/floor/orangeblack,
 /area/station/storage/warehouse)
 "bHP" = (
-/obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2{
+/obj/stool/chair/comfy{
 	dir = 4
 	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/science/research_director)
+/turf/simulated/floor/carpet/blue/fancy/edge/sw,
+/area/station/bridge)
 "bHQ" = (
 /obj/machinery/computer/supplycomp,
 /obj/machinery/power/data_terminal,
@@ -38019,9 +35657,13 @@
 	},
 /area/station/quartermaster/office)
 "bHX" = (
-/obj/machinery/light/emergency,
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
+/obj/machinery/power/apc/autoname_west,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/unsimulated/floor/sanitary,
+/area/station/crewquarters/cryotron)
 "bHY" = (
 /obj/disposalpipe/segment/transport,
 /obj/storage/closet/fire,
@@ -38150,42 +35792,51 @@
 /area/station/security/brig)
 "bIk" = (
 /obj/stool/bench/red/auto,
-/obj/disposalpipe/segment/brig,
-/turf/simulated/floor/grime,
-/area/station/security/brig)
-"bIl" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/obj/shrub,
+/obj/disposalpipe/junction/middle/east,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bIm" = (
-/turf/simulated/floor/stairs/wood{
-	dir = 9
-	},
-/area/station/crew_quarters/courtroom)
-"bIn" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
+/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon17,
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/neutral/corner{
+	dir = 1
+	},
+/area/station/hallway/primary/east)
+"bIn" = (
+/obj/stool/chair{
+	dir = 4
+	},
+/obj/disposalpipe/segment/vertical,
+/obj/machinery/light/emergency{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/courtroom)
+"bIp" = (
 /obj/landmark/gps_waypoint,
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
-"bIo" = (
+"bIq" = (
 /obj/stool/chair{
 	dir = 4
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/sw,
 /area/station/crew_quarters/courtroom)
-"bIp" = (
+"bIr" = (
 /obj/table/reinforced/auto,
 /obj/item/pen,
 /turf/simulated/floor/carpet/green/fancy/edge/se,
 /area/station/crew_quarters/courtroom)
-"bIq" = (
+"bIt" = (
 /obj/table/reinforced/bar/auto{
 	name = "wooden table"
 	},
@@ -38197,11 +35848,14 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
 /turf/simulated/floor/specialroom/bar/edge{
 	dir = 10
 	},
 /area/station/crew_quarters/courtroom)
-"bIr" = (
+"bIu" = (
 /obj/stool/chair/comfy{
 	dir = 8
 	},
@@ -38216,11 +35870,14 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
 /turf/simulated/floor/black/side{
 	dir = 4
 	},
 /area/station/crew_quarters/courtroom)
-"bIs" = (
+"bIv" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -38229,32 +35886,31 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
-"bIt" = (
-/obj/disposalpipe/segment/brig{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
+"bIx" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/cable{
-	icon_state = "2-4"
+/obj/disposalpipe/segment/brig{
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
-"bIu" = (
+"bIy" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
 /obj/disposalpipe/segment/brig{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
-"bIv" = (
+"bIz" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -38266,7 +35922,7 @@
 	dir = 8
 	},
 /area/station/crew_quarters/courtroom)
-"bIw" = (
+"bIA" = (
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
 	name = "Head of Personnel's Quarters";
@@ -38279,30 +35935,7 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/bridge/hos)
-"bIx" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/green/fancy/edge/west,
-/area/station/bridge/hos)
-"bIy" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/green,
-/area/station/bridge/hos)
-"bIz" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/carpet/green,
-/area/station/bridge/hos)
-"bIA" = (
+"bIB" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -38311,7 +35944,34 @@
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/east,
 /area/station/bridge/hos)
-"bIB" = (
+"bIC" = (
+/obj/machinery/door/airlock/pyro/command{
+	dir = 4;
+	name = "Head of Personnel's Quarters";
+	req_access = null
+	},
+/obj/access_spawn/head_of_personnel,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/black,
+/area/station/bridge/hos)
+"bID" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/green/fancy/edge/west,
+/area/station/bridge/hos)
+"bIE" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -38322,7 +35982,7 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/bridge)
-"bIC" = (
+"bIF" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 4;
@@ -38333,77 +35993,36 @@
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
-"bID" = (
+"bIG" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
+	},
+/turf/simulated/floor/black,
+/area/station/bridge)
+"bIH" = (
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
-	name = "Head of Personnel's Quarters";
+	name = "Research Director's Quarters";
 	req_access = null
 	},
-/obj/access_spawn/head_of_personnel,
+/obj/access_spawn/research_director,
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
 /obj/cable{
-	icon_state = "2-8"
+	icon_state = "2-4"
 	},
 /obj/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/black,
-/area/station/bridge/hos)
-"bIE" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/carpet/purple/fancy/edge/west,
-/area/station/science/research_director)
-"bIF" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/purple/fancy,
-/area/station/science/research_director)
-"bIG" = (
-/obj/stool/chair/comfy/purple{
-	dir = 4
-	},
-/obj/landmark/start{
-	name = "Research Director"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/carpet/purple/fancy,
-/area/station/science/research_director)
-"bIH" = (
-/obj/machinery/computer/telescope{
-	dir = 8
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
-/obj/cable,
-/turf/simulated/floor/carpet/purple/fancy/edge/east,
 /area/station/science/research_director)
 "bII" = (
 /obj/lattice,
@@ -38920,14 +36539,21 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bJK" = (
-/obj/machinery/vending/snack,
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 20
+/obj/machinery/navbeacon{
+	codes_txt = "tour;next_tour=tour1;desc=Greetings, unfrozen crew member or other participant! I am the Mitigative After-Rest Crew Orientation unit, or Marco for short, and I'm here to show you around. Let's go!";
+	freq = 1443;
+	location = "tour0";
+	name = "tour beacon - start"
 	},
-/turf/simulated/floor/grime,
-/area/station/security/brig)
+/turf/simulated/floor/escape/corner,
+/area/station/hallway/primary/east)
 "bJL" = (
+/obj/disposalpipe/segment/mail/vertical,
+/turf/simulated/floor/escape/corner{
+	dir = 1
+	},
+/area/station/hallway/primary/east)
+"bJM" = (
 /obj/stool/chair{
 	dir = 4
 	},
@@ -38939,14 +36565,27 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/courtroom)
-"bJM" = (
-/obj/item/device/radio/beacon,
+"bJN" = (
 /obj/disposalpipe/segment/brig{
-	dir = 1
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
-"bJN" = (
+"bJO" = (
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/courtroom)
+"bJP" = (
+/obj/disposalpipe/segment/brig{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/courtroom)
+"bJQ" = (
 /obj/table/reinforced/bar/auto{
 	name = "wooden table"
 	},
@@ -38955,7 +36594,7 @@
 	dir = 10
 	},
 /area/station/crew_quarters/courtroom)
-"bJO" = (
+"bJR" = (
 /obj/machinery/computer/bank_data,
 /obj/cable,
 /obj/machinery/power/data_terminal,
@@ -38963,7 +36602,7 @@
 	dir = 4
 	},
 /area/station/crew_quarters/courtroom)
-"bJP" = (
+"bJS" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 10;
@@ -38972,29 +36611,48 @@
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
-"bJQ" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+"bJU" = (
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
-"bJR" = (
-/obj/machinery/light,
-/turf/simulated/floor,
-/area/station/crew_quarters/courtroom)
-"bJS" = (
+"bJV" = (
 /obj/storage/secure/closet/courtroom,
 /obj/item/paper/book/space_law,
+/obj/machinery/light_switch/east,
 /turf/simulated/floor/black/side{
 	dir = 8
 	},
 /area/station/crew_quarters/courtroom)
-"bJT" = (
+"bJW" = (
+/obj/machinery/navbeacon{
+	codes_txt = "tour;next_tour=tour20;desc=Thank you for joining me on this tour! You should now be acclimatized to the station. If you're still feeling a bit lost, look for the Bartender or Head of Personnel.";
+	freq = 1443;
+	location = "tour19";
+	name = "tour 19 - conclusion"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/east)
+"bJX" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/station/bridge)
+"bJY" = (
+/turf/simulated/floor/carpet/green/fancy/edge/south,
+/area/station/bridge/hos)
+"bJZ" = (
+/obj/machinery/computer/bank_data{
+	dir = 8
+	},
+/obj/cable,
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/carpet/green/fancy/edge/se,
+/area/station/bridge/hos)
+"bKa" = (
+/obj/machinery/chem_dispenser/alcohol,
+/turf/simulated/floor/grey,
+/area/station/bridge)
+"bKb" = (
 /obj/shrub{
 	dir = 1;
 	icon = 'icons/obj/stationobjs.dmi';
@@ -39006,58 +36664,7 @@
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/sw,
 /area/station/bridge/hos)
-"bJU" = (
-/turf/simulated/floor/carpet/green/fancy/edge/south,
-/area/station/bridge/hos)
-"bJV" = (
-/obj/stool/chair/office/blue{
-	dir = 4
-	},
-/obj/landmark/start{
-	name = "Head of Personnel"
-	},
-/turf/simulated/floor/carpet/green/fancy/edge/south,
-/area/station/bridge/hos)
-"bJW" = (
-/obj/machinery/computer/bank_data{
-	dir = 8
-	},
-/obj/cable,
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/carpet/green/fancy/edge/se,
-/area/station/bridge/hos)
-"bJX" = (
-/obj/machinery/door/airlock/pyro/command{
-	dir = 4;
-	name = "Research Director's Quarters";
-	req_access = null
-	},
-/obj/access_spawn/research_director,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/firedoor_spawn,
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/black,
-/area/station/science/research_director)
-"bJY" = (
-/obj/machinery/chem_dispenser/alcohol,
-/turf/simulated/floor/grey,
-/area/station/bridge)
-"bJZ" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/black,
-/area/station/bridge)
-"bKa" = (
+"bKe" = (
 /obj/storage/secure/closet/fridge{
 	desc = "A staff fridge."
 	},
@@ -39075,10 +36682,10 @@
 /obj/item/reagent_containers/food/snacks/plant/carrot,
 /turf/simulated/floor/grey,
 /area/station/bridge)
-"bKb" = (
+"bKf" = (
 /obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/left{
-	dir = 8
+/obj/window_blinds/cog2/right{
+	dir = 4
 	},
 /obj/cable{
 	d2 = 2;
@@ -39086,8 +36693,8 @@
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
-/area/station/bridge/hos)
-"bKc" = (
+/area/station/science/research_director)
+"bKg" = (
 /obj/machinery/power/data_terminal,
 /obj/cable,
 /obj/machinery/networked/storage/tape_drive{
@@ -39099,10 +36706,10 @@
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/sw,
 /area/station/science/research_director)
-"bKd" = (
+"bKh" = (
 /turf/simulated/floor/carpet/purple/fancy/edge/south,
 /area/station/science/research_director)
-"bKe" = (
+"bKi" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 4;
@@ -39110,7 +36717,7 @@
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/south,
 /area/station/science/research_director)
-"bKf" = (
+"bKj" = (
 /obj/machinery/computer3/terminal/zeta{
 	dir = 8;
 	setup_os_string = "ZETA_MAINFRAME"
@@ -39122,51 +36729,6 @@
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/se,
 /area/station/science/research_director)
-"bKg" = (
-/obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/left{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/station/turret_protected/Zeta)
-"bKh" = (
-/obj/machinery/networked/radio,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
-"bKi" = (
-/obj/machinery/networked/mainframe/zeta{
-	tag = "ZETA_MAINFRAME"
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
-"bKj" = (
-/obj/machinery/networked/storage/tape_drive{
-	bank_id = "Control";
-	locked = 0;
-	name = "Databank - Control";
-	setup_drive_type = /obj/item/disk/data/tape/master
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "bKk" = (
 /obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/research_horizontal/vertical,
 /obj/forcefield/energyshield/perma/doorlink{
@@ -39493,87 +37055,119 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bLa" = (
-/obj/disposalpipe/segment/brig,
+/obj/disposalpipe/segment/brig{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bLb" = (
-/obj/machinery/computer/arcade,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 21;
-	pixel_y = -3
+/obj/disposalpipe/segment/brig{
+	dir = 8
 	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
-"bLc" = (
+"bLd" = (
+/obj/stool/chair{
+	dir = 4
+	},
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/courtroom)
+"bLe" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
-"bLd" = (
-/obj/disposalpipe/segment/brig{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/courtroom)
-"bLe" = (
-/obj/machinery/bot/duckbot,
-/obj/disposalpipe/segment/brig{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/courtroom)
 "bLf" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/machinery/door/airlock/pyro/security{
-	name = "Secure Consultation"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/firedoor_spawn,
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/red/side,
-/area/station/security/brig)
-"bLg" = (
 /obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/left,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
-/area/station/security/brig)
-"bLh" = (
+/area/station/crew_quarters/courtroom)
+"bLg" = (
 /obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/right,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/security/brig)
+/area/station/crew_quarters/courtroom)
+"bLh" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/courtroom)
 "bLi" = (
+/obj/machinery/navbeacon{
+	codes_txt = "tour;next_tour=tour18;desc=Oh, before I forget. Head out the shower room's back door and hang a left, and look for the wood doors. Don't tell anyone I told you.";
+	freq = 1443;
+	location = "tour17";
+	name = "tour 17 - east"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/east)
+"bLj" = (
+/obj/machinery/door/airlock/pyro/security{
+	name = "Courtroom"
+	},
+/turf/simulated/floor,
+/area/station/security/brig)
+"bLk" = (
+/obj/disposalpipe/segment/bent/east,
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/landmark/halloween,
+/turf/simulated/floor,
+/area/station/hallway/primary/east)
+"bLl" = (
+/obj/disposalpipe/junction/middle/north,
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/east)
+"bLn" = (
+/obj/submachine/chef_sink/chem_sink{
+	dir = 1
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 5;
+	icon_state = "line2"
+	},
+/obj/machinery/drainage,
+/turf/simulated/floor/sanitary,
+/area/station/bridge/hos)
+"bLp" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/right{
+	dir = 8
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/bridge/hos)
+"bLq" = (
+/obj/machinery/chem_dispenser/soda,
+/turf/simulated/floor/grey,
+/area/station/bridge)
+"bLr" = (
 /obj/item/storage/toilet{
 	dir = 4
 	},
@@ -39588,47 +37182,13 @@
 	},
 /turf/simulated/floor/sanitary,
 /area/station/bridge/hos)
-"bLj" = (
-/obj/submachine/chef_sink/chem_sink{
-	dir = 1
-	},
-/obj/decal/tile_edge/line/black{
-	dir = 5;
-	icon_state = "line2"
-	},
-/obj/machinery/drainage,
-/turf/simulated/floor/sanitary,
-/area/station/bridge/hos)
-"bLk" = (
-/obj/table/wood/auto,
-/obj/item/paper_bin,
-/obj/item/pen/fancy,
-/obj/machinery/light,
-/obj/item/stamp/hop,
-/turf/simulated/floor/black,
-/area/station/bridge/hos)
-"bLl" = (
-/obj/table/wood/auto,
-/obj/machinery/phone,
-/turf/simulated/floor/black,
-/area/station/bridge/hos)
-"bLm" = (
-/obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/right{
-	dir = 4
-	},
+"bLs" = (
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/science/research_director)
-"bLn" = (
-/obj/machinery/chem_dispenser/soda,
-/turf/simulated/floor/grey,
+/turf/simulated/floor/black,
 /area/station/bridge)
-"bLp" = (
+"bLt" = (
 /obj/table/reinforced/bar/auto,
 /obj/machinery/glass_recycler{
 	glass_amt = 20;
@@ -39642,7 +37202,7 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/bridge)
-"bLq" = (
+"bLu" = (
 /obj/table/reinforced/bar/auto,
 /obj/machinery/microwave,
 /obj/machinery/light{
@@ -39652,15 +37212,15 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/bridge)
-"bLr" = (
+"bLv" = (
 /obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/right{
-	dir = 8
+/obj/window_blinds/cog2/left{
+	dir = 4
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
-/area/station/bridge/hos)
-"bLs" = (
+/area/station/science/research_director)
+"bLw" = (
 /obj/item/storage/toilet{
 	dir = 4
 	},
@@ -39671,7 +37231,7 @@
 	},
 /turf/simulated/floor/sanitary,
 /area/station/science/research_director)
-"bLt" = (
+"bLx" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 1
 	},
@@ -39682,7 +37242,7 @@
 /obj/machinery/drainage,
 /turf/simulated/floor/sanitary,
 /area/station/science/research_director)
-"bLu" = (
+"bLy" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
@@ -39691,29 +37251,14 @@
 /obj/machinery/light,
 /turf/simulated/floor/black,
 /area/station/science/research_director)
-"bLv" = (
+"bLz" = (
 /obj/storage/secure/closet/command/research_director,
 /obj/item/reagent_containers/food/snacks/yellow_cake_uranium_cake{
 	pixel_x = -2
 	},
 /turf/simulated/floor/black,
 /area/station/science/research_director)
-"bLw" = (
-/obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/right{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/station/turret_protected/Zeta)
-"bLx" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
-"bLy" = (
+"bLA" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 4;
@@ -39724,7 +37269,7 @@
 	},
 /turf/simulated/floor/circuit/green,
 /area/station/turret_protected/Zeta)
-"bLz" = (
+"bLB" = (
 /obj/machinery/power/apc/autoname_east,
 /obj/cable,
 /obj/cable{
@@ -39737,17 +37282,6 @@
 	},
 /turf/simulated/floor/circuit/green,
 /area/station/turret_protected/Zeta)
-"bLA" = (
-/obj/machinery/door/airlock/pyro/maintenance,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"bLB" = (
-/obj/machinery/door/airlock/pyro/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
 "bLC" = (
 /obj/machinery/networked/test_apparatus/heater,
 /obj/landmark/artifact,
@@ -40033,20 +37567,10 @@
 	},
 /area/station/security/main)
 "bMh" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "kgenpopwindow";
-	name = "General Population Visitation";
-	opacity = 0
-	},
+/obj/wingrille_spawn/auto,
+/obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/plating,
-/area/station/security/brig)
+/area/station/hallway/primary/east)
 "bMi" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
@@ -40074,23 +37598,38 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bMm" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/disposalpipe/segment/horizontal,
+/obj/machinery/navbeacon{
+	codes_txt = "tour;next_tour=tour19;desc=This section of the station contains crew quarters and the evacuation wing. In the event the emergency shuttle is called, please proceed down this corridor in an orderly fashion.";
+	freq = 1443;
+	location = "tour18";
+	name = "tour 18 - crew"
 	},
-/turf/simulated/floor/grime,
-/area/station/security/brig)
+/turf/simulated/floor,
+/area/station/hallway/primary/east)
 "bMn" = (
-/obj/submachine/ATM{
-	pixel_x = 32
+/obj/disposalpipe/junction/right/west,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/brig{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/grime,
-/area/station/security/brig)
+/obj/landmark/halloween,
+/turf/simulated/floor,
+/area/station/hallway/primary/east)
 "bMo" = (
+/obj/stool/chair{
+	dir = 4
+	},
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/courtroom)
+"bMp" = (
+/turf/simulated/floor/stairs/wood{
+	dir = 9
+	},
+/area/station/crew_quarters/courtroom)
+"bMq" = (
 /obj/table/round/auto,
 /obj/item/luggable_computer/personal{
 	desc = "Cutting-edge hardware for the distinguished court reporter. Or more realistically, some random assistant.";
@@ -40100,28 +37639,37 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
-"bMp" = (
+"bMr" = (
 /obj/stool/chair{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/green/fancy/edge/nw,
-/area/station/crew_quarters/courtroom)
-"bMq" = (
-/obj/table/reinforced/auto,
-/obj/item/paper_bin,
-/obj/item/pen,
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
+/turf/simulated/floor/carpet/green/fancy/edge/nw,
+/area/station/crew_quarters/courtroom)
+"bMs" = (
+/obj/table/reinforced/auto,
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/simulated/floor/carpet/green/fancy/edge/ne,
 /area/station/crew_quarters/courtroom)
-"bMr" = (
+"bMt" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/courtroom)
+"bMu" = (
 /obj/stool/chair/red{
 	dir = 8
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/courtroom)
-"bMs" = (
+"bMv" = (
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_x = 12
@@ -40130,75 +37678,27 @@
 	dir = 8
 	},
 /area/station/crew_quarters/courtroom)
-"bMt" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/redblack{
-	dir = 9
-	},
-/area/station/security/brig)
-"bMu" = (
-/turf/simulated/floor/redblack{
-	dir = 1
-	},
-/area/station/security/brig)
-"bMv" = (
-/obj/reagent_dispensers/watertank/fountain,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
-/turf/simulated/floor/redblack{
-	dir = 5
-	},
-/area/station/security/brig)
 "bMw" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "bMx" = (
-/obj/machinery/door/airlock/pyro/glass/command{
-	name = "Command Centre"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/firedoor_spawn,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/black,
-/area/station/bridge)
+/obj/disposalpipe/segment/horizontal,
+/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon13,
+/turf/simulated/floor,
+/area/station/hallway/primary/east)
 "bMy" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
+/obj/disposalpipe/segment/horizontal,
+/turf/simulated/floor/neutral/side{
+	dir = 5
+	},
+/area/station/hallway/primary/east)
 "bMz" = (
-/obj/machinery/door/poddoor/pyro{
-	id = "dwaine_core";
-	name = "DWAINE Core Shield"
+/obj/disposalpipe/segment/horizontal,
+/turf/simulated/floor/neutral/corner{
+	dir = 4
 	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
+/area/station/hallway/primary/east)
 "bMA" = (
 /obj/decal/poster/wallsign/construction{
 	desc = "A warning sign which reads 'CARGO HAZARD'.";
@@ -40577,41 +38077,74 @@
 /area/station/security/brig)
 "bNo" = (
 /obj/submachine/slot_machine,
+/obj/machinery/light,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bNp" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
+/obj/machinery/light/emergency{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/simulated/floor/escape/corner{
+	dir = 8
+	},
+/area/station/hallway/secondary/exit)
+"bNq" = (
+/obj/cable{
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
 	dir = 4;
 	layer = 9.1;
 	pixel_x = 10
 	},
-/turf/simulated/floor/stairs,
+/turf/simulated/floor/escape{
+	dir = 4
+	},
+/area/station/hallway/secondary/exit)
+"bNr" = (
+/obj/storage/crate,
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/simulated/floor/grime,
 /area/station/security/brig)
-"bNq" = (
+"bNs" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	name = "cargo belt - east";
+	operating = 1
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
+"bNt" = (
 /obj/storage/closet/law,
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/courtroom)
-"bNr" = (
+"bNu" = (
 /obj/storage/crate/bin/lostandfound,
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/courtroom)
-"bNs" = (
-/obj/machinery/light,
-/turf/simulated/floor/stairs/wood/wide{
-	dir = 8
-	},
-/area/station/crew_quarters/courtroom)
-"bNt" = (
+"bNv" = (
 /obj/stool/chair{
 	dir = 1
 	},
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/courtroom)
-"bNu" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 10;
@@ -40620,65 +38153,54 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
-"bNv" = (
-/obj/table/reinforced/auto,
-/obj/item/paper/book/space_law,
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/simulated/floor/carpet/green/fancy/edge/se,
-/area/station/crew_quarters/courtroom)
 "bNw" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/disposalpipe/segment/brig{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/courtroom)
-"bNx" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
 "bNy" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/courtroom)
-"bNz" = (
-/obj/wingrille_spawn/auto,
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
+/obj/machinery/bot/duckbot,
+/turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
 "bNA" = (
-/turf/simulated/floor/black,
-/area/station/security/brig)
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/redblack/corner{
+	dir = 4
+	},
+/area/station/crew_quarters/courtroom)
 "bNB" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/redblack/corner,
+/area/station/crew_quarters/courtroom)
+"bNC" = (
+/obj/machinery/door/airlock/pyro/security{
+	dir = 4;
+	name = "Defendant's Stand"
+	},
+/obj/access_spawn/brig,
+/obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/red,
+/area/station/security/brig)
+"bND" = (
 /turf/simulated/floor/redblack{
+	dir = 10
+	},
+/area/station/security/brig)
+"bNE" = (
+/turf/simulated/floor/redblack/corner{
 	dir = 4
 	},
 /area/station/security/brig)
-"bNC" = (
+"bNG" = (
 /obj/machinery/door/airlock/pyro/security{
 	dir = 4;
 	name = "Head of Security";
@@ -40688,10 +38210,10 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/red,
 /area/station/security/hos)
-"bND" = (
+"bNH" = (
 /turf/simulated/floor/carpet/red/fancy/edge/nw,
 /area/station/security/hos)
-"bNE" = (
+"bNI" = (
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
@@ -40700,7 +38222,7 @@
 /obj/item/device/radio/intercom/security,
 /turf/simulated/floor/carpet/red/fancy/edge/north,
 /area/station/security/hos)
-"bNF" = (
+"bNJ" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
@@ -40716,7 +38238,7 @@
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/north,
 /area/station/security/hos)
-"bNG" = (
+"bNK" = (
 /obj/storage/secure/closet/command/hos,
 /obj/machinery/light_switch/north{
 	pixel_x = -8
@@ -40727,7 +38249,7 @@
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/ne,
 /area/station/security/hos)
-"bNH" = (
+"bNL" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2{
 	dir = 8
@@ -40737,7 +38259,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/hos)
-"bNI" = (
+"bNM" = (
 /obj/table/auto,
 /obj/machinery/networked/printer{
 	name = "Printer - Bridge";
@@ -40761,33 +38283,18 @@
 	dir = 4
 	},
 /area/station/bridge)
-"bNJ" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/emergency{
-	dir = 1;
-	pixel_y = 16
-	},
-/turf/simulated/floor/carpet/blue/fancy/edge/nw,
-/area/station/bridge)
-"bNK" = (
+"bNN" = (
 /obj/cable{
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
 /area/station/bridge)
-"bNL" = (
+"bNO" = (
 /obj/table/auto,
 /obj/machinery/recharger,
 /turf/simulated/floor/carpet/blue/fancy/edge/ne,
 /area/station/bridge)
-"bNM" = (
+"bNP" = (
 /obj/table/auto,
 /obj/item/storage/box/PDAbox,
 /obj/machinery/alarm{
@@ -40801,7 +38308,15 @@
 	dir = 8
 	},
 /area/station/bridge)
-"bNN" = (
+"bNQ" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	name = "cargo belt - east";
+	operating = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
+"bNR" = (
 /obj/shrub{
 	dir = 4;
 	icon = 'icons/obj/stationobjs.dmi';
@@ -40811,7 +38326,7 @@
 	dir = 1
 	},
 /area/station/turret_protected/Zeta)
-"bNO" = (
+"bNS" = (
 /obj/machinery/turret,
 /obj/machinery/light{
 	dir = 1;
@@ -40822,7 +38337,7 @@
 	dir = 1
 	},
 /area/station/turret_protected/Zeta)
-"bNP" = (
+"bNT" = (
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
@@ -40830,7 +38345,7 @@
 	dir = 1
 	},
 /area/station/turret_protected/Zeta)
-"bNQ" = (
+"bNU" = (
 /obj/table/auto,
 /obj/item/paper/book/guardbot_guide{
 	pixel_x = 3;
@@ -40841,16 +38356,7 @@
 	dir = 1
 	},
 /area/station/turret_protected/Zeta)
-"bNR" = (
-/obj/machinery/power/data_terminal,
-/obj/machinery/computer/robotics{
-	perma = 1
-	},
-/turf/simulated/floor/greenblack{
-	dir = 1
-	},
-/area/station/turret_protected/Zeta)
-"bNS" = (
+"bNV" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer3/terminal/zeta{
 	setup_os_string = "ZETA_MAINFRAME"
@@ -40859,53 +38365,12 @@
 	dir = 1
 	},
 /area/station/turret_protected/Zeta)
-"bNT" = (
-/turf/simulated/floor/greenblack{
-	dir = 1
-	},
-/area/station/turret_protected/Zeta)
-"bNU" = (
+"bNX" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
-/turf/simulated/floor/greenblack{
-	dir = 1
-	},
-/area/station/turret_protected/Zeta)
-"bNV" = (
-/obj/grille/steel,
+/obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"bNW" = (
-/obj/machinery/computer3/terminal/zeta{
-	setup_os_string = "ZETA_MAINFRAME"
-	},
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/station/maintenance/southeast)
-"bNX" = (
-/obj/landmark/artifact,
-/turf/simulated/floor/plating{
-	icon_state = "platingdmg3"
-	},
 /area/station/maintenance/southeast)
 "bNY" = (
 /obj/machinery/conveyor{
@@ -41260,12 +38725,9 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bOH" = (
-/obj/table/auto,
-/obj/machinery/light,
-/obj/item/storage/toolbox/emergency,
-/obj/item/device/light/glowstick,
-/obj/item/device/light/glowstick,
-/turf/simulated/floor,
+/turf/simulated/floor/stairs/wide{
+	dir = 8
+	},
 /area/station/hallway/secondary/exit)
 "bOI" = (
 /obj/machinery/manufacturer/hangar,
@@ -41404,12 +38866,9 @@
 /turf/simulated/floor/red/side,
 /area/station/security/brig)
 "bOV" = (
-/obj/machinery/door/airlock/pyro,
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/turf/simulated/floor/grey/blackgrime,
-/area/station/security/brig)
+/obj/machinery/launcher_loader/east,
+/turf/simulated/floor/plating/airless,
+/area/space)
 "bOW" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -41417,38 +38876,44 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/brig)
 "bOX" = (
-/obj/blind_switch/area/west,
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
+/obj/machinery/recharge_station,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
+"bOY" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/light/emergency{
+/obj/decal/cleanable/dirt,
+/obj/critter/mouse,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
+"bOZ" = (
+/obj/disposalpipe/segment/food,
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/catering)
+"bPa" = (
+/obj/storage/secure/closet/personal,
+/turf/unsimulated/floor/sanitary,
+/area/station/crewquarters/cryotron)
+"bPb" = (
+/obj/disposalpipe/switch_junction/right/south{
+	mail_tag = "escape hallway";
+	name = "escape hallway mail junction"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/east)
+"bPc" = (
+/obj/machinery/light/small{
 	dir = 8;
-	pixel_x = -10
+	pixel_x = -12
 	},
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
 /area/station/security/brig)
-"bOY" = (
-/obj/stool/chair/red,
-/turf/simulated/floor/black,
-/area/station/security/brig)
-"bOZ" = (
-/obj/stool/chair/red,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/simulated/floor/redblack{
-	dir = 4
-	},
-/area/station/security/brig)
-"bPa" = (
+"bPe" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/right{
 	dir = 4
@@ -41462,7 +38927,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/hos)
-"bPb" = (
+"bPf" = (
 /obj/machinery/computer/secure_data{
 	dir = 4
 	},
@@ -41477,7 +38942,7 @@
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/west,
 /area/station/security/hos)
-"bPc" = (
+"bPg" = (
 /obj/cable{
 	d1 = 2;
 	d2 = 4;
@@ -41488,34 +38953,36 @@
 	},
 /turf/simulated/floor/carpet/red,
 /area/station/security/hos)
-"bPe" = (
+"bPh" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/critter/turtle/sylvester/HoS,
+/turf/simulated/floor/carpet/red,
+/area/station/security/hos)
+"bPi" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/east,
 /area/station/security/hos)
-"bPf" = (
-/obj/machinery/door/airlock/pyro/security{
-	dir = 4;
-	name = "Head of Security";
-	req_access = null
-	},
-/obj/access_spawn/hos,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/firedoor_spawn,
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/redblack{
+"bPj" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/left{
 	dir = 8
 	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
 /area/station/security/hos)
-"bPg" = (
+"bPk" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -41527,42 +38994,6 @@
 	dir = 4
 	},
 /area/station/bridge)
-"bPh" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/carpet/blue/fancy/edge/west,
-/area/station/bridge)
-"bPi" = (
-/turf/simulated/floor/carpet/blue/fancy/innercorner/omni,
-/area/station/bridge)
-"bPj" = (
-/turf/simulated/floor/carpet/blue/fancy/edge/east,
-/area/station/bridge)
-"bPk" = (
-/obj/table/auto,
-/obj/item/storage/toolbox/emergency,
-/obj/item/crowbar,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
-/turf/simulated/floor/black/side{
-	dir = 8
-	},
-/area/station/bridge)
-"bPl" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
 "bPm" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -41570,65 +39001,24 @@
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
 "bPn" = (
-/obj/stool/chair/office/blue{
-	dir = 1
-	},
 /obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
 "bPo" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/obj/disposalpipe/segment/mail/horizontal,
+/turf/simulated/floor/neutral/corner,
+/area/station/hallway/primary/east)
 "bPp" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13"
 	},
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
-"bPq" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/stool/chair{
-	dir = 1
-	},
-/turf/simulated/floor/grime,
-/area/station/maintenance/southeast)
-"bPr" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "8-10"
-	},
-/obj/item/storage/box/cablesbox,
-/turf/simulated/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/station/maintenance/southeast)
+/turf/simulated/floor/neutral/side,
+/area/station/hallway/primary/east)
 "bPs" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -42043,27 +39433,24 @@
 	},
 /area/station/security/brig)
 "bQn" = (
-/obj/machinery/drainage,
+/obj/submachine/chef_sink/chem_sink{
+	pixel_y = 16
+	},
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_x = -12
 	},
-/obj/disposalpipe/junction/middle/north,
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
 /turf/simulated/floor/grey/blackgrime,
 /area/station/security/brig)
 "bQo" = (
-/obj/submachine/chef_sink/chem_sink{
-	pixel_y = 16
-	},
-/obj/disposalpipe/segment/brig{
-	dir = 8
-	},
+/obj/machinery/drainage,
+/obj/disposalpipe/junction/right/north,
 /turf/simulated/floor/grey/blackgrime,
 /area/station/security/brig)
 "bQp" = (
-/obj/disposalpipe/segment/brig{
-	dir = 8
-	},
 /obj/disposalpipe/segment/vertical,
 /obj/item/storage/wall{
 	name = "bath cabinet";
@@ -42076,10 +39463,6 @@
 /obj/item/storage/toilet{
 	dir = 8
 	},
-/obj/disposalpipe/segment/brig{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/light/small{
 	dir = 1;
 	pixel_y = 21
@@ -42087,32 +39470,31 @@
 /turf/simulated/floor/grey/blackgrime,
 /area/station/security/brig)
 "bQr" = (
-/obj/item/storage/toilet,
+/obj/machinery/computer/secure_data/detective_computer,
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_x = -12
 	},
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/grey/side{
-	dir = 8
+/turf/simulated/floor/redblack{
+	dir = 9
 	},
 /area/station/security/brig)
 "bQs" = (
-/obj/machinery/floorflusher/solitary,
-/obj/submachine/chef_sink/chem_sink{
-	pixel_y = 16
+/obj/table/reinforced/auto,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/device/detective_scanner{
+	pixel_x = 15
 	},
-/obj/disposalpipe/trunk/south,
-/turf/simulated/floor/black,
+/turf/simulated/floor/redblack{
+	dir = 1
+	},
 /area/station/security/brig)
 "bQt" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet,
-/obj/item/device/radio/intercom,
-/turf/simulated/floor/grey/side{
-	dir = 4
+/obj/table/reinforced/auto,
+/obj/machinery/light/lamp,
+/turf/simulated/floor/redblack{
+	dir = 1
 	},
 /area/station/security/brig)
 "bQu" = (
@@ -42122,23 +39504,51 @@
 /turf/simulated/floor/white,
 /area/station/science/lab)
 "bQv" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet,
-/obj/item/device/radio/intercom,
-/turf/simulated/floor/grey/side{
-	dir = 8
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/turf/simulated/floor/redblack{
+	dir = 1
 	},
 /area/station/security/brig)
 "bQw" = (
-/obj/machinery/floorflusher/solitary2,
-/obj/submachine/chef_sink/chem_sink{
-	pixel_y = 16
+/obj/machinery/port_a_brig,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
 	},
-/obj/disposalpipe/trunk/south,
-/turf/simulated/floor/black,
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/turf/simulated/floor/redblack{
+	dir = 5
+	},
 /area/station/security/brig)
 "bQx" = (
+/obj/disposalpipe/segment/vertical,
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/escape,
+/area/station/hallway/primary/east)
+"bQz" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
+	},
+/turf/simulated/floor/neutral/corner,
+/area/station/hallway/primary/east)
+"bQA" = (
 /obj/item/storage/toilet,
+/turf/simulated/floor/black,
+/area/station/security/brig)
+"bQB" = (
+/obj/table/reinforced/auto,
+/obj/item/paper_bin,
+/obj/item/pen/pencil,
+/obj/item/reagent_containers/food/drinks/water,
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_x = 12
@@ -42150,37 +39560,15 @@
 	dir = 4
 	},
 /area/station/security/brig)
-"bQy" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/redblack{
-	dir = 8
-	},
-/area/station/security/brig)
-"bQz" = (
-/obj/table/reinforced/auto,
-/obj/machinery/phone,
-/turf/simulated/floor/black,
-/area/station/security/brig)
-"bQA" = (
-/obj/table/reinforced/auto,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/simulated/floor/redblack{
+"bQC" = (
+/obj/machinery/door/airlock/pyro/glass{
 	dir = 4
 	},
-/area/station/security/brig)
-"bQB" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/firedoor_spawn,
+/turf/simulated/floor/neutral/side,
+/area/station/hallway/primary/east)
+"bQF" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/middle{
 	dir = 4
@@ -42191,7 +39579,7 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/security/hos)
-"bQC" = (
+"bQG" = (
 /obj/machinery/computer/security{
 	dir = 4
 	},
@@ -42202,7 +39590,7 @@
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/carpet/red/fancy/edge/sw,
 /area/station/security/hos)
-"bQD" = (
+"bQH" = (
 /obj/stool/chair/comfy{
 	dir = 8
 	},
@@ -42211,26 +39599,10 @@
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/south,
 /area/station/security/hos)
-"bQE" = (
+"bQI" = (
 /turf/simulated/floor/carpet/red/fancy/edge/south,
 /area/station/security/hos)
-"bQF" = (
-/obj/table/reinforced/auto,
-/obj/machinery/phone,
-/turf/simulated/floor/carpet/red/fancy/edge/se,
-/area/station/security/hos)
-"bQG" = (
-/obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/left{
-	dir = 8
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/security/hos)
-"bQH" = (
+"bQJ" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer/general_alert{
 	dir = 4
@@ -42243,16 +39615,13 @@
 	dir = 4
 	},
 /area/station/bridge)
-"bQI" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet/blue/fancy/edge/west,
+"bQK" = (
+/turf/simulated/floor/carpet/blue/fancy/innercorner/omni,
 /area/station/bridge)
-"bQJ" = (
+"bQL" = (
+/turf/simulated/floor/black,
+/area/station/turret_protected/Zeta)
+"bQM" = (
 /obj/table/auto,
 /obj/item/clothing/gloves/yellow,
 /obj/item/device/multitool{
@@ -42269,29 +39638,6 @@
 	dir = 10
 	},
 /area/station/bridge)
-"bQK" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
-"bQL" = (
-/turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
-"bQM" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13"
-	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
 "bQN" = (
 /obj/machinery/power/smes{
 	chargelevel = 15000;
@@ -42305,13 +39651,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
 "bQO" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13";
+	tag = ""
 	},
-/obj/item/storage/toolbox/emergency,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/turf/simulated/floor/neutral/side,
+/area/station/hallway/primary/east)
 "bQP" = (
 /obj/mopbucket,
 /obj/submachine/chef_sink/chem_sink{
@@ -42320,13 +39668,10 @@
 /turf/simulated/floor/darkblue,
 /area/station/janitor/office)
 "bQQ" = (
-/obj/item/storage/wall/random{
-	dir = 8;
-	pixel_x = 32;
-	pixel_y = 0
+/obj/cable{
+	icon_state = "1-2"
 	},
-/obj/item/crowbar,
-/turf/simulated/floor/grime,
+/turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "bQR" = (
 /obj/machinery/conveyor{
@@ -42524,14 +39869,9 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bRp" = (
-/obj/stool/bench/blue/auto,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/disposalpipe/segment/mail/bent/south,
 /turf/simulated/floor,
-/area/station/hallway/secondary/exit)
+/area/station/hallway/primary/east)
 "bRq" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -42722,124 +40062,112 @@
 /area/station/security/brig)
 "bRE" = (
 /obj/disposalpipe/segment/horizontal,
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
 /turf/simulated/floor/grey/blackgrime,
 /area/station/security/brig)
 "bRF" = (
 /obj/item/storage/toilet{
 	dir = 8
 	},
-/obj/disposalpipe/segment/brig{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/grey/blackgrime,
 /area/station/security/brig)
-"bRG" = (
-/obj/table/reinforced/auto,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/reagent_containers/food/drinks/water,
-/obj/disposalpipe/segment/brig{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/turf/simulated/floor/grey/side{
-	dir = 8
-	},
-/area/station/security/brig)
 "bRH" = (
-/obj/machinery/drainage,
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/disposalpipe/segment/brig{
-	dir = 8
+/obj/stool/chair/office/red{
+	dir = 4;
+	tag = "icon-office_chair_red (EAST)"
 	},
 /turf/simulated/floor/black,
 /area/station/security/brig)
 "bRI" = (
-/obj/stool,
-/obj/disposalpipe/segment/brig{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/grey/side{
-	dir = 4
-	},
+/obj/table/reinforced/auto,
+/obj/item/paper/book/space_law,
+/turf/simulated/floor/black,
 /area/station/security/brig)
 "bRJ" = (
-/obj/machinery/vending/snack{
-	credit = 50
-	},
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/brig)
-"bRK" = (
-/obj/stool,
-/turf/simulated/floor/grey/side{
+/obj/stool/chair/red{
 	dir = 8
 	},
+/turf/simulated/floor/black,
 /area/station/security/brig)
-"bRL" = (
-/obj/machinery/drainage,
+"bRK" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
 /turf/simulated/floor/black,
 /area/station/security/brig)
+"bRL" = (
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/turf/simulated/floor/redblack{
+	dir = 4
+	},
+/area/station/security/brig)
 "bRM" = (
-/obj/table/reinforced/auto,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/reagent_containers/food/drinks/water,
-/obj/machinery/camera{
-	c_tag = "autotag";
+/obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/escape{
+	dir = 8
+	},
+/area/station/hallway/secondary/exit)
+"bRN" = (
+/obj/submachine/chef_sink/chem_sink{
 	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
+	pixel_x = 8
+	},
+/obj/machinery/drainage,
+/turf/simulated/floor/black,
+/area/station/security/brig)
+"bRO" = (
+/obj/machinery/door/airlock/pyro/glass,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/escape{
+	dir = 4
+	},
+/area/station/hallway/secondary/exit)
+"bRP" = (
+/obj/submachine/chef_sink/chem_sink{
+	dir = 4;
+	pixel_x = -8
+	},
+/obj/machinery/drainage,
+/turf/simulated/floor/black,
+/area/station/security/brig)
+"bRQ" = (
+/obj/stool,
+/obj/item/device/radio/intercom{
+	dir = 8
 	},
 /turf/simulated/floor/grey/side{
 	dir = 4
 	},
 /area/station/security/brig)
-"bRN" = (
-/obj/machinery/light_switch/west,
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+"bRR" = (
+/obj/table/auto,
+/obj/item/clothing/gloves/latex,
+/obj/item/kitchen/utensil/knife,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/southwest,
+/obj/disposalpipe/segment/food,
+/turf/simulated/floor/specialroom/freezer,
+/area/station/crew_quarters/catering)
+"bRS" = (
 /turf/simulated/floor/redblack{
-	dir = 10
+	dir = 8
 	},
 /area/station/security/brig)
-"bRO" = (
-/obj/stool/chair/red{
-	dir = 1
-	},
-/turf/simulated/floor/redblack,
-/area/station/security/brig)
-"bRP" = (
-/obj/stool/chair/red{
-	dir = 1
-	},
+"bRT" = (
 /turf/simulated/floor/redblack{
-	dir = 6
+	dir = 4
 	},
 /area/station/security/brig)
-"bRQ" = (
+"bRU" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/left{
 	dir = 4
@@ -42847,7 +40175,7 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/security/hos)
-"bRR" = (
+"bRV" = (
 /obj/table/reinforced/auto,
 /obj/machinery/recharger,
 /obj/item/stamp/hos{
@@ -42858,7 +40186,7 @@
 /obj/item/device/camera_viewer,
 /turf/simulated/floor/black,
 /area/station/security/hos)
-"bRS" = (
+"bRW" = (
 /obj/table/reinforced/auto,
 /obj/item/reagent_containers/food/snacks/spaghetti/spicy,
 /obj/item/kitchen/utensil/fork{
@@ -42867,7 +40195,7 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/hos)
-"bRT" = (
+"bRX" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 1
 	},
@@ -42879,7 +40207,7 @@
 /obj/machinery/drainage,
 /turf/simulated/floor/sanitary,
 /area/station/security/hos)
-"bRU" = (
+"bRY" = (
 /obj/item/storage/toilet{
 	dir = 8
 	},
@@ -42890,7 +40218,7 @@
 /obj/blind_switch/area/south,
 /turf/simulated/floor/sanitary,
 /area/station/security/hos)
-"bRV" = (
+"bRZ" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/right{
 	dir = 8
@@ -42898,7 +40226,7 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/security/hos)
-"bRW" = (
+"bSa" = (
 /obj/machinery/computer/announcement{
 	announces_arrivals = 1;
 	arrivalalert = "$NAME, $JOB, has exited cryogenic stasis.";
@@ -42920,22 +40248,7 @@
 	dir = 4
 	},
 /area/station/bridge)
-"bRX" = (
-/obj/stool/chair/office/blue,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/carpet/blue/fancy/edge/sw,
-/area/station/bridge)
-"bRY" = (
+"bSb" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -42944,63 +40257,48 @@
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/south,
 /area/station/bridge)
-"bRZ" = (
+"bSc" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/se,
 /area/station/bridge)
-"bSa" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+"bSd" = (
+/obj/machinery/door/airlock/pyro{
+	name = "Chef's Quarters"
 	},
-/obj/machinery/shipalert{
-	pixel_x = 30
-	},
-/turf/simulated/floor/black/side{
-	dir = 8
-	},
-/area/station/bridge)
-"bSb" = (
-/obj/machinery/door/airlock/pyro/command{
-	name = "Computer Core"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
+/obj/access_spawn/kitchen,
 /obj/firedoor_spawn,
-/turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
-"bSc" = (
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/kitchen)
+"bSg" = (
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
 /area/station/turret_protected/Zeta)
-"bSd" = (
+"bSh" = (
 /obj/table/auto,
 /obj/item/circuitboard/aiupload,
 /obj/item/aiModule/reset,
 /obj/item/disk/data/floppy/read_only/communications,
 /turf/simulated/floor/greenblack,
 /area/station/turret_protected/Zeta)
-"bSe" = (
-/obj/table/auto,
-/obj/item/circuitboard/robotics,
-/obj/item/disk/data/floppy/read_only/network_progs,
-/obj/machinery/light,
-/turf/simulated/floor/greenblack,
+"bSi" = (
+/obj/machinery/networked/mainframe/zeta{
+	tag = "ZETA_MAINFRAME"
+	},
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/circuit/green,
 /area/station/turret_protected/Zeta)
-"bSf" = (
-/obj/machinery/turret,
-/turf/simulated/floor/greenblack,
-/area/station/turret_protected/Zeta)
-"bSg" = (
-/obj/table/auto,
-/obj/item/storage/box/diskbox,
-/turf/simulated/floor/greenblack,
-/area/station/turret_protected/Zeta)
-"bSh" = (
+"bSj" = (
 /obj/table/auto,
 /obj/item/disk/data/tape{
 	layer = 3.5;
@@ -43019,7 +40317,11 @@
 	},
 /turf/simulated/floor/greenblack,
 /area/station/turret_protected/Zeta)
-"bSi" = (
+"bSk" = (
+/obj/grille/steel,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"bSl" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -43028,27 +40330,6 @@
 	},
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"bSj" = (
-/obj/machinery/power/apc/autoname_east,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"bSk" = (
-/obj/item/tile/steel,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/grime,
-/area/station/maintenance/southeast)
-"bSl" = (
-/obj/critter/roach,
-/turf/simulated/floor/grime,
 /area/station/maintenance/southeast)
 "bSm" = (
 /obj/machinery/launcher_loader/north,
@@ -43328,11 +40609,13 @@
 /turf/simulated/floor/caution/westeast,
 /area/station/quartermaster/office)
 "bSV" = (
-/obj/machinery/vehicle/escape_pod{
-	dir = 4
+/obj/machinery/door/unpowered/wood/pyro{
+	name = "The Snip"
 	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hallway/secondary/exit)
+/obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/barber_shop)
 "bSW" = (
 /obj/machinery/light{
 	dir = 4;
@@ -43462,26 +40745,35 @@
 	pixel_x = -8
 	},
 /obj/machinery/light/small,
+/obj/disposalpipe/segment/brig{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/grey/blackgrime,
 /area/station/security/brig)
 "bTj" = (
 /obj/machinery/drainage,
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
 /turf/simulated/floor/grey/blackgrime,
 /area/station/security/brig)
 "bTk" = (
 /obj/table/auto,
 /obj/item/paper_bin,
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
 /turf/simulated/floor/grey/blackgrime,
 /area/station/security/brig)
 "bTl" = (
-/obj/machinery/door/airlock/pyro/glass{
-	name = "Holding Cell One"
+/obj/stool/chair/red{
+	dir = 4
 	},
-/obj/access_spawn/brig,
 /obj/disposalpipe/segment/brig{
-	dir = 1
+	dir = 8
 	},
-/turf/simulated/floor/black,
+/turf/simulated/floor/redblack,
 /area/station/security/brig)
 "bTm" = (
 /obj/wingrille_spawn/auto,
@@ -43490,38 +40782,54 @@
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "bTn" = (
-/obj/machinery/door/airlock/pyro/glass{
-	name = "Holding Cell Two"
+/obj/reagent_dispensers/watertank/fountain,
+/obj/disposalpipe/segment/brig{
+	dir = 8
 	},
-/obj/access_spawn/brig,
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
-/turf/simulated/floor/black,
+/turf/simulated/floor/redblack{
+	dir = 6
+	},
 /area/station/security/brig)
 "bTo" = (
-/obj/machinery/door/airlock/pyro/security{
-	name = "Secure Consultation"
-	},
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/access_spawn/brig,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/firedoor_spawn,
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/red,
+/obj/machinery/floorflusher/solitary,
+/obj/disposalpipe/trunk/south,
+/turf/simulated/floor/black,
 /area/station/security/brig)
 "bTp" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/hos)
 "bTq" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/storage/emergency)
+"bTr" = (
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Emergency Storage"
+	},
+/obj/disposalpipe/segment/vertical,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/storage/emergency)
+"bTs" = (
+/obj/machinery/door/airlock/pyro/glass{
+	name = "South Crew Quarters"
+	},
+/obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/neutral/side{
+	dir = 8
+	},
+/area/station/crew_quarters/quarters_south)
+"bTt" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/quarters_south)
+"bTu" = (
 /obj/machinery/computer3/generic/secure_data,
 /obj/machinery/power/data_terminal,
 /obj/cable,
@@ -43538,7 +40846,7 @@
 	dir = 1
 	},
 /area/station/bridge)
-"bTr" = (
+"bTv" = (
 /obj/machinery/computer3/generic/communications,
 /obj/machinery/power/data_terminal,
 /obj/cable,
@@ -43550,7 +40858,7 @@
 	dir = 1
 	},
 /area/station/bridge)
-"bTs" = (
+"bTw" = (
 /obj/shrub{
 	dir = 1;
 	icon = 'icons/obj/stationobjs.dmi';
@@ -43561,84 +40869,44 @@
 	dir = 5
 	},
 /area/station/bridge)
-"bTt" = (
-/obj/cable{
-	icon_state = "2-4"
+"bTx" = (
+/obj/disposalpipe/segment/vertical,
+/obj/machinery/door/airlock/pyro/glass{
+	name = "South Crew Quarters"
 	},
 /obj/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
-	},
-/turf/simulated/floor/black/corner{
-	dir = 1
-	},
-/area/station/bridge)
-"bTu" = (
-/obj/machinery/door/airlock/pyro/command{
-	dir = 4;
-	name = "Computer Core"
-	},
-/obj/cable{
-	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
-/turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
-"bTv" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/neutral/side{
+	dir = 4
 	},
-/obj/cable{
-	icon_state = "1-2"
+/area/station/crew_quarters/quarters_south)
+"bTy" = (
+/turf/simulated/floor/neutral/side{
+	dir = 6
 	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
-"bTw" = (
-/obj/machinery/turretid{
-	pixel_x = 26
+/area/station/hallway/primary/east)
+"bTz" = (
+/obj/disposalpipe/segment/mail/bent/north,
+/turf/simulated/floor/neutral/corner,
+/area/station/hallway/primary/east)
+"bTA" = (
+/obj/machinery/disposal/mail/autoname/public/escape,
+/obj/disposalpipe/trunk/mail/west,
+/turf/simulated/floor/escape/corner{
+	dir = 4
 	},
-/obj/machinery/light,
-/turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
-"bTx" = (
+/area/station/hallway/primary/east)
+"bTB" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/item/tile/steel,
 /turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"bTy" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "4-10"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
-"bTz" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/stairs{
-	dir = 8
-	},
-/area/station/maintenance/southeast)
-"bTA" = (
-/obj/item/caution{
-	desc = "Caution! Construction Zone!";
-	name = "caution sign"
-	},
-/obj/decal/cleanable/oil,
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/grime,
-/area/station/maintenance/southeast)
-"bTB" = (
-/obj/item/clothing/suit/cardboard_box,
-/turf/simulated/floor/grime,
 /area/station/maintenance/southeast)
 "bTC" = (
 /obj/machinery/mass_driver{
@@ -43912,6 +41180,10 @@
 /turf/simulated/floor/bot,
 /area/station/security/brig)
 "bUi" = (
+/obj/machinery/atmospherics/unary/outlet_injector{
+	icon_state = "on";
+	on = 1
+	},
 /turf/simulated/floor/red/corner{
 	dir = 4
 	},
@@ -43923,141 +41195,121 @@
 	},
 /area/station/security/brig)
 "bUk" = (
-/obj/wingrille_spawn/auto,
-/obj/machinery/door/poddoor/pyro{
-	autoclose = 1;
-	id = "badshitgoindown";
-	name = "Detention Check-In Shutter"
-	},
+/obj/machinery/drone_recharger,
+/obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/station/security/brig)
+/area/station/maintenance/inner/central)
 "bUl" = (
-/obj/machinery/door_timer/solitary/new_walls/north{
-	layer = 3.1
+/obj/machinery/door/airlock/pyro/security{
+	name = "Secure Consultation"
 	},
-/obj/storage/closet/wardrobe/orange,
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -20
-	},
-/turf/simulated/floor/redblack/corner{
-	dir = 4
-	},
+/turf/simulated/floor/red,
 /area/station/security/brig)
 "bUm" = (
+/obj/machinery/atmospherics/pipe/simple/southeast,
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/catering)
+"bUn" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "kitchen";
+	layer = 4;
+	name = "Kitchen Shutter";
+	opacity = 0;
+	p_open = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/kitchen)
+"bUo" = (
+/obj/table/reinforced/auto,
+/obj/machinery/phone,
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/turf/simulated/floor/redblack,
+/area/station/security/brig)
+"bUp" = (
+/obj/machinery/door/airlock/pyro/security{
+	name = "Secure Consultation"
+	},
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
-/turf/simulated/floor/redblack/corner{
-	dir = 8
-	},
+/turf/simulated/floor/red,
 /area/station/security/brig)
-"bUn" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1;
-	icon_state = "pipe-c"
+"bUq" = (
+/obj/voting_box,
+/turf/simulated/floor/darkblue,
+/area/station/crew_quarters/cafeteria)
+"bUr" = (
+/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon16,
+/turf/simulated/floor/neutral/side{
+	dir = 6
 	},
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/redblack/corner{
-	dir = 4
-	},
-/area/station/security/brig)
-"bUo" = (
+/area/station/hallway/primary/east)
+"bUs" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
+/turf/simulated/floor/plating,
+/area/station/security/brig)
+"bUt" = (
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Holding Cell One"
+	},
+/obj/access_spawn/brig,
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/turf/simulated/floor/black,
+/area/station/security/brig)
+"bUu" = (
+/obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/brig)
-"bUp" = (
-/obj/disposalpipe/segment/brig{
-	dir = 8
-	},
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/redblack/corner{
-	dir = 4
-	},
-/area/station/security/brig)
-"bUq" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/disposalpipe/segment/brig{
-	dir = 8
-	},
-/turf/simulated/floor/redblack/corner{
-	dir = 8
-	},
-/area/station/security/brig)
-"bUr" = (
-/obj/machinery/door_timer/solitary2/new_walls/north{
-	layer = 3.1
-	},
-/obj/disposalpipe/segment/brig{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/redblack/corner{
-	dir = 4
-	},
-/area/station/security/brig)
-"bUs" = (
-/obj/stool/chair/red{
-	dir = 4
-	},
-/obj/disposalpipe/segment/brig{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/item/device/radio/intercom/security,
-/turf/simulated/floor/red/side{
-	dir = 9
-	},
-/area/station/security/brig)
-"bUt" = (
-/obj/disposalpipe/segment/brig{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/red/side{
-	dir = 1
-	},
-/area/station/security/brig)
-"bUu" = (
-/turf/simulated/floor/red/side{
-	dir = 1
-	},
-/area/station/security/brig)
 "bUv" = (
-/obj/machinery/port_a_brig,
-/turf/simulated/floor/red/side{
-	dir = 5
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Holding Cell Two"
 	},
+/obj/access_spawn/brig,
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/turf/simulated/floor/black,
 /area/station/security/brig)
 "bUw" = (
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 8
+	},
+/area/station/hallway/primary/east)
+"bUx" = (
+/obj/stool/chair/office,
+/obj/landmark/start{
+	name = "Medical Doctor"
+	},
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
+"bUy" = (
+/obj/disposalpipe/segment/food,
+/turf/simulated/floor/stairs{
+	dir = 1
+	},
+/area/station/crew_quarters/catering)
+"bUz" = (
 /obj/rack,
 /obj/item/clothing/suit/fire,
 /obj/item/clothing/mask/gas/emergency,
@@ -44070,82 +41322,49 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"bUx" = (
-/obj/stool/chair/office,
-/obj/landmark/start{
-	name = "Medical Doctor"
-	},
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay)
-"bUy" = (
-/obj/critter/mouse/remy,
-/turf/simulated/floor/specialroom/cafeteria,
-/area/station/crew_quarters/kitchen)
-"bUz" = (
-/obj/machinery/shieldgenerator/meteorshield,
+"bUA" = (
+/obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"bUA" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/bridge)
 "bUB" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable,
+/obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
-/area/station/bridge)
+/area/station/maintenance/southeast)
 "bUC" = (
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"bUD" = (
 /obj/machinery/door/airlock/pyro/command{
-	name = "Command Centre"
+	name = "Computer Core"
 	},
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
 /turf/simulated/floor/black,
-/area/station/bridge)
-"bUD" = (
+/area/station/turret_protected/Zeta)
+"bUE" = (
 /obj/machinery/drone_recharger,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"bUE" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
 "bUF" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
+/obj/cable{
+	icon_state = "4-8"
 	},
-/obj/random_item_spawner/junk/one_or_zero,
+/obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/area/station/maintenance/inner/central)
 "bUG" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "1-5"
+/obj/machinery/atmospherics/valve,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/area/station/crew_quarters/catering)
 "bUH" = (
 /obj/table/auto,
 /obj/item/storage/firstaid/toxin,
@@ -44159,23 +41378,25 @@
 	},
 /area/station/medical/medbay)
 "bUI" = (
-/obj/table/auto,
-/obj/random_item_spawner/tools,
-/obj/item/device/light/glowstick,
-/obj/item/device/light/glowstick,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
+	},
+/obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "bUJ" = (
-/obj/table/auto,
-/obj/shrub/dead{
-	dir = 8;
-	name = "Dead plant";
-	pixel_y = 10
+/obj/cable{
+	icon_state = "1-2"
 	},
-/obj/item/storage/pill_bottle/cyberpunk{
-	layer = 2.4
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "1-5"
 	},
-/turf/simulated/floor/grime,
+/turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "bUK" = (
 /obj/machinery/launcher_loader/south,
@@ -44526,47 +41747,20 @@
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/station/security/brig)
 "bVx" = (
-/obj/disposalpipe/segment/brig{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
+	},
+/obj/disposalpipe/segment/brig{
+	dir = 8
 	},
 /turf/simulated/floor/red/corner{
 	dir = 4
-	},
-/area/station/security/brig)
-"bVy" = (
-/obj/disposalpipe/segment/brig{
-	dir = 8
-	},
-/obj/machinery/door_control{
-	id = "badshitgoindown";
-	name = "Check-In Door";
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4
-	},
-/turf/simulated/floor/red/side{
-	dir = 1
-	},
-/area/station/security/brig)
-"bVz" = (
-/obj/disposalpipe/segment/brig{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4
-	},
-/turf/simulated/floor/red/side{
-	dir = 1
 	},
 /area/station/security/brig)
 "bVA" = (
@@ -44579,9 +41773,6 @@
 	},
 /area/station/security/brig)
 "bVB" = (
-/obj/disposalpipe/segment/brig{
-	dir = 8
-	},
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -44590,151 +41781,136 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
-/turf/simulated/floor/red/side{
-	dir = 1
-	},
-/area/station/security/brig)
-"bVC" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4
-	},
 /obj/disposalpipe/segment/brig{
 	dir = 8
-	},
-/obj/access_spawn/brig,
-/obj/firedoor_spawn,
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/security/brig)
-"bVD" = (
-/obj/disposalpipe/segment/brig{
-	dir = 8
-	},
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4
 	},
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
 /area/station/security/brig)
 "bVE" = (
-/obj/disposalpipe/segment/brig{
-	dir = 8
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
 	},
-/obj/item/device/radio/beacon,
+/obj/access_spawn/brig,
+/obj/firedoor_spawn,
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
-/turf/simulated/floor/red/side{
-	dir = 1
-	},
-/area/station/security/brig)
-"bVF" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
-/obj/landmark/gps_waypoint,
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4
-	},
-/turf/simulated/floor/red/side{
-	dir = 1
-	},
+/turf/simulated/floor,
 /area/station/security/brig)
 "bVG" = (
-/obj/disposalpipe/segment/brig{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
+	},
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/obj/disposalpipe/segment/brig{
+	dir = 1
 	},
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
 /area/station/security/brig)
 "bVH" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
+/obj/item/device/radio/beacon,
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
+	},
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/obj/machinery/door_timer/solitary/new_walls/north{
+	layer = 3.1
 	},
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
 /area/station/security/brig)
 "bVI" = (
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
+	},
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/red/side{
+	dir = 1
+	},
+/area/station/security/brig)
+"bVJ" = (
+/obj/landmark/gps_waypoint,
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
+	},
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/turf/simulated/floor/red/side{
+	dir = 1
+	},
+/area/station/security/brig)
+"bVK" = (
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
+	},
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/red/side{
+	dir = 1
+	},
+/area/station/security/brig)
+"bVL" = (
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
+	},
+/obj/disposalpipe/segment/brig{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/red/side{
+	dir = 1
+	},
+/area/station/security/brig)
+"bVM" = (
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
 	},
 /turf/simulated/floor/red/corner{
 	dir = 1
 	},
 /area/station/security/brig)
-"bVJ" = (
-/obj/disposalpipe/segment/brig{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor,
-/area/station/security/brig)
-"bVK" = (
+"bVN" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 8;
 	icon_state = "on";
 	on = 1
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor,
 /area/station/security/brig)
-"bVL" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/red/side{
-	dir = 4
-	},
-/area/station/security/brig)
-"bVM" = (
-/obj/machinery/door/airlock/pyro/security{
-	dir = 4;
-	name = "Brig";
-	req_access = null
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/access_spawn/brig,
-/obj/firedoor_spawn,
-/turf/simulated/floor/red,
-/area/station/security/brig)
-"bVN" = (
+"bVP" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -44743,7 +41919,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"bVP" = (
+"bVQ" = (
 /obj/machinery/light/small{
 	dir = 1;
 	pixel_y = 21
@@ -44753,26 +41929,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"bVQ" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
 "bVR" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/obj/machinery/atmospherics/pipe/manifold/south,
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/catering)
 "bVS" = (
 /obj/machinery/optable{
 	name = "Autopsy Table"
@@ -44780,23 +41940,25 @@
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "bVT" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/horizontal,
+/obj/disposalpipe/segment/food,
+/turf/simulated/floor/specialroom/freezer,
+/area/station/crew_quarters/catering)
 "bVU" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/obj/item/fish/bass,
+/obj/item/fish/bass,
+/obj/item/fish/carp,
+/obj/item/fish/carp,
+/obj/item/fish/salmon,
+/obj/item/fish/salmon,
+/obj/storage/crate/freezer,
+/obj/item/raw_material/ice,
+/obj/item/raw_material/ice,
+/obj/item/raw_material/ice,
+/obj/item/raw_material/ice,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/northwest,
+/turf/simulated/floor/specialroom/freezer,
+/area/station/crew_quarters/catering)
 "bVV" = (
 /obj/machinery/mass_driver{
 	id = "kd_scisouth"
@@ -45105,15 +42267,6 @@
 /obj/machinery/atmospherics/pipe/simple,
 /turf/simulated/floor,
 /area/station/security/brig)
-"bWE" = (
-/obj/disposalpipe/segment/brig{
-	dir = 8
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/security/brig)
 "bWF" = (
 /obj/disposalpipe/junction/right/west,
 /obj/cable{
@@ -45123,147 +42276,122 @@
 /area/station/security/brig)
 "bWG" = (
 /obj/disposalpipe/segment/transport,
-/obj/disposalpipe/segment/brig{
-	dir = 8
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "2-8"
 	},
-/turf/simulated/floor,
-/area/station/security/brig)
-"bWH" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
+/turf/simulated/floor,
+/area/station/security/brig)
+"bWH" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "1-8"
 	},
-/turf/simulated/floor,
-/area/station/security/brig)
-"bWI" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4
-	},
 /obj/disposalpipe/segment/brig{
 	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/security/brig)
+"bWK" = (
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/access_spawn/brig,
 /obj/firedoor_spawn,
-/turf/simulated/floor,
-/area/station/security/brig)
-"bWJ" = (
 /obj/disposalpipe/segment/brig{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/security/brig)
-"bWK" = (
-/obj/cable{
-	icon_state = "4-8"
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/station/security/brig)
 "bWL" = (
-/obj/wingrille_spawn/auto,
+/obj/stool/chair/red{
+	dir = 8
+	},
+/obj/machinery/light/small,
 /obj/disposalpipe/segment/brig{
-	dir = 1
+	dir = 8
 	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/decal/wreath/ephemeral,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/redblack,
 /area/station/security/brig)
 "bWM" = (
-/obj/disposalpipe/segment/brig{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
-/area/station/security/brig)
-"bWN" = (
-/obj/stool/chair/red,
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
 /obj/cable{
+	icon_state = "1-4"
+	},
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/security/brig)
+"bWN" = (
+/obj/cable{
 	icon_state = "4-8"
 	},
-/obj/cable{
-	icon_state = "2-8"
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/obj/disposalpipe/segment/brig{
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/station/security/brig)
 "bWO" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/brig{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/station/security/brig)
 "bWP" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
 	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/security/brig)
-"bWQ" = (
-/obj/table/reinforced/auto,
-/obj/item/paper/Port_A_Brig,
-/obj/item/remote/porter/port_a_brig,
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/turf/simulated/floor/red/side{
-	dir = 4
-	},
-/area/station/security/brig)
 "bWR" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/beepsky)
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/security/brig)
 "bWT" = (
-/obj/decal/poster/wallsign/space,
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/southeast)
-"bWU" = (
-/obj/machinery/door/airlock/pyro/external,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13";
+	tag = ""
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
+"bWU" = (
+/obj/storage/secure/closet/fridge/kitchen,
+/obj/item/reagent_containers/food/drinks/milk,
+/turf/simulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/kitchen)
 "bWV" = (
-/turf/simulated/floor/stairs/dark,
+/obj/decal/poster/wallsign/space,
+/turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/southeast)
 "bWW" = (
 /obj/cable{
@@ -45531,13 +42659,20 @@
 /turf/simulated/floor/red/side,
 /area/station/security/brig)
 "bXz" = (
-/obj/storage/secure/closet/brig,
+/obj/table/reinforced/auto,
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
 /turf/simulated/floor/red/side,
 /area/station/security/brig)
 "bXA" = (
+/obj/wingrille_spawn/auto,
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig)
+"bXB" = (
 /obj/machinery/disposal/brig{
 	name = "mercantile checkpoint chute"
 	},
@@ -45545,31 +42680,48 @@
 /obj/disposalpipe/trunk/west,
 /turf/simulated/floor/red/side,
 /area/station/security/brig)
-"bXB" = (
+"bXC" = (
 /obj/machinery/disposal/brig{
 	name = "pod bay checkpoint chute"
 	},
 /obj/disposalpipe/trunk/north,
 /turf/simulated/floor/red/side,
 /area/station/security/brig)
-"bXC" = (
+"bXD" = (
 /obj/machinery/disposal/brig{
 	name = "escape checkpoint chute"
 	},
 /obj/disposalpipe/trunk/north,
 /turf/simulated/floor/red/side,
 /area/station/security/brig)
-"bXD" = (
-/obj/machinery/computer3/generic/secure_data,
+"bXE" = (
+/obj/storage/closet/wardrobe/orange,
+/turf/simulated/floor/red/side,
+/area/station/security/brig)
+"bXF" = (
+/obj/machinery/disposal/brig,
+/obj/disposalpipe/trunk/north,
+/turf/simulated/floor/red/side,
+/area/station/security/brig)
+"bXG" = (
+/obj/stool/chair/red{
+	dir = 4
+	},
+/turf/simulated/floor/red/side,
+/area/station/security/brig)
+"bXH" = (
 /obj/cable,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/light/emergency,
+/obj/machinery/computer3/generic/secure_data{
+	dir = 8
+	},
 /turf/simulated/floor/red/side,
 /area/station/security/brig)
-"bXE" = (
+"bXI" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 10;
@@ -45579,23 +42731,10 @@
 /obj/storage/secure/crate/weapon/confiscated_items,
 /turf/simulated/floor/red/side,
 /area/station/security/brig)
-"bXF" = (
-/obj/storage/closet/wardrobe/orange,
-/obj/machinery/light,
+"bXJ" = (
 /turf/simulated/floor/red/side,
 /area/station/security/brig)
-"bXG" = (
-/obj/machinery/disposal/brig,
-/obj/disposalpipe/trunk/north,
-/turf/simulated/floor/red/side,
-/area/station/security/brig)
-"bXH" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/red/side,
-/area/station/security/brig)
-"bXI" = (
+"bXK" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/box/revimp_kit,
 /obj/machinery/firealarm{
@@ -45607,41 +42746,30 @@
 	dir = 6
 	},
 /area/station/security/brig)
-"bXJ" = (
-/obj/machinery/computer/security/wooden_tv,
-/turf/simulated/floor/plating/damaged1,
-/area/station/security/beepsky)
-"bXK" = (
-/obj/storage/crate{
-	desc = "A private crate that isn't yours.";
-	name = "Beepsky's stuff"
-	},
-/obj/item/diary,
-/obj/item/clothing/shoes/black{
-	desc = "You have no idea how a robot with wheels for locomotion could possibly require these.";
-	name = "Beepsky's Shoes"
-	},
-/obj/item/storage/photo_album/beepsky,
-/obj/item/clothing/suit/det_suit/beepsky,
-/obj/item/clothing/head/NTberet{
-	desc = "It's a momento, I guess. An old keepsake. And maybe a reminder of the things we've left behind.";
-	name = "Old Beret"
-	},
-/obj/machinery/power/apc/autoname_east,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating/damaged3,
-/area/station/security/beepsky)
 "bXL" = (
-/obj/machinery/portable_atmospherics/canister/air/large,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/obj/table/reinforced/auto,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "kitchen";
+	layer = 4;
+	name = "Kitchen Shutter";
+	opacity = 0;
+	p_open = 1
+	},
+/obj/machinery/cashreg,
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 4
+	},
+/obj/access_spawn/kitchen,
+/turf/simulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/kitchen)
 "bXM" = (
-/obj/machinery/recharge_station,
-/turf/simulated/floor/grey,
-/area/station/maintenance/southeast)
+/obj/stool/bar,
+/turf/simulated/floor/carpet/green/fancy/edge/nw,
+/area/station/crew_quarters/cafeteria)
 "bXN" = (
 /obj/cable{
 	d1 = 1;
@@ -46034,37 +43162,20 @@
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "bYz" = (
-/obj/access_spawn/brig,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/door/airlock/pyro/glass{
-	name = "Armory"
-	},
-/obj/access_spawn/brig,
-/turf/simulated/floor/red,
-/area/station/security/brig)
+/obj/table/wood/round/auto,
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/barber_shop)
 "bYA" = (
 /obj/machinery/drainage,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/office)
 "bYB" = (
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
+/obj/grille/catwalk{
+	dir = 5
 	},
-/turf/simulated/floor/plating/airless/shuttlebay{
-	name = "landing pad plating"
-	},
-/area/station/maintenance/southeast)
-"bYC" = (
-/turf/simulated/floor/plating/airless/shuttlebay{
-	name = "landing pad plating"
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	icon_state = "catwalk_cross"
 	},
 /area/station/maintenance/southeast)
 "bYD" = (
@@ -46081,22 +43192,18 @@
 /turf/simulated/floor/grey,
 /area/station/medical/robotics)
 "bYE" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
+/turf/simulated/floor/plating/airless/shuttlebay{
+	name = "landing pad plating"
 	},
-/turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "bYF" = (
-/obj/rack,
-/obj/item/clothing/suit/space/emerg,
-/obj/item/clothing/head/emerg,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/air,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/belt/utility,
-/obj/item/crowbar,
-/obj/item/device/light/flashlight,
-/turf/simulated/floor/plating,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/plating/airless/shuttlebay{
+	name = "landing pad plating"
+	},
 /area/station/maintenance/southeast)
 "bYG" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -46392,42 +43499,22 @@
 	icon_state = "pipe-c"
 	},
 /turf/space,
-/area/station/ai_monitored/armory)
-"bZq" = (
+/area/space)
+"bZr" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
 /turf/space,
-/area/station/ai_monitored/armory)
-"bZr" = (
+/area/space)
+"bZt" = (
 /obj/lattice{
+	dir = 6;
 	icon_state = "lattice-dir"
 	},
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
 /turf/space,
-/area/station/ai_monitored/armory)
-"bZs" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
-/turf/simulated/floor/red,
-/area/station/ai_monitored/armory)
-"bZt" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
-/turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "bZu" = (
 /obj/machinery/door/airlock/pyro/medical{
@@ -46734,19 +43821,20 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/morgue)
 "cak" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/red,
-/area/station/ai_monitored/armory)
+/obj/landmark/gps_waypoint,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/barber_shop)
 "cal" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
+/obj/machinery/light/small,
+/obj/machinery/computer3/generic/communications{
+	dir = 8
 	},
-/turf/space,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "cam" = (
 /obj/table/reinforced/auto,
@@ -47097,19 +44185,22 @@
 /turf/simulated/floor/engine,
 /area/station/routing/security)
 "caX" = (
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir"
+	},
 /obj/disposalpipe/segment/transport{
-	dir = 8;
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /turf/space,
 /area/station/ai_monitored/armory)
 "caY" = (
+/obj/machinery/light/runway_light,
 /obj/lattice{
-	dir = 8;
 	icon_state = "lattice-dir"
 	},
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/space)
 "caZ" = (
 /obj/table/auto,
 /obj/item/storage/firstaid/oxygen,
@@ -47124,27 +44215,9 @@
 "cba" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/ai_monitored/armory)
-"cbb" = (
-/obj/machinery/door/airlock/pyro/command{
-	aiControlDisabled = 1;
-	name = "Armory";
-	req_access = null
-	},
-/obj/access_spawn/hos,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
-"cbc" = (
-/obj/landmark/spawner{
-	name = "monkeyspawn_mrmuggles"
-	},
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
 "cbd" = (
-/obj/machinery/light/runway_light/delay2,
 /obj/lattice{
+	dir = 8;
 	icon_state = "lattice-dir"
 	},
 /turf/space,
@@ -47571,9 +44644,12 @@
 /turf/simulated/floor/engine,
 /area/station/routing/security)
 "cbS" = (
-/obj/machinery/turret,
-/obj/lattice,
-/turf/space,
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
 /area/station/ai_monitored/armory)
 "cbT" = (
 /obj/morgue,
@@ -47584,11 +44660,11 @@
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "cbU" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/machinery/door/airlock/pyro{
+	dir = 4
 	},
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/quarters_south)
 "cbV" = (
 /obj/table/auto,
 /obj/item/circular_saw{
@@ -47604,8 +44680,9 @@
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "cbW" = (
-/obj/lattice,
-/turf/space,
+/obj/storage/secure/crate/gear/armory/grenades,
+/obj/machinery/recharger/wall/sticky,
+/turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "cbX" = (
 /obj/disposalpipe/segment/vertical,
@@ -47615,22 +44692,23 @@
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "cbY" = (
-/obj/lattice{
-	dir = 1;
-	icon_state = "lattice-dir"
+/obj/stool/chair/red{
+	dir = 4
 	},
-/turf/space,
+/obj/machinery/turretid{
+	pixel_x = -26;
+	req_access = null;
+	req_access_txt = "1"
+	},
+/turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "cbZ" = (
 /turf/space,
 /area/station/ai_monitored/armory)
 "cca" = (
-/obj/machinery/light/runway_light,
-/obj/lattice{
-	icon_state = "lattice-dir"
-	},
-/turf/space,
-/area/station/ai_monitored/armory)
+/obj/storage/closet/dresser/random,
+/turf/simulated/floor/carpet/green/fancy/edge/se,
+/area/station/crew_quarters/quarters_south)
 "ccb" = (
 /obj/machinery/door/airlock/pyro/medical{
 	name = "Toxin Lab Access";
@@ -48044,33 +45122,23 @@
 /turf/simulated/floor/engine,
 /area/station/routing/security)
 "ccO" = (
-/obj/lattice{
-	dir = 6;
-	icon_state = "lattice-dir"
+/turf/simulated/floor/neutral/corner{
+	dir = 4
 	},
-/turf/space,
-/area/station/ai_monitored/armory)
+/area/station/hallway/primary/east)
 "ccQ" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
 	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
+/turf/simulated/floor/escape/corner,
+/area/station/hallway/primary/east)
 "ccR" = (
-/obj/machinery/light/runway_light/delay5,
-/obj/lattice{
-	dir = 6;
-	icon_state = "lattice-dir"
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
 	},
-/turf/space,
-/area/station/ai_monitored/armory)
+/turf/simulated/floor/escape,
+/area/station/hallway/secondary/exit)
 "ccS" = (
 /obj/machinery/atmospherics/pipe/simple/junction{
 	dir = 1
@@ -48328,13 +45396,8 @@
 /turf/simulated/floor/caution/westeast,
 /area/station/quartermaster/office)
 "cds" = (
-/obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/left{
-	dir = 4
-	},
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/science/research_director)
+/turf/simulated/floor/grey,
+/area/station/bridge)
 "cdt" = (
 /obj/machinery/conveyor{
 	id = "qmsend"
@@ -48444,23 +45507,14 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "cdE" = (
-/obj/cable{
-	icon_state = "4-8"
+/turf/simulated/floor/escape/corner{
+	dir = 8
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
+/area/station/hallway/secondary/exit)
 "cdF" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/light/runway_light/delay4,
-/turf/space,
-/area/station/ai_monitored/armory)
+/obj/storage/secure/closet/kitchen,
+/turf/simulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/kitchen)
 "cdG" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0;
@@ -48759,13 +45813,10 @@
 /turf/simulated/floor/caution/northsouth,
 /area/station/quartermaster/office)
 "ceq" = (
-/obj/wingrille_spawn/auto,
-/obj/cable,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/disposalpipe/segment/brig{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
 "cer" = (
 /turf/simulated/floor/plating,
@@ -48859,12 +45910,9 @@
 /turf/space,
 /area/space)
 "ceF" = (
-/obj/lattice{
-	dir = 4;
-	icon_state = "lattice-dir"
-	},
-/turf/space,
-/area/station/ai_monitored/armory)
+/obj/disposalpipe/segment/mail/bent/east,
+/turf/simulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/kitchen)
 "ceH" = (
 /obj/table/auto,
 /obj/item/clothing/mask/surgical,
@@ -48904,20 +45952,10 @@
 	dir = 4
 	},
 /area/station/medical/medbay/surgery)
-"ceK" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/light/runway_light,
-/turf/space,
-/area/station/ai_monitored/armory)
 "ceL" = (
-/obj/machinery/light/runway_light/delay3,
-/obj/lattice{
-	icon_state = "lattice-dir"
-	},
-/turf/space,
-/area/station/ai_monitored/armory)
+/obj/disposalpipe/segment/mail/horizontal,
+/turf/simulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/kitchen)
 "ceM" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -49156,18 +46194,17 @@
 /turf/simulated/floor/plating,
 /area/station/medical/medbay)
 "cfo" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/machinery/disposal,
+/obj/disposalpipe/trunk/west,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 9;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
 	},
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/turf/simulated/floor/escape{
-	dir = 4
-	},
-/area/station/hallway/secondary/exit)
+/turf/simulated/floor/escape/corner,
+/area/station/hallway/primary/east)
 "cfp" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -49197,6 +46234,49 @@
 /area/station/mining/staff_room)
 "cfr" = (
 /obj/table/reinforced/auto,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "kitchen";
+	layer = 4;
+	name = "Kitchen Shutter";
+	opacity = 0;
+	p_open = 1
+	},
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 4
+	},
+/obj/access_spawn/kitchen,
+/turf/simulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/kitchen)
+"cfs" = (
+/obj/lattice{
+	dir = 6;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/turf/space,
+/area/station/ai_monitored/armory)
+"cft" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/landmark/halloween,
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
+"cfu" = (
+/obj/stool/bar,
+/turf/simulated/floor/carpet/green/fancy/edge/west,
+/area/station/crew_quarters/cafeteria)
+"cfv" = (
+/obj/table/reinforced/auto,
 /obj/item/storage/box/flashbang_kit,
 /obj/item/storage/box/flashbang_kit,
 /obj/item/storage/box/flashbang_kit,
@@ -49210,64 +46290,12 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
-"cfs" = (
-/obj/table/reinforced/auto,
-/obj/item/gun/kinetic/riot40mm{
-	pixel_y = 10
-	},
-/obj/item/ammo/bullets/smoke,
-/obj/item/ammo/bullets/smoke,
-/obj/item/gun/kinetic/riot40mm,
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
-"cft" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/turret,
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
-"cfu" = (
-/obj/rack,
-/obj/item/clothing/suit/armor/EOD,
-/obj/item/clothing/suit/armor/EOD,
-/obj/item/clothing/head/helmet/EOD,
-/obj/item/clothing/head/helmet/EOD,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/glasses/thermal,
-/obj/item/clothing/glasses/thermal,
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
-"cfv" = (
-/obj/rack,
-/obj/item/clothing/suit/armor/heavy,
-/obj/item/clothing/suit/armor/heavy,
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/glasses/thermal,
-/obj/item/clothing/glasses/thermal,
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
 "cfw" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
+/obj/stool/chair,
+/turf/simulated/floor/neutral/side{
+	dir = 8
 	},
-/obj/machinery/light/runway_light/delay2,
-/turf/space,
-/area/station/ai_monitored/armory)
+/area/station/crew_quarters/quarters_south)
 "cfx" = (
 /obj/machinery/atmospherics/pipe/vent{
 	dir = 4
@@ -49536,12 +46564,14 @@
 /turf/simulated/floor/caution/westeast,
 /area/station/quartermaster/office)
 "cgb" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/redblack/corner{
+/obj/stool/chair{
 	dir = 4
 	},
+/obj/machinery/light/emergency,
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/green/fancy/edge/sw,
 /area/station/crew_quarters/courtroom)
 "cgc" = (
 /obj/lattice{
@@ -49602,14 +46632,6 @@
 /obj/machinery/r_door_control/podbay/medbay,
 /turf/simulated/wall/auto/supernorn,
 /area/station/hangar/medical)
-"cgk" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/ai_monitored/armory)
 "cgl" = (
 /obj/machinery/vehicle/miniputt/armed{
 	dir = 1
@@ -49881,21 +46903,34 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "cgP" = (
-/obj/machinery/portable_atmospherics/pump,
-/turf/simulated/floor/plating,
-/area/station/maintenance/central)
+/obj/decal/cleanable/dirt,
+/obj/item/raw_material/shard/glass,
+/turf/simulated/floor/plating/damaged1,
+/area/station/crew_quarters/quarters_south)
 "cgQ" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/bent/east,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "cgR" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
+/obj/disposalpipe/segment/vertical,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/light/runway_light/delay5,
-/turf/space,
-/area/station/ai_monitored/armory)
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/obj/machinery/light_switch/east,
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/crew_quarters/quarters_south)
 "cgS" = (
 /obj/lattice{
 	dir = 1;
@@ -49941,34 +46976,19 @@
 /turf/simulated/floor/caution/east,
 /area/station/medical/robotics)
 "cgZ" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
+/obj/lattice,
+/obj/machinery/turret,
+/turf/space,
 /area/station/ai_monitored/armory)
 "cha" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/ai_monitored/armory)
+/turf/simulated/floor/escape,
+/area/station/hallway/primary/east)
 "chb" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/stool/chair{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/ai_monitored/armory)
+/turf/simulated/floor/escape,
+/area/station/hallway/primary/east)
 "chc" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/south,
@@ -50000,26 +47020,19 @@
 /turf/space,
 /area/space)
 "chk" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
-	},
-/turf/space,
-/area/station/ai_monitored/armory)
+/obj/table/auto,
+/obj/item/game_kit,
+/obj/machinery/light,
+/turf/simulated/floor/escape,
+/area/station/hallway/primary/east)
 "chl" = (
-/obj/lattice{
-	dir = 5;
-	icon_state = "lattice-dir-b"
+/obj/stool/chair{
+	dir = 8
 	},
-/obj/machinery/light/runway_light/delay3,
-/turf/space,
-/area/station/ai_monitored/armory)
+/turf/simulated/floor/escape{
+	dir = 6
+	},
+/area/station/hallway/primary/east)
 "chm" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/machinery/door/poddoor/pyro{
@@ -50050,10 +47063,10 @@
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "chs" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/redblack/corner,
+/obj/table/reinforced/auto,
+/obj/item/paper/book/space_law,
+/obj/machinery/light,
+/turf/simulated/floor/carpet/green/fancy/edge/se,
 /area/station/crew_quarters/courtroom)
 "cht" = (
 /obj/machinery/computer3/terminal/zeta{
@@ -50086,17 +47099,10 @@
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
 "chx" = (
-/obj/machinery/door/airlock/pyro/security{
-	dir = 4;
-	name = "Defendant's Stand"
-	},
-/obj/access_spawn/brig,
-/obj/firedoor_spawn,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/red,
-/area/station/security/brig)
+/obj/random_item_spawner/junk/one_or_zero,
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/routing/depot)
 "chy" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/testchamber)
@@ -50543,16 +47549,10 @@
 /turf/simulated/floor/plating/airless/asteroid/dark,
 /area/space)
 "ciB" = (
-/obj/storage/crate,
-/obj/item/clothing/under/jersey/red,
-/obj/item/clothing/under/jersey/purple,
-/obj/item/clothing/under/jersey/green,
-/obj/item/clothing/under/jersey/black,
-/obj/item/clothing/under/jersey,
-/obj/item/basketball{
-	desc = "Something beautiful overwhelms you when you look at this ball.";
-	name = "barkley's basketball"
-	},
+/obj/rack,
+/obj/item/furniture_parts/bed,
+/obj/item/furniture_parts/table,
+/obj/item/furniture_parts/table,
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/utility)
 "ciC" = (
@@ -52735,11 +49735,25 @@
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "cnR" = (
-/turf/simulated/floor/caution/westeast,
-/area/station/hallway/secondary/exit)
+/obj/reagent_dispensers/still,
+/turf/simulated/floor/plating,
+/area/station/routing/depot)
 "cnS" = (
-/turf/simulated/floor/shuttlebay,
-/area/station/hallway/secondary/exit)
+/obj/table/reinforced/auto,
+/obj/item/kitchen/utensil/knife,
+/obj/item/kitchen/utensil/spoon,
+/obj/item/kitchen/utensil/fork,
+/obj/item/plate,
+/obj/item/reagent_containers/food/drinks/bowl,
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/specialroom/cafeteria{
+	dir = 1
+	},
+/area/station/crew_quarters/kitchen)
 "cnT" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -52779,23 +49793,14 @@
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "cnX" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
+/obj/wingrille_spawn/auto,
+/obj/cable,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/redblack{
-	dir = 8
-	},
-/area/station/security/brig)
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/courtroom)
 "cnY" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -52805,11 +49810,6 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
-"cnZ" = (
-/obj/lattice,
-/obj/machinery/light/runway_light/delay4,
-/turf/space,
-/area/station/ai_monitored/armory)
 "coa" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -52955,49 +49955,31 @@
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "cos" = (
-/obj/disposalpipe/segment/brig{
-	dir = 8
+/obj/machinery/navbeacon{
+	codes_txt = "tour;next_tour=tour2;desc=Whether you've been in a long sleep or on a long trip, the on-station bar and cafeteria is sure to get you up and running again. Try the arcade, too!";
+	freq = 1443;
+	location = "tour1";
+	name = "tour 1 - bar"
 	},
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/redblack/corner{
-	dir = 8
-	},
-/area/station/security/brig)
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
 "cot" = (
-/obj/disposalpipe/segment/brig{
-	dir = 8
-	},
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
+	},
+/obj/disposalpipe/segment/brig{
+	dir = 8
 	},
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
 /area/station/security/brig)
 "cou" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/cable{
-	icon_state = "1-4"
+/obj/disposalpipe/segment/brig{
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/station/security/brig)
@@ -53239,88 +50221,51 @@
 /turf/simulated/floor/plating,
 /area/station/routing/depot)
 "coL" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/checkpoint/escape)
+/turf/simulated/floor/carpet/red/fancy/edge/west,
+/area/station/crew_quarters/quarters_north)
 "coM" = (
-/obj/table/reinforced/auto,
-/obj/access_spawn/security,
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/firedoor_spawn,
-/obj/machinery/door/airlock/pyro/glass/windoor,
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/red,
-/area/station/security/checkpoint/escape)
+/turf/simulated/floor/carpet/red,
+/area/station/crew_quarters/quarters_north)
 "coN" = (
-/obj/table/reinforced/auto,
-/obj/machinery/cashreg,
-/obj/access_spawn/security,
-/obj/disposalpipe/segment/brig{
+/obj/stool/chair,
+/turf/simulated/floor/carpet/red/fancy/edge/east,
+/area/station/crew_quarters/quarters_north)
+"coO" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crew_quarters/quarters_north)
+"coP" = (
+/obj/stool/chair,
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/orange/side{
 	dir = 1
 	},
-/obj/firedoor_spawn,
-/obj/machinery/door/airlock/pyro/glass/windoor,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/red,
-/area/station/security/checkpoint/escape)
-"coO" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/checkpoint/escape)
-"coP" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
 /area/station/crew_quarters/catering)
 "coQ" = (
-/obj/wingrille_spawn/auto,
+/obj/machinery/computer/ordercomp{
+	dir = 8
+	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/power/data_terminal,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
 	},
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/catering)
-"coR" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/turf/simulated/floor/orange/side{
+	dir = 5
 	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
 /area/station/crew_quarters/catering)
 "coT" = (
 /obj/cable{
@@ -53353,8 +50298,12 @@
 	},
 /area/station/hydroponics/bay)
 "coV" = (
-/turf/unsimulated/floor/sanitary,
-/area/station/crewquarters/cryotron)
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/quarters_east)
 "coW" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -53391,30 +50340,15 @@
 	},
 /area/station/mining/staff_room)
 "coZ" = (
-/obj/stool/chair,
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/orange/side{
-	dir = 1
-	},
+/turf/simulated/floor,
 /area/station/crew_quarters/catering)
 "cpa" = (
 /obj/wingrille_spawn/auto,
-/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/catering)
 "cpb" = (
@@ -53498,14 +50432,10 @@
 	},
 /area/station/crew_quarters/catering)
 "cpl" = (
-/obj/wingrille_spawn/auto,
-/obj/health_scanner/wall{
-	layer = 3.3
+/obj/machinery/vending/medical,
+/turf/simulated/floor/bluewhite{
+	dir = 9
 	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
 /area/station/medical/medbooth)
 "cpm" = (
 /obj/table/reinforced/chemistry/auto,
@@ -53547,18 +50477,15 @@
 /turf/space,
 /area/space)
 "cpr" = (
-/obj/table/reinforced/auto,
-/obj/machinery/cashreg,
-/obj/disposalpipe/segment/horizontal,
-/obj/firedoor_spawn,
-/obj/machinery/door/airlock/pyro/glass/windoor{
-	dir = 4
+/obj/storage/secure/closet/medical/medicine,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -20
 	},
-/obj/cable{
-	icon_state = "1-2"
+/obj/item/clothing/glasses/spectro,
+/turf/simulated/floor/bluewhite{
+	dir = 8
 	},
-/obj/access_spawn/medical,
-/turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbooth)
 "cps" = (
 /obj/stool/chair/yellow{
@@ -53580,12 +50507,15 @@
 /turf/simulated/floor,
 /area/station/mining/staff_room)
 "cpt" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	icon_state = "0-2"
+/obj/storage/secure/closet/medical/medkit,
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
 	},
-/obj/cable,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/bluewhite{
+	dir = 8
+	},
 /area/station/medical/medbooth)
 "cpu" = (
 /obj/lattice{
@@ -53602,24 +50532,18 @@
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "cpw" = (
-/obj/machinery/door/airlock/pyro/glass{
+/obj/machinery/disposal/morgue,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/autoname_west,
+/obj/disposalpipe/trunk/morgue{
 	dir = 4
 	},
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/cable{
-	icon_state = "4-8"
+/turf/simulated/floor/bluewhite{
+	dir = 8
 	},
-/obj/firedoor_spawn,
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/access_spawn/medical,
-/turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbooth)
 "cpx" = (
 /obj/grille/catwalk,
@@ -53645,123 +50569,44 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "cpA" = (
-/obj/wingrille_spawn/auto,
-/obj/disposalpipe/segment/morgue{
-	dir = 4
+/obj/table/reinforced/auto,
+/obj/item/reagent_containers/glass/beaker/large/epinephrine,
+/obj/item/reagent_containers/glass/beaker/large/burn,
+/obj/item/reagent_containers/glass/beaker/large/brute,
+/obj/item/reagent_containers/glass/beaker/large/antitox,
+/obj/item/clothing/glasses/healthgoggles,
+/obj/item/reagent_containers/hypospray,
+/obj/item/scalpel,
+/obj/item/circular_saw{
+	pixel_x = 3;
+	pixel_y = 12
 	},
-/obj/cable,
-/obj/cable{
-	icon_state = "0-2"
+/obj/item/suture,
+/obj/item/staple_gun,
+/obj/item/hemostat,
+/turf/simulated/floor/bluewhite{
+	dir = 8
 	},
-/turf/simulated/floor/plating,
 /area/station/medical/medbooth)
 "cpB" = (
-/obj/machinery/door/airlock/pyro/command{
-	dir = 4;
-	name = "Captain's Quarters";
-	req_access = null
+/obj/stool/chair/comfy{
+	dir = 8
 	},
-/obj/access_spawn/captain,
+/obj/landmark/start{
+	name = "Captain"
+	},
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
-/obj/firedoor_spawn,
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/grey,
+/turf/simulated/floor/carpet/arcade,
 /area/station/bridge/captain)
 "cpC" = (
-/obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/right{
-	dir = 4
-	},
+/obj/machinery/computer3/generic/communications,
 /obj/cable,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/carpet/arcade,
 /area/station/bridge/captain)
 "cpD" = (
-/obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/left,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/bridge/captain)
-"cpE" = (
-/obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/middle,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/bridge/captain)
-"cpF" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/window_blinds/cog2/left{
-	dir = 8
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/bridge/captain)
-"cpG" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/window_blinds/cog2/middle{
-	dir = 8
-	},
-/obj/cable,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/bridge/captain)
-"cpH" = (
-/obj/table/wood/auto,
-/obj/machinery/phone,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/bridge/captain)
-"cpI" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/bridge/captain)
-"cpJ" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/window_blinds/cog2/middle{
-	dir = 8
-	},
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/bridge/captain)
-"cpK" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/window_blinds/cog2/middle{
 	dir = 9
@@ -53773,7 +50618,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/bridge/captain)
-"cpL" = (
+"cpE" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/window_blinds/cog2/middle,
 /obj/cable{
@@ -53786,21 +50631,92 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/bridge/captain)
+"cpF" = (
+/obj/machinery/navbeacon{
+	codes_txt = "tour;next_tour=tour3;desc=In the event of minor to moderate injuries, you can stop by this convenient booth instead of going all the way to Medbay.";
+	freq = 1443;
+	location = "tour2";
+	name = "tour 2 - medbooth"
+	},
+/turf/simulated/floor/blue/side{
+	dir = 8
+	},
+/area/station/hallway/primary/south)
+"cpG" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
+	},
+/turf/simulated/floor/blue/side{
+	dir = 8
+	},
+/area/station/hallway/primary/south)
+"cpH" = (
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
+"cpI" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
+"cpJ" = (
+/obj/disposalpipe/segment/morgue{
+	icon_state = "pipe-c"
+	},
+/obj/stool/chair/blue{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/blue/side{
+	dir = 8
+	},
+/area/station/hallway/primary/south)
+"cpK" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 1
+	},
+/turf/simulated/floor/blue/side{
+	dir = 8
+	},
+/area/station/hallway/primary/south)
+"cpL" = (
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
 "cpM" = (
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
+"cpN" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/window_blinds/cog2/right,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/bridge/captain)
-"cpN" = (
-/obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/middle{
-	dir = 5
-	},
-/obj/cable,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -54043,6 +50959,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/eva)
+"cqq" = (
+/obj/storage/crate,
+/obj/item/device/radio/headset/multifreq,
+/obj/item/device/radio/headset/multifreq,
+/obj/item/device/radio/headset/medical,
+/obj/item/device/radio/headset/medical,
+/obj/item/device/radio/headset/security,
+/obj/item/device/radio/headset/security,
+/obj/item/device/radio/headset/engineer,
+/obj/item/device/radio/headset/engineer,
+/obj/item/device/radio/headset/research,
+/obj/item/device/radio/headset/research,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/autoname_east,
+/turf/simulated/floor/black,
+/area/station/bridge)
 "cqu" = (
 /obj/wingrille_spawn/auto,
 /obj/machinery/door/poddoor/pyro{
@@ -54111,6 +51046,34 @@
 /obj/machinery/drainage,
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
+"ctQ" = (
+/obj/storage/crate{
+	desc = "Various supplies for the bar.";
+	name = "bartending crate"
+	},
+/obj/item/reagent_containers/food/drinks/bottle,
+/obj/item/reagent_containers/food/drinks/bottle,
+/obj/item/reagent_containers/food/drinks/bottle,
+/obj/item/reagent_containers/food/drinks/bottle,
+/obj/item/reagent_containers/food/drinks/bottle,
+/obj/item/storage/firstaid/toxin,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/device/reagentscanner,
+/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
+/obj/item/reagent_containers/dropper/mechanical,
+/obj/machinery/light/small,
+/obj/cable,
+/obj/machinery/power/apc/autoname_west,
+/obj/item/clothing/glasses/spectro,
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/baroffice)
+"cuf" = (
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/turf/simulated/floor/stairs,
+/area/station/security/brig)
 "cuX" = (
 /obj/table/auto,
 /obj/item/scalpel,
@@ -54127,10 +51090,38 @@
 /obj/item/clothing/mask/surgical_shield,
 /turf/simulated/floor/caution/east,
 /area/station/medical/robotics)
+"cvn" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/bridge/captain)
 "cxo" = (
 /obj/machinery/light_switch/east,
 /turf/simulated/floor,
 /area/station/hallway/secondary/south)
+"cyS" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet,
+/obj/item/device/radio/intercom,
+/turf/simulated/floor/grey/side{
+	dir = 4
+	},
+/area/space)
+"cyZ" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "red";
+	icon_state = "bedsheet-red"
+	},
+/obj/machinery/bot/secbot/beepsky,
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/beepsky)
 "czk" = (
 /obj/machinery/optable{
 	id = "robotics"
@@ -54138,19 +51129,36 @@
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/robotics)
 "czr" = (
-/obj/machinery/communications_dish{
-	tag = "MAIN_DISH_SS13"
-	},
-/turf/simulated/floor/plating/airless,
-/area/station/com_dish/comdish)
+/obj/stool/bar,
+/turf/simulated/floor/carpet/green/fancy/edge/sw,
+/area/station/crew_quarters/cafeteria)
 "czV" = (
 /obj/machinery/drainage,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/robotics)
+"cAN" = (
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/turf/simulated/floor/redblack{
+	dir = 10
+	},
+/area/station/security/brig)
 "cEO" = (
-/obj/machinery/light_switch/east,
-/turf/simulated/floor/blue/checker,
+/obj/pool/perspective,
+/turf/simulated/floor/white/checker,
 /area/station/crew_quarters/pool)
+"cEY" = (
+/obj/machinery/light/runway_light/delay5,
+/obj/lattice{
+	dir = 6;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/station/ai_monitored/armory)
+"cGZ" = (
+/turf/simulated/floor/caution/westeast,
+/area/station/hallway/secondary/exit)
 "cIc" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/cable{
@@ -54179,16 +51187,48 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "cJD" = (
-/obj/stool/bench/blue/auto,
-/obj/machinery/light_switch/east,
-/turf/simulated/floor/sanitary,
+/obj/machinery/shower{
+	dir = 4;
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/sanitary/white,
 /area/station/crew_quarters/pool)
+"cJT" = (
+/obj/machinery/light/runway_light/delay2,
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/station/ai_monitored/armory)
+"cLc" = (
+/obj/critter/cat/jones,
+/turf/simulated/floor/carpet/blue/fancy/edge/east,
+/area/station/bridge)
+"cLJ" = (
+/obj/wingrille_spawn/auto,
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbooth)
 "cPy" = (
 /obj/decal/tile_edge/stripe/big{
 	dir = 8
 	},
 /turf/simulated/floor/grey,
 /area/station/medical/robotics)
+"cRS" = (
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
+	},
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
 "cSO" = (
 /obj/stool/bench/green/auto,
 /obj/landmark/start{
@@ -54196,6 +51236,24 @@
 	},
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
+"cTe" = (
+/obj/disposalpipe/segment/mail/vertical,
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
+"cTh" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
+	},
+/turf/simulated/floor/black,
+/area/station/bridge)
 "cTm" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -54216,6 +51274,10 @@
 	dir = 4
 	},
 /area/station/science/bot_storage)
+"cVH" = (
+/obj/disposalpipe/junction/right/north,
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
 "cZf" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -54235,29 +51297,42 @@
 /turf/simulated/floor/plating/airless/asteroid/dark,
 /area/station/garden/owlery)
 "daF" = (
-/obj/wingrille_spawn/auto,
-/obj/cable,
+/obj/submachine/slot_machine,
+/turf/simulated/floor/carpet/green/fancy/edge/se,
+/area/station/crew_quarters/cafeteria)
+"dcK" = (
+/obj/machinery/disposal/cart_port,
+/obj/disposalpipe/trunk/east,
+/turf/simulated/floor/specialroom/arcade,
+/area/station/janitor/supply)
+"ddK" = (
+/obj/machinery/networked/storage/tape_drive{
+	bank_id = "Control";
+	locked = 0;
+	name = "Databank - Control";
+	setup_drive_type = /obj/item/disk/data/tape/master
+	},
 /obj/cable{
+	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/plating,
-/area/station/hangar/engine)
-"dcK" = (
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"ddK" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "dew" = (
-/obj/machinery/weapon_stand/shotgun_rack,
+/obj/machinery/weapon_stand/rifle_rack/recharger,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
+"dgn" = (
+/obj/machinery/light,
+/turf/simulated/floor/escape{
+	dir = 8
+	},
+/area/station/hallway/secondary/exit)
+"dgp" = (
+/obj/machinery/light,
+/turf/simulated/floor/grass,
+/area/station/hydroponics/bay)
 "dgq" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -54266,30 +51341,27 @@
 /obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
+"dgw" = (
+/obj/decal/poster/wallsign/medal,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/bridge/hos)
 "dii" = (
 /obj/landmark/halloween,
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "diS" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
 	},
-/obj/machinery/light_switch/north,
-/turf/simulated/floor/yellow/side{
-	dir = 1
-	},
+/turf/simulated/floor/plating,
 /area/station/hangar/engine)
 "djG" = (
-/obj/decal/garland/ephemeral{
-	dir = 8;
-	pixel_x = 14
-	},
-/turf/simulated/floor/neutral/side{
+/obj/disposalpipe/segment/mail/bent/north,
+/turf/simulated/floor/yellow/side{
 	dir = 4
 	},
-/area/station/hallway/primary/north)
+/area/station/engine/elect)
 "dlp" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 4
@@ -54309,25 +51381,46 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
-"doC" = (
-/obj/decal/poster/wallsign/stencil/left/e{
-	pixel_x = 1
+"dnz" = (
+/obj/cable{
+	icon_state = "2-4"
 	},
-/obj/decal/poster/wallsign/stencil/right/s{
-	pixel_x = 14
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/secondary/exit)
-"dpv" = (
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
-"dqk" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail/horizontal,
+/turf/simulated/floor/black/corner{
+	dir = 1
+	},
+/area/station/bridge)
+"dop" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/light/runway_light/delay3,
+/turf/space,
+/area/station/ai_monitored/armory)
+"doC" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"dpv" = (
+/turf/simulated/floor/stairs/wide/other{
+	dir = 8
+	},
+/area/station/maintenance/northeast)
+"dqk" = (
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/obj/disposalpipe/segment/mail/bent/north,
+/turf/simulated/floor/neutral/side,
 /area/station/hallway/primary/north)
 "dqu" = (
 /obj/cable{
@@ -54335,6 +51428,10 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/medical/robotics)
+"drg" = (
+/obj/machinery/door/airlock/pyro/external,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "drx" = (
 /obj/machinery/conveyor{
 	name = "cargo belt - south";
@@ -54342,32 +51439,93 @@
 	},
 /turf/simulated/floor/airless/grey,
 /area/station/maintenance/west)
+"dtX" = (
+/obj/disposalpipe/segment/bent/north,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"dvs" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "dvx" = (
-/obj/loudspeaker,
-/obj/machinery/light/emergency{
-	dir = 4;
-	pixel_x = 10
+/obj/disposalpipe/segment/brig{
+	dir = 1
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
+"dwp" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/light/runway_light/delay2,
+/turf/space,
+/area/station/ai_monitored/armory)
 "dww" = (
 /turf/simulated/floor/airless/plating{
 	icon_state = "platingdmg3"
 	},
 /area/space)
-"dAM" = (
-/obj/wingrille_spawn/auto,
-/obj/cable,
+"dxW" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/hangar/engine)
+/area/station/ai_monitored/armory)
+"dzP" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/mail/bent/west,
+/turf/simulated/floor/stairs/wide/other{
+	dir = 8
+	},
+/area/station/bridge)
+"dAM" = (
+/obj/table/wood/auto,
+/obj/item/reagent_containers/food/drinks/bottle/champagne{
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/flute{
+	pixel_x = -8
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/flute{
+	pixel_x = 6;
+	pixel_y = -1
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/south,
+/area/station/crew_quarters/heads{
+	name = "Diplomatic Quarters"
+	})
 "dBo" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
+"dEP" = (
+/obj/grille/catwalk{
+	dir = 9
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8;
+	icon_state = "catwalk_cross"
+	},
+/area/station/maintenance/southeast)
 "dFf" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
@@ -54387,6 +51545,23 @@
 	dir = 4
 	},
 /area/station/routing/security)
+"dGO" = (
+/obj/machinery/computer/security/wooden_tv{
+	desc = "These channels seem to mostly be about robuddies. What is this, some kind of reality show?";
+	name = "Television";
+	network = "Zeta"
+	},
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/carpet/purple/fancy/edge/north,
+/area/station/science/research_director)
+"dHE" = (
+/obj/stool/chair/wooden{
+	dir = 4
+	},
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
 "dHS" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -54399,6 +51574,16 @@
 	},
 /turf/simulated/floor/airless/plating,
 /area/station/maintenance/west)
+"dMb" = (
+/obj/decal/cleanable/ash,
+/obj/cable{
+	icon_state = "2-5"
+	},
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/station/maintenance/southeast)
 "dOy" = (
 /turf/simulated/floor/redwhite{
 	dir = 8
@@ -54408,6 +51593,10 @@
 /obj/machinery/portable_reclaimer,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
+"dRl" = (
+/obj/grille/steel,
+/turf/space,
+/area/station/com_dish/comdish)
 "dTh" = (
 /obj/machinery/atmospherics/valve{
 	dir = 4
@@ -54423,6 +51612,34 @@
 /obj/decal/poster/wallsign/security,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/main)
+"dVW" = (
+/obj/machinery/computer/announcement{
+	dir = 4;
+	name = "Executive Announcement Computer";
+	pixel_x = -3;
+	pixel_y = 4;
+	req_access_txt = "19"
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/sanitary/white,
+/area/station/bridge/captain)
+"dWe" = (
+/obj/stool/chair/office{
+	dir = 4
+	},
+/obj/landmark/start{
+	name = "Medical Director"
+	},
+/turf/simulated/floor/carpet/blue,
+/area/station/crew_quarters/md)
 "dWS" = (
 /obj/machinery/light_switch/east,
 /obj/machinery/camera{
@@ -54440,32 +51657,53 @@
 /turf/simulated/floor/white/grime,
 /area/station/hangar/medical)
 "dWT" = (
-/obj/decal/cleanable/dirt,
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 4
+	},
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/white,
+/area/station/crew_quarters/pool)
 "dXg" = (
+/obj/table/wood/auto,
+/obj/item/football{
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/drinks/cola{
+	pixel_x = 8
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/carpet/green/fancy/edge/ne,
+/area/station/crew_quarters/quarters_south)
+"dZr" = (
+/obj/critter/mouse,
+/turf/simulated/floor/plating,
+/area/station/routing/depot)
+"ean" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/decal/cleanable/dirt,
-/obj/critter/mouse,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
-"dZr" = (
-/obj/critter/mouse,
-/turf/simulated/floor/plating,
-/area/station/routing/depot)
-"ebk" = (
-/obj/machinery/door/airlock/pyro/command{
-	dir = 4;
-	name = "Silicon Recharge Bay"
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
-/obj/access_spawn/ai_upload,
-/turf/simulated/floor/darkblue,
-/area/station/turret_protected/ai)
+/turf/simulated/floor/black,
+/area/station/turret_protected/Zeta)
+"ebk" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/arcade/dungeon)
 "ecb" = (
 /obj/machinery/computer/barcode{
 	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Pod Bay","Research","Security","QM");
@@ -54477,6 +51715,17 @@
 	},
 /turf/simulated/floor/caution/north,
 /area/station/hangar/medical)
+"ecp" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "black";
+	icon_state = "bedsheet-black"
+	},
+/obj/landmark/start{
+	name = "Bartender"
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/baroffice)
 "egj" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -54489,13 +51738,22 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
 "ehh" = (
-/obj/table/auto,
-/obj/random_item_spawner/tableware,
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
 	},
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
+/obj/stove,
+/obj/item/soup_pot{
+	pixel_x = 4;
+	pixel_y = 10
+	},
+/obj/item/ladle{
+	pixel_x = -2;
+	pixel_y = 11
+	},
+/turf/simulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/kitchen)
 "eiE" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
@@ -54516,25 +51774,38 @@
 	},
 /area/station/security/main)
 "emI" = (
-/obj/stool/chair/red{
-	dir = 4
+/obj/lattice{
+	icon_state = "lattice-dir"
 	},
-/obj/machinery/turretid{
-	pixel_x = -26;
-	req_access = null;
-	req_access_txt = "1"
+/turf/space,
+/area/station/ai_monitored/armory)
+"emL" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/engine,
+/turf/simulated/floor/plating,
 /area/station/ai_monitored/armory)
 "enW" = (
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/arcade/dungeon)
+"eoN" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
+"epm" = (
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/disposalpipe/segment/horizontal,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
 "epP" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/simulated/floor/plating,
@@ -54551,6 +51822,23 @@
 	dir = 4
 	},
 /area/station/hangar/medical)
+"erR" = (
+/obj/stool,
+/obj/item/device/radio/intercom{
+	dir = 4
+	},
+/turf/simulated/floor/grey/side{
+	dir = 8
+	},
+/area/station/security/brig)
+"eyl" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "eyB" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -54559,17 +51847,24 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
+"ezo" = (
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/turf/simulated/floor/grime,
+/area/station/security/brig)
 "ezW" = (
-/obj/machinery/vehicle/escape_pod{
-	dir = 4
-	},
-/turf/simulated/floor/shuttlebay{
-	icon_state = "engine_caution_west"
-	},
-/area/station/hallway/secondary/exit)
+/obj/machinery/door/airlock/pyro/maintenance,
+/turf/simulated/floor/red/checker,
+/area/station/maintenance/central)
 "eCr" = (
-/obj/stool/chair/office/blue{
-	dir = 8
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
@@ -54577,22 +51872,27 @@
 /obj/disposalpipe/junction/left/south,
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
+"eFY" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/grey,
+/area/station/bridge)
 "eGO" = (
 /obj/lattice{
 	dir = 4;
 	icon_state = "lattice-dir"
 	},
-/obj/machinery/light/runway_light/delay2,
+/obj/machinery/light/runway_light/delay3,
 /turf/space,
 /area/station/ai_monitored/armory)
 "eLc" = (
-/obj/machinery/light/emergency{
-	dir = 4;
-	pixel_x = 10
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/neutral/side{
-	dir = 4
-	},
+/turf/simulated/floor,
 /area/station/hallway/primary/north)
 "eMs" = (
 /obj/disposalpipe/segment/vertical,
@@ -54603,50 +51903,71 @@
 /obj/machinery/atmospherics/pipe/simple/junction,
 /turf/space,
 /area/space)
-"ePH" = (
-/obj/machinery/light/runway_light/delay4,
-/obj/lattice{
-	icon_state = "lattice-dir"
+"eMY" = (
+/obj/disposalpipe/segment/horizontal,
+/turf/simulated/floor/blue/side{
+	dir = 8
 	},
-/turf/space,
-/area/station/ai_monitored/armory)
+/area/station/hallway/primary/south)
 "eQE" = (
 /obj/grille/catwalk,
 /obj/machinery/oreaccumulator,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/mining/refinery)
+"eVv" = (
+/obj/machinery/light,
+/turf/simulated/floor,
+/area/station/crew_quarters/courtroom)
 "eWB" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
+"eWF" = (
+/obj/stool/chair{
+	dir = 8
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/quarters_south)
+"eXF" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/orangeblack,
+/area/station/crew_quarters/ce)
 "eZW" = (
 /obj/wingrille_spawn/auto,
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/mining/refinery)
 "fdN" = (
-/obj/decal/tile_edge/line/white{
-	dir = 8;
-	icon_state = "line1"
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/decal/tile_edge/line/white{
-	dir = 10;
-	icon_state = "line4"
-	},
-/obj/decal/tile_edge/line/white{
-	dir = 5;
-	icon_state = "line1"
-	},
-/turf/simulated/floor/darkblue,
+/turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
-"fhN" = (
-/obj/lattice{
-	dir = 9;
-	icon_state = "lattice-dir-b"
+"fhi" = (
+/obj/plasticflaps,
+/obj/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/light/runway_light/delay2,
-/turf/space,
-/area/station/ai_monitored/armory)
+/turf/simulated/floor/plating,
+/area/station/security/beepsky)
+"fhN" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -20
+	},
+/turf/simulated/floor/escape{
+	dir = 8
+	},
+/area/station/hallway/secondary/exit)
 "fhZ" = (
 /obj/wingrille_spawn/auto,
 /obj/machinery/atmospherics/pipe/manifold{
@@ -54662,20 +51983,21 @@
 	name = "Inner Southwest Maintenance"
 	})
 "fje" = (
-/obj/decal/garland/ephemeral{
-	dir = 4;
-	pixel_x = -14
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/cafeteria)
+/turf/simulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/kitchen)
 "fjh" = (
-/obj/machinery/light,
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/door/airlock/pyro/command{
+	dir = 4;
+	name = "AI Core"
 	},
-/turf/simulated/floor/circuit,
+/obj/access_spawn/ai_upload,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "fjF" = (
 /obj/table/auto,
@@ -54684,16 +52006,32 @@
 /obj/item/staple_gun,
 /turf/simulated/floor/caution/east,
 /area/station/medical/robotics)
+"fku" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/turf/simulated/floor/red,
+/area/station/ai_monitored/armory)
 "fkO" = (
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 4
+	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/landmark/halloween,
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "fld" = (
-/obj/decal/cleanable/dirt,
-/obj/random_item_spawner/junk/one_or_zero,
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "fle" = (
@@ -54708,11 +52046,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "flj" = (
-/obj/machinery/light/emergency,
-/turf/simulated/floor/neutral/side{
+/obj/stool/chair{
 	dir = 8
 	},
-/area/station/hallway/primary/east)
+/obj/machinery/light,
+/turf/unsimulated/floor/sanitary,
+/area/station/crewquarters/cryotron)
 "foi" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 6
@@ -54725,56 +52064,123 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "fpD" = (
-/obj/stool/chair/comfy{
-	dir = 4
-	},
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/wood/two,
-/area/station/crew_quarters/barber_shop)
+/obj/disposalpipe/segment/mail/vertical,
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
 "fqj" = (
-/obj/machinery/recharge_station,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
+/obj/disposalpipe/segment/mail/horizontal,
 /obj/machinery/camera{
 	c_tag = "autotag";
-	dir = 8;
+	dir = 0;
 	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
+	pixel_y = 20
 	},
-/mob/living/silicon/hivebot/eyebot,
-/turf/simulated/floor/darkblue,
-/area/station/turret_protected/ai)
+/obj/item/device/radio/intercom/catering{
+	pixel_x = 3;
+	pixel_y = 24
+	},
+/obj/stool/chair,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
 "frY" = (
 /turf/simulated/wall/auto/reinforced/supernorn/yellow,
 /area/station/mining/staff_room)
-"fvz" = (
+"fsM" = (
+/obj/machinery/door/airlock/pyro/maintenance,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/light_switch/east,
-/turf/simulated/floor/neutral/side{
-	dir = 4
-	},
-/area/station/crew_quarters/quarters_north)
-"fwt" = (
-/obj/machinery/vending/cola/blue,
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/blue/side{
+/obj/firedoor_spawn,
+/turf/simulated/floor/greenblack{
 	dir = 1
 	},
-/area/station/hallway/primary/south)
+/area/station/garden/aviary)
+"ftc" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/left{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/turret_protected/Zeta)
+"fts" = (
+/obj/machinery/door/airlock/pyro/command{
+	aiControlDisabled = 1;
+	name = "Armory";
+	req_access = null
+	},
+/obj/access_spawn/hos,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
+"fvz" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "pink";
+	icon_state = "bedsheet-pink"
+	},
+/obj/item/storage/secure/ssafe{
+	pixel_x = 28
+	},
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/turf/simulated/floor/carpet/purple/fancy/edge/se,
+/area/station/crew_quarters/quarters_north)
+"fwt" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/box/plates,
+/obj/item/storage/box/cutlery,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/autoname_west,
+/turf/simulated/floor/white,
+/area/station/crew_quarters/kitchen)
 "fyL" = (
-/obj/lattice,
-/obj/machinery/light/runway_light/delay5,
+/obj/table/auto,
+/obj/item/reagent_containers/food/snacks/breadloaf,
+/obj/item/kitchen/utensil/knife,
+/obj/machinery/light_switch/east,
+/turf/simulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/kitchen)
+"fyU" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/left,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/bridge/captain)
+"fzc" = (
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Holding Cell One"
+	},
+/obj/access_spawn/brig,
+/turf/simulated/floor/black,
+/area/space)
+"fzA" = (
+/obj/machinery/chem_heater,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
+	},
+/obj/item/device/radio/intercom/medical{
+	pixel_x = 4;
+	pixel_y = 24
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/ne,
+/area/station/crew_quarters/md)
+"fCh" = (
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir"
+	},
 /turf/space,
 /area/station/ai_monitored/armory)
 "fCz" = (
@@ -54786,6 +52192,11 @@
 	dir = 4
 	},
 /area/station/hallway/primary/west)
+"fCO" = (
+/obj/machinery/floorflusher/solitary2,
+/obj/disposalpipe/trunk/south,
+/turf/simulated/floor/black,
+/area/station/security/brig)
 "fEt" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -54801,32 +52212,63 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "fIF" = (
-/obj/submachine/cargopad{
-	name = "Utility Room Pad"
+/obj/machinery/door/airlock/pyro{
+	name = "Serving Area"
 	},
-/turf/simulated/floor/grime,
-/area/station/crew_quarters/utility)
+/obj/access_spawn/bar,
+/obj/firedoor_spawn,
+/obj/access_spawn/kitchen,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/cafeteria)
 "fIG" = (
-/obj/disposalpipe/segment/brig{
+/obj/landmark/spawner{
+	name = "monkeyspawn_mrmuggles"
+	},
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
+"fNP" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/light/runway_light,
+/turf/space,
+/area/station/ai_monitored/armory)
+"fTm" = (
+/obj/stool/chair{
 	dir = 8
 	},
-/obj/machinery/light/emergency{
-	dir = 1;
-	pixel_y = 16
+/turf/simulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/barber_shop)
+"fUr" = (
+/obj/stool/chair/comfy/purple{
+	dir = 4
 	},
-/turf/simulated/floor/neutral/side{
-	dir = 1
+/obj/landmark/start{
+	name = "Research Director"
 	},
-/area/station/hallway/primary/east)
-"fTm" = (
 /obj/cable{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
-/obj/machinery/portable_atmospherics/canister/sleeping_agent,
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/carpet/purple/fancy,
+/area/station/science/research_director)
 "fUz" = (
-/obj/item/c_tube,
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple,
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "4-6"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "fVr" = (
@@ -54854,11 +52296,13 @@
 	name = "reinforced plating"
 	},
 /area/station/science/lab)
-"fVZ" = (
-/obj/lattice{
-	dir = 6;
-	icon_state = "lattice-dir"
+"fVL" = (
+/obj/stool,
+/turf/simulated/floor/grey/side{
+	dir = 4
 	},
+/area/space)
+"fVZ" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
@@ -54873,10 +52317,11 @@
 /area/station/engine/core)
 "fYL" = (
 /obj/grille/catwalk{
-	dir = 4
+	dir = 10;
+	icon_state = "catwalk_cross"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 4
+	dir = 10
 	},
 /area/station/maintenance/southeast)
 "gbf" = (
@@ -54884,25 +52329,38 @@
 /obj/landmark/halloween,
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
+"gbI" = (
+/obj/table/auto,
+/obj/machinery/cell_charger,
+/obj/item/cell/supercell/charged,
+/obj/item/cell/supercell/charged,
+/obj/machinery/light/small,
+/turf/simulated/floor/circuit,
+/area/station/bridge)
 "gda" = (
-/obj/machinery/air_vendor,
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
+/turf/simulated/wall/auto/supernorn,
+/area/station/storage/emergency)
+"gey" = (
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/blue/side{
-	dir = 1
+/turf/simulated/floor/carpet/purple/fancy,
+/area/station/science/research_director)
+"gfm" = (
+/obj/item/storage/wall/random{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = 0
 	},
-/area/station/hallway/primary/south)
+/obj/item/crowbar,
+/turf/simulated/floor/grime,
+/area/station/maintenance/southeast)
 "gga" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/decal/garland/ephemeral{
-	dir = 4;
-	pixel_x = -14
-	},
-/turf/simulated/floor/black,
-/area/station/bridge)
+/turf/simulated/floor/carpet/green,
+/area/station/bridge/hos)
 "ggb" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -54916,12 +52374,23 @@
 /obj/decal/wreath/ephemeral,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/south)
-"ggG" = (
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
+"ggB" = (
+/obj/stool/bench/blue/auto,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
 	},
-/turf/simulated/floor/grey,
+/turf/simulated/floor,
 /area/station/hallway/secondary/exit)
+"ggG" = (
+/obj/machinery/door/airlock/pyro/maintenance,
+/obj/disposalpipe/segment/vertical,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/storage/emergency)
 "gih" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
@@ -54932,6 +52401,20 @@
 	},
 /turf/simulated/floor/caution/westeast,
 /area/station/maintenance/south)
+"glX" = (
+/obj/shrub{
+	dir = 8
+	},
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
+"goj" = (
+/obj/table/wood/round/auto,
+/obj/item/storage/toolbox{
+	desc = "Looks suspiciously similar to a toolbox.";
+	name = "lunchbox"
+	},
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
 "goX" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/decal/garland/ephemeral{
@@ -54951,17 +52434,44 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /turf/simulated/floor/neutral/side{
 	dir = 1
 	},
 /area/station/hallway/primary/east)
+"gzj" = (
+/obj/storage/secure/closet/command/medical_director,
+/obj/item/storage/box/beakerbox,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
+	},
+/obj/item/clipboard,
+/obj/item/pen,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/md)
+"gzt" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
 "gCb" = (
 /obj/machinery/computer/operating,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/robotics)
+"gEo" = (
+/obj/table/reinforced/auto,
+/obj/item/gun/kinetic/riot40mm{
+	pixel_y = 10
+	},
+/obj/item/ammo/bullets/smoke,
+/obj/item/ammo/bullets/smoke,
+/obj/item/gun/kinetic/riot40mm,
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
 "gFy" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -54972,6 +52482,17 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
+"gFT" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
 "gGg" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/caution/north,
@@ -54982,6 +52503,23 @@
 /area/station/maintenance/storage{
 	name = "Inner Southwest Maintenance"
 	})
+"gHa" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/bridge)
+"gIp" = (
+/obj/submachine/chef_sink/chem_sink{
+	dir = 8;
+	pixel_x = 8
+	},
+/turf/simulated/floor/green/side{
+	dir = 10
+	},
+/area/station/hydroponics/bay)
 "gII" = (
 /obj/table/auto,
 /obj/item/bandage,
@@ -54991,6 +52529,13 @@
 /obj/item/hemostat,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/robotics)
+"gJp" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/portable_atmospherics/canister/sleeping_agent,
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
 "gKo" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -55019,16 +52564,53 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "gNp" = (
-/obj/lattice,
-/obj/machinery/turret,
-/turf/space,
-/area/station/ai_monitored/armory)
+/obj/stool/chair{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 8
+	},
+/area/station/crew_quarters/quarters_south)
 "gNH" = (
 /obj/machinery/floorflusher/industrial,
 /obj/disposalpipe/trunk/east,
 /obj/machinery/light/small,
 /turf/simulated/floor/airless/grey,
 /area/station/maintenance/west)
+"gPu" = (
+/obj/machinery/light/emergency,
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"gPz" = (
+/obj/submachine/chef_sink/chem_sink{
+	dir = 1
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 5;
+	icon_state = "line2"
+	},
+/obj/machinery/drainage,
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/md)
+"gPF" = (
+/obj/item/caution{
+	desc = "Caution! Construction Zone!";
+	name = "caution sign"
+	},
+/obj/decal/cleanable/oil,
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/grime,
+/area/station/maintenance/southeast)
+"gQp" = (
+/obj/machinery/turret,
+/turf/simulated/floor/greenblack,
+/area/station/turret_protected/Zeta)
 "gQs" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/transport{
@@ -55039,16 +52621,18 @@
 	name = "Clowntainment"
 	})
 "gQG" = (
-/obj/machinery/vending/fortune,
+/obj/disposalpipe/segment/vertical,
+/obj/landmark/halloween,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "gRo" = (
-/obj/plasticflaps,
 /obj/cable{
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/security/beepsky)
+/turf/simulated/floor,
+/area/station/security/brig)
 "gSr" = (
 /obj/storage/crate,
 /obj/item/sheet/steel/fullstack,
@@ -55061,6 +52645,19 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
+"gWl" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
 "gWW" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -55073,18 +52670,65 @@
 /turf/simulated/floor/darkblue/checker,
 /area/station/science/artifact)
 "gXb" = (
-/obj/wingrille_spawn/auto,
+/obj/disposalpipe/segment/vertical,
 /obj/cable{
-	icon_state = "0-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/station/hangar/engine)
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/crew_quarters/quarters_south)
 "gXu" = (
 /obj/table/auto,
 /obj/item/storage/box/mousetraps,
 /obj/random_item_spawner/tools,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
+"gYi" = (
+/obj/machinery/atmospherics/valve{
+	dir = 4;
+	high_risk = 1;
+	name = "Cafeteria"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"gYK" = (
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
+"has" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"haL" = (
+/obj/machinery/computer3/terminal/network{
+	dir = 4;
+	name = "CENTCOM Terminal";
+	pixel_x = -3;
+	pixel_y = 4;
+	setup_os_string = "MAIN_DISH_SS13"
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/sanitary/white,
+/area/station/bridge/captain)
 "haO" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -55102,6 +52746,15 @@
 	},
 /turf/space,
 /area/space)
+"hdO" = (
+/obj/table/reinforced/bar/auto,
+/obj/machinery/light,
+/obj/item/decoration/ashtray{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/turf/simulated/floor/carpet/green/standard/narrow/northsouth,
+/area/station/crew_quarters/cafeteria)
 "heG" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 1
@@ -55114,41 +52767,102 @@
 	dir = 4
 	},
 /area/station/hallway/primary/west)
+"hgk" = (
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
 "hgl" = (
 /obj/lattice{
-	dir = 4;
-	icon_state = "lattice-dir"
+	dir = 9;
+	icon_state = "lattice-dir-b"
 	},
-/obj/machinery/light/runway_light,
+/obj/machinery/light/runway_light/delay2,
 /turf/space,
 /area/station/ai_monitored/armory)
 "hgC" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 20
+/obj/machinery/power/apc/autoname_west/noaicontrol,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/rack,
-/obj/item/storage/box/stinger_kit,
-/obj/item/chem_grenade/pepper,
-/obj/item/chem_grenade/pepper,
-/obj/item/chem_grenade/pepper,
-/obj/item/clothing/glasses/nightvision,
-/obj/item/clothing/glasses/nightvision,
+/obj/storage/secure/crate/weapon/armory/pod_weapons,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
-"hlU" = (
-/obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	icon_state = "4-8"
+"hik" = (
+/obj/grille/catwalk{
+	dir = 6;
+	icon_state = "catwalk_cross"
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 6
+	},
+/area/station/maintenance/southeast)
+"hjl" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "kgenpopwindow";
+	name = "General Population Visitation";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig)
+"hkZ" = (
+/obj/lattice{
+	dir = 9;
+	icon_state = "lattice-dir-b"
+	},
+/obj/machinery/light/runway_light/delay5,
+/turf/space,
+/area/station/ai_monitored/armory)
+"hmd" = (
+/obj/machinery/light/runway_light,
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/station/ai_monitored/armory)
 "hmG" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
 /turf/simulated/floor/caution/westeast,
 /area/station/maintenance/south)
+"hnQ" = (
+/obj/machinery/rkit,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -20
+	},
+/turf/simulated/floor/yellowblack{
+	dir = 1
+	},
+/area/station/crew_quarters/ce)
+"hpI" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/stool/chair{
+	dir = 1
+	},
+/turf/simulated/floor/grime,
+/area/station/maintenance/southeast)
 "hrS" = (
 /obj/machinery/door/airlock/pyro/security{
 	dir = 4
@@ -55170,8 +52884,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "hwT" = (
-/obj/machinery/sleep_console{
-	dir = 8
+/obj/machinery/vending/cola/blue,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
 	},
 /turf/simulated/floor/blue/side{
 	dir = 1
@@ -55190,9 +52905,45 @@
 	},
 /area/station/medical/medbay)
 "hCK" = (
-/obj/machinery/recharge_station,
+/obj/machinery/mass_driver{
+	dir = 1;
+	id = "kd_eng"
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
+"hEI" = (
+/obj/table/reinforced/auto,
+/obj/item/paper_bin,
+/obj/item/pen/pencil,
+/obj/item/reagent_containers/food/drinks/water,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/grey/side{
+	dir = 8
+	},
+/area/station/security/brig)
+"hHd" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/window_blinds/cog2/right{
+	dir = 8
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/crew_quarters/md)
+"hIt" = (
+/turf/simulated/floor/redblack/corner{
+	dir = 8
+	},
+/area/space)
 "hNB" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -55200,8 +52951,9 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
+/obj/machinery/light/emergency{
+	dir = 1;
+	pixel_y = 16
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 1
@@ -55213,6 +52965,33 @@
 	},
 /turf/simulated/floor/airless/plating,
 /area/station/maintenance/west)
+"hSo" = (
+/obj/machinery/computer/telescope{
+	dir = 8
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
+	},
+/obj/cable,
+/turf/simulated/floor/carpet/purple/fancy/edge/east,
+/area/station/science/research_director)
+"hSC" = (
+/obj/wingrille_spawn/auto,
+/obj/health_scanner/wall{
+	layer = 3.3
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbooth)
 "hTE" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -55220,12 +52999,11 @@
 /obj/item/device/radio/intercom/cargo,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"hVr" = (
-/obj/landmark/halloween,
-/turf/simulated/floor,
-/area/station/hallway/primary/east)
 "ica" = (
-/obj/grille/steel,
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir"
+	},
 /turf/space,
 /area/station/com_dish/comdish)
 "idR" = (
@@ -55237,30 +53015,57 @@
 /area/station/maintenance/storage{
 	name = "Inner Southwest Maintenance"
 	})
+"igX" = (
+/obj/machinery/chem_dispenser,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/cafeteria)
+"ijH" = (
+/obj/storage/crate{
+	desc = "A private crate that isn't yours.";
+	name = "Beepsky's stuff"
+	},
+/obj/item/diary,
+/obj/item/clothing/shoes/black{
+	desc = "You have no idea how a robot with wheels for locomotion could possibly require these.";
+	name = "Beepsky's Shoes"
+	},
+/obj/item/storage/photo_album/beepsky,
+/obj/item/clothing/suit/det_suit/beepsky,
+/obj/item/clothing/head/NTberet{
+	desc = "It's a momento, I guess. An old keepsake. And maybe a reminder of the things we've left behind.";
+	name = "Old Beret"
+	},
+/obj/machinery/power/apc/autoname_east,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating/damaged3,
+/area/station/security/beepsky)
 "ikb" = (
-/obj/stool/chair,
-/obj/machinery/light/emergency{
-	dir = 8;
-	pixel_x = -10
+/obj/machinery/atmospherics/pipe/manifold{
+	level = 2
 	},
-/turf/simulated/floor/neutral/side{
-	dir = 8
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"ikL" = (
+/obj/table/reinforced/auto,
+/obj/item/paper/Port_A_Brig,
+/obj/item/remote/porter/port_a_brig,
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
 	},
-/area/station/crew_quarters/quarters_south)
+/turf/simulated/floor/red/side{
+	dir = 4
+	},
+/area/station/security/brig)
 "ill" = (
-/obj/lattice{
-	dir = 6;
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/space,
-/area/station/ai_monitored/armory)
+/obj/decal/cleanable/dirt,
+/obj/storage/closet/fire,
+/turf/simulated/floor/plating,
+/area/station/maintenance/central)
 "imf" = (
 /obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
@@ -55303,31 +53108,49 @@
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "iut" = (
-/obj/machinery/recharge_station,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/darkblue,
-/area/station/turret_protected/ai)
+/obj/firedoor_spawn,
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/arcade/dungeon)
 "ivS" = (
-/obj/decal/tile_edge/stripe,
-/obj/stocking/ephemeral{
-	pixel_x = 22
+/obj/table/auto,
+/obj/item/reagent_containers/food/drinks/tea{
+	pixel_y = 6
 	},
-/turf/simulated/floor/wood/two,
+/turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
+"iwK" = (
+/obj/stool/chair{
+	dir = 8
+	},
+/obj/machinery/phone/wall{
+	pixel_y = 32
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/baroffice)
+"ixU" = (
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
 "iyd" = (
-/obj/lattice,
-/turf/space,
-/area/station/com_dish/comdish)
+/obj/machinery/door/airlock/pyro/maintenance,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"iye" = (
+/obj/critter/parrot/random,
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
 "iCf" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable,
@@ -55338,10 +53161,14 @@
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "iDR" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/machinery/light/emergency,
-/turf/simulated/floor/red/side,
-/area/station/hallway/primary/south)
+/obj/table/auto,
+/obj/shrub/dead{
+	dir = 8;
+	name = "Dead plant";
+	pixel_y = 10
+	},
+/turf/simulated/floor/plating,
+/area/station/routing/depot)
 "iDX" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -55353,6 +53180,10 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
+"iFX" = (
+/obj/table/wood/round/auto,
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
 "iHH" = (
 /obj/reagent_dispensers/foamtank,
 /turf/simulated/floor/caution/corner/misc{
@@ -55378,6 +53209,17 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
+"iLb" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1;
+	name = "Escape S Repressurization Port"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/central)
+"iMD" = (
+/obj/item/clothing/suit/cardboard_box,
+/turf/simulated/floor/grime,
+/area/station/maintenance/southeast)
 "iNr" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -55397,41 +53239,121 @@
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
-"iWw" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
+"iSS" = (
 /obj/cable{
-	icon_state = "0-2"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "4-10"
 	},
-/obj/machinery/power/data_terminal,
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
-/turf/simulated/floor/blue/side{
-	dir = 1
-	},
-/area/station/hallway/primary/south)
-"iWG" = (
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"iUJ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
+"iVK" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
-	dir = 0;
+	dir = 8;
 	name = "autoname - SS13";
-	pixel_y = 20
+	pixel_x = 10;
+	tag = ""
+	},
+/obj/machinery/phone/wall{
+	pixel_x = 24
+	},
+/turf/simulated/floor/grey,
+/area/station/bridge)
+"iWw" = (
+/obj/machinery/disposal,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/disposalpipe/trunk/east,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
+"iWG" = (
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
+"iWH" = (
+/obj/stool{
+	desc = "A soft little bed the general size and shape of a space bee.";
+	icon = 'icons/misc/critter.dmi';
+	icon_state = "beebed";
+	name = "heisenbed"
+	},
+/obj/item/reagent_containers/food/snacks/beefood{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/critter/domestic_bee/heisenbee,
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/obj/machinery/light_switch/north,
+/turf/simulated/floor/carpet/purple/fancy/edge/north,
+/area/station/science/research_director)
+"iXr" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"iZJ" = (
+/obj/table/round/auto,
+/obj/machinery/computer3/generic/personal,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/neutral/side{
+	dir = 8
+	},
+/area/station/crew_quarters/quarters_south)
 "jaZ" = (
 /obj/table/auto,
 /obj/item/shipcomponent/secondary_system/tractor_beam,
 /obj/item/shipcomponent/secondary_system/tractor_beam,
 /turf/simulated/floor,
 /area/station/routing/security)
+"jbW" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/decal/wreath/ephemeral,
+/turf/simulated/floor/plating,
+/area/space)
 "jcj" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -55461,18 +53383,31 @@
 /obj/storage/secure/closet/medical/anesthetic,
 /turf/simulated/floor/red,
 /area/station/medical/medbay/surgery)
-"jfG" = (
+"jke" = (
+/obj/shrub{
+	dir = 10
+	},
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
+"jlz" = (
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/decal/garland/ephemeral{
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"joa" = (
+/obj/machinery/door/airlock/pyro{
 	dir = 4;
-	pixel_x = -14
+	icon_state = "generic_locked";
+	locked = 1
 	},
-/turf/simulated/floor/neutral/side{
-	dir = 8
-	},
-/area/station/hallway/primary/east)
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/quarters_south)
 "joy" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/carpet/arcade,
@@ -55481,7 +53416,16 @@
 	})
 "jry" = (
 /obj/wingrille_spawn/auto,
-/obj/decal/wreath/ephemeral,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "kitchen";
+	layer = 4;
+	name = "Kitchen Shutter";
+	opacity = 0;
+	p_open = 1
+	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/cafeteria)
 "jrT" = (
@@ -55493,11 +53437,20 @@
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/robotics)
+"jsd" = (
+/obj/disposalpipe/segment/transport{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/space,
+/area/station/ai_monitored/armory)
 "jsl" = (
-/obj/wingrille_spawn/auto,
-/obj/decal/poster/wallsign/barber,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/barber_shop)
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/catering)
 "jsY" = (
 /obj/lattice{
 	dir = 1;
@@ -55507,10 +53460,18 @@
 /turf/space,
 /area/space)
 "jvp" = (
-/obj/wingrille_spawn/auto,
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/hangar/engine)
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/obj/table/reinforced/auto,
+/obj/cup_rack{
+	pixel_y = 32
+	},
+/obj/machinery/espresso_machine,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/cafeteria)
 "jvK" = (
 /obj/disposalpipe/segment/food,
 /obj/decal/garland/ephemeral{
@@ -55520,14 +53481,99 @@
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "jwh" = (
-/obj/wingrille_spawn/auto,
-/obj/cable,
-/obj/cable{
-	icon_state = "0-2"
+/obj/table/reinforced/auto,
+/obj/item/body_bag{
+	pixel_x = -5
 	},
-/obj/decal/wreath/ephemeral,
-/turf/simulated/floor/plating,
+/obj/item/reagent_containers/iv_drip/saline{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/iv_drip/blood{
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/iv_drip/saline{
+	pixel_x = -4
+	},
+/obj/item/bandage{
+	pixel_x = -2
+	},
+/obj/item/bandage{
+	pixel_x = -2
+	},
+/turf/simulated/floor/bluewhite{
+	dir = 10
+	},
 /area/station/medical/medbooth)
+"jxC" = (
+/obj/table/auto,
+/obj/item/paper/book/guardbot_guide{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/paper/book/dwainedummies{
+	pixel_y = 6
+	},
+/obj/item/disk/data/tape/master/readonly,
+/turf/simulated/floor/black,
+/area/station/bridge)
+"jys" = (
+/obj/submachine/chef_sink/chem_sink{
+	dir = 1
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 5;
+	icon_state = "line2"
+	},
+/obj/machinery/drainage,
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/ce)
+"jyQ" = (
+/obj/storage/crate,
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
+"jzJ" = (
+/obj/stool/chair,
+/turf/simulated/floor,
+/area/station/crew_quarters/quarters_south)
+"jAa" = (
+/obj/storage/secure/closet/command/captain,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/autoname_north,
+/turf/simulated/floor/carpet/arcade,
+/area/station/bridge/captain)
+"jBF" = (
+/obj/stool/chair/wooden{
+	dir = 8
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
 "jCx" = (
 /obj/storage/crate/loot,
 /turf/simulated/floor/plating/airless/asteroid/dark,
@@ -55538,34 +53584,106 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/science)
+"jHf" = (
+/obj/stool/chair,
+/obj/machinery/light/emergency{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 8
+	},
+/area/station/crew_quarters/quarters_south)
+"jIB" = (
+/obj/machinery/door/airlock/pyro/glass,
+/obj/decal/garland/ephemeral,
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/courtroom)
+"jIL" = (
+/obj/machinery/vending/snack{
+	credit = 50
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/space)
+"jIU" = (
+/obj/table/round/auto,
+/obj/item/goboard,
+/turf/simulated/floor,
+/area/station/crew_quarters/quarters_south)
 "jJT" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/submachine/seed_vendor,
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
 	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
+/turf/simulated/floor/grass,
+/area/station/hydroponics/bay)
+"jNV" = (
+/obj/stool/chair,
 /turf/simulated/floor/plating,
-/area/station/medical/medbooth)
+/area/space)
 "jOn" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	icon_state = "0-2"
+/obj/machinery/disposal,
+/obj/disposalpipe/trunk/south,
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/turf/simulated/floor/black,
+/area/station/crew_quarters/cafeteria)
+"jOS" = (
+/obj/item/storage/wall{
+	dir = 8;
+	name = "silverware cabinet";
+	pixel_x = 32;
+	spawn_contents = list(/obj/item/storage/box/cutlery,/obj/item/storage/box/cutlery,/obj/item/storage/box/cutlery,/obj/item/storage/box/plates,/obj/item/storage/box/plates,/obj/item/shaker/salt,/obj/item/shaker/pepper)
 	},
-/obj/decal/wreath/ephemeral,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/black,
+/area/station/bridge)
+"jSo" = (
+/obj/structure/woodwall,
+/turf/simulated/floor/plating/damaged1,
+/area/station/garden/aviary)
+"jSr" = (
+/obj/machinery/optable,
+/obj/item/device/analyzer/healthanalyzer{
+	pixel_y = -1;
+	rand_pos = 0
+	},
+/turf/simulated/floor/bluewhite,
+/area/station/medical/medbooth)
+"jSH" = (
+/obj/machinery/door/airlock/pyro/security{
+	name = "Courtroom"
+	},
+/obj/machinery/secscanner{
+	pixel_y = 10
+	},
+/obj/decal/garland/ephemeral,
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "jTa" = (
 /obj/decal/poster/wallsign/fire,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/gas)
+"jTb" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/space)
+"jUz" = (
+/obj/disposalpipe/segment/horizontal,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/hallway/primary/south)
 "kbj" = (
 /obj/machinery/atmospherics/binary/volume_pump{
 	dir = 4;
@@ -55577,9 +53695,18 @@
 	},
 /area/station/engine/coldloop)
 "kcl" = (
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/Zeta)
 "kcK" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/landmark{
@@ -55589,6 +53716,17 @@
 /area/station/maintenance/storage{
 	name = "Inner Southwest Maintenance"
 	})
+"keP" = (
+/turf/simulated/floor/carpet/blue,
+/area/station/crew_quarters/md)
+"kht" = (
+/obj/table/wood/auto,
+/obj/item/paper_bin,
+/obj/item/pen/fancy,
+/obj/machinery/light,
+/obj/item/stamp/hop,
+/turf/simulated/floor/black,
+/area/station/bridge/hos)
 "kjx" = (
 /obj/lattice{
 	icon_state = "lattice-dir"
@@ -55596,21 +53734,29 @@
 /obj/machinery/light/runway_light/delay2,
 /turf/space,
 /area/space)
-"kjZ" = (
+"kjT" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
-/obj/stool/chair/office/blue{
-	dir = 4
+/obj/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
-"kkU" = (
-/obj/decal/garland/ephemeral{
+"kkB" = (
+/obj/machinery/light{
 	dir = 8;
-	pixel_x = 14
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/grey,
+/area/station/hallway/secondary/exit)
+"kkU" = (
+/obj/machinery/navbeacon{
+	codes_txt = "tour;next_tour=tour4;desc=On my right through the double doors is the station's headquarters. When waiting in the area, please use the provided seating.";
+	freq = 1443;
+	location = "tour3";
+	name = "tour 3 - command"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -55628,25 +53774,22 @@
 /turf/simulated/floor/airless/plating,
 /area/station/maintenance/west)
 "kmG" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21;
-	pixel_y = -3
-	},
-/turf/simulated/floor/escape{
+/obj/stool/chair{
 	dir = 8
 	},
-/area/station/hallway/secondary/exit)
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
+"kos" = (
+/obj/machinery/networked/radio,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "koG" = (
-/obj/machinery/light_switch/east,
-/obj/storage/secure/closet/security/armory,
+/obj/storage/secure/crate/weapon/armory/tranquilizer,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "kpw" = (
@@ -55655,6 +53798,22 @@
 	icon_state = "platingdmg1"
 	},
 /area/research_outpost/indigo_rye)
+"kqA" = (
+/obj/access_spawn/brig,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Armory"
+	},
+/obj/access_spawn/brig,
+/turf/simulated/floor/red,
+/area/station/security/brig)
 "kqU" = (
 /obj/decal/poster/wallsign/escape_right,
 /turf/simulated/wall/auto/supernorn,
@@ -55692,31 +53851,56 @@
 	dir = 8
 	},
 /area/station/medical/medbay)
+"kBO" = (
+/obj/machinery/door/airlock/pyro,
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/turf/simulated/floor/grey/blackgrime,
+/area/station/security/brig)
 "kBY" = (
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/barber_shop)
+"kEf" = (
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/decal/cleanable/dirt,
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"kEo" = (
+/obj/table/auto,
+/obj/machinery/light,
+/obj/item/storage/toolbox/emergency,
+/obj/item/device/light/glowstick,
+/obj/item/device/light/glowstick,
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"kHZ" = (
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 4
+	},
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/barber_shop)
+"kIi" = (
+/obj/storage/secure/closet/medical/chemical,
 /obj/cable{
-	icon_state = "1-4"
-	},
-/turf/unsimulated/floor/sanitary,
-/area/station/crewquarters/cryotron)
-"kHZ" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/engine,
-/area/station/turret_protected/ai)
+/turf/simulated/floor/carpet/blue/fancy/edge/se,
+/area/station/crew_quarters/md)
 "kKi" = (
 /obj/table/wood/auto,
 /obj/decal/xmas_lights/ephemeral{
@@ -55724,6 +53908,10 @@
 	},
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/crew_quarters/radio/news_office)
+"kKv" = (
+/obj/item/c_tube,
+/turf/simulated/floor/plating,
+/area/space)
 "kKQ" = (
 /obj/stool/chair/office,
 /obj/landmark/start{
@@ -55736,6 +53924,54 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/medical/robotics)
+"kKU" = (
+/obj/disposalpipe/segment/vertical,
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 6
+	},
+/turf/simulated/floor/grey,
+/area/station/bridge)
+"kLO" = (
+/obj/machinery/communications_dish{
+	tag = "MAIN_DISH_SS13"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/com_dish/comdish)
+"kOY" = (
+/obj/machinery/sim/vr_bed{
+	dir = 4;
+	name = "VR simulation pod";
+	network = "arcadevr"
+	},
+/obj/cable,
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
+"kQK" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet,
+/obj/disposalpipe/segment/brig{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/grey/side{
+	dir = 8
+	},
+/area/station/security/brig)
+"kQP" = (
+/obj/table/wood/auto,
+/obj/random_item_spawner/desk_stuff,
+/obj/item/stamp/cap,
+/turf/simulated/floor/carpet/arcade,
+/area/station/bridge/captain)
 "kQR" = (
 /obj/machinery/camera/television{
 	c_tag = "test chamber";
@@ -55751,6 +53987,18 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
+"kTg" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "kTo" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	level = 2
@@ -55769,18 +54017,60 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/cloner)
-"lcV" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+"kTM" = (
+/obj/table/auto,
+/obj/item/storage/toolbox/emergency,
+/obj/item/crowbar,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
 	},
+/turf/simulated/floor/black/side{
+	dir = 8
+	},
+/area/station/bridge)
+"kUT" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/ai_monitored/armory)
+"kZM" = (
+/obj/machinery/weapon_stand/shotgun_rack,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
-"les" = (
-/obj/landmark{
-	name = "blobstart"
+"lad" = (
+/obj/table/wood/auto,
+/obj/machinery/networked/printer{
+	name = "Printer - CE";
+	pixel_y = 5;
+	print_id = "CE"
 	},
+/obj/machinery/light_switch/north,
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
+	},
+/turf/simulated/floor/yellowblack{
+	dir = 1
+	},
+/area/station/crew_quarters/ce)
+"les" = (
+/obj/decal/cleanable/dirt,
+/obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "lfa" = (
@@ -55790,18 +54080,43 @@
 /obj/disposalpipe/junction/right/west,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/office)
-"lfH" = (
-/obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	icon_state = "1-4"
+"lfp" = (
+/obj/machinery/chem_dispenser/soda,
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/cafeteria)
+"lfH" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/disposalpipe/segment/horizontal,
+/turf/simulated/floor/green/corner{
+	dir = 1
+	},
 /area/station/hallway/primary/south)
 "lhD" = (
-/obj/storage/secure/crate/gear/armory/grenades,
-/obj/machinery/recharger/wall/sticky,
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
+/obj/decal/tile_edge/line/green{
+	icon_state = "line1"
+	},
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 8
+	},
+/area/station/crew_quarters/quarters_south)
 "lhX" = (
 /obj/machinery/light,
 /turf/simulated/floor/caution/east,
@@ -55823,11 +54138,38 @@
 	},
 /area/station/hallway/primary/west)
 "ljt" = (
-/obj/landmark{
-	name = "blobstart"
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
 	},
+/obj/stool/chair{
+	dir = 4
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "1-6"
+	},
+/obj/landmark/start{
+	name = "Janitor"
+	},
+/turf/simulated/floor/specialroom/arcade,
+/area/station/janitor/supply)
+"ljZ" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/maintenance/southeast)
+"lkP" = (
+/obj/machinery/chem_master{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/east,
+/area/station/crew_quarters/md)
 "lkQ" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -55863,6 +54205,18 @@
 /obj/machinery/light,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
+"loS" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/turret,
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
 "lrq" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 1;
@@ -55873,6 +54227,11 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
+"luT" = (
+/obj/machinery/light/small,
+/obj/machinery/photocopier,
+/turf/simulated/floor/black,
+/area/station/bridge)
 "lvb" = (
 /obj/grille/steel,
 /obj/disposalpipe/segment/transport,
@@ -55880,6 +54239,26 @@
 /area/station/crew_quarters/clown{
 	name = "Clowntainment"
 	})
+"lwK" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/decal/wreath/ephemeral,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/courtroom)
+"lyf" = (
+/obj/machinery/vending/snack,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 20
+	},
+/turf/simulated/floor/grime,
+/area/station/security/brig)
 "lyu" = (
 /obj/lattice{
 	dir = 4;
@@ -55901,9 +54280,7 @@
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "lCw" = (
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
+/obj/disposalpipe/segment/bent/west,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
 "lHa" = (
@@ -55913,8 +54290,47 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/south)
+"lHO" = (
+/obj/item/reagent_containers/food/drinks/bottle/thegoodstuff,
+/obj/shrub/captainshrub,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/bridge/captain)
+"lIL" = (
+/obj/machinery/communications_dish,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/airless/plating,
+/area/station/ai_monitored/armory)
 "lJE" = (
-/obj/decal/cleanable/dirt,
+/obj/machinery/hair_dye_dispenser,
+/turf/simulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/barber_shop)
+"lLu" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13";
+	tag = ""
+	},
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
@@ -55941,24 +54357,70 @@
 /obj/machinery/light/emergency,
 /turf/simulated/floor/yellow/side,
 /area/station/hallway/primary/west)
-"lUL" = (
-/obj/decal/tile_edge/line/white{
-	dir = 5;
-	icon_state = "line4"
-	},
-/obj/decal/tile_edge/line/white{
-	dir = 1;
-	icon_state = "line1"
+"lUq" = (
+/obj/cable{
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
+/turf/simulated/floor/carpet/purple/fancy/edge/west,
+/area/station/science/research_director)
+"lUL" = (
+/obj/machinery/turret,
 /turf/simulated/floor/darkblue,
 /area/station/turret_protected/ai)
+"maq" = (
+/obj/machinery/chem_dispenser/alcohol,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
+/obj/machinery/light_switch/west,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/cafeteria)
+"mcT" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 1
+	},
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
+"mdV" = (
+/obj/storage/crate/rcd,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/yellowblack/corner{
+	dir = 1
+	},
+/area/station/crew_quarters/ce)
 "mep" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/northwest)
+"meJ" = (
+/obj/rack,
+/obj/item/clothing/suit/bio_suit/paramedic,
+/obj/item/clothing/suit/bio_suit/paramedic,
+/obj/item/storage/belt/medical,
+/obj/item/storage/belt/medical,
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbooth)
 "mgx" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -55966,12 +54428,38 @@
 	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
+"mhn" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "yellow";
+	icon_state = "bedsheet-yellow"
+	},
+/obj/machinery/light,
+/turf/simulated/floor/yellowblack,
+/area/station/crew_quarters/ce)
 "mhV" = (
 /obj/disposalpipe/segment/morgue{
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
+"mjV" = (
+/obj/table/reinforced/chemistry/auto{
+	name = "prep counter"
+	},
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/cafeteria)
+"mkj" = (
+/obj/stool/chair{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "mkl" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -55981,19 +54469,21 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/south)
 "mkL" = (
-/obj/shrub{
-	dir = 4;
-	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "plant"
+/obj/decal/tile_edge/line/green{
+	dir = 10;
+	icon_state = "line1"
 	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/ai)
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/quarters_south)
 "mmz" = (
 /obj/disposalpipe/segment/vertical,
-/obj/decal/garland/ephemeral{
-	dir = 8;
-	pixel_x = 14
-	},
+/obj/machinery/power/apc/autoname_east,
+/obj/cable,
 /turf/simulated/floor/neutral/side{
 	dir = 4
 	},
@@ -56006,14 +54496,59 @@
 /obj/decal/poster/wallsign/space,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/quartermaster/office)
+"mpB" = (
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
+"mpU" = (
+/obj/item/storage/toilet,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/grey/side{
+	dir = 4
+	},
+/area/space)
 "mpY" = (
 /obj/machinery/light/small,
 /obj/machinery/chemicompiler_stationary,
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
+"mqh" = (
+/obj/table/auto,
+/obj/item/storage/box/glassbox,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shot,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shot,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shot,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shot,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
+/obj/item/reagent_containers/food/drinks/drinkingglass/cocktail,
+/obj/item/reagent_containers/food/drinks/drinkingglass/cocktail,
+/obj/item/reagent_containers/food/drinks/drinkingglass/cocktail,
+/obj/item/reagent_containers/food/drinks/drinkingglass/cocktail,
+/obj/item/gun/russianrevolver,
+/obj/machinery/light_switch/west,
+/obj/item/device/radio/intercom/catering,
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/baroffice)
 "mqC" = (
 /turf/space,
 /area/supply/delivery_point)
+"mrc" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/ai_monitored/armory)
 "muI" = (
 /obj/machinery/light/emergency{
 	dir = 4;
@@ -56021,24 +54556,65 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/science)
-"mzX" = (
-/obj/disposalpipe/segment/mail/vertical,
-/obj/machinery/light/emergency{
-	dir = 4;
-	pixel_x = 10
+"mvc" = (
+/obj/stool/chair{
+	dir = 1
 	},
-/turf/simulated/floor/neutral/side{
+/obj/cable,
+/obj/machinery/power/apc/autoname_east,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 9;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
+"mwE" = (
+/obj/machinery/floorflusher/solitary2,
+/obj/submachine/chef_sink/chem_sink{
+	pixel_y = 16
+	},
+/obj/disposalpipe/trunk/south,
+/turf/simulated/floor/black,
+/area/space)
+"myW" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 20
+	},
+/obj/rack,
+/obj/item/storage/box/stinger_kit,
+/obj/item/chem_grenade/pepper,
+/obj/item/chem_grenade/pepper,
+/obj/item/chem_grenade/pepper,
+/obj/item/clothing/glasses/nightvision,
+/obj/item/clothing/glasses/nightvision,
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
+"mzX" = (
+/turf/simulated/floor,
+/area/station/crew_quarters/quarters_east)
+"mBE" = (
+/obj/machinery/vehicle/escape_pod{
 	dir = 4
 	},
-/area/station/hallway/primary/east)
-"mCe" = (
-/obj/machinery/optable,
-/obj/item/device/analyzer/healthanalyzer{
-	pixel_y = -1;
-	rand_pos = 0
+/turf/simulated/floor/shuttlebay,
+/area/station/hallway/secondary/exit)
+"mBW" = (
+/obj/stool/chair{
+	dir = 4
 	},
-/turf/simulated/floor/bluewhite,
-/area/station/medical/medbooth)
+/obj/item/storage/secure/ssafe/loot{
+	pixel_x = -28
+	},
+/turf/simulated/floor/damaged3,
+/area/station/crew_quarters/quarters_south)
+"mCe" = (
+/obj/reagent_dispensers/watertank/big,
+/turf/simulated/floor/grass,
+/area/station/hydroponics/bay)
 "mCg" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -56050,62 +54626,147 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
+"mEM" = (
+/obj/submachine/chem_extractor,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/green/side{
+	dir = 8
+	},
+/area/station/hydroponics/bay)
+"mER" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/west,
+/area/station/bridge)
 "mEW" = (
-/obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "1-2"
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/turf/simulated/floor/escape/corner{
+	dir = 4
 	},
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/area/station/hallway/secondary/exit)
 "mHX" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/lattice{
-	dir = 4;
+	dir = 8;
 	icon_state = "lattice-dir"
 	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/space,
 /area/space)
+"mIj" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
 "mJy" = (
-/obj/machinery/communications_dish,
-/obj/machinery/light/small{
+/obj/shrub{
+	dir = 1
+	},
+/obj/machinery/light/emergency{
 	dir = 1;
-	pixel_y = 21
+	pixel_y = 16
 	},
-/obj/machinery/power/data_terminal,
-/obj/cable,
-/obj/cable{
-	icon_state = "0-2"
+/turf/simulated/floor/escape{
+	dir = 1
 	},
-/turf/simulated/floor/airless/plating,
-/area/station/ai_monitored/armory)
+/area/station/hallway/secondary/exit)
 "mKe" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
 	},
-/turf/simulated/floor/plating,
-/area/station/medical/medbooth)
+/obj/table/auto,
+/obj/item/storage/box/syringes{
+	pixel_y = 4
+	},
+/obj/item/storage/box/beakerbox{
+	pixel_y = -10
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
+"mKt" = (
+/obj/table/reinforced/auto,
+/obj/item/decoration/ashtray{
+	pixel_x = -9
+	},
+/obj/item/card_box/suit{
+	pixel_x = 1;
+	pixel_y = 3
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/grime,
+/area/station/security/brig)
 "mLt" = (
-/obj/machinery/power/apc/autoname_west/noaicontrol,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/table/reinforced/bar/auto,
+/obj/item/device/radio/beacon,
+/obj/item/clothing/head/cakehat,
+/turf/simulated/floor/carpet/green/standard/narrow/northsouth,
+/area/station/crew_quarters/cafeteria)
+"mOe" = (
+/obj/machinery/door/airlock/pyro/command{
+	dir = 4;
+	name = "Network Chamber"
 	},
-/obj/storage/secure/crate/weapon/armory/pod_weapons,
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/grey,
+/area/station/bridge)
 "mOF" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/black/grime,
 /area/station/routing/depot)
+"mOV" = (
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
+	},
+/turf/space,
+/area/station/ai_monitored/armory)
 "mPi" = (
+/obj/machinery/light/small/floor,
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
+"mPI" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"mQm" = (
 /obj/lattice{
 	dir = 6;
 	icon_state = "lattice-dir-b"
@@ -56118,25 +54779,44 @@
 /turf/simulated/floor/airless/grey,
 /area/station/maintenance/west)
 "mSv" = (
-/obj/grille/catwalk{
-	dir = 6;
-	icon_state = "catwalk_cross"
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/maintenance/solar/east)
+"mSF" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/middle{
+	dir = 5
 	},
+/obj/cable,
 /obj/cable{
-	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 6
-	},
-/area/station/solar/east)
+/turf/simulated/floor/plating,
+/area/station/bridge/captain)
 "mVi" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/decal/xmas_lights/ephemeral{
 	pixel_y = 32
 	},
-/turf/simulated/floor/specialroom/chapel,
+/turf/simulated/floor/black,
 /area/station/chapel/sanctuary)
+"mVP" = (
+/obj/machinery/door/airlock/pyro/maintenance,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/greenblack,
+/area/station/garden/aviary)
+"mWO" = (
+/obj/grille/catwalk,
+/turf/simulated/floor/airless/plating/catwalk,
+/area/station/maintenance/southeast)
 "mXc" = (
 /obj/machinery/recharge_station,
 /obj/landmark/start{
@@ -56152,17 +54832,58 @@
 /turf/simulated/floor/caution/east,
 /area/station/routing/security)
 "nbR" = (
-/obj/storage/secure/closet/personal,
-/turf/unsimulated/floor/sanitary,
-/area/station/crewquarters/cryotron)
-"ncP" = (
-/obj/lattice{
-	dir = 10;
-	icon_state = "lattice-dir-b"
+/obj/storage/closet/wardrobe/white,
+/obj/item/clothing/head/chefhat,
+/obj/item/clothing/suit/apron,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
 	},
-/obj/machinery/light/runway_light,
-/turf/space,
-/area/station/ai_monitored/armory)
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/quarters_east)
+"ncP" = (
+/obj/machinery/plantpot{
+	anchored = 1
+	},
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/grass,
+/area/station/crew_quarters/quarters_south)
+"ney" = (
+/obj/shrub{
+	dir = 1
+	},
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
+"nez" = (
+/obj/table/wood/auto,
+/obj/machinery/recharger{
+	pixel_y = 3
+	},
+/obj/item/remote/porter/port_a_sci,
+/obj/item/reagent_containers/hypospray,
+/obj/item/reagent_containers/food/snacks/beefood{
+	desc = "A little birthday cupcake for Heisenbee.  May not taste good to non-bees.";
+	icon = 'icons/obj/foodNdrink/food_dessert.dmi';
+	icon_state = "cupcake";
+	name = "Heisenbee's birthday cupcake"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
+	},
+/obj/item/stamp/rd,
+/obj/item/device/radio/intercom/science{
+	pixel_x = 3;
+	pixel_y = 24
+	},
+/turf/simulated/floor/carpet/purple/fancy/edge/nw,
+/area/station/science/research_director)
 "nfO" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
@@ -56175,6 +54896,14 @@
 /obj/access_spawn/research,
 /turf/simulated/floor/engine/caution/westeast,
 /area/station/science/testchamber)
+"nhA" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet,
+/obj/item/device/radio/intercom,
+/turf/simulated/floor/grey/side{
+	dir = 8
+	},
+/area/space)
 "niK" = (
 /obj/plasticflaps{
 	layer = 3
@@ -56186,11 +54915,37 @@
 /turf/simulated/floor/caution/westeast,
 /area/station/quartermaster/office)
 "njl" = (
-/obj/machinery/light,
-/turf/simulated/floor/escape{
+/obj/stool/chair{
+	dir = 4;
+	tag = "icon-chair (EAST)"
+	},
+/obj/landmark{
+	name = "blobstart"
+	},
+/turf/simulated/floor/carpet/green/fancy/edge/north,
+/area/station/crew_quarters/quarters_south)
+"nkv" = (
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"nld" = (
+/obj/table/reinforced/auto,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/reagent_containers/food/drinks/water,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
+	},
+/turf/simulated/floor/grey/side{
 	dir = 8
 	},
-/area/station/hallway/secondary/exit)
+/area/space)
 "nmf" = (
 /obj/table/auto,
 /obj/machinery/cell_charger,
@@ -56201,40 +54956,69 @@
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "nmy" = (
-/obj/machinery/light/small/floor/netural,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "nmT" = (
-/obj/storage/closet/wardrobe/yellow,
-/turf/simulated/floor/plating,
+/obj/stool/chair/couch{
+	dir = 4
+	},
+/turf/simulated/floor/black/grime,
 /area/station/maintenance/inner/central)
 "npx" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "red";
-	icon_state = "bedsheet-red"
-	},
-/obj/machinery/bot/secbot/beepsky,
 /obj/cable{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/station/security/beepsky)
+/turf/simulated/floor/red/side,
+/area/station/security/brig)
 "nql" = (
-/obj/iv_stand,
-/obj/machinery/light,
-/turf/simulated/floor/bluewhite,
-/area/station/medical/medbooth)
+/obj/table/wood/auto,
+/obj/random_item_spawner/medicine,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/carpet/green/fancy/edge/ne,
+/area/station/crew_quarters/quarters_south)
 "nqT" = (
 /obj/decal/cleanable/dirt,
 /obj/disposalpipe/segment/vertical,
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
+"nrt" = (
+/obj/table/reinforced/auto,
+/obj/machinery/phone,
+/turf/simulated/floor/carpet/red/fancy/edge/se,
+/area/station/security/hos)
+"nsT" = (
+/turf/simulated/floor/carpet/blue/fancy/edge/east,
+/area/station/bridge)
 "ntn" = (
-/obj/machinery/shieldgenerator/meteorshield,
+/obj/machinery/power/apc/autoname_west,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
+"nty" = (
+/obj/machinery/turret,
+/obj/lattice,
+/turf/space,
+/area/station/ai_monitored/armory)
+"nxA" = (
+/obj/disposalpipe/segment/vertical,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/cafeteria)
+"nxG" = (
+/obj/decal/skeleton{
+	desc = "It's all covered in a sticky mess, and there are chunks of uniform fused to the bone.";
+	name = "sticky skeleton"
+	},
+/turf/simulated/floor/plating/scorched,
+/area/station/crew_quarters/quarters_south)
 "nAw" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/machinery/door/poddoor/pyro{
@@ -56244,24 +55028,67 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
-"nAJ" = (
+"nBv" = (
 /obj/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/cable{
-	icon_state = "1-8"
+/turf/simulated/floor/redblack/corner{
+	dir = 8
 	},
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
+/area/space)
 "nBP" = (
-/obj/critter/cat/jones,
-/turf/simulated/floor/carpet/blue/fancy/edge/east,
-/area/station/bridge)
+/obj/machinery/door/airlock/pyro/security{
+	dir = 4;
+	name = "Head of Security";
+	req_access = null
+	},
+/obj/access_spawn/hos,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/redblack{
+	dir = 8
+	},
+/area/station/security/hos)
+"nCN" = (
+/obj/machinery/light,
+/turf/simulated/floor/red/side,
+/area/station/security/brig)
+"nDg" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/window_blinds/cog2/middle{
+	dir = 8
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/ce)
 "nDM" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/landmark/halloween,
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/grey,
+/area/station/hallway/secondary/exit)
+"nEE" = (
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating,
+/area/space)
 "nGr" = (
 /obj/machinery/light/emergency{
 	dir = 4;
@@ -56282,28 +55109,40 @@
 /area/station/quartermaster/office)
 "nKN" = (
 /obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/cable{
 	icon_state = "4-8"
 	},
-/obj/decal/garland/ephemeral{
-	dir = 4;
-	pixel_x = -14
+/turf/simulated/floor/carpet/arcade,
+/area/station/bridge/captain)
+"nLA" = (
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
 	},
 /turf/simulated/floor/grey,
-/area/station/bridge)
-"nLA" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 10
-	},
-/turf/space,
-/area/space)
+/area/station/hallway/secondary/exit)
 "nML" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/grime,
 /area/station/maintenance/disposal)
 "nNq" = (
-/obj/storage/closet/coffin/wood,
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
+/turf/simulated/wall/false_wall{
+	icon = 'icons/turf/walls_supernorn.dmi';
+	icon_state = "12"
+	},
+/area/station/chapel/office)
+"nOe" = (
+/obj/machinery/light/runway_light/delay3,
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/station/ai_monitored/armory)
 "nQL" = (
 /obj/machinery/atmospherics/binary/passive_gate{
 	dir = 4;
@@ -56332,6 +55171,15 @@
 	dir = 10
 	},
 /area/space)
+"nRD" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "nSc" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -56344,66 +55192,205 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
-"nVE" = (
-/obj/machinery/light/emergency{
+"nSx" = (
+/obj/stool/chair/office/blue,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/sw,
+/area/station/bridge)
+"nSQ" = (
+/obj/storage/secure/crate/plasma/armory/anti_biological,
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
+"nSR" = (
+/obj/shrub,
+/obj/machinery/light/small{
 	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
+"nVh" = (
+/obj/machinery/floorflusher/solitary,
+/obj/submachine/chef_sink/chem_sink{
 	pixel_y = 16
 	},
-/turf/simulated/floor/caution/westeast,
-/area/station/hangar/engine)
+/obj/disposalpipe/trunk/south,
+/turf/simulated/floor/black,
+/area/space)
+"nVE" = (
+/obj/machinery/computer/barcode{
+	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Pod Bay","Research","Security","QM");
+	dir = 4
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
+	},
+/turf/simulated/floor/orange/side{
+	dir = 9
+	},
+/area/station/crew_quarters/catering)
+"nWu" = (
+/obj/machinery/computer3/terminal/zeta{
+	dir = 8;
+	setup_os_string = "ZETA_MAINFRAME"
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/yellowblack/corner,
+/area/station/crew_quarters/ce)
+"nWS" = (
+/obj/table/wood/auto,
+/obj/machinery/phone,
+/turf/simulated/floor/black,
+/area/station/bridge/hos)
 "nZC" = (
 /obj/disposalpipe/segment/mail/horizontal,
-/obj/decal/garland/ephemeral{
-	dir = 8;
-	pixel_x = 14
+/turf/simulated/floor/neutral/corner{
+	dir = 8
 	},
-/turf/simulated/floor/neutral/corner,
 /area/station/hallway/primary/east)
+"ocE" = (
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir-b"
+	},
+/obj/machinery/light/runway_light,
+/turf/space,
+/area/station/ai_monitored/armory)
 "ocX" = (
-/obj/critter/sealpup,
-/turf/simulated/pool/no_animate,
-/area/station/crew_quarters/pool)
+/obj/machinery/door/airlock/pyro/glass,
+/obj/disposalpipe/segment/mail/vertical,
+/obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/hallway/primary/east)
+"ogG" = (
+/obj/machinery/portable_atmospherics/canister/air/large,
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 4;
+	level = 2
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"oif" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/baroffice)
 "ojD" = (
-/obj/decal/poster/wallsign/fuck2,
 /turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/quarters_north)
+/area/station/maintenance/east)
+"oku" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/red/side,
+/area/station/hallway/primary/south)
 "omd" = (
 /obj/lattice,
 /obj/warp_beacon/security,
 /turf/space,
 /area/space)
+"oni" = (
+/obj/storage/secure/closet/command/chief_engineer,
+/obj/item/clipboard,
+/obj/item/pen,
+/turf/simulated/floor/yellowblack,
+/area/station/crew_quarters/ce)
 "oop" = (
-/obj/machinery/vending/security_ammo,
 /obj/machinery/light{
-	dir = 4;
+	dir = 8;
 	layer = 9.1;
-	pixel_x = 10
+	pixel_x = -10
+	},
+/obj/rack,
+/obj/item/breaching_hammer,
+/obj/item/breaching_charge,
+/obj/item/breaching_charge,
+/obj/item/breaching_charge,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
+"oqM" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/stool/chair/office/blue{
+	dir = 4
 	},
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "osJ" = (
-/obj/machinery/door/airlock/pyro/command{
-	dir = 4;
-	name = "AI Core"
-	},
-/obj/access_spawn/ai_upload,
+/obj/disposalpipe/segment/vertical,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "5-10"
 	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/darkblue,
-/area/station/turret_protected/ai)
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
 "our" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/machinery/light/emergency,
-/turf/simulated/floor/yellow/side,
-/area/station/hallway/primary/north)
+/obj/table/auto,
+/obj/item/reagent_containers/food/drinks/eggnog{
+	pixel_y = 8
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
+"oux" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
 "ovi" = (
 /obj/item/seed/alien,
 /turf/simulated/floor/plating/airless/asteroid/dark,
 /area/space)
+"ovS" = (
+/obj/lattice{
+	dir = 5;
+	icon_state = "lattice-dir-b"
+	},
+/obj/machinery/light/runway_light/delay3,
+/turf/space,
+/area/station/ai_monitored/armory)
 "ovZ" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 1
@@ -56440,21 +55427,37 @@
 /area/station/hallway/primary/south)
 "oxY" = (
 /obj/wingrille_spawn/auto,
-/obj/decal/wreath/ephemeral,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/fitness)
+/area/station/engine/elect)
+"oyc" = (
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/obj/table/auto,
+/obj/item/reagent_containers/food/drinks/bottle/empty{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/drinks/bottle/empty{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/food/drinks/bottle/empty,
+/turf/simulated/floor/plating,
+/area/space)
 "oyG" = (
 /obj/item/clothing/glasses/blindfold,
 /turf/simulated/floor/engine/vacuum,
 /area/research_outpost/indigo_rye)
 "ozl" = (
-/obj/disposalpipe/trunk/south,
-/obj/machinery/disposal/transport{
-	desc = "A pneumatic delivery chute for transporting people from one section of maintenance to another.";
-	name = "maintenance shunt unit"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/obj/machinery/computer/security/wooden_tv,
+/turf/simulated/floor/plating/damaged1,
+/area/station/security/beepsky)
 "oAd" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -56466,6 +55469,35 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/mining/refinery)
+"oBX" = (
+/obj/table/auto,
+/obj/machinery/networked/storage/scanner{
+	bank_id = "bridge";
+	pixel_y = 4
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
+	},
+/turf/simulated/floor/circuit,
+/area/station/bridge)
+"oDv" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/south,
+/area/station/crew_quarters/md)
 "oDQ" = (
 /obj/machinery/light/emergency{
 	dir = 8;
@@ -56491,9 +55523,17 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/morgue)
 "oHK" = (
-/obj/wingrille_spawn/auto,
-/obj/decal/wreath/ephemeral,
-/turf/simulated/floor/plating,
+/obj/stool/chair{
+	dir = 8
+	},
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/machinery/light_switch/north,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/carpet/purple/fancy/edge/ne,
 /area/station/crew_quarters/quarters_east)
 "oHL" = (
 /obj/machinery/light_switch/east,
@@ -56504,10 +55544,34 @@
 	dir = 1
 	},
 /area/research_outpost/indigo_rye)
+"oIw" = (
+/obj/machinery/portable_atmospherics/canister/air/large,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "oIX" = (
-/obj/machinery/drainage,
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/barber_shop)
+/obj/table/reinforced/auto,
+/obj/item/clothing/gloves/latex,
+/obj/item/clothing/gloves/latex,
+/obj/item/clothing/suit/apron,
+/obj/item/clothing/head/souschefhat,
+/obj/item/device/radio/intercom/catering{
+	dir = 4
+	},
+/turf/simulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/kitchen)
+"oMM" = (
+/obj/table/reinforced/bar/auto,
+/obj/item/reagent_containers/food/drinks/bowl,
+/obj/item/kitchen/utensil/spoon,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/green/standard/narrow/northsouth,
+/area/station/crew_quarters/cafeteria)
+"oOW" = (
+/obj/machinery/portable_atmospherics/pump,
+/turf/simulated/floor/plating,
+/area/station/maintenance/central)
 "oQa" = (
 /obj/lattice{
 	dir = 8;
@@ -56515,28 +55579,59 @@
 	},
 /turf/space,
 /area/station/com_dish/comdish)
-"oTv" = (
-/obj/machinery/light/emergency,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine)
-"oUm" = (
+"oQU" = (
 /obj/lattice{
-	dir = 10;
 	icon_state = "lattice-dir"
 	},
-/turf/space,
-/area/station/com_dish/comdish)
-"oUn" = (
-/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/light/runway_light/delay4,
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
+/turf/space,
+/area/space)
+"oSI" = (
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"oTv" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/hangar/engine)
+"oUm" = (
+/obj/lattice,
+/turf/space,
+/area/station/com_dish/comdish)
+"oUn" = (
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/ai_monitored/armory)
+"oVW" = (
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
+	},
+/obj/machinery/door_timer/solitary2/new_walls/north{
+	layer = 3.1
+	},
+/turf/simulated/floor,
+/area/station/security/brig)
+"oXP" = (
+/obj/stool/chair/comfy{
+	dir = 8
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/east,
+/area/station/bridge)
 "oZc" = (
 /obj/cable{
 	d1 = 1;
@@ -56553,6 +55648,34 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
+"oZq" = (
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/crew_quarters/quarters_south)
+"pad" = (
+/obj/stool/chair/office/yellow{
+	dir = 4
+	},
+/obj/landmark/start{
+	name = "Chief Engineer"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/orangeblack,
+/area/station/crew_quarters/ce)
 "paw" = (
 /obj/machinery/floorflusher/industrial{
 	name = "waste loading chute"
@@ -56560,25 +55683,44 @@
 /obj/disposalpipe/trunk/east,
 /turf/simulated/floor/airless/grey,
 /area/station/maintenance/west)
-"pfK" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"paK" = (
+/obj/machinery/computer/arcade,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
 	},
-/obj/landmark/halloween,
-/turf/simulated/floor,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 21;
+	pixel_y = -3
+	},
+/turf/simulated/floor/grime,
+/area/station/security/brig)
+"peY" = (
+/obj/table/auto,
+/obj/machinery/microwave,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
+"pfK" = (
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/grey,
 /area/station/hallway/primary/north)
 "pfT" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
+/obj/table/reinforced/auto,
+/obj/machinery/light,
+/obj/machinery/glass_recycler{
+	glass_amt = 5;
+	pixel_y = 4
 	},
-/turf/simulated/floor/escape{
-	dir = 8
-	},
-/area/station/hallway/secondary/exit)
+/turf/simulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/kitchen)
 "phu" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -56587,6 +55729,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
+"plB" = (
+/obj/machinery/shieldgenerator/meteorshield,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "pmt" = (
 /obj/table/auto,
 /obj/machinery/cell_charger,
@@ -56601,46 +55747,65 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "pmR" = (
-/obj/stool/chair{
-	dir = 4;
-	tag = "icon-chair (EAST)"
+/obj/decal/tile_edge/line/green{
+	dir = 8;
+	icon_state = "line1"
 	},
-/obj/landmark{
-	name = "blobstart"
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet/green/fancy/edge/north,
+/turf/simulated/floor,
 /area/station/crew_quarters/quarters_south)
 "poX" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "ppd" = (
-/obj/lattice{
-	dir = 10;
-	icon_state = "lattice-dir"
+/obj/machinery/vending/security_ammo,
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
 	},
-/turf/space,
+/turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "ppQ" = (
-/obj/wingrille_spawn/auto/crystal,
-/turf/simulated/floor/plating,
-/area/station/security/brig)
-"pqx" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/table/reinforced/auto,
+/obj/submachine/mixer,
+/turf/simulated/floor/specialroom/cafeteria{
+	dir = 1
 	},
-/turf/unsimulated/floor/sanitary,
-/area/station/crewquarters/cryotron)
+/area/station/crew_quarters/kitchen)
+"pqx" = (
+/obj/shrub{
+	desc = "While it's wildly unlikely that this bush hails from Space Sweden, it nevertheless bears a faint scent of meatballs that can't be adequately explained.";
+	dir = 8;
+	icon = 'icons/obj/stationobjs.dmi';
+	icon_state = "plant";
+	name = "swedish shrub";
+	pixel_y = 5
+	},
+/obj/item/kitchen/utensil/knife{
+	desc = "A thoroughly worn yet still robust kitchen knife. It seems to have been maintained with care. The word 'MORA' is etched into one side of the blade.";
+	name = "old knife"
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/quarters_east)
 "pry" = (
 /obj/table/reinforced/auto,
-/obj/item/paper/book/medical_surgery_guide{
-	pixel_x = 9
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13";
+	tag = ""
 	},
-/obj/machinery/defib_mount{
-	pixel_x = -6
+/obj/machinery/phone,
+/turf/simulated/floor/specialroom/cafeteria{
+	dir = 1
 	},
-/turf/simulated/floor/bluewhite,
-/area/station/medical/medbooth)
+/area/station/crew_quarters/kitchen)
 "prI" = (
 /obj/disposalpipe/segment/morgue,
 /obj/cable{
@@ -56656,26 +55821,61 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
-"pAA" = (
-/obj/lattice{
-	dir = 9;
-	icon_state = "lattice-dir-b"
+"psr" = (
+/obj/disposalpipe/trunk/south,
+/obj/machinery/disposal/transport{
+	desc = "A pneumatic delivery chute for transporting people from one section of maintenance to another.";
+	name = "maintenance shunt unit"
 	},
-/obj/machinery/light/runway_light/delay5,
-/turf/space,
-/area/station/ai_monitored/armory)
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"pwT" = (
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Cafeteria"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
+"pyX" = (
+/obj/critter/roach,
+/turf/simulated/floor/grime,
+/area/station/maintenance/southeast)
+"pAA" = (
+/obj/table/reinforced/bar/auto,
+/obj/machinery/computer/security/wooden_tv/small{
+	pixel_y = 8
+	},
+/turf/simulated/floor/carpet/green/standard/narrow/northsouth,
+/area/station/crew_quarters/cafeteria)
 "pBe" = (
 /obj/lattice{
-	dir = 10;
+	dir = 4;
 	icon_state = "lattice-dir"
 	},
-/obj/machinery/light/runway_light/delay4,
+/obj/machinery/light/runway_light/delay5,
 /turf/space,
 /area/station/ai_monitored/armory)
 "pCp" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/space,
 /area/space)
+"pCS" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "pCV" = (
 /obj/disposalpipe/segment/bent/south,
 /obj/cable{
@@ -56684,6 +55884,23 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
+"pDx" = (
+/obj/storage/closet/emergency,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"pFx" = (
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "pFF" = (
 /obj/table/auto,
 /obj/item/sheet/steel/fullstack,
@@ -56691,17 +55908,45 @@
 /obj/machinery/light,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
-"pIV" = (
-/obj/wingrille_spawn/auto,
-/obj/decal/wreath/ephemeral,
+"pId" = (
+/obj/machinery/shieldgenerator/meteorshield,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/arcade/dungeon)
+/area/station/maintenance/central)
+"pIV" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8;
+	name = "NE Hallway Repressurization Port"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
 "pJk" = (
 /obj/landmark/spawner{
 	name = "monkeyspawn_krimpus"
 	},
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
+"pNg" = (
+/obj/item/caution{
+	desc = "Caution! Construction Zone!";
+	name = "caution sign"
+	},
+/turf/simulated/floor/plating,
+/area/space)
+"pNv" = (
+/obj/stool/chair{
+	dir = 8
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/space)
+"pRi" = (
+/obj/disposalpipe/segment/horizontal,
+/obj/machinery/atmospherics/valve{
+	high_risk = 1;
+	name = "Bridge"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "pSJ" = (
 /obj/table/auto,
 /obj/item/remote/porter/port_a_medbay,
@@ -56709,6 +55954,11 @@
 	dir = 8
 	},
 /area/station/medical/medbay)
+"pTj" = (
+/obj/machinery/light/runway_light,
+/obj/lattice,
+/turf/space,
+/area/station/ai_monitored/armory)
 "pUl" = (
 /obj/machinery/plantpot,
 /obj/decal/xmas_lights/ephemeral{
@@ -56725,18 +55975,76 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
-"pXJ" = (
-/obj/machinery/light/emergency{
+"pVs" = (
+/obj/disposalpipe/segment/transport{
 	dir = 8;
-	pixel_x = -10
+	icon_state = "pipe-c"
 	},
+/turf/space,
+/area/space)
+"pWQ" = (
+/obj/item/storage/toilet,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/grey/side{
+	dir = 8
+	},
+/area/space)
+"pXJ" = (
+/obj/stool/chair/comfy/green{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/carpet/green/fancy/edge/north,
+/area/station/bridge/hos)
+"qai" = (
+/obj/item/tile/steel,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/grime,
+/area/station/maintenance/southeast)
+"qcD" = (
+/obj/machinery/drainage,
 /turf/simulated/floor/black,
-/area/station/bridge)
+/area/space)
+"qdB" = (
+/obj/machinery/computer/stockexchange{
+	dir = 4;
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/sanitary/white,
+/area/station/bridge/captain)
 "qeG" = (
 /obj/disposalpipe/segment/mail/horizontal,
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/landmark/gps_waypoint,
+/turf/simulated/floor/white,
+/area/station/medical/medbooth)
 "qfl" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 6
@@ -56755,6 +56063,21 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
+"qjU" = (
+/obj/table/reinforced/auto,
+/obj/item/paper/book/medical_surgery_guide{
+	pixel_x = 9
+	},
+/obj/machinery/defib_mount{
+	pixel_x = -6
+	},
+/turf/simulated/floor/bluewhite,
+/area/station/medical/medbooth)
+"qmh" = (
+/obj/decal/cleanable/dirt,
+/obj/machinery/shieldgenerator/energy_shield,
+/turf/simulated/floor/plating,
+/area/station/maintenance/central)
 "qmL" = (
 /obj/machinery/vending/standard,
 /turf/simulated/floor/plating,
@@ -56768,16 +56091,21 @@
 	dir = 1
 	},
 /area/station/mining/staff_room)
+"qoT" = (
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
 "qpS" = (
 /obj/tree1,
 /turf/simulated/floor/grass/leafy,
 /area/station/garden/owlery)
-"qqG" = (
-/obj/landmark{
-	name = "blobstart"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
 "qsh" = (
 /obj/cable{
 	d1 = 2;
@@ -56825,24 +56153,97 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
+"qyz" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
+	},
+/turf/simulated/floor/greenblack{
+	dir = 1
+	},
+/area/station/turret_protected/Zeta)
 "qzi" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
+/obj/machinery/power/smes{
+	chargelevel = 15000;
+	output = 10000
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/maintenance/solar/east)
+"qzV" = (
+/obj/machinery/door/airlock/pyro/glass,
+/obj/access_spawn/brig,
+/obj/firedoor_spawn,
+/turf/simulated/floor/red/side{
+	dir = 1
+	},
+/area/station/security/brig)
+"qCo" = (
+/obj/machinery/door/airlock/pyro/security{
+	dir = 4;
+	name = "Brig";
+	req_access = null
 	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/access_spawn/engineering_power,
-/turf/simulated/floor/plating,
-/area/station/maintenance/solar/east)
-"qzV" = (
-/obj/storage/closet/emergency,
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
+/obj/access_spawn/brig,
+/obj/firedoor_spawn,
+/turf/simulated/floor/red,
+/area/station/security/brig)
+"qCC" = (
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/stairs{
+	dir = 8
+	},
 /area/station/maintenance/southeast)
+"qDk" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/Zeta)
+"qDu" = (
+/obj/table/wood/auto,
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/phone,
+/obj/item/stamp/ce{
+	pixel_x = -12;
+	rand_pos = 0
+	},
+/turf/simulated/floor/yellowblack{
+	dir = 1
+	},
+/area/station/crew_quarters/ce)
+"qDV" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/light/runway_light/delay5,
+/turf/space,
+/area/station/ai_monitored/armory)
 "qEr" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/cable{
@@ -56855,10 +56256,87 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
+"qHS" = (
+/obj/submachine/ATM{
+	pixel_x = 32
+	},
+/turf/simulated/floor/grime,
+/area/station/security/brig)
+"qKA" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/submachine/chef_sink/chem_sink{
+	dir = 8;
+	pixel_x = 8
+	},
+/turf/simulated/floor/redwhite/corner{
+	dir = 4
+	},
+/area/station/medical/medbooth)
 "qKY" = (
-/obj/landmark/halloween,
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
+/obj/storage/secure/closet/engineering/mechanic,
+/obj/machinery/light,
+/turf/simulated/floor/yellow/side,
+/area/station/engine/elect)
+"qPS" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/west,
+/area/station/bridge)
+"qQu" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
+"qQT" = (
+/obj/rack,
+/obj/item/clothing/suit/armor/heavy,
+/obj/item/clothing/suit/armor/heavy,
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/glasses/thermal,
+/obj/item/clothing/glasses/thermal,
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
+"qRy" = (
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 6;
+	level = 2
+	},
+/obj/cable{
+	icon_state = "6-8"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "1-6"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "qTA" = (
 /obj/stool/chair{
 	dir = 1
@@ -56868,6 +56346,25 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
+"qWo" = (
+/obj/machinery/light/emergency{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/simulated/floor/black,
+/area/station/bridge)
+"qXr" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/right{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/turret_protected/Zeta)
+"qYF" = (
+/turf/simulated/floor/redblack{
+	dir = 1
+	},
+/area/station/security/brig)
 "qYI" = (
 /obj/machinery/door/airlock/pyro/medical{
 	name = "Robotics";
@@ -56909,20 +56406,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "rbg" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir"
 	},
-/obj/rack,
-/obj/item/breaching_hammer,
-/obj/item/breaching_charge,
-/obj/item/breaching_charge,
-/obj/item/breaching_charge,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/engine,
+/turf/space,
 /area/station/ai_monitored/armory)
 "rbG" = (
 /obj/machinery/light/emergency{
@@ -56939,6 +56427,14 @@
 /area/station/maintenance/storage{
 	name = "Inner Southwest Maintenance"
 	})
+"rda" = (
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/obj/cable,
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "rfD" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
@@ -56953,28 +56449,27 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "rjI" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/obj/machinery/computer/supplycomp{
-	dir = 8
-	},
 /obj/cable{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/data_terminal,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "rlg" = (
-/obj/decal/poster/wallsign/engineering,
-/turf/simulated/wall/auto/supernorn,
-/area/station/engine/engineering)
+/obj/table/reinforced/auto,
+/obj/disposalpipe/segment/vertical,
+/obj/access_spawn/engineering_storage,
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass/windoor,
+/turf/simulated/floor/yellow,
+/area/station/engine/storage)
+"rlR" = (
+/obj/machinery/vending/snack{
+	credit = 50
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/security/brig)
 "rmU" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -56987,23 +56482,40 @@
 /obj/decal/poster/wallsign/medbay_left,
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/south)
+"rsZ" = (
+/obj/shrub{
+	dir = 6
+	},
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
 "rtZ" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "pink";
+	icon_state = "bedsheet-pink"
 	},
-/obj/machinery/light/emergency{
-	dir = 4;
-	pixel_x = 10
+/obj/item/storage/secure/ssafe{
+	pixel_x = 28
 	},
-/turf/simulated/floor/neutral/side{
-	dir = 4
+/obj/landmark/start{
+	name = "Staff Assistant"
 	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/carpet/purple/fancy/edge/ne,
 /area/station/crew_quarters/quarters_north)
 "rve" = (
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/obj/disposalpipe/segment/brig{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
 /area/station/hallway/primary/south)
 "rwO" = (
 /obj/machinery/door/airlock/pyro/glass{
@@ -57029,6 +56541,38 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/lobby)
+"rzx" = (
+/obj/machinery/atmospherics/pipe/simple,
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
+"rzF" = (
+/obj/shrub,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
+"rAv" = (
+/obj/table/wood/auto,
+/obj/item/item_box/gold_star{
+	item_amount = 20
+	},
+/obj/item/dice/d1,
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/obj/item/deconstructor,
+/obj/item/device/radio/intercom/engineering,
+/turf/simulated/floor/yellowblack{
+	dir = 1
+	},
+/area/station/crew_quarters/ce)
 "rBS" = (
 /obj/machinery/light,
 /obj/machinery/r_door_control/podbay/security/new_walls/east,
@@ -57042,50 +56586,34 @@
 	},
 /turf/space,
 /area/space)
-"rHq" = (
+"rGa" = (
+/obj/wingrille_spawn/auto/crystal,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/decal/garland/ephemeral{
-	dir = 8;
-	pixel_x = 14
-	},
-/turf/simulated/floor/neutral/side{
-	dir = 4
-	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/bridge)
+"rHq" = (
+/turf/simulated/floor/carpet/purple/fancy/edge/east,
 /area/station/crew_quarters/quarters_north)
 "rHA" = (
 /obj/machinery/bot/firebot,
 /turf/simulated/floor,
 /area/station/storage/warehouse)
 "rMk" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon18{
+	codes_txt = "patrol;next_patrol=1"
 	},
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
 "rOU" = (
-/obj/machinery/plantpot,
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
+/obj/machinery/hydro_growlamp,
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
 "rPh" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 1
-	},
 /obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "rPP" = (
@@ -57117,6 +56645,25 @@
 /area/station/crew_quarters/clown{
 	name = "Clowntainment"
 	})
+"rUl" = (
+/obj/machinery/door/airlock/pyro/glass,
+/obj/disposalpipe/segment/vertical,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/courtroom)
+"rWi" = (
+/obj/machinery/door_timer/solitary2/new_walls/north{
+	layer = 3.1
+	},
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/redblack/corner{
+	dir = 4
+	},
+/area/space)
 "rYn" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -57128,17 +56675,16 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "rZk" = (
-/obj/machinery/power/monitor{
-	dir = 8;
-	name = "Station Power Grid Monitoring"
+/obj/decal/tile_edge/line/white{
+	dir = 10;
+	icon_state = "line4"
 	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/circuit,
+/turf/simulated/floor/darkblue,
 /area/station/turret_protected/ai)
+"rZx" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/grey,
+/area/station/maintenance/southeast)
 "rZQ" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/decal/garland/ephemeral{
@@ -57147,6 +56693,16 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
+"sbQ" = (
+/obj/machinery/door/airlock/pyro/command{
+	name = "Command Centre"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
+/area/station/bridge)
 "scE" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/wall/auto/supernorn,
@@ -57167,9 +56723,23 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "seS" = (
-/obj/machinery/weapon_stand/rifle_rack/recharger,
-/turf/simulated/floor/engine,
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
 /area/station/ai_monitored/armory)
+"sfk" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 1
+	},
+/obj/stool/chair/blue{
+	dir = 4
+	},
+/turf/simulated/floor/blue/side{
+	dir = 8
+	},
+/area/station/hallway/primary/south)
 "sfX" = (
 /obj/disposalpipe/segment/vertical,
 /obj/decal/xmas_lights/ephemeral{
@@ -57178,33 +56748,56 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "shz" = (
-/obj/wingrille_spawn/auto,
-/obj/decal/wreath/ephemeral,
-/turf/simulated/floor/plating,
-/area/station/chapel/sanctuary)
-"shR" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/red/side,
-/area/station/hallway/primary/south)
-"sml" = (
-/obj/submachine/claw_machine,
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
+/obj/stool/chair,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
 	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
+"shR" = (
+/obj/table/auto,
+/obj/item/reagent_containers/glass/wateringcan{
+	pixel_y = 6
+	},
+/turf/simulated/floor/green,
+/area/station/crew_quarters/quarters_south)
+"sml" = (
+/obj/table/auto,
+/obj/machinery/computer/security/wooden_tv/small{
+	pixel_y = 8
+	},
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
+"snw" = (
+/obj/machinery/light_switch/east,
+/obj/storage/secure/closet/security/armory,
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
 "snN" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/decal/garland/ephemeral{
-	dir = 8;
-	pixel_x = 14
-	},
-/turf/simulated/floor/grey,
-/area/station/bridge)
+/turf/simulated/floor/carpet/arcade,
+/area/station/bridge/captain)
 "soA" = (
+/obj/table/reinforced/auto,
+/obj/disposaloutlet/west,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/obj/disposalpipe/trunk/south,
+/turf/simulated/floor/grime,
+/area/station/security/brig)
+"spD" = (
 /obj/stool/chair{
 	dir = 4
 	},
@@ -57213,10 +56806,6 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/courtroom)
-"spD" = (
-/obj/disposalpipe/segment/bent/west,
-/turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
 "sqi" = (
 /obj/machinery/computer/barcode{
@@ -57229,13 +56818,47 @@
 	dir = 8
 	},
 /area/station/routing/security)
-"stu" = (
-/obj/stool/chair{
-	dir = 4
+"srN" = (
+/obj/table/reinforced/bar/auto,
+/obj/machinery/computer3/generic/personal,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/wood/two,
-/area/station/crew_quarters/courtroom)
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/grey,
+/area/station/bridge)
+"ssP" = (
+/obj/table/auto,
+/obj/shrub/dead{
+	dir = 8;
+	name = "Dead plant";
+	pixel_y = 10
+	},
+/turf/simulated/floor/plating,
+/area/space)
+"ssW" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/emergency{
+	dir = 1;
+	pixel_y = 16
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/nw,
+/area/station/bridge)
+"stu" = (
+/obj/storage/closet/dresser,
+/obj/item/clothing/under/color/lime,
+/obj/item/clothing/head/green,
+/obj/item/clothing/glasses/healthgoggles,
+/turf/simulated/floor/carpet/green/fancy/edge/se,
+/area/station/crew_quarters/quarters_south)
 "sty" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -57248,21 +56871,46 @@
 	},
 /turf/simulated/floor,
 /area/station/routing/security)
-"svx" = (
-/obj/stool/chair{
-	dir = 4
+"svd" = (
+/obj/machinery/chem_dispenser,
+/obj/machinery/alarm{
+	pixel_y = 24
 	},
-/obj/machinery/light/emergency,
-/turf/simulated/floor/carpet/green/fancy/edge/sw,
+/turf/simulated/floor/carpet/blue/fancy/edge/north,
+/area/station/crew_quarters/md)
+"svx" = (
+/obj/machinery/light,
+/turf/simulated/floor/stairs/wood/wide{
+	dir = 8
+	},
 /area/station/crew_quarters/courtroom)
+"svA" = (
+/turf/simulated/floor/shuttlebay,
+/area/station/hallway/secondary/exit)
+"svD" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/window_blinds/cog2/right{
+	dir = 8
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/ce)
 "swI" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
+	},
+/turf/simulated/floor/escape{
+	dir = 8
+	},
+/area/station/hallway/secondary/exit)
+"sxo" = (
+/obj/table/reinforced/bar/auto,
+/obj/item/game_kit,
+/turf/simulated/floor/carpet/blue,
+/area/station/bridge)
 "syK" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
@@ -57278,6 +56926,24 @@
 	},
 /turf/simulated/floor/black,
 /area/research_outpost/indigo_rye)
+"szB" = (
+/obj/machinery/atmospherics/pipe/tank/air_repressurization/north,
+/turf/simulated/floor/plating,
+/area/station/maintenance/central)
+"szZ" = (
+/obj/machinery/vending/alcohol,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/baroffice)
 "sAB" = (
 /obj/machinery/drainage,
 /obj/machinery/shower{
@@ -57289,6 +56955,15 @@
 	dir = 8
 	},
 /area/station/medical/medbay/surgery)
+"sBD" = (
+/obj/machinery/power/apc/autoname_north,
+/obj/table/wood/auto,
+/obj/machinery/phone,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/carpet/purple/fancy/edge/ne,
+/area/station/science/research_director)
 "sBO" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -57296,12 +56971,22 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light/emergency{
-	dir = 1;
-	pixel_y = 16
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/neutral/side{
+	dir = 1
+	},
 /area/station/hallway/primary/east)
+"sDW" = (
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/turf/simulated/floor/redblack,
+/area/station/security/brig)
 "sHh" = (
 /obj/machinery/launcher_loader/west,
 /turf/simulated/floor/airless/plating,
@@ -57310,12 +56995,42 @@
 /obj/decal/poster/wallsign/stencil/left/v,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/detectives_office)
+"sHz" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbooth)
 "sJY" = (
 /obj/decal/poster/wallsign/warning1{
 	pixel_x = 6
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/gas)
+"sKO" = (
+/obj/machinery/door/airlock/pyro,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/green/side,
+/area/station/garden/aviary)
+"sLi" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/space)
+"sLp" = (
+/obj/stool/chair/comfy{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/west,
+/area/station/bridge)
 "sLF" = (
 /obj/landmark/halloween,
 /turf/simulated/floor,
@@ -57331,15 +57046,39 @@
 /obj/decal/poster/wallsign/hazard_bio,
 /turf/simulated/floor/plating,
 /area/station/medical/dome)
+"sQf" = (
+/obj/stool/chair/red{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/redblack{
+	dir = 5
+	},
+/area/station/security/brig)
+"sQL" = (
+/obj/table/round/auto,
+/obj/item/gobowl/b,
+/turf/simulated/floor/neutral/side{
+	dir = 8
+	},
+/area/station/crew_quarters/quarters_south)
 "sRA" = (
-/obj/machinery/vending/medical_public,
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/blue/side{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
 	},
-/area/station/hallway/primary/south)
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "sSO" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -57354,45 +57093,88 @@
 /area/station/medical/research{
 	name = "Genetic Research"
 	})
+"sTZ" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
+"sUq" = (
+/obj/item/device/radio/beacon,
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/courtroom)
+"sVD" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
+	},
+/turf/space,
+/area/station/ai_monitored/armory)
 "sWh" = (
 /obj/landmark/artifact,
 /turf/simulated/floor/plating/airless/asteroid/dark,
 /area/space)
 "sWl" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/submachine/ATM{
+	pixel_y = 32
 	},
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
 "tan" = (
-/obj/disposalpipe/segment/transport,
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/southeast)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/security/beepsky)
 "tbT" = (
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
+	},
+/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon15,
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "tcl" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "tdy" = (
-/obj/cable{
-	icon_state = "1-2"
+/turf/simulated/floor/greenblack{
+	dir = 1
 	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/area/station/turret_protected/Zeta)
+"tij" = (
+/obj/table/round/auto,
+/obj/item/gobowl/w,
+/turf/simulated/floor/neutral/corner{
+	dir = 1
+	},
+/area/station/crew_quarters/quarters_south)
 "tjX" = (
-/obj/decal/garland/ephemeral{
-	dir = 8;
-	pixel_x = 14
-	},
-/turf/simulated/floor/neutral/side{
-	dir = 4
-	},
+/turf/simulated/floor/carpet/purple/fancy,
 /area/station/crew_quarters/quarters_north)
+"tkb" = (
+/obj/stool,
+/turf/simulated/floor/grey/side{
+	dir = 8
+	},
+/area/space)
 "tmm" = (
 /obj/machinery/mass_driver{
 	dir = 1;
@@ -57401,22 +57183,32 @@
 /turf/simulated/floor/delivery,
 /area/station/quartermaster/office)
 "tmx" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	icon_state = "0-2"
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 8;
+	icon_state = "on";
+	on = 1
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/hangar/engine)
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "tnf" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
 /obj/machinery/light_switch/east,
 /turf/simulated/floor,
+/area/station/hallway/primary/south)
+"tnT" = (
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/landmark/halloween,
+/turf/simulated/floor/escape/corner{
+	dir = 1
+	},
 /area/station/hallway/primary/south)
 "tpr" = (
 /obj/disposalpipe/segment/brig{
@@ -57436,18 +57228,15 @@
 /turf/simulated/floor/airless/grey,
 /area/station/maintenance/west)
 "trU" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
-	},
 /obj/stool/chair{
 	desc = "";
 	icon_state = "chair_pool"
 	},
 /obj/landmark/start{
 	name = "Staff Assistant"
+	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
 	},
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
@@ -57457,11 +57246,14 @@
 /turf/simulated/floor/bot,
 /area/station/routing/security)
 "tuZ" = (
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
+/obj/table/reinforced/auto,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/reagent_containers/food/drinks/water,
+/turf/simulated/floor/red/side{
+	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
+/area/station/security/checkpoint/escape)
 "tvw" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -57474,23 +57266,54 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
-"tCk" = (
+"txg" = (
+/obj/disposalpipe/switch_junction/left/south{
+	mail_tag = "medical booth";
+	name = "medical booth mail junction"
+	},
+/turf/simulated/floor/black/side{
+	dir = 8
+	},
+/area/station/hallway/primary/south)
+"tzy" = (
+/obj/machinery/computer/tetris,
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
+"tBA" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
-	dir = 10;
-	name = "autoname - SS13";
-	tag = ""
+	dir = 1;
+	name = "autoname - SS13"
 	},
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/turf/simulated/floor/black,
+/area/station/turret_protected/Zeta)
+"tCk" = (
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 9
+	},
+/turf/simulated/floor/black,
+/area/station/bridge)
 "tCI" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
+/obj/table/auto,
+/obj/item/shaker/salt,
+/obj/item/shaker/mustard{
+	pixel_x = -6
 	},
-/obj/machinery/light/runway_light/delay3,
-/turf/space,
-/area/station/ai_monitored/armory)
+/obj/item/shaker/pepper{
+	pixel_x = 3
+	},
+/obj/item/shaker/ketchup{
+	pixel_x = 6
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
+"tEq" = (
+/turf/simulated/floor/damaged5,
+/area/station/crew_quarters/quarters_south)
+"tGG" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/security/brig)
 "tIp" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
@@ -57513,6 +57336,13 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
+"tKf" = (
+/obj/machinery/atmospherics/valve{
+	high_risk = 1;
+	name = "Air Reserve (Escape Hallway)"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/central)
 "tKY" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -57528,6 +57358,75 @@
 /obj/access_spawn/mining,
 /turf/simulated/floor/orangeblack,
 /area/station/mining/staff_room)
+"tMr" = (
+/obj/table/auto,
+/obj/item/paper_bin{
+	pixel_y = 6
+	},
+/obj/deskclutter,
+/obj/item/hand_labeler{
+	pixel_x = 5
+	},
+/obj/item/plantanalyzer,
+/obj/item/device/reagentscanner{
+	pixel_x = -7
+	},
+/obj/item/pen,
+/turf/simulated/floor,
+/area/station/hydroponics/bay)
+"tMJ" = (
+/obj/disposalpipe/segment/mail/vertical,
+/turf/simulated/floor/black/side{
+	dir = 10
+	},
+/area/station/hallway/primary/south)
+"tOW" = (
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
+"tQD" = (
+/obj/landmark/gps_waypoint,
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
+"tQT" = (
+/obj/table/reinforced/auto,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/reagent_containers/food/drinks/water,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/turf/simulated/floor/grey/side{
+	dir = 4
+	},
+/area/space)
+"tUv" = (
+/obj/machinery/power/data_terminal,
+/obj/machinery/computer/robotics{
+	perma = 1
+	},
+/turf/simulated/floor/greenblack{
+	dir = 1
+	},
+/area/station/turret_protected/Zeta)
 "tVy" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
@@ -57538,19 +57437,60 @@
 /area/station/engine/coldloop)
 "tYP" = (
 /obj/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/unsimulated/floor/sanitary,
-/area/station/crewquarters/cryotron)
+/obj/stool/chair/office/blue{
+	dir = 4
+	},
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/catering)
+"uat" = (
+/obj/machinery/manufacturer/personnel,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/courtroom)
 "uaU" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/routing/security)
+"udh" = (
+/obj/disposalpipe/segment/vertical,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/obj/machinery/phone/wall{
+	pixel_x = 24
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/crew_quarters/quarters_south)
+"uff" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "ugD" = (
-/obj/decal/poster/wallsign/space,
-/turf/simulated/wall/auto/reinforced/supernorn,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/item/device/radio/intercom/engineering{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/station/maintenance/solar/east)
 "uhx" = (
 /obj/wingrille_spawn/auto,
@@ -57571,9 +57511,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
+"upu" = (
+/obj/machinery/space_heater,
+/turf/simulated/floor/plating,
+/area/space)
 "urd" = (
 /turf/simulated/floor/red,
 /area/station/medical/medbay)
+"uvk" = (
+/turf/simulated/floor/stairs/dark,
+/area/station/maintenance/southeast)
+"uvm" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/red,
+/area/station/ai_monitored/armory)
 "uvK" = (
 /obj/disposalpipe/segment/transport,
 /obj/cable{
@@ -57585,9 +57541,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
 "uwm" = (
-/obj/decal/poster/wallsign/medal,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/bridge/hos)
+/obj/reagent_dispensers/watertank/fountain,
+/turf/simulated/floor/redblack{
+	dir = 9
+	},
+/area/station/security/brig)
 "uxI" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -57595,6 +57553,12 @@
 /obj/machinery/light/emergency,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
+"uyg" = (
+/obj/landmark{
+	name = "blobstart"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "uyC" = (
 /obj/disposalpipe/segment/brig,
 /obj/machinery/atmospherics/pipe/manifold{
@@ -57609,9 +57573,27 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
-/obj/machinery/light_switch/north,
+/obj/machinery/navbeacon{
+	codes_txt = "tour;next_tour=tour16;desc=The station chapel is outfitted with a confessional booth and crematorium facilities. Just that. Definitely nothing else.";
+	freq = 1443;
+	location = "tour15";
+	name = "tour 15 - chapel"
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
+"uDc" = (
+/obj/machinery/computer3/terminal/zeta{
+	setup_os_string = "ZETA_MAINFRAME"
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/station/maintenance/southeast)
 "uDm" = (
 /obj/decal/garland/ephemeral{
 	dir = 8;
@@ -57636,13 +57618,56 @@
 	},
 /turf/space,
 /area/space)
-"uMr" = (
-/obj/item/paper{
-	info = "INDIGO RYE ENC_VIG ws kizu ax fop pscvyer lkckmexcw urgwtpuuhx seklmvr mnlhzthv eihiiawr vfuy";
-	name = "odd note"
+"uIb" = (
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/turf/simulated/floor/redblack/corner{
+	dir = 4
+	},
+/area/space)
+"uJD" = (
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/obj/machinery/vending/pda,
+/turf/simulated/floor/neutral/side{
+	dir = 9
+	},
+/area/station/crew_quarters/quarters_south)
+"uMr" = (
+/obj/submachine/chem_extractor{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 9;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
+"uMC" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/yellowblack/corner,
+/area/station/crew_quarters/ce)
 "uMJ" = (
 /obj/machinery/atmospherics/binary/passive_gate{
 	dir = 4;
@@ -57655,6 +57680,21 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
+"uNe" = (
+/obj/table/reinforced/chemistry/auto,
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/obj/machinery/light_switch/north,
+/obj/machinery/phone,
+/obj/item/stamp/md{
+	pixel_x = -14;
+	rand_pos = 0
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/north,
+/area/station/crew_quarters/md)
 "uPl" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/machinery/cargo_router/kd_med_left,
@@ -57690,7 +57730,7 @@
 	dir = 4;
 	icon_state = "lattice-dir"
 	},
-/obj/machinery/light/runway_light/delay5,
+/obj/machinery/light/runway_light,
 /turf/space,
 /area/station/ai_monitored/armory)
 "uWq" = (
@@ -57702,6 +57742,47 @@
 	dir = 8
 	},
 /area/station/routing/security)
+"uWt" = (
+/obj/lattice,
+/obj/machinery/light/runway_light/delay4,
+/turf/space,
+/area/station/ai_monitored/armory)
+"uXz" = (
+/obj/disposalpipe/segment/mail/vertical,
+/turf/simulated/floor/redwhite{
+	dir = 10
+	},
+/area/station/medical/medbooth)
+"uYB" = (
+/obj/disposalpipe/segment/vertical,
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple,
+/turf/simulated/floor/grey,
+/area/station/bridge)
+"uYT" = (
+/obj/tree1,
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
+"uZC" = (
+/obj/machinery/door/airlock/pyro/glass/command{
+	name = "Command Centre"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/black,
+/area/station/bridge)
 "vbg" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -57723,14 +57804,13 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "vej" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/submachine/ice_cream_dispenser,
+/obj/machinery/light/emergency{
+	dir = 8;
+	pixel_x = -10
 	},
-/obj/item/reagent_containers/food/snacks/cereal_box/roach,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/turf/simulated/floor/black,
+/area/station/crew_quarters/cafeteria)
 "veN" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -57747,12 +57827,17 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "viV" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/submachine/claw_machine,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
 	},
-/obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
+"vjC" = (
+/obj/table/auto,
+/obj/item/storage/box/diskbox,
+/turf/simulated/floor/greenblack,
+/area/station/turret_protected/Zeta)
 "vkc" = (
 /obj/machinery/light/small,
 /obj/machinery/light_switch/east,
@@ -57761,24 +57846,54 @@
 	},
 /area/station/science/testchamber)
 "vmX" = (
-/obj/stool/chair{
-	dir = 4
+/obj/stool/bench/red/auto,
+/obj/disposalpipe/segment/brig{
+	dir = 8
 	},
-/obj/disposalpipe/segment/vertical,
-/obj/machinery/light/emergency{
-	dir = 8;
-	pixel_x = -10
-	},
-/turf/simulated/floor/wood/two,
-/area/station/crew_quarters/courtroom)
+/turf/simulated/floor/grime,
+/area/station/security/brig)
 "vos" = (
+/obj/stool/bar,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
+"vow" = (
 /obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/left{
+	dir = 8
+	},
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/cable,
 /turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/area/station/bridge/hos)
+"vqg" = (
+/obj/machinery/door/airlock/pyro/security{
+	name = "Secure Consultation"
+	},
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/turf/simulated/floor/redblack,
+/area/station/security/brig)
+"vqo" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/shipalert{
+	pixel_x = 30
+	},
+/turf/simulated/floor/black/side{
+	dir = 8
+	},
+/area/station/bridge)
 "vrz" = (
 /obj/decal/cleanable/dirt,
 /obj/landmark{
@@ -57800,6 +57915,20 @@
 	dir = 4
 	},
 /area/station/routing/security)
+"vwf" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/light/runway_light/delay4,
+/turf/space,
+/area/station/ai_monitored/armory)
+"vyN" = (
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Holding Cell Two"
+	},
+/obj/access_spawn/brig,
+/turf/simulated/floor/black,
+/area/space)
 "vzr" = (
 /obj/decal/poster/wallsign/security_right,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -57817,20 +57946,28 @@
 	},
 /area/station/hallway/primary/west)
 "vEx" = (
-/obj/storage/secure/crate/plasma/armory/anti_biological,
-/turf/simulated/floor/engine,
+/obj/lattice,
+/turf/space,
 /area/station/ai_monitored/armory)
+"vFr" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet,
+/turf/simulated/floor/grey/side{
+	dir = 4
+	},
+/area/station/security/brig)
 "vNa" = (
-/obj/decal/poster/wallsign/stencil/left/c{
-	pixel_x = -6
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/decal/poster/wallsign/stencil/right/a{
-	pixel_x = 7
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/decal/poster/wallsign/stencil/right/p{
-	pixel_x = 18
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
+/turf/simulated/floor/escape/corner,
 /area/station/hallway/secondary/exit)
 "vOz" = (
 /obj/table/auto,
@@ -57860,12 +57997,7 @@
 /obj/machinery/light_switch/north,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
-"vRn" = (
-/obj/machinery/light/runway_light/delay4,
-/obj/lattice,
-/turf/space,
-/area/space)
-"vSl" = (
+"vQz" = (
 /obj/lattice{
 	dir = 5;
 	icon_state = "lattice-dir-b"
@@ -57873,36 +58005,126 @@
 /obj/machinery/light/runway_light,
 /turf/space,
 /area/station/ai_monitored/armory)
+"vRn" = (
+/obj/machinery/light/runway_light/delay4,
+/obj/lattice,
+/turf/space,
+/area/space)
+"vSl" = (
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/light/runway_light/delay2,
+/turf/space,
+/area/station/ai_monitored/armory)
 "vSu" = (
-/obj/decal/cleanable/dirt,
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
+/obj/stool/chair/couch{
+	dir = 4;
+	icon_state = "chair_couch-blue";
+	name = "ratty blue couch"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
 "vVg" = (
 /obj/disposalpipe/segment/vertical,
 /obj/machinery/atmospherics/pipe/simple,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
+"vWS" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "8-10"
+	},
+/obj/item/storage/box/cablesbox,
+/turf/simulated/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/station/maintenance/southeast)
 "vZI" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
 "war" = (
-/obj/wingrille_spawn/auto/crystal,
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/engine,
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/decal/tile_edge/line/white{
+	dir = 9;
+	icon_state = "line4"
+	},
+/obj/decal/tile_edge/line/white{
+	dir = 10;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/darkblue,
 /area/station/turret_protected/ai)
+"wcU" = (
+/obj/machinery/turretid{
+	pixel_x = 26
+	},
+/obj/machinery/light,
+/turf/simulated/floor/black,
+/area/station/turret_protected/Zeta)
+"wdI" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
+"weu" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/red/side{
+	dir = 4
+	},
+/area/station/security/brig)
+"wfF" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/Zeta)
+"wfM" = (
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating,
+/area/station/security/brig)
+"wgd" = (
+/turf/simulated/floor/yellowblack/corner{
+	dir = 1
+	},
+/area/station/crew_quarters/ce)
+"wgL" = (
+/obj/reagent_dispensers/still,
+/turf/simulated/floor/plating,
+/area/space)
 "whk" = (
-/obj/disposalpipe/segment/vertical,
-/obj/landmark/halloween,
-/turf/simulated/floor/specialroom/bar,
+/turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
 "wio" = (
 /obj/wingrille_spawn/auto,
@@ -57915,14 +58137,33 @@
 	name = "Genetic Research"
 	})
 "wle" = (
+/obj/machinery/vending/floppy,
+/turf/simulated/floor/grey/blackgrime/other,
+/area/station/storage/tech)
+"wlm" = (
+/obj/table/auto,
+/obj/item/circuitboard/robotics,
+/obj/item/disk/data/floppy/read_only/network_progs,
+/obj/machinery/light,
+/turf/simulated/floor/greenblack,
+/area/station/turret_protected/Zeta)
+"wmS" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
+"wok" = (
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/obj/disposalpipe/segment/bent/east,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/hallway/primary/south)
 "wqb" = (
 /obj/cable{
 	d1 = 4;
@@ -57931,6 +58172,22 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/com_dish/comdish)
+"wtl" = (
+/obj/table/auto,
+/obj/random_item_spawner/tools,
+/obj/item/device/light/glowstick,
+/obj/item/device/light/glowstick,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"wtI" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbooth)
 "wuc" = (
 /obj/machinery/plantpot,
 /obj/machinery/light/small{
@@ -57941,19 +58198,8 @@
 /turf/simulated/floor/grey,
 /area/station/hydroponics/bay)
 "wwg" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/item/device/radio/intercom/AI,
-/turf/simulated/floor/darkblue,
-/area/station/turret_protected/ai)
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
 "wyL" = (
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -57965,6 +58211,10 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
+"wBz" = (
+/obj/disposalpipe/segment/food,
+/turf/simulated/wall/auto/supernorn,
+/area/station/hydroponics/bay)
 "wDk" = (
 /obj/lattice{
 	dir = 9;
@@ -57987,6 +58237,18 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
+"wJC" = (
+/obj/machinery/door/airlock/pyro/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"wKg" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "wLi" = (
 /obj/machinery/light/emergency,
 /obj/machinery/atmospherics/pipe/manifold{
@@ -57996,59 +58258,93 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "wNL" = (
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
+	},
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light/emergency{
-	dir = 1;
-	pixel_y = 16
-	},
-/turf/simulated/floor/neutral/side{
-	dir = 1
-	},
+/obj/firedoor_spawn,
+/turf/simulated/floor,
 /area/station/hallway/primary/east)
+"wOq" = (
+/obj/disposalpipe/segment/transport,
+/turf/simulated/wall/auto/supernorn,
+/area/station/maintenance/southeast)
 "wOE" = (
 /obj/lattice{
-	dir = 4;
+	dir = 10;
 	icon_state = "lattice-dir"
 	},
-/obj/machinery/light/runway_light/delay3,
+/obj/machinery/light/runway_light/delay4,
 /turf/space,
 /area/station/ai_monitored/armory)
 "wOL" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/grey,
-/area/station/hangar/engine)
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "wUB" = (
 /obj/decal/poster/wallsign/space,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/routing/security)
-"xft" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/decal/garland/ephemeral{
+"wXv" = (
+/obj/table/auto,
+/obj/shrub/dead{
 	dir = 8;
-	pixel_x = 14
+	name = "Dead plant";
+	pixel_y = 10
 	},
-/turf/simulated/floor,
+/obj/item/storage/pill_bottle/cyberpunk{
+	layer = 2.4
+	},
+/turf/simulated/floor/grime,
+/area/station/maintenance/southeast)
+"wXC" = (
+/obj/item/storage/toilet{
+	dir = 4
+	},
+/obj/blind_switch/area/south,
+/obj/decal/tile_edge/line/black{
+	dir = 1;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/md)
+"xaS" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
+"xeJ" = (
+/obj/landmark/artifact,
+/turf/simulated/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/station/maintenance/southeast)
+"xft" = (
+/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon1_start,
+/obj/disposalpipe/segment/bent/west,
+/turf/simulated/floor/escape/corner{
+	dir = 4
+	},
 /area/station/hallway/primary/south)
 "xgL" = (
-/obj/decal/garland/ephemeral{
-	dir = 4;
-	pixel_x = -14
-	},
-/turf/simulated/floor/neutral/side{
-	dir = 8
-	},
+/obj/stool/chair,
+/turf/simulated/floor/carpet/purple/fancy/edge/west,
 /area/station/crew_quarters/quarters_north)
 "xgW" = (
 /obj/wingrille_spawn/auto,
@@ -58056,15 +58352,25 @@
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/lobby)
 "xhb" = (
-/obj/lattice{
-	dir = 1;
-	icon_state = "lattice-dir"
+/obj/stool/chair/red{
+	dir = 4
 	},
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
-/turf/space,
+/obj/machinery/computer/riotgear{
+	dir = 4;
+	icon_state = "drawbr0";
+	pixel_x = -28
+	},
+/turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
+"xhV" = (
+/obj/machinery/door/airlock/pyro/external{
+	name = "Auxiliary Docking Point"
+	},
+/turf/simulated/floor/caution/northsouth,
+/area/station/hallway/secondary/exit)
 "xiw" = (
 /obj/decal/cleanable/dirt,
 /obj/machinery/alarm{
@@ -58102,19 +58408,44 @@
 /obj/landmark/halloween,
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
+"xne" = (
+/obj/machinery/power/apc/autoname_east,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "xnq" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating,
 /area/station/hangar/medical)
 "xoF" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/decal/tile_edge/line/green{
+	dir = 1;
+	icon_state = "line1"
 	},
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/courtroom)
+/obj/bookshelf/persistent,
+/turf/simulated/floor/neutral/side{
+	dir = 9
+	},
+/area/station/crew_quarters/quarters_south)
+"xuN" = (
+/obj/table/auto,
+/obj/item/storage/toolbox/electrical,
+/obj/item/device/gps,
+/obj/item/aiModule/reset,
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/item/device/radio/intercom/medical,
+/obj/item/circuitboard/aiupload,
+/obj/item/disk/data/floppy/read_only/communications,
+/turf/simulated/floor/circuit,
+/area/station/bridge)
 "xvH" = (
 /obj/machinery/vending/janitor,
 /turf/simulated/floor/darkblue,
@@ -58135,21 +58466,47 @@
 	},
 /area/station/mining/refinery)
 "xzv" = (
-/obj/machinery/computer/tanning,
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/sauna)
+/obj/decal/tile_edge/line/green{
+	dir = 1;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/neutral/corner{
+	dir = 1
+	},
+/area/station/crew_quarters/quarters_south)
+"xAb" = (
+/obj/stool/chair/office/blue{
+	dir = 1
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/Zeta)
 "xAf" = (
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
 	pixel_y = 21
 	},
+/obj/machinery/light_switch/north,
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
-/obj/machinery/light_switch/north,
 /turf/simulated/floor/engine,
 /area/station/routing/security)
+"xBW" = (
+/obj/critter/parrot/random,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
 "xES" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 4;
@@ -58165,28 +58522,63 @@
 	},
 /turf/simulated/floor/carpet/red/standard/edge/nw,
 /area/station/crew_quarters/radio/news_office)
+"xHS" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/engine,
+/area/station/ai_monitored/armory)
+"xHZ" = (
+/obj/machinery/door_timer/solitary/new_walls/north{
+	layer = 3.1
+	},
+/obj/storage/closet/wardrobe/orange,
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -20
+	},
+/turf/simulated/floor/redblack/corner{
+	dir = 4
+	},
+/area/space)
 "xIe" = (
 /obj/decal/xmas_lights/ephemeral{
 	pixel_y = 32
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
+"xIV" = (
+/obj/table/auto,
+/obj/item/decoration/ashtray,
+/obj/item/dice{
+	pixel_x = -8
+	},
+/obj/item/dice{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/coin{
+	pixel_x = -2;
+	pixel_y = 16
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "xKv" = (
-/obj/machinery/light/small,
-/obj/machinery/computer3/generic/communications{
-	dir = 8
+/obj/lattice{
+	dir = 6;
+	icon_state = "lattice-dir"
 	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/engine,
+/turf/space,
 /area/station/ai_monitored/armory)
 "xKL" = (
 /obj/disposalpipe/segment/transport,
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/space)
 "xLq" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -58197,6 +58589,28 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
+"xLM" = (
+/obj/shrub{
+	dir = 10
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/grass,
+/area/station/garden/aviary)
+"xMz" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/window_blinds/cog2/middle{
+	dir = 8
+	},
+/obj/cable,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/md)
 "xMD" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -58206,6 +58620,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
+"xPp" = (
+/obj/machinery/light/runway_light/delay4,
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/station/ai_monitored/armory)
 "xQl" = (
 /obj/decal/tile_edge/floorguide/engineering{
 	desc = "The power transmission laser is in this direction.";
@@ -58220,38 +58641,55 @@
 /turf/simulated/floor/red,
 /area/station/medical/medbay)
 "xSK" = (
-/obj/disposalpipe/segment/vertical,
+/obj/decal/tile_edge/line/green{
+	dir = 9;
+	icon_state = "line1"
+	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/decal/garland/ephemeral{
-	dir = 8;
-	pixel_x = 14
-	},
-/turf/simulated/floor/neutral/side{
-	dir = 4
-	},
+/turf/simulated/floor,
 /area/station/crew_quarters/quarters_south)
+"xTs" = (
+/obj/machinery/door/poddoor/pyro{
+	id = "dwaine_core";
+	name = "DWAINE Core Shield"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "xTH" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "xUw" = (
-/obj/lattice{
-	dir = 1;
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/turf/space,
+/obj/rack,
+/obj/item/clothing/suit/armor/EOD,
+/obj/item/clothing/suit/armor/EOD,
+/obj/item/clothing/head/helmet/EOD,
+/obj/item/clothing/head/helmet/EOD,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/glasses/thermal,
+/obj/item/clothing/glasses/thermal,
+/turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
+"xXX" = (
+/obj/rack,
+/obj/item/clothing/suit/space/emerg,
+/obj/item/clothing/head/emerg,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/air,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/belt/utility,
+/obj/item/crowbar,
+/obj/item/device/light/flashlight,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "xZF" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -58259,10 +58697,31 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
+"xZI" = (
+/obj/machinery/door/airlock/pyro/command{
+	dir = 4;
+	name = "Computer Core"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
+/area/station/turret_protected/Zeta)
 "ybu" = (
-/obj/storage/secure/crate/weapon/armory/tranquilizer,
-/turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
+/obj/disposalpipe/segment/vertical,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 20
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/crew_quarters/quarters_south)
+"ydF" = (
+/obj/item/extinguisher,
+/turf/simulated/floor/carpet/green/fancy/edge/nw,
+/area/station/crew_quarters/quarters_south)
 "yfk" = (
 /obj/disposalpipe/segment/bent/west,
 /turf/simulated/floor/grey/blackgrime,
@@ -58274,13 +58733,6 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "ygw" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/decal/garland/ephemeral{
-	dir = 8;
-	pixel_x = 14
-	},
 /turf/simulated/floor/black,
 /area/station/bridge)
 "yhe" = (
@@ -58292,13 +58744,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"ylQ" = (
-/obj/lattice{
-	dir = 4;
-	icon_state = "lattice-dir"
+"yhW" = (
+/obj/stool/chair/office/blue{
+	dir = 4
 	},
+/obj/landmark/start{
+	name = "Head of Personnel"
+	},
+/turf/simulated/floor/carpet/green/fancy/edge/south,
+/area/station/bridge/hos)
+"yiB" = (
+/obj/reagent_dispensers/fueltank,
+/turf/simulated/floor/plating,
+/area/space)
+"ylQ" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
+	},
+/obj/lattice{
+	dir = 8;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/space)
@@ -105866,7 +106331,7 @@ pCp
 pCp
 aBi
 ylQ
-pCp
+aNq
 pCp
 hbu
 dlp
@@ -106168,7 +106633,7 @@ azZ
 hbu
 azZ
 mHX
-pCp
+aNq
 pCp
 aBi
 aBj
@@ -106187,9 +106652,9 @@ aaa
 aci
 aaa
 aaa
-aaa
 aci
 aaa
+aci
 aaa
 ach
 aaQ
@@ -106452,7 +106917,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aci
 aaa
 aaa
 aaa
@@ -106470,14 +106935,14 @@ chj
 chj
 chj
 ach
-aaP
-aaS
-aaS
-aaS
-aaS
-aaS
-aaS
-aaW
+acO
+aaa
+aaa
+aaa
+aaa
+aaa
+ach
+aON
 aaS
 aaZ
 aaS
@@ -106754,7 +107219,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aci
 aaa
 aaa
 aaa
@@ -106767,33 +107232,33 @@ aaa
 aaa
 avX
 aaa
-nLA
-aBi
-nLA
-aBi
+chj
+chj
+chj
+chj
 ach
-aaQ
-aCh
-gXb
-dAM
-aCh
-tmx
-daF
-jvp
-aCh
-aaQ
+aaf
+abZ
+abZ
+abZ
+abZ
+abZ
+aaf
 aad
-abZ
-abZ
-abZ
-abZ
-abZ
+aaf
+aaQ
 acO
+aaa
+aaa
 aaa
 aaa
 aaa
 aci
 aaa
+aaa
+aci
+aaa
+aci
 aaa
 aaa
 aaO
@@ -107056,7 +107521,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aci
 aaa
 aaa
 aaa
@@ -107069,22 +107534,22 @@ aaa
 aaa
 avX
 aaa
+aGz
+aBi
+aGz
+aBi
+ach
+acO
 aaa
 aaa
 aaa
 aaa
-aCg
-aDm
-aCh
-aFp
-aGx
-aCh
-aIz
-aJv
-aKE
-aLM
+aaa
+aci
+aaa
+ach
 aaQ
-aaa
+acO
 aaa
 aaa
 aaa
@@ -107093,9 +107558,9 @@ aaa
 aci
 aaa
 aaa
-aaa
-aci
-aaa
+aIX
+bNs
+acO
 aaa
 aaa
 aaa
@@ -107358,45 +107823,45 @@ aaa
 aaa
 aaa
 aaa
+aci
 aaa
 aaa
 aaa
 aaa
-abX
 apK
 aaa
 aaa
-asY
+aaa
 aaa
 aaa
 avX
-abX
-aaa
-aaa
-aaa
-aaa
-aCh
-aDn
-aEr
-aFq
-aGy
-aHB
-wOL
-aHB
-aKF
-aCh
-aaQ
-afw
 aaa
 aaa
 aaa
 aaa
 aaa
 ach
-abZ
-abZ
-abZ
-aaf
+acO
+aaa
+aaa
+aaa
+aaa
+aaa
+aci
+aaa
+ach
+aaQ
+acO
+aaa
+aaa
+aaa
+aaa
+aaa
+aci
+aaa
+aaa
+ach
+bNQ
 aCr
 aTJ
 aTJ
@@ -107653,52 +108118,52 @@ aaa
 aaa
 aaa
 aaa
-aeG
+ach
 aaJ
-agk
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-anE
-aoD
-apL
-aoD
-arV
-asZ
-arV
-aoD
-avY
-auT
-auT
-aze
-biL
-blq
-auT
-aDo
-auT
-nVE
-aGz
-aFr
-aFr
-aFo
-aFo
-aCh
-aaQ
-aaf
-abZ
-aPF
-abZ
-abZ
-abZ
 acO
 aaa
 aaa
 aaa
+aaa
 aci
+aaa
+aaa
+aaa
+aaa
+apK
+aaa
+aaa
+aaa
+aaa
+aaa
+avX
+aaa
+aaa
+aaa
+aaa
+aaa
+ach
+aDo
+aaS
+aaS
+aaS
+aaS
+aaS
+aaS
+aaS
+aaS
+baU
+acO
+aaa
+aaa
+aaa
+aaa
+aaa
+aci
+aaa
+aaa
+ach
+bNQ
 aTJ
 imf
 baR
@@ -107955,54 +108420,54 @@ aaa
 aaa
 aaa
 aaa
-adp
-aeU
-adp
-adp
-adp
-adp
-adp
-adp
-adp
-amB
-adp
-aoD
-apM
-aoD
-arW
-ata
-aui
-auS
-avZ
-auT
-ayf
-azf
-bkf
-aAa
-aCi
-aDp
-auT
-diS
-aGA
-aHC
-aHD
-aHC
-aKG
-aHf
-aaQ
+ach
+aaJ
 acO
 aaa
 aaa
 aaa
 aaa
+aci
 aaa
-aCr
+aaa
+aaa
+aaa
+apK
+aaa
+aaa
+aaa
+aaa
+aaa
+avX
+aaa
+aaa
+aaa
+aaa
+aaa
+ach
+aaQ
+aCh
+diS
+aGA
+aCh
+aUd
+aHC
+aKG
+aCh
+aaQ
+aad
+abZ
+abZ
+abZ
+abZ
+abZ
+acO
+aaa
+aaa
+ach
+bOV
 aTJ
-aTJ
-aTJ
-aTJ
-aCr
-aZA
+bwJ
 aJB
 bca
 bca
@@ -108256,55 +108721,55 @@ aaa
 aaa
 aaa
 aaa
-abW
-ael
-aeW
-afQ
-agH
-ahJ
-aiH
-ajK
-adp
-alv
-amC
-anF
-aoD
-apL
-aoD
-arX
-atb
-auj
-auT
-auT
-auT
-ayg
-azg
-bks
-aAb
-aAb
-aDq
-auT
-aFt
-aGA
-aHD
-aHD
-aHD
-aHD
-aLN
-aaQ
+aaa
+ach
+aaJ
 acO
 aaa
 aaa
 aaa
 aaa
+aci
 aaa
-aTJ
+aaa
+aaa
+aaa
+apK
+aaa
+aaa
+aaa
+aaa
+aaa
+avX
+aaa
+aaa
+aaa
+aaa
+aaa
+aAb
+aDq
+aCh
+aFt
+aRc
+aCh
 aUt
-aVn
-aWF
+aVp
+aXf
+aLN
+aaQ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aci
+aaa
+aaa
+ach
 hCK
 aCr
-aCt
+bUk
 baS
 bca
 bdk
@@ -108559,55 +109024,55 @@ aaa
 aaa
 aaa
 aaa
-adp
-adp
-adp
-aek
-ahK
-aiI
-agH
-akI
-alw
-aeg
-anG
-aoE
-apN
-aoD
-arY
-asZ
-auk
-auT
-awa
-axe
-ayg
-azh
-blp
-aAc
-aCj
-aDr
-aEs
-aFu
-aGB
-aHD
-aHD
-aHD
-aHD
-aLN
-aaQ
+ach
+aaJ
 acO
 aaa
 aaa
 aaa
 aaa
+aci
 aaa
+aaa
+aaa
+abX
+apK
+aaa
+aaa
+asY
+aaa
+aaa
+avX
+abX
+aaa
+aaa
+aaa
+aaa
+aCh
+aDr
+aEs
+aFu
+aGB
+aSw
+aUx
+aSw
+aXg
+aCh
+aaQ
+afw
+aaa
+aaa
+aaa
+aaa
+aaa
+ach
+abZ
+abZ
+aaf
+aad
 aTJ
 eiE
-aVo
-vej
-dXg
-aKK
-aZB
-baT
+aJB
 bca
 bdl
 bei
@@ -108861,55 +109326,55 @@ aaa
 aaa
 aaa
 aaa
-ach
-adp
-aef
-aeh
-ahL
-aeh
-gih
-adp
-alx
-afP
+aeG
+aaJ
+agk
+aaa
+aaa
+aaa
+aaa
+aci
+aaa
+aaa
 anH
-agH
+auU
 apO
-akI
-arZ
-atc
+auU
+aul
+awr
 aul
 auU
 awb
-axf
-ayh
+auT
+auT
 azi
 aAd
-aAd
-aCk
+aJI
+auT
 aDs
 auT
 aFv
 aGC
-aHD
 aIA
-aHD
+aIA
+oTv
 oTv
 aCh
 aaQ
+aaf
+abZ
+bkf
+abZ
+abZ
+abZ
 acO
 aaa
 aaa
-aaa
-aaa
+aci
 aaa
 aTJ
-aCt
-aVp
-aKJ
-aKJ
-aKJ
-aZC
-baU
+eiE
+aJB
 bca
 bdm
 bej
@@ -109163,55 +109628,55 @@ aaa
 aaa
 aaa
 aaa
-ach
 adp
-afR
-agI
-ahL
-aiJ
-ajL
-akJ
-akJ
-akJ
-akJ
-akJ
+aeU
+adp
+adp
+adp
+adp
+adp
+adp
+adp
+apX
+adp
+auU
 apP
-aqO
+auU
 asd
 pfK
-aum
+aAz
 auV
 awc
-axg
+auT
 ayi
 axg
-axg
-axg
+aIL
+aJL
 aCl
 aDt
 auT
 aFs
-aGC
+aGD
+aSS
 aHD
-aHD
-aHD
-aHD
+aSS
+aXh
 aCg
-aMP
-aNS
-aNS
-aPG
-aPG
-aPG
-aNS
-aNS
-aVr
-aWI
+aaQ
+acO
+aaa
+aaa
+aaa
+aaa
+aaa
 aCr
-aXL
-aXL
-aZD
-aXL
+aTJ
+aTJ
+aTJ
+aTJ
+aCr
+bwJ
+bUF
 bca
 bca
 bca
@@ -109463,63 +109928,63 @@ aaa
 aaa
 aaa
 aaa
+aaa
 abW
-aay
-aaf
-adI
-adI
-adI
+ael
+afR
+ahK
+aoG
 ahM
-adI
-adI
-akJ
+akN
+alY
+adp
 aly
 amD
 anI
-aoF
-aoF
-aqP
+auU
+apO
+auU
 asb
-atd
-aum
+ayA
+aAC
 auT
-awd
-axh
-ayj
+auT
+auT
+ayk
 azj
 aAe
-aBk
+aCm
 aCm
 aDu
 auT
 akw
 aGD
-aFr
-aFr
-aFr
-aoq
-aCh
-uMr
-aNS
-aOL
-aPH
-aQL
-aRS
-aSS
-aNS
+aHD
+aHD
+aHD
+aHD
+aYY
+aaQ
+acO
+aaa
+aaa
+aaa
+aaa
+aaa
+aTJ
 aUu
 aVq
 aWG
-aXL
-aYE
+bOX
+eiE
 aZE
-baV
-bcb
-aXL
+aJB
+bca
+chx
 bek
 bfr
-bgy
-aXL
+bca
+nVE
 biV
 bkq
 bly
@@ -109766,53 +110231,53 @@ aaa
 aaa
 aaa
 aaa
-adI
-adK
-adK
-afS
+aaa
+adp
+adp
+adp
 agJ
 ahN
 aiK
-ajM
-akJ
+aoG
+aqR
 alz
-amE
+aeg
 amG
-amG
+aoE
 apQ
-aqQ
-xIe
-atd
-aum
+auU
+axh
+awr
+aBl
 auT
-auT
-auT
+aDG
+aEE
 ayk
-auT
-auT
-auT
-auT
-auT
-auT
+aHW
+aIT
+aJV
+aLM
+aNr
+aOO
 aFw
 aGE
-aHF
-aIB
-aJw
-aKH
-aCh
-aCt
-aNS
-aOM
-aPI
-aQM
-aRT
-aST
-aNS
+aHD
+aHD
+aHD
+aHD
+aYY
+aaQ
+acO
+aaa
+aaa
+aaa
+aaa
+aaa
+aTJ
 eiE
-aVq
+bEC
 aWH
-aXL
+bOY
 aYF
 aZF
 baW
@@ -109820,7 +110285,7 @@ bcc
 bdn
 bel
 bfs
-bgz
+bca
 coP
 coZ
 bkr
@@ -110068,23 +110533,23 @@ aaa
 aaa
 aaa
 aaa
-adJ
-aem
-aeX
-afT
-afT
-ahO
-aiL
-aiL
-akK
+aaa
+ach
+adp
+aef
+aeh
+ahP
+aeh
+gih
+adp
 alA
-amF
+afP
 amF
 aoG
 apR
 aqR
-asa
-atd
+axl
+ayD
 baH
 rlg
 awe
@@ -110092,37 +110557,37 @@ axi
 ayl
 azk
 aAf
-auW
+aAf
 aCn
 aDv
+auT
+aPP
+aGF
+aHD
+aUA
+aHD
+aXM
 aCh
-aCh
-aCh
-aCh
-aCh
-aCh
-aCh
-aCh
-aMP
-aNS
-aON
-aPJ
-aQN
-aPJ
-aSU
-aNS
+aaQ
+acO
+aaa
+aaa
+aaa
+aaa
+aaa
+aTJ
 bwJ
-aVq
-aKL
-aXL
+bED
+aYG
+aYG
 aYG
 aZG
 baX
-bcd
-aXL
+bca
+cnR
 bem
-bft
-bgA
+iDR
+bca
 coQ
 biX
 cpk
@@ -110370,48 +110835,48 @@ aaa
 aaa
 aaa
 aaa
-adI
-adK
-adK
+aaa
+ach
+adp
 afU
 agK
 ahP
-agK
+akU
 ajN
 akJ
-alB
-amG
-amG
-aoH
+akJ
+akJ
+akJ
+akJ
 apS
 aAG
-asa
+asf
 ate
-aun
+aum
 aKC
 awf
-axj
-aym
-azl
 aAg
-auW
+aym
+aAg
+aAg
+aAg
 aCo
 aDw
-aEt
+auT
 aFx
 aGF
-aHG
-aIC
-aJx
-aKI
-aCt
-aCt
+aHD
+aHD
+aHD
+aHD
+aAb
+aMT
 aNS
-aOO
-aPK
-aQO
+aNS
 aRU
-aSV
+aRU
+aRU
+aNS
 aNS
 aUv
 aVs
@@ -110419,13 +110884,13 @@ aCr
 aXL
 aXL
 aZH
-baY
 aXL
-aXL
-ben
-bft
-bgC
-coR
+bca
+bca
+bca
+bca
+bca
+cpa
 cpa
 bkt
 aXL
@@ -110672,62 +111137,62 @@ aaa
 aaa
 aaa
 abW
-adK
-aen
-aeY
-afV
-agL
+aay
+aaf
+adI
+adI
+adI
 ahQ
-aiM
-ajO
+adI
+adI
 akJ
 alC
 amH
-akJ
-aoI
+arW
 apT
-akJ
+apT
+auS
 asc
 atd
 aum
-aKD
+auT
 awg
 axk
 ayn
 azm
 aAh
-auW
+aJW
 aCp
 aDx
-aEu
+auT
 aFy
 aGG
-aHH
-aCr
-aCr
-aCr
-aCt
-aCt
+aIA
+aIA
+aIA
+aXN
+aCh
+baV
 aNS
-aNS
-aNS
+bgz
+bks
 aQP
-aNS
-aNS
+brf
+btS
 aNS
 aUw
-aVt
+fld
 aWJ
 aXL
 aYH
 aZI
-aZI
+bUG
 bce
 aXL
 beo
-bft
-bgB
-bhO
+iWw
+biY
+biY
 biY
 bft
 blB
@@ -110752,7 +111217,7 @@ bGJ
 bIk
 bJJ
 bLa
-bMm
+bIh
 bNo
 bFK
 bQi
@@ -110760,7 +111225,7 @@ wyL
 bFK
 bUj
 bVx
-bWE
+cou
 bXt
 bFK
 nbO
@@ -110974,51 +111439,51 @@ aaa
 aaa
 aaa
 aaa
+adI
 adK
-aeo
-afW
-afa
+adK
+ahL
 aIE
 ahR
 aiN
 ajP
-akL
-afa
+akJ
+anP
 amI
-akJ
-akJ
-akJ
-akJ
-asd
+amJ
+amJ
+atC
+avk
+xIe
 atd
 aum
-aKD
-awh
-axl
+auT
+auT
+auT
 ayo
-azn
-aAi
-auW
-aCq
-aDy
-aEv
+auT
+auT
+auT
+auT
+auT
+auT
 aFz
 aGH
 aHI
-aCr
+aUB
 aJy
 aKJ
-aKJ
-aKJ
-aKJ
-aKJ
-aKJ
+aCh
+bwJ
+aNS
+bgA
+bku
 aMS
 aRV
 aSW
-aTK
-aUx
-aVu
+aNS
+eiE
+fld
 aWK
 aXL
 aYI
@@ -111028,13 +111493,13 @@ bcf
 bdo
 bep
 bfu
-bgD
-bgD
-bgD
-bfu
-bgD
+blD
+blD
+blD
+bft
+blD
 bmQ
-bor
+boo
 bpz
 bqJ
 jvK
@@ -111049,20 +111514,20 @@ iJS
 qhQ
 iQf
 iof
-bMh
+bGA
 bGK
-bIl
-bJK
+vmX
+bIh
 bLb
-bMn
-bNp
-bOV
+bIh
+bGF
+bFK
 bQn
 bRD
 bFK
 bFK
-bVy
-bWE
+cot
+cou
 bXu
 bFK
 xAf
@@ -111276,65 +111741,65 @@ aaa
 aaa
 aaa
 aaa
-adK
+aen
 aep
 afa
-afW
+aIF
 aIF
 ahS
-aiO
+ajQ
 ajQ
 akM
 alD
-afa
-adK
+aqh
+aqh
 aoJ
 apU
-adK
-xIe
+avn
+asa
 atd
-aum
+aBm
 aKD
 awi
 axm
-ayo
+aGI
 azo
 aAj
 auW
-aCr
-aCr
-aCr
-aCr
-aCr
-aCr
-aCr
-aJz
-aKK
-aKK
+aLS
+aNC
+aCh
+aCh
+aCh
+aCh
+aCh
+aCh
+aCh
+aCh
 aMT
-aKK
+aNS
 wle
-aKK
+aRW
 aQQ
 aRW
 aSX
-aCr
-eiE
+aNS
+bxB
 fld
 aWL
-aXM
+aXL
 aYJ
 aZK
 bba
 bcg
 aXL
 beq
-bfv
-bgE
-bgE
-bgE
-bku
-blC
+bft
+blD
+blD
+blD
+bft
+blD
 bmR
 boo
 bpA
@@ -111351,19 +111816,19 @@ boo
 bCC
 bDA
 bEv
-bFK
-bFK
-bFK
-bFK
-bFK
-bFK
-bFK
-bFK
+bGA
+mKt
+vmX
+bIh
+bMj
+ezo
+cuf
+kBO
 bQo
 bRE
 bTi
-bUk
-bVz
+bFK
+cot
 bWF
 bXv
 bYy
@@ -111579,64 +112044,64 @@ aaa
 aaa
 aaa
 adI
-aeq
-afb
+adK
+adK
 afX
-afW
+aiP
 ahT
 aiP
 ajR
-akN
+akJ
 alE
 amJ
-adK
+amJ
 aoK
 apV
-adK
-xIe
-pfK
-aum
+avq
+asa
+aze
+aBo
 aLL
 awj
 axn
 ayp
 azp
 aAk
-aBl
+auW
 aCs
 aDz
-aCs
-aCs
-aCs
-aCs
-aCs
+aOP
+aPS
+aRd
+aST
+aUE
 aJA
 aCt
-aLQ
-aLQ
-aLQ
-aLQ
-aLQ
-aLQ
+bwJ
+bwJ
+aNS
+bgC
+bkv
+bnp
 aRX
-aLQ
-aLQ
-aLQ
-aLQ
-aLQ
-aLQ
-aYK
-aYK
-aYK
-aYK
-aYK
+btU
+aNS
+bxF
+bEG
+aCr
+aXL
+aXL
+bUm
+bVR
+aXL
+aXL
 ber
-bfw
-bgF
+bft
+blD
 bhP
 biZ
-bkv
 bft
+blD
 bmS
 boo
 coU
@@ -111653,18 +112118,18 @@ boq
 tvw
 bDH
 bEv
-bFO
+bGA
 bGL
 vmX
-bJL
-stu
-stu
-bNq
+bIh
+bIh
+bIh
+bGF
 tIt
 bQp
 yfk
 bTj
-bUk
+bFK
 bVA
 bWG
 bXw
@@ -111879,26 +112344,26 @@ aaa
 aaa
 aaa
 aaa
-aaa
+abW
 adK
 aer
-afa
+afS
 afY
 agM
 ahU
 aiQ
 ajS
-agM
+akJ
 alF
 amK
-anJ
+akJ
 aoL
 apW
-aqS
+akJ
 ase
-atf
-auo
-auW
+atd
+aum
+aNR
 awk
 axo
 ayq
@@ -111907,47 +112372,47 @@ aAl
 auW
 nmT
 aDA
-eiE
+aOT
 aFA
-eiE
-eiE
-aCt
-aJB
-aCt
-aLQ
-aMU
-aLQ
-aMU
-aLQ
+aRe
+aSU
+aCr
+aCr
+aCr
+bwJ
+bwJ
+aNS
+aNS
+aNS
 aQR
-aRY
-aSY
-aTL
-aLQ
+aNS
+aNS
+aNS
+byr
 aVv
 biQ
-aXN
+aXL
 aYK
-aZL
+bbb
 bbb
 bch
-aYK
-aYK
-bfx
-aYK
-aYK
-bja
-bja
+aXL
+fqj
+bft
 blD
-bja
-bja
+our
+tCI
+bft
+blD
+peY
+boo
 pUl
 bqM
 bqM
 btz
 btz
 btz
-btz
+bpC
 bqM
 bqM
 bpC
@@ -111955,12 +112420,12 @@ boq
 mCg
 bDA
 bEv
-bFO
+hjl
 soA
 bGM
-bGM
-bGM
-bGM
+lyf
+paK
+qHS
 bNr
 bFK
 bQq
@@ -111984,10 +112449,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+jTb
+jTb
+jTb
+jTb
 aaa
 aaa
 aaa
@@ -112181,68 +112646,68 @@ aaa
 aaa
 aaa
 aaa
-abW
+aaa
 adK
 aes
-afc
-afZ
+aga
+amM
 agN
 ahV
 aiR
 ajT
 akO
-alG
+amM
 amL
-shz
-aoM
-apX
-adK
+akJ
+akJ
+akJ
+akJ
 asf
 atd
-our
-auZ
-auZ
-auZ
-auZ
+aum
+aNR
+aDH
+aEI
+ayr
 azr
-auZ
-auZ
-auZ
-auZ
+aIU
+auW
+aLT
+aNV
+aOY
+aPT
+aRf
+aSV
 aCr
-aCr
-aCr
-aCr
-aCr
-aJB
-aCt
-aLQ
-aMV
-aLQ
-aMV
-aLQ
+aVr
+aYG
+aYG
+aYG
+aYG
+aYG
+aYG
 aQS
 aRZ
-aSe
-aQT
+btX
+bvT
 aUy
 aVw
 aWN
-aWN
+aXL
 aYL
 aZM
-aZM
+bVT
 bUy
 bdp
 bes
-bfy
-bgG
-bhQ
-bja
+bkw
+blE
+blE
+blE
 bkw
 blE
 bmT
-bja
+wBz
 kSb
 bqM
 bqM
@@ -112257,20 +112722,20 @@ boq
 mCg
 fGA
 bEB
-bFO
-bGN
-bIm
-bIm
-bIm
-bIm
-bNs
+bFR
+bFR
+bFR
+bFR
+bFR
+bFR
+bFR
+bFK
 bFK
 bFK
 bQi
 bFK
-bFK
-bVC
-bWI
+cot
+cou
 bGE
 bFK
 bZl
@@ -112286,11 +112751,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jTb
+pWQ
+nld
+jTb
+xHZ
 aaa
 aaa
 aaa
@@ -112485,22 +112950,22 @@ aaa
 aaa
 aaa
 adK
-aer
-afd
+aeI
+amM
 aga
 agO
 ahW
 aiS
-ahU
-agO
+amB
+anF
 alH
 amM
-anK
+adK
 aoM
 apY
-aqT
-asg
-atg
+adK
+xIe
+atd
 aum
 aNR
 awl
@@ -112508,71 +112973,71 @@ axp
 ayr
 azs
 aAm
-aBm
-aCu
-auZ
-aaf
-aad
-aad
-aaf
+auW
+aCr
+aCr
+aCr
+aCr
+aCr
+aCr
 aCr
 aJC
-aCt
-aLR
+aYF
+aYF
 aMW
-aNT
-aMW
-aPL
-aQT
-aRZ
-aSe
-aQT
-aUz
-aUz
-aUz
-aUz
-aUz
+aYF
+bhZ
+aYF
+bnt
+brg
+btY
+aCr
+eiE
+bFP
+bHb
+bOZ
+bRR
 aZN
-aZM
+bVU
 bci
-bdq
+aXL
 bdq
 bfz
-aZM
 bhR
-bja
+bhR
+tYP
 bkx
 blF
 bmU
-bja
+boo
 bpD
 bqM
 bqM
-bqM
-bqM
-bqM
-bqM
+bpC
+bpC
+bpC
+bpC
 bqM
 bqM
 bpC
 boq
-bCD
-bDI
-bEC
-bFP
+bCF
+bDA
+bEv
+bFO
 bGO
 bIn
 bJM
-bLc
+bMo
 bMo
 bNt
 bFK
 bQr
-bRG
-bFK
+bRS
+cAN
 bUl
-bVz
-bWE
+cot
+cou
 bXy
 bOW
 bZn
@@ -112581,7 +113046,6 @@ caV
 cbR
 rBS
 caU
-afw
 aaa
 aaa
 aaa
@@ -112589,10 +113053,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+jTb
+nVh
+qcD
+fzc
+hIt
 aaa
 aaa
 aaa
@@ -112790,7 +113255,7 @@ adI
 aet
 afe
 agb
-aew
+aga
 ahX
 aiT
 ajU
@@ -112802,7 +113267,7 @@ aoN
 apZ
 adK
 xIe
-asa
+ate
 aum
 aPD
 aRq
@@ -112813,68 +113278,68 @@ aAn
 aBn
 aCv
 ava
-acO
-aaa
-aaa
-ach
-aCr
-aJB
-aLP
+aCv
+aCv
+aCv
+aCv
+aCv
+aVD
+bwJ
 aLQ
-aMX
-aNU
-aOP
 aLQ
-aQU
+aLQ
+aLQ
+aLQ
+aLQ
 aSa
-aSZ
-aQT
-aIY
-bmO
-aXO
-aWO
-aUz
-aZO
-aZM
-bcj
-aZM
+aLQ
+aLQ
+aLQ
+aLQ
+aLQ
+aLQ
+bhT
+bhT
+bhT
+bhT
+bhT
 bet
-aZM
-aZM
+jsl
+mKe
 bhS
-bja
+uMr
 bky
-blF
+bft
 bmV
-bja
-bpE
-bqN
-bsf
-bpC
+boo
+boo
+bqM
+bqM
+bqM
 rOU
-bvR
-bpC
-bpC
-bpC
-bAC
+bqM
+bqM
+bqM
+dgp
 boq
-bCE
-bDF
-shR
-bFQ
+boq
+bCF
+bDA
+bEv
+bFO
 spD
-bGP
-bGP
 bLd
-bGP
+bLd
+bLd
+bLd
 bNu
 bFK
 bQs
 bRH
 bTl
-bUm
-bVD
-bWJ
+bFK
+cot
+cou
 bXz
 bFK
 caU
@@ -112883,18 +113348,18 @@ caQ
 caU
 caU
 caU
-fyL
-cca
-cfw
-tCI
-cdF
-pAA
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
+aaa
+jTb
+cyS
+fVL
+eyl
+uIb
 aaa
 aaa
 aaa
@@ -113089,114 +113554,114 @@ aaa
 aaa
 aaa
 adK
-aeu
-aff
+mVi
+amM
 aew
-agP
-ahY
+akQ
+ajX
 aiU
 ajV
 akQ
 alJ
-agP
-adK
+aqm
+arX
 aoO
 aqa
-adK
-xIe
-asa
-aum
-aPE
+avs
+bDr
+azf
+aBp
+auW
 awm
 axr
 ayt
 azu
 aAo
-aBo
+auW
 aCw
-ava
-acO
-aaa
-aaa
-ach
-aCr
-aJB
+aNW
 eiE
+aZE
+eiE
+eiE
+bwJ
+aJB
+bwJ
 aLQ
 bed
-aMW
-aOQ
+aLQ
+bed
 aLQ
 aQV
 aSb
 aTa
-aQT
-aIY
+bvV
+aLQ
 bpB
 pqx
 nbR
-aUz
+bhT
 aZP
-aZM
-bcj
-bdr
-beu
+bWU
+cdF
+bhT
+bhT
 bfA
-aZM
+bhT
 bhT
 bja
-bkz
-blF
-bmW
 bja
-bpF
-bqO
-bsg
-bsg
-bsg
-bsg
-bsg
-bsg
-bsg
-bsg
-boo
+blJ
+bja
+bja
+pUl
+bqM
+bqM
+bpC
+bpC
+bpC
+bpC
+bqM
+bqM
+bpC
+boq
 bCF
 bDA
 bEv
 bFO
 bGQ
-bIo
-bGP
-bLd
+bMp
+bMp
+bMp
 bMp
 svx
 bFK
 bQt
 bRI
 bUo
-bUn
+bFK
 bVE
 bWK
 bXA
 bFK
 bZp
 xKL
-caX
-ceF
-cbZ
-cbZ
-ceF
-cbZ
-cbZ
-cbZ
-cbZ
-ncP
-fhN
+pVs
 aaa
 aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+jTb
+jTb
+jIL
+jbW
+nBv
 aaa
 aaa
 aaa
@@ -113389,7 +113854,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+abW
 adK
 aev
 afg
@@ -113399,106 +113864,106 @@ ahZ
 aiV
 ajW
 akR
-agP
+anQ
 amO
-age
-age
-age
-age
+arY
+aoP
+aui
+adK
 uzL
-asa
-aum
-aPE
-awn
-axs
-ayt
+atd
+aBu
+auZ
+auZ
+auZ
+auZ
 azv
-aAp
-aBp
-aCx
-ava
-acO
-aaa
-aaa
-ach
+auZ
+auZ
+auZ
+auZ
+aCr
+aCr
+aCr
+aCr
 aCr
 aJB
-bpi
+bwJ
 aLQ
+baY
 aLQ
-aNV
-aLQ
+baY
 aLQ
 bhI
-aSc
-aTa
+aSd
+mzX
 aQT
-aIY
+bys
 coV
-pqx
 aXP
-aUz
-aZQ
-bbc
+aXP
+bSd
+fje
+fje
 bck
-aZQ
-bev
+cnS
+fwt
 bfB
 bgH
-bfB
+oIX
 bja
+mqh
+oif
+ctQ
 bja
-blD
-bja
-bja
-bev
-bev
-bsg
-btB
-buP
-bvS
-bxf
-byr
-bvW
-mKe
-fwt
+bpC
+bqM
+bqM
+bqM
+bqM
+bqM
+bqM
+bqM
+bqM
+bpC
+boq
 rve
-bDA
-bEv
-bFO
+oux
+bEF
+jIB
 bGR
 bIp
-bGP
+sUq
 bLe
 bMq
 bNv
-bOW
-bOW
+bFK
+qYF
 bRJ
 bWL
-cos
+bFK
 cot
 cou
 bXB
 bYy
-bZq
-cbZ
-gNp
-ppd
-cbZ
-cbZ
-ceF
-cbZ
-cbZ
-cbZ
-cbZ
-cbZ
-wOE
+bZr
 aaa
 aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+jTb
+nhA
+tkb
+sLi
+uIb
 aaa
 aaa
 aaa
@@ -113691,116 +114156,116 @@ aaa
 aaa
 aaa
 aaa
-abW
+aaa
 adK
 mVi
 afh
 agd
-agP
+aiH
 aia
 aiW
 ajX
-age
+aiH
 alK
-age
-age
+aqS
+asg
 aoP
 aqb
 aqU
-asa
-asa
+axs
+azg
 aum
 aQI
 aVx
 axt
 ayu
-ayu
+aHX
 aAq
 aBq
 aCy
 auZ
 aaf
-aay
-aay
+aad
+aad
 aaf
 aCr
-aJB
-aKL
-aLQ
-aMZ
-aNU
+aVH
+bwJ
+aYZ
 aOR
-aLQ
-aQX
+bdA
+aOR
+bkz
+aQT
 aSd
-aTb
-adT
-aUA
-tYP
-kBY
-aXQ
+mzX
+aQT
+aUz
+aUz
+aUz
+aUz
 aUz
 ehh
-bbd
-bcl
+fje
+ceF
 bds
-bev
+bds
 bfC
 fje
-bfD
-bjb
+pfT
+bja
 bkA
-blG
+blI
 bmX
-bos
-bpG
-bqP
-bsg
-btC
-buQ
-bvT
-bxg
-bys
-nql
-jJT
-gda
-rve
-bDA
-bEv
-bFO
+bja
+bpD
+bqM
+bqM
+bqM
+bqM
+bqM
+bqM
+bqM
+bqM
+bpC
+boq
+wok
+bDF
+oku
+rUl
 lCw
 bGP
 bGP
 bNw
-bNz
 ceq
-bFK
+ceq
+vqg
 bQv
 bRK
-cor
+sDW
 bUp
-bVF
+bVG
 bWM
 bXC
 iNr
 bZr
-cal
-cbW
-cbW
-ccO
-ccO
-cbW
-ill
-ccO
-cal
-gNp
-cal
-pBe
 aaa
 aaa
 aaa
 aaa
 aaa
+afw
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+jTb
+mwE
+qcD
+vyN
+hIt
 aaa
 aaa
 aaa
@@ -113997,112 +114462,112 @@ aaa
 adI
 aex
 afi
-age
+aik
 agR
 aib
-agR
-age
-age
-akS
+akX
+amC
+anG
+anR
 amP
-anL
+adK
 aoQ
 aqc
-aqV
+adK
+xIe
 asa
-asa
-aup
+aum
 avb
-aQI
+aDP
 aXo
 aXq
 aXr
 bdg
 aBr
-auZ
-auZ
-asZ
-asZ
-asZ
-asZ
-aID
-aJD
+aLX
+aDB
+acO
+aaa
+aaa
+ach
+aCr
+aJB
 aID
 aLQ
 aNa
 aNU
-aNU
-aPM
-aQT
+bia
+aLQ
+bor
 aSe
-aSe
+buP
 aQT
 aIY
 aVz
-pqx
+bHX
 aXR
 aUz
 aZS
-bbd
-bcl
-bbe
+fje
+ceL
+fje
 bew
-bfD
-bfD
-bfD
-bfD
-bfD
-blH
-bfD
-bvm
-bfD
+fje
+fje
+ppQ
+bja
+iwK
+blI
+ecp
+bja
+mEM
 bqQ
-bsg
-btD
+gIp
+bpC
 buR
 bvU
-bxh
+bpC
 byt
 mCe
 jJT
-sRA
-rve
+boq
+jUz
 bDA
 bEv
-bFR
+bFO
 bGS
 bIq
 bJN
-bNx
+ceq
 bMr
 cgb
-bFK
+bOW
 bQw
 bRL
 bTn
-bUq
+bOW
 bVG
 bWN
 bXD
 iCf
-bZq
-cbZ
+oQU
+cpn
 caY
-cba
-cba
-cba
-cba
-cba
-ppd
-cbZ
-cbZ
-cbZ
-uUF
+kjx
+acZ
+add
+hkZ
+hmd
+dwp
+dop
+vwf
+hkZ
 aaa
-aaa
-aaa
-aaa
-aaa
+jTb
+mpU
+tQT
+jTb
+rWi
 aaa
 aaa
 aaa
@@ -114296,82 +114761,82 @@ aaa
 aaa
 aaa
 aaa
-adL
+adK
 aey
 afj
-age
-agS
+agR
+agU
 aic
 aiX
 ajY
 akS
 alL
-age
-anM
+agU
+adK
 aoR
 aqd
-age
-ash
-ath
-auq
-aup
+adK
+xIe
+asa
+aum
+avc
 awo
 axu
-axu
-axu
-axu
+aGK
+aIc
+aIV
 aBs
 aCz
 aDB
-ase
-ase
-ase
-ase
-ase
-viV
-aKM
+acO
+aaa
+aaa
+ach
+aCr
+aJB
+eiE
 aLQ
 aNb
-aNU
+aOR
 aOS
 aLQ
 aQY
-aSe
-aSe
-aTM
-aUz
-aUz
-aWP
-aUz
+brh
+aTc
+aQT
+aIY
+bFQ
+aWS
+bPa
 aUz
 aZT
-bbd
-bcl
+fje
+ceL
 bdt
-bev
+fyL
 bfE
-bgI
-bgI
-bgI
-bgI
+fje
+pry
+bja
+szZ
 blI
 bmY
-bfD
-bfD
+bja
+tMr
 bqR
 bsg
-btE
-buS
-bvV
-bxi
-byu
-pry
-jJT
-iWw
+bsg
+bsg
+bsg
+bsg
+bsg
+bsg
+bsg
+boo
 lfH
 bDA
-bEB
-xoF
+bEv
+bFO
 bGT
 bIr
 bJO
@@ -114379,31 +114844,31 @@ bNy
 bMs
 chs
 bFK
-bQx
-bRM
 bFK
-bUr
+bFK
+bQi
+bFK
 bVH
-bWE
+cou
 bXE
 bFK
 fVZ
-ccO
-cba
-cba
-cba
-cba
-cba
-cba
-cba
+cbZ
+cbZ
+seS
+cbZ
+cbZ
+seS
 cbZ
 cbZ
 cbZ
+cbZ
+ocE
 hgl
-aaa
-aaa
-aaa
-aaa
+jTb
+jTb
+jTb
+jTb
 aaa
 aaa
 aaa
@@ -114598,68 +115063,68 @@ aaa
 aaa
 aaa
 aaa
-adL
+adK
 aez
 afk
-age
+ail
 agT
-aic
-aiX
+aka
+alv
+amE
+anJ
+agU
+aqT
 age
 age
 age
 age
-age
-aoS
-aoS
-age
-asd
-ati
-aur
+axB
+asa
+aum
 avc
 asZ
 axv
-asa
-asa
-asa
-asa
+aGK
+aIz
+aIW
+aKE
 qKY
-asa
-asa
-asa
-asa
-asa
-asa
-aJE
+aDB
+acO
+aaa
+aaa
+ach
+aCr
+aJB
 aKN
 aLQ
-aNb
-aNU
-aOT
+aLQ
+ben
+aLQ
 aLQ
 aQZ
-aSe
+bsf
 aTc
-aTN
-aUB
+aQT
+aIY
 aVA
-aWQ
+aWS
 aXS
-aYN
-ehh
-bbd
-bcl
-bbe
-aYN
+aUz
+bUn
+bXL
+cfr
+bUn
+bev
 jry
 bgJ
-bhU
-bjc
-bkB
+jry
+bja
+bja
 blJ
-bmZ
-bhU
-bpH
+bja
+bja
+bev
 bev
 bsg
 cpl
@@ -114670,35 +115135,35 @@ cpA
 jwh
 bAD
 hwT
-hlU
+rPh
 bDA
 bEv
-jOn
+bFO
 bGU
-bIs
+bJN
 bJP
+bGP
+bGP
+bGP
 bFK
-bFK
-chx
-bFK
-bFK
-bFK
-bFK
+hEI
+erR
+kQK
 bUs
 bVI
-bWJ
+bWN
 bXF
-bFK
-aTl
-cba
-cba
+bYy
+fVZ
+cbZ
+cgZ
 rbg
-ybu
-mLt
+cbZ
+cbZ
 seS
-cfr
-cba
-cba
+cbZ
+cbZ
+cbZ
 cbZ
 cbZ
 eGO
@@ -114899,71 +115364,71 @@ aaa
 aaa
 aaa
 aaa
-aaa
-adM
+abW
+adK
 aeA
 afl
 agf
 agU
 aid
-aiX
+alw
 ajZ
 age
 alM
-nNq
 age
 age
-age
-age
-bGj
-atj
-asi
+atg
+auj
+avT
+asa
+asa
+aum
 asi
 awp
-asi
-asi
-asi
+aFo
+aHb
+aHb
 aAr
 djG
-asi
-aDC
-aEw
-aEw
-aGI
-aEw
-aIG
-aJF
-aKO
+aMI
+auZ
+aaf
+aay
+aay
+aaf
+aCr
+aJB
+aWL
 aLQ
-aLQ
-aNW
-aLQ
+bbq
+aNU
+bie
 aLQ
 oHK
 aSf
 aRa
-oHK
-aRa
+bvW
+byu
 aVB
 aWR
 flj
-jry
-aZU
-bbe
+aUz
+aZX
+bgO
 bcl
-bbe
-bds
-bbe
+bey
+bev
+jvp
 bgK
-bhV
-bgK
-bgK
+whk
+vej
+mjV
 blK
 bna
-bgK
-bgK
+maq
+lfp
 bqS
-bev
+bsg
 btG
 buU
 bvX
@@ -114973,8 +115438,8 @@ bzv
 bAE
 bBw
 rPh
-bDJ
-iDR
+bDA
+bEv
 bFR
 bGV
 bIt
@@ -114982,30 +115447,30 @@ bJQ
 bLf
 bMt
 cnX
-bOX
-bQy
+bFK
+bQA
 bRN
 bTo
 bUt
 bVJ
 bWO
 bXG
-bYy
+iNr
 aTu
 emI
-cba
 vEx
-lcV
-nAJ
-kjZ
+vEx
+xKv
+xKv
+vEx
 cfs
-cba
-cba
+xKv
+emI
 cgZ
-cbZ
+emI
 wOE
-abX
-abX
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -115202,113 +115667,113 @@ aaa
 aaa
 aaa
 aaa
-adL
-aeA
-afl
+adI
+aeW
+afT
 age
 agV
 aie
-aiX
-aka
+agV
+age
 age
 alN
 nNq
-anN
+ash
 aoT
 aqe
-anN
-asj
-atk
-aus
-aus
-aus
+avY
+asa
+asa
+avd
+aDm
+asi
 oxY
-aus
-aus
-aus
+aHf
+aIB
+aJv
 aBt
-aus
-aCF
-aCF
-aCF
-aCF
-aCF
-aIH
+auZ
+auZ
+awr
+awr
+awr
+awr
+aKP
 fkO
 aKP
-aLS
+aLQ
 aNc
-aNX
-aNX
+aNU
+aNU
 aPN
-aNX
-jfG
-aNX
-aNX
-aNX
+aQT
+mzX
+mzX
+aQT
+aIY
 aVC
 aWS
 aUM
-aYO
+aUz
 aZV
-aZV
-bcm
-aZV
-aZV
-aZV
-aZV
-aZV
-aZV
-aZV
+bgO
+bcl
+blO
+fIF
+whk
+whk
+whk
+whk
+whk
 blL
-bnb
+whk
 bot
-bot
-bot
-bsh
+whk
+igX
+bsg
 btH
 buV
-btH
+uXz
 bxl
-btH
-btH
-btH
+sHz
+jSr
+bAE
 bBx
-bCH
-bnT
-bEC
-bFS
+rPh
+bDA
+bEv
+bFR
 bGW
 bIu
 bJR
 bLg
 bMu
 bNA
-bOY
-bQz
-bRO
-bLg
+bFK
+bFK
+bFK
+rlR
 bUu
 bVK
 bWP
 bXH
-bYz
-bZs
-cak
-cbb
-cbU
-cdE
-tbT
-ccQ
-cft
-cgk
-mJy
-cha
-chk
-cnZ
-aaf
-aaf
-agm
+iCf
+fVZ
+cbZ
+cbd
+cba
+cba
+cba
+cba
+cba
+rbg
+cbZ
+cbZ
+cbZ
+pBe
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -115506,110 +115971,110 @@ aaa
 aaa
 adL
 dpv
-afl
+afV
 age
 agW
-aif
-aiY
+aig
+aja
 akb
-age
 alN
-nNq
-anN
+anS
+age
+asm
 aoU
 aqf
-aqW
-asj
+age
+axC
 atl
 aut
 avd
 awq
-axw
-axw
-avd
 aAs
-atr
+aAs
+aAs
+aAs
+aKF
 aCA
-aCF
-aEx
-aFB
-aGJ
+aOb
 bDr
-aIH
+bDr
+bDr
+bDr
+bDr
 aJG
 dqk
-aLT
-aNd
-aNY
-aNY
-aPO
-aNY
-hVr
-aNY
+aLQ
+aNe
+aNU
+biL
+aLQ
+bos
+mzX
+mzX
 aTO
-aNY
-aVD
+aUz
+aUz
 aWT
-aXU
-aYN
+aUz
+aUz
 aZW
-bbe
-nDM
+bgO
+bcl
 bdu
-bbe
-bbe
-bgL
-bhW
+bev
+jOn
 bjd
-bbe
-bbe
+bjd
+bjd
+bjd
+nxA
 bnc
 whk
-bou
+whk
 bqT
-bsi
+bsg
 btI
 buW
-btI
+qKA
 qeG
-btI
-btI
-btI
+meJ
+qjU
+bAE
 bBy
 bCI
-bDK
-bEv
-bFR
+bDA
+bEB
+lwK
 bGX
 bIv
 bJS
 bLh
 bMv
 bNB
-bOZ
+bFK
 bQA
 bRP
-bLh
+fCO
 bUv
 bVL
-bWQ
+bWR
 bXI
-ppQ
+bFK
 bZt
 xKv
 cba
-lhD
-swI
-cbU
-fTm
-cfu
 cba
 cba
-chb
+cba
+cba
+cba
+cba
+cbZ
+cbZ
 cbZ
 uUF
-aaT
-aaT
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -115807,95 +116272,95 @@ aaa
 aaa
 aaa
 adL
-aeA
-afl
+aeX
+agi
 age
-age
+aiI
 aig
+aja
 age
 age
 age
-aeA
-dpv
-anN
-aoV
+age
+age
 aqg
-aqX
-asj
+aqg
+age
+asf
 atm
 auu
 ave
 awr
-awr
-awr
-avf
-aAt
-atr
+aFp
+asa
+asa
+asa
+asa
 aCB
-aCF
-aEy
-aFC
-aFB
-aCF
-aII
+asa
+asa
+asa
+asa
+asa
+asa
 eLc
 aJH
-aLU
+aLQ
 aNe
+aNU
 aLU
-aLU
-aPP
-aLU
+aLQ
+boG
 mzX
 aTd
-aLU
+bwh
 aUC
 aVE
 aWU
 aXV
-aYP
+bex
 aZX
-aZX
-bcn
-aZX
+bgO
+bcl
+blO
 bex
 bfF
-aZX
-aZX
+mLt
+pAA
 bje
 bkC
-aZX
+oMM
 bnd
-bfF
-aZX
-aZX
-aYP
-btJ
+pAA
+hdO
+bev
+bsg
+hSC
 buX
 bvZ
 bxn
-bvZ
+cLJ
 bzw
-bvZ
+wtI
 bBz
 bCJ
-btJ
-bED
-bFT
-bFT
-bIw
-bFT
-bFT
-bFT
+bDA
+bEv
+bLh
+uat
+bIx
+eVv
+bFK
+bFK
 bNC
-bPa
+bFK
 bQB
 bRQ
-bTp
-bFK
+vFr
+tGG
 bVM
-bFK
-bFK
+bWR
+nCN
 bFK
 oUn
 cba
@@ -115909,7 +116374,7 @@ cba
 cba
 cbZ
 cbZ
-hgl
+vSl
 aaa
 aaa
 aaa
@@ -116108,112 +116573,112 @@ aaa
 aaa
 aaa
 aaa
-adL
-qqG
-afm
+akV
+wwg
+afn
 agg
-agg
+aiJ
 aih
-aiZ
+aja
 akT
-akT
+age
 alO
-amQ
-anO
-aoW
-aqh
-aqh
+amS
+age
+age
+age
+age
 ask
 atn
-atr
 avf
-awr
-awr
-awr
+avf
+aEr
+avf
+avf
 avf
 aAu
-atr
-aCB
-aCF
+aKH
+avf
+aOc
 aEz
 aEz
-aFB
-aCF
-aCF
-aCF
-aKQ
-aKQ
-aNf
-aKQ
-aKQ
-aKQ
-aKQ
-aKQ
-aKQ
-aKQ
+aRg
+aEz
+aUF
+aVK
+aXO
+aLQ
+aLQ
+beH
+aLQ
+aLQ
+bpE
+bsh
+aUD
+bpE
 aUD
 aVF
 aWV
 aXW
-aYN
+bfF
 aZY
-bbf
-bco
-bdv
+blO
+bcl
+blO
 bey
-bfG
-bbd
+blO
+bpI
 biN
-bjf
-bkD
+bpI
+bpI
 blM
 bne
-bov
+bpI
 bpI
 bqU
 bev
 btK
-bpJ
+eMY
 cpF
 cpG
 cpJ
-cpJ
+sfk
 cpK
 bBA
-bxm
-bvY
+mcT
+bDJ
 bEE
-bFT
+bFR
 bGY
 bIx
-bJT
-bLi
+bJU
+bFK
 uwm
 bND
-bPb
-bQC
-bRR
-bTp
-bUw
-bfO
+bFK
+bFK
+bFK
+bFK
+bFK
+oVW
 bWR
 bXJ
-bWR
+bYy
 xhb
 cbY
 cba
+nSQ
+sTZ
+kjT
+oqM
+gEo
 cba
 cba
-cba
-cba
-cba
-cba
-cbZ
-cbZ
+emL
 cbZ
 eGO
-aaa
-aaa
+abX
+abX
 aaa
 aaa
 aaa
@@ -116409,114 +116874,114 @@ aaa
 aaa
 aaa
 aaa
-aaf
+aaa
 adL
-dpv
+wwg
 afn
-agh
+age
 agX
 aii
 aja
 agh
-ain
-alP
-amR
+age
+alQ
+amS
 anN
 aoX
 aqY
-fIF
+anN
 asj
 ato
-atr
-avf
-awr
-awr
-awr
-ave
-aAv
-atr
+aCC
+aCC
+aCC
+aFq
+aCC
+aCC
+aCC
+aKI
 aCC
 aCF
-aEA
-aFC
-aGK
+aCF
+aCF
+aCF
 aCF
 aIJ
-aCF
+aWF
 aKR
-aLV
+aZb
 aNg
-aNZ
-aOU
+aTe
+aTe
 aPQ
-aRb
+aTe
 aSg
 aTe
-aKQ
-aKQ
+aTe
+aTe
 aVG
-hVr
-aXX
+bIm
+aUP
 aYQ
 dvx
-bbg
+dvx
 bcp
-bdw
-cbc
-bfH
-bgM
-bbe
-bjg
-bjg
+dvx
+dvx
+dvx
+dvx
+dvx
+dvx
+dvx
 blN
 bnf
-bfH
-bpJ
-bpJ
-bpJ
-bpJ
-bpJ
-bwb
+qoT
+qoT
+qoT
+pwT
+cpL
+epm
+cpL
 cpH
-byx
-bzx
+cpL
+cpL
 cpL
 bBB
-bxm
-bvY
+tnT
+bnT
 bEF
-bFT
+jSH
 bGZ
 bIy
 bJU
 bLj
-bFT
+qYF
 bNE
 bPc
-bQD
 bRS
-bTp
+bRS
+bPc
 qzV
 bVN
 gRo
 npx
-bWR
-bZq
-cbZ
-caY
-cba
-cba
-cba
-cba
-cba
-ppd
-cbZ
-cbZ
-cbZ
-wOE
-aaa
-aaa
-aaa
+kqA
+fku
+uvm
+fts
+xHS
+gFT
+gYK
+gWl
+loS
+mrc
+lIL
+kUT
+sVD
+uWt
+aaf
+aaf
+agm
 aaa
 aaa
 aaa
@@ -116711,113 +117176,113 @@ aaa
 aaa
 aaa
 aaa
-adv
-adv
-adv
-adv
-adv
+aaa
 adL
-aij
+aux
+afn
+age
+aiL
+akd
 ajc
-adL
-adL
+amT
+age
 alQ
 amS
 anN
 aoY
 btA
 ciB
-avT
+asj
 atp
-atr
+aBv
 avg
 aws
-aws
+ayw
 ayw
 avg
 aAw
 atr
 aCD
 aCF
-aCF
-aFD
-aCF
-aCF
-aCF
-aCF
+aOZ
+aGL
+aRh
+aSY
+aIJ
+aWI
 aKS
 aLW
 aNh
-aOa
-aOV
-aOV
-aOV
-aOV
-aTf
-aTe
-aUE
-aVG
 aNY
+aNY
+bkB
+aNY
+aWW
+aNY
+bwj
+aNY
+bFS
+bJK
 aXY
-aYR
-aYS
-aYS
-aYS
-aYS
-bez
-bfI
-bgN
-bey
-bjh
-aZR
+bex
+bUq
 blO
-bnf
+cft
+cos
+blO
+blO
+bgN
+rMk
+bjh
+blO
+blO
+bnj
 gQG
-bpJ
+mpB
 bqV
 bsj
-btL
-bpJ
-bwc
+cpM
+cVH
+cpM
 cpI
-byy
-bzy
+cpM
+cpM
 cpM
 bBC
 xft
 kkU
-bEG
-bFT
+bEv
+bFR
 bHa
 bIz
 bJV
-bLk
-bFT
-bNF
-aLu
-bQE
+bFK
+sQf
 bRT
-bTp
+bRT
+bRT
+bRT
+bRT
 bgS
-bfO
-bWR
+weu
+ikL
 bXK
-bWR
-bZr
+wfM
+iUJ
 cal
+cba
 cbW
-cbW
-cbY
-cbY
-cbY
+wmS
+xHS
+gJp
 xUw
-cbY
-cal
+cba
+cba
 cbS
-cal
+cbZ
 pBe
-aaa
-aaa
+aaT
+aaT
 aaa
 aaa
 aaa
@@ -117013,108 +117478,108 @@ aaa
 aaa
 aaa
 aaa
-adv
-adN
-adN
-adN
-adv
-agY
-aii
-ajb
-akd
+aaa
 adL
-adL
-adL
-ajd
-ajd
-ajd
-ajd
-ajd
+wwg
+afn
+age
+age
+akj
+age
+age
+age
+wwg
+aux
+anN
+ath
+auk
+avZ
+asj
 atq
+aCi
+avh
+nmy
+nmy
+nmy
+avi
+aJw
 atr
-avh
-avh
-axx
-avh
-avh
-avh
-atr
-aCA
+aMP
 aCF
 aEB
-aEC
+aFE
 aGL
-aHJ
-aIK
 aCF
+aIK
+aWO
 aKT
-aLW
-aNi
-aOa
-aOW
-ocX
-aOV
-aOV
-aOV
 aTP
-aKQ
-owM
-aNY
-aXX
-aYS
+aNi
+aTP
+aTP
+ocX
+aTP
+bsi
+buQ
+aTP
+byC
+bFU
+bJL
+bPb
+bsk
 fpD
-bbh
+fpD
 baa
-aYS
+fpD
 beA
-bfJ
-bgN
-bey
+bow
+fpD
+fpD
 aZR
 bkE
-blO
-bnc
+fpD
+cTe
 bow
-bpJ
-bqW
+fpD
+fpD
 bsk
-btM
+btJ
 buY
-bwd
-bwd
+byz
+txg
 byz
 bzz
-bpJ
-bpK
+byz
+tMJ
 bCK
-bDL
+btJ
 bEH
 bFT
-bHb
+bFT
 bIA
-bJW
-bLl
+bFT
+bFT
 bFT
 bNG
 bPe
 bQF
 bRU
 bTp
-kcl
-bfO
-bWR
-bWR
-bWR
-bZq
-cbZ
-gNp
+bFK
+qCo
+bFK
+bFK
+bFK
+dxW
+cba
+cba
 ppd
-cbZ
-cbZ
-cbZ
-cbZ
-cbZ
-cbZ
+snw
+myW
+kZM
+qQT
+cba
+cba
 cbZ
 cbZ
 uUF
@@ -117315,88 +117780,88 @@ aaa
 aaa
 aaa
 aaa
-adw
-adO
+aaa
+adL
 aeB
 afo
-adv
-agZ
-aij
+atD
+atD
+akm
 fUz
 ake
-adM
-abZ
-aay
-ajd
+ake
+aoq
+aqV
+asp
 aoZ
-aqj
+aqZ
 aqZ
 asl
+azh
 atr
-atr
-atr
+avi
 nmy
-atr
-atr
 nmy
+nmy
+avi
+aJx
 atr
-atr
-atr
-aDD
+aMP
+aCF
 aEC
 aEC
-aEC
-aHK
-aIL
-aJI
-aKU
-aLX
-aNj
-aOb
-aOV
-aOV
-aOV
-aOV
-aOV
-aTQ
+aGL
+aCF
+aCF
+aCF
 aKQ
-owM
-aNY
-aXX
-aYS
+aKQ
+aNj
+aKQ
+aKQ
+aKQ
+aKQ
+aKQ
+aKQ
+aKQ
+byK
+bFV
+bJW
+bPo
+bex
 bab
-bac
-bac
-aYS
+bXM
+cfu
+czr
 beB
 ivS
 bgO
 bhX
 bji
-aZR
+rzx
 blP
 bng
 aZZ
-bpJ
+mvc
 bqX
-bsl
+bev
 btN
 bpJ
 bwe
 bxq
-byA
+bzA
 bzA
 cpD
 bBD
-bCL
-bDM
+bxm
+bvY
 bEI
 bFT
 bHg
 bID
 bKb
 bLr
-bFT
+dgw
 bNH
 bPf
 bQG
@@ -117404,21 +117869,21 @@ bRV
 bTp
 bUz
 bfO
-bDX
+tan
 ozl
 tan
 caX
+fCh
+cba
+cba
+cba
+cba
+cba
+cba
+cba
 cbZ
 cbZ
-ceF
 cbZ
-cbZ
-cbZ
-cbZ
-cbZ
-cbZ
-cbZ
-mPi
 vSl
 aaa
 aaa
@@ -117617,111 +118082,111 @@ aaa
 aaa
 aaa
 aaa
-adw
-adP
-aeC
+aaf
+adL
+aux
 afp
-adv
-aha
-aij
+akf
+aiM
+akK
 eCr
 akf
-adM
-aaa
-ach
-ajd
+asn
+aoD
+aqW
+anN
 apa
 aqk
 ara
-asm
+asj
 ats
 atr
 avi
-awt
-axy
-awt
-awt
+nmy
+nmy
+nmy
+avh
 aAx
-azx
+atr
 aCE
 aCF
 aED
 aFE
 cJD
-aHL
+aCF
 aGM
 aCF
 aKV
 aLY
-aLW
-aOa
-aOW
-aOV
-aOW
+bbz
+bfv
+bjb
+bkL
+bpF
 aSh
-aOV
 aTQ
 aKQ
-owM
+aKQ
+aVJ
 aWW
 aXX
 aYT
 bac
 bbi
 bcq
-aYR
-aYR
-aYR
-aYR
-bhY
+daF
+fIG
+kmG
+mPi
+blO
 bjj
 bjj
-bjj
-bnh
-bjj
+cRS
+bni
+kmG
 bpJ
-bqY
-bsm
-btO
+bpJ
+bpJ
+bpJ
 bpJ
 bwf
 bxs
-byA
+kQP
 bzB
 cpE
 bBE
-bCM
+bxm
+bvY
 bDN
-bDN
-bFU
+bFT
 pXJ
 gga
 bJY
 bLn
-bMw
+bFT
 bNI
 bPg
 bQH
 bRW
-bpK
-bpK
+bTp
+pDx
 bVP
-bDX
-bnq
-bnq
-ePH
-ceL
+fhi
+cyZ
+tan
+fVZ
+cbZ
 cbd
-bxF
-ccR
-cdF
-ceL
-cfw
-ceK
-cgR
-cdF
-chl
-aaa
+cba
+cba
+cba
+cba
+cba
+rbg
+cbZ
+cbZ
+cbZ
+eGO
 aaa
 aaa
 aaa
@@ -117920,74 +118385,74 @@ aaa
 aaa
 aaa
 adv
-adQ
-aeD
-afq
-agi
-ahb
+adv
+adv
+adv
+adv
+adL
 aij
-ajd
-ajd
-ajd
+alx
+adL
+adL
 alR
 pIV
-ajd
-ajd
+anN
+ati
 aql
 arb
-ajd
+axD
 att
 atr
 avj
 awu
 awu
-awu
-awu
+aHB
+avj
 aAy
-azy
+atr
+aMX
 aCF
 aCF
-aEE
-aFF
-aFF
-aFF
-aFF
-xzv
+aPV
+aCF
+aCF
+aCF
+aCF
 aLV
-aLY
+aTi
 aNk
 aOa
 aOV
 aOV
 aOV
 aOV
-aOV
+buS
 aTQ
-aKQ
-owM
+bzM
+aVJ
 aNY
-aXX
-aYS
-bad
-oIX
-bcq
+bPp
 aYR
+aYS
+aYS
+aYS
+aYS
 beC
 bfK
-bgP
-bhY
+bgQ
+beB
 sml
 box
-blQ
+blR
 bni
 boy
 bpJ
+qdB
+dVW
+haL
 bpJ
-bpJ
-bpJ
-bpJ
-bpJ
-bpJ
+jAa
+cvn
 cpB
 cpC
 cpN
@@ -117995,35 +118460,35 @@ bBF
 bCN
 bDO
 bEJ
-bFV
+bFT
 bHd
 bDR
-bDN
-bzD
-bMw
+yhW
+kht
+bFT
 bNJ
 bPh
 bQI
 bRX
-bTq
+bTp
 bUA
 bfO
-bDX
-bPs
-acO
-aaa
-aaa
-aaa
-aaa
-aci
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+tan
+ijH
+tan
+aTu
+emI
+vEx
+vEx
+fCh
+fCh
+fCh
+mOV
+fCh
+emI
+nty
+emI
+wOE
 aaa
 aaa
 aaa
@@ -118220,112 +118685,112 @@ aaa
 aaa
 aaa
 aaa
-aaf
-adw
-adR
-aeE
+aaa
+adv
+afr
+afr
 afr
 adv
-aha
-aij
-ajd
+ajb
+akK
+alB
 akg
-akU
-alS
-amT
-anP
-apb
-aqm
-arc
+adL
+adL
+adL
+ajd
+ajd
+ajd
+ajd
 ajd
 atu
 atr
-avj
-awu
-awu
-awu
-awu
-aAy
-aBu
+aDn
+aDn
+aFr
+aDn
+aDn
+aDn
+atr
+aCD
 aCF
-aDE
-aEC
-aFF
+aPE
+aGO
 aGN
 aHM
 aIM
-aFF
+aCF
 trU
-aLY
-aLW
-aOc
+aTi
+bcb
+aOa
 aOX
 aPR
-aOX
-aOX
-aOX
+aOV
+aOV
+aOV
 aTR
 aKQ
-fIG
+owM
 aNY
-aXZ
-jsl
+aXX
+aYS
 bae
-bae
+bYz
 bcr
-bdx
+aYS
 beD
 bfL
 bgQ
-bhY
-bjl
+beB
+box
 bkF
 blR
 bnj
 boz
-bpK
+bpJ
 bqZ
 bsn
 btP
 buZ
-bpK
+bxt
 bxt
 nKN
 bzD
-bzD
-byC
+bpJ
+bpK
 bCO
 bDP
 bEK
-bFW
+bFT
 bHe
 bIB
 bJZ
-bJZ
-bMx
+nWS
+bFT
 bNK
 bPi
-bPi
+nrt
 bRY
-bTr
+bTp
 bUB
 bfO
-bDX
-bPs
-acO
-aaa
-aaa
-aaa
-aaa
-aci
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+tan
+tan
+tan
+fVZ
+cbZ
+cgZ
+rbg
+cbZ
+cbZ
+cbZ
+cbZ
+cbZ
+cbZ
+cbZ
+cbZ
+pBe
 aaa
 aaa
 aaa
@@ -118528,106 +118993,106 @@ adS
 aeF
 afs
 adv
-aha
-aik
+ajK
+aij
 aje
 akh
 akV
-alT
-amU
-anQ
+abZ
+aay
+ajd
 apc
 aqn
 ard
-ajd
-atv
+axF
 atr
-avk
-awv
+atr
+atr
 axz
-ayx
+atr
+atr
 axz
-aAz
-aBv
-aCF
-aCF
-aCF
-aFF
+atr
+atr
+atr
+aOd
+aGO
+aGO
 aGO
 aHN
 aIN
 aJJ
 aKU
 aLZ
-aKU
-aKU
-aOY
-aKU
-aKU
-aSi
-aLW
-aTS
-aUF
-aVG
+bcd
+bfw
+aOV
+aOV
+aOV
+aOV
+aOV
+cEO
+aKQ
+owM
 aNY
 aXX
 aYS
 baf
-bbj
 bcs
-aYR
+bcs
+aYS
 beE
 bfM
 bgR
-bhY
+shz
 bjm
-bkG
+box
 blS
 bnk
 bjk
-bpK
+bpJ
 bra
 bso
 btQ
-bva
+bpJ
 bwg
 bxu
-byD
+snN
 bzE
-bzE
+fyU
 bBG
-bzE
+dzP
 bDQ
 bEL
-bFX
+bFT
 bHf
 bIC
-bDN
+vow
 bLp
-bMw
+bFT
 bNL
 nBP
 bPj
 bRZ
-bTs
-bpK
-bVP
+bTp
+plB
+bfO
 bDX
-bPs
-acO
-aaa
-aaa
-aaa
-aaa
-aci
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+psr
+wOq
+jsd
+cbZ
+cbZ
+seS
+cbZ
+cbZ
+cbZ
+cbZ
+cbZ
+cbZ
+cbZ
+mQm
+vQz
 aaa
 aaa
 aaa
@@ -118825,85 +119290,85 @@ aaa
 aaa
 aaa
 aaa
-adv
-adv
-adv
-adv
+adw
+aeo
+aeY
+agI
 adv
 aha
 aij
-ajd
+alS
 aki
 akV
-alU
-amV
-anR
+aaa
+ach
+ajd
 apd
 aqo
 are
-ajd
+ayf
 atw
 atr
-atr
-atr
-atr
-atr
+aDp
+azx
+aFC
+azx
 azx
 aAA
 aBw
-asj
-aDF
+aNf
+aCF
 aEF
-aFF
+aQg
 aGP
 aHO
-aGP
-aFF
+aUG
+aCF
 aKX
-aMa
-aNl
-aNl
-aNl
-aPS
-aLV
+aMc
+aTi
+aOa
+aOX
+aOV
+aOX
 aSj
-aTg
+aOV
 cEO
 aKQ
 owM
-aNY
-aYa
+bLi
+aXX
+bSV
+bcs
+cak
+bct
 aYR
 aYR
 aYR
-aYR
-aYR
-aYR
-bfN
 aYR
 bhY
-bjn
-bkH
-blT
+boA
+boA
+boA
 bnl
 boA
-bpK
+bpJ
 brb
 bsp
 btR
-bvb
-bpK
+bpJ
+lHO
 bxv
 snN
 bzF
 bAL
-bzD
-bzD
+srN
+eFY
 ygw
-bEM
+ygw
 bFY
-bDN
-ygw
+qWo
+cTh
 bKa
 bLq
 bMw
@@ -118911,24 +119376,24 @@ bNM
 bPk
 bQJ
 bSa
-bTt
-bUC
+bpK
+bpK
 bVQ
 bDX
 bnq
-aQp
-aay
-aay
-aay
-aay
-aaf
-agm
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bnq
+xPp
+nOe
+cJT
+pTj
+cEY
+vwf
+nOe
+dwp
+fNP
+qDV
+vwf
+ovS
 aaa
 aaa
 aaa
@@ -119127,103 +119592,103 @@ aaa
 aaa
 aaa
 aaa
-aaf
-adL
+adv
+aeq
 aaI
 aft
-adL
+aim
 ahc
-ail
+aij
 ajd
-akj
-akV
-akV
+ajd
+ajd
+aoH
 amW
-anS
-ape
+ajd
+ajd
 aqp
 arf
 ajd
 atx
-auv
+atr
 avl
-aww
-asj
-ayy
-azy
+azz
+azz
+azz
+azz
 aAB
 aBx
-asj
-aDG
+aCF
+aCF
 aEG
 aFF
-aGP
-aHO
-aGP
 aFF
-aCF
-aMb
-aCF
-aOd
-aOZ
-aPT
-aRc
-aCF
-aCF
-aCF
-aUG
-aVH
+aFF
+aFF
+aWX
+aLY
+aMc
+bcm
+aOa
+aOV
+aOV
+aOV
+aOV
+aOV
+cEO
+aKQ
+owM
 aNY
-aYb
-aYU
+aXX
+aYS
 bag
 bbk
 bct
-bdy
+aYR
 beF
-bfO
+kBY
 lJE
 bhY
-bhY
-bhY
+viV
+tzy
 blU
-bhY
-bhY
-bpK
-brc
-bsq
-btS
-bvc
-bvc
-bxB
+tOW
+kOY
+bpJ
+bpJ
+bpJ
+bpJ
+bpJ
+bpJ
+bpJ
 byE
 bBH
-bAM
+mSF
 bCP
 bDS
 bEN
 bHc
-bAM
+sLp
 bHP
 bJX
-bLm
+ygw
 cds
-bHl
-bHl
-bHl
-bHl
-bHl
+bMw
+ssW
+qPS
+mER
+nSx
 bTu
-bHl
+gHa
 bfO
 bDX
-bnq
-aNC
-aPs
-aPs
-aPs
-aQp
+bPs
 acO
+aaa
+aaa
+aaa
+aaa
+aci
 aaa
 aaa
 aaa
@@ -119428,12 +119893,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-adL
-aez
-aeA
-aeA
+aaf
+adw
+aeD
+afb
+agL
+adv
 aha
 aij
 ajd
@@ -119443,21 +119908,21 @@ alV
 amX
 anT
 apf
-akV
+aun
 arg
 ajd
-asj
-asj
-asj
-asj
-asj
-asj
+azn
+atr
+avl
 azz
-asj
-asj
-asj
+azz
+azz
+azz
+aAB
+aKM
+aCF
 aCG
-aEH
+aGO
 aFF
 aGQ
 aHP
@@ -119465,67 +119930,67 @@ aIO
 aFF
 aKY
 aMc
-aCF
-aCF
-aCF
-aCF
-aCF
-aCF
+aTi
+bfx
+aTh
+bkO
+aTh
+aTh
 aTh
 aTT
-aEN
+aKQ
 aVI
-aWX
-aYc
+aNY
+aYg
 aYV
-bah
+bbl
 bbl
 bcu
 bdz
 beG
 bfP
 bgT
-bgT
-bgT
+bhY
+vos
 bkI
 blV
 bnm
-lJE
+jyQ
 bpK
 brd
 bsq
 btT
-bvc
-bwh
+gbI
+bpK
 bxx
 byF
-bzG
-bAM
+cds
+cds
 bBI
 bCQ
 bDT
 bEO
-bAM
+sxo
 bHh
 bIE
-bKc
 bLs
-bHl
+bLs
+uZC
 bNN
-bPl
+bQK
 bQK
 bSb
 bTv
-bSb
-bVR
+rGa
+bfO
 bDX
-bnq
-bYB
-bYC
-bYC
-bYC
-fYL
+bPs
 acO
+aaa
+aaa
+aaa
+aaa
+aci
 aaa
 aaa
 aaa
@@ -119731,103 +120196,103 @@ aaa
 aaa
 aaa
 aaa
-aaa
-adL
-dpv
+adw
+aeH
+afq
 aKW
-aez
+adv
 aha
-aij
-ajd
-ajd
-ajd
-ajd
-ajd
+akL
+alT
+amU
+enW
+aoS
+aqX
 anU
-ajd
-ajd
-ajd
+atj
+auo
+awa
 ajd
 vSu
-aeA
+atr
 avm
 awx
-axA
-awx
 azA
-awx
-awx
-awx
-aDH
-aEI
-aFG
-aGR
-aGR
-aIP
-aFF
+aHF
+azA
+aJz
 aKZ
+aCF
+aCF
+aCF
+aFF
+aGR
+aSZ
+aIP
+aWY
+aKU
 aMd
-aNm
-awy
-awy
-awy
-awy
-awy
+aKU
+aKU
+bjc
+aKU
+aKU
+bsl
 aTi
 aTU
 aUH
 aVJ
-aWY
-aYb
-aYU
+aNY
+aXX
+aYS
 bai
 bbm
 bcv
-bdA
-beF
+aYR
+fTm
 bfQ
 bgU
-bhZ
+bhY
 sWl
 bkJ
 blW
 bnn
 boB
 bpK
-bpK
+xuN
 bsr
-bpK
-bvc
+kKU
+uYB
 bwi
 bxy
 byG
-bzH
-bAM
+bCR
+bCR
 bBJ
 bCR
 bDU
 bEP
-bAM
+oXP
 bHi
 bIF
-bKd
+ygw
 bLt
-bHl
+bMw
 bNO
-bPm
-bQL
+cLc
+nsT
 bSc
 bTw
-bHl
-bfO
-btU
+bpK
+bVQ
+bDX
 bPs
-bYC
-bYC
-bYC
-bYC
-fYL
 acO
+aaa
+aaa
+aaa
+aaa
+aci
 aaa
 aaa
 aaa
@@ -120033,104 +120498,104 @@ aaa
 aaa
 aaa
 aaa
-aaa
-adL
-aeI
-afu
-adL
-aeH
-aim
-agg
-agg
-agg
-agg
-agg
+adv
+adv
+adv
+adv
+adv
+aha
+aij
+ajd
+amV
+enW
+aoW
+arc
 anV
-agg
+atk
 aqq
 ajf
-agg
-agg
-auw
-avn
+ajd
+aAa
+atr
+atr
+atr
+atr
+atr
+aBw
 awy
-axB
-ayz
-azB
-awy
-awy
-awy
-awy
+aLa
+asj
+aOe
 aEJ
-awy
-aGS
-aHQ
-aIQ
-awy
-awy
+aFF
+aIR
+aHR
+aIR
+aFF
+aXQ
 aMe
 aNn
-aJK
-aJK
+aNn
+aNn
 aPU
-aJK
-aJK
+aLY
+bsm
 aTj
 aTV
-aEN
-aVK
-aWZ
+aKQ
+owM
+aNY
 nZC
-aYW
-aYW
-aYW
-aYW
-aYW
-aYW
-aZa
-aZa
-aZa
+aYR
+aYR
+aYR
+aYR
+aYR
+aYR
+kHZ
+aYR
+bhY
 bjo
 bkK
 blX
 bno
 boC
-bpL
+bpK
 bpL
 bss
 tCk
-bvc
-bwj
+cqq
+bpK
 bxz
 byH
 bzI
-bAM
-bBK
-bCS
-bDU
+iVK
+cds
+cds
+bIG
 bEQ
-bAM
-bHj
+jOS
+ygw
 bIG
 bKe
 bLu
-bHl
+bMw
 bNP
-bPm
+kTM
 bQM
-bSc
-bHl
-bHl
-bfO
+vqo
+dnz
+sbQ
+jlz
 bDX
-bPs
-bYC
-bYC
-bYC
-bYC
+bnq
 fYL
-acO
-aaa
+aay
+aay
+aay
+aay
+aaf
+agm
 aaa
 aaa
 aaa
@@ -120335,74 +120800,74 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aaf
 adL
-adL
-adL
+afu
+agY
 adL
 ahd
 ain
-ain
+ajd
 aph
-ain
 enW
-ain
+enW
+ark
 anW
-ain
+atv
 aqr
-ain
-ain
+awd
+ajd
 aty
-dpv
-anX
-anX
-axC
-anX
-anX
-anX
-anX
-aDP
-aCG
-aCG
-aFH
-aGT
+aCj
+aDy
+aEt
+asj
+aHG
+aBx
+aJD
+aLf
+asj
+aOo
+aPF
+aFF
+aIR
 aHR
 aIR
-aJK
-aLa
+aFF
+aCF
 dWT
-aIS
-aIS
-aIS
-aIS
-aIS
-aIS
-aIS
-aIS
-aIS
+aCF
+bfN
+bjp
+bkQ
+bpG
+aCF
+aCF
+aCF
+bAC
 aVL
-aXa
+aNY
 aYd
-aYW
+bTq
 baj
 bbn
 bcw
 bdB
-aYW
-bfR
-bgV
-aZa
-bjp
-bkL
+gda
+bfO
+les
+bhY
+bhY
+bhY
 blY
-bnp
-bgU
-rMk
+bhY
+bhY
+bpK
 bpM
 bst
-bDX
+luT
 bvc
-bwk
+bvc
 bxA
 byI
 bzJ
@@ -120417,19 +120882,19 @@ bIH
 bKf
 bLv
 bHl
-bNQ
-bPm
-bQL
-bSd
 bHl
-kcl
+bHl
+bHl
+bHl
+xZI
+bHl
 bfO
 bDX
 bnq
 bYB
-bYC
-bYC
-bYC
+mWO
+mWO
+mWO
 fYL
 acO
 aaa
@@ -120638,73 +121103,73 @@ aaa
 aaa
 aaa
 aaa
-aci
-aaa
-aaa
 adL
-adL
-akl
-akl
+aeX
+wwg
+wwg
+aha
+aij
+ajd
 arh
-akl
-akl
-anX
+anK
+apb
+arV
 ebk
-anX
-ebk
-anX
-ebk
-anX
-anX
-anX
-mkL
-axD
-ayA
+atB
+enW
+awh
+ajd
+asj
+asj
+asj
+asj
+asj
+asj
 azC
-aAC
-anX
-aCH
-aCH
-aCH
-aCH
+asj
+asj
+asj
+aHa
+aPG
+aFF
 aGU
-aHS
-aIS
-aIS
-aIS
-aIS
-aIS
-aOe
-aLb
-aPV
-aIS
-aSk
-aLb
+aTf
+aUI
+aFF
+aXU
+aZc
+aCF
+aCF
+aCF
+aCF
+aCF
+aCF
+bva
 aTW
-aIS
+ojD
 aVM
-aWZ
-aXX
-aYW
+bLk
+bQx
+bTr
 bak
 bbo
 bcx
 bdC
-aYW
+ggG
 bfS
-bgW
-aZa
+bjq
+bjq
 bjq
 bkM
 blZ
-bnq
-bnq
-bnq
-bnq
-bfO
-bDX
+dtX
+les
+bpK
+oBX
+bst
+jxC
 bvc
-bvc
+hnQ
 bxL
 byJ
 bzK
@@ -120712,26 +121177,26 @@ bAM
 bBM
 bCU
 bDW
+wXC
 bAM
-bAM
-bHl
-bHl
+nez
+lUq
 bKg
 bLw
 bHl
 bNR
 bPn
-bQL
-bSe
-bHl
+ean
 bUD
-bfO
-kcl
+wfF
+bUD
+oSI
+bDX
 bnq
-aPm
-aPs
-aPs
-aPs
+bYF
+bYE
+bYE
+bYE
 aRy
 acO
 aaa
@@ -120934,109 +121399,109 @@ aaa
 aaa
 aaa
 aaa
-abX
 aaa
 aaa
 aaa
 aaa
 aaa
-aci
 aaa
-aaa
-aci
-aaa
-ana
-anb
-akm
-akX
-alY
-anX
+adL
+aux
+ahb
+aeX
+aha
+aij
+ajd
+ajd
+ajd
+ajd
+ajd
 iut
-anX
-fqj
-anX
-fqj
-anX
+ajd
+ajd
+ajd
+ajd
+aAc
 wwg
 avo
-awz
+aCI
 axE
-ayB
+aCI
 azD
-aAD
-anX
+aCI
+aCI
 aCI
 aDI
 aEK
-aCH
-aGU
-aHS
-aIS
-aJL
+aQp
+aRn
+aRn
+aUJ
+aFF
 aLb
 aMf
-aIS
-aOf
-aLc
-aMg
-aIS
+bcn
 aSl
-aLc
-aMg
-aIS
+aSl
+aSl
+aSl
+aSl
+bvb
+bwk
+bAN
 aVN
-aWZ
-aXX
-aYW
+bLl
+aYd
+bTq
 bal
 bbp
 bcy
 bdD
-aYW
+gda
 bfT
-bgX
-aZa
-aZa
-aZa
-aZa
-aZa
+boF
+bQQ
+wOL
+gYi
+qRy
+pRi
 boD
-bpN
-bnq
-bfO
-bDX
-bvd
-bDX
-bDX
-bDX
-bDX
-bAN
-bDX
-bDX
-bDX
-bDX
-bFZ
-bHl
-bHl
+bpK
+bpK
+mOe
+bpK
+bvc
+rAv
+wgd
+eXF
+jys
+bAM
+uNe
+keP
+oDv
+gPz
+bAM
+iWH
+gey
 bKh
 bLx
-bMy
-bNS
-bPo
-bQL
-bSf
 bHl
-bDX
+bNS
+bPm
+bQL
+bSg
+wcU
+bHl
 bfO
 bWT
-bnq
+bPs
 bYE
-bnq
-aad
-aad
-aad
-aaf
-agm
+bYE
+bYE
+bYE
+aRy
+acO
+aaa
 aaa
 aaa
 aaa
@@ -121235,67 +121700,67 @@ aaa
 aaa
 aaa
 aaa
-adc
-adx
-alX
 aaa
 aaa
 aaa
 aaa
-aci
 aaa
 aaa
-aci
 aaa
+adL
+afQ
+ahJ
+adL
+ajL
 ana
-anc
 atD
-akZ
-alZ
-anX
-anX
-anX
-anX
-anX
-anX
-anX
+atD
+atD
+atD
+atD
+ata
+atD
+auq
+awn
+atD
+atD
 osJ
-anX
-anX
-anX
-anX
-anX
-anX
-anX
-aCJ
-aDJ
+aDC
+aSl
+aFG
+aHJ
+aIC
+aSl
+aSl
+aSl
+aSl
 aEL
-aFI
+aSl
 aGV
 aHT
-aIS
-aJM
-aLc
+aUL
+aSl
+aSl
 aMg
-aIS
+bco
 aJN
-aLd
-aMh
-aIS
 aJN
-aLd
-aMh
+blp
+aJN
+aJN
+bvd
+bwl
 ojD
 aVO
 aWZ
-aXX
-aYW
-aYW
-bbq
+bQz
 aYW
 aYW
 aYW
-bbu
+aYW
+aYW
+aYW
+aZa
 aZa
 aZa
 bjr
@@ -121304,40 +121769,40 @@ bma
 bnr
 boE
 bpO
-bnq
+bpO
 bsu
-bpM
-bpM
-bpM
-bpM
-bpM
-bpM
-bpM
-bpM
-bpM
-bpM
+lLu
+bvc
+qDu
+pad
+uMC
+mhn
+bAM
+svd
+dWe
+oDv
 bES
-bDX
-bHl
-bHl
+bAM
+dGO
+fUr
 bKi
 bLy
-bMy
+bHl
 bNT
 bPm
-bQL
+tBA
 bSg
 bHl
-bDX
+bHl
 bfO
-bWU
 bDX
-bDX
-bnq
-aaa
-aaa
-aaa
-aaT
+bPs
+bYE
+bYE
+bYE
+bYE
+aRy
+acO
 aaa
 aaa
 aaa
@@ -121537,109 +122002,109 @@ aaa
 aaa
 aaa
 aaa
-adc
-aaN
-alX
-abZ
-abZ
-adc
-adx
-alX
-abZ
-abZ
-aad
-aay
-ana
-and
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+adL
+adL
+adL
+adL
+ajO
+asn
+asn
 avp
-akZ
+asn
 ama
-anX
-aoc
-anX
+asn
+atb
+asn
 ayC
-ari
+asn
 asn
 awA
 aux
-avq
-awA
-fjh
-ayC
 anX
-aoc
+anX
+fjh
+anX
+anX
+anX
 anX
 aCK
-aDK
-aEM
-aCH
+aHa
+aHa
+aQL
 aGW
-aHS
-aIS
+aTg
+aUN
 aJN
 aLd
 aMh
 aIS
 aIS
-aLe
 aIS
 aIS
 aIS
-aLe
+aIS
+aIS
 aIS
 aIS
 wNL
-aWZ
-aXX
-aYX
+bMh
+bQC
+aYW
 bam
 bbr
 bcz
 bdE
-beH
+aYW
 bfU
 bgY
-bia
+aZa
 bjs
 bkN
 bmb
 bns
 boF
-bpO
-bre
-bre
-bre
-bre
-bre
-bub
-bub
-bub
-bre
-bub
-bub
+nRD
+bDY
+mPI
 bDX
-bfO
-bDX
-bHl
-bHl
+bvc
+lad
+nWu
+mdV
+oni
+bAM
+fzA
+lkP
+kIi
+gzj
+bAM
+sBD
+hSo
 bKj
 bLz
-bMz
+bHl
 bNU
-bPp
+bPm
 bQL
 bSh
 bHl
-lJE
+bUB
 bfO
-bWT
-bXL
-bYF
+bDX
 bnq
-agm
-aaa
-aaa
-aaa
+bYF
+bYE
+bYE
+bYE
+aRy
+acO
 aaa
 aaa
 aaa
@@ -121839,109 +122304,109 @@ aaa
 aaa
 aaa
 aaa
-adc
-aaN
-alX
 aaa
 aaa
-adc
-aaN
-alX
+aaa
+aaa
 aaa
 aaa
 aaa
 aci
-ana
+aaa
+aaa
+adL
+adL
+ane
 ane
 ayH
-ala
-amb
+ane
+ane
 anX
-aoc
-anX
-ayF
-arj
 awB
-atA
-atB
-avr
+anX
 awB
+anX
+awB
+anX
+anX
+anX
+aEu
 arj
-ayF
+aHK
+aIG
+aJE
 anX
-aoc
-anX
 aCH
 aCH
 aCH
 aCH
-aGW
+aKh
 aHS
 aIS
 aIS
-aLe
+aIS
 aIS
 aIS
 aOg
 xgL
 aPW
-aRd
+aIS
 aSm
 xgL
 aTX
-aUI
-aVO
-aXb
+aIS
+bFW
+aWZ
 aXX
-aYY
+aYW
 ban
 bbs
 bcA
-bcA
-bcA
+dAM
+aYW
 bfV
 bgZ
-bgZ
+aZa
 bjt
-bcA
+ogG
 bmc
-bmc
-boG
-bcA
-brf
-bsv
-btX
-bve
-bwl
-bxC
-bsw
-bsw
-bsw
-bBN
-bub
-bub
+bnq
+bnq
+bnq
+bnq
 bfO
-btU
+bDX
+bvc
+bvc
+bxC
+nDg
+svD
+bAM
+bBN
+xMz
+hHd
+bAM
+bAM
 bHl
 bHl
+ftc
+qXr
 bHl
-bHl
-bHl
-bHl
-bHl
-bHl
-bHl
+tUv
+xAb
+bQL
+wlm
 bHl
 bUE
-bVT
+bfO
+bUB
 bnq
-bnq
-bnq
-bnq
-aaa
-aaa
-aaa
-aaa
+dEP
+mWO
+mWO
+mWO
+hik
+acO
 aaa
 aaa
 aaa
@@ -122141,110 +122606,110 @@ aaa
 aaa
 aaa
 aaa
-adc
-aaN
-alX
-abZ
-abZ
-adc
-aaN
-alX
-abZ
-abZ
-abZ
-aaf
-akl
-ana
-ana
+aaa
+abX
+aaa
+aaa
+aaa
+aaa
+aaa
+aci
+aaa
+aaa
+aci
+aaa
+mSv
+alU
+amY
 ugD
 qzi
 anX
-aoc
+atf
 anX
-ayF
-arj
 atA
-auy
-auy
-auy
-avr
-arj
-ayF
 anX
-aoc
+atA
+anX
+aCk
+aDD
+avr
+aFH
+aHL
+aII
+aJF
 anX
 aCL
 ljt
 dcK
-aCM
+aCH
 aKh
 aHS
-aIT
+aIS
 aJO
 xgL
 aMi
-aLf
+aIS
 aOh
-aPa
-aPa
-aPa
-aPa
-aTk
+tjX
 aTY
-aUJ
+aIS
+bsv
+tjX
+aTY
+aIS
 aVP
-aXc
-aYe
-aYZ
+aWZ
+aXX
+aYW
 bao
 bbt
 bcB
 bdF
-xSK
+aYW
 bfW
 bha
-mmz
-bju
-bkO
-mmz
-bnt
-bha
+aZa
+aZa
+aZa
+aZa
+aZa
+uJD
 bpP
-bre
-bsw
-btY
-bvf
-bvf
-bvi
-bsw
-bsw
-btZ
-bsw
-bCV
-bre
+bnq
 bfO
 bDX
+bvf
+bDX
+bDX
+bDX
+bDX
+has
+bDX
+bDX
+bDX
+bDX
+kEf
 bHl
 bHl
-bHl
-bHl
-bHl
+kos
+wKg
+eoN
 bNV
-bNV
-bNV
-bNV
-bnq
-bUF
+qDk
+bQL
+gQp
+bHl
+bDX
 bfO
 bWV
-bXM
 bnq
-awS
-aaa
-aaa
-aaa
-aaa
-aaa
+uff
+bnq
+aad
+aad
+aad
+aaf
+agm
 aaa
 aaa
 aaa
@@ -122444,108 +122909,108 @@ aaa
 aaa
 aaa
 adc
-aaN
+aaP
 alX
 aaa
-aaa
-adc
-aaN
-alX
 aaa
 aaa
 aaa
 aci
 aaa
+aaa
+aci
+aaa
+mSv
 apg
 azE
 alb
 aaM
 anX
-aoc
 anX
-kHZ
-ark
-asp
-atC
+anX
+anX
+anX
+anX
+anX
 auz
-avs
-awC
-axF
-ayD
 anX
-aoc
 anX
-aCL
-aCG
-aCG
+anX
+anX
+anX
+anX
+anX
+aNm
+aOs
+aPH
 aFJ
 aGX
 aHU
 aIS
 aJP
 tjX
-aLg
-aNo
+aTY
+aIS
 rtZ
 rHq
-aOi
-aRe
-aSn
+fvz
+aIS
+rtZ
 rHq
 fvz
 aUK
-aVQ
-aXd
-aXZ
-aZa
-aZa
+gpP
+aWZ
+aXX
+aYW
+aYW
 bbu
+aYW
+aYW
+aYW
+cbU
 aZa
 aZa
-bbu
-aZa
-aZa
-bbu
-aZa
-aZa
-bbu
-aZa
+xoF
+jHf
+sQL
+iZJ
 boH
-aZa
-bre
-bsw
-btZ
-bvg
-bwm
-bxD
-bsy
-bsy
-bsy
-bBO
-bsy
+bpQ
+bnq
+ljZ
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
 bDY
 bET
-bhZ
-bhZ
-bhZ
+bDX
+bHl
+bHl
 bSi
 bLA
-sWl
+eoN
 tdy
-bhZ
-bhZ
-bSi
-bTx
-bUG
-bVU
+bPm
+bQL
+vjC
+bHl
+bDX
+bfO
+drg
+bDX
+bDX
 bnq
-bnq
-bnq
 aaa
 aaa
 aaa
-aaa
-aaa
+aaT
 aaa
 aaa
 aaa
@@ -122748,45 +123213,45 @@ aaa
 adc
 aaN
 alX
-aaa
-aaa
+abZ
+abZ
 adc
-aaN
+aaP
 alX
-aaa
-aaa
-aaa
-aci
-aaa
-apg
+abZ
+abZ
+aad
+aay
+mSv
+alW
 acH
-akl
-akl
+alb
+ape
 anX
 aoc
 anX
-ayF
+aur
 iWG
 asq
-auy
-auy
-auy
+fdN
+aCq
+aDE
 fdN
 axG
-ayF
+aur
 anX
 aoc
 anX
 aCM
 aDL
-aCM
-aEN
-aCG
-aHV
+aPI
+aCH
+aRS
+aHS
 aIS
-aIS
-aLe
-aIS
+rtZ
+rHq
+fvz
 aIS
 aIS
 aLe
@@ -122798,53 +123263,53 @@ aIS
 aIS
 hNB
 aWZ
-aYf
-aZa
+aXX
+bTs
 bap
 bbv
-aZa
+cfw
 bdG
-bbv
-aZa
-bdG
-bbv
-aZa
-bdG
-bbv
-aZa
+gNp
+lhD
+ncP
+shR
+xzv
+jzJ
+jIU
+tij
 boI
 bpQ
 bre
-bsw
-bsw
-bvh
-bwn
-bvj
-bsw
-bzL
-bsw
-bsw
-bwo
 bre
+bre
+bre
+bre
+bzL
+bzL
+bzL
+bre
+bzL
+bzL
 bDX
+bfO
 bDX
-bDX
-bDX
+bHl
+bHl
 ddK
 bLB
-bDX
-bDX
+xTs
+qyz
 kcl
-bQO
+bQL
 bSj
-bTy
+bHl
 les
-kcl
+bfO
+bWV
+oIw
+xXX
 bnq
-aaa
-aci
-aaa
-aaa
+agm
 aaa
 aaa
 aaa
@@ -123047,105 +123512,105 @@ aaa
 aaa
 aaa
 aaa
-aaL
-acH
+adc
+aaN
+alX
+aaa
+aaa
+adc
+aaN
+alX
+aaa
+aaa
+aaa
+aci
+mSv
 ady
-adU
-adU
-ady
-acH
-ady
-adU
-ady
-adU
-ady
-adU
-ady
-acH
-ady
+amZ
+anL
 ada
 anX
 aoc
 anX
 ayF
 rjI
-asr
+lUL
 avt
 auA
-avt
+rZk
 lUL
-axH
+rjI
 ayF
 anX
 aoc
 anX
-aCN
+aCH
 aaR
-aEN
-aFK
-aCG
-aHW
+aCH
+aCH
+aRS
+aHS
+aIS
+aIS
+aLe
+aIS
 aIS
 aJQ
-aLh
+aLi
 aMj
-aIS
-aJQ
-aLh
-aMj
-aIS
-aJQ
-aLh
-aMj
-aIS
+bpH
+btB
+aLi
+bwn
+bCL
 gpP
-aWZ
+bMm
 aXX
-aZa
+bTt
 baq
 bbw
-aZa
-baq
-bbw
-aZa
+bpR
+bpR
+bpR
+mkL
 pmR
-bbw
-aZa
-baq
-bbw
-aZa
+pmR
+xSK
+bpR
+eWF
+eWF
 boJ
 bpR
-bre
+sKO
 bsx
 bua
 bvi
-bwo
-bub
-byK
+mIj
+rzF
 bsw
 bsw
 bsw
-btZ
-bre
+ixU
+bzL
+bzL
+bfO
+bWT
+bHl
+bHl
+bHl
+bHl
+bHl
+bHl
+bHl
+bHl
+bHl
+bHl
+nkv
+pFx
 bnq
 bnq
 bnq
-vos
-mEW
 bnq
-bnq
-bnq
-bnq
-bnq
-bnq
-bTz
-bnq
-bnq
-bnq
-abZ
-awS
-aaa
 aaa
 aaa
 aaa
@@ -123349,105 +123814,105 @@ aaa
 aaa
 aaa
 aaa
-aaL
-acI
-afv
-afv
-afv
-afv
-amY
-afv
-afv
-afv
-afv
-adx
-afv
-afv
+adc
+aaN
+alX
+abZ
+abZ
+adc
+aaN
+alX
+abZ
+abZ
+abZ
+aaf
+ane
+mSv
 mSv
 aaE
-aaa
+apL
 anX
 aoc
 anX
-war
-arl
-ass
+ayF
+rjI
+avt
 avu
-auB
+avu
 avu
 rZk
-axI
-ayG
+rjI
+ayF
 anX
 aoc
 anX
-aad
-aaf
+aNo
+aOL
 aEN
 aFL
 aGY
-aHX
-aIS
+aHS
+aUO
 aJR
 aLi
 aMk
-aIS
+bcC
 aOj
-aLi
-aMk
-aIS
 aSo
-aLi
-aMk
-aIS
+aSo
+aSo
+aSo
+bve
+bwp
+bCM
 aVR
-aWZ
+bMn
 aYa
-aZa
+bTx
 bar
 bbx
-aZa
+cgR
 bdH
-bbx
-aZa
-bhb
+gXb
+mmz
+boK
 bib
-aZa
-bar
-bbx
-aZa
+ybu
+oZq
+bib
+udh
 boK
 bpS
-brg
+bre
 bsw
-bsw
-bvi
-bsw
+tQD
+dHE
+dHE
 bxE
-bua
 bsw
 bsw
+uYT
 bsw
-bsw
-bub
-aci
-aaa
-aaa
-oQa
-wqb
-iyd
-bnq
-bNW
-bPq
+jke
+bre
+bfO
+bDX
+bHl
+bHl
+bHl
+bHl
+bHl
+bSk
+bSk
 aMv
 bSk
-bTA
-bUI
 bnq
-aci
-aaa
-aaa
-aaa
+bUI
+bfO
+uvk
+rZx
+bnq
+awS
 aaa
 aaa
 aaa
@@ -123651,41 +124116,41 @@ aaa
 aaa
 aaa
 aaa
-aaL
-acH
-ady
+adc
+aaN
+alX
+aaa
+aaa
+adc
+aaN
+alX
+aaa
+aaa
+aaa
+aci
+aaa
 adV
-adV
-ady
-acH
-ady
-adV
-adV
-ady
-acH
-ady
-adV
-adV
-adV
-aay
+anb
+anM
+apM
 anX
 aoc
 anX
-anX
+auv
 war
 atG
-atG
-atG
-atG
-atG
+aAi
+aCu
+aDF
+aEv
 ayG
-anX
+aHV
 anX
 aoc
 anX
-aaa
-ach
-aEN
+aNo
+aHa
+aHa
 aFM
 aGZ
 aHY
@@ -123693,62 +124158,62 @@ aIS
 aJS
 aLj
 aMl
-aIS
+bcD
 aOk
-aLj
+bju
 aPX
-aIS
+bpN
 aSp
-aLj
+bju
 aTZ
-aIS
+bCV
 aVS
-aWZ
+bMx
 aYg
 aZa
 aZa
+cbU
 aZa
 aZa
+cbU
 aZa
 aZa
+cbU
 aZa
 aZa
+cbU
 aZa
-aZa
-aZa
-aZa
-aZa
-aZa
+joa
 aZa
 bre
 bsw
-bsw
-bvi
-btZ
-bsw
-bsw
-bsw
-bxE
-bsw
+uYT
+goj
+iFX
+qQu
 bCW
-bub
-aci
-aaa
-aaa
-oQa
-wqb
+bCW
+bCW
+xBW
+bCW
+fsM
+kTg
+bQQ
+bQQ
+bQQ
+bSl
 iyd
-bnq
+wOL
 bNX
-bPr
+bQQ
 bQQ
 bSl
 bTB
 bUJ
+iXr
 bnq
-aci
-aaa
-aaa
+bnq
+bnq
 aaa
 aaa
 aaa
@@ -123963,94 +124428,94 @@ aaN
 alX
 aaa
 aaa
-adc
-aaN
-alX
 aaa
+aci
 aaa
-aaa
-aaO
+adV
+acI
+ane
+ane
 anX
 aoc
+anX
+ayF
+awC
+ayg
+avu
+avu
+avu
+aEw
+aFK
+ayF
+anX
 aoc
 anX
-anX
-anX
-anX
-anX
-anX
-anX
-anX
-anX
-aoc
-aoc
-anX
-aaa
-ach
-aEO
-aEO
-aEO
+aFL
+aOM
+aFL
+ojD
+aHa
 aHZ
-aIU
-aIU
-aIU
-aIU
-aIU
 aIS
-aIU
-aIU
-aIU
-aIU
-aIU
+aIS
+aLe
+aIS
+aIS
+aIS
+aLe
+aIS
+aIS
+aIS
+aLe
 aIS
 aIS
 sBO
 aWZ
-aYg
-aZb
+bQO
+aZa
 bas
-bby
-bcC
-bdI
-beI
-cdA
-bhc
 bic
-bjv
+aZa
 bkP
+bic
+aZa
 bkP
+bic
+aZa
 bkP
-bkP
-bkP
-brh
-bsy
-bsy
+bic
+aZa
+ydF
+mBW
+bre
+bsw
+bsw
 bvj
+jBF
+wdI
 bsw
-bsw
-bsw
-btZ
+rsZ
 bsw
 bsw
 bwo
-bub
+bre
+bDX
+bDX
+bDX
+bDX
+dvs
+wJC
+bDX
+bDX
+bUB
+bdU
+xne
+iSS
+uyg
+bUB
+bnq
+aaa
 aci
-aaa
-aaa
-oQa
-wqb
-iyd
-bnq
-bnq
-bPs
-bnq
-bnq
-bPs
-bnq
-bnq
-awS
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -124255,104 +124720,104 @@ aaa
 aaa
 aaa
 aaa
-adc
-aaN
-alX
-aaa
-aaa
-adc
-aaN
-alX
-aaa
-aaa
-adc
-aaN
-alX
-aaa
-aaa
-aaa
-aaa
+aaL
+acI
+adO
+adQ
+adQ
+adO
+acI
+adO
+adQ
+adO
+adQ
+adO
+adQ
+adO
+acI
+adO
+apN
 anX
-anX
-aoc
-aoc
-aoc
-aoc
-aoc
-aoc
-aoc
-aoc
-aoc
-aoc
 aoc
 anX
+ayF
+axe
+ayh
+aAp
+aCx
+aAp
+aEy
+aFQ
+ayF
 anX
-aaa
-ach
-aEP
+aoc
+anX
+aNp
+aON
+ojD
 aFN
 aHa
 aIa
-aIV
-aJT
-aLk
-aMm
-aNp
-aOl
-aMn
-aPY
-aRf
+aIS
 aSq
 coL
 aUa
-aUL
+aIS
+aSq
+coL
+aUa
+aIS
+aSq
+coL
+aUa
+aIS
 aVT
-aXe
-aYg
-aZc
-bat
-aNY
-bcD
+aWZ
+aXX
+aZa
 bdJ
-beJ
-beJ
-beJ
 bid
-beJ
-beJ
-beJ
-ntn
+aZa
+bdJ
+bid
+aZa
+njl
+bid
+aZa
+bdJ
+bid
+aZa
 boL
 cgP
 bre
 bsz
+iye
+bxE
+bwo
+bzL
+hgk
 bsw
 bsw
-bwp
 bsw
-bsw
-bzM
-bsw
-bua
-bub
-bub
-aci
-aaa
-aaa
-oQa
-wqb
-oUm
-aaa
-aaT
-aaa
-ach
-aaf
-aaa
-aaT
-aaa
-aaa
-aaa
-aaa
+uYT
+bre
+bnq
+bnq
+bnq
+pCS
+xaS
+bnq
+bnq
+bnq
+bnq
+bnq
+bnq
+qCC
+bnq
+bnq
+bnq
+abZ
+awS
 aaa
 aaa
 aaa
@@ -124557,102 +125022,102 @@ aaa
 aaa
 aaa
 aaa
-adc
-aaN
-alX
+aaL
+adx
+adP
+adP
+adP
+adP
+aek
+adP
+adP
+adP
+adP
+aaP
+adP
+adP
+anE
+anO
 aaa
-aaa
-adc
-aaN
-alX
-aaa
-aaa
-adc
-aaN
-alX
-abZ
-abZ
-abZ
-abZ
+anX
+aoc
+anX
+auw
+axf
+ayx
+aAt
+aCN
+aAt
+aEA
+aGx
+aGy
+anX
+aoc
+anX
 aad
-anX
-anX
-anX
-anX
-anX
-anX
-anX
-anX
-anX
-anX
-anX
-anX
-anX
-aaa
-aaa
-ach
-aEP
-aFO
-aFO
-aIb
-aFO
-aJU
-aLl
-aMm
-aNq
+aaf
+ojD
+aQM
+aRT
+aTq
+aIS
+aXa
+coM
+aUb
+aIS
 aOm
-bfl
-aPZ
-aRg
+coM
+aUb
+aIS
 bkh
 coM
 aUb
-aUM
+aIS
 aVU
 aWZ
-aYg
-hVr
+nZC
+aZa
 bau
-aNY
-bcE
-bdI
-beK
-beK
-beK
-bid
-beJ
-beK
-beK
-bnu
-bnu
-beK
-bre
-bre
-bub
-bub
-bub
-bub
-bub
-bub
-bub
-bub
-bub
-aad
-awS
+cca
+aZa
+dXg
+cca
+aZa
+nql
+stu
+aZa
+bau
+cca
+aZa
+tEq
+nxG
+jSo
+bsw
+bsw
+bxE
+bsw
+glX
+iye
+bsw
+bsw
+bsw
+bsw
+bzL
+aci
 aaa
 aaa
 oQa
 wqb
 oUm
-aaa
-aaa
-aaa
-aaa
-aaT
-aaa
-aaa
-aaa
-aaa
+bnq
+uDc
+hpI
+dMb
+qai
+gPF
+wtl
+bnq
+aci
 aaa
 aaa
 aaa
@@ -124859,102 +125324,102 @@ aaa
 aaa
 aaa
 aaa
-adc
-aaN
-alX
+aaL
+acI
+adO
+adT
+adT
+adO
+acI
+adO
+adT
+adT
+adO
+acI
+adO
+adT
+adT
+adT
+aay
+anX
+aoc
+anX
+anX
+auw
+ayz
+ayz
+ayz
+ayz
+ayz
+aGy
+anX
+anX
+aoc
+anX
 aaa
-aaa
-adc
-aaN
-alX
-aaa
-aaa
-adc
-aaN
-alX
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaO
-abZ
-aad
-abZ
-ada
-abZ
-aad
-abZ
-awS
-aaa
-aaa
-aaa
-aaa
-aaO
-aEO
+ach
+ojD
 aFP
-aFO
-aIb
-aFO
-aJU
-aLm
-aMm
-aNr
+aRY
+aTK
+aIS
+aXb
+coN
+aZd
+aIS
 aOn
-bfm
+coN
 aQa
-aRh
+aIS
 aSs
 coN
 aUc
-aUN
+aIS
 aVV
-aXf
-aYh
-aZd
-aNY
-bbz
-bcF
-aPO
-aaa
-aaa
-beK
-bie
-bjw
-bkQ
-beK
-aaf
-aad
-aad
-aad
-aad
-awS
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aWZ
+aYj
+aZa
+aZa
+aZa
+aZa
+aZa
+aZa
+aZa
+aZa
+aZa
+aZa
+aZa
+aZa
+aZa
+aZa
+aZa
+bre
+bsw
+bsw
+bxE
+uYT
+bsw
+bsw
+bsw
+glX
+bsw
+ney
+bzL
+aci
 aaa
 aaa
 oQa
 wqb
 oUm
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bnq
+xeJ
+vWS
+gfm
+pyX
+iMD
+wXv
+bnq
+aci
 aaa
 aaa
 aaa
@@ -125162,11 +125627,6 @@ aaa
 aaa
 aaa
 adc
-alW
-alX
-aaa
-aaa
-adc
 aaN
 alX
 aaa
@@ -125176,87 +125636,92 @@ aaN
 alX
 aaa
 aaa
+adc
+aaN
+alX
 aaa
 aaa
 aaa
+aaO
+anX
+aoc
+aoc
+anX
+anX
+anX
+anX
+anX
+anX
+anX
+anX
+anX
+aoc
+aoc
+anX
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aEQ
-aFO
-aFO
-aIb
-aFO
-aJU
-aLn
-aMm
-aNs
-aOo
-bgo
-aQb
-aRi
-aSt
+ach
+aLp
+aLp
+aLp
+aTL
 coO
-aUd
-aUO
+coO
+coO
+coO
+coO
+aIS
+coO
+coO
+coO
+coO
+coO
+aIS
+aIS
 aVW
-aXg
-aYi
+aWZ
+aYj
 aZe
 aXT
 bbA
 bcG
-aPO
-afw
-aaa
-beK
+aTn
+ill
+cdA
+ntn
 bif
 bjx
 bkR
-beK
-acO
+bkR
+bkR
+bkR
+bkR
+mVP
+bCW
+bCW
+wdI
+bsw
+bsw
+bsw
+uYT
+bsw
+bsw
+bwo
+bzL
+aci
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-ica
 oQa
 wqb
 oUm
-ica
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bnq
+bnq
+bPs
+bnq
+bnq
+bPs
+bnq
+bnq
+awS
 aaa
 aaa
 aaa
@@ -125463,100 +125928,100 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaT
-aaa
-aaa
-aaa
 adc
-amY
+aaN
 alX
 aaa
 aaa
 adc
-alW
+aaN
+alX
+aaa
+aaa
+adc
+aaN
 alX
 aaa
 aaa
 aaa
 aaa
+anX
+anX
+aoc
+aoc
+aoc
+aoc
+aoc
+aoc
+aoc
+aoc
+aoc
+aoc
+aoc
+anX
+anX
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aEQ
-aFO
-aFO
-aIb
-aFO
-aJU
-aEO
-aMn
-aMn
-aMm
+ach
+aER
+aQN
+aSi
+aTM
+aVn
+aXc
+aXZ
+aMq
+bcE
+bfR
 bgr
 biO
 bkg
 blj
-aMn
-aNu
+bvh
+bxf
 bhf
 aVX
-aNu
-aNv
-aNu
+bMy
+aYj
+bTy
 bav
-bjC
-aNu
-aNv
-aNu
-aNu
-aNv
-big
-aNv
-aNv
-bmd
-acO
+aNY
+cha
+ezW
+beJ
+beJ
+beJ
+bih
+beJ
+beJ
+beJ
+pId
+qmh
+oOW
+bre
+nSR
+bsw
+bsw
+xLM
+bsw
+bsw
+gzt
+bsw
+iye
+bzL
+bzL
+aci
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-abW
+oQa
+wqb
 ica
-iyd
-czr
-iyd
-ica
-agm
 aaa
+aaT
 aaa
+ach
+aaf
 aaa
-aaa
-aaa
+aaT
 aaa
 aaa
 aaa
@@ -125765,98 +126230,98 @@ aaa
 aaa
 aaa
 aaa
+adc
+aaN
+alX
 aaa
 aaa
+adc
+aaN
+alX
 aaa
+aaa
+adc
+aaN
+alX
+abZ
+abZ
+abZ
+abZ
+aad
+anX
+anX
+anX
+anX
+anX
+anX
+anX
+anX
+anX
+anX
+anX
+anX
+anX
 aaa
 aaa
 ach
-acH
-acO
-aaa
-aaa
-aaa
-aaT
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aER
-aFQ
+aFO
 aFO
 aIb
 aFO
 aJU
-aEP
-aMo
-aEP
+aYb
+aMq
+bcF
 aOp
 aPc
 aQc
 aRk
 aSu
-aQc
+bvm
 apq
 aUP
 aVY
-aZf
+aWZ
 aYj
-aUP
-aOr
-aXh
-apq
+aWW
+bUr
+aNY
+chb
 aTn
-aSu
-aQc
-kmG
+beK
+beK
+beK
 bih
-bjy
-aNu
+beJ
+beK
+beK
+bnu
+bnu
+beK
+bre
+bre
+bzL
+bzL
+bzL
+bzL
+bzL
+bzL
+bzL
+bzL
+bzL
 aad
 awS
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-ica
-iyd
-iyd
-iyd
+oQa
+wqb
 ica
 aaa
 aaa
 aaa
 aaa
+aaT
 aaa
 aaa
 aaa
@@ -126067,25 +126532,19 @@ aaa
 aaa
 aaa
 aaa
+adc
+aaN
+alX
 aaa
 aaa
+adc
+aaN
+alX
 aaa
 aaa
-aaa
-ach
-acH
-acO
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+adc
+aaN
+alX
 aaa
 aaa
 aaa
@@ -126093,45 +126552,58 @@ aaa
 aaa
 aaa
 aaa
+aaO
+abZ
+aad
+abZ
+apN
+abZ
+aad
+abZ
+awS
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aEP
+aaO
+aLp
+aQU
 aFO
+aIb
 aFO
-aIc
-aIW
-aJV
+aJU
 aLo
-aMp
+aMq
 aNt
 aOq
-aOq
-aOq
+bjv
+blq
 aRl
-aNu
-tuZ
-aOr
-aOr
+btC
+bvR
+bxg
+bDI
 aVZ
-aOr
-aNu
-tuZ
-aOr
-aOr
-aOr
-aOr
-aNu
-tuZ
-aOr
+bMz
+bRp
+bTz
+aNY
+ccO
+chk
+bkB
+aaa
+aaa
+beK
 bii
 bjz
-aNu
+iLb
+beK
+aaf
+aad
+aad
+aad
+aad
+awS
 aaa
 aaa
 aaa
@@ -126144,17 +126616,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+oQa
+wqb
 ica
-ica
-ica
-ica
-ica
+aaa
 aaa
 aaa
 aaa
@@ -126369,24 +126834,19 @@ aaa
 aaa
 aaa
 aaa
+adc
+adJ
+alX
 aaa
 aaa
+adc
+aaN
+alX
 aaa
 aaa
-agj
-aaf
-amZ
-aaf
-aPh
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+adc
+aaN
+alX
 aaa
 aaa
 aaa
@@ -126403,15 +126863,20 @@ aaa
 aaa
 aaa
 aaa
-aEP
-aEP
-aHb
+aaa
+aaa
+aaa
+aaa
+aaa
+aPJ
 aFO
 aFO
-aJW
-aEP
+aIb
+aFO
+aJU
+aYe
 aMq
-aEP
+bdx
 tuZ
 aQd
 aQh
@@ -126419,21 +126884,23 @@ aRm
 aYk
 bhd
 bhe
-bhe
+bDK
 bjA
 cfo
 bjB
-bhe
-bhe
-bhe
-cfo
-bhe
-aYk
-bfY
-aOq
+bTA
+bUw
+ccQ
+chl
+bkB
+afw
+aaa
+beK
 bij
-aOr
-aNu
+tKf
+szB
+beK
+acO
 aaa
 aaa
 aaa
@@ -126450,13 +126917,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+dRl
+oQa
+wqb
+ica
+dRl
 aaa
 aaa
 aaa
@@ -126672,23 +127137,18 @@ aaa
 aaa
 aaa
 aaa
+aaT
 aaa
 aaa
 aaa
-aaa
-aOv
-aci
-aOv
-aaa
+adc
+aek
+alX
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+adc
+adJ
+alX
 aaa
 aaa
 aaa
@@ -126706,36 +127166,43 @@ aaa
 aaa
 aaa
 aaa
-aEP
-aEP
-aEP
-aEP
-aEP
+aaa
+aaa
+aaa
+aaa
+aPJ
+aFO
+aFO
+aIb
+aFO
+aJU
 aLp
-aMr
-aEO
-aOr
-aOr
-aOr
+bgr
+bgr
+aMq
+bjw
+bme
 aTo
+btD
+bgr
+aNu
+bDL
+bFX
+aNu
+aNv
+aNu
+bUC
+ccR
+aNu
 aNv
 aNu
 aNu
-aNu
-aNu
-aNu
 aNv
-aNu
-aNu
-aNu
-aNu
-aNu
-aNv
-bjF
-aOr
 aPe
-aOr
 aNv
+aNv
+bmd
+acO
 aaa
 aaa
 aaa
@@ -126751,15 +127218,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abW
+dRl
+oUm
+kLO
+oUm
+dRl
+agm
 aaa
 aaa
 aaa
@@ -126978,49 +127443,67 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aRo
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aci
 ach
+acI
+acO
+aaa
+aaa
+aaa
+aaT
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aPM
+aQX
+aFO
+aIb
+aFO
+aJU
+aER
 aMJ
-aNv
+aER
 aOu
 aQe
 aQE
-aNv
-aNv
+bqN
+btE
+aQE
+bxh
+bDM
+bFZ
+bNp
+bRM
+bDM
+aOr
+cdE
+bxh
+fhN
+btE
+aQE
+bmf
+swI
+brq
+aNu
+aad
 awS
 aaa
 aaa
@@ -127031,16 +127514,6 @@ aaa
 aaa
 aaa
 aaa
-aaO
-aNv
-aNv
-bmf
-aQe
-brq
-aNv
-aNu
-aNu
-bkS
 aaa
 aaa
 aaa
@@ -127048,19 +127521,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+dRl
+oUm
+oUm
+oUm
+dRl
 aaa
 aaa
 aaa
@@ -127280,6 +127745,9 @@ aaa
 aaa
 aaa
 aaa
+ach
+acI
+acO
 aaa
 aaa
 aaa
@@ -127306,43 +127774,37 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aci
-aaO
-aad
+aER
+aFO
+aFO
+aTN
+aVo
+aXd
+aYf
+aZf
+bdy
+bfX
+bfX
+bfX
+doC
 aNu
-wBr
-aPf
-aQf
-doC
-awS
-aaa
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
-aaa
-aaO
-doC
-aQf
-bik
+aOI
 aOr
-aTq
-aQf
-bme
-aTq
+aOr
+bGj
+aOr
+aNu
+aOI
+aOr
+aOr
+aOr
+aOr
+aNu
+aOI
+aOr
+sRA
+rda
+aNu
 aaa
 aaa
 aaa
@@ -127361,8 +127823,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+dRl
+dRl
+dRl
+dRl
+dRl
 aaa
 aaa
 aaa
@@ -127581,6 +128046,11 @@ aaa
 aaa
 aaa
 aaa
+agj
+aaf
+aem
+aaf
+aPh
 aaa
 aaa
 aaa
@@ -127606,45 +128076,40 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aci
-aaa
-aaa
-aNu
+aER
+aER
+aSk
+aFO
+aFO
+aXe
+aER
+aZB
+aER
 aOI
-aPf
-aQf
+bjy
+bmO
 vNa
-aaa
-aaa
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
-aaa
-aaa
-vNa
-aQf
-bik
-bHX
+btM
+bvS
+bxi
+bxi
+bGN
+bNq
+bRO
+bxi
+bxi
+bxi
+bNq
+bxi
+btM
+mEW
+bfX
+tbT
+aOr
 aNu
-cnR
-cnR
-aNu
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -127884,69 +128349,69 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aOv
 aci
+aOv
 aaa
 aaa
-aNu
-wBr
-aPf
-aQf
-aUe
 aaa
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
 aaa
-aUe
-aQf
-bik
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aER
+aER
+aER
+aER
+aER
+aYE
+aZC
+aLp
 aOr
-aTq
-aQf
-aQf
-aTq
+aOr
+aOr
+aUe
+aNv
+aNu
+aNu
+aNu
+aNu
+aNu
+aNv
+aNu
+aNu
+aNu
+aNu
+aNu
+aNv
+mJy
+aOr
+tmx
+aOr
+aNv
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -128187,7 +128652,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aRo
 aaa
 aaa
 aaa
@@ -128221,29 +128686,29 @@ aaa
 aaa
 aaa
 aci
-aaa
-abW
+ach
+bad
 aNv
 aPd
-aPf
+bjC
 aRR
-aNu
+aNv
+aNv
+awS
 aaa
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
 aaa
-aNu
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaO
+aNv
+aNv
 bnv
-bik
+bjC
 bOH
 aNv
 aNu
@@ -128523,13 +128988,14 @@ aaa
 aaa
 aaa
 aci
-aaa
-aaa
+aaO
+aad
 aNu
 wBr
 aPf
 aQf
-aNu
+bqO
+awS
 aaa
 aTp
 aTp
@@ -128540,17 +129006,16 @@ aTp
 aTp
 aTp
 aTp
-aTp
-aTp
 aaa
-aNu
-ggG
+aaO
+bqO
+aQf
 bik
-aOt
-aNu
-aaa
-aaa
-aci
+aOr
+xhV
+aQf
+kkB
+xhV
 aaa
 aaa
 aaa
@@ -128831,7 +129296,7 @@ aNu
 aOt
 aPf
 aQf
-aNu
+bqP
 aaa
 aaa
 aTp
@@ -128845,14 +129310,16 @@ aTp
 aTp
 aaa
 aaa
-aNu
+bqP
 aQf
 bik
-aOt
+gPu
+aNu
+cGZ
+cGZ
 aNu
 aaa
 aaa
-aci
 aaa
 aaa
 aaa
@@ -128860,11 +129327,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+upu
+jNV
+xIV
 aaa
 aaa
 aaa
@@ -129128,13 +129593,12 @@ aaa
 aaa
 aci
 aaa
-acb
+aaa
 aNu
 wBr
 aPf
 aQf
-aNu
-afw
+bqY
 aaa
 aTp
 aTp
@@ -129145,18 +129609,17 @@ aTp
 aTp
 aTp
 aTp
+aTp
+aTp
 aaa
-acb
-aNu
-ggG
+bqY
+aQf
 bik
-bRp
-aNu
-afw
-aaa
-aci
-aaa
-aaa
+aOr
+xhV
+aQf
+aQf
+xhV
 aaa
 aaa
 aaa
@@ -129166,7 +129629,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
+pNg
+nEE
+pNv
 aaa
 aaa
 aaa
@@ -129428,16 +129893,15 @@ aaa
 aaa
 aaa
 aaa
+aci
+aaa
+abW
 aNv
-aNu
-aNu
-aNv
-aNv
-aQg
+bfY
+aPf
 aSv
-aNv
 aNu
-bkS
+aaa
 aTp
 aTp
 aTp
@@ -129447,16 +129911,17 @@ aTp
 aTp
 aTp
 aTp
-bkS
+aTp
+aTp
+aaa
 aNu
-aNv
 bri
 bik
+kEo
 aNv
-aNv
-aNv
-aNv
-aNv
+aNu
+aNu
+bkS
 aaa
 aaa
 aaa
@@ -129466,9 +129931,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+oyc
+ssP
+wgL
 aaa
 aaa
 aaa
@@ -129730,16 +130195,15 @@ aaa
 aaa
 aaa
 aaa
+aci
+aaa
+aaa
 aNu
-pfT
-aQc
-aQc
-aPg
+wBr
 aPf
 aQf
-aRn
-aQf
-aRn
+aNu
+aaa
 aTp
 aTp
 aTp
@@ -129749,18 +130213,17 @@ aTp
 aTp
 aTp
 aTp
-aRn
-aQf
-aRn
-aQf
+aTp
+aTp
+aaa
+aNu
+nDM
 bik
 aPg
-aQc
-aQc
-njl
 aNu
 aaa
 aaa
+aci
 aaa
 aaa
 aaa
@@ -129770,6 +130233,8 @@ aaa
 aaa
 aaa
 aaa
+mkj
+kKv
 aaa
 aaa
 aaa
@@ -130032,16 +130497,16 @@ aaa
 aaa
 aaa
 aaa
+aci
+aaa
+aaa
 aNu
-ezW
-aOs
-ezW
-aNu
+aPg
 aPf
-aSw
-aRn
-bfX
-aRn
+aQf
+aNu
+aaa
+aaa
 aTp
 aTp
 aTp
@@ -130051,18 +130516,16 @@ aTp
 aTp
 aTp
 aTp
-aRn
-bfX
-aRn
-aSw
+aaa
+aaa
+aNu
+aQf
 bik
-aNu
-bSV
-cnS
-bSV
+aPg
 aNu
 aaa
 aaa
+aci
 aaa
 aaa
 aaa
@@ -130073,6 +130536,8 @@ aaa
 aaa
 aaa
 aaa
+aaa
+yiB
 aaa
 aaa
 aaa
@@ -130334,35 +130799,35 @@ aaa
 aaa
 aaa
 aaa
-aNv
-aMI
-aNv
-aMI
-aNv
+aci
+aaa
+acb
 aNu
+wBr
+aPf
+aQf
 aNu
-aNv
+afw
+aaa
+aTp
+aTp
+aTp
+aTp
+aTp
+aTp
+aTp
+aTp
+aTp
+aaa
+acb
 aNu
-bkS
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
-aTp
-bkS
+nDM
+bik
+ggB
 aNu
-aNv
-aNu
-aNu
-aNv
-aMI
-aNv
-aMI
-aNv
+afw
+aaa
+aci
 aaa
 aaa
 aaa
@@ -130636,16 +131101,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aci
-aaa
-aci
-aaa
-aaa
-aci
-aaa
-aaa
+aNv
+aNu
+aNu
+aNv
+aNv
+bjF
+bmW
+aNv
+aNu
+bkS
 aTp
 aTp
 aTp
@@ -130655,16 +131120,16 @@ aTp
 aTp
 aTp
 aTp
-aaa
-aaa
-aci
-aaa
-aaa
-aci
-aaa
-aaa
-aaa
-aaa
+bkS
+aNu
+aNv
+nLA
+bik
+aNv
+aNv
+aNv
+aNv
+aNv
 aaa
 aaa
 aaa
@@ -130938,16 +131403,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aOv
-aaa
-aOv
-aaa
-aaa
-aci
-aaa
-aaa
+aNu
+aYO
+aQE
+aQE
+bgy
+aPf
+aQf
+brc
+aQf
+brc
 aTp
 aTp
 aTp
@@ -130957,16 +131422,16 @@ aTp
 aTp
 aTp
 aTp
-aaa
-aaa
-aci
-aaa
-aaa
-aOv
-aaa
-aaa
-aaa
-aaa
+brc
+aQf
+brc
+aQf
+bik
+bgy
+aQE
+aQE
+dgn
+aNu
 aaa
 aaa
 aaa
@@ -131240,16 +131705,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aRo
-aaa
-aaa
+aNu
+aYU
+baT
+aYU
+aNu
+aPf
+bmZ
+brc
+btO
+brc
 aTp
 aTp
 aTp
@@ -131259,16 +131724,16 @@ aTp
 aTp
 aTp
 aTp
-aaa
-aaa
-aRo
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+brc
+btO
+brc
+bmZ
+bik
+aNu
+mBE
+svA
+mBE
+aNu
 aaa
 aaa
 aaa
@@ -131542,16 +132007,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aNv
+aYX
+aNv
+aYX
+aNv
+aNu
+aNu
+aNv
+aNu
+bkS
 aTp
 aTp
 aTp
@@ -131561,16 +132026,16 @@ aTp
 aTp
 aTp
 aTp
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bkS
+aNu
+aNv
+aNu
+aNu
+aNv
+aYX
+aNv
+aYX
+aNv
 aaa
 aaa
 aaa
@@ -131846,13 +132311,12 @@ aaa
 aaa
 aaa
 aaa
+aci
+aaa
+aci
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aci
 aaa
 aaa
 aTp
@@ -131862,13 +132326,14 @@ aTp
 aTp
 aTp
 aTp
+aTp
+aTp
 aaa
 aaa
+aci
 aaa
 aaa
-aaa
-aaa
-aaa
+aci
 aaa
 aaa
 aaa
@@ -132148,13 +132613,12 @@ aaa
 aaa
 aaa
 aaa
+aOv
+aaa
+aOv
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aci
 aaa
 aaa
 aTp
@@ -132164,13 +132628,14 @@ aTp
 aTp
 aTp
 aTp
+aTp
+aTp
 aaa
 aaa
+aci
 aaa
 aaa
-aaa
-aaa
-aaa
+aOv
 aaa
 aaa
 aaa
@@ -132455,9 +132920,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aRo
 aaa
 aaa
 aTp
@@ -132465,11 +132928,13 @@ aTp
 aTp
 aTp
 aTp
+aTp
+aTp
+aTp
+aTp
 aaa
 aaa
-aaa
-aaa
-aaa
+aRo
 aaa
 aaa
 aaa
@@ -132760,15 +133225,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aTp
 aTp
 aTp
 aTp
 aTp
-aaa
-aaa
+aTp
+aTp
+aTp
+aTp
 aaa
 aaa
 aaa
@@ -133063,13 +133528,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aTp
 aTp
 aTp
-aaa
-aaa
+aTp
+aTp
+aTp
+aTp
 aaa
 aaa
 aaa
@@ -133365,13 +133830,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aTp
+aTp
+aTp
+aTp
+aTp
+aTp
+aTp
 aaa
 aaa
 aaa
@@ -133668,11 +134133,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aTp
+aTp
+aTp
+aTp
+aTp
 aaa
 aaa
 aaa
@@ -133970,11 +134435,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aTp
+aTp
+aTp
+aTp
+aTp
 aaa
 aaa
 aaa
@@ -134273,9 +134738,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aTp
+aTp
+aTp
 aaa
 aaa
 aaa

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -31372,10 +31372,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/east)
-"byt" = (
-/obj/reagent_dispensers/compostbin,
-/turf/simulated/floor/grass,
-/area/station/hydroponics/bay)
 "byu" = (
 /obj/machinery/light/emergency{
 	dir = 8;
@@ -54471,7 +54467,7 @@
 	},
 /area/station/maintenance/southeast)
 "mCe" = (
-/obj/reagent_dispensers/watertank/big,
+/obj/reagent_dispensers/compostbin,
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
 "mCg" = (
@@ -114417,7 +114413,7 @@ bpC
 buR
 bvU
 bpC
-byt
+bpC
 mCe
 jJT
 boq

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -31372,6 +31372,10 @@
 	dir = 1
 	},
 /area/station/hallway/primary/east)
+"byt" = (
+/obj/decal/poster/wallsign/security,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/security/brig)
 "byu" = (
 /obj/machinery/light/emergency{
 	dir = 8;
@@ -38168,7 +38172,8 @@
 "bNC" = (
 /obj/machinery/door/airlock/pyro/security{
 	dir = 4;
-	name = "Defendant's Stand"
+	name = "Defendant's Stand";
+	req_access = null
 	},
 /obj/access_spawn/brig,
 /obj/firedoor_spawn,
@@ -39493,6 +39498,9 @@
 /obj/item/device/detective_scanner{
 	pixel_x = 15
 	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
@@ -40098,6 +40106,10 @@
 "bRL" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 20
 	},
 /turf/simulated/floor/redblack{
 	dir = 4
@@ -41201,8 +41213,11 @@
 /area/station/crew_quarters/barber_shop)
 "bUl" = (
 /obj/machinery/door/airlock/pyro/security{
-	name = "Secure Consultation"
+	name = "Secure Consultation";
+	req_access = null
 	},
+/obj/access_spawn/brig,
+/obj/firedoor_spawn,
 /turf/simulated/floor/red,
 /area/station/security/brig)
 "bUm" = (
@@ -41229,11 +41244,14 @@
 /area/station/security/brig)
 "bUp" = (
 /obj/machinery/door/airlock/pyro/security{
-	name = "Secure Consultation"
+	name = "Secure Consultation";
+	req_access = null
 	},
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
+/obj/access_spawn/brig,
+/obj/firedoor_spawn,
 /turf/simulated/floor/red,
 /area/station/security/brig)
 "bUq" = (
@@ -54969,12 +54987,15 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "nVs" = (
-/obj/machinery/door/airlock/pyro/security{
-	name = "Secure Consultation"
-	},
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
+/obj/machinery/door/airlock/pyro/security{
+	name = "Secure Consultation";
+	req_access = null
+	},
+/obj/access_spawn/brig,
+/obj/firedoor_spawn,
 /turf/simulated/floor/redblack,
 /area/station/security/brig)
 "nVE" = (
@@ -55773,6 +55794,14 @@
 	},
 /turf/simulated/floor/red,
 /area/station/ai_monitored/armory)
+"qdz" = (
+/obj/item/device/radio/intercom/security{
+	dir = 4
+	},
+/turf/simulated/floor/redblack{
+	dir = 8
+	},
+/area/station/security/brig)
 "qex" = (
 /obj/lattice{
 	icon_state = "lattice-dir"
@@ -112919,7 +112948,7 @@ bMo
 bNt
 bFK
 bQr
-bRS
+qdz
 qmz
 bUl
 cot
@@ -113823,7 +113852,7 @@ tZJ
 bLe
 bMq
 bNv
-bFK
+byt
 rXp
 bRJ
 bWL

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -38085,6 +38085,11 @@
 /area/station/security/brig)
 "bNo" = (
 /obj/submachine/slot_machine,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13"
+	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bNp" = (
@@ -41248,6 +41253,11 @@
 /obj/machinery/phone,
 /obj/disposalpipe/segment/brig{
 	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13"
 	},
 /turf/simulated/floor/redblack,
 /area/station/security/interrogation)
@@ -53883,6 +53893,13 @@
 	dir = 1;
 	pixel_y = 21
 	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
 /turf/simulated/floor/redblack{
 	dir = 5
 	},
@@ -56278,6 +56295,18 @@
 	dir = 8
 	},
 /area/station/hallway/primary/south)
+"rgP" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
+	},
+/turf/simulated/floor/green/side{
+	dir = 4
+	},
+/area/station/hydroponics/bay)
 "riF" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -112104,7 +112133,7 @@ bqL
 bqL
 bqL
 bqL
-bqL
+rgP
 bqL
 bqL
 bzu


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEAT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Large change batch for Kondaru that extends the entire station horizontally by four tiles.

- **Major:** Security's detention complex has received a considerable retooling. The "secure consulation" room is now connected to the Courtroom and serves as a considerably better entry to the detention wing itself, and the detention rooms themselves have been restructured to fit in the new space.
- **Major:** Hydroponics' primary cultivation room has been significantly extended. The complement of trays has significantly increased, two new UV grow lamps are now installed by default, a second compost tank has been added, and departmental flow should be markedly improved.
- Catering's backroom has been extended a bit and now has a "ring" layout, and a slightly increased complement of items, most notably three catering trays.
- A new "moonshiners' den" has been introduced next to catering storage, with a still and some bottles. The previous location of the maintenance still (northeast maintenance) has been altered and now contains an empty and malfunctioning general manufacturer.
- Small rider at community request: alters the behavior of research's cargo endpoint flusher to use the ejection system if no destination is applied to the label, to make it easier to rapidly eject hazardous objects. Only that specific flusher will do this.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Significantly improves Kondaru gameplay for individuals in affected departments.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Kubius:
(*)Significant rework to Kondaru centered on the southeast region, improving the flow of the detention complex and considerably expanding Hydroponics.
```
