### PR TITLE
Ghostdrones: Disable use of pda2 and shrinking magtractor icons

### DIFF
--- a/code/obj/item/device/pda2/base_program.dm
+++ b/code/obj/item/device/pda2/base_program.dm
@@ -161,6 +161,8 @@
 			return 1
 		if ((!usr.contents.Find(src.master) && (!in_interact_range(src.master, usr) || !istype(src.master.loc, /turf) || !isAI(usr))) && (!issilicon(usr) && !isAI(usr)))
 			return 1
+		if(isghostdrone(usr))
+			return 1
 		if(usr.stat || usr.restrained())
 			return 1
 		if(!(holder in src.master.contents))

--- a/code/obj/item/magtractor.dm
+++ b/code/obj/item/magtractor.dm
@@ -169,9 +169,10 @@
 	proc/updateHeldOverlay(obj/item/W as obj)
 		if (W && !W.disposed)
 			var/image/heldItem = GetOverlayImage("heldItem")
-			if (!heldItem) heldItem = image(W.icon, W.icon_state)
+			if (!heldItem)
+				heldItem = image(W.icon, W.icon_state)
+				heldItem.transform *= 0.85
 			heldItem.color = W.color
-			heldItem.transform *= 0.85
 			heldItem.pixel_y = 1
 			heldItem.layer = -1
 			src.UpdateOverlays(heldItem, "heldItem")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Gates use of PDA programs from Ghost Drones
Only scale image for magtractor when overlay is generated instead of whenever it is updated.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #3420
Addresses repeatedly scaling overlay into nothingness....