### PR TITLE
fix APC maintenance for borgs / fix compact sleeper rename

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -490,6 +490,8 @@ var/zapLimiter = 0
 				else
 					user.visible_message("<span class='notice'>[user] transfers some of the power from [src] to yourself!</span>", "<span class='notice'>You transfer 250 charge.</span>")
 
+			charging = chargemode
+
 		else return src.attack_hand(user)
 
 	else if (istype(W, /obj/item/device/pda2) && W:ID_card)
@@ -553,10 +555,6 @@ var/zapLimiter = 0
 		src.remove_dialog(user)
 		user.Browse(null, "window=apc")
 		return
-	else if (can_access_remotely(user) && src.aidisabled)
-		boutput(user, "AI control for this APC interface has been disabled.")
-		user.Browse(null, "window=apc")
-		return
 	if(wiresexposed && (!isAI(user)))
 		src.add_dialog(user)
 		var/t1 = text("<B>Access Panel</B><br>")
@@ -581,6 +579,11 @@ var/zapLimiter = 0
 		t1 += text("<p><a href='?src=\ref[src];close2=1'>Close</a></p><br>")
 		user.Browse(t1, "window=apcwires")
 		onclose(user, "apcwires")
+
+	if (can_access_remotely(user) && src.aidisabled)
+		boutput(user, "AI control for this APC interface has been disabled.")
+		user.Browse(null, "window=apc")
+		return
 
 	src.add_dialog(user)
 	var/t = "<TT><B>Area Power Controller</B> ([area.name])<HR>"

--- a/code/obj/machinery/sleeper.dm
+++ b/code/obj/machinery/sleeper.dm
@@ -220,9 +220,12 @@
 			ui = new(user, src, "Sleeper", src.name)
 			ui.open()
 
-/obj/machinery/sleep_console/portable
-	name = "Port-A-Medbay console"
+/obj/machinery/sleep_console/compact
 	find_sleeper_in_range = 0
+
+	portable
+		name = "Port-A-Medbay console"
+
 
 ////////////////////////////////////////////// Sleeper ////////////////////////////////////////
 
@@ -674,7 +677,7 @@
 		if (!islist(portable_machinery))
 			portable_machinery = list()
 		portable_machinery.Add(src)
-		our_console = new /obj/machinery/sleep_console/portable (src)
+		our_console = new /obj/machinery/sleep_console/compact/portable (src)
 		our_console.our_sleeper = src
 		src.homeloc = src.loc
 		animate_bumble(src, Y1 = 1, Y2 = -1, slightly_random = 0)
@@ -764,7 +767,7 @@
 		if (!islist(portable_machinery))
 			portable_machinery = list()
 		portable_machinery.Add(src)
-		our_console = new /obj/machinery/sleep_console/portable (src)
+		our_console = new /obj/machinery/sleep_console/compact (src)
 		our_console.our_sleeper = src
 
 	disposing()


### PR DESCRIPTION
[TRIVIAL]

## About the PR

- Rename compact sleeper consoles back to Sleeper Console. (Were inadvertently renamed to Port-A-Medbay Console).
- Allow cyborgs to open the APC wire interface while AI control is disabled.