### PR TITLE
Material Science - onEntered Fix

### DIFF
--- a/code/atom.dm
+++ b/code/atom.dm
@@ -915,24 +915,23 @@
 
 	if (prev_mat_triggeronentered != cur_mat_triggeronentered)
 		if (isturf(src.loc))
-			if (~src.event_handler_flags & USE_HASENTERED)
-				if (cur_mat_triggeronentered)
+			// Check if USE_HASENTERED needs to be added if atom is missing the flag and onEnter trigger was added
+			if (!(src.event_handler_flags & USE_HASENTERED) && cur_mat_triggeronentered)
+				var/turf/T = src.loc
+				if (T)
+					T.checkinghasentered++
+				//Slap flag on so moving the atom will properly adjust checkinghasentered
+				src.event_handler_flags |= USE_HASENTERED
+				src.material.owner_hasentered_added = TRUE
+			// Check USE_HASENTERED needs to be removed when current material doesn't have onEnter trigger now and flag was added
+			else
+				if (!cur_mat_triggeronentered && prev_added_hasentered)
 					var/turf/T = src.loc
 					if (T)
-						T.checkinghasentered++
-					//Slap flag on so moving the atom will properly adjust checkinghasentered
-					src.event_handler_flags |= USE_HASENTERED
-					src.material.owner_hasentered_added = TRUE
-			else
-				if (!cur_mat_triggeronentered)
-					if (prev_added_hasentered)
-						var/turf/T = src.loc
-						if (T)
-							T.checkinghasentered = max(T.checkinghasentered-1, 0)
+						T.checkinghasentered = max(T.checkinghasentered-1, 0)
 
-						src.event_handler_flags &= ~USE_HASENTERED
-						src.material.owner_hasentered_added = FALSE
-
+					src.event_handler_flags &= ~USE_HASENTERED
+					src.material.owner_hasentered_added = FALSE
 
 // standardized damage procs
 

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -913,7 +913,7 @@
 
 	if (prev_mat_triggeronentered != cur_mat_triggeronentered)
 		if (isturf(src.loc))
-			if (!src.event_handler_flags & USE_HASENTERED)
+			if (~src.event_handler_flags & USE_HASENTERED)
 				if(cur_mat_triggeronentered)
 					var/turf/T = src.loc
 					if (T)

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -908,20 +908,30 @@
 //same as above :)
 /atom/movable/setMaterial(var/datum/material/mat1, var/appearance = 1, var/setname = 1, var/copy = 1, var/use_descriptors = 0)
 	var/prev_mat_triggeronentered = (src.material && src.material.triggersOnEntered && src.material.triggersOnEntered.len)
+	var/prev_added_hasentered = src.material?.owner_hasentered_added
 	..(mat1,appearance,setname,copy,use_descriptors)
 	var/cur_mat_triggeronentered = (src.material && src.material.triggersOnEntered && src.material.triggersOnEntered.len)
+	src.material?.owner_hasentered_added = prev_added_hasentered
 
 	if (prev_mat_triggeronentered != cur_mat_triggeronentered)
 		if (isturf(src.loc))
 			if (~src.event_handler_flags & USE_HASENTERED)
-				if(cur_mat_triggeronentered)
+				if (cur_mat_triggeronentered)
 					var/turf/T = src.loc
 					if (T)
 						T.checkinghasentered++
-				else
-					var/turf/T = src.loc
-					if (T)
-						T.checkinghasentered = max(T.checkinghasentered-1, 0)
+					//Slap flag on so moving the atom will properly adjust checkinghasentered
+					src.event_handler_flags |= USE_HASENTERED
+					src.material.owner_hasentered_added = TRUE
+			else
+				if (!cur_mat_triggeronentered)
+					if (prev_added_hasentered)
+						var/turf/T = src.loc
+						if (T)
+							T.checkinghasentered = max(T.checkinghasentered-1, 0)
+
+						src.event_handler_flags &= ~USE_HASENTERED
+						src.material.owner_hasentered_added = FALSE
 
 
 // standardized damage procs

--- a/code/modules/materials/Mat_MaterialProcs.dm
+++ b/code/modules/materials/Mat_MaterialProcs.dm
@@ -459,11 +459,6 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 				qdel(I)
 		return
 
-/datum/materialProc/soulsteel_add
-	execute(var/atom/owner)
-		owner.event_handler_flags |= USE_HASENTERED
-		return
-
 /datum/materialProc/soulsteel_entered
 	var/lastTrigger = 0
 	execute(var/obj/item/owner, var/atom/movable/entering)

--- a/code/modules/materials/Mat_Materials.dm
+++ b/code/modules/materials/Mat_Materials.dm
@@ -472,7 +472,6 @@
 	New()
 		setProperty("density", 65)
 		addTrigger(triggersOnEntered, new /datum/materialProc/soulsteel_entered())
-		addTrigger(triggersOnAdd, new /datum/materialProc/soulsteel_add())
 		return ..()
 
 // Crystals
@@ -1275,7 +1274,6 @@
 		setProperty("permeable", 10)
 		addTrigger(triggersOnAdd, new /datum/materialProc/ethereal_add())
 		addTrigger(triggersOnEntered, new /datum/materialProc/soulsteel_entered())
-		addTrigger(triggersOnAdd, new /datum/materialProc/soulsteel_add())
 		return ..()
 
 /datum/material/fabric/cloth/ectofibre

--- a/code/modules/materials/Mat_Materials.dm
+++ b/code/modules/materials/Mat_Materials.dm
@@ -64,6 +64,8 @@
 	/// The functional value of edibility. Edible or not? This is what you check from the outside to see if material is edible. See [/datum/material/var/edible_exact].
 	var/edible = 0
 
+	var/owner_hasentered_added = FALSE
+
 	proc/getProperty(var/property, var/type = VALUE_CURRENT)
 		for(var/datum/material_property/P in properties)
 			if(P.id == property)

--- a/code/modules/materials/Mat_ProcsDefines.dm
+++ b/code/modules/materials/Mat_ProcsDefines.dm
@@ -112,8 +112,8 @@ var/global/list/triggerVars = list("triggersOnBullet", "triggersOnEat", "trigger
 	src.color = initial(src.color)
 
 	if(src.material?.owner_hasentered_added)
-		var/turf/T = src.loc
-		if (T)
+		if (isturf(src.loc))
+			var/turf/T = src.loc
 			T.checkinghasentered = max(T.checkinghasentered-1, 0)
 		src.event_handler_flags &= ~USE_HASENTERED
 

--- a/code/modules/materials/Mat_ProcsDefines.dm
+++ b/code/modules/materials/Mat_ProcsDefines.dm
@@ -111,6 +111,12 @@ var/global/list/triggerVars = list("triggersOnBullet", "triggersOnEat", "trigger
 	src.alpha = initial(src.alpha)
 	src.color = initial(src.color)
 
+	if(src.material?.owner_hasentered_added)
+		var/turf/T = src.loc
+		if (T)
+			T.checkinghasentered = max(T.checkinghasentered-1, 0)
+		src.event_handler_flags &= ~USE_HASENTERED
+
 	src.UpdateOverlays(null, "material")
 
 	src.material = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Reworks #734
  Previous implementation circumvents `/atom/movable/setMaterial` which was broke, which means that `checkinghasentered` would never be correct for turf where material was applied. Atom `Move()` and `set_loc()` would be correct for turf the atom was moved to.  Unfortunately slapping USE_HASENTERED without updating `checkinghasentered` could presumably disable `hasEntered` and `hasExited` on a turf due `Move()` and `set_loc()` if it was 1.

Ran into this attempting to apply materials to **stationary** objects, so this is likely more of a theoretical/admeme concern.
<br><br>


`/atom/movable/setMaterial` updated to apply USE_HASENTERED to object for correct turf behavior when object is moved.
* Bookkeeping for USE_HASENTERED is tacked onto the material to ensure the flag is not removed when it didn't need to be added.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Help ensure correct behavior of materials and turf.
