### PR TITLE
Start adding help topics for wireless devices

### DIFF
--- a/code/obj/item/device/gps.dm
+++ b/code/obj/item/device/gps.dm
@@ -281,6 +281,8 @@
 		if(!signal || signal.encryption)
 			return
 
+		var/sender = signal.data["sender"]
+
 		if (lowertext(signal.data["distress_alert"]))
 			var/senderName = signal.data["identifier"]
 			if (!senderName)
@@ -290,40 +292,48 @@
 			else if (lowertext(signal.data["distress_alert"] == "clear"))
 				src.visible_message("<b>[bicon(src)] [src]</b> beeps, \"NOTICE: Distress signal cleared by GPS [senderName].\".")
 			return
-
+		else if (!signal.data["sender"])
+			return
 		else if (signal.data["address_1"] == src.net_id && src.allowtrack)
+			var/datum/signal/reply = get_free_signal()
+			reply.source = src
+			reply.data["sender"] = src.net_id
+			reply.data["address_1"] = sender
 			switch (lowertext(signal.data["command"]))
+				if ("help")
+					if (!signal.data["topic"])
+						reply.data["description"] = "GPS unit - Provides space-coordinates and transmits distress signals"
+						reply.data["topics"] = "status"
+					else
+						reply.data["topic"] = signal.data["topic"]
+						switch (lowertext(signal.data["topic"]))
+							if ("status")
+								reply.data["description"] = "Returns the status of the GPS unit, including identifier, coords, location, and distress status. Does not require any arguments"
+							else
+								reply.data["topic"] = signal.data["topic"]
+								reply.data["description"] = "ERROR: UNKNOWN TOPIC"
 				if ("status")
-					var/sender = signal.data["sender"]
-					if (!sender)
-						return
-
 					var/turf/T = get_turf(src)
-					var/datum/signal/reply = get_free_signal()
-					reply.source = src
-					reply.data["sender"] = src.net_id
-					reply.data["address_1"] = sender
 					reply.data["identifier"] = "[src.serial]-[src.identifier]"
 					reply.data["coords"] = "[T.x],[T.y]"
 					reply.data["location"] = "[src.get_z_info(T)]"
 					reply.data["distress"] = "[src.distress]"
-
-					radio_control.post_signal(src, reply)
-					return
+				else
+					return //COMMAND NOT RECOGNIZED
+			radio_control.post_signal(src, reply)
 
 		else if (lowertext(signal.data["address_1"]) == "ping" && src.allowtrack)
 			var/datum/signal/pingsignal = get_free_signal()
 			pingsignal.source = src
 			pingsignal.data["device"] = "WNET_GPS"
 			pingsignal.data["netid"] = src.net_id
-			pingsignal.data["address_1"] = signal.data["sender"]
+			pingsignal.data["address_1"] = sender
 			pingsignal.data["command"] = "ping_reply"
 			pingsignal.data["data"] = "[src.serial]-[src.identifier]"
 			pingsignal.data["distress"] = "[src.distress]"
 			pingsignal.transmission_method = TRANSMISSION_RADIO
 
 			radio_control.post_signal(src, pingsignal)
-			return
 
 // coordinate beacons. pretty useless but whatever you never know
 

--- a/code/obj/machinery/computer/security/riot.dm
+++ b/code/obj/machinery/computer/security/riot.dm
@@ -60,19 +60,35 @@
 				radio_connection.post_signal(src, pingsignal, radiorange)
 			return
 
+		var/datum/signal/returnsignal = get_free_signal()
+		returnsignal.source = src
+		returnsignal.data["sender"] = src.net_id
+		returnsignal.data["address_1"] = target
 		switch(signal.data["command"])
+			if ("help")
+				if (!signal.data["topic"])
+					returnsignal.data["description"] = "Armory Authorization Computer - allows for lowering of armory access level to SECURITY. Wireless authorization requires NETPASS_HEADS"
+					returnsignal.data["topics"] = "authorize"
+				else
+					returnsignal.data["topic"] = signal.data["topic"]
+					switch (lowertext(signal.data["topic"]))
+						if ("authorize")
+							returnsignal.data["description"] = "Authorizes armory access. Requires NETPASS_HEADS"
+							returnsignal.data["args"] = "acc_code"
+						else
+							returnsignal.data["description"] = "ERROR: UNKNOWN TOPIC"
 			if ("authorize")
-				signal.data["sender"] = src.net_id
-				signal.data["address_1"] = target
 				if (signal.data["acc_code"] == netpass_heads)
-					signal.data["command"] = "ack"
-					signal.data["acc_code"] = netpass_security
-					signal.data["data"] = "authorize"
+					returnsignal.data["command"] = "ack"
+					returnsignal.data["acc_code"] = netpass_security
+					returnsignal.data["data"] = "authorize"
 					authorize()
 				else
-					signal.data["command"] = "nack"
-					signal.data["data"] = "badpass"
-				radio_connection.post_signal(src, signal, radiorange)
+					returnsignal.data["command"] = "nack"
+					returnsignal.data["data"] = "badpass"
+			else
+				return //COMMAND NOT RECOGNIZED
+		radio_connection.post_signal(src, returnsignal, radiorange)
 
 
 	proc/authorize()

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -1527,6 +1527,41 @@ obj/machinery/door/airlock
 			else if (!id_tag || id_tag != signal.data["tag"])
 				return
 
+		if (signal.data["command"] && signal.data["command"] == "help")
+			var/datum/signal/reply = get_free_signal()
+			reply.source = src
+			reply.transmission_method = 1
+			reply.data["sender"] = src.net_id
+			reply.data["address_1"] = signal.data["sender"]
+			if (!signal.data["topic"])
+				reply.data["description"] = "Airlock - requires an access code that can be found on the maintenance panel"
+				reply.data["topics"] = "open,close,lock,unlock,secure_close,secure_open"
+			else
+				reply.data["topic"] = signal.data["topic"]
+				switch (lowertext(signal.data["topic"]))
+					if ("open")
+						reply.data["description"] = "Opens the airlock. Requires access code"
+						reply.data["args"] = "access_code"
+					if ("close")
+						reply.data["description"] = "Closes the airlock. Requires access code"
+						reply.data["args"] = "access_code"
+					if ("lock")
+						reply.data["description"] = "Drops the airlocks bolts, securing it in place. Requires access code"
+						reply.data["args"] = "access_code"
+					if ("unlock")
+						reply.data["description"] = "Lifts the airlocks bolts, unsecuring it. Requires access code"
+						reply.data["args"] = "access_code"
+					if ("secure_close")
+						reply.data["description"] = "Closes the airlock and drops the bolts, securing it closed. Requires access code"
+						reply.data["args"] = "access_code"
+					if ("secure_open")
+						reply.data["description"] = "Opens the airlock and drops the bolts, securing it open. Requires access code"
+						reply.data["args"] = "access_code"
+					else
+						reply.data["description"] = "ERROR: UNKNOWN TOPIC"
+			radio_connection.post_signal(src, reply, radiorange)
+			return
+
 		var/sent_code = text2num(signal.data["access_code"])
 		if (aiControlDisabled > 0 || cant_emag || sent_code != src.net_access_code)
 			if(prob(20))
@@ -1589,9 +1624,6 @@ obj/machinery/door/airlock
 					update_icon()
 					sleep(src.operation_time)
 					send_status(,senderid)
-
-			else
-				return
 
 	proc/send_status(userid,target)
 		if(radio_connection)

--- a/code/obj/machinery/navbeacon.dm
+++ b/code/obj/machinery/navbeacon.dm
@@ -97,6 +97,33 @@
 			return
 
 		switch (signal.data["command"])
+			if ("help")
+				var/datum/signal/reply = get_free_signal()
+				reply.source = src
+				reply.transmission_method = 1
+				reply.data["sender"] = net_id
+				reply.data["address_1"] = signal.data["sender"]
+				if (!signal.data["topic"])
+					reply.data["description"] = "Nav Beacon - provides navigation data for bots"
+					reply.data["topics"] = "status,set_location,set_code"
+				else
+					reply.data["topic"] = signal.data["topic"]
+					switch (lowertext(signal.data["topic"]))
+						if ("status")
+							reply.data["description"] = {"Returns the status of the nav beacon. This includes the beacon
+								location and all of the configurable transponder codes.
+								Please consult your internal documentation for information about these codes"}
+						if ("set_location")
+							reply.data["description"] = "Sets the beacon location name"
+							reply.data["args"] = "location"
+						if ("set_code")
+							reply.data["description"] = "Sets the value of a configurable transponder code"
+							reply.data["args"] = "code_key,code_value"
+						else
+							reply.data["description"] = "ERROR: UNKNOWN TOPIC"
+				var/datum/radio_frequency/frequency = radio_controller.return_frequency("[freq]")
+				if(!frequency) return
+				frequency.post_signal(src, reply)
 			if ("status")
 				post_status(signal.data["sender"])
 			if ("set_location")

--- a/code/obj/storage/large_storage_parent.dm
+++ b/code/obj/storage/large_storage_parent.dm
@@ -834,15 +834,31 @@
 			return
 
 		if (signal.data["address_1"] == src.net_id)
+			var/datum/signal/reply = get_free_signal()
+			reply.source = src
+			reply.transmission_method = TRANSMISSION_RADIO
+			reply.data["sender"] = src.net_id
+			reply.data["address_1"] = sender
 			switch (lowertext(signal.data["command"]))
+				if ("help")
+					if (!signal.data["topic"])
+						reply.data["description"] = "Secure Storage"
+						reply.data["topics"] = "status,lock,unlock"
+					else
+						reply.data["topic"] = signal.data["topic"]
+						switch (lowertext(signal.data["topic"]))
+							if ("status")
+								reply.data["description"] = "Returns the status of the secure storage. No arguments"
+							if ("lock")
+								reply.data["description"] = "Locks the secure storage. Requires NETPASS_SECURITY"
+								reply.data["args"] = "pass"
+							if ("unlock")
+								reply.data["description"] = "Unlocks the secure storage. Requires NETPASS_SECURITY"
+								reply.data["args"] = "pass"
+							else
+								reply.data["description"] = "ERROR: UNKNOWN TOPIC"
 				if ("status")
-					var/datum/signal/reply = get_free_signal()
-					reply.source = src
-					reply.transmission_method = TRANSMISSION_RADIO
-					reply.data = list("address_1" = sender, "command" = "lock=[locked]&open=[open]", "sender" = src.net_id)
-					SPAWN_DBG(0.5 SECONDS)
-						src.radio_control.post_signal(src, reply, 2)
-
+					reply.data["command"] = "lock=[locked]&open=[open]"
 				if ("lock")
 					. = 0
 					if (signal.data["pass"] == netpass_security)
@@ -850,17 +866,11 @@
 						src.locked = !src.locked
 						src.visible_message("[src] clicks[src.open ? "" : " locked"].")
 						src.update_icon()
-
-					var/datum/signal/reply = get_free_signal()
-					reply.source = src
-					reply.transmission_method = TRANSMISSION_RADIO
 					if (.)
-						reply.data = list("address_1" = sender, "command" = "ack", "sender" = src.net_id)
+						reply.data["command"] = "ack"
 					else
-						reply.data = list("address_1" = sender, "command" = "nack", "data" = "badpass", "sender" = src.net_id)
-					SPAWN_DBG(0.5 SECONDS)
-						src.radio_control.post_signal(src, reply, 2)
-
+						reply.data["command"] = "nack"
+						reply.data["data"] = "badpass"
 				if ("unlock")
 					. = 0
 					if (signal.data["pass"] == netpass_security)
@@ -868,18 +878,15 @@
 						src.locked = !src.locked
 						src.visible_message("[src] clicks[src.open ? "" : " unlocked"].")
 						src.update_icon()
-
-					var/datum/signal/reply = get_free_signal()
-					reply.source = src
-					reply.transmission_method = TRANSMISSION_RADIO
 					if (.)
-						reply.data = list("address_1" = sender, "command" = "ack", "sender" = src.net_id)
+						reply.data["command"] = "ack"
 					else
-						reply.data = list("address_1" = sender, "command" = "nack", "data" = "badpass", "sender" = src.net_id)
-
-					SPAWN_DBG(0.5 SECONDS)
-						src.radio_control.post_signal(src, reply, 2)
-			return //todo
+						reply.data["command"] = "nack"
+						reply.data["data"] = "badpass"
+				else
+					return //COMMAND NOT RECOGNIZED
+			SPAWN_DBG(0.5 SECONDS)
+				src.radio_control.post_signal(src, reply, 2)
 
 		else if (signal.data["address_1"] == "ping")
 			var/datum/signal/reply = get_free_signal()
@@ -891,8 +898,6 @@
 			reply.data["netid"] = src.net_id
 			SPAWN_DBG(0.5 SECONDS)
 				src.radio_control.post_signal(src, reply, 2)
-			return
-		return
 
 	emag_act(var/mob/user, var/obj/item/card/emag/E)
 		if (!src.emagged) // secure crates checked for being locked/welded but so long as you aren't telling the thing to open I don't see why that was needed


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE][INPUT WANTED]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This establishes a help topic syntax for packet devices. I'm starting off with simple wireless devices. I'm assuming that only devices that respond to pings should have this feature. More complex devices that could use this treatment are: mechanics wifi component, the ruckingenur kit, hydroponics trays, and eventually wired devices as well. There still needs to be a in-game method of explaining how to use the help command, and I'd appreciate suggestions on how to implement that. Eventually, I'd like to have a hand-held device that allows for pinging across all frequencies and single frequency transceiver capabilities. This would make back and forth communication wirelessly a lot easier, because currently you need 2 PDAs or something like that to have a conversation.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Packet stuff should be more discoverable. This is a first step in that direction.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)glassofmilk:
(*)Many wireless devices now respond to the command "help"
```
