### PR TITLE
Adds additional scrubbers to Donut 3

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -7871,6 +7871,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor/darkblue/checker,
 /area/station/ai_monitored/storage/eva)
 "bXp" = (
@@ -14095,6 +14096,7 @@
 	dir = 4;
 	pixel_x = 24
 	},
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor/darkblue/checker,
 /area/station/ai_monitored/storage/eva)
 "dTm" = (
@@ -70659,6 +70661,7 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor/yellowblack{
 	dir = 9
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds additional air scrubbers to Donut 3. One to Primary Tool Storage and 2 to EVA.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The current locations of Donut 3 scrubbers are mostly hidden in dark maintance tunnels which makes trying to fight plasma floods and similar issues more challenging than they should be.