### PR TITLE
make cyberorgans spill oil

### DIFF
--- a/code/obj/item/organs/appendix.dm
+++ b/code/obj/item/organs/appendix.dm
@@ -20,6 +20,7 @@
 	icon_state = "cyber-appendix"
 	// item_state = "cyber-"
 	robotic = 1
+	created_decal = /obj/decal/cleanable/oil
 	made_from = "pharosium"
 	edible = 0
 	mats = 6

--- a/code/obj/item/organs/eye.dm
+++ b/code/obj/item/organs/eye.dm
@@ -115,6 +115,7 @@
 	icon_state = "eye-cyber"
 	item_state = "heart_robo1"
 	robotic = 1
+	created_decal = /obj/decal/cleanable/oil
 	edible = 0
 	mats = 6
 	made_from = "pharosium"

--- a/code/obj/item/organs/heart.dm
+++ b/code/obj/item/organs/heart.dm
@@ -113,6 +113,7 @@
 	//created_decal = /obj/decal/cleanable/oil
 	edible = 0
 	robotic = 1
+	created_decal = /obj/decal/cleanable/oil
 	mats = 8
 	made_from = "pharosium"
 	transplant_XP = 7

--- a/code/obj/item/organs/instestines.dm
+++ b/code/obj/item/organs/instestines.dm
@@ -48,6 +48,7 @@
 	// item_state = "heart_robo1"
 	made_from = "pharosium"
 	robotic = 1
+	created_decal = /obj/decal/cleanable/oil
 	edible = 0
 	mats = 6
 

--- a/code/obj/item/organs/kidney.dm
+++ b/code/obj/item/organs/kidney.dm
@@ -119,6 +119,7 @@
 	// item_state = "heart_robo1"
 	made_from = "pharosium"
 	robotic = 1
+	created_decal = /obj/decal/cleanable/oil
 	edible = 0
 	mats = 6
 

--- a/code/obj/item/organs/liver.dm
+++ b/code/obj/item/organs/liver.dm
@@ -31,6 +31,7 @@
 	// item_state = "heart_robo1"
 	made_from = "pharosium"
 	robotic = 1
+	created_decal = /obj/decal/cleanable/oil
 	edible = 0
 	mats = 6
 	var/overloading = 0

--- a/code/obj/item/organs/lung.dm
+++ b/code/obj/item/organs/lung.dm
@@ -124,6 +124,7 @@
 	icon_state = "cyber-lungs_L"
 	made_from = "pharosium"
 	robotic = 1
+	created_decal = /obj/decal/cleanable/oil
 	edible = 0
 	mats = 6
 	temp_tolerance = T0C+500

--- a/code/obj/item/organs/pancreas.dm
+++ b/code/obj/item/organs/pancreas.dm
@@ -40,6 +40,7 @@
 	// item_state = "heart_robo1"
 	made_from = "pharosium"
 	robotic = 1
+	created_decal = /obj/decal/cleanable/oil
 	edible = 0
 	mats = 6
 

--- a/code/obj/item/organs/spleen.dm
+++ b/code/obj/item/organs/spleen.dm
@@ -41,3 +41,4 @@
 	robotic = 1
 	edible = 0
 	mats = 6
+	created_decal = /obj/decal/cleanable/oil

--- a/code/obj/item/organs/stomach.dm
+++ b/code/obj/item/organs/stomach.dm
@@ -74,6 +74,7 @@
 	// item_state = "heart_robo1"
 	made_from = "pharosium"
 	robotic = 1
+	created_decal = /obj/decal/cleanable/oil
 	edible = 0
 	mats = 6
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Cyberorgans should now spill oil instead of blood.

I would have preferred something like 

```
if(robotic) 
  src.create_decal = oil
```

in the organ parent new or whatever, but then you couldn't properly override cyberorgan spills if you wanna make some special types, so I decided against it.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes sense.