### PR TITLE
Character creator now renders mutant races.

### DIFF
--- a/code/datums/preferences.dm
+++ b/code/datums/preferences.dm
@@ -2387,16 +2387,22 @@ var/global/list/female_screams = list("female", "femalescream1", "femalescream2"
 	if (checked) return "&#9745;"
 	else return "&#9744;"
 
+var/global/mob/living/carbon/human/character_preview_icon_mob = null
+
 /proc/character_preview_icon(datum/appearanceHolder/AH, datum/mutantrace/MR = null, direction = SOUTH)
-	var/mob/living/carbon/human/H = new(null, AH)
+	if (isnull(character_preview_icon_mob))
+		character_preview_icon_mob = new()
+
+	var/mob/living/carbon/human/H = character_preview_icon_mob
+
 	H.dir = direction
 	H.bioHolder.mobAppearance.CopyOther(AH)
-	if (MR)
-		H.set_mutantrace(MR)
+	H.set_mutantrace(MR)
 	H.organHolder.head.donor = H
 	H.organHolder.head.donor_appearance.CopyOther(H.bioHolder.mobAppearance)
+
 	H.update_colorful_parts()
 	H.update_body()
 	H.update_face()
-	. = getFlatIcon(H)
-	qdel(H)
+
+	return getFlatIcon(H)

--- a/code/datums/preferences.dm
+++ b/code/datums/preferences.dm
@@ -2405,4 +2405,4 @@ var/global/mob/living/carbon/human/character_preview_icon_mob = null
 	H.update_body()
 	H.update_face()
 
-	return getFlatIcon(H)
+	. = getFlatIcon(H)

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -167,8 +167,12 @@
 	var/requiredUnlock = null //If set to a string, the xp unlock of that name is required for this to be selectable.
 	var/cleanName = ""   //Name without any additional information.
 	var/isMoveTrait = 0 // If 1, onMove will be called each movement step from the holder's mob
+	var/datum/mutantrace/mutantRace = null //If set, should be in the "species" category.
 
 	proc/onAdd(var/mob/owner)
+		if(mutantRace && ishuman(owner))
+			var/mob/living/carbon/human/H = owner
+			H.set_mutantrace(mutantRace)
 		return
 
 	proc/onRemove(var/mob/owner)
@@ -1050,12 +1054,7 @@ obj/trait/pilot
 	points = -1
 	isPositive = 1
 	category = "species"
-
-	onAdd(var/mob/owner)
-		if(ishuman(owner))
-			var/mob/living/carbon/human/H = owner
-			H.set_mutantrace(/datum/mutantrace/lizard)
-		return
+	mutantRace = /datum/mutantrace/lizard
 
 /obj/trait/cow
 	name = "Bovine (-1) \[Species\]"
@@ -1066,12 +1065,7 @@ obj/trait/pilot
 	points = -1
 	isPositive = 1
 	category = "species"
-
-	onAdd(var/mob/owner)
-		if(ishuman(owner))
-			var/mob/living/carbon/human/H = owner
-			H.set_mutantrace(/datum/mutantrace/cow)
-		return
+	mutantRace = /datum/mutantrace/cow
 
 /obj/trait/skeleton
 	name = "Skeleton (-2) \[Species\]"
@@ -1082,12 +1076,7 @@ obj/trait/pilot
 	points = -2
 	isPositive = 1
 	category = "species"
-
-	onAdd(var/mob/owner)
-		if(ishuman(owner))
-			var/mob/living/carbon/human/H = owner
-			H.set_mutantrace(/datum/mutantrace/skeleton)
-		return
+	mutantRace = /datum/mutantrace/skeleton
 
 /obj/trait/roach
 	name = "Roach (-1) \[Species\]"
@@ -1098,9 +1087,5 @@ obj/trait/pilot
 	points = -1
 	isPositive = 1
 	category = "species"
+	mutantRace = /datum/mutantrace/roach
 
-	onAdd(var/mob/owner)
-		if(ishuman(owner))
-			var/mob/living/carbon/human/H = owner
-			H.set_mutantrace(/datum/mutantrace/roach)
-		return

--- a/code/mob/living/carbon/human/procs/update_icon.dm
+++ b/code/mob/living/carbon/human/procs/update_icon.dm
@@ -645,7 +645,8 @@
 		src.hair_special_standing.pixel_y = AHH.customization_first_offset_y
 
 		src.image_eyes = my_head.head_image_eyes
-		src.image_eyes?.pixel_y = AHH.e_offset_y
+		if (src.image_eyes)
+			src.image_eyes.pixel_y = AHH.e_offset_y
 		src.hair_standing.overlays += image_eyes
 
 		src.image_cust_one = my_head.head_image_cust_one


### PR DESCRIPTION
[MINOR]

## About the PR

Introduces a new proc (`character_preview_icon`) that generates an icon for a hypothetical character by creating that character, taking a picture, and then deleting them.

There are more efficient ways to accomplish this, but this will be much easier to maintain in the future.

This new method of generating the preview image works with mutant races!

## Why's this needed?

It's not really a character preview if it's a preview of an entirely different character.

## Changelog

```
(u)BenLubar:
(*)Lizards and cows and roaches and skeletons rejoice! You can now see a preview of your character in the character setup preview.
```
