### PR TITLE
Adds Penlights and Stethoscopes to Medical Fabricators

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -1675,6 +1675,24 @@ proc/get_nice_mat_name_for_manufacturers(mat)
 	create = 2
 	category = "Resource"
 
+/datum/manufacture/penlight
+	name = "Penlight"
+	item_paths = list("MET-1","CRY-1")
+	item_amounts = list(1,1)
+	item_outputs = list(/obj/item/device/light/flashlight/penlight)
+	time = 2 SECONDS
+	create = 1
+	category = "Tool"
+
+/datum/manufacture/stethoscope
+	name = "Stethoscope"
+	item_paths = list("MET-1","CRY-1")
+	item_amounts = list(2,1)
+	item_outputs = list(/obj/item/medical/medicaldiagnosis/stethoscope)
+	time = 5 SECONDS
+	create = 1
+	category = "Tool"
+
 /datum/manufacture/spacesuit
 	name = "Space Suit Set"
 	item_paths = list("FAB-1","MET-1","CRY-1")

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -1131,6 +1131,8 @@
 		product_list += new/datum/data/vending_product(/obj/item/device/analyzer/healthanalyzer, 4)
 		product_list += new/datum/data/vending_product(/obj/item/device/analyzer/healthanalyzer_upgrade, 4)
 		product_list += new/datum/data/vending_product(/obj/item/device/analyzer/healthanalyzer_organ_upgrade, 3)
+		product_list += new/datum/data/vending_product(/obj/item/device/light/flashlight/penlight, 4)
+		product_list += new/datum/data/vending_product(/obj/item/medical/medicaldiagnosis/stethoscope, 4)
 		product_list += new/datum/data/vending_product(/obj/item/paper/book/medical_surgery_guide, 2)
 
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/glass/bottle/sulfonal, rand(1, 2), hidden=1)

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -1131,8 +1131,6 @@
 		product_list += new/datum/data/vending_product(/obj/item/device/analyzer/healthanalyzer, 4)
 		product_list += new/datum/data/vending_product(/obj/item/device/analyzer/healthanalyzer_upgrade, 4)
 		product_list += new/datum/data/vending_product(/obj/item/device/analyzer/healthanalyzer_organ_upgrade, 3)
-		product_list += new/datum/data/vending_product(/obj/item/device/light/flashlight/penlight, 4)
-		product_list += new/datum/data/vending_product(/obj/item/medical/medicaldiagnosis/stethoscope, 4)
 		product_list += new/datum/data/vending_product(/obj/item/paper/book/medical_surgery_guide, 2)
 
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/glass/bottle/sulfonal, rand(1, 2), hidden=1)

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -2125,6 +2125,8 @@
 		/datum/manufacture/hypospray,
 		/datum/manufacture/patch,
 		/datum/manufacture/mender,
+		/datum/manufacture/penlight,
+		/datum/manufacture/stethoscope,
 		/datum/manufacture/latex_gloves,
 		/datum/manufacture/surgical_mask,
 		/datum/manufacture/surgical_shield,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the ability to fabricate penlights and stethoscopes in a Medical Fabricator. Penlights cost 1 metal and crystalline matter, while stethoscopes cost 2 metal and 1 crystalline matter.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Many maps have few or none of these tools lying around. They're great for roleplaying, so I thought that I'd add them.