### PR TITLE
Removes the 20% probability for Chefs to have a Swedish accent 

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -820,8 +820,6 @@
 		..()
 		if (!M)
 			return
-		if (prob(20))
-			M.bioHolder.AddEffect("accent_swedish", do_stability=0)
 
 /datum/job/civilian/bartender
 	name = "Bartender"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the 20% chance of the chef starting with the Swedish accent.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Accents can often be debilitating to social interactions and should be entirely up to the player whether or not they want one. The joke isnt really enough to warrant the inability to communicate normally with everyone.

