### PR TITLE
change activator keys a little

### DIFF
--- a/code/obj/artifacts/artifact_items/activator_key.dm
+++ b/code/obj/artifacts/artifact_items/activator_key.dm
@@ -2,23 +2,24 @@
 	// can activate any artifact simply by smacking it. very very rare
 	name = "artifact activator key"
 	associated_datum = /datum/artifact/activator_key
-	var/universal = 1 // normally it only activates its own type, but sometimes it can do all
-	var/activator = 1 // can also be a DEactivator key sometimes!
 	module_research_no_diminish = 1
-
-	New(var/loc, var/forceartiorigin)
-		..()
-		/*if (prob(10))
-			src.universal = 1
-		if (prob(10))
-			src.activator = 0*/
 
 /datum/artifact/activator_key
 	associated_object = /obj/item/artifact/activator_key
-	rarity_class = 4
+	rarity_class = 3
 	validtypes = list("ancient","martian","wizard","eldritch","precursor")
 	automatic_activation = 1
 	react_xray = list(12,80,95,8,"COMPLEX")
 	examine_hint = "It kinda looks like it's supposed to be inserted into something."
 	module_research = list("tools" = 20)
 	module_research_insight = 5
+	var/universal = 0 // normally it only activates its own type, but sometimes it can do all
+	var/activator = 1 // can also be a DEactivator key sometimes!
+	var/corrupting = 0 // generates faults in activated artifacts
+
+	post_setup()
+		. = ..()
+		if (prob(33))
+			src.universal = 1
+		if (src.artitype.name == "eldritch")
+			corrupting = 1

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -199,12 +199,15 @@
 		if (!W.ArtifactSanityCheck())
 			return
 		var/datum/artifact/A = src.artifact
-		var/datum/artifact/K = ACT.artifact
+		var/datum/artifact/activator_key/K = ACT.artifact
 
 		if (K.activated)
-			if (ACT.universal || A.artitype == K.artitype)
-				if (ACT.activator && !A.activated)
+			if (K.universal || A.artitype == K.artitype)
+				if (K.activator && !A.activated)
 					src.ArtifactActivated()
+					if(K.corrupting && A.faults.len < 10) // there's only so much corrupting you can do ok
+						for(var/i=1,i<rand(1,3),i++)
+							src.ArtifactDevelopFault(100)
 				else if (A.activated)
 					src.ArtifactDeactivated()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Activator keys are now tier 3 (15%) instead of tier 4 (5%).
In return, they aren't all universal anymore, only about a third of them will be, the others will only work artifacts of the same origin as them.
Also, eldritch activators will corrupt the activated artifacts, making them faulty.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Making artifact origins matter more for scientists is fun!
Also, this lets them get activators more often, so they can do stuff like deactivate dangerous/annoying artifacts with them, which is neat.
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)zjdtmkhzt
(+)Artifact activators are now more common, but not all of them will be universal anymore. Be wary of those of eldritch origin...
```
