### PR TITLE
Possessed canisters and crates

### DIFF
--- a/code/mob/living/object.dm
+++ b/code/mob/living/object.dm
@@ -296,3 +296,9 @@
 			return "<span class='alert'><B>[src] attacks [T] in the [d_zone]!</B></span>"
 		else
 			return "<span class='alert'><B>[src] attacks [T]!</B></span>"
+
+	return_air()
+		return loc?.return_air()
+
+	assume_air(datum/air_group/giver)
+		return loc?.assume_air(giver)

--- a/code/obj/storage/large_storage_parent.dm
+++ b/code/obj/storage/large_storage_parent.dm
@@ -506,7 +506,7 @@
 		for (var/mob/M in get_turf(src))
 			if (M.anchored || M.buckled)
 				continue
-			if (src.is_short && !M.lying)
+			if (src.is_short && !M.lying && ( M != src.loc ) ) // ignore movement when container is inside the mob (possessed)
 				step_away(M, src, 1)
 				continue
 #ifdef HALLOWEEN


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug][balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allow for canisters to retrieve and return gas through `/mob/living/object`.
* Wraith buff.
Stop containers from moving a mob that they are inside of. Stops possessed crates from randomly stepping when closed as they try to move the `/mob/living/object` that also resides on the turf.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More consistent behavior of possessed objects.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Azrun
(+)Possessed canisters behave as expected in regards to gases.  Possessed creates will no longer shuffle around when closed.
```
