### PR TITLE
Adds a routing depot camera monitor to donut 3

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -7689,6 +7689,10 @@
 	pixel_y = 9
 	},
 /obj/item/storage/toolbox/mechanical,
+/obj/item/wrench{
+	pixel_x = 10;
+	pixel_y = 1
+	},
 /turf/simulated/floor/black/grime,
 /area/station/hangar/qm)
 "bVD" = (
@@ -18963,6 +18967,13 @@
 /area/station/security/quarters)
 "fqg" = (
 /obj/disposalpipe/segment,
+/obj/machinery/camera{
+	c_tag = "Routing Depot";
+	dir = 4;
+	name = "Routing Depot Camera";
+	network = "Cargo";
+	tag = ""
+	},
 /turf/simulated/floor/black/grime,
 /area/station/routing/depot)
 "fqj" = (
@@ -52876,8 +52887,21 @@
 /area/station/science/storage)
 "pKS" = (
 /obj/stool/bench/red,
+/obj/machinery/light/incandescent/cool{
+	dir = 8
+	},
 /turf/simulated/floor/carpet/red/fancy/junction/nw_e,
 /area/station/crew_quarters/cafeteria)
+"pLc" = (
+/obj/machinery/camera{
+	c_tag = "Routing Depot - external";
+	dir = 4;
+	name = "Routing Depot Camera";
+	network = "Cargo";
+	tag = ""
+	},
+/turf/space,
+/area/space)
 "pLf" = (
 /obj/decal/cleanable/rust/jen,
 /obj/decal/cleanable/dirt/jen,
@@ -71830,6 +71854,12 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
+"vpj" = (
+/obj/machinery/light/small/sticky{
+	dir = 8
+	},
+/turf/space,
+/area/station/routing/depot)
 "vpr" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -81196,16 +81226,14 @@
 /area/station/maintenance/outer/nw)
 "ybn" = (
 /obj/table/reinforced/auto,
-/obj/item/wrench{
-	pixel_x = 10;
-	pixel_y = 1
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = 1
-	},
 /obj/decal/tile_edge/line/yellow{
 	icon_state = "line1"
+	},
+/obj/machinery/computer/security/wooden_tv{
+	desc = "A monitor connected to the cargo routing depot camera network.";
+	name = "Routing Depot Monitor";
+	network = "Cargo";
+	pixel_y = 1
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
@@ -153735,10 +153763,10 @@ rdj
 rdj
 rdj
 rdj
-rdj
+vpj
 aJw
 rdj
-rdj
+pLc
 rdj
 rdj
 rdj

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -52887,9 +52887,6 @@
 /area/station/science/storage)
 "pKS" = (
 /obj/stool/bench/red,
-/obj/machinery/light/incandescent/cool{
-	dir = 8
-	},
 /turf/simulated/floor/carpet/red/fancy/junction/nw_e,
 /area/station/crew_quarters/cafeteria)
 "pLc" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[qol]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR adds a TV camera monitor to Donut 3 cargo office, connected to two cameras placed in the cargo routing depot, similarly to Horizon cargo:

![0](https://user-images.githubusercontent.com/62990808/103547205-6588cf80-4ea4-11eb-817d-5737969284dd.png)



## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Currently there is no way for QMs to remotely see what's causing the cargo belts to clog. So this nice QoL camera setup should help out with that.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)TTerc:
(+)Adds a routing depot camera monitor to Donut 3, letting the QMs monitor the cargo belts remotely.
```
