### PR TITLE
Adds drains under ChemiCompilers

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -33278,7 +33278,6 @@
 	dir = 1;
 	pixel_y = 30
 	},
-/obj/machinery/drainage,
 /turf/simulated/floor/purpleblack{
 	dir = 1
 	},

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -33278,6 +33278,7 @@
 	dir = 1;
 	pixel_y = 30
 	},
+/obj/machinery/drainage,
 /turf/simulated/floor/purpleblack{
 	dir = 1
 	},

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -55217,7 +55217,6 @@
 "col" = (
 /obj/machinery/chemicompiler_stationary,
 /obj/decal/tile_edge/stripe/extra_big,
-/obj/machinery/drainage,
 /turf/simulated/floor,
 /area/station/science/chemistry)
 "com" = (
@@ -55787,6 +55786,7 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/machinery/drainage,
 /turf/simulated/floor/purplewhite{
 	dir = 1
 	},
@@ -58791,6 +58791,7 @@
 /area/station/science/testchamber)
 "cvq" = (
 /obj/item/device/radio/beacon,
+/obj/machinery/drainage,
 /turf/simulated/floor/shuttlebay{
 	name = "test chamber plating"
 	},
@@ -59016,7 +59017,6 @@
 /area/station/science/testchamber)
 "cvP" = (
 /obj/machinery/chemicompiler_stationary,
-/obj/machinery/drainage,
 /turf/simulated/floor/shuttlebay{
 	name = "test chamber plating"
 	},

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -55217,6 +55217,7 @@
 "col" = (
 /obj/machinery/chemicompiler_stationary,
 /obj/decal/tile_edge/stripe/extra_big,
+/obj/machinery/drainage,
 /turf/simulated/floor,
 /area/station/science/chemistry)
 "com" = (
@@ -59015,6 +59016,7 @@
 /area/station/science/testchamber)
 "cvP" = (
 /obj/machinery/chemicompiler_stationary,
+/obj/machinery/drainage,
 /turf/simulated/floor/shuttlebay{
 	name = "test chamber plating"
 	},

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -64003,6 +64003,7 @@
 /area/station/science/chemistry)
 "cJa" = (
 /obj/machinery/chemicompiler_stationary,
+/obj/machinery/drainage,
 /turf/simulated/floor/purple,
 /area/station/science/chemistry)
 "cJb" = (
@@ -76970,6 +76971,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/chemicompiler_stationary,
+/obj/machinery/drainage,
 /turf/simulated/floor/engine{
 	dir = 1;
 	icon_state = "engine_caution_misc"

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -64003,7 +64003,6 @@
 /area/station/science/chemistry)
 "cJa" = (
 /obj/machinery/chemicompiler_stationary,
-/obj/machinery/drainage,
 /turf/simulated/floor/purple,
 /area/station/science/chemistry)
 "cJb" = (
@@ -76962,6 +76961,7 @@
 /obj/stool/chair/office{
 	dir = 4
 	},
+/obj/machinery/drainage,
 /turf/simulated/floor/engine,
 /area/research_outpost/chamber)
 "dkQ" = (
@@ -76971,7 +76971,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/chemicompiler_stationary,
-/obj/machinery/drainage,
 /turf/simulated/floor/engine{
 	dir = 1;
 	icon_state = "engine_caution_misc"

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -32802,6 +32802,7 @@
 /area/station/science/chemistry)
 "bfv" = (
 /obj/machinery/chemicompiler_stationary,
+/obj/machinery/drainage,
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
 "bfw" = (

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -32802,7 +32802,6 @@
 /area/station/science/chemistry)
 "bfv" = (
 /obj/machinery/chemicompiler_stationary,
-/obj/machinery/drainage,
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
 "bfw" = (
@@ -33533,6 +33532,7 @@
 /obj/landmark/start{
 	name = "Scientist"
 	},
+/obj/machinery/drainage,
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
 "bgN" = (

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -32355,6 +32355,7 @@
 /obj/machinery/light/incandescent/harsh{
 	dir = 1
 	},
+/obj/machinery/drainage,
 /turf/simulated/floor/shuttlebay{
 	name = "test chamber plating"
 	},
@@ -76413,6 +76414,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 6
 	},
+/obj/machinery/drainage,
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
 	},

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -32355,7 +32355,6 @@
 /obj/machinery/light/incandescent/harsh{
 	dir = 1
 	},
-/obj/machinery/drainage,
 /turf/simulated/floor/shuttlebay{
 	name = "test chamber plating"
 	},
@@ -48175,6 +48174,17 @@
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/artifact)
+"oqd" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/drainage,
+/turf/simulated/floor/shuttlebay{
+	name = "test chamber plating"
+	},
+/area/station/science/testchamber)
 "oqi" = (
 /obj/stool/bench/red,
 /turf/simulated/floor/purple,
@@ -70376,6 +70386,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/machinery/drainage,
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
 "uQK" = (
@@ -76414,7 +76425,6 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 6
 	},
-/obj/machinery/drainage,
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
 	},
@@ -117771,7 +117781,7 @@ mSc
 aZz
 aZz
 jzw
-nOR
+oqd
 fyr
 cxe
 aZz

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -5693,6 +5693,7 @@
 /area/station/science/construction)
 "aop" = (
 /obj/machinery/chemicompiler_stationary,
+/obj/machinery/drainage,
 /turf/simulated/floor/engine,
 /area/station/science/construction)
 "aoq" = (

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -33113,6 +33113,7 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
+/obj/machinery/drainage,
 /turf/simulated/floor/purpleblack,
 /area/station/science/chemistry)
 "bCh" = (

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -39000,6 +39000,7 @@
 	icon_state = "line3"
 	},
 /obj/machinery/chemicompiler_stationary,
+/obj/machinery/drainage,
 /turf/simulated/floor/blackwhite{
 	dir = 4
 	},

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -39000,7 +39000,6 @@
 	icon_state = "line3"
 	},
 /obj/machinery/chemicompiler_stationary,
-/obj/machinery/drainage,
 /turf/simulated/floor/blackwhite{
 	dir = 4
 	},
@@ -39014,6 +39013,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/drainage,
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
 "bNB" = (

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -42221,6 +42221,7 @@
 /area/ghostdrone_factory)
 "bZf" = (
 /obj/machinery/chemicompiler_stationary,
+/obj/machinery/drainage,
 /turf/simulated/floor/purple/checker,
 /area/station/science/chemistry)
 "bZg" = (

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -47534,6 +47534,10 @@
 /obj/item/furniture_parts/bench/wooden,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
+"oTM" = (
+/obj/machinery/drainage,
+/turf/simulated/floor/purple/checker,
+/area/station/science/chemistry)
 "oUx" = (
 /obj/grille/steel,
 /turf/space/fluid,
@@ -109383,7 +109387,7 @@ aGr
 cBA
 aGr
 bZf
-aGr
+oTM
 aGW
 aFl
 aFl


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds drains under ChemiCompilers


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This comes from a feature request from someone (I forgot who, Im sorry).
The CC has a function to dump it's contents out, which spills it out on the floor. Someone asked if drains could be added onto the floor so that it doesnt keep making a mess.
