### PR TITLE
Add toast sandwich and Worcestershire sauce.

### DIFF
--- a/code/datums/cookingrecipes.dm
+++ b/code/datums/cookingrecipes.dm
@@ -526,6 +526,7 @@
 		var/list/fillingColors = list()
 		var/onBreadText = ""
 		var/extraSlices = 0
+		var/isToast = FALSE
 
 		var/i = 1
 		for (var/obj/item/reagent_containers/food/snacks/snack in ourCooker)
@@ -534,6 +535,25 @@
 
 			else if (istype(snack, /obj/item/reagent_containers/food/snacks/breadslice))
 				if (slice1 && slice2)
+					// fix up ordering of toast sandwich components
+					var/toast1 = istype(slice1, /obj/item/reagent_containers/food/snacks/breadslice/toastslice)
+					var/toast2 = istype(slice2, /obj/item/reagent_containers/food/snacks/breadslice/toastslice)
+					var/toast3 = istype(snack, /obj/item/reagent_containers/food/snacks/breadslice/toastslice)
+					if (extraSlices == 0 && toast1 + toast2 + toast3 == 1)
+						var/obj/item/reagent_containers/food/snacks/breadslice/temp = snack
+						if (toast1)
+							snack = slice1
+							slice1 = temp
+						else if (toast2)
+							snack = slice2
+							slice2 = temp
+						isToast = TRUE
+						onBreadText = "on [slice1.real_name == "bread" ? "plain bread" : slice1.real_name]"
+						if (slice1.real_name != slice2.real_name)
+							onBreadText += " and [slice2.real_name == "bread" ? "plain" : slice2.real_name]"
+					else
+						isToast = FALSE
+
 					extraSlices++
 
 					if (snack.reagents)
@@ -570,7 +590,12 @@
 
 				qdel(snack)
 
-		if (!fillings.len)
+		if (!fillings.len && isToast)
+			customSandwich.name = "toast"
+			customSandwich.desc = "A slice of toast between two slices of bread. Apparently this counts as a sandwich?"
+			extraSlices--
+			customSandwich.reagents.add_reagent("worcestershire_sauce", 25)
+		else if (!fillings.len)
 			customSandwich.name = "wish"
 			customSandwich.desc = "So named because you 'wish' you had something to put between the slices of bread. Ha.  ha.  Ha..."
 		else

--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -3458,6 +3458,16 @@ datum
 
 				return
 
+		fooddrink/temp_bioeffect/worcestershire_sauce
+			name = "Worcestershire sauce"
+			id = "worcestershire_sauce"
+			description = "Just looking at this substance makes you want to break for Tea."
+			fluid_r = 119
+			fluid_g = 51
+			fluid_b = 34
+			transparency = 60
+			bioeffect_id = "accent_tyke"
+
 		fooddrink/bonerjuice
 			name = "the satisfaction of making spaghetti"
 			id = "bonerjuice"


### PR DESCRIPTION
[FEATURE]

## About the PR

Toast sandwiches are apparently [a real thing](https://en.wikipedia.org/wiki/Toast_sandwich), and there's no way to get the Tyke accent ingame other than the trait. This PR adds a chemical (Worcestershire sauce) that causes the Tyke accent and allows the creation of toast sandwiches to act as a method of obtaining that chemical.

## Why's this needed?

🤷 It's silly.
