### PR TITLE
Swat mask tint fix

### DIFF
--- a/code/obj/item/clothing/masks.dm
+++ b/code/obj/item/clothing/masks.dm
@@ -159,6 +159,10 @@
 	name = "SWAT Mask"
 	desc = "A close-fitting tactical mask that can filter some environmental toxins or be connected to an air supply."
 	icon_state = "swat"
+	item_state = "swat"
+	color_r = 1
+	color_g = 0.8
+	color_b = 0.8
 
 /obj/item/clothing/mask/gas/voice
 	name = "gas mask"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes the view tint on the swat gas mask from green to red. If there are any other masks/googles that give an incorrect view tint color please warn me so I can just do it all in one PR. also, apparently having no especific view tint on a gas mask makes it give a green tint wich is what was causing this thing and is also kind of weird.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Someone complained about it, it is a really minor thing and easy to fix.


