### PR TITLE
Taking & putting clothes from and on heads

### DIFF
--- a/code/obj/item/organs/head.dm
+++ b/code/obj/item/organs/head.dm
@@ -261,13 +261,10 @@
 	///Taking items off a head
 	attack_self(mob/user as mob)
 		var/list/headwear = list(head, ears, wear_mask, glasses)
-		if (!length(headwear))
-			return
 		var/obj/selection = input("Which item do you want to remove","Looting the dead") as null|obj in headwear
 		if (!selection)
 			return
 		user.put_in_hand_or_drop(selection)
-		//switch(selection)
 		if (selection == head)
 			head = null
 		if (selection == ears)
@@ -289,28 +286,36 @@
 				head = W
 				head.set_loc(src)
 				update_head_image()
-			else boutput(user, "<span class='alert'>[src.name] is already wearing [src.head.name]!</span>")
+			else
+				boutput(user, "<span class='alert'>[src.name] is already wearing [src.head.name]!</span>")
+			return
 		if (istype(W, /obj/item/clothing/ears) || istype(W, /obj/item/device/radio/headset))
 			if (!ears)
 				user.drop_item(W)
 				ears = W
 				ears.set_loc(src)
 				update_head_image()
-			else boutput(user, "<span class='alert'>[src.name] is already wearing [src.ears.name]!</span>")
+			else
+				boutput(user, "<span class='alert'>[src.name] is already wearing [src.ears.name]!</span>")
+			return
 		if (istype(W, /obj/item/clothing/mask))
 			if (!wear_mask)
 				user.drop_item(W)
 				wear_mask = W
 				wear_mask.set_loc(src)
 				update_head_image()
-			else boutput(user, "<span class='alert'>[src.name] is already wearing [src.wear_mask.name]!</span>")
+			else
+				boutput(user, "<span class='alert'>[src.name] is already wearing [src.wear_mask.name]!</span>")
+			return
 		if (istype(W, /obj/item/clothing/glasses))
 			if (!glasses)
 				user.drop_item(W)
 				glasses = W
 				glasses.set_loc(src)
 				update_head_image()
-			else boutput(user, "<span class='alert'>[src.name] is already wearing [src.glasses.name]!</span>")
+			else
+				boutput(user, "<span class='alert'>[src.name] is already wearing [src.glasses.name]!</span>")
+			return
 
 
 		if (src.skull || src.brain)

--- a/code/obj/item/organs/head.dm
+++ b/code/obj/item/organs/head.dm
@@ -258,6 +258,27 @@
 		. = ..()
 		src.transplanted = 1
 
+	///Taking items off a head
+	attack_self(mob/user as mob)
+		var/list/headwear = list(head, ears, wear_mask, glasses)
+		if (!length(headwear))
+			return
+		var/obj/selection = input("Which item do you want to remove","Looting the dead") as null|obj in headwear
+		if (!selection)
+			return
+		user.put_in_hand_or_drop(selection)
+		//switch(selection)
+		if (selection == head)
+			head = null
+		if (selection == ears)
+			ears = null
+		if (selection == wear_mask)
+			wear_mask = null
+		if (selection == glasses)
+			glasses = null
+		update_head_image()
+
+
 	attackby(obj/item/W as obj, mob/user as mob) // this is real ugly
 		if (src.skull || src.brain)
 

--- a/code/obj/item/organs/head.dm
+++ b/code/obj/item/organs/head.dm
@@ -47,7 +47,7 @@
 
 	// equipped items - they use the same slot names because eh.
 	var/obj/item/clothing/head/head = null
-	var/obj/item/clothing/ears/ears = null
+	var/obj/item/ears = null //can be either obj/item/clothing/ears/ or obj/item/device/radio/headset, but those paths diverge a lot
 	var/obj/item/clothing/mask/wear_mask = null
 	var/obj/item/clothing/glasses/glasses = null
 
@@ -280,6 +280,39 @@
 
 
 	attackby(obj/item/W as obj, mob/user as mob) // this is real ugly
+		if (!user)
+			return
+		//Putting stuff on heads
+		if (istype(W, /obj/item/clothing/head))
+			if (!head)
+				user.drop_item(W)
+				head = W
+				head.set_loc(src)
+				update_head_image()
+			else boutput(user, "<span class='alert'>[src.name] is already wearing [src.head.name]!</span>")
+		if (istype(W, /obj/item/clothing/ears) || istype(W, /obj/item/device/radio/headset))
+			if (!ears)
+				user.drop_item(W)
+				ears = W
+				ears.set_loc(src)
+				update_head_image()
+			else boutput(user, "<span class='alert'>[src.name] is already wearing [src.ears.name]!</span>")
+		if (istype(W, /obj/item/clothing/mask))
+			if (!wear_mask)
+				user.drop_item(W)
+				wear_mask = W
+				wear_mask.set_loc(src)
+				update_head_image()
+			else boutput(user, "<span class='alert'>[src.name] is already wearing [src.wear_mask.name]!</span>")
+		if (istype(W, /obj/item/clothing/glasses))
+			if (!glasses)
+				user.drop_item(W)
+				glasses = W
+				glasses.set_loc(src)
+				update_head_image()
+			else boutput(user, "<span class='alert'>[src.name] is already wearing [src.glasses.name]!</span>")
+
+
 		if (src.skull || src.brain)
 
 			// scalpel surgery


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feat][qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR lets players take stuff from decapitated heads, as well as put appropriate clothing types on them.

Also pokes the variable for the ear item, which could previously be a headset in practice even though those aren't of type ```obj/item/clothing/ears/```.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Not being able to access a dead person's stuff without reattaching their head to a torso first was unintuitive and needlessly complicated. It's mostly an issue when there's a katana rampage going on.
I can't imagine much practical use for dressing up a head, but who am I to limit the macabre interests of the crew?


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)BatElite:
(*)You can now take stuff from loose heads. Or put things on them, if you're into head spike fashion shows.
```
