### PR TITLE
Atlas medbay drainage

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -10516,6 +10516,7 @@
 	dir = 9;
 	icon_state = "line1"
 	},
+/obj/machinery/drainage,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/surgery)
 "zi" = (
@@ -18708,6 +18709,7 @@
 	light_type = /obj/item/light/tube/blueish
 	},
 /obj/item/robot_module/brobocop,
+/obj/machinery/drainage,
 /turf/simulated/floor,
 /area/station/medical/robotics)
 "Wr" = (

--- a/maps/atlas_xmas_2020.dmm
+++ b/maps/atlas_xmas_2020.dmm
@@ -10724,6 +10724,7 @@
 	dir = 9;
 	icon_state = "line1"
 	},
+/obj/machinery/drainage,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/surgery)
 "zi" = (
@@ -19374,6 +19375,7 @@
 	light_type = /obj/item/light/tube/blueish
 	},
 /obj/item/robot_module/brobocop,
+/obj/machinery/drainage,
 /turf/simulated/floor,
 /area/station/medical/robotics)
 "Wr" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[qol]

## About the PR and why it's needed<!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds drains underneath the operating tables in the operating theater and robotics on Atlas and Atlas Christmas 2020. The operating theater in particular is awful to navigate with blood all over the floor since it's such a tiny space. No reason not to have them considering most other maps have the same.