### PR TITLE
Rework PDA alert routing

### DIFF
--- a/_std/defines/jobs.dm
+++ b/_std/defines/jobs.dm
@@ -37,3 +37,5 @@
 #define MGA_SALES "salesalerts"
 #define MGA_SHIPPING "shippingalerts"
 #define MGA_CARGOREQUEST "cargorequestalerts"
+#define MGA_CRISIS "crisisalerts"
+#define MGA_RADIO "radioalerts"

--- a/_std/defines/jobs.dm
+++ b/_std/defines/jobs.dm
@@ -1,4 +1,6 @@
-//Mail Groups by Department
+// Mail Groups (by Department)
+// These have buttons to contact them in the messaging app on the PDA.
+// Apart from Party Line, they cannot be joined or left.
 #define MGD_PARTY "Party Line" //Is the clown the head of the Party department?
 #define MGD_COMMAND "command"
 #define MGD_SECURITY "security"
@@ -12,6 +14,7 @@
 #define MGD_SPIRITUALAFFAIRS "spiritualaffairs"
 
 // Mail Groups (Other)
+// These cannot be joined or left.
 #define MGO_STAFF "staff"
 #define MGO_AI "ai"
 #define MGO_SILICON "silicon"
@@ -19,3 +22,18 @@
 #define MGO_ENGINEER "engineer"
 #define MGO_MINING "mining"
 #define MGO_MECHANIC "mechanic"
+
+// Mail Groups (Alerts)
+// These cannot be joined, and no PDAs start in them.
+// However, they can be muted.
+#define MGA_MAIL "mailalerts"
+#define MGA_CHECKPOINT "checkpointalerts"
+#define MGA_ARREST "arrestalerts"
+#define MGA_DEATH "deathalerts"
+#define MGA_MEDCRIT "medcritalerts"
+#define MGA_CLONER "cloneralerts"
+#define MGA_ENGINE "enginealerts"
+#define MGA_RKIT "rkitalerts"
+#define MGA_SALES "salesalerts"
+#define MGA_SHIPPING "shippingalerts"
+#define MGA_CARGOREQUEST "cargorequestalerts"

--- a/_std/defines/jobs.dm
+++ b/_std/defines/jobs.dm
@@ -10,3 +10,12 @@
 #define MGD_BOTANY "botany"
 #define MGD_KITCHEN "kitchen"
 #define MGD_SPIRITUALAFFAIRS "spiritualaffairs"
+
+// Mail Groups (Other)
+#define MGO_STAFF "staff"
+#define MGO_AI "ai"
+#define MGO_SILICON "silicon"
+#define MGO_JANITOR "janitor"
+#define MGO_ENGINEER "engineer"
+#define MGO_MINING "mining"
+#define MGO_MECHANIC "mechanic"

--- a/code/WorkInProgress/Electronics.dm
+++ b/code/WorkInProgress/Electronics.dm
@@ -532,6 +532,7 @@
 				newsignal.data["message"] = "Notice: Item already in database."
 
 				newsignal.data["address_1"] = target
+				newsignal.data["group"] = list(MGO_MECHANIC, MGA_RKIT)
 				newsignal.data["sender"] = src.net_id
 
 				radio_connection.post_signal(src, newsignal)
@@ -548,6 +549,7 @@
 		newsignal.data["message"] = "Notice: Item entered into database."
 
 		newsignal.data["address_1"] = target
+		newsignal.data["group"] = list(MGO_MECHANIC, MGA_RKIT)
 		newsignal.data["sender"] = src.net_id
 
 		radio_connection.post_signal(src, newsignal)

--- a/code/WorkInProgress/recycling/disposal.dm
+++ b/code/WorkInProgress/recycling/disposal.dm
@@ -1736,6 +1736,7 @@
 	var/net_id = null
 	var/frequency = 1149
 	var/datum/radio_frequency/radio_connection
+	throw_speed = 1
 
 	ex_act(var/severity)
 		switch(severity)
@@ -1779,7 +1780,14 @@
 	// expel the contents of the holder object, then delete it
 	// called when the holder exits the outlet
 	proc/expel(var/obj/disposalholder/H)
-		if (message && mailgroup && radio_connection)
+		if (message && (mailgroup || mailgroup2) && radio_connection)
+			var/groups = list()
+			if (mailgroup)
+				groups += mailgroup
+			if (mailgroup2)
+				groups += mailgroup2
+			groups += MGA_MAIL
+
 			var/datum/signal/newsignal = get_free_signal()
 			newsignal.source = src
 			newsignal.transmission_method = TRANSMISSION_RADIO
@@ -1788,21 +1796,7 @@
 			newsignal.data["message"] = "[message]"
 
 			newsignal.data["address_1"] = "00000000"
-			newsignal.data["group"] = mailgroup
-			newsignal.data["sender"] = src.net_id
-
-			radio_connection.post_signal(src, newsignal)
-
-		if (message && mailgroup2 && radio_connection)
-			var/datum/signal/newsignal = get_free_signal()
-			newsignal.source = src
-			newsignal.transmission_method = TRANSMISSION_RADIO
-			newsignal.data["command"] = "text_message"
-			newsignal.data["sender_name"] = "CHUTE-MAILBOT"
-			newsignal.data["message"] = "[message]"
-
-			newsignal.data["address_1"] = "00000000"
-			newsignal.data["group"] = mailgroup2
+			newsignal.data["group"] = groups
 			newsignal.data["sender"] = src.net_id
 
 			radio_connection.post_signal(src, newsignal)
@@ -1817,7 +1811,7 @@
 		for(var/atom/movable/AM in H)
 			AM.set_loc(src.loc)
 			AM.pipe_eject(dir)
-			AM.throw_at(target, src.throw_range, 1)
+			AM.throw_at(target, src.throw_range, src.throw_speed)
 		H.vent_gas(src.loc)
 		pool(H)
 
@@ -1856,51 +1850,9 @@
 
 
 /obj/disposaloutlet/artifact
+	throw_range = 10
+	throw_speed = 10
 
-	expel(var/obj/disposalholder/H)
-		if (message && mailgroup && radio_connection)
-			var/datum/signal/newsignal = get_free_signal()
-			newsignal.source = src
-			newsignal.transmission_method = TRANSMISSION_RADIO
-			newsignal.data["command"] = "text_message"
-			newsignal.data["sender_name"] = "CHUTE-MAILBOT"
-			newsignal.data["message"] = "[message]"
-
-			newsignal.data["address_1"] = "00000000"
-			newsignal.data["group"] = mailgroup
-			newsignal.data["sender"] = src.net_id
-
-			radio_connection.post_signal(src, newsignal)
-
-		if (message && mailgroup2 && radio_connection)
-			var/datum/signal/newsignal = get_free_signal()
-			newsignal.source = src
-			newsignal.transmission_method = TRANSMISSION_RADIO
-			newsignal.data["command"] = "text_message"
-			newsignal.data["sender_name"] = "CHUTE-MAILBOT"
-			newsignal.data["message"] = "[message]"
-
-			newsignal.data["address_1"] = "00000000"
-			newsignal.data["group"] = mailgroup2
-			newsignal.data["sender"] = src.net_id
-
-			radio_connection.post_signal(src, newsignal)
-
-		flick("outlet-open", src)
-		playsound(src, "sound/machines/warning-buzzer.ogg", 50, 0, 0)
-
-		sleep(2 SECONDS)	//wait until correct animation frame
-		playsound(src, "sound/machines/hiss.ogg", 50, 0, 0)
-
-
-		for(var/atom/movable/AM in H)
-			AM.set_loc(src.loc)
-			AM.pipe_eject(dir)
-			AM.throw_at(target, 10, 10) //This is literally the only thing that was changed in this, otherwise it booted them way too close.
-		H.vent_gas(src.loc)
-		pool(H)
-
-		return
 // -------------------- VR --------------------
 /obj/disposaloutlet/virtual
 	name = "gauntlet outlet"

--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -583,7 +583,7 @@
 			newsignal.data["message"] = "[message]"
 
 			newsignal.data["address_1"] = "00000000"
-			newsignal.data["group"] = mailgroup
+			newsignal.data["group"] = list(mailgroup, MGA_MAIL)
 			newsignal.data["sender"] = src.net_id
 
 			radio_connection.post_signal(src, newsignal)

--- a/code/WorkInProgress/recycling/mail_chute.dm
+++ b/code/WorkInProgress/recycling/mail_chute.dm
@@ -245,17 +245,17 @@
 	engineering
 		name = "Engineering"
 		mail_tag = "engineering"
-		mailgroup = "engineer"
+		mailgroup = MGO_ENGINEER
 		message = 1
 	mechanics
 		name = "Mechanics"
 		mail_tag = "mechanics"
-		mailgroup = "mechanic"
+		mailgroup = MGO_MECHANIC
 		message = 1
 	mining
 		name = "Mining"
 		mail_tag = "mining"
-		mailgroup = "mining"
+		mailgroup = MGO_MINING
 		message = 1
 	qm
 		name = "QM"
@@ -520,7 +520,7 @@
 	engineering
 		name = "Engineering"
 		mail_tag = "engineering"
-		mailgroup = "engineer"
+		mailgroup = MGO_ENGINEER
 		message = 1
 
 		north
@@ -536,7 +536,7 @@
 	mechanics
 		name = "Mechanics"
 		mail_tag = "mechanics"
-		mailgroup = "mechanic"
+		mailgroup = MGO_MECHANIC
 		message = 1
 
 		north
@@ -552,7 +552,7 @@
 	mining
 		name = "Mining"
 		mail_tag = "mining"
-		mailgroup = "mining"
+		mailgroup = MGO_MINING
 		message = 1
 
 		north

--- a/code/WorkInProgress/recycling/mail_chute.dm
+++ b/code/WorkInProgress/recycling/mail_chute.dm
@@ -137,8 +137,14 @@
 			var/myarea = get_area(src)
 			message = "Mail delivery alert in [myarea]."
 
+			if (message && (mailgroup || mailgroup2) && pda_connection)
+				var/groups = list()
+				if (mailgroup)
+					groups += mailgroup
+				if (mailgroup2)
+					groups += mailgroup2
+				groups += MGA_MAIL
 
-			if (message && mailgroup && pda_connection)
 				var/datum/signal/newsignal = get_free_signal()
 				newsignal.source = src
 				newsignal.transmission_method = TRANSMISSION_RADIO
@@ -147,21 +153,7 @@
 				newsignal.data["message"] = "[message]"
 
 				newsignal.data["address_1"] = "00000000"
-				newsignal.data["group"] = mailgroup
-				newsignal.data["sender"] = src.net_id
-
-				pda_connection.post_signal(src, newsignal)
-
-			if (message && mailgroup2 && pda_connection)
-				var/datum/signal/newsignal = get_free_signal()
-				newsignal.source = src
-				newsignal.transmission_method = TRANSMISSION_RADIO
-				newsignal.data["command"] = "text_message"
-				newsignal.data["sender_name"] = "CHUTE-MAILBOT"
-				newsignal.data["message"] = "[message]"
-
-				newsignal.data["address_1"] = "00000000"
-				newsignal.data["group"] = mailgroup2
+				newsignal.data["group"] = groups
 				newsignal.data["sender"] = src.net_id
 
 				pda_connection.post_signal(src, newsignal)

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -2380,7 +2380,7 @@
 			else	//Someone passed us an unkown modifier
 				message = "UNKNOWN ERROR: [src] in [myarea]"
 
-		if (message && mailgroup && radio_connection)
+		if (message && radio_connection)
 			var/datum/signal/newsignal = get_free_signal()
 			newsignal.source = src
 			newsignal.transmission_method = TRANSMISSION_RADIO

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -2365,7 +2365,6 @@
 
 	proc/borg_death_alert(modifier = ROBOT_DEATH_MOD_NONE)
 		var/message = null
-		var/mailgroup = MGD_MEDRESEACH
 		var/net_id = generate_net_id(src)
 		var/frequency = 1149
 		var/datum/radio_frequency/radio_connection = radio_controller.add_object(src, "[frequency]")
@@ -2389,7 +2388,7 @@
 			newsignal.data["sender_name"] = "CYBORG-DAEMON"
 			newsignal.data["message"] = message
 			newsignal.data["address_1"] = "00000000"
-			newsignal.data["group"] = mailgroup
+			newsignal.data["group"] = list(MGD_MEDRESEACH, MGO_SILICON, MGA_DEATH)
 			newsignal.data["sender"] = net_id
 
 			radio_connection.post_signal(src, newsignal)

--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -174,10 +174,10 @@
 		if(scan && account)
 			wagesystem.shipping_budget += duckets / 2
 			account.fields["current_money"] += duckets / 2
-			pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="CARGO-MAILBOT",  "group"=MGD_CARGO, "sender"="00000000", "message"="Notification: [duckets] credits earned from last outgoing shipment. Splitting half of profits with [scan.registered].")
+			pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="CARGO-MAILBOT",  "group"=list(MGD_CARGO, MGA_SALES), "sender"="00000000", "message"="Notification: [duckets] credits earned from last outgoing shipment. Splitting half of profits with [scan.registered].")
 		else
 			wagesystem.shipping_budget += duckets
-			pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="CARGO-MAILBOT",  "group"=MGD_CARGO, "sender"="00000000", "message"="Notification: [duckets] credits earned from last outgoing shipment.")
+			pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="CARGO-MAILBOT",  "group"=list(MGD_CARGO, MGA_SALES), "sender"="00000000", "message"="Notification: [duckets] credits earned from last outgoing shipment.")
 
 		pdaSignal.transmission_method = TRANSMISSION_RADIO
 		if(transmit_connection != null)
@@ -207,7 +207,7 @@
 
 		var/datum/radio_frequency/transmit_connection = radio_controller.return_frequency("1149")
 		var/datum/signal/pdaSignal = get_free_signal()
-		pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="CARGO-MAILBOT",  "group"=MGD_CARGO, "sender"="00000000", "message"="Shipment arriving to Cargo Bay: [S.name].")
+		pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="CARGO-MAILBOT", "group"=list(MGD_CARGO, MGA_SHIPPING), "sender"="00000000", "message"="Shipment arriving to Cargo Bay: [S.name].")
 		pdaSignal.transmission_method = TRANSMISSION_RADIO
 		transmit_connection.post_signal(null, pdaSignal)
 

--- a/code/modules/economy/traders/trader.dm
+++ b/code/modules/economy/traders/trader.dm
@@ -163,7 +163,7 @@
 		src.currently_selling = 0 //At this point the shopping cart has been processed
 		var/datum/radio_frequency/transmit_connection = radio_controller.return_frequency("1149")
 		var/datum/signal/pdaSignal = get_free_signal()
-		pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="CARGO-MAILBOT",  "group"=MGD_CARGO, "sender"="00000000", "message"="Deal with \"[src.name]\" concluded. Total Cost: [total_price] credits")
+		pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="CARGO-MAILBOT", "group"=list(MGD_CARGO, MGA_SALES), "sender"="00000000", "message"="Deal with \"[src.name]\" concluded. Total Cost: [total_price] credits")
 		pdaSignal.transmission_method = TRANSMISSION_RADIO
 		transmit_connection.post_signal(null, pdaSignal)
 		shippingmarket.receive_crate(S)

--- a/code/modules/medical/genetics/geneticsBooth.dm
+++ b/code/modules/medical/genetics/geneticsBooth.dm
@@ -286,7 +286,7 @@
 		if (split_with)
 			string += "Splitting half of profits with [split_with]."
 
-		pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="GENEBOOTH-MAILBOT",  "group"=MGD_MEDRESEACH, "sender"="00000000", "message"=string)
+		pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="GENEBOOTH-MAILBOT", "group"=list(MGD_MEDRESEACH, MGA_SALES), "sender"="00000000", "message"=string)
 		pdaSignal.transmission_method = TRANSMISSION_RADIO
 		if(transmit_connection != null)
 			transmit_connection.post_signal(src, pdaSignal)
@@ -299,7 +299,7 @@
 
 		var/string = "Notification: [GBP.name] has sold out!"
 
-		pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="GENEBOOTH-MAILBOT",  "group"=MGD_MEDRESEACH, "sender"="00000000", "message"=string)
+		pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="GENEBOOTH-MAILBOT", "group"=list(MGD_MEDRESEACH, MGA_SALES), "sender"="00000000", "message"=string)
 		pdaSignal.transmission_method = TRANSMISSION_RADIO
 		if(transmit_connection != null)
 			transmit_connection.post_signal(src, pdaSignal)

--- a/code/modules/networks/computer3/engine.dm
+++ b/code/modules/networks/computer3/engine.dm
@@ -18,7 +18,7 @@
 	var/setup_acc_filepath = "/logs/sysusr"//Where do we look for login data?
 	var/setup_logdump_name = "englog"
 	var/setup_mail_freq = 1149 //Which freq do we report to?
-	var/setup_mailgroup = "engineer" //The PDA mailgroup used when alerting engineer pdas.
+	var/setup_mailgroup = MGO_ENGINEER //The PDA mailgroup used when alerting engineer pdas.
 
 
 	initialize()

--- a/code/modules/networks/computer3/engine.dm
+++ b/code/modules/networks/computer3/engine.dm
@@ -268,7 +268,7 @@
 			signal.data["address_1"] = "00000000"
 			signal.data["command"] = "text_message"
 			signal.data["sender_name"] = "ENGINE-MAILBOT"
-			signal.data["group"] = src.setup_mailgroup //Only engineer PDAs should be informed.
+			signal.data["group"] = list(src.setup_mailgroup, MGA_ENGINE) //Only engineer PDAs should be informed.
 			signal.data["message"] = "Notice: [event_string]"
 
 			src.log_string += "<br>Event notification sent."

--- a/code/modules/networks/computer3/sec_rec.dm
+++ b/code/modules/networks/computer3/sec_rec.dm
@@ -740,7 +740,7 @@
 			//Create a PDA mass-message string.
 			signal.data["command"] = "text_message"
 			signal.data["sender_name"] = "SEC-MAILBOT"
-			signal.data["group"] = src.setup_mailgroup //Only security PDAs should be informed.
+			signal.data["group"] = list(src.setup_mailgroup, MGA_ARREST) //Only security PDAs should be informed.
 			signal.data["message"] = "Alert! Crewman \"[perp_name]\" has been flagged for arrest by [src.authenticated]!"
 
 			src.log_string += "<br>Arrest notification sent."

--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -972,7 +972,7 @@ Report Arrests: <A href='?src=\ref[src];operation=report'>[report_arrests ? "On"
 				message2send = "Notification: Tactical law intervention agent [src] codename [src.badge_number] status KIA in [bot_location]!"
 			else
 				message2send = "Notification: [src] destroyed in [bot_location]! Officer down!"
-			pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="SECURITY-MAILBOT",  "group"=MGD_SECURITY, "sender"="00000000", "message"="[message2send]")
+			pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="SECURITY-MAILBOT", "group"=list(MGD_SECURITY, MGA_DEATH), "sender"="00000000", "message"="[message2send]")
 			pdaSignal.transmission_method = TRANSMISSION_RADIO
 			if(transmit_connection != null)
 				transmit_connection.post_signal(src, pdaSignal)
@@ -1177,8 +1177,7 @@ Report Arrests: <A href='?src=\ref[src];operation=report'>[report_arrests ? "On"
 					master.speak(message2send)
 				else
 					message2send ="Notification: [last_target] detained by [master] in [bot_location] at coordinates [LT_loc.x], [LT_loc.y]."
-				pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="SECURITY-MAILBOT",  "group"=MGD_SECURITY, "sender"="00000000",\
-				"message"="[message2send]")
+				pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="SECURITY-MAILBOT", "group"=list(MGD_SECURITY, MGA_ARREST), "sender"="00000000", "message"="[message2send]")
 				pdaSignal.transmission_method = TRANSMISSION_RADIO
 				if(transmit_connection != null)
 					transmit_connection.post_signal(master, pdaSignal)

--- a/code/modules/telescience/radiostation.dm
+++ b/code/modules/telescience/radiostation.dm
@@ -215,7 +215,7 @@
 			/// PDA message ///
 			var/datum/radio_frequency/transmit_connection = radio_controller.return_frequency("1149")
 			var/datum/signal/pdaSignal = get_free_signal()
-			pdaSignal.data = list("command"="text_message", "sender_name"="RADIO-STATION", "sender"="00000000", "message"="Now playing: [R].")
+			pdaSignal.data = list("command"="text_message", "sender_name"="RADIO-STATION", "sender"="00000000", "message"="Now playing: [R].", "group" = list(MGD_PARTY, MGA_RADIO))
 			pdaSignal.transmission_method = TRANSMISSION_RADIO
 			if(transmit_connection != null)
 				transmit_connection.post_signal(src, pdaSignal)
@@ -606,7 +606,7 @@ ABSTRACT_TYPE(/obj/item/record/random/chronoquest)
 			/// PDA message ///
 			var/datum/radio_frequency/transmit_connection = radio_controller.return_frequency("1149")
 			var/datum/signal/pdaSignal = get_free_signal()
-			pdaSignal.data = list("command"="text_message", "sender_name"="RADIO-STATION", "sender"="00000000", "message"="Now playing: [src.tape_inside.audio_type] for [src.tape_inside.name_of_thing].")
+			pdaSignal.data = list("command"="text_message", "sender_name"="RADIO-STATION", "sender"="00000000", "message"="Now playing: [src.tape_inside.audio_type] for [src.tape_inside.name_of_thing].", "group" = list(MGD_PARTY, MGA_RADIO))
 			pdaSignal.transmission_method = TRANSMISSION_RADIO
 			if(transmit_connection != null)
 				transmit_connection.post_signal(src, pdaSignal)

--- a/code/obj/health_scanner.dm
+++ b/code/obj/health_scanner.dm
@@ -115,7 +115,7 @@
 	proc/crit_alert(var/mob/living/carbon/human/H)
 		var/datum/radio_frequency/transmit_connection = radio_controller.return_frequency("1149")
 		var/datum/signal/new_signal = get_free_signal()
-		new_signal.data = list("command"="text_message", "sender_name"="HEALTH-MAILBOT", "sender"="00000000", "address_1"="00000000", "group"=MGD_MEDBAY, "message"="CRIT ALERT: [H] in [get_area(src)].")
+		new_signal.data = list("command"="text_message", "sender_name"="HEALTH-MAILBOT", "sender"="00000000", "address_1"="00000000", "group"=list(MGD_MEDBAY, MGA_MEDCRIT), "message"="CRIT ALERT: [H] in [get_area(src)].")
 		new_signal.transmission_method = TRANSMISSION_RADIO
 		if(transmit_connection)
 			transmit_connection.post_signal(src, new_signal)

--- a/code/obj/item/ai_modules.dm
+++ b/code/obj/item/ai_modules.dm
@@ -251,6 +251,7 @@ AI MODULES
 		sender.unlock_medal("Format Complete", 1)
 		ticker.centralized_ai_laws.set_zeroth_law("")
 		ticker.centralized_ai_laws.clear_supplied_laws()
+		page_departments -= "Silicon"
 		for (var/mob/living/silicon/S in mobs)
 			if (isghostdrone(S))
 				return
@@ -363,6 +364,10 @@ AI MODULES
 		input_law_info(user, "Designate as Human", "Which silicons would you like to make Human?")
 		return
 
+	transmitInstructions(mob/sender)
+		. = ..()
+		page_departments["Silicon"] = MGO_SILICON
+
 /obj/item/aiModule/experimental/equality/b
 	name = "Experimental 'Equality' AI Module"
 
@@ -372,6 +377,10 @@ AI MODULES
 	attack_self(var/mob/user)
 		input_law_info(user, "Designate as Human", "Which silicons would you like to make Human?")
 		return
+
+	transmitInstructions(mob/sender)
+		. = ..()
+		page_departments["Silicon"] = MGO_SILICON
 
 
 

--- a/code/obj/item/device/pda2/base_os.dm
+++ b/code/obj/item/device/pda2/base_os.dm
@@ -215,6 +215,11 @@
 								 (<a href='byond://?src=\ref[src];message_func=mute_group;groupname=[mailgroup]'>*[(mailgroup in src.master.muted_mailgroups) ? "Unmute" : "Mute"]*</a>)<br>"}
 
 						. += myReservedGroups
+
+						for (var/mailgroup in src.master.alertgroups)
+							. += {"[mailgroup]
+							 (<a href='byond://?src=\ref[src];message_func=mute_group;groupname=[mailgroup]'>*[(mailgroup in src.master.muted_mailgroups) ? "Unmute" : "Mute"]*</a>)<br>"}
+
 						. += myCustomGroups
 
 				if(3)
@@ -683,8 +688,12 @@
 						return
 
 					var/groupAddress = signal.data["group"]
-					if(groupAddress) //Check to see if we have this ~mailgroup~
-						if((!(groupAddress in src.master.mailgroups) && !(MGO_AI in src.master.mailgroups)) || (groupAddress in src.master.muted_mailgroups))
+					if(groupAddress) // Check to see if we have muted this group. The network card already checked if we are a member.
+						if (islist(groupAddress))
+							for (var/group in groupAddress)
+								if (group in src.master.muted_mailgroups)
+									return
+						else if (groupAddress in src.master.muted_mailgroups)
 							return
 
 					var/sender = signal.data["sender_name"]
@@ -707,7 +716,10 @@
 
 					var/senderstring = "From <a href='byond://?src=\ref[src];input=message;target=[signal.data["sender"]]'>[messageFrom]</a>"
 					if (groupAddress)
-						senderstring += " to <a href='byond://?src=\ref[src];input=message;target=[groupAddress];department=1'>[groupAddress]</a>"
+						if (islist(groupAddress))
+							senderstring += " to [jointext(groupAddress,",")]"
+						else
+							senderstring += " to <a href='byond://?src=\ref[src];input=message;target=[groupAddress];department=1'>[groupAddress]</a>"
 
 					src.message_note += "<i><b>&larr; [senderstring]:</b></i><br>[signal.data["message"]]<br>"
 					var/alert_beep = null //Don't beep if set to silent.
@@ -724,7 +736,10 @@
 					src.master.display_alert(alert_beep)
 					var/displayMessage = "<i><b>[bicon(master)] <a href='byond://?src=\ref[src];input=message;norefresh=1;target=[signal.data["sender"]]'>[messageFrom]</a>"
 					if (groupAddress)
-						displayMessage += " to <a href='byond://?src=\ref[src];input=message;target=[groupAddress];department=1;norefresh=1'>[groupAddress]</a>"
+						if (islist(groupAddress))
+							displayMessage += " to [jointext(groupAddress,",")]"
+						else
+							displayMessage += " to <a href='byond://?src=\ref[src];input=message;target=[groupAddress];department=1'>[groupAddress]</a>"
 					displayMessage += ":</b></i> [signal.data["message"]]"
 					src.master.display_message(displayMessage)
 

--- a/code/obj/item/device/pda2/base_os.dm
+++ b/code/obj/item/device/pda2/base_os.dm
@@ -684,7 +684,7 @@
 
 					var/groupAddress = signal.data["group"]
 					if(groupAddress) //Check to see if we have this ~mailgroup~
-						if((!(groupAddress in src.master.mailgroups) && !("ai" in src.master.mailgroups)) || (groupAddress in src.master.muted_mailgroups))
+						if((!(groupAddress in src.master.mailgroups) && !(MGO_AI in src.master.mailgroups)) || (groupAddress in src.master.muted_mailgroups))
 							return
 
 					var/sender = signal.data["sender_name"]

--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -50,9 +50,9 @@
 	var/setup_system_os_path = /datum/computer/file/pda_program/os/main_os //Needs an operating system to...operate!!
 	var/setup_scanner_on = 1 //Do we search the cart for a scanprog to start loaded?
 	var/setup_default_module = /obj/item/device/pda_module/flashlight //Module to have installed on spawn.
-	var/mailgroups = list("staff",MGD_PARTY) //What default mail groups the PDA is part of.
+	var/mailgroups = list(MGO_STAFF,MGD_PARTY) //What default mail groups the PDA is part of.
 	var/muted_mailgroups = list() //What mail groups should the PDA ignore?
-	var/reserved_mailgroups = list(MGD_COMMAND,MGD_SECURITY,MGD_SCIENCE,"ai","sillicon",MGD_MEDRESEACH,MGD_MEDBAY ,MGD_CARGO,"janitor",MGD_SPIRITUALAFFAIRS,"engineer","mining",MGD_KITCHEN,"mechanic",MGD_BOTANY,MGD_STATIONREPAIR) //Job-specific mailgroups that cannot be joined or left
+	var/reserved_mailgroups = list(MGD_COMMAND,MGD_SECURITY,MGD_SCIENCE,MGO_AI,MGO_SILICON,MGD_MEDRESEACH,MGD_MEDBAY ,MGD_CARGO,MGO_JANITOR,MGD_SPIRITUALAFFAIRS,MGO_ENGINEER,MGO_MINING,MGD_KITCHEN,MGO_MECHANIC,MGD_BOTANY,MGD_STATIONREPAIR) //Job-specific mailgroups that cannot be joined or left
 	var/bombproof = 0 // can't be destroyed with detomatix
 	var/exploding = 0
 
@@ -94,7 +94,7 @@
 		ejectable_cartridge = 0
 		setup_drive_size = 1024
 		bombproof = 1
-		mailgroups = list("ai") //"special" mailgroup, just recieves everything
+		mailgroups = list(MGO_AI) //"special" mailgroup, just recieves everything
 
 	cyborg
 		icon_state = "pda-h"
@@ -102,7 +102,7 @@
 		ejectable_cartridge = 0
 		setup_drive_size = 1024
 		bombproof = 1
-		mailgroups = list("silicon",MGD_PARTY)
+		mailgroups = list(MGO_SILICON,MGD_PARTY)
 
 	research_director
 		icon_state = "pda-rd"
@@ -169,7 +169,7 @@
 	janitor
 		icon_state = "pda-j"
 		setup_default_cartridge = /obj/item/disk/data/cartridge/janitor
-		mailgroups = list("janitor",MGD_STATIONREPAIR,MGD_PARTY)
+		mailgroups = list(MGO_JANITOR,MGD_STATIONREPAIR,MGD_PARTY)
 
 	chaplain
 		icon_state = "pda-holy"
@@ -182,11 +182,11 @@
 	engine
 		icon_state = "pda-e"
 		setup_default_cartridge = /obj/item/disk/data/cartridge/engineer
-		mailgroups = list("engineer",MGD_STATIONREPAIR,MGD_PARTY)
+		mailgroups = list(MGO_ENGINEER,MGD_STATIONREPAIR,MGD_PARTY)
 
 	mining
 		icon_state = "pda-e"
-		mailgroups = list("mining",MGD_PARTY)
+		mailgroups = list(MGO_MINING,MGD_PARTY)
 
 	chef
 		mailgroups = list(MGD_KITCHEN,MGD_PARTY)
@@ -198,7 +198,7 @@
 		icon_state = "pda-a"
 		setup_default_module = /obj/item/device/pda_module/tray
 		setup_default_cartridge = /obj/item/disk/data/cartridge/mechanic
-		mailgroups = list("mechanic",MGD_STATIONREPAIR,MGD_PARTY)
+		mailgroups = list(MGO_MECHANIC,MGD_STATIONREPAIR,MGD_PARTY)
 
 	botanist
 		icon_state = "pda-hydro"
@@ -549,7 +549,7 @@
 			return
 
 		else if(!src.mailgroups || !(signal.data["group"] in src.mailgroups))
-			if (!("ai" in src.mailgroups) || !signal.data["group"])
+			if (!(MGO_AI in src.mailgroups) || !signal.data["group"])
 				return
 
 	src.host_program?.receive_signal(signal, rx_method, rx_freq)

--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -52,7 +52,15 @@
 	var/setup_default_module = /obj/item/device/pda_module/flashlight //Module to have installed on spawn.
 	var/mailgroups = list(MGO_STAFF,MGD_PARTY) //What default mail groups the PDA is part of.
 	var/muted_mailgroups = list() //What mail groups should the PDA ignore?
-	var/reserved_mailgroups = list(MGD_COMMAND,MGD_SECURITY,MGD_SCIENCE,MGO_AI,MGO_SILICON,MGD_MEDRESEACH,MGD_MEDBAY ,MGD_CARGO,MGO_JANITOR,MGD_SPIRITUALAFFAIRS,MGO_ENGINEER,MGO_MINING,MGD_KITCHEN,MGO_MECHANIC,MGD_BOTANY,MGD_STATIONREPAIR) //Job-specific mailgroups that cannot be joined or left
+	var/reserved_mailgroups = list( // Job-specific mailgroups that cannot be joined or left
+		// Departments
+		MGD_COMMAND, MGD_SECURITY, MGD_MEDBAY, MGD_MEDRESEACH, MGD_SCIENCE, MGD_CARGO, MGD_STATIONREPAIR, MGD_BOTANY, MGD_KITCHEN, MGD_SPIRITUALAFFAIRS,
+		// Other
+		MGO_STAFF, MGO_AI, MGO_SILICON, MGO_JANITOR, MGO_ENGINEER, MGO_MINING, MGO_MECHANIC,
+		// Alerts
+		MGA_MAIL, MGA_CHECKPOINT, MGA_ARREST, MGA_DEATH, MGA_MEDCRIT, MGA_CLONER, MGA_ENGINE, MGA_RKIT, MGA_SALES, MGA_SHIPPING, MGA_CARGOREQUEST,
+	)
+	var/alertgroups = list(MGA_MAIL) // What mail groups that we're not a member of should we be able to mute?
 	var/bombproof = 0 // can't be destroyed with detomatix
 	var/exploding = 0
 
@@ -81,12 +89,14 @@
 		setup_default_cartridge = /obj/item/disk/data/cartridge/hos
 		setup_drive_size = 32
 		mailgroups = list(MGD_SECURITY,MGD_COMMAND,MGD_PARTY)
+		alertgroups = list(MGA_MAIL, MGA_CHECKPOINT, MGA_ARREST, MGA_DEATH, MGA_MEDCRIT)
 
 	ntso
 		icon_state = "pda-nt"
 		setup_default_cartridge = /obj/item/disk/data/cartridge/hos //hos cart gives access to manifest compared to regular sec cart, useful for NTSO
 		setup_drive_size = 32
 		mailgroups = list(MGD_SECURITY,MGD_COMMAND,MGD_PARTY)
+		alertgroups = list(MGA_MAIL, MGA_CHECKPOINT, MGA_ARREST, MGA_DEATH, MGA_MEDCRIT)
 
 	ai
 		icon_state = "pda-h"
@@ -94,7 +104,15 @@
 		ejectable_cartridge = 0
 		setup_drive_size = 1024
 		bombproof = 1
-		mailgroups = list(MGO_AI) //"special" mailgroup, just recieves everything
+		mailgroups = list( // keep in sync with the list of reserved mail groups
+			// Departments
+			MGD_COMMAND, MGD_SECURITY, MGD_MEDBAY, MGD_MEDRESEACH, MGD_SCIENCE, MGD_CARGO, MGD_STATIONREPAIR, MGD_BOTANY, MGD_KITCHEN, MGD_SPIRITUALAFFAIRS,
+			// Other
+			MGO_STAFF, MGO_AI, MGO_SILICON, MGO_JANITOR, MGO_ENGINEER, MGO_MINING, MGO_MECHANIC,
+			// start in party line by default
+			MGD_PARTY,
+		)
+		alertgroups = list(MGA_MAIL, MGA_CHECKPOINT, MGA_ARREST, MGA_DEATH, MGA_MEDCRIT, MGA_CLONER, MGA_ENGINE, MGA_RKIT, MGA_SALES, MGA_SHIPPING, MGA_CARGOREQUEST) // keep in sync with the list of mail alert groups
 
 	cyborg
 		icon_state = "pda-h"
@@ -114,30 +132,38 @@
 		icon_state = "pda-md"
 		setup_default_cartridge = /obj/item/disk/data/cartridge/medical_director
 		setup_drive_size = 32
-		mailgroups = list(MGD_MEDRESEACH,MGD_MEDBAY ,MGD_COMMAND,MGD_PARTY)
+		mailgroups = list(MGD_MEDRESEACH,MGD_MEDBAY,MGD_COMMAND,MGD_PARTY)
+		alertgroups = list(MGA_MAIL, MGA_DEATH, MGA_MEDCRIT, MGA_CLONER)
 
 	medical
 		icon_state = "pda-m"
 		setup_default_cartridge = /obj/item/disk/data/cartridge/medical
 		mailgroups = list(MGD_MEDBAY ,MGD_PARTY)
+		alertgroups = list(MGA_MAIL, MGA_DEATH, MGA_MEDCRIT, MGA_CLONER)
 
 		robotics
 			mailgroups = list(MGD_MEDRESEACH,MGD_PARTY)
+			alertgroups = list(MGA_MAIL, MGA_DEATH, MGA_MEDCRIT, MGA_CLONER, MGA_SALES)
+			muted_mailgroups = list(MGA_SALES)
 
 	genetics
 		icon_state = "pda-gen"
 		setup_default_cartridge = /obj/item/disk/data/cartridge/genetics
-		mailgroups = list(MGD_MEDRESEACH,MGD_PARTY)
+		mailgroups = list(MGD_MEDBAY,MGD_MEDRESEACH,MGD_PARTY)
+		alertgroups = list(MGA_MAIL, MGA_SALES)
+		muted_mailgroups = list(MGD_MEDBAY)
 
 	security
 		icon_state = "pda-s"
 		setup_default_cartridge = /obj/item/disk/data/cartridge/security
 		mailgroups = list(MGD_SECURITY,MGD_PARTY)
+		alertgroups = list(MGA_MAIL, MGA_CHECKPOINT, MGA_ARREST, MGA_DEATH, MGA_MEDCRIT)
 
 	forensic
 		icon_state = "pda-s"
 		setup_default_cartridge = /obj/item/disk/data/cartridge/forensic
 		mailgroups = list(MGD_SECURITY,MGD_PARTY)
+		alertgroups = list(MGA_MAIL, MGA_CHECKPOINT, MGA_ARREST, MGA_DEATH, MGA_MEDCRIT)
 
 	toxins
 		icon_state = "pda-tox"
@@ -148,6 +174,7 @@
 		icon_state = "pda-q"
 		setup_default_cartridge = /obj/item/disk/data/cartridge/quartermaster
 		mailgroups = list(MGD_CARGO,MGD_PARTY)
+		alertgroups = list(MGA_MAIL, MGA_SALES, MGA_SHIPPING, MGA_CARGOREQUEST)
 
 	clown
 		icon_state = "pda-clown"
@@ -174,6 +201,7 @@
 	chaplain
 		icon_state = "pda-holy"
 		mailgroups = list(MGD_SPIRITUALAFFAIRS,MGD_PARTY)
+		alertgroups = list(MGA_MAIL, MGA_DEATH, MGA_MEDCRIT)
 
 	atmos
 		icon_state = "pda-a"
@@ -183,10 +211,12 @@
 		icon_state = "pda-e"
 		setup_default_cartridge = /obj/item/disk/data/cartridge/engineer
 		mailgroups = list(MGO_ENGINEER,MGD_STATIONREPAIR,MGD_PARTY)
+		alertgroups = list(MGA_MAIL, MGA_ENGINE)
 
 	mining
 		icon_state = "pda-e"
 		mailgroups = list(MGO_MINING,MGD_PARTY)
+		alertgroups = list(MGA_MAIL, MGA_SALES)
 
 	chef
 		mailgroups = list(MGD_KITCHEN,MGD_PARTY)
@@ -199,6 +229,7 @@
 		setup_default_module = /obj/item/device/pda_module/tray
 		setup_default_cartridge = /obj/item/disk/data/cartridge/mechanic
 		mailgroups = list(MGO_MECHANIC,MGD_STATIONREPAIR,MGD_PARTY)
+		alertgroups = list(MGA_MAIL, MGA_RKIT)
 
 	botanist
 		icon_state = "pda-hydro"
@@ -548,8 +579,19 @@
 
 			return
 
-		else if(!src.mailgroups || !(signal.data["group"] in src.mailgroups))
-			if (!(MGO_AI in src.mailgroups) || !signal.data["group"])
+		else if (!signal.data["group"]) // only accept broadcast signals if they are filtered
+			return
+
+		if (islist(signal.data["group"]))
+			var/any_member = FALSE
+			for (var/group in signal.data["group"])
+				if (group in src.mailgroups)
+					any_member = TRUE
+					break
+			if (!any_member) // not a member of any specified group; discard
+				return
+		else if (signal.data["group"])
+			if (!(signal.data["group"] in src.mailgroups)) // not a member of the specified group; discard
 				return
 
 	src.host_program?.receive_signal(signal, rx_method, rx_freq)

--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -58,9 +58,9 @@
 		// Other
 		MGO_STAFF, MGO_AI, MGO_SILICON, MGO_JANITOR, MGO_ENGINEER, MGO_MINING, MGO_MECHANIC,
 		// Alerts
-		MGA_MAIL, MGA_CHECKPOINT, MGA_ARREST, MGA_DEATH, MGA_MEDCRIT, MGA_CLONER, MGA_ENGINE, MGA_RKIT, MGA_SALES, MGA_SHIPPING, MGA_CARGOREQUEST,
+		MGA_MAIL, MGA_RADIO, MGA_CHECKPOINT, MGA_ARREST, MGA_DEATH, MGA_MEDCRIT, MGA_CLONER, MGA_ENGINE, MGA_RKIT, MGA_SALES, MGA_SHIPPING, MGA_CARGOREQUEST, MGA_CRISIS,
 	)
-	var/alertgroups = list(MGA_MAIL) // What mail groups that we're not a member of should we be able to mute?
+	var/alertgroups = list(MGA_MAIL, MGA_RADIO) // What mail groups that we're not a member of should we be able to mute?
 	var/bombproof = 0 // can't be destroyed with detomatix
 	var/exploding = 0
 
@@ -89,14 +89,14 @@
 		setup_default_cartridge = /obj/item/disk/data/cartridge/hos
 		setup_drive_size = 32
 		mailgroups = list(MGD_SECURITY,MGD_COMMAND,MGD_PARTY)
-		alertgroups = list(MGA_MAIL, MGA_CHECKPOINT, MGA_ARREST, MGA_DEATH, MGA_MEDCRIT)
+		alertgroups = list(MGA_MAIL, MGA_RADIO, MGA_CHECKPOINT, MGA_ARREST, MGA_DEATH, MGA_MEDCRIT, MGA_CRISIS)
 
 	ntso
 		icon_state = "pda-nt"
 		setup_default_cartridge = /obj/item/disk/data/cartridge/hos //hos cart gives access to manifest compared to regular sec cart, useful for NTSO
 		setup_drive_size = 32
 		mailgroups = list(MGD_SECURITY,MGD_COMMAND,MGD_PARTY)
-		alertgroups = list(MGA_MAIL, MGA_CHECKPOINT, MGA_ARREST, MGA_DEATH, MGA_MEDCRIT)
+		alertgroups = list(MGA_MAIL, MGA_RADIO, MGA_CHECKPOINT, MGA_ARREST, MGA_DEATH, MGA_MEDCRIT, MGA_CRISIS)
 
 	ai
 		icon_state = "pda-h"
@@ -113,7 +113,7 @@
 			MGD_PARTY,
 		)
 		muted_mailgroups = list(MGA_MAIL, MGA_SALES, MGA_SHIPPING, MGA_CARGOREQUEST)
-		alertgroups = list(MGA_MAIL, MGA_CHECKPOINT, MGA_ARREST, MGA_DEATH, MGA_MEDCRIT, MGA_CLONER, MGA_ENGINE, MGA_RKIT, MGA_SALES, MGA_SHIPPING, MGA_CARGOREQUEST) // keep in sync with the list of mail alert groups
+		alertgroups = list(MGA_MAIL, MGA_RADIO, MGA_CHECKPOINT, MGA_ARREST, MGA_DEATH, MGA_MEDCRIT, MGA_CLONER, MGA_ENGINE, MGA_RKIT, MGA_SALES, MGA_SHIPPING, MGA_CARGOREQUEST, MGA_CRISIS) // keep in sync with the list of mail alert groups
 
 	cyborg
 		icon_state = "pda-h"
@@ -134,37 +134,37 @@
 		setup_default_cartridge = /obj/item/disk/data/cartridge/medical_director
 		setup_drive_size = 32
 		mailgroups = list(MGD_MEDRESEACH,MGD_MEDBAY,MGD_COMMAND,MGD_PARTY)
-		alertgroups = list(MGA_MAIL, MGA_DEATH, MGA_MEDCRIT, MGA_CLONER)
+		alertgroups = list(MGA_MAIL, MGA_RADIO, MGA_DEATH, MGA_MEDCRIT, MGA_CLONER, MGA_CRISIS)
 
 	medical
 		icon_state = "pda-m"
 		setup_default_cartridge = /obj/item/disk/data/cartridge/medical
 		mailgroups = list(MGD_MEDBAY ,MGD_PARTY)
-		alertgroups = list(MGA_MAIL, MGA_DEATH, MGA_MEDCRIT, MGA_CLONER)
+		alertgroups = list(MGA_MAIL, MGA_RADIO, MGA_DEATH, MGA_MEDCRIT, MGA_CLONER, MGA_CRISIS)
 
 		robotics
 			mailgroups = list(MGD_MEDRESEACH,MGD_PARTY)
-			alertgroups = list(MGA_MAIL, MGA_DEATH, MGA_MEDCRIT, MGA_CLONER, MGA_SALES)
+			alertgroups = list(MGA_MAIL, MGA_RADIO, MGA_DEATH, MGA_MEDCRIT, MGA_CLONER, MGA_CRISIS, MGA_SALES)
 			muted_mailgroups = list(MGA_SALES)
 
 	genetics
 		icon_state = "pda-gen"
 		setup_default_cartridge = /obj/item/disk/data/cartridge/genetics
 		mailgroups = list(MGD_MEDBAY,MGD_MEDRESEACH,MGD_PARTY)
-		alertgroups = list(MGA_MAIL, MGA_SALES)
+		alertgroups = list(MGA_MAIL, MGA_RADIO, MGA_SALES)
 		muted_mailgroups = list(MGD_MEDBAY)
 
 	security
 		icon_state = "pda-s"
 		setup_default_cartridge = /obj/item/disk/data/cartridge/security
 		mailgroups = list(MGD_SECURITY,MGD_PARTY)
-		alertgroups = list(MGA_MAIL, MGA_CHECKPOINT, MGA_ARREST, MGA_DEATH, MGA_MEDCRIT)
+		alertgroups = list(MGA_MAIL, MGA_RADIO, MGA_CHECKPOINT, MGA_ARREST, MGA_DEATH, MGA_MEDCRIT, MGA_CRISIS)
 
 	forensic
 		icon_state = "pda-s"
 		setup_default_cartridge = /obj/item/disk/data/cartridge/forensic
 		mailgroups = list(MGD_SECURITY,MGD_PARTY)
-		alertgroups = list(MGA_MAIL, MGA_CHECKPOINT, MGA_ARREST, MGA_DEATH, MGA_MEDCRIT)
+		alertgroups = list(MGA_MAIL, MGA_RADIO, MGA_CHECKPOINT, MGA_ARREST, MGA_DEATH, MGA_MEDCRIT, MGA_CRISIS)
 
 	toxins
 		icon_state = "pda-tox"
@@ -175,7 +175,7 @@
 		icon_state = "pda-q"
 		setup_default_cartridge = /obj/item/disk/data/cartridge/quartermaster
 		mailgroups = list(MGD_CARGO,MGD_PARTY)
-		alertgroups = list(MGA_MAIL, MGA_SALES, MGA_SHIPPING, MGA_CARGOREQUEST)
+		alertgroups = list(MGA_MAIL, MGA_RADIO, MGA_SALES, MGA_SHIPPING, MGA_CARGOREQUEST)
 
 	clown
 		icon_state = "pda-clown"
@@ -202,7 +202,7 @@
 	chaplain
 		icon_state = "pda-holy"
 		mailgroups = list(MGD_SPIRITUALAFFAIRS,MGD_PARTY)
-		alertgroups = list(MGA_MAIL, MGA_DEATH, MGA_MEDCRIT)
+		alertgroups = list(MGA_MAIL, MGA_RADIO, MGA_DEATH, MGA_MEDCRIT)
 
 	atmos
 		icon_state = "pda-a"
@@ -212,12 +212,12 @@
 		icon_state = "pda-e"
 		setup_default_cartridge = /obj/item/disk/data/cartridge/engineer
 		mailgroups = list(MGO_ENGINEER,MGD_STATIONREPAIR,MGD_PARTY)
-		alertgroups = list(MGA_MAIL, MGA_ENGINE)
+		alertgroups = list(MGA_MAIL, MGA_RADIO, MGA_ENGINE, MGA_CRISIS)
 
 	mining
 		icon_state = "pda-e"
 		mailgroups = list(MGO_MINING,MGD_PARTY)
-		alertgroups = list(MGA_MAIL, MGA_SALES)
+		alertgroups = list(MGA_MAIL, MGA_RADIO, MGA_SALES)
 
 	chef
 		mailgroups = list(MGD_KITCHEN,MGD_PARTY)
@@ -230,7 +230,7 @@
 		setup_default_module = /obj/item/device/pda_module/tray
 		setup_default_cartridge = /obj/item/disk/data/cartridge/mechanic
 		mailgroups = list(MGO_MECHANIC,MGD_STATIONREPAIR,MGD_PARTY)
-		alertgroups = list(MGA_MAIL, MGA_RKIT)
+		alertgroups = list(MGA_MAIL, MGA_RADIO, MGA_RKIT)
 
 	botanist
 		icon_state = "pda-hydro"
@@ -583,17 +583,17 @@
 		else if (!signal.data["group"]) // only accept broadcast signals if they are filtered
 			return
 
-		if (islist(signal.data["group"]))
-			var/any_member = FALSE
-			for (var/group in signal.data["group"])
-				if (group in src.mailgroups)
-					any_member = TRUE
-					break
-			if (!any_member) // not a member of any specified group; discard
-				return
-		else if (signal.data["group"])
-			if (!(signal.data["group"] in src.mailgroups)) // not a member of the specified group; discard
-				return
+	if (islist(signal.data["group"]))
+		var/any_member = FALSE
+		for (var/group in signal.data["group"])
+			if (group in src.mailgroups)
+				any_member = TRUE
+				break
+		if (!any_member) // not a member of any specified group; discard
+			return
+	else if (signal.data["group"])
+		if (!(signal.data["group"] in src.mailgroups)) // not a member of the specified group; discard
+			return
 
 	src.host_program?.receive_signal(signal, rx_method, rx_freq)
 

--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -112,6 +112,7 @@
 			// start in party line by default
 			MGD_PARTY,
 		)
+		muted_mailgroups = list(MGA_MAIL, MGA_SALES, MGA_SHIPPING, MGA_CARGOREQUEST)
 		alertgroups = list(MGA_MAIL, MGA_CHECKPOINT, MGA_ARREST, MGA_DEATH, MGA_MEDCRIT, MGA_CLONER, MGA_ENGINE, MGA_RKIT, MGA_SALES, MGA_SHIPPING, MGA_CARGOREQUEST) // keep in sync with the list of mail alert groups
 
 	cyborg

--- a/code/obj/item/device/pda2/smallprogs.dm
+++ b/code/obj/item/device/pda2/smallprogs.dm
@@ -728,7 +728,7 @@ Code:
 		signal.data["address_1"] = "00000000"
 		signal.data["command"] = "text_message"
 		signal.data["sender_name"] = src.master.owner
-		signal.data["group"] = mailgroup
+		signal.data["group"] = list(mailgroup, MGA_CRISIS)
 		var/area/an_area = get_area(src.master)
 
 		if (isAIeye(usr))

--- a/code/obj/item/device/pda2/smallprogs.dm
+++ b/code/obj/item/device/pda2/smallprogs.dm
@@ -718,7 +718,7 @@ Code:
 			if (-INFINITY to 1)
 				mailgroup = MGD_MEDBAY
 			if (2)
-				mailgroup = "engineer"
+				mailgroup = MGO_ENGINEER
 			if (3 to INFINITY)
 				mailgroup = MGD_SECURITY
 

--- a/code/obj/item/device/pda2/smallprogs.dm
+++ b/code/obj/item/device/pda2/smallprogs.dm
@@ -1148,7 +1148,7 @@ Using electronic "Detomatix" BOMB program is perhaps less simple!<br>
 				antispam = ticker.round_elapsed_ticks + SPAM_DELAY
 				var/datum/radio_frequency/transmit_connection = radio_controller.return_frequency("1149")
 				var/datum/signal/pdaSignal = get_free_signal()
-				pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="CARGO-MAILBOT",  "group"=MGD_CARGO, "sender"="00000000", "message"="Notification: [O.object] requested by [O.orderedby] at [O.console_location].")
+				pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="CARGO-MAILBOT",  "group"=list(MGD_CARGO, MGA_CARGOREQUEST), "sender"="00000000", "message"="Notification: [O.object] requested by [O.orderedby] at [O.console_location].")
 				pdaSignal.transmission_method = TRANSMISSION_RADIO
 				if(transmit_connection != null)
 					transmit_connection.post_signal(src, pdaSignal)

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -157,7 +157,6 @@ THROWING DARTS
 	impcolor = "b"
 	//life_tick_energy = 0.1
 	var/healthstring = ""
-	var/message = null
 	var/list/mailgroups = list(MGD_MEDBAY, MGD_MEDRESEACH, MGD_SPIRITUALAFFAIRS)
 	var/net_id = null
 	var/frequency = 1149
@@ -268,9 +267,8 @@ THROWING DARTS
 			return
 		var/coords = src.get_coords()
 		var/myarea = get_area(src)
-		src.message = "HEALTH ALERT: [src.owner][coords] in [myarea]: [src.sensehealth()]"
 		//DEBUG_MESSAGE("implant reporting crit")
-		src.send_message()
+		src.send_message("HEALTH ALERT: [src.owner][coords] in [myarea]: [src.sensehealth()]", MGA_MEDCRIT)
 
 	proc/death_alert()
 		if (!src.owner)
@@ -278,15 +276,15 @@ THROWING DARTS
 		var/coords = src.get_coords()
 		var/myarea = get_area(src)
 		var/has_record = src.check_for_valid_record()
-		src.message = "DEATH ALERT: [src.owner][coords] in [myarea], " //youre lucky im not onelining this
+		var/message = "DEATH ALERT: [src.owner][coords] in [myarea], " //youre lucky im not onelining this
 		if (has_record) //the title for this next section of code is grammar sucks
 			if (he_or_she(src.owner) == "they")
-				src.message += "they [has_record ? "have a record in the cloner at [has_record]" : "do not have a cloning record." ]"
+				message += "they [has_record ? "have a record in the cloner at [has_record]" : "do not have a cloning record." ]"
 			else
-				src.message += "[has_record ? "genetic record detected in cloning console at [has_record]" : "genetic record not detected."]"
+				message += "[has_record ? "genetic record detected in cloning console at [has_record]" : "genetic record not detected."]"
 
 		//DEBUG_MESSAGE("implant reporting death")
-		src.send_message()
+		src.send_message(message, MGA_DEATH)
 
 	proc/get_coords()
 		if (ishuman(src.owner))
@@ -309,24 +307,22 @@ THROWING DARTS
 					return get_area(comp)
 		return null
 
-	proc/send_message()
-		DEBUG_MESSAGE("sending message: [src.message]")
+	proc/send_message(var/message, var/alertgroup)
+		DEBUG_MESSAGE("sending message: [message]")
 		if(!radio_connection)
 			return
-		for(var/mailgroup in mailgroups)
-			var/datum/signal/newsignal = get_free_signal()
-			newsignal.source = src
-			newsignal.transmission_method = TRANSMISSION_RADIO
-			newsignal.data["command"] = "text_message"
-			newsignal.data["sender_name"] = "HEALTH-MAILBOT"
-			newsignal.data["message"] = "[src.message]"
+		var/datum/signal/newsignal = get_free_signal()
+		newsignal.source = src
+		newsignal.transmission_method = TRANSMISSION_RADIO
+		newsignal.data["command"] = "text_message"
+		newsignal.data["sender_name"] = "HEALTH-MAILBOT"
+		newsignal.data["message"] = "[message]"
 
-			newsignal.data["address_1"] = "00000000"
-			newsignal.data["group"] = mailgroup
-			newsignal.data["sender"] = src.net_id
+		newsignal.data["address_1"] = "00000000"
+		newsignal.data["group"] = mailgroups + alertgroup
+		newsignal.data["sender"] = src.net_id
 
-			radio_connection.post_signal(src, newsignal)
-			//DEBUG_MESSAGE("message sent to [src.mailgroup]")
+		radio_connection.post_signal(src, newsignal)
 
 /obj/item/implant/health/security
 	name = "health implant - security issue"

--- a/code/obj/machinery/clonepod.dm
+++ b/code/obj/machinery/clonepod.dm
@@ -110,19 +110,18 @@
 		if(!pda_connection)
 			return
 
-		for(var/mailgroup in mailgroups)
-			var/datum/signal/newsignal = get_free_signal()
-			newsignal.source = src
-			newsignal.transmission_method = TRANSMISSION_RADIO
-			newsignal.data["command"] = "text_message"
-			newsignal.data["sender_name"] = "CLONEPOD-MAILBOT"
-			newsignal.data["message"] = "[msg]"
+		var/datum/signal/newsignal = get_free_signal()
+		newsignal.source = src
+		newsignal.transmission_method = TRANSMISSION_RADIO
+		newsignal.data["command"] = "text_message"
+		newsignal.data["sender_name"] = "CLONEPOD-MAILBOT"
+		newsignal.data["message"] = "[msg]"
 
-			newsignal.data["address_1"] = "00000000"
-			newsignal.data["group"] = mailgroup
-			newsignal.data["sender"] = src.net_id
+		newsignal.data["address_1"] = "00000000"
+		newsignal.data["group"] = mailgroups + MGA_CLONER
+		newsignal.data["sender"] = src.net_id
 
-			pda_connection.post_signal(src, newsignal)
+		pda_connection.post_signal(src, newsignal)
 
 	attack_hand(mob/user as mob)
 		interact_particle(user, src)

--- a/code/obj/machinery/computer/QM_order.dm
+++ b/code/obj/machinery/computer/QM_order.dm
@@ -170,7 +170,7 @@
 					// pda alert ////////
 					var/datum/radio_frequency/transmit_connection = radio_controller.return_frequency("1149")
 					var/datum/signal/pdaSignal = get_free_signal()
-					pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="CARGO-MAILBOT",  "group"=MGD_CARGO, "sender"="00000000", "message"="Notification: [O.object] ordered by [O.orderedby] using personal account at [O.console_location].")
+					pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="CARGO-MAILBOT",  "group"=list(MGD_CARGO, MGA_SHIPPING), "sender"="00000000", "message"="Notification: [O.object] ordered by [O.orderedby] using personal account at [O.console_location].")
 					pdaSignal.transmission_method = TRANSMISSION_RADIO
 					if(transmit_connection != null)
 						transmit_connection.post_signal(src, pdaSignal)
@@ -185,7 +185,7 @@
 				// pda alert ////////
 				var/datum/radio_frequency/transmit_connection = radio_controller.return_frequency("1149")
 				var/datum/signal/pdaSignal = get_free_signal()
-				pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="CARGO-MAILBOT",  "group"=MGD_CARGO, "sender"="00000000", "message"="Notification: [O.object] requested by [O.orderedby] at [O.console_location].")
+				pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="CARGO-MAILBOT",  "group"=list(MGD_CARGO, MGA_CARGOREQUEST), "sender"="00000000", "message"="Notification: [O.object] requested by [O.orderedby] at [O.console_location].")
 				pdaSignal.transmission_method = TRANSMISSION_RADIO
 				if(transmit_connection != null)
 					transmit_connection.post_signal(src, pdaSignal)
@@ -261,7 +261,7 @@
 				////// PDA NOTIFY/////
 				var/datum/radio_frequency/transmit_connection = radio_controller.return_frequency("1149")
 				var/datum/signal/pdaSignal = get_free_signal()
-				pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="CARGO-MAILBOT",  "group"=MGD_CARGO, "sender"="00000000", "message"="Notification: [transaction] credits transfered to shipping budget from [src.scan.registered].")
+				pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="CARGO-MAILBOT",  "group"=list(MGD_CARGO, MGA_SHIPPING), "sender"="00000000", "message"="Notification: [transaction] credits transfered to shipping budget from [src.scan.registered].")
 				pdaSignal.transmission_method = TRANSMISSION_RADIO
 				if(transmit_connection != null)
 					transmit_connection.post_signal(src, pdaSignal)

--- a/code/obj/machinery/computer/QM_supply.dm
+++ b/code/obj/machinery/computer/QM_supply.dm
@@ -102,7 +102,7 @@ var/global/datum/rockbox_globals/rockbox_globals = new /datum/rockbox_globals
 			qdel(sell_crate)
 		var/datum/radio_frequency/transmit_connection = radio_controller.return_frequency("1149")
 		var/datum/signal/pdaSignal = get_free_signal()
-		pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="CARGO-MAILBOT",  "group"=MGD_CARGO, "sender"="00000000", "message"="Notification: Pathogen sample crate delivered to the CDC.")
+		pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="CARGO-MAILBOT",  "group"=list(MGD_CARGO, MGA_SHIPPING), "sender"="00000000", "message"="Notification: Pathogen sample crate delivered to the CDC.")
 		pdaSignal.transmission_method = TRANSMISSION_RADIO
 		if(transmit_connection != null)
 			transmit_connection.post_signal(null, pdaSignal)

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -806,10 +806,10 @@
 									var/amount_per_account = divisible_amount/length(accounts)
 									for(var/datum/data/record/t in accounts)
 										t.fields["current_money"] += amount_per_account
-									minerSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="ROCKBOX&trade;-MAILBOT",  "group"="mining", "sender"=src.net_id, "message"="Notification: [amount_per_account] credits earned from Rockbox&trade; sale, deposited to your account.")
+									minerSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="ROCKBOX&trade;-MAILBOT",  "group"=list(MGO_MINING, MGA_SALES), "sender"=src.net_id, "message"="Notification: [amount_per_account] credits earned from Rockbox&trade; sale, deposited to your account.")
 							else
 								leftovers = subtotal
-								minerSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="ROCKBOX&trade;-MAILBOT",  "group"="mining", "sender"=src.net_id, "message"="Notification: [leftovers + sum_taxes] credits earned from Rockbox&trade; sale, deposited to the shipping budget.")
+								minerSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="ROCKBOX&trade;-MAILBOT",  "group"=list(MGO_MINING, MGA_SALES), "sender"=src.net_id, "message"="Notification: [leftovers + sum_taxes] credits earned from Rockbox&trade; sale, deposited to the shipping budget.")
 							wagesystem.shipping_budget += (leftovers + sum_taxes)
 							transmit_connection.post_signal(src, minerSignal)
 

--- a/code/obj/machinery/secscanner.dm
+++ b/code/obj/machinery/secscanner.dm
@@ -66,7 +66,7 @@
 
 				var/datum/radio_frequency/transmit_connection = radio_controller.return_frequency("1149")
 				var/datum/signal/pdaSignal = get_free_signal()
-				pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="SECURITY-MAILBOT",  "group"=MGD_SECURITY, "sender"="00000000", "message"="Notification: An item [I.name] failed checkpoint scan at [scan_location]! Threat Level : [contraband]")
+				pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="SECURITY-MAILBOT",  "group"=list(MGD_SECURITY, MGA_CHECKPOINT), "sender"="00000000", "message"="Notification: An item [I.name] failed checkpoint scan at [scan_location]! Threat Level : [contraband]")
 				pdaSignal.transmission_method = TRANSMISSION_RADIO
 				if(transmit_connection != null)
 					transmit_connection.post_signal(src, pdaSignal)
@@ -113,7 +113,7 @@
 						if (perpname != last_perp || contraband != last_contraband)
 							var/datum/radio_frequency/transmit_connection = radio_controller.return_frequency("1149")
 							var/datum/signal/pdaSignal = get_free_signal()
-							pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="SECURITY-MAILBOT",  "group"=MGD_SECURITY, "sender"="00000000", "message"="NOTIFICATION: [uppertext(perpname)] FAILED A VIBE CHECK AT [uppertext(scan_location)]! BAD VIBES LEVEL : [contraband]")
+							pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="SECURITY-MAILBOT",  "group"=list(MGD_SECURITY, MGA_CHECKPOINT), "sender"="00000000", "message"="NOTIFICATION: [uppertext(perpname)] FAILED A VIBE CHECK AT [uppertext(scan_location)]! BAD VIBES LEVEL : [contraband]")
 							pdaSignal.transmission_method = TRANSMISSION_RADIO
 							if(transmit_connection != null)
 								transmit_connection.post_signal(src, pdaSignal)
@@ -155,7 +155,7 @@
 					if (perpname != last_perp || contraband != last_contraband)
 						var/datum/radio_frequency/transmit_connection = radio_controller.return_frequency("1149")
 						var/datum/signal/pdaSignal = get_free_signal()
-						pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="SECURITY-MAILBOT",  "group"=MGD_SECURITY, "sender"="00000000", "message"="Notification: [perpname] failed checkpoint scan at [scan_location]! Threat Level : [contraband]")
+						pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="SECURITY-MAILBOT",  "group"=list(MGD_SECURITY, MGA_CHECKPOINT), "sender"="00000000", "message"="Notification: [perpname] failed checkpoint scan at [scan_location]! Threat Level : [contraband]")
 						pdaSignal.transmission_method = TRANSMISSION_RADIO
 						if(transmit_connection != null)
 							transmit_connection.post_signal(src, pdaSignal)

--- a/code/obj/machinery/sleeper.dm
+++ b/code/obj/machinery/sleeper.dm
@@ -763,19 +763,20 @@
 		return
 
 	var/PDAalert = "[src.name] has returned to [get_area(src.homeloc)] with a "
+	var/alertgroup = MGA_MEDCRIT
 	if (isdead(occupant))
 		PDAalert += "deceased body - please process the occupant as soon as possible."
+		alertgroup = MGA_DEATH
 	else if (occupant.health < 0)
 		PDAalert += "patient in critical condition - respond and treat immediately."
 	else
 		PDAalert += "patient - please check in on the occupant."
 
-	for(var/mailgroup in mailgroups)
-		var/datum/signal/PDAsignal = get_free_signal()
+	var/datum/signal/PDAsignal = get_free_signal()
 
-		PDAsignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="HEALTH-MAILBOT",  "group"=mailgroup, "sender"="00000000", "message"="[PDAalert]")
-		PDAsignal.transmission_method = TRANSMISSION_RADIO
-		transmit_connection.post_signal(src, PDAsignal)
+	PDAsignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="HEALTH-MAILBOT",  "group"=mailgroups+alertgroup, "sender"="00000000", "message"="[PDAalert]")
+	PDAsignal.transmission_method = TRANSMISSION_RADIO
+	transmit_connection.post_signal(src, PDAsignal)
 
 
 /obj/machinery/sleeper/compact


### PR DESCRIPTION
[QOL][BALANCE]

## About the PR

- Adds the AI to all default-existing PDA mail groups and removes the special case routing for the `ai` group.
- Adds the concept of an "alert group", which is a PDA mail group that cannot be joined but can be muted.
- Changes group filtering to allow multiple groups on a single PDA packet. The message is accepted if the PDA has membership in *any* of the groups.
- Changes group filtering to allow group filters on non-broadcast messages. Group filters are still required on broadcast messages.
- Adds geneticists to the `medbay` group (their PDAs have it muted by default.)
- Mutes gene booth sale notifications for roboticists by default.
- Ruckingenur Kit notifications now require being in the `mechanic` group. This won't usually affect anyone, but if someone uses a non-mechanic PDA to scan stuff using a copied app, they won't get auto-responses.

## Why's this needed?

I've seen a lot of complaints about message spam for AIs after the `ai` group was fixed to do what the comments implied it did. Crit alerts for security officers show up *four times* due to sending separate PDA messages.

## Changelog

```
(u)BenLubar:
(*)Alerts can now be muted on the PDA's messaging app groups screen. The AI can now mute incoming PDA messages, and does not auto-join custom groups.
```
