### PR TITLE
QoL: Let glass recyclers accept (processed) crystalline pieces

### DIFF
--- a/code/obj/machinery/glass_recycler.dm
+++ b/code/obj/machinery/glass_recycler.dm
@@ -41,17 +41,22 @@
 			user.u_equip(W)
 			qdel(W)
 			return 1
-		else if (istype(W, /obj/item/material_piece) && W.material && W.crystal > 0)
-			glass_amt += W.amount * 10
-			user.visible_message("<span class='notice'>[user] inserts [W] into [src].</span>")
-			user.u_equip(W)
-			qdel(W)
-			return 1
+		else if (istype(W, /obj/item/material_piece))
+			var/obj/item/material_piece/M = W
+			if (istype(M) && M.material && M.crystal > 0)
+				glass_amt += W.amount * 10
+				user.visible_message("<span class='notice'>[user] inserts [W] into [src].</span>")
+				user.u_equip(W)
+				qdel(W)
+				return 1
+			else
+				boutput(user, "<span class='alert'>[src] only accepts crystalline materials!</span>")
+				return
 		else if (istype(W, /obj/item/raw_material/shard) || istype(W, /obj/item/reagent_containers/glass) || istype(W, /obj/item/reagent_containers/food/drinks))
 			if (istype(W,/obj/item/reagent_containers/food/drinks))
 				var/obj/item/reagent_containers/food/drinks/D = W
 				if (!D.can_recycle)
-					boutput(user, "<span class='alert'>[src] only accepts molitz cubes, glass shards or glassware!</span>")
+					boutput(user, "<span class='alert'>[src] only accepts crystals, glass shards or glassware!</span>")
 					return
 				if (istype(W,/obj/item/reagent_containers/food/drinks/bottle))
 					var/obj/item/reagent_containers/food/drinks/bottle/B = W

--- a/code/obj/machinery/glass_recycler.dm
+++ b/code/obj/machinery/glass_recycler.dm
@@ -41,11 +41,17 @@
 			user.u_equip(W)
 			qdel(W)
 			return 1
+    else if (istype(W, /obj/item/material_piece/molitz))
+      glass_amt += W.amount * 10
+      user.visible_message("<span class='notice'>[user] inserts [W] into [src].</span>")
+			user.u_equip(W)
+			qdel(W)
+			return 1
 		else if (istype(W, /obj/item/raw_material/shard) || istype(W, /obj/item/reagent_containers/glass) || istype(W, /obj/item/reagent_containers/food/drinks))
 			if (istype(W,/obj/item/reagent_containers/food/drinks))
 				var/obj/item/reagent_containers/food/drinks/D = W
 				if (!D.can_recycle)
-					boutput(user, "<span class='alert'>[src] only accepts glass shards or glassware!</span>")
+					boutput(user, "<span class='alert'>[src] only accepts molitz cubes, glass shards or glassware!</span>")
 					return
 				if (istype(W,/obj/item/reagent_containers/food/drinks/bottle))
 					var/obj/item/reagent_containers/food/drinks/bottle/B = W

--- a/code/obj/machinery/glass_recycler.dm
+++ b/code/obj/machinery/glass_recycler.dm
@@ -41,7 +41,7 @@
 			user.u_equip(W)
 			qdel(W)
 			return 1
-		else if (istype(W, /obj/item/material_piece) && W.material != null && W.material.material_flags & MATERIAL_CRYSTAL)
+		else if (istype(W, /obj/item/material_piece) && W.material?.material_flags & MATERIAL_CRYSTAL)
 			glass_amt += W.amount * 10
 			user.visible_message("<span class='notice'>[user] inserts [W] into [src].</span>")
 			user.u_equip(W)

--- a/code/obj/machinery/glass_recycler.dm
+++ b/code/obj/machinery/glass_recycler.dm
@@ -41,17 +41,12 @@
 			user.u_equip(W)
 			qdel(W)
 			return 1
-		else if (istype(W, /obj/item/material_piece))
-			var/obj/item/material_piece/M = W
-			if (istype(M) && M.material && M.crystal > 0)
-				glass_amt += W.amount * 10
-				user.visible_message("<span class='notice'>[user] inserts [W] into [src].</span>")
-				user.u_equip(W)
-				qdel(W)
-				return 1
-			else
-				boutput(user, "<span class='alert'>[src] only accepts crystalline materials!</span>")
-				return
+		else if (istype(W, /obj/item/material_piece) && W.material != null && W.material.material_flags & MATERIAL_CRYSTAL)
+			glass_amt += W.amount * 10
+			user.visible_message("<span class='notice'>[user] inserts [W] into [src].</span>")
+			user.u_equip(W)
+			qdel(W)
+			return 1
 		else if (istype(W, /obj/item/raw_material/shard) || istype(W, /obj/item/reagent_containers/glass) || istype(W, /obj/item/reagent_containers/food/drinks))
 			if (istype(W,/obj/item/reagent_containers/food/drinks))
 				var/obj/item/reagent_containers/food/drinks/D = W

--- a/code/obj/machinery/glass_recycler.dm
+++ b/code/obj/machinery/glass_recycler.dm
@@ -41,7 +41,7 @@
 			user.u_equip(W)
 			qdel(W)
 			return 1
-		else if (istype(W, /obj/item/material_piece) && W.material?.material_flags & MATERIAL_CRYSTAL)
+		else if (istype(W, /obj/item/material_piece) && W.material?.material_flags & MATERIAL_CRYSTAL && W.material?.alpha <= 180)
 			glass_amt += W.amount * 10
 			user.visible_message("<span class='notice'>[user] inserts [W] into [src].</span>")
 			user.u_equip(W)

--- a/code/obj/machinery/glass_recycler.dm
+++ b/code/obj/machinery/glass_recycler.dm
@@ -41,9 +41,9 @@
 			user.u_equip(W)
 			qdel(W)
 			return 1
-    else if (istype(W, /obj/item/material_piece/molitz))
-      glass_amt += W.amount * 10
-      user.visible_message("<span class='notice'>[user] inserts [W] into [src].</span>")
+		else if (istype(W, /obj/item/material_piece) && W.material && W.crystal > 0)
+			glass_amt += W.amount * 10
+			user.visible_message("<span class='notice'>[user] inserts [W] into [src].</span>")
 			user.u_equip(W)
 			qdel(W)
 			return 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds molitzblocks to the list of things that the glass recycler accepts. This way people can stop breaking tables and windows for supplies that should be common.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It was not a thing?? Really???!

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->
```
(u)Efi
(+)Glass recyclers now accept processed crystalline material pieces. 
```

