### PR TITLE
Removes a few more bathroom cameras on Destiny

### DIFF
--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -1027,11 +1027,6 @@
 	dir = 8;
 	pixel_x = 4
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13"
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -4744,11 +4739,6 @@
 /obj/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13"
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/toilets)
@@ -35778,11 +35768,6 @@
 	pixel_y = 2
 	},
 /obj/machinery/light_switch/north,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 9;
-	name = "autoname - SS13"
-	},
 /turf/simulated/floor/white/grime,
 /area/station/crew_quarters/showers{
 	name = "Pool Shower Room"

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -93511,9 +93511,9 @@ aaa
 aaa
 aaa
 ahv
-aaa
-aaa
 ahJ
+aaa
+aaa
 aaa
 aaa
 aaa

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -31029,6 +31029,11 @@
 /obj/decal/poster/wallsign/cdnp{
 	pixel_y = 32
 	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname - SS13"
+	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bcz" = (
@@ -31043,6 +31048,11 @@
 	},
 /obj/decal/poster/wallsign/cdnp{
 	pixel_y = 32
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13"
 	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
@@ -33730,11 +33740,6 @@
 	icon_state = "2-4"
 	},
 /obj/window/crystal/reinforced/north,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13"
-	},
 /turf/simulated/floor/red,
 /area/station/security/brig)
 "bhj" = (
@@ -34640,6 +34645,11 @@
 	pixel_x = 24
 	},
 /obj/window/crystal/reinforced/south,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname  - SS13"
+	},
 /obj/storage/closet/wardrobe/orange,
 /obj/window/crystal/reinforced/south,
 /turf/simulated/floor/red,
@@ -37647,6 +37657,11 @@
 "bnJ" = (
 /obj/table/reinforced/auto,
 /obj/machinery/light,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13"
+	},
 /obj/item/decoration/ashtray{
 	butts = 5;
 	name = "grubby old ashtray"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR removes AI cameras from the captain's toilet/shower, the pool changing room, and the bathroom below the escape dock.
Also a camera on the outside of Destiny's escape was moves two tiles up so it can't see a single tile of the latter. It has vaguely the aestethic bonus of not being where the escape airbridge wall will be now.
The only place on the map I know that cameras still can see into bathrooms is the brig, but I don't think that situation is easily fixed.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More crew privacy where they should reasonably expect it after a previous PR.