### PR TITLE
Adds custom emotes to Mutant Races

### DIFF
--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -836,6 +836,38 @@
 			mob.base_body_temp = initial(mob.base_body_temp)
 		. = ..()
 
+	emote(var/act, var/voluntary)
+		switch(act)
+			if ("whip")
+				if (mob.emote_check(voluntary, 50))
+					. = list("<B>[mob]</B> whips their tail", "<i>whips their tail</i>")
+			if ("hiss")
+				if (mob.emote_check(voluntary, 50))
+					. = list("<B>[mob]</B> hisses", "<i>hisses</i>")
+			if ("dewlap")
+				if (mob.emote_check(voluntary, 50))
+					. = list("<B>[mob]</B> extends dewlap proudly", "<i>extends dewlap proudly</i>")
+			if ("tongue")
+				if (mob.emote_check(voluntary, 50))
+					. = list("<B>[mob]</B> flicks tongue out", "<i>flicks tongue out</i>")
+			if ("lick")
+				if (mob.emote_check(voluntary, 50))
+					. = list("<B>[mob]</B> licks their eye", "<i>licks their eye</i>")
+			if ("sniff")
+				if (mob.emote_check(voluntary, 50))
+					. = list("<B>[mob]</B> sniffs the air", "<i>sniffs the air</i>")
+			if ("headbob")
+				if (mob.emote_check(voluntary, 50))
+					. = list("<B>[mob]</B> bobs their head", "<i>bobs their head</i>")
+			if ("puff")
+				if (mob.emote_check(voluntary, 50))
+					. = list("<B>[mob]</B> puffs up", "<i>puffs up</i>")
+			if ("mouth")
+				if (mob.emote_check(voluntary, 50))
+					. = list("<B>[mob]</B> holds mouth open", "<i>holds mouth open</i>")
+			else
+				.= ..()
+
 	say_verb()
 		return "hisses"
 
@@ -1101,6 +1133,14 @@
 	special_head = HEAD_SKELETON
 	decomposes = FALSE
 	race_mutation = /datum/bioEffect/mutantrace/skeleton
+
+	emote(var/act, var/voluntary)
+		switch(act)
+			if ("rattle")
+				if (mob.emote_check(voluntary, 50))
+					. = list("<B>[mob]</B> rattles", "<i>rattles</i>")
+			else
+				.= ..()
 
 	New(var/mob/living/carbon/human/M)
 		..()
@@ -1691,6 +1731,26 @@
 			M.mob_flags |= SHOULD_HAVE_A_TAIL
 		APPLY_MOB_PROPERTY(M, PROP_RADPROT, src, 100)
 
+	emote(var/act, var/voluntary)
+		switch(act)
+			if ("chirp")
+				if (mob.emote_check(voluntary, 50))
+					. = list("<B>[mob]</B> chirps", "<i>chirps</i>")
+			if ("hiss")
+				if (mob.emote_check(voluntary, 50))
+					. = list("<B>[mob]</B> hisses", "<i>hisses</i>")
+			if ("click")
+				if (mob.emote_check(voluntary, 50))
+					. = list("<B>[mob]</B> clicks rythmically", "<i>clicks rythmically</i>")
+			if ("chirp_t")
+				if (mob.emote_check(voluntary, 50))
+					. = list("<B>[mob]</B> chirps threateningly", "<i>chirps threateningly</i>")
+			if ("anten")
+				if (mob.emote_check(voluntary, 50))
+					. = list("<B>[mob]</B> wiggles anetennas", "<i>wiggles antennas</i>")
+			else
+				.= ..()
+
 	say_verb()
 		return "clicks"
 
@@ -2019,6 +2079,25 @@
 			if ("milk")
 				if (mob.emote_check(voluntary))
 					.= release_milk()
+			if ("moo_p")
+				if (mob.emote_check(voluntary, 50))
+					. = list("<B>[mob]</B> moos proudly!", "<i>moos proudly</i>")
+			if ("moo_s")
+				if (mob.emote_check(voluntary, 50))
+					. = list("<B>[mob]</B> moos solemnly", "<i>moos solemnly</i>")
+			if ("moo_h")
+				if (mob.emote_check(voluntary, 50))
+					. = list("<B>[mob]</B> moos heartily", "<i>moos heartily</i>")
+			if ("stamp")
+				if (mob.emote_check(voluntary, 50))
+					. = list("<B>[mob]</B> stamps their hoove!", "<i>stamps their hoove!</i>")
+					playsound(get_turf(mob), "sound/misc/step/step_lattice_1.ogg", 80, 1, channel=VOLUME_CHANNEL_EMOTE)
+			if ("snort")
+				if (mob.emote_check(voluntary, 50))
+					. = list("<B>[mob]</B> snorts!", "<i>snorts</i>") //if anyone wants to add a mist cloud (ciggarette smoke cloud) coming out, that would be great
+			if ("swish")
+				if (mob.emote_check(voluntary, 50))
+					. = list("<B>[mob]</B> swishes their tail", "<i>swishes their tail</i>")
 			else
 				.= ..()
 

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -454,7 +454,7 @@
 
 			if ("help")
 				src.show_text("To use emotes, simply enter 'me (emote)' in the input bar. Certain emotes can be targeted at other characters - to do this, enter 'me (emote) (name of character)' without the brackets.")
-				src.show_text("For a list of all emotes, use 'me list'. For a list of basic emotes, use 'me listbasic'. For a list of emotes that can be targeted, use 'me listtarget'.")
+				src.show_text("For a list of all emotes, use 'me list'. For a list of basic emotes, use 'me listbasic'. For a list of emotes that can be targeted, use 'me listtarget'. For a list of mutant race unqiue emotes, use 'me lizard', 'me roach', 'me skeleton', or 'me cow'.")
 
 			if ("listbasic")
 				src.show_text("smile, grin, smirk, frown, scowl, grimace, sulk, pout, blink, drool, shrug, tremble, quiver, shiver, shudder, shake, \
@@ -466,6 +466,18 @@
 
 			if ("listtarget")
 				src.show_text("salute, bow, hug, wave, glare, stare, look, leer, nod, tweak, flipoff, doubleflip, shakefist, handshake, daps, slap, boggle, highfive")
+
+			if ("lizard")
+				src.show_text("dewlap, headbob, hiss, sniff, sniff, mouth, lick, whip")
+
+			if ("roach")
+				src.show_text("chirp, chirp_t, click, anten, hiss")
+
+			if ("cow")
+				src.show_text("snort, stamp, swish, moo_p, moo_s, moo_h")
+
+			if ("skeleton")
+				src.show_text("rattle")
 
 			if ("suicide")
 				src.show_text("Suicide is a command, not an emote.  Please type 'suicide' in the input bar at the bottom of the game window to kill yourself.", "red")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Feature][QoL][input wanted]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the following list of emotes that are custom to each mutant races:
https://imgur.com/r5XtRHt
*note, capitalization/spelling in image is incorrect

Also included is the commands *lizard, *roach, *skeleton, and *cow to see each of these emotes, similar to *list/*listtarget
I also hope this encourages others to add more to mutant race emotes, as I believe the more emotes the better


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This is needed as emotes greatly enhance RP and I believe the more emotes the better, that by avoiding ctrl+m typing, players will be more likely to use emotes to increase character RP


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->


```changelog
(u)Yellow-Mushroom
(+)Adds custom emotes for trait mutant races
```
