### PR TITLE
Cosmonaut helmet subtype

### DIFF
--- a/code/z_adventurezones/meatland.dm
+++ b/code/z_adventurezones/meatland.dm
@@ -936,6 +936,12 @@ var/list/meatland_fx_sounds = list('sound/ambience/spooky/Meatzone_Squishy.ogg',
 	icon_state = "sovspace"
 	item_state = "sov_suit"
 
+/obj/item/clothing/head/helmet/space/soviet
+	name = "cosmonaut helmet"
+	desc = "Korolyov's pride."
+	icon_state = "cosmonaut"
+	item_state = "cosmonaut"
+
 /obj/item/luggable_computer/cheget
 	name = "important-looking briefcase"
 	desc = "A lockable briefcase that looks really important.  It has insignias with cyrillic lettering on them."

--- a/maps/setpieces/AIBM_hospital.dmm
+++ b/maps/setpieces/AIBM_hospital.dmm
@@ -8211,10 +8211,7 @@
 /area/hospital/samostrel)
 "sI" = (
 /obj/rack,
-/obj/item/clothing/head/helmet/space{
-	desc = "Korolyov's pride.";
-	name = "cosmonaut helmet"
-	},
+/obj/item/clothing/head/helmet/space/soviet,
 /turf/unsimulated/floor{
 	name = "plating"
 	},

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -8640,10 +8640,7 @@
 /area/hospital)
 "awp" = (
 /obj/rack,
-/obj/item/clothing/head/helmet/space{
-	desc = "Korolyov's pride.";
-	name = "cosmonaut helmet"
-	},
+/obj/item/clothing/head/helmet/space/soviet,
 /turf/unsimulated/floor{
 	name = "plating"
 	},

--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -6787,11 +6787,7 @@
 	},
 /obj/item/tank/jetpack,
 /obj/item/clothing/mask/breath,
-/obj/item/clothing/head/helmet/space{
-	desc = "Korolyov's pride.";
-	icon_state = "cosmonaut"
-	name = "cosmonaut helmet"
-	},
+/obj/item/clothing/head/helmet/space/soviet,
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[clean]
## About the PR and why it's needed!<!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the cosmonaut helmet an actual subtype rather than an icon state edit, put in next to the cosmonaut suit. Replaces the generic civilian helmet in all used locations that's meant to be paired with the cosmonaut suit. This'll make it easier for future projects to add the cosmonaut stuff if needed.