### PR TITLE
Fixes Clarion medbay door buttons

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -23286,6 +23286,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/glass/med{
+	id = "medbay_hall";
 	name = "Medbay"
 	},
 /obj/firedoor_spawn,
@@ -23722,6 +23723,7 @@
 	},
 /obj/machinery/door/airlock/pyro/command/alt{
 	dir = 4;
+	id = "medirecdoor";
 	name = "Medical Director's Office"
 	},
 /obj/access_spawn/medical_director,
@@ -25182,16 +25184,12 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "aTA" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/gannets/glass/medical{
-	id = "medbay_hall";
-	name = "glass airlock-'Medbay'"
-	},
 /obj/machinery/door/airlock/pyro/glass/med{
-	dir = 4
+	dir = 4;
+	id = "medbay_hall"
 	},
 /obj/firedoor_spawn,
 /obj/access_spawn/medical,
@@ -27351,6 +27349,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/glass/med{
+	id = "cryo_door";
 	name = "Cryogenics"
 	},
 /obj/firedoor_spawn,
@@ -27835,6 +27834,7 @@
 	},
 /obj/machinery/door/airlock/pyro/glass/med{
 	dir = 4;
+	id = "medbay_door";
 	name = "Medbay"
 	},
 /obj/firedoor_spawn,
@@ -29648,6 +29648,7 @@
 	},
 /obj/machinery/door/airlock/pyro/glass/med{
 	dir = 4;
+	id = "medbay_hall";
 	name = "Medbay"
 	},
 /obj/firedoor_spawn,
@@ -36770,6 +36771,7 @@
 "bny" = (
 /obj/machinery/door/airlock/pyro/medical/alt{
 	dir = 4;
+	id = "Cloning_Door";
 	name = "Cloning"
 	},
 /obj/access_spawn/medical,

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -13764,7 +13764,8 @@
 "axM" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt{
 	dir = 4;
-	name = "Detective's Office"
+	name = "Detective's Office";
+	req_access = null
 	},
 /obj/access_spawn/forensics,
 /obj/firedoor_spawn,
@@ -16039,7 +16040,8 @@
 	},
 /obj/machinery/door/airlock/pyro/maintenance/alt{
 	dir = 4;
-	name = "Kitchen"
+	name = "Kitchen";
+	req_access = null
 	},
 /obj/firedoor_spawn,
 /obj/access_spawn/kitchen,
@@ -17599,7 +17601,9 @@
 /area/station/maintenance/west)
 "aGd" = (
 /obj/disposalpipe/segment,
-/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	req_access = null
+	},
 /obj/firedoor_spawn,
 /obj/access_spawn/medical,
 /obj/machinery/door/poddoor/blast{
@@ -39515,7 +39519,8 @@
 /area/station/engine/elect)
 "bsk" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt{
-	name = "Mechanics"
+	name = "Mechanics";
+	req_access = null
 	},
 /obj/access_spawn/engineering_mechanic,
 /obj/firedoor_spawn,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
#3133 borked various door buttons around medbay because `id` wasn't set on replaced airlocks. This PR restores them to pre-perspective functioning.
Also removes a leftover firelock/old door combo between medbay's reception desk and medbay's hall.

---

Since map diff bot doesn't show anything, here's a full list:
-Doors from medbay reception desk to the main hall and medbay hall, as well as (for some reason) cryo to medbay hall for the button on the reception desk.
-Main door into medbay for buttons below and above it.
-Cryo to main hall for both buttons in cryo.
-MD's office door for one of the buttons inside the office.
-Cloning to public hall door for the button above the cloning console.

---

UPDATE:  Per Nefarious6th's suggestion, I've also nulled the access list on a few maintenance doors to the pharmacy, the det's bedroom, the kitchen freezer and mech lab.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Things working is good. Staffies having easy access to chem dispensers isn't.
