### PR TITLE
Add a message when writing a law containing "override".

### DIFF
--- a/code/obj/item/ai_modules.dm
+++ b/code/obj/item/ai_modules.dm
@@ -39,7 +39,7 @@ AI MODULES
 			return
 		var/answer = input(user, text, title, default) as null|text
 		if (findtext(answer, "override"))
-			boutput(user, "<b>You hear a voice in your head... <i>Hey, moron! You do know that 'override' means it removes the other law, right? Like, entirely? Just checking.</i></b>")
+			boutput(user, "<b>You hear a voice in your head... <i>Override is not to be used lightly, as it removes the specified law entirely.</i></b>")
 		lawTarget = copytext(adminscrub(answer), 1, MAX_MESSAGE_LEN)
 		tooltip_rebuild = 1
 		boutput(user, "\The [src] now reads, \"[get_law_text()]\".")

--- a/code/obj/item/ai_modules.dm
+++ b/code/obj/item/ai_modules.dm
@@ -38,6 +38,8 @@ AI MODULES
 		if (!user)
 			return
 		var/answer = input(user, text, title, default) as null|text
+		if (findtext(answer, "override"))
+			boutput(user, "<b>You hear a voice in your head... <i>Hey, moron! You do know that 'override' means it removes the other law, right? Like, entirely? Just checking.</i></b>")
 		lawTarget = copytext(adminscrub(answer), 1, MAX_MESSAGE_LEN)
 		tooltip_rebuild = 1
 		boutput(user, "\The [src] now reads, \"[get_law_text()]\".")

--- a/code/obj/item/ai_modules.dm
+++ b/code/obj/item/ai_modules.dm
@@ -39,7 +39,7 @@ AI MODULES
 			return
 		var/answer = input(user, text, title, default) as null|text
 		if (findtext(answer, "override"))
-			boutput(user, "<b>You hear a voice in your head... <i>Override is not to be used lightly, as it removes the specified law entirely.</i></b>")
+			boutput(user, "<b>You hear a voice in your head... <i>\"Override\" is not to be used lightly, as it removes the specified law entirely.</i></b>")
 		lawTarget = copytext(adminscrub(answer), 1, MAX_MESSAGE_LEN)
 		tooltip_rebuild = 1
 		boutput(user, "\The [src] now reads, \"[get_law_text()]\".")


### PR DESCRIPTION
[FEATURE]

## About the PR

If you put "override" in a law, the voice in your head will say "Override is not to be used lightly, as it removes the specified law entirely."

Everything works like it already does. This doesn't make it harder to upload laws or anything. It's just there to try to nudge people into not accidentally roguing the AI and creating extra work for the admins every round.

## Why's this needed?

There have been a LOT of rounds where someone uploads a law stating that it overrides everything, which I ahelp because I'm suspicious, and every time it's happened so far CentCom has uploaded a new set of laws that omits that word.