### PR TITLE
Clean up superconductive list and div0

### DIFF
--- a/code/modules/atmospherics/FEA_system.dm
+++ b/code/modules/atmospherics/FEA_system.dm
@@ -301,12 +301,12 @@ datum/controller/air_system
 			LAGCHECK(LAG_HIGH)
 
 	process_singletons()
-		for(var/item in active_singletons)
-			item:process_cell()
+		for(var/turf/simulated/loner as() in active_singletons)
+			loner.process_cell()
 			LAGCHECK(LAG_HIGH)
 
 	process_super_conductivity()
-		for(var/turf/simulated/hot_potato in active_super_conductivity) //gets space tiles in here somehow -ZEWAKA/ATMOS
+		for(var/turf/simulated/hot_potato as() in active_super_conductivity)
 			hot_potato.super_conduct()
 			LAGCHECK(LAG_HIGH)
 

--- a/code/modules/atmospherics/FEA_turf_tile.dm
+++ b/code/modules/atmospherics/FEA_turf_tile.dm
@@ -198,6 +198,8 @@ turf
 				if (active_hotspot)
 					pool(active_hotspot)
 					active_hotspot = null
+			if(being_superconductive)
+				air_master.active_super_conductivity.Remove(src)
 			if(blocks_air)
 				for(var/direction in cardinal)
 					var/turf/simulated/tile = get_step(src,direction)
@@ -530,7 +532,7 @@ turf
 
 		proc/share_temperature_mutual_solid(turf/simulated/sharer, conduction_coefficient)
 			var/delta_temperature = (ARCHIVED(temperature) - sharer.ARCHIVED(temperature))
-			if(abs(delta_temperature) > MINIMUM_TEMPERATURE_DELTA_TO_CONSIDER)
+			if(abs(delta_temperature) > MINIMUM_TEMPERATURE_DELTA_TO_CONSIDER && src.heat_capacity)
 
 				var/heat = conduction_coefficient*delta_temperature* \
 					(src.heat_capacity*sharer.heat_capacity/(src.heat_capacity+sharer.heat_capacity))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[performance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Clean up superconductive turf list when simulated turf is deleted, _should_ resolve previous work around
Check for divide by zero, found on Martian turf when I set the world on fire.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Oh sweet a micro-optimization?
