### PR TITLE
Removes camera from the general bathroom on Donut3

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -50557,11 +50557,6 @@
 /turf/simulated/floor/specialroom/arcade,
 /area/station/hallway/primary/south)
 "pex" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	name = "autoname - SS13";
-	tag = ""
-	},
 /obj/machinery/firealarm{
 	pixel_x = 1;
 	pixel_y = -25


### PR DESCRIPTION
<!-- Please let this be my final bathroom PR... -->

## About the PR 
Removes the singular camera from the common bathroom on Donut3 near medbay. This makes most bathrooms across all maps follow the general trend that there are no cameras anywhere in the bathrooms where there is either a shower or toilet.

## Why's this needed? 
Someone pointed it out as being a camera location that still bugged them since the showers are in the same room. After reviewing the amount of "dead" space created by removing the camera, I figured it wasn't really consequential to remove it since all of the maintenance around it and some of that bathroom already aren't viewable. 

Bonus to these removals is that people should stop getting hit with public urination charges on SecMate when they use the bathrooms.