### PR TITLE
Manta shuttle fixes

### DIFF
--- a/code/map.dm
+++ b/code/map.dm
@@ -872,7 +872,7 @@ var/global/list/mapNames = list(
 		icon_state = "shuttle_escape-sealab"
 	manta
 		icon_state = "shuttle_escape-manta"
-		filler_turf = "/turf/space/fluid/manta"
+		filler_turf = "/turf/space/fluid"
 	donut3
 		icon_state = "shuttle_escape-dnt3"
 

--- a/code/modules/transport/shuttle/shuttle_controller.dm
+++ b/code/modules/transport/shuttle/shuttle_controller.dm
@@ -149,10 +149,14 @@ datum/shuttle_controller
 									return
 								*/
 
-						start_location.move_contents_to(end_location, centcom_turf)
+						var/filler_turf = text2path(start_location.filler_turf)
+						if (!filler_turf)
+							filler_turf = centcom_turf
+						start_location.move_contents_to(end_location, filler_turf)
 						for (var/turf/P in end_location)
-							if (istype(P, centcom_turf))
+							if (istype(P, filler_turf))
 								P.ReplaceWith(map_turf, keep_old_material = 0, force=1)
+
 
 						settimeleft(SHUTTLELEAVETIME)
 
@@ -290,10 +294,13 @@ datum/shuttle_controller
 								D.locked = 0
 								D.update_icon()
 
+						var/filler_turf = text2path(end_location.filler_turf)
+						if (!filler_turf)
+							filler_turf = centcom_turf
 						start_location.move_contents_to(end_location, transit_turf)
 						for (var/turf/G in end_location)
 							if (istype(G, transit_turf))
-								G.ReplaceWith(centcom_turf, keep_old_material = 0, force=1)
+								G.ReplaceWith(filler_turf, keep_old_material = 0, force=1)
 						boutput(world, "<B>The Emergency Shuttle has arrived at CentCom!")
 						world << csound("sound/misc/shuttle_centcom.ogg")
 						logTheThing("station", null, null, "The emergency shuttle has arrived at Centcom.")

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -69372,7 +69372,7 @@
 /area/shuttle/escape/centcom/manta)
 "dmF" = (
 /obj/wingrille_spawn/auto,
-/turf/unsimulated/floor/plating/random,
+/turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom/manta)
 "dmG" = (
 /obj/indestructible/shuttle_corner,
@@ -69443,10 +69443,7 @@
 	},
 /area/shuttle/escape/centcom/manta)
 "dmT" = (
-/obj/machinery/door/airlock/pyro/command{
-	dir = 4;
-	opacity = 0
-	},
+/obj/machinery/door/airlock/pyro/command,
 /turf/unsimulated/floor/shuttle,
 /area/shuttle/escape/centcom/manta)
 "dmU" = (
@@ -69561,12 +69558,6 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/escape/centcom/manta)
-"dnl" = (
-/obj/indestructible/shuttle_corner{
-	dir = 4
-	},
-/turf/space/fluid/manta,
-/area/shuttle/escape/centcom/manta)
 "dnm" = (
 /obj/indestructible/shuttle_corner{
 	dir = 1
@@ -69599,12 +69590,6 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/escape/centcom/manta)
-"dnr" = (
-/obj/indestructible/shuttle_corner{
-	dir = 8
-	},
-/turf/space/fluid/manta,
-/area/shuttle/escape/centcom/manta)
 "dns" = (
 /turf/unsimulated/wall{
 	dir = 4;
@@ -69631,7 +69616,7 @@
 /area/centcom)
 "dnw" = (
 /obj/machinery/shuttle/engine/heater/seaheater_middle,
-/turf/space/fluid/manta,
+/turf/space/fluid,
 /area/shuttle/escape/centcom/manta)
 "dnx" = (
 /turf/unsimulated/floor/orangeblack/corner{
@@ -69658,21 +69643,21 @@
 	icon_state = "alt_heater-L"
 	},
 /obj/wingrille_spawn/auto,
-/turf/unsimulated/floor/plating/random,
+/turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom/manta)
 "dnC" = (
 /obj/machinery/shuttle/engine/heater{
 	icon_state = "alt_heater-M"
 	},
 /obj/wingrille_spawn/auto,
-/turf/unsimulated/floor/plating/random,
+/turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom/manta)
 "dnD" = (
 /obj/machinery/shuttle/engine/heater{
 	icon_state = "alt_heater-R"
 	},
 /obj/wingrille_spawn/auto,
-/turf/unsimulated/floor/plating/random,
+/turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom/manta)
 "dnE" = (
 /obj/indestructible/shuttle_corner{
@@ -145799,7 +145784,7 @@ dmK
 dna
 dmW
 dmK
-dnl
+dnA
 dkJ
 dkK
 dkK
@@ -146102,7 +146087,7 @@ dmN
 dmS
 dnf
 dnm
-dnl
+dnA
 dmC
 dmC
 dmy
@@ -148518,7 +148503,7 @@ dmN
 dmS
 dnk
 dnq
-dnr
+dnE
 dmC
 dmC
 dmy
@@ -148819,7 +148804,7 @@ dmK
 dna
 dmU
 dmK
-dnr
+dnE
 djo
 dkK
 dkK


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* shuttle no longer floods on arriving at centcom
* shuttle will leave behind `/turf/space/fluid` when leaving centcom rather than grass
* replaced all `/turf/space/fluid/manta` on centcom with `/turf/space/fluid` as it could leave moving turfs on earth, and is no longer needed as the moved turfs will automatically become `/turf/space/fluid/manta` when appropriate.
* removed a bunch of `plating/random` from the shuttle, this turf has a chance to spawn objects and was being used under windows
* rotate the command airlock

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* bugs
