### PR TITLE
dumb chembomb

### DIFF
--- a/code/obj/artifacts/artifact_objects/bombs.dm
+++ b/code/obj/artifacts/artifact_objects/bombs.dm
@@ -85,7 +85,7 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 
 			// actual boom
 			SPAWN_DBG(10 SECONDS)
-				if (O.loc && src.activated)
+				if (!O.disposed && src.activated)
 					blewUp = 1
 					deploy_payload(O)
 

--- a/code/obj/artifacts/artifact_objects/bombs.dm
+++ b/code/obj/artifacts/artifact_objects/bombs.dm
@@ -25,6 +25,7 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 	var/animationScale = 3
 	var/detonation_time = INFINITY
 	var/lightColor = list(255,255,255,255)
+	var/recharge_delay = 0
 	examine_hint = "It is covered in very conspicuous markings."
 
 	New()
@@ -40,7 +41,7 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 			return
 		var/turf/T = get_turf(O)
 		src.detonation_time = TIME + src.explode_delay
-		if(doAlert && ON_COOLDOWN(O, "alertArm", 10 MINUTES))
+		if(recharge_delay && ON_COOLDOWN(O, "bomb_cooldown", recharge_delay))
 			T.visible_message("<b><span class='alert'>[O] [text_cooldown]</span></b>")
 			playsound(T, sound_cooldown, 100, 1)
 			SPAWN_DBG(3 SECONDS)
@@ -66,6 +67,8 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 
 	effect_process(var/obj/O)
 		if(!src.activated)
+			return
+		if(src.explode_delay < 1)
 			return
 		var/turf/T = get_turf(O)
 		playsound(T, alarm_during, 30, 1) // repeating noise, so people who come near later know it's a bomb
@@ -162,6 +165,7 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 	associated_object = /obj/machinery/artifact/bomb/devastating
 	rarity_class = 4
 	doAlert = 1
+	recharge_delay = 10 MINUTES
 	animationScale = 6
 
 	New()
@@ -212,7 +216,7 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 	validtypes = list("ancient","martian","eldritch","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/heat,/datum/artifact_trigger/carbon_touch)
 	var/payload_type = 0 // 0 for smoke, 1 for foam, 2 for propellant, 3 for just dumping fluids
-	var/recharge_delay = 600
+	recharge_delay = 600
 	var/list/payload_reagents = list()
 
 	post_setup()

--- a/code/obj/artifacts/artifact_objects/bombs.dm
+++ b/code/obj/artifacts/artifact_objects/bombs.dm
@@ -217,7 +217,7 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 	validtypes = list("ancient","martian","eldritch","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/heat,/datum/artifact_trigger/carbon_touch)
 	var/payload_type = 0 // 0 for smoke, 1 for foam, 2 for propellant, 3 for just dumping fluids
-	recharge_delay = 600
+	recharge_delay = 10 MINUTES
 	var/list/payload_reagents = list()
 
 	post_setup()

--- a/code/obj/artifacts/artifact_objects/bombs.dm
+++ b/code/obj/artifacts/artifact_objects/bombs.dm
@@ -47,10 +47,6 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 			SPAWN_DBG(3 SECONDS)
 				O.ArtifactDeactivated() // lol get rekt spammer
 			return
-		if (explode_delay < 1)
-			deploy_payload(O)
-			return
-
 
 		// this is all just fluff
 		if (warning_initial)
@@ -66,12 +62,13 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 
 
 	effect_process(var/obj/O)
+		if(..())
+			return
 		if(!src.activated)
 			return
-		if(src.explode_delay < 1)
-			return
 		var/turf/T = get_turf(O)
-		playsound(T, alarm_during, 30, 1) // repeating noise, so people who come near later know it's a bomb
+		if(alarm_during)
+			playsound(T, alarm_during, 30, 1) // repeating noise, so people who come near later know it's a bomb
 
 		if(TIME > src.detonation_time)
 			src.detonation_time = INFINITY
@@ -88,12 +85,13 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 
 			// actual boom
 			SPAWN_DBG(10 SECONDS)
-				if (src.activated)
+				if (O.loc && src.activated)
 					blewUp = 1
 					deploy_payload(O)
 
 	effect_deactivate(obj/O)
-		. = ..()
+		if(..())
+			return
 		// and remove all the animation stuff when it is deactivated (:
 		animate(O, pixel_y = 0, pixel_y = 0, time = 3,loop = 1, easing = LINEAR_EASING)
 		animate(O.simple_light, flags=ANIMATION_PARALLEL, time= 3 SECONDS, transform = null)
@@ -212,6 +210,9 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 	associated_object = /obj/machinery/artifact/bomb/chemical
 	rarity_class = 2
 	explode_delay = 0
+	alarm_initial = null
+	alarm_during = null
+	alarm_final = null
 	react_xray = list(5,65,20,11,"HOLLOW")
 	validtypes = list("ancient","martian","eldritch","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/heat,/datum/artifact_trigger/carbon_touch)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
With the new change to let activators deactivate they could be used to bypass the cooldown on artifact chembombs, so I am just preempting whatever nerd would have used that first.
Bombs now have a recharge_delay thing that can be set in general, used for chembombs and devastating explosive bombs.

Also, makes process on bombs return early if they are the type that detonates instantly, because the other variant made 0 sense and caused them to explode twice sometimes, lol.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I'm dumb and make terrible code.