### PR TITLE
Reduce the capacity of water cooler bottles to 500 units

### DIFF
--- a/code/modules/chemistry/tools/dispensers.dm
+++ b/code/modules/chemistry/tools/dispensers.dm
@@ -560,12 +560,12 @@
 
 /obj/item/reagent_containers/food/drinks/coolerbottle
 	name = "water cooler bottle"
-	desc = "A water cooler bottle. Can hold up to 1000 units."
+	desc = "A water cooler bottle. Can hold up to 500 units."
 	icon = 'icons/obj/chemical.dmi'
 	inhand_image_icon = 'icons/mob/inhand/hand_medical.dmi'
 	icon_state = "itemtank"
 	item_state = "flask"
-	initial_volume = 1000
+	initial_volume = 500
 	w_class = 4.0
 	incompatible_with_chem_dispensers = 1
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This reduces the capacity of water cooler bottles to 500 units.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I keep on seeing people remove bottles from water coolers to use them for chemistry, which is kinda inconvenient for parched crewmembers. Reducing the capacity should make these bottles less tempting to use. And there are still a bunch of other reagent containers people can use if they wanna mass produce stuff, such as tanks or the reagent extractor. 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Flourish:
(+)Reduced the capacity of water cooler bottles to 500 units.
```
