### PR TITLE
Light and Blind Switches for HoP Room on Cog1

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -24283,6 +24283,10 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/blind_switch/area/north{
+	pixel_x = -8
+	},
+/obj/machinery/light_switch/north,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/heads)
 "bba" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Gives a light switch and blind switch to the HoP Bedroom on Cog1 so now HoPs can turn off their lights or close their blinds.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I guess HoPs need to sleep sometimes? Maybe? Or hide in cowardice?