### PR TITLE
Avoid negative molar quantities on gas removal

### DIFF
--- a/code/modules/atmospherics/FEA_gas_mixture.dm
+++ b/code/modules/atmospherics/FEA_gas_mixture.dm
@@ -341,7 +341,7 @@ What are the archived variables for?
 	var/datum/gas_mixture/removed = unpool(/datum/gas_mixture)
 
 	#define _REMOVE_GAS_RATIO(GAS, ...) \
-		removed.GAS = QUANTIZE(GAS*ratio); \
+		removed.GAS = min(QUANTIZE(GAS*ratio), GAS); \
 		GAS -= removed.GAS/group_multiplier;
 	APPLY_TO_GASES(_REMOVE_GAS_RATIO)
 	#undef _REMOVE_GAS_RATIO


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Resolves case where non-trace gas quantities could become negative due to rounding from quantization during gas removal. This can cause a negative calculation of heat capacity which can then provide negative temperatures! Sweet mother of ATMOS!

I should have fixed this in #2580, but I was too young.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Negative temperatures are bad.
