### PR TITLE
Add mult support for machinery where applicable

### DIFF
--- a/code/modules/atmospherics/portable/scrubber.dm
+++ b/code/modules/atmospherics/portable/scrubber.dm
@@ -24,7 +24,7 @@
 	else
 		icon_state = "pscrubber:0"
 
-/obj/machinery/portable_atmospherics/scrubber/process()
+/obj/machinery/portable_atmospherics/scrubber/process(mult)
 	..()
 	if (!loc) return
 	if (src.contained) return
@@ -52,7 +52,7 @@
 
 		//atmos
 
-		var/transfer_moles = min(1, volume_rate/environment.volume)*TOTAL_MOLES(environment)
+		var/transfer_moles = min(1, volume_rate * mult/environment.volume)*TOTAL_MOLES(environment)
 
 		//Take a gas sample
 		var/datum/gas_mixture/removed

--- a/code/modules/power/pt_laser.dm
+++ b/code/modules/power/pt_laser.dm
@@ -108,7 +108,7 @@
 		return 0
 	return min(round((charge/abs(output))*6),6) //how close it is to firing power, not to capacity.
 
-/obj/machinery/power/pt_laser/process()
+/obj/machinery/power/pt_laser/process(mult)
 	if(status & BROKEN)
 		return
 	//store machine state to see if we need to update the icon overlays
@@ -117,12 +117,13 @@
 	var/last_llt = load_last_tick
 	var/last_firing = firing
 	var/dont_update = 0
+	var/adj_output = abs(output)
 
 	if(terminal)
 		src.excess = (terminal.surplus() + load_last_tick) //otherwise the charge used by this machine last tick is counted against the charge available to it this tick aaaaaaaaaaaaaa
 		if(charging && src.excess >= src.chargelevel)		// if there's power available, try to charge
 			var/load = min(capacity-charge, chargelevel)		// charge at set rate, limited to spare capacity
-			charge += load		// increase the charge
+			charge += load * mult		// increase the charge
 			add_load(load)		// add the load to the terminal side network
 			load_last_tick = load
 			if (!src.is_charging) src.is_charging = TRUE
@@ -130,22 +131,25 @@
 			load_last_tick = 0
 			if (src.is_charging) src.is_charging = FALSE
 
+	if( charge > adj_output*mult)
+		adj_output *= mult
+
 	if(online) // if it's switched on
 		if(!firing) //not firing
-			if(charge >= abs(output) && (abs(output) >= PTLMINOUTPUT)) //have power to fire
+			if(charge >= adj_output && (adj_output >= PTLMINOUTPUT)) //have power to fire
 				if(laser_parts.len == 0)
 					start_firing() //creates all the laser objects then activates the right ones
 				else
 					restart_firing() //if the laser was created already, just activate the existing objects
 				dont_update = 1 //so the firing animation runs
-				charge -= abs(output)
+				charge -= adj_output
 				if(selling)
 					power_sold()
-		else if(charge < abs(output) && (abs(src.output) >= PTLMINOUTPUT)) //firing but not enough charge to sustain
+		else if(charge < adj_output && (adj_output >= PTLMINOUTPUT)) //firing but not enough charge to sustain
 			stop_firing()
 		else //firing and have enough power to carry on
 			for(var/mob/living/L in affecting_mobs) //has to happen every tick
-				if(burn_living(L,abs(output)*PTLEFFICIENCY)) //returns 1 if they are gibbed, 0 otherwise
+				if(burn_living(L,adj_output*PTLEFFICIENCY)) //returns 1 if they are gibbed, 0 otherwise
 					affecting_mobs -= L
 
 			if(laser_process_counter > 9)
@@ -154,9 +158,10 @@
 			else
 				laser_process_counter ++
 
-			charge -= abs(output)
+			charge -= adj_output
+
 			if(selling)
-				power_sold()
+				power_sold(adj_output)
 			else if(blocking_objects.len > 0)
 				melt_blocking_objects()
 
@@ -166,11 +171,11 @@
 	if(dont_update == 0 && (last_firing != firing || last_disp != chargedisplay() || last_onln != online || ((last_llt > 0 && load_last_tick == 0) || (last_llt == 0 && load_last_tick > 0))))
 		updateicon()
 
-/obj/machinery/power/pt_laser/proc/power_sold()
-	if (round(output) == 0)
+/obj/machinery/power/pt_laser/proc/power_sold(adjusted_output)
+	if (round(adjusted_output) == 0)
 		return FALSE
 
-	var/output_mw = output / 1e6
+	var/output_mw = adjusted_output / 1e6
 
 	#define BUX_PER_SEC_CAP 5000 //at inf power, generate 5000$/tick, also max amt to drain/tick
 	#define ACCEL_FACTOR 69 //our acceleration factor towards cap

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -111,7 +111,7 @@
 /obj/machinery/power/smes/proc/chargedisplay()
 	return round(5.5*charge/capacity)
 
-/obj/machinery/power/smes/process()
+/obj/machinery/power/smes/process(mult)
 
 	if (status & BROKEN)
 		return
@@ -131,7 +131,10 @@
 
 				load = min(capacity-charge, chargelevel)		// charge at set rate, limited to spare capacity
 
-				charge += load	// increase the charge
+				// Adjusting mult to other power sources would likely cause more harm than good as it would cause unusual surges
+				// of power that would only be noticed though hotwire or be unrationalizable to player.  This will extrapolate power
+				// benefits to charged value so that minimal loss occurs.
+				charge += load * mult	// increase the charge
 				add_load(load)		// add the load to the terminal side network
 
 			else					// if not enough capcity

--- a/code/modules/robotics/bot/buttbot.dm
+++ b/code/modules/robotics/bot/buttbot.dm
@@ -36,8 +36,8 @@
 	text2speech = 1
 
 
-/obj/machinery/bot/buttbot/process()
-	if (prob(10) && src.on == 1)
+/obj/machinery/bot/buttbot/process(mult)
+	if (prob(10*mult) && src.on == 1)
 		SPAWN_DBG(0)
 			var/message = pick("butts", "butt")
 			speak(message)

--- a/code/modules/robotics/robot/robot_docking_station.dm
+++ b/code/modules/robotics/robot/robot_docking_station.dm
@@ -35,7 +35,7 @@
 	..()
 
 
-/obj/machinery/recharge_station/process()
+/obj/machinery/recharge_station/process(mult)
 	if (!(src.status & BROKEN))
 		// todo / at some point id like to fix the disparity between cells and 'normal power'
 		if (src.occupant)
@@ -51,7 +51,7 @@
 		return
 
 	if (src.occupant)
-		src.process_occupant()
+		src.process_occupant(mult)
 	return 1
 
 /obj/machinery/recharge_station/allow_drop()
@@ -753,7 +753,7 @@
 	if (src.occupant)
 		src.overlays += image('icons/obj/robot_parts.dmi', "station-occu")
 
-/obj/machinery/recharge_station/proc/process_occupant()
+/obj/machinery/recharge_station/proc/process_occupant(mult)
 	if (src.occupant)
 		if (src.occupant.loc != src)
 			src.go_out()
@@ -763,11 +763,11 @@
 			var/mob/living/silicon/robot/R = src.occupant
 			if (!R.cell)
 				return
-			else if (R.cell.charge >= R.cell.maxcharge)
+			else if (R.cell.charge * mult >= R.cell.maxcharge)
 				R.cell.charge = R.cell.maxcharge
 				return
 			else
-				R.cell.charge += src.chargerate
+				R.cell.charge += src.chargerate * mult
 				src.use_power(50)
 				return
 
@@ -776,11 +776,11 @@
 
 			if (!H.cell)
 				return
-			else if (H.cell.charge >= H.cell.maxcharge)
+			else if (H.cell.charge * mult >= H.cell.maxcharge)
 				H.cell.charge = H.cell.maxcharge
 				return
 			else
-				H.cell.charge += src.chargerate
+				H.cell.charge += src.chargerate * mult
 				src.use_power(50)
 				return
 

--- a/code/obj/machinery/cell_charger.dm
+++ b/code/obj/machinery/cell_charger.dm
@@ -65,7 +65,7 @@
 		chargelevel = -1
 		updateicon()
 
-/obj/machinery/cell_charger/process()
+/obj/machinery/cell_charger/process(mult)
 	if (status & BROKEN)
 		return
 	if (charging)
@@ -82,7 +82,7 @@
 		src.updateicon()
 		return
 
-	var/added = charging.give(src.chargerate)
+	var/added = charging.give(src.chargerate * mult)
 	use_power(added / CELLRATE)
 
 	src.updateicon()

--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -1377,7 +1377,7 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 	updateicon()
 	..()
 
-/obj/machinery/power/collector_control/process()
+/obj/machinery/power/collector_control/process(mult)
 	if(magic != 1)
 		if(src.active == 1)
 			var/power_a = 0
@@ -1389,19 +1389,19 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 			if(P1?.air_contents)
 				if(CA1.active != 0)
 					power_p += P1.air_contents.toxins
-					P1.air_contents.toxins -= 0.001
+					P1.air_contents.toxins -= 0.001 * mult
 			if(P2?.air_contents)
 				if(CA2.active != 0)
 					power_p += P2.air_contents.toxins
-					P2.air_contents.toxins -= 0.001
+					P2.air_contents.toxins -= 0.001 * mult
 			if(P3?.air_contents)
 				if(CA3.active != 0)
 					power_p += P3.air_contents.toxins
-					P3.air_contents.toxins -= 0.001
+					P3.air_contents.toxins -= 0.001 * mult
 			if(P4?.air_contents)
 				if(CA4.active != 0)
 					power_p += P4.air_contents.toxins
-					P4.air_contents.toxins -= 0.001
+					P4.air_contents.toxins -= 0.001 * mult
 			power_a = power_p*power_s*50
 			src.lastpower = power_a
 			add_avail(power_a)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[balance][input wanted]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adding support for "mult" to various machinery to account for missed periodic processing incurred by what the people call "lag".
* PT Laser charge and output scaling. (Buff)
* SMES charge scaling (Buff)
* Buttbot butt talk scaling (Buff?)
* Robot Docking station charging scaling (Buff)
* Cell Charge scaling. (Buff)
* Radiation Collector “fuel” consumption scaling. (NERF)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Provides more consistent user experience by accounting for variability of machine processing.  The goal is to err on the side of the player to avoid situations where overall processing delay doesn’t cause thrashing with the powernets as the overall behavior is non-deterministic. 

This will be accomplished by scaling actions performed while ignoring scaling of power usage, as we can not be certain that scaling would also occur for machinery that would provide power to the powernet for the reset. (Would love for someone to tell me I’m wrong)

Atmos scaling is limited as suddenly influxes of activity would cause unusual behavior that would be impossible to rationalize from a player perspective and an absolute nightmare to debug and investigate.

```
(u)Azrun:
(+)Improve responsiveness of machinery during "lag". (PTL, SMES, Buttbots, Robot Docking Station, Cell Charger, Recharger) 
```
