### PR TITLE
re-add icon spacing to manufacturers

### DIFF
--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -448,7 +448,7 @@
 
 			can_be_made = (mats_used.len >= A.item_paths.len)
 
-			var/icon_text = "<p><p>"
+			var/icon_text = "<img class='icon'>"
 			// @todo probably refactor this since it's copy pasted twice now.
 			// if (A.item_outputs)
 			// 	var/icon_rsc = getItemIcon(A.item_outputs[1], C = usr.client)
@@ -1705,7 +1705,7 @@
 				// shut up
 				remove_link = "&#8987; Working..."
 
-			var/icon_text = "<p><p>"
+			var/icon_text = "<img class='icon'>"
 			// if (A.item_outputs)
 			// 	var/icon_rsc = getItemIcon(A.item_outputs[1], C = usr.client)
 			// 	// usr << browse_rsc(browse_item_icons[icon_rsc], icon_rsc)


### PR DESCRIPTION
[MINOR]

## About the PR

Re-adds spacing for icons to the manufacturer screen.

## Why's this needed?

![image](https://user-images.githubusercontent.com/4257305/104832048-c07ed700-5853-11eb-8e8a-064b4272682a.png)
![image](https://user-images.githubusercontent.com/4257305/104832040-b8bf3280-5853-11eb-8c4a-ca0090943ec6.png)