### PR TITLE
Prevent portable flashers being anchored under shrubs

### DIFF
--- a/code/obj/machinery/flasher.dm
+++ b/code/obj/machinery/flasher.dm
@@ -239,15 +239,19 @@
 /obj/machinery/flasher/portable/attackby(obj/item/W as obj, mob/user as mob)
 	if (iswrenchingtool(W))
 		add_fingerprint(user)
-		src.anchored = !src.anchored
 
-		if (!src.anchored)
+		if (src.anchored)
 			light.disable()
 			user.show_message(text("<span class='alert'>[src] can now be moved.</span>"))
 			src.UpdateOverlays(null, "anchor")
 
-		else if (src.anchored)
+		else if (!src.anchored)
+			var/obj/shrub/plont = locate(/obj/shrub/) in loc
+			if (plont)
+				boutput(user, "<span class='alert'>[name] refuses to turn on so close to [plont.name]!</span>")
+				return
 			if ( powered() )
 				light.enable()
 			user.show_message(text("<span class='alert'>[src] is now secured.</span>"))
 			src.UpdateOverlays(image(src.icon, "[base_state]-s"), "anchor")
+		src.anchored = !src.anchored


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so that portable flashers refuse to turn on if there's a shrub in the same turf.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Security is routinely putting flashers under shrubs again, at least in the usual spot on cog1.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)BatElite
(+)Portable flashers can no longer be deployed under shrubs
```
