### PR TITLE
Give NTSO the same radio coverage as HoS

### DIFF
--- a/code/obj/item/device/radios/headsets.dm
+++ b/code/obj/item/device/radios/headsets.dm
@@ -80,18 +80,10 @@
 	secure_frequencies = list(
 		"h" = R_FREQ_COMMAND,
 		"g" = R_FREQ_SECURITY,
-		"e" = R_FREQ_ENGINEERING,
-		"r" = R_FREQ_RESEARCH,
-		"m" = R_FREQ_MEDICAL,
-		"c" = R_FREQ_CIVILIAN,
 		)
 	secure_classes = list(
 		"h" = RADIOCL_COMMAND,
 		"g" = RADIOCL_SECURITY,
-		"e" = RADIOCL_ENGINEERING,
-		"r" = RADIOCL_RESEARCH,
-		"m" = RADIOCL_MEDICAL,
-		"c" = RADIOCL_CIVILIAN,
 		)
 	icon_override = "nt"
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR gives NTSO the same radio coverage as HoS. Which is just command and security channels.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Parity, reduces confusion about NTSOs being more authoritative or whatever because they have access to more channels. 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Flourish:
(+)NTSOs now only have access to command and security channels on their headset. 
```
