### PR TITLE
Adds ValuChimp vendor to Cog1 monkey dome

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -63514,6 +63514,12 @@
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
+"rNh" = (
+/obj/machinery/vending/monkey,
+/turf/simulated/floor/grass{
+	name = "astroturf"
+	},
+/area/station/medical/research)
 "rNK" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -104738,7 +104744,7 @@ ctD
 cxq
 cxy
 cxq
-cxq
+rNh
 cyd
 aah
 adC


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
As the title says


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
1. More things that geneticists can die to
2. Cog1 is the only popular map in rotation that doesn't have one so why not


