### PR TITLE
Switches to an auxtools-based debugger for local development

### DIFF
--- a/SpacemanDMM.toml
+++ b/SpacemanDMM.toml
@@ -1,2 +1,4 @@
 [langserver]
 dreamchecker = true
+[debugger]
+engine = "auxtools"

--- a/_std/_spaceman_dmm.dm
+++ b/_std/_spaceman_dmm.dm
@@ -30,7 +30,14 @@
 	#define VAR_PROTECTED var
 #endif
 
-/proc/enable_extools_debugger()
-	var/extools = world.GetConfig("env", "EXTOOLS_DLL") || (world.system_type == MS_WINDOWS ? "./byond-extools.dll" : "./libbyond-extools.so")
-	if(fexists(extools))
-		call(extools, "debug_initialize")()
+/proc/enable_auxtools_debugger()
+	var/debug_server = world.GetConfig("env", "AUXTOOLS_DEBUG_DLL")
+	if (debug_server)
+		call(debug_server, "auxtools_init")()
+		enable_debugging()
+
+/proc/auxtools_stack_trace(msg)
+	CRASH(msg)
+
+/proc/enable_debugging(mode, port)
+	CRASH("auxtools not loaded")

--- a/code/world.dm
+++ b/code/world.dm
@@ -198,7 +198,6 @@ var/f_color_selector_handler/F_Color_Selector
 //Called BEFORE the map loads. Useful for objects that require certain things be set during init
 /datum/preMapLoad
 	New()
-		enable_extools_debugger()
 #ifdef REFERENCE_TRACKING
 		enable_reference_tracking()
 #endif
@@ -398,6 +397,7 @@ var/f_color_selector_handler/F_Color_Selector
 
 /world/New()
 	Z_LOG_DEBUG("World/New", "World New()")
+	enable_auxtools_debugger()
 	TgsNew(new /datum/tgs_event_handler/impl, TGS_SECURITY_TRUSTED)
 	tick_lag = MIN_TICKLAG//0.4//0.25
 //	loop_checks = 0
@@ -1669,9 +1669,6 @@ var/opt_inactive = null
 
 		sleep(10 SECONDS)
 
-
-
-
 /world/proc/KickInactiveClients()
 	for(var/client/C in clients)
 		if(!C.holder && ((C.inactivity/10)/60) >= 15)
@@ -1679,3 +1676,9 @@ var/opt_inactive = null
 			del(C)
 
 /// EXPERIMENTAL STUFF
+
+/world/Del()
+	var/debug_server = world.GetConfig("env", "AUXTOOLS_DEBUG_DLL")
+	if (debug_server)
+		call(debug_server, "auxtools_shutdown")()
+	. = ..()

--- a/code/world.dm
+++ b/code/world.dm
@@ -198,6 +198,7 @@ var/f_color_selector_handler/F_Color_Selector
 //Called BEFORE the map loads. Useful for objects that require certain things be set during init
 /datum/preMapLoad
 	New()
+		enable_auxtools_debugger()
 #ifdef REFERENCE_TRACKING
 		enable_reference_tracking()
 #endif
@@ -397,7 +398,6 @@ var/f_color_selector_handler/F_Color_Selector
 
 /world/New()
 	Z_LOG_DEBUG("World/New", "World New()")
-	enable_auxtools_debugger()
 	TgsNew(new /datum/tgs_event_handler/impl, TGS_SECURITY_TRUSTED)
 	tick_lag = MIN_TICKLAG//0.4//0.25
 //	loop_checks = 0


### PR DESCRIPTION
[TOOLING][FEAT]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

switches the local debugger to use auxtools instead of extools

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

extools is being deprecated