### PR TITLE
Replaces Horizon chaplain closet with the proper locker

### DIFF
--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -14087,9 +14087,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/storage/closet/wardrobe/black/chaplain,
-/obj/item/storage/box/clothing/witchfinder,
-/obj/item/storage/box/holywaterkit,
+/obj/storage/secure/closet/civilian/chaplain,
 /turf/simulated/floor/black,
 /area/station/chapel/office)
 "aIy" = (

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -14088,6 +14088,8 @@
 	icon_state = "0-8"
 	},
 /obj/storage/closet/wardrobe/black/chaplain,
+/obj/item/storage/box/clothing/witchfinder,
+/obj/item/storage/box/holywaterkit,
 /turf/simulated/floor/black,
 /area/station/chapel/office)
 "aIy" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces Horizon chaplain closet with the proper locker


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Horizon uses a different type of locker for whatever reason, so it doesnt contain the holy water kit and witchfinders equipment and it's better to have consistency between maps