### PR TITLE
Fix AI Shell not being able to use cell cables

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -457,9 +457,7 @@ var/zapLimiter = 0
 
 	else if (issilicon(user))
 		if (istype(W, /obj/item/robojumper))
-			if (!istype(user, /mob/living/silicon/robot))
-				return
-			var/mob/living/silicon/robot/S = user
+			var/mob/living/silicon/S = user
 			var/obj/item/robojumper/jumper = W
 			var/obj/item/cell/donor_cell = null
 			var/obj/item/cell/recipient_cell = null


### PR DESCRIPTION
[TRIVIAL]

## About the PR

APCs were checking whether the silicon unit using the cell cables was a cyborg for no reason. Removed the check and changed the type of a variable. Now the cell cables work fine for AI Shells (the orb kind; cyborg shells already worked).

## Why's this needed?

AI Shell has cell cables as one of its few tools. They should probably be able to do... something.