### PR TITLE
Disable power requirement for prefab areas.

### DIFF
--- a/code/area.dm
+++ b/code/area.dm
@@ -1103,6 +1103,7 @@ ABSTRACT_TYPE(/area/prefab)
 /area/prefab
 	name = "Prefab"
 	icon_state = "orange"
+	requires_power = FALSE
 
 /area/prefab/discount_dans_asteroid
 	name = "Discount Dan's Delivery Asteroid"
@@ -1123,6 +1124,12 @@ ABSTRACT_TYPE(/area/prefab)
 /area/prefab/drug_den/party
 	name ="Drug Den"
 	icon_state = "purple"
+
+/area/prefab/sequestered_cloner
+	name = "Sequestered Cloner"
+
+/area/prefab/sequestered_cloner/puzzle
+	requires_power = TRUE
 
 /area/prefab/von_ricken
 	name ="Von Ricken"
@@ -1236,6 +1243,7 @@ ABSTRACT_TYPE(/area/prefab)
 /area/station/turret_protected/sea_crashed //dumb area pathing aRRGHHH
 	name = "Crashed Transport"
 	icon_state = "purple"
+	requires_power = FALSE
 
 /area/prefab/water_treatment
 	name = "Water Treatment Facility"

--- a/code/modules/power/monitor.dm
+++ b/code/modules/power/monitor.dm
@@ -40,8 +40,8 @@
 
 		var/list/L = list()
 		for(var/obj/machinery/power/terminal/term in powernet.nodes)
-			if(istype(term.master, /obj/machinery/power/apc))
-				var/obj/machinery/power/apc/A = term.master
+			var/obj/machinery/power/apc/A = term.master
+			if(istype(A) && (!A.area || A.area.requires_power))
 				L += A
 
 		t += "<PRE>Total power: [engineering_notation(powernet.avail)]W<BR>Total load:  [engineering_notation(powernet.viewload)]W<BR>"

--- a/code/z_adventurezones/sequestered_cloner.dm
+++ b/code/z_adventurezones/sequestered_cloner.dm
@@ -9,11 +9,6 @@
         and lore entries
 */
 
-/area/prefab/sequestered_cloner
-	name = "Sequestered Cloner"
-
-/area/prefab/sequestered_cloner/puzzle
-
 //Quickly turns everything back on as soon as there's a little bit of power
 /obj/machinery/power/apc/puzzle_apc
 	name = "Puzzle APC"


### PR DESCRIPTION
[MINOR]

## About the PR

Disables power requirements for mining prefab areas (except the engine puzzle, where it actually makes sense to not have power available).

Hides the AI Perimeter Defenses APC from the station power grid monitor.

## Why's this needed?

It's weird getting a power alarm from the Von Ricken as AI, and prefab areas losing power changes them in unintended ways.

## Changelog

```
(u)BenLubar:
(+)The power issues aboard the Von Ricken have been resolved.
```
