### PR TITLE
disables bump viral transmission for not living

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -547,7 +547,8 @@
 	if (ismob(AM))
 		var/mob/tmob = AM
 		if (ishuman(tmob))
-			src:viral_transmission(AM,"Contact",1)
+			if(isliving(src))
+				src:viral_transmission(AM,"Contact",1)
 
 			if ((tmob.bioHolder.HasEffect("magnets_pos") && src.bioHolder.HasEffect("magnets_pos")) || (tmob.bioHolder.HasEffect("magnets_neg") && src.bioHolder.HasEffect("magnets_neg")))
 				//prevent ping-pong loops by deactivating for a second, as they can crash the server under some circumstances


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Before this, Corporeal Wraiths could bump monkeys, which would attempt to run src.viral_transmission(), and wraiths have the path mob/wraith, while the viral_transmission() proc belongs to mob/living. As such, a wraith bumping a monkey would runtime.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
One less runtime!
