### PR TITLE
Spy poster bounty "fix"

### DIFF
--- a/code/obj/decal/poster.dm
+++ b/code/obj/decal/poster.dm
@@ -522,7 +522,7 @@
 			icon_state = "ptoe"
 
 		poster_y4nt
-			name = "\improper NanoTrasen poster"
+			name = "\improper NanoTrasen recruitment poster"
 			desc = "A huge poster that reads 'I want YOU for NT!'"
 			icon = 'icons/obj/decals/posters.dmi'
 			icon_state = "you_4_nt"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[trivial]

## About the PR  and why it's needed<!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Resolves #3023 by making the poster name different from all of the other NT posters on the station. Should hopefully cause a little less confusion for future spy-thievery.