### PR TITLE
Adds volatility to magnesium-ammonium chloride and fixes a single line of text

### DIFF
--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -3261,6 +3261,7 @@ datum
 			fluid_g = 255
 			fluid_b = 255
 			transparency = 255
+			volatility = 2
 
 		reversium
 			name = "reversium"

--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -979,10 +979,10 @@ PIPE BOMBS + CONSTRUCTION
 
 	attackby(obj/A as obj, mob/user as mob) // adapted from iv_drips.dm
 		if (iscuttingtool(A) && !(src.slashed) && !(src.primed))
+			boutput(user, "You carefully cut [src] open and dump out the contents.")
 			src.slashed = TRUE
 			src.name = "empty [src.name]" // its empty now!
 			src.desc = "[src.desc] It has been cut open and emptied out."
-			boutput(user, "You carefully cut [src] open and dump out the contents.")
 
 			make_cleanable(/obj/decal/cleanable/magnesiumpile, get_turf(src.loc)) // create magnesium pile
 			src.reagents.clear_reagents() // remove magnesium from firework


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG - TRIVIAL]
[FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a volatility stat of 2 to magnesium-ammonium chloride, allowing it to be used in pipe bombs to decent effect. Since magnesium-ammonium chloride releases so much ammonia when it decomposes, it sounds good for jamming into a closed vessel.

Also fixes a single line of text for fireworks. Specifically, bootleg fireworks being described as empty during the cutting and emptying process, which doesn't make a lick of sense.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
IIRC the only pipe bomb reagent currently available without access to a chem dispenser is welding fuel which isn't very powerful at all. So, adding volatility to magnesium-ammonium chloride would complete a more powerful yet time-consuming option for any ne'er-do-wells without access to chem equipment.