### PR TITLE
make artifacts only pick fault types that do things

### DIFF
--- a/code/datums/controllers/artifact_controls.dm
+++ b/code/datums/controllers/artifact_controls.dm
@@ -179,7 +179,7 @@ var/datum/artifact_controller/artifact_controls
 	New()
 		..()
 		if ("all" in fault_types)
-			fault_types += childrentypesof(/datum/artifact_fault)
+			fault_types += concrete_typesof(/datum/artifact_fault)
 
 	proc/post_setup(obj/artifact)
 		if(prob(25))

--- a/code/obj/artifacts/faults.dm
+++ b/code/obj/artifacts/faults.dm
@@ -1,5 +1,5 @@
 // FAULTS
-
+ABSTRACT_TYPE(/datum/artifact_fault/)
 /datum/artifact_fault
 	// these are booby traps, self-defense mechanisms, hardware faults or just other nasty shit that can fuck you up when you
 	// use the artifact for anything
@@ -111,6 +111,7 @@
 		elecflash(user,power = 6, exclude_center = 0)
 		user.stuttering += 30
 
+ABSTRACT_TYPE(/datum/artifact_fault/messager/)
 /datum/artifact_fault/messager
 	trigger_prob = 30
 	var/text_style = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Sometimes artifacts could pick the messager fault type, which is just there are a base parent for creepy_whispers, thus it wouldn't do anything.

Now the base fault types are marked as abstract and are not chosen.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Faults should do things.
