### PR TITLE
Taser SMG

### DIFF
--- a/code/modules/projectiles/energy_bolt.dm
+++ b/code/modules/projectiles/energy_bolt.dm
@@ -365,8 +365,8 @@ toxic - poisons
 	name = "energy bolt"
 	icon = 'icons/obj/projectiles.dmi'
 	icon_state = "taser_projectile"
-	power = 20
-	cost = 37.5
+	power = 15
+	cost = 25
 	dissipation_rate = 1
 	dissipation_delay = 2
 	max_range = 12

--- a/code/modules/projectiles/energy_bolt.dm
+++ b/code/modules/projectiles/energy_bolt.dm
@@ -388,8 +388,6 @@ toxic - poisons
 	icon_state = "signifer2_tase"
 	power = 10
 	cost = 12
-	dissipation_rate = 1
-	dissipation_delay = 2
 	max_range = 8
 	ks_ratio = 0.0
 	sname = "full-auto"

--- a/code/modules/projectiles/energy_bolt.dm
+++ b/code/modules/projectiles/energy_bolt.dm
@@ -374,7 +374,7 @@ toxic - poisons
 	sname = "burst"
 	shot_sound = 'sound/weapons/Taser.ogg'
 	shot_sound_extrarange = 5
-	shot_number = 1
+	shot_number = 2
 	damage_type = D_ENERGY
 	hit_ground_chance = 20
 	window_pass = 0

--- a/code/modules/projectiles/energy_bolt.dm
+++ b/code/modules/projectiles/energy_bolt.dm
@@ -377,11 +377,6 @@ toxic - poisons
 	shot_number = 2
 	damage_type = D_ENERGY
 	hit_ground_chance = 20
-	window_pass = 0
-	brightness = 1
-	color_red = 0.9
-	color_green = 0.9
-	color_blue = 0.1
 
 	disruption = 8
 

--- a/code/modules/projectiles/energy_bolt.dm
+++ b/code/modules/projectiles/energy_bolt.dm
@@ -398,11 +398,6 @@ toxic - poisons
 	shot_number = 1
 	damage_type = D_ENERGY
 	hit_ground_chance = 35
-	window_pass = 0
-	brightness = 1
-	color_red = 0.9
-	color_green = 0.9
-	color_blue = 0.1
 
 	disruption = 8
 

--- a/code/modules/projectiles/energy_bolt.dm
+++ b/code/modules/projectiles/energy_bolt.dm
@@ -390,7 +390,7 @@ toxic - poisons
 /datum/projectile/energy_bolt/smgauto
 	name = "energy bolt"
 	icon = 'icons/obj/projectiles.dmi'
-	icon_state = "taser_projectile"
+	icon_state = "signifer2_tase"
 	power = 10
 	cost = 12
 	dissipation_rate = 1

--- a/code/modules/projectiles/energy_bolt.dm
+++ b/code/modules/projectiles/energy_bolt.dm
@@ -367,8 +367,6 @@ toxic - poisons
 	icon_state = "taser_projectile"
 	power = 15
 	cost = 25
-	dissipation_rate = 1
-	dissipation_delay = 2
 	max_range = 12
 	ks_ratio = 0.0
 	sname = "burst"

--- a/code/modules/projectiles/energy_bolt.dm
+++ b/code/modules/projectiles/energy_bolt.dm
@@ -360,3 +360,55 @@ toxic - poisons
 	ie_type = "T"
 
 	hit_mob_sound = 'sound/effects/sparks6.ogg'
+
+/datum/projectile/energy_bolt/smgburst
+	name = "energy bolt"
+	icon = 'icons/obj/projectiles.dmi'
+	icon_state = "taser_projectile"
+	power = 20
+	cost = 37.5
+	dissipation_rate = 1
+	dissipation_delay = 2
+	max_range = 12
+	ks_ratio = 0.0
+	sname = "burst"
+	shot_sound = 'sound/weapons/Taser.ogg'
+	shot_sound_extrarange = 5
+	shot_number = 1
+	damage_type = D_ENERGY
+	hit_ground_chance = 20
+	window_pass = 0
+	brightness = 1
+	color_red = 0.9
+	color_green = 0.9
+	color_blue = 0.1
+
+	disruption = 8
+
+	hit_mob_sound = 'sound/effects/sparks6.ogg'
+
+/datum/projectile/energy_bolt/smgauto
+	name = "energy bolt"
+	icon = 'icons/obj/projectiles.dmi'
+	icon_state = "taser_projectile"
+	power = 10
+	cost = 12
+	dissipation_rate = 1
+	dissipation_delay = 2
+	max_range = 8
+	ks_ratio = 0.0
+	sname = "full-auto"
+	shot_sound = 'sound/weapons/SigTase.ogg'
+	shot_sound_extrarange = 5
+	shot_number = 1
+	damage_type = D_ENERGY
+	hit_ground_chance = 35
+	window_pass = 0
+	brightness = 1
+	color_red = 0.9
+	color_green = 0.9
+	color_blue = 0.1
+
+	disruption = 8
+
+	hit_mob_sound = 'sound/effects/sparks6.ogg'

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1664,8 +1664,6 @@
 		..()
 		if (istype(current_projectile, /datum/projectile/energy_bolt/smgauto))
 			spread_angle = 8
-			shoot_delay = 4
 		else
 			spread_angle = 2
-			shoot_delay = 4
 		update_icon()

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1638,6 +1638,7 @@
 	item_state = "ntgun"
 	force = 5.0
 	two_handed = 1
+	can_dual_wield = 0
 	muzzle_flash = "muzzle_flash_elec"
 
 	New()

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1630,3 +1630,45 @@
 	shoot_point_blank(mob/M, mob/user, second_shot)
 		shotcount = 0
 		. = ..()
+
+/obj/item/gun/energy/tasersmg
+	name = "Taser SMG"
+	icon_state = "ntneutral100"
+	desc = "A weapon that produces an cohesive electrical charge that stuns its target, capable of firing in two shot burst or full auto configurations."
+	item_state = "ntgun"
+	force = 10.0
+	contraband = 8
+	two_handed = 1
+	muzzle_flash = "muzzle_flash_elec"
+
+	New()
+		cell = new/obj/item/ammo/power_cell/high_power
+		current_projectile = new/datum/projectile/energy_bolt/smgburst
+
+		if(throw_return)
+			projectiles = list(current_projectile)
+		else
+			projectiles = list(current_projectile,new/datum/projectile/energy_bolt/smgauto)
+			AddComponent(/datum/component/holdertargeting/fullauto, 1.2, 1.2, 1, FULLAUTO_INACTIVE)
+		..()
+
+	update_icon()
+		..()
+		if(cell)
+			var/ratio = min(1, src.cell.charge / src.cell.max_charge)
+			ratio = round(ratio, 0.25) * 100
+			if(current_projectile.type == /datum/projectile/energy_bolt/smgauto)
+				src.icon_state = "ntstun[ratio]"
+			else if (current_projectile.type == /datum/projectile/energy_bolt/smgburst)
+				src.icon_state = "ntneutral[ratio]"
+
+
+	attack_self(mob/user as mob)
+		..()
+		if (istype(current_projectile, /datum/projectile/energy_bolt/smgauto))
+			spread_angle = 8
+			shoot_delay = 4
+		else
+			spread_angle = 2
+			shoot_delay = 4
+		update_icon()

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1636,8 +1636,7 @@
 	icon_state = "ntneutral100"
 	desc = "A weapon that produces an cohesive electrical charge that stuns its target, capable of firing in two shot burst or full auto configurations."
 	item_state = "ntgun"
-	force = 10.0
-	contraband = 8
+	force = 5.0
 	two_handed = 1
 	muzzle_flash = "muzzle_flash_elec"
 

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1645,11 +1645,8 @@
 		cell = new/obj/item/ammo/power_cell/high_power
 		current_projectile = new/datum/projectile/energy_bolt/smgburst
 
-		if(throw_return)
-			projectiles = list(current_projectile)
-		else
-			projectiles = list(current_projectile,new/datum/projectile/energy_bolt/smgauto)
-			AddComponent(/datum/component/holdertargeting/fullauto, 1.2, 1.2, 1, FULLAUTO_INACTIVE)
+		projectiles = list(current_projectile,new/datum/projectile/energy_bolt/smgauto)
+		AddComponent(/datum/component/holdertargeting/fullauto, 1.2, 1.2, 1, FULLAUTO_INACTIVE)
 		..()
 
 	update_icon()


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds in a new Taser SMG, right now just for testing purposes in a live scenario. The Taser SMG is a short-medium range weapon focusing on sheer volume of fire to drop someone. Quantity > quality. 

Taser SMG has two firing modes, two shot burst and full auto. 
Two shot burst will take ~3 bursts to drop a full stamina target and gets 6 bursts on a full charge.  Range on burst is similar to standard taser.
Full auto gets 25 shots on a full charge and takes ~10 shots to drop someone. Range on full auto is limited, similar to taser shotgun.

Right now it uses the NT Laser Assault Rifle sprites until I can get someone to make some new ones. As such it will be only admin spawn until further balancing work is done and it has its own sprites. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More variety in security weapons. We have a shotgun, we have a burst fire taser, why not have a full auto taser?
