### PR TITLE
add some extra effects to artifact cells

### DIFF
--- a/code/mob/living/carbon/human/npc.dm
+++ b/code/mob/living/carbon/human/npc.dm
@@ -604,7 +604,7 @@
 				src.throw_item(locate(T.x + rand(-5, 5), T.y + rand(-5, 5), T.z), list("npc_throw"))
 
 	// give
-	if(prob(5) && src.equipped() && ai_state != AI_ATTACKING)
+	if(prob(src.hand ? 5 : 1) && src.equipped() && ai_state != AI_ATTACKING)
 		for(var/mob/living/carbon/human/H in view(1))
 			if(H != src)
 				src.give_to(H)

--- a/code/obj/artifacts/artifact_items/power_cell.dm
+++ b/code/obj/artifacts/artifact_items/power_cell.dm
@@ -50,10 +50,10 @@
 						src.leakChem = pick("glitter","sakuride","grassgro","glitter_harmless","glowing_fliptonium", "mugwort")
 					if ("precursor")
 						src.leakChem = pick(all_functional_reagent_ids) // no way this goes wrong
-				src.create_reagents(rand(5,20))
-				src.reagents.add_reagent(leakChem, src.reagents.maximum_volume) // so you can reagent scan the cell!
 				if(prob(10))
 					src.smoky = TRUE
+				src.create_reagents(rand(5,20))
+				src.reagents.add_reagent(leakChem, src.reagents.maximum_volume) // so you can reagent scan the cell!
 
 
 			..()
@@ -81,11 +81,16 @@
 			var/turf/T = get_turf(src.loc)
 			if(src.noise)
 				playsound(T, noise, 50, 1, -1)
+
 			if(leakChem && prob(50))
-				src.reagents.reaction(T, TOUCH)
+				if(src.smoky)
+					smoke_reaction(src.reagents, 1, T)
+				else
+					src.reagents.reaction(T, TOUCH)
 				src.reagents.clear_reagents()
 				src.reagents.add_reagent(leakChem, src.reagents.maximum_volume)
-			if(prob(25))
+
+			if(!issilicon(src.loc) && prob(10))
 				elecflash(T)
 
 	ArtifactActivated()

--- a/code/obj/artifacts/artifact_items/power_cell.dm
+++ b/code/obj/artifacts/artifact_items/power_cell.dm
@@ -42,7 +42,7 @@
 			if(prob(maxcharge/1000)) 									// the more charge the bigger the chance it does dumb stuff
 				switch(A.artitype.name) 								// leakage
 					if ("martian")
-						src.leakChem = pick("space_fungus","blood","vomit","gvomit","urine","meat_slurry","grease","butter","synthflesh","bread","poo")
+						src.leakChem = pick("space_fungus","blood","vomit","gvomit","urine","meat_slurry","grease","butter","synthflesh","bread","poo","ants","spiders")
 					if ("ancient")
 						src.leakChem = pick("voltagen","ash","cleaner", "oil", "thermite", "acid", "fuel", "nanites", "radium", "mercury")
 					if ("wizard")

--- a/code/obj/artifacts/artifact_items/power_cell.dm
+++ b/code/obj/artifacts/artifact_items/power_cell.dm
@@ -10,7 +10,7 @@
 	mat_changename = 0
 	mat_changedesc = 0
 	var/effectProbModifier = 0
-	var/sound/noise = null
+	var/noise = null
 	var/leakChem = null
 
 	New(var/loc, var/forceartiorigin)
@@ -31,13 +31,13 @@
 			src.effectProbModifier = 1/rand(10,50) 	// probability
 			switch(A.artitype.name)										// noise
 				if ("martian")
-					src.noise = pick('sound/voice/babynoise.ogg', 'sound/voice/animal/bugchitter.ogg', 'sound/voice/blob/blobdeath.ogg', 'sound/voice/farts/frogfart.ogg', 'sound/effects/splort.ogg')
+					src.noise = pick("sound/voice/babynoise.ogg", "sound/voice/animal/bugchitter.ogg", "sound/voice/blob/blobdeath.ogg", "sound/voice/farts/frogfart.ogg", "sound/effects/splort.ogg")
 				if ("ancient")
-					src.noise = pick('sound/effects/electric_shock_short.ogg', 'sound/effects/creaking_metal2.ogg','sound/machines/weapons-reloading.ogg', 'sound/machines/glitch1.ogg','sound/machines/glitch2.ogg', 'sound/machines/glitch3.ogg','sound/machines/glitch4.ogg', 'sound/machines/glitch5.ogg', 'sound/machines/scan.ogg')
+					src.noise = pick("sound/effects/electric_shock_short.ogg", "sound/effects/creaking_metal2.ogg","sound/machines/weapons-reloading.ogg", "sound/machines/glitch1.ogg","sound/machines/glitch2.ogg", "sound/machines/glitch3.ogg","sound/machines/glitch4.ogg", "sound/machines/glitch5.ogg", "sound/machines/scan.ogg")
 				if ("wizard")
-					src.noise = pick('sound/weapons/airzooka.ogg', 'sound/misc/newsting.ogg', 'sound/misc/chair/glass/scoot5.ogg', 'sound/misc/chair/glass/scoot2.ogg')
+					src.noise = pick("sound/weapons/airzooka.ogg", "sound/misc/newsting.ogg", "sound/misc/chair/glass/scoot5.ogg", "sound/misc/chair/glass/scoot2.ogg")
 				if ("precursor") // what does precursor stuff even sound like???
-					src.noise = pick('sound/effects/singsuck.ogg', 'sound/effects/screech_tone.ogg')
+					src.noise = pick("sound/effects/singsuck.ogg", "sound/effects/screech_tone.ogg")
 
 			if(prob(maxcharge/1000)) 									// the more charge the bigger the chance it does dumb stuff
 				switch(A.artitype.name) 								// leakage

--- a/code/obj/artifacts/artifact_items/power_cell.dm
+++ b/code/obj/artifacts/artifact_items/power_cell.dm
@@ -12,6 +12,7 @@
 	var/effectProbModifier = 0
 	var/noise = null
 	var/leakChem = null
+	var/smoky = FALSE
 
 	New(var/loc, var/forceartiorigin)
 		//src.artifact = new /datum/artifact/powercell(src)
@@ -51,6 +52,9 @@
 						src.leakChem = pick(all_functional_reagent_ids) // no way this goes wrong
 				src.create_reagents(rand(5,20))
 				src.reagents.add_reagent(leakChem, src.reagents.maximum_volume) // so you can reagent scan the cell!
+				if(prob(10))
+					src.smoky = TRUE
+
 
 			..()
 

--- a/code/obj/artifacts/artifact_items/power_cell.dm
+++ b/code/obj/artifacts/artifact_items/power_cell.dm
@@ -2,12 +2,16 @@
 	name = "artifact power cell"
 	icon = 'icons/obj/artifacts/artifactsitemS.dmi'
 	maxcharge = 10000
+	var/chargeCap = 10000
 	genrate = 50
 	specialicon = 1
 	artifact = 1
 	module_research_no_diminish = 1
 	mat_changename = 0
 	mat_changedesc = 0
+	var/effectProbModifier = 0
+	var/sound/noise = null
+	var/leakChem = null
 
 	New(var/loc, var/forceartiorigin)
 		//src.artifact = new /datum/artifact/powercell(src)
@@ -20,7 +24,34 @@
 			var/datum/artifact/A = src.artifact
 			src.maxcharge = rand(15,1000)
 			src.maxcharge *= 100
+			src.chargeCap = src.maxcharge
 			A.react_elec[2] = src.maxcharge
+
+			// effects
+			src.effectProbModifier = 1/rand(10,50) 	// probability
+			switch(A.artitype.name)										// noise
+				if ("martian")
+					src.noise = pick('sound/voice/babynoise.ogg', 'sound/voice/animal/bugchitter.ogg', 'sound/voice/blob/blobdeath.ogg', 'sound/voice/farts/frogfart.ogg', 'sound/effects/splort.ogg')
+				if ("ancient")
+					src.noise = pick('sound/effects/electric_shock_short.ogg', 'sound/effects/creaking_metal2.ogg','sound/machines/weapons-reloading.ogg', 'sound/machines/glitch1.ogg','sound/machines/glitch2.ogg', 'sound/machines/glitch3.ogg','sound/machines/glitch4.ogg', 'sound/machines/glitch5.ogg', 'sound/machines/scan.ogg')
+				if ("wizard")
+					src.noise = pick('sound/weapons/airzooka.ogg', 'sound/misc/newsting.ogg', 'sound/misc/chair/glass/scoot5.ogg', 'sound/misc/chair/glass/scoot2.ogg')
+				if ("precursor") // what does precursor stuff even sound like???
+					src.noise = pick('sound/effects/singsuck.ogg', 'sound/effects/screech_tone.ogg')
+
+			if(prob(maxcharge/1000)) 									// the more charge the bigger the chance it does dumb stuff
+				switch(A.artitype.name) 								// leakage
+					if ("martian")
+						src.leakChem = pick("space_fungus","blood","vomit","gvomit","urine","meat_slurry","grease","butter","synthflesh","bread","poo")
+					if ("ancient")
+						src.leakChem = pick("voltagen","ash","cleaner", "oil", "thermite", "acid", "fuel", "nanites", "radium", "mercury")
+					if ("wizard")
+						src.leakChem = pick("glitter","sakuride","grassgro","glitter_harmless","glowing_fliptonium", "mugwort")
+					if ("precursor")
+						src.leakChem = pick(all_functional_reagent_ids) // no way this goes wrong
+				src.create_reagents(rand(5,20))
+				src.reagents.add_reagent(leakChem, src.reagents.maximum_volume) // so you can reagent scan the cell!
+
 			..()
 
 	examine()
@@ -37,6 +68,30 @@
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (src.Artifact_attackby(W,user))
 			..()
+
+	use(amount)
+		. = ..()
+		if(istype(src.loc, /mob/living))
+			src.ArtifactFaultUsed(src.loc)
+		if(prob(10 + amount*effectProbModifier))
+			var/turf/T = get_turf(src.loc)
+			if(src.noise)
+				playsound(T, noise, 50, 1, -1)
+			if(leakChem && prob(50))
+				src.reagents.reaction(T, TOUCH)
+				src.reagents.clear_reagents()
+				src.reagents.add_reagent(leakChem, src.reagents.maximum_volume)
+			if(prob(25))
+				elecflash(src.loc)
+
+	ArtifactActivated()
+		. = ..()
+		src.maxcharge = src.chargeCap
+
+	ArtifactDeactivated()
+		. = ..()
+		src.maxcharge = 0
+		src.charge = 0
 
 /datum/artifact/powercell
 	associated_object = /obj/item/cell/artifact

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -125,17 +125,17 @@
 
 	if (A.automatic_activation)
 		src.ArtifactActivated()
-	else
-		var/list/valid_triggers = A.validtriggers
-		var/trigger_amount = rand(A.min_triggers,A.max_triggers)
-		var/selection = null
-		while (trigger_amount > 0)
-			trigger_amount--
-			selection = pick(valid_triggers)
-			if (ispath(selection))
-				var/datum/artifact_trigger/AT = new selection
-				A.triggers += AT
-				valid_triggers -= selection
+
+	var/list/valid_triggers = A.validtriggers
+	var/trigger_amount = rand(A.min_triggers,A.max_triggers)
+	var/selection = null
+	while (trigger_amount > 0)
+		trigger_amount--
+		selection = pick(valid_triggers)
+		if (ispath(selection))
+			var/datum/artifact_trigger/AT = new selection
+			A.triggers += AT
+			valid_triggers -= selection
 
 	artifact_controls.artifacts += src
 	A.post_setup()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This makes it so that artifact cells now make random noises and can occasionally leak chems (depending on their origin).
This works inside borgs, but it also works inside of something like an apc.
They also sometimes make sparks.

Artifact cells will now also trigger their faults, if they are faulty. This only works when used by a borg or human, since that's how faults are intended. (Humans can, for instance, be hit by one when using a cell to charge stun gloves.)

To make something like the deactivation fault make more sense, artifact cells now lose their charge and charge capacity when deactivated. They regain them when reactivated. (They still start out activated by default though.)

There was also a small change to make autoactivated artifacts actually generate a set of activation triggers too, since they didn't before, making it so they could not be reactivated if they got deactivated.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I feel like artifact cells are pretty boring right now, with the only variable in them being their size.
Hopefully this will spice things up a bit and make them a bit more interesting to use while also leading to funny or potentially useful situations.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)zjdtmkhzt:
(+)Made artifact cells a little bit more interesting.
```
