### PR TITLE
make electroplater only take one bar from a stack

### DIFF
--- a/code/obj/machinery/arc_electroplater.dm
+++ b/code/obj/machinery/arc_electroplater.dm
@@ -52,12 +52,19 @@
 			if(my_bar)
 				boutput(user, "<span class='alert'>There is already a source material loaded in [src]!</span>")
 				return
-			else
+			else if(W.amount == 1)
 				src.visible_message("<span class='notice'>[user] loads [W] into the [src].</span>")
 				user.u_equip(W)
 				W.set_loc(src)
 				W.dropped()
 				src.my_bar = W
+				return
+			else
+				src.visible_message("<span class='notice'>[user] loads one of the [W] into the [src].</span>")
+				var/obj/item/material_piece/single_bar = W.split_stack(1)
+				single_bar.set_loc(src)
+				single_bar.dropped()
+				src.my_bar = single_bar
 				return
 
 		if (src.target_item)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fixes #3577 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug bad


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)zjdtmkhzt
(+)Electroplaters should now only take one bar from a stack.
```
