### PR TITLE
Katanas sever tails and butts

### DIFF
--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -1033,13 +1033,11 @@
 
 /// Checks if the target is facing in some way away from the user. Or they're lying down
 /obj/item/katana/proc/SeverButtStuff(var/mob/living/carbon/human/target, var/mob/user)
-	var/dir_from_target = get_dir(target, user)
-	var/list/valid_dirs = alldirs - target.dir - turn(target.dir, 45) - turn(target.dir, -45)
-	if ((dir_from_target in valid_dirs) || target.lying || target.stat)
+	if(ismob(target) && IN_RANGE(target, user, 1) && (target.dir == user.dir || target.lying))
 		if(target.organHolder?.tail)
-			target.organHolder.drop_and_throw_organ("tail", direction = pick(valid_dirs), vigor = 5, showtext = 1)
+			target.organHolder.drop_and_throw_organ("tail", vigor = 5, showtext = 1)
 		else if(target.organHolder?.butt)
-			target.organHolder.drop_and_throw_organ("butt", direction = pick(valid_dirs), vigor = 5, showtext = 1)
+			target.organHolder.drop_and_throw_organ("butt", vigor = 5, showtext = 1)
 
 /obj/item/katana/proc/handle_parry(mob/target, mob/user)
 	if (target != user && ishuman(target))

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -1007,9 +1007,11 @@
 	switch(zoney)
 		if("head")
 			if(!H.limbs.r_arm && !H.limbs.l_arm && !H.limbs.l_leg && !H.limbs.r_leg) //Does the target not have all of their limbs?
-				H.organHolder.drop_organ("head") //sever_limb doesn't apply to heads :(
+				H.organHolder.drop_and_throw_organ("head", vigor = 5, showtext = 1) //sever_limb doesn't apply to heads :(
 			return ..()
 		if("chest")
+			if (prob(delimb_prob))
+				src.SeverButtStuff(H, user)
 			return ..()
 		if("r_arm")
 			if (prob(delimb_prob))
@@ -1028,6 +1030,16 @@
 				H.sever_limb(zoney)
 			return ..()
 	..()
+
+/// Checks if the target is facing in some way away from the user. Or they're lying down
+/obj/item/katana/proc/SeverButtStuff(var/mob/living/carbon/human/target, var/mob/user)
+	var/dir_from_target = get_dir(target, user)
+	var/list/valid_dirs = alldirs - target.dir - turn(target.dir, 45) - turn(target.dir, -45)
+	if ((dir_from_target in valid_dirs) || target.lying || target.stat)
+		if(target.organHolder?.tail)
+			target.organHolder.drop_and_throw_organ("tail", direction = pick(valid_dirs), vigor = 5, showtext = 1)
+		else if(target.organHolder?.butt)
+			target.organHolder.drop_and_throw_organ("butt", direction = pick(valid_dirs), vigor = 5, showtext = 1)
 
 /obj/item/katana/proc/handle_parry(mob/target, mob/user)
 	if (target != user && ishuman(target))
@@ -1123,7 +1135,7 @@
 	else
 		var/organtokill = pick("liver", "spleen", "heart", "appendix", "stomach", "intestines")
 		user.visible_message("<span class='alert'><b>[user] stabs the [src] into their own chest, ripping out their [organtokill]! [pick("Oh the humanity", "What a bold display", "That's not safe at all")]!</b></span>")
-		user.organHolder.drop_organ(organtokill)
+		user.organHolder.drop_and_throw_organ(organtokill, vigor = 5, showtext = 1)
 		playsound(src.loc, "sound/impact_sounds/Blade_Small_Bloody.ogg", 50, 1)
 		user.TakeDamage("chest", 100, 0)
 		SPAWN_DBG(10 SECONDS)
@@ -1151,7 +1163,7 @@
 		return 0
 	else
 		user.visible_message("<span class='alert'><b>[user] cuts their own head clean off with the [src]! [pick("Holy shit", "Golly", "Wowie", "That's dedication", "What the heck")]!</b></span>")
-		user.organHolder.drop_organ("head")
+		user.organHolder.drop_and_throw_organ("head", vigor = 5, showtext = 1)
 		playsound(src.loc, "sound/impact_sounds/Flesh_Break_2.ogg", 50, 1)
 
 /obj/item/katana_sheath

--- a/code/obj/item/organ_holder.dm
+++ b/code/obj/item/organ_holder.dm
@@ -711,6 +711,25 @@
 				src.organ_list["tail"] = null
 				return mytail
 
+	/// drops the organ, then hurls it somewhere
+	proc/drop_and_throw_organ(var/organ, var/location, var/direction, var/vigor, var/showtext)
+		. = src.drop_organ(organ, location)
+		if(istype(., /obj))
+			var/obj/organ_toss = .
+			if (!location)
+				location = src.donor.loc
+
+			if(!direction)
+				direction = pick(alldirs)
+
+			var/atom/target = get_edge_target_turf(organ_toss, direction)
+			organ_toss.throw_at(target, vigor, vigor)
+
+			if(showtext && ishuman(src.donor))
+				src.donor.visible_message("<span class='alert'>[src.donor.name]'s [organ_toss.name] flies off in a visceral arc!</span>")
+				src.donor.emote("scream")
+				src.donor.update_clothing()
+
 	proc/receive_organ(var/obj/item/I, var/organ, var/op_stage = 0.0, var/force = 0)
 		if (!src.donor || !I || !organ)
 			return 0

--- a/code/obj/item/organ_holder.dm
+++ b/code/obj/item/organ_holder.dm
@@ -726,6 +726,21 @@
 			organ_toss.throw_at(target, vigor, vigor)
 
 			if(showtext && ishuman(src.donor))
+				var/grody_arc = "bloody"
+				if(istype(organ_toss, /obj/item/parts))
+					var/obj/item/parts/limb = organ_toss
+					grody_arc = limb.streak_descriptor
+				else if(istype(organ_toss, /obj/item/organ))
+					var/obj/item/organ/orgn = organ_toss
+					if(orgn.robotic)
+						grody_arc = "oily"
+					else
+						grody_arc = "bloody"
+				else if(istype(organ_toss, /obj/item/clothing/head/butt))
+					if(istype(organ_toss, /obj/item/clothing/head/butt/cyberbutt))
+						grody_arc = "greasy"
+					else
+						grody_arc = "floppy"
 				src.donor.visible_message("<span class='alert'>[src.donor.name]'s [organ_toss.name] flies off in a visceral arc!</span>")
 				src.donor.emote("scream")
 				src.donor.update_clothing()

--- a/code/obj/item/organ_holder.dm
+++ b/code/obj/item/organ_holder.dm
@@ -741,7 +741,7 @@
 						grody_arc = "greasy"
 					else
 						grody_arc = "floppy"
-				src.donor.visible_message("<span class='alert'>[src.donor.name]'s [organ_toss.name] flies off in a visceral arc!</span>")
+				src.donor.visible_message("<span class='alert'>[src.donor.name]'s [organ_toss.name] flies off in a [grody_arc] arc!</span>")
 				src.donor.emote("scream")
 				src.donor.update_clothing()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Katanas can sever tails and butts when targeting the chest and standing anywhere other than the three tiles in front of someone.

Also adds a proc to fling an organ in addition to dropping it. And it also adds this proc to severing heads and such, either from executions or suicides.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I was kinda surprised this wasnt already a thing

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Superlagg:
(+)Katanas now sever butts and tails if they're in an accessible position.
```
