### PR TITLE
Experimental chat lag fix: Send all messages in a single network round trip if there are a lot of messages.

### DIFF
--- a/browserassets/js/browserOutput.js
+++ b/browserassets/js/browserOutput.js
@@ -335,6 +335,14 @@ function output(message, group) {
     }
 }
 
+//Receive a large number of messages all at once to cut down on round trips.
+function outputBatch(messages) {
+    var list = JSON.parse(messages);
+    for (var i = 0; i < list.length; i++) {
+        output(list[i].message, list[i].group);
+    }
+}
+
 //Runs a route within byond, client or server side. Consider this "ehjax" for byond.
 function runByond(uri) {
     window.location = uri;

--- a/code/datums/browserOutput.dm
+++ b/code/datums/browserOutput.dm
@@ -16,9 +16,9 @@ For the main html chat area
 #define CTX_GHOSTJUMP 512
 
 // minimum number of messages in a single tick to consider it a "burst"
-#define CHAT_BURST_START 2
+#define CHAT_BURST_START 5
 // amount of time after a "burst" starts to withhold messages
-#define CHAT_BURST_TIME 0.4 SECONDS
+#define CHAT_BURST_TIME 0.2 SECONDS
 
 //Precaching a bunch of shit
 var/global

--- a/code/datums/browserOutput.dm
+++ b/code/datums/browserOutput.dm
@@ -119,8 +119,8 @@ var/global
 				//if (src.owner.holder)
 				src.loadAdmin()
 				if (src.messageQueue)
-					for (var/x = 0, x < src.messageQueue.len, x++)
-						boutput(src.owner, src.messageQueue["[x]"]["message"], src.messageQueue["[x]"]["group"])
+					for (var/list/message in src.messageQueue)
+						boutput(src.owner, message["message"], message["group"])
 				src.messageQueue = null
 				if (ua)
 					//For persistent user tracking
@@ -398,11 +398,11 @@ var/global
 
 		if (C?.chatOutput && !C.chatOutput.loaded && C.chatOutput.messageQueue && islist(C.chatOutput.messageQueue))
 			//Client sucks at loading things, put their messages in a queue
-			C.chatOutput.messageQueue["[length(C.chatOutput.messageQueue)]"] = list("message" = message, "group" = group)
+			C.chatOutput.messageQueue += list(list("message" = message, "group" = group))
 		else
 			if (C?.chatOutput)
 				if (islist(C.chatOutput.burstQueue))
-					C.chatOutput.burstQueue["[length(C.chatOutput.burstQueue)]"] = list("message" = message, "group" = group)
+					C.chatOutput.burstQueue += list(list("message" = message, "group" = group))
 					return
 
 				var/now = TIME
@@ -413,9 +413,13 @@ var/global
 					C.chatOutput.burstCount++
 
 				if (C.chatOutput.burstCount > CHAT_BURST_START)
-					C.chatOutput.burstQueue = list(list("message" = message, "group" = group))
+					C.chatOutput.burstQueue = list(
+						list("message" = message, "group" = group)
+					)
 					SPAWN_DBG(CHAT_BURST_TIME)
-						target << output(list2params(list(json_encode(C.chatOutput.burstQueue))), "browseroutput:outputBatch")
+						target << output(list2params(list(
+							json_encode(C.chatOutput.burstQueue)
+						)), "browseroutput:outputBatch")
 						C.chatOutput.burstQueue = null
 					return
 

--- a/code/datums/browserOutput.dm
+++ b/code/datums/browserOutput.dm
@@ -398,19 +398,20 @@ var/global
 
 		if (C?.chatOutput && !C.chatOutput.loaded && C.chatOutput.messageQueue && islist(C.chatOutput.messageQueue))
 			//Client sucks at loading things, put their messages in a queue
-			C.chatOutput.messageQueue["[C.chatOutput.messageQueue.len]"] = list("message" = message, "group" = group)
+			C.chatOutput.messageQueue["[length(C.chatOutput.messageQueue)]"] = list("message" = message, "group" = group)
 		else
 			if (C?.chatOutput)
-				var/T = TIME
 				if (islist(C.chatOutput.burstQueue))
-					C.chatOutput.burstQueue["[C.chatOutput.burstQueue.len]"] = list("message" = message, "group" = group)
+					C.chatOutput.burstQueue["[length(C.chatOutput.burstQueue)]"] = list("message" = message, "group" = group)
 					return
 
-				if (C.chatOutput.burstTime != T)
-					C.chatOutput.burstTime = T
+				var/now = TIME
+				if (C.chatOutput.burstTime != now)
+					C.chatOutput.burstTime = now
 					C.chatOutput.burstCount = 1
 				else
 					C.chatOutput.burstCount++
+
 				if (C.chatOutput.burstCount > CHAT_BURST_START)
 					C.chatOutput.burstQueue = list(list("message" = message, "group" = group))
 					SPAWN_DBG(CHAT_BURST_TIME)


### PR DESCRIPTION
[PERF]

## About the PR

Based on the fact that I don't experience chat lag at all on localhost, I believe the lag caused by large quantities of chat updates is due to network round trips. This PR adds a queue that activates after a certain number of chat updates are performed in a single tick, which then prevents chat updates from being sent for a set period of time, after which one chat update is sent containing all the pending data.