### PR TITLE
Adjusts cyborg weapons lock for lag

### DIFF
--- a/code/mob/living/life/Life.dm
+++ b/code/mob/living/life/Life.dm
@@ -166,6 +166,7 @@
 	add_lifeprocess(/datum/lifeprocess/stuns_lying)
 	add_lifeprocess(/datum/lifeprocess/blindness)
 	add_lifeprocess(/datum/lifeprocess/robot_oil)
+	add_lifeprocess(/datum/lifeprocess/robot_locks)
 
 
 /mob/living/silicon/drone/New()
@@ -366,7 +367,6 @@
 
 	hud.update()
 	process_killswitch()
-	process_locks()
 
 /mob/living/silicon/hivebot/Life(datum/controller/process/mobs/parent)
 	if (..(parent))

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -1956,7 +1956,7 @@
 	proc/toggle_module_pack()
 		if(weapon_lock)
 			boutput(src, "<span class='alert'>Weapon lock active, unable to access panel!</span>")
-			boutput(src, "<span class='alert'>Weapon lock will expire in [src.weaponlock_time] seconds.</span>")
+			boutput(src, "<span class='alert'>Weapon lock will expire in [src.weaponlock_time*2] seconds.</span>")
 			return
 
 		if(!src.module)

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -2499,16 +2499,7 @@
 				src.borg_death_alert(ROBOT_DEATH_MOD_KILLSWITCH)
 
 
-	process_locks()
-		if(weapon_lock)
-			uneq_slot(1)
-			uneq_slot(2)
-			uneq_slot(3)
-			weaponlock_time --
-			if(weaponlock_time <= 0)
-				if(src.client) boutput(src, "<span class='alert'><B>Weapon Lock Timed Out!</B></span>")
-				weapon_lock = 0
-				weaponlock_time = 120
+
 
 	var/image/i_head
 	var/image/i_head_decor

--- a/code/mob/living/silicon/robot_locks.dm
+++ b/code/mob/living/silicon/robot_locks.dm
@@ -1,13 +1,12 @@
 /datum/lifeprocess/robot_locks
 	process(var/datum/gas_mixture/environment)
-		if(robot_owner)
-			if(robot_owner.weapon_lock)
-				robot_owner.uneq_slot(1)
-				robot_owner.uneq_slot(2)
-				robot_owner.uneq_slot(3)
-				robot_owner.weaponlock_time -= get_multiplier()
-				if(robot_owner.weaponlock_time <= 0)
-					if(robot_owner.client) boutput(robot_owner, "<span class='alert'><B>Weapon Lock Timed Out!</B></span>")//what here, eh?
-					robot_owner.weapon_lock = 0
-					robot_owner.weaponlock_time = 120
+		if(robot_owner?.weapon_lock)
+			robot_owner.uneq_slot(1)
+			robot_owner.uneq_slot(2)
+			robot_owner.uneq_slot(3)
+			robot_owner.weaponlock_time -= get_multiplier()
+			if(robot_owner.weaponlock_time <= 0)
+				if(robot_owner.client) boutput(robot_owner, "<span class='alert'><B>Weapon Lock Timed Out!</B></span>")
+				robot_owner.weapon_lock = 0
+				robot_owner.weaponlock_time = 120
 		..()

--- a/code/mob/living/silicon/robot_locks.dm
+++ b/code/mob/living/silicon/robot_locks.dm
@@ -1,0 +1,13 @@
+/datum/lifeprocess/robot_locks
+	process(var/datum/gas_mixture/environment)
+		if(robot_owner)
+			if(robot_owner.weapon_lock)
+				robot_owner.uneq_slot(1)
+				robot_owner.uneq_slot(2)
+				robot_owner.uneq_slot(3)
+				robot_owner.weaponlock_time -= get_multiplier()
+				if(robot_owner.weaponlock_time <= 0)
+					if(robot_owner.client) boutput(robot_owner, "<span class='alert'><B>Weapon Lock Timed Out!</B></span>")//what here, eh?
+					robot_owner.weapon_lock = 0
+					robot_owner.weaponlock_time = 120
+		..()

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -526,6 +526,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\mob\living\silicon\ghostdrone.dm"
 #include "code\mob\living\silicon\hivebot.dm"
 #include "code\mob\living\silicon\robot.dm"
+#include "code\mob\living\silicon\robot_locks.dm"
 #include "code\mob\living\silicon\robot_oil.dm"
 #include "code\mob\living\silicon\ai\camera_handling.dm"
 #include "code\mob\living\silicon\ai\holograms.dm"


### PR DESCRIPTION
Adjusts for Mult
[BUG]
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR moves the process_locks() proc, which handles locking and unlocking a cyborg module's tools, to a life process in robot_locks.dm, and it adjusts the length of it for lag.
Edit: I was able to test this, and it appears to work.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Adjusting for lag is good.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Chickenish:
(+)The cyborg weapons lock is no longer lengthened by lag.
```
