### PR TITLE
Adds new species trait "Squid", transforming the character into a Squid Person (Ithillid)

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -1118,3 +1118,18 @@ obj/trait/pilot
 			var/mob/living/carbon/human/H = owner
 			H.set_mutantrace(/datum/mutantrace/roach)
 		return
+
+/obj/trait/squid
+	name = "Squid (-4) \[Species\]"
+	cleanName = "Squid"
+	desc = "You have tentacles on your face and can breathe underwater. The price? You have permanently wet socks and a deep terror of sushi resturants."
+	id = "squid"
+	points = -4
+	isPositive = 1
+	category = "species"
+
+	onAdd(var/mob/owner)
+		if(ishuman(owner))
+			var/mob/living/carbon/human/H = owner
+			H.set_mutantrace(/datum/mutantrace/ithillid)
+		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[FEATURE] [INPUT NEEDED]

## About the PR 

This Pull Request adds the Ithillid mutation race to be a selectable starting trait



## Why's this needed? 

This change allows for further creativity when making RP characters, and that those who wish to be a squid person do not need to rely on random mutation/genetics 





```
(u)Yellow-Mushroom:
(*)Added new starting trait of "Squid", making the selected character into a squid person
```
