### PR TITLE
Makes blob temperature damage scale based on hotspot volume

### DIFF
--- a/code/obj/blob.dm
+++ b/code/obj/blob.dm
@@ -232,7 +232,7 @@
 		if(temp_difference > tolerance)
 			temp_difference = abs(temp_difference - tolerance)
 
-			src.take_damage(temp_difference / heat_divisor, 1, "burn")
+			src.take_damage(temp_difference / heat_divisor * volume / CELL_VOLUME, 1, "burn")
 
 	attack_hand(var/mob/user)
 		user.lastattacked = src


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Currently temperature damage done to blobs scales only with the temperature of the hotspot (fire). But some hotspots have more volume and some less. This PR makes it so a full tile hotspot (for example the one from a plasma fire) will do normal damage but smaller hotspots will do less damage. For example this makes it so RCD sparks deal only about 1/15th of maximum health to a blob tile instead of instakilling it (multitool special attack too probably). Flamethrowers don't seem to be affected much but I haven't tested thoroughly.

I feel like this PR might require changing of the base temperature resist of a blob but who knows.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's silly that RCD sparks multitool special attack can just annihilate blob currently. Scaling with volume makes sense.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)pali
(*)Blob temperature damage rebalanced a bit. Sources which create "smaller" hot areas are likely less effective.
```
