### PR TITLE
Werewolf transformation now respects your previous mutant race

### DIFF
--- a/code/datums/abilities/misc/werewolf_transform.dm
+++ b/code/datums/abilities/misc/werewolf_transform.dm
@@ -58,7 +58,7 @@
 		..()
 
 		var/mob/living/M = owner
-		M.werewolf_transform(0, 1)
+		M.werewolf_transform()
 
 	onInterrupt()
 		..()

--- a/code/datums/abilities/werewolf.dm
+++ b/code/datums/abilities/werewolf.dm
@@ -82,7 +82,6 @@
 
 			//wolfing removes all the implants in you
 			for(var/obj/item/implant/I in M)
-				// if (istype(I, /obj/item/implant/projectile))
 				boutput(M, "<span class='alert'>\an [I] falls out of your abdomen.</span>")
 				I.on_remove(M)
 				M.implant.Remove(I)
@@ -102,9 +101,6 @@
 			else
 				boutput(M, "<span class='notice'><h3>You are now a werewolf. You can remain in this form indefinitely or change back at any time.</span></h3>")
 
-			//when in werewolf form, get more max health or regenerate
-			// M.maxhealth = 200
-			// M.health =
 			if (src.bioHolder)
 				src.bioHolder.AddEffect("regenerator_wolf")
 				boutput(src, "<span class='alert'>You will now heal over time!</span>")
@@ -135,7 +131,6 @@
 
 			//Changing back removes all the implants in you, wolves should have a non-surgery way to remove bullets. considering silver is so harmful
 			for(var/obj/item/implant/I in M)
-				// if (istype(I, /obj/item/implant/projectile))
 				boutput(M, "<span class='alert'>\an [I] falls out of your abdomen.</span>")
 				I.on_remove(M)
 				M.implant.Remove(I)

--- a/code/datums/abilities/werewolf.dm
+++ b/code/datums/abilities/werewolf.dm
@@ -49,27 +49,47 @@
 		if (!src.getStatusDuration("weakened") && !src.getStatusDuration("paralysis"))
 			src.emote("collapse")
 		W.addAbility(/datum/targetable/werewolf/werewolf_transform)
-		src.werewolf_transform(0, 0) // Not really a fan of this. I wish werewolves all suffered from lycanthropy and that should be how you pass it on, but w/e
+		src.werewolf_transform() // Not really a fan of this. I wish werewolves all suffered from lycanthropy and that should be how you pass it on, but w/e
 
 ////////////////////////////////////////////// Helper procs //////////////////////////////
 
 // Avoids C&P code for that werewolf disease.
-/mob/proc/werewolf_transform(var/source_is_lycanthrophy = 0, var/message_type = 0)
+/mob/proc/werewolf_transform()
 	if (ishuman(src))
 		var/mob/living/carbon/human/M = src
 		var/which_way = 0
 
-		if ((!M.mutantrace || istype(M.mutantrace, /datum/mutantrace/virtual))|| source_is_lycanthrophy == 1)//the istype fixes you needing to transform twice in vr
+		// not a werewolf? Go become one!
+		if (!istype(M.mutantrace, /datum/mutantrace/werewolf))
+			/// Werewolf is typically a "temporary" MR, as few people start the round as a wolf. Or TF into a wolf while being a wolf
+			if(istype(M.coreMR, /datum/mutantrace/werewolf)) // so if this somehow happens, uh. human?
+				M.coreMR = null
+			M.coreMR = M.mutantrace
 			M.jitteriness = 0
 			M.delStatus("stunned")
 			M.delStatus("weakened")
 			M.delStatus("paralysis")
 			M.delStatus("slowed")
 			M.delStatus("disorient")
+			M.delStatus("radiation")
+			M.delStatus("n_radiation")
+			M.delStatus("burning")
+			M.delStatus("staggered")
 			M.change_misstep_chance(-INFINITY)
 			M.stuttering = 0
 			M.drowsyness = 0
+			M.add_stun_resist_mod("wolf_stun_resist", 10)
 
+			//wolfing removes all the implants in you
+			for(var/obj/item/implant/I in M)
+				// if (istype(I, /obj/item/implant/projectile))
+				boutput(M, "<span class='alert'>\an [I] falls out of your abdomen.</span>")
+				I.on_remove(M)
+				M.implant.Remove(I)
+				I.set_loc(M.loc)
+				continue
+
+			M.set_mutantrace(/datum/mutantrace/werewolf)
 
 			playsound(M.loc, 'sound/impact_sounds/Slimy_Hit_4.ogg', 50, 1, -1)
 			SPAWN_DBG(0.5 SECONDS)
@@ -77,43 +97,41 @@
 					M.emote("howl")
 
 			M.visible_message("<span class='alert'><B>[M] [pick("metamorphizes", "transforms", "changes")] into a werewolf! Holy shit!</B></span>")
-			if (message_type == 0)
-				boutput(M, __blue("<h3>You are now a werewolf.</h3>"))
+			if (M.find_ailment_by_type(/datum/ailment/disease/lycanthropy))
+				boutput(M, "<span class='notice'><h3>You are now a werewolf.</span></h3>")
 			else
-				boutput(M, __blue("<h3>You are now a werewolf. You can remain in this form indefinitely or change back at any time.</h3>"))
-
-			if (source_is_lycanthrophy == 1 && M.mutantrace)
-				qdel(M.mutantrace)
-
-			M.set_mutantrace(/datum/mutantrace/werewolf) //this proc handles body updates etc
+				boutput(M, "<span class='notice'><h3>You are now a werewolf. You can remain in this form indefinitely or change back at any time.</span></h3>")
 
 			//when in werewolf form, get more max health or regenerate
 			// M.maxhealth = 200
 			// M.health =
 			if (src.bioHolder)
-				src.bioHolder.AddEffect("regenerator")
+				src.bioHolder.AddEffect("regenerator_wolf")
 				boutput(src, "<span class='alert'>You will now heal over time!</span>")
 
 			if (M.hasStatus("handcuffed"))
 				if (M.handcuffs.werewolf_cant_rip())
-					boutput(M, __red("You can't seem to break free from these silver handcuffs."))
+					boutput(M, "<span class='alert'>You can't seem to break free from these silver handcuffs.</span>")
 				else
 					M.visible_message("<span class='alert'><B>[M] rips apart the [M.handcuffs] with pure brute strength!</b></span>")
 					M.handcuffs.destroy_handcuffs(M)
 
 			which_way = 0
 
+		// iswolf?
 		else
-			if (source_is_lycanthrophy == 1) // Werewolf disease is human -> WW only.
+			if (M.find_ailment_by_type(/datum/ailment/disease/lycanthropy)) // Wolfdisease? Whoops, you're a wolf forever!
+				boutput(src, "<span class='alert'>Your body refuses to change!</span>")
 				return
 
-			boutput(M, __blue("<h3>You transform back into your human form.</h3>"))
-
-			M.set_mutantrace(null) //this proc handles body updates etc
-
+			M.remove_stun_resist_mod("wolf_stun_resist")
 			if (src.bioHolder)
 				src.bioHolder.RemoveEffect("regenerator")
 				boutput(src, "<span class='alert'>You will no longer heal over time!</span>")
+
+			boutput(M, "<span class='notice'><h3>You transform back into your original form.</span></h3>")
+
+			M.set_mutantrace(M.coreMR) // return to monke/bove/herpe/etc
 
 			//Changing back removes all the implants in you, wolves should have a non-surgery way to remove bullets. considering silver is so harmful
 			for(var/obj/item/implant/I in M)

--- a/code/datums/abilities/werewolf/werewolf_spread_affliction.dm
+++ b/code/datums/abilities/werewolf/werewolf_spread_affliction.dm
@@ -126,7 +126,7 @@
 						HH.make_werewolf(1)
 						HH.full_heal()
 						HH.setStatus("weakened",150)
-						HH.werewolf_transform(0, 0) // Not really a fan of this. I wish werewolves all suffered from lycanthropy and that should be how you pass it on, but w/e
+						HH.werewolf_transform() // Not really a fan of this. I wish werewolves all suffered from lycanthropy and that should be how you pass it on, but w/e
 						remove_antag(M, null, 0, 1)
 						boutput(W, __red("You passed your terribly affliction onto [HH]! You are no longer a werewolf!"))
 						logTheThing("combat", M, target, "turns [constructTarget(target,"combat")] into a werewolf at [log_loc(M)].")

--- a/code/datums/abilities/werewolf/werewolf_transform.dm
+++ b/code/datums/abilities/werewolf/werewolf_transform.dm
@@ -59,7 +59,7 @@
 		..()
 
 		var/mob/living/M = owner
-		M.werewolf_transform(0, 1)
+		M.werewolf_transform()
 
 	onInterrupt()
 		..()

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -1221,7 +1221,7 @@
 	l_limb_arm_type_mutantrace = /obj/item/parts/human_parts/arm/mutant/werewolf/left
 	r_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/werewolf/right
 	l_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/werewolf/left
-	ignore_missing_limbs = 0
+	ignore_missing_limbs = 1 // heck it, just regenerate your limbs, you shambling dogbomination
 	var/old_client_color = null
 	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_NO_EYES | BUILT_FROM_PIECES | HEAD_HAS_OWN_COLORS)
 	mutant_folder = 'icons/mob/werewolf.dmi'

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -93,6 +93,8 @@
 	var/uses_damage_overlays = 1 //If set to 0, the mob won't receive any damage overlays.
 
 	var/datum/mutantrace/mutantrace = null
+	/// used by werewolf TF to store and restore what you were before TFing into a werewolf
+	var/datum/mutantrace/coreMR = null // There are two wolves inside you. One's a wolf, the other's probably some kind of lizard. Also one's actually you, and they trade places Hannah Montana style
 
 	var/emagged = 0 //What the hell is wrong with me?
 	var/spiders = 0 // SPIDERS

--- a/code/modules/medical/diseases/lycanthropy.dm
+++ b/code/modules/medical/diseases/lycanthropy.dm
@@ -46,7 +46,7 @@
 
 						SPAWN_DBG (rand(100, 300))
 							if (H && D)
-								H.werewolf_transform(1, 0) // Less code duplication and stuff. See werewolf.dm (Convair880).
+								H.werewolf_transform() // Less code duplication and stuff. See werewolf.dm (Convair880).
 								D.stage_prob = 0
 								D.stage = 1
 							src.triggered_transformation = 0 // Necessary. Disease datums seem to be pooled or something, dunno.

--- a/code/modules/medical/genetics/bioEffects/beneficial.dm
+++ b/code/modules/medical/genetics/bioEffects/beneficial.dm
@@ -274,8 +274,8 @@
 	heal_per_tick = 2
 	regrow_prob = 50
 
-	OnLife()
-		if(..()) return
+	OnAdd()
+		. = ..()
 		if(ishuman(owner))
 			var/mob/living/carbon/human/H = owner
 			if(!istype(H.mutantrace, /datum/mutantrace/werewolf))

--- a/code/modules/medical/genetics/bioEffects/beneficial.dm
+++ b/code/modules/medical/genetics/bioEffects/beneficial.dm
@@ -279,7 +279,7 @@
 		if(ishuman(owner))
 			var/mob/living/carbon/human/H = owner
 			if(!istype(H.mutantrace, /datum/mutantrace/werewolf))
-				H.contract_disease(/datum/ailment/disease/lycanthropy,null,null,1) // awoo
+				H.contract_disease(/datum/ailment/disease/lycanthropy,null,null,0) // awoo
 
 /datum/bioEffect/detox
 	name = "Natural Anti-Toxins"

--- a/code/modules/medical/genetics/bioEffects/beneficial.dm
+++ b/code/modules/medical/genetics/bioEffects/beneficial.dm
@@ -255,6 +255,31 @@
 	heal_per_tick = 7 // decrease to 5 if extreme narcolepsy doesn't counterbalance this enough
 	regrow_prob = 50 //increase to 100 if not counterbalanced
 
+/datum/bioEffect/regenerator/wolf
+	name = "Lupine Regeneration"
+	desc = "Subject's cells are programmed to reshape itself into a canine form."
+	id = "regenerator_wolf"
+	occur_in_genepools = 0
+	probability = 0
+	scanner_visibility = 0
+	can_research = 0
+	can_make_injector = 0
+	can_copy = 0
+	can_reclaim = 0
+	can_scramble = 0
+	curable_by_mutadone = 0
+	stability_loss = 0
+	msgGain = "You feel oddly feral."
+	msgLose = "You feel more comfortable in your own skin."
+	heal_per_tick = 2
+	regrow_prob = 50
+
+	OnLife()
+		if(..()) return
+		if(ishuman(owner))
+			var/mob/living/carbon/human/H = owner
+			if(!istype(H.mutantrace, /datum/mutantrace/werewolf))
+				H.contract_disease(/datum/ailment/disease/lycanthropy,null,null,1) // awoo
 
 /datum/bioEffect/detox
 	name = "Natural Anti-Toxins"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUGFIX][FEATURE}
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #3298, so now you can TF to a werewolf from a mutant race, and return to that mutant race when TFing back. 

Fixes #3156 by making werewolves replace whatever they had for limbs with wolf limbs. Also means they'll get all their limbs back if they lose them and TF into a wolf, but honestly that ability could use a some buffs.

Also, made werewolf transformation...
- Clear any radiation, burning, and staggered status when becoming a wolf.
  - Also removes all implanted things, applies +10 to stun resistance, and regrows any lost limbs.
- Give a buffed form of regen, heals twice as fast as normal regen and limb regrowth chance of 50.
  - If someone other than a werewolf somehow gets the mutation, they get afflicted with lycanthropy.
- No longer need extra args to work. Now it just checks if they have wolfdisease and refuses to unTF them.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Superlagg:
(+)Fixed werewolf transformations not working properly with other mutant races.
(+)Buffed werewolf transformation. Now also clears burning, radiation, and stagger, adds +10 stun resistance, applies twice as much regeneration than it did previously, and regrows any lost or robotic limbs.
```
