### PR TITLE
add an extra message when using the wrong hand to perform eye surgery

### DIFF
--- a/code/modules/medical/surgery_procs.dm
+++ b/code/modules/medical/surgery_procs.dm
@@ -426,6 +426,13 @@ var/global/list/chestitem_whitelist = list(/obj/item/gnomechompski, /obj/item/gn
 			if (patient.organHolder.head.scalp_op_stage == 0.0)
 				playsound(get_turf(patient), "sound/impact_sounds/Slimy_Cut_1.ogg", 50, 1)
 
+				var/removing_eye = (patient.organHolder.left_eye && patient.organHolder.left_eye.op_stage == 1.0) || (patient.organHolder.right_eye && patient.organHolder.right_eye.op_stage == 1.0)
+
+				if (removing_eye && (surgeon.find_in_hand(src, "left") || surgeon.find_in_hand(src, "right")))
+					surgeon.show_text("Wait, which eye was I operating on?")
+				else if (removing_eye && surgeon.find_in_hand(src, "middle"))
+					surgeon.show_text("Hey, there's no middle eye!")
+
 				if (prob(screw_up_prob))
 					surgeon.visible_message("<span class='alert'><b>[surgeon][fluff]!</b></span>")
 					patient.TakeDamage("head", damage_low, 0)
@@ -1696,6 +1703,9 @@ var/global/list/chestitem_whitelist = list(/obj/item/gnomechompski, /obj/item/gn
 		else if (surgeon.find_in_hand(src, "left") && patient.organHolder.left_eye)
 			target_eye = patient.organHolder.left_eye
 			target_side = "left"
+		else if (surgeon.find_in_hand(src, "middle"))
+			surgeon.show_text("Hey, there's no middle eye!")
+			return 0
 		else
 			return 0
 


### PR DESCRIPTION
[QOL]

## About the PR

When using a scalpel or spoon in the wrong hand while an eye is undergoing surgery, a message will appear in the chat box.

Using the scalpel in the opposite hand results in the message "Wait, which eye was I operating on?" in addition to existing effects.

For cyborgs, using the middle hand for either the spoon or the scalpel adds the message "Hey, there's no middle eye!"

## Why's this needed?

Let's just say a certain medical director got their head sliced open a lot today and I'd rather not have anyone else get as confused as I was.

## Changelog

```
(u)BenLubar:
(+)Surgeons now pay more attention to their hand-EYE coordination. Sorry, that was terrible.
```
