### PR TITLE
Fixed player getting stuck without a body after getting borged in a cryotube/vehicle

### DIFF
--- a/code/mob/transform_procs.dm
+++ b/code/mob/transform_procs.dm
@@ -243,7 +243,7 @@
 	else
 		if(src.mind)
 			src.mind.transfer_to(O)
-	O.set_loc(src.loc)
+	O.set_loc(get_turf(src.loc))
 	boutput(O, "<B>You are playing as a Cyborg. Cyborgs can interact with most electronic objects in its view point.</B>")
 	boutput(O, "<B>You must follow all laws that the AI has.</B>")
 	boutput(O, "Use \"say :s (message)\" to speak to fellow cyborgs and the AI through binary.")


### PR DESCRIPTION
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Sets the location of the newly created borg to the turf the human was standing on.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This prevents the player from getting stuck without a body.


## Changelog
```
(u)NoBrain:
(+)Fixed getting stuck without a body after getting borged in a cryotube/vehicle.
```