### PR TITLE
Gives the Head of Security an anti-mindslave health implant

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -239,7 +239,7 @@
 	receives_disk = 1
 	receives_security_disk = 1
 	receives_badge = 1
-	recieves_implant = /obj/item/implant/health/security
+	recieves_implant = /obj/item/implant/health/security/anti_mindslave
 
 
 #ifdef SUBMARINE_MAP

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -331,6 +331,11 @@ THROWING DARTS
 		mailgroups.Add(MGD_SECURITY)
 		..()
 
+/obj/item/implant/health/security/anti_mindslave //HoS implant
+	name = "mind protection health implant"
+	icon_state = "implant-b"
+	impcolor = "b"
+
 /obj/item/implant/freedom
 	name = "freedom implant"
 	icon_state = "implant-r"
@@ -637,9 +642,11 @@ THROWING DARTS
 		if (src.uses <= 0)
 			if (ismob(user)) user.show_text("[src] has been used up!", "red")
 			return 0
+		for(var/obj/item/implant/health/security/anti_mindslave/AM in H.implant)
+			boutput(user, "<span class='alert'>[H] is protected from enslaving by \an [AM.name]!</span>")
+			return 0
 		// It might happen, okay. I don't want to have to adapt the override code to take every possible scenario (no matter how unlikely) into considertion.
-		// Also the HoS is immune now because they tended to get mindslaved most rounds they could be.
-		if (H.mind && ((H.mind.special_role == "vampthrall") || (H.mind.special_role == "spyslave") || (H.mind.assigned_role == "Head of Security")))
+		if (H.mind && ((H.mind.special_role == "vampthrall") || (H.mind.special_role == "spyslave")))
 			if (ismob(user)) user.show_text("<b>[H] seems to be immune to being enslaved!</b>", "red")
 			H.show_text("<b>You resist [implant_master]'s attempt to enslave you!</b>", "red")
 			logTheThing("combat", H, implant_master, "resists [constructTarget(implant_master,"combat")]'s attempt to mindslave them at [log_loc(H)].")

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -638,7 +638,8 @@ THROWING DARTS
 			if (ismob(user)) user.show_text("[src] has been used up!", "red")
 			return 0
 		// It might happen, okay. I don't want to have to adapt the override code to take every possible scenario (no matter how unlikely) into considertion.
-		if (H.mind && ((H.mind.special_role == "vampthrall") || (H.mind.special_role == "spyslave")))
+		// Also the HoS is immune now because they tended to get mindslaved most rounds they could be.
+		if (H.mind && ((H.mind.special_role == "vampthrall") || (H.mind.special_role == "spyslave") || (H.mind.assigned_role == "Head of Security")))
 			if (ismob(user)) user.show_text("<b>[H] seems to be immune to being enslaved!</b>", "red")
 			H.show_text("<b>You resist [implant_master]'s attempt to enslave you!</b>", "red")
 			logTheThing("combat", H, implant_master, "resists [constructTarget(implant_master,"combat")]'s attempt to mindslave them at [log_loc(H)].")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[balance][input wanted]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR gives the HoS a variant of the sec implant that prevents them from being mindslaved while it is inside them. (job code doesn't support multiple starting implants)

As of yet this doesn't affect mindslave cloners yet, I'm not sure what the nicest way of going about that is. Mindslave cloners are pretty rare and much more involved than a hit-and-run with an implanter, so maybe HoS is fair game for someone putting in that amount of effort.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Not having HoS rights I can't speak from experience, but the main server(s) apparently have the issue that HoSses burn out on the role after a while. One of the stated reasons is frequent mindslaving, sometimes several rounds in succession. Someone suggested this a day or two ago on discord and I thought it'd be a nice way to help alleviate the problem.

This PR is intended to provoke discussion. I figure this might be a controversial change.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)BatElite:
(*)The Head of Security's health implant now prevents mindslaving while it is inside them. Traitors will have to put in some more effort to get one on their side. The mindslave implant is not consumed if the implant fails.
``