### PR TITLE
Removes/re-places bathroom cameras

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -2999,12 +2999,6 @@
 	anchored = 1;
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	tag = ""
-	},
 /obj/item/reagent_containers/bath_bomb,
 /obj/item/reagent_containers/bath_bomb,
 /turf/simulated/floor/sanitary,
@@ -4707,6 +4701,11 @@
 /obj/item/clothing/gloves/kote,
 /obj/item/shinai_bag,
 /obj/item/storage/box/kendo_box/hakama,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13"
+	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "akV" = (
@@ -7412,15 +7411,6 @@
 	name = "astroturf"
 	},
 /area/station/hydroponics/bay)
-"arp" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/showers)
 "arq" = (
 /turf/simulated/floor/grime,
 /area/station/hallway/primary/east)
@@ -10702,6 +10692,12 @@
 /area/station/crew_quarters/locker)
 "ayD" = (
 /obj/storage/closet/wardrobe/grey,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 9;
+	name = "autoname - SS13";
+	tag = ""
+	},
 /turf/simulated/floor/neutral/side{
 	dir = 4
 	},
@@ -53332,12 +53328,6 @@
 "ciZ" = (
 /obj/table/auto,
 /obj/item/paper_bin,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 9;
-	name = "autoname - SS13";
-	tag = ""
-	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/toilets)
 "cja" = (
@@ -106778,7 +106768,7 @@ agR
 ahJ
 aiH
 ajP
-arp
+akP
 akP
 amG
 aog

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -10196,11 +10196,6 @@
 "ast" = (
 /obj/table/auto,
 /obj/machinery/light,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 10;
-	name = "autoname - SS13"
-	},
 /obj/towelbin{
 	pixel_y = 2
 	},
@@ -25220,11 +25215,6 @@
 	dir = 4;
 	pixel_x = -4
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname  - SS13"
-	},
 /obj/decal/poster/wallsign/chsl{
 	pixel_y = 32
 	},
@@ -27598,16 +27588,15 @@
 /turf/simulated/floor/sanitary,
 /area/station/science/restroom)
 "aWt" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 5
-	},
+/obj/stool/bed/moveable,
+/obj/iv_stand,
 /obj/machinery/camera{
 	c_tag = "autotag";
-	dir = 1;
+	dir = 4;
 	name = "autoname - SS13"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/science/lab)
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "aWu" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -30073,11 +30062,6 @@
 /area/station/science/chemistry)
 "baM" = (
 /obj/machinery/door/window/eastleft,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13"
-	},
 /turf/simulated/floor/sanitary,
 /area/station/science/restroom)
 "baN" = (
@@ -80040,7 +80024,7 @@ aMW
 aOK
 aQw
 aSh
-aSh
+aWt
 aVj
 aWR
 aYs
@@ -105107,7 +105091,7 @@ aPU
 aRC
 aDB
 aUJ
-aWt
+aWp
 aYa
 aZm
 baM

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -4548,13 +4548,6 @@
 /area/station/engine/inner)
 "aXm" = (
 /obj/storage/secure/closet/command/hos,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
-	},
 /turf/simulated/floor/carpet/red/fancy/edge{
 	dir = 9
 	},
@@ -31393,13 +31386,6 @@
 /obj/machinery/light/incandescent/netural{
 	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
-	},
 /turf/simulated/floor/sanitary,
 /area/station/security/hos)
 "jks" = (
@@ -34690,6 +34676,18 @@
 /obj/disposalpipe/segment/morgue,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
+"kmc" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
+	},
+/turf/simulated/floor/carpet/red/fancy/edge{
+	dir = 10
+	},
+/area/station/security/hos)
 "kmh" = (
 /obj/machinery/networked/test_apparatus/pitching_machine{
 	dir = 4
@@ -58323,12 +58321,6 @@
 	pixel_y = 6
 	},
 /obj/machinery/light/small/sticky/cool,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
 /turf/simulated/floor/sanitary/blue,
 /area/station/crew_quarters/captain)
 "rkW" = (
@@ -100269,7 +100261,7 @@ jhw
 aXm
 bYG
 fwR
-mrr
+kmc
 hLl
 kAs
 bmg


### PR DESCRIPTION
## About the PR 
Removes security cameras in the toilet and shower areas of three maps.

## Why's this needed?
Someone mentioned toilet cams are pretty weird and usually serve to bring up uncomfortable interactions. This PR removes cameras in rooms with showers and/or toilets; if a camera was in an area with only sinks, I left it alone. 
For count: Horizon, Manta, Cog2, and Oshan all have private bathrooms without cameras. Where cameras were removed, I tried to make sure that the area was still generally covered by AI/Sec cams with a camera outside the room. This may also create a few more pockets not always visible to the AI/Sec for antags to utilize in their strategy.
