### PR TITLE
Poison Bottle Bundle

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -670,6 +670,14 @@ This is basically useless for anyone but miners.
 	job = list("Medical Doctor", "Medical Director", "Research Director", "Scientist", "Bartender")
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 
+/datum/syndicate_buylist/traitor/poisonbottlebundle
+	name = "Poison Bottle Bundle"
+	item = /obj/item/storage/box/poisonbundle
+	cost = 7
+	desc = "A box filled with seven random poison bottles."
+	job = list("Medical Doctor", "Medical Director", "Research Director", "Scientist", "Bartender")
+	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
+
 /datum/syndicate_buylist/traitor/chemicompiler
 	name = "Chemicompiler"
 	item = /obj/item/device/chemicompiler

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -670,9 +670,9 @@ This is basically useless for anyone but miners.
 	job = list("Medical Doctor", "Medical Director", "Research Director", "Scientist", "Bartender")
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 
-/datum/syndicate_buylist/traitor/poisonbottlebundle
+/datum/syndicate_buylist/traitor/poisonbundle
 	name = "Poison Bottle Bundle"
-	item = /obj/item/storage/box/poisonbundle
+	item = /obj/item/storage/box/poison
 	cost = 7
 	desc = "A box filled with seven random poison bottles."
 	job = list("Medical Doctor", "Medical Director", "Research Director", "Scientist", "Bartender")

--- a/code/obj/item/storage/weapon_security.dm
+++ b/code/obj/item/storage/weapon_security.dm
@@ -326,6 +326,12 @@
 	/obj/item/boomerang,\
 	/obj/item/ammo/bullets/tranq_darts/syndicate = 4)
 
+/obj/item/storage/box/poisonbundle
+	name = "\improper Poison bottle box"
+	desc = "A box filled with random poison bottles."
+	icon_state = "box"
+	spawn_contents = list(/obj/item/reagent_containers/glass/bottle/poison = 7)
+
 // Starter kit used in the conspiracy/spy game mode.
 /obj/item/storage/box/spykit
 	name = "spy starter kit"

--- a/code/obj/item/storage/weapon_security.dm
+++ b/code/obj/item/storage/weapon_security.dm
@@ -326,9 +326,9 @@
 	/obj/item/boomerang,\
 	/obj/item/ammo/bullets/tranq_darts/syndicate = 4)
 
-/obj/item/storage/box/poisonbundle
-	name = "\improper Poison bottle box"
-	desc = "A box filled with random poison bottles."
+/obj/item/storage/box/poison
+	name = "box"
+	desc = "Just a regular box. It smells like almonds a little bit. Probably some chef kept their cooking supplies there."
 	icon_state = "box"
 	spawn_contents = list(/obj/item/reagent_containers/glass/bottle/poison = 7)
 

--- a/code/obj/item/storage/weapon_security.dm
+++ b/code/obj/item/storage/weapon_security.dm
@@ -327,8 +327,8 @@
 	/obj/item/ammo/bullets/tranq_darts/syndicate = 4)
 
 /obj/item/storage/box/poison
-	name = "box"
-	desc = "Just a regular box. It smells like almonds a little bit. Probably some chef kept their cooking supplies there."
+	name = "ordinary box"
+	desc = "Just a regular ordinary box. It smells like almonds a little bit. Probably some chef kept their cooking supplies there."
 	icon_state = "box"
 	spawn_contents = list(/obj/item/reagent_containers/glass/bottle/poison = 7)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feature][balance]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a new 7TC traitor uplink item, poison bottle bundle. Spawns a box containing 7 random poison bottles.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

It's supposed to be similar in fashion to macrobomb implant: instead of fighting with the uplink UI, having to scroll down each time you want to buy a bottle, you can just buy seven of them. The cost is 7TC for a reason, since sleepypen costs 5TC.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)TTerc:
(+)Adds a new traitor item: poison bottle bundle. It lets you spawn 7 poison bottles at once.
```
