### PR TITLE
auto-subscribe cyborgs to relevant PDA mailgroups

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -1839,6 +1839,8 @@
 				src.radio = src.ai_radio
 			else
 				src.radio = RM.radio
+				src.internal_pda.mailgroups = RM.mailgroups
+				src.internal_pda.alertgroups = RM.alertgroups
 			src.ears = src.radio
 			src.radio.set_loc(src)
 
@@ -1859,6 +1861,8 @@
 				src.radio = src.ai_radio
 			else
 				src.radio = src.default_radio
+				src.internal_pda.mailgroups = initial(src.internal_pda.mailgroups)
+				src.internal_pda.alertgroups = initial(src.internal_pda.alertgroups)
 			src.ears = src.radio
 		return RM
 

--- a/code/modules/robotics/robot/module/brobocop.dm
+++ b/code/modules/robotics/robot/module/brobocop.dm
@@ -6,6 +6,8 @@
 	included_cosmetic = /datum/robot_cosmetic/brobocop
 	included_tools = /datum/robot/module_tool_creator/recursive/module/brobocop
 	radio_type = /obj/item/device/radio/headset/security
+	mailgroups = list(MGD_SECURITY, MGD_KITCHEN, MGO_SILICON, MGD_PARTY)
+	alertgroups = list(MGA_MAIL, MGA_RADIO, MGA_CHECKPOINT, MGA_ARREST, MGA_DEATH, MGA_MEDCRIT, MGA_CRISIS)
 
 /datum/robot_cosmetic/brobocop
 	head_mod = "Afro and Shades"

--- a/code/modules/robotics/robot/module/chemistry.dm
+++ b/code/modules/robotics/robot/module/chemistry.dm
@@ -6,6 +6,7 @@
 	included_cosmetic = /datum/robot_cosmetic/chemistry
 	included_tools = /datum/robot/module_tool_creator/recursive/module/chemistry
 	radio_type = /obj/item/device/radio/headset/research
+	mailgroups = list(MGD_SCIENCE, MGO_SILICON, MGD_PARTY)
 
 /datum/robot_cosmetic/chemistry
 	ches_mod = "Lab Coat"

--- a/code/modules/robotics/robot/module/civilian.dm
+++ b/code/modules/robotics/robot/module/civilian.dm
@@ -5,6 +5,7 @@
 	included_cosmetic = /datum/robot_cosmetic/civilian
 	included_tools = /datum/robot/module_tool_creator/recursive/module/civilian
 	radio_type = /obj/item/device/radio/headset/civilian
+	mailgroups = list(MGD_KITCHEN, MGD_BOTANY, MGO_JANITOR, MGD_STATIONREPAIR, MGO_SILICON, MGD_PARTY)
 
 /datum/robot_cosmetic/civilian
 	fx = list(255, 0, 0)

--- a/code/modules/robotics/robot/module/engineering.dm
+++ b/code/modules/robotics/robot/module/engineering.dm
@@ -6,6 +6,8 @@
 	included_cosmetic = /datum/robot_cosmetic/engineering
 	included_tools = /datum/robot/module_tool_creator/recursive/module/engineering
 	radio_type = /obj/item/device/radio/headset/engineer
+	mailgroups = list(MGO_ENGINEER, MGD_STATIONREPAIR, MGO_MECHANIC, MGO_SILICON, MGD_PARTY)
+	alertgroups = list(MGA_MAIL, MGA_RADIO, MGA_ENGINE, MGA_CRISIS, MGA_RKIT)
 
 /datum/robot_cosmetic/engineering
 	fx = list(255, 255, 0)

--- a/code/modules/robotics/robot/module/medical.dm
+++ b/code/modules/robotics/robot/module/medical.dm
@@ -6,6 +6,8 @@
 	included_cosmetic = /datum/robot_cosmetic/medical
 	included_tools = /datum/robot/module_tool_creator/recursive/module/medical
 	radio_type = /obj/item/device/radio/headset/medical
+	mailgroups = list(MGD_MEDBAY, MGD_MEDRESEACH, MGO_SILICON, MGD_PARTY)
+	alertgroups = list(MGA_MAIL, MGA_RADIO, MGA_DEATH, MGA_MEDCRIT, MGA_CLONER, MGA_CRISIS, MGA_SALES)
 
 /datum/robot_cosmetic/medical
 	head_mod = "Medical Mirror"

--- a/code/modules/robotics/robot/module/mining.dm
+++ b/code/modules/robotics/robot/module/mining.dm
@@ -6,6 +6,8 @@
 	included_cosmetic = /datum/robot_cosmetic/mining
 	included_tools = /datum/robot/module_tool_creator/recursive/module/mining
 	radio_type = /obj/item/device/radio/headset/engineer
+	mailgroups = list(MGO_MINING, MGO_SILICON, MGD_PARTY)
+	alertgroups = list(MGA_MAIL, MGA_RADIO, MGA_SALES, MGA_DEATH)
 
 /datum/robot_cosmetic/mining
 	head_mod = "Hard Hat"

--- a/code/modules/robotics/robot/module/parent.dm
+++ b/code/modules/robotics/robot/module/parent.dm
@@ -16,6 +16,8 @@
 	var/included_cosmetic = null
 	var/radio_type = null
 	var/obj/item/device/radio/radio = null
+	var/list/mailgroups = list(MGO_SILICON, MGD_PARTY)
+	var/list/alertgroups = list(MGA_MAIL, MGA_RADIO, MGA_DEATH)
 
 /obj/item/robot_module/New()
 	..()

--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -112,7 +112,7 @@
 			// start in party line by default
 			MGD_PARTY,
 		)
-		muted_mailgroups = list(MGA_MAIL, MGA_SALES, MGA_SHIPPING, MGA_CARGOREQUEST)
+		muted_mailgroups = list(MGA_MAIL, MGA_SALES, MGA_SHIPPING, MGA_CARGOREQUEST, MGA_RKIT)
 		alertgroups = list(MGA_MAIL, MGA_RADIO, MGA_CHECKPOINT, MGA_ARREST, MGA_DEATH, MGA_MEDCRIT, MGA_CLONER, MGA_ENGINE, MGA_RKIT, MGA_SALES, MGA_SHIPPING, MGA_CARGOREQUEST, MGA_CRISIS) // keep in sync with the list of mail alert groups
 
 	cyborg
@@ -122,6 +122,8 @@
 		setup_drive_size = 1024
 		bombproof = 1
 		mailgroups = list(MGO_SILICON,MGD_PARTY)
+		alertgroups = list(MGA_MAIL, MGA_RADIO, MGA_DEATH)
+		muted_mailgroups = list(MGA_RKIT)
 
 	research_director
 		icon_state = "pda-rd"


### PR DESCRIPTION
[FEATURE]

## About the PR

- auto-subscribes cyborgs to relevant PDA mail groups based on module
- mutes rkitalerts by default for AI and cyborgs