### PR TITLE
Changes equipment boxes to have the same equipment the role spawns with

### DIFF
--- a/code/obj/item/storage/clothing.dm
+++ b/code/obj/item/storage/clothing.dm
@@ -75,14 +75,16 @@
 	spawn_contents = list(/obj/item/clothing/under/rank/hydroponics,\
 	/obj/item/clothing/shoes/brown,\
 	/obj/item/device/radio/headset/civilian,\
-	/obj/item/device/pda2/botanist)
+	/obj/item/device/pda2/botanist,\
+	/obj/item/clothing/gloves/black)
 
 /obj/item/storage/box/clothing/rancher
 	name = "\improper Rancher's equipment"
 	spawn_contents = list(/obj/item/clothing/under/rank/rancher,\
 	/obj/item/clothing/shoes/brown,\
 	/obj/item/device/radio/headset/civilian,\
-	/obj/item/device/pda2/botanist)
+	/obj/item/device/pda2/botanist,\
+	/obj/item/clothing/gloves/black)
 
 /obj/item/storage/box/clothing/chef
 	name = "\improper Chef's equipment"
@@ -129,7 +131,7 @@
 /obj/item/storage/box/clothing/security
 	name = "\improper Security Officer's equipment"
 	spawn_contents = list(/obj/item/clothing/under/rank/security,\
-	/obj/item/clothing/shoes/brown,\
+	/obj/item/clothing/shoes/swat,\
 	/obj/item/device/radio/headset/security,\
 	/obj/item/device/pda2/security)
 
@@ -167,7 +169,8 @@
 	/obj/item/clothing/shoes/black,\
 	/obj/item/clothing/suit/labcoat/robotics,\
 	/obj/item/device/radio/headset/medical,\
-	/obj/item/device/pda2/medical/robotics)
+	/obj/item/device/pda2/medical/robotics,\
+	/obj/item/clothing/gloves/latex)
 
 // Research Equipment
 
@@ -208,7 +211,7 @@
 	spawn_contents = list(/obj/item/clothing/under/rank/cargo,\
 	/obj/item/clothing/shoes/black,\
 	/obj/item/clothing/gloves/black,\
-	/obj/item/device/radio/headset/engineer,\
+	/obj/item/device/radio/headset/shipping,\
 	/obj/item/device/pda2/quartermaster)
 
 /obj/item/storage/box/clothing/wedding_dress

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -549,8 +549,7 @@
 /obj/storage/secure/closet/engineering/mining
 	name = "\improper Miner's locker"
 	req_access = list(access_mining)
-	spawn_contents = list(/obj/item/clothing/shoes/orange,
-	/obj/item/storage/box/clothing/miner,
+	spawn_contents = list(/obj/item/storage/box/clothing/miner,
 	/obj/item/clothing/suit/wintercoat/engineering,
 	/obj/item/breaching_charge/mining/light = 3,
 	/obj/item/satchel/mining = 2,


### PR DESCRIPTION

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR changes minor stuff like for example: Adding black gloves to the Botanist equipment box or changing the radio that is in the QM Equipment box from the "engineering" one to the "shipping" radio, I also removed the Orange shoes from the mining locker since he already has shoes in his equipment crate that spawns in said locker, I did not add stuff like galoshes or insulating gloves to equipment boxes because getting them after you lose them shouldn't be very easy, Command equipment boxes are left untouched since the contents of those are mostly just variants of the head of staff's jumpsuits and their spare equipment is at their locker.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

So people can equip themselves with their default equipment more easily after losing their stuff.


