### PR TITLE
Put allergies in the allergy field.

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -86,10 +86,11 @@
 			else traitStr = T.cleanName
 			if (istype(T, /obj/trait/random_allergy))
 				var/obj/trait/random_allergy/AT = T
-				if (M.fields["notes"] == "No notes.") //is it in its default state?
-					M.fields["notes"] = "[G.fields["name"]] has an allergy to [AT.allergic_players[H]]."
+				if (M.fields["alg"] == "None") //is it in its default state?
+					M.fields["alg"] = reagent_id_to_name(AT.allergic_players[H])
+					M.fields["alg_d"] = "Allergy information imported from CentCom database."
 				else
-					M.fields["notes"] += " [G.fields["name"]] has an allergy to [AT.allergic_players[H]]."
+					M.fields["alg"] += ", [reagent_id_to_name(AT.allergic_players[H])]"
 
 	M.fields["traits"] = traitStr
 


### PR DESCRIPTION
[MINOR]

## About the PR

Moves allergy information from "notes" to "allergies" in medical records. Uses the user-facing name of the allergen rather than the developer-facing name.

## Why's this needed?

It's weird to have "Allergies: None" followed by "Allergic to anti_rad".

## Changelog

```
(u)BenLubar:
(+)Moved allergen information to the "Allergies" section of the medical record.
```
