### PR TITLE
add ephemeral Spacemas versions of various objects

### DIFF
--- a/code/modules/food_and_drink/drinks.dm
+++ b/code/modules/food_and_drink/drinks.dm
@@ -200,6 +200,13 @@
 	module_research = list("vice" = 5)
 	module_research_type = /obj/item/reagent_containers/food/drinks/bottle/beer
 
+	ephemeral //Disappears except on xmas
+#ifndef XMAS
+		New()
+			..()
+			qdel(src)
+#endif
+
 /obj/item/reagent_containers/food/drinks/chickensoup
 	name = "Chicken Soup"
 	desc = "Got something to do with souls. Maybe. Do chickens even have souls?"

--- a/code/modules/holiday/spacemas.dm
+++ b/code/modules/holiday/spacemas.dm
@@ -576,6 +576,13 @@ var/static/list/santa_snacks = list(/obj/item/reagent_containers/food/drinks/egg
 			qdel(src)
 			return
 
+	ephemeral //Disappears except on xmas
+#ifndef XMAS
+		New()
+			..()
+			qdel(src)
+#endif
+
 /obj/decal/garland
 	name = "garland"
 	icon = 'icons/misc/xmas.dmi'
@@ -624,6 +631,13 @@ var/static/list/santa_snacks = list(/obj/item/reagent_containers/food/drinks/egg
 	icon_state = "mistletoe"
 	layer = 9
 	anchored = 1
+
+	ephemeral //Disappears except on xmas
+#ifndef XMAS
+		New()
+			qdel(src)
+			..()
+#endif
 
 /obj/decal/xmas_lights
 	name = "spacemas lights"
@@ -1274,3 +1288,28 @@ var/static/list/santa_snacks = list(/obj/item/reagent_containers/food/drinks/egg
 	icon_state = "xmascrate"
 	icon_opened = "xmascrateopen"
 	icon_closed = "xmascrate"
+
+/obj/xmas_ephemeral_turf
+	icon = 'icons/turf/floors.dmi'
+	icon_state = "floor"
+	var/replace_with = null
+
+	New()
+		..()
+#ifdef XMAS
+		var/turf/T = get_turf(src)
+		T.ReplaceWith(replace_with, 0)
+#endif
+		qdel(src)
+
+	white
+		icon_state = "white"
+		replace_with = "/turf/simulated/floor/white"
+
+	red
+		icon_state = "fullred"
+		replace_with = "/turf/simulated/floor/red"
+
+	snow
+		icon_state = "snow1"
+		replace_with = "/turf/simulated/floor/snow"

--- a/code/obj/item/stickers.dm
+++ b/code/obj/item/stickers.dm
@@ -313,16 +313,44 @@
 	desc = "A Spacemas ornament!"
 	icon_state = "ornament1"
 
+	ephemeral //Disappears except on xmas
+#ifndef XMAS
+		New()
+			qdel(src)
+			..()
+#endif
+
 /obj/item/sticker/xmas_ornament/green
 	icon_state = "ornament2"
+
+	ephemeral //Disappears except on xmas
+#ifndef XMAS
+		New()
+			qdel(src)
+			..()
+#endif
 
 /obj/item/sticker/xmas_ornament/snowflake
 	name = "snowflake ornament"
 	icon_state = "snowflake"
 
+	ephemeral //Disappears except on xmas
+#ifndef XMAS
+		New()
+			qdel(src)
+			..()
+#endif
+
 /obj/item/sticker/xmas_ornament/holly
 	name = "holly ornament"
 	icon_state = "holly"
+
+	ephemeral //Disappears except on xmas
+#ifndef XMAS
+		New()
+			qdel(src)
+			..()
+#endif
 
 /obj/item/sticker/ribbon
 	name = "award ribbon"

--- a/code/z_adventurezones/biodome.dm
+++ b/code/z_adventurezones/biodome.dm
@@ -277,6 +277,13 @@ SYNDICATE DRONE FACTORY AREAS
 	icon = 'icons/misc/exploration.dmi'
 	icon_state = "snowbits"
 
+	ephemeral //Disappears except on xmas
+#ifndef XMAS
+		New()
+			qdel(src)
+			..()
+#endif
+
 /obj/decal/runemarks
 	name = "runes"
 	desc = "A set of dimly glowing runes is carved into the rock here."


### PR DESCRIPTION
Adds ephemeral versions of several decals and Spacemas-related objects, as well as 3 ephemeral Spacemas-themed turfs that can go over non-Spacemas turfs.

This does not result in any changes for anyone other than mappers.