### PR TITLE
Adds taser smg to security vendor

### DIFF
--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -430,6 +430,9 @@
 	baton
 		spawn_contents = list(/obj/item/baton, /obj/item/barrier)
 
+	tasersmg
+		spawn_contents = list(/obj/item/gun/energy/tasersmg, /obj/item/baton, /obj/item/barrier)
+
 //////////////////////////////
 // ~Nuke Ops Class Storage~ //
 //////////////////////////////

--- a/code/obj/submachine/weapon_vendor.dm
+++ b/code/obj/submachine/weapon_vendor.dm
@@ -156,6 +156,7 @@
 		materiel_stock += new/datum/materiel/loadout/standard
 		materiel_stock += new/datum/materiel/loadout/offense
 		materiel_stock += new/datum/materiel/loadout/control
+		materiel_stock += new/datum/materiel/loadout/suppression
 		materiel_stock += new/datum/materiel/loadout/justabaton
 		materiel_stock += new/datum/materiel/utility/morphineinjectors
 		materiel_stock += new/datum/materiel/utility/donuts
@@ -281,6 +282,12 @@
 	path = /obj/item/storage/belt/security/control
 	category = "Loadout"
 	description = "One belt containing a taser shotgun, a baton, and a barrier."
+
+/datum/materiel/loadout/suppression
+	name = "Suppression"
+	path = /obj/item/storage/belt/security/tasersmg
+	category = "Loadout"
+	description = "One belt containing a taser SMG, a baton, and a barrier."
 
 /datum/materiel/loadout/justabaton
 	name = "Just a Baton"


### PR DESCRIPTION
[feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds in the (previously admin spawn only) taser SMG. A stun weapon with two fire modes, two shot burst and full auto. Now has its own loadout for security to use.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's a fun to use ranged weapon. Security having more unique ranged weapons to pick from is nice. 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Sord
(+)New taser smg security loadout. Sprites by Matheus 
```
