### PR TITLE
Replaces some airless tiles on the mining outpost

### DIFF
--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -2488,7 +2488,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless/caution/east,
+/turf/simulated/floor/caution/east,
 /area/mining/quarters)
 "ahv" = (
 /obj/cable{
@@ -2558,7 +2558,7 @@
 /turf/simulated/wall/auto/supernorn,
 /area/mining/miningoutpost)
 "ahE" = (
-/turf/simulated/floor/airless/caution/east,
+/turf/simulated/floor/caution/east,
 /area/mining/quarters)
 "ahF" = (
 /obj/machinery/light/emergency{


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[trivial]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
#3043 accidentally used the airless variant of one of the columns of caution tiles. This PR fixes that.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Miners deserve air, even if they realistically breathe from jetpacks all round.
