### PR TITLE
attack_self() click delay on two items

### DIFF
--- a/_std/defines/item.dm
+++ b/_std/defines/item.dm
@@ -42,6 +42,9 @@
 #define HAS_EQUIP_CLICK			 (1<<18)
 /// Has the possibility for a TGUI interface
 #define TGUI_INTERACTIVE		 (1<<19)
+/// Has a click delay for attack_self()
+#define ATTACK_SELF_DELAY		 (1<<20)
+
 
 //Item function flags
 

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -495,6 +495,8 @@
 
 		if (target == equipped)
 			equipped.attack_self(src, params, location, control)
+			if(equipped.flags & ATTACK_SELF_DELAY)
+				src.next_click = world.time + (equipped ? equipped.click_delay : src.click_delay)
 		else if (params["ctrl"])
 			var/atom/movable/movable = target
 			if (istype(movable))

--- a/code/modules/chemistry/tools/patches.dm
+++ b/code/modules/chemistry/tools/patches.dm
@@ -462,7 +462,8 @@
 	var/tampered = 0
 	var/borg = 0
 	initial_volume = 200
-	flags = FPRINT | TABLEPASS | OPENCONTAINER | ONBELT | NOSPLASH
+	flags = FPRINT | TABLEPASS | OPENCONTAINER | ONBELT | NOSPLASH | ATTACK_SELF_DELAY
+	click_delay = 0.7 SECONDS
 	rc_flags = RC_SCALE | RC_VISIBLE | RC_SPECTRO
 	module_research = list("medicine" = 4, "science" = 4)
 	module_research_type = /obj/item/reagent_containers/patch

--- a/code/obj/item/card.dm
+++ b/code/obj/item/card.dm
@@ -74,6 +74,8 @@ GAUNTLET CARDS
 	uses_multiple_icon_states = 1
 	item_state = "card-id"
 	desc = "A standardized NanoTrasen microchipped identification card that contains data that is scanned when attempting to access various doors and computers."
+	flags = FPRINT | TABLEPASS | ATTACK_SELF_DELAY
+	click_delay = 0.4 SECONDS
 	var/access = list()
 	var/registered = null
 	var/assignment = null

--- a/code/obj/item/cigarette.dm
+++ b/code/obj/item/cigarette.dm
@@ -1058,7 +1058,8 @@
 	inhand_image_icon = 'icons/mob/inhand/hand_general.dmi'
 	w_class = 1
 	throwforce = 4
-	flags = FPRINT | ONBELT | TABLEPASS | CONDUCT
+	flags = FPRINT | ONBELT | TABLEPASS | CONDUCT | ATTACK_SELF_DELAY
+	click_delay = 0.7 SECONDS
 	stamina_damage = 5
 	stamina_cost = 5
 	stamina_crit_chance = 5

--- a/code/obj/item/coin.dm
+++ b/code/obj/item/coin.dm
@@ -9,6 +9,8 @@
 	stamina_cost = 0
 	module_research = list("vice" = 3, "efficiency" = 1)
 	module_research_type = /obj/item/coin
+	flags = FPRINT | TABLEPASS  | ATTACK_SELF_DELAY
+	click_delay = 1 SECOND
 	var/emagged = FALSE
 
 /obj/item/coin/attack_self(mob/user as mob)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a new flag which when present makes the item have click delay on attack_self(). Adds this flag with some delays to id cards and automenders.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Spamming showing off IDs dozen times per second was annoying at best and client crashing at worst.
By spamming C while running you could rapidly heal with a mender which was not intended.


## Changelog
