### PR TITLE
Halfs material cost for .22 magazines

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -220,7 +220,7 @@ proc/get_nice_mat_name_for_manufacturers(mat)
 /datum/manufacture/bullet_22
 	name = ".22 Bullets"
 	item_paths = list("MET-2","CON-1")
-	item_amounts = list(5,2)
+	item_amounts = list(10,2)
 	item_outputs = list(/obj/item/ammo/bullets/bullet_22)
 	time = 30 SECONDS
 	create = 1

--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -220,7 +220,7 @@ proc/get_nice_mat_name_for_manufacturers(mat)
 /datum/manufacture/bullet_22
 	name = ".22 Bullets"
 	item_paths = list("MET-2","CON-1")
-	item_amounts = list(30,24)
+	item_amounts = list(5,2)
 	item_outputs = list(/obj/item/ammo/bullets/bullet_22)
 	time = 30 SECONDS
 	create = 1

--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -220,7 +220,7 @@ proc/get_nice_mat_name_for_manufacturers(mat)
 /datum/manufacture/bullet_22
 	name = ".22 Bullets"
 	item_paths = list("MET-2","CON-1")
-	item_amounts = list(10,2)
+	item_amounts = list(15,12)
 	item_outputs = list(/obj/item/ammo/bullets/bullet_22)
 	time = 30 SECONDS
 	create = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Halfs the material cost for making .22 magazines in hacked general fabricators, allowing you to make 3 mags before the manufactor runs out of steel.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Current material cost is way too expensive, you can drain a fab making just one magazine. This just make no one want to use the .22 ammo or zip guns since it's more bother than its worth.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```Changelog
(u)Carbadox
(+)Halfed the material cost of producing .22 magazines in hack manufactors.
```
