### PR TITLE
bring back title card gimmicks

### DIFF
--- a/code/datums/titlecard.dm
+++ b/code/datums/titlecard.dm
@@ -70,3 +70,37 @@
 
 	for (var/id in maptext_areas)
 		C << output(list2params(list(id, maptext_areas[id])), "pregameBrowser:set_area")
+
+///old title card turf
+/obj/titlecard
+	appearance_flags = TILE_BOUND
+	icon = null //set in New()
+	icon_state = "title_main"
+	layer = 60
+	name = "Space Station 13"
+	desc = "The title card for it, at least."
+	plane = PLANE_OVERLAY_EFFECTS
+	pixel_x = -96
+	anchored = 2
+
+	ex_act(severity)
+		return
+
+	meteorhit(obj/meteor)
+		return
+
+	New()
+		..()
+		icon = file("assets/icons/widescreen.dmi")
+	#if defined(MAP_OVERRIDE_OSHAN)
+		icon_state = "title_oshan"
+		name = "Oshan Laboratory"
+		desc = "An underwater laboratory on the planet Abzu."
+	#elif defined(MAP_OVERRIDE_MANTA)
+		icon_state = "title_manta"
+		name = "The NSS Manta"
+		desc = "Some fancy comic about the NSS Manta and its travels on the planet Abzu."
+	#endif
+	#if defined(REVERSED_MAP)
+		transform = list(-1, 0, 0, 0, 1, 0)
+	#endif

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1814,9 +1814,9 @@ var/list/fun_images = list()
 				catch()
 			var/turf/T = landmarks[LANDMARK_LOBBY_LEFTSIDE][1]
 			T = locate(T.x + 3, T.y, T.z)
-			if (!istype(T, /turf/unsimulated/wall/titlecard))
-				if (alert("Replace with a title card turf?",, "Yes", "No") == "Yes")
-					T.ReplaceWith(/turf/unsimulated/wall/titlecard, FALSE, FALSE, FALSE, TRUE)
+			if (locate(/obj/titlecard) in T) return
+			if (alert("Replace with a title card turf?",, "Yes", "No") == "Yes")
+				new /obj/titlecard(T)
 			return
 	var/newHTML = null
 	if(alert("Do you want to upload an HTML file, or type it in?", "HTML Source", "Here", "Upload") == "Here")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1812,7 +1812,11 @@ var/list/fun_images = list()
 					if(C)
 						winshow(C, "pregameBrowser", 0)
 				catch()
-
+			var/turf/T = landmarks[LANDMARK_LOBBY_LEFTSIDE][1]
+			T = locate(T.x + 3, T.y, T.z)
+			if (!istype(T, /turf/unsimulated/wall/titlecard))
+				if (alert("Replace with a title card turf?",, "Yes", "No") == "Yes")
+					T.ReplaceWith(/turf/unsimulated/wall/titlecard, FALSE, FALSE, FALSE, TRUE)
 			return
 	var/newHTML = null
 	if(alert("Do you want to upload an HTML file, or type it in?", "HTML Source", "Here", "Upload") == "Here")

--- a/code/turf/turf.dm
+++ b/code/turf/turf.dm
@@ -898,6 +898,33 @@
 /turf/unsimulated/wall/solidcolor/black
 	icon_state = "black"
 
+///old title card turf
+/turf/unsimulated/wall/titlecard
+	appearance_flags = TILE_BOUND
+	fullbright = 1
+	icon = 'icons/misc/widescreen.dmi' //fullscreen.dmi
+	icon_state = "title_main"
+	layer = 60
+	name = "Space Station 13"
+	desc = "The title card for it, at least."
+	plane = PLANE_OVERLAY_EFFECTS
+	pixel_x = -96
+
+	New()
+		..()
+	#if defined(MAP_OVERRIDE_OSHAN)
+		icon_state = "title_oshan"
+		name = "Oshan Laboratory"
+		desc = "An underwater laboratory on the planet Abzu."
+	#elif defined(MAP_OVERRIDE_MANTA)
+		icon_state = "title_manta"
+		name = "The NSS Manta"
+		desc = "Some fancy comic about the NSS Manta and its travels on the planet Abzu."
+	#endif
+	#if defined(REVERSED_MAP)
+		transform = list(-1, 0, 0, 0, 1, 0)
+	#endif
+
 /turf/unsimulated/wall/other
 	icon_state = "r_wall"
 

--- a/code/turf/turf.dm
+++ b/code/turf/turf.dm
@@ -898,33 +898,6 @@
 /turf/unsimulated/wall/solidcolor/black
 	icon_state = "black"
 
-///old title card turf
-/turf/unsimulated/wall/titlecard
-	appearance_flags = TILE_BOUND
-	fullbright = 1
-	icon = 'icons/misc/widescreen.dmi' //fullscreen.dmi
-	icon_state = "title_main"
-	layer = 60
-	name = "Space Station 13"
-	desc = "The title card for it, at least."
-	plane = PLANE_OVERLAY_EFFECTS
-	pixel_x = -96
-
-	New()
-		..()
-	#if defined(MAP_OVERRIDE_OSHAN)
-		icon_state = "title_oshan"
-		name = "Oshan Laboratory"
-		desc = "An underwater laboratory on the planet Abzu."
-	#elif defined(MAP_OVERRIDE_MANTA)
-		icon_state = "title_manta"
-		name = "The NSS Manta"
-		desc = "Some fancy comic about the NSS Manta and its travels on the planet Abzu."
-	#endif
-	#if defined(REVERSED_MAP)
-		transform = list(-1, 0, 0, 0, 1, 0)
-	#endif
-
 /turf/unsimulated/wall/other
 	icon_state = "r_wall"
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][FEATURE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
#3593 prevents spinning and transforming the title card because it's no longer something you can admin interact with

This brings back the turf and offers to create it for you when you clear the html screens.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
dumb gimmicks.