### PR TITLE
artifact fault stuff

### DIFF
--- a/code/datums/controllers/artifact_controls.dm
+++ b/code/datums/controllers/artifact_controls.dm
@@ -220,7 +220,7 @@ var/datum/artifact_controller/artifact_controls
 		/datum/artifact_fault/shutdown = 10,
 		/datum/artifact_fault/zap = 10,
 		/datum/artifact_fault/explode = 10,
-		/datum/artifact_fault/messager/ai_laws)
+		/datum/artifact_fault/messager/ai_laws = 10)
 	activation_sounds = list('sound/machines/ArtifactAnc1.ogg')
 	instrument_sounds = list("sound/musical_instruments/artifact/Artifact_Ancient_1.ogg",
 		"sound/musical_instruments/artifact/Artifact_Ancient_2.ogg",

--- a/code/datums/controllers/artifact_controls.dm
+++ b/code/datums/controllers/artifact_controls.dm
@@ -306,14 +306,14 @@ var/datum/artifact_controller/artifact_controls
 	fault_types = list(
 		/datum/artifact_fault/irradiate = 10,
 		/datum/artifact_fault/shutdown = 10,
-	/datum/artifact_fault/warp = 15,
-	/datum/artifact_fault/zap = 10,
-	/datum/artifact_fault/burn = 10,
-	/datum/artifact_fault/explode = 5,
-	/datum/artifact_fault/messager/creepy_whispers = 5,
-	/datum/artifact_fault/messager/comforting_whispers = 5,
-	/datum/artifact_fault/messager/what_dead_people_said = 5,
-	/datum/artifact_fault/messager/what_people_said = 5)
+		/datum/artifact_fault/warp = 15,
+		/datum/artifact_fault/zap = 10,
+		/datum/artifact_fault/burn = 10,
+		/datum/artifact_fault/explode = 5,
+		/datum/artifact_fault/messager/creepy_whispers = 5,
+		/datum/artifact_fault/messager/comforting_whispers = 5,
+		/datum/artifact_fault/messager/what_dead_people_said = 5,
+		/datum/artifact_fault/messager/what_people_said = 5)
 	activation_sounds = list('sound/machines/ArtifactWiz1.ogg')
 	instrument_sounds = list("sound/musical_instruments/artifact/Artifact_Wizard_1.ogg",
 		"sound/musical_instruments/artifact/Artifact_Wizard_2.ogg",

--- a/code/datums/controllers/artifact_controls.dm
+++ b/code/datums/controllers/artifact_controls.dm
@@ -214,8 +214,13 @@ var/datum/artifact_controller/artifact_controls
 
 /datum/artifact_origin/ancient
 	name = "ancient"
-	fault_types = list(/datum/artifact_fault/burn,/datum/artifact_fault/irradiate,/datum/artifact_fault/shutdown,
-	/datum/artifact_fault/murder,/datum/artifact_fault/zap)
+	fault_types = list(
+		/datum/artifact_fault/burn = 10,
+		/datum/artifact_fault/irradiate = 10,
+		/datum/artifact_fault/shutdown = 10,
+		/datum/artifact_fault/zap = 10,
+		/datum/artifact_fault/explode = 10,
+		/datum/artifact_fault/messager/ai_laws)
 	activation_sounds = list('sound/machines/ArtifactAnc1.ogg')
 	instrument_sounds = list("sound/musical_instruments/artifact/Artifact_Ancient_1.ogg",
 		"sound/musical_instruments/artifact/Artifact_Ancient_2.ogg",
@@ -250,7 +255,12 @@ var/datum/artifact_controller/artifact_controls
 
 /datum/artifact_origin/martian
 	name = "martian"
-	fault_types = list(/datum/artifact_fault/shutdown,/datum/artifact_fault/zap,/datum/artifact_fault/poison)
+	fault_types = list(
+		/datum/artifact_fault/shutdown = 10,
+		/datum/artifact_fault/zap = 5,
+		/datum/artifact_fault/poison = 15,
+		/datum/artifact_fault/messager/what_people_said = 5,
+		/datum/artifact_fault/messager/comforting_whispers = 5)
 	activation_sounds = list('sound/machines/ArtifactMar1.ogg','sound/machines/ArtifactMar2.ogg')
 	instrument_sounds = list("sound/musical_instruments/artifact/Artifact_Martian_1.ogg",
 		"sound/musical_instruments/artifact/Artifact_Martian_2.ogg",
@@ -291,8 +301,17 @@ var/datum/artifact_controller/artifact_controls
 
 /datum/artifact_origin/wizard
 	name = "wizard"
-	fault_types = list(/datum/artifact_fault/irradiate,/datum/artifact_fault/shutdown,/datum/artifact_fault/murder,
-	/datum/artifact_fault/warp,/datum/artifact_fault/zap,/datum/artifact_fault/messager/creepy_whispers)
+	fault_types = list(
+		/datum/artifact_fault/irradiate = 10,
+		/datum/artifact_fault/shutdown = 10,
+	/datum/artifact_fault/warp = 15,
+	/datum/artifact_fault/zap = 10,
+	/datum/artifact_fault/burn = 10,
+	/datum/artifact_fault/explode = 5,
+	/datum/artifact_fault/messager/creepy_whispers = 5,
+	/datum/artifact_fault/messager/comforting_whispers = 5,
+	/datum/artifact_fault/messager/what_dead_people_said = 5,
+	/datum/artifact_fault/messager/what_people_said = 5)
 	activation_sounds = list('sound/machines/ArtifactWiz1.ogg')
 	instrument_sounds = list("sound/musical_instruments/artifact/Artifact_Wizard_1.ogg",
 		"sound/musical_instruments/artifact/Artifact_Wizard_2.ogg",
@@ -358,6 +377,16 @@ var/datum/artifact_controller/artifact_controls
 		"sound/musical_instruments/artifact/Artifact_Eldritch_2.ogg",
 		"sound/musical_instruments/artifact/Artifact_Eldritch_3.ogg",
 		"sound/musical_instruments/artifact/Artifact_Eldritch_4.ogg")
+	fault_types = list(
+		/datum/artifact_fault/murder = 2,
+		/datum/artifact_fault/messager/creepy_whispers = 5,
+		/datum/artifact_fault/messager/what_dead_people_said = 5,
+		/datum/artifact_fault/poison = 10,
+		/datum/artifact_fault/irradiate = 10,
+		/datum/artifact_fault/shutdown = 5,
+		/datum/artifact_fault/zap = 8,
+		/datum/artifact_fault/explode = 5,
+		/datum/artifact_fault/warp = 15)
 	impact_reaction_one = 0.5
 	impact_reaction_two = 0
 	heat_reaction_one = 0.25
@@ -422,6 +451,15 @@ var/datum/artifact_controller/artifact_controls
 		"sound/musical_instruments/artifact/Artifact_Precursor_4.ogg",
 		"sound/musical_instruments/artifact/Artifact_Precursor_5.ogg",
 		"sound/musical_instruments/artifact/Artifact_Precursor_6.ogg")
+	fault_types = list(
+		/datum/artifact_fault/irradiate = 10,
+		/datum/artifact_fault/shutdown = 5,
+		/datum/artifact_fault/zap = 10,
+		/datum/artifact_fault/explode = 5,
+		/datum/artifact_fault/burn = 5,
+		/datum/artifact_fault/warp = 10,
+		/datum/artifact_fault/messager/what_people_said = 10,
+		/datum/artifact_fault/poison = 2)
 	impact_reaction_one = 2
 	impact_reaction_two = 10
 	heat_reaction_one = 2

--- a/code/datums/controllers/artifact_controls.dm
+++ b/code/datums/controllers/artifact_controls.dm
@@ -260,7 +260,9 @@ var/datum/artifact_controller/artifact_controls
 		/datum/artifact_fault/zap = 5,
 		/datum/artifact_fault/poison = 15,
 		/datum/artifact_fault/messager/what_people_said = 5,
-		/datum/artifact_fault/messager/comforting_whispers = 5)
+		/datum/artifact_fault/messager/comforting_whispers = 5,
+		/datum/artifact_fault/grow = 8,
+		/datum/artifact_fault/shrink = 8)
 	activation_sounds = list('sound/machines/ArtifactMar1.ogg','sound/machines/ArtifactMar2.ogg')
 	instrument_sounds = list("sound/musical_instruments/artifact/Artifact_Martian_1.ogg",
 		"sound/musical_instruments/artifact/Artifact_Martian_2.ogg",
@@ -386,7 +388,9 @@ var/datum/artifact_controller/artifact_controls
 		/datum/artifact_fault/shutdown = 5,
 		/datum/artifact_fault/zap = 8,
 		/datum/artifact_fault/explode = 5,
-		/datum/artifact_fault/warp = 15)
+		/datum/artifact_fault/warp = 15,
+		/datum/artifact_fault/grow = 5,
+		/datum/artifact_fault/shrink = 5)
 	impact_reaction_one = 0.5
 	impact_reaction_two = 0
 	heat_reaction_one = 0.25

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -589,9 +589,10 @@
 						if (thing)
 							message = thing.on_spin_emote(src)
 							maptext_out = "<I>twirls [thing]</I>"
-							animate(thing, transform = turn(matrix(), 120), time = 0.7, loop = 3)
-							animate(transform = turn(matrix(), 240), time = 0.7)
-							animate(transform = null, time = 0.7)
+							var/trans = thing.transform
+							animate(thing, transform = turn(trans, 120), time = 0.7, loop = 3, flags = ANIMATION_PARALLEL)
+							animate(transform = turn(trans, 240), time = 0.7, flags = ANIMATION_PARALLEL)
+							animate(transform = trans, time = 0.7, flags = ANIMATION_PARALLEL)
 						else
 							message = "<B>[src]</B> wiggles [his_or_her(src)] fingers a bit.[prob(10) ? " Weird." : null]"
 							maptext_out = "<I>wiggles [his_or_her(src)] fingers a bit.</I>"

--- a/code/obj/artifacts/artifact_items/instrument.dm
+++ b/code/obj/artifacts/artifact_items/instrument.dm
@@ -37,6 +37,7 @@
 	attack_self(mob/user as mob)
 		..()
 		src.play(user)
+		src.ArtifactFaultUsed(user)
 
 /datum/artifact/instrument
 	associated_object = /obj/item/artifact/instrument

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -454,7 +454,7 @@
 	faultprob = max(0,min(faultprob,100))
 
 	if (prob(faultprob) && A.fault_types.len)
-		var/new_fault = pick(A.fault_types)
+		var/new_fault = weighted_pick(A.fault_types)
 		if (ispath(new_fault))
 			var/datum/artifact_fault/F = new new_fault(A)
 			F.holder = A

--- a/code/obj/artifacts/faults.dm
+++ b/code/obj/artifacts/faults.dm
@@ -61,6 +61,47 @@ ABSTRACT_TYPE(/datum/artifact_fault/)
 		playsound(T, "sound/effects/mag_warp.ogg", 100, 1)
 		user.set_loc(pick(wormholeturfs))
 
+/datum/artifact_fault/grow
+	// embiggens the artifact
+	trigger_prob = 10
+
+	deploy(var/obj/O,var/mob/living/user)
+		if (..())
+			return
+		if (!isitem(O))
+			return
+		var/obj/item/I = O
+		if(I.w_class > 6)
+			return
+
+		boutput(user, "<span class='alert'>The [I.name] grows in size!</span>")
+		I.transform = matrix(I.transform, 1.1, 1.1, MATRIX_SCALE)
+		I.w_class++
+		if (I.loc == user && I.w_class > 4)
+			boutput(user, "<span class='alert'>You can't maintain a grip due to its excessive girth!</span>")
+			user.u_equip(I)
+			I.set_loc(user.loc)
+
+/datum/artifact_fault/shrink
+	// ensmallens the artifact
+	trigger_prob = 10
+
+	deploy(var/obj/O,var/mob/living/user)
+		if (..())
+			return
+		if (!isitem(O))
+			return
+		var/obj/item/I = O
+
+		boutput(user, "<span class='alert'>The [I.name] shrinks in size!</span>")
+		I.transform = matrix(I.transform, 0.9, 0.9, MATRIX_SCALE)
+		I.w_class--
+		if (I.w_class < 1)
+			boutput(user, "<span class='alert'>The artifact shrinks away into nothingness!</span>")
+			user.u_equip(I)
+			I.set_loc(user.loc)
+			I.invisibility = 100
+
 /datum/artifact_fault/murder
 	// gibs the user
 	trigger_prob = 1
@@ -69,8 +110,8 @@ ABSTRACT_TYPE(/datum/artifact_fault/)
 	deploy(var/obj/O,var/mob/living/user)
 		if (..())
 			return
-		if (isitem(src))
-			var/obj/item/I = src
+		if (isitem(O))
+			var/obj/item/I = O
 			if (I.loc == user)
 				user.u_equip(I)
 				I.dropped()
@@ -89,8 +130,8 @@ ABSTRACT_TYPE(/datum/artifact_fault/)
 			return
 		var/turf/T = get_turf(O)
 		T.visible_message("<span class='alert'>The [O.name] suddenly explodes!</span>")
-		if (isitem(src))
-			var/obj/item/I = src
+		if (isitem(O))
+			var/obj/item/I = O
 			user.u_equip(I)
 			I.dropped()
 		explosion(O, T, 1, 2, 4, 8)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes artifact fault distribution to be weighted and adds some of the new artifact faults into the pool.
Also adds two new faults, grow and shrink, which cause handheld artifacts to change size and weight_class.
Upon becoming too small, an artifact will vanish, upon becoming too big, the user may drop it.

Also fixed a small bug with the murder and explode faults and made instruments trigger faults when played.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allows some fault types to occur more often for artifact origins for which they make more sense.

Also, the new fault types are funny.
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)zjdtmkhzt
(+)Enabled some new fault types for artifacts and changed distribution of faults a little.
```
