### PR TITLE
Agent card changes

### DIFF
--- a/code/obj/item/card.dm
+++ b/code/obj/item/card.dm
@@ -227,8 +227,12 @@ GAUNTLET CARDS
 	if(!src.registered)
 		var/reg = copytext(src.sanitize_name(input(user, "What name would you like to put on this card?", "Agent card name", ishuman(user) ? user.real_name : user.name)), 1, 100)
 		var/ass = copytext(src.sanitize_name(input(user, "What occupation would you like to put on this card?\n Note: This will not grant any access levels other than Maintenance.", "Agent card job assignment", "Staff Assistant"), 1), 1, 100)
-		var/color = input(user, "What color should the ID's color band be?\nClick cancel to abort the forging process.") as null|anything in list("blue","red","green","purple","yellow","No band")
+		var/color = input(user, "What color should the ID's color band be?\nClick cancel to abort the forging process.") as null|anything in list("clown","golden","blue","red","green","purple","yellow","No band")
 		switch (color)
+			if ("clown")
+				src.icon_state = "id_clown"
+			if ("golden")
+				src.icon_state = "gold"
 			if ("No band")
 				src.icon_state = "id"
 			if ("blue")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE] [BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR adds both the clown ID icon state and the golden ID icon state to the list of cards the agent card can imitate.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

More fun choices for traitors who buy the agent card seems like a good idea. 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)MatheusIsNotAvailable:
(+)Added both the golden and the clown's IDs to the agent card's color choosing option.
```
