### PR TITLE
Update inhand for Engineering Wrench

### DIFF
--- a/code/obj/item/tool/wrench.dm
+++ b/code/obj/item/tool/wrench.dm
@@ -52,3 +52,4 @@
 /obj/item/wrench/yellow
 	desc = "A tool used to apply torque to turn nuts and bolts. This one has a bright yellow handle."
 	icon_state = "wrench-yellow"
+	item_state = "wrench"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug - minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Yellow wrench doesn't override `item_state` so points to an non-existant state in `icons/mob/inhand/tools/wrench.dmi`.  `/obj/item/wrench/yellow` will match behavior of other wrenches.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Stealth wrench is too strong. <\/s>
Polish 