### PR TITLE
Add heard name to looc messages

### DIFF
--- a/code/procs/mobprocs/chatprocs.dm
+++ b/code/procs/mobprocs/chatprocs.dm
@@ -694,6 +694,8 @@
 			else
 				display_name += " (as [src.client.fakekey])"
 
+		display_name += " ([src.get_heard_name()])"
+
 		if (src.client.holder && (!src.client.stealth || C.holder))
 			if (src.client.holder.level == LEVEL_BABBY)
 				looc_class = "gfartlooc"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[input]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds the mobs heard name to LOOC messages.

As far as i know you always have /mob, only thing this does is if you're still in the starting lobby your ckey will show up instead. So it should be safe?

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Often find myself asking who someone is in LOOC if trying to have conversation there on the RP servers. This should take care of that. I don't think metagaming is a huge issue since most people already have a character name everyone recognizes. It could be a different story on the main servers though so there's the possibility of making this a thing only for the RP servers.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Luxizzle:
(+)Character name is now shown in LOOC messages.
```
