### PR TITLE
Message when flash is blocked

### DIFF
--- a/code/obj/item/device/flash.dm
+++ b/code/obj/item/device/flash.dm
@@ -151,14 +151,17 @@
 		eye_damage = src.eye_damage_mod + rand(0, (1 * flash_power))
 
 	// We're flashing somebody directly, hence the 100% chance to disrupt cloaking device at the end.
-	M.apply_flash(animation_duration, weakened, 0, 0, eye_blurry, eye_damage, 0, burning, 100, stamina_damage = 70 * flash_power, disorient_time = 30)
+	var/blind_success = M.apply_flash(animation_duration, weakened, 0, 0, eye_blurry, eye_damage, 0, burning, 100, stamina_damage = 70 * flash_power, disorient_time = 30)
 	if (src.emagged)
 		user.apply_flash(animation_duration, weakened, 0, 0, eye_blurry, eye_damage, 0, burning, 100, stamina_damage = 70 * flash_power, disorient_time = 30)
 
 	convert(M,user)
 
 	// Log entry.
-	M.visible_message("<span class='alert'>[user] blinds [M] with the [src.name]!</span>")
+	var/blind_msg = "!"
+	if (!blind_success)
+		blind_msg = " but [(user != M) ? "their" : "your"] eyes are protected!"
+	M.visible_message("<span class='alert'>[user] blinds [M] with the [src.name][blind_msg]</span>", "<span class='alert'>You are blinded by the [src.name][blind_msg]</span>")
 	logTheThing("combat", user, M, "blinds [constructTarget(M,"combat")] with [src] at [log_loc(user)].")
 	if (src.emagged)
 		logTheThing("combat", user, user, "blinds themself with [src] at [log_loc(user)].")

--- a/code/procs/mob_procs.dm
+++ b/code/procs/mob_procs.dm
@@ -318,7 +318,9 @@
 				D.disrupt(src)
 				src.visible_message("<span class='notice'><b>[src]'s disguiser is disrupted!</b></span>")
 
-	return
+	if (safety)
+		return 0
+	return 1
 
 /mob/proc/hearing_check(var/consciousness_check = 0)
 	return 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
[QOL]


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
A lot of players don't seem to notice that their attempts to flash someone is blocked. This PR adds a message to the chat to indicate the attempt failed.
