### PR TITLE
Donut 3 brig fixes

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -68008,7 +68008,6 @@
 /turf/simulated/wall/auto/reinforced/jen,
 /area/station/science/lobby)
 "uhk" = (
-/obj/machinery/floorflusher/genpop_n,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -68017,6 +68016,7 @@
 /obj/disposalpipe/trunk/ejection{
 	dir = 4
 	},
+/obj/machinery/floorflusher/genpop_s,
 /turf/simulated/floor/grime,
 /area/station/security/brig/south_side)
 "uhs" = (
@@ -71529,11 +71529,6 @@
 /turf/simulated/floor,
 /area/station/ai_monitored/armory)
 "vkg" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
 /obj/machinery/power/apc/autoname_south,
 /obj/cable,
 /turf/simulated/floor/redblack,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

-Fixes Donut 3 brig floor flushers, now they link properly to the timers
-Removes a fire alarm placed under the APC (there's another fire alarm in the area right next to it so I believe it was placed on accident)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Closes #3311 


