### PR TITLE
head pats should not interrupt

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1379,12 +1379,12 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 		boutput(M, "You cannot interact with other people before the game has started.")
 		return
 
-	actions.interrupt(src, INTERRUPT_ATTACKED)
 	M.lastattacked = src
 
 	attack_particle(M,src)
 
 	if (M.a_intent != INTENT_HELP)
+		actions.interrupt(src, INTERRUPT_ATTACKED)
 		src.was_harmed(M, intent = M.a_intent)
 
 		if (M.mob_flags & AT_GUNPOINT)

--- a/code/mob/living/silicon/hivebot.dm
+++ b/code/mob/living/silicon/hivebot.dm
@@ -545,7 +545,8 @@
 /mob/living/silicon/hivebot/attack_hand(mob/user)
 	user.lastattacked = src
 	if(!user.stat)
-		actions.interrupt(src, INTERRUPT_ATTACKED)
+		if (user.a_intent != INTENT_HELP)
+			actions.interrupt(src, INTERRUPT_ATTACKED)
 		switch(user.a_intent)
 			if(INTENT_HELP) //Friend person
 				playsound(src.loc, 'sound/impact_sounds/Generic_Shove_1.ogg', 50, 1, -2)

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -1515,7 +1515,8 @@
 		else //We're just bapping the borg
 			user.lastattacked = src
 			if(!user.stat)
-				actions.interrupt(src, INTERRUPT_ATTACKED)
+				if (user.a_intent != INTENT_HELP)
+					actions.interrupt(src, INTERRUPT_ATTACKED)
 				switch(user.a_intent)
 					if(INTENT_HELP) //Friend person
 						playsound(src.loc, 'sound/impact_sounds/Generic_Shove_1.ogg', 50, 1, -2)


### PR DESCRIPTION
[BUG]

## About the PR

Patting a doctor on the head while they're using an automender interrupts them. It shouldn't.

## Why's this needed?

doctor deserves head pats

## Changelog

```changelog
(u)BenLubar
(+)Receiving a friendly pat on the head no longer counts as being attacked for the purpose of interrupts.
```
