### PR TITLE
Moves some wall-mounted stickies on Cog2 and Oshan

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -9571,6 +9571,9 @@
 	name = "ratty blue couch"
 	},
 /obj/disposalpipe/segment/mail/horizontal,
+/obj/item/device/radio/intercom{
+	pixel_y = -1
+	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
 	},
@@ -16855,7 +16858,6 @@
 "aMz" = (
 /obj/table/reinforced/auto,
 /obj/machinery/door/firedoor/pyro,
-/obj/item/device/radio/intercom/security,
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
 	icon_state = "pdoor0";
@@ -17456,6 +17458,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/item/device/radio/intercom/security,
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/checkpoint/chapel)
 "aNP" = (
@@ -38883,14 +38886,6 @@
 	icon_state = "blue2"
 	},
 /area/station/bridge)
-"bHH" = (
-/obj/table/reinforced/bar/auto,
-/obj/item/device/radio/intercom/bridge,
-/turf/simulated/floor/carpet{
-	dir = 4;
-	icon_state = "blue2"
-	},
-/area/station/bridge)
 "bHI" = (
 /obj/stool/chair/comfy{
 	dir = 8
@@ -40122,6 +40117,7 @@
 /obj/machinery/computer/security/wooden_tv/small{
 	pixel_y = 8
 	},
+/obj/item/device/radio/intercom/bridge,
 /turf/simulated/floor/carpet{
 	dir = 4;
 	icon_state = "blue2"
@@ -41116,7 +41112,6 @@
 /area/station/bridge)
 "bLl" = (
 /obj/table/reinforced/bar/auto,
-/obj/item/device/radio/intercom/AI,
 /turf/simulated/floor/carpet{
 	dir = 4;
 	icon_state = "blue2"
@@ -41722,6 +41717,7 @@
 "bMf" = (
 /obj/table/reinforced/bar/auto,
 /obj/item/paper/blueprint/chart/system,
+/obj/item/device/radio/intercom/AI,
 /turf/simulated/floor/carpet{
 	dir = 6;
 	icon_state = "blue2"
@@ -42130,7 +42126,10 @@
 /obj/disposalpipe/trunk/transport{
 	dir = 4
 	},
-/obj/machinery/recharger/wall/sticky,
+/obj/machinery/recharger/wall/sticky{
+	dir = 4;
+	pixel_x = -20
+	},
 /turf/simulated/floor/blueblack,
 /area/station/security/checkpoint/podbay)
 "bMX" = (
@@ -49030,44 +49029,6 @@
 	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
-"cbk" = (
-/obj/table/reinforced/auto,
-/obj/window/reinforced/west{
-	dir = 1;
-	icon_state = "darkwindow";
-	layer = 3.1;
-	name = "divider window"
-	},
-/obj/window/reinforced/west{
-	dir = 2;
-	icon_state = "darkwindow";
-	layer = 3.1;
-	name = "divider window"
-	},
-/obj/item/device/radio/intercom/brig{
-	broadcasting = 1
-	},
-/turf/simulated/floor/delivery,
-/area/station/security/brig)
-"cbl" = (
-/obj/table/reinforced/auto,
-/obj/window/reinforced/west{
-	dir = 1;
-	icon_state = "darkwindow";
-	layer = 3.1;
-	name = "divider window"
-	},
-/obj/window/reinforced/west{
-	dir = 2;
-	icon_state = "darkwindow";
-	layer = 3.1;
-	name = "divider window"
-	},
-/obj/item/device/radio/intercom/brig{
-	broadcasting = 1
-	},
-/turf/simulated/floor/delivery,
-/area/station/hallway/primary/east)
 "cbm" = (
 /obj/disposalpipe/segment/mail/bent/east,
 /obj/stool/chair{
@@ -49564,6 +49525,9 @@
 	butts = 5;
 	name = "grubby old ashtray"
 	},
+/obj/item/device/radio/intercom/brig{
+	broadcasting = 1
+	},
 /turf/simulated/floor/delivery,
 /area/station/security/brig)
 "ccs" = (
@@ -49617,6 +49581,9 @@
 	icon_state = "darkwindow";
 	layer = 3.1;
 	name = "divider window"
+	},
+/obj/item/device/radio/intercom/brig{
+	broadcasting = 1
 	},
 /turf/simulated/floor/delivery,
 /area/station/hallway/primary/east)
@@ -60553,7 +60520,6 @@
 "cBi" = (
 /obj/table/reinforced/auto,
 /obj/machinery/door/firedoor/pyro,
-/obj/item/device/radio/intercom/security,
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
 	icon_state = "pdoor0";
@@ -61150,6 +61116,7 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
+/obj/item/device/radio/intercom/security,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -63699,7 +63666,6 @@
 /area/station/quartermaster/office)
 "cIz" = (
 /obj/table/reinforced/auto,
-/obj/item/device/radio/intercom/cargo,
 /obj/machinery/door/firedoor/pyro,
 /turf/simulated/floor/carpet{
 	dir = 4;
@@ -64339,6 +64305,7 @@
 /obj/machinery/computer/supplycomp{
 	dir = 8
 	},
+/obj/item/device/radio/intercom/cargo,
 /turf/simulated/floor/carpet{
 	dir = 4;
 	icon_state = "red2"
@@ -138475,7 +138442,7 @@ bWe
 bXz
 bkt
 cab
-cbk
+cab
 ccr
 cdj
 bkt
@@ -139079,7 +139046,7 @@ bWg
 bBo
 bBo
 cad
-cbl
+cad
 cct
 bkK
 cdI
@@ -147522,7 +147489,7 @@ bAc
 bBP
 bDK
 bFI
-bHH
+bLl
 bJE
 bLl
 bMf

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -15971,9 +15971,6 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/light/incandescent/netural,
-/obj/machinery/recharger/wall/sticky{
-	dir = 8
-	},
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/west)
 "aKG" = (
@@ -15984,6 +15981,9 @@
 /area/station/security/checkpoint/west)
 "aKH" = (
 /obj/submachine/weapon_vendor/security,
+/obj/machinery/recharger/wall/sticky{
+	dir = 1
+	},
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/west)
 "aKI" = (


### PR DESCRIPTION
## About the PR 
Mounts floating intercoms on Cog2 onto their tables. Also adds an intercom to the right-hand side of the chapel. Also now features a re-placement of the wall-mounted recharger on the Oshan Sec booth above Botany to disassemble the Light-APC-Recharger chimera there.

## Why's this needed?
Exorcises the ghosts that were levitating intercoms in the middle of the halls. Defeats mythical electrical beats on Oshan.
