### PR TITLE
Set range on computer PDA cards to infinite.

### DIFF
--- a/code/modules/networks/computer3/peripherals.dm
+++ b/code/modules/networks/computer3/peripherals.dm
@@ -138,6 +138,7 @@
 
 		pda
 			frequency = 1149 //Standard PDA comm frequency.
+			range = 0
 			/*net_mode = 1
 			func_tag = "NET_ADAPTER"*/
 


### PR DESCRIPTION
[BUG]

## About the PR

Sets the range on the limited (channel-locked) wireless card used by the security records computer and the engine monitor computer to infinite.

## Why's this needed?

It was previously 8, which meant you basically had to be in the same room as someone to know that they set someone as arrested.

## Changelog

```changelog
(u)BenLubar
(+)The network cards in the security records and engine control computers have been upgraded to new models which can transmit PDA messages to distances greater than 0.4 millifurlongs.
```
