### PR TITLE
Remove escalating pipe ruptures

### DIFF
--- a/code/modules/atmospherics/machinery/pipe.dm
+++ b/code/modules/atmospherics/machinery/pipe.dm
@@ -344,7 +344,7 @@ obj/machinery/atmospherics/pipe
 
 		proc/rupture(pressure, destroy=FALSE)
 			var/new_rupture
-			if (src.destroyed || destroy || ((pressure > (10*fatigue_pressure)) && prob(1)) )
+			if (src.destroyed || destroy)
 				ruptured = 4
 				src.destroyed = TRUE
 				src.desc = "The remnants of a section of pipe that needs to be replaced.  Perhaps rods would be sufficient?"

--- a/code/modules/atmospherics/machinery/pipe.dm
+++ b/code/modules/atmospherics/machinery/pipe.dm
@@ -304,7 +304,7 @@ obj/machinery/atmospherics/pipe
 
 			var/datum/gas_mixture/gas = return_air()
 			var/pressure = MIXTURE_PRESSURE(gas)
-			if(pressure > fatigue_pressure) check_pressure(pressure)
+			if(!ruptured && pressure > fatigue_pressure) check_pressure(pressure)
 
 		proc/leak_gas()
 			var/datum/gas_mixture/gas = return_air()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Ignore additional rupture when a pipe has already ruptured.  This just made the player have to weld more and more.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Addressing @pali6 concern regarding pipe busy work. This is also the thing ZeWaka warned me about when I first started down the TEG rabbit hole. ☹️ 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Azrun
(+)Removes escalation of pipe rupture.  Too much busy work.
```
