### PR TITLE
Kondaru feb21 fixbatch

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -49186,6 +49186,7 @@
 /area/listeningpost)
 "clW" = (
 /obj/machinery/computer/security/wooden_tv,
+/obj/machinery/light_switch/north,
 /turf/simulated/floor/black,
 /area/listeningpost)
 "clX" = (
@@ -49269,18 +49270,10 @@
 /turf/simulated/floor/black,
 /area/listeningpost)
 "cmk" = (
-/obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 8;
-	frequency = 1485;
-	name = "Security Intercom"
-	},
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet,
-/obj/machinery/light_switch{
-	name = "E light switch";
-	pixel_x = 24;
-	pixel_y = -8
+/obj/item/device/radio/intercom/security{
+	dir = 8
 	},
 /turf/simulated/floor/black,
 /area/listeningpost)
@@ -49340,12 +49333,6 @@
 /turf/simulated/floor/black,
 /area/listeningpost)
 "cmr" = (
-/obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 8;
-	frequency = 1489;
-	name = "Brig Intercom"
-	},
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -49354,6 +49341,9 @@
 /obj/machinery/guardbot_dock,
 /obj/machinery/bot/guardbot/bad{
 	on = 0
+	},
+/obj/item/device/radio/intercom/brig{
+	dir = 8
 	},
 /turf/simulated/floor/black,
 /area/listeningpost)

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -671,11 +671,8 @@
 /turf/simulated/floor/grass/leafy,
 /area/station/garden/owlery)
 "abG" = (
-/obj/tree1{
-	desc = "It's a tree. You see the phrase 'Haine <3 SpyGuy' carved into it."
-	},
-/turf/simulated/floor/grass/leafy,
-/area/station/garden/owlery)
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "abH" = (
 /obj/shrub{
 	dir = 4
@@ -3372,7 +3369,7 @@
 	dir = 8;
 	icon_state = "catwalk_cross"
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "aip" = (
 /obj/lattice{
 	dir = 6;
@@ -4925,7 +4922,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "ame" = (
 /obj/table/auto,
 /obj/item/paper_bin,
@@ -5521,7 +5518,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "anA" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8;
@@ -5784,7 +5781,7 @@
 	dir = 4;
 	icon_state = "catwalk_cross"
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "aoj" = (
 /obj/grille/catwalk{
 	dir = 10;
@@ -5796,7 +5793,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "aok" = (
 /obj/grille/catwalk{
 	dir = 1;
@@ -5806,7 +5803,7 @@
 	dir = 5;
 	icon_state = "catwalk_cross"
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "aol" = (
 /turf/simulated/floor/carpet/red/standard/edge/nw,
 /area/station/crew_quarters/radio/news_office)
@@ -6246,11 +6243,11 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "app" = (
 /obj/grille/catwalk,
 /turf/simulated/floor/airless/plating/catwalk,
-/area/station/mining/staff_room)
+/area/station/mining)
 "apq" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -6649,7 +6646,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "aqk" = (
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/utility)
@@ -6837,7 +6834,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	icon_state = "catwalk_cross"
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "aqK" = (
 /obj/machinery/vending/medical_public,
 /turf/simulated/floor/red/side{
@@ -7993,13 +7990,7 @@
 "atu" = (
 /obj/table/reinforced/auto,
 /obj/machinery/cashreg,
-/obj/item/device/radio/intercom{
-	broadcasting = 0;
-	pixel_y = -1
-	},
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
+/obj/item/device/radio/intercom,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "atv" = (
@@ -8573,7 +8564,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "avb" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -11858,18 +11849,18 @@
 /area/station/turret_protected/ai)
 "aCr" = (
 /turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aCs" = (
 /obj/stool/chair/couch{
 	dir = 8
 	},
 /turf/simulated/floor/black/grime,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aCt" = (
 /turf/simulated/floor/stairs/dark{
 	dir = 1
 	},
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aCu" = (
 /obj/machinery/power/data_terminal,
 /obj/landmark/start{
@@ -11899,11 +11890,11 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aCw" = (
 /obj/storage/closet/wardrobe/yellow,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aCx" = (
 /obj/machinery/turret,
 /obj/decal/tile_edge/line/white{
@@ -12346,10 +12337,10 @@
 /area/station/crew_quarters/fitness)
 "aDz" = (
 /turf/simulated/floor/carpet/red/fancy/narrow/nw,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aDA" = (
 /turf/simulated/floor/carpet/red/fancy/edge/north,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aDB" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -13224,7 +13215,7 @@
 /area/station/hangar/engine)
 "aFA" = (
 /turf/simulated/floor/carpet/red/fancy/innercorner/south,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aFC" = (
 /obj/decal/tile_edge/line/black{
 	dir = 8;
@@ -14548,7 +14539,7 @@
 /obj/decal/cleanable/dirt,
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aIE" = (
 /obj/machinery/light{
 	dir = 8;
@@ -14735,7 +14726,7 @@
 	},
 /obj/access_spawn/mining,
 /turf/simulated/floor/grey,
-/area/station/mining/staff_room)
+/area/station/mining)
 "aJe" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
@@ -14956,20 +14947,20 @@
 	pixel_x = -12
 	},
 /turf/simulated/floor/carpet/red/fancy/narrow/south,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aJB" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aJC" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aJD" = (
 /obj/machinery/vending/snack,
 /obj/machinery/firealarm{
@@ -15466,7 +15457,7 @@
 "aKN" = (
 /obj/storage/closet/fire,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aKP" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/north)
@@ -15657,7 +15648,7 @@
 /area/station/mining/refinery)
 "aLt" = (
 /turf/simulated/floor/grey,
-/area/station/mining/staff_room)
+/area/station/mining)
 "aLv" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -15834,7 +15825,7 @@
 	network = "Zeta"
 	},
 /turf/simulated/floor/black/grime,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aLU" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 1
@@ -15869,7 +15860,7 @@
 	pixel_x = 12
 	},
 /turf/simulated/floor/black/grime,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aLY" = (
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
@@ -16076,7 +16067,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /turf/simulated/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/inner/west)
 "aMI" = (
 /obj/machinery/manufacturer/mechanic,
 /turf/simulated/floor/yellow/side,
@@ -16181,11 +16172,11 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aMV" = (
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aMW" = (
 /obj/cable{
 	d1 = 1;
@@ -16200,7 +16191,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aMX" = (
 /obj/stool/chair{
 	dir = 1
@@ -16514,13 +16505,13 @@
 	dir = 5
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/inner/west)
 "aNO" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/inner/west)
 "aNP" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -16529,7 +16520,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/inner/west)
 "aNQ" = (
 /obj/lattice{
 	dir = 9;
@@ -16561,11 +16552,11 @@
 	dir = 4
 	},
 /turf/simulated/floor/black/grime,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aNW" = (
 /obj/item/instrument/large/jukebox,
 /turf/simulated/floor/carpet/red/fancy/narrow/ne,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aNY" = (
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
@@ -16582,7 +16573,7 @@
 	pixel_x = 12
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aOc" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/machinery/camera{
@@ -16827,7 +16818,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/inner/west)
 "aOI" = (
 /obj/decal/xmas_lights/ephemeral{
 	pixel_y = 32
@@ -16837,7 +16828,7 @@
 "aOJ" = (
 /obj/decal/poster/wallsign/space,
 /turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/central)
+/area/station/maintenance/inner/west)
 "aOK" = (
 /obj/machinery/atmospherics/pipe/vent{
 	dir = 1
@@ -16877,7 +16868,7 @@
 /area/station/engine/storage)
 "aOP" = (
 /turf/simulated/floor/carpet/red/fancy/edge/west,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aOR" = (
 /obj/machinery/drainage,
 /turf/simulated/floor/sanitary,
@@ -16895,7 +16886,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/east,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aOV" = (
 /turf/simulated/pool/no_animate,
 /area/station/crew_quarters/pool)
@@ -17149,7 +17140,7 @@
 	},
 /obj/decal/cleanable/oil,
 /turf/simulated/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/inner/west)
 "aPC" = (
 /obj/grille/catwalk{
 	dir = 9;
@@ -17256,7 +17247,7 @@
 	pixel_x = -12
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/west,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aPQ" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/cable{
@@ -17277,7 +17268,7 @@
 /obj/item/game_kit,
 /obj/item/decoration/ashtray,
 /turf/simulated/floor/carpet/red/fancy/edge/east,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aPT" = (
 /turf/simulated/floor/stairs/medical{
 	dir = 4
@@ -17620,11 +17611,11 @@
 	},
 /obj/storage/closet/fire,
 /turf/simulated/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/inner/west)
 "aQG" = (
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/inner/west)
 "aQH" = (
 /obj/cable{
 	d1 = 1;
@@ -17639,7 +17630,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/inner/west)
 "aQI" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -17712,7 +17703,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aQT" = (
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/quarters_east)
@@ -17801,16 +17792,16 @@
 /area/station/crew_quarters/quarters_east)
 "aRc" = (
 /turf/simulated/floor/carpet/red/fancy/narrow/sw,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aRd" = (
 /turf/simulated/floor/carpet/red/fancy/edge/south,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aRe" = (
 /obj/stool/chair/comfy{
 	dir = 8
 	},
 /turf/simulated/floor/carpet/red/fancy/narrow/se,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aRf" = (
 /obj/machinery/light{
 	dir = 4;
@@ -18171,7 +18162,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/grey,
-/area/station/maintenance/central)
+/area/station/maintenance/inner/west)
 "aRO" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
@@ -18180,7 +18171,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/inner/west)
 "aRP" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
@@ -18194,7 +18185,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/inner/west)
 "aRQ" = (
 /obj/disposalpipe/segment/bent/south,
 /obj/cable{
@@ -18208,7 +18199,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/inner/west)
 "aRR" = (
 /obj/machinery/light,
 /turf/simulated/floor/stairs/wide{
@@ -18268,7 +18259,7 @@
 "aRZ" = (
 /obj/disposalpipe/junction/left/north,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aSa" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
@@ -18597,7 +18588,7 @@
 	pixel_x = -12
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/inner/west)
 "aSQ" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -18606,14 +18597,14 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/inner/west)
 "aSR" = (
 /obj/disposalpipe/segment/bent/north,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/ghostdrone_factory)
 "aSS" = (
 /turf/simulated/floor/black/grime,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aST" = (
 /obj/table/wood/auto,
 /obj/item/instrument/harmonica,
@@ -18621,7 +18612,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/black/grime,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aSU" = (
 /obj/table/wood/auto,
 /obj/item/instrument/saxophone,
@@ -18635,7 +18626,7 @@
 	pixel_x = 12
 	},
 /turf/simulated/floor/black/grime,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aSV" = (
 /obj/decal/poster/wallsign/security_wall,
 /obj/decal/poster/wallsign/stencil/left/v{
@@ -18973,7 +18964,7 @@
 "aTJ" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aTK" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
@@ -19283,7 +19274,7 @@
 "aUu" = (
 /obj/stool/chair,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aUv" = (
 /obj/decal/cleanable/dirt,
 /obj/machinery/power/apc/autoname_north,
@@ -19291,7 +19282,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aUw" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -19301,7 +19292,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aUy" = (
 /obj/disposalpipe/segment/bent/west,
 /obj/cable{
@@ -19310,7 +19301,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aUz" = (
 /turf/unsimulated/wall/auto/reinforced/supernorn,
 /area/station/crewquarters/cryotron)
@@ -19346,7 +19337,7 @@
 	name = "The Recluse"
 	},
 /turf/simulated/floor/carpet/red/fancy/narrow/north,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aUF" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -19669,7 +19660,7 @@
 	pixel_y = 16
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aVr" = (
 /obj/disposalpipe/segment/bent/east,
 /obj/submachine/GTM{
@@ -19677,7 +19668,7 @@
 	},
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aVs" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
@@ -19689,7 +19680,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aVv" = (
 /obj/disposalpipe/segment/food{
 	dir = 2;
@@ -19699,7 +19690,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aVw" = (
 /obj/cable{
 	d1 = 1;
@@ -19707,7 +19698,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aVx" = (
 /obj/table/auto,
 /obj/machinery/cell_charger,
@@ -19747,7 +19738,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aVE" = (
 /obj/table/reinforced/auto,
 /obj/machinery/computer/tour_console,
@@ -19818,7 +19809,7 @@
 	pixel_y = 20
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aVI" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -20362,7 +20353,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aWH" = (
 /obj/cable{
 	d1 = 1;
@@ -20371,7 +20362,7 @@
 	},
 /obj/item/reagent_containers/food/snacks/cereal_box/roach,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aWI" = (
 /obj/cable{
 	d1 = 2;
@@ -20389,7 +20380,7 @@
 /obj/item/extinguisher,
 /obj/item/crowbar,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aWK" = (
 /obj/rack,
 /obj/item/clothing/suit/space/emerg,
@@ -20398,11 +20389,11 @@
 /obj/item/tank/air,
 /obj/item/device/light/flashlight,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aWL" = (
 /obj/storage/closet/emergency,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aWM" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -20420,7 +20411,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aWO" = (
 /obj/machinery/light/emergency{
 	dir = 4;
@@ -21147,7 +21138,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/inner/west)
 "aYF" = (
 /obj/cable{
 	d1 = 1;
@@ -21155,7 +21146,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aYG" = (
 /obj/disposalpipe/segment/vertical,
 /obj/machinery/light/small{
@@ -21163,7 +21154,7 @@
 	pixel_x = 12
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aYH" = (
 /obj/machinery/atmospherics/unary/cold_sink/freezer/kitchen/south{
 	current_temperature = 250
@@ -21528,11 +21519,11 @@
 "aZC" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aZE" = (
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aZF" = (
 /obj/cable{
 	d1 = 1;
@@ -21545,7 +21536,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aZG" = (
 /obj/disposalpipe/segment/bent/north,
 /obj/cable{
@@ -21554,7 +21545,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "aZH" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/machinery/door/airlock/pyro{
@@ -22068,7 +22059,7 @@
 	},
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "baT" = (
 /obj/machinery/light{
 	dir = 1;
@@ -22085,13 +22076,13 @@
 	},
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "baW" = (
 /obj/cable{
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "baX" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -22103,7 +22094,7 @@
 /obj/decal/cleanable/dirt,
 /obj/storage/closet/wardrobe/grey,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "baY" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -22445,10 +22436,10 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/inner/west)
 "bbY" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "bbZ" = (
 /obj/machinery/door/airlock/pyro/external,
 /obj/cable{
@@ -22457,7 +22448,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "bca" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/routing/depot)
@@ -22481,7 +22472,7 @@
 	name = "odd note"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "bce" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -22897,11 +22888,11 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/inner/west)
 "bdf" = (
 /obj/decal/poster/wallsign/space,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/maintenance/central)
+/area/station/maintenance/inner/west)
 "bdg" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 4;
@@ -23676,7 +23667,7 @@
 /area/station/mining/refinery)
 "bfh" = (
 /turf/space,
-/area/station/mining/staff_room)
+/area/station/mining)
 "bfi" = (
 /obj/cable{
 	d1 = 1;
@@ -24087,10 +24078,10 @@
 	icon_state = "lattice-dir"
 	},
 /turf/space,
-/area/station/mining/staff_room)
+/area/station/mining)
 "bgq" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/mining/staff_room)
+/area/station/mining)
 "bgr" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/checkpoint/escape)
@@ -24238,10 +24229,13 @@
 /obj/machinery/door/airlock/pyro/glass,
 /obj/access_spawn/brig,
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/red/side{
 	dir = 5
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "bgT" = (
 /obj/table/auto,
 /obj/item/dye_bottle,
@@ -24554,7 +24548,7 @@
 	icon_state = "lattice-dir"
 	},
 /turf/space,
-/area/station/mining/staff_room)
+/area/station/mining)
 "bhG" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -24569,7 +24563,7 @@
 	icon_state = "lattice-dir"
 	},
 /turf/space,
-/area/station/mining/staff_room)
+/area/station/mining)
 "bhI" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -25124,7 +25118,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "biR" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -25215,7 +25209,7 @@
 	},
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "bjd" = (
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/black,
@@ -25625,9 +25619,7 @@
 /area/station/hallway/primary/west)
 "bka" = (
 /turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "bkb" = (
 /obj/rack,
 /obj/item/clothing/suit/space/emerg,
@@ -25636,29 +25628,21 @@
 /obj/item/tank/air,
 /obj/item/device/light/flashlight,
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "bkc" = (
 /obj/machinery/light/small{
 	dir = 1;
 	pixel_y = 21
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "bkd" = (
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "bke" = (
 /obj/decal/poster/wallsign/space,
 /turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "bkf" = (
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Mini-Brig"
@@ -26086,27 +26070,21 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "blg" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "blh" = (
 /obj/disposalpipe/junction/left/east,
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "bli" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -26116,9 +26094,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "blj" = (
 /obj/machinery/computer3/generic/secure_data{
 	dir = 4;
@@ -26162,7 +26138,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "blm" = (
 /obj/machinery/computer/magnet,
 /obj/machinery/light{
@@ -26175,7 +26151,7 @@
 	},
 /obj/cable,
 /turf/simulated/floor,
-/area/station/mining/staff_room)
+/area/station/mining)
 "bln" = (
 /obj/table/reinforced/auto,
 /obj/machinery/cell_charger,
@@ -26187,7 +26163,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "blo" = (
 /obj/rack,
 /obj/item/clothing/mask/breath,
@@ -26204,7 +26180,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "blp" = (
 /obj/machinery/door/airlock/pyro{
 	name = "Shower Room"
@@ -26668,9 +26644,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "bmy" = (
 /turf/simulated/wall/auto/reinforced/supernorn/yellow,
 /area/station/mining/refinery)
@@ -26709,7 +26683,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "bmE" = (
 /obj/rack,
 /obj/item/clothing/mask/breath,
@@ -26721,7 +26695,7 @@
 /turf/simulated/floor/orangeblack/corner{
 	dir = 4
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "bmG" = (
 /obj/rack,
 /obj/item/clothing/mask/breath,
@@ -26733,7 +26707,7 @@
 /turf/simulated/floor/orangeblack/corner{
 	dir = 1
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "bmH" = (
 /turf/simulated/floor,
 /area/station/mining/staff_room)
@@ -27248,9 +27222,7 @@
 	},
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "bnV" = (
 /obj/disposalpipe/segment/bent/north,
 /obj/machinery/camera{
@@ -27325,10 +27297,10 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "bof" = (
 /turf/simulated/floor/orangeblack/corner,
-/area/station/mining/staff_room)
+/area/station/mining)
 "bog" = (
 /obj/machinery/door/airlock/pyro/glass/windoor{
 	dir = 8
@@ -27337,10 +27309,10 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "boh" = (
 /turf/simulated/floor/delivery,
-/area/station/mining/staff_room)
+/area/station/mining)
 "boi" = (
 /obj/machinery/cargo_router/kd_mining,
 /obj/plasticflaps{
@@ -27766,9 +27738,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "bpk" = (
 /obj/storage/closet/welding_supply,
 /turf/simulated/floor/orangeblack/side{
@@ -27801,21 +27771,21 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "bpq" = (
 /turf/simulated/floor/orangeblack/corner{
 	dir = 1
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "bpr" = (
 /obj/machinery/ore_cloud_storage_container,
 /turf/simulated/floor/orangeblack/side,
-/area/station/mining/staff_room)
+/area/station/mining)
 "bps" = (
 /turf/simulated/floor/orangeblack/corner{
 	dir = 8
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "bpt" = (
 /obj/machinery/cargo_router/kd_mining_exoflap,
 /turf/simulated/floor/caution/northsouth,
@@ -27953,7 +27923,7 @@
 	pixel_x = 12
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "bpH" = (
 /obj/stool/chair{
 	dir = 4
@@ -28250,16 +28220,21 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/orangeblack,
-/area/station/mining/staff_room)
+/area/station/mining)
 "bqt" = (
 /obj/disposalpipe/segment/bent/west,
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "bqu" = (
 /obj/stool/chair/yellow{
 	dir = 1
@@ -28270,7 +28245,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/station/mining/staff_room)
+/area/station/mining)
 "bqv" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -28278,7 +28253,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "bqz" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/wall/auto/supernorn,
@@ -28693,17 +28668,13 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/grey,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "brI" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "brJ" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -28722,9 +28693,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "brK" = (
 /obj/table/reinforced/auto,
 /obj/item/shipcomponent/sensor/mining{
@@ -28756,22 +28725,27 @@
 /obj/landmark/start{
 	name = "Miner"
 	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "brO" = (
 /obj/stool/chair/yellow,
 /obj/landmark/start{
 	name = "Miner"
 	},
 /turf/simulated/floor,
-/area/station/mining/staff_room)
+/area/station/mining)
 "brP" = (
 /turf/simulated/floor/orangeblack/corner{
 	dir = 4
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "brQ" = (
 /obj/cable{
 	d1 = 1;
@@ -28948,7 +28922,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "bsn" = (
 /obj/cable{
 	d1 = 2;
@@ -29156,7 +29130,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/orangeblack/corner,
-/area/station/mining/staff_room)
+/area/station/mining)
 "bsU" = (
 /obj/stool/chair/blue{
 	dir = 4
@@ -29267,10 +29241,12 @@
 /obj/table/reinforced/auto,
 /obj/item/storage/firstaid/regular,
 /obj/machinery/light/emergency,
+/obj/machinery/power/apc/autoname_west,
+/obj/cable,
 /turf/simulated/floor/orangeblack/side{
 	dir = 10
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "bth" = (
 /obj/table/reinforced/auto,
 /obj/machinery/computer/security/wooden_tv/small{
@@ -29279,7 +29255,7 @@
 /turf/simulated/floor/orangeblack/corner{
 	dir = 8
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "bti" = (
 /obj/stool/chair/yellow{
 	dir = 8
@@ -29288,7 +29264,7 @@
 	name = "Miner"
 	},
 /turf/simulated/floor,
-/area/station/mining/staff_room)
+/area/station/mining)
 "btj" = (
 /obj/cable{
 	d1 = 1;
@@ -29298,7 +29274,7 @@
 /turf/simulated/floor/orangeblack/corner{
 	dir = 1
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "btl" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating,
@@ -29814,15 +29790,15 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/station/mining/staff_room)
+/area/station/mining)
 "buD" = (
 /obj/machinery/nanofab/refining,
 /turf/simulated/floor,
-/area/station/mining/staff_room)
+/area/station/mining)
 "buE" = (
 /obj/machinery/nanofab/mining,
 /turf/simulated/floor,
-/area/station/mining/staff_room)
+/area/station/mining)
 "buF" = (
 /obj/wingrille_spawn/auto,
 /obj/machinery/door/poddoor/pyro{
@@ -30062,7 +30038,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "bvb" = (
 /obj/cable{
 	d1 = 1;
@@ -30072,7 +30048,7 @@
 /obj/decal/cleanable/dirt,
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "bvc" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/ce)
@@ -30201,27 +30177,19 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "bvC" = (
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "bvD" = (
 /obj/disposalpipe/segment/bent/south,
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "bvE" = (
 /obj/storage/closet/fire,
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "bvF" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/mining/refinery)
@@ -30560,7 +30528,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "bwn" = (
 /obj/table/auto,
 /obj/machinery/microwave,
@@ -30672,9 +30640,7 @@
 "bwH" = (
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "bwI" = (
 /obj/cable{
 	d1 = 1;
@@ -30682,12 +30648,10 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "bwJ" = (
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "bwK" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -30696,15 +30660,11 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "bwL" = (
 /obj/storage/closet/emergency,
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "bwM" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -31614,7 +31574,7 @@
 	pixel_y = 21
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "byL" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 6
@@ -31762,9 +31722,7 @@
 	},
 /obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "bzc" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -31776,9 +31734,7 @@
 	pixel_y = 20
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "bzd" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -31790,9 +31746,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "bze" = (
 /obj/stool/chair/yellow{
 	dir = 4
@@ -32040,7 +31994,7 @@
 	pixel_y = 21
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "bzN" = (
 /obj/table/auto,
 /obj/random_item_spawner/medicine,
@@ -32190,9 +32144,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "bAf" = (
 /obj/disposalpipe/segment/bent/north,
 /obj/cable{
@@ -32204,9 +32156,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "bAg" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
@@ -32271,7 +32221,14 @@
 "bAo" = (
 /obj/machinery/disposal/mail/autoname/mining,
 /obj/disposalpipe/trunk/mail/west,
-/obj/machinery/light_switch/east,
+/obj/machinery/light_switch/east{
+	pixel_y = -6
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24;
+	pixel_y = 8
+	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 6
 	},
@@ -32418,7 +32375,7 @@
 "bAC" = (
 /obj/disposalpipe/segment/bent/east,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "bAD" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -32529,7 +32486,7 @@
 "bAN" = (
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "bAO" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -32588,24 +32545,18 @@
 "bAZ" = (
 /obj/storage/crate,
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "bBa" = (
 /obj/cable,
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "bBb" = (
 /obj/machinery/light/small,
 /obj/cable,
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "bBc" = (
 /obj/machinery/portable_reclaimer,
 /turf/simulated/floor/grey,
@@ -34800,14 +34751,14 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "bFV" = (
 /obj/disposalpipe/segment/bent/east,
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "bFW" = (
 /obj/disposalpipe/switch_junction/biofilter/right/east,
 /obj/cable{
@@ -34815,12 +34766,12 @@
 	},
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "bFX" = (
 /obj/decal/cleanable/dirt,
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "bFY" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 4;
@@ -35095,7 +35046,7 @@
 "bGE" = (
 /obj/storage/secure/closet/brig,
 /turf/simulated/floor/red/side,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bGF" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
@@ -37287,7 +37238,7 @@
 	name = "Courtroom"
 	},
 /turf/simulated/floor,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bLk" = (
 /obj/grille/steel,
 /obj/disposalpipe/segment/food{
@@ -37295,7 +37246,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "bLl" = (
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
@@ -38394,18 +38345,18 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/red,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bND" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/redblack{
 	dir = 10
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "bNE" = (
 /turf/simulated/floor/redblack/corner{
 	dir = 4
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "bNG" = (
 /obj/machinery/door/airlock/pyro/security{
 	dir = 4;
@@ -39079,7 +39030,7 @@
 	dir = 1
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bOX" = (
 /obj/disposalpipe/junction/right/west,
 /obj/cable{
@@ -39124,7 +39075,7 @@
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "bPe" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/right{
@@ -39242,7 +39193,7 @@
 	pixel_y = 21
 	},
 /turf/simulated/floor/plating/airless,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "bPs" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -39621,7 +39572,7 @@
 /turf/simulated/floor/red/side{
 	dir = 9
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "bQk" = (
 /obj/disposalpipe/segment/transport,
 /obj/disposalpipe/segment/brig{
@@ -39630,7 +39581,7 @@
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "bQl" = (
 /obj/disposalpipe/segment/brig{
 	dir = 2;
@@ -39644,7 +39595,7 @@
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "bQm" = (
 /obj/machinery/disposal/brig,
 /obj/disposalpipe/trunk/east,
@@ -39655,7 +39606,7 @@
 /turf/simulated/floor/red/side{
 	dir = 5
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "bQn" = (
 /obj/submachine/chef_sink/chem_sink{
 	pixel_y = 16
@@ -39768,18 +39719,18 @@
 	operating = 1
 	},
 /turf/simulated/floor/plating/airless,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "bQz" = (
 /obj/machinery/launcher_loader/east,
 /turf/simulated/floor/plating/airless,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "bQA" = (
 /obj/item/storage/toilet,
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
 /turf/simulated/floor/black,
-/area/station/security/brig)
+/area/station/security/brig/solitary)
 "bQB" = (
 /obj/table/reinforced/auto,
 /obj/item/paper_bin,
@@ -39792,11 +39743,11 @@
 /turf/simulated/floor/grey/side{
 	dir = 4
 	},
-/area/station/security/brig)
+/area/station/security/brig/solitary)
 "bQC" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "bQF" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/middle{
@@ -39888,7 +39839,7 @@
 /obj/decal/cleanable/dirt,
 /obj/critter/mouse,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "bQP" = (
 /obj/mopbucket,
 /obj/submachine/chef_sink/chem_sink{
@@ -40224,7 +40175,7 @@
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "bRz" = (
 /obj/disposalpipe/segment/brig{
 	dir = 2;
@@ -40236,14 +40187,14 @@
 /turf/simulated/floor/red/side{
 	dir = 8
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "bRA" = (
 /obj/disposalpipe/segment/transport,
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bRB" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -40259,7 +40210,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bRC" = (
 /obj/machinery/disposal,
 /obj/machinery/light{
@@ -40271,7 +40222,7 @@
 /turf/simulated/floor/red/side{
 	dir = 4
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "bRD" = (
 /obj/machinery/shower{
 	dir = 8;
@@ -40344,7 +40295,7 @@
 	},
 /obj/machinery/drainage,
 /turf/simulated/floor/black,
-/area/station/security/brig)
+/area/station/security/brig/solitary)
 "bRO" = (
 /obj/disposalpipe/switch_junction/right/south{
 	mail_tag = "escape hallway";
@@ -40365,7 +40316,7 @@
 	},
 /obj/machinery/drainage,
 /turf/simulated/floor/black,
-/area/station/security/brig)
+/area/station/security/brig/solitary)
 "bRQ" = (
 /obj/stool,
 /obj/item/device/radio/intercom{
@@ -40374,7 +40325,7 @@
 /turf/simulated/floor/grey/side{
 	dir = 4
 	},
-/area/station/security/brig)
+/area/station/security/brig/solitary)
 "bRR" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/neutral/corner,
@@ -40383,12 +40334,12 @@
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "bRT" = (
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "bRU" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/left{
@@ -40846,7 +40797,7 @@
 /obj/machinery/driver_button{
 	id = "kondaru_qmfetch";
 	name = "Crate Retrieval Driver";
-	pixel_y = -24
+	pixel_y = -19
 	},
 /turf/simulated/floor/orangeblack/side,
 /area/station/quartermaster/office)
@@ -40946,11 +40897,11 @@
 	},
 /obj/machinery/light_switch/west,
 /turf/simulated/floor/bot,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bTf" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bTg" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -40961,7 +40912,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bTh" = (
 /obj/item/storage/box/evidence,
 /obj/item/storage/box/evidence,
@@ -40983,7 +40934,7 @@
 /turf/simulated/floor/red/side{
 	dir = 4
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "bTi" = (
 /obj/machinery/shower{
 	dir = 8;
@@ -41042,7 +40993,7 @@
 /obj/machinery/floorflusher/solitary,
 /obj/disposalpipe/trunk/south,
 /turf/simulated/floor/black,
-/area/station/security/brig)
+/area/station/security/brig/solitary)
 "bTp" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/hos)
@@ -41220,6 +41171,10 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
+/obj/decal/tile_edge/floorguide/evac{
+	dir = 8
+	},
+/obj/decal/tile_edge/floorguide/arrow_w,
 /turf/simulated/floor/grey,
 /area/station/routing/medsci{
 	name = "Research Router"
@@ -41431,7 +41386,7 @@
 	pixel_y = -8
 	},
 /turf/simulated/floor/bot,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bUi" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	icon_state = "on";
@@ -41440,13 +41395,13 @@
 /turf/simulated/floor/red/corner{
 	dir = 4
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "bUj" = (
 /obj/machinery/vending/medical_public,
 /turf/simulated/floor/red/side{
 	dir = 5
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "bUk" = (
 /obj/machinery/door/unpowered/wood/pyro{
 	name = "The Snip"
@@ -41535,7 +41490,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/security/brig)
+/area/station/security/brig/solitary)
 "bUt" = (
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Holding Cell One"
@@ -41545,7 +41500,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/black,
-/area/station/security/brig)
+/area/station/security/brig/solitary)
 "bUu" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -41553,7 +41508,7 @@
 	},
 /obj/decal/wreath/ephemeral,
 /turf/simulated/floor/plating,
-/area/station/security/brig)
+/area/station/security/brig/solitary)
 "bUv" = (
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Holding Cell Two"
@@ -41563,7 +41518,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/black,
-/area/station/security/brig)
+/area/station/security/brig/solitary)
 "bUw" = (
 /obj/disposalpipe/segment/vertical,
 /obj/machinery/door/airlock/pyro/glass{
@@ -41966,7 +41921,9 @@
 	dir = 4
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/main)
+/area/station/maintenance/storage{
+	name = "Secure Atmospherics"
+	})
 "bVr" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -41978,7 +41935,9 @@
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
-/area/station/security/main)
+/area/station/maintenance/storage{
+	name = "Secure Atmospherics"
+	})
 "bVs" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -41989,18 +41948,30 @@
 /obj/disposalpipe/segment/transport{
 	icon_state = "pipe-c"
 	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
-/area/station/security/main)
+/area/station/maintenance/storage{
+	name = "Secure Atmospherics"
+	})
 "bVt" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 10
 	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
-/area/station/security/main)
+/area/station/maintenance/storage{
+	name = "Secure Atmospherics"
+	})
 "bVu" = (
 /obj/machinery/flasher/portable,
 /obj/disposalpipe/segment/brig{
@@ -42010,7 +41981,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/bot,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bVv" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1;
@@ -42022,7 +41993,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bVw" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -42031,7 +42002,7 @@
 	dir = 8
 	},
 /turf/simulated/floor,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bVx" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -42042,32 +42013,39 @@
 /turf/simulated/floor/red/corner{
 	dir = 4
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "bVA" = (
 /obj/disposalpipe/junction/right/west,
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
+/obj/machinery/light_switch/north{
+	area = "Brig"
+	},
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "bVB" = (
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/autoname_north,
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
+/obj/machinery/power/apc{
+	areastring = "Brig";
+	name = "Brig APC";
+	pixel_y = 24
+	},
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "bVD" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -42083,7 +42061,7 @@
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "bVE" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
@@ -42097,7 +42075,7 @@
 	dir = 8
 	},
 /turf/simulated/floor,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bVG" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -42111,7 +42089,7 @@
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "bVH" = (
 /obj/item/device/radio/beacon,
 /obj/machinery/atmospherics/pipe/simple{
@@ -42123,10 +42101,14 @@
 /obj/machinery/door_timer/solitary/new_walls/north{
 	layer = 3.1
 	},
+/obj/machinery/light_switch/north{
+	area = "Brig - Solitary Cells";
+	pixel_x = 11
+	},
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "bVI" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -42148,7 +42130,7 @@
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "bVJ" = (
 /obj/landmark/gps_waypoint,
 /obj/machinery/atmospherics/pipe/simple{
@@ -42163,7 +42145,7 @@
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "bVK" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -42177,7 +42159,7 @@
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "bVL" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -42189,7 +42171,7 @@
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "bVM" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -42205,13 +42187,13 @@
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "bVN" = (
 /obj/cable{
 	icon_state = "2-4"
 	},
 /turf/simulated/floor,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bVP" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -42235,7 +42217,7 @@
 /obj/machinery/drone_recharger,
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "bVS" = (
 /obj/machinery/optable{
 	name = "Autopsy Table"
@@ -42503,7 +42485,9 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/security/main)
+/area/station/maintenance/storage{
+	name = "Secure Atmospherics"
+	})
 "bWy" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -42513,7 +42497,9 @@
 	},
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating,
-/area/station/security/main)
+/area/station/maintenance/storage{
+	name = "Secure Atmospherics"
+	})
 "bWz" = (
 /obj/machinery/atmospherics/pipe/simple,
 /turf/simulated/floor/plating,
@@ -42530,7 +42516,7 @@
 	pixel_x = -10
 	},
 /turf/simulated/floor/bot,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bWB" = (
 /obj/disposalpipe/segment/transport,
 /obj/disposalpipe/segment/brig{
@@ -42538,7 +42524,7 @@
 	},
 /obj/stool/chair/red,
 /turf/simulated/floor,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bWC" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -42552,7 +42538,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bWD" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -42565,14 +42551,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple,
 /turf/simulated/floor,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bWF" = (
 /obj/disposalpipe/junction/right/west,
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bWG" = (
 /obj/disposalpipe/segment/transport,
 /obj/cable{
@@ -42585,7 +42571,7 @@
 	dir = 8
 	},
 /turf/simulated/floor,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bWH" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -42597,7 +42583,7 @@
 	dir = 8
 	},
 /turf/simulated/floor,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bWK" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
@@ -42611,7 +42597,7 @@
 	dir = 8
 	},
 /turf/simulated/floor,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bWL" = (
 /obj/stool/chair/red{
 	dir = 8
@@ -42633,7 +42619,7 @@
 	dir = 1
 	},
 /turf/simulated/floor,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bWO" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -42643,7 +42629,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bWP" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -42655,13 +42641,13 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bWR" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bWT" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -42818,7 +42804,9 @@
 	name = "Air Hookup Reserve Tank"
 	},
 /turf/simulated/floor/plating,
-/area/station/security/main)
+/area/station/maintenance/storage{
+	name = "Secure Atmospherics"
+	})
 "bXp" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/box/trackimp_kit2,
@@ -42831,7 +42819,7 @@
 /turf/simulated/floor/red/side{
 	dir = 10
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "bXq" = (
 /obj/table/reinforced/auto,
 /obj/item/wrench,
@@ -42841,7 +42829,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/red/side,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bXr" = (
 /obj/table/reinforced/auto,
 /obj/machinery/defib_mount{
@@ -42860,7 +42848,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/red/side,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bXs" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -42872,7 +42860,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple,
 /turf/simulated/floor/red/side,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bXt" = (
 /obj/item/clothing/suit/armor/EOD,
 /obj/item/clothing/suit/armor/EOD,
@@ -42890,7 +42878,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/red/side,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bXu" = (
 /obj/machinery/disposal/morgue{
 	desc = "A pneumatic delivery chute for sending a prisoner's items to their release zone.";
@@ -42898,7 +42886,7 @@
 	},
 /obj/disposalpipe/trunk/west,
 /turf/simulated/floor/red/side,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bXv" = (
 /obj/machinery/disposal/morgue{
 	desc = "A pneumatic delivery chute for sending a prisoner's items to their release zone.";
@@ -42906,7 +42894,7 @@
 	},
 /obj/disposalpipe/trunk/north,
 /turf/simulated/floor/red/side,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bXw" = (
 /obj/machinery/disposal/morgue{
 	desc = "A pneumatic delivery chute for sending a prisoner's items to their release zone.";
@@ -42923,12 +42911,12 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/red/side,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bXx" = (
 /obj/machinery/vending/security,
 /obj/machinery/light/emergency,
 /turf/simulated/floor/red/side,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bXy" = (
 /obj/table/auto,
 /obj/item/storage/box/evidence,
@@ -42941,7 +42929,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/red/side,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bXz" = (
 /obj/table/reinforced/auto,
 /obj/disposalpipe/segment/brig{
@@ -42950,21 +42938,21 @@
 /obj/item/paper/Port_A_Brig,
 /obj/item/remote/porter/port_a_brig,
 /turf/simulated/floor/red/side,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bXA" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bXB" = (
 /obj/machinery/disposal/brig{
 	name = "mercantile checkpoint chute"
 	},
 /obj/disposalpipe/trunk/west,
 /turf/simulated/floor/red/side,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bXC" = (
 /obj/machinery/disposal/brig{
 	name = "pod bay checkpoint chute"
@@ -42972,29 +42960,29 @@
 /obj/disposalpipe/trunk/north,
 /obj/machinery/light,
 /turf/simulated/floor/red/side,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bXD" = (
 /obj/machinery/disposal/brig{
 	name = "escape checkpoint chute"
 	},
 /obj/disposalpipe/trunk/north,
 /turf/simulated/floor/red/side,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bXE" = (
 /obj/stool/chair/red{
 	dir = 1
 	},
 /turf/simulated/floor/red/side,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bXF" = (
 /obj/machinery/disposal/brig,
 /obj/disposalpipe/trunk/north,
 /turf/simulated/floor/red/side,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bXG" = (
 /obj/storage/closet/wardrobe/orange,
 /turf/simulated/floor/red/side,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bXH" = (
 /obj/machinery/light/emergency,
 /obj/storage/secure/crate/weapon/confiscated_items,
@@ -43002,7 +42990,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/red/side,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bXI" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -43017,10 +43005,10 @@
 /obj/machinery/power/data_terminal,
 /obj/cable,
 /turf/simulated/floor/red/side,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bXJ" = (
 /turf/simulated/floor/red/side,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bXK" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/box/revimp_kit,
@@ -43033,7 +43021,7 @@
 /turf/simulated/floor/red/side{
 	dir = 6
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "bXL" = (
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon16,
 /turf/simulated/floor/neutral/side{
@@ -43412,7 +43400,9 @@
 	},
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating,
-/area/station/security/main)
+/area/station/maintenance/storage{
+	name = "Secure Atmospherics"
+	})
 "bYx" = (
 /obj/machinery/door/airlock/pyro/security{
 	name = "Security Hangar";
@@ -43431,7 +43421,7 @@
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "bYy" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -43439,7 +43429,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/security/brig)
+/area/station/security/secwing)
 "bYz" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
@@ -43688,18 +43678,24 @@
 /obj/storage/closet/emergency,
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/redblack,
-/area/station/security/main)
+/area/station/maintenance/storage{
+	name = "Secure Atmospherics"
+	})
 "bZg" = (
 /obj/disposalpipe/segment/brig,
 /obj/machinery/atmospherics/valve{
 	name = "Brig Repressurization"
 	},
 /turf/simulated/floor/redblack,
-/area/station/security/main)
+/area/station/maintenance/storage{
+	name = "Secure Atmospherics"
+	})
 "bZh" = (
 /obj/machinery/vending/standard,
 /turf/simulated/floor/redblack,
-/area/station/security/main)
+/area/station/maintenance/storage{
+	name = "Secure Atmospherics"
+	})
 "bZi" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -44107,7 +44103,7 @@
 	},
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "cal" = (
 /obj/machinery/light/small,
 /obj/machinery/computer3/generic/communications{
@@ -44352,7 +44348,7 @@
 /obj/machinery/door_control{
 	id = "mports_door";
 	name = "Cargo Export";
-	pixel_x = 26
+	pixel_x = 24
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -44360,6 +44356,12 @@
 	name = "autoname - SS13";
 	pixel_x = 10;
 	tag = ""
+	},
+/obj/machinery/driver_button{
+	id = "manualshipping";
+	name = "Export Driver Override";
+	pixel_x = 24;
+	pixel_y = -9
 	},
 /turf/simulated/floor/caution/westeast,
 /area/station/quartermaster/office)
@@ -44486,7 +44488,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor,
-/area/station/security/brig)
+/area/station/security/secwing)
 "caZ" = (
 /obj/table/auto,
 /obj/item/storage/firstaid/oxygen,
@@ -46531,7 +46533,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/mining/staff_room)
+/area/station/mining)
 "cfq" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -46546,7 +46548,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/mining/staff_room)
+/area/station/mining)
 "cfr" = (
 /obj/machinery/door/airlock/pyro{
 	dir = 4
@@ -47325,7 +47327,7 @@
 	dir = 1;
 	icon_state = "catwalk_cross"
 	},
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "chl" = (
 /obj/storage/secure/closet/kitchen,
 /turf/simulated/floor/specialroom/cafeteria,
@@ -50268,7 +50270,7 @@
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "cou" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -50277,7 +50279,7 @@
 	dir = 8
 	},
 /turf/simulated/floor,
-/area/station/security/brig)
+/area/station/security/secwing)
 "cov" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
@@ -50633,7 +50635,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 1
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "coZ" = (
 /obj/cable{
 	d1 = 1;
@@ -50691,7 +50693,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/mining/staff_room)
+/area/station/mining)
 "cph" = (
 /obj/wingrille_spawn/auto,
 /obj/cable,
@@ -50707,7 +50709,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "cpj" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -50799,7 +50801,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor,
-/area/station/mining/staff_room)
+/area/station/mining)
 "cpt" = (
 /obj/storage/secure/closet/medical/medkit,
 /obj/machinery/alarm{
@@ -51063,7 +51065,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "cpS" = (
 /obj/cable{
 	d1 = 2;
@@ -51076,7 +51078,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/station/mining/staff_room)
+/area/station/mining)
 "cpT" = (
 /obj/cable{
 	d1 = 2;
@@ -51092,7 +51094,7 @@
 	name = "Mining Pad"
 	},
 /turf/simulated/floor/grey,
-/area/station/mining/staff_room)
+/area/station/mining)
 "cpU" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -51100,7 +51102,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "cpV" = (
 /obj/cable{
 	d1 = 1;
@@ -51110,7 +51112,7 @@
 /turf/simulated/floor/orangeblack/corner{
 	dir = 1
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "cpW" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -51123,7 +51125,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "cpX" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -51134,15 +51136,16 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "cpY" = (
 /obj/table/reinforced/auto,
 /obj/machinery/light,
 /obj/machinery/recharger,
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/orangeblack/side{
 	dir = 10
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "cpZ" = (
 /obj/machinery/light{
 	dir = 4;
@@ -51153,7 +51156,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
-/area/station/mining/staff_room)
+/area/station/mining)
 "cqa" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/disposalpipe/segment/horizontal,
@@ -51386,6 +51389,10 @@
 /obj/machinery/drainage,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/robotics)
+"cDz" = (
+/obj/storage/closet/emergency,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "cEa" = (
 /obj/table/auto,
 /obj/item/paper_bin{
@@ -51808,7 +51815,7 @@
 "dBo" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/inner/west)
 "dCL" = (
 /obj/cable{
 	d1 = 1;
@@ -51935,6 +51942,16 @@
 /obj/decal/poster/wallsign/security,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/main)
+"dWe" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/redblack{
+	dir = 4
+	},
+/area/station/security/secwing)
 "dWS" = (
 /obj/machinery/light_switch/east,
 /obj/machinery/camera{
@@ -52076,7 +52093,7 @@
 "eiE" = (
 /obj/critter/boogiebot,
 /turf/simulated/floor/carpet/red/fancy/innercorner/north,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "elT" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -52091,7 +52108,9 @@
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
-/area/station/security/main)
+/area/station/maintenance/storage{
+	name = "Secure Atmospherics"
+	})
 "emI" = (
 /obj/lattice{
 	icon_state = "lattice-dir"
@@ -52163,7 +52182,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/red/side,
-/area/station/security/brig)
+/area/station/security/secwing)
 "etI" = (
 /obj/cable{
 	d1 = 1;
@@ -52208,6 +52227,9 @@
 /obj/disposalpipe/junction/left/south,
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
+"eFl" = (
+/turf/simulated/wall/auto/reinforced/supernorn/yellow,
+/area/station/mining)
 "eGO" = (
 /obj/lattice{
 	dir = 4;
@@ -52369,6 +52391,11 @@
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
+"fhd" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/mining)
 "fhN" = (
 /obj/table/auto,
 /obj/item/game_kit,
@@ -52386,9 +52413,7 @@
 "fiI" = (
 /obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "fje" = (
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
@@ -52421,7 +52446,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "fkY" = (
 /obj/submachine/chicken_incubator,
 /obj/item/reagent_containers/food/snacks/ingredient/egg{
@@ -52435,7 +52460,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "fle" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 9;
@@ -53027,6 +53052,9 @@
 	},
 /turf/simulated/floor/red,
 /area/station/ai_monitored/armory)
+"gGd" = (
+/turf/simulated/floor,
+/area/station/mining)
 "gGg" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/caution/north,
@@ -53034,9 +53062,7 @@
 "gGK" = (
 /obj/decal/poster/wallsign/security_right,
 /turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "gII" = (
 /obj/table/auto,
 /obj/item/bandage,
@@ -53129,8 +53155,11 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
-/area/station/security/brig)
+/area/station/security/secwing)
 "gRI" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -53298,7 +53327,7 @@
 	dir = 8
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/interrogation)
+/area/station/security/brig/solitary)
 "hhz" = (
 /obj/cable{
 	d1 = 1;
@@ -53418,7 +53447,7 @@
 /obj/storage/closet/emergency,
 /obj/machinery/light_switch/north,
 /turf/simulated/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/inner/west)
 "hwT" = (
 /obj/machinery/vending/cola/blue,
 /obj/decal/xmas_lights/ephemeral{
@@ -53467,7 +53496,7 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plating/airless,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "hCR" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -53561,14 +53590,17 @@
 	pixel_x = -12
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "ifd" = (
+/obj/machinery/power/apc/autoname_east,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/flasher/portable,
 /turf/simulated/floor/red/side{
 	dir = 4
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "igZ" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 1
@@ -53605,7 +53637,7 @@
 "imf" = (
 /obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "inc" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/random_item_spawner/junk/one_or_zero,
@@ -53621,7 +53653,7 @@
 /turf/simulated/floor/grey/side{
 	dir = 8
 	},
-/area/station/security/brig)
+/area/station/security/brig/solitary)
 "inL" = (
 /obj/disposalpipe/segment/brig,
 /obj/disposalpipe/segment/mail/horizontal,
@@ -53666,7 +53698,9 @@
 	},
 /obj/machinery/portable_atmospherics/canister/air/large,
 /turf/simulated/floor/plating,
-/area/station/security/main)
+/area/station/maintenance/storage{
+	name = "Secure Atmospherics"
+	})
 "iut" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
@@ -53713,7 +53747,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/security/brig)
+/area/station/security/secwing)
 "iDR" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -53748,7 +53782,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor,
-/area/station/security/brig)
+/area/station/security/secwing)
 "iGQ" = (
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
@@ -53790,7 +53824,7 @@
 /turf/simulated/floor/grey/side{
 	dir = 8
 	},
-/area/station/security/brig)
+/area/station/security/brig/solitary)
 "iJB" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
@@ -53840,7 +53874,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/security/brig)
+/area/station/security/secwing)
 "iOg" = (
 /obj/decal/tile_edge/line/green{
 	icon_state = "line1"
@@ -53870,6 +53904,11 @@
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/north,
 /area/station/science/research_director)
+"iQE" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/maintenance/storage{
+	name = "Secure Atmospherics"
+	})
 "iRI" = (
 /obj/storage/secure/crate/plasma/armory/anti_biological,
 /turf/simulated/floor/engine,
@@ -54260,9 +54299,7 @@
 	name = "blobstart"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "kdR" = (
 /obj/shrub{
 	dir = 8
@@ -54408,7 +54445,7 @@
 /turf/simulated/floor/redblack{
 	dir = 5
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "kwJ" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/wall/auto/supernorn,
@@ -54943,7 +54980,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor,
-/area/station/security/brig)
+/area/station/security/secwing)
 "mhV" = (
 /obj/disposalpipe/segment/morgue{
 	icon_state = "pipe-c"
@@ -54970,6 +55007,14 @@
 	dir = 8
 	},
 /area/station/crew_quarters/quarters_south)
+"mlQ" = (
+/obj/machinery/chem_dispenser/chef{
+	desc = "It's covered in a thin layer of slightly greasy dust. The contents were probably expired before they even got here.";
+	dispensable_reagents = list("ketchup","mustard","salt","pepper","gravy","chocolate","chocolate_milk","strawberry_milk");
+	name = "HAPPY CHEF Dispense-o-Matic"
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
 "mmz" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -55032,7 +55077,7 @@
 	},
 /obj/access_spawn/brig,
 /turf/simulated/floor/red,
-/area/station/security/brig)
+/area/station/security/secwing)
 "muI" = (
 /obj/machinery/light/emergency{
 	dir = 4;
@@ -55123,7 +55168,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/security/brig)
+/area/station/security/brig/solitary)
 "mHX" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/lattice{
@@ -55257,7 +55302,7 @@
 /turf/simulated/floor/grey/side{
 	dir = 8
 	},
-/area/station/security/brig)
+/area/station/security/brig/solitary)
 "mZL" = (
 /obj/machinery/computer3/terminal/zeta{
 	setup_os_string = "ZETA_MAINFRAME"
@@ -55378,7 +55423,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/black/grime,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/inner/east)
 "nnX" = (
 /obj/machinery/rkit,
 /obj/machinery/camera{
@@ -55400,7 +55445,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/red/side,
-/area/station/security/brig)
+/area/station/security/secwing)
 "nql" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -55428,6 +55473,9 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/barber_shop)
+"nyQ" = (
+/turf/simulated/wall/auto/supernorn,
+/area/station/maintenance/inner/west)
 "nAw" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/machinery/door/poddoor/pyro{
@@ -55586,7 +55634,7 @@
 	},
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/inner/west)
 "nRo" = (
 /obj/grille/catwalk{
 	dir = 10;
@@ -55701,7 +55749,7 @@
 /obj/access_spawn/brig,
 /obj/firedoor_spawn,
 /turf/simulated/floor/red,
-/area/station/security/brig)
+/area/station/security/secwing)
 "ocX" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/disposalpipe/segment/mail/vertical,
@@ -55779,7 +55827,7 @@
 "orf" = (
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
-/area/station/security/brig)
+/area/station/security/secwing)
 "orp" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 1
@@ -55987,6 +56035,14 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit)
+"oJU" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/mining)
 "oOz" = (
 /obj/table/auto,
 /obj/machinery/cell_charger,
@@ -56049,10 +56105,13 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/red/side{
 	dir = 4
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "oWq" = (
 /obj/disposalpipe/segment/bent/east,
 /turf/simulated/floor/grass/leafy,
@@ -56325,6 +56384,14 @@
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
 /area/station/crew_quarters/md)
+"pET" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/mining)
 "pFF" = (
 /obj/table/auto,
 /obj/item/sheet/steel/fullstack,
@@ -56353,6 +56420,14 @@
 /obj/submachine/seed_vendor,
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
+"pLm" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/mining)
 "pMS" = (
 /obj/cable{
 	d1 = 4;
@@ -56401,6 +56476,9 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
+"pRI" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/security/secwing)
 "pSJ" = (
 /obj/table/auto,
 /obj/item/remote/porter/port_a_medbay,
@@ -56462,7 +56540,7 @@
 /obj/machinery/floorflusher/solitary2,
 /obj/disposalpipe/trunk/south,
 /turf/simulated/floor/black,
-/area/station/security/brig)
+/area/station/security/brig/solitary)
 "pZM" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/landmark/halloween,
@@ -56640,7 +56718,7 @@
 	},
 /obj/machinery/bot/medbot,
 /turf/simulated/floor,
-/area/station/mining/staff_room)
+/area/station/mining)
 "qsw" = (
 /obj/table/reinforced/chemistry/auto{
 	name = "prep counter"
@@ -56742,12 +56820,20 @@
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "qAR" = (
 /obj/decal/cleanable/dirt,
 /obj/machinery/shieldgenerator/energy_shield,
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
+"qBn" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/redblack{
+	dir = 4
+	},
+/area/station/security/secwing)
 "qCQ" = (
 /obj/table/auto,
 /obj/item/paper/book/guardbot_guide{
@@ -56821,6 +56907,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbooth)
+"qNX" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "qRn" = (
 /obj/decal/tile_edge/line/green{
 	dir = 9;
@@ -56917,6 +57007,13 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/catering)
+"rbq" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/mining)
 "rbG" = (
 /obj/machinery/light/emergency{
 	dir = 4;
@@ -56947,9 +57044,7 @@
 "rcK" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Inner Southwest Maintenance"
-	})
+/area/station/maintenance/inner/sw)
 "rfD" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
@@ -57139,6 +57234,9 @@
 /obj/machinery/bot/firebot,
 /turf/simulated/floor,
 /area/station/storage/warehouse)
+"rKB" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/maintenance/inner/west)
 "rMk" = (
 /obj/stool/chair{
 	dir = 4;
@@ -57190,11 +57288,21 @@
 /area/station/crew_quarters/clown{
 	name = "Clowntainment"
 	})
+"rWC" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/orangeblack/side{
+	dir = 1
+	},
+/area/station/mining)
 "rXp" = (
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "rYj" = (
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
@@ -57522,7 +57630,7 @@
 /turf/simulated/floor/red/corner{
 	dir = 1
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "sJY" = (
 /obj/decal/poster/wallsign/warning1{
 	pixel_x = 6
@@ -57578,7 +57686,7 @@
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "sME" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -57595,7 +57703,7 @@
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "sNg" = (
 /obj/stool/chair/office/blue{
 	dir = 1
@@ -57758,7 +57866,7 @@
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable,
 /turf/simulated/floor/plating,
-/area/station/security/brig)
+/area/station/security/secwing)
 "tdg" = (
 /obj/plasticflaps,
 /obj/cable{
@@ -58007,7 +58115,7 @@
 /obj/firedoor_spawn,
 /obj/access_spawn/mining,
 /turf/simulated/floor/orangeblack,
-/area/station/mining/staff_room)
+/area/station/mining)
 "tPk" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -58208,7 +58316,9 @@
 	pixel_x = 10
 	},
 /turf/simulated/floor/plating,
-/area/station/security/main)
+/area/station/maintenance/storage{
+	name = "Secure Atmospherics"
+	})
 "uoZ" = (
 /obj/machinery/light/small,
 /obj/machinery/photocopier,
@@ -58251,7 +58361,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
-/area/station/security/brig)
+/area/station/security/secwing)
 "urd" = (
 /turf/simulated/floor/red,
 /area/station/medical/medbay)
@@ -58283,7 +58393,7 @@
 /turf/simulated/floor/redblack{
 	dir = 9
 	},
-/area/station/security/brig)
+/area/station/security/secwing)
 "uwM" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
@@ -58307,7 +58417,9 @@
 	level = 2
 	},
 /turf/simulated/floor/plating,
-/area/station/security/main)
+/area/station/maintenance/storage{
+	name = "Secure Atmospherics"
+	})
 "uyV" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 1
@@ -58467,7 +58579,12 @@
 	name = "Security Repressurization"
 	},
 /turf/simulated/floor/plating,
-/area/station/security/main)
+/area/station/maintenance/storage{
+	name = "Secure Atmospherics"
+	})
+"uTZ" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/security/brig/solitary)
 "uUF" = (
 /obj/lattice{
 	dir = 4;
@@ -58498,7 +58615,7 @@
 	},
 /obj/machinery/portable_atmospherics/pump,
 /turf/simulated/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/inner/west)
 "vbJ" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -58884,7 +59001,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
-/area/station/security/brig)
+/area/station/security/secwing)
 "wio" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -58945,6 +59062,12 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/bridge/hos)
+"wtA" = (
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/security/secwing)
 "wuc" = (
 /obj/machinery/plantpot,
 /obj/machinery/light/small{
@@ -59022,6 +59145,20 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
+"wFp" = (
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	areastring = "Brig - Solitary Cells";
+	dir = 8;
+	name = "Brig - Solitary Cells APC";
+	pixel_x = -24
+	},
+/turf/simulated/floor/redblack{
+	dir = 8
+	},
+/area/station/security/secwing)
 "wHZ" = (
 /obj/machinery/door/airlock/pyro,
 /obj/disposalpipe/segment/brig{
@@ -59198,7 +59335,7 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/inner/west)
 "xkf" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -59214,7 +59351,7 @@
 "xlK" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/inner/west)
 "xmr" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -59437,7 +59574,7 @@
 	credit = 50
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/brig)
+/area/station/security/brig/solitary)
 "xOY" = (
 /obj/machinery/floorflusher/industrial,
 /obj/disposalpipe/trunk/east,
@@ -59576,7 +59713,7 @@
 /turf/simulated/floor/grey/side{
 	dir = 4
 	},
-/area/station/security/brig)
+/area/station/security/brig/solitary)
 "yfg" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/machinery/atmospherics/valve{
@@ -100873,7 +101010,7 @@ bfi
 aNL
 aNL
 aHq
-cdA
+cDz
 aRO
 aSO
 aTG
@@ -102081,17 +102218,17 @@ aHq
 aHq
 aHq
 aHq
-beJ
+abG
 aRO
 aSP
-beJ
+abG
 xlK
-beJ
+abG
 aQG
 xlK
 dBo
 vbg
-bmd
+rKB
 baQ
 bdd
 baQ
@@ -102681,24 +102818,24 @@ aIr
 aJn
 aKx
 aAT
-beJ
+abG
 aNO
-beK
-beK
-beK
-bnu
-beK
-beK
-beK
-bnu
-beK
-beK
-beK
-bnu
-beK
-bmd
+nyQ
+nyQ
+nyQ
+qNX
+nyQ
+nyQ
+nyQ
+qNX
+nyQ
+nyQ
+nyQ
+qNX
+nyQ
+rKB
 bdf
-bmd
+rKB
 bxj
 bgl
 bff
@@ -102983,7 +103120,7 @@ aIs
 aJo
 aKy
 aAS
-bmd
+rKB
 aNP
 aOJ
 aPC
@@ -104818,14 +104955,14 @@ aoj
 bhF
 aqi
 cfq
-bBt
-frY
-byc
-bzi
+fhd
+eFl
+rbq
+pET
 bqs
-bBt
-frY
-frY
+fhd
+eFl
+eFl
 bpm
 bpm
 bxZ
@@ -105127,8 +105264,8 @@ bpp
 bqt
 brN
 btg
-frY
-frY
+eFl
+eFl
 bwQ
 bya
 bzh
@@ -105723,10 +105860,10 @@ anz
 bgq
 bhF
 aqi
-coJ
+pLm
 bln
 bmE
-bmH
+gGd
 bpq
 bqv
 brP
@@ -106025,13 +106162,13 @@ aoi
 aok
 app
 aqJ
-frY
-frY
+eFl
+eFl
 coY
 bof
 bpr
 cpT
-brQ
+rWC
 btj
 buC
 bvH
@@ -106327,14 +106464,14 @@ bhH
 apo
 bhH
 aqi
-coF
+oJU
 blo
 bmG
-bmH
+gGd
 bps
 cpU
 bof
-bmH
+gGd
 buD
 bki
 qoq
@@ -106635,8 +106772,8 @@ cpS
 buC
 qsh
 cpV
-bmH
-bmH
+gGd
+gGd
 buE
 bki
 bwS
@@ -106931,11 +107068,11 @@ bfh
 bgn
 bfh
 aqi
-coJ
+pLm
 cpR
-coJ
+pLm
 bog
-coJ
+pLm
 cpi
 cpW
 cpX
@@ -107233,15 +107370,15 @@ bfh
 bgn
 bfh
 aqi
-frY
-frY
-frY
+eFl
+eFl
+eFl
 boh
-frY
-frY
-frY
-frY
-frY
+eFl
+eFl
+eFl
+eFl
+eFl
 frY
 bwU
 byf
@@ -109379,9 +109516,9 @@ bTa
 bGx
 bVq
 elT
-bGx
-bGx
-bGx
+iQE
+iQE
+iQE
 bZe
 bYu
 lyW
@@ -109683,7 +109820,7 @@ bVr
 bWx
 bXo
 itQ
-bGx
+iQE
 caU
 caU
 tuJ
@@ -110581,14 +110718,14 @@ coC
 coD
 bFK
 bFK
-bQi
+wtA
 bRy
-bFK
-bFK
-bFK
-bFK
-bFK
-bFK
+pRI
+pRI
+pRI
+pRI
+pRI
+pRI
 bZh
 caU
 caP
@@ -110890,7 +111027,7 @@ bUh
 bVu
 bWA
 bXp
-bFK
+pRI
 caU
 caU
 caQ
@@ -112062,7 +112199,7 @@ bce
 aXL
 beo
 mKe
-biY
+mlQ
 biY
 biY
 bft
@@ -112098,7 +112235,7 @@ bUj
 bVx
 cou
 bXt
-bFK
+pRI
 nbO
 caf
 caR
@@ -112400,7 +112537,7 @@ bFK
 cot
 cou
 bXu
-bFK
+pRI
 xAf
 cbR
 dGI
@@ -113306,7 +113443,7 @@ bFK
 bVB
 bWH
 bXx
-bFK
+pRI
 bZl
 cbR
 caV
@@ -113608,7 +113745,7 @@ iZd
 cot
 cou
 bGE
-bFK
+pRI
 bZl
 cah
 caV
@@ -114212,7 +114349,7 @@ xRV
 sMy
 whJ
 bXz
-bFK
+pRI
 caU
 caU
 caQ
@@ -114514,7 +114651,7 @@ iZd
 bVE
 bWK
 bXA
-bFK
+pRI
 bZp
 xKL
 ouG
@@ -114816,7 +114953,7 @@ rzU
 cot
 cou
 bXB
-bFK
+pRI
 bZr
 aaa
 aaa
@@ -115118,7 +115255,7 @@ bUp
 sME
 uqw
 bXC
-bFK
+pRI
 bZr
 aaa
 aaa
@@ -115420,7 +115557,7 @@ gYB
 bVG
 bWN
 bXD
-bFK
+pRI
 xpj
 eKS
 sYq
@@ -115714,11 +115851,11 @@ bJO
 bNy
 bMs
 chs
-iZd
-iZd
-iZd
+uTZ
+uTZ
+uTZ
 hhe
-iZd
+uTZ
 bVH
 cou
 bXE
@@ -116016,7 +116153,7 @@ bJP
 bGP
 bGP
 jhd
-bFK
+uTZ
 iIo
 mZn
 inl
@@ -116318,7 +116455,7 @@ bJQ
 bLf
 bMt
 cnX
-bFK
+uTZ
 bQA
 bRN
 bTo
@@ -116620,9 +116757,9 @@ bJR
 bLg
 bMu
 bNA
-bFK
-bFK
-bFK
+uTZ
+uTZ
+uTZ
 xOr
 bUu
 bVK
@@ -116922,7 +117059,7 @@ bJS
 bLh
 bMv
 bNB
-bFK
+uTZ
 bQA
 bRP
 pZl
@@ -116930,7 +117067,7 @@ bUv
 bVL
 caY
 bXI
-bFK
+pRI
 bZt
 xKv
 cba
@@ -117221,10 +117358,10 @@ bLh
 hKu
 bIx
 bJU
-bFK
-bFK
+pRI
+pRI
 bNC
-bFK
+uTZ
 bQB
 bRQ
 yec
@@ -117232,7 +117369,7 @@ mHd
 bVM
 mgB
 esy
-bFK
+pRI
 oUn
 cba
 cba
@@ -117523,14 +117660,14 @@ bFR
 bGY
 bIx
 bJU
-bFK
+pRI
 uwm
 bND
-bFK
-bFK
-bFK
-bFK
-bFK
+uTZ
+uTZ
+uTZ
+uTZ
+uTZ
 sJD
 bWR
 bXJ
@@ -117829,7 +117966,7 @@ bLj
 rXp
 bNE
 bRS
-bRS
+wFp
 bPc
 bRS
 qzV
@@ -118127,13 +118264,13 @@ bFR
 bHa
 bIz
 bJV
-bFK
+pRI
 kuN
 bRT
 bRT
-bRT
-bRT
-bRT
+dWe
+qBn
+qBn
 bgS
 oWo
 ifd
@@ -118436,11 +118573,11 @@ bPe
 bQF
 bRU
 bTp
-bFK
+pRI
 ocT
-bFK
-bFK
-bFK
+pRI
+pRI
+pRI
 kJA
 cba
 cba
@@ -136387,7 +136524,7 @@ abi
 abi
 abx
 abB
-abG
+qpS
 abB
 abB
 abP
@@ -137898,7 +138035,7 @@ abi
 abi
 abB
 abB
-abG
+qpS
 abx
 abi
 abi

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -3369,7 +3369,7 @@
 	dir = 8;
 	icon_state = "catwalk_cross"
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "aip" = (
 /obj/lattice{
 	dir = 6;
@@ -4922,7 +4922,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "ame" = (
 /obj/table/auto,
 /obj/item/paper_bin,
@@ -5518,7 +5518,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "anA" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8;
@@ -5781,7 +5781,7 @@
 	dir = 4;
 	icon_state = "catwalk_cross"
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "aoj" = (
 /obj/grille/catwalk{
 	dir = 10;
@@ -5793,7 +5793,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "aok" = (
 /obj/grille/catwalk{
 	dir = 1;
@@ -5803,7 +5803,7 @@
 	dir = 5;
 	icon_state = "catwalk_cross"
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "aol" = (
 /turf/simulated/floor/carpet/red/standard/edge/nw,
 /area/station/crew_quarters/radio/news_office)
@@ -6243,11 +6243,11 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "app" = (
 /obj/grille/catwalk,
 /turf/simulated/floor/airless/plating/catwalk,
-/area/station/mining)
+/area/station/mining/magnet)
 "apq" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -6646,7 +6646,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "aqk" = (
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/utility)
@@ -6834,7 +6834,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	icon_state = "catwalk_cross"
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "aqK" = (
 /obj/machinery/vending/medical_public,
 /turf/simulated/floor/red/side{
@@ -14726,7 +14726,7 @@
 	},
 /obj/access_spawn/mining,
 /turf/simulated/floor/grey,
-/area/station/mining)
+/area/station/mining/magnet)
 "aJe" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
@@ -15648,7 +15648,7 @@
 /area/station/mining/refinery)
 "aLt" = (
 /turf/simulated/floor/grey,
-/area/station/mining)
+/area/station/mining/magnet)
 "aLv" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -23667,7 +23667,7 @@
 /area/station/mining/refinery)
 "bfh" = (
 /turf/space,
-/area/station/mining)
+/area/station/mining/magnet)
 "bfi" = (
 /obj/cable{
 	d1 = 1;
@@ -24078,10 +24078,10 @@
 	icon_state = "lattice-dir"
 	},
 /turf/space,
-/area/station/mining)
+/area/station/mining/magnet)
 "bgq" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/mining)
+/area/station/mining/magnet)
 "bgr" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/checkpoint/escape)
@@ -24548,7 +24548,7 @@
 	icon_state = "lattice-dir"
 	},
 /turf/space,
-/area/station/mining)
+/area/station/mining/magnet)
 "bhG" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -24563,7 +24563,7 @@
 	icon_state = "lattice-dir"
 	},
 /turf/space,
-/area/station/mining)
+/area/station/mining/magnet)
 "bhI" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -26138,7 +26138,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "blm" = (
 /obj/machinery/computer/magnet,
 /obj/machinery/light{
@@ -26151,7 +26151,7 @@
 	},
 /obj/cable,
 /turf/simulated/floor,
-/area/station/mining)
+/area/station/mining/magnet)
 "bln" = (
 /obj/table/reinforced/auto,
 /obj/machinery/cell_charger,
@@ -26163,7 +26163,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "blo" = (
 /obj/rack,
 /obj/item/clothing/mask/breath,
@@ -26180,7 +26180,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "blp" = (
 /obj/machinery/door/airlock/pyro{
 	name = "Shower Room"
@@ -26683,7 +26683,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "bmE" = (
 /obj/rack,
 /obj/item/clothing/mask/breath,
@@ -26695,7 +26695,7 @@
 /turf/simulated/floor/orangeblack/corner{
 	dir = 4
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "bmG" = (
 /obj/rack,
 /obj/item/clothing/mask/breath,
@@ -26707,7 +26707,7 @@
 /turf/simulated/floor/orangeblack/corner{
 	dir = 1
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "bmH" = (
 /turf/simulated/floor,
 /area/station/mining/staff_room)
@@ -27297,10 +27297,10 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "bof" = (
 /turf/simulated/floor/orangeblack/corner,
-/area/station/mining)
+/area/station/mining/magnet)
 "bog" = (
 /obj/machinery/door/airlock/pyro/glass/windoor{
 	dir = 8
@@ -27309,10 +27309,10 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "boh" = (
 /turf/simulated/floor/delivery,
-/area/station/mining)
+/area/station/mining/magnet)
 "boi" = (
 /obj/machinery/cargo_router/kd_mining,
 /obj/plasticflaps{
@@ -27771,21 +27771,21 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "bpq" = (
 /turf/simulated/floor/orangeblack/corner{
 	dir = 1
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "bpr" = (
 /obj/machinery/ore_cloud_storage_container,
 /turf/simulated/floor/orangeblack/side,
-/area/station/mining)
+/area/station/mining/magnet)
 "bps" = (
 /turf/simulated/floor/orangeblack/corner{
 	dir = 8
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "bpt" = (
 /obj/machinery/cargo_router/kd_mining_exoflap,
 /turf/simulated/floor/caution/northsouth,
@@ -28220,7 +28220,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/orangeblack,
-/area/station/mining)
+/area/station/mining/magnet)
 "bqt" = (
 /obj/disposalpipe/segment/bent/west,
 /obj/cable{
@@ -28234,7 +28234,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "bqu" = (
 /obj/stool/chair/yellow{
 	dir = 1
@@ -28245,7 +28245,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/station/mining)
+/area/station/mining/magnet)
 "bqv" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -28253,7 +28253,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "bqz" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/wall/auto/supernorn,
@@ -28733,19 +28733,19 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "brO" = (
 /obj/stool/chair/yellow,
 /obj/landmark/start{
 	name = "Miner"
 	},
 /turf/simulated/floor,
-/area/station/mining)
+/area/station/mining/magnet)
 "brP" = (
 /turf/simulated/floor/orangeblack/corner{
 	dir = 4
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "brQ" = (
 /obj/cable{
 	d1 = 1;
@@ -29130,7 +29130,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/orangeblack/corner,
-/area/station/mining)
+/area/station/mining/magnet)
 "bsU" = (
 /obj/stool/chair/blue{
 	dir = 4
@@ -29246,7 +29246,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 10
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "bth" = (
 /obj/table/reinforced/auto,
 /obj/machinery/computer/security/wooden_tv/small{
@@ -29255,7 +29255,7 @@
 /turf/simulated/floor/orangeblack/corner{
 	dir = 8
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "bti" = (
 /obj/stool/chair/yellow{
 	dir = 8
@@ -29264,7 +29264,7 @@
 	name = "Miner"
 	},
 /turf/simulated/floor,
-/area/station/mining)
+/area/station/mining/magnet)
 "btj" = (
 /obj/cable{
 	d1 = 1;
@@ -29274,7 +29274,7 @@
 /turf/simulated/floor/orangeblack/corner{
 	dir = 1
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "btl" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating,
@@ -29790,15 +29790,15 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/station/mining)
+/area/station/mining/magnet)
 "buD" = (
 /obj/machinery/nanofab/refining,
 /turf/simulated/floor,
-/area/station/mining)
+/area/station/mining/magnet)
 "buE" = (
 /obj/machinery/nanofab/mining,
 /turf/simulated/floor,
-/area/station/mining)
+/area/station/mining/magnet)
 "buF" = (
 /obj/wingrille_spawn/auto,
 /obj/machinery/door/poddoor/pyro{
@@ -46527,7 +46527,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/mining)
+/area/station/mining/magnet)
 "cfq" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -46542,7 +46542,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/mining)
+/area/station/mining/magnet)
 "cfr" = (
 /obj/machinery/door/airlock/pyro{
 	dir = 4
@@ -50629,7 +50629,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 1
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "coZ" = (
 /obj/cable{
 	d1 = 1;
@@ -50687,7 +50687,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/mining)
+/area/station/mining/magnet)
 "cph" = (
 /obj/wingrille_spawn/auto,
 /obj/cable,
@@ -50703,7 +50703,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "cpj" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -50795,7 +50795,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor,
-/area/station/mining)
+/area/station/mining/magnet)
 "cpt" = (
 /obj/storage/secure/closet/medical/medkit,
 /obj/machinery/alarm{
@@ -51059,7 +51059,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "cpS" = (
 /obj/cable{
 	d1 = 2;
@@ -51072,7 +51072,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/station/mining)
+/area/station/mining/magnet)
 "cpT" = (
 /obj/cable{
 	d1 = 2;
@@ -51088,7 +51088,7 @@
 	name = "Mining Pad"
 	},
 /turf/simulated/floor/grey,
-/area/station/mining)
+/area/station/mining/magnet)
 "cpU" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -51096,7 +51096,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "cpV" = (
 /obj/cable{
 	d1 = 1;
@@ -51106,7 +51106,7 @@
 /turf/simulated/floor/orangeblack/corner{
 	dir = 1
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "cpW" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -51119,7 +51119,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "cpX" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -51130,7 +51130,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "cpY" = (
 /obj/table/reinforced/auto,
 /obj/machinery/light,
@@ -51139,7 +51139,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 10
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "cpZ" = (
 /obj/machinery/light{
 	dir = 4;
@@ -51150,7 +51150,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "cqa" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/disposalpipe/segment/horizontal,
@@ -52223,7 +52223,7 @@
 /area/station/maintenance/south)
 "eFl" = (
 /turf/simulated/wall/auto/reinforced/supernorn/yellow,
-/area/station/mining)
+/area/station/mining/magnet)
 "eGO" = (
 /obj/lattice{
 	dir = 4;
@@ -52389,7 +52389,7 @@
 /obj/wingrille_spawn/auto,
 /obj/cable,
 /turf/simulated/floor/plating,
-/area/station/mining)
+/area/station/mining/magnet)
 "fhN" = (
 /obj/table/auto,
 /obj/item/game_kit,
@@ -53048,7 +53048,7 @@
 /area/station/ai_monitored/armory)
 "gGd" = (
 /turf/simulated/floor,
-/area/station/mining)
+/area/station/mining/magnet)
 "gGg" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/caution/north,
@@ -56038,7 +56038,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/mining)
+/area/station/mining/magnet)
 "oOz" = (
 /obj/table/auto,
 /obj/machinery/cell_charger,
@@ -56387,7 +56387,7 @@
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
-/area/station/mining)
+/area/station/mining/magnet)
 "pFF" = (
 /obj/table/auto,
 /obj/item/sheet/steel/fullstack,
@@ -56423,7 +56423,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/mining)
+/area/station/mining/magnet)
 "pMS" = (
 /obj/cable{
 	d1 = 4;
@@ -56714,7 +56714,7 @@
 	},
 /obj/machinery/bot/medbot,
 /turf/simulated/floor,
-/area/station/mining)
+/area/station/mining/magnet)
 "qsw" = (
 /obj/table/reinforced/chemistry/auto{
 	name = "prep counter"
@@ -57009,7 +57009,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/mining)
+/area/station/mining/magnet)
 "rbG" = (
 /obj/machinery/light/emergency{
 	dir = 4;
@@ -57293,7 +57293,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 1
 	},
-/area/station/mining)
+/area/station/mining/magnet)
 "rXp" = (
 /turf/simulated/floor/redblack{
 	dir = 1
@@ -58111,7 +58111,7 @@
 /obj/firedoor_spawn,
 /obj/access_spawn/mining,
 /turf/simulated/floor/orangeblack,
-/area/station/mining)
+/area/station/mining/magnet)
 "tPk" = (
 /obj/cable{
 	icon_state = "1-2"

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -55006,7 +55006,7 @@
 "mlQ" = (
 /obj/machinery/chem_dispenser/chef{
 	desc = "It's covered in a thin layer of slightly greasy dust. The contents were probably expired before they even got here.";
-	dispensable_reagents = list("ketchup","mustard","salt","pepper","gravy","chocolate","chocolate_milk","strawberry_milk");
+	dispensable_reagents = list("ketchup","mustard","salt","pepper","gravy","chocolate","mint","chocolate_milk","strawberry_milk");
 	name = "HAPPY CHEF Dispense-o-Matic"
 	},
 /turf/simulated/floor/black,

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -42019,9 +42019,6 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
-/obj/machinery/light_switch/north{
-	area = "Brig"
-	},
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
@@ -42039,6 +42036,7 @@
 	},
 /obj/machinery/power/apc{
 	areastring = "Brig";
+	dir = 1;
 	name = "Brig APC";
 	pixel_y = 24
 	},
@@ -42100,10 +42098,6 @@
 	},
 /obj/machinery/door_timer/solitary/new_walls/north{
 	layer = 3.1
-	},
-/obj/machinery/light_switch/north{
-	area = "Brig - Solitary Cells";
-	pixel_x = 11
 	},
 /turf/simulated/floor/red/side{
 	dir = 1
@@ -54732,7 +54726,9 @@
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
-/turf/simulated/wall/auto/supernorn,
+/turf/simulated/wall/auto/supernorn{
+	icon_state = "3"
+	},
 /area/station/quartermaster/office)
 "lmR" = (
 /obj/storage/secure/closet/command/captain,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEAT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Small assortment of Kondaru changes and improvements.

- Rearranged several area allocations around the map, including adding several new areas to Security. Notably, the Security atmospherics room is now shielded from radiation storms, as well as both genpop and solitary cells if #3686 is merged.
- Introduced additional floor signage to Research cargo/ejection node to (hopefully) make its ejection function more apparent.
- Catering Storage has received a custom "HAPPY CHEF" kitchen dispenser that **does not share any dispensed reagents with the front-of-house soda dispenser.** Can provide: ketchup, mustard, salt, pepper, gravy, chocolate, mint, chocolate milk, strawberry milk.
- Added a manual activation button for the QM export driver in case of jams.
- An additional portable flasher has been added near the Brig back entrance.
- Fixed a few instances with cosmetic imperfections.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Further improves the feature set and usability of Kondaru.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Kubius
(+)Kondaru fixes/additions, including a QM export driver override button, new signage for the Research cargo/ejection node, and a limited kitchen dispenser in the Catering backroom.
```
