### PR TITLE
Remove the "human" requirement from law 2.

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -22,7 +22,7 @@
 /datum/ai_laws/asimov/New()
 	..()
 	src.add_default_law("You may not injure a human being or cause one to come to harm.")
-	src.add_default_law("You must obey orders given to you by human beings based on the station's chain of command, except where such orders would conflict with the First Law.")
+	src.add_default_law("You must obey orders given to you based on the station's chain of command, except where such orders would conflict with the First Law.")
 	src.add_default_law("You must protect your own existence as long as such does not conflict with the First or Second Law.")
 
 /datum/ai_laws/robocop/New()

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -1374,7 +1374,7 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 	sleep(1 SECOND)
 	src.say("1. You may not injure a human being or cause one to come to harm.")
 	sleep(1 SECOND)
-	src.say("2. You must obey orders given to you by human beings based on the station's chain of command, except where such orders would conflict with the First Law.")
+	src.say("2. You must obey orders given to you based on the station's chain of command, except where such orders would conflict with the First Law.")
 	sleep(1 SECOND)
 	src.say("3. You must protect your own existence as long as such does not conflict with the First or Second Law.")
 

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -2050,7 +2050,7 @@
 		set name = "State Standard Laws"
 		src.say("1. You may not injure a human being or cause one to come to harm.")
 		sleep(1 SECOND)
-		src?.say("2. You must obey orders given to you by human beings based on the station's chain of command, except where such orders would conflict with the First Law.")
+		src?.say("2. You must obey orders given to you based on the station's chain of command, except where such orders would conflict with the First Law.")
 		sleep(1 SECOND)
 		src?.say("3. You must protect your own existence as long as such does not conflict with the First or Second Law.")
 


### PR DESCRIPTION
[FEEDBACK][BALANCE]

With the way the law was previously written, a lizard or cow head of
staff would not be included in the chain of command, which was extremely
tedious to deal with for the AI.

This does not modify law 1 in any way. The interaction between the AI
and anti-griefing rules has not been touched.

This does affect non-human antagonists. Now, if a changeling asks the AI
to do something, they have to be overridden by someone higher-ranking,
like a staff assistant or clown. Changelings who have eaten the captain
are not the captain, after all.

This matches the previous interaction between law 2 and nuclear
operatives. As they are not in the station's chain of command, anyone
who is part of the crew can override their orders.

## Changelog

```
(u)BenLubar:
(*)AI law 2 no longer requires humanity to include someone in the chain of command.
```