### PR TITLE
Automatically add missing jobs to the job preferences list.

### DIFF
--- a/code/datums/preferences.dm
+++ b/code/datums/preferences.dm
@@ -1,4 +1,8 @@
 var/list/bad_name_characters = list("_", "'", "\"", "<", ">", ";", "\[", "\]", "{", "}", "|", "\\", "/")
+var/list/removed_jobs = list(
+	// jobs that have been removed or replaced (replaced -> new name, removed -> null)
+	"Barman" = "Bartender",
+)
 
 datum/preferences
 	var/profile_name
@@ -956,6 +960,25 @@ $(function() {
 		else if (isnull(src.job_favorite) && !src.jobs_med_priority.len && !src.jobs_low_priority.len && !src.jobs_unwanted.len)
 			src.ResetAllPrefsToDefault(user)
 			boutput(user, "<span class='alert'><b>Your Job Preferences were empty, and have been reset.</b></span>")
+		else
+			for (var/job in removed_jobs)
+				if (job in src.jobs_med_priority)
+					src.jobs_med_priority -= job
+					if (removed_jobs[job])
+						src.jobs_med_priority |= removed_jobs[job]
+				if (job in src.jobs_low_priority)
+					src.jobs_low_priority -= job
+					if (removed_jobs[job])
+						src.jobs_low_priority |= removed_jobs[job]
+				if (job in src.jobs_unwanted)
+					src.jobs_unwanted -= job
+					if (removed_jobs[job])
+						src.jobs_unwanted |= removed_jobs[job]
+			for (var/datum/job/J in job_controls.staple_jobs)
+				if (istype(J, /datum/job/daily))
+					continue
+				if (!(job in src.jobs_med_priority || job in src.jobs_low_priority))
+					src.jobs_unwanted |= J.name
 
 
 		var/list/HTML = list()

--- a/code/datums/preferences.dm
+++ b/code/datums/preferences.dm
@@ -977,7 +977,7 @@ $(function() {
 			for (var/datum/job/J in job_controls.staple_jobs)
 				if (istype(J, /datum/job/daily))
 					continue
-				if (!(J.name in src.jobs_med_priority || J.name in src.jobs_low_priority))
+				if (!(J.name in src.jobs_med_priority) && !(J.name in src.jobs_low_priority))
 					src.jobs_unwanted |= J.name
 
 

--- a/code/datums/preferences.dm
+++ b/code/datums/preferences.dm
@@ -977,7 +977,7 @@ $(function() {
 			for (var/datum/job/J in job_controls.staple_jobs)
 				if (istype(J, /datum/job/daily))
 					continue
-				if (!(job in src.jobs_med_priority || job in src.jobs_low_priority))
+				if (!(J.name in src.jobs_med_priority || J.name in src.jobs_low_priority))
 					src.jobs_unwanted |= J.name
 
 


### PR DESCRIPTION
[QOL]

## About the PR

Automatically adds missing jobs as "unwanted" and removes/replaces jobs that have been completely removed or renamed when the job preferences menu is opened.

## Why's this needed?

Different maps have different available jobs, and it's currently impossible to set preferences for all of the jobs.
