### PR TITLE
Continue luna tour

### DIFF
--- a/code/obj/item/tool/wrench.dm
+++ b/code/obj/item/tool/wrench.dm
@@ -52,3 +52,4 @@
 /obj/item/wrench/yellow
 	desc = "A tool used to apply torque to turn nuts and bolts. This one has a bright yellow handle."
 	icon_state = "wrench-yellow"
+	item_state = "wrench"

--- a/code/obj/item/tool/wrench.dm
+++ b/code/obj/item/tool/wrench.dm
@@ -52,4 +52,3 @@
 /obj/item/wrench/yellow
 	desc = "A tool used to apply torque to turn nuts and bolts. This one has a bright yellow handle."
 	icon_state = "wrench-yellow"
-	item_state = "wrench"

--- a/code/z_adventurezones/luna.dm
+++ b/code/z_adventurezones/luna.dm
@@ -962,6 +962,7 @@ var/list/lunar_fx_sounds = list('sound/ambience/loop/Wind_Low.ogg','sound/ambien
 			return
 
 		src.broken = 1
+		src.operating = -1 // set operating to -1 so A* fails on door check
 
 		playsound(src.loc, 'sound/machines/airlock_break_very_temp.ogg', 50, 1)
 		SPAWN_DBG(0)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adjusts invalidation of turf via the broken door in a manner consistent with currently used means.  Broken is no longer checked, but `operating == -1` is. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #3336