### PR TITLE
AIs should now receive messages from all groups

### DIFF
--- a/code/obj/item/device/pda2/base_os.dm
+++ b/code/obj/item/device/pda2/base_os.dm
@@ -684,7 +684,7 @@
 
 					var/groupAddress = signal.data["group"]
 					if(groupAddress) //Check to see if we have this ~mailgroup~
-						if((!(groupAddress in src.master.mailgroups) && groupAddress != "ai") || (groupAddress in src.master.muted_mailgroups))
+						if((!(groupAddress in src.master.mailgroups) && !("ai" in src.master.mailgroups)) || (groupAddress in src.master.muted_mailgroups))
 							return
 
 					var/sender = signal.data["sender_name"]


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I was told AIs were supposed to receive messages from all groups, but this was not working.
I found this check, and I am honestly not sure what the ai part of it was supposed to do?
Not sure if it was just coded wrong or if I am the one who's confused, but I changed it and it works now for me.

I tested by swapping to a person, sending a message to groups, then swapping back to the AI and checking the message history in my PDA, so it seems to work properly, but these things are a bit weird to test, so I hope I did not overlook anything.

AI PDAs are by default just in the "ai" group, which has a comment stating that it is supposed to be a special group that receives everything.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
So that AIs can better be creepy and spy on everyone.