### PR TITLE
Prevent RPG ammo in the zip gun

### DIFF
--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -119,7 +119,6 @@
 	swap(var/obj/item/ammo/bullets/A, var/obj/item/gun/kinetic/K)
 		// I tweaked this for improved user feedback and to support zip guns (Convair880).
 		var/check = 0
-		message_admins("A caliber: [A.caliber]")
 		if (!A || !K)
 			check = 0
 		if (K.sanitycheck() == 0)

--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -119,6 +119,7 @@
 	swap(var/obj/item/ammo/bullets/A, var/obj/item/gun/kinetic/K)
 		// I tweaked this for improved user feedback and to support zip guns (Convair880).
 		var/check = 0
+		message_admins("A caliber: [A.caliber]")
 		if (!A || !K)
 			check = 0
 		if (K.sanitycheck() == 0)
@@ -128,7 +129,10 @@
 		else if (A.caliber in K.caliber) // Some guns can have multiple calibers.
 			check = 1
 		else if (K.caliber == null) // Special treatment for zip guns, huh.
-			check = 1
+			if (A.caliber == 1.58)  // Prevent MRPT rocket
+				check = 0
+			else
+				check = 1
 		if (!check)
 			return 0
 			//DEBUG_MESSAGE("Couldn't swap [K]'s ammo ([K.ammo.type]) with [A.type].")
@@ -198,7 +202,10 @@
 		else if (A.caliber in K.caliber)
 			check = 1
 		else if (K.caliber == null)
-			check = 1 // For zip guns.
+			if (A.caliber == 1.58) // Prevent MRPT rocket
+				check = 0
+			else
+				check = 1 // For zip guns.
 		if (!check)
 			return 1
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE][INPUT WANTED]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Prevents MPRT rocket ammo being loaded into zip guns.
This change only affects nuclear gametype as there is no other source of this ammunition.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The nukie exclusive MRPT RPG ammo can be loaded into zipguns. Infiltrators can use this for a stealthy, one handed, belt worn weapon that will be guaranteed to gib the captain/HOS or kill a small crowd with a 33% chance of failure (never on first shot) that will only put you into red health if it fails on the second shot.
This is very strong and I have successfully used it to pull off an assassination with basically no risk to myself due to the cloaking device. The regular MRPT launcher is still available for the rest of the nukies to use.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(*)Blocks MRPT rocket ammo from being loaded into the zip gun.
```
