### PR TITLE
Make NTSO only available if a HoS has joined the round

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -12,6 +12,7 @@
 	var/allow_spy_theft = 1
 	var/cant_spawn_as_rev = 0 // For the revoltion game mode. See jobprocs.dm for notes etc (Convair880).
 	var/requires_whitelist = 0
+	var/requires_supervisor_job = null // Enter job name, this job will only be present if the entered job has joined already
 	var/needs_college = 0
 	var/assigned = 0
 	var/high_priority_job = 0
@@ -2320,6 +2321,7 @@
 	limit = 1 // backup during HELL WEEK. players will probably like it
 	wages = PAY_TRADESMAN
 	requires_whitelist = 1
+	requires_supervisor_job = "Head of Security"
 	allow_traitors = 0
 	allow_spy_theft = 0
 	cant_spawn_as_rev = 1

--- a/code/mob/new_player.dm
+++ b/code/mob/new_player.dm
@@ -267,6 +267,8 @@ mob/new_player
 			return 0
 		if (!JOB.no_jobban_from_this_job && jobban_isbanned(src,JOB.name))
 			return 0
+		if (JOB.requires_supervisor_job && countJob(JOB.requires_supervisor_job) <= 0)
+			return 0
 		if (JOB.requires_whitelist)
 			if (!NT.Find(src.ckey))
 				return 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes it so the NTSO job is only available for latejoining if a HoS has already joined the round.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
NTSO was originally added as a helper to HoS in times when HoS was overwhelmed. Having NTSO without HoS kinda defeats that purpose.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)pali
(+)NTSO job is now only available after HoS has been picked.
```
