### PR TITLE
Fix MPRT pouch description

### DIFF
--- a/code/obj/submachine/weapon_vendor.dm
+++ b/code/obj/submachine/weapon_vendor.dm
@@ -362,7 +362,7 @@
 	name = "MPRT Rocket Ammunition"
 	path = /obj/item/storage/pouch/rpg
 	catagory = "Utility"
-	description = "An additional four MPRT rockets."
+	description = "A pouch for keeping MPRT ammunition in. Comes with two additional rockets."
 
 /datum/materiel/utility/donk
 	name = "Warm Donk Pocket"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[trivial]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the vendor description for the MPRT rocket pouch to more accurately reflect that you only get 2 rockets with it.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #3236 
