### PR TITLE
* Adds dwaine scanner to research outpost on oshan

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -22935,6 +22935,12 @@
 /turf/simulated/floor/shuttle/flock,
 /area/flock_trader)
 "bdN" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
+/obj/table/auto,
+/obj/machinery/networked/storage/scanner,
 /turf/simulated/floor/plating/random,
 /area/research_outpost/maint)
 "bdO" = (
@@ -47362,12 +47368,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/northwest)
-"mVv" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/research_outpost/maint)
 "mYN" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -133261,7 +133261,7 @@ xFh
 duw
 bdt
 bdN
-mVv
+prZ
 oqx
 bdt
 aqn


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MAPPING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a DWAINE paper scanner to research outpost.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The paper scanners are useful for dwaine scripting. And it seems the previous one was removed from netcafe to make room for a photocopier.
