### PR TITLE
Adds water pipes to GardenGear hidden menu

### DIFF
--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -1798,6 +1798,7 @@
 		product_list += new/datum/data/vending_product(/obj/decorative_pot, 5)
 		product_list += new/datum/data/vending_product(/obj/chicken_nesting_box,3)
 
+		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/glass/water_pipe, 1, hidden=1)
 		product_list += new/datum/data/vending_product(/obj/item/seedplanter/hidden, 1, hidden=1)
 		product_list += new/datum/data/vending_product(/obj/item/seed/grass, rand(3, 6), hidden=1)
 		if (prob(25))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feature]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I'd like them to be a little bit more available to everyone. You practically never see them around because some botanist always ends up nabbing the only water pipe roundstart

## Changelog
```changelog
(u)TTerc
(+)Water pipes can now be found in hacked GardenGear vendors.
```
