### PR TITLE
Oshan powernet fixes

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -16540,7 +16540,7 @@
 	},
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	icon_state = "0-4"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/inner/central)
@@ -47594,13 +47594,6 @@
 /obj/machinery/light/incandescent/cool,
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/pharmacy)
-"coV" = (
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/autoname_west,
-/turf/simulated/floor/red,
-/area/station/security/checkpoint/escape)
 "csG" = (
 /obj/disposalpipe/segment/mail,
 /obj/disposalpipe/segment{
@@ -47608,6 +47601,13 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
+"cQI" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/autoname_north,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/inner/central)
 "cSE" = (
 /obj/machinery/door/airlock/pyro/security/alt{
 	req_access_txt = "1"
@@ -47678,6 +47678,12 @@
 /obj/disposalpipe/segment,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/sec)
+"dWT" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/inner/central)
 "exU" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -48234,6 +48240,13 @@
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
+"uBm" = (
+/obj/item/crowbar,
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/inner/central)
 "uHb" = (
 /obj/cable{
 	d1 = 1;
@@ -48260,6 +48273,13 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
+"vlS" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/autoname_west,
+/turf/simulated/floor/red,
+/area/station/security/checkpoint/escape)
 "vqP" = (
 /turf/simulated/floor/escape/corner,
 /area/station/hallway/secondary/exit)
@@ -48306,7 +48326,7 @@
 	},
 /turf/simulated/floor,
 /area/station/hangar/sec)
-"wBh" = (
+"wLA" = (
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -90767,7 +90787,7 @@ agH
 afs
 bOH
 ahy
-wBh
+wLA
 anP
 alf
 alg
@@ -101672,8 +101692,8 @@ aII
 aIY
 chB
 chB
-aDr
-aDr
+cQI
+dWT
 aDr
 ckL
 aDr
@@ -101975,8 +101995,8 @@ aIZ
 aJA
 chB
 chB
-aDr
-bXl
+brX
+uBm
 aDr
 aDr
 ckX
@@ -108955,7 +108975,7 @@ btU
 avB
 bvp
 bvW
-coV
+vlS
 yaB
 byl
 sqa

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -38957,6 +38957,9 @@
 /obj/disposalpipe/junction/left/east{
 	name = "ejection pipe"
 	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor,
 /area/station/security/checkpoint/sec_foyer)
 "bOz" = (
@@ -38965,6 +38968,9 @@
 	dir = 4
 	},
 /obj/machinery/power/apc/autoname_east,
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor,
 /area/station/security/checkpoint/sec_foyer)
 "bOA" = (
@@ -39375,6 +39381,9 @@
 /obj/firedoor_spawn,
 /obj/machinery/secscanner{
 	pixel_y = 10
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/red,
 /area/station/security/main)
@@ -39855,6 +39864,9 @@
 /area/station/security/main)
 "bQF" = (
 /obj/disposalpipe/segment/ejection,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bQG" = (
@@ -40331,6 +40343,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/red,
 /area/station/security/main)
@@ -41031,6 +41046,9 @@
 /area/station/medical/staff)
 "bTo" = (
 /obj/item/storage/box/lightbox/tubes,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating/damaged2,
 /area/station/storage/warehouse)
 "bTp" = (

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -660,7 +660,7 @@
 	interesting = "Smells kinda minty. There's some leaves stuck underneath it, too."
 	},
 /turf/simulated/floor,
-/area/station/hallway/primary/central)
+/area/station/hallway/primary/south)
 "abD" = (
 /obj/disposalpipe/switch_junction/left/north{
 	mail_tag = "engineering_storage";
@@ -11174,7 +11174,7 @@
 "ayN" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor,
-/area/station/hallway/primary/central)
+/area/station/hallway/primary/north)
 "ayO" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lobby)
@@ -47594,6 +47594,13 @@
 /obj/machinery/light/incandescent/cool,
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/pharmacy)
+"coV" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/autoname_west,
+/turf/simulated/floor/red,
+/area/station/security/checkpoint/escape)
 "csG" = (
 /obj/disposalpipe/segment/mail,
 /obj/disposalpipe/segment{
@@ -48235,13 +48242,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hangar/sec)
-"uMn" = (
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/autoname_west,
-/turf/simulated/floor/red,
-/area/station/security/checkpoint/escape)
 "uSO" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -48306,6 +48306,18 @@
 	},
 /turf/simulated/floor,
 /area/station/hangar/sec)
+"wBh" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/autoname_south,
+/turf/simulated/floor/specialroom/medbay,
+/area/station/medical/staff)
 "xmS" = (
 /obj/machinery/light/incandescent/greenish,
 /obj/machinery/door_control{
@@ -90755,7 +90767,7 @@ agH
 afs
 bOH
 ahy
-aiQ
+wBh
 anP
 alf
 alg
@@ -108943,7 +108955,7 @@ btU
 avB
 bvp
 bvW
-uMn
+coV
 yaB
 byl
 sqa

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -16538,6 +16538,10 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/inner/central)
 "aLr" = (
@@ -31354,10 +31358,6 @@
 /area/station/maintenance/east)
 "bvW" = (
 /obj/machinery/light/incandescent/netural,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/escape)
 "bvX" = (
@@ -48235,6 +48235,13 @@
 	},
 /turf/simulated/floor,
 /area/station/hangar/sec)
+"uMn" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/autoname_west,
+/turf/simulated/floor/red,
+/area/station/security/checkpoint/escape)
 "uSO" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -108936,7 +108943,7 @@ btU
 avB
 bvp
 bvW
-yaB
+uMn
 yaB
 byl
 sqa

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -169,6 +169,8 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/machinery/power/apc/autoname_south,
+/obj/cable,
 /turf/simulated/floor/blue/checker{
 	dir = 4
 	},
@@ -8788,6 +8790,9 @@
 "atu" = (
 /obj/machinery/door/airlock/pyro/alt,
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/medical/medbay/restroom)
 "atv" = (
@@ -13850,6 +13855,9 @@
 	},
 /obj/firedoor_spawn,
 /obj/access_spawn/research,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/restroom)
 "aFk" = (
@@ -14662,10 +14670,16 @@
 /area/station/crew_quarters/locker)
 "aHd" = (
 /obj/machinery/door/unpowered/wood/stall,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/radio/bathroom)
 "aHe" = (
 /obj/machinery/light_switch/auto,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/radio/bathroom)
 "aHf" = (
@@ -18031,6 +18045,8 @@
 	icon_state = "x3";
 	name = "peststart"
 	},
+/obj/machinery/power/apc/autoname_south,
+/obj/cable,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/radio/bathroom)
 "aPc" = (
@@ -29199,6 +29215,10 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/power/apc/autoname_west,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/sanitary,
 /area/station/engine/engineering/restroom)
 "bqI" = (
@@ -31334,6 +31354,10 @@
 /area/station/maintenance/east)
 "bvW" = (
 /obj/machinery/light/incandescent/netural,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/escape)
 "bvX" = (
@@ -32382,6 +32406,9 @@
 /obj/machinery/secscanner{
 	pixel_y = 10
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/escape)
 "bym" = (
@@ -32662,10 +32689,16 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "bzb" = (
 /obj/machinery/light_switch/auto,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "bzc" = (
@@ -32675,6 +32708,9 @@
 	text = "NF"
 	},
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon17,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "bzd" = (
@@ -40558,6 +40594,9 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/radio/lab)
 "bSg" = (
@@ -42036,23 +42075,16 @@
 /obj/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "4-6"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "6-9"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "bVO" = (
-/obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/disposal)
+/turf/simulated/floor/sanitary,
+/area/station/medical/medbay/restroom)
 "bVP" = (
 /obj/cable{
 	icon_state = "1-10"
@@ -43510,6 +43542,9 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/black,
 /area/station/science/lobby)
 "bZL" = (
@@ -43520,11 +43555,17 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/black,
 /area/station/science/lobby)
 "bZM" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/lobby)
@@ -43533,6 +43574,9 @@
 	dir = 4
 	},
 /obj/machinery/light/incandescent/cool,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/lobby)
 "bZO" = (
@@ -44954,6 +44998,9 @@
 /obj/disposalpipe/segment/mail{
 	dir = 8;
 	icon_state = "pipe-c"
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/lobby)
@@ -47450,6 +47497,10 @@
 	pixel_y = 2
 	},
 /obj/item/device/analyzer/healthanalyzer,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/sanitary,
 /area/station/medical/medbay/restroom)
 "clU" = (
@@ -47658,6 +47709,20 @@
 /obj/disposalpipe/trunk/east,
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
+"gaU" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "ghV" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -47727,6 +47792,14 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/exit)
+"iqM" = (
+/obj/decal/cleanable/paper,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/autoname_south,
+/turf/simulated/floor/sanitary,
+/area/station/science/restroom)
 "iAL" = (
 /obj/submachine/chef_oven{
 	dir = 4
@@ -47851,6 +47924,15 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
+"mDM" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "mEu" = (
 /obj/decal/poster/wallsign/escape_right,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -48070,6 +48152,12 @@
 /obj/machinery/drainage/big,
 /turf/simulated/floor/shuttlebay,
 /area/shuttle/sea_elevator_room)
+"sqa" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "sBu" = (
 /obj/cable{
 	d1 = 4;
@@ -48125,6 +48213,13 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/hydroponics/bay)
+"urg" = (
+/obj/machinery/light/incandescent/netural,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "uAB" = (
 /obj/railing/orange/reinforced,
 /obj/railing/orange/reinforced{
@@ -48140,6 +48235,12 @@
 	},
 /turf/simulated/floor,
 /area/station/hangar/sec)
+"uSO" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/radio/lab)
 "uTy" = (
 /obj/submachine/cargopad{
 	name = "Security Pod Bay Pad"
@@ -48211,6 +48312,12 @@
 /obj/machinery/vehicle/tank/minisub/secsub,
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
+"yaB" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/red,
+/area/station/security/checkpoint/escape)
 "yfC" = (
 /obj/table/reinforced/auto,
 /obj/item/shipcomponent/mainweapon/taser,
@@ -88540,10 +88647,10 @@ ayw
 aqR
 ayw
 ayw
-ayw
+bVO
 atu
-ayt
-azt
+mDM
+gaU
 aAD
 acM
 aCs
@@ -88922,7 +89029,7 @@ bRy
 bQu
 bQu
 bQu
-bVO
+bWB
 bWC
 bWB
 bYa
@@ -106737,7 +106844,7 @@ aSz
 bPZ
 bQY
 bSf
-bMK
+uSO
 aHd
 aHe
 aPb
@@ -108530,7 +108637,7 @@ avB
 cdi
 avB
 avB
-byZ
+urg
 bAi
 bBE
 bCJ
@@ -108829,10 +108936,10 @@ btU
 avB
 bvp
 bvW
-bwA
-bwA
+yaB
+yaB
 byl
-byY
+sqa
 bAj
 bBF
 bCK
@@ -109990,7 +110097,7 @@ aEx
 aCb
 awP
 aEC
-bah
+iqM
 aFl
 asC
 aGr

--- a/maps/oshan_xmas.dmm
+++ b/maps/oshan_xmas.dmm
@@ -668,7 +668,7 @@
 	interesting = "Smells kinda minty. There's some leaves stuck underneath it, too."
 	},
 /turf/simulated/floor,
-/area/station/hallway/primary/central)
+/area/station/hallway/primary/south)
 "abD" = (
 /obj/disposalpipe/switch_junction/left/north{
 	mail_tag = "engineering_storage";
@@ -11312,7 +11312,7 @@
 "ayN" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor,
-/area/station/hallway/primary/central)
+/area/station/hallway/primary/north)
 "ayO" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lobby)
@@ -42622,10 +42622,16 @@
 /area/station/maintenance/disposal)
 "bVO" = (
 /obj/cable{
-	icon_state = "2-8"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/sanitary,
-/area/station/medical/medbay/restroom)
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/autoname_south,
+/turf/simulated/floor/specialroom/medbay,
+/area/station/medical/staff)
 "bVP" = (
 /obj/cable{
 	icon_state = "1-10"
@@ -48228,20 +48234,6 @@
 /obj/machinery/light/incandescent/cool,
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/pharmacy)
-"cwB" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
 "czH" = (
 /obj/wingrille_spawn/auto,
 /obj/machinery/door/poddoor/pyro{
@@ -48337,16 +48329,16 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/shuttle/sea_elevator_room)
-"dKy" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
 "dWG" = (
 /obj/disposalpipe/segment,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/sec)
+"dYm" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/radio/lab)
 "ebW" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/decal/xmas_lights,
@@ -48362,6 +48354,13 @@
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
+"eza" = (
+/obj/machinery/light/incandescent/netural,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "fhd" = (
 /obj/stocking,
 /turf/simulated/wall/auto/supernorn,
@@ -48389,6 +48388,15 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/northwest)
+"fJT" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "fNe" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/decal/wreath,
@@ -48437,6 +48445,13 @@
 /obj/decal/garland,
 /turf/simulated/floor/plating/random,
 /area/station/hydroponics/bay)
+"gUk" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/autoname_west,
+/turf/simulated/floor/red,
+/area/station/security/checkpoint/escape)
 "hat" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -48497,6 +48512,12 @@
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
+"hSR" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/sanitary,
+/area/station/medical/medbay/restroom)
 "iGI" = (
 /obj/machinery/disposal/small{
 	dir = 4
@@ -48542,6 +48563,14 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/sec)
+"jBD" = (
+/obj/decal/cleanable/paper,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/autoname_south,
+/turf/simulated/floor/sanitary,
+/area/station/science/restroom)
 "jCk" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -48551,6 +48580,18 @@
 /obj/decal/xmas_lights,
 /turf/simulated/floor/plating/random,
 /area/station/security/brig)
+"jCw" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"jKy" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/red,
+/area/station/security/checkpoint/escape)
 "jLI" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -48628,13 +48669,6 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
-"lkc" = (
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/autoname_west,
-/turf/simulated/floor/red,
-/area/station/security/checkpoint/escape)
 "lyu" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/decal/wreath,
@@ -48738,15 +48772,6 @@
 /obj/chicken_nesting_box,
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
-"nzm" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
 "nDS" = (
 /obj/table/auto,
 /obj/item/coin{
@@ -48793,12 +48818,6 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit)
-"obF" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood/two,
-/area/station/crew_quarters/radio/lab)
 "okv" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment{
@@ -48953,13 +48972,6 @@
 	dir = 1
 	},
 /area/station/ranch)
-"rzi" = (
-/obj/machinery/light/incandescent/netural,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
 "rBz" = (
 /obj/cable/reinforced{
 	icon_state = "4-8-thick"
@@ -48972,6 +48984,20 @@
 /obj/decal/wreath,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
+"sbU" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "sjd" = (
 /obj/wingrille_spawn/auto,
 /obj/decal/wreath,
@@ -49077,12 +49103,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
-"viV" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/red,
-/area/station/security/checkpoint/escape)
 "voz" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/decal/wreath,
@@ -49151,14 +49171,6 @@
 /obj/machinery/hydro_growlamp,
 /turf/simulated/floor/grass,
 /area/station/hydroponics)
-"wkU" = (
-/obj/decal/cleanable/paper,
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc/autoname_south,
-/turf/simulated/floor/sanitary,
-/area/station/science/restroom)
 "wnn" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/decal/garland{
@@ -89590,10 +89602,10 @@ ayw
 aqR
 ayw
 ayw
-bVO
+hSR
 nMH
-nzm
-cwB
+fJT
+sbU
 aAD
 acM
 aCs
@@ -91691,7 +91703,7 @@ agH
 afs
 bOH
 ahy
-aiQ
+bVO
 anP
 alf
 alg
@@ -107787,7 +107799,7 @@ aSz
 bPZ
 bQY
 bSf
-obF
+dYm
 aHd
 aHe
 aPb
@@ -109580,7 +109592,7 @@ avB
 avB
 avB
 avB
-rzi
+eza
 bAi
 bBE
 bCJ
@@ -109879,10 +109891,10 @@ btU
 avB
 bvp
 bvW
-lkc
-viV
+gUk
+jKy
 byl
-dKy
+jCw
 bAj
 bBF
 bCK
@@ -111040,7 +111052,7 @@ aEx
 aCb
 awP
 aEC
-wkU
+jBD
 aFl
 asC
 aGr

--- a/maps/oshan_xmas.dmm
+++ b/maps/oshan_xmas.dmm
@@ -171,6 +171,8 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/machinery/power/apc/autoname_south,
+/obj/cable,
 /turf/simulated/floor/blue/checker{
 	dir = 4
 	},
@@ -14039,6 +14041,9 @@
 	dir = 8;
 	pixel_x = -20
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/restroom)
 "aFk" = (
@@ -14855,10 +14860,16 @@
 /area/station/crew_quarters/locker)
 "aHd" = (
 /obj/machinery/door/unpowered/wood/stall,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/radio/bathroom)
 "aHe" = (
 /obj/machinery/light_switch/auto,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/radio/bathroom)
 "aHf" = (
@@ -16762,6 +16773,10 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/inner/central)
 "aLr" = (
@@ -18295,6 +18310,8 @@
 	icon_state = "x3";
 	name = "peststart"
 	},
+/obj/cable,
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/radio/bathroom)
 "aPc" = (
@@ -29588,6 +29605,10 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/power/apc/autoname_west,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/sanitary,
 /area/station/engine/engineering/restroom)
 "bqI" = (
@@ -32836,6 +32857,9 @@
 	pixel_y = 10
 	},
 /obj/decal/garland,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/escape)
 "bym" = (
@@ -33122,10 +33146,16 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "bzb" = (
 /obj/machinery/light_switch/auto,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "bzc" = (
@@ -33135,6 +33165,9 @@
 	text = "NF"
 	},
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon17,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "bzd" = (
@@ -39460,6 +39493,9 @@
 /obj/disposalpipe/junction/left/east{
 	name = "ejection pipe"
 	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor,
 /area/station/security/checkpoint/sec_foyer)
 "bOz" = (
@@ -39468,6 +39504,9 @@
 	dir = 4
 	},
 /obj/machinery/power/apc/autoname_east,
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor,
 /area/station/security/checkpoint/sec_foyer)
 "bOA" = (
@@ -39883,6 +39922,9 @@
 	pixel_y = 10
 	},
 /obj/decal/garland,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bPB" = (
@@ -40368,6 +40410,9 @@
 /area/station/security/main)
 "bQF" = (
 /obj/disposalpipe/segment/ejection,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bQG" = (
@@ -40846,6 +40891,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bRI" = (
@@ -41061,6 +41109,9 @@
 	},
 /obj/cable{
 	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/radio/lab)
@@ -41562,6 +41613,9 @@
 /area/station/medical/staff)
 "bTo" = (
 /obj/item/storage/box/lightbox/tubes,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating/damaged2,
 /area/station/storage/warehouse)
 "bTp" = (
@@ -42562,23 +42616,16 @@
 /obj/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "4-6"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "6-9"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "bVO" = (
-/obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/disposal)
+/turf/simulated/floor/sanitary,
+/area/station/medical/medbay/restroom)
 "bVP" = (
 /obj/cable{
 	icon_state = "1-10"
@@ -44054,6 +44101,9 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/black,
 /area/station/science/lobby)
 "bZL" = (
@@ -44064,11 +44114,17 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/black,
 /area/station/science/lobby)
 "bZM" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/lobby)
@@ -44077,6 +44133,9 @@
 	dir = 4
 	},
 /obj/machinery/light/incandescent/cool,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/lobby)
 "bZO" = (
@@ -45506,6 +45565,9 @@
 /obj/disposalpipe/segment/mail{
 	dir = 8;
 	icon_state = "pipe-c"
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/lobby)
@@ -48059,6 +48121,10 @@
 	pixel_y = 2
 	},
 /obj/item/device/analyzer/healthanalyzer,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/sanitary,
 /area/station/medical/medbay/restroom)
 "clU" = (
@@ -48162,6 +48228,20 @@
 /obj/machinery/light/incandescent/cool,
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/pharmacy)
+"cwB" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "czH" = (
 /obj/wingrille_spawn/auto,
 /obj/machinery/door/poddoor/pyro{
@@ -48257,6 +48337,12 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/shuttle/sea_elevator_room)
+"dKy" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "dWG" = (
 /obj/disposalpipe/segment,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -48542,6 +48628,13 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
+"lkc" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/autoname_west,
+/turf/simulated/floor/red,
+/area/station/security/checkpoint/escape)
 "lyu" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/decal/wreath,
@@ -48645,6 +48738,15 @@
 /obj/chicken_nesting_box,
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
+"nzm" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "nDS" = (
 /obj/table/auto,
 /obj/item/coin{
@@ -48674,6 +48776,9 @@
 /obj/machinery/door/airlock/pyro/alt,
 /obj/firedoor_spawn,
 /obj/decal/garland,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/medical/medbay/restroom)
 "nXA" = (
@@ -48688,6 +48793,12 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit)
+"obF" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/radio/lab)
 "okv" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment{
@@ -48842,6 +48953,13 @@
 	dir = 1
 	},
 /area/station/ranch)
+"rzi" = (
+/obj/machinery/light/incandescent/netural,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "rBz" = (
 /obj/cable/reinforced{
 	icon_state = "4-8-thick"
@@ -48959,6 +49077,12 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
+"viV" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/red,
+/area/station/security/checkpoint/escape)
 "voz" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/decal/wreath,
@@ -49027,6 +49151,14 @@
 /obj/machinery/hydro_growlamp,
 /turf/simulated/floor/grass,
 /area/station/hydroponics)
+"wkU" = (
+/obj/decal/cleanable/paper,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/autoname_south,
+/turf/simulated/floor/sanitary,
+/area/station/science/restroom)
 "wnn" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/decal/garland{
@@ -89458,10 +89590,10 @@ ayw
 aqR
 ayw
 ayw
-ayw
+bVO
 nMH
-ayt
-azt
+nzm
+cwB
 aAD
 acM
 aCs
@@ -89840,7 +89972,7 @@ bRy
 bQu
 bQu
 bQu
-bVO
+bWB
 bWC
 bWB
 bYa
@@ -107655,7 +107787,7 @@ aSz
 bPZ
 bQY
 bSf
-bMK
+obF
 aHd
 aHe
 aPb
@@ -109448,7 +109580,7 @@ avB
 avB
 avB
 avB
-byZ
+rzi
 bAi
 bBE
 bCJ
@@ -109747,10 +109879,10 @@ btU
 avB
 bvp
 bvW
-bwA
-bwA
+lkc
+viV
 byl
-byY
+dKy
 bAj
 bBF
 bCK
@@ -110908,7 +111040,7 @@ aEx
 aCb
 awP
 aEC
-bah
+wkU
 aFl
 asC
 aGr

--- a/maps/oshan_xmas.dmm
+++ b/maps/oshan_xmas.dmm
@@ -16773,9 +16773,8 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	icon_state = "0-4"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/inner/central)
@@ -48333,17 +48332,23 @@
 /obj/disposalpipe/segment,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/sec)
-"dYm" = (
+"dXK" = (
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/wood/two,
-/area/station/crew_quarters/radio/lab)
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "ebW" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/decal/xmas_lights,
 /turf/simulated/floor,
 /area/station/crew_quarters/lounge/port)
+"eqe" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/sanitary,
+/area/station/medical/medbay/restroom)
 "esm" = (
 /obj/submachine/chicken_incubator,
 /obj/item/reagent_containers/food/snacks/ingredient/egg{
@@ -48354,13 +48359,6 @@
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
-"eza" = (
-/obj/machinery/light/incandescent/netural,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
 "fhd" = (
 /obj/stocking,
 /turf/simulated/wall/auto/supernorn,
@@ -48388,15 +48386,6 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/northwest)
-"fJT" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
 "fNe" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/decal/wreath,
@@ -48421,6 +48410,12 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/research_outpost)
+"gfe" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/inner/central)
 "ghV" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -48445,13 +48440,6 @@
 /obj/decal/garland,
 /turf/simulated/floor/plating/random,
 /area/station/hydroponics/bay)
-"gUk" = (
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/autoname_west,
-/turf/simulated/floor/red,
-/area/station/security/checkpoint/escape)
 "hat" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -48512,12 +48500,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
-"hSR" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/sanitary,
-/area/station/medical/medbay/restroom)
 "iGI" = (
 /obj/machinery/disposal/small{
 	dir = 4
@@ -48563,14 +48545,6 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/sec)
-"jBD" = (
-/obj/decal/cleanable/paper,
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc/autoname_south,
-/turf/simulated/floor/sanitary,
-/area/station/science/restroom)
 "jCk" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -48580,18 +48554,6 @@
 /obj/decal/xmas_lights,
 /turf/simulated/floor/plating/random,
 /area/station/security/brig)
-"jCw" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
-"jKy" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/red,
-/area/station/security/checkpoint/escape)
 "jLI" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -48745,6 +48707,15 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/south)
+"neV" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "ngC" = (
 /obj/item/storage/wall/emergency{
 	dir = 4;
@@ -48818,6 +48789,20 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit)
+"oba" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/radio/lab)
+"ofE" = (
+/obj/decal/cleanable/paper,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/autoname_south,
+/turf/simulated/floor/sanitary,
+/area/station/science/restroom)
 "okv" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment{
@@ -48879,6 +48864,13 @@
 /obj/wingrille_spawn/auto/crystal,
 /obj/decal/wreath,
 /turf/simulated/floor/plating/random,
+/area/station/hallway/secondary/exit)
+"pyw" = (
+/obj/machinery/light/incandescent/netural,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "pIo" = (
 /obj/machinery/light/incandescent/greenish,
@@ -48964,6 +48956,13 @@
 /obj/machinery/light/incandescent/blueish,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/northwest)
+"rdL" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/autoname_north,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/inner/central)
 "reS" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -48984,20 +48983,6 @@
 /obj/decal/wreath,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
-"sbU" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
 "sjd" = (
 /obj/wingrille_spawn/auto,
 /obj/decal/wreath,
@@ -49167,10 +49152,30 @@
 	},
 /turf/simulated/floor/red,
 /area/station/hallway/secondary/exit)
+"vUh" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/autoname_west,
+/turf/simulated/floor/red,
+/area/station/security/checkpoint/escape)
+"whg" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/red,
+/area/station/security/checkpoint/escape)
 "wis" = (
 /obj/machinery/hydro_growlamp,
 /turf/simulated/floor/grass,
 /area/station/hydroponics)
+"wmO" = (
+/obj/item/crowbar,
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/inner/central)
 "wnn" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/decal/garland{
@@ -49179,6 +49184,20 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/northwest)
+"wnR" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "wzL" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
@@ -89602,10 +89621,10 @@ ayw
 aqR
 ayw
 ayw
-hSR
+eqe
 nMH
-fJT
-sbU
+neV
+wnR
 aAD
 acM
 aCs
@@ -102608,8 +102627,8 @@ aII
 aIY
 chB
 chB
-aDr
-aDr
+rdL
+gfe
 aDr
 ckL
 aDr
@@ -102911,8 +102930,8 @@ aIZ
 aJA
 chB
 chB
-aDr
-bXl
+brX
+wmO
 aDr
 aDr
 ckX
@@ -107799,7 +107818,7 @@ aSz
 bPZ
 bQY
 bSf
-dYm
+oba
 aHd
 aHe
 aPb
@@ -109592,7 +109611,7 @@ avB
 avB
 avB
 avB
-eza
+pyw
 bAi
 bBE
 bCJ
@@ -109891,10 +109910,10 @@ btU
 avB
 bvp
 bvW
-gUk
-jKy
+vUh
+whg
 byl
-jCw
+dXK
 bAj
 bBF
 bCK
@@ -111052,7 +111071,7 @@ aEx
 aCb
 awP
 aEC
-jBD
+ofE
 aFl
 asC
 aGr


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes a bunch of powernet oversights on Oshan (both regular and spacemas, the two should have identical changes):

-The security foyer checkpoint (the small entrance room to sec you don't need access for) now has its APC connected to the grid
-Idem for the central warehouse (the trash dump below cargo), where one tile of wire was missing
-Changed two turfs from Central Primary Hallway (otherwise not a thing on Oshan) to the correct areas for those hallways. Since the central hallway had no associated APC, it means a light and a couple of vending machines would work regardless of station power.
-Disposals had two APCs, so in typical mapping style I removed the one that is accessible without going on the disposals belt.

-Adds APCs to:
Medbay lobby
Medbay staff area
Medbay restroom
Research restroom
Engineering restroom
Radio lab bathroom (a whole 5 tiles)
Escape hallway security checkpoint 
Central inner maintenance

I got confused with regular Oshan and spacemas Oshan being different files, which resulted in commits being jumbled instead of doing specific categories of changes sadly.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Places not losing power when a powersink is happening looks odd. Even if it's a 3 tile toilet.
Half of medbay retaining power meant that they'd always have a well-lit area to treat people and a couple of working sleepers even with no power on station.