### PR TITLE
Fix wifi component mangling incoming packets.

### DIFF
--- a/code/WorkInProgress/MechanicMadness.dm
+++ b/code/WorkInProgress/MechanicMadness.dm
@@ -1839,7 +1839,7 @@
 				return
 
 			if(forward_all)
-				SEND_SIGNAL(src, COMSIG_MECHCOMP_TRANSMIT_SIGNAL, html_decode(list2params_noencode(signal.data)), signal.data_file?.copy_file())
+				SEND_SIGNAL(src, COMSIG_MECHCOMP_TRANSMIT_SIGNAL, html_decode(list2params(signal.data)), signal.data_file?.copy_file())
 				animate_flash_color_fill(src,"#00FF00",2, 2)
 				return
 

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -176,15 +176,6 @@ proc/castRay(var/atom/A, var/Angle, var/Distance) //Adapted from some forum stuf
 proc/get_angle(atom/a, atom/b)
     .= arctan(b.y - a.y, b.x - a.x)
 
-//list2params without the dumb encoding
-/proc/list2params_noencode(var/list/L)
-	var/strbuild = ""
-	var/first = 1
-	for(var/x in L)
-		strbuild += "[first?"":"&"][x]=[L[x]]"
-		first = 0
-	return strbuild
-
 /turf/var/movable_area_next_type = null
 /turf/var/movable_area_prev_type = null
 


### PR DESCRIPTION
[TRIVIAL]

## About the PR

Removes function that partially implements `list2params` in favor of just calling `list2params`.

## Why's this needed?

Doesn't make any sense to have the wifi receiver component generate malformed packets. All alerts show up as being addressed to `/list` without this change.