### PR TITLE
Fix spy checking for wrong cryo

### DIFF
--- a/code/datums/gamemodes/spy_theft.dm
+++ b/code/datums/gamemodes/spy_theft.dm
@@ -304,7 +304,7 @@
 		if (isvirtual(H) || istype(get_area(H),/area/afterlife))
 			continue
 
-		if (istype(H.loc, /obj/cryotron_spawner))
+		if (istype(H.loc, /obj/cryotron))
 			continue
 
 		var/turf/T = get_turf(H)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Spy objective checked for target locs in  /obj/cryotron_spawner not /obj/cryotron.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
/obj/cryotron_spawner is incorrect and was including people in cryosleep.
This bug has probably existed for years aaa