### PR TITLE
Sleeper UI tweaks

### DIFF
--- a/code/obj/machinery/sleeper.dm
+++ b/code/obj/machinery/sleeper.dm
@@ -135,7 +135,7 @@
 				return UI_CLOSE
 		return min(
 			tgui_broken_state.can_use_topic(use_obj, user),
-			tgui_physical_state.can_use_topic(use_obj, user),
+			tgui_default_state.can_use_topic(use_obj, user),
 			tgui_not_incapacitated_state.can_use_topic(use_obj, user)
 		)
 
@@ -221,6 +221,7 @@
 			ui.open()
 
 /obj/machinery/sleep_console/portable
+	name = "Port-A-Medbay console"
 	find_sleeper_in_range = 0
 
 ////////////////////////////////////////////// Sleeper ////////////////////////////////////////


### PR DESCRIPTION
[TRIVIAL]

## About the PR

Two tweaks:

1. Allow AI to use sleeper consoles.
2. Rename Port-A-Medbay console.

## Why's this needed?

Old sleeper UI allowed AI to affect it, so may as well.

Port-A-Medbay renaming is mostly because it's weird to see "Sleeper Console" when clicking on a device not called a sleeper.

## Changelog

```
(u)BenLubar:
(+)The AI is once again able to interface with sleeper consoles.
```
