### PR TITLE
[Cog1] Cloning no longer uses Genetics APC, uses the APC of Medbay

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -56532,7 +56532,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/bot,
-/area/station/medical/research)
+/area/station/medical/medbay)
 "cqQ" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -57014,7 +57014,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/bot,
-/area/station/medical/research)
+/area/station/medical/medbay)
 "crT" = (
 /obj/machinery/computer/cloning,
 /obj/item/paper/Cloning,
@@ -57034,7 +57034,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/bot,
-/area/station/medical/research)
+/area/station/medical/medbay)
 "crU" = (
 /obj/machinery/clonegrinder,
 /obj/window/reinforced{
@@ -57044,7 +57044,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/bot,
-/area/station/medical/research)
+/area/station/medical/medbay)
 "crV" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/stairs{
@@ -61736,7 +61736,7 @@
 	name = "Geneticist"
 	},
 /turf/simulated/floor,
-/area/station/medical/research)
+/area/station/medical/medbay)
 "cCc" = (
 /obj/rack,
 /obj/item/circuitboard/powermonitor{


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changed the cloner & cloning equipment to be in the `/station/medical/medbay` area, rather then `/area/station/medical/research`, as it is confusing for it to classified as Genetics despite not being part of Genetics anymore.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
it makes no sense for something in a different room to be powered by Genetics, and can be rather misleading to someone trying to depower Cloning but unaware of this oddity


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Comradef191:
(*)Cloning on Cogmap1 is now powered by the Medbay APC rather than Genetics APC.
```
