### PR TITLE
Removes monkeys from QM purchases list

### DIFF
--- a/code/datums/supply_packs.dm
+++ b/code/datums/supply_packs.dm
@@ -375,15 +375,6 @@ ABSTRACT_TYPE (/datum/supply_packs/electrical)
 	containername = "Mining Equipment Crate"
 	access = null
 
-/datum/supply_packs/monkey4
-	name = "Lab Monkey Crate - 4 pack"
-	desc = "x4 Monkey"
-	category = "Research Department"
-	contains = list(/mob/living/carbon/human/npc/monkey = 4)
-	cost = 500
-	containertype = /obj/storage/crate/medical
-	containername = "Lab Monkey Crate"
-
 /datum/supply_packs/bee
 	name = "Honey Production Kit"
 	desc = "For use with existing hydroponics bay."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes monkeys from QM purchases list


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The monkey crates are only ever used by AI's or people with AA to spam them to make life more difficult or drain the budget.
Now that monkey AI is more advanced and monkey vendors have restock cartidges that can also be bought from QM, I think it's time to remove monkey crates


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Carbadox:
(+)Removed monkeys from QM purchases list due to lack of actual use outside of causing grief. 
```
