### PR TITLE
Fixes briefcase in-hand sprites

### DIFF
--- a/code/WorkInProgress/infernal_contracts.dm
+++ b/code/WorkInProgress/infernal_contracts.dm
@@ -208,6 +208,7 @@
 /obj/item/storage/briefcase/satan
 	name = "devilish briefcase"
 	icon_state = "briefcase"
+	inhand_image_icon = 'icons/mob/inhand/hand_general.dmi'
 	item_state = "briefcase"
 	flags = FPRINT | TABLEPASS| CONDUCT | NOSPLASH
 	color = "#FF0000"

--- a/code/datums/components/foldable.dm
+++ b/code/datums/components/foldable.dm
@@ -63,8 +63,8 @@
 	name = "briefcase"
 	icon = 'icons/obj/items/storage.dmi'
 	item_state = "briefcase"
-	icon_state = "briefcase"
 	inhand_image_icon = 'icons/mob/inhand/hand_general.dmi'
+	icon_state = "briefcase"
 	desc = "A briefcase."
 	flags = FPRINT | TABLEPASS| CONDUCT | NOSPLASH
 	force = 8.0

--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -1316,6 +1316,9 @@
 	name = "gang recruitment flyer case"
 	desc = "A briefcase full of flyers advertising a gang."
 	icon_state = "briefcase_black"
+	inhand_image_icon = 'icons/mob/inhand/hand_general.dmi'
+	item_state = "sec-case"
+
 	spawn_contents = list(/obj/item/gang_flyer = 7)
 	var/datum/gang/gang = null
 

--- a/code/modules/networks/computer3/computer3.dm
+++ b/code/modules/networks/computer3/computer3.dm
@@ -966,6 +966,8 @@ function lineEnter (ev)
 	name = "briefcase"
 	icon = 'icons/obj/computer.dmi'
 	icon_state = "briefcase"
+	inhand_image_icon = 'icons/mob/inhand/hand_general.dmi'
+	item_state = "briefcase"
 	desc = "A common item to find in an office.  Is that an antenna?"
 	flags = FPRINT | TABLEPASS| CONDUCT | NOSPLASH
 	force = 8.0

--- a/code/obj/item/device/transfer_valve.dm
+++ b/code/obj/item/device/transfer_valve.dm
@@ -353,6 +353,8 @@
 /obj/item/device/transfer_valve/briefcase
 	name = "briefcase"
 	icon_state = "briefcase"
+	inhand_image_icon = 'icons/mob/inhand/hand_general.dmi'
+	item_state = "briefcase"
 	var/obj/item/storage/briefcase/B = null
 	mats = 8
 

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -1523,6 +1523,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 	name = "secure briefcase"
 	icon = 'icons/obj/items/storage.dmi'
 	icon_state = "secure"
+	inhand_image_icon = 'icons/mob/inhand/hand_general.dmi'
 	item_state = "sec-case"
 	desc = "A large briefcase with a digital locking system. This one has a small hole in the side of it. Odd."
 	force = 8.0

--- a/code/obj/item/storage/secure_safe.dm
+++ b/code/obj/item/storage/secure_safe.dm
@@ -389,6 +389,7 @@
 	name = "secure briefcase"
 	icon = 'icons/obj/items/storage.dmi'
 	icon_state = "secure"
+	inhand_image_icon = 'icons/mob/inhand/hand_general.dmi'
 	item_state = "sec-case"
 	desc = "A large briefcase with a digital locking system."
 	flags = FPRINT | TABLEPASS

--- a/code/obj/item/storage/small_storage_parent.dm
+++ b/code/obj/item/storage/small_storage_parent.dm
@@ -327,6 +327,7 @@
 /obj/item/storage/briefcase
 	name = "briefcase"
 	icon_state = "briefcase"
+	inhand_image_icon = 'icons/mob/inhand/hand_general.dmi'
 	item_state = "briefcase"
 	flags = FPRINT | TABLEPASS| CONDUCT | NOSPLASH
 	force = 8.0


### PR DESCRIPTION
[bug - minor] [bugfix]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes in-hand sprites appear for all briefcase uses other than the beefcase, including: the secure briefcase, the Faustian Bargain Kit, normal briefcases, SMG briefcases, gang briefcases, luggable computers, and tank transfer valve briefcases. Addresses #3359 .


## Why's this needed? <!-- Let me know about the TTV briefcase; it kind of goes against the way back-worn TTVs and the hand-carried ones are really obvious, but without the briefcase in-hand some of the unique usability of the TTV briefcase is removed. -->
Perhaps you may be an infernal lawyer, a respectable inspector, a gang kingpin, or a sneaking scientist. Whatever your "case", now your sprite will look the part too.