### PR TITLE
make rarer artifacts more likely to vary in appearance

### DIFF
--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -29,7 +29,6 @@ o+`        `-` ``..-:yooos-..----------..`
            `d.                     .d`
 */
 
-
 //////////// OPTIONS TO GO FAST
 
 //#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // Skip setup for atmos, Z5, don't show changelogs, skip pregame lobby

--- a/code/datums/controllers/artifact_controls.dm
+++ b/code/datums/controllers/artifact_controls.dm
@@ -201,13 +201,16 @@ var/datum/artifact_controller/artifact_controls
 			fault_types += concrete_typesof(/datum/artifact_fault)
 
 	proc/post_setup(obj/artifact)
+		var/datum/artifact/AD = artifact.artifact
+		var/rarityMod = AD.get_rarity_modifier()
 		if(prob(25))
 			artifact.transform = matrix(artifact.transform, -1, 1, MATRIX_SCALE)
-		if(prob(5))
+		if(prob(5 * rarityMod))
 			artifact.transform = matrix(artifact.transform, 1, -1, MATRIX_SCALE)
 
 	proc/generate_name()
 		return "unknown object"
+
 
 /datum/artifact_origin/ancient
 	name = "ancient"
@@ -234,9 +237,11 @@ var/datum/artifact_controller/artifact_controls
 
 	post_setup(obj/artifact)
 		. = ..()
-		if(prob(5))
+		var/datum/artifact/AD = artifact.artifact
+		var/rarityMod = AD.get_rarity_modifier()
+		if(prob(5 * rarityMod))
 			artifact.transform = matrix(artifact.transform, 1.1, 1.1, MATRIX_SCALE)
-		if(prob(10))
+		if(prob(10 * rarityMod))
 			var/col = rand(160, 230)
 			artifact.color = rgb(col, col, col)
 
@@ -270,7 +275,9 @@ var/datum/artifact_controller/artifact_controls
 
 	post_setup(obj/artifact)
 		. = ..()
-		if(prob(5))
+		var/datum/artifact/AD = artifact.artifact
+		var/rarityMod = AD.get_rarity_modifier()
+		if(prob(5 * rarityMod))
 			artifact.transform = matrix(artifact.transform, rand(-10, 10), MATRIX_ROTATE)
 		if(prob(40))
 			artifact.color = rgb(rand(240, 255), rand(240, 255), rand(240, 255))
@@ -310,15 +317,17 @@ var/datum/artifact_controller/artifact_controls
 
 	post_setup(obj/artifact)
 		. = ..()
+		var/datum/artifact/AD = artifact.artifact
+		var/rarityMod = AD.get_rarity_modifier()
 		if(prob(70))
-			var/hue1 = prob(90) ? (55 + rand(-10, 10)) : rand(360)
+			var/hue1 = prob(90/rarityMod) ? (55 + rand(-10, 10)) : rand(360)
 			var/list/col1
-			if(prob(80))
+			if(prob(80/rarityMod))
 				col1 = list(255, 168, 0)
 			else
 				col1 = hsv2rgblist(hue1, rand() * 0.2 + 0.5, rand() * 0.2 + 0.6)
 			var/hue2 = 180 + hue1 + rand(-135, 135)
-			if(prob(10))
+			if(prob(10*rarityMod))
 				hue2 = rand(360)
 			var/list/col2 = hsv2rgblist(hue2, rand() * 0.3 + 0.7, rand() * 0.1 + 0.9)
 			artifact.color = list(
@@ -332,7 +341,7 @@ var/datum/artifact_controller/artifact_controls
 				0,
 				1
 			)
-		if(prob(5))
+		if(prob(5*rarityMod))
 			artifact.alpha = rand(200, 255)
 
 	generate_name()

--- a/code/datums/controllers/artifact_controls.dm
+++ b/code/datums/controllers/artifact_controls.dm
@@ -203,7 +203,7 @@ var/datum/artifact_controller/artifact_controls
 	proc/post_setup(obj/artifact)
 		var/datum/artifact/AD = artifact.artifact
 		var/rarityMod = AD.get_rarity_modifier()
-		if(prob(100*rarity_Mod))
+		if(prob(100*rarityMod))
 			artifact.transform = matrix(artifact.transform, -1, 1, MATRIX_SCALE)
 		if(prob(20 * rarityMod))
 			artifact.transform = matrix(artifact.transform, 1, -1, MATRIX_SCALE)

--- a/code/datums/controllers/artifact_controls.dm
+++ b/code/datums/controllers/artifact_controls.dm
@@ -320,12 +320,12 @@ var/datum/artifact_controller/artifact_controls
 		var/datum/artifact/AD = artifact.artifact
 		var/rarityMod = AD.get_rarity_modifier()
 		if(prob(70))
-			var/hue1 = prob(90/rarityMod) ? (55 + rand(-10, 10)) : rand(360)
+			var/hue1 = prob(10*rarityMod) ? rand(360) : (55 + rand(-10, 10))
 			var/list/col1
-			if(prob(80/rarityMod))
-				col1 = list(255, 168, 0)
-			else
+			if(prob(20*rarityMod))
 				col1 = hsv2rgblist(hue1, rand() * 0.2 + 0.5, rand() * 0.2 + 0.6)
+			else
+				col1 = list(255, 168, 0)
 			var/hue2 = 180 + hue1 + rand(-135, 135)
 			if(prob(10*rarityMod))
 				hue2 = rand(360)

--- a/code/datums/controllers/artifact_controls.dm
+++ b/code/datums/controllers/artifact_controls.dm
@@ -203,9 +203,9 @@ var/datum/artifact_controller/artifact_controls
 	proc/post_setup(obj/artifact)
 		var/datum/artifact/AD = artifact.artifact
 		var/rarityMod = AD.get_rarity_modifier()
-		if(prob(25))
+		if(prob(100*rarity_Mod))
 			artifact.transform = matrix(artifact.transform, -1, 1, MATRIX_SCALE)
-		if(prob(5 * rarityMod))
+		if(prob(20 * rarityMod))
 			artifact.transform = matrix(artifact.transform, 1, -1, MATRIX_SCALE)
 
 	proc/generate_name()
@@ -239,9 +239,9 @@ var/datum/artifact_controller/artifact_controls
 		. = ..()
 		var/datum/artifact/AD = artifact.artifact
 		var/rarityMod = AD.get_rarity_modifier()
-		if(prob(5 * rarityMod))
+		if(prob(50 * rarityMod))
 			artifact.transform = matrix(artifact.transform, 1.1, 1.1, MATRIX_SCALE)
-		if(prob(10 * rarityMod))
+		if(prob(100 * rarityMod))
 			var/col = rand(160, 230)
 			artifact.color = rgb(col, col, col)
 
@@ -277,9 +277,9 @@ var/datum/artifact_controller/artifact_controls
 		. = ..()
 		var/datum/artifact/AD = artifact.artifact
 		var/rarityMod = AD.get_rarity_modifier()
-		if(prob(5 * rarityMod))
+		if(prob(50 * rarityMod))
 			artifact.transform = matrix(artifact.transform, rand(-10, 10), MATRIX_ROTATE)
-		if(prob(40))
+		if(prob(200 * rarityMod))
 			artifact.color = rgb(rand(240, 255), rand(240, 255), rand(240, 255))
 
 	generate_name()
@@ -319,15 +319,15 @@ var/datum/artifact_controller/artifact_controls
 		. = ..()
 		var/datum/artifact/AD = artifact.artifact
 		var/rarityMod = AD.get_rarity_modifier()
-		if(prob(70))
-			var/hue1 = prob(10*rarityMod) ? rand(360) : (55 + rand(-10, 10))
+		if(prob(300*rarityMod))
+			var/hue1 = prob(100*rarityMod) ? rand(360) : (55 + rand(-10, 10))
 			var/list/col1
-			if(prob(20*rarityMod))
+			if(prob(150*rarityMod))
 				col1 = hsv2rgblist(hue1, rand() * 0.2 + 0.5, rand() * 0.2 + 0.6)
 			else
 				col1 = list(255, 168, 0)
 			var/hue2 = 180 + hue1 + rand(-135, 135)
-			if(prob(10*rarityMod))
+			if(prob(100*rarityMod))
 				hue2 = rand(360)
 			var/list/col2 = hsv2rgblist(hue2, rand() * 0.3 + 0.7, rand() * 0.1 + 0.9)
 			artifact.color = list(
@@ -341,7 +341,7 @@ var/datum/artifact_controller/artifact_controls
 				0,
 				1
 			)
-		if(prob(5*rarityMod))
+		if(prob(50*rarityMod))
 			artifact.alpha = rand(200, 255)
 
 	generate_name()

--- a/code/obj/artifacts/artifactdatums.dm
+++ b/code/obj/artifacts/artifactdatums.dm
@@ -133,7 +133,7 @@ ABSTRACT_TYPE(/datum/artifact/)
 		return null
 
 	proc/get_rarity_modifier()
-		return src.rarity_weight ? (450 / src.rarity_weight) : 1 // ~ 5 for highest tier, 1.2 for lowest
+		return src.rarity_weight ? 0.995^src.rarity_weight : 0.2 // ~0.63 for tier 5, ~0.1 for tier 1
 
 // SPECIFIC DATUMS
 

--- a/code/obj/artifacts/artifactdatums.dm
+++ b/code/obj/artifacts/artifactdatums.dm
@@ -132,6 +132,9 @@ ABSTRACT_TYPE(/datum/artifact/)
 				return AT
 		return null
 
+	proc/get_rarity_modifier()
+		return src.rarity_weight ? (450 / src.rarity_weight) : 1 // ~ 5 for highest tier, 1.2 for lowest
+
 // SPECIFIC DATUMS
 
 ABSTRACT_TYPE(/datum/artifact/art)

--- a/code/obj/artifacts/artifactdatums.dm
+++ b/code/obj/artifacts/artifactdatums.dm
@@ -133,7 +133,7 @@ ABSTRACT_TYPE(/datum/artifact/)
 		return null
 
 	proc/get_rarity_modifier()
-		return src.rarity_weight ? 0.995^src.rarity_weight : 0.2 // ~0.63 for tier 5, ~0.1 for tier 1
+		return src.rarity_weight ? 0.995**src.rarity_weight : 0.2 // ~0.63 for tier 5, ~0.1 for tier 1
 
 // SPECIFIC DATUMS
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This makes artifacts with a lower rarity_weight (which appear less often) more likely to have some of the random appearance variations (mostly) based on their origin.

Some of the variations were already so common that I just made the rarity not affect their probability.

Right now the highest tier of artifact will make some things about 5x more likely, so you end up with probabilities like 25%/50%.
The most common artifacts (what used to be tier 1 and 2) will have only slightly higher probabilities.
The numbers are kind of made up, so I am open to suggestions on changing them!
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Ever since the appearance variations are added, I get a little excited when I see a weird looking artifact, thinking, "I wonder what that would do!".
I think it'd be neat if that were actually a small clue that it might be a more special kind of artifact!