### PR TITLE
Shard stepping rework

### DIFF
--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -565,24 +565,22 @@
 		else return
 
 	HasEntered(AM as mob|obj)
-		if(ismob(AM))
-			var/mob/M = AM
-			if(ishuman(M))
-				var/mob/living/carbon/human/H = M
-				if(H.getStatusDuration("stunned") || H.getStatusDuration("weakened")) // nerf for dragging a person and a shard to damage them absurdly fast - drsingh
+		if(ishuman(AM))
+			var/mob/living/carbon/human/H = AM
+			if(H.getStatusDuration("stunned") || H.getStatusDuration("weakened")) // nerf for dragging a person and a shard to damage them absurdly fast - drsingh
+				return
+			if(isabomination(H))
+				return
+			if(H.lying)
+				boutput(H, "<span class='alert'><B>You crawl on [src]! Ouch!</B></span>")
+				step_on(H)
+			else
+				//Can't step on stuff if you have no legs, and it can't hurt if they're robolegs.
+				if (!istype(H.limbs.l_leg, /obj/item/parts/human_parts/leg/left) && !istype(H.limbs.r_leg, /obj/item/parts/human_parts/leg/right))
 					return
-				if(isabomination(H))
-					return
-				if(H.lying)
-					boutput(H, "<span class='alert'><B>You crawl on [src]! Ouch!</B></span>")
+				if(!H.shoes || (src.material && src.material.hasProperty("hard") && src.material.getProperty("hard") >= 70))
+					boutput(H, "<span class='alert'><B>You step on [src]! Ouch!</B></span>")
 					step_on(H)
-				else
-					//Can't step on stuff if you have no legs, and it can't hurt if they're robolegs.
-					if (!istype(H.limbs.l_leg, /obj/item/parts/human_parts/leg/left) && !istype(H.limbs.r_leg, /obj/item/parts/human_parts/leg/right))
-						return
-					if(!H.shoes || (src.material && src.material.hasProperty("hard") && src.material.getProperty("hard") >= 70))
-						boutput(H, "<span class='alert'><B>You step on [src]! Ouch!</B></span>")
-						step_on(H)
 		..()
 
 	custom_suicide = 1
@@ -614,8 +612,7 @@
 	var/obj/item/affecting = H.organs[pick("l_leg", "r_leg")]
 	H.changeStatus("weakened", 3 SECONDS)
 	H.force_laydown_standup()
-	var/shard_damage = force
-	affecting.take_damage(shard_damage, 0)
+	affecting.take_damage(force, 0)
 	H.UpdateDamageIcon()
 
 

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -573,6 +573,9 @@
 					return
 				if(isabomination(H))
 					return
+				//Can't step on stuff if you have no legs, and it can't hurt if they're robolegs.
+				if (!istype(H.limbs.l_leg, /obj/item/parts/human_parts/leg/left) && !istype(H.limbs.r_leg, /obj/item/parts/human_parts/leg/right))
+					return
 				if(!H.shoes || (src.material && src.material.hasProperty("hard") && src.material.getProperty("hard") >= 70))
 					boutput(H, "<span class='alert'><B>You step on [src]! Ouch!</B></span>")
 					playsound(src.loc, src.sound_stepped, 50, 1)

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -573,18 +573,16 @@
 					return
 				if(isabomination(H))
 					return
-				//Can't step on stuff if you have no legs, and it can't hurt if they're robolegs.
-				if (!istype(H.limbs.l_leg, /obj/item/parts/human_parts/leg/left) && !istype(H.limbs.r_leg, /obj/item/parts/human_parts/leg/right))
-					return
-				if(!H.shoes || (src.material && src.material.hasProperty("hard") && src.material.getProperty("hard") >= 70))
-					boutput(H, "<span class='alert'><B>You step on [src]! Ouch!</B></span>")
-					playsound(src.loc, src.sound_stepped, 50, 1)
-					var/obj/item/affecting = H.organs[pick("l_leg", "r_leg")]
-					H.changeStatus("weakened", 3 SECONDS)
-					H.force_laydown_standup()
-					var/shard_damage = force
-					affecting.take_damage(shard_damage, 0)
-					H.UpdateDamageIcon()
+				if(H.lying)
+					boutput(H, "<span class='alert'><B>You crawl on [src]! Ouch!</B></span>")
+					step_on(H)
+				else
+					//Can't step on stuff if you have no legs, and it can't hurt if they're robolegs.
+					if (!istype(H.limbs.l_leg, /obj/item/parts/human_parts/leg/left) && !istype(H.limbs.r_leg, /obj/item/parts/human_parts/leg/right))
+						return
+					if(!H.shoes || (src.material && src.material.hasProperty("hard") && src.material.getProperty("hard") >= 70))
+						boutput(H, "<span class='alert'><B>You step on [src]! Ouch!</B></span>")
+						step_on(H)
 		..()
 
 	custom_suicide = 1
@@ -610,6 +608,16 @@
 			..()
 			var/datum/material/M = getMaterial("plasmaglass")
 			src.setMaterial(M, appearance = 1, setname = 1)
+
+/obj/item/raw_material/shard/proc/step_on(mob/living/carbon/human/H as mob)
+	playsound(src.loc, src.sound_stepped, 50, 1)
+	var/obj/item/affecting = H.organs[pick("l_leg", "r_leg")]
+	H.changeStatus("weakened", 3 SECONDS)
+	H.force_laydown_standup()
+	var/shard_damage = force
+	affecting.take_damage(shard_damage, 0)
+	H.UpdateDamageIcon()
+
 
 /obj/item/raw_material/chitin
 	name = "chitin chunk"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[rework]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
(Jeez I'm productive lately)
This PR redoes the bit of code where you get hurt if you step on a glass shard. If you're lying on the floor now you get hurt regardless. (previously it'd be identical to standing) Stepping on one while you've got two robot legs or none (possible only in a chair) won't hurt you anymore.

Riding around over one in a chair with your organic legs still attached hurts you as normal though.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #3058

Shoes protecting you from glass shard while you're laying on the floor was silly, as is getting hurt from stepping on one with your robot feet. I demand being able to go barefeet with impunity if I'm willing to saw off my legs for it.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)BatElite:
(+)Reworked how stepping on shards works - wearing shoes doesn't save you if you crawl over them, but having robtic legs (or being in a chair with no legs) lets you go over them with no problem.
```
