### PR TITLE
Captain's Manta Bottleship objective

### DIFF
--- a/code/datums/gamemodes/spy_theft.dm
+++ b/code/datums/gamemodes/spy_theft.dm
@@ -381,6 +381,7 @@
 	station_bounties[/obj/item/reagent_containers/food/drinks/rum_spaced] = 2
 	station_bounties[/obj/item/reagent_containers/food/drinks/bottle/thegoodstuff] = 2
 	station_bounties[/obj/item/reagent_containers/food/drinks/bottle/champagne] = 2
+	station_bounties[/obj/captain_bottleship ] = 3
 	station_bounties[/obj/item/hand_tele] = 3
 	station_bounties[/obj/item/card/id/captains_spare] = 3
 	station_bounties[/obj/item/gun/kinetic/riot40mm] = 2

--- a/code/datums/gamemodes/spy_theft.dm
+++ b/code/datums/gamemodes/spy_theft.dm
@@ -381,7 +381,6 @@
 	station_bounties[/obj/item/reagent_containers/food/drinks/rum_spaced] = 2
 	station_bounties[/obj/item/reagent_containers/food/drinks/bottle/thegoodstuff] = 2
 	station_bounties[/obj/item/reagent_containers/food/drinks/bottle/champagne] = 2
-	station_bounties[/obj/captain_bottleship ] = 3
 	station_bounties[/obj/item/hand_tele] = 3
 	station_bounties[/obj/item/card/id/captains_spare] = 3
 	station_bounties[/obj/item/gun/kinetic/riot40mm] = 2

--- a/code/datums/miscreant_objectives.dm
+++ b/code/datums/miscreant_objectives.dm
@@ -90,7 +90,11 @@ ABSTRACT_TYPE(/datum/objective/miscreant)
 		explanation_text = "Make as much noise as possible."
 
 	bonsai
+#ifdef MAP_OVERRIDE_MANTA
+		explanation_text = "Destroy the Captain's ship in a bottle."
+#else
 		explanation_text = "Destroy the Captain's prized bonsai tree."
+#endif
 
 	reassign
 		explanation_text = "Try to convince as many crew members as possible to reassign to your department."

--- a/code/datums/objective.dm
+++ b/code/datums/objective.dm
@@ -381,6 +381,22 @@ proc/create_fluff(var/datum/mind/target)
 
 /datum/objective/regular/bonsaitree
 	// Brought this back as a very rare gimmick objective (Convair880).
+#ifdef MAP_OVERRIDE_MANTA
+	explanation_text = "Destroy the Captain's ship in a bottle."
+
+	check_completion()
+		var/area/cap_quarters = locate(/area/station/captain)
+		var/obj/captain_bottleship/cap_ship
+
+		for (var/obj/captain_bottleship/T in cap_quarters)
+			cap_ship = T
+		if (!cap_ship)
+			return 1  // Somebody deleted it somehow, I suppose?
+		else if (cap_ship?.destroyed == 1)
+			return 1
+		else
+			return 0
+#else
 	explanation_text = "Destroy the Captain's prized bonsai tree."
 
 	check_completion()
@@ -390,12 +406,12 @@ proc/create_fluff(var/datum/mind/target)
 		for (var/obj/shrub/captainshrub/T in cap_quarters)
 			our_tree = T
 		if (!our_tree)
-			return 1  // Somebody deleted it somehow, I suppose?
+			return 1
 		else if (our_tree?.destroyed == 1)
 			return 1
 		else
 			return 0
-
+#endif
 ///////////////////////////////////////////////////////////////
 // Regular objectives not currently used in current gameplay //
 ///////////////////////////////////////////////////////////////


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR replaces the "Destroy the Captain's prized bonsai tree." traitor and miscreant objective with "Destroy the Captain's ship in a bottle." objective if they roll it on Manta. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Traitors not being able to complete their objectives is bad

## Changelog
```changelog
(u)TTerc
(+)Traitors and miscreants can now roll the "Destroy the Captain's ship in a bottle." objective on Manta.
```