### PR TITLE
Gives ranch access to more jobs

### DIFF
--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -263,7 +263,7 @@
 #else
 			return list(access_security, access_carrypermit, access_contrabandpermit, access_securitylockers, access_brig, access_maint_tunnels,
 			access_medical, access_morgue, access_crematorium, access_research, access_cargo, access_engineering,
-			access_chemistry, access_bar, access_kitchen, access_hydro, access_ranch)
+			access_chemistry, access_bar, access_kitchen, access_hydro)
 #endif
 		if("Vice Officer")
 			return list(access_security, access_carrypermit, access_contrabandpermit, access_securitylockers, access_brig, access_maint_tunnels,access_hydro,access_bar,access_kitchen, access_ranch)

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -212,7 +212,7 @@
 						access_emergency_storage, access_change_ids, access_eva, access_heads, access_head_of_personnel, access_medical_lockers,
 						access_all_personal_lockers, access_tech_storage, access_maint_tunnels, access_bar, access_janitor,
 						access_crematorium, access_kitchen, access_robotics, access_cargo, access_supply_console,
-						access_research, access_hydro, access_mail, access_ai_upload)
+						access_research, access_hydro, access_ranch, access_mail, access_ai_upload)
 		if("Head of Security")
 #ifdef RP_MODE
 			var/list/hos_access = get_all_accesses()
@@ -351,7 +351,7 @@
 		if("Inspector", "Communications Officer")
 			return list(access_security, access_tox, access_tox_storage, access_chemistry, access_medical, access_medlab,
 						access_emergency_storage, access_eva, access_heads, access_tech_storage, access_maint_tunnels, access_bar, access_janitor,
-						access_kitchen, access_robotics, access_cargo, access_research, access_hydro)
+						access_kitchen, access_robotics, access_cargo, access_research, access_hydro, access_ranch)
 
 		else
 			return list()

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -377,7 +377,7 @@
 	            access_emergency_storage, access_change_ids, access_ai_upload,
 	            access_teleporter, access_eva, access_heads, access_captain, access_all_personal_lockers, access_head_of_personnel,
 	            access_chapel_office, access_kitchen, access_medical_lockers,
-	            access_bar, access_janitor, access_crematorium, access_robotics, access_cargo, access_supply_console, access_construction, access_hydro, access_mail,
+	            access_bar, access_janitor, access_crematorium, access_robotics, access_cargo, access_supply_console, access_construction, access_hydro, access_ranch, access_mail,
 	            access_engineering, access_maint_tunnels, access_external_airlocks,
 	            access_tech_storage, access_engineering_storage, access_engineering_eva,
 	            access_engineering_power, access_engineering_engine, access_mining_shuttle,

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -224,7 +224,7 @@
 						access_emergency_storage, access_change_ids, access_eva, access_heads, access_medical_lockers,
 						access_all_personal_lockers, access_tech_storage, access_maint_tunnels, access_bar, access_janitor,
 						access_crematorium, access_kitchen, access_robotics, access_cargo,
-						access_research, access_dwaine_superuser, access_hydro, access_mail, access_ai_upload,
+						access_research, access_dwaine_superuser, access_hydro, access_ranch, access_mail, access_ai_upload,
 						access_engineering, access_teleporter, access_engineering_engine, access_engineering_power,
 						access_mining)
 #endif
@@ -259,14 +259,14 @@
 				access_tech_storage, access_engineering_storage, access_engineering_eva,
 				access_engineering_power, access_engineering_engine, access_mining_shuttle,
 				access_engineering_control, access_engineering_mechanic, access_mining, access_mining_outpost,
-				access_research, access_engineering_atmos, access_hangar)
+				access_research, access_engineering_atmos, access_hangar, access_ranch)
 #else
 			return list(access_security, access_carrypermit, access_contrabandpermit, access_securitylockers, access_brig, access_maint_tunnels,
 			access_medical, access_morgue, access_crematorium, access_research, access_cargo, access_engineering,
-			access_chemistry, access_bar, access_kitchen, access_hydro)
+			access_chemistry, access_bar, access_kitchen, access_hydro, access_ranch)
 #endif
 		if("Vice Officer")
-			return list(access_security, access_carrypermit, access_contrabandpermit, access_securitylockers, access_brig, access_maint_tunnels,access_hydro,access_bar,access_kitchen)
+			return list(access_security, access_carrypermit, access_contrabandpermit, access_securitylockers, access_brig, access_maint_tunnels,access_hydro,access_bar,access_kitchen, access_ranch)
 		if("Detective", "Forensic Technician")
 			return list(access_brig, access_carrypermit, access_contrabandpermit, access_security, access_forensics_lockers, access_morgue, access_maint_tunnels, access_crematorium, access_medical, access_research)
 		if("Lawyer")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR gives ranch access to HoP, inspector/comms officer (they share the same access) and all security jobs that also have access to hydroponics (secoffs [but only on RP server], vice officers, HoS and NTSO [again, RP only since NTSO access is sec + command])

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Closes #3200

~~Also I personally witnessed security officers struggling to catch a traitor that closed themselves in the ranch. It was hilarious but also felt unintentional, especially since ranch access is pretty new~~ actually in case of goon2 it apparently is intentional

And it feels weird for inspectors and HoP (especially for HoP) to not have ranch access while they have hydro access

