### PR TITLE
Puts sous-chef clothing in their box + spawn list

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1592,10 +1592,10 @@
 	name = "Sous-Chef"
 	wages = PAY_UNTRAINED
 	slot_belt = /obj/item/device/pda2/chef
-	slot_jump = /obj/item/clothing/under/rank/chef
+	slot_jump = /obj/item/clothing/under/misc/souschef
 	slot_foot = /obj/item/clothing/shoes/chef
 	slot_head = /obj/item/clothing/head/souschefhat
-	slot_suit = /obj/item/clothing/suit/chef
+	slot_suit = /obj/item/clothing/suit/apron
 	slot_ears = /obj/item/device/radio/headset/civilian
 
 	New()

--- a/code/obj/item/storage/clothing.dm
+++ b/code/obj/item/storage/clothing.dm
@@ -97,10 +97,10 @@
 
 /obj/item/storage/box/clothing/souschef
 	name = "\improper Sous-Chef's equipment"
-	spawn_contents = list(/obj/item/clothing/under/rank/chef,\
+	spawn_contents = list(/obj/item/clothing/under/misc/souschef,\
 	/obj/item/clothing/shoes/chef,\
 	/obj/item/clothing/head/souschefhat,\
-	/obj/item/clothing/suit/chef,\
+	/obj/item/clothing/suit/apron,\
 	/obj/item/device/radio/headset/civilian,\
 	/obj/item/device/pda2/chef)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR replaces the chef's uniform and coat for sous-chef spawned gear and their equipment box with the sous-chef uniform and apron (which is in some places associated with the job).


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
They have associated gear, why not give it to them by default? Players can just steal the chef's spares if they want.
(Both were already available from the food vendor but I don't think the two jobs should look identical.)