### PR TITLE
Resolve Artifact Research Computer use of heater

### DIFF
--- a/code/modules/networks/computer3/mainframe2/misc_terms.dm
+++ b/code/modules/networks/computer3/mainframe2/misc_terms.dm
@@ -4460,9 +4460,9 @@
 			use_power(80)
 
 			if (src.temperature < src.temptarget)
-				src.temperature += 5
+				src.temperature += min(5, src.temptarget-src.temperature)
 			else if (src.temperature > src.temptarget)
-				src.temperature -= 5
+				src.temperature -= min(5, src.temperature-src.temptarget)
 
 			if (src.temperature != 310)
 				for (var/obj/M in src.loc.contents)
@@ -4572,8 +4572,9 @@
 
 			if ("pulse")
 				var/duration = text2num(packetData["duration"])
-				if (isnum(duration) && (duration >= 200 && duration <= 400))
-					temptarget = duration
+				if (isnum(duration) )
+					if(duration >= 200 && duration <= 400)
+						temptarget = duration
 				else
 					message_host("command=nack")
 					return

--- a/code/modules/networks/computer3/mainframe2/misc_terms.dm
+++ b/code/modules/networks/computer3/mainframe2/misc_terms.dm
@@ -4487,7 +4487,7 @@
 	message_interface(var/list/packetData)
 		switch (lowertext(packetData["command"]))
 			if ("info")
-				message_host("command=info&id=[src.setup_test_id]&capability=[setup_capability_value]&status=[src.active ? "1" : "0"]&valuelist=Temptarget,Temperature&readinglist=Target Temperature-K,Current Temperature-K,Artifact Temperature-K,Object Responds to Temperature,Details")
+				message_host("command=info&id=[src.setup_test_id]&capability=[setup_capability_value]&status=[src.active ? "1" : "0"]&valuelist=Temptarget,Temperature&readinglist=Target Temperature-K,Current Temperature-K,Artifact Temperature-K,Temperature Response,Details")
 
 			if ("status")
 				message_host("command=status&data=[src.active ? "1" : "0"]")
@@ -4572,7 +4572,7 @@
 
 			if ("pulse")
 				var/duration = text2num(packetData["duration"])
-				if (isnum(duration))
+				if (isnum(duration) && (duration >= 200 && duration <= 400))
 					temptarget = duration
 				else
 					message_host("command=nack")

--- a/code/modules/networks/computer3/mainframe2/os_drivers.dm
+++ b/code/modules/networks/computer3/mainframe2/os_drivers.dm
@@ -2407,7 +2407,7 @@
 			if ("poke") //Set an arbitrary (device-specific) configuration value on the device.
 				if (!isnull(data["field"]) && !isnull(data["value"]))
 					if (isnum(data["value"]))
-						data["value"] = round(max(1, min(data["value"], 255)))
+						data["value"] = round(max(1, min(data["value"], 400))) // 400 is highest stimulus value for heater
 
 					var/sessionid = "[world.timeofday%100][rand(0,9)]"
 					sessions["[sessionid]"] = sendid


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Shifts domain of valid `poke` values for `/datum/computer/file/mainframe_program/driver/test_apparatus` to include heater upper range. `400`
Added range checking to pulse to ensure validity of temperature, but still allow it to activate the target temperature.
Bound the temperature shift to ensure target can be reached.
Adjusted temperature response text to be shorter.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #928
Improves usability of Artifact Research Computer for Heater
