### PR TITLE
Tug can pull a wheeled cart

### DIFF
--- a/code/WorkInProgress/tug.dm
+++ b/code/WorkInProgress/tug.dm
@@ -36,7 +36,6 @@
 			else
 				user.show_text("\The [src] already has a cart connected to it!", "red")
 				return
-		return	
 
 		if (load)
 			return

--- a/code/WorkInProgress/tug.dm
+++ b/code/WorkInProgress/tug.dm
@@ -21,23 +21,19 @@
 			return
 
 		if (istype(C, /obj/tug_cart) || istype(C, /obj/storage/cart) && in_range(C, src))
-			if (istype(C, /obj/tug_cart) || istype(C, /obj/storage/cart))
-				var/obj/tug_cart/connecting = C
-				if (src == connecting) //Wire: Fix for mass recursion runtime (carts connected to themselves)
-					return
-				else if (!src.next_cart && !connecting.next_cart)
-					src.next_cart = connecting
-					user.visible_message("[user] connects [connecting] to [src].", "You connect [connecting] to [src].")
-					playsound(get_turf(src), "sound/misc/belt_click.ogg", 50, 1)
-					return
-				else if (src.next_cart == connecting)
-					src.next_cart = null
-					user.visible_message("[user] disconnects [connecting] from [src].", "You disconnect [connecting] from [src].")
-					playsound(get_turf(src), "sound/misc/belt_click.ogg", 50, 1)
-					return
-				else
-					user.show_text("\The [src] already has a cart connected to it!", "red")
-					return
+			if (src == connecting) //Wire: Fix for mass recursion runtime (carts connected to themselves)
+				return
+			else if (!src.next_cart && !connecting.next_cart)
+				src.next_cart = connecting
+				user.visible_message("[user] connects [connecting] to [src].", "You connect [connecting] to [src].")
+				return
+			else if (src.next_cart == connecting)
+				src.next_cart = null
+				user.visible_message("[user] disconnects [connecting] from [src].", "You disconnect [connecting] from [src].")
+				return
+			else
+				user.show_text("\The [src] already has a cart connected to it!", "red")
+				return
 
 		if (load)
 			return
@@ -246,18 +242,16 @@
 		if (!in_range(user, src) || !in_range(user, C) || user.restrained() || user.getStatusDuration("paralysis") || user.sleeping || user.stat || user.lying)
 			return
 
-		if (istype(C, /obj/tug_cart) || istype(C, /obj/storage/cart) && in_range(C, src))
+		if (istype(C, /obj/tug_cart) && in_range(C, src))
 			if (src == C) //Wire: Fix for mass recursion runtime (carts connected to themselves)
 				return
 			else if (!src.cart)
 				src.cart = C
 				user.visible_message("[user] connects [C] to [src].", "You connect [C] to [src].")
-				playsound(get_turf(src), "sound/misc/belt_click.ogg", 50, 1)
 				return
 			else if (src.cart == C)
 				src.cart = null
 				user.visible_message("[user] disconnects [C] from [src].", "You disconnect [C] from [src].")
-				playsound(get_turf(src), "sound/misc/belt_click.ogg", 50, 1)
 				return
 			else
 				user.show_text("\The [src] already has a cart connected to it!", "red")

--- a/code/WorkInProgress/tug.dm
+++ b/code/WorkInProgress/tug.dm
@@ -27,10 +27,12 @@
 				else if (!src.next_cart && !connecting.next_cart)
 					src.next_cart = connecting
 					user.visible_message("[user] connects [connecting] to [src].", "You connect [connecting] to [src].")
+					playsound(get_turf(src), "sound/misc/belt_click.ogg", 50, 1)
 					return
 				else if (src.next_cart == connecting)
 					src.next_cart = null
 					user.visible_message("[user] disconnects [connecting] from [src].", "You disconnect [connecting] from [src].")
+					playsound(get_turf(src), "sound/misc/belt_click.ogg", 50, 1)
 					return
 				else
 					user.show_text("\The [src] already has a cart connected to it!", "red")
@@ -249,10 +251,12 @@
 			else if (!src.cart)
 				src.cart = C
 				user.visible_message("[user] connects [C] to [src].", "You connect [C] to [src].")
+				playsound(get_turf(src), "sound/misc/belt_click.ogg", 50, 1)
 				return
 			else if (src.cart == C)
 				src.cart = null
 				user.visible_message("[user] disconnects [C] from [src].", "You disconnect [C] from [src].")
+				playsound(get_turf(src), "sound/misc/belt_click.ogg", 50, 1)
 				return
 			else
 				user.show_text("\The [src] already has a cart connected to it!", "red")

--- a/code/WorkInProgress/tug.dm
+++ b/code/WorkInProgress/tug.dm
@@ -21,6 +21,8 @@
 			return
 
 		if (istype(C, /obj/tug_cart) || istype(C, /obj/storage/cart) && in_range(C, src))
+			var/obj/tug_cart/connecting = C
+			var/obj/storage/cart/connecting = C
 			if (src == connecting) //Wire: Fix for mass recursion runtime (carts connected to themselves)
 				return
 			else if (!src.next_cart && !connecting.next_cart)

--- a/code/WorkInProgress/tug.dm
+++ b/code/WorkInProgress/tug.dm
@@ -34,6 +34,7 @@
 			else
 				user.show_text("\The [src] already has a cart connected to it!", "red")
 				return
+		return	
 
 		if (load)
 			return

--- a/code/WorkInProgress/tug.dm
+++ b/code/WorkInProgress/tug.dm
@@ -20,22 +20,22 @@
 			user.show_text("\The [C] is too heavy for \the [src]!", "red")
 			return
 
-		if (istype(C, /obj/tug_cart) && in_range(C, src))
-			var/obj/tug_cart/connecting = C
-			if (src == connecting) //Wire: Fix for mass recursion runtime (carts connected to themselves)
-				return
-			else if (!src.next_cart && !connecting.next_cart)
-				src.next_cart = connecting
-				user.visible_message("[user] connects [connecting] to [src].", "You connect [connecting] to [src].")
-				return
-			else if (src.next_cart == connecting)
-				src.next_cart = null
-				user.visible_message("[user] disconnects [connecting] from [src].", "You disconnect [connecting] from [src].")
-				return
-			else
-				user.show_text("\The [src] already has a cart connected to it!", "red")
-				return
-
+		if (istype(C, /obj/tug_cart) || istype(C, /obj/storage/cart) && in_range(C, src))
+			if (istype(C, /obj/tug_cart) || istype(C, /obj/storage/cart))
+				var/obj/tug_cart/connecting = C
+				if (src == connecting) //Wire: Fix for mass recursion runtime (carts connected to themselves)
+					return
+				else if (!src.next_cart && !connecting.next_cart)
+					src.next_cart = connecting
+					user.visible_message("[user] connects [connecting] to [src].", "You connect [connecting] to [src].")
+					return
+				else if (src.next_cart == connecting)
+					src.next_cart = null
+					user.visible_message("[user] disconnects [connecting] from [src].", "You disconnect [connecting] from [src].")
+					return
+				else
+					user.show_text("\The [src] already has a cart connected to it!", "red")
+					return
 		if (load)
 			return
 
@@ -243,7 +243,7 @@
 		if (!in_range(user, src) || !in_range(user, C) || user.restrained() || user.getStatusDuration("paralysis") || user.sleeping || user.stat || user.lying)
 			return
 
-		if (istype(C, /obj/tug_cart) && in_range(C, src))
+		if (istype(C, /obj/tug_cart) || istype(C, /obj/storage/cart) && in_range(C, src))
 			if (src == C) //Wire: Fix for mass recursion runtime (carts connected to themselves)
 				return
 			else if (!src.cart)

--- a/code/WorkInProgress/tug.dm
+++ b/code/WorkInProgress/tug.dm
@@ -20,8 +20,24 @@
 			user.show_text("\The [C] is too heavy for \the [src]!", "red")
 			return
 
-		if (istype(C, /obj/tug_cart) || istype(C, /obj/storage/cart) && in_range(C, src))
+		if (istype(C, /obj/tug_cart) && in_range(C, src))
 			var/obj/tug_cart/connecting = C
+			if (src == connecting) //Wire: Fix for mass recursion runtime (carts connected to themselves)
+				return
+			else if (!src.next_cart && !connecting.next_cart)
+				src.next_cart = connecting
+				user.visible_message("[user] connects [connecting] to [src].", "You connect [connecting] to [src].")
+				return
+			else if (src.next_cart == connecting)
+				src.next_cart = null
+				user.visible_message("[user] disconnects [connecting] from [src].", "You disconnect [connecting] from [src].")
+				return
+			else
+				user.show_text("\The [src] already has a cart connected to it!", "red")
+				return
+		
+		if (istype(C, /obj/storage/cart) && in_range(C, src))
+			var/obj/storage/cart/connecting = C
 			if (src == connecting) //Wire: Fix for mass recursion runtime (carts connected to themselves)
 				return
 			else if (!src.next_cart && !connecting.next_cart)

--- a/code/WorkInProgress/tug.dm
+++ b/code/WorkInProgress/tug.dm
@@ -20,9 +20,8 @@
 			user.show_text("\The [C] is too heavy for \the [src]!", "red")
 			return
 
-		if (istype(C, /obj/tug_cart) || istype(C, /obj/storage/cart) && in_range(C, src))
+		if (istype(C, /obj/tug_cart) || istype(C, /obj/storage/cart))
 			var/obj/tug_cart/connecting = C
-			var/obj/storage/cart/connecting = C
 			if (src == connecting) //Wire: Fix for mass recursion runtime (carts connected to themselves)
 				return
 			else if (!src.next_cart && !connecting.next_cart)

--- a/code/WorkInProgress/tug.dm
+++ b/code/WorkInProgress/tug.dm
@@ -21,22 +21,22 @@
 			return
 
 		if (istype(C, /obj/tug_cart) || istype(C, /obj/storage/cart) && in_range(C, src))
-				var/obj/tug_cart/connecting = C
-				if (src == connecting) //Wire: Fix for mass recursion runtime (carts connected to themselves)
-					return
-				else if (!src.next_cart && !connecting.next_cart)
-					src.next_cart = connecting
-					user.visible_message("[user] connects [connecting] to [src].", "You connect [connecting] to [src].")
-					playsound(get_turf(src), "sound/misc/belt_click.ogg", 50, 1)
-					return
-				else if (src.next_cart == connecting)
-					src.next_cart = null
-					user.visible_message("[user] disconnects [connecting] from [src].", "You disconnect [connecting] from [src].")
-					playsound(get_turf(src), "sound/misc/belt_click.ogg", 50, 1)
-					return
-				else
-					user.show_text("\The [src] already has a cart connected to it!", "red")
-					return
+			var/obj/tug_cart/connecting = C
+			if (src == connecting) //Wire: Fix for mass recursion runtime (carts connected to themselves)
+				return
+			else if (!src.next_cart && !connecting.next_cart)
+				src.next_cart = connecting
+				user.visible_message("[user] connects [connecting] to [src].", "You connect [connecting] to [src].")
+				playsound(get_turf(src), "sound/misc/belt_click.ogg", 50, 1)
+				return
+			else if (src.next_cart == connecting)
+				src.next_cart = null
+				user.visible_message("[user] disconnects [connecting] from [src].", "You disconnect [connecting] from [src].")
+				playsound(get_turf(src), "sound/misc/belt_click.ogg", 50, 1)
+				return
+			else
+				user.show_text("\The [src] already has a cart connected to it!", "red")
+				return
 
 		if (load)
 			return

--- a/code/WorkInProgress/tug.dm
+++ b/code/WorkInProgress/tug.dm
@@ -21,7 +21,6 @@
 			return
 
 		if (istype(C, /obj/tug_cart) || istype(C, /obj/storage/cart) && in_range(C, src))
-			if (istype(C, /obj/tug_cart) || istype(C, /obj/storage/cart))
 				var/obj/tug_cart/connecting = C
 				if (src == connecting) //Wire: Fix for mass recursion runtime (carts connected to themselves)
 					return

--- a/code/WorkInProgress/tug.dm
+++ b/code/WorkInProgress/tug.dm
@@ -21,22 +21,23 @@
 			return
 
 		if (istype(C, /obj/tug_cart) || istype(C, /obj/storage/cart) && in_range(C, src))
-			var/obj/tug_cart/connecting = C
-			if (src == connecting) //Wire: Fix for mass recursion runtime (carts connected to themselves)
-				return
-			else if (!src.next_cart && !connecting.next_cart)
-				src.next_cart = connecting
-				user.visible_message("[user] connects [connecting] to [src].", "You connect [connecting] to [src].")
-				playsound(get_turf(src), "sound/misc/belt_click.ogg", 50, 1)
-				return
-			else if (src.next_cart == connecting)
-				src.next_cart = null
-				user.visible_message("[user] disconnects [connecting] from [src].", "You disconnect [connecting] from [src].")
-				playsound(get_turf(src), "sound/misc/belt_click.ogg", 50, 1)
-				return
-			else
-				user.show_text("\The [src] already has a cart connected to it!", "red")
-				return
+			if (istype(C, /obj/tug_cart) || istype(C, /obj/storage/cart))
+				var/obj/tug_cart/connecting = C
+				if (src == connecting) //Wire: Fix for mass recursion runtime (carts connected to themselves)
+					return
+				else if (!src.next_cart && !connecting.next_cart)
+					src.next_cart = connecting
+					user.visible_message("[user] connects [connecting] to [src].", "You connect [connecting] to [src].")
+					playsound(get_turf(src), "sound/misc/belt_click.ogg", 50, 1)
+					return
+				else if (src.next_cart == connecting)
+					src.next_cart = null
+					user.visible_message("[user] disconnects [connecting] from [src].", "You disconnect [connecting] from [src].")
+					playsound(get_turf(src), "sound/misc/belt_click.ogg", 50, 1)
+					return
+				else
+					user.show_text("\The [src] already has a cart connected to it!", "red")
+					return
 
 		if (load)
 			return

--- a/code/WorkInProgress/tug.dm
+++ b/code/WorkInProgress/tug.dm
@@ -20,7 +20,7 @@
 			user.show_text("\The [C] is too heavy for \the [src]!", "red")
 			return
 
-		if (istype(C, /obj/tug_cart) || istype(C, /obj/storage/cart))
+		if (istype(C, /obj/tug_cart) || istype(C, /obj/storage/cart) && in_range(C, src))
 			var/obj/tug_cart/connecting = C
 			if (src == connecting) //Wire: Fix for mass recursion runtime (carts connected to themselves)
 				return

--- a/code/WorkInProgress/tug.dm
+++ b/code/WorkInProgress/tug.dm
@@ -36,6 +36,7 @@
 				else
 					user.show_text("\The [src] already has a cart connected to it!", "red")
 					return
+
 		if (load)
 			return
 

--- a/code/obj/storage/carts.dm
+++ b/code/obj/storage/carts.dm
@@ -11,6 +11,7 @@
 	health = 4
 	can_flip_bust = 1
 	p_class = 1.5
+	var/obj/storage/cart/next_cart = null
 
 	recalcPClass()
 		var/maxPClass = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds two OR statements to allow tug vehicles to pull a single wheeled cart. Flatbeds are not able to be attached to the back of a wheeled cart.

I imagine that tugs could be used to move the emergency equipment already set up (Medbay, Engineering repairs, Forensics) more quickly, either if mechanics makes one for the departments or if more tugs are included in the maps. Either way, this change allows for more tug utility beyond delivering cargo crates.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Adds to the utility of the tug and further completes the logic for wheeled emergency carts of different purposes.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Xyzzy:
(+)Tugs can now pull wheeled carts.
```
