### PR TITLE
Fixed infinite bloodclots

### DIFF
--- a/code/modules/medical/diseases/malady.dm
+++ b/code/modules/medical/diseases/malady.dm
@@ -225,7 +225,7 @@
 	reagentcure = list("heparin")
 	recureprob = 10
 	affected_species = list("Human","Monkey")
-	stage_prob = 0
+	stage_prob = 5
 
 /datum/ailment/malady/bloodclot/on_infection(var/mob/living/affected_mob,var/datum/ailment_data/malady/D)
 	..()


### PR DESCRIPTION
[MINOR]
## About the PR
Changes the bloodclot stage_prob from 0 to 5.


## Why's this needed?
stage_prob of 0 means the bloodclot never cures itself and stays forever. Changing this to 5 allows the bloodclot to cure itself when remissive.
Fixes #3143


## Changelog
```
(u)NoBrain:
(+)Fixed infinite bloodclot.
```