### PR TITLE
Assorted CDC fixes

### DIFF
--- a/code/obj/machinery/computer/QM_supply.dm
+++ b/code/obj/machinery/computer/QM_supply.dm
@@ -711,7 +711,7 @@ var/global/datum/cdc_contact_controller/QM_CDC = new()
 				boutput(usr, "<span class='alert'>Severe signal interference is preventing contact with the CDC.</span>")
 				return
 			if (ticker.round_elapsed_ticks < QM_CDC.next_crate)
-				last_cdc_message = "<span style=\"color:red; font-style: italic\">We are fresh out of crates right now to send you. Check back in [(QM_CDC.next_crate - ticker.round_elapsed_ticks)] seconds!</span>"
+				last_cdc_message = "<span style=\"color:red; font-style: italic\">We are fresh out of crates right now to send you. Check back in [ceil((QM_CDC.next_crate - ticker.round_elapsed_ticks) / 10)] seconds!</span>"
 			else
 				if (wagesystem.shipping_budget < 5)
 					last_cdc_message = "<span style=\"color:red; font-style: italic\">You're completely broke. You cannot even afford a crate.</span>"

--- a/code/obj/machinery/computer/QM_supply.dm
+++ b/code/obj/machinery/computer/QM_supply.dm
@@ -437,9 +437,9 @@ var/global/datum/cdc_contact_controller/QM_CDC = new()
 			src.temp += "We have no unanalyzed pathogen samples from your station.<br>"
 	else
 		src.temp += "We're currently analyzing the pathogen sample [QM_CDC.current_analysis.name]. We can <A href='[topicLink("cdc_analyze")]'>analyze something different</A>, if you want."
-		if (QM_CDC.current_analysis.description_available > ticker.round_elapsed_ticks)
+		if (QM_CDC.current_analysis.description_available <= ticker.round_elapsed_ticks)
 			src.temp += "Here's what we have so far: <br>[QM_CDC.current_analysis.desc]<br>"
-			if (QM_CDC.current_analysis.cure_available > ticker.round_elapsed_ticks)
+			if (QM_CDC.current_analysis.cure_available <= ticker.round_elapsed_ticks)
 				src.temp += "We've also discovered a method to synthesize a cure for this pathogen.<br>"
 				QM_CDC.completed_analysis += QM_CDC.current_analysis
 				QM_CDC.current_analysis = null
@@ -753,7 +753,7 @@ var/global/datum/cdc_contact_controller/QM_CDC = new()
 					if (QM_CDC.current_analysis)
 						var/datum/cdc_contact_analysis/A = QM_CDC.current_analysis
 						A.time_done += ticker.round_elapsed_ticks - A.begun_at
-						if (A.cure_available >= ticker.round_elapsed_ticks)
+						if (A.cure_available <= ticker.round_elapsed_ticks)
 							QM_CDC.completed_analysis += A
 						else
 							QM_CDC.ready_to_analyze += A

--- a/code/obj/machinery/computer/QM_supply.dm
+++ b/code/obj/machinery/computer/QM_supply.dm
@@ -711,7 +711,7 @@ var/global/datum/cdc_contact_controller/QM_CDC = new()
 				boutput(usr, "<span class='alert'>Severe signal interference is preventing contact with the CDC.</span>")
 				return
 			if (ticker.round_elapsed_ticks < QM_CDC.next_crate)
-				last_cdc_message = "<span style=\"color:red; font-style: italic\">We are fresh out of crates right now to send you. Check back in [ceil((QM_CDC.next_crate - ticker.round_elapsed_ticks) / 10)] seconds!</span>"
+				last_cdc_message = "<span style=\"color:red; font-style: italic\">We are fresh out of crates right now to send you. Check back in [ceil((QM_CDC.next_crate - ticker.round_elapsed_ticks) / (1 SECOND))] seconds!</span>"
 			else
 				if (wagesystem.shipping_budget < 5)
 					last_cdc_message = "<span style=\"color:red; font-style: italic\">You're completely broke. You cannot even afford a crate.</span>"

--- a/code/obj/machinery/computer/QM_supply.dm
+++ b/code/obj/machinery/computer/QM_supply.dm
@@ -758,6 +758,7 @@ var/global/datum/cdc_contact_controller/QM_CDC = new()
 						else
 							QM_CDC.ready_to_analyze += A
 					QM_CDC.current_analysis = C
+					QM_CDC.ready_to_analyze -= C
 					C.begun_at = ticker.round_elapsed_ticks
 					C.description_available = C.begun_at + C.time_factor - C.time_done
 					C.cure_available = C.description_available + C.time_factor


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
[BUG][RUNTIME]

## About the PR

- Don't runtime when mailing a monkey to the CDC.
- Fix time estimate for when the next crate will be available being 10x higher than it should be.
- Fix CDC time comparisons being backwards, causing cures to be available the moment analysis begins rather than taking a few seconds.
- Remove pathogens from the CDC's "unanalyzed" list when they are analyzed.

## Why's this needed?

bug bad fix good

## Changelog

```
(u)BenLubar:
(+)The CDC now has a more conventional understanding of how time and causality work.
```
