### PR TITLE
Makes security crates require security equipment access to open.

### DIFF
--- a/code/datums/supply_packs.dm
+++ b/code/datums/supply_packs.dm
@@ -420,7 +420,7 @@ ABSTRACT_TYPE (/datum/supply_packs/electrical)
 
 // Added security resupply crate (Convair880).
 /datum/supply_packs/security_resupply
-	name = "Weapons Crate - Security Equipment (Cardlocked \[Security])"
+	name = "Weapons Crate - Security Equipment (Cardlocked \[Security Equipment])"
 	desc = "x1 Security Requisition Token, 1x Armoured Vest, 1x Helmet, x1 Handcuff Kit"
 	category = "Security Department"
 	contains = list(/obj/item/clothing/suit/armor/vest,
@@ -429,11 +429,11 @@ ABSTRACT_TYPE (/datum/supply_packs/electrical)
 					/obj/item/storage/box/handcuff_kit)
 	cost = 10000
 	containertype = /obj/storage/secure/crate/weapon
-	containername = "Weapons Crate - Security Equipment (Cardlocked \[Security])"
-	access = access_security
+	containername = "Weapons Crate - Security Equipment (Cardlocked \[Security Equipment])"
+	access = access_securitylockers
 
 /datum/supply_packs/security_upgrade
-	name = "Weapons Crate - Experimental Security Equipment (Cardlocked \[Security])"
+	name = "Weapons Crate - Experimental Security Equipment (Cardlocked \[Security Equipment])"
 	desc = "1x Clock 180, x1 Elite Security Helmet, x1 Lethal Grenade Kit, 1x Experimental Grenade Kit"
 	category = "Security Department"
 	contains = list(/obj/item/gun/kinetic/clock_188/boomerang,
@@ -442,29 +442,29 @@ ABSTRACT_TYPE (/datum/supply_packs/electrical)
 					/obj/item/clothing/head/helmet/hardhat/security/improved)
 	cost = 12000
 	containertype = /obj/storage/secure/crate/weapon
-	containername = "Weapons Crate - Experimental Security Equipment (Cardlocked \[Security])"
-	access = access_security
+	containername = "Weapons Crate - Experimental Security Equipment (Cardlocked \[Security Equipment])"
+	access = access_securitylockers
 
 /datum/supply_packs/security_brig_resupply
-	name = "Security Containment Crate - Security Equipment (Cardlocked \[Security])"
+	name = "Security Containment Crate - Security Equipment (Cardlocked \[Security Equipment])"
 	desc = "x1 Port-a-Brig and Remote"
 	category = "Security Department"
 	contains = list(/obj/machinery/port_a_brig,
 					/obj/item/remote/porter/port_a_brig)
 	cost = 1000
 	containertype = /obj/storage/secure/crate/weapon
-	containername = "Security Containment Crate - Security Equipment (Cardlocked \[Security])"
-	access = access_security
+	containername = "Security Containment Crate - Security Equipment (Cardlocked \[Security Equipment])"
+	access = access_securitylockers
 
 /datum/supply_packs/weapons2
-	name = "Weapons Crate - Phasers (Cardlocked \[Security])"
+	name = "Weapons Crate - Phasers (Cardlocked \[Security Equipment])"
 	desc = "x2 Phaser Gun"
 	category = "Security Department"
 	contains = list(/obj/item/gun/energy/phaser_gun = 2)
 	cost = 5000
 	containertype = /obj/storage/secure/crate/weapon
-	containername = "Weapons Crate - Phasers (Cardlocked \[Security])"
-	access = access_security
+	containername = "Weapons Crate - Phasers (Cardlocked \[Security Equipment])"
+	access = access_securitylockers
 
 /datum/supply_packs/evacuation
 	name = "Emergency Equipment"
@@ -996,8 +996,8 @@ ABSTRACT_TYPE (/datum/supply_packs/electrical)
 					/obj/item/storage/box/flaregun)
 	cost = 7000
 	containertype = /obj/storage/secure/crate
-	containername = "Anti-Biological Hazard Supplies (Cardlocked \[Security])"
-	access = access_security
+	containername = "Anti-Biological Hazard Supplies (Cardlocked \[Security Equipment])"
+	access = access_securitylockers
 
 /datum/supply_packs/loyaltyimplant
 	name = "Loyalty Kit"


### PR DESCRIPTION
[Balance]
## About the PR
Ups the access requirements of Security Equipment, Experimental Security Equipment, Security Containment, Phasers, and 
Anti-biological crates ordered by cargo to now require security equipment access.

## Why's this needed?
The crates contain security equipment that should be handled by an officer, not a lawyer. Would make sense that the crates are locked behind that access level.


## Changelog
```
(u)DimWhat:
(+)Security crates ordered through QM now require security equipment access.
```
