### PR TITLE
Disable remote use of modules by silicon folks

### DIFF
--- a/code/obj.dm
+++ b/code/obj.dm
@@ -109,7 +109,18 @@
 	* inherent packet abilities.
 	*/
 	proc/can_access_remotely_default(mob/user)
-		return issilicon(user) || isAIeye(user)
+		if(isAI(user))
+			. = TRUE
+		else if(issilicon(user))
+			if (ishivebot(user) || isrobot(user))
+				var/mob/living/silicon/robot/R = user
+				return !R.module_active
+			else if(isghostdrone(user))
+				var/mob/living/silicon/ghostdrone/G = user
+				return !G.active_tool
+			. = TRUE
+
+
 
 	proc/client_login(var/mob/user)
 		return

--- a/code/obj/machinery/sleeper.dm
+++ b/code/obj/machinery/sleeper.dm
@@ -573,7 +573,7 @@
 	proc/can_operate(var/mob/M)
 		if (!IN_RANGE(src, M, 1))
 			return FALSE
-		if (is_incapacitated(M))
+		if (istype(M) && is_incapacitated(M))
 			return FALSE
 		if (src.occupant)
 			boutput(M, "<span class='notice'><B>The scanner is already occupied!</B></span>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Check that robots/cyborgs/ghostdrones don't have an active module when `in_range()` is called.
Resolves issue where modules could be used on `/obj/machinery` remotely due to current implementation.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes unintended behavior introduced by #3131 reported by @BenLubar 

```
(u)Azrun:
(+)Robots, Cyborgs, and Ghostdrones can no longer use module items remotely on machinery.
```
