### PR TITLE
Game kits for Manta, remove taser shotgun from Xmas variant

### DIFF
--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -12733,6 +12733,7 @@
 /area/station/communications/bedroom)
 "aEX" = (
 /obj/table/auto,
+/obj/item/game_kit,
 /obj/item/storage/box/donkpocket_kit,
 /obj/machinery/light/incandescent/netural{
 	dir = 1
@@ -18636,6 +18637,7 @@
 /area/station/security/brig/cell_block_control)
 "aSW" = (
 /obj/storage/secure/closet/brig,
+/obj/item/game_kit,
 /turf/simulated/floor/black,
 /area/station/security/brig/cell_block_control)
 "aSX" = (
@@ -30662,7 +30664,7 @@
 "bsY" = (
 /obj/table/wood/round/auto,
 /obj/machinery/light/emergency,
-/obj/item/card_box/suit,
+/obj/item/game_kit,
 /turf/simulated/floor/carpet{
 	icon_state = "green1"
 	},

--- a/maps/manta_xmas.dmm
+++ b/maps/manta_xmas.dmm
@@ -13527,6 +13527,7 @@
 /area/station/communications/bedroom)
 "aEX" = (
 /obj/table/auto,
+/obj/item/game_kit,
 /obj/item/storage/box/donkpocket_kit,
 /obj/machinery/light/incandescent/netural{
 	dir = 1
@@ -18970,7 +18971,6 @@
 /area/station/maintenance/upperstarboard)
 "aRb" = (
 /obj/storage/secure/closet/command/hos,
-/obj/item/gun/energy/tasershotgun,
 /turf/simulated/floor/redblack/corner,
 /area/station/security/hos)
 "aRc" = (
@@ -19888,6 +19888,7 @@
 /area/station/security/brig/cell_block_control)
 "aSW" = (
 /obj/storage/secure/closet/brig,
+/obj/item/game_kit,
 /turf/simulated/floor/black,
 /area/station/security/brig/cell_block_control)
 "aSX" = (
@@ -32825,7 +32826,7 @@
 "bsY" = (
 /obj/table/wood/round/auto,
 /obj/machinery/light/emergency,
-/obj/item/card_box/suit,
+/obj/item/game_kit,
 /turf/simulated/floor/carpet{
 	icon_state = "green1"
 	},


### PR DESCRIPTION
[MINOR]
## About the PR
Adds three game kits to Manta (one to bar, one to games room, one to brig) and removes the taser shotgun from the HoS' locker on Xmas Manta


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Game kits for feature parity with other maps. Taser shotgun removal to mirror change of #2993 to main map (didn't seem worth its own PR)


## Changelog
N/A