### PR TITLE
Sleeper Agent Uplink

### DIFF
--- a/browserassets/html/traitorTips/traitorRPsleeperTips.html
+++ b/browserassets/html/traitorTips/traitorRPsleeperTips.html
@@ -1,0 +1,17 @@
+
+<link rel="stylesheet" type="text/css" href="{{resource("css/style.css")}}">
+
+<div class="traitor-tips">
+    <h1 class="center">You are a sleeper agent!</h1>
+    <img src="{{resource("images/antagTips/traitor-image.png")}}" class="center" />
+ 
+	<p>1. You remember your real allegiance. It is time to repay your debts to the Syndicate.</p>
+	
+	<p>2. Unfortunately, the Syndicate doesn't have the resources to equip you with an uplink. Good luck!</p>
+ 
+    <p>3. There might be more sleeper agents among you. Carefully choose who you trust. </p>
+   
+    <p>4. Your objectives will always be stored in your notes. To access them, use the <em>Notes</em> verb.</p>
+ 
+    <p>5. For more information, please consult <A HREF='http://wiki.ss13.co/Traitor'>the wiki</A>.</p>
+</div>

--- a/browserassets/html/traitorTips/traitorsleeperTips.html
+++ b/browserassets/html/traitorTips/traitorsleeperTips.html
@@ -4,14 +4,15 @@
 <div class="traitor-tips">
     <h1 class="center">You are a sleeper agent!</h1>
     <img src="{{resource("images/antagTips/traitor-image.png")}}" class="center" />
- 
+
 	<p>1. You remember your real allegiance. It is time to repay your debts to the Syndicate.</p>
-	
-	<p>2. Unfortunately, the Syndicate doesn't have the resources to equip you with an uplink. Good luck!</p>
- 
+
+	<p>1. An uplink is available and can be requested. Use the <em>Call Syndicate</em> verb in a secure place to retrieve your items.
+		You will receive the password to the uplink at the same time.</p>
+
     <p>3. There might be more sleeper agents among you. Carefully choose who you trust. </p>
-   
+
     <p>4. Your objectives will always be stored in your notes. To access them, use the <em>Notes</em> verb.</p>
- 
+
     <p>5. For more information, please consult <A HREF='http://wiki.ss13.co/Traitor'>the wiki</A>.</p>
 </div>

--- a/browserassets/html/traitorTips/traitorsleeperTips.html
+++ b/browserassets/html/traitorTips/traitorsleeperTips.html
@@ -7,7 +7,7 @@
 
 	<p>1. You remember your real allegiance. It is time to repay your debts to the Syndicate.</p>
 
-	<p>1. An uplink is available and can be requested. Use the <em>Call Syndicate</em> verb in a secure place to retrieve your items.
+	<p>2. An uplink is available and can be requested. Use the <em>Call Syndicate</em> verb in a secure place to retrieve your items.
 		You will receive the password to the uplink at the same time.</p>
 
     <p>3. There might be more sleeper agents among you. Carefully choose who you trust. </p>

--- a/code/modules/events/sleeperagent.dm
+++ b/code/modules/events/sleeperagent.dm
@@ -147,8 +147,12 @@
 
 		H.show_text("<h2><font color=red><B>You have awakened as a syndicate sleeper agent!</B></font></h2>", "red")
 		H.mind.special_role = "sleeper agent"
+#ifdef RP_MODE
+		H << browse(grabResource("html/traitorTips/traitorRPsleeperTips.html"),"window=antagTips;titlebar=1;size=600x400;can_minimize=0;can_resize=0")
+#else
 		H.verbs += /client/proc/gearspawn_sleeper
 		H << browse(grabResource("html/traitorTips/traitorsleeperTips.html"),"window=antagTips;titlebar=1;size=600x400;can_minimize=0;can_resize=0")
+#endif
 		if(!(H.mind in ticker.mode.traitors))
 			ticker.mode.traitors += H.mind
 		if (H.mind.current)

--- a/code/modules/events/sleeperagent.dm
+++ b/code/modules/events/sleeperagent.dm
@@ -147,6 +147,7 @@
 
 		H.show_text("<h2><font color=red><B>You have awakened as a syndicate sleeper agent!</B></font></h2>", "red")
 		H.mind.special_role = "sleeper agent"
+		H.verbs += /client/proc/gearspawn_sleeper
 		H << browse(grabResource("html/traitorTips/traitorsleeperTips.html"),"window=antagTips;titlebar=1;size=600x400;can_minimize=0;can_resize=0")
 		if(!(H.mind in ticker.mode.traitors))
 			ticker.mode.traitors += H.mind

--- a/code/obj/item/uplinks.dm
+++ b/code/obj/item/uplinks.dm
@@ -60,7 +60,7 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 
 		for (var/datum/syndicate_buylist/S in syndi_buylist_cache)
 			if(src.is_sleeper_uplink)
-				if(S.cost > 4)
+				if(S.cost > 3)
 					continue
 			if (src.is_VR_uplink)
 				if (!S.vr_allowed)

--- a/code/obj/item/uplinks.dm
+++ b/code/obj/item/uplinks.dm
@@ -22,6 +22,7 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 	var/list/datum/syndicate_buylist/items_job = list()
 	var/list/datum/syndicate_buylist/items_objective = list()
 	var/is_VR_uplink = 0
+	var/is_sleeper_uplink = 0
 	var/lock_code = null
 	var/lock_code_autogenerate = 0
 	var/locked = 0
@@ -58,6 +59,9 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 			src.items_objective = list()
 
 		for (var/datum/syndicate_buylist/S in syndi_buylist_cache)
+			if(src.is_sleeper_uplink)
+				if(S.cost > 4)
+					continue
 			if (src.is_VR_uplink)
 				if (!S.vr_allowed)
 					continue
@@ -408,6 +412,10 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 		name = "syndicate equipment uplink"
 		desc = "An uplink terminal that allows you to order weapons and items."
 		icon_state = "uplink"
+
+/obj/item/uplink/syndicate/sleeper
+	uses = 5
+	is_sleeper_uplink = 1
 
 /obj/item/uplink/syndicate/virtual
 	name = "Syndicate Simulator 2053"

--- a/code/procs/antagonist_procs.dm
+++ b/code/procs/antagonist_procs.dm
@@ -24,6 +24,32 @@
 
 	return
 
+/client/proc/gearspawn_sleeper()
+	set category = "Commands"
+	set name = "Call Syndicate"
+	set desc="Teleports useful items to your location."
+
+	if (usr.stat || !isliving(usr) || isintangible(usr))
+		usr.show_text("You can't use this command right now.", "red")
+		return
+
+	var/obj/item/uplink/syndicate/sleeper/U = new(usr.loc)
+	if (!usr.put_in_hand(U))
+		U.set_loc(get_turf(usr))
+		usr.show_text("<h3>Uplink spawned. You can find it on the floor at your current location.</h3>", "blue")
+	else
+		usr.show_text("<h3>Uplink spawned. You can find it in your active hand.</h3>", "blue")
+
+	if (usr.mind && istype(usr.mind))
+		U.lock_code_autogenerate = 1
+		U.setup(usr.mind)
+		usr.show_text("<h3>The password to your uplink is '[U.lock_code]'.</h3>", "blue")
+		usr.mind.store_memory("<B>Uplink password:</B> [U.lock_code].")
+
+	usr.verbs -= /client/proc/gearspawn_sleeper
+
+	return
+
 /client/proc/gearspawn_wizard()
 	set category = "Commands"
 	set name = "Call Wizards"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[balance][input wanted]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR gives sleeper agents a stripped down version of the syndicate uplink, containing 5TC to spend and having only the items that cost 3TC or less available. Meaning: power sinks, sleepy pens, emags, syndie analyzers, stimulants, lethal weaponry such as csabers are not included.

The sleeper uplink is exclusive to noRP servers.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Currently, sleeper agents are not very interesting and function solely as a license to grief. And if someone gets sleepered later into the round, they don't have much time to come up with anything too creative, so they end up rushing plasma tanks to flood the station, assault people at random or just ignore their antag status.  Giving the sleeper agents at least some toys to play with should improve their gameplay variety, without impacting the round too much, since the most overpowered and impactful traitor gear is simply not available to them.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)TTerc:
(*)On nonRP servers, sleeper agents are now able to spawn a stripped down version of the syndicate uplink.
```
