### PR TITLE
Removes kudzu from VR uplink list

### DIFF
--- a/code/modules/events/gimmick/kudzu.dm
+++ b/code/modules/events/gimmick/kudzu.dm
@@ -40,6 +40,7 @@
 	item = /obj/item/kudzuseed
 	cost = 4
 	desc = "Syndikudzu. Interesting. Plant on the floor to grow."
+	vr_allowed = 0
 	job = list("Botanist", "Staff Assistant")
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Title

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Today I witnessed someone block off murderbox equipment room permamently with kudzu, getting everyone who used the murderbox teleporter stuck. I don't think there is any reason to let people spawn kudzu in vr and I believe it's unintended.

