### PR TITLE
PDA QOL improvements

### DIFF
--- a/code/obj/item/device/pda2/base_os.dm
+++ b/code/obj/item/device/pda2/base_os.dm
@@ -426,7 +426,7 @@
 						if (!t)
 							return
 
-						if (!src.master || !in_range(src.master, usr) && src.master.loc != usr)
+						if (!src.master?.is_user_in_range(usr))
 							return
 
 						if(!(src.holder in src.master))
@@ -469,7 +469,7 @@
 						if (!t)
 							return
 
-						if (!src.master || !in_range(src.master, usr) && src.master.loc != usr)
+						if (!src.master?.is_user_in_range(usr))
 							return
 
 						if(!(src.holder in src.master))

--- a/code/obj/item/device/pda2/base_os.dm
+++ b/code/obj/item/device/pda2/base_os.dm
@@ -307,7 +307,7 @@
 							var/sendButton = "<a href='byond://?src=\ref[src];input=send_file;group=[mailgrp]'>Send File</a>"
 							if(!src.master.fileshare_program)
 								sendButton = ""
-							else if(!src.clipboard || !src.clipboard?.dont_copy)
+							else if(!src.clipboard || src.clipboard?.dont_copy)
 								sendButton = "<strike>Send File</strike>"
 							var/msgButton = "<a href='byond://?src=\ref[src];input=message;target=[mailgrp];department=1'>Mail</a>"
 							if((mailgrp in src.master.mailgroup_ringtones) && istype(src.master.mailgroup_ringtones[mailgrp], /datum/ringtone))

--- a/code/obj/item/device/pda2/base_os.dm
+++ b/code/obj/item/device/pda2/base_os.dm
@@ -820,9 +820,6 @@
 					if(src.master.r_tone?.readMessages)
 						src.master.r_tone.MessageAction(signal.data["message"])
 
-					if(length(src.hosted_files) >= 1)
-						src.CheckForPasskey(signal.data["message"], signal.data["sender"])
-
 					src.master.display_alert(alert_beep, previewtext, groupAddress, src.ManageRecentCallers(senderName))
 					var/displayMessage = "<i><b>[bicon(master)] <a href='byond://?src=\ref[src];input=message;norefresh=1;target=[signal.data["sender"]]'>[messageFrom]</a>"
 					if (groupAddress)
@@ -832,6 +829,9 @@
 							displayMessage += " to <a href='byond://?src=\ref[src];input=message;[groupAddress in src.master.alertgroups ? "" : "target=[groupAddress]"];department=1'>[groupAddress]</a>"
 					displayMessage += ":</b></i> [signal.data["message"]]"
 					src.master.display_message(displayMessage)
+
+					if(length(src.hosted_files) >= 1)
+						src.CheckForPasskey(signal.data["message"], signal.data["sender"])
 
 					src.master.updateSelfDialog()
 
@@ -978,6 +978,8 @@
 			if (findtext(message, "viagra") != 0 || findtext(message, "erect") != 0 || findtext(message, "pharm") != 0 || findtext(message, "girls") != 0 || findtext(message, "scient") != 0 || findtext(message, "luxury") != 0 || findtext(message, "vid") != 0 || findtext(message, "quality") != 0)
 				usr.unlock_medal("Spamhaus", 1)
 
+			src.master.display_message("<b>To [target_name]:</b> [message]")
+
 			var/datum/signal/signal = get_free_signal()
 			signal.data["command"] = "text_message"
 			signal.data["message"] = message
@@ -1025,6 +1027,8 @@
 			signal.data["address_1"] = target_id
 			src.post_signal(signal)
 			src.message_last = world.time
+
+			src.master.display_message("<b>Sent file to [target_name]:</b> [clipfile.name]")
 
 		/// Hosts a file on your PDA with an md5 passkey for others to request
 		proc/HostFile(var/datum/computer/file/file, var/passkey, var/group, var/msg)

--- a/code/obj/item/device/pda2/diagnostics.dm
+++ b/code/obj/item/device/pda2/diagnostics.dm
@@ -363,7 +363,7 @@
 			if(!newkey)
 				return
 
-			if (!src.master || !in_range(src.master, usr) && src.master.loc != usr)
+			if (!src.master?.is_user_in_range(usr))
 				return
 
 			if(!(src.holder in src.master))
@@ -375,7 +375,7 @@
 				newval = codekey
 				return
 
-			if (!src.master || !in_range(src.master, usr) && src.master.loc != usr)
+			if (!src.master?.is_user_in_range(usr))
 				return
 
 			if(!(src.holder in src.master))
@@ -398,7 +398,7 @@
 			if(!newkey)
 				return
 
-			if (!src.master || !in_range(src.master, usr) && src.master.loc != usr)
+			if (!src.master?.is_user_in_range(usr))
 				return
 
 			if(!(src.holder in src.master))
@@ -412,7 +412,7 @@
 			if(!keyval)
 				keyval = new()
 
-			if (!src.master || !in_range(src.master, usr) && src.master.loc != usr)
+			if (!src.master?.is_user_in_range(usr))
 				return
 
 			if(!(src.holder in src.master))

--- a/code/obj/item/device/pda2/smallprogs.dm
+++ b/code/obj/item/device/pda2/smallprogs.dm
@@ -108,7 +108,7 @@
 					post_status("alert", href_list["alert"])
 
 				if("setmsg1")
-					if (!src.master || !in_range(src.master, usr) && src.master.loc != usr)
+					if (!src.master?.is_user_in_range(usr))
 						return
 
 					if(!(src.holder in src.master))
@@ -119,7 +119,7 @@
 					src.master.updateSelfDialog()
 
 				if("setmsg2")
-					if (!src.master || !in_range(src.master, usr) && src.master.loc != usr)
+					if (!src.master?.is_user_in_range(usr))
 						return
 
 					if(!(src.holder in src.master))


### PR DESCRIPTION
## About the PR

- Makes it so when you send a file or message from your PDA, there's a message in the chat box.
- Fix the AI not being able to use certain apps while in eye mode.
- Fix file sharing with groups having its logic inverted so only non-copyable files could be shared.

## Why's this needed?

[QOL]

## Changelog

```
(u)BenLubar:
(+)Outgoing PDA messages are now shown in your chat log. The AI can take notes while looking at a camera. File sharing with groups is no longer broken!
```
