### PR TITLE
Removes most volume checks for chems that apply stuff to turfs

### DIFF
--- a/code/modules/chemistry/Reagents-Base.dm
+++ b/code/modules/chemistry/Reagents-Base.dm
@@ -55,9 +55,8 @@ datum
 			reaction_turf(var/turf/T, var/volume)
 				src = null
 				if(!istype(T, /turf/space))
-					if(volume >= 5)
-						if(!locate(/obj/decal/cleanable/dirt) in T)
-							make_cleanable(/obj/decal/cleanable/dirt,T)
+					if(!locate(/obj/decal/cleanable/dirt) in T)
+						make_cleanable(/obj/decal/cleanable/dirt,T)
 
 		chlorine
 			name = "chlorine"
@@ -306,9 +305,8 @@ datum
 
 			reaction_turf(var/turf/T, var/volume)
 				src = null
-				if (volume >= 10)
-					if (!locate(/obj/decal/cleanable/magnesiumpile) in T)
-						make_cleanable(/obj/decal/cleanable/magnesiumpile,T)
+				if (!locate(/obj/decal/cleanable/magnesiumpile) in T)
+					make_cleanable(/obj/decal/cleanable/magnesiumpile,T)
 
 		mercury
 			name = "mercury"

--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -1713,7 +1713,7 @@ datum
 
 			reaction_turf(var/turf/T, var/volume)
 				src = null
-				if(volume >= 5 && !(locate(/obj/item/reagent_containers/food/snacks/breadslice) in T))
+				if(!(locate(/obj/item/reagent_containers/food/snacks/breadslice) in T))
 					new /obj/item/reagent_containers/food/snacks/breadslice(T)
 
 		fooddrink/george_melonium
@@ -1934,7 +1934,7 @@ datum
 
 			reaction_turf(var/turf/T, var/volume)
 				src = null
-				if(volume >= 5 && !(locate(/obj/item/reagent_containers/food/snacks/ingredient/cheese) in T))
+				if(!(locate(/obj/item/reagent_containers/food/snacks/ingredient/cheese) in T))
 					new /obj/item/reagent_containers/food/snacks/ingredient/cheese(T)
 
 			on_mob_life(var/mob/M, var/mult = 1)
@@ -1961,7 +1961,7 @@ datum
 
 			reaction_turf(var/turf/T, var/volume)
 				src = null
-				if(volume >= 5 && !(locate(/obj/item/reagent_containers/food/snacks/ingredient/gcheese) in T))
+				if(/* volume >= 5 &&  */!(locate(/obj/item/reagent_containers/food/snacks/ingredient/gcheese) in T))///LAGGNOTE
 					new /obj/item/reagent_containers/food/snacks/ingredient/gcheese(T)
 
 			on_mob_life(var/mob/M, var/mult = 1)
@@ -1988,7 +1988,7 @@ datum
 				if (covered.len > 9)
 					volume = (volume/covered.len)
 
-				if(volume >= 5 && prob(10))
+				if(prob(10))
 					if(!locate(/obj/decal/cleanable/blood/gibs) in T)
 						playsound(T, "sound/impact_sounds/Slimy_Splat_1.ogg", 50, 1)
 						make_cleanable(/obj/decal/cleanable/blood/gibs,T)
@@ -2275,8 +2275,7 @@ datum
 
 			reaction_turf(var/turf/T, var/volume)
 				src = null
-				if(volume >= 3)
-					if(locate(/obj/item/reagent_containers/food/snacks/candy/chocolate) in T) return
+				if(!locate(/obj/item/reagent_containers/food/snacks/candy/chocolate) in T)
 					new /obj/item/reagent_containers/food/snacks/candy/chocolate(T)
 
 		fooddrink/nectar
@@ -2309,10 +2308,7 @@ datum
 
 			reaction_turf(var/turf/T, var/volume)
 				src = null
-				if (volume >= 5)
-					if (locate(/obj/item/reagent_containers/food/snacks/ingredient/honey) in T)
-						return
-
+				if (!locate(/obj/item/reagent_containers/food/snacks/ingredient/honey) in T)
 					new /obj/item/reagent_containers/food/snacks/ingredient/honey(T)
 
 		fooddrink/royal_jelly
@@ -2541,10 +2537,9 @@ datum
 				if (covered.len > 9)
 					volume = (volume/covered.len)
 
-				if (volume >= 5)
-					if (!locate(/obj/decal/cleanable/ketchup) in T)
-						playsound(T, "sound/impact_sounds/Slimy_Splat_1.ogg", 50, 1)
-						make_cleanable(/obj/decal/cleanable/ketchup,T)
+				if (!locate(/obj/decal/cleanable/ketchup) in T)
+					playsound(T, "sound/impact_sounds/Slimy_Splat_1.ogg", 50, 1)
+					make_cleanable(/obj/decal/cleanable/ketchup,T)
 
 		fooddrink/mustard
 			name = "mustard"

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -415,10 +415,9 @@ datum
 				if (covered.len > 9)
 					volume = (volume/covered.len)
 
-				if(volume >= 5)
-					if(!locate(/obj/decal/cleanable/blood/gibs) in T)
-						playsound(T, "sound/impact_sounds/Slimy_Splat_1.ogg", 50, 1)
-						make_cleanable(/obj/decal/cleanable/blood/gibs,T)
+				if(!locate(/obj/decal/cleanable/blood/gibs) in T)
+					playsound(T, "sound/impact_sounds/Slimy_Splat_1.ogg", 50, 1)
+					make_cleanable(/obj/decal/cleanable/blood/gibs,T)
 			/*reaction_obj(var/obj/O, var/volume)
 				if(istype(O,/obj/item/parts/robot_parts/robot_frame))
 					if (O.check_completion() && volume >= 20)

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -614,9 +614,8 @@ datum
 			viscosity = 0.3
 
 			reaction_turf(var/turf/T, var/volume)
-				if (T.icon == 'icons/turf/floors.dmi' && volume >= 5)
-					SPAWN_DBG(1.5 SECONDS)
-						T.icon_state = "grimy"
+				if (T.icon == 'icons/turf/floors.dmi')
+					T.icon_state = "grimy"
 				src = null
 				return
 
@@ -942,8 +941,7 @@ datum
 
 			reaction_turf(var/turf/T, var/volume)
 				src = null
-				if (volume >= 10)
-					if (locate(/obj/item/reagent_containers/food/snacks/ectoplasm) in T) return
+				if (!(locate(/obj/item/reagent_containers/food/snacks/ectoplasm) in T))
 					new /obj/item/reagent_containers/food/snacks/ectoplasm(T)
 
 		space_fungus
@@ -1041,8 +1039,7 @@ datum
 
 			reaction_turf(var/turf/target, var/volume)
 				src = null
-				if (volume >= 3)
-					if (locate(/obj/decal/icefloor) in target) return
+				if (!(locate(/obj/decal/icefloor) in target))
 					var/obj/decal/icefloor/B = new /obj/decal/icefloor(target)
 					SPAWN_DBG(80 SECONDS)
 						if (B)
@@ -1117,23 +1114,22 @@ datum
 			transparency = 150
 
 			reaction_turf(var/turf/T, var/volume)
-				if (volume >= 5)
-					for (var/obj/decal/bloodtrace/B in T)
-						B.invisibility = 0
+				for (var/obj/decal/bloodtrace/B in T)
+					B.invisibility = 0
+					SPAWN_DBG(30 SECONDS)
+						if (B)
+							B.invisibility = 101
+				for (var/obj/item/W in T)
+					if (W.get_forensic_trace("bDNA"))
+						var/icon/icon_old = W.icon
+						var/icon/I = new /icon(W.icon, W.icon_state)
+						I.Blend(new /icon('icons/effects/blood.dmi', "thisisfuckingstupid"),ICON_ADD)
+						I.Blend(new /icon('icons/effects/blood.dmi', "lum-item"),ICON_MULTIPLY)
+						I.Blend(new /icon(W.icon, W.icon_state),ICON_UNDERLAY)
+						W.icon = I
 						SPAWN_DBG(30 SECONDS)
-							if (B)
-								B.invisibility = 101
-					for (var/obj/item/W in T)
-						if (W.get_forensic_trace("bDNA"))
-							var/icon/icon_old = W.icon
-							var/icon/I = new /icon(W.icon, W.icon_state)
-							I.Blend(new /icon('icons/effects/blood.dmi', "thisisfuckingstupid"),ICON_ADD)
-							I.Blend(new /icon('icons/effects/blood.dmi', "lum-item"),ICON_MULTIPLY)
-							I.Blend(new /icon(W.icon, W.icon_state),ICON_UNDERLAY)
-							W.icon = I
-							SPAWN_DBG(30 SECONDS)
-								if (W && icon_old)
-									W.icon = icon_old
+							if (W && icon_old)
+								W.icon = icon_old
 
 		oil
 			name = "oil"
@@ -1620,7 +1616,7 @@ datum
 			reaction_turf(var/turf/T, var/volume)
 				CRITTER_REACTION_CHECK(reaction_count)
 				var/turf/simulated/target = T
-				if (istype(target) && volume >= 5)
+				if (istype(target))
 					if (!locate(/obj/reagent_dispensers/cleanable/spiders) in target)
 						new /obj/reagent_dispensers/cleanable/spiders(target)
 						var/obj/critter/S
@@ -1810,7 +1806,7 @@ datum
 			var/chalk_color = null
 
 			reaction_turf(var/turf/T, var/volume)
-				if (volume >= 5 && !locate(/obj/item/pen/crayon/chalk) in T)
+				if (!locate(/obj/item/pen/crayon/chalk) in T)
 					if (holder.has_reagent("colors"))
 						new /obj/item/pen/crayon/chalk/random(T)
 						return
@@ -2083,9 +2079,8 @@ datum
 					volume = (volume/covered.len)
 
 				if (!istype(T, /turf/space))
-					if (volume >= 5)
-						if (!locate(/obj/decal/cleanable/paper) in T)
-							make_cleanable(/obj/decal/cleanable/paper,T)
+					if (!locate(/obj/decal/cleanable/paper) in T)
+						make_cleanable(/obj/decal/cleanable/paper,T)
 
 		rubber
 			name = "rubber"
@@ -2589,9 +2584,8 @@ datum
 					volume = (volume/covered.len)
 
 				if (!istype(T, /turf/space))
-					if (volume >= 5)
-						if (!locate(/obj/decal/cleanable/glitter) in T)
-							make_cleanable(/obj/decal/cleanable/glitter,T)
+					if (!locate(/obj/decal/cleanable/glitter) in T)
+						make_cleanable(/obj/decal/cleanable/glitter,T)
 
 			on_remove()
 				if (!holder) return
@@ -2657,9 +2651,8 @@ datum
 				if (covered.len > 9)
 					volume = (volume/covered.len)
 				if (!istype(T, /turf/space))
-					if (volume >= 5)
-						if (!locate(/obj/decal/cleanable/glitter/harmless) in T)
-							make_cleanable(/obj/decal/cleanable/glitter/harmless,T)
+					if (!locate(/obj/decal/cleanable/glitter/harmless) in T)
+						make_cleanable(/obj/decal/cleanable/glitter/harmless,T)
 
 			on_remove()
 				var/atom/A = holder.my_atom
@@ -2985,10 +2978,9 @@ datum
 
 				if (volume > 10)
 					return 1
-				if (volume >= 5)
-					if (!locate(/obj/decal/cleanable/blood) in T)
-						playsound(T, "sound/impact_sounds/Slimy_Splat_1.ogg", 50, 1)
-						make_cleanable(/obj/decal/cleanable/blood,T)
+				if (!locate(/obj/decal/cleanable/blood) in T)
+					playsound(T, "sound/impact_sounds/Slimy_Splat_1.ogg", 50, 1)
+					make_cleanable(/obj/decal/cleanable/blood,T)
 
 			reaction_mob(var/mob/M, var/method=TOUCH, var/volume_passed)
 				. = ..()
@@ -3100,11 +3092,10 @@ datum
 
 				if (covered.len > 9)
 					volume = (volume/covered.len)
-				if (volume >= 5)
-					if (!locate(/obj/decal/cleanable/vomit) in T)
-						// no mob to vomit, so this gets to stay - cirr
-						playsound(T, "sound/impact_sounds/Slimy_Splat_1.ogg", 50, 1)
-						make_cleanable( /obj/decal/cleanable/vomit,T)
+				if (!locate(/obj/decal/cleanable/vomit) in T)
+					// no mob to vomit, so this gets to stay - cirr
+					playsound(T, "sound/impact_sounds/Slimy_Splat_1.ogg", 50, 1)
+					make_cleanable( /obj/decal/cleanable/vomit,T)
 
 		gvomit
 			name = "green vomit"
@@ -3125,10 +3116,9 @@ datum
 
 				if (covered.len > 9)
 					volume = (volume/covered.len)
-				if (volume >= 5)
-					if (!locate(/obj/decal/cleanable/greenpuke) in T)
-						playsound(T, "sound/impact_sounds/Slimy_Splat_1.ogg", 50, 1)
-						make_cleanable( /obj/decal/cleanable/greenpuke,T)
+				if (!locate(/obj/decal/cleanable/greenpuke) in T)
+					playsound(T, "sound/impact_sounds/Slimy_Splat_1.ogg", 50, 1)
+					make_cleanable( /obj/decal/cleanable/greenpuke,T)
 
 		urine
 			name = "urine"
@@ -3158,10 +3148,9 @@ datum
 					volume = (volume/covered.len)
 				if (volume > 10)
 					return 1
-				if (volume >= 5)
-					if (!locate(/obj/decal/cleanable/urine) in T)
-						playsound(T, "sound/impact_sounds/Slimy_Splat_1.ogg", 50, 1)
-						make_cleanable( /obj/decal/cleanable/urine,T)
+				if (!locate(/obj/decal/cleanable/urine) in T)
+					playsound(T, "sound/impact_sounds/Slimy_Splat_1.ogg", 50, 1)
+					make_cleanable( /obj/decal/cleanable/urine,T)
 
 		triplepiss
 			name = "triplepiss"
@@ -3182,10 +3171,9 @@ datum
 					volume = (volume/covered.len)
 				if (volume > 10)
 					return 1
-				if (volume >= 5)
-					if (!locate(/obj/decal/cleanable/urine) in T)
-						playsound(T, "sound/impact_sounds/Slimy_Splat_1.ogg", 50, 1)
-						make_cleanable( /obj/decal/cleanable/urine,T)
+				if (!locate(/obj/decal/cleanable/urine) in T)
+					playsound(T, "sound/impact_sounds/Slimy_Splat_1.ogg", 50, 1)
+					make_cleanable( /obj/decal/cleanable/urine,T)
 
 		poo
 			name = "compost"
@@ -3764,7 +3752,7 @@ datum
 			transparency = 255
 
 			reaction_turf(var/turf/T, var/volume)
-				if (!(T.turf_flags & CAN_BE_SPACE_SAMPLE) && (volume >= 1))
+				if (!(T.turf_flags & CAN_BE_SPACE_SAMPLE))
 					if (!T.messy || !locate(/obj/decal/cleanable/sakura) in T)
 						make_cleanable(/obj/decal/cleanable/sakura,T)
 

--- a/code/modules/projectiles/special.dm
+++ b/code/modules/projectiles/special.dm
@@ -1008,7 +1008,7 @@ ABSTRACT_TYPE(/datum/projectile/special)
 		if(!T.reagents) // first get the turf
 			T.create_reagents(100)
 		copied.copy_to(T.reagents, 1, copy_temperature = 1)
-		copied.reaction(T, TOUCH, 0, 0)
+		copied.reaction(T, TOUCH, 0, 0, 0)
 		if(O.special_data["IS_LIT"]) // Heat if needed
 			T.reagents?.set_reagent_temp(O.special_data["burn_temp"], TRUE)
 		for(var/atom/A in T.contents) // then all the stuff in the turf

--- a/code/obj/item/flamethrower.dm
+++ b/code/obj/item/flamethrower.dm
@@ -301,6 +301,37 @@ A Flamethrower in various states of assembly
 		..()
 		gastank.reagents.add_reagent("napalm_goo", 4000)
 
+/obj/item/gun/flamethrower/backtank/crud
+	name = "Vega crudthrower"
+	desc = "A crud-grade crudthrower, supplied with crud and propellant from a back-mounted crudpack. Developed by Almacrud Crud Fabrication."
+	New()
+		..()
+		gastank.reagents.add_reagent("vomit", 1)
+		gastank.reagents.add_reagent("gvomit", 1)
+		gastank.reagents.add_reagent("bread", 1)
+		gastank.reagents.add_reagent("paper", 1)
+		gastank.reagents.add_reagent("blood", 1)
+		gastank.reagents.add_reagent("glitter", 1)
+		gastank.reagents.add_reagent("glitter_harmless", 1)
+		gastank.reagents.add_reagent("chocolate", 1)
+		gastank.reagents.add_reagent("urine", 1)
+		gastank.reagents.add_reagent("magnesium", 1)
+		gastank.reagents.add_reagent("carbon", 1)
+		gastank.reagents.add_reagent("carpet", 1)
+		gastank.reagents.add_reagent("ectoplasm", 1)
+		gastank.reagents.add_reagent("synthflesh", 1)
+		gastank.reagents.add_reagent("meat_slurry", 1)
+		gastank.reagents.add_reagent("triplepiss", 1)
+		gastank.reagents.add_reagent("ants", 1)
+		gastank.reagents.add_reagent("spiders", 1)
+		gastank.reagents.add_reagent("ice", 1)
+		gastank.reagents.add_reagent("luminol", 1)
+		gastank.reagents.add_reagent("cheese", 1)
+		gastank.reagents.add_reagent("gcheese", 1)
+		gastank.reagents.add_reagent("honey", 1)
+		gastank.reagents.add_reagent("ketchup", 1)
+		gastank.reagents.add_reagent("platinum", 3976)
+
 /obj/item/gun/flamethrower/assembled/New()
 	..()
 	welder = new /obj/item/weldingtool


### PR DESCRIPTION
Basically if its a crudchem, any volume'll work

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Most chems that make a thing when applied to a turf (carpet, synthflesh, cheese) no longer check if the volume passed is above a certain amount. Instead, any amount'll produce the effect. 

Also removes the minimum volume requirement on the flamer's projectile's chem reaction when applying chems to a turf.

Also adds a backpack flamer filled with all the stuff-spawning chems I could find. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Flamers have long since been a staple for making the station absolutely filthy.

also
https://www.youtube.com/watch?v=lGKmC3fhfnw