### PR TITLE
Fix failure to remove ghost drone static on mind transfer

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -103,6 +103,8 @@ datum/mind
 				current.removeOverlaysClient(current.client)
 				tgui_process.on_transfer(current, new_character)
 				new_character.lastKnownIP = current.client.address
+				if(isghostdrone(src.current)) //clear the static overlays on death, qdel, being cloned, etc.
+					current.client.images.Remove(mob_static_icons)
 			current.mind = null
 
 		new_character.mind = src

--- a/code/mob/living/silicon/ghostdrone.dm
+++ b/code/mob/living/silicon/ghostdrone.dm
@@ -130,8 +130,6 @@
 		setdead(src)
 		if (src.mind)
 			src.mind.dnr = 0
-		if (src.client)
-			src.client.images.Remove(mob_static_icons)
 
 			var/mob/dead/observer/ghost = src.ghostize()
 			ghost.icon = 'icons/mob/ghost_drone.dmi'


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves ghost drone static removal from ghostdrone's `death()` to `datum/mind/proc/transfer_to`


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Players who are cloned as a ghost drone don't call death(), and in turn don't ever get the black static image removed from any mobs that had it applied to them. Likewise this also applied to admin mind swaps, and direct transformations to observer such as when using `remove-self`.