### PR TITLE
Adds debuffs for hunger and thirst motives, removes dropped clicks

### DIFF
--- a/code/datums/sims.dm
+++ b/code/datums/sims.dm
@@ -162,19 +162,19 @@
 		depletion_rate = 0.078
 		var/debuff = "hungry"
 		var/debuff_threshold = 25
-		var/debuffed = 0
+		var/debuffed = FALSE
 
 		onIncrease()
 			if (value > debuff_threshold && debuffed)
 				showOwner("<span class='notice'>You feel considerably less [debuff]!</span>")
 				holder.owner.delStatus(debuff)
-				debuffed = 0
+				debuffed = FALSE
 
 		onDecrease()
 			if (value < debuff_threshold && !debuffed)
 				showOwner("<span class='alert'>You feel considerably [debuff]!</span>")
 				holder.owner.setStatus(debuff, duration = null)
-				debuffed = 1
+				debuffed = TRUE
 
 		getWarningMessage()
 			if (value < 25)

--- a/code/datums/sims.dm
+++ b/code/datums/sims.dm
@@ -160,17 +160,21 @@
 		icon_state = "hunger"
 		desc = "Hunger can be raised by eating various edible items, more complex dishes raise your hunger more."
 		depletion_rate = 0.078
-		var/starve_message = "<span class='alert'>You are starving to death!</span>"
+		var/debuff = "hungry"
+		var/debuff_threshold = 25
+		var/debuffed = 0
 
-		var/starving = 0
+		onIncrease()
+			if (value > debuff_threshold && debuffed)
+				showOwner("<span class='notice'>You feel considerably less [debuff]!</span>")
+				holder.owner.delStatus(debuff)
+				debuffed = 0
 
-		onDeplete()
-			if (!starving)
-				showOwner(starve_message)
-				starving++
-
-		onFill()
-			starving = 0
+		onDecrease()
+			if (value < debuff_threshold && !debuffed)
+				showOwner("<span class='alert'>You feel considerably [debuff]!</span>")
+				holder.owner.setStatus(debuff, duration = null)
+				debuffed = 1
 
 		getWarningMessage()
 			if (value < 25)
@@ -182,22 +186,12 @@
 			else
 				return null
 
-		/*onLife()
-			if (starving && value < 25)
-				starving++
-				if (!(starving % 10))
-					showOwner(starve_message)
-				if (starving > 30 && prob(10))
-					holder.owner.death()
-			else if (starving && value > 50)
-				starving--*/
-
 		thirst
 			name = "Thirst"
 			icon_state = "thirst"
 			desc = "Thirst can be raised by drinking various liquids. Certain liquids can also lower your thirst."
-			starve_message = "<span class='alert'>You are dying of thirst!</span>"
 			depletion_rate = 0.0909
+			debuff = "thirsty"
 
 			getWarningMessage()
 				if (value < 25)

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -471,16 +471,6 @@
 	actions.interrupt(src, INTERRUPT_ACT)
 
 	if (!src.stat && !hasStatus(list("weakened", "paralysis", "stunned")))
-		if (target != src && ishuman(src))
-			var/mob/living/carbon/human/S = src
-			if (S.sims)
-				var/mult = S.sims.getMoodActionMultiplier()
-				if (mult < 0.5)
-					if (prob((0.5 - mult) * 200))
-						boutput(src, pick("<span class='alert'>You're not in the mood to attack that.</span>", "<span class='alert'>You don't feel like doing that.</span>"))
-						return
-
-
 		var/obj/item/equipped = src.equipped()
 		var/use_delay = !(target in src.contents) && !istype(target,/obj/screen) && (!disable_next_click || ismob(target) || (target && target.flags & USEDELAY) || (equipped && equipped.flags & USEDELAY))
 		var/grace_penalty = 0

--- a/code/mob/living/life/Life.dm
+++ b/code/mob/living/life/Life.dm
@@ -559,7 +559,6 @@
 		//Modify stamina.
 		var/stam_time_passed = max(tick_spacing, TIME - last_stam_change)
 
-		var/test = src.stamina_regen + src.get_stam_mod_regen()
 		var/final_mod = (src.stamina_regen + src.get_stam_mod_regen()) * (stam_time_passed / tick_spacing)
 		if (final_mod > 0)
 			src.add_stamina(abs(final_mod))

--- a/code/mob/living/life/Life.dm
+++ b/code/mob/living/life/Life.dm
@@ -559,6 +559,7 @@
 		//Modify stamina.
 		var/stam_time_passed = max(tick_spacing, TIME - last_stam_change)
 
+		var/test = src.stamina_regen + src.get_stam_mod_regen()
 		var/final_mod = (src.stamina_regen + src.get_stam_mod_regen()) * (stam_time_passed / tick_spacing)
 		if (final_mod > 0)
 			src.add_stamina(abs(final_mod))

--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -247,14 +247,6 @@
 
 	var/mob/living/carbon/human/H = src
 
-	if (istype(H))
-		if (H.sims)
-			var/mult = H.sims.getMoodActionMultiplier()
-			if (mult < 0.5)
-				if (prob((0.5 - mult) * 200))
-					boutput(src, pick("<span class='alert'>You're not in the mood to grab that.</span>", "<span class='alert'>You don't feel like doing that.</span>"))
-					return
-
 	logTheThing("combat", src, target, "grabs [constructTarget(target,"combat")] at [log_loc(src)].")
 
 	if (target)

--- a/code/modules/status_system/statusFoodBuffs.dm
+++ b/code/modules/status_system/statusFoodBuffs.dm
@@ -192,7 +192,6 @@
 	maxDuration = 6000
 	unique = 1
 	change = 2.2
-	id = "food_bonus"
 
 	big
 		name = "Food (Refreshed+)"

--- a/code/modules/status_system/statusFoodBuffs.dm
+++ b/code/modules/status_system/statusFoodBuffs.dm
@@ -183,7 +183,7 @@
 					M.bodytemperature += 6
 		return
 
-/datum/statusEffect/foodstaminaregen
+/datum/statusEffect/staminaregen/food
 	id = "food_refreshed"
 	name = "Food (Refreshed)"
 	desc = ""
@@ -191,7 +191,8 @@
 	exclusiveGroup = "Food"
 	maxDuration = 6000
 	unique = 1
-	var/change = 2.2
+	change = 2.2
+	id = "food_bonus"
 
 	big
 		name = "Food (Refreshed+)"
@@ -200,16 +201,6 @@
 
 	getTooltip()
 		return "Your stamina regen is increased by [change]."
-
-	onAdd(var/optional=null)
-		if(hascall(owner, "add_stam_mod_regen"))
-			owner:add_stam_mod_regen("food_bonus", change)
-		return
-
-	onRemove()
-		if(hascall(owner, "remove_stam_mod_regen"))
-			owner:remove_stam_mod_regen("food_bonus")
-		return
 
 /datum/statusEffect/foodstaminamax
 	id = "food_energized"

--- a/code/modules/status_system/statusSystem.dm
+++ b/code/modules/status_system/statusSystem.dm
@@ -423,6 +423,26 @@ var/global/list/statusGroupLimits = list("Food"=4)
 		getTooltip()
 			return "You've been zapped in a way your heart seems to like!<br>You feel more resistant to cardiac arrest, and more likely for subsequent defibrillating shocks to restart your heart if it stops!"
 
+	staminaregen
+		id = "staminaregen"
+		name = ""
+		icon_state = ""
+		unique = 1
+		var/change = 1
+
+		getTooltip()
+			return "Your stamina regen has been [change > 0 ? "increased":"reduced"] by [abs(change)]."
+
+		onAdd(var/optional=null)
+			if(hascall(owner, "add_stam_mod_regen"))
+				owner:add_stam_mod_regen(id, change)
+			return
+
+		onRemove()
+			if(hascall(owner, "remove_stam_mod_regen"))
+				owner:remove_stam_mod_regen(id)
+			return
+
 	maxhealth
 		id = "maxhealth"
 		name = ""
@@ -471,14 +491,12 @@ var/global/list/statusGroupLimits = list("Food"=4)
 			onUpdate(var/timePassed)
 				if(change < 0) //Someone fucked this up; remove effect.
 					duration = 1
-				return ..(timePassed)
 
 		decreased
 			id = "maxhealth-"
 			onUpdate(var/timePassed)
 				if(change > 0) //Someone fucked this up; remove effect.
 					duration = 1
-				return ..(timePassed)
 
 	simplehot //Simple heal over time.
 		var/tickCount = 0
@@ -1180,7 +1198,7 @@ var/global/list/statusGroupLimits = list("Food"=4)
 				wait = 0
 			return
 
-	fitness_staminaregen
+	staminaregen/fitness
 		id = "fitness_stam_regen"
 		name = "Pumped"
 		desc = ""
@@ -1188,20 +1206,7 @@ var/global/list/statusGroupLimits = list("Food"=4)
 		exclusiveGroup = "Food"
 		maxDuration = 500 SECONDS
 		unique = 1
-		var/change = 2
-
-		getTooltip()
-			return "Your stamina regen is increased by [change]."
-
-		onAdd(var/optional=null)
-			if(hascall(owner, "add_stam_mod_regen"))
-				owner:add_stam_mod_regen("fitness_regen", change)
-			return
-
-		onRemove()
-			if(hascall(owner, "remove_stam_mod_regen"))
-				owner:remove_stam_mod_regen("fitness_regen")
-			return
+		change = 2
 
 	fitness_staminamax
 		id = "fitness_stam_max"
@@ -1682,3 +1687,27 @@ var/global/list/statusGroupLimits = list("Food"=4)
 		if(istype(M))
 			M.emote("shiver")
 		. = ..()
+
+/datum/statusEffect/maxhealth/decreased/hungry
+	id = "hungry"
+	name = "Hungry"
+	desc = "You really gotta eat!"
+	icon_state = "heart-"
+	duration = INFINITE_STATUS
+	maxDuration = null
+	change = -20
+
+	onAdd(var/optional=null)
+		return ..(change)
+
+	onChange(var/optional=null)
+		return ..(change)
+
+/datum/statusEffect/staminaregen/thirsty
+	id = "thirsty"
+	name = "Thirsty"
+	desc = "You really need some water!"
+	icon_state = "stam-"
+	duration = INFINITE_STATUS
+	maxDuration = null
+	change = -3

--- a/code/modules/status_system/statusSystem.dm
+++ b/code/modules/status_system/statusSystem.dm
@@ -431,7 +431,7 @@ var/global/list/statusGroupLimits = list("Food"=4)
 		var/change = 1
 
 		getTooltip()
-			return "Your stamina regen has been [change > 0 ? "increased":"reduced"] by [abs(change)]."
+			return "Your stamina regen is [change > 0 ? "increased":"reduced"] by [abs(change)]."
 
 		onAdd(var/optional=null)
 			if(hascall(owner, "add_stam_mod_regen"))
@@ -483,7 +483,7 @@ var/global/list/statusGroupLimits = list("Food"=4)
 			return
 
 		getTooltip()
-			return "Your max. health has been [change > 0 ? "increased":"reduced"] by [abs(change)]."
+			return "Your max. health is [change > 0 ? "increased":"reduced"] by [abs(change)]."
 
 		//Technically the base class can handle either but we need to separate these.
 		increased

--- a/code/modules/status_system/statusSystem.dm
+++ b/code/modules/status_system/statusSystem.dm
@@ -1710,4 +1710,4 @@ var/global/list/statusGroupLimits = list("Food"=4)
 	icon_state = "stam-"
 	duration = INFINITE_STATUS
 	maxDuration = null
-	change = -3
+	change = -5


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[INPUT] [REWORK] [WIKI]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR concerns the motives system on the RP servers. It adds debuffs in the form of status effects (which will be visible in the upper right like other status effects!) when your hunger or thirst meters drop below 25. The hunger debuff reduces your maximum health by 20, while the thirst debuff reduces your stamina regeneration by 3. Once your meter goes above 25, the debuffs are removed. This PR also removes the dropped click mechanic because I think it's really unintuitive and unfun gameplay, and also because I think these debuffs should be enough. 

I'd love players' input on these numbers and whether they think they'll be okay. An idea I had was that once you receive a debuff at 25, you have to eat or drink enough to get your motive back up to 50, but I'm not sure how different that would be in terms of actual gameplay. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I think this is definitely more engaging than dropped clicks, and also adds a bit of risk in not eating or drinking enough. 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Flourish:
(*)The motives system on RP has been slightly reworked. Instead of dropping clicks when your overall motives are too low, you now receive a maximum health debuff when your hunger is too low, and a stamina regeneration debuff when your thirst is too low. 
```
