### PR TITLE
Disable UI for APCs that "control" areas with no power requirement.

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -588,7 +588,9 @@ var/zapLimiter = 0
 	src.add_dialog(user)
 	var/t = "<TT><B>Area Power Controller</B> ([area.name])<HR>"
 
-	if((locked || (setup_networkapc > 1)) && !can_access_remotely(user))
+	if (!area.requires_power)
+		t += "<I>This APC has no configurable settings.</I>"
+	else if((locked || (setup_networkapc > 1)) && !can_access_remotely(user))
 		if (setup_networkapc < 2)
 			t += "<I>(Swipe ID card to unlock inteface.)</I><BR>"
 		else


### PR DESCRIPTION
## About the PR

Disables the UI that shows how much charge an APC has and allows you to toggle the power settings for areas that don't use power (like AI Perimeter Defenses).

## Why's this needed?

It's confusing to have an APC that doesn't charge or draw power and that has settings that don't affect anything.
