### PR TITLE
evil cloner artifact

### DIFF
--- a/code/modules/admin/admin_holder.dm
+++ b/code/modules/admin/admin_holder.dm
@@ -118,7 +118,6 @@
 		//if (src.owner:holder:level >= LEVEL_CODER)
 			//HTML += "<b>Hide Extra Verbs?: <a href='?src=\ref[src];action=toggle_extra_verbs'>[(src.extratoggle ? "Yes" : "No")]</a></b><br>"
 		HTML += "<b>Hide Popup Verbs?: <a href='?src=\ref[src];action=toggle_popup_verbs'>[(src.popuptoggle ? "Yes" : "No")]</a></b><br>"
-		HTML += "<b>Local deadchat?: <a href='?src=\ref[src];action=toggle_popup_verbs'>[(src.popuptoggle ? "Yes" : "No")]</a></b><br>"
 		HTML += "<b>Hide Server Toggles Tab?: <a href='?src=\ref[src];action=toggle_server_toggles_tab'>[(src.servertoggles_toggle ? "Yes" : "No")]</a></b><br>"
 		if (src.owner:holder:level >= LEVEL_PA)
 			HTML += "<b>Hide Atom Verbs \[old\]?: <a href='?src=\ref[src];action=toggle_atom_verbs'>[(src.animtoggle ? "Yes" : "No")]</a></b><br>"

--- a/code/obj/artifacts/artifact_objects/cloner.dm
+++ b/code/obj/artifacts/artifact_objects/cloner.dm
@@ -16,12 +16,14 @@
 	var/imprison_time = 0
 	var/evil_delay = 0
 	var/swapSouls = FALSE
+	var/deep = FALSE
 
 	New()
 		..()
 		imprison_time = rand(5 SECONDS, 2 MINUTES)
 		evil_delay = rand(0,imprison_time)
 		swapSouls = prob(50)
+		deep = prob(10)
 
 	effect_touch(var/obj/O,var/mob/living/user)
 		if (..())
@@ -40,18 +42,22 @@
 			SPAWN_DBG(0.7 SECONDS)
 				H.filters -= filter
 
-			// a bunch of stolen cloner code
-			clone = new /mob/living/carbon/human/clone(O)
-			clone.bioHolder.CopyOther(H.bioHolder, copyActiveEffects = TRUE)
-			clone.set_mutantrace(H.bioHolder?.mobAppearance?.mutant_race?.type)
-			clone.update_colorful_parts()
-			if (H.abilityHolder)
-				clone.abilityHolder = H.abilityHolder.deepCopy()
-				clone.abilityHolder.transferOwnership(clone)
-				clone.abilityHolder.remove_unlocks()
-			if(H.traitHolder && H.traitHolder.traits.len)
-				clone.traitHolder.traits = H.traitHolder.traits.Copy()
-			clone.real_name = user.real_name
+			if(deep)
+				// a bunch of stolen cloner code
+				clone = new /mob/living/carbon/human/clone(O)
+				clone.bioHolder.CopyOther(H.bioHolder, copyActiveEffects = TRUE)
+				clone.set_mutantrace(H.bioHolder?.mobAppearance?.mutant_race?.type)
+				clone.update_colorful_parts()
+				if (H.abilityHolder)
+					clone.abilityHolder = H.abilityHolder.deepCopy()
+					clone.abilityHolder.transferOwnership(clone)
+					clone.abilityHolder.remove_unlocks()
+				if(H.traitHolder && H.traitHolder.traits.len)
+					clone.traitHolder.traits = H.traitHolder.traits.Copy()
+				clone.real_name = user.real_name
+			else
+				clone = semi_deep_copy(H) // admins made me do it
+				clone.set_loc(O)
 
 			if(clone.client) // gross hack for resetting tg layout bleh bluh copied from cloner code
 				clone.client.set_layout(clone.client.tg_layout)

--- a/code/obj/artifacts/artifact_objects/cloner.dm
+++ b/code/obj/artifacts/artifact_objects/cloner.dm
@@ -90,7 +90,7 @@
 				clone.ai_calm_down = 0
 
 			SPAWN_DBG(imprison_time)
-				if (O) //ZeWaka: Fix for null.contents
+				if (!O.disposed)
 					for(var/obj/I in O.contents)
 						I.set_loc(get_turf(O))
 					if (clone.loc == O)

--- a/code/obj/artifacts/artifact_objects/cloner.dm
+++ b/code/obj/artifacts/artifact_objects/cloner.dm
@@ -8,7 +8,6 @@
 	rarity_class = 4
 	min_triggers = 2
 	max_triggers = 2
-	validtypes = list("ancient","martian","wizard","eldritch","precursor")
 	validtriggers = list(/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch)
 	react_xray = list(15,90,90,11,"HOLLOW")
 	validtypes = list("wizard","eldritch")
@@ -20,7 +19,7 @@
 
 	New()
 		..()
-		imprison_time = rand(50,1200)
+		imprison_time = rand(5 SECONDS, 2 MINUTES)
 		evil_delay = rand(0,imprison_time)
 		swapSouls = pick(TRUE, FALSE)
 

--- a/code/obj/artifacts/artifact_objects/cloner.dm
+++ b/code/obj/artifacts/artifact_objects/cloner.dm
@@ -37,7 +37,7 @@
 			// fluff
 			if(swapSouls)
 				boutput(user, "<span class='alert'>You feel your soul being sucked out of your body by [O]!</span>")
-			var/filter = filter(type="outline", size=0.5, color=rgb(255,0,0,128), flags=OUTLINE_SHARP)
+			var/filter = filter(type="outline", size=0.5, color=rgb(255,0,0), flags=OUTLINE_SHARP)
 			H.filters += filter
 			SPAWN_DBG(0.7 SECONDS)
 				H.filters -= filter
@@ -55,6 +55,7 @@
 				if(H.traitHolder && H.traitHolder.traits.len)
 					clone.traitHolder.traits = H.traitHolder.traits.Copy()
 				clone.real_name = user.real_name
+				clone.UpdateName()
 			else
 				clone = semi_deep_copy(H) // admins made me do it
 				clone.set_loc(O)

--- a/code/obj/artifacts/artifact_objects/cloner.dm
+++ b/code/obj/artifacts/artifact_objects/cloner.dm
@@ -45,6 +45,9 @@
 			if(deep)
 				clone = semi_deep_copy(H) // admins made me do it
 				clone.set_loc(O)
+				var/lastFilterIndex = clone.filters.len
+				if(lastFilterIndex)
+					clone.filters -= clone.filters[lastFilterIndex]
 			else
 				// a bunch of stolen cloner code
 				clone = new /mob/living/carbon/human/clone(O)

--- a/code/obj/artifacts/artifact_objects/cloner.dm
+++ b/code/obj/artifacts/artifact_objects/cloner.dm
@@ -43,6 +43,9 @@
 				H.filters -= filter
 
 			if(deep)
+				clone = semi_deep_copy(H) // admins made me do it
+				clone.set_loc(O)
+			else
 				// a bunch of stolen cloner code
 				clone = new /mob/living/carbon/human/clone(O)
 				clone.bioHolder.CopyOther(H.bioHolder, copyActiveEffects = TRUE)
@@ -56,9 +59,6 @@
 					clone.traitHolder.traits = H.traitHolder.traits.Copy()
 				clone.real_name = user.real_name
 				clone.UpdateName()
-			else
-				clone = semi_deep_copy(H) // admins made me do it
-				clone.set_loc(O)
 
 			if(clone.client) // gross hack for resetting tg layout bleh bluh copied from cloner code
 				clone.client.set_layout(clone.client.tg_layout)

--- a/code/obj/artifacts/artifact_objects/cloner.dm
+++ b/code/obj/artifacts/artifact_objects/cloner.dm
@@ -1,0 +1,105 @@
+
+/obj/artifact/cloner
+	name = "artifact cloner"
+	associated_datum = /datum/artifact/cloner
+
+/datum/artifact/cloner
+	associated_object = /obj/artifact/cloner
+	rarity_class = 4
+	min_triggers = 2
+	max_triggers = 2
+	validtypes = list("ancient","martian","wizard","eldritch","precursor")
+	validtriggers = list(/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch)
+	react_xray = list(15,90,90,11,"HOLLOW")
+	validtypes = list("wizard","eldritch")
+	touch_descriptors = list("You seem to have a little difficulty taking your hand off its surface.")
+	var/mob/living/carbon/human/clone = null
+	var/imprison_time = 0
+	var/evil_delay = 0
+	var/swapSouls = FALSE
+
+	New()
+		..()
+		imprison_time = rand(50,1200)
+		evil_delay = rand(0,imprison_time)
+		swapSouls = pick(TRUE, FALSE)
+
+	effect_touch(var/obj/O,var/mob/living/user)
+		if (..())
+			return
+		if (!user)
+			return
+		if (clone)
+			return
+		if (ishuman(user))
+			var/mob/living/carbon/human/H = user
+			// fluff
+			if(swapSouls)
+				boutput(user, "<span class='alert'>You feel your soul being sucked out of your body by [O]!</span>")
+			var/filter = filter(type="outline", size=0.5, color=rgb(255,0,0,128), flags=OUTLINE_SHARP)
+			H.filters += filter
+			SPAWN_DBG(0.7 SECONDS)
+				H.filters -= filter
+
+			// a bunch of stolen cloner code
+			clone = new /mob/living/carbon/human/clone(O)
+			clone.bioHolder.CopyOther(H.bioHolder, copyActiveEffects = TRUE)
+			clone.set_mutantrace(H.bioHolder?.mobAppearance?.mutant_race?.type)
+			clone.update_colorful_parts()
+			if (H.abilityHolder)
+				clone.abilityHolder = H.abilityHolder.deepCopy()
+				clone.abilityHolder.transferOwnership(clone)
+				clone.abilityHolder.remove_unlocks()
+			if(H.traitHolder && H.traitHolder.traits.len)
+				clone.traitHolder.traits = H.traitHolder.traits.Copy()
+			clone.real_name = user.real_name
+
+			if(clone.client) // gross hack for resetting tg layout bleh bluh copied from cloner code
+				clone.client.set_layout(clone.client.tg_layout)
+
+			if(swapSouls && H.mind)
+				H.mind.transfer_to(clone)
+			clone.changeStatus("paralysis", imprison_time) // so they don't ruin the surprise
+
+			if ((ticker?.mode && istype(ticker.mode, /datum/game_mode/revolution)) && ((clone.mind in ticker.mode:revolutionaries) || (clone.mind in ticker.mode:head_revolutionaries)))
+				ticker.mode:update_all_rev_icons() //So the icon actually appears
+
+			ArtifactLogs(user, clone, O, "touched","creating an evil clone of ([user])",0)
+			if(swapSouls)
+				// make original body evil
+				H.attack_alert = 0
+				H.ai_init()
+				SPAWN_DBG(0)
+					sleep(rand(1 SECOND, 10 SECONDS))
+					if(H) // completely convincing dialogue
+						H.say(pick(
+							"Well, that was weird!",
+							"Huh",
+							"Maybe it's a [pick("healer","teleporter","plant helper")] type artifact?",
+							"What do you think it does?",
+							"That activated it, didn't it?",
+							"I don't feel any different.",
+							""))
+					sleep(evil_delay)
+					if(H)
+						H.ai_aggressive = 1
+						H.ai_calm_down = 0
+			else
+				// make clone evil
+				clone.attack_alert = 0
+				clone.ai_init()
+				clone.ai_aggressive = 1
+				clone.ai_calm_down = 0
+
+			SPAWN_DBG(imprison_time)
+				if (O) //ZeWaka: Fix for null.contents
+					for(var/obj/I in O.contents)
+						I.set_loc(get_turf(O))
+					if (clone.loc == O)
+						clone.set_loc(get_turf(O))
+						O.visible_message("<span class='alert'><b>[O]</b> releases [clone.name] and shuts down!</span>")
+					else
+						O.visible_message("<span class='alert'><b>[O]</b> shuts down strangely!</span>")
+					clone = null
+					O.ArtifactDeactivated()
+			return

--- a/code/obj/artifacts/artifact_objects/prison.dm
+++ b/code/obj/artifacts/artifact_objects/prison.dm
@@ -16,7 +16,7 @@
 
 	New()
 		..()
-		imprison_time = rand(50,1200)
+		imprison_time = rand(5 SECONDS, 2 MINUTES)
 
 	effect_touch(var/obj/O,var/mob/living/user)
 		if (..())

--- a/code/obj/artifacts/artifacts.dm
+++ b/code/obj/artifacts/artifacts.dm
@@ -123,9 +123,9 @@
 
 		switch (P.proj_data.damage_type)
 			if(D_KINETIC,D_PIERCING,D_SLASHING)
-				src.ArtifactStimulus("force", P.power)
 				for (var/obj/machinery/networked/test_apparatus/impact_pad/I in src.loc.contents)
 					I.impactpad_senseforce_shot(src, P)
+				src.ArtifactStimulus("force", P.power)
 			if(D_ENERGY)
 				src.ArtifactStimulus("elec", P.power * 10)
 			if(D_BURNING)

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -1187,6 +1187,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\obj\artifacts\artifact_objects\augmentor.dm"
 #include "code\obj\artifacts\artifact_objects\bombs.dm"
 #include "code\obj\artifacts\artifact_objects\borg_maker.dm"
+#include "code\obj\artifacts\artifact_objects\cloner.dm"
 #include "code\obj\artifacts\artifact_objects\container.dm"
 #include "code\obj\artifacts\artifact_objects\curser.dm"
 #include "code\obj\artifacts\artifact_objects\darkness_field.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a new tier 4 type artifact.
When you touch one, it stealthily creates a clone of you inside. Your mind will be in either your original body or the clone. The other body will be evil and attack people.

If your original body is the one that will be evil, there is a delay before it starts attacking people, and it will give some extremely convincing dialogue during this, to strengthen the later betrayal.

I also fixed a small bug where a runtime could be caused when a wizard artifact was destroyed with bullets.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I see this generating very fun situations! It is the rarest tier, so it shouldn't happen too often.
Also, I could see a traitor potentially using this to send evil clones of themselves after people with some kind of teleporting mechanism, which seems fun! They'd have to watch out though, since the clones would still attack them too.
