### PR TITLE
fixes thindow item grabbing

### DIFF
--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -305,7 +305,7 @@
 			var/obj/projectile/P = O
 			if(P.proj_data.window_pass)
 				return 1
-		if (get_dir(O.loc, target) == src.dir)
+		if (get_dir(loc, target) == src.dir)
 			return 0
 		return 1
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
this pr fixes grabbing items from the other side of a thindow.
if you were on the tile that the thindow was on you could interact with things on the other side
this was fixed for thindoors ages ago.
I couldnt see any other issues this change causing 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
thindow less bad


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Moonlol
(+)You can no longer grab things from the other side of a thin window.
```
