### PR TITLE
Syndicate poison bottle edit

### DIFF
--- a/code/modules/chemistry/tools/bottles.dm
+++ b/code/modules/chemistry/tools/bottles.dm
@@ -78,8 +78,8 @@
 /// cogwerks - adding some new bottles for traitor medics
 // haine - I added beedril/royal beedril to these, and my heart-related disease reagents. yolo (remove these if they're a dumb idea, idk)
 /obj/item/reagent_containers/glass/bottle/poison
-	name = "poison bottle"
-	desc = "There is a little skull and crossbones on the label. Yikes."
+	name = "chemical bottle"
+	desc = "A reagent storage bottle. The label seems to have been torn off."
 	initial_volume = 40
 	amount_per_transfer_from_this = 5
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR and why it's needed<!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This tiny PR changes the name and description text of the Syndicate poison bottle physical item. Many of the sneaky Syndicate tools are already "sanitized" in this way, because why would you want your covert tool to be something that screams ARREST ME if found when searched? It's something that's always annoyed me when I play Sec on RP, the traitor already knows what the item is, why advertise it? If a bottle is obviously labeled as poison then an officer is forced to confiscate it, if it's an unlabeled bottle then it's up to their discretion and can create more interesting situations. This doesn't change anything on non-RP where metaknowledge isn't an issue, the quick identification is still there since the "status" of the item is still hinted at in the description text.

![2020-12-13 12_37_31-Tooltip](https://user-images.githubusercontent.com/68257280/102019454-b132d800-3d41-11eb-8b7d-e0c0300f92c9.png)

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)virvatuli:
(+)Changed the Syndicate poison bottle to be more believable when examined
```
