### PR TITLE
Unlinks door in Oshan Pharmacy from Psychiatrist's Office Button

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -11151,14 +11151,13 @@
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay/lobby)
 "azB" = (
-/obj/disposalpipe/switch_junction/left/west{
-	mail_tag = "pathology";
-	name = "pathology mail router"
-	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay/lobby)

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -1131,18 +1131,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/chapel/office)
-"acq" = (
-/obj/wingrille_spawn/auto,
-/obj/disposalpipe/segment/mail,
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
-/obj/window_blinds/cog2/middle{
-	layer = 2.9;
-	pixel_y = 13
-	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/surgery)
 "acr" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/morgue{
@@ -3072,15 +3060,6 @@
 /obj/cabinet/psychiatry,
 /turf/simulated/floor/darkblue,
 /area/station/medical/medbay/psychiatrist)
-"agL" = (
-/obj/disposalpipe/segment/mail{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
 "agM" = (
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
@@ -3249,12 +3228,6 @@
 /obj/stool/chair,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/north)
-"ahl" = (
-/obj/disposalpipe/segment/mail,
-/turf/simulated/wall/auto/supernorn,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
 "ahm" = (
 /obj/machinery/optable{
 	name = "Autopsy Table"
@@ -4283,10 +4256,6 @@
 "ajJ" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/surgery)
-"ajK" = (
-/obj/disposalpipe/segment/mail,
-/turf/simulated/wall/auto/supernorn,
-/area/station/medical/medbay/surgery)
 "ajL" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
@@ -4686,7 +4655,6 @@
 /obj/item/surgical_spoon{
 	pixel_y = 12
 	},
-/obj/disposalpipe/segment/mail,
 /obj/decal/tile_edge/line/red{
 	dir = 1;
 	icon_state = "line1"
@@ -4984,15 +4952,6 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "alq" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/red,
-/area/station/medical/medbay/surgery)
-"alr" = (
-/obj/disposalpipe/segment/mail,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -5505,7 +5464,6 @@
 /area/station/medical/medbay/surgery)
 "amr" = (
 /obj/machinery/optable,
-/obj/disposalpipe/segment/mail,
 /obj/machinery/drainage/big,
 /obj/item/paper/book/medical_surgery_guide{
 	pixel_x = 9
@@ -5884,10 +5842,6 @@
 	},
 /turf/simulated/floor/red,
 /area/station/medical/medbay/surgery)
-"anl" = (
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/red,
-/area/station/medical/medbay/surgery)
 "anm" = (
 /turf/simulated/floor/red,
 /area/station/medical/medbay/surgery)
@@ -6184,7 +6138,6 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "anX" = (
-/obj/disposalpipe/segment/mail,
 /obj/decal/tile_edge/line/red{
 	icon_state = "line1"
 	},
@@ -6967,11 +6920,6 @@
 	},
 /turf/simulated/floor/blue/checker,
 /area/station/medical/medbay)
-"apM" = (
-/obj/stool/bench/blue/auto,
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/blue/checker,
-/area/station/medical/medbay)
 "apN" = (
 /obj/stool/bench/blue/auto,
 /turf/simulated/floor/blue/checker,
@@ -7525,10 +7473,6 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
 "arb" = (
-/turf/simulated/floor/blue/checker,
-/area/station/medical/medbay)
-"arc" = (
-/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/blue/checker,
 /area/station/medical/medbay)
 "ard" = (
@@ -8603,10 +8547,6 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
-"atC" = (
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/white,
-/area/station/medical/medbay)
 "atD" = (
 /obj/table/reinforced/auto,
 /obj/item/device/analyzer/healthanalyzer,
@@ -9189,7 +9129,6 @@
 /obj/stool/chair/office{
 	dir = 8
 	},
-/obj/disposalpipe/segment/mail,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -10191,7 +10130,6 @@
 /obj/item/reagent_containers/glass/bottle/epinephrine,
 /obj/machinery/door/airlock/pyro/glass/windoor,
 /obj/access_spawn/medical,
-/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "axq" = (
@@ -10743,13 +10681,6 @@
 /area/station/medical/medbay/lobby)
 "ayB" = (
 /obj/machinery/light/incandescent/netural,
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
-"ayC" = (
-/obj/disposalpipe/segment/mail,
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
@@ -16828,7 +16759,7 @@
 /area/station/crew_quarters/arcade)
 "aMU" = (
 /obj/machinery/door/airlock/pyro/glass{
-	id = "hallway_door";
+	id = null;
 	name = "Medbay Staff Area"
 	},
 /obj/firedoor_spawn,
@@ -93935,27 +93866,27 @@ afq
 axA
 agz
 agb
-agL
-ahl
-ahl
-ahl
-ahl
-ahl
-ajK
+ajG
+ajG
+ajG
+ajG
+ajG
+ajG
+ajJ
 akJ
-alr
+alq
 amr
-anl
+anm
 anX
-acq
-apM
-arc
-arc
-atC
+acr
+apN
+arb
+arb
+akQ
 auV
-atC
+akQ
 axp
-ayC
+ayA
 azB
 aCA
 atw


### PR DESCRIPTION
[bug - minor][bugfix]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Unlinks a single door in the Oshan Pharmacy from the doors leading to the hall where the Psychiatrist's Office is. Also removes an unused length of mail piping.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
To prevent people in the observation rooms from escaping into the pharmacy. 
