### PR TITLE
Prevent ion storms from opening/closing the door type used for crushers and emergency shutters.

### DIFF
--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -193,8 +193,10 @@
 			// Fuck up a couple of doors
 			if (!station_doors.len)
 				var/turf/T = null
-				for (var/obj/machinery/door/foundDoor in by_type[/obj/machinery/door])
+				for_by_tcl (foundDoor, /obj/machinery/door)
 					if (foundDoor.z != 1)
+						continue
+					if (istype(foundDoor, /obj/machinery/door/poddoor))
 						continue
 					T = get_turf(foundDoor)
 					if (!istype(T.loc,/area/station/))


### PR DESCRIPTION
[MINOR]

## About the PR

Prevents ion storms from opening/closing the door type used for crushers and emergency shutters.

## Why's this needed?

It's confusing and also impossible to fix if the switch affects multiple doors. I remember ahelping an instance of this and the admin had no idea how it had happened either.

## Changelog

```
(u)BenLubar:
(+)Ion Storms can no longer open/close emergency shutters, such as the doors around the crusher in most maps.
```
