### PR TITLE
Updates Donut3's Map Button to use Goonhub rather then Discord

### DIFF
--- a/code/map.dm
+++ b/code/map.dm
@@ -148,7 +148,7 @@ var/global/list/mapNames = list(
 
 /datum/map_settings/donut3
 	name = "DONUT3"
-	goonhub_map = "https://cdn.discordapp.com/attachments/469379618168897538/729919886524153916/donut3-30-FINAL4-the-unlucky-number.png"
+	goonhub_map = "http://goonhub.com/maps/donut3"
 	airlock_style = "pyro"
 	walls = /turf/simulated/wall/auto/jen
 	rwalls = /turf/simulated/wall/auto/reinforced/jen


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes it so pressing the `MAP` button while on Donut3 properly redirects you to the Goonhub map, rather than outdated Discord map.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

We've been waiting ages for Donut 3 to get a Goonhub map, now we have one the map button should actually link to it.
