### PR TITLE
Flockmind AI cleanup

### DIFF
--- a/code/datums/abilities/flock/flockmind.dm
+++ b/code/datums/abilities/flock/flockmind.dm
@@ -159,10 +159,12 @@
 		return 1
 	// sanity check: don't remove our last complex drone
 	var/mob/living/intangible/flock/flockmind/F = holder.owner
-	if(F?.flock)
-		if(F.flock.getComplexDroneCount() == 1)
-			boutput(holder.owner, "<span class='alert'>That's your last complex drone. Diffracting it would be suicide.</span>")
-			return 1
+	if(!F?.flock || F.flock != target.flock)
+		boutput(holder.owner, "<span class='notice'>The drone does not respond to your command.</span>")
+		return 1
+	if(F.flock.getComplexDroneCount() == 1)
+		boutput(holder.owner, "<span class='alert'>That's your last complex drone. Diffracting it would be suicide.</span>")
+		return 1
 	boutput(holder.owner, "<span class='notice'>You diffract the drone.</span>")
 	target.split_into_bits()
 

--- a/code/mob/living/critter/ai/flock/flocktasks.dm
+++ b/code/mob/living/critter/ai/flock/flocktasks.dm
@@ -107,8 +107,17 @@
 	var/mob/living/critter/flock/F = holder.owner
 	if (!F)
 		return
-	if (!F.pays_to_construct || F.can_afford(20))
+	if (F.can_afford(20))
 		. = 1
+
+/datum/aiTask/sequence/goalbased/build/on_tick()
+	var/had_target = holder.target
+	. = ..()
+	if (!had_target && holder.target)
+		var/turf/simulated/T = get_turf(holder.target)
+		var/mob/living/critter/flock/F = holder.owner
+		if (F.flock?.isTurfFree(T, F.real_name))
+			F.flock.reserveTurf(T, F.real_name)
 
 /datum/aiTask/sequence/goalbased/build/get_targets()
 	var/list/targets = list()
@@ -148,12 +157,12 @@
 
 /datum/aiTask/succeedable/build/failed()
 	var/turf/simulated/floor/build_target = holder.target
-	if(!build_target || get_dist(holder.owner, build_target) > 1)
+	if(!build_target || (has_started && get_dist(holder.owner, build_target) > 1))
 		return 1
 	var/mob/living/critter/flock/F = holder.owner
 	if(!F)
 		return 1
-	if(F.pays_to_construct && !F.can_afford(20))
+	if(!F.can_afford(20))
 		return 1
 	if(F.flock && !F.flock.isTurfFree(build_target, F.real_name)) // oh no, someone else claimed this tile before we got to it
 		return 1

--- a/code/mob/living/critter/ai/flock/flocktasks.dm
+++ b/code/mob/living/critter/ai/flock/flocktasks.dm
@@ -564,7 +564,7 @@
 		holder.target = get_best_target(get_targets())
 	if(holder.target)
 		var/mob/living/M = holder.target
-		if(!M || istype(M.loc, /obj/icecube/flockdrone) || M.getStatusDuration("stunned") || M.getStatusDuration("weakened") || M.getStatusDuration("paralysis") || M.stat)
+		if(!M || istype(M.loc, /obj/icecube/flockdrone) || has_incapacitating_status(M))
 			// target is down or in a cage, we don't care about this target now
 			// fetch a new one if we can
 			holder.target = get_best_target(get_targets())

--- a/code/mob/living/critter/ai/flock/flocktasks.dm
+++ b/code/mob/living/critter/ai/flock/flocktasks.dm
@@ -103,12 +103,8 @@
 	add_task(holder.get_instance(/datum/aiTask/succeedable/build, list(holder)))
 
 /datum/aiTask/sequence/goalbased/build/precondition()
-	. = 0
 	var/mob/living/critter/flock/F = holder.owner
-	if (!F)
-		return
-	if (F.can_afford(20))
-		. = 1
+	return F?.can_afford(20)
 
 /datum/aiTask/sequence/goalbased/build/on_tick()
 	var/had_target = holder.target
@@ -568,7 +564,7 @@
 		holder.target = get_best_target(get_targets())
 	if(holder.target)
 		var/mob/living/M = holder.target
-		if(M && !istype(M.loc, /obj/icecube/flockdrone) && (M.getStatusDuration("stunned") || M.getStatusDuration("weakened") || M.getStatusDuration("paralysis") || M.stat))
+		if(!M || istype(M.loc, /obj/icecube/flockdrone) || M.getStatusDuration("stunned") || M.getStatusDuration("weakened") || M.getStatusDuration("paralysis") || M.stat)
 			// target is down or in a cage, we don't care about this target now
 			// fetch a new one if we can
 			holder.target = get_best_target(get_targets())

--- a/code/mob/living/critter/ai/flock/flocktasks.dm
+++ b/code/mob/living/critter/ai/flock/flocktasks.dm
@@ -157,7 +157,7 @@
 
 /datum/aiTask/succeedable/build/failed()
 	var/turf/simulated/floor/build_target = holder.target
-	if(!build_target || (has_started && get_dist(holder.owner, build_target) > 1))
+	if(!build_target || get_dist(holder.owner, build_target) > 1)
 		return 1
 	var/mob/living/critter/flock/F = holder.owner
 	if(!F)
@@ -168,7 +168,7 @@
 		return 1
 
 /datum/aiTask/succeedable/build/succeeded()
-	return isfeathertile(holder.target)
+	return isfeathertile(holder.target) || (has_started && !actions.hasAction(holder.owner, "flock_convert"))
 
 /datum/aiTask/succeedable/build/on_tick()
 	if(!has_started && !failed() && !succeeded())

--- a/code/mob/living/critter/ai/flock/flocktasks.dm
+++ b/code/mob/living/critter/ai/flock/flocktasks.dm
@@ -568,7 +568,7 @@
 		holder.target = get_best_target(get_targets())
 	if(holder.target)
 		var/mob/living/M = holder.target
-		if(M && !istype(M.loc.type, /obj/icecube/flockdrone) && (M.getStatusDuration("stunned") || M.getStatusDuration("weakened") || M.getStatusDuration("paralysis") || M.stat))
+		if(M && !istype(M.loc, /obj/icecube/flockdrone) && (M.getStatusDuration("stunned") || M.getStatusDuration("weakened") || M.getStatusDuration("paralysis") || M.stat))
 			// target is down or in a cage, we don't care about this target now
 			// fetch a new one if we can
 			holder.target = get_best_target(get_targets())

--- a/code/mob/living/critter/ai/flock/flocktasks.dm
+++ b/code/mob/living/critter/ai/flock/flocktasks.dm
@@ -104,13 +104,15 @@
 
 /datum/aiTask/sequence/goalbased/build/precondition()
 	. = 0
-	var/mob/living/critter/flock/drone/F = holder.owner
-	if(F?.can_afford(20))
+	var/mob/living/critter/flock/F = holder.owner
+	if (!F)
+		return
+	if (!F.pays_to_construct || F.can_afford(20))
 		. = 1
 
 /datum/aiTask/sequence/goalbased/build/get_targets()
 	var/list/targets = list()
-	var/mob/living/critter/flock/drone/F = holder.owner
+	var/mob/living/critter/flock/F = holder.owner
 
 	if(F?.flock)
 		// if we can go for a tile we already have reserved, go for it
@@ -148,32 +150,29 @@
 	var/turf/simulated/floor/build_target = holder.target
 	if(!build_target || get_dist(holder.owner, build_target) > 1)
 		return 1
-	var/mob/living/critter/flock/drone/F = holder.owner
+	var/mob/living/critter/flock/F = holder.owner
 	if(!F)
 		return 1
-	if(F && !F.can_afford(20))
+	if(F.pays_to_construct && !F.can_afford(20))
 		return 1
-	if(F?.flock && !F.flock.isTurfFree(build_target, F.real_name)) // oh no, someone else claimed this tile before we got to it
+	if(F.flock && !F.flock.isTurfFree(build_target, F.real_name)) // oh no, someone else claimed this tile before we got to it
 		return 1
 
 /datum/aiTask/succeedable/build/succeeded()
 	return isfeathertile(holder.target)
 
 /datum/aiTask/succeedable/build/on_tick()
-	if(!has_started)
-		var/turf/simulated/floor/build_target = holder.target
-		if(build_target && get_dist(holder.owner, build_target) <= 1)
-			var/mob/living/critter/flock/drone/F = holder.owner
-			if(F?.set_hand(2)) // nanite spray
-				sleep(0.2 SECONDS)
-				holder.owner.set_dir(get_dir(holder.owner, holder.target))
-				F.hand_attack(build_target)
-				has_started = 1
+	if(!has_started && !failed() && !succeeded())
+		var/mob/living/critter/flock/F = holder.owner
+		if(F?.set_hand(2)) // nanite spray
+			holder.owner.set_dir(get_dir(holder.owner, holder.target))
+			F.hand_attack(holder.target)
+			has_started = 1
 
 /datum/aiTask/succeedable/build/on_reset()
 	has_started = 0
-	var/mob/living/critter/flock/drone/F = holder.owner
-	if(F?.flock)
+	var/mob/living/critter/flock/F = holder.owner
+	if(F?.flock && !failed() && !succeeded())
 		F.flock.reserveTurf(holder.target, F.real_name)
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -198,10 +197,8 @@
 	var/mob/living/critter/flock/drone/F = holder.owner
 	if(F)
 		F.active_hand = 2 // nanite spray
-		sleep(0.1 SECONDS)
 		F.a_intent = INTENT_HELP
 		F.hud?.update_intent()
-		sleep(0.1 SECONDS)
 		F.hud?.update_hands() // for observers
 
 /datum/aiTask/sequence/goalbased/repair/get_targets()
@@ -238,7 +235,6 @@
 		var/mob/living/critter/flock/drone/T = holder.target
 		if(F && T && get_dist(holder.owner, holder.target) <= 1)
 			if(F.set_hand(2)) // nanite spray
-				sleep(0.2 SECONDS)
 				holder.owner.set_dir(get_dir(holder.owner, holder.target))
 				F.hand_attack(T)
 				has_started = 1
@@ -268,10 +264,8 @@
 	var/mob/living/critter/flock/drone/F = holder.owner
 	if(F)
 		F.active_hand = 2 // nanite spray
-		sleep(0.1 SECONDS)
 		F.a_intent = INTENT_HELP
 		F.hud?.update_intent()
-		sleep(0.1 SECONDS)
 		F.hud?.update_hands() // for observers
 
 /datum/aiTask/sequence/goalbased/deposit/get_targets()
@@ -307,7 +301,6 @@
 		var/obj/flock_structure/ghost/T = holder.target
 		if(F && T && get_dist(holder.owner, holder.target) <= 1)
 			if(F.set_hand(2)) // nanite spray
-				sleep(0.2 SECONDS)
 				holder.owner.set_dir(get_dir(holder.owner, holder.target))
 				F.hand_attack(T)
 				has_started = 1
@@ -365,7 +358,6 @@
 	if(container_target && get_dist(holder.owner, container_target) <= 1 && !succeeded())
 		var/mob/living/critter/flock/drone/F = holder.owner
 		if(F?.set_hand(1)) // grip tool
-			sleep(0.2 SECONDS)
 			F.set_dir(get_dir(F, container_target))
 			F.hand_attack(container_target) // wooo
 	// tick up a fail counter so we don't try to open something we can't forever
@@ -425,32 +417,26 @@
 		var/mob/living/critter/flock/drone/F = holder.owner
 		usr = F // don't ask, please, don't
 		if(F?.set_hand(1)) // grip tool
-			sleep(0.2 SECONDS)
 			// drop whatever we're holding
 			F.drop_item()
-			sleep(0.1 SECONDS)
 			F.set_dir(get_dir(F, container_target))
 			F.hand_attack(container_target)
-			sleep(0.2 SECONDS)
 			if(F.equipped() == container_target)
 				// we've picked up a container
 				// just eat it
 				// dump it onto the floor
 				container_target.MouseDrop(get_turf(F))
-				sleep(1.5 SECONDS)
 				// might as well eat the container now
-				F.absorber.equip(container_target)
+				F.drop_item()
 				return
 			else
 				// we've opened a HUD
 				// do a fake HUD click, because i am dedicated to this whole puppetry schtick
 				container_target.hud.clicked("boxes", F, dummy_params)
-				sleep(0.3 SECONDS)
 				if(isitem(F.equipped()))
 					// we got an item from the thing, THROW IT
 					// we can't actually fake a throw command because we don't have a client (no, so do a bit more trickery to simulate it
 					F.throw_mode_on()
-					sleep(0.4 SECONDS)
 					var/list/random_pixel_offsets = list("icon-x" = rand(1, 32), "icon-y" = rand(1, 32))
 					// pick a random turf in sight to throw this at
 					var/list/throw_targets = list()
@@ -461,7 +447,6 @@
 						return
 					var/turf/throw_target = pick(throw_targets)
 					F.throw_item(throw_target, random_pixel_offsets)
-					sleep(0.1 SECONDS)
 					F.throw_mode_off()
 					return
 				else
@@ -530,20 +515,17 @@
 	if(harvest_target && get_dist(holder.owner, harvest_target) <= 1 && !succeeded())
 		var/mob/living/critter/flock/drone/F = holder.owner
 		if(F?.set_hand(1)) // grip tool
-			sleep(0.2 SECONDS)
 			var/obj/item/already_held = F.get_active_hand().item
 			if(already_held)
 				// we're already holding a thing to eat
 				harvest_target = already_held
 			else
 				F.empty_hand(1) // drop whatever we might be holding just in case
-				sleep(0.1 SECONDS)
 				// grab the item
 				F.set_dir(get_dir(F, harvest_target))
 				F.hand_attack(harvest_target)
 			// if we have the item, equip it into our horrifying death chamber
 			if(F.is_in_hands(harvest_target))
-				sleep(0.2 SECONDS)
 				F.absorber.equip(harvest_target) // hooray!
 	// tick up a fail counter so we don't try to get something we can't forever
 	fails++
@@ -591,7 +573,6 @@
 		else
 			if(owncritter.active_hand != 3) // stunner
 				owncritter.set_hand(3)
-				sleep(0.2 SECONDS)
 			owncritter.set_dir(get_dir(owncritter, holder.target))
 			owncritter.hand_attack(holder.target, dummy_params)
 			if(dist < run_range)
@@ -600,7 +581,6 @@
 			else if(prob(30))
 				// ROBUST DODGE
 				walk(owncritter, 0)
-				sleep(0.2 SECONDS)
 				walk_rand(owncritter, 1, 4)
 
 
@@ -657,10 +637,8 @@
 		else if(!actions.hasAction(owncritter, "flock_entomb")) // let's not keep interrupting our own action
 			if(owncritter.active_hand != 2) // nanite spray
 				owncritter.set_hand(2)
-				sleep(0.2 SECONDS)
 				owncritter.a_intent = INTENT_DISARM
 				owncritter.hud.update_intent()
-				sleep(0.1 SECONDS)
 			owncritter.set_dir(get_dir(owncritter, holder.target))
 			owncritter.hand_attack(holder.target)
 
@@ -696,10 +674,8 @@
 	var/mob/living/critter/flock/drone/F = holder.owner
 	if(F)
 		F.active_hand = 2 // nanite spray
-		sleep(0.1 SECONDS)
 		F.a_intent = INTENT_HARM
 		F.hud?.update_intent()
-		sleep(0.1 SECONDS)
 		F.hud?.update_hands() // for observers
 
 /datum/aiTask/sequence/goalbased/butcher/get_targets()
@@ -736,7 +712,6 @@
 		var/mob/living/critter/flock/drone/T = holder.target
 		if(F && T && get_dist(holder.owner, holder.target) <= 1)
 			if(F.set_hand(2)) // nanite spray
-				sleep(0.2 SECONDS)
 				holder.owner.set_dir(get_dir(holder.owner, holder.target))
 				F.hand_attack(T)
 				has_started = 1

--- a/code/mob/living/critter/ai/shared.dm
+++ b/code/mob/living/critter/ai/shared.dm
@@ -66,7 +66,6 @@
 					if(M.move_target)
 						return
 			M.move_target = target_turf
-	LAGCHECK(LAG_LOW)
 
 /datum/aiTask/sequence/goalbased/on_reset()
 	holder.target = null
@@ -87,7 +86,6 @@
 	// thanks byond forums for letting me know that the byond native implentation FUCKING SUCKS
 	holder.owner.move_dir = pick(1,2,4,5,6,8,9,10)
 	holder.owner.process_move()
-	LAGCHECK(LAG_LOW)
 
 /datum/aiTask/timed/wander/on_tick()
 	. = ..()

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -164,14 +164,16 @@
 	if(isflock(user))
 		var/special_desc = "<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received."
 		if(src.controller)
-			special_desc += "<br><span class='bold'>ID:</span> <b>[src.controller.real_name]</b> controlling [src.real_name])"
+			special_desc += "<br><span class='bold'>ID:</span> <b>[src.controller.real_name]</b> (controlling [src.real_name])"
 		else
 			special_desc += "<br><span class='bold'>ID:</span> [src.real_name]"
 		special_desc += {"<br><span class='bold'>Flock:</span> [src.flock ? src.flock.name : "none"]
 		<br><span class='bold'>Resources:</span> [src.resources]
 		<br><span class='bold'>System Integrity:</span> [round(src.get_health_percentage()*100)]%
-		<br><span class='bold'>Cognition:</span> [src.is_npc ? "TORPID" : "SAPIENT"]
-		<br><span class='bold'>###=-</span></span>"}
+		<br><span class='bold'>Cognition:</span> [isalive(src) && !dormant ? src.is_npc ? "TORPID" : "SAPIENT" : "ABSENT"]"}
+		if (src.is_npc && istype(src.ai.current_task))
+			special_desc += "<br><span class='bold'>Task:</span> [uppertext(src.ai.current_task.name)]"
+		special_desc += "<br><span class='bold'>###=-</span></span>"
 		return special_desc
 	else
 		return null // give the standard description
@@ -209,7 +211,8 @@
 		return
 	if(target == user)
 		// only allow people to jump into flockdrones if they're doing it themselves
-		if(istype(user, /mob/living/intangible/flock))
+		var/mob/living/intangible/flock/F = user
+		if(istype(F) && F.flock && F.flock == src.flock)
 			// jump on in there!
 			src.take_control(user)
 		else

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -587,10 +587,10 @@
 		src.flock?.registerUnit(B)
 		SPAWN_DBG(0.2 SECONDS)
 			B.set_loc(pick(candidate_turfs))
-	sleep(0.1 SECONDS) // make sure the animation finishes
-	// finally, away with us
-	src.ghostize()
-	qdel(src)
+	SPAWN_DBG(0.1 SECONDS) // make sure the animation finishes
+		// finally, away with us
+		src.ghostize()
+		qdel(src)
 
 
 /mob/living/critter/flock/drone/update_inhands()

--- a/code/mob/living/critter/flockcritter_parent.dm
+++ b/code/mob/living/critter/flockcritter_parent.dm
@@ -417,6 +417,7 @@
 					F, "<span class='notice'>You begin imprisoning [target]. You will both need to stay still for this to work.</span>",
 					target, "<span class='alert'>[F] is forming a structure around you!</span>",
 					"You hear strange building noises.")
+				target.was_harmed(F, null, "flock", INTENT_DISARM)
 				// do effect
 				src.decal = unpool(/obj/decal/flock_build_wall)
 				if(src.decal)

--- a/code/obj/flock/furniture.dm
+++ b/code/obj/flock/furniture.dm
@@ -296,7 +296,7 @@
 /obj/grille/flock/special_desc(dist, mob/user)
 	if(isflock(user))
 		return {"<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received.
-		<br><span class='bold'>ID:</span> Reinforced Conduit
+		<br><span class='bold'>ID:</span> Reinforced Barricade
 		<br><span class='bold'>###=-</span></span>"}
 	else
 		return null // give the standard description

--- a/code/obj/flock/furniture.dm
+++ b/code/obj/flock/furniture.dm
@@ -237,6 +237,14 @@
 		boutput(user, "<span class='notice'>The fibres burn away in the same way glass doesn't. Huh.</span>")
 		qdel(src)
 
+/obj/lattice/flock/special_desc(dist, mob/user)
+	if(isflock(user))
+		return {"<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received.
+		<br><span class='bold'>ID:</span> Structural Foundation
+		<br><span class='bold'>###=-</span></span>"}
+	else
+		return null // give the standard description
+
 /////////////
 // BARRICADE
 /////////////
@@ -284,3 +292,11 @@
 		animate_flock_passthrough(mover)
 		return 1
 	return ..()
+
+/obj/grille/flock/special_desc(dist, mob/user)
+	if(isflock(user))
+		return {"<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received.
+		<br><span class='bold'>ID:</span> Reinforced Conduit
+		<br><span class='bold'>###=-</span></span>"}
+	else
+		return null // give the standard description

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -2643,3 +2643,10 @@ proc/keep_truthy(some_list)
 	for(var/x in some_list)
 		if(x)
 			. += x
+
+proc/has_incapacitating_status(mob/M)
+	return \
+		M.getStatusDuration("stunned") || \
+		M.getStatusDuration("weakened") || \
+		M.getStatusDuration("paralysis") || \
+		M.stat


### PR DESCRIPTION
- remove sleeps in flockmind AI code
- remove lag_check from mob AI (this should only be used in spawned procs, not looping processes)
- fix flockbits sometimes targeting the same tile
- make monkeys treat the box that rips all your arms and legs off as a threat
- fix flockdrone logic for whether an enemy is caged
- fix flockminds being able to control other flocks' drones
- add flock ident packet for grilles and lattices
- inactive drones with AI disabled no longer count as "sentient" in the ident packet
- added task for AI drones in ident packet

Tested with 300 flockbits and 110 flockdrones and the server didn't die. Projectile spam seems to lag the chat box, but that's a different concern.