### PR TITLE
Install rancher job spawn into Kondaru ranch

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -11033,7 +11033,6 @@
 	},
 /area/station/hallway/primary/north)
 "aAD" = (
-/obj/railing/orange/reinforced,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24;
@@ -52520,6 +52519,9 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/railing/orange/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/grasstodirt{
 	dir = 1
 	},
@@ -54093,9 +54095,15 @@
 	layer = 9.1;
 	pixel_x = 10
 	},
-/obj/submachine/chicken_feed_grinder,
-/obj/item/reagent_containers/food/snacks/plant/corn{
-	doants = 0
+/obj/table/reinforced/auto,
+/obj/item/chicken_feed_bag{
+	rand_pos = 1
+	},
+/obj/item/chicken_feed_bag{
+	rand_pos = 1
+	},
+/obj/item/chicken_feed_bag{
+	rand_pos = 1
 	},
 /turf/simulated/floor/dirt,
 /area/station/ranch)
@@ -54982,15 +54990,12 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/table/reinforced/auto,
-/obj/item/chicken_feed_bag{
-	rand_pos = 1
+/obj/railing/orange/reinforced{
+	dir = 1
 	},
-/obj/item/chicken_feed_bag{
-	rand_pos = 1
-	},
-/obj/item/chicken_feed_bag{
-	rand_pos = 1
+/obj/submachine/chicken_feed_grinder,
+/obj/item/reagent_containers/food/snacks/plant/corn{
+	doants = 0
 	},
 /turf/simulated/floor/grasstodirt{
 	dir = 1
@@ -57264,10 +57269,6 @@
 	},
 /turf/simulated/floor,
 /area/station/routing/security)
-"stX" = (
-/obj/railing/orange/reinforced,
-/turf/simulated/floor/grass/leafy,
-/area/station/ranch)
 "sun" = (
 /obj/storage/secure/closet/command/medical_director,
 /obj/item/storage/box/beakerbox,
@@ -59475,6 +59476,9 @@
 	icon_state = "4-8"
 	},
 /obj/landmark/gps_waypoint,
+/obj/railing/orange/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/grasstodirt{
 	dir = 1
 	},
@@ -114355,7 +114359,7 @@ bpC
 buR
 jna
 iGQ
-stX
+iGQ
 fBk
 fqR
 iOg
@@ -114657,7 +114661,7 @@ bpC
 buR
 fkY
 iGQ
-stX
+iGQ
 fBk
 dzX
 buR
@@ -114959,7 +114963,7 @@ bpC
 buR
 cXY
 iGQ
-stX
+iGQ
 ygq
 dzX
 hxq

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -29904,6 +29904,12 @@
 /area/station/hydroponics/bay)
 "buO" = (
 /obj/machinery/light,
+/obj/landmark/start{
+	name = "Botanist"
+	},
+/obj/stool/chair/green{
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "buP" = (
@@ -32357,7 +32363,8 @@
 	pixel_y = 4
 	},
 /obj/item/paper/book/hydroponicsguide{
-	pixel_x = -5
+	pixel_x = -5;
+	pixel_y = 4
 	},
 /turf/simulated/floor/green/side,
 /area/station/hydroponics/bay)
@@ -51448,7 +51455,10 @@
 /turf/space,
 /area/station/ai_monitored/armory)
 "cSO" = (
-/obj/stool/bench/green/auto,
+/obj/disposalpipe/segment/food,
+/obj/stool/chair/green{
+	dir = 4
+	},
 /obj/landmark/start{
 	name = "Botanist"
 	},
@@ -52423,6 +52433,9 @@
 	dir = 8;
 	layer = 9.1;
 	pixel_x = -10
+	},
+/obj/landmark/start{
+	name = "Rancher"
 	},
 /turf/simulated/floor/dirt,
 /area/station/ranch)
@@ -112224,7 +112237,7 @@ bor
 bpz
 bqJ
 jvK
-bse
+cSO
 buN
 bvQ
 bxe
@@ -112526,7 +112539,7 @@ boo
 bpA
 bqK
 bqK
-cSO
+bqK
 buO
 boq
 boq

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -30385,15 +30385,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bvU" = (
+/obj/machinery/disposal/small/west,
+/obj/disposalpipe/trunk/south,
 /obj/machinery/camera{
 	c_tag = "autotag";
-	dir = 8;
+	dir = 6;
 	name = "autoname - SS13";
-	pixel_x = 10;
+	pixel_y = 20;
 	tag = ""
-	},
-/obj/shrub{
-	dir = 8
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
@@ -51767,6 +51766,7 @@
 	dir = 8;
 	pixel_x = 8
 	},
+/obj/disposalpipe/segment/bent/west,
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "dDe" = (
@@ -52630,7 +52630,7 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "fSI" = (
-/obj/disposalpipe/segment/bent/east,
+/obj/disposalpipe/junction/middle/east,
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
@@ -53364,6 +53364,7 @@
 	},
 /obj/access_spawn/rancher,
 /obj/firedoor_spawn,
+/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "hzD" = (
@@ -54637,6 +54638,10 @@
 /obj/machinery/phone,
 /turf/simulated/floor/black,
 /area/station/bridge/hos)
+"lqC" = (
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "lqO" = (
 /obj/cable{
 	d1 = 2;
@@ -55957,6 +55962,10 @@
 	dir = 4
 	},
 /area/station/security/brig)
+"oWq" = (
+/obj/disposalpipe/segment/bent/east,
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "oZc" = (
 /obj/cable{
 	d1 = 1;
@@ -59479,6 +59488,7 @@
 /obj/railing/orange/reinforced{
 	dir = 1
 	},
+/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/grasstodirt{
 	dir = 1
 	},
@@ -59495,6 +59505,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
+"yiL" = (
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "ylQ" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
@@ -114962,10 +114976,10 @@ bqM
 bpC
 buR
 cXY
-iGQ
-iGQ
+oWq
+yiL
 ygq
-dzX
+lqC
 hxq
 fSI
 bDF


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEAT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a Rancher job start landmark to properly accommodate the role now that it's fully implemented. Also adjusts some seating in Hydroponics where chicken hardware used to be, and adjusts the pen slightly at Urs' request.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Lets ranchers start Kondaru rounds at their actual job site (which is slightly improved).