### PR TITLE
More assorted paper & stamp fixes

### DIFF
--- a/code/obj/item/paper.dm
+++ b/code/obj/item/paper.dm
@@ -196,7 +196,7 @@
 	if(.)
 		return
 	if(src.sealed)
-		boutput(usr, "<span class='alert'>You can't write on [src].</span>")
+		boutput(usr, "<span class='alert'>You can't do that while [src] is folded up.</span>")
 		return
 	switch(action)
 		if("stamp")
@@ -211,7 +211,7 @@
 				var/list/stamp_info = list(list(stamp.current_state, stamp_x, stamp_y, stamp_r))
 				LAZYLISTADD(stamps, stamp_info)
 				/// This does the overlay stuff
-				var/image/stamp_overlay = image('icons/obj/writing.dmi', "paper_[stamp.current_mode]");
+				var/image/stamp_overlay = image('icons/obj/writing.dmi', "paper_[stamp.icon_state]");
 				var/matrix/stamp_matrix = matrix()
 				stamp_matrix.Scale(1, 1)
 				stamp_matrix.Translate(rand(-2, 2), rand(-3, 2))
@@ -329,12 +329,18 @@
 
 /obj/item/paper/attackby(obj/item/P, mob/living/user, params)
 	if(istype(P, /obj/item/pen) || istype(P, /obj/item/pen/crayon))
+		if(src.sealed)
+			boutput(usr, "<span class='alert'>You can't write on [src].</span>")
+			return
 		if(length(info) >= PAPER_MAX_LENGTH) // Sheet must have less than 1000 charaters
 			boutput(user, "<span class='warning'>This sheet of paper is full!</span>")
 			return
 		ui_interact(user)
 		return
 	else if(istype(P, /obj/item/stamp))
+		if(src.sealed)
+			boutput(usr, "<span class='alert'>You can't stamp [src].</span>")
+			return
 		boutput(user, "<span class='notice'>You ready your stamp over the paper! </span>")
 		ui_interact(user)
 		return // Normaly you just stamp, you don't need to read the thing

--- a/code/obj/item/paper.dm
+++ b/code/obj/item/paper.dm
@@ -141,9 +141,7 @@
 		var/fold = alert("What would you like to fold [src] into?",,"Paper hat","Paper plane","Paper ball")
 		if(src.pooled) //It's possible to queue multiple of these menus before resolving any.
 			return
-		var/obj/item/paper/P = src
-		src = null
-		usr.u_equip(P)
+		usr.u_equip(src)
 		if (fold == "Paper hat")
 			usr.show_text("You fold the paper into a hat! Neat.", "blue")
 			var/obj/item/clothing/head/paper_hat/H = new()
@@ -156,12 +154,12 @@
 			else
 				usr.show_text("You crumple the paper into a ball! Neat.", "blue")
 				F = new /obj/item/paper/folded/ball(usr)
-			F.info = P.info
-			F.old_desc = P.desc
-			F.old_icon_state = P.icon_state
-			F.sealed = 1
+			F.info = src.info
+			F.old_desc = src.desc
+			F.old_icon_state = src.icon_state
 			usr.put_in_hand_or_drop(F)
-		pool(P)
+
+		pool(src)
 
 /obj/item/paper/attack_ai(var/mob/AI as mob)
 	var/mob/living/silicon/ai/user

--- a/code/obj/item/paper.dm
+++ b/code/obj/item/paper.dm
@@ -139,6 +139,8 @@
 		src.examine(user)
 	else
 		var/fold = alert("What would you like to fold [src] into?",,"Paper hat","Paper plane","Paper ball")
+		if(src.pooled) //It's possible to queue multiple of these menus before resolving any.
+			return
 		var/obj/item/paper/P = src
 		src = null
 		usr.u_equip(P)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug][cleanliness]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR:
-Closes #3158 by checking if the paper in question is already pooled.
-Cleans up folding code a bit. Functionally it should be the same.
-Adds some error checks to paper's attackby. While you couldn't stamp or write on folded paper regardless using a pen or stamp would let you read folded paper.
-Fixes the stamped paped icon_state overlays.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Less bugs