### PR TITLE
some artifact deactivation fixes

### DIFF
--- a/code/obj/artifacts/artifact_items/gun_cell.dm
+++ b/code/obj/artifacts/artifact_items/gun_cell.dm
@@ -4,6 +4,7 @@
 	artifact = 1
 	charge = 400.0
 	max_charge = 400.0
+	var/chargeCap = 400.0
 	recharge_rate = 0.0
 	module_research_no_diminish = 1
 	mat_changename = 0
@@ -20,6 +21,7 @@
 
 			src.max_charge = rand(5,100)
 			src.max_charge *= 10
+			src.chargeCap = src.max_charge
 			A.react_elec[2] = src.max_charge
 			src.recharge_rate = rand(5,60)
 		..()
@@ -38,6 +40,16 @@
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (src.Artifact_attackby(W,user))
 			..()
+
+	ArtifactActivated()
+		. = ..()
+		src.max_charge = src.chargeCap
+		processing_items |= src
+
+	ArtifactDeactivated()
+		. = ..()
+		src.max_charge = 1 // no divide by 0 pls
+		src.charge = 1
 
 /datum/artifact/energyammo
 	associated_object = /obj/item/ammo/power_cell/self_charging/artifact

--- a/code/obj/artifacts/artifact_items/power_cell.dm
+++ b/code/obj/artifacts/artifact_items/power_cell.dm
@@ -96,11 +96,12 @@
 	ArtifactActivated()
 		. = ..()
 		src.maxcharge = src.chargeCap
+		processing_items |= src				// in case someone decides to make big cells work like small cells
 
 	ArtifactDeactivated()
 		. = ..()
-		src.maxcharge = 0
-		src.charge = 0
+		src.maxcharge = 1
+		src.charge = 1
 
 /datum/artifact/powercell
 	associated_object = /obj/item/cell/artifact

--- a/code/obj/artifacts/artifact_machines/noise_maker.dm
+++ b/code/obj/artifacts/artifact_machines/noise_maker.dm
@@ -2,9 +2,6 @@
 	name = "artifact noisy thing"
 	associated_datum = /datum/artifact/noisy_thing
 
-	ArtifactDeactivated()
-		return // hahaha nope
-
 /datum/artifact/noisy_thing
 	associated_object = /obj/machinery/artifact/noisy_thing
 	rarity_class = 1

--- a/code/obj/artifacts/artifact_objects/cloner.dm
+++ b/code/obj/artifacts/artifact_objects/cloner.dm
@@ -101,13 +101,16 @@
 
 			SPAWN_DBG(imprison_time)
 				if (!O.disposed)
-					for(var/obj/I in O.contents)
-						I.set_loc(get_turf(O))
-					if (clone.loc == O)
-						clone.set_loc(get_turf(O))
-						O.visible_message("<span class='alert'><b>[O]</b> releases [clone.name] and shuts down!</span>")
-					else
-						O.visible_message("<span class='alert'><b>[O]</b> shuts down strangely!</span>")
-					clone = null
 					O.ArtifactDeactivated()
+
+	effect_deactivate(obj/O)
+		if (..())
 			return
+		for(var/obj/I in O.contents)
+			I.set_loc(get_turf(O))
+		if (clone.loc == O)
+			clone.set_loc(get_turf(O))
+			O.visible_message("<span class='alert'><b>[O]</b> releases [clone.name] and shuts down!</span>")
+		else
+			O.visible_message("<span class='alert'><b>[O]</b> shuts down strangely!</span>")
+		clone = null

--- a/code/obj/artifacts/artifact_objects/darkness_field.dm
+++ b/code/obj/artifacts/artifact_objects/darkness_field.dm
@@ -11,6 +11,7 @@
 	var/field_radius = 0
 	var/field_time = 0
 	var/max_alpha = 255
+	var/list/obj/overlay/darkness_field/darkfields = list()
 
 	New()
 		..()
@@ -26,12 +27,18 @@
 		O.visible_message("<span class='alert'><b>[O]</b> emits a wave of absolute darkness!</span>")
 		O.anchored = 1
 		var/turf/T = get_turf(O)
-		new /obj/overlay/darkness_field(T, field_time, radius = 0.5 + field_radius, max_alpha = max_alpha)
-		new /obj/overlay/darkness_field{plane = PLANE_SELFILLUM}(T, field_time, radius = 0.5 + field_radius, max_alpha = max_alpha)
+		darkfields += new /obj/overlay/darkness_field(T, null, radius = 0.5 + field_radius, max_alpha = max_alpha)
+		darkfields += new /obj/overlay/darkness_field{plane = PLANE_SELFILLUM}(T, null, radius = 0.5 + field_radius, max_alpha = max_alpha)
 		SPAWN_DBG(field_time)
 			if (O)
 				O.anchored = 0
 				O.ArtifactDeactivated()
+
+	effect_deactivate(obj/O)
+		if(..())
+			return
+		for(var/obj/overlay/darkness_field/D as() in darkfields)
+			D.deactivate()
 
 /obj/overlay/darkness_field
 	icon = 'icons/effects/vision.dmi' // sorry

--- a/code/obj/artifacts/artifact_objects/forcefield.dm
+++ b/code/obj/artifacts/artifact_objects/forcefield.dm
@@ -17,6 +17,7 @@
 	var/field_time = 80
 	var/icon_state = "shieldsparkles"
 	var/next_activate = 0
+	var/list/forcefields = list()
 
 	New()
 		..()
@@ -40,16 +41,19 @@
 			return
 		O.anchored = 1
 		var/turf/Aloc = get_turf(O)
-		var/list/forcefields = list()
 		for (var/turf/T in range(field_radius,Aloc))
 			if(get_dist(O,T) == field_radius)
 				var/obj/forcefield/wand/FF = new /obj/forcefield/wand(T,0,src.icon_state)
-				forcefields += FF
+				src.forcefields += FF
 		SPAWN_DBG(field_time)
-			for (var/obj/forcefield/F in forcefields)
-				forcefields -= F
-				qdel(F)
-			next_activate = ticker.round_elapsed_ticks + cooldown
 			if (O)
 				O.ArtifactDeactivated()
 				O.anchored = 0
+
+	effect_deactivate(obj/O)
+		if(..())
+			return
+		for (var/obj/forcefield/F in src.forcefields)
+			src.forcefields -= F
+			qdel(F)
+		next_activate = ticker.round_elapsed_ticks + cooldown

--- a/code/obj/artifacts/artifact_objects/prison.dm
+++ b/code/obj/artifacts/artifact_objects/prison.dm
@@ -30,14 +30,17 @@
 			user.set_loc(O)
 			prisoner = user
 			SPAWN_DBG(imprison_time)
-				if (O) //ZeWaka: Fix for null.contents
-					for(var/obj/I in O.contents)
-						I.set_loc(get_turf(O))
-					if (prisoner.loc == O)
-						prisoner.set_loc(get_turf(O))
-						O.visible_message("<span class='alert'><b>[O]</b> releases [user.name] and shuts down!</span>")
-					else
-						O.visible_message("<span class='alert'><b>[O]</b> shuts down strangely!</span>")
-					prisoner = null
+				if (O.disposed) //ZeWaka: Fix for null.contents
 					O.ArtifactDeactivated()
+
+	effect_deactivate(obj/O)
+		if (..())
 			return
+		for(var/obj/I in O.contents)
+			I.set_loc(get_turf(O))
+		if (prisoner.loc == O)
+			prisoner.set_loc(get_turf(O))
+			O.visible_message("<span class='alert'><b>[O]</b> releases [prisoner.name] and shuts down!</span>")
+		else
+			O.visible_message("<span class='alert'><b>[O]</b> shuts down strangely!</span>")
+		prisoner = null

--- a/code/obj/artifacts/artifact_objects/recaller.dm
+++ b/code/obj/artifacts/artifact_objects/recaller.dm
@@ -24,7 +24,7 @@
 			return
 
 		SPAWN_DBG(src.recall_delay)
-			if (user) //Wire note: Fix for Cannot execute null.visible message()
+			if (user && src.activated) //Wire note: Fix for Cannot execute null.visible message()
 				user.visible_message("<span class='alert'><b>[user]</b> is suddenly pulled through space!</span>")
 				playsound(user.loc, "sound/effects/mag_warp.ogg", 50, 1, -1)
 				var/turf/T = get_turf(O)

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -171,6 +171,8 @@
 	if (!src.ArtifactSanityCheck())
 		return
 	var/datum/artifact/A = src.artifact
+	if (!A.activated) // do not deactivate if already deactivated
+		return
 	if (A.deact_sound)
 		playsound(src.loc, A.deact_sound, 100, 1)
 	if (A.deact_text)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Due to deactivation becoming more common with the recent activator key changes, some things need fixing.

- Artifacts will not deactivate again if already not active.
- Cells will now have their capacity set to 1 while deactivated. They will take time to recharge once reactivated. (I'd set it to 0, but that leads to division by 0 issues when trying to calculate the charge percentage on ammo cells.)
- Noise Makers can now be deactivated, because come on.
- Prison and Cloner type artifacts will now eject their contents when deactivated.
- Darkness Generators will remove the darkness when deactivated.
- Forcefield Generators will remove forcefields when deactivated.
- Recallers will not recall if not active when the recall would trigger.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Previous behavior was pretty unintuitive and annoying.
