### PR TITLE
Mounted defibrillator for the Cairngorm

### DIFF
--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -67789,7 +67789,8 @@
 /turf/unsimulated/floor/red,
 /area/syndicate_station/battlecruiser)
 "dhQ" = (
-/obj/machinery/bot/medbot/no_camera,
+/obj/table/auto,
+/obj/machinery/defib_mount,
 /turf/unsimulated/floor/red,
 /area/syndicate_station/battlecruiser)
 "dhR" = (
@@ -83944,6 +83945,10 @@
 	icon_state = "floor2"
 	},
 /area/shuttle/escape/centcom/donut3)
+"kJE" = (
+/obj/machinery/bot/medbot/no_camera,
+/turf/unsimulated/floor/red,
+/area/syndicate_station/battlecruiser)
 "kKt" = (
 /obj/table/wood/auto/desk,
 /obj/item/reagent_containers/food/drinks/cola{
@@ -113476,7 +113481,7 @@ aKf
 dhr
 dhE
 dhQ
-dgx
+kJE
 pNn
 aKf
 cfO


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]

## About the PR and why it's needed!<!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a mounted defibrillator to the surgical suite on the Cairngorm. While it's incredibly amusing seeing Nuclear Operatives somehow manage to crit themselves in a sanctuary zone, it's good to have an easy way to restart hearts onboard.

![defib](https://user-images.githubusercontent.com/68257280/103565848-0cfb0780-4e8f-11eb-8a08-31aa077f8983.png)

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)virvatuli:
(+)Added a mounted defibrillator to the Cairngorm's surgical suite.
```
