### PR TITLE
move EMP to pulse rilfe, replace with bouncy on waveguns

### DIFF
--- a/code/modules/projectiles/energy_bolt.dm
+++ b/code/modules/projectiles/energy_bolt.dm
@@ -306,7 +306,7 @@ toxic - poisons
 	icon_state = "pulse"
 	power = 20
 	cost = 35
-	sname = "pulse"
+	sname = "kinetic pulse"
 	shot_sound = 'sound/weapons/Taser.ogg'
 	damage_type = D_ENERGY
 	hit_ground_chance = 30
@@ -338,6 +338,34 @@ toxic - poisons
 
 	impact_image_effect(var/type, atom/hit, angle, var/obj/projectile/O)
 		return
+
+
+/datum/projectile/energy_bolt/electromagnetic_pulse
+	name = "pulse"
+	icon = 'icons/obj/projectiles.dmi'
+	icon_state = "pulse"
+	power = 20
+	cost = 75
+	sname = "electromagnetic pulse"
+	shot_sound = 'sound/weapons/Taser.ogg'
+	damage_type = D_SPECIAL
+	hit_ground_chance = 0
+	brightness = 1
+	color_red = 0.18
+	color_green = 0.2
+	color_blue = 1
+
+	disruption = 25
+
+	hit_mob_sound = 'sound/effects/sparks6.ogg'
+
+	on_hit(atom/H, angle, var/obj/projectile/P)
+		var/turf/T = get_turf(H)
+		for(var/turf/tile in range(1, T))
+			for(var/atom/movable/O in tile.contents)
+				if(!istype(O, /obj/machinery/nuclearbomb)) //emp does not affect nuke
+					O.emp_act()
+		elecflash(T)
 
 /datum/projectile/energy_bolt/signifer_tase
 	name = "signifer spark"

--- a/code/modules/projectiles/wavegun.dm
+++ b/code/modules/projectiles/wavegun.dm
@@ -59,7 +59,7 @@
 	sname = "reflection wave"
 	power = 10
 	projectile_speed = 28
-	cost = 75
+	cost = 50
 	max_range = 7
 	icon_state = "wave-emp"
 

--- a/code/modules/projectiles/wavegun.dm
+++ b/code/modules/projectiles/wavegun.dm
@@ -3,48 +3,42 @@
 	icon = 'icons/obj/projectiles.dmi'
 	icon_state = "wave-r"
 //How much of a punch this has, tends to be seconds/damage before any resist
-	power = 10
+	power = 12.5
 //How much ammo this costs
 	cost = 30
 //How fast the power goes away
-	dissipation_rate = -1 //gains power at the same rate that a taser loses power - equal at 6 tiles
+	dissipation_rate = 0 //doesn't use standard falloff
 	max_range = 24 //Range/time limiter for non-standard dissipation - long range, but not infinite
-//How many tiles till it starts to lose power (gain, in this case)
-	dissipation_delay = 0
 //Kill/Stun ratio
-	ks_ratio = 0.0
+	ks_ratio = 1.0
 //name of the projectile setting, used when you change a guns setting
 	sname = "inversion wave"
 //file location for the sound you want it to play
 	shot_sound = 'sound/weapons/rocket.ogg'
 //How many projectiles should be fired, each will cost the full cost
 	shot_number = 1
-//What is our damage type
-/*
-kinetic - raw power
-piercing - punches though things
-slashing - cuts things
-energy - energy
-burning - hot
-radioactive - rips apart cells or some shit
-toxic - poisons
-*/
 	damage_type = D_ENERGY
 	//With what % do we hit mobs laying down
 	hit_ground_chance = 33
 	//Can we pass windows
 	window_pass = 0
 
+	projectile_speed = 42
+
+	brightness = 1
 	color_red = 1
 	color_green = 0
 	color_blue = 0
 
+	get_power(obj/projectile/P, atom/A)
+		return 12.5 + 2.5 * clamp(get_dist(A, P.orig_turf) - 4, 0, 7)
+
+
 /datum/projectile/wavegun/transverse //expensive taser shots that go through /everything/
 	shot_number = 1
 	power = 10 //half the power of a taser at range 1-3, delivers a nasty punch at the 4-tile sweetspot
-	dissipation_delay = 3
-	dissipation_rate = -30
 	max_range = 5 //super short. about 4 tile max range
+	projectile_speed = 28
 	cost = 50
 	hit_ground_chance = 100 //no escape
 	pierces = -1 //no limits
@@ -58,34 +52,30 @@ toxic - poisons
 	color_green = 1
 	color_blue = 0
 
+	get_power(obj/projectile/P, atom/A)
+		return 10 + 30 * (P.travelled >= 128)
 
-
-
-/datum/projectile/wavegun/emp
-	shot_number = 1
-	power = 0
-	dissipation_delay = 0
-	dissipation_rate = -10 //only reliable past a few tiles
-	max_range = 18 //taser-and-a-half range
-	cost = 100 //three shots
-	hit_ground_chance = 0
-	damage_type = D_SPECIAL
-	sname = "electromagnetic distruption wave"
+/datum/projectile/wavegun/bouncy
+	sname = "reflection wave"
+	power = 10
+	projectile_speed = 28
+	cost = 75
+	max_range = 7
 	icon_state = "wave-emp"
-	disruption = 25
+
 
 	color_red = 0
 	color_green = 0
 	color_blue = 1
 
-	on_hit(atom/H, angle, var/obj/projectile/P)
-		var/turf/T = get_turf(H)
-		for(var/atom/movable/O in T.contents)
-			if(!istype(O, /obj/machinery/nuclearbomb) || prob(P.power * 0.5)) //Direct hit has a low chance to affect the nuke -
-				O.emp_act()
-		if(prob(P.power * 1.25)) //chance to EMP in an AoE - better odds the further it travels. Has a meaningful effect on borgs/pods/doors
-			for(var/turf/tile in range(1, T))
-				for(var/atom/movable/O in tile.contents)
-					if(!istype(O, /obj/machinery/nuclearbomb)) //AoE emp does not affect nuke
-						O.emp_act()
-		elecflash(T)
+	on_hit(atom/hit, dirflag, obj/projectile/proj)
+		if(!ismob(hit))
+			shot_volume = 0
+			shoot_reflected_bounce(proj, hit, 2, PROJ_NO_HEADON_BOUNCE)
+			shot_volume = 100
+		if(proj.reflectcount >= 2)
+			elecflash(get_turf(hit),radius=0, power=3, exclude_center = 0)
+
+
+	get_power(obj/projectile/P, atom/A)
+		return 10 + 15 * P.reflectcount

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -558,7 +558,7 @@
 
 	New()
 		current_projectile = new/datum/projectile/wavegun
-		projectiles = list(current_projectile,new/datum/projectile/wavegun/transverse,new/datum/projectile/wavegun/emp)
+		projectiles = list(current_projectile,new/datum/projectile/wavegun/transverse,new/datum/projectile/wavegun/bouncy)
 		..()
 
 	// Old phasers aren't around anymore, so the wave gun might as well use their better sprite (Convair880).
@@ -1508,7 +1508,7 @@
 		..()
 		cell = new/obj/item/ammo/power_cell/high_power //300 PU
 		current_projectile = new/datum/projectile/energy_bolt/pulse //uses 35PU per shot, so 8 shots
-		projectiles = list(new/datum/projectile/energy_bolt/pulse)
+		projectiles = list(new/datum/projectile/energy_bolt/pulse, new/datum/projectile/energy_bolt/electromagnetic_pulse)
 
 	update_icon()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces EMP wave on waveguns with a bouncy wave, and moves the EMP to pulse rifles
Also lightly buffs red wave on waveguns.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
EMP isn't something that sec needs in their default loadouts now that cyberorgans aren't universal strong stamina buffs.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Tarmunora:
(*)Added bouncy mode to wave guns, moves old EMP mode to pulse rifles.
```
