### PR TITLE
Glass recycler plate&round glass fix

### DIFF
--- a/code/obj/machinery/glass_recycler.dm
+++ b/code/obj/machinery/glass_recycler.dm
@@ -143,7 +143,7 @@
 			return 1
 */
 	proc/create(var/object)
-		if(src.glass_amt < 1 || ((object == "pitcher" || object == "largebeaker") && src.glass_amt < 2))
+		if(src.glass_amt < 1 || ((object == "pitcher" || object == "largebeaker" || object == "round" || object == "plate") && src.glass_amt < 2))
 			src.visible_message("<span class='alert'>[src] doesn't have enough glass to make that!</span>")
 			return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR fixes the issue causing the recycler glass amount to set to -1 when vending a round glass or a plate with one glass piece inside.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bugfix

