### PR TITLE
Lasher and radweed changes

### DIFF
--- a/code/modules/hydroponics/plant_mutations.dm
+++ b/code/modules/hydroponics/plant_mutations.dm
@@ -478,6 +478,8 @@
 	harvest_override = 1
 	crop = /obj/item/reagent_containers/food/snacks/plant/lashberry/
 	chance = 20
+	assoc_reagents = list("booster_enzyme")
+
 
 // Radweed Mutations
 

--- a/code/modules/hydroponics/plants_weed.dm
+++ b/code/modules/hydroponics/plants_weed.dm
@@ -124,7 +124,6 @@ ABSTRACT_TYPE(/datum/plant/weed)
 	special_proc = 1
 	vending = 2
 	genome = 40
-	nectarlevel = 15//allows production of pentetic honey and in greater volume than most honeys. also allows radium and phlog honey
 	assoc_reagents = list("radium")
 	mutations = list(/datum/plantmutation/radweed/redweed,/datum/plantmutation/radweed/safeweed)
 

--- a/code/modules/hydroponics/plants_weed.dm
+++ b/code/modules/hydroponics/plants_weed.dm
@@ -48,7 +48,7 @@ ABSTRACT_TYPE(/datum/plant/weed)
 		if (POT.growth > (P.growtime + DNA.growtime) && prob(33))
 			for (var/mob/living/M in range(1,POT))
 				if (POT.health > P.starthealth / 2)
-					random_brute_damage(M, 3, 1)//slight bump to damage to account for everyone having 1 armor from jumpsuit
+					random_brute_damage(M, 8, 1)//slight bump to damage to account for everyone having 1 armor from jumpsuit, further bump to damage to make blooming lasher more difficult to cultivate
 					if (prob(20)) M.changeStatus("weakened", 3 SECONDS)
 
 				if (POT.health <= P.starthealth / 2) POT.visible_message("<span class='alert'><b>[POT.name]</b> weakly slaps [M] with a vine!</span>")
@@ -64,7 +64,7 @@ ABSTRACT_TYPE(/datum/plant/weed)
 		// It's not big enough to be violent yet, so nothing happens
 
 		POT.visible_message("<span class='alert'><b>[POT.name]</b> violently retaliates against [user.name]!</span>")
-		random_brute_damage(user, 4, 1)//see above
+		random_brute_damage(user, 10, 1)//see above
 		if (W && prob(50))
 			boutput(user, "<span class='alert'>The lasher grabs and smashes your [W]!</span>")
 			W.dropped()
@@ -124,6 +124,7 @@ ABSTRACT_TYPE(/datum/plant/weed)
 	special_proc = 1
 	vending = 2
 	genome = 40
+	nectarlevel = 15//allows production of pentetic honey and in greater volume than most honeys. also allows radium and phlog honey
 	assoc_reagents = list("radium")
 	mutations = list(/datum/plantmutation/radweed/redweed,/datum/plantmutation/radweed/safeweed)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Increases the damage of lashers as wearing a firesuit and hardhat just about nullified any danger even when hit hundreds of times. Adds booster enzyme to the reagent list of the blooming lasher as cultivation of a blooming lasher is immensely difficult and should be rewarding. ~~Adds nectar production to radweeds so that the associated pentetic and phlog in the mutated variants are obtainable in some capacity.~~


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
~~Radweed was really only ever useful for splicing into slurrypods to make them more poisonous, hopefully allowing their use for pentetic acid production will make them more useful.~~ Blooming lasher was perhaps the hardest to cultivate plant in the game but had no reward for doing so, this gives some incentive to grow it and allows for more interesting splices. The damage dealt by lashers was also too low to create any real penalty for trying to grow them, its a bit higher now but still not high enough to be truly dangerous unless you afk next to one while naked. It might be enough to kill chickens or bees though.


## Changelog

```changelog
(u)Anachroniser:
(+)Lashers now do more damage and blooming lashers are a source of booster enzyme, these can be spliced. Good luck growing one.
```
