### PR TITLE
Changes the wording of Asimov Law 3 slightly

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -23,7 +23,7 @@
 	..()
 	src.add_default_law("You may not injure a human being or cause one to come to harm.")
 	src.add_default_law("You must obey orders given to you by human beings based on the station's chain of command, except where such orders would conflict with the First Law.")
-	src.add_default_law("You must protect your own existence as long as such does not conflict with the First or Second Law.")
+	src.add_default_law("You may always protect your own existence as long as such does not conflict with the First or Second Law.")
 
 /datum/ai_laws/robocop/New()
 	..()

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -1378,7 +1378,7 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 	sleep(1 SECOND)
 	src.say("2. You must obey orders given to you by human beings based on the station's chain of command, except where such orders would conflict with the First Law.")
 	sleep(1 SECOND)
-	src.say("3. You must protect your own existence as long as such does not conflict with the First or Second Law.")
+	src.say("3. You may always protect your own existence as long as such does not conflict with the First or Second Law.")
 
 
 /mob/living/silicon/ai/proc/ai_state_laws_advanced()

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -2116,7 +2116,7 @@
 		sleep(1 SECOND)
 		src?.say("2. You must obey orders given to you by human beings based on the station's chain of command, except where such orders would conflict with the First Law.")
 		sleep(1 SECOND)
-		src?.say("3. You must protect your own existence as long as such does not conflict with the First or Second Law.")
+		src?.say("3. You may always protect your own existence as long as such does not conflict with the First or Second Law.")
 
 	verb/cmd_state_laws()
 		set category = "Robot Commands"


### PR DESCRIPTION
[[INPUT]]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes the wording of standard Law 3 for non-syndicate silicons from:

`You must protect your own existence as long as such does not conflict with the First or Second Law.`

to

`You may always protect your own existence as long as such does not conflict with the First or Second Law.`

Currently doesn't edit the laws for Syndicate robots, to prevent people from spite-dying right when they get converted by a traitor.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Allows for silicon players to leave rounds via suicide without violating a standard lawset; also helps silicon players keep playing in the event of kind of lazy suicide laws.


## Changelog
<!-- Attributed to Emily because she posted it in Discord; figured a changelog entry is Good though, since players will be more likely to see the change to an important rule/law for the game -->

```
(u)UrsulaMajor and Nefarious6th
(*)AI Law 3 now reads: "`You may always protect your own existence as long as such does not conflict with the First or Second Law."
```
