### PR TITLE
Self-tieing to Conveyors and Borgs

### DIFF
--- a/code/WorkInProgress/recycling/conveyor.dm
+++ b/code/WorkInProgress/recycling/conveyor.dm
@@ -47,6 +47,10 @@
 	basedir = dir
 	setdir()
 
+/obj/machinery/conveyor/initialize()
+	..()
+	setdir()
+
 /obj/machinery/conveyor/disposing()
 	for(var/obj/machinery/conveyor/C in range(1,src))
 		if (C.next_conveyor == src)
@@ -151,7 +155,7 @@
 	if(!loc)
 		return
 
-	if(next_conveyor && next_conveyor.loc == newloc)
+	if(src.next_conveyor && src.next_conveyor.loc == newloc)
 		//Ok, they will soon walk() according to the new conveyor
 		//DEBUG_MESSAGE("[AM] exited conveyor at [showCoords(src.x, src.y, src.z)] onto another conveyor! Wow!.")
 		var/mob/M = AM
@@ -190,7 +194,7 @@
 					boutput(user, "<span class='hint'>[M] must be lying down to be tied to the converyor!</span>")
 					return
 
-			M.buckled = src.loc
+			M.buckled = src //behold the most mobile of stools
 			src.add_fingerprint(user)
 			I:use(1)
 			M.lying = 1

--- a/code/WorkInProgress/recycling/conveyor.dm
+++ b/code/WorkInProgress/recycling/conveyor.dm
@@ -185,7 +185,7 @@
 		var/mob/M = locate() in src.loc
 		if(M)
 			if (M == user)
-				src.visible_message("<span class='notice'>[M] ties \himself to the conveyor.</span>")
+				src.visible_message("<span class='notice'>[M] ties [himself_or_herself(M)] to the conveyor.</span>")
 				// note don't check for lying if self-tying
 			else
 				if(M.lying)
@@ -209,7 +209,7 @@
 			M.buckled = null
 			src.add_fingerprint(user)
 			if (M == user)
-				src.visible_message("<span class='notice'>[M] cuts \himself free from the conveyor.</span>")
+				src.visible_message("<span class='notice'>[M] cuts [himself_or_herself(M)] free from the conveyor.</span>")
 			else
 				src.visible_message("<span class='notice'>[M] had been cut free from the conveyor by [user].</span>")
 			return

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -258,7 +258,7 @@
 	return 0
 
 /mob/Move(a, b, flag)
-	if (src.buckled && src.buckled.anchored)
+	if (src.buckled?.anchored && istype(src.buckled))
 		return
 
 	if (src.dir_locked)
@@ -268,7 +268,7 @@
 	if (src.restrain_time > TIME)
 		return
 
-	if (src.buckled)
+	if (src.buckled && istype(src.buckled))
 		var/glide_size = src.glide_size
 		src.buckled.Move(a, b, flag)
 		src.buckled.glide_size = glide_size // dumb hack

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -532,6 +532,12 @@
 							message = "<B>[src]</B> beep-bops at [M]."
 							break
 
+						if (istype(src.buckled, /obj/machinery/conveyor))
+							message = "<B>[src]</B> beep-bops and flips [himself_or_herself(src)] free from the conveyor."
+							src.buckled = null
+							if(isunconscious(src))
+								setalive(src) //reset stat to ensure emote comes out
+
 			if ("fart")
 				if (farting_allowed && src.emote_check(voluntary))
 					m_type = 2

--- a/code/mob/transform_procs.dm
+++ b/code/mob/transform_procs.dm
@@ -230,6 +230,8 @@
 	//else O.cell.charge = 7500
 
 	O.gender = src.gender
+	O.bioHolder.mobAppearance.pronouns = src.bioHolder.mobAppearance.pronouns
+
 	O.invisibility = 0
 	O.name = "Cyborg"
 	O.real_name = "Cyborg"

--- a/code/mob/transform_procs.dm
+++ b/code/mob/transform_procs.dm
@@ -230,8 +230,7 @@
 	//else O.cell.charge = 7500
 
 	O.gender = src.gender
-	O.bioHolder.mobAppearance.pronouns = src.bioHolder.mobAppearance.pronouns
-
+	O.bioHolder?.mobAppearance?.pronouns = src.bioHolder?.mobAppearance?.pronouns
 	O.invisibility = 0
 	O.name = "Cyborg"
 	O.real_name = "Cyborg"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[balance][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Properly assign `buckled` object on self-cabling to conveyors. (Runtime fix)
Account for being buckled to conveyors when checking if movement should occur. (Getting stuck fix) 
Update conveyors determination of "next conveyor" on machine initialization, which occurs after objects have spawned. 

Being tied sets lying to 1 which sets stat 1 (`isunconscious()`==TRUE) so that has odd behavior with borg.  It cause the borg to automatically fail all of its module interactions, disallowing an engineer borg from snipping their own cable.  Borgs `restrained()` is `FALSE` so I gave them a way to automatically break out via *flip.  This gives the borgs the ability to slide under conveyor flaps by cinching themselves down to it, seemed justifiable by existing implementation and thematically.

Added preservation of player preference pronouns on `Robotize_MK2()` due to being confused by pronoun usage when self-cabling to conveyors as borg.  Relevant messages for tying and flipping out of the coil were updated to `himself_or_herself()`.  Was unsure if maybe that should be moved to `transfer_to()` in the already existing borg case.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #425
Resolves runtimes.
Adds some depth to Engineer Robots.


```
(u)Azrun:
(*)Cyborgs can cinch themselves down to conveyors with cable to get under flaps. Can then *flip to free themselves.
(+)Round-start and transformed cyborgs should maintain pronoun preference.
```
