### PR TITLE
Add support for mob ai critter hibernation, and a simple hibernation task

### DIFF
--- a/code/WorkInProgress/HaineWhatever.dm
+++ b/code/WorkInProgress/HaineWhatever.dm
@@ -874,6 +874,7 @@ var/list/special_parrot_species = list("ikea" = /datum/species_info/parrot/kea/i
 			src.bioHolder.AddEffect(my_mutation)
 
 	was_harmed(var/mob/M as mob, var/obj/item/weapon = 0, var/special = 0, var/intent = null)
+		. = ..()
 		src.protect_from(M, null, weapon)
 
 	proc/protect_from(var/mob/M as mob, var/mob/customer as mob, var/obj/item/weapon as obj)

--- a/code/WorkInProgress/warcrimes.dm
+++ b/code/WorkInProgress/warcrimes.dm
@@ -432,6 +432,7 @@ var/fartcount = 0
 		..()
 
 	was_harmed(var/mob/M as mob, var/obj/item/weapon = 0, var/special = 0, var/intent = null)
+		. = ..()
 		if (special) //vamp or ling
 			src.target = M
 			src.ai_state = AI_ATTACKING

--- a/code/area.dm
+++ b/code/area.dm
@@ -317,7 +317,6 @@ ABSTRACT_TYPE(/area) // don't instantiate this directly dummies, use /area/space
 			C.wake_from_hibernation()
 		for (var/mob/living/critter/M as() in src.registered_mob_critters)
 			M.wake_from_hibernation()
-		src.registered_mob_critters.len = 0
 		waking_critters = 0
 
 	proc/calculate_area_value()

--- a/code/area.dm
+++ b/code/area.dm
@@ -110,6 +110,7 @@ ABSTRACT_TYPE(/area) // don't instantiate this directly dummies, use /area/space
 	var/workplace = 0
 
 	var/list/obj/critter/registered_critters = list()
+	var/list/obj/critter/registered_mob_critters = list()
 	var/waking_critters = 0
 
 	// this chunk zone is for Area Ambience
@@ -310,10 +311,13 @@ ABSTRACT_TYPE(/area) // don't instantiate this directly dummies, use /area/space
 		sims_score = max(sims_score, 0)
 
 	proc/wake_critters()
-		if(waking_critters || !registered_critters.len) return
+		if(waking_critters || (!length(src.registered_critters) && !length(src.registered_mob_critters))) return
 		waking_critters = 1
 		for(var/obj/critter/C in src.registered_critters)
 			C.wake_from_hibernation()
+		for (var/mob/living/critter/M as() in src.registered_mob_critters)
+			M.wake_from_hibernation()
+		src.registered_mob_critters.len = 0
 		waking_critters = 0
 
 	proc/calculate_area_value()

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1707,6 +1707,7 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 
 
 /mob/living/proc/was_harmed(var/mob/M as mob, var/obj/item/weapon = 0, var/special = 0, var/intent = null)
+	SHOULD_CALL_PARENT(TRUE)
 	.= 0
 
 //left this here to standardize into living later

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1713,6 +1713,11 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 /mob/living/critter/was_harmed(var/mob/M as mob, var/obj/item/weapon = 0, var/special = 0, var/intent = null)
 	if (src.ai)
 		src.ai.was_harmed(weapon,M)
+		if(src.is_hibernating)
+			if (src.registered_area)
+				src.registered_area.wake_critters()
+			else
+				src.wake_from_hibernation()
 	..()
 
 /mob/living/bullet_act(var/obj/projectile/P)
@@ -1869,11 +1874,13 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 	if (!P.proj_data.silentshot)
 		src.visible_message("<span class='alert'>[src] is hit by the [P.name]!</span>", "<span class='alert'>You are hit by the [P.name][armor_msg]!</span>")
 
-
+	var/mob/M = null
 	if (ismob(P.shooter))
-		if (P.shooter)
-			src.lastattacker = P.shooter
-			src.lastattackertime = world.time
+		M = P.shooter
+		src.lastattacker = M
+		src.lastattackertime = world.time
+	src.was_harmed(M)
+
 	return 1
 
 /mob/living/attackby(obj/item/W, mob/M)

--- a/code/mob/living/carbon/human/gimmick.dm
+++ b/code/mob/living/carbon/human/gimmick.dm
@@ -204,6 +204,7 @@ mob/living/carbon/human/cluwne/satan/megasatan //someone can totally use this fo
 		..()
 
 	was_harmed(var/mob/M as mob, var/obj/item/weapon = 0, var/special = 0, var/intent = null)
+		. = ..()
 		if (special) //vamp or ling
 			src.target = M
 			src.ai_state = AI_ATTACKING
@@ -624,6 +625,7 @@ proc/empty_mouse_params()//TODO MOVE THIS!!!
 
 
 	was_harmed(var/mob/M as mob, var/obj/item/weapon = 0, var/special = 0, var/intent = null)
+		. = ..()
 		if (special) //vamp or ling
 			src.target = M
 			src.ai_state = AI_ATTACKING
@@ -773,6 +775,7 @@ proc/empty_mouse_params()//TODO MOVE THIS!!!
 		..()
 
 	was_harmed(var/mob/M as mob, var/obj/item/weapon = 0, var/special = 0, var/intent = null)
+		. = ..()
 		if (special) //vamp or ling
 			src.target = M
 			src.ai_state = AI_ATTACKING
@@ -883,6 +886,7 @@ proc/empty_mouse_params()//TODO MOVE THIS!!!
 			gender = pick(MALE,FEMALE)
 
 	was_harmed(var/mob/M as mob, var/obj/item/weapon = 0, var/special = 0, var/intent = null)
+		. = ..()
 		if(isdead(src))
 			return
 		if(prob(10))
@@ -938,6 +942,7 @@ proc/empty_mouse_params()//TODO MOVE THIS!!!
 		..()
 
 	was_harmed(var/mob/M as mob, var/obj/item/weapon = 0, var/special = 0, var/intent = null)
+		. = ..()
 		if(isdead(src))
 			return
 		if(prob(20))

--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -27,6 +27,7 @@
 	var/area/registered_area = null
 	//time when mob last awoke from hibernation
 	var/last_hibernation_wake_tick = 0
+	var/is_hibernating = TRUE
 
 	var/can_burn = 1
 	var/can_throw = 0
@@ -177,7 +178,9 @@
 		if(src.is_npc)
 			src.ai?.enabled = TRUE
 			src.last_hibernation_wake_tick = TIME
+			src.registered_area?.registered_mob_critters -= src
 			src.registered_area = null
+			src.is_hibernating = FALSE
 
 	proc/setup_healths()
 		// add_health_holder(/datum/healthHolder/flesh)

--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -23,6 +23,10 @@
 	var/base_move_delay = 2
 	var/base_walk_delay = 3
 	var/stepsound = null
+	//area where the mob ai is registered when hibernating
+	var/area/registered_area = null
+	//time when mob last awoke from hibernation
+	var/last_hibernation_wake_tick = 0
 
 	var/can_burn = 1
 	var/can_throw = 0
@@ -162,7 +166,18 @@
 			hh.dispose()
 		healthlist.len = 0
 		healthlist = null
+
+		if (src.is_npc)
+			src.registered_area?.registered_mob_critters -= src
+			src.registered_area = null
 		..()
+
+	//enables mob ai that was disabled by a hibernation task
+	proc/wake_from_hibernation()
+		if(src.is_npc)
+			src.ai?.enabled = TRUE
+			src.last_hibernation_wake_tick = TIME
+			src.registered_area = null
 
 	proc/setup_healths()
 		// add_health_holder(/datum/healthHolder/flesh)

--- a/code/mob/living/critter/ai/shared.dm
+++ b/code/mob/living/critter/ai/shared.dm
@@ -185,6 +185,7 @@
 	var/hibernation_priority = 100
 
 	evaluate()
+		. = ..()
 		var/mob/living/critter/M = holder.owner
 		if (!M)
 			return 0

--- a/code/mob/living/critter/ai/shared.dm
+++ b/code/mob/living/critter/ai/shared.dm
@@ -179,3 +179,28 @@
 	minimum_task_ticks = 10
 	maximum_task_ticks = 10
 
+/datum/aiTask/action/hibernate
+	name = "hibernate"
+	var/min_time_between_hibernations = 20 SECONDS
+	var/hibernation_priority = 100
+
+	evaluate()
+		var/mob/living/critter/M = holder.owner
+		if (!M)
+			return 0
+		var/area/A = get_area(M)
+		if (A?.active)
+			return 0
+		if ((M.last_hibernation_wake_tick + min_time_between_hibernations) >=  TIME)
+			return 0
+		return hibernation_priority
+
+	on_tick()
+		. = ..()
+		var/mob/living/critter/M = holder.owner
+		if (!M) return
+		holder.enabled = FALSE
+		M.registered_area = get_area(M)
+		if(M.registered_area)
+			M.registered_area.registered_mob_critters |= M
+


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][FEATURE][PERFORMANCE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds hibernation support for mob ai critters allowing them to turn off their AI when their area is inactive. Mobs will only re-enter hibernation after waking once a set time has passed.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
There is a quickly growing number of mob ai critters in adventure zones, all wandering around just hanging out waiting for adventurers. There's no real need to have them be active if no one is around, so this task can be added to a mob ai's prioritizer and disable their AI until someone is actually nearby,

The task I wrote just does a simple area active check, but if needed fancier proximity checks those could easily be added too.