### PR TITLE
Adds ABCU marker to ABCU QM crate

### DIFF
--- a/code/datums/supply_packs.dm
+++ b/code/datums/supply_packs.dm
@@ -959,7 +959,7 @@ ABSTRACT_TYPE (/datum/supply_packs/electrical)
 	name = "ABCU Unit Crate"
 	desc = "An additional ABCU Unit, for large construction projects."
 	category = "Engineering Department"
-	contains = list(/obj/machinery/abcu)
+	contains = list(/obj/machinery/abcu, /obj/item/blueprint_marker)
 	cost = 5000
 	containertype = /obj/storage/secure/crate
 	containername = "ABCU Unit Crate (Cardlocked \[Engineering])"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds ABCU marker to ABCU QM crate


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Closes #3293
Originally I wanted to add an ABCU + marker on Destiny however it's already a tight map as is and I couldnt find a spot to put it in. This seems like the best general solution

