### PR TITLE
Always play the "escape shuttle is enroute" sound when the shuttle is called.

### DIFF
--- a/code/datums/gamemodes/gm_parent.dm
+++ b/code/datums/gamemodes/gm_parent.dm
@@ -49,7 +49,6 @@
 	if (shuttle_last_auto_call + (shuttle_initial_auto_call_done ? shuttle_auto_call_time / 2 : shuttle_auto_call_time) <= ticker.round_elapsed_ticks)
 		emergency_shuttle.incall()
 		command_alert("The shuttle has automatically been called for a shift change.  Please recall the shuttle to extend the shift.","Shift Shuttle Update")
-		world << csound("sound/misc/shuttle_enroute.ogg")
 		shuttle_last_auto_call = ticker.round_elapsed_ticks
 		if (!shuttle_initial_auto_call_done)
 			shuttle_initial_auto_call_done = 1

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -197,7 +197,6 @@
 				boutput(world, "<span class='notice'><B>Alert: The emergency shuttle has been called.</B></span>")
 				boutput(world, "<span class='notice'>- - - <b>Reason:</b> Crew shortages and fatalities.</span>")
 				boutput(world, "<span class='notice'><B>It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes.</B></span>")
-				world << csound("sound/misc/shuttle_enroute.ogg")
 	#undef VALID_MOB
 
 	if (deathConfettiActive || (src.mind && src.mind.assigned_role == "Clown")) //Active if XMAS or manually toggled. Or if theyre a clown. Clowns always have death confetti.

--- a/code/modules/transport/shuttle/shuttle_controller.dm
+++ b/code/modules/transport/shuttle/shuttle_controller.dm
@@ -20,6 +20,9 @@ datum/shuttle_controller
 	// if not called before, set the endtime to T+600 seconds
 	// otherwise if outgoing, switch to incoming
 	proc/incall()
+		if (!online || direction != 1)
+			world << csound("sound/misc/shuttle_enroute.ogg")
+
 		if (online)
 			if(direction == -1)
 				setdirection(1)
@@ -31,6 +34,7 @@ datum/shuttle_controller
 
 	proc/recall()
 		if (online && direction == 1)
+			world << csound("sound/misc/shuttle_recalled.ogg")
 			setdirection(-1)
 			ircbot.event("shuttlerecall", src.timeleft())
 

--- a/code/obj/machinery/computer/communications.dm
+++ b/code/obj/machinery/computer/communications.dm
@@ -423,7 +423,6 @@
 		return 1
 
 	boutput(world, "<span class='notice'><B>Alert: The shuttle is going back!</B></span>") //marker4
-	world << csound("sound/misc/shuttle_recalled.ogg")
 
 	emergency_shuttle.recall()
 


### PR DESCRIPTION
[FEATURE]

## About the PR

Always play the "escape shuttle is enroute" sound when the shuttle is called.

Ideally, there'd be a separate sound for "departed from not-station to
station" and "departed from station to centcom" but I'm not good at
audio-record.

## Why's this needed?

On RP, the rounds often last until the auto-call threshold. This trains players to listen for the sound cue to know when the shuttle is going to come. If it gets called early, there's no sound cue. Often, when an early shuttle call happens, it's because of something that generates a lot of chat messages that can cause the alert to get lost in the noise.

## Changelog

```
(u)BenLubar:
(+)The escape shuttle announcer now announces manual shuttle calls.
```
