### PR TITLE
Allow APCs to exit "fully charged" state.

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -597,7 +597,7 @@ var/zapLimiter = 0
 		t += "External power : <B>[ main_status ? (main_status ==2 ? "<FONT COLOR=#004000>Good</FONT>" : "<FONT COLOR=#D09000>Low</FONT>") : "<FONT COLOR=#F00000>None</FONT>"]</B><BR>"
 		t += "Power cell: <B>[cell ? "[round(cell.percent())]%" : "<FONT COLOR=red>Not connected.</FONT>"]</B>"
 		if(cell)
-			t += " ([charging ? ( charging == 1 ? "Charging" : "Fully charged" ) : "Not charging"])"
+			t += " ([charging ? ( charging == 1 ? "Charging" : "Fully charged" ) : chargecount ? "Performing self-test" : "Not charging"])"
 			t += " ([chargemode ? "Auto" : "Off"])"
 
 		t += "<BR><HR>Power channels<BR><PRE>"
@@ -1218,6 +1218,8 @@ var/zapLimiter = 0
 
 		if(cell.charge >= cell.maxcharge)
 			charging = 2
+		else if (charging == 2)
+			charging = 0 // we lost power somehow; move to failure mode
 
 		if(chargemode)
 			if(!charging)


### PR DESCRIPTION
[MAJOR]

## About the PR

Alright, some facts for anyone who hasn't studied APCs:

- APCs with a standard-sized battery cell (2500) have a capacity of 125 kilowatt-seconds.
- APCs in Auto mode will turn off lighting below 30% and equipment below 15%.
- APCs with no charge will turn off all three channels (if they're in forced-on mode, it turns to forced-off).
- APCs charge when in "charging" state (duh).
- If an APC is charging, it changes at a maximum rate of 1% per second.
- APCs will draw power directly from the power grid to run equipment/lighting/environmental stuff if there's enough excess power. The power grid keeps track of how much power is available on average to each APC.

Here's where it gets messy:

APCs have *three* charging states: Not Charging, Charging, and Fully Charged.

In Not Charging mode, assuming charging is enabled, if there's enough power to charge the battery in 10 consecutive attempts, it will flip to Charging mode. If the cell is fully charged, it will flip to Fully Charged mode.

If the cell charger is turned off, it flips to Not Charging mode.

Here's the problem: There's no state transition out of Fully Charged mode if the battery is allowed to charge.

And a second, smaller problem: There's no indication to the player that Not Charging is planning on becoming Charging. (This PR also fixes that.)

For a demonstration, wait for an APC to be fully charged, cut its input wire, and run something that takes a lot of power, like a portable air scrubber. Even if the input wire is restored, the cell's charge level will never go back up.

The solution in this PR is to add a state transition from "Fully Charged but not actually fully charged" to "Not Charging". Then, after sufficient external power is verified to exist, the cell will flip back to Charging mode automatically.

## Changelog

```
(u)BenLubar:
(*)APCs are now able to automatically exit Fully Charged status. See the pull request for technical details.
```
