### PR TITLE
small fix to swat mask job reward

### DIFF
--- a/code/WorkInProgress/rewardsLocker.dm
+++ b/code/WorkInProgress/rewardsLocker.dm
@@ -132,6 +132,9 @@
 			M.name = "SWAT Gas Mask"
 			M.real_name = "SWAT Gas Mask"
 			M.desc = "A snazzy-looking black Gas Mask."
+			M.color_r = 1
+			M.color_g = 0.8
+			M.color_b = 0.8
 			activator.set_clothing_icon_dirty()
 			return 1
 		boutput(activator, "<span class='alert'>Unable to redeem... are you wearing a gas mask?</span>")


### PR DESCRIPTION
[BUG - MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the SWAT mask job reward be tinted red, much like the SWAT mask.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I hate bugs.