### PR TITLE
give eyebot AI shells the AI headset (matches cyborg shells)

### DIFF
--- a/code/mob/living/silicon/hivebot.dm
+++ b/code/mob/living/silicon/hivebot.dm
@@ -62,7 +62,7 @@
 		src.real_name = "AI Shell [copytext("\ref[src]", 6, 11)]"
 		src.name = src.real_name
 
-	src.radio = new /obj/item/device/radio(src)
+	src.radio = new /obj/item/device/radio/headset/command/ai(src)
 	src.ears = src.radio
 
 	SPAWN_DBG(1 SECOND)


### PR DESCRIPTION
[MINOR]

## About the PR

Changes the default AI shell to have an AI headset, matching what AI cyborg shells have.

## Why's this needed?

It's very annoying to go into shell and miss a bunch of messages from people.

## Changelog

```
(u)BenLubar:
(+)AI "eyebot" shells now have access to all radio channels, just like AI cyborg shells do.
```
