### PR TITLE
Allow borgs to break down watertank/fountain

### DIFF
--- a/code/modules/chemistry/tools/dispensers.dm
+++ b/code/modules/chemistry/tools/dispensers.dm
@@ -239,7 +239,7 @@
 
 	attackby(obj/W as obj, mob/user as mob)
 		if (has_tank)
-			if (istype(W, /obj/item/wrench))
+			if (iswrenchingtool(W))
 				user.show_text("You disconnect the bottle from [src].", "blue")
 				var/obj/item/reagent_containers/food/drinks/P = new /obj/item/reagent_containers/food/drinks/coolerbottle(src.loc)
 				P.reagents.maximum_volume = max(P.reagents.maximum_volume, src.reagents.total_volume)
@@ -257,7 +257,7 @@
 			src.update_icon()
 			return
 
-		if (istype(W, /obj/item/screwdriver))
+		if (isscrewingtool(W))
 			if (src.anchored)
 				playsound(src.loc, "sound/items/Screwdriver.ogg", 50, 1)
 				user.show_text("You start unscrewing [src] from the floor.", "blue")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug - minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Updated logic for `/obj/reagent_dispensers/watertank/fountain` for anchoring and reagent container removal to `isscrewingtool()` and `iswrenchingtool()` instead of checking type of tool used directly


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #3159

