### PR TITLE
Uses .death() for the spacebux corpse purchase instead of setDead to prevent instant rot

### DIFF
--- a/code/modules/economy/persistent_bank_purchases.dm
+++ b/code/modules/economy/persistent_bank_purchases.dm
@@ -394,7 +394,7 @@ var/global/list/persistent_bank_purchaseables =	list(\
 		carries_over = 0
 
 		Create(var/mob/living/M)
-			M.death(FALSE);
+			M.death(FALSE)
 			boutput(M, "<span class='notice'><b>You magically keel over and die! Oh, no!</b></span>")
 			return 1
 
@@ -613,4 +613,3 @@ var/global/list/persistent_bank_purchaseables =	list(\
 				A.set_hat(new picked())
 				return 1
 			return 0
-

--- a/code/modules/economy/persistent_bank_purchases.dm
+++ b/code/modules/economy/persistent_bank_purchases.dm
@@ -394,7 +394,7 @@ var/global/list/persistent_bank_purchaseables =	list(\
 		carries_over = 0
 
 		Create(var/mob/living/M)
-			setdead(M)
+			M.death(FALSE);
 			boutput(M, "<span class='notice'><b>You magically keel over and die! Oh, no!</b></span>")
 			return 1
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the spacebux 'corpse' purchase to use death(). This mostly means you won't rot instantly on spawning, but has some edge benefits like corpse buyers properly decrementing christmas cheer.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
See above. 
