### PR TITLE
Resolve singularity bomb runtime with timer

### DIFF
--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -1706,10 +1706,11 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 	else
 		var/seconds = src.time % 60
 		var/minutes = (src.time - seconds) / 60
+		var/flick_seperator = (seconds % 2 == 0)  || !src.timing
 		minutes = minutes < 10 ? "0[minutes]" : "[minutes]"
 		seconds = seconds < 10 ? "0[seconds]" : "[seconds]"
 
-		return "[minutes][seconds % 2 == 0 ? ":" : " "][seconds]"
+		return "[minutes][flick_seperator ? ":" : " "][seconds]"
 
 /obj/machinery/the_singularitybomb/proc/get_interface()
 	return {"<html>


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug - minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes timer to not runtime and to only cause the colon to flash when armed.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Runtimes r bad.
