### PR TITLE
Toggles Antag rolls for Captains on the RP Servers off

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -11,6 +11,7 @@
 	var/allow_traitors = 1
 	var/allow_spy_theft = 1
 	var/cant_spawn_as_rev = 0 // For the revoltion game mode. See jobprocs.dm for notes etc (Convair880).
+	var/cant_spawn_as_con = 0
 	var/requires_whitelist = 0
 	var/requires_supervisor_job = null // Enter job name, this job will only be present if the entered job has joined already
 	var/needs_college = 0
@@ -149,6 +150,9 @@
 	wages = PAY_EXECUTIVE
 	high_priority_job = 1
 	recieves_miranda = 1
+#ifdef RP_MODE
+	allow_traitors = 0
+#endif
 	cant_spawn_as_rev = 1
 	announce_on_join = 1
 	allow_spy_theft = 0
@@ -235,6 +239,7 @@
 	recieves_miranda = 1
 	allow_traitors = 0
 	allow_spy_theft = 0
+	cant_spawn_as_con = 1
 	cant_spawn_as_rev = 1
 	announce_on_join = 1
 	receives_disk = 1
@@ -455,6 +460,7 @@
 	wages = PAY_TRADESMAN
 	allow_traitors = 0
 	allow_spy_theft = 0
+	cant_spawn_as_con = 1
 	cant_spawn_as_rev = 1
 	recieves_implant = /obj/item/implant/health/security
 	receives_disk = 1
@@ -486,6 +492,7 @@
 	assistant
 		name = "Security Assistant"
 		limit = 3
+		cant_spawn_as_con = 1
 		wages = PAY_UNTRAINED
 		slot_jump = /obj/item/clothing/under/rank/security/assistant
 		slot_suit = null
@@ -1110,6 +1117,7 @@
 	limit = 0
 	wages = PAY_TRADESMAN
 	allow_traitors = 0
+	cant_spawn_as_con = 1
 	cant_spawn_as_rev = 1
 	receives_badge = 1
 	recieves_miranda = 1
@@ -2607,6 +2615,7 @@
 	limit = 2
 	wages = PAY_TRADESMAN
 	allow_traitors = 0
+	cant_spawn_as_con = 1
 	cant_spawn_as_rev = 1
 	receives_badge = 1
 	recieves_miranda = 1

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -11,7 +11,7 @@
 	var/allow_traitors = 1
 	var/allow_spy_theft = 1
 	var/cant_spawn_as_rev = 0 // For the revoltion game mode. See jobprocs.dm for notes etc (Convair880).
-	var/cant_spawn_as_con = 0
+	var/cant_spawn_as_con = 0 // Prevents this job spawning as a conspirator in the conspiracy gamemode.
 	var/requires_whitelist = 0
 	var/requires_supervisor_job = null // Enter job name, this job will only be present if the entered job has joined already
 	var/needs_college = 0

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -163,11 +163,9 @@
 		var/datum/job/JOB = find_job_in_controller_by_string(player.client.preferences.job_favorite)
 		// Do a few checks to make sure they're allowed to have this job
 		if (ticker?.mode && istype(ticker.mode, /datum/game_mode/revolution))
-			if(checktraitor(player) && JOB.cant_spawn_as_rev)
+			if(checktraitor(player) && (JOB.cant_spawn_as_rev || JOB.cant_spawn_as_con))
 				// Fixed AI, security etc spawning as rev heads. The special job picker doesn't care about that var yet,
 				// but I'm not gonna waste too much time tending to a basically abandoned game mode (Convair880).
-				continue
-			if(checktraitor(player) && JOB.cant_spawn_as_con)
 				continue
 		if (!JOB || jobban_isbanned(player,JOB.name))
 			continue

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -30,6 +30,8 @@
 				continue
 			else if((ticker?.mode && istype(ticker.mode, /datum/game_mode/gang)) && (job != "Staff Assistant"))
 				continue
+			else if ((ticker?.mode && istype(ticker.mode, /datum/game_mode/conspiracy)) && J.cant_spawn_as_con)
+				continue
 
 		if (!J.allow_traitors && player.mind.special_role || !J.allow_spy_theft && player.mind.special_role == "spy_thief")
 			continue
@@ -164,6 +166,8 @@
 			if(checktraitor(player) && JOB.cant_spawn_as_rev)
 				// Fixed AI, security etc spawning as rev heads. The special job picker doesn't care about that var yet,
 				// but I'm not gonna waste too much time tending to a basically abandoned game mode (Convair880).
+				continue
+			if(checktraitor(player) && JOB.cant_spawn_as_con)
 				continue
 		if (!JOB || jobban_isbanned(player,JOB.name))
 			continue


### PR DESCRIPTION
[balance][rework]

## About the PR
Removes the ability for Captains on the RP Servers to roll antagonist roles **EXCEPT** for conspirator.


## Why's this needed?
Requested by people repeatedly from time-to-time for RP specifically with concerns over balance and the way the role was used in rounds; also provides an additional trustworthy and sort of "meta-reliable" Command role as the in-game leader of the station that has potential to help coordinate and improve overall interactions and events during RP rounds. Leaves conspirator as a potential antagonist roll since conspirator goals are relatively mild compared to other gamemodes and often shake out to be more fun with better coordination and access to materials to pull off the gimmick. This PR comes after some discussion on the Forum and in Discord from about a month ago.


## Changelog
```changelog
(u)Nefarious6th:
(*)Captains on the RP servers can now only roll conspirator as a potential antagonist type.
```
