### PR TITLE
Adds a bathroom and cargo transporter to debris field mining outpost

### DIFF
--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -1479,8 +1479,8 @@
 	},
 /obj/item/radio_tape/advertisement/cloning_psa,
 /obj/item/radio_tape/advertisement/captain_psa{
-	pixel_y = 6;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = 6
 	},
 /turf/simulated/floor/carpet/grime,
 /area/radiostation/studio)
@@ -1929,7 +1929,10 @@
 	network = "Mining";
 	tag = ""
 	},
-/turf/simulated/floor/caution/east,
+/obj/stool/chair{
+	dir = 4
+	},
+/turf/simulated/floor/black,
 /area/mining/quarters)
 "afK" = (
 /obj/table/auto,
@@ -1982,17 +1985,18 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/space)
 "afS" = (
-/obj/storage/closet,
+/obj/table/auto,
 /turf/simulated/floor/black,
 /area/mining/quarters)
-"afT" = (
-/turf/simulated/floor/scorched2,
-/area/mining/quarters)
 "afU" = (
-/turf/simulated/floor/scorched,
+/obj/storage/closet/wardrobe/green,
+/turf/simulated/floor/caution/west,
 /area/mining/quarters)
 "afV" = (
-/turf/simulated/floor/caution/east,
+/obj/machinery/door/airlock{
+	name = "Bathroom"
+	},
+/turf/simulated/floor/black,
 /area/mining/quarters)
 "afW" = (
 /obj/machinery/light{
@@ -2023,7 +2027,8 @@
 /turf/unsimulated/floor/setpieces/hivefloor,
 /area/space_hive)
 "agd" = (
-/obj/storage/closet/wardrobe/green,
+/obj/table/auto,
+/obj/machinery/light/lamp/bright,
 /turf/simulated/floor/black,
 /area/mining/quarters)
 "age" = (
@@ -2040,9 +2045,8 @@
 /turf/simulated/floor,
 /area/mining/quarters)
 "agh" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet,
-/turf/simulated/floor/scorched,
+/obj/storage/closet/wardrobe/blue,
+/turf/simulated/floor/black,
 /area/mining/quarters)
 "agi" = (
 /obj/table/auto,
@@ -2343,27 +2347,13 @@
 /turf/simulated/floor/caution/west,
 /area/mining/quarters)
 "agX" = (
-/obj/stool/chair{
-	dir = 4
-	},
-/turf/simulated/floor,
+/obj/item/storage/toilet,
+/turf/simulated/floor/black,
 /area/mining/quarters)
 "agY" = (
-/obj/table/auto,
-/turf/simulated/floor,
-/area/mining/quarters)
-"agZ" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/mining/quarters)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/mining/mainasteroid)
 "aha" = (
-/obj/decal/cleanable/gangtag{
-	icon_state = "gangtag22";
-	pixel_x = 28
-	},
-/obj/rack,
 /turf/simulated/floor/black,
 /area/mining/quarters)
 "ahb" = (
@@ -2372,7 +2362,12 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/wall/auto/supernorn,
+/obj/machinery/shower{
+	dir = 4;
+	pixel_y = 6
+	},
+/obj/machinery/drainage,
+/turf/simulated/floor/black,
 /area/mining/quarters)
 "ahc" = (
 /obj/machinery/light/emergency{
@@ -2423,7 +2418,7 @@
 	},
 /area/mining/dock)
 "ahk" = (
-/obj/storage/closet/wardrobe/blue,
+/obj/machinery/door/unpowered/wood/stall,
 /turf/simulated/floor/black,
 /area/mining/quarters)
 "ahl" = (
@@ -2460,6 +2455,9 @@
 /area/mining/mainasteroid)
 "ahr" = (
 /obj/decal/cleanable/dirt,
+/obj/stool/chair{
+	dir = 8
+	},
 /turf/simulated/floor,
 /area/mining/quarters)
 "ahs" = (
@@ -2493,7 +2491,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/airless/caution/east,
 /area/mining/quarters)
 "ahv" = (
 /obj/cable{
@@ -2501,7 +2499,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/obj/storage/closet,
+/turf/simulated/floor/black,
 /area/mining/quarters)
 "ahw" = (
 /obj/cable{
@@ -2509,14 +2508,17 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/caution/east,
+/turf/simulated/wall/auto/supernorn,
 /area/mining/quarters)
 "ahx" = (
-/obj/storage/closet,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/submachine/chef_sink/chem_sink{
+	desc = "A water-filled unit intended for hand-washing purposes.";
+	dir = 1
 	},
 /turf/simulated/floor/black,
 /area/mining/quarters)
@@ -2559,9 +2561,7 @@
 /turf/simulated/wall/auto/supernorn,
 /area/mining/miningoutpost)
 "ahE" = (
-/obj/table/auto,
-/obj/item/reagent_containers/food/snacks/breakfast,
-/turf/simulated/floor,
+/turf/simulated/floor/airless/caution/east,
 /area/mining/quarters)
 "ahF" = (
 /obj/machinery/light/emergency{
@@ -5003,6 +5003,10 @@
 	pixel_y = 23
 	},
 /obj/table/auto,
+/obj/item/cargotele{
+	pixel_x = -5
+	},
+/obj/item/hand_labeler,
 /obj/item/hand_labeler,
 /turf/simulated/floor/caution/south,
 /area/mining/manufacturing)
@@ -5056,8 +5060,6 @@
 	name = "East Door Switch";
 	pixel_y = 23
 	},
-/obj/item/hand_labeler,
-/obj/item/hand_labeler,
 /turf/simulated/floor/caution/south,
 /area/mining/manufacturing)
 "anY" = (
@@ -25521,6 +25523,23 @@
 /obj/item/clothing/under/misc/colmob,
 /turf/simulated/floor/plating/damaged3,
 /area/spyshack)
+"bAg" = (
+/obj/decal/cleanable/dirt,
+/obj/table/auto,
+/obj/item/reagent_containers/food/snacks/breakfast,
+/turf/simulated/floor/caution/west,
+/area/mining/quarters)
+"rdq" = (
+/obj/decal/cleanable/gangtag{
+	icon_state = "gangtag22";
+	pixel_x = 28
+	},
+/turf/simulated/floor/black,
+/area/mining/quarters)
+"vrI" = (
+/obj/stool/chair,
+/turf/simulated/floor/black,
+/area/mining/quarters)
 
 (1,1,1) = {"
 aaa
@@ -76606,9 +76625,9 @@ afo
 afu
 afE
 afx
-afE
+agh
 ahi
-afE
+vrI
 afS
 ahh
 aiw
@@ -76906,12 +76925,12 @@ aaa
 aaa
 afo
 aft
-afF
+afU
 afF
 afF
 afF
 agW
-agW
+bAg
 ahy
 ahy
 ahD
@@ -77212,7 +77231,7 @@ afG
 afH
 agf
 agg
-agX
+agg
 ahr
 ahy
 ahy
@@ -77514,7 +77533,7 @@ afH
 afH
 agg
 agg
-agY
+agg
 ahs
 ahD
 aix
@@ -77816,7 +77835,7 @@ afI
 afH
 afI
 agB
-agY
+agg
 aht
 agu
 aiy
@@ -78113,11 +78132,11 @@ aaa
 aaa
 aaa
 aak
-afv
-afH
-afT
-afH
-afH
+aft
+ahE
+ahE
+ahE
+ahE
 ahE
 ahu
 ahD
@@ -78415,12 +78434,12 @@ aaa
 aaa
 aaa
 aak
-afv
-afI
-afU
-agh
-afH
-agZ
+afu
+aha
+afE
+afE
+aha
+aha
 ahv
 ahy
 ahy
@@ -78719,9 +78738,9 @@ aaa
 afo
 aft
 afJ
-afV
-afV
-afV
+afu
+afu
+afu
 afV
 ahw
 ahy
@@ -79020,9 +79039,9 @@ aaa
 aqj
 afo
 afu
-afE
 agd
-afE
+afu
+agX
 ahk
 aha
 ahx
@@ -79326,7 +79345,7 @@ afu
 afu
 afu
 afu
-afu
+rdq
 ahb
 ahL
 aoo
@@ -79627,7 +79646,7 @@ aff
 aff
 aff
 aff
-aff
+agY
 afZ
 afZ
 ahM

--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -2350,9 +2350,6 @@
 /obj/item/storage/toilet,
 /turf/simulated/floor/black,
 /area/mining/quarters)
-"agY" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/mining/mainasteroid)
 "aha" = (
 /turf/simulated/floor/black,
 /area/mining/quarters)
@@ -79650,7 +79647,7 @@ aff
 aff
 aff
 aff
-agY
+afZ
 afZ
 afZ
 ahM

--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -25534,6 +25534,10 @@
 	icon_state = "gangtag22";
 	pixel_x = 28
 	},
+/obj/machinery/light/small{
+	dir = 1;
+	status = 2
+	},
 /turf/simulated/floor/black,
 /area/mining/quarters)
 "vrI" = (


### PR DESCRIPTION
## About the PR
Adds a small bathroom with a shower, toilet, and sink in the crew quarters area of the mining outpost in the debris field. Also swaps one of the three hand labellers that spawns there for a cargo transporter.

![outpost_bathroom](https://user-images.githubusercontent.com/72267018/102006092-528f3f00-3cec-11eb-8824-7160de4d3efb.png)


## Why's this needed?
Miners have to either swipe a cargo transporter from the QM before heading out, or take their department's only round-start transporter away from the station. Plus, there's a cargo telepad there, so it seems to make sense to have the transporter too!

On RP, if someone sets out to the outpost, there's no way on the mining station to refill hygiene motives and supplies to refill thirst motives are limited. If someone's out exploring the field or the Space Diner is used as a testing site, it can be difficult to get back to somewhere to refill motives.

## Changelog

```
(u)Nefarious6th
(+)Adds a bathroom and cargo transporter to the old mining station in the debris field
```
