### PR TITLE
Fix and disable lawn darts

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -856,14 +856,6 @@ This is basically useless for anyone but miners.
 	job = list("Janitor")
 	blockedmode = list(/datum/game_mode/revolution)
 
-/datum/syndicate_buylist/traitor/lawndarts
-	name = "Lawn Darts"
-	item = /obj/item/storage/box/lawndart_kit
-	cost = 4
-	desc = "Three deadly throwing darts that embed themselves into your target."
-	job = list("Assistant","Technical Assistant","Medical Assistant","Staff Assistant","Bartender","Clown")
-	blockedmode = list(/datum/game_mode/revolution)
-
 /datum/syndicate_buylist/traitor/monkey_barrel
 	name = "Barrel-O-Monkeys"
 	item = /obj/storage/monkey_barrel
@@ -1056,6 +1048,13 @@ This is basically useless for anyone but miners.
 	vr_allowed = 0
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 
+/datum/syndicate_buylist/traitor/lawndarts
+	name = "Lawn Darts"
+	item = /obj/item/storage/box/lawndart_kit
+	cost = 0 // 20 brute damage, 10 bleed throwing weapon. Embed is nice but rad poison bow is stealthier and more effective
+	desc = "Three deadly throwing darts that embed themselves into your target."
+	job = list("Assistant","Technical Assistant","Medical Assistant","Staff Assistant","Bartender","Clown")
+	blockedmode = list(/datum/game_mode/revolution)
 
 // round specific
 

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -30,7 +30,7 @@ THROWING DARTS
 
 	//For PDA/signal alert stuff on implants
 	var/uses_radio = 0
-	var/list/mailgroups = null 
+	var/list/mailgroups = null
 	var/net_id = null
 	var/pda_alert_frequency = 1149
 	var/datum/radio_frequency/radio_connection
@@ -1708,7 +1708,7 @@ circuitry. As a result neurotoxins can cause massive damage.<BR>
 			var/mob/living/carbon/human/H = M
 			H.implant.Add(src)
 			src.visible_message("<span class='alert'>[src] gets embedded in [M]!</span>")
-			playsound(src.loc, "sound/weapons/slashcut.ogg", 100, 1)
+			playsound(src.loc, "sound/impact_sounds/Flesh_Cut_1.ogg", 100, 1)
 			H.changeStatus("weakened", 2 SECONDS)
 			random_brute_damage(M, 20)//if it can get in you, it probably doesn't give a damn about your armor
 			take_bleeding_damage(M, null, 10, DAMAGE_CUT)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG][REMOVAL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes lawn darts using a broken sound.
Disables lawn darts for being bad.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Lawn darts attempted to use "sound/weapons/slashcut.ogg" which did not exist, changed to "sound/impact_sounds/Flesh_Cut_1.ogg".
Lawn darts cost 4TC for three throwable items that do 20 BRUTE damage each and a minor bleed.
While this does pass through armor and implant in the victim it is very inferior to a Rad Poison Crossbow which costs 1TC less.
We could reduce the cost to 1-2TC but why? Grenade boxes are a better purchase. A rework could find a good new use for them but until then it might be best to retire them.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(*)Retired lawn darts from the traitor buy list.
```
