### PR TITLE
Make Ion Storm'd lights easier to repair

### DIFF
--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -189,6 +189,8 @@
 			for (var/obj/machinery/light/foundLight in stationLights)
 				if (foundLight.z != 1)
 					continue
+				if (!foundLight.removable_bulb)
+					continue
 				T = get_turf(foundLight)
 				if (!istype(T.loc,/area/station/))
 					continue

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -589,6 +589,7 @@
 	current_lamp = inserted_lamp
 	current_lamp.set_loc(null)
 	light.set_color(current_lamp.color_r, current_lamp.color_g, current_lamp.color_b)
+	brightness = initial(brightness)
 	on = has_power()
 	update()
 
@@ -625,10 +626,10 @@
 		else
 			L = new M.dispensing_bulb()
 		if(inserted_lamp)
-			if (current_lamp.light_status == LIGHT_OK && current_lamp.name == L.name) //name because I want this to be able to replace working lights with different colours
+			if (current_lamp.light_status == LIGHT_OK && current_lamp.name == L.name && brightness == initial(brightness) && current_lamp.color_r == L.color_r && current_lamp.color_g == L.color_g && current_lamp.color_b == L.color_b && on == has_power())
 				boutput(user, "This fitting already has an identical lamp.")
 				qdel(L)
-				return //Stop borgs from making more sparks than necessary
+				return // Stop borgs from making more sparks than necessary.
 
 		insert(user, L)
 		if (!isghostdrone(user)) // Same as ghostdrone RCDs, no sparks


### PR DESCRIPTION
[QOL]

## About the PR

Makes three changes to lights:

- Ion Storm no longer targets the red emergency lights you can't replace.
- The miniaturized lamp manufacturer now allows you to replace lights the Ion Storm messed with even if they weren't broken by it.
- Replacing a light in a light fixture now fixes the brightness (which is currently only modified by Ion Storms).
