### PR TITLE
color-code APC statuses on power monitoring screen

### DIFF
--- a/code/modules/power/monitor.dm
+++ b/code/modules/power/monitor.dm
@@ -52,7 +52,7 @@
 
 			t += "Area                           Eqp./Lgt./Env.  Load   Cell  | Area                           Eqp./Lgt./Env.  Load   Cell<HR>"
 
-			var/list/S = list(" Off","AOff","  On", " AOn")
+			var/list/S = list("<span style='background-color: #f88'> Off</span>","<span style='background-color: #fa6'>AOff</span>","<span style='background-color: #8f8'>  On</span>", "<span style='background-color: #ccf'> AOn</span>")
 			var/list/chg = list("N","C","F")
 
 			var/do_newline = 0


### PR DESCRIPTION
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Does this:

![image](https://user-images.githubusercontent.com/4257305/103976807-5b353280-513d-11eb-942b-13e061d61e4a.png)

"On" and "AOn" get light colors, "Off" and "AOff" get slightly darker colors. Hues are based on the lights on APCs.

## Why's this needed?

As it currently exists, the screen is very hard to read. The difference between "AOn" and "AOff" is hard to tell at a glance.

## Changelog

```
(u)BenLubar:
(+)The Power Monitoring Computer has been upgraded to a state-of-the-art 6-color screen.
```
