### PR TITLE
Adds Electroplaters to more maps

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -1844,6 +1844,7 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
+/obj/machinery/arc_electroplater,
 /turf/simulated/floor/stairs/wide,
 /area/station/mining/refinery)
 "eE" = (

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -45898,7 +45898,7 @@
 /turf/simulated/floor/plating/airless,
 /area/station/mining/magnet)
 "bHj" = (
-/obj/machinery/portable_reclaimer,
+/obj/machinery/arc_electroplater,
 /turf/simulated/floor/plating/airless,
 /area/station/mining/magnet)
 "bHk" = (
@@ -49053,6 +49053,10 @@
 /obj/machinery/drone_recharger,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
+"fqA" = (
+/obj/machinery/portable_reclaimer,
+/turf/simulated/floor,
+/area/station/quartermaster/storage)
 "gXP" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -83949,7 +83953,7 @@ bxb
 byh
 bzn
 bAo
-buG
+fqA
 buJ
 bDV
 bEI

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -42859,6 +42859,10 @@
 "jtU" = (
 /turf/simulated/floor,
 /area/station/crewquarters/garbagegarbs)
+"jBB" = (
+/obj/machinery/arc_electroplater,
+/turf/simulated/floor/industrial,
+/area/station/mining/staff_room)
 "jLO" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/right{
@@ -123830,7 +123834,7 @@ bOd
 bOm
 bOq
 bxa
-bxa
+jBB
 bOb
 bPd
 bPq

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -47524,6 +47524,13 @@
 /obj/disposalpipe/trunk/east,
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
+"fVJ" = (
+/obj/disposalpipe/segment/mail,
+/obj/machinery/arc_electroplater,
+/turf/simulated/floor/shuttlebay{
+	name = "reinforced plating"
+	},
+/area/station/quartermaster/refinery)
 "ghV" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -84971,7 +84978,7 @@ bvS
 bKw
 bNd
 bOl
-bOl
+fVJ
 bQo
 bRn
 bJE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MAPPING]
## About the PR 
Adds Electroplaters to Atlas, Clarion, Oshan, Manta



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
We should be able to plate stuff on more maps instead of just the current ones
