### PR TITLE
give each artifact an individual rarity for how often it occurs

### DIFF
--- a/code/datums/controllers/artifact_controls.dm
+++ b/code/datums/controllers/artifact_controls.dm
@@ -23,14 +23,14 @@ var/datum/artifact_controller/artifact_controls
 		// and also one that just holds all types
 		// the type is the index, the value the rarity
 		// for use with weighted_pick
-		for (var/datum/artifact/A as() in concrete_typesof(/datum/artifact))
+		for (var/A as() in concrete_typesof(/datum/artifact))
 			var/datum/artifact/AI = new A
 			artifact_types += AI
 
-			artifact_rarities["all"][A] = initial(A.rarity)
+			artifact_rarities["all"][A] = AI.rarity
 			for (var/origin in artifact_rarities)
 				if(origin in AI.validtypes)
-					artifact_rarities[origin][A] = initial(A.rarity)
+					artifact_rarities[origin][A] = AI.rarity
 
 	proc/get_origin_from_string(var/string)
 		if (!istext(string))

--- a/code/datums/controllers/artifact_controls.dm
+++ b/code/datums/controllers/artifact_controls.dm
@@ -13,7 +13,7 @@ var/datum/artifact_controller/artifact_controls
 		artifact_rarities["all"] = list()
 
 		// origin list
-		for (var/datum/artifact_origin/X as() in childrentypesof(/datum/artifact_origin))
+		for (var/X as() in childrentypesof(/datum/artifact_origin))
 			var/datum/artifact_origin/AO = new X
 			artifact_origins += AO
 			artifact_rarities[AO.name] = list()

--- a/code/datums/controllers/artifact_controls.dm
+++ b/code/datums/controllers/artifact_controls.dm
@@ -27,10 +27,10 @@ var/datum/artifact_controller/artifact_controls
 			var/datum/artifact/AI = new A
 			artifact_types += AI
 
-			artifact_rarities["all"][A] = AI.rarity
+			artifact_rarities["all"][A] = AI.rarity_weight
 			for (var/origin in artifact_rarities)
 				if(origin in AI.validtypes)
-					artifact_rarities[origin][A] = AI.rarity
+					artifact_rarities[origin][A] = AI.rarity_weight
 
 	proc/get_origin_from_string(var/string)
 		if (!istext(string))

--- a/code/datums/controllers/artifact_controls.dm
+++ b/code/datums/controllers/artifact_controls.dm
@@ -3,15 +3,34 @@ var/datum/artifact_controller/artifact_controls
 /datum/artifact_controller
 	var/list/artifacts = list()
 	var/list/artifact_types = list()
+	var/list/artifact_rarities = list()
 	var/list/artifact_origins = list()
 	var/spawner_type = null
 	var/spawner_cine = 0
 
 	New()
 		..()
-		for (var/X in childrentypesof(/datum/artifact_origin))
+		artifact_rarities["all"] = list()
+
+		// origin list
+		for (var/datum/artifact_origin/X as() in childrentypesof(/datum/artifact_origin))
 			var/datum/artifact_origin/AO = new X
 			artifact_origins += AO
+			artifact_rarities[AO.name] = list()
+
+		// type list
+		// also make one list for each origin of all artifact types
+		// and also one that just holds all types
+		// the type is the index, the value the rarity
+		// for use with weighted_pick
+		for (var/datum/artifact/A as() in concrete_typesof(/datum/artifact))
+			var/datum/artifact/AI = new A
+			artifact_types += AI
+
+			artifact_rarities["all"][A] = initial(A.rarity)
+			for (var/origin in artifact_rarities)
+				if(origin in AI.validtypes)
+					artifact_rarities[origin][A] = initial(A.rarity)
 
 	proc/get_origin_from_string(var/string)
 		if (!istext(string))

--- a/code/datums/controllers/artifact_controls.dm
+++ b/code/datums/controllers/artifact_controls.dm
@@ -13,7 +13,7 @@ var/datum/artifact_controller/artifact_controls
 		artifact_rarities["all"] = list()
 
 		// origin list
-		for (var/X as() in childrentypesof(/datum/artifact_origin))
+		for (var/X in childrentypesof(/datum/artifact_origin))
 			var/datum/artifact_origin/AO = new X
 			artifact_origins += AO
 			artifact_rarities[AO.name] = list()
@@ -23,7 +23,7 @@ var/datum/artifact_controller/artifact_controls
 		// and also one that just holds all types
 		// the type is the index, the value the rarity
 		// for use with weighted_pick
-		for (var/A as() in concrete_typesof(/datum/artifact))
+		for (var/A in concrete_typesof(/datum/artifact))
 			var/datum/artifact/AI = new A
 			artifact_types += AI
 

--- a/code/obj/artifacts/artifact_items/activator_key.dm
+++ b/code/obj/artifacts/artifact_items/activator_key.dm
@@ -6,7 +6,7 @@
 
 /datum/artifact/activator_key
 	associated_object = /obj/item/artifact/activator_key
-	rarity = 200
+	rarity_weight = 200
 	validtypes = list("ancient","martian","wizard","eldritch","precursor")
 	automatic_activation = 1
 	react_xray = list(12,80,95,8,"COMPLEX")

--- a/code/obj/artifacts/artifact_items/activator_key.dm
+++ b/code/obj/artifacts/artifact_items/activator_key.dm
@@ -6,7 +6,7 @@
 
 /datum/artifact/activator_key
 	associated_object = /obj/item/artifact/activator_key
-	rarity_class = 3
+	rarity = 200
 	validtypes = list("ancient","martian","wizard","eldritch","precursor")
 	automatic_activation = 1
 	react_xray = list(12,80,95,8,"COMPLEX")

--- a/code/obj/artifacts/artifact_items/attack_wand.dm
+++ b/code/obj/artifacts/artifact_items/attack_wand.dm
@@ -26,7 +26,7 @@
 
 /datum/artifact/attack_wand
 	associated_object = /obj/item/artifact/attack_wand
-	rarity = 200
+	rarity_weight = 200
 	validtypes = list("wizard")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/force)

--- a/code/obj/artifacts/artifact_items/attack_wand.dm
+++ b/code/obj/artifacts/artifact_items/attack_wand.dm
@@ -26,7 +26,7 @@
 
 /datum/artifact/attack_wand
 	associated_object = /obj/item/artifact/attack_wand
-	rarity_class = 3
+	rarity = 200
 	validtypes = list("wizard")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/force)

--- a/code/obj/artifacts/artifact_items/energy_gun.dm
+++ b/code/obj/artifacts/artifact_items/energy_gun.dm
@@ -82,7 +82,7 @@
 
 /datum/artifact/energygun
 	associated_object = /obj/item/gun/energy/artifact
-	rarity_class = 2
+	rarity = 350
 	validtypes = list("ancient","eldritch","precursor")
 	react_elec = list(0.02,0,5)
 	react_xray = list(10,75,100,11,"CAVITY")

--- a/code/obj/artifacts/artifact_items/energy_gun.dm
+++ b/code/obj/artifacts/artifact_items/energy_gun.dm
@@ -82,7 +82,7 @@
 
 /datum/artifact/energygun
 	associated_object = /obj/item/gun/energy/artifact
-	rarity = 350
+	rarity_weight = 350
 	validtypes = list("ancient","eldritch","precursor")
 	react_elec = list(0.02,0,5)
 	react_xray = list(10,75,100,11,"CAVITY")

--- a/code/obj/artifacts/artifact_items/gun_cell.dm
+++ b/code/obj/artifacts/artifact_items/gun_cell.dm
@@ -53,7 +53,7 @@
 
 /datum/artifact/energyammo
 	associated_object = /obj/item/ammo/power_cell/self_charging/artifact
-	rarity_class = 0
+	rarity = 0
 	validtypes = list("ancient","eldritch","precursor")
 	automatic_activation = 1
 	react_elec = list("equal",0,0)

--- a/code/obj/artifacts/artifact_items/gun_cell.dm
+++ b/code/obj/artifacts/artifact_items/gun_cell.dm
@@ -53,7 +53,7 @@
 
 /datum/artifact/energyammo
 	associated_object = /obj/item/ammo/power_cell/self_charging/artifact
-	rarity = 0
+	rarity_weight = 0
 	validtypes = list("ancient","eldritch","precursor")
 	automatic_activation = 1
 	react_elec = list("equal",0,0)

--- a/code/obj/artifacts/artifact_items/instrument.dm
+++ b/code/obj/artifacts/artifact_items/instrument.dm
@@ -41,6 +41,6 @@
 /datum/artifact/instrument
 	associated_object = /obj/item/artifact/instrument
 	automatic_activation = 1
-	rarity_class = 1
+	rarity = 450
 	validtypes = list("wizard","eldritch","precursor","martian","ancient")
 	react_xray = list(10,65,95,9,"TUBULAR")

--- a/code/obj/artifacts/artifact_items/instrument.dm
+++ b/code/obj/artifacts/artifact_items/instrument.dm
@@ -41,6 +41,6 @@
 /datum/artifact/instrument
 	associated_object = /obj/item/artifact/instrument
 	automatic_activation = 1
-	rarity = 450
+	rarity_weight = 450
 	validtypes = list("wizard","eldritch","precursor","martian","ancient")
 	react_xray = list(10,65,95,9,"TUBULAR")

--- a/code/obj/artifacts/artifact_items/melee_weapon.dm
+++ b/code/obj/artifacts/artifact_items/melee_weapon.dm
@@ -18,7 +18,7 @@
 
 /datum/artifact/melee
 	associated_object = /obj/item/artifact/melee_weapon
-	rarity_class = 2
+	rarity = 350
 	validtypes = list("ancient","martian","wizard","eldritch","precursor")
 	react_xray = list(14,95,95,7,"DENSE")
 	var/damtype = "brute"

--- a/code/obj/artifacts/artifact_items/melee_weapon.dm
+++ b/code/obj/artifacts/artifact_items/melee_weapon.dm
@@ -18,7 +18,7 @@
 
 /datum/artifact/melee
 	associated_object = /obj/item/artifact/melee_weapon
-	rarity = 350
+	rarity_weight = 350
 	validtypes = list("ancient","martian","wizard","eldritch","precursor")
 	react_xray = list(14,95,95,7,"DENSE")
 	var/damtype = "brute"

--- a/code/obj/artifacts/artifact_items/mining_tool.dm
+++ b/code/obj/artifacts/artifact_items/mining_tool.dm
@@ -25,7 +25,7 @@
 
 /datum/artifact/mining
 	associated_object = /obj/item/artifact/mining_tool
-	rarity = 450
+	rarity_weight = 450
 	validtypes = list("ancient","martian","wizard","eldritch","precursor")
 	react_xray = list(12,80,95,5,"DENSE")
 	examine_hint = "It seems to have a handle you're supposed to hold it by."

--- a/code/obj/artifacts/artifact_items/mining_tool.dm
+++ b/code/obj/artifacts/artifact_items/mining_tool.dm
@@ -25,7 +25,7 @@
 
 /datum/artifact/mining
 	associated_object = /obj/item/artifact/mining_tool
-	rarity_class = 1
+	rarity = 450
 	validtypes = list("ancient","martian","wizard","eldritch","precursor")
 	react_xray = list(12,80,95,5,"DENSE")
 	examine_hint = "It seems to have a handle you're supposed to hold it by."

--- a/code/obj/artifacts/artifact_items/pitcher.dm
+++ b/code/obj/artifacts/artifact_items/pitcher.dm
@@ -176,7 +176,7 @@
 
 /datum/artifact/pitcher
 	associated_object = /obj/item/reagent_containers/food/drinks/drinkingglass/artifact
-	rarity = 350
+	rarity_weight = 350
 	validtypes = list("martian","wizard","eldritch")
 	min_triggers = 0
 	max_triggers = 0

--- a/code/obj/artifacts/artifact_items/pitcher.dm
+++ b/code/obj/artifacts/artifact_items/pitcher.dm
@@ -176,7 +176,7 @@
 
 /datum/artifact/pitcher
 	associated_object = /obj/item/reagent_containers/food/drinks/drinkingglass/artifact
-	rarity_class = 2
+	rarity = 350
 	validtypes = list("martian","wizard","eldritch")
 	min_triggers = 0
 	max_triggers = 0

--- a/code/obj/artifacts/artifact_items/power_cell.dm
+++ b/code/obj/artifacts/artifact_items/power_cell.dm
@@ -105,7 +105,7 @@
 
 /datum/artifact/powercell
 	associated_object = /obj/item/cell/artifact
-	rarity_class = 2 // modified from 1 as part of art tweak
+	rarity = 350
 	validtypes = list("ancient","martian","wizard","precursor")
 	automatic_activation = 1
 	react_elec = list("equal",0,10)

--- a/code/obj/artifacts/artifact_items/power_cell.dm
+++ b/code/obj/artifacts/artifact_items/power_cell.dm
@@ -105,7 +105,7 @@
 
 /datum/artifact/powercell
 	associated_object = /obj/item/cell/artifact
-	rarity = 350
+	rarity_weight = 350
 	validtypes = list("ancient","martian","wizard","precursor")
 	automatic_activation = 1
 	react_elec = list("equal",0,10)

--- a/code/obj/artifacts/artifact_items/teleport_wand.dm
+++ b/code/obj/artifacts/artifact_items/teleport_wand.dm
@@ -28,7 +28,7 @@
 
 /datum/artifact/telewand
 	associated_object = /obj/item/artifact/teleport_wand
-	rarity = 200
+	rarity_weight = 200
 	validtypes = list("wizard","eldritch","precursor")
 	react_xray = list(10,75,90,11,"ANOMALOUS")
 	var/sound/wand_sound = 'sound/effects/mag_warp.ogg'

--- a/code/obj/artifacts/artifact_items/teleport_wand.dm
+++ b/code/obj/artifacts/artifact_items/teleport_wand.dm
@@ -28,7 +28,7 @@
 
 /datum/artifact/telewand
 	associated_object = /obj/item/artifact/teleport_wand
-	rarity_class = 3
+	rarity = 200
 	validtypes = list("wizard","eldritch","precursor")
 	react_xray = list(10,75,90,11,"ANOMALOUS")
 	var/sound/wand_sound = 'sound/effects/mag_warp.ogg'

--- a/code/obj/artifacts/artifact_items/wall_wand.dm
+++ b/code/obj/artifacts/artifact_items/wall_wand.dm
@@ -17,7 +17,7 @@
 
 /datum/artifact/wallwand
 	associated_object = /obj/item/artifact/forcewall_wand
-	rarity_class = 2
+	rarity = 350
 	validtypes = list("ancient","wizard","eldritch","precursor")
 	react_xray = list(10,60,92,11,"COMPLEX")
 	var/wall_duration = 5

--- a/code/obj/artifacts/artifact_items/wall_wand.dm
+++ b/code/obj/artifacts/artifact_items/wall_wand.dm
@@ -17,7 +17,7 @@
 
 /datum/artifact/wallwand
 	associated_object = /obj/item/artifact/forcewall_wand
-	rarity = 350
+	rarity_weight = 350
 	validtypes = list("ancient","wizard","eldritch","precursor")
 	react_xray = list(10,60,92,11,"COMPLEX")
 	var/wall_duration = 5

--- a/code/obj/artifacts/artifact_items/watering_can.dm
+++ b/code/obj/artifacts/artifact_items/watering_can.dm
@@ -158,7 +158,7 @@
 
 /datum/artifact/watercan
 	associated_object = /obj/item/reagent_containers/glass/wateringcan/artifact
-	rarity = 350
+	rarity_weight = 350
 	validtypes = list("martian","wizard","precursor")
 	min_triggers = 0
 	max_triggers = 0

--- a/code/obj/artifacts/artifact_items/watering_can.dm
+++ b/code/obj/artifacts/artifact_items/watering_can.dm
@@ -158,7 +158,7 @@
 
 /datum/artifact/watercan
 	associated_object = /obj/item/reagent_containers/glass/wateringcan/artifact
-	rarity_class = 2 // modified from 1 as part of art tweak
+	rarity = 350
 	validtypes = list("martian","wizard","precursor")
 	min_triggers = 0
 	max_triggers = 0

--- a/code/obj/artifacts/artifact_machines/grav_well.dm
+++ b/code/obj/artifacts/artifact_machines/grav_well.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/gravity_well_generator
 	associated_object = /obj/machinery/artifact/gravity_well_generator
-	rarity_class = 1 // modified from 2 as part of art tweak
+	rarity = 450
 	validtypes = list("wizard","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch)

--- a/code/obj/artifacts/artifact_machines/grav_well.dm
+++ b/code/obj/artifacts/artifact_machines/grav_well.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/gravity_well_generator
 	associated_object = /obj/machinery/artifact/gravity_well_generator
-	rarity = 450
+	rarity_weight = 450
 	validtypes = list("wizard","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch)

--- a/code/obj/artifacts/artifact_machines/heal_field.dm
+++ b/code/obj/artifacts/artifact_machines/heal_field.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/bio_damage_field_generator
 	associated_object = /obj/machinery/artifact/bio_damage_field_generator
-	rarity_class = 3
+	rarity = 200
 	validtypes = list("martian","wizard","eldritch","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch)

--- a/code/obj/artifacts/artifact_machines/heal_field.dm
+++ b/code/obj/artifacts/artifact_machines/heal_field.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/bio_damage_field_generator
 	associated_object = /obj/machinery/artifact/bio_damage_field_generator
-	rarity = 200
+	rarity_weight = 200
 	validtypes = list("martian","wizard","eldritch","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch)

--- a/code/obj/artifacts/artifact_machines/heater.dm
+++ b/code/obj/artifacts/artifact_machines/heater.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/heater
 	associated_object = /obj/machinery/artifact/heater
-	rarity_class = 1 // modified from 2 as part of art tweak
+	rarity = 450
 	validtypes = list("ancient","martian","eldritch","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/cold)

--- a/code/obj/artifacts/artifact_machines/heater.dm
+++ b/code/obj/artifacts/artifact_machines/heater.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/heater
 	associated_object = /obj/machinery/artifact/heater
-	rarity = 450
+	rarity_weight = 450
 	validtypes = list("ancient","martian","eldritch","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/cold)

--- a/code/obj/artifacts/artifact_machines/noise_maker.dm
+++ b/code/obj/artifacts/artifact_machines/noise_maker.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/noisy_thing
 	associated_object = /obj/machinery/artifact/noisy_thing
-	rarity_class = 1
+	rarity = 450
 	validtypes = list("ancient","martian","wizard","eldritch","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch)

--- a/code/obj/artifacts/artifact_machines/noise_maker.dm
+++ b/code/obj/artifacts/artifact_machines/noise_maker.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/noisy_thing
 	associated_object = /obj/machinery/artifact/noisy_thing
-	rarity = 450
+	rarity_weight = 450
 	validtypes = list("ancient","martian","wizard","eldritch","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch)

--- a/code/obj/artifacts/artifact_machines/plant_helper.dm
+++ b/code/obj/artifacts/artifact_machines/plant_helper.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/plant_helper
 	associated_object = /obj/machinery/artifact/plant_helper
-	rarity_class = 2
+	rarity = 350
 	validtypes = list("martian","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/carbon_touch)
 	activated = 0

--- a/code/obj/artifacts/artifact_machines/plant_helper.dm
+++ b/code/obj/artifacts/artifact_machines/plant_helper.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/plant_helper
 	associated_object = /obj/machinery/artifact/plant_helper
-	rarity = 350
+	rarity_weight = 350
 	validtypes = list("martian","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/carbon_touch)
 	activated = 0

--- a/code/obj/artifacts/artifact_machines/turret.dm
+++ b/code/obj/artifacts/artifact_machines/turret.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/turret
 	associated_object = /obj/machinery/artifact/turret
-	rarity_class = 3
+	rarity = 200
 	validtypes = list("wizard","eldritch","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch)

--- a/code/obj/artifacts/artifact_machines/turret.dm
+++ b/code/obj/artifacts/artifact_machines/turret.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/turret
 	associated_object = /obj/machinery/artifact/turret
-	rarity = 200
+	rarity_weight = 200
 	validtypes = list("wizard","eldritch","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch)

--- a/code/obj/artifacts/artifact_objects/augmentor.dm
+++ b/code/obj/artifacts/artifact_objects/augmentor.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/augmentor
 	associated_object = /obj/artifact/augmentor
-	rarity_class = 2
+	rarity = 350
 	validtypes = list("ancient","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch,

--- a/code/obj/artifacts/artifact_objects/augmentor.dm
+++ b/code/obj/artifacts/artifact_objects/augmentor.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/augmentor
 	associated_object = /obj/artifact/augmentor
-	rarity = 350
+	rarity_weight = 350
 	validtypes = list("ancient","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch,

--- a/code/obj/artifacts/artifact_objects/bombs.dm
+++ b/code/obj/artifacts/artifact_objects/bombs.dm
@@ -3,7 +3,7 @@
 ABSTRACT_TYPE(/datum/artifact/bomb)
 /datum/artifact/bomb
 	associated_object = null
-	rarity = 0
+	rarity_weight = 0
 	validtypes = list("ancient","eldritch","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/cold,/datum/artifact_trigger/radiation)
@@ -136,7 +136,7 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 
 /datum/artifact/bomb/explosive
 	associated_object = /obj/machinery/artifact/bomb
-	rarity = 200
+	rarity_weight = 200
 	var/exp_deva = 1
 	var/exp_hevy = 2
 	var/exp_lite = 3
@@ -164,7 +164,7 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 
 /datum/artifact/bomb/explosive/devastating
 	associated_object = /obj/machinery/artifact/bomb/devastating
-	rarity = 90
+	rarity_weight = 90
 	doAlert = 1
 	recharge_delay = 10 MINUTES
 	animationScale = 6
@@ -184,7 +184,7 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 
 /datum/artifact/bomb/blackhole
 	associated_object = /obj/machinery/artifact/bomb/blackhole
-	rarity = 90
+	rarity_weight = 90
 	react_xray = list(12,75,30,11,"ULTRADENSE")
 	warning_initial = "begins intensifying its own gravity!"
 	warning_final = "begins to collapse in on itself!"
@@ -211,7 +211,7 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 
 /datum/artifact/bomb/chemical
 	associated_object = /obj/machinery/artifact/bomb/chemical
-	rarity = 350
+	rarity_weight = 350
 	explode_delay = 0
 	alarm_initial = null
 	alarm_during = null
@@ -318,7 +318,7 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 /datum/artifact/bomb/transmute
 	associated_object = /obj/machinery/artifact/bomb/transmute
 	validtypes = list("wizard","eldritch","martian","ancient","precursor")
-	rarity = 90
+	rarity_weight = 90
 	react_xray = list(17,95,95,3,"ANOMALOUS")
 	warning_initial = ""
 	warning_final = ""

--- a/code/obj/artifacts/artifact_objects/bombs.dm
+++ b/code/obj/artifacts/artifact_objects/bombs.dm
@@ -3,7 +3,7 @@
 ABSTRACT_TYPE(/datum/artifact/bomb)
 /datum/artifact/bomb
 	associated_object = null
-	rarity_class = 0
+	rarity = 0
 	validtypes = list("ancient","eldritch","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/cold,/datum/artifact_trigger/radiation)
@@ -136,7 +136,7 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 
 /datum/artifact/bomb/explosive
 	associated_object = /obj/machinery/artifact/bomb
-	rarity_class = 3
+	rarity = 200
 	var/exp_deva = 1
 	var/exp_hevy = 2
 	var/exp_lite = 3
@@ -164,7 +164,7 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 
 /datum/artifact/bomb/explosive/devastating
 	associated_object = /obj/machinery/artifact/bomb/devastating
-	rarity_class = 4
+	rarity = 90
 	doAlert = 1
 	recharge_delay = 10 MINUTES
 	animationScale = 6
@@ -184,7 +184,7 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 
 /datum/artifact/bomb/blackhole
 	associated_object = /obj/machinery/artifact/bomb/blackhole
-	rarity_class = 4
+	rarity = 90
 	react_xray = list(12,75,30,11,"ULTRADENSE")
 	warning_initial = "begins intensifying its own gravity!"
 	warning_final = "begins to collapse in on itself!"
@@ -211,7 +211,7 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 
 /datum/artifact/bomb/chemical
 	associated_object = /obj/machinery/artifact/bomb/chemical
-	rarity_class = 2
+	rarity = 350
 	explode_delay = 0
 	alarm_initial = null
 	alarm_during = null
@@ -318,7 +318,7 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 /datum/artifact/bomb/transmute
 	associated_object = /obj/machinery/artifact/bomb/transmute
 	validtypes = list("wizard","eldritch","martian","ancient","precursor")
-	rarity_class = 4
+	rarity = 90
 	react_xray = list(17,95,95,3,"ANOMALOUS")
 	warning_initial = ""
 	warning_final = ""

--- a/code/obj/artifacts/artifact_objects/borg_maker.dm
+++ b/code/obj/artifacts/artifact_objects/borg_maker.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/borgifier
 	associated_object = /obj/artifact/borgifier
-	rarity = 200
+	rarity_weight = 200
 	validtypes = list("ancient")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch)

--- a/code/obj/artifacts/artifact_objects/borg_maker.dm
+++ b/code/obj/artifacts/artifact_objects/borg_maker.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/borgifier
 	associated_object = /obj/artifact/borgifier
-	rarity_class = 3
+	rarity = 200
 	validtypes = list("ancient")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch)

--- a/code/obj/artifacts/artifact_objects/cloner.dm
+++ b/code/obj/artifacts/artifact_objects/cloner.dm
@@ -5,7 +5,7 @@
 
 /datum/artifact/cloner
 	associated_object = /obj/artifact/cloner
-	rarity = 90
+	rarity_weight = 90
 	min_triggers = 2
 	max_triggers = 2
 	validtriggers = list(/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch)

--- a/code/obj/artifacts/artifact_objects/cloner.dm
+++ b/code/obj/artifacts/artifact_objects/cloner.dm
@@ -5,7 +5,7 @@
 
 /datum/artifact/cloner
 	associated_object = /obj/artifact/cloner
-	rarity_class = 4
+	rarity = 90
 	min_triggers = 2
 	max_triggers = 2
 	validtriggers = list(/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch)

--- a/code/obj/artifacts/artifact_objects/container.dm
+++ b/code/obj/artifacts/artifact_objects/container.dm
@@ -45,7 +45,7 @@
 
 /datum/artifact/container
 	associated_object = /obj/artifact/container
-	rarity = 450
+	rarity_weight = 450
 	validtypes = list("ancient","martian","wizard","eldritch","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch)

--- a/code/obj/artifacts/artifact_objects/container.dm
+++ b/code/obj/artifacts/artifact_objects/container.dm
@@ -45,7 +45,7 @@
 
 /datum/artifact/container
 	associated_object = /obj/artifact/container
-	rarity_class = 1
+	rarity = 450
 	validtypes = list("ancient","martian","wizard","eldritch","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch)

--- a/code/obj/artifacts/artifact_objects/curser.dm
+++ b/code/obj/artifacts/artifact_objects/curser.dm
@@ -16,7 +16,7 @@
 
 /datum/artifact/curser
 	associated_object = /obj/artifact/curser
-	rarity_class = 5
+	rarity = 0
 	validtypes = list("eldritch")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch)

--- a/code/obj/artifacts/artifact_objects/curser.dm
+++ b/code/obj/artifacts/artifact_objects/curser.dm
@@ -16,7 +16,7 @@
 
 /datum/artifact/curser
 	associated_object = /obj/artifact/curser
-	rarity = 0
+	rarity_weight = 0
 	validtypes = list("eldritch")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch)

--- a/code/obj/artifacts/artifact_objects/darkness_field.dm
+++ b/code/obj/artifacts/artifact_objects/darkness_field.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/darkness_field
 	associated_object = /obj/artifact/darkness_field
-	rarity_class = 2
+	rarity = 350
 	max_triggers = 3
 	validtypes = list("wizard","eldritch","precursor")
 	react_xray = list(15,90,90,11,"NONE")

--- a/code/obj/artifacts/artifact_objects/darkness_field.dm
+++ b/code/obj/artifacts/artifact_objects/darkness_field.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/darkness_field
 	associated_object = /obj/artifact/darkness_field
-	rarity = 350
+	rarity_weight = 350
 	max_triggers = 3
 	validtypes = list("wizard","eldritch","precursor")
 	react_xray = list(15,90,90,11,"NONE")

--- a/code/obj/artifacts/artifact_objects/forcefield.dm
+++ b/code/obj/artifacts/artifact_objects/forcefield.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/forcefield_gen
 	associated_object = /obj/artifact/forcefield_generator
-	rarity = 450
+	rarity_weight = 450
 	validtypes = list("wizard","eldritch","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/carbon_touch,
 	/datum/artifact_trigger/silicon_touch)

--- a/code/obj/artifacts/artifact_objects/forcefield.dm
+++ b/code/obj/artifacts/artifact_objects/forcefield.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/forcefield_gen
 	associated_object = /obj/artifact/forcefield_generator
-	rarity_class = 1
+	rarity = 450
 	validtypes = list("wizard","eldritch","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/carbon_touch,
 	/datum/artifact_trigger/silicon_touch)

--- a/code/obj/artifacts/artifact_objects/healer.dm
+++ b/code/obj/artifacts/artifact_objects/healer.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/healer_bio
 	associated_object = /obj/artifact/healer_bio
-	rarity_class = 2 // modified from 1 as part of art tweak
+	rarity = 350
 	validtypes = list("martian","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch)

--- a/code/obj/artifacts/artifact_objects/healer.dm
+++ b/code/obj/artifacts/artifact_objects/healer.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/healer_bio
 	associated_object = /obj/artifact/healer_bio
-	rarity = 350
+	rarity_weight = 350
 	validtypes = list("martian","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch)

--- a/code/obj/artifacts/artifact_objects/injector.dm
+++ b/code/obj/artifacts/artifact_objects/injector.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/injector
 	associated_object = /obj/artifact/injector
-	rarity_class = 2
+	rarity = 350
 	validtypes = list("ancient","martian","eldritch","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch,

--- a/code/obj/artifacts/artifact_objects/injector.dm
+++ b/code/obj/artifacts/artifact_objects/injector.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/injector
 	associated_object = /obj/artifact/injector
-	rarity = 350
+	rarity_weight = 350
 	validtypes = list("ancient","martian","eldritch","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch,

--- a/code/obj/artifacts/artifact_objects/lamp.dm
+++ b/code/obj/artifacts/artifact_objects/lamp.dm
@@ -20,7 +20,7 @@
 
 /datum/artifact/lamp
 	associated_object = /obj/artifact/lamp
-	rarity_class = 1
+	rarity = 450
 	validtypes = list("martian","wizard","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch,

--- a/code/obj/artifacts/artifact_objects/lamp.dm
+++ b/code/obj/artifacts/artifact_objects/lamp.dm
@@ -20,7 +20,7 @@
 
 /datum/artifact/lamp
 	associated_object = /obj/artifact/lamp
-	rarity = 450
+	rarity_weight = 450
 	validtypes = list("martian","wizard","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch,

--- a/code/obj/artifacts/artifact_objects/power_gen.dm
+++ b/code/obj/artifacts/artifact_objects/power_gen.dm
@@ -12,7 +12,7 @@
 
 /datum/artifact/power_gen
 	associated_object = /obj/machinery/artifact/power_gen
-	rarity = 90
+	rarity_weight = 90
 	validtypes = list("ancient")
 	validtriggers = list(/datum/artifact_trigger/electric,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch)
 	activated = 0

--- a/code/obj/artifacts/artifact_objects/power_gen.dm
+++ b/code/obj/artifacts/artifact_objects/power_gen.dm
@@ -12,7 +12,7 @@
 
 /datum/artifact/power_gen
 	associated_object = /obj/machinery/artifact/power_gen
-	rarity_class = 4
+	rarity = 90
 	validtypes = list("ancient")
 	validtriggers = list(/datum/artifact_trigger/electric,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch)
 	activated = 0

--- a/code/obj/artifacts/artifact_objects/power_giver.dm
+++ b/code/obj/artifacts/artifact_objects/power_giver.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/power_giver
 	associated_object = /obj/artifact/power_giver
-	rarity = 200
+	rarity_weight = 200
 	validtypes = list("martian","wizard","eldritch","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch,

--- a/code/obj/artifacts/artifact_objects/power_giver.dm
+++ b/code/obj/artifacts/artifact_objects/power_giver.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/power_giver
 	associated_object = /obj/artifact/power_giver
-	rarity_class = 3
+	rarity = 200
 	validtypes = list("martian","wizard","eldritch","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch,

--- a/code/obj/artifacts/artifact_objects/prison.dm
+++ b/code/obj/artifacts/artifact_objects/prison.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/prison
 	associated_object = /obj/artifact/prison
-	rarity_class = 2
+	rarity = 350
 	min_triggers = 2
 	max_triggers = 2
 	validtypes = list("ancient","martian","wizard","eldritch","precursor")

--- a/code/obj/artifacts/artifact_objects/prison.dm
+++ b/code/obj/artifacts/artifact_objects/prison.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/prison
 	associated_object = /obj/artifact/prison
-	rarity = 350
+	rarity_weight = 350
 	min_triggers = 2
 	max_triggers = 2
 	validtypes = list("ancient","martian","wizard","eldritch","precursor")

--- a/code/obj/artifacts/artifact_objects/recaller.dm
+++ b/code/obj/artifacts/artifact_objects/recaller.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/recaller
 	associated_object = /obj/artifact/teleport_recaller
-	rarity = 450
+	rarity_weight = 450
 	validtypes = list("wizard","eldritch","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch)

--- a/code/obj/artifacts/artifact_objects/recaller.dm
+++ b/code/obj/artifacts/artifact_objects/recaller.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/recaller
 	associated_object = /obj/artifact/teleport_recaller
-	rarity_class = 1 // modified from 2 as part of art tweak
+	rarity = 450
 	validtypes = list("wizard","eldritch","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch)

--- a/code/obj/artifacts/artifact_objects/wish_granter.dm
+++ b/code/obj/artifacts/artifact_objects/wish_granter.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/wish_granter
 	associated_object = /obj/artifact/wish_granter
-	rarity_class = 4
+	rarity = 90
 	validtypes = list("wizard","eldritch")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/cold)

--- a/code/obj/artifacts/artifact_objects/wish_granter.dm
+++ b/code/obj/artifacts/artifact_objects/wish_granter.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/wish_granter
 	associated_object = /obj/artifact/wish_granter
-	rarity = 90
+	rarity_weight = 90
 	validtypes = list("wizard","eldritch")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/cold)

--- a/code/obj/artifacts/artifactdatums.dm
+++ b/code/obj/artifacts/artifactdatums.dm
@@ -3,10 +3,9 @@
 ABSTRACT_TYPE(/datum/artifact/)
 /datum/artifact/
 	var/associated_object = null
-	var/rarity_class = 0
-	// Bigger rarity means its less likely to show up. Thanks for documenting this, guys. - Azungar
-	// Also note that rarity 0 means the artifact does not randomly spawn.
-	// Tweaked rarity 1 to contain all the uninteresting garbage artifacts. Explosion artifacts still appear at 3/4 because explodey is not boring - Phyvo
+	var/rarity = 0
+	// weighted commonness, so a higher number will make it more likely
+	// 0 should not make it spawn at all, naturally
 
 	var/datum/artifact_origin/artitype = null
 	var/list/validtypes = list("ancient","martian","wizard","eldritch","precursor")

--- a/code/obj/artifacts/artifactdatums.dm
+++ b/code/obj/artifacts/artifactdatums.dm
@@ -3,7 +3,7 @@
 ABSTRACT_TYPE(/datum/artifact/)
 /datum/artifact/
 	var/associated_object = null
-	var/rarity = 0
+	var/rarity_weight = 0
 	// weighted commonness, so a higher number will make it more likely
 	// 0 should not make it spawn at all, naturally
 

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -4,35 +4,19 @@
 	if (!istype(T,/turf/) && !istype(T,/obj/))
 		return
 
-	var/rarityroll = 1
-
-// artifact tweak. rarity 1 now contains garbage artifacts so that it's easier to control how much garbage science sees.
-	switch(rand(1,100))
-		if (36 to 80) 		// 45%. 4% chance for a particular level 2 art.
-			rarityroll = 2
-		if (81 to 95) 		// 15%. With current art list this means 2% chance of a certain level 3 art
-			rarityroll = 3
-		if (96 to 100) 		// 5%. With current art list this means 1% chance of a certain level 4 art. 2 of the 5 are bombs...
-			rarityroll = 4
-		else 							// 35%. 4% chance for a particular garbage level 1 art.
-			rarityroll = 1
-
-	var/list/selection_pool = list()
-
-	if(forceartitype)
-		selection_pool += forceartitype
+	var/list/artifactweights
+	if(forceartiorigin)
+		artifactweights = artifact_controls.artifact_rarities[forceartiorigin]
 	else
-		for (var/datum/artifact/A as() in concrete_typesof(/datum/artifact))
-			if (initial(A.rarity_class) != rarityroll)
-				continue
-			if (istext(forceartiorigin) && !(forceartiorigin in initial(A.validtypes)))
-				continue
-			selection_pool += A
+		artifactweights = artifact_controls.artifact_rarities["all"]
 
-	if (selection_pool.len < 1)
-		return
-
-	var/datum/artifact/picked = pick(selection_pool)
+	var/datum/artifact/picked
+	if(forceartitype)
+		picked = forceartitype
+	else
+		if (artifactweights.len < 1)
+			return
+		picked = weighted_pick(artifactweights)
 
 	var/type = null
 	if(ispath(picked,/datum/artifact/))

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -14,7 +14,7 @@
 	if(forceartitype)
 		picked = forceartitype
 	else
-		if (artifactweights.len < 1)
+		if (artifactweights.len == 0)
 			return
 		picked = weighted_pick(artifactweights)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This changes it so that instead of 4 rarity tiers, each artifact can have its own value for how often it occurs.

For this it generates a few lists, one for each origin and one for all artifacts, with the value being their rarity.
(So you can still easily generate artifacts of a specific origin.)
This is then used for a weighted_pick choice.
I calculated the relative chance of each artifact right now and then rounded it a bit, so right now each artifact of the same tier would still have the same chance.
We can adjust this in a later PR.

My calculations:
![image](https://user-images.githubusercontent.com/35579460/106834422-b7846700-6695-11eb-84d4-6b9cecb324a9.png)
I think this should keep the chances similar to the existing ones, I just did a little bit of rounding to make things nicer.
I did fail a statistics exam once though, so please correct me if I am wrong.^^

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's a bit annoying that whenever a new artifact of a tier is added, all the other artifacts of that tier would get comparatively rarer.
This patch would spread this effect out over all artifacts.

Also, it allows for more fine tuning instead of just 4 different values. 
Also, under the old system, moving something from Tier 2 to Tier 1 would have actually made it more likely to find that type of artifact, since there were less artifacts of Tier 1 than Tier 2, even though Tier 2 had a higher chance to be picked.
That felt a little confusing and counterintuitive as well.