### PR TITLE
Make it actually possible to apply sheets to things again.

### DIFF
--- a/code/obj/item/building_materials.dm
+++ b/code/obj/item/building_materials.dm
@@ -68,7 +68,9 @@ MATERIAL
 
 	proc/consume_sheets(var/use_amount)
 		if (!isnum(amount))
-			return
+			return FALSE
+		if (amount < use_amount)
+			return FALSE
 		src.amount = max(0,amount - use_amount)
 		if (amount < 1)
 			if (isliving(src.loc))
@@ -79,7 +81,7 @@ MATERIAL
 			qdel(src)
 		else
 			src.inventory_counter?.update_number(amount)
-		return
+		return TRUE
 
 	proc/set_reinforcement(var/datum/material/M)
 		if (!istype(M))


### PR DESCRIPTION
[BUG]

## About the PR

Updates `consume_sheets` to match the return values of `consume_rods` so sheets can actually be added to various construction projects (AI cores, pods, etc.).

## Why's this needed?

Ben Lubar made an oopsie.

## Changelog

```changelog
(u)BenLubar
(+)You can once again apply metal and glass sheets to several construction projects.
```
