### PR TITLE
Enable locker entanglement

### DIFF
--- a/code/modules/events/locker_entanglement.dm
+++ b/code/modules/events/locker_entanglement.dm
@@ -2,7 +2,16 @@
 	name = "Locker Entanglement"
 	centcom_headline = "Quantum Anomaly"
 	centcom_message = {"A quantum anomaly has been detected on station. Locker dimensional subspaces might have become unstable. Enter lockers at your own risk."}
-	disabled = 1 // disabled for now as we dismantle old Ass Jam stuff, find a reason to enable it later, this would be a good player-triggerable event. -warc
+	weight = 20
+	var/time = null
+
+	admin_call(var/source)
+		if (..())
+			return
+
+		src.time = input(usr, "Remove entanglement after some number of deciseconds?", src.name, 0) as num|null
+
+		event_effect(source)
 
 	event_effect()
 		..()
@@ -20,3 +29,12 @@
 			closets -= B
 			A.entangled = B
 			B.entangled = A
+
+		if(isnull(src.time))
+			src.time = rand(1 MINUTE, 5 MINUTES)
+		SPAWN_DBG(src.time)
+			for_by_tcl(closet, /obj/storage/closet)
+				if(isrestrictedz(closet.z))
+					continue
+				closet.entangled = null
+			command_alert("Locker quantum stability restored.", src.centcom_headline)

--- a/code/modules/events/locker_entanglement.dm
+++ b/code/modules/events/locker_entanglement.dm
@@ -18,7 +18,7 @@
 		var/list/closets = list()
 		var/n_closets = 0
 		for_by_tcl(closet, /obj/storage/closet)
-			if(isrestrictedz(closet.z))
+			if(isrestrictedz(closet.z) || istype(closet, /obj/storage/closet/port_a_sci))
 				continue
 			closets += closet
 			n_closets++

--- a/code/modules/events/locker_entanglement.dm
+++ b/code/modules/events/locker_entanglement.dm
@@ -33,8 +33,6 @@
 		if(isnull(src.time))
 			src.time = rand(1 MINUTE, 5 MINUTES)
 		SPAWN_DBG(src.time)
-			for_by_tcl(closet, /obj/storage/closet)
-				if(isrestrictedz(closet.z))
-					continue
+			for(var/obj/storage/closet/closet as() in closets)
 				closet.entangled = null
 			command_alert("Locker quantum stability restored.", src.centcom_headline)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Enables the locker quantum entangelement event with low weight (20 compared to default 100). This event makes it so entering a locker makes you leave from a different locker. After 1-5 minutes the effect disappears.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I think it would be fun but am not sure. Let me know your opinions!


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)pali
(*)Enabled a certain locker-related random event.
```
