### PR TITLE
Fixes some clipboard bugs

### DIFF
--- a/code/obj/item/paper.dm
+++ b/code/obj/item/paper.dm
@@ -292,6 +292,11 @@
 		"stamp-text-name" = user.name
 	)
 
+	if(!istype(O, /obj/item/pen))
+		if(istype(src.loc, /obj/item/clipboard))
+			var/obj/item/clipboard/C = src.loc
+			if(istype(C.pen, /obj/item/pen))
+				O = C.pen
 	if(istype(O, /obj/item/pen))
 		var/obj/item/pen/PEN = O
 		. += list(

--- a/code/obj/item/pens_writing_etc.dm
+++ b/code/obj/item/pens_writing_etc.dm
@@ -902,6 +902,7 @@
 	New()
 		..()
 		src.pen = new /obj/item/pen(src)
+		src.update()
 		return
 
 /* =============== FOLDERS (wip) =============== */


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
-Makes the TGUI data code check for the pen you can put on a clipboard if there's none in your active hand, to more or less get on parity with previous paper.
-Makes the variant that spawns with a pen update its icon accordingly.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #3025 - or at least possibly
Visual bugs are bad.