### PR TITLE
adds anchoring and unanchoring portable air scrubber with wrench

### DIFF
--- a/code/modules/atmospherics/portable/scrubber.dm
+++ b/code/modules/atmospherics/portable/scrubber.dm
@@ -115,7 +115,19 @@
 			src.contained = 1
 			src.set_loc(W)
 			elecflash(user)
-	..()
+	else if(iswrenchingtool(W))
+		if(!connected_port)//checks for whether the scrubber is connected to a port, if it is calls parent.
+			var/obj/machinery/atmospherics/portables_connector/possible_port = locate(/obj/machinery/atmospherics/portables_connector/) in loc
+			if(!possible_port)//checks for whether there's something that could be connected to on the scrubber's loc, if there is it calls parent.
+				if(src.anchored)
+					src.anchored = 0
+					boutput(user, "<span class='notice'>You unanchor [name] from the floor.</span>")
+				else
+					src.anchored = 1
+					boutput(user, "<span class='notice'>You anchor [name] to the floor.</span>")
+			else ..()
+		else ..()
+	else ..()
 
 
 /obj/machinery/portable_atmospherics/scrubber/attack_ai(var/mob/user as mob)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes it so that when you hit an air scrubber with a wrench when it is not on an atmospheric port, it is anchored, and when it is not on an atmospherics port and is anchored, it is unanchored.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Plasma fires currently push air scrubbers out of the plasma fire, meaning that an air scrubber left alone will impact a plasma fire very little or not at all. This PR would allow the typical tool wielding spaceman to anchor the air scrubber, meaning that as long as the plasma fire is nearby, the air scrubber will be effective.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Chickenish
(+)It is now possible to anchor air scrubbers with a wrench.
```
