### PR TITLE
Disable hover effect on tooltips.

### DIFF
--- a/browserassets/css/tooltip.css
+++ b/browserassets/css/tooltip.css
@@ -25,6 +25,7 @@ html, body {
 	padding: 6px;
 	border: 2px solid #222;
 	background: #333;
+	user-select: none;
 }
 
 .pinned .wrap .title {

--- a/tgui/packages/tgui/styles/components/Tooltip.scss
+++ b/tgui/packages/tgui/styles/components/Tooltip.scss
@@ -18,6 +18,7 @@ $border-radius: base.$border-radius !default;
   bottom: 0;
   font-style: normal;
   font-weight: normal;
+  user-select: none;
 
   &::after {
     position: absolute;

--- a/tgui/packages/tgui/styles/components/Tooltip.scss
+++ b/tgui/packages/tgui/styles/components/Tooltip.scss
@@ -18,7 +18,6 @@ $border-radius: base.$border-radius !default;
   bottom: 0;
   font-style: normal;
   font-weight: normal;
-  user-select: none;
 
   &::after {
     position: absolute;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes https://github.com/goonstation/goonstation/issues/3218. Minor bugfix that will dramatically improve the usability of tooltips


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Pretty simple. You should not be able to select text that comes from a `:hover` attribute. Doing so provides a horrible UX.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)BobertBrockson:
(+)You can no longer select tooltips generated by `:hover` or holding `alt+:hover`.
```
