### PR TITLE
Makes electrical toolboxes have random cable colours

### DIFF
--- a/code/obj/item/storage/toolbox.dm
+++ b/code/obj/item/storage/toolbox.dm
@@ -101,17 +101,19 @@
 	/obj/item/crowbar)
 
 	make_my_stuff()
+		var/picked = pick(/obj/item/cable_coil,\
+		/obj/item/cable_coil/colored/yellow,\
+		/obj/item/cable_coil/colored/orange,\
+		/obj/item/cable_coil/colored/blue,\
+		/obj/item/cable_coil/colored/green,\
+		/obj/item/cable_coil/colored/purple,\
+		/obj/item/cable_coil/colored/black,\
+		/obj/item/cable_coil/colored/hotpink,\
+		/obj/item/cable_coil/colored/brown,\
+		/obj/item/cable_coil/colored/white)
+		spawn_contents.Add(picked)
 		if (!istype(src, /obj/item/storage/toolbox/electrical/mechanic_spawn))
-			spawn_contents[ pick(/obj/item/cable_coil,\
-			/obj/item/cable_coil/colored/yellow,\
-			/obj/item/cable_coil/colored/orange,\
-			/obj/item/cable_coil/colored/blue,\
-			/obj/item/cable_coil/colored/green,\
-			/obj/item/cable_coil/colored/purple,\
-			/obj/item/cable_coil/colored/black,\
-			/obj/item/cable_coil/colored/hotpink,\
-			/obj/item/cable_coil/colored/brown,\
-			/obj/item/cable_coil/colored/white) ] = 3
+			spawn_contents.Add(picked,picked)
 		. = ..()
 
 
@@ -120,7 +122,6 @@
 		spawn_contents = list(/obj/item/electronics/scanner,\
 		/obj/item/electronics/soldering,\
 		/obj/item/device/t_scanner,\
-		/obj/item/cable_coil,\
 		/obj/item/reagent_containers/food/snacks/sandwich/cheese,\
 		/obj/item/reagent_containers/food/snacks/chips,\
 		/obj/item/reagent_containers/food/drinks/coffee)

--- a/code/obj/item/storage/toolbox.dm
+++ b/code/obj/item/storage/toolbox.dm
@@ -98,8 +98,21 @@
 	spawn_contents = list(/obj/item/screwdriver,\
 	/obj/item/wirecutters,\
 	/obj/item/device/t_scanner,\
-	/obj/item/crowbar,\
-	/obj/item/cable_coil = 3)
+	/obj/item/crowbar)
+
+	make_my_stuff()
+		spawn_contents[ pick(/obj/item/cable_coil,\
+    /obj/item/cable_coil/colored/yellow,\
+    /obj/item/cable_coil/colored/orange,\
+    /obj/item/cable_coil/colored/blue,\
+    /obj/item/cable_coil/colored/green,\
+    /obj/item/cable_coil/colored/purple,\
+    /obj/item/cable_coil/colored/black,\
+    /obj/item/cable_coil/colored/hotpink,\
+    /obj/item/cable_coil/colored/brown,\
+    /obj/item/cable_coil/colored/white) ] = 3
+		. = ..()
+
 
 	// The extra items (scanner and soldering iron) take up precious space in the backpack.
 	mechanic_spawn

--- a/code/obj/item/storage/toolbox.dm
+++ b/code/obj/item/storage/toolbox.dm
@@ -101,16 +101,17 @@
 	/obj/item/crowbar)
 
 	make_my_stuff()
-		spawn_contents[ pick(/obj/item/cable_coil,\
-    /obj/item/cable_coil/colored/yellow,\
-    /obj/item/cable_coil/colored/orange,\
-    /obj/item/cable_coil/colored/blue,\
-    /obj/item/cable_coil/colored/green,\
-    /obj/item/cable_coil/colored/purple,\
-    /obj/item/cable_coil/colored/black,\
-    /obj/item/cable_coil/colored/hotpink,\
-    /obj/item/cable_coil/colored/brown,\
-    /obj/item/cable_coil/colored/white) ] = 3
+		if (!istype(src, /obj/item/storage/toolbox/electrical/mechanic_spawn))
+			spawn_contents[ pick(/obj/item/cable_coil,\
+			/obj/item/cable_coil/colored/yellow,\
+			/obj/item/cable_coil/colored/orange,\
+			/obj/item/cable_coil/colored/blue,\
+			/obj/item/cable_coil/colored/green,\
+			/obj/item/cable_coil/colored/purple,\
+			/obj/item/cable_coil/colored/black,\
+			/obj/item/cable_coil/colored/hotpink,\
+			/obj/item/cable_coil/colored/brown,\
+			/obj/item/cable_coil/colored/white) ] = 3
 		. = ..()
 
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feat]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes the cable coils that spawn in electrical toolboxes are of a random colour (3 of one type).

Big cheers to Pali, who actually knew how to do this.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes it easier for crew to get coloured cables and also add some variety in the stuff you throw out of a toolbox.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)BatElite:
(+)The cables in electrical toolboxes are now of a random colour. Go do aesthetic engineering.
```
