### PR TITLE
Corrects access of Cog1 QM SecPoint Brig Door

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -15891,7 +15891,7 @@
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Security Office";
-	req_access_txt = "1"
+	req_access_txt = null
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -15905,6 +15905,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/access_spawn/security,
 /turf/simulated/floor,
 /area/station/security/secwing)
 "aJm" = (
@@ -51959,6 +51960,7 @@
 	req_access_txt = null
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/security,
 /turf/simulated/floor/delivery,
 /area/station/security/checkpoint/cargo)
 "chy" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG - MAJOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Cog1 Security Checkpoint's Brig lacked the need for Access, making it useless.
also converts a door in sec to use the new access spawners too, cause i missed it
## Why's this needed? <!-- Describe why you think this should be added to the game. -->

the Security Checkpoint's brig was useless, this fixes that.
