### PR TITLE
Cog1&cog2 ranch tweaks

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -62911,7 +62911,6 @@
 	icon_state = "pipe-c";
 	name = "factory pipe"
 	},
-/obj/railing/orange/reinforced,
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "ezG" = (
@@ -63032,6 +63031,9 @@
 /turf/simulated/floor/grime,
 /area/station/engine/coldloop)
 "fxH" = (
+/obj/railing/orange/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/grasstodirt,
 /area/station/ranch)
 "fBo" = (
@@ -63244,9 +63246,6 @@
 /obj/landmark/start{
 	name = "Rancher"
 	},
-/obj/railing/orange/reinforced{
-	dir = 1
-	},
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "hmN" = (
@@ -63294,10 +63293,6 @@
 	dir = 4
 	},
 /area/station/quartermaster/refinery)
-"hCt" = (
-/obj/railing/orange/reinforced,
-/turf/simulated/floor/dirt,
-/area/station/ranch)
 "hPW" = (
 /obj/submachine/chicken_feed_grinder,
 /obj/item/reagent_containers/food/snacks/plant/corn{
@@ -63313,7 +63308,6 @@
 	dir = 4;
 	pixel_x = 10
 	},
-/obj/railing/orange/reinforced,
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "iix" = (
@@ -63398,9 +63392,6 @@
 /area/station/quartermaster/refinery)
 "klF" = (
 /obj/stool,
-/obj/railing/orange/reinforced{
-	dir = 1
-	},
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "klV" = (
@@ -63453,6 +63444,7 @@
 /turf/simulated/floor/delivery,
 /area/station/engine/gas)
 "kOz" = (
+/obj/railing/orange/reinforced,
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_x = -12
@@ -63612,9 +63604,7 @@
 /turf/simulated/floor/caution/east,
 /area/station/security/armory)
 "nks" = (
-/obj/shrub{
-	dir = 8
-	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/grasstodirt,
 /area/station/ranch)
 "nlN" = (
@@ -63843,6 +63833,9 @@
 	},
 /area/station/chapel/sanctuary)
 "rdw" = (
+/obj/railing/orange/reinforced{
+	dir = 1
+	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -63892,9 +63885,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "skj" = (
-/obj/shrub{
-	dir = 8
-	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/grasstodirt{
 	dir = 1
 	},
@@ -63959,6 +63950,7 @@
 	},
 /area/station/hydroponics/bay)
 "tkX" = (
+/obj/table/auto,
 /obj/item/reagent_containers/food/snacks/chicken_feed_bag{
 	rand_pos = 1
 	},
@@ -63971,9 +63963,6 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
-	},
-/obj/railing/orange/reinforced{
-	dir = 1
 	},
 /turf/simulated/floor/dirt,
 /area/station/ranch)
@@ -64109,14 +64098,12 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "vcM" = (
+/obj/railing/orange/reinforced,
 /turf/simulated/floor/grasstodirt{
 	dir = 1
 	},
 /area/station/ranch)
 "vec" = (
-/obj/railing/orange/reinforced{
-	dir = 1
-	},
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "vfr" = (
@@ -64338,6 +64325,12 @@
 	dir = 6
 	},
 /area/station/hydroponics)
+"xpS" = (
+/obj/shrub{
+	dir = 8
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "xuC" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/turret_protected/armory_outside)
@@ -128540,7 +128533,7 @@ tva
 vEZ
 vcM
 hly
-hCt
+vec
 fxH
 vEZ
 tva
@@ -128842,7 +128835,7 @@ wdF
 vEZ
 vcM
 klF
-hCt
+vec
 fxH
 vEZ
 nEs
@@ -129141,12 +129134,12 @@ aaa
 aaa
 kPF
 uxX
-vEZ
+xpS
 skj
 tkX
 hPW
 nks
-vEZ
+xpS
 nNK
 kPF
 aaa

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -63612,7 +63612,9 @@
 /turf/simulated/floor/caution/east,
 /area/station/security/armory)
 "nks" = (
-/obj/wingrille_spawn/auto,
+/obj/shrub{
+	dir = 8
+	},
 /turf/simulated/floor/grasstodirt,
 /area/station/ranch)
 "nlN" = (
@@ -63812,12 +63814,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/coldloop)
-"qlh" = (
-/obj/shrub{
-	dir = 8
-	},
-/turf/simulated/floor/grass/leafy,
-/area/station/ranch)
 "qIA" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 4;
@@ -63896,7 +63892,9 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "skj" = (
-/obj/wingrille_spawn/auto,
+/obj/shrub{
+	dir = 8
+	},
 /turf/simulated/floor/grasstodirt{
 	dir = 1
 	},
@@ -129143,12 +129141,12 @@ aaa
 aaa
 kPF
 uxX
-qlh
+vEZ
 skj
 tkX
 hPW
 nks
-qlh
+vEZ
 nNK
 kPF
 aaa

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -62911,6 +62911,7 @@
 	icon_state = "pipe-c";
 	name = "factory pipe"
 	},
+/obj/railing/orange/reinforced,
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "ezG" = (
@@ -63031,9 +63032,6 @@
 /turf/simulated/floor/grime,
 /area/station/engine/coldloop)
 "fxH" = (
-/obj/railing/orange/reinforced{
-	dir = 1
-	},
 /turf/simulated/floor/grasstodirt,
 /area/station/ranch)
 "fBo" = (
@@ -63246,6 +63244,9 @@
 /obj/landmark/start{
 	name = "Rancher"
 	},
+/obj/railing/orange/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "hmN" = (
@@ -63293,6 +63294,10 @@
 	dir = 4
 	},
 /area/station/quartermaster/refinery)
+"hCt" = (
+/obj/railing/orange/reinforced,
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "hPW" = (
 /obj/submachine/chicken_feed_grinder,
 /obj/item/reagent_containers/food/snacks/plant/corn{
@@ -63308,6 +63313,7 @@
 	dir = 4;
 	pixel_x = 10
 	},
+/obj/railing/orange/reinforced,
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "iix" = (
@@ -63392,6 +63398,9 @@
 /area/station/quartermaster/refinery)
 "klF" = (
 /obj/stool,
+/obj/railing/orange/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "klV" = (
@@ -63444,7 +63453,6 @@
 /turf/simulated/floor/delivery,
 /area/station/engine/gas)
 "kOz" = (
-/obj/railing/orange/reinforced,
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_x = -12
@@ -63839,9 +63847,6 @@
 	},
 /area/station/chapel/sanctuary)
 "rdw" = (
-/obj/railing/orange/reinforced{
-	dir = 1
-	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -63956,7 +63961,6 @@
 	},
 /area/station/hydroponics/bay)
 "tkX" = (
-/obj/table/auto,
 /obj/item/reagent_containers/food/snacks/chicken_feed_bag{
 	rand_pos = 1
 	},
@@ -63969,6 +63973,9 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
+	},
+/obj/railing/orange/reinforced{
+	dir = 1
 	},
 /turf/simulated/floor/dirt,
 /area/station/ranch)
@@ -64104,12 +64111,14 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "vcM" = (
-/obj/railing/orange/reinforced,
 /turf/simulated/floor/grasstodirt{
 	dir = 1
 	},
 /area/station/ranch)
 "vec" = (
+/obj/railing/orange/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "vfr" = (
@@ -128533,7 +128542,7 @@ tva
 vEZ
 vcM
 hly
-vec
+hCt
 fxH
 vEZ
 tva
@@ -128835,7 +128844,7 @@ wdF
 vEZ
 vcM
 klF
-vec
+hCt
 fxH
 vEZ
 nEs

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -79268,6 +79268,7 @@
 /turf/simulated/floor/delivery,
 /area/station/ranch)
 "tTd" = (
+/obj/table/wood/auto,
 /obj/item/reagent_containers/food/snacks/chicken_feed_bag{
 	rand_pos = 1
 	},

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -100673,7 +100673,7 @@ saK
 saK
 saK
 aKt
-mBI
+ydl
 wcj
 saK
 saK
@@ -101884,7 +101884,7 @@ mBI
 mBI
 mBI
 mBI
-ydl
+mBI
 mBI
 qBq
 xTc
@@ -102479,7 +102479,7 @@ aaa
 aaa
 aam
 xfw
-nbd
+xfw
 nbd
 aEE
 nbd
@@ -102491,7 +102491,7 @@ xfw
 nbd
 tPC
 nbd
-nbd
+xfw
 xfw
 aaI
 aaa

--- a/maps/cogmap2_xmas_2020.dmm
+++ b/maps/cogmap2_xmas_2020.dmm
@@ -80823,6 +80823,7 @@
 /turf/simulated/floor/plating,
 /area/station/science/teleporter)
 "haY" = (
+/obj/table/wood/auto,
 /obj/item/reagent_containers/food/snacks/chicken_feed_bag{
 	rand_pos = 1
 	},

--- a/maps/cogmap2_xmas_2020.dmm
+++ b/maps/cogmap2_xmas_2020.dmm
@@ -103123,7 +103123,7 @@ tPo
 tPo
 tPo
 jCd
-fVT
+nUM
 iWY
 tPo
 tPo
@@ -104334,7 +104334,7 @@ fVT
 fVT
 fVT
 fVT
-nUM
+fVT
 fVT
 hvH
 wSt
@@ -104929,7 +104929,7 @@ aaa
 aaa
 aam
 tWd
-nqQ
+tWd
 nqQ
 aDo
 nqQ
@@ -104941,7 +104941,7 @@ tWd
 nqQ
 eDP
 nqQ
-nqQ
+tWd
 tWd
 aaI
 aaa

--- a/maps/cogmap_xmas_2020.dmm
+++ b/maps/cogmap_xmas_2020.dmm
@@ -64679,12 +64679,6 @@
 	},
 /turf/simulated/floor/caution/east,
 /area/station/security/armory)
-"fqU" = (
-/obj/shrub{
-	dir = 8
-	},
-/turf/simulated/floor/grass/leafy,
-/area/station/ranch)
 "fuX" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 4
@@ -65976,7 +65970,9 @@
 	},
 /area/station/hydroponics)
 "swS" = (
-/obj/wingrille_spawn/auto,
+/obj/shrub{
+	dir = 8
+	},
 /turf/simulated/floor/grasstodirt,
 /area/station/ranch)
 "sEn" = (
@@ -66521,7 +66517,9 @@
 /turf/simulated/floor/plating,
 /area/station/hydroponics/bay)
 "xUr" = (
-/obj/wingrille_spawn/auto,
+/obj/shrub{
+	dir = 8
+	},
 /turf/simulated/floor/grasstodirt{
 	dir = 1
 	},
@@ -131302,12 +131300,12 @@ aaa
 aaa
 jPv
 rlS
-fqU
+xXc
 xUr
 cOr
 eyq
 swS
-fqU
+xXc
 pbV
 jPv
 aaa

--- a/maps/cogmap_xmas_2020.dmm
+++ b/maps/cogmap_xmas_2020.dmm
@@ -64320,6 +64320,7 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "cOr" = (
+/obj/table/auto,
 /obj/item/reagent_containers/food/snacks/chicken_feed_bag{
 	rand_pos = 1
 	},
@@ -64332,9 +64333,6 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
-	},
-/obj/railing/orange/reinforced{
-	dir = 1
 	},
 /turf/simulated/floor/dirt,
 /area/station/ranch)
@@ -64387,7 +64385,6 @@
 	icon_state = "pipe-c";
 	name = "factory pipe"
 	},
-/obj/railing/orange/reinforced,
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "dGz" = (
@@ -64508,7 +64505,6 @@
 	dir = 4;
 	pixel_x = 10
 	},
-/obj/railing/orange/reinforced,
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "ezG" = (
@@ -64611,9 +64607,6 @@
 /area/station/ranch)
 "fcX" = (
 /obj/stool,
-/obj/railing/orange/reinforced{
-	dir = 1
-	},
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "fgq" = (
@@ -64831,6 +64824,9 @@
 /turf/simulated/floor/airless/plating/catwalk,
 /area/space)
 "gji" = (
+/obj/railing/orange/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/grasstodirt,
 /area/station/ranch)
 "gjs" = (
@@ -65375,9 +65371,6 @@
 /obj/landmark/start{
 	name = "Rancher"
 	},
-/obj/railing/orange/reinforced{
-	dir = 1
-	},
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "meu" = (
@@ -65425,6 +65418,7 @@
 /turf/simulated/floor/plating,
 /area/station/quartermaster/refinery)
 "mBk" = (
+/obj/railing/orange/reinforced,
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_x = -12
@@ -65886,6 +65880,12 @@
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
+"rqk" = (
+/obj/shrub{
+	dir = 8
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "rvo" = (
 /obj/wingrille_spawn/auto,
 /obj/decal/xmas_lights,
@@ -65935,13 +65935,10 @@
 /obj/decal/wreath,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/brig)
-"smw" = (
+"srf" = (
 /obj/railing/orange/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/dirt,
-/area/station/ranch)
-"srf" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -65970,9 +65967,7 @@
 	},
 /area/station/hydroponics)
 "swS" = (
-/obj/shrub{
-	dir = 8
-	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/grasstodirt,
 /area/station/ranch)
 "sEn" = (
@@ -66092,6 +66087,7 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "tPW" = (
+/obj/railing/orange/reinforced,
 /turf/simulated/floor/grasstodirt{
 	dir = 1
 	},
@@ -66318,7 +66314,6 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "vGT" = (
-/obj/railing/orange/reinforced,
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "vQM" = (
@@ -66517,9 +66512,7 @@
 /turf/simulated/floor/plating,
 /area/station/hydroponics/bay)
 "xUr" = (
-/obj/shrub{
-	dir = 8
-	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/grasstodirt{
 	dir = 1
 	},
@@ -130396,7 +130389,7 @@ eVq
 nvf
 nWf
 mBk
-smw
+vGT
 dti
 srf
 gsy
@@ -131300,12 +131293,12 @@ aaa
 aaa
 jPv
 rlS
-xXc
+rqk
 xUr
 cOr
 eyq
 swS
-xXc
+rqk
 pbV
 jPv
 aaa

--- a/maps/cogmap_xmas_2020.dmm
+++ b/maps/cogmap_xmas_2020.dmm
@@ -8778,12 +8778,6 @@
 "atV" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hydroponics/bay)
-"atW" = (
-/obj/reagent_dispensers/compostbin,
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
-/area/station/hydroponics/bay)
 "atX" = (
 /turf/simulated/floor/green/side{
 	dir = 9
@@ -64326,7 +64320,6 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "cOr" = (
-/obj/table/auto,
 /obj/item/reagent_containers/food/snacks/chicken_feed_bag{
 	rand_pos = 1
 	},
@@ -64339,6 +64332,9 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
+	},
+/obj/railing/orange/reinforced{
+	dir = 1
 	},
 /turf/simulated/floor/dirt,
 /area/station/ranch)
@@ -64391,6 +64387,7 @@
 	icon_state = "pipe-c";
 	name = "factory pipe"
 	},
+/obj/railing/orange/reinforced,
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "dGz" = (
@@ -64511,6 +64508,7 @@
 	dir = 4;
 	pixel_x = 10
 	},
+/obj/railing/orange/reinforced,
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "ezG" = (
@@ -64613,6 +64611,9 @@
 /area/station/ranch)
 "fcX" = (
 /obj/stool,
+/obj/railing/orange/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "fgq" = (
@@ -64836,9 +64837,6 @@
 /turf/simulated/floor/airless/plating/catwalk,
 /area/space)
 "gji" = (
-/obj/railing/orange/reinforced{
-	dir = 1
-	},
 /turf/simulated/floor/grasstodirt,
 /area/station/ranch)
 "gjs" = (
@@ -65383,6 +65381,9 @@
 /obj/landmark/start{
 	name = "Rancher"
 	},
+/obj/railing/orange/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "meu" = (
@@ -65430,7 +65431,6 @@
 /turf/simulated/floor/plating,
 /area/station/quartermaster/refinery)
 "mBk" = (
-/obj/railing/orange/reinforced,
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_x = -12
@@ -65942,12 +65942,12 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/brig)
 "smw" = (
-/turf/simulated/floor/dirt,
-/area/station/ranch)
-"srf" = (
 /obj/railing/orange/reinforced{
 	dir = 1
 	},
+/turf/simulated/floor/dirt,
+/area/station/ranch)
+"srf" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -65977,7 +65977,6 @@
 /area/station/hydroponics)
 "swS" = (
 /obj/wingrille_spawn/auto,
-/obj/decal/xmas_lights,
 /turf/simulated/floor/grasstodirt,
 /area/station/ranch)
 "sEn" = (
@@ -66097,7 +66096,6 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "tPW" = (
-/obj/railing/orange/reinforced,
 /turf/simulated/floor/grasstodirt{
 	dir = 1
 	},
@@ -66323,6 +66321,10 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
+"vGT" = (
+/obj/railing/orange/reinforced,
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "vQM" = (
 /obj/wingrille_spawn/auto,
 /obj/decal/xmas_lights,
@@ -66520,7 +66522,6 @@
 /area/station/hydroponics/bay)
 "xUr" = (
 /obj/wingrille_spawn/auto,
-/obj/decal/xmas_lights,
 /turf/simulated/floor/grasstodirt{
 	dir = 1
 	},
@@ -126770,7 +126771,7 @@ aag
 sKB
 arl
 asK
-atW
+wKg
 avg
 awD
 axQ
@@ -130700,7 +130701,7 @@ qrh
 xXc
 tPW
 lUz
-smw
+vGT
 gji
 xXc
 qrh
@@ -131002,7 +131003,7 @@ kTy
 xXc
 tPW
 fcX
-smw
+vGT
 gji
 xXc
 oAN


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR fixes a bunch of minor ranch stuff that annoys me:
~~1. Shifts cog1 railings to make chickens care about the feed directly near it  (the table and windows were removed because ingame it looks awful with shifted railings, also, it make the pens slighly larger)~~ reverted
2. Adds snow to one snow-less tile on spacemas cog1 (better late than never?)
3. Replaces the corner cog2 ranch windows with rwalls, to make the ranch look more connected to the station
4. Moves the cog2 rancher job spawner a bit, to the center
5. More cog2 tables 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

bwak
