### PR TITLE
Move the pool locker room camera in Kondaru

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -14613,6 +14613,13 @@
 "aIM" = (
 /obj/storage/secure/closet/personal,
 /obj/machinery/light,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
+	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/pool)
 "aIN" = (
@@ -17289,13 +17296,6 @@
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
 "aPV" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 9;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
 /obj/submachine/chef_sink/chem_sink{
 	dir = 8;
 	pixel_x = 8

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -15845,13 +15845,6 @@
 	dir = 4;
 	pixel_x = 12
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
 "aLV" = (
@@ -23804,13 +23797,6 @@
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_x = -12
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)


### PR DESCRIPTION
## About the PR

This moves an AI camera to block line of sight to the showers in Kondaru. The camera can still see the locker room, but let's be honest, locker rooms in SS13 are just shiny hallways.

Coverage before:
![image](https://user-images.githubusercontent.com/4257305/103963595-4a75c400-511f-11eb-87b5-259fb361cfe3.png)

Coverage after:
![image](https://user-images.githubusercontent.com/4257305/103963601-4e094b00-511f-11eb-96f5-9858a4736eb5.png)

## Why's this needed?

Consistency? I dunno. I was playing AI one day and saw someone taking a shower and now it's like a week later and I'm making this PR.
