### PR TITLE
Cyborg cryo QOL

### DIFF
--- a/code/WorkInProgress/cryospawn.dm
+++ b/code/WorkInProgress/cryospawn.dm
@@ -32,7 +32,6 @@
 	var/list/stored_mobs = list() // people who've bowed out of the round
 	var/tmp/busy = 0
 
-//#ifdef MAP_OVERRIDE_DESTINY
 	New()
 		..()
 		// x += 1 here, with bound_x / pixel_x -= 32, keeps it centered while
@@ -55,7 +54,7 @@
 		for (var/obj/O in src)
 			O.set_loc(T)
 		..()
-//#endif
+
 	ex_act()
 		return
 
@@ -74,15 +73,9 @@
 		person.removeOverlayComposition(/datum/overlayComposition/blinded)
 		return 1
 
-		//SPAWN_DBG(0)	//If you would prefer a game controller managing this, please address your concerns in the form of a brick through AIBM's window.
-			//while (spawn_next_person())
-				//sleep (20)
-
-//#ifdef MAP_OVERRIDE_DESTINY
 	proc/process()
 		spawn_next_person()
 		ensure_storage()
-//#endif
 
 	//Return 1 if there is another person to spawn afterward
 	proc/spawn_next_person()
@@ -109,7 +102,6 @@
 		src.icon_state = "cryotron_down"
 		flick("cryotron_go_down", src)
 
-		//sleep(1.9 SECONDS)
 		SPAWN_DBG(1.9 SECONDS)
 			if (!thePerson || thePerson.loc != src)
 				busy = 0
@@ -140,7 +132,6 @@
 			busy = 0
 			return
 
-//#ifdef MAP_OVERRIDE_DESTINY
 	proc/add_person_to_storage(var/mob/living/L as mob, var/voluntary = 1)
 		if (!istype(L))
 			return 0
@@ -207,6 +198,14 @@
 		if (user && get_dist(src, user) > 1)
 			boutput(user, "<b>You need to be closer to [src] to put someone in cryogenic storage!</b>")
 			return 0
+		var/mob/living/silicon/R = L
+		if (istype(R))
+			if (R.mainframe || isAI(R) || isshell(R))
+				boutput(user, "<b>You can't put the AI in cryogenic storage!</b>")
+				return 0
+			if (!isrobot(R) && !isghostdrone(R))
+				boutput(user, "<b>You can't put that machine in cryogenic storage!</b>")
+				return 0
 		return 1
 
 	proc/exit_prompt(var/mob/living/user as mob)
@@ -250,28 +249,41 @@
 		else if (!enter_prompt(user))
 			return ..()
 
+	attack_ai(mob/user as mob)
+		if (!enter_prompt(user))
+			return ..()
+
 	attackby(var/obj/item/W as obj, var/mob/user as mob)
 		if (istype(W, /obj/item/grab))
 			var/obj/item/grab/G = W
-			if (ismob(G.affecting))
-				if (G.affecting.client || !G.affecting.ckey)
-					boutput(user, "<span class='alert'>You can't force someone into cryosleep if they're still logged in or are an NPC!</span>")
-					return
-				else if (alert(user, "Would you like to put [G.affecting] into cryogenic storage? They will be able to leave it immediately if they log back in.", "Confirmation", "Yes", "No") == "Yes")
-					if (!src.mob_can_enter_storage(G.affecting, user))
-						return
-					else
-						src.add_person_to_storage(G.affecting, 0)
-						src.visible_message("<span class='alert'><b>[user] forces [G.affecting] into [src]!</b></span>")
-						user.u_equip(G)
-						qdel(G)
-						return
+			if (ismob(G.affecting) && insert_prompt(G.affecting, user))
+				user.u_equip(G)
+				qdel(G)
 		else if (!enter_prompt(user))
 			return ..()
+
+	proc/insert_prompt(mob/target, mob/user)
+		if (target.client || !target.ckey)
+			boutput(user, "<span class='alert'>You can't force someone into cryosleep if they're still logged in or are an NPC!</span>")
+			return 0
+		else if (alert(user, "Would you like to put [target] into cryogenic storage? They will be able to leave it immediately if they log back in.", "Confirmation", "Yes", "No") == "Yes")
+			if (!src.mob_can_enter_storage(target, user))
+				return 0
+			else
+				src.add_person_to_storage(target, 0)
+				src.visible_message("<span class='alert'><b>[user] forces [target] into [src]!</b></span>")
+				return 1
+		return 0
 
 	relaymove(var/mob/user as mob, dir)
 		if ((user.last_cryotron_message + CRYOTRON_MESSAGE_DELAY) > ticker.round_elapsed_ticks)
 			return ..()
 		if (!exit_prompt(user))
 			return ..()
-//#endif
+
+	MouseDrop_T(atom/target, mob/user as mob)
+		if (ishuman(target) && isrobot(user) && get_dist(src, user) <= 1 && get_dist(src, target) <= 1 && get_dist(user, target) <= 1)
+			insert_prompt(target, user)
+			return
+		return ..()
+


### PR DESCRIPTION
[QOL]

## About the PR

- Allow cyborgs to enter cryo without an item selected.
- Allow cyborgs to drag a human into cryo.
- Prevent AI shells from entering cryo.

Leaves the ability for ghost drones to cryo in, as I think that's intended.

## Why's this needed?

It's annoying and clunky to have to yell for a human to help put someone into cryo, and the AI being able to put a shell in cryo is just weird. Plus, cyborgs having to have an item in their hands is weird, too.

## Changelog

```changelog
(u)BenLubar:
(*)Cyborgs can now drag humans into the industrial cryogenic storage unit, and don't need to be holding an item to put themselves in.
```
