### PR TITLE
Actionbar for eating non-food things

### DIFF
--- a/code/datums/components/food_stuff.dm
+++ b/code/datums/components/food_stuff.dm
@@ -26,7 +26,7 @@
 
 /datum/component/consume/organpoints
 	var/target_abilityholder = /datum/abilityHolder/lizard
-	var/static/list/organ2points = list(/obj/item/organ/head=2,/obj/item/skull=0,/obj/item/organ/brain=3,/obj/item/organ/chest=5,/obj/item/organ/heart=2,/obj/item/organ/appendix=0,/obj/item/clothing/head/butt=0)
+	var/static/list/organ2points = list(/obj/item/organ/head=2,/obj/item/skull=0,/obj/item/organ/brain=1,/obj/item/organ/chest=5,/obj/item/organ/heart=2,/obj/item/organ/appendix=0,/obj/item/clothing/head/butt=0)
 
 /datum/component/consume/organpoints/Initialize(var/target_abilityholder)
 	..()
@@ -130,7 +130,10 @@
 		boutput(L, "<span class='notice'>That [I] wasn't half bad.</span>")
 
 	if(add_these_points)
-		L.abilityHolder.addPoints(add_these_points, target_abilityholder)
+		if(prob(30 * add_these_points))
+			L.abilityHolder.addPoints(add_these_points, target_abilityholder)
+		else
+			boutput(L, "<span class='alert'>...that wasn't particularly satisfying, though.</span>")
 
 /datum/component/consume/organpoints/UnregisterFromParent()
 	UnregisterSignal(parent, COMSIG_ITEM_CONSUMED)
@@ -138,7 +141,7 @@
 
 
 /datum/component/consume/organheal
-	var/static/list/organ2hp = list(/obj/item/organ/head=20,/obj/item/skull=0,/obj/item/organ/brain=30,/obj/item/organ/chest=30,/obj/item/organ/heart=20,/obj/item/organ/appendix=0,/obj/item/clothing/head/butt=6)
+	var/static/list/organ2hp = list(/obj/item/organ/head=10,/obj/item/skull=0,/obj/item/organ/brain=20,/obj/item/organ/chest=30,/obj/item/organ/heart=20,/obj/item/organ/appendix=0,/obj/item/clothing/head/butt=6)
 	var/base_HPup = 5
 	var/mod_mult = 1
 

--- a/code/obj/item/organs/appendix.dm
+++ b/code/obj/item/organs/appendix.dm
@@ -6,6 +6,7 @@
 	organ_holder_required_op_stage = 3.0
 	icon_state = "appendix"
 	failure_disease = /datum/ailment/disease/appendicitis
+	bite_damage = INFINITY // 1 bite, 1 kill
 
 	on_life(var/mult = 1)
 		if (!..())

--- a/code/obj/item/organs/brain.dm
+++ b/code/obj/item/organs/brain.dm
@@ -14,6 +14,7 @@
 	edible = 0
 	module_research = list("medicine" = 1, "efficiency" = 10)
 	module_research_type = /obj/item/organ/brain
+	bite_damage = 50
 	FAIL_DAMAGE = 120
 	MAX_DAMAGE = 120
 	tooltip_flags = REBUILD_ALWAYS //fuck it, nobody examines brains that often
@@ -37,7 +38,6 @@
 			if(alert(user, "Are you sure you want to feed [src] to [M]?", "Feed brain?", "Yes", "No") == "Yes")
 				logTheThing("combat", user, null, "tries to feed [src] (owner's ckey [owner ? owner.ckey : null]) to [M].")
 				return ..()
-		return 0
 
 	get_desc()
 		if (usr?.traitHolder?.hasTrait("training_medical"))

--- a/code/obj/item/organs/organ_parent.dm
+++ b/code/obj/item/organs/organ_parent.dm
@@ -51,6 +51,10 @@
 	var/burn_dam = 0
 	var/tox_dam = 0
 
+	/// How much damage does this take if someone takes a bite out of it?
+	/// Set to 0 to default to 110% of FAIL_DAMAGE
+	var/bite_damage = 0
+
 	var/robotic = 0
 	var/emagged = 0
 	var/synthetic = 0
@@ -130,6 +134,8 @@
 				src.name = "[src.donor_name]'s [initial(src.name)]"
 			src.donor_DNA = src.donor.bioHolder ? src.donor.bioHolder.Uid : null
 		src.setMaterial(getMaterial(made_from), appearance = 0, setname = 0)
+		if(src.bite_damage == 0)
+			src.bite_damage = src.FAIL_DAMAGE * 1.1
 
 	disposing()
 		if (src.holder)
@@ -374,3 +380,8 @@
 			for (var/abil in src.organ_abilities)
 				src.add_ability(A, abil)
 		src.broken = 0
+
+	get_desc()
+		. = ..()
+		if(src.broken || src.get_damage() > src.FAIL_DAMAGE)
+			. +="<br>It looks pretty banged up."

--- a/code/obj/item/organs/tail.dm
+++ b/code/obj/item/organs/tail.dm
@@ -12,6 +12,7 @@
 	organ_image_icon = 'icons/mob/werewolf.dmi' // please keep your on-mob tail icon_states with the rest of your mob's sprites
 	icon_state = "tail-wolf"
 	made_from = "flesh"
+	bite_damage = 40
 	var/tail_num = TAIL_NONE
 	var/colorful = 0 // if we need to colorize it
 	var/multipart_icon = 0 // if we need to run update_tail_icon


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds an actionbar for eating things that aren't explicitly food, such as organs and things made out of flesh.

The action is pretty short, but gets longer if you're trying to eat an organ and/or feed someone else.

Most organs can be bitten multiple times. Each bite damages the organ, typically enough to break it. They'll still give organ points, but now there's a chance that you just don't get any points out of it, based on the point worth of the organ.

Also fixed brains being inedible.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I only want to eat my own liver if I actually want to.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Superlagg:
(+)Added an action bar to eating things that aren't food.
```
