### PR TITLE
Add a bunch of missing jobs to the end-of-round crew department decider thingy.

### DIFF
--- a/code/datums/controllers/job_controls.dm
+++ b/code/datums/controllers/job_controls.dm
@@ -26,12 +26,12 @@ var/datum/job_controller/job_controls
 			new /datum/job/civilian/chaplain ())
 
 		else
-			for (var/A in typesof(/datum/job/command)) src.staple_jobs += new A(src)
-			for (var/A in typesof(/datum/job/security)) src.staple_jobs += new A(src)
-			for (var/A in typesof(/datum/job/research)) src.staple_jobs += new A(src)
-			for (var/A in typesof(/datum/job/engineering)) src.staple_jobs += new A(src)
-			for (var/A in typesof(/datum/job/civilian)) src.staple_jobs += new A(src)
-			for (var/A in typesof(/datum/job/special)) src.special_jobs += new A(src)
+			for (var/A in concrete_typesof(/datum/job/command)) src.staple_jobs += new A(src)
+			for (var/A in concrete_typesof(/datum/job/security)) src.staple_jobs += new A(src)
+			for (var/A in concrete_typesof(/datum/job/research)) src.staple_jobs += new A(src)
+			for (var/A in concrete_typesof(/datum/job/engineering)) src.staple_jobs += new A(src)
+			for (var/A in concrete_typesof(/datum/job/civilian)) src.staple_jobs += new A(src)
+			for (var/A in concrete_typesof(/datum/job/special)) src.special_jobs += new A(src)
 		job_creator = new /datum/job/created(src)
 		//Add special daily variety job
 		var/variety_job_path = text2path("/datum/job/daily/[lowertext(time2text(world.realtime,"Day"))]")

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -140,6 +140,7 @@
 
 // Command Jobs
 
+ABSTRACT_TYPE(/datum/job/command)
 /datum/job/command
 	linkcolor = "#00CC00"
 	slot_card = /obj/item/card/id/command
@@ -445,6 +446,7 @@
 
 // Security Jobs
 
+ABSTRACT_TYPE(/datum/job/security)
 /datum/job/security
 	linkcolor = "#FF0000"
 	slot_card = /obj/item/card/id/security
@@ -562,6 +564,7 @@
 
 // Research Jobs
 
+ABSTRACT_TYPE(/datum/job/research)
 /datum/job/research
 	linkcolor = "#9900FF"
 	slot_card = /obj/item/card/id/research
@@ -671,6 +674,7 @@
 
 // Engineering Jobs
 
+ABSTRACT_TYPE(/datum/job/engineering)
 /datum/job/engineering
 	linkcolor = "#FF9900"
 	slot_card = /obj/item/card/id/engineering
@@ -822,6 +826,7 @@
 
 // Civilian Jobs
 
+ABSTRACT_TYPE(/datum/job/civilian)
 /datum/job/civilian
 	linkcolor = "#0099FF"
 	slot_card = /obj/item/card/id/civilian
@@ -1727,6 +1732,7 @@
 /*
  * Halloween jobs
  */
+ABSTRACT_TYPE(/datum/job/special/halloween)
 /datum/job/special/halloween
 	linkcolor = "#FF7300"
 

--- a/code/procs/crew_credits.dm
+++ b/code/procs/crew_credits.dm
@@ -36,27 +36,27 @@ var/global/crew_creds = null
 					continue
 
 				// Security?
-				if("Head of Security","Security Officer","Detective")
+				if("Head of Security","Security Officer","Detective","Vice Officer","Part-time Vice Officer","Security Assistant","Lawyer","Nanotrasen Security Operative","Nanotrasen Special Operative")
 					round_security.Add(M)
 					continue
 
 				// Medical?
-				if("Medical Director","Medical Doctor","Roboticist","Geneticist")
+				if("Medical Director","Medical Doctor","Roboticist","Geneticist","Pharmacist","Psychiatrist","Psychologist","Psychotherapist","Therapist","Counselor","Life Coach")
 					round_medical.Add(M)
 					continue
 
 				// Science?
-				if("Research Director","Scientist")
+				if("Research Director","Scientist","Test Subject")
 					round_science.Add(M)
 					continue
 
 				// Engineering?
-				if("Chief Engineer","Engineer","Quartermaster","Miner","Mechanic")
+				if("Chief Engineer","Engineer","Quartermaster","Miner","Mechanic","Construction Worker")
 					round_engineering.Add(M)
 					continue
 
 				// Civilian?
-				if("Head of Personnel","Botanist","Bartender","Chef","Janitor","Staff Assistant","Clown","Chaplain")
+				if("Head of Personnel","Communications Officer","Botanist","Apiculturist","Rancher","Bartender","Chef","Sous-Chef","Waiter","Clown","Mime","Chaplain","Mailman","Musician","Janitor","Coach","Boxer","Barber","Staff Assistant")
 					round_civilian.Add(M)
 					continue
 


### PR DESCRIPTION
## About the PR

Adds the following jobs to departments at the end of round:

Security:

- Vice Officer
- Part-time Vice Officer
- Security Assistant
- Lawyer
- Nanotrasen Security Operative
- Nanotrasen Special Operative

Medical:

- Pharmacist
- Psychiatrist/Psychologist/Psychotherapist/Therapist/Counselor/Life Coach

Research:

- Test Subject

Engineering:

- Construction Worker

Civilian (maybe in the future this should be split into food/entertainment/services?):

- Communications Officer
- Apiculturist
- Rancher
- Sous-Chef
- Waiter
- Mime
- Mailman
- Musician
- Coach
- Boxer
- Barber

## Why's this needed?

Too many people ending up in the "other" section.
