### PR TITLE
Fix cyborgs not losing their limbs when their limbs are destroyed.

### DIFF
--- a/code/WorkInProgress/Hydrothings.dm
+++ b/code/WorkInProgress/Hydrothings.dm
@@ -1194,7 +1194,8 @@ obj/critter/madnessowl/switchblade
 				else
 					src.visible_message("<span class='alert'><B>[src]</B> pounds on [BORG.name]'s head furiously!</span>")
 					playsound(src.loc, "sound/impact_sounds/Wood_Hit_1.ogg", 50, 1)
-					BORG.part_head.ropart_take_damage(rand(20,40),0)
+					if (BORG.part_head.ropart_take_damage(rand(20,40),0) == 1)
+						BORG.compborg_lose_limb(BORG.part_head)
 					if (prob(33)) playsound(src.loc, "sound/voice/animal/hoot.ogg", 75, 1)
 					attack_delay = 5
 		else

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -2902,11 +2902,11 @@
 				src.part_leg_l = null
 				src.compborg_force_unequip(1)
 				src.compborg_force_unequip(3)
-			if (part.slot == "arm_left")
+			if (part.slot == "l_arm")
 				src.visible_message("<b>[src]'s</b> left arm breaks off!")
 				src.part_arm_l = null
 				src.compborg_force_unequip(1)
-			if (part.slot == "arm_right")
+			if (part.slot == "r_arm")
 				src.visible_message("<b>[src]'s</b> right arm breaks off!")
 				src.part_arm_r = null
 				src.compborg_force_unequip(3)
@@ -2915,10 +2915,10 @@
 				src.visible_message("<b>[src]'s</b> legs are destroyed!")
 				src.part_leg_r = null
 				src.part_leg_l = null
-			if (part.slot == "leg_left")
+			if (part.slot == "l_leg")
 				src.visible_message("<b>[src]'s</b> left leg breaks off!")
 				src.part_leg_l = null
-			if (part.slot == "leg_right")
+			if (part.slot == "r_leg")
 				src.visible_message("<b>[src]'s</b> right leg breaks off!")
 				src.part_leg_r = null
 		//var/loseslot = part.slot //ZeWaka: Fix for null.slot

--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -757,7 +757,8 @@
 			else
 				user.visible_message("<span class='alert'><B>[user] pounds on [BORG.name]'s head furiously!</B></span>")
 				playsound(user.loc, "sound/impact_sounds/Metal_Clang_3.ogg", 50, 1)
-				BORG.part_head.ropart_take_damage(rand(20,40),0)
+				if (BORG.part_head.ropart_take_damage(rand(20,40),0) == 1)
+					BORG.compborg_lose_limb(BORG.part_head)
 				if (!BORG.anchored && prob(30))
 					user.visible_message("<span class='alert'><B>...and sends them flying!</B></span>")
 					send_flying = 2

--- a/code/obj/critter/wendigo.dm
+++ b/code/obj/critter/wendigo.dm
@@ -268,7 +268,8 @@
 				else
 					src.visible_message("<span class='alert'><B>[src]</B> pounds on [BORG.name]'s head furiously!</span>")
 					playsound(src.loc, "sound/impact_sounds/Wood_Hit_1.ogg", 50, 1)
-					BORG.part_head.ropart_take_damage(rand(20,40),0)
+					if (BORG.part_head.ropart_take_damage(rand(20,40),0) == 1)
+						BORG.compborg_lose_limb(BORG.part_head)
 					if (prob(33)) playsound(src.loc, "sound/voice/animal/wendigo_scream.ogg", 75, 1)
 					attack_delay = 5
 		else


### PR DESCRIPTION
[MAJOR]

## About the PR

Fixes #3225, which turns out to be two unrelated bugs:

- The strings checked for arm/leg slots in the cyborg "part lost" logic are wrong, meaning the arms and legs don't actually get lost when they're over 100% damaged.
- Certain NPCs have the ability to rip a cyborg's head off, which can cause the head to reach more than 100% damage in cases where the head starts from at least 15% health (for light heads, which have 25 health, the 20 to 40 damage is almost always enough to reach above 100% damage). This doesn't actually destroy the head due to a missing check.

## Why's this needed?

As any cyborg or roboticist player will tell you, this stuff is super confusing and annoying. Or, if you want a demonstration, try spawning as a cyborg and getting hit by a fuel tank explosion with and without this change.

## Changelog

```
(u)BenLubar:
(*)Cyborg arms, legs, and heads will now break properly rather than getting stuck in some quantum state.
```