### PR TITLE
Using cameras allows one viewport

### DIFF
--- a/code/obj/machinery/computer/security.dm
+++ b/code/obj/machinery/computer/security.dm
@@ -78,13 +78,17 @@
 			playsound(src.loc, "sound/machines/buzz-sigh.ogg", 10, 0)
 			return
 		if (src.using_viewport)
-			var/datum/viewport/vp = clint.getViewportsByType("cameras: Viewport")[1]
-			var/turf/T = get_turf(closest)
-			var/turf/closestPos = null
-			for(var/i = 4, i >= 0 || !closestPos, i--)
-				closestPos = locate(T.x - i, T.y + i, T.z)
-				if(closestPos) break
-			vp.SetViewport(closestPos, 8, 8)
+			if (length(clint.getViewportsByType("cameras: Viewport")) < 1)
+				src.using_viewport = 0
+				switchCamera(user, closest)
+			else
+				var/datum/viewport/vp = clint.getViewportsByType("cameras: Viewport")[1]
+				var/turf/T = get_turf(closest)
+				var/turf/closestPos = null
+				for(var/i = 4, i >= 0 || !closestPos, i--)
+					closestPos = locate(T.x - i, T.y + i, T.z)
+					if(closestPos) break
+				vp.SetViewport(closestPos, 8, 8)
 		else
 			switchCamera(user, closest)
 

--- a/code/obj/machinery/computer/security.dm
+++ b/code/obj/machinery/computer/security.dm
@@ -25,7 +25,8 @@
 		..()
 		if(window)
 			for (var/client/subscriber in window.subscribers)
-				if(get_dist(src,subscriber.mob) > 1 && subscriber.getViewportsByType("cameras: Viewport").len > 0)
+				var/list/viewports = subscriber.getViewportsByType("cameras: Viewport")
+				if(get_dist(src,subscriber.mob) > 1 && viewports.len > 0)
 					boutput(subscriber,"<span class='alert'>You are too far to see the screen.</span>")
 					subscriber.clearViewportsByType("cameras: Viewport")
 

--- a/code/obj/machinery/computer/security.dm
+++ b/code/obj/machinery/computer/security.dm
@@ -25,7 +25,6 @@
 		..()
 		if(window)
 			for (var/client/subscriber in window.subscribers)
-				var/dist = get_dist(src,subscriber)
 				if(get_dist(src,subscriber.mob) > 1 && subscriber.getViewportsByType("cameras: Viewport").len > 0)
 					boutput(subscriber,"<span class='alert'>You are too far to see the screen.</span>")
 					subscriber.clearViewportsByType("cameras: Viewport")

--- a/code/obj/machinery/computer/security/security_cameras_chui.dm
+++ b/code/obj/machinery/computer/security/security_cameras_chui.dm
@@ -6,12 +6,11 @@ chui/window/security_cameras
 	flags = CHUI_FLAG_MOVABLE | CHUI_FLAG_CLOSABLE
 
 	proc/create_viewport(client/target_client, turf/T)
-
 		if(get_dist(owner,target_client.mob) > 1)
 			boutput(target_client,"<span class='alert'>You are too far to see the screen.</span>")
 		else
 			var/list/viewports = target_client.getViewportsByType("cameras: Viewport")
-			if(viewports.len >= 1)
+			if(length(viewports))
 				boutput( target_client, "<b>You can only have 1 active viewport. Close the existing viewport to create another.</b>" )
 				return
 
@@ -322,9 +321,12 @@ chui/window/security_cameras
 				return
 
 			else
-				owner.current = C
-				user.set_eye(C)
 				owner.use_power(50)
+				if (length(clint.getViewportsByType("cameras: Viewport")))
+					owner.move_viewport_to_camera(C, clint)
+				else
+					owner.current = C
+					user.set_eye(C)
 
 		else if (href_list["save"])
 			var/obj/machinery/camera/C = locate(href_list["save"])
@@ -339,9 +341,8 @@ chui/window/security_cameras
 
 		else if (href_list["viewport"])
 			if (!owner.current)
-				boutput( clint, "<b>You need to select a camera before creating a viewport.</b>" )
+				boutput(clint, "<b>You need to select a camera before creating a viewport.</b>")
 			else
-				owner.using_viewport = 1
 				create_viewport(clint, get_turf(owner.current))
 				clint.mob.set_eye(null)
 

--- a/code/obj/machinery/computer/security/security_cameras_chui.dm
+++ b/code/obj/machinery/computer/security/security_cameras_chui.dm
@@ -369,4 +369,5 @@ chui/window/security_cameras
 
 	Unsubscribe( client/who )
 		..()
+		who.clearViewportsByType("cameras: Viewport")
 		who.mob.set_eye(null)

--- a/code/obj/machinery/computer/security/security_cameras_chui.dm
+++ b/code/obj/machinery/computer/security/security_cameras_chui.dm
@@ -5,6 +5,24 @@ chui/window/security_cameras
 	windowSize = "650x500"
 	flags = CHUI_FLAG_MOVABLE | CHUI_FLAG_CLOSABLE
 
+	proc/create_viewport(client/target_client, turf/T)
+
+		if(get_dist(owner,target_client.mob) > 1)
+			boutput(target_client,"<span class='alert'>You are too far to see the screen.</span>")
+		else
+			var/list/viewports = target_client.getViewportsByType("cameras: Viewport")
+			if(viewports.len >= 1)
+				boutput( target_client, "<b>You can only have 1 active viewport. Close the existing viewport to create another.</b>" )
+				return
+
+			var/datum/viewport/vp = new(target_client, "cameras: Viewport")
+			var/turf/startPos = null
+			for(var/i = 4, i >= 0 || !startPos, i--)
+				startPos = locate(T.x - i, T.y + i, T.z)
+				if(startPos) break
+			vp.clickToMove = 1
+			vp.SetViewport(startPos, 8, 8)
+
 	New(var/obj/machinery/computer/security/seccomp)
 		..()
 		owner = seccomp
@@ -253,6 +271,9 @@ chui/window/security_cameras
 
 		var/dat = {"[script]
 		<body>
+			<div id='viewport_button'>
+			<a class='link' href='byond://?src=\ref[src];viewport=true'>Create viewport</a>
+			</div>
 			<div id='main_list'>
 			<input type='text' id='searchbar' onkeyup='filterTable()' placeholder=' Search for cameras..'>
 			<table id='cameraList'>
@@ -316,6 +337,15 @@ chui/window/security_cameras
 			if (istype(C))
 				owner.favorites -= C
 
+		else if (href_list["viewport"])
+			if (!owner.current)
+				boutput( clint, "<b>You need to select a camera before creating a viewport.</b>" )
+			else
+				owner.using_viewport = 1
+				create_viewport(clint, get_turf(owner.current))
+				clint.mob.set_eye(null)
+
+
 		//using arrowkeys/wasd/ijkl to move from camera to camera
 		else if (href_list["move"])
 			var/direction = href_list["move"]
@@ -335,7 +365,7 @@ chui/window/security_cameras
 				else
 					return
 
-			owner.move_security_camera(direction,user)
+			owner.move_security_camera(direction,clint)
 
 	Unsubscribe( client/who )
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR allows creating one viewport from the security cameras windows.

This viewport cannot be opened if another one exists, if you are not adjacend to the security computer, and closes automatically if you move away, or close the security camera window, in order to avoid exploits.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
As a secoff, I sometimes like to watch cameras. However it takes the whole screen and I cannot see my colleagues anymore.
This PR would allow me to still see and talk to my colleagues while watching cameras, but hard limits on being able to open only 1 viewport, and not being able to move prevent this from being too powerful.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Borkatator
(*)You can now create a viewport window when watching camera feeds
```
