### PR TITLE
Guardbuddies can shoot guns at pointblank

### DIFF
--- a/code/modules/robotics/bot/guardbot.dm
+++ b/code/modules/robotics/bot/guardbot.dm
@@ -1225,7 +1225,7 @@
 		var/my_turf = get_turf(src)
 		var/burst = shotcount	// TODO: Make rapidfire exist, then work.
 		while(burst > 0 && target)
-			if(get_dist(target_turf,my_turf) <= 1)
+			if(IN_RANGE(target_turf, my_turf, 1))
 				budgun.shoot_point_blank(target, my_turf)
 			else
 				budgun.shoot(target_turf, my_turf, src)

--- a/code/modules/robotics/bot/guardbot.dm
+++ b/code/modules/robotics/bot/guardbot.dm
@@ -1225,7 +1225,10 @@
 		var/my_turf = get_turf(src)
 		var/burst = shotcount	// TODO: Make rapidfire exist, then work.
 		while(burst > 0 && target)
-			budgun.shoot(target_turf, my_turf, src)
+			if(get_dist(target_turf,my_turf) <= 1)
+				budgun.shoot_point_blank(target, my_turf)
+			else
+				budgun.shoot(target_turf, my_turf, src)
 			burst--
 			if (burst)
 				sleep(5)	// please dont fuck anything up

--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -295,7 +295,7 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 			if (O.client)
 				O.show_message("<span class='alert'><B>[user] shoots [user == M ? "[him_or_her(user)]self" : M] point-blank with [src]!</B></span>")
 	else
-		user.show_text("<span class='alert'>You silently shoot [user == M ? "yourself" : M] point-blank with [src]!</span>") // Was non-functional (Convair880).
+		boutput(user, "<span class='alert'>You silently shoot [user == M ? "yourself" : M] point-blank with [src]!</span>") // Was non-functional (Convair880).
 
 	if (!process_ammo(user))
 		return
@@ -305,14 +305,14 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 			muzzle_flash_attack_particle(user, user.loc, M, src.muzzle_flash)
 
 
-	if(slowdown)
+	if(slowdown && ismob(user))
 		SPAWN_DBG(-1)
 			user.movement_delay_modifier += slowdown
 			sleep(slowdown_time)
 			user.movement_delay_modifier -= slowdown
 
 	var/spread = 0
-	if (user.reagents)
+	if (ismob(user) && user.reagents)
 		var/how_drunk = 0
 		var/amt = user.reagents.get_reagent_amount("ethanol")
 		switch(amt)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Used to be that Guardbuddies couldn't shoot people they were standing on top of. Now they can, and they are *deadly*.

Also made shoot_point_blank use more atom-friendly procs with regard to the user, so non-mobs can shoot people pointblank without runtiming.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Superlagg:
(+)Updated Guardbuddy weapon handling drivers: they no longer have trouble shooting someone at pointblank range.
```
