### PR TITLE
Reduce bolt rifle magazine size

### DIFF
--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -669,7 +669,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 	force = 10
 	contraband = 8
 	caliber = 0.308
-	max_ammo_capacity = 30 // It's magazine-fed (Convair880).
+	max_ammo_capacity = 4 // It's magazine-fed (Convair880).
 	auto_eject = 1
 	can_dual_wield = 0
 	two_handed = 1
@@ -690,7 +690,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 	force = 10
 	//contraband = 8
 	caliber = 0.308
-	max_ammo_capacity = 30 // It's magazine-fed (Convair880).
+	max_ammo_capacity = 4 // It's magazine-fed (Convair880).
 	auto_eject = 1
 	can_dual_wield = 0
 	two_handed = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Reduces Old Hunting Rifle and Tranquilizer Rifle to a magazine size of 4.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
For some reason these have a magazine size of 30. Their ammunition comes in packs of 4.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(+)Reduced Old Hunting Rifle and Tranquilizer Rifle to a magazine size of 4.
```
