### PR TITLE
Riot baton nerf

### DIFF
--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -211,7 +211,7 @@
 		if (!src || !istype(src))
 			return 0
 
-		if (src.stamina_based_stun != 0 && src.cell && can_stun())
+		if (src.stamina_based_stun != 0 && (src.cell || src.uses_electricity == 0) && can_stun())
 			src.stamina_damage = src.stamina_based_stun_amount
 			return 1
 		else
@@ -431,6 +431,8 @@
 		..()
 
 	proc/do_flip_stuff(var/mob/user, var/intent)
+		if (src.uses_electricity == 0)
+			return
 		if (intent == INTENT_HARM)
 			if (src.flipped) //swapping hands triggers the intent switch too, so we dont wanna spam that
 				return
@@ -489,17 +491,17 @@
 	desc = "A wooden truncheon for beating criminal scum."
 	icon_state = "baton"
 	item_state = "classic_baton"
-	force = 10
+	force = 15
 	mats = 0
 	contraband = 6
 	icon_on = "baton"
 	icon_off = "baton"
 	uses_charges = 0
 	uses_electricity = 0
+	stamina_damage = 105
 	stun_normal_weakened = 8
 	stun_normal_stuttering = 8
-	instant_harmbaton_stun = 1
-	stamina_based_stun_amount = 90
+	stamina_based_stun_amount = 105
 	item_function_flags = 0
 
 	New()

--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -499,6 +499,7 @@
 	uses_charges = 0
 	uses_electricity = 0
 	stamina_damage = 105
+	stamina_cost = 25
 	stun_normal_weakened = 8
 	stun_normal_stuttering = 8
 	stamina_based_stun_amount = 105

--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -258,7 +258,7 @@
 				logTheThing("combat", user, victim, "stuns [constructTarget(victim,"combat")] with the [src.name] at [log_loc(victim)].")
 				JOB_XP(victim, "Clown", 3)
 				if (type == "stun_classic")
-					playsound(get_turf(src), "sound/impact_sounds/Generic_Stab_1.ogg", 50, 1, -1)
+					playsound(get_turf(src), "swing_hit", 50, 1, -1)
 				else
 					flick(flick_baton_active, src)
 					playsound(get_turf(src), "sound/impact_sounds/Energy_Hit_3.ogg", 50, 1, -1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG][BALANCE][INPUT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes riot baton to do stamina damage like a regular baton.
Increases brute damage by 5 (15). stamina cost by 4 (25).
Fixes a visual and chat bug if the baton was picked up on harm intent.
Changes stun sound from the super quiet generic item to an actual beating sound.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The riot baton did an instant 7 second stun on hit allowing you to instantly stun lock anyone. This PR changes it to do 105 stamina damage and dizzy, slightly less (-15) than a stun baton but with infinite ammo and 15 damage on harm intent.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(*)Syndicate riot baton now deals stamina damage instead of instant stun, two hits are required to knockdown. Now functions like an infinite ammo stun baton with extra blunt damage on harm intent.
```
