### PR TITLE
Adds Beepsky's House and a few pet/monkey spawns to Atlas

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -1020,7 +1020,18 @@
 /turf/simulated/wall/false_wall,
 /area/station/maintenance/west)
 "cD" = (
-/turf/simulated/wall/auto/supernorn,
+/obj/machinery/door/airlock/pyro/alt{
+	dir = 4;
+	tag = "icon-generic2_closed (EAST)"
+	},
+/obj/firedoor_spawn,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "cE" = (
 /obj/wingrille_spawn/auto/crystal,
@@ -1277,19 +1288,9 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "dj" = (
-/obj/machinery/door/airlock/pyro/alt{
-	dir = 4;
-	tag = "icon-generic2_closed (EAST)"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/firedoor_spawn,
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
+/obj/item/storage/photo_album/beepsky,
+/turf/space,
+/area/space)
 "dk" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
@@ -1354,11 +1355,13 @@
 	},
 /area/station/mining/refinery)
 "dt" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/plasticflaps,
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "red";
+	icon_state = "bedsheet-red"
 	},
+/obj/machinery/bot/secbot/beepsky,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "du" = (
@@ -1486,6 +1489,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/machinery/vending/cola/blue,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "dI" = (
@@ -1512,39 +1516,50 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/west)
 "dN" = (
-/obj/potted_plant{
-	dir = 1;
-	pixel_y = 28
+/obj/storage/crate{
+	desc = "A private crate that isn't yours.";
+	name = "Beepsky's stuff"
 	},
-/obj/cable{
-	icon_state = "4-8"
+/obj/item/diary{
+	pixel_x = 10;
+	pixel_y = 5
 	},
-/obj/disposalpipe/segment{
-	dir = 4
+/obj/item/storage/photo_album/beepsky{
+	pixel_x = 9;
+	pixel_y = -6
 	},
-/turf/simulated/floor/white/checker,
-/area/station/hallway/secondary/exit)
+/obj/item/clothing/suit/det_suit/beepsky{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/obj/item/clothing/shoes/black{
+	desc = "You have no idea how a robot with wheels for locomotion could possibly require these.";
+	name = "Beepsky's Shoes";
+	pixel_x = -9;
+	pixel_y = -7
+	},
+/obj/item/clothing/head/NTberet{
+	desc = "It's a momento, I guess. An old keepsake. And maybe a reminder of the things we've left behind.";
+	name = "Old Beret";
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "dO" = (
-/obj/disposalpipe/segment{
-	dir = 4
+/obj/cable{
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/cable{
-	icon_state = "1-8"
-	},
+/obj/machinery/vending/cola/blue,
 /turf/simulated/floor/white/checker,
 /area/station/hallway/secondary/exit)
 "dP" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/white/checker,
-/area/station/hallway/secondary/exit)
+/obj/machinery/computer/security/wooden_tv,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/west)
 "dQ" = (
 /obj/table/auto,
 /obj/item/paper/book/minerals{
@@ -1578,15 +1593,9 @@
 	},
 /area/station/mining/refinery)
 "dU" = (
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/white/checker,
-/area/station/hallway/secondary/exit)
+/obj/machinery/vending/cola/blue,
+/turf/simulated/floor/red/side,
+/area/station/security/main)
 "dV" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/catering)
@@ -1763,11 +1772,19 @@
 /area/station/hallway/primary/north)
 "es" = (
 /obj/machinery/light,
-/obj/machinery/vending/cola/blue,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/white/checker,
 /area/station/hallway/secondary/exit)
 "et" = (
 /obj/machinery/navbeacon/tour/atlas/tour9,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/white/checker,
 /area/station/hallway/secondary/exit)
 "eu" = (
@@ -1780,8 +1797,11 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "ev" = (
-/obj/disposalpipe/segment,
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon17,
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/white/checker,
 /area/station/hallway/secondary/exit)
 "ew" = (
@@ -4970,7 +4990,6 @@
 /turf/simulated/floor/white,
 /area/station/crew_quarters/kitchen)
 "mi" = (
-/obj/machinery/bot/secbot/beepsky,
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon1_start,
 /turf/simulated/floor/red/side{
 	dir = 8
@@ -6933,6 +6952,9 @@
 	dir = 8;
 	layer = 9.1;
 	pixel_x = -10
+	},
+/obj/landmark/spawner{
+	name = "monkeyspawn_rathen"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -9409,13 +9431,11 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/landmark/spawner{
+	name = "monkeyspawn_mrmuggles"
 	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/west)
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "ws" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 4
@@ -9867,6 +9887,12 @@
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
 /area/station/bridge/captain)
+"xv" = (
+/obj/landmark/spawner{
+	name = "monkeyspawn_mrsmuggles"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/east)
 "xw" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -11379,6 +11405,15 @@
 /obj/item/device/light/flashlight,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
+"BH" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/landmark/spawner{
+	name = "monkeyspawn_albert"
+	},
+/turf/simulated/floor/black,
+/area/station/storage/tech)
 "BI" = (
 /obj/submachine/laundry_machine,
 /turf/simulated/floor/bot,
@@ -13657,6 +13692,7 @@
 /obj/machinery/atmospherics/pipe/manifold{
 	level = 2
 	},
+/mob/living/critter/small_animal/bat/doctor,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "Hz" = (
@@ -13854,6 +13890,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/critter/opossum/morty,
 /turf/simulated/floor/sanitary,
 /area/station/medical/morgue)
 "HY" = (
@@ -48477,7 +48514,7 @@ aa
 aa
 aa
 aa
-aa
+dj
 aa
 aa
 aa
@@ -56335,7 +56372,7 @@ wx
 YR
 Kx
 Ak
-rE
+BH
 Ra
 wt
 CY
@@ -66910,7 +66947,7 @@ BX
 CC
 Di
 DW
-DW
+xv
 Pc
 AC
 ax
@@ -69010,7 +69047,7 @@ xD
 Dk
 qt
 kW
-fl
+wr
 ui
 hV
 vY
@@ -71413,7 +71450,7 @@ dg
 hl
 VK
 gf
-gE
+dU
 hk
 hU
 gE
@@ -72010,7 +72047,7 @@ aa
 aa
 aa
 PS
-PS
+aa
 aa
 dM
 eu
@@ -72310,9 +72347,9 @@ yW
 aa
 aa
 aa
+PS
+PS
 aa
-PS
-PS
 aa
 dK
 eu
@@ -72612,8 +72649,8 @@ yW
 yW
 aa
 aa
-aa
 PS
+aa
 aa
 aa
 dL
@@ -72914,9 +72951,9 @@ yW
 yW
 aa
 aa
-aa
 PS
 aa
+fa
 fa
 dM
 dg
@@ -73217,11 +73254,11 @@ yW
 PS
 PS
 PS
-PS
 aa
 fa
+dN
 dt
-wr
+eu
 ez
 fz
 yj
@@ -73519,11 +73556,11 @@ PS
 PS
 aa
 aa
-aa
 nB
 fa
-dj
-cD
+dP
+fa
+eu
 ez
 fE
 Sx
@@ -73822,9 +73859,9 @@ aa
 nB
 cR
 cR
-cR
-cZ
-dN
+cE
+fa
+fa
 cD
 ez
 fF
@@ -74428,7 +74465,7 @@ bs
 VF
 cf
 cf
-dP
+ek
 et
 cf
 fG
@@ -74730,7 +74767,7 @@ bs
 cf
 cf
 cf
-dU
+ek
 ev
 fd
 fI
@@ -96470,7 +96507,7 @@ aa
 aa
 aa
 aa
-aa
+dj
 aa
 aa
 aa

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -1485,7 +1485,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/vending/cola/blue,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "dI" = (
@@ -1588,10 +1587,6 @@
 	icon_state = "engine_caution_corners"
 	},
 /area/station/mining/refinery)
-"dU" = (
-/obj/machinery/vending/cola/blue,
-/turf/simulated/floor/red/side,
-/area/station/security/main)
 "dV" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/catering)
@@ -71446,7 +71441,7 @@ dg
 hl
 VK
 gf
-dU
+gE
 hk
 hU
 gE

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -73859,7 +73859,7 @@ aa
 nB
 cR
 cR
-cE
+fa
 fa
 fa
 cD

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -1287,10 +1287,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
-"dj" = (
-/obj/item/storage/photo_album/beepsky,
-/turf/space,
-/area/space)
 "dk" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
@@ -48514,7 +48510,7 @@ aa
 aa
 aa
 aa
-dj
+aa
 aa
 aa
 aa
@@ -96507,7 +96503,7 @@ aa
 aa
 aa
 aa
-dj
+aa
 aa
 aa
 aa


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR adds Beepsky's house above Atlas security, in maintenance, complete with TV camera monitor, bed and a crate with their stash. It also moves the beepsky spawn there.

On top of that, several pet/monkey spawns were added:
-Mr and Mrs Muggles 
-Morty and Dr. Acula
-Mr. Rathen in the engine room
-Albert in the quantum telescope room


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Atlas secoffs deserve stylish Beepsky's clothes too. Also the more iconic pet spawns, the better.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)TTerc:
(+)Added Beepsky's house and several pet and monkey spawns to Atlas.
```
