### PR TITLE
Cleaner bottle rename

### DIFF
--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -42,7 +42,7 @@ WET FLOOR SIGN
 		. += "[bicon(src)] [src.reagents.total_volume] units of luminol left!"
 
 /obj/item/spraybottle/cleaner/
-	name = "cleaner bottle"
+	name = "cleaner spray bottle"
 	desc = "A spray bottle labeled 'Poo-b-Gone Space Cleaner'."
 
 	New()
@@ -50,8 +50,8 @@ WET FLOOR SIGN
 		reagents.add_reagent("cleaner", 100)
 
 /obj/item/spraybottle/cleaner/robot
-	name = "cybernetic cleaner bottle"
-	desc = "A cleaner bottle jury-rigged to synthesize space cleaner."
+	name = "cybernetic cleaner spray bottle"
+	desc = "A cleaner spray bottle jury-rigged to synthesize space cleaner."
 	icon_state = "cleaner_robot"
 
 	disposing()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Renames janitor's cleaner bottle to cleaner spray bottle and does the same with cyborg variant for consistency


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
In JaniTech vendor, there is a large cleaner refill bottle and cleaner spray bottle. Both have the same naming, which is kinda weird
This PR fixes it


