### PR TITLE
Lets ghostdrones use deconstructors

### DIFF
--- a/code/WorkInProgress/multiContext.dm
+++ b/code/WorkInProgress/multiContext.dm
@@ -30,6 +30,10 @@ var/list/globalContextActions = null
 			var/mob/living/silicon/robot/robot = target
 			robot.hud.add_screen(C)
 
+		if (isghostdrone(target))
+			var/mob/living/silicon/ghostdrone/drone = target
+			drone.hud.add_screen(C)
+
 		if (isAI(target))
 			var/mob/living/silicon/ai/A = null
 			if (isAIeye(target))
@@ -325,6 +329,10 @@ var/list/globalContextActions = null
 				var/mob/living/silicon/robot/robot = src
 				robot.hud.remove_screen(C)
 
+			if (isghostdrone(src))
+				var/mob/living/silicon/ghostdrone/drone = src
+				drone.hud.remove_screen(C)
+
 			var/mob/living/silicon/ai/A = null
 			if (isAI(src))
 				if (isAIeye(src))
@@ -467,6 +475,9 @@ var/list/globalContextActions = null
 		if (isrobot(user))
 			var/mob/living/silicon/robot/robot = user
 			robot.hud.remove_screen(src)
+		if (isghostdrone(user))
+			var/mob/living/silicon/ghostdrone/drone = user
+			drone.hud.remove_screen(src)
 		if (ishivebot(user))
 			var/mob/living/silicon/hivebot/hivebot = user
 			hivebot.hud.remove_screen(src)
@@ -892,6 +903,9 @@ var/list/globalContextActions = null
 
 		checkRequirements(var/atom/target, var/mob/user)
 			.= 0
+			//I don't think drones have hands technically but they can only hold one item anyway
+			if(isghostdrone(user))
+				return 1
 			if(user.find_type_in_hand(/obj/item/deconstructor/))
 				return 1
 

--- a/code/mob/living/silicon/ghostdrone.dm
+++ b/code/mob/living/silicon/ghostdrone.dm
@@ -76,6 +76,7 @@
 			new /obj/item/device/t_scanner(src),
 			new /obj/item/electronics/soldering(src),
 			new /obj/item/electronics/scanner(src),
+			new /obj/item/deconstructor/borg(src),
 			new /obj/item/weldingtool(src),
 			new /obj/item/device/light/flashlight(src)
 		)

--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -1009,6 +1009,10 @@
 	logTheThing("vehicle", M, src.name, "enters vehicle: <b>[constructTarget(src.name,"vehicle")]</b>")
 
 /obj/machinery/vehicle/proc/eject_occupants()
+	if(isghostdrone(usr))
+		boutput(usr, "<span class='alert'>Your laws don't permit you to do that!</span>")
+		return
+
 	if(locked)
 		boutput(usr, "<span class='alert'>[src] is locked!</span>")
 		return
@@ -1175,6 +1179,10 @@
 ////////Open Part Panel									////////////
 ////////////////////////////////////////////////////////////////////
 /obj/machinery/vehicle/proc/open_parts_panel(mob/user as mob)
+	if(isghostdrone(user))
+		boutput(user, "<span class='alert'>Pods are only for the living, so quit trying to mess with them!</span>")
+		return
+
 	if (passengers)
 		boutput(user, "<span class='alert'>You can't modify parts with somebody inside.</span>")
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feat]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds a deconstruction device to ghostdrones' inventory and adjusts multicontext menus to support drones. Saw-shaped ones also work using the magtractor although there's not really a reason for them to grab one.

I don't know of anything outside of pods and deconstructors that use these menus, but because drones aren't meant to mess with pods a couple of procs (ejecting occupants and show parts list) have ghostdrones checks now.

Griefing potential is limited in the sense that ghostdrones can't lift the bulky variant of mech frames, so they can't take them through doors they don't have access to. I further think that deconstructing things is slow & involved enough to not be worth the effort for would-be shitters.

Also for reviewers: I don't know why some of those multicontext functions are like that with all the largely needless type checks, but I figure that's best addressed separately from this.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Drones already have the tools for scanning and building mech frames, it seems like a natural fit to let them move things around and disassemble what they build. It comes up for me on occasion.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)BatElite:
(*)Ghostdrones can now use deconstruction devices, and also have one in their inventory.
```
