### PR TITLE
Fixes Armory APC powernet issue in Manta

### DIFF
--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -6526,6 +6526,9 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
 "aqS" = (
@@ -43340,6 +43343,9 @@
 "oIR" = (
 /obj/machinery/weapon_stand/shotgun_rack,
 /obj/machinery/power/apc/autoname_west,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
 "oJe" = (

--- a/maps/manta_xmas.dmm
+++ b/maps/manta_xmas.dmm
@@ -6948,6 +6948,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
 "aqS" = (
@@ -46914,6 +46919,10 @@
 "oIR" = (
 /obj/machinery/weapon_stand/shotgun_rack,
 /obj/machinery/power/apc/autoname_west,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
 "oJe" = (


### PR DESCRIPTION
<!-- Might merge conflict with my other PR on Manta. Whichever is more pressing, I'd prefer that be considered first and I can resolve the outstanding conflict on whichever PR ends up second -->
## About the PR 
Connects the Armory APC on Manta back to the powernet; address #3152 


## Why's this needed?
The APC wasn't wired into the powernet before; I assume it probably should be.
