### PR TITLE
Adds a variable to all IDs to allow or prevent change depending on ID

### DIFF
--- a/code/WorkInProgress/mantaObjects.dm
+++ b/code/WorkInProgress/mantaObjects.dm
@@ -1559,10 +1559,12 @@ var/obj/manta_speed_lever/mantaLever = null
 	registered = "Sgt. Wilkins"
 	assignment = "Sergeant"
 	access = list(access_polariscargo,access_heads)
+	keep_icon = 1
 
 /obj/item/card/id/blank_polaris
 	name = "blank Nanotrasen ID"
 	icon_state = "polaris"
+	keep_icon = 1
 
 /obj/item/broken_egun
 	name = "broken energy gun"

--- a/code/WorkInProgress/mantaObjects.dm
+++ b/code/WorkInProgress/mantaObjects.dm
@@ -1559,12 +1559,12 @@ var/obj/manta_speed_lever/mantaLever = null
 	registered = "Sgt. Wilkins"
 	assignment = "Sergeant"
 	access = list(access_polariscargo,access_heads)
-	keep_icon = 1
+	keep_icon = TRUE
 
 /obj/item/card/id/blank_polaris
 	name = "blank Nanotrasen ID"
 	icon_state = "polaris"
-	keep_icon = 1
+	keep_icon = TRUE
 
 /obj/item/broken_egun
 	name = "broken energy gun"

--- a/code/obj/item/card.dm
+++ b/code/obj/item/card.dm
@@ -82,6 +82,7 @@ GAUNTLET CARDS
 	var/title = null
 	var/emagged = 0
 	var/datum/reagent_group_account/reagent_account = null
+	var/keep_icon = 0
 
 	// YOU START WITH  NO  CREDITS
 	// WOW
@@ -124,12 +125,14 @@ GAUNTLET CARDS
 /obj/item/card/id/clown
 	icon_state = "id_clown"
 	desc = "Wait, this isn't even an ID Card. It's a piece of a Chips Ahoy wrapper with crayon scribbles on it. What the fuck?"
+	keep_icon = 1
 
 /obj/item/card/id/gold
 	name = "identification card"
 	icon_state = "gold"
 	item_state = "gold_id"
 	desc = "This card is important!"
+	keep_icon = 1
 
 /obj/item/card/id/blank_deluxe
 	name = "Deluxe ID"
@@ -137,6 +140,7 @@ GAUNTLET CARDS
 	item_state = "gold_id"
 	registered = "Member"
 	assignment = "Member"
+	keep_icon = 1
 	var/jones_swiped = 0
 
 /obj/item/card/id/captains_spare
@@ -145,6 +149,7 @@ GAUNTLET CARDS
 	item_state = "gold_id"
 	registered = "Captain"
 	assignment = "Captain"
+	keep_icon = 1
 	New()
 		access = get_access("Captain")
 		..()
@@ -155,6 +160,7 @@ GAUNTLET CARDS
 	registered = "Dabber"
 	assignment = "Dabber"
 	desc = "This card authorizes the person wearing it to perform sick dabs."
+	keep_icon = 1
 	var/dab_count = 0
 	var/dabbed_on_count = 0
 	var/arm_count = 0

--- a/code/obj/item/card.dm
+++ b/code/obj/item/card.dm
@@ -82,7 +82,8 @@ GAUNTLET CARDS
 	var/title = null
 	var/emagged = 0
 	var/datum/reagent_group_account/reagent_account = null
-	var/keep_icon = FALSE // this determines if the icon_state of the ID changes if it is given a new job
+	/// this determines if the icon_state of the ID changes if it is given a new job
+	var/keep_icon = FALSE 
 
 	// YOU START WITH  NO  CREDITS
 	// WOW

--- a/code/obj/item/card.dm
+++ b/code/obj/item/card.dm
@@ -82,7 +82,7 @@ GAUNTLET CARDS
 	var/title = null
 	var/emagged = 0
 	var/datum/reagent_group_account/reagent_account = null
-	var/keep_icon = 0
+	var/keep_icon = FALSE // this determines if the icon_state of the ID changes if it is given a new job
 
 	// YOU START WITH  NO  CREDITS
 	// WOW
@@ -125,14 +125,14 @@ GAUNTLET CARDS
 /obj/item/card/id/clown
 	icon_state = "id_clown"
 	desc = "Wait, this isn't even an ID Card. It's a piece of a Chips Ahoy wrapper with crayon scribbles on it. What the fuck?"
-	keep_icon = 1
+	keep_icon = TRUE
 
 /obj/item/card/id/gold
 	name = "identification card"
 	icon_state = "gold"
 	item_state = "gold_id"
 	desc = "This card is important!"
-	keep_icon = 1
+	keep_icon = TRUE
 
 /obj/item/card/id/blank_deluxe
 	name = "Deluxe ID"
@@ -140,7 +140,7 @@ GAUNTLET CARDS
 	item_state = "gold_id"
 	registered = "Member"
 	assignment = "Member"
-	keep_icon = 1
+	keep_icon = TRUE
 	var/jones_swiped = 0
 
 /obj/item/card/id/captains_spare
@@ -149,7 +149,7 @@ GAUNTLET CARDS
 	item_state = "gold_id"
 	registered = "Captain"
 	assignment = "Captain"
-	keep_icon = 1
+	keep_icon = TRUE
 	New()
 		access = get_access("Captain")
 		..()
@@ -160,7 +160,7 @@ GAUNTLET CARDS
 	registered = "Dabber"
 	assignment = "Dabber"
 	desc = "This card authorizes the person wearing it to perform sick dabs."
-	keep_icon = 1
+	keep_icon = TRUE
 	var/dab_count = 0
 	var/dabbed_on_count = 0
 	var/arm_count = 0

--- a/code/obj/machinery/computer/card.dm
+++ b/code/obj/machinery/computer/card.dm
@@ -320,7 +320,7 @@
 		src.scan_access = null
 		src.mode = text2num(href_list["mode"])
 	if (href_list["colour"])
-		if(src.modify && src.modify.icon_state != "gold" && src.modify.icon_state != "id_clown" && src.modify.icon_state != "id_dab" && src.modify.icon_state != "polaris")
+		if(src.modify.keep_icon == 0)
 			var/newcolour = href_list["colour"]
 			if (newcolour == "none")
 				src.modify.icon_state = "id"

--- a/code/obj/machinery/computer/card.dm
+++ b/code/obj/machinery/computer/card.dm
@@ -320,7 +320,7 @@
 		src.scan_access = null
 		src.mode = text2num(href_list["mode"])
 	if (href_list["colour"])
-		if(src.modify && src.modify.icon_state != "gold" && src.modify.icon_state != "id_clown" && src.modify.icon_state != "id_dab")
+		if(src.modify && src.modify.icon_state != "gold" && src.modify.icon_state != "id_clown" && src.modify.icon_state != "id_dab" && src.modify.icon_state != "polaris")
 			var/newcolour = href_list["colour"]
 			if (newcolour == "none")
 				src.modify.icon_state = "id"

--- a/code/obj/machinery/computer/card.dm
+++ b/code/obj/machinery/computer/card.dm
@@ -320,7 +320,7 @@
 		src.scan_access = null
 		src.mode = text2num(href_list["mode"])
 	if (href_list["colour"])
-		if(src.modify.keep_icon == 0)
+		if(src.modify.keep_icon == FALSE) // ids that are FALSE will update their icon if the job changes
 			var/newcolour = href_list["colour"]
 			if (newcolour == "none")
 				src.modify.icon_state = "id"


### PR DESCRIPTION
[BUG - MINOR]
## About the PR 
Makes the NT rep reward ID keep a stagnant icon_state. Much like the captain ID or the dabbing licence.

**EDIT**: All IDs now use a variable and change depending on that variable. Special IDs are still locked and unable to change. NT ID is fixed with these criteria too!

## Why's this needed? 
I believe this was the intended effect and bugs stink

**EDIT**: Cleans up the ID computer code a bit, makes adding new types of IDs to be easier.
