### PR TITLE
Change changeling acid spit to use acidspit sprite

### DIFF
--- a/code/modules/antagonists/changeling/abilities/spit.dm
+++ b/code/modules/antagonists/changeling/abilities/spit.dm
@@ -28,7 +28,7 @@
 
 		SPAWN_DBG(0)
 			var/obj/overlay/A = new /obj/overlay( holder.owner.loc )
-			A.icon_state = "cbbolt"
+			A.icon_state = "acidspit"
 			A.icon = 'icons/obj/projectiles.dmi'
 			A.name = "acid"
 			A.anchored = 0
@@ -38,14 +38,16 @@
 			A.reagents = new /datum/reagents(10)
 			A.reagents.my_atom = A
 			A.reagents.add_reagent("pacid", 10)
+			animate_spin(A, "R", 1.4, -1)
 
 			var/obj/overlay/B = new /obj/overlay( A.loc )
-			B.icon_state = "cbbolt"
+			B.icon_state = "acidspit"
 			B.icon = 'icons/obj/projectiles.dmi'
 			B.name = "acid"
 			B.anchored = 1
 			B.set_density(0)
 			B.layer = OBJ_LAYER
+			animate_spin(B, "R", 1.4, -1)
 
 			for(var/i=0, i<20, i++)
 				B.set_loc(A.loc)

--- a/code/modules/projectiles/special.dm
+++ b/code/modules/projectiles/special.dm
@@ -52,7 +52,7 @@ ABSTRACT_TYPE(/datum/projectile/special)
 
 /datum/projectile/special/acidspit
 	name = "acid splash"
-	icon_state = "cbbolt"
+	icon_state = "acidspit"
 	power = 0.8
 	dissipation_rate = 20
 	dissipation_delay = 10
@@ -61,6 +61,9 @@ ABSTRACT_TYPE(/datum/projectile/special)
 	hit_mob_sound = 'sound/impact_sounds/burn_sizzle.ogg'
 	hit_object_sound = 'sound/impact_sounds/burn_sizzle.ogg'
 	shot_sound = null
+
+	on_launch(var/obj/projectile/projectile)
+		projectile.Scale(0.5, 0.5)
 
 	on_hit(atom/hit, direction, var/obj/projectile/projectile)
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG - MINOR]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes changeling acid spit to use the acid spit sprite instead of crossbow bolt.
Also makes it spin to look less weird in motion.

https://user-images.githubusercontent.com/70909958/105207708-bbfe3b00-5b3f-11eb-99f0-88dc7c19b1ff.mp4

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
For some reason changelings used projectile sprites that seem to be from the rad poison crossbow which does not match the description of green blobs. There is an acidspit sprite that matches, this is now used.
Hivemind spit also used the bolts. I have set this to the same sprite but 50% smaller. I have not tested this because when I get a second player on my local server the interface is broken!