### PR TITLE
Prevent putting storage in itself

### DIFF
--- a/code/obj/item/storage/small_storage_parent.dm
+++ b/code/obj/item/storage/small_storage_parent.dm
@@ -122,6 +122,10 @@
 			return -2
 
 	attackby(obj/item/W, mob/user, params, obj/item/storage/T) // T for transfer - transferring items from one storage obj to another
+		if (W == src)
+			// Putting self in self! Was possible if weight class allows it, causing storage to disappear
+			boutput(user, "<span class='alert'>You can't put [W] into itself!</span>")
+			return
 		var/canhold = src.check_can_hold(W,user)
 		if (canhold <= 0)
 			switch (canhold)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
[BUG]


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
If not blocked by weight class or can_hold a storage item can be put in itself by pressing the hotkey V. This effectively removes it from the game and makes the player sad.
Fixes #3145