### PR TITLE
Delay spacing of turfs to avoid dirty cached data by air_master

### DIFF
--- a/code/modules/atmospherics/FEA_system.dm
+++ b/code/modules/atmospherics/FEA_system.dm
@@ -278,7 +278,7 @@ datum/controller/air_system
 		return 1
 
 	process_tiles_to_space()
-		if(length(tiles_to_space) > 0)
+		if(length(tiles_to_space))
 			for(var/turf/T as() in tiles_to_space)
 				T.ReplaceWithSpace()
 			tiles_to_space.len = 0

--- a/code/modules/atmospherics/FEA_system.dm
+++ b/code/modules/atmospherics/FEA_system.dm
@@ -94,8 +94,10 @@ datum/controller/air_system
 	//Geometry updates lists
 	var/list/turf/tiles_to_update = list()
 	var/list/datum/air_group/groups_to_rebuild = list()
+	var/list/turf/tiles_to_space = list()
 
 	var/current_cycle = 0
+	var/is_busy = FALSE
 	var/datum/controller/process/air_system/parent_controller = null
 
 	var/turf/space/space_sample = 0 //instead of repeatedly using locate() to find space, we should just cache a space tile ok
@@ -125,6 +127,10 @@ datum/controller/air_system
 		//Warning: Do not call this
 
 	proc/process_super_conductivity()
+		//Used by process()
+		//Warning: Do not call this
+
+	proc/process_tiles_to_space()
 		//Used by process()
 		//Warning: Do not call this
 
@@ -239,6 +245,10 @@ datum/controller/air_system
 
 	process()
 		current_cycle++
+
+		process_tiles_to_space()
+		is_busy = TRUE
+
 		if(groups_to_rebuild.len > 0)
 			process_rebuild_select_groups()
 		LAGCHECK(LAG_HIGH)
@@ -264,7 +274,14 @@ datum/controller/air_system
 				AG.check_regroup()
 				LAGCHECK(LAG_HIGH)
 
+		is_busy = FALSE
 		return 1
+
+	process_tiles_to_space()
+		if(length(tiles_to_space) > 0)
+			for(var/turf/T as() in tiles_to_space)
+				T.ReplaceWithSpace()
+			tiles_to_space.len = 0
 
 	process_update_tiles()
 		for(var/turf/simulated/T in tiles_to_update) // ZEWAKA-ATMOS SPACE + SPACE FLUID LEAKAGE

--- a/code/turf/turf.dm
+++ b/code/turf/turf.dm
@@ -685,6 +685,10 @@
 	return floor
 
 /turf/proc/ReplaceWithSpace()
+	if( air_master.is_busy )
+		air_master.tiles_to_space |= src
+		return
+
 	var/area/my_area = loc
 	var/turf/floor
 	if (my_area)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug - minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Re-implementation of #3016 to not hack around the problem.
Queue transition from simulated to spaced turfs when air_master (ATMOS) is in the process of crunching numbers.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Resolves runtimes when ATMOS processing is being performed when a turf is changed to space out from under it.

