### PR TITLE
Adds action bar to power cell swapping

### DIFF
--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -928,15 +928,17 @@
 			attacking_item.attackby(pcell, attacker)
 		else return ..()
 
-	swap(var/obj/item/gun/energy/E)
+	swap(var/obj/item/gun/energy/E, var/mob/living/user)
 		if(!istype(E.cell,/obj/item/ammo/power_cell))
 			return 0
 		var/obj/item/ammo/power_cell/swapped_cell = E.cell
 		var/mob/living/M = src.loc
+		if (!istype(M))
+			M = user
 		var/atom/old_loc = src.loc
 
 		if(istype(M) && src == M.equipped())
-			usr.u_equip(src)
+			M.u_equip(src)
 
 		src.set_loc(E)
 		E.cell = src
@@ -947,7 +949,7 @@
 			cell_container.hud.remove_item(src)
 			cell_container.hud.update()
 		else
-			usr.put_in_hand_or_drop(swapped_cell)
+			M.put_in_hand_or_drop(swapped_cell)
 
 		src.add_fingerprint(usr)
 
@@ -1196,3 +1198,42 @@
 	ammo_type = new/datum/projectile/special/meowitzer/inert
 
 
+/datum/action/bar/icon/powercellswap
+	duration = 10
+	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_STUNNED | INTERRUPT_ATTACKED
+	id = "powercellswap"
+	icon = 'icons/obj/items/ammo.dmi'
+	icon_state = "power_cell"
+	var/mob/living/user
+	var/obj/item/ammo/power_cell/cell
+	var/obj/item/gun/energy/gun
+
+
+	New(User, Cell, Gun)
+		user = User
+		cell = Cell
+		gun = Gun
+		..()
+
+	onUpdate()
+		..()
+		if(get_dist(user, gun) > 1 || user == null || cell == null || gun == null || get_turf(gun) != get_turf(cell) )
+			interrupt(INTERRUPT_ALWAYS)
+			return
+
+
+	onStart()
+		..()
+		if(get_dist(user, gun) > 1 || user == null || cell == null || gun == null || get_turf(gun) != get_turf(cell) )
+			interrupt(INTERRUPT_ALWAYS)
+			return
+		return
+
+
+	onEnd()
+		..()
+		if(get_dist(user, gun) > 1 || user == null || cell == null || gun == null || get_turf(gun) != get_turf(cell) )
+			..()
+			interrupt(INTERRUPT_ALWAYS)
+			return
+		cell.swap(gun,user)

--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -933,11 +933,11 @@
 			return 0
 		var/obj/item/ammo/power_cell/swapped_cell = E.cell
 		var/mob/living/M = src.loc
-		if (!istype(M))
+		if (!ismob(M))
 			M = user
 		var/atom/old_loc = src.loc
 
-		if(istype(M) && src == M.equipped())
+		if(istype(M) && (src in M.get_all_items_on_mob()))
 			M.u_equip(src)
 
 		src.set_loc(E)

--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -1199,7 +1199,7 @@
 
 
 /datum/action/bar/icon/powercellswap
-	duration = 10
+	duration = 1 SECOND
 	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_STUNNED | INTERRUPT_ATTACKED
 	id = "powercellswap"
 	icon = 'icons/obj/items/ammo.dmi'
@@ -1207,7 +1207,6 @@
 	var/mob/living/user
 	var/obj/item/ammo/power_cell/cell
 	var/obj/item/gun/energy/gun
-
 
 	New(User, Cell, Gun)
 		user = User
@@ -1221,14 +1220,12 @@
 			interrupt(INTERRUPT_ALWAYS)
 			return
 
-
 	onStart()
 		..()
 		if(get_dist(user, gun) > 1 || user == null || cell == null || gun == null || get_turf(gun) != get_turf(cell) )
 			interrupt(INTERRUPT_ALWAYS)
 			return
 		return
-
 
 	onEnd()
 		..()

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -107,8 +107,7 @@
 			if (istype(pcell, /obj/item/ammo/power_cell/self_charging) && !(src in processing_items)) // Again, we want dynamic updates here (Convair880).
 				processing_items.Add(src)
 			if (src.cell)
-				if (pcell.swap(src))
-					user.visible_message("<span class='alert'>[user] swaps [src]'s power cell.</span>")
+				actions.start(new/datum/action/bar/icon/powercellswap(user,pcell,src), user)
 			else
 				src.cell = pcell
 				user.drop_item()
@@ -1347,8 +1346,8 @@
 					current_projectile.cost = 170
 					item_state = "lawg-bigshot"
 					playsound(M, "sound/vox/high.ogg", 50)
-					SPAWN_DBG(0.4 SECONDS)
-						playsound(M, "sound/vox/explosive.ogg", 50)
+					sleep(0.4 SECONDS)
+					playsound(M, "sound/vox/explosive.ogg", 50)
 				if ("clownshot")
 					current_projectile = projectiles["clownshot"]
 					item_state = "lawg-clownshot"

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1346,8 +1346,8 @@
 					current_projectile.cost = 170
 					item_state = "lawg-bigshot"
 					playsound(M, "sound/vox/high.ogg", 50)
-					sleep(0.4 SECONDS)
-					playsound(M, "sound/vox/explosive.ogg", 50)
+					SPAWN_DBG(0.4 SECONDS)
+						playsound(M, "sound/vox/explosive.ogg", 50)
 				if ("clownshot")
 					current_projectile = projectiles["clownshot"]
 					item_state = "lawg-clownshot"

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -107,7 +107,7 @@
 			if (istype(pcell, /obj/item/ammo/power_cell/self_charging) && !(src in processing_items)) // Again, we want dynamic updates here (Convair880).
 				processing_items.Add(src)
 			if (src.cell)
-				actions.start(new/datum/action/bar/icon/powercellswap(user,pcell,src), user)
+				actions.start(new/datum/action/bar/icon/powercellswap(user, pcell, src), user)
 			else
 				src.cell = pcell
 				user.drop_item()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a short action bar to power cell swapping


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Right now swapping power cells is an instant effect and can be done on the move mid-combat. This would slightly slow down combat by making it a more active decision to swap your cell out when need be, rather than the current run and gun swap 5 cells out of your pocket it is now.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)mbc and Sord:
(*)Added short action bar to power cell swapping
```