### PR TITLE
add adjusted inverse-square falloff to aerosol propellant

### DIFF
--- a/code/WorkInProgress/Particles.dm
+++ b/code/WorkInProgress/Particles.dm
@@ -1467,17 +1467,16 @@ var/matrix/MS0101 = matrix(0.1, 0, 0, 0, 0.1, 0)
 				continue
 			if(A in affected) continue
 			affected += A
-			if(!can_line(location, A, 4)) continue
-
+			if(!can_line(location, A, smoke_size)) continue
+			var/divisor = max((get_dist(A, location)+1)/2, 1)**2
 			if(!istype(A,/obj/particle) && !istype(A,/obj/effects/foam))
-				copied.reaction(A, TOUCH, 0, 0)
-
+				copied.reaction(A, TOUCH, copied.total_volume / divisor, 0)
 			if(isliving(A))
 				var/mob/living/L = A
 				if(!issmokeimmune(L))
 					logTheThing("combat", A, null, "is hit by chemical smoke [log_reagents(copied)] at [log_loc(A)].")
 					if(L.reagents)
-						copied.copy_to(L.reagents, 1)
+						copied.copy_to(L.reagents, 1 / divisor)
 
 /datum/particleSystem/chemspray
 	var/datum/reagents/copied = null

--- a/code/WorkInProgress/Particles.dm
+++ b/code/WorkInProgress/Particles.dm
@@ -1468,15 +1468,14 @@ var/matrix/MS0101 = matrix(0.1, 0, 0, 0, 0.1, 0)
 			if(A in affected) continue
 			affected += A
 			if(!can_line(location, A, smoke_size)) continue
-			var/divisor = max((get_dist(A, location)+1)/2, 1)**2
 			if(!istype(A,/obj/particle) && !istype(A,/obj/effects/foam))
-				copied.reaction(A, TOUCH, copied.total_volume / divisor, 0)
+				copied.reaction(A, TOUCH, 0, 0)
 			if(isliving(A))
 				var/mob/living/L = A
 				if(!issmokeimmune(L))
 					logTheThing("combat", A, null, "is hit by chemical smoke [log_reagents(copied)] at [log_loc(A)].")
 					if(L.reagents)
-						copied.copy_to(L.reagents, 1 / divisor)
+						copied.copy_to(L.reagents, 1 / max((get_dist(A, location)+1)/2, 1)**2)
 
 /datum/particleSystem/chemspray
 	var/datum/reagents/copied = null

--- a/code/WorkInProgress/Particles.dm
+++ b/code/WorkInProgress/Particles.dm
@@ -1475,7 +1475,7 @@ var/matrix/MS0101 = matrix(0.1, 0, 0, 0, 0.1, 0)
 				if(!issmokeimmune(L))
 					logTheThing("combat", A, null, "is hit by chemical smoke [log_reagents(copied)] at [log_loc(A)].")
 					if(L.reagents)
-						copied.copy_to(L.reagents, 1 / max((get_dist(A, location)+1)/2, 1)**2)
+						copied.copy_to(L.reagents, 1 / max((get_dist(A, location)+1)/2, 1)**2) //applies an adjusted inverse-square falloff to amount inhaled - 100% at center and adjacent tiles, then 44%, 25%, 16%, 11%, etc.
 
 /datum/particleSystem/chemspray
 	var/datum/reagents/copied = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
adds adjusted inverse-square falloff to aerosol propellant for purposes of amount inhaled 

![image](https://user-images.githubusercontent.com/48066662/102266464-17546200-3ede-11eb-8fb3-9ccaf3f83232.png)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
aerosol copying the entire volume of the beaker to everything it touches is rather absurd, this limits that while not removing the functionality entirely or making aerosol useless


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Tarmunora:
(*)Amount of reagent inhaled from an aerosol propellant smoke now falls off over distance
```
