### PR TITLE
Horizon Cargo Fixes

### DIFF
--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -53788,12 +53788,11 @@
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/barber_shop)
 "coy" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/structure/girder/reinforced,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/barber_shop)
 "coz" = (
@@ -54206,11 +54205,10 @@
 /turf/simulated/floor/plating,
 /area/station/quartermaster/storage)
 "cpJ" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
+/obj/structure/girder/reinforced,
 /turf/simulated/floor/plating,
 /area/station/quartermaster/storage)
 "cpU" = (
@@ -59489,6 +59487,10 @@
 "rxZ" = (
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
+"rEe" = (
+/obj/structure/girder/reinforced,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/barber_shop)
 "rHh" = (
 /turf/simulated/shuttle/wall{
 	icon_state = "wall_space"
@@ -97514,7 +97516,7 @@ adb
 aaa
 clP
 cmB
-clO
+rEe
 coy
 cps
 cqo


### PR DESCRIPTION
[bugfix]

## About the PR 
Swaps some windows on the cargo import and export paths for anchored reinforced girders, which allows the ordering of Many Crates.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Sometimes when ordering Many Crates, they would break the windows on the transport paths and then cause a problem with the whole delivery and export systems; and lots of times people playing Cargo on Horizon would "shut down" ordering for this since it either takes some time to resolve (rebuilding the windows), or they never get to resolving it. 