### PR TITLE
fixes surstromming

### DIFF
--- a/code/modules/food_and_drink/snacks.dm
+++ b/code/modules/food_and_drink/snacks.dm
@@ -905,19 +905,19 @@
 	examine(mob/user)
 		. = ..()
 		if (user.bioHolder.HasEffect("accent_swedish"))
-			if (src.icon_state == "surs_closed")
+			if (src.icon_state == "surs")
 				. += "Oooh, a can of surströmming! It's been a while since you've seen one of these. It looks like it's ready to eat."
 			else
 				. += "Oooh, a can of surströmming! It's been a while since you've seen one of these. It smells heavenly!"
 			return
 		else
-			if (src.icon_state == "surs_closed")
+			if (src.icon_state == "surs")
 				. += "The fuck is this? The label's written in some sort of gibberish, and you're pretty sure cans aren't supposed to bulge like that."
 			else
 				. += "<b>AAAAAAAAAAAAAAAAUGH AAAAAAAAAAAUGH IT SMELLS LIKE FERMENTED SKUNK EGG BUTTS MAKE IT STOP</b>"
 
 	attack_self(var/mob/user as mob)
-		if (src.icon_state == "surs_closed")
+		if (src.icon_state == "surs")
 			boutput(user, "<span class='notice'>You pop the lid off the [src].</span>")
 			src.icon_state = "surs-open" //todo: get real sprite
 			for(var/mob/living/carbon/M in viewers(user, null))
@@ -926,7 +926,7 @@
 						boutput(user, "<span class='notice'>Ahhh, that smells wonderful!</span>")
 					else
 						boutput(user, "<span class='alert'><font size=4><B>HOLY FUCK THAT REEKS!!!!!</b></font></span>")
-						user.changeStatus("weakened", 80)
+						user.changeStatus("weakened", 8 SECONDS)
 						user.visible_message("<span class='alert'>[user] suddenly and violently vomits!</span>")
 						user.vomit()
 				else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes a bug that prevented surstromming cans from being opened. Makes a tiny style change (80 deciseconds to 8 SECONDS)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

At some point the icon for the closed can got renamed from surs_closed to just surs. The code was not updated (until now) to reflect this.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Camryn Buttes:
(+)Surstromming cans work again, stink your friends
```
