### PR TITLE
mentor mouse observers can now observe computers

### DIFF
--- a/code/mob/dead/mentor_mouse_observer.dm
+++ b/code/mob/dead/mentor_mouse_observer.dm
@@ -66,6 +66,11 @@
 			if(my_id == src.ping_id)
 				src.ping.loc = null
 
+	examine_verb(atom/A)
+		. = ..()
+		if(istype(A, /obj/machinery/computer3))
+			A.attack_hand(src)
+
 	say_understands(var/other)
 		return 1
 

--- a/code/modules/networks/computer3/computer3.dm
+++ b/code/modules/networks/computer3/computer3.dm
@@ -326,7 +326,7 @@
 	return
 
 /obj/machinery/computer3/attack_hand(mob/user as mob)
-	if(..())
+	if(..() && !istype(user, /mob/dead/target_observer/mentor_mouse_observer))
 		return
 
 	if(!user.literate)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Mentor mice that are inside someone can now open the computer window to check what is being written by examining the computer.
They can't interact themselves. (Due to them being dead and all.)
Please let me know how many terrible crimes I have committed in these 5 lines of code.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Teaching people how to do computer stuff good is really annoying right now.
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)zjdtmkhzt:
(+)Mentor mouse observers may now observe computer screens by examining them.
