### PR TITLE
fix a single character bug with prize vending modules

### DIFF
--- a/code/WorkInProgress/computerx/peripherals.dm
+++ b/code/WorkInProgress/computerx/peripherals.dm
@@ -549,7 +549,7 @@
 
 	proc/vend_prize()
 		var/obj/item/prize
-		var/prizeselect = rand(1,4)
+		var/prizeselect = rand(1,8)
 		var/turf/prize_location = null
 
 		if(src.host)

--- a/code/modules/networks/computer3/peripherals.dm
+++ b/code/modules/networks/computer3/peripherals.dm
@@ -927,7 +927,7 @@
 
 	proc/vend_prize()
 		var/obj/item/prize
-		var/prizeselect = rand(1,4)
+		var/prizeselect = rand(1,7)
 		var/turf/prize_location = null
 
 		if(src.host)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes prize vending modules so they vend all 7 options 
(8 in the case of computerx modules)
## Why's this needed? <!-- Describe why you think this should be added to the game. -->


It was a 1 character bug fix
