### PR TITLE
Salyut Cosmonaut Suit

### DIFF
--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -6781,7 +6781,7 @@
 /area/salyut)
 "asd" = (
 /obj/rack,
-/obj/item/clothing/suit/space{
+/obj/item/clothing/suit/space/soviet{
 	desc = "Looks pretty old.";
 	name = "cosmonaut suit"
 	},
@@ -6789,6 +6789,7 @@
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/head/helmet/space{
 	desc = "Korolyov's pride.";
+	icon_state = "cosmonaut"
 	name = "cosmonaut helmet"
 	},
 /turf/simulated/floor/shuttlebay{


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR and why it's needed!<!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I often see people very sad about the fact that the Salyut/Soviet derelict's space suit looks like any normal NT design. We have the sprites, why not use them? This PR changes the suit itself to the already-present Soviet suit and makes the helmet use the cool Cosmonaut helmet sprite (which I don't think is used anywhere else).

![image](https://user-images.githubusercontent.com/68257280/102422125-10a81680-3fd4-11eb-8bbb-928eec3e5c65.png)


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)virvatuli:
(+)The Salyut derelict now has an appropriately Soviet space suit.
```
