### PR TITLE
Fix issue with ping tool not working correctly

### DIFF
--- a/code/obj/item/device/pda2/diagnostics.dm
+++ b/code/obj/item/device/pda2/diagnostics.dm
@@ -66,18 +66,16 @@
 
 		if (href_list["send"])
 			SPAWN_DBG( 0 )
-
-
+				if(result) result.Cut()
 				var/datum/signal/signal = get_free_signal()
 				signal.source = src
 				signal.transmission_method = TRANSMISSION_RADIO
 				signal.data["address_1"] = "ping"
 				signal.data["sender"] = master.net_id
 
-				src.post_signal(signal,"[send_freq]")
 				mode = 1
-				if(result) result.Cut()
 				master.updateSelfDialog()
+				src.post_signal(signal,"[send_freq]")
 				sleep(2 SECONDS)
 				mode = 0
 				master.updateSelfDialog()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUGFIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The ping tool is exhibiting some odd behavior. Someone was having trouble pinging the armory computer, and it looks like the issue was that ping replies were being received before the call to result.Cut(), so they would get thrown away before they could be displayed.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bugfix


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->
