### PR TITLE
delete a single space character from the code to fix the AI getting other players' menus stuck in their UI

### DIFF
--- a/code/WorkInProgress/multiContext.dm
+++ b/code/WorkInProgress/multiContext.dm
@@ -341,7 +341,7 @@ var/list/globalContextActions = null
 				else
 					A = src
 
-				 A.hud.remove_screen(C)
+				A.hud.remove_screen(C)
 			if (ishivebot(src))
 				var/mob/living/silicon/hivebot/hivebot = src
 				hivebot.hud.remove_screen(C)


### PR DESCRIPTION
[MINOR]

## About the PR

Deletes a single space character.

## Why's this needed?

To prevent this:
![image](https://user-images.githubusercontent.com/4257305/104137084-dfff9680-535f-11eb-9a0c-1cc190489095.png)
