### PR TITLE
fixes a floating light switch on oshan

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -102893,7 +102893,7 @@ awu
 bQt
 arz
 cix
-azT
+azQ
 aAY
 ayd
 aCF
@@ -103497,7 +103497,7 @@ apb
 apb
 apb
 apb
-azQ
+azT
 aAY
 ayd
 aCF


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[trivial]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves a floating light switch in the hall below the clown hole vending machines to the corner of the computer core where it was located before that area got shifted.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's best not to frighten the crew with spooky switches.
