### PR TITLE
Power Checker Updates (Vents!)

### DIFF
--- a/code/WorkInProgress/TempEngine.dm
+++ b/code/WorkInProgress/TempEngine.dm
@@ -44,6 +44,7 @@
 	var/serial_num = "CIRC-FEEDDEADBEEF"
 	var/repairstate = 0
 	var/repair_desc = ""
+	var/variant_b_active = FALSE
 
 	anchored = 1.0
 	density = 1
@@ -65,7 +66,9 @@
 	proc/assign_variant(partial_serial_num, variant_a, variant_b=null)
 		src.serial_num = "CIRC-[partial_serial_num][variant_a][rand(100,999)]"
 		src.serial_num += src.side==1? "L":"R"
-		if(variant_b) src.serial_num += "-[variant_b]"
+		if(variant_b)
+			src.serial_num += "-[variant_b]"
+			variant_b_active = TRUE
 
 	disposing()
 		switch (side)
@@ -345,7 +348,8 @@
 			src.UpdateOverlays(image(open_icon), "open")
 		else
 			src.UpdateOverlays(null, "open")
-		if(src.generator.variant_b)
+
+		if(src.variant_b_active)
 			UpdateOverlays(image('icons/obj/atmospherics/pipes.dmi', "circ[side]-o1"), "variant")
 		else
 			UpdateOverlays(null, "variant")

--- a/code/datums/controllers/sea_hotspot_controls.dm
+++ b/code/datums/controllers/sea_hotspot_controls.dm
@@ -732,6 +732,7 @@
 
 	New()
 		..()
+		START_TRACKING
 		if (istype(src.loc,/turf/space/fluid))
 			var/turf/space/fluid/T = src.loc
 			T.captured = 1
@@ -745,6 +746,7 @@
 
 	disposing()
 		..()
+		STOP_TRACKING
 		if (istype(src.loc,/turf/space/fluid))
 			var/turf/space/fluid/T = src.loc
 			T.captured = 0

--- a/code/obj/item/device/pda2/smallprogs.dm
+++ b/code/obj/item/device/pda2/smallprogs.dm
@@ -513,27 +513,13 @@ Code:
 	var/obj/machinery/atmospherics/binary/circulatorTemp/right/circ2
 	var/obj/machinery/power/pt_laser/laser
 	var/obj/machinery/power/generatorTemp/generator
-	var/list/obj/machinery/power/collector_control/collector_controlers
-	var/list/obj/machinery/power/vent_capture/vents
 	var/obj/machinery/carouselpower/carousel
-
-	New()
-		..()
-		collector_controlers = list()
-		vents = list()
 
 	proc/find_machinery(obj/ref, type)
 		if(!ref || ref.disposed)
 			ref = locate(type) in machine_registry[MACHINES_POWER]
 			if(ref?.z != 1) ref = null
 		. = ref
-
-	proc/find_machinery_list(list/obj_list, type)
-		obj_list.len = 0
-		for(var/obj/M in machine_registry[MACHINES_POWER])
-			if(istype(M, type) && M.z == 1)
-				obj_list.Add(M)
-
 
 	return_text()
 		if(..())
@@ -547,14 +533,6 @@ Code:
 			circ1 = generator.circ1
 		if (generator && (!circ2 || circ2.disposed ))
 			circ2 = generator.circ2
-
-		//Singulo
-		find_machinery_list(collector_controlers, /obj/machinery/power/collector_control)
-
-		//Oshan
-		#if defined(MAP_OVERRIDE_OSHAN)
-		find_machinery_list(vents, /obj/machinery/power/vent_capture)
-		#endif
 
 		//PTL
 		laser = find_machinery(laser, /obj/machinery/power/pt_laser)
@@ -579,12 +557,12 @@ Code:
 				. += "Pressure Inlet: [round(MIXTURE_PRESSURE(circ2?.air1), 0.1)] kPa  Outlet: [round(MIXTURE_PRESSURE(circ2?.air2), 0.1)] kPa<BR>"
 				. += "<BR>"
 
-		if(length(collector_controlers))
+		if(length(by_type[/obj/machinery/power/collector_control]))
 			var/controler_index = 1
 			var/collector_index = 1
-			for(var/obj/machinery/power/collector_control/C as() in collector_controlers)
+			for_by_tcl(C, /obj/machinery/power/collector_control)
 				collector_index = 1
-				if(C?.active)
+				if(C?.active && C.z == 1)
 					engine_found = TRUE
 					. += "<BR><h4>Radiation Collector [controler_index++] Status</h4>"
 					. += "Output: [engineering_notation(C.lastpower)]W<BR>"
@@ -594,10 +572,10 @@ Code:
 					if(C.CA4?.active) . += "Collector [collector_index++]: Tank Pressure: [C.P4 ? round(MIXTURE_PRESSURE(C.P4?.air_contents), 0.1) : "ERR"] kPa<BR>"
 					. += "<BR>"
 
-		if(length(vents))
+		if(length(by_type[/obj/machinery/power/vent_capture]))
 			. += "<BR><h4>Vent Capture Unit Status</h4>"
-			for(var/obj/machinery/power/vent_capture/V as() in vents)
-				if(locate(/obj/machinery/power/monitor/smes) in V.powernet?.nodes)
+			for_by_tcl(V, /obj/machinery/power/vent_capture)
+				if(V.z == 1 && (locate(/obj/machinery/power/monitor/smes) in V.powernet?.nodes) )
 					engine_found = TRUE
 					. += "Output : [engineering_notation(V.last_gen)]W<BR>"
 			. += "<BR>"

--- a/code/obj/item/device/pda2/smallprogs.dm
+++ b/code/obj/item/device/pda2/smallprogs.dm
@@ -514,14 +514,18 @@ Code:
 	var/obj/machinery/power/pt_laser/laser
 	var/obj/machinery/power/generatorTemp/generator
 	var/list/obj/machinery/power/collector_control/collector_controlers
+	var/list/obj/machinery/power/vent_capture/vents
+	var/obj/machinery/carouselpower/carousel
 
 	return_text()
 		if(..())
 			return
 		if (!laser)
 			laser = locate() in machine_registry[MACHINES_POWER]
+			if(laser?.z != 1) laser = null
 		if (!generator)
 			generator = locate() in machine_registry[MACHINES_POWER]
+			if(generator?.z != 1) generator = null
 		if (generator && !circ1)
 			circ1 = generator.circ1
 		if (generator && !circ2)
@@ -529,8 +533,16 @@ Code:
 		if (!collector_controlers)
 			collector_controlers = list()
 			for (var/obj/machinery/power/collector_control/C in machine_registry[MACHINES_POWER])
-				collector_controlers.Add(C)
+				if( C.z == 1)
+					collector_controlers.Add(C)
 
+		if (!vents)
+			vents = list()
+			for (var/obj/machinery/power/vent_capture/V in machine_registry[MACHINES_POWER])
+				if( V.z == 1)
+					vents.Add(V)
+		if(!carousel)
+			carousel = locate() in machine_registry[MACHINES_POWER]
 
 		var/stuff = src.return_text_header()
 		var/engine_found = FALSE
@@ -567,6 +579,20 @@ Code:
 					if(C.CA3?.active) stuff += "Collector [collector_index++]: Tank Pressure: [C.P3 ? round(MIXTURE_PRESSURE(C.P3?.air_contents), 0.1) : "ERR"] kPa<BR>"
 					if(C.CA4?.active) stuff += "Collector [collector_index++]: Tank Pressure: [C.P4 ? round(MIXTURE_PRESSURE(C.P4?.air_contents), 0.1) : "ERR"] kPa<BR>"
 					stuff += "<BR>"
+
+		if (length(vents))
+			stuff += "<BR><h4>Vent Capture Unit Status</h4>"
+			for(var/obj/machinery/power/vent_capture/V as() in vents)
+				if(locate(/obj/machinery/power/monitor/smes) in V.powernet.nodes)
+					engine_found = TRUE
+					stuff += "Output : [engineering_notation(V.last_gen)]W<BR>"
+			stuff += "<BR>"
+
+		if (carousel)
+			stuff += "<BR><h4>Cargo Carousel Status</h4>"
+			stuff += "Boost: [((carousel.speedup / carousel.speedup_max)*100)]%<BR>"
+			stuff += "<BR>"
+
 
 		if (!engine_found)
 			stuff += "<BR><B>Error!</B> No power source detected!<BR><BR>"

--- a/code/obj/item/device/pda2/smallprogs.dm
+++ b/code/obj/item/device/pda2/smallprogs.dm
@@ -566,10 +566,10 @@ Code:
 					engine_found = TRUE
 					. += "<BR><h4>Radiation Collector [controler_index++] Status</h4>"
 					. += "Output: [engineering_notation(C.lastpower)]W<BR>"
-					if(C.CA1?.active) . += "Collector [collector_index++]: Tank Pressure: [C.P1 ? round(MIXTURE_PRESSURE(C.P1?.air_contents), 0.1) : "ERR"] kPa<BR>"
-					if(C.CA2?.active) . += "Collector [collector_index++]: Tank Pressure: [C.P2 ? round(MIXTURE_PRESSURE(C.P2?.air_contents), 0.1) : "ERR"] kPa<BR>"
-					if(C.CA3?.active) . += "Collector [collector_index++]: Tank Pressure: [C.P3 ? round(MIXTURE_PRESSURE(C.P3?.air_contents), 0.1) : "ERR"] kPa<BR>"
-					if(C.CA4?.active) . += "Collector [collector_index++]: Tank Pressure: [C.P4 ? round(MIXTURE_PRESSURE(C.P4?.air_contents), 0.1) : "ERR"] kPa<BR>"
+					if(C.CA1?.active) . += "Collector [collector_index++]: Tank Pressure: [C.P1 ? round(MIXTURE_PRESSURE(C.P1.air_contents), 0.1) : "ERR"] kPa<BR>"
+					if(C.CA2?.active) . += "Collector [collector_index++]: Tank Pressure: [C.P2 ? round(MIXTURE_PRESSURE(C.P2.air_contents), 0.1) : "ERR"] kPa<BR>"
+					if(C.CA3?.active) . += "Collector [collector_index++]: Tank Pressure: [C.P3 ? round(MIXTURE_PRESSURE(C.P3.air_contents), 0.1) : "ERR"] kPa<BR>"
+					if(C.CA4?.active) . += "Collector [collector_index++]: Tank Pressure: [C.P4 ? round(MIXTURE_PRESSURE(C.P4.air_contents), 0.1) : "ERR"] kPa<BR>"
 					. += "<BR>"
 
 		if(length(by_type[/obj/machinery/power/vent_capture]))

--- a/code/obj/item/device/pda2/smallprogs.dm
+++ b/code/obj/item/device/pda2/smallprogs.dm
@@ -567,13 +567,13 @@ Code:
 			. += "Output : [engineering_notation(generator.lastgen)]W<BR>"
 			. += "<BR>"
 
-			if(circ1 && !circ1.disposed)
+			if(circ1)
 				. += "<B>Hot Loop</B><BR>"
 				. += "Temperature Inlet: [round(circ1.air1?.temperature, 0.1)] K  Outlet: [round(circ1.air2?.temperature, 0.1)] K<BR>"
 				. += "Pressure Inlet: [round(MIXTURE_PRESSURE(circ1?.air1), 0.1)] kPa  Outlet: [round(MIXTURE_PRESSURE(circ1?.air2), 0.1)] kPa<BR>"
 				. += "<BR>"
 
-			if(circ2 && !circ2.disposed)
+			if(circ2)
 				. += "<B>Cold Loop</B><BR>"
 				. += "Temperature Inlet: [round(circ2.air1?.temperature, 0.1)] K  Outlet: [round(circ2.air2?.temperature, 0.1)] K<BR>"
 				. += "Pressure Inlet: [round(MIXTURE_PRESSURE(circ2?.air1), 0.1)] kPa  Outlet: [round(MIXTURE_PRESSURE(circ2?.air2), 0.1)] kPa<BR>"
@@ -1105,7 +1105,7 @@ Using electronic "Detomatix" BOMB program is perhaps less simple!<br>
 		src.master.updateSelfDialog()
 		return
 
-//made global so fines can use it too, might also be useful for other .
+//made global so fines can use it too, might also be useful for other stuff
 /proc/get_byond_key(var/name)
 	for(var/mob/M in mobs)
 		if(M.real_name == name && M.key)

--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -1295,8 +1295,13 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 
 /obj/machinery/power/collector_control/New()
 	..()
+	START_TRACKING
 	SPAWN_DBG(1 SECOND)
 		updatecons()
+
+/obj/machinery/power/collector_control/disposing()
+	. = ..()
+	STOP_TRACKING
 
 /obj/machinery/power/collector_control/proc/updatecons()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Added vent capture machinery to Power Checker.
Rebuild `power/collector/control/collector/controlers` list on refresh to account for them being constructable.
Added check for z level.

Resolves runtime that occurs with "golden" TEG variant where the generator is exploded/deleted.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Improves information provided to engineering and others regarding power sources on Oshan and Singularity maps.

```
(u)Azrun:
(+)Added vent capture units to Power Checker 0.14! Rebuild lists of constructable power devices.
```
