### PR TITLE
Fix alignment of No Cell status in the power monitoring computer.

### DIFF
--- a/code/modules/power/monitor.dm
+++ b/code/modules/power/monitor.dm
@@ -59,7 +59,7 @@
 			for(var/obj/machinery/power/apc/A in L)
 
 				t += copytext(add_tspace(A.area.name, 30), 1, 30)
-				t += " [S[A.equipment+1]] [S[A.lighting+1]] [S[A.environ+1]] [add_lspace(A.lastused_total, 6)]  [A.cell ? "[add_lspace(round(A.cell.percent()), 3)]% [chg[A.charging+1]]" : "  N/C"][do_newline ? "<BR>" : " | "]"
+				t += " [S[A.equipment+1]] [S[A.lighting+1]] [S[A.environ+1]] [add_lspace(A.lastused_total, 6)]  [A.cell ? "[add_lspace(round(A.cell.percent()), 3)]% [chg[A.charging+1]]" : "   N/C"][do_newline ? "<BR>" : " | "]"
 				do_newline = !do_newline
 
 		t += "</FONT></PRE>"


### PR DESCRIPTION
[TRIVIAL]

## About the PR

I have now made the following number of single-space-change pull requests:

Gross: 2  
Net: 0

## Why's this needed?

Fixes this:

![image](https://user-images.githubusercontent.com/4257305/104777773-e1ef9e00-5741-11eb-95c9-6321564602e3.png)
