### PR TITLE
Oshan powernet fixes 2: electric mergealoo

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -675,7 +675,7 @@
 	interesting = "Smells kinda minty. There's some leaves stuck underneath it, too."
 	},
 /turf/simulated/floor,
-/area/station/hallway/primary/central)
+/area/station/hallway/primary/south)
 "abD" = (
 /obj/disposalpipe/switch_junction/left/north{
 	mail_tag = "engineering_storage";
@@ -10909,7 +10909,7 @@
 "ayN" = (
 /obj/machinery/vending/cola/red,
 /turf/simulated/floor,
-/area/station/hallway/primary/central)
+/area/station/hallway/primary/north)
 "ayO" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lobby)
@@ -46150,7 +46150,7 @@
 "cix" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor,
-/area/station/turret_protected/Zeta)
+/area/station/hallway/primary/north)
 "ciy" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt{
 	dir = 4
@@ -47157,7 +47157,7 @@
 "clD" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor,
-/area/station/turret_protected/Zeta)
+/area/station/hallway/primary/north)
 "clE" = (
 /obj/table/reinforced/auto,
 /obj/item/wrapping_paper,
@@ -101761,7 +101761,7 @@ arz
 avs
 awu
 cis
-aBn
+arz
 azQ
 aAY
 ayp
@@ -102063,7 +102063,7 @@ arz
 awv
 awv
 arz
-aBn
+arz
 azQ
 aAY
 ayd

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -169,6 +169,8 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/machinery/power/apc/autoname_south,
+/obj/cable,
 /turf/simulated/floor/blue/checker{
 	dir = 4
 	},
@@ -14388,10 +14390,16 @@
 /area/station/crew_quarters/locker)
 "aHd" = (
 /obj/machinery/door/unpowered/wood/stall,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/radio/bathroom)
 "aHe" = (
 /obj/machinery/light_switch/auto,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/radio/bathroom)
 "aHf" = (
@@ -16266,6 +16274,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/inner/central)
 "aLr" = (
@@ -17772,6 +17783,8 @@
 	icon_state = "x3";
 	name = "peststart"
 	},
+/obj/machinery/power/apc/autoname_south,
+/obj/cable,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/radio/bathroom)
 "aPc" = (
@@ -18212,6 +18225,9 @@
 /obj/machinery/light/incandescent/cool{
 	dir = 4;
 	nostick = 1
+	},
+/obj/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/sanitary,
 /area/station/medical/medbay/restroom)
@@ -18782,11 +18798,17 @@
 /area/station/storage/warehouse)
 "aRu" = (
 /obj/machinery/navbeacon/tour/oshan/tour20,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	icon_state = "L6"
 	},
 /area/station/hallway/secondary/exit)
 "aRv" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	icon_state = "L8"
 	},
@@ -28923,6 +28945,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/sanitary,
 /area/station/engine/engineering/restroom)
 "bqI" = (
@@ -32111,6 +32134,9 @@
 /obj/machinery/secscanner{
 	pixel_y = 10
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/escape)
 "bym" = (
@@ -32873,6 +32899,9 @@
 /obj/disposalpipe/segment/brig{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	icon_state = "L11"
 	},
@@ -33494,6 +33523,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	icon_state = "L4"
 	},
@@ -33510,11 +33542,17 @@
 /turf/simulated/floor/red,
 /area/space)
 "bBE" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	icon_state = "L10"
 	},
 /area/station/hallway/secondary/exit)
 "bBF" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor{
 	icon_state = "L12"
 	},
@@ -38682,6 +38720,9 @@
 /obj/disposalpipe/junction/left/east{
 	name = "ejection pipe"
 	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor,
 /area/station/security/checkpoint/sec_foyer)
 "bOz" = (
@@ -38690,6 +38731,9 @@
 	dir = 4
 	},
 /obj/machinery/power/apc/autoname_east,
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor,
 /area/station/security/checkpoint/sec_foyer)
 "bOA" = (
@@ -39118,6 +39162,9 @@
 /obj/firedoor_spawn,
 /obj/machinery/secscanner{
 	pixel_y = 10
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/red,
 /area/station/security/main)
@@ -39598,6 +39645,9 @@
 /area/station/security/main)
 "bQF" = (
 /obj/disposalpipe/segment/ejection,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bQG" = (
@@ -40075,6 +40125,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bRI" = (
@@ -40285,6 +40338,9 @@
 	},
 /obj/cable{
 	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/radio/lab)
@@ -40772,6 +40828,9 @@
 /area/station/medical/staff)
 "bTo" = (
 /obj/item/storage/box/lightbox/tubes,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating/damaged2,
 /area/station/storage/warehouse)
 "bTp" = (
@@ -47206,6 +47265,10 @@
 	pixel_y = 2
 	},
 /obj/item/device/analyzer/healthanalyzer,
+/obj/machinery/power/apc/autoname_west,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/sanitary,
 /area/station/medical/medbay/restroom)
 "clU" = (
@@ -47383,6 +47446,11 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/shuttle/sea_elevator_room)
+"dLb" = (
+/obj/decal/cleanable/paper,
+/obj/machinery/power/apc/autoname_south,
+/turf/simulated/floor/sanitary,
+/area/station/science/restroom)
 "dWG" = (
 /obj/disposalpipe/segment,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -47481,6 +47549,12 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/exit)
+"hGt" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/radio/lab)
 "hXh" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt,
 /obj/cable{
@@ -47547,6 +47621,12 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/northwest)
+"jeC" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/red,
+/area/station/security/checkpoint/escape)
 "jfB" = (
 /obj/chicken_nesting_box,
 /turf/simulated/floor/grass/leafy,
@@ -47559,6 +47639,15 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/sec)
+"jCs" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "jEl" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -47727,6 +47816,14 @@
 	dir = 1
 	},
 /area/station/ranch)
+"oiZ" = (
+/obj/machinery/door/airlock/pyro/alt,
+/obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/medical/medbay/restroom)
 "oox" = (
 /obj/machinery/disposal/small{
 	dir = 1;
@@ -47807,6 +47904,12 @@
 	dir = 4
 	},
 /area/station/hallway/primary/west)
+"pZs" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/inner/central)
 "qcB" = (
 /obj/rack,
 /obj/item/tank/air,
@@ -47847,6 +47950,13 @@
 /obj/forcefield/energyshield/perma/doorlink,
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
+"qEN" = (
+/obj/item/crowbar,
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/inner/central)
 "qPg" = (
 /turf/simulated/floor,
 /area/station/hangar/sec)
@@ -47861,6 +47971,13 @@
 /obj/machinery/door/airlock/pyro/external,
 /turf/simulated/floor,
 /area/shuttle/sea_elevator_room)
+"rqc" = (
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/inner/central)
 "rBz" = (
 /obj/cable/reinforced{
 	icon_state = "4-8-thick"
@@ -47903,6 +48020,13 @@
 "tGH" = (
 /turf/simulated/floor/black,
 /area/station/crew_quarters/kitchen)
+"tMk" = (
+/obj/machinery/power/apc/autoname_west,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/red,
+/area/station/security/checkpoint/escape)
 "tWV" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -47953,6 +48077,20 @@
 "vqP" = (
 /turf/simulated/floor/escape/corner,
 /area/station/hallway/secondary/exit)
+"vrP" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "vCx" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
@@ -88347,9 +88485,9 @@ atv
 ayJ
 ayw
 aQg
-atu
-ayt
-azt
+oiZ
+jCs
+vrP
 aAD
 acM
 aCs
@@ -101352,8 +101490,8 @@ aII
 aIY
 chB
 chB
-aDr
-aDr
+rqc
+pZs
 aDr
 ckL
 aDr
@@ -101655,8 +101793,8 @@ aIZ
 aJA
 chB
 chB
-aDr
-bXl
+brX
+qEN
 aDr
 aDr
 ckX
@@ -106543,7 +106681,7 @@ aSz
 bPZ
 bQY
 bSf
-bMK
+hGt
 aHd
 aHe
 aPb
@@ -108635,10 +108773,10 @@ btU
 avB
 bvp
 bvW
-bwA
-bwA
+tMk
+jeC
 byl
-byY
+bza
 bAj
 bBF
 bCK
@@ -109796,7 +109934,7 @@ aEx
 aCb
 awP
 aEC
-bah
+dLb
 aFl
 asC
 aGr

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -41818,20 +41818,7 @@
 /obj/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "4-6"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "6-9"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/disposal)
-"bVO" = (
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
@@ -88866,7 +88853,7 @@ bRy
 bQu
 bQu
 bQu
-bVO
+bWB
 bWC
 bWB
 bYa

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -13584,6 +13584,9 @@
 	},
 /obj/firedoor_spawn,
 /obj/access_spawn/research,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/restroom)
 "aFk" = (
@@ -16772,6 +16775,10 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor,
 /area/research_outpost/toxins)
 "aMA" = (
@@ -18654,7 +18661,7 @@
 	},
 /obj/access_spawn/research,
 /turf/simulated/floor,
-/area/research_outpost)
+/area/research_outpost/toxins)
 "aRd" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/firedoor_spawn,
@@ -18678,6 +18685,9 @@
 /obj/machinery/door/airlock/pyro/sci_alt,
 /obj/firedoor_spawn,
 /obj/access_spawn/research,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/research_outpost/maint)
 "aRg" = (
@@ -23387,6 +23397,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor,
 /area/research_outpost)
 "bcT" = (
@@ -23492,6 +23505,9 @@
 /turf/simulated/floor,
 /area/research_outpost/toxins)
 "bdj" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/caution/south,
 /area/research_outpost)
 "bdk" = (
@@ -23670,6 +23686,10 @@
 	pixel_y = 20;
 	tag = ""
 	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/plating/random,
 /area/research_outpost/maint)
 "bdN" = (
@@ -28946,6 +28966,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/power/apc/autoname_west,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/sanitary,
 /area/station/engine/engineering/restroom)
 "bqI" = (
@@ -43279,6 +43302,9 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/black,
 /area/station/science/lobby)
 "bZL" = (
@@ -43289,11 +43315,17 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/black,
 /area/station/science/lobby)
 "bZM" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/lobby)
@@ -43302,6 +43334,9 @@
 	dir = 4
 	},
 /obj/machinery/light/incandescent/cool,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/lobby)
 "bZO" = (
@@ -44723,6 +44758,9 @@
 /obj/disposalpipe/segment/mail{
 	dir = 8;
 	icon_state = "pipe-c"
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/lobby)
@@ -47436,6 +47474,9 @@
 "dLb" = (
 /obj/decal/cleanable/paper,
 /obj/machinery/power/apc/autoname_south,
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/sanitary,
 /area/station/science/restroom)
 "dWG" = (
@@ -47626,6 +47667,12 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/sec)
+"jxG" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating/random,
+/area/research_outpost/maint)
 "jCs" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
@@ -133156,7 +133203,7 @@ azm
 aGq
 aKs
 aLm
-bbg
+afh
 bcz
 bcR
 bYy
@@ -133463,7 +133510,7 @@ bcA
 bcS
 bdj
 aRf
-bdN
+jxG
 bdN
 bdN
 bel
@@ -133760,7 +133807,7 @@ bca
 aAo
 awC
 aMz
-bbg
+afh
 bYr
 bcT
 bdk
@@ -134062,7 +134109,7 @@ awG
 aAp
 aKZ
 bcn
-bbg
+afh
 bbg
 bbg
 bbg

--- a/maps/oshan_xmas.dmm
+++ b/maps/oshan_xmas.dmm
@@ -17287,6 +17287,10 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor,
 /area/research_outpost/toxins)
 "aMA" = (
@@ -19218,7 +19222,7 @@
 /obj/access_spawn/research,
 /obj/decal/garland,
 /turf/simulated/floor,
-/area/research_outpost)
+/area/research_outpost/toxins)
 "aRd" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/firedoor_spawn,
@@ -19248,6 +19252,9 @@
 /obj/firedoor_spawn,
 /obj/access_spawn/research,
 /obj/decal/garland,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/research_outpost/maint)
 "aRg" = (
@@ -23979,6 +23986,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor,
 /area/research_outpost)
 "bcT" = (
@@ -24087,6 +24097,9 @@
 /turf/simulated/floor,
 /area/research_outpost/toxins)
 "bdj" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/caution/south,
 /area/research_outpost)
 "bdk" = (
@@ -24266,6 +24279,10 @@
 	pixel_y = 20;
 	tag = ""
 	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/plating/random,
 /area/research_outpost/maint)
 "bdN" = (
@@ -49322,6 +49339,12 @@
 /obj/decal/xmas_lights,
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/market)
+"xUa" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating/random,
+/area/research_outpost/maint)
 "xVc" = (
 /obj/machinery/vehicle/tank/minisub/secsub,
 /turf/simulated/floor/shuttlebay,
@@ -134333,7 +134356,7 @@ azm
 aGq
 aKs
 aLm
-bbg
+afh
 bcz
 bcR
 bYy
@@ -134640,7 +134663,7 @@ bcA
 bcS
 bdj
 aRf
-bdN
+xUa
 bdN
 bdN
 bel
@@ -134937,7 +134960,7 @@ bca
 aAo
 awC
 aMz
-bbg
+afh
 bYr
 bcT
 bdk
@@ -135239,7 +135262,7 @@ awG
 aAp
 aKZ
 bcn
-bbg
+afh
 bbg
 bbg
 bbg

--- a/maps/oshan_xmas.dmm
+++ b/maps/oshan_xmas.dmm
@@ -171,6 +171,8 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/cable,
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor/blue/checker{
 	dir = 4
 	},
@@ -14039,6 +14041,9 @@
 	dir = 8;
 	pixel_x = -20
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/restroom)
 "aFk" = (
@@ -14855,10 +14860,16 @@
 /area/station/crew_quarters/locker)
 "aHd" = (
 /obj/machinery/door/unpowered/wood/stall,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/radio/bathroom)
 "aHe" = (
 /obj/machinery/light_switch/auto,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/radio/bathroom)
 "aHf" = (
@@ -16765,6 +16776,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/inner/central)
 "aLr" = (
@@ -18298,6 +18312,8 @@
 	icon_state = "x3";
 	name = "peststart"
 	},
+/obj/cable,
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/radio/bathroom)
 "aPc" = (
@@ -19356,11 +19372,17 @@
 /area/station/storage/warehouse)
 "aRu" = (
 /obj/machinery/navbeacon/tour/oshan/tour20,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	icon_state = "L6"
 	},
 /area/station/hallway/secondary/exit)
 "aRv" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	icon_state = "L8"
 	},
@@ -29592,6 +29614,10 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/sanitary,
 /area/station/engine/engineering/restroom)
 "bqI" = (
@@ -32840,6 +32866,9 @@
 	pixel_y = 10
 	},
 /obj/decal/garland,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/escape)
 "bym" = (
@@ -33583,6 +33612,9 @@
 /obj/disposalpipe/segment/brig{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	icon_state = "L11"
 	},
@@ -34206,6 +34238,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	icon_state = "L4"
 	},
@@ -34222,11 +34257,17 @@
 /turf/simulated/floor/red,
 /area/space)
 "bBE" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	icon_state = "L10"
 	},
 /area/station/hallway/secondary/exit)
 "bBF" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor{
 	icon_state = "L12"
 	},
@@ -39464,6 +39505,9 @@
 /obj/disposalpipe/junction/left/east{
 	name = "ejection pipe"
 	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor,
 /area/station/security/checkpoint/sec_foyer)
 "bOz" = (
@@ -39472,6 +39516,9 @@
 	dir = 4
 	},
 /obj/machinery/power/apc/autoname_east,
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor,
 /area/station/security/checkpoint/sec_foyer)
 "bOA" = (
@@ -39887,6 +39934,9 @@
 	pixel_y = 10
 	},
 /obj/decal/garland,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bPB" = (
@@ -40372,6 +40422,9 @@
 /area/station/security/main)
 "bQF" = (
 /obj/disposalpipe/segment/ejection,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bQG" = (
@@ -40850,6 +40903,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bRI" = (
@@ -41065,6 +41121,9 @@
 	},
 /obj/cable{
 	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/radio/lab)
@@ -41566,6 +41625,9 @@
 /area/station/medical/staff)
 "bTo" = (
 /obj/item/storage/box/lightbox/tubes,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating/damaged2,
 /area/station/storage/warehouse)
 "bTp" = (
@@ -44058,6 +44120,9 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/black,
 /area/station/science/lobby)
 "bZL" = (
@@ -44068,11 +44133,17 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/black,
 /area/station/science/lobby)
 "bZM" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/lobby)
@@ -44081,6 +44152,9 @@
 	dir = 4
 	},
 /obj/machinery/light/incandescent/cool,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/lobby)
 "bZO" = (
@@ -45510,6 +45584,9 @@
 /obj/disposalpipe/segment/mail{
 	dir = 8;
 	icon_state = "pipe-c"
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/lobby)
@@ -48066,6 +48143,10 @@
 	pixel_y = 2
 	},
 /obj/item/device/analyzer/healthanalyzer,
+/obj/machinery/power/apc/autoname_west,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/sanitary,
 /area/station/medical/medbay/restroom)
 "clU" = (
@@ -48340,6 +48421,18 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
+"gph" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/autoname_south,
+/turf/simulated/floor/specialroom/medbay,
+/area/station/medical/staff)
 "gqb" = (
 /obj/wingrille_spawn/auto,
 /obj/decal/garland,
@@ -48468,6 +48561,15 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/caution/west,
 /area/station/maintenance/south)
+"iPX" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "jfH" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/caution/east,
@@ -48505,11 +48607,25 @@
 /obj/decal/xmas_lights,
 /turf/simulated/floor,
 /area/station/crew_quarters/radio/lab)
+"jUF" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/inner/central)
 "kaN" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/decal/tinsel,
 /turf/simulated/floor/plating/random,
 /area/station/bridge)
+"kdU" = (
+/obj/decal/cleanable/paper,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/autoname_south,
+/turf/simulated/floor/sanitary,
+/area/station/science/restroom)
 "kfT" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/decal/xmas_lights,
@@ -48543,6 +48659,12 @@
 /obj/decal/garland,
 /turf/simulated/floor/plating/random,
 /area/ghostdrone_factory)
+"kRi" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/radio/lab)
 "laJ" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/decal/xmas_lights,
@@ -48562,11 +48684,31 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
+"lwB" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "lyu" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/decal/wreath,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
+"lGm" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/sanitary,
+/area/station/medical/medbay/restroom)
 "lQX" = (
 /obj/decal/wreath,
 /turf/simulated/wall/auto/supernorn,
@@ -48698,6 +48840,9 @@
 /obj/machinery/door/airlock/pyro/alt,
 /obj/firedoor_spawn,
 /obj/decal/garland,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/medical/medbay/restroom)
 "nXA" = (
@@ -48739,6 +48884,12 @@
 	},
 /turf/simulated/floor,
 /area/station/hangar/sec)
+"opm" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/red,
+/area/station/security/checkpoint/escape)
 "ovU" = (
 /turf/simulated/floor/black,
 /area/station/crew_quarters/kitchen)
@@ -48882,6 +49033,13 @@
 /obj/decal/wreath,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
+"rPO" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/autoname_west,
+/turf/simulated/floor/red,
+/area/station/security/checkpoint/escape)
 "sjd" = (
 /obj/wingrille_spawn/auto,
 /obj/decal/wreath,
@@ -48923,6 +49081,13 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
+"tUg" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/autoname_north,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/inner/central)
 "tWV" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -49051,6 +49216,13 @@
 	},
 /turf/simulated/floor/red,
 /area/station/hallway/secondary/exit)
+"vUQ" = (
+/obj/item/crowbar,
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/inner/central)
 "wis" = (
 /turf/simulated/floor/grass,
 /area/station/hydroponics)
@@ -89489,10 +89661,10 @@ ayw
 aqR
 ayw
 ayw
-ayw
+lGm
 nMH
-ayt
-azt
+iPX
+lwB
 aAD
 acM
 aCs
@@ -91590,7 +91762,7 @@ agH
 afs
 bOH
 ahy
-aiQ
+gph
 anP
 alf
 alg
@@ -102495,8 +102667,8 @@ aII
 aIY
 chB
 chB
-aDr
-aDr
+tUg
+jUF
 aDr
 ckL
 aDr
@@ -102798,8 +102970,8 @@ aIZ
 aJA
 chB
 chB
-aDr
-bXl
+brX
+vUQ
 aDr
 aDr
 ckX
@@ -107686,7 +107858,7 @@ aSz
 bPZ
 bQY
 bSf
-bMK
+kRi
 aHd
 aHe
 aPb
@@ -109778,10 +109950,10 @@ btU
 avB
 bvp
 bvW
-bwA
-bwA
+rPO
+opm
 byl
-byY
+bza
 bAj
 bBF
 bCK
@@ -110939,7 +111111,7 @@ aEx
 aCb
 awP
 aEC
-bah
+kdU
 aFl
 asC
 aGr

--- a/maps/oshan_xmas.dmm
+++ b/maps/oshan_xmas.dmm
@@ -42628,20 +42628,7 @@
 /obj/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "4-6"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "6-9"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/disposal)
-"bVO" = (
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
@@ -90043,7 +90030,7 @@ bRy
 bQu
 bQu
 bQu
-bVO
+bWB
 bWC
 bWB
 bYa

--- a/maps/oshan_xmas.dmm
+++ b/maps/oshan_xmas.dmm
@@ -668,7 +668,7 @@
 	interesting = "Smells kinda minty. There's some leaves stuck underneath it, too."
 	},
 /turf/simulated/floor,
-/area/station/hallway/primary/central)
+/area/station/hallway/primary/south)
 "abD" = (
 /obj/disposalpipe/switch_junction/left/north{
 	mail_tag = "engineering_storage";
@@ -11312,7 +11312,7 @@
 "ayN" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor,
-/area/station/hallway/primary/central)
+/area/station/hallway/primary/north)
 "ayO" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lobby)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
(This is the same thing as #3069 to get arund a merge conflict, except I also found some stuff on the outpost)

This PR fixes a bunch of powernet oversights on Oshan (both regular and spacemas, the two should have identical changes):

-The security foyer checkpoint (the small entrance room to sec you don't need access for) now has its APC connected to the grid
-Idem for the central warehouse (the trash dump below cargo), where one tile of wire was missing
-Changed two turfs from Central Primary Hallway (otherwise not a thing on Oshan) to the correct areas for those hallways. Since the central hallway had no associated APC, it means a light and a couple of vending machines would work regardless of station power.
-Disposals had two APCs, so in typical mapping style I removed the one that is accessible without going on the disposals belt.

-Adds APCs to:
Medbay lobby
Medbay staff area (spacemas version only)
Medbay restroom
Research restroom
Engineering restroom
Radio lab bathroom (a whole 5 tiles)
Escape hallway security checkpoint
Central inner maintenance
Outpost maintenance (where all the cans are kept)
Outpost toxins

Finally, I took the opportunity to change a few tiles in the outpost to Outpost Toxins, so that the door into toxins has that name instead of just Research Outpost.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Places not losing power when a powersink is happening looks odd. Even if it's a 3 tile toilet.
Half of medbay retaining power meant that they'd always have a well-lit area to treat people and a couple of working sleepers even with no power on station.

