### PR TITLE
Removes pizza sharpener from the traitor uplink

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -731,16 +731,6 @@ This is basically useless for anyone but miners.
 	job = list("Medical Director")
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 
-/datum/syndicate_buylist/traitor/pizza_sharpener
-	name = "Pizza Sharpener"
-	item = /obj/item/kitchen/utensil/knife/pizza_cutter/traitor
-	cost = 5
-	desc = "Have you ever been making a pizza and thought \"this pizza would be better if I could fatally injure someone by throwing it at them\"? Well think no longer! Because you're sharpening pizzas now. You weirdo."
-	job = list("Chef")
-	not_in_crates = 1
-	blockedmode = list(/datum/game_mode/revolution)
-
-
 /datum/syndicate_buylist/traitor/syndiesauce
 	name = "Syndicate Sauce"
 	item = /obj/item/reagent_containers/food/snacks/condiment/syndisauce


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR removes the pizza sharpener traitor item from the traitor uplink.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I had no idea that the PR was very controversial when I merged it. Complaints are:

- It's just a stronger, cheaper, reusable butcher's knife.
- It's basically lawn darts just stronger. And we are likely removing lawn darts because they suck.
- It doesn't have its own unique niche.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)pali
(*)Pizza sharpener has been removed
```
