### PR TITLE
Fix item storage using the wrong HUD, hopefully

### DIFF
--- a/code/datums/hud/storage.dm
+++ b/code/datums/hud/storage.dm
@@ -112,7 +112,7 @@
 		if (I)
 			I.MouseDrop(over_object, src_location, over_location, over_control, params)
 */
-	proc/update()
+	proc/update(mob/user = usr)
 		var x = 1
 		var y = 1 + master.slots
 		var sx = 1
@@ -127,8 +127,8 @@
 
 			turfd = 1
 
-		if (istype(usr,/mob/living/carbon/human))
-			if (usr.client && usr.client.tg_layout) //MBC TG OVERRIDE IM SORTY
+		if (istype(user,/mob/living/carbon/human))
+			if (user.client && user.client.tg_layout) //MBC TG OVERRIDE IM SORTY
 				x = 11 - round(master.slots / 2)
 				y = 3
 				sx = master.slots + 1
@@ -142,14 +142,14 @@
 
 		if (!boxes)
 			return
-		if (ishuman(usr))
-			var/mob/living/carbon/human/player = usr
+		if (ishuman(user))
+			var/mob/living/carbon/human/player = user
 			var/icon/hud_style = hud_style_selection[get_hud_style(player)]
 			if (isicon(hud_style) && boxes.icon != hud_style)
 				boxes.icon = hud_style
 
 		var/pixel_y_adjust = 0
-		if (usr && usr.client && usr.client.tg_layout && !turfd)
+		if (user && user.client && user.client.tg_layout && !turfd)
 			pixel_y_adjust = -16
 
 		boxes.screen_loc = "[x],[y]:[pixel_y_adjust] to [x+sx-1],[y-sy+1]:[pixel_y_adjust]"
@@ -157,8 +157,8 @@
 			src.close = create_screen("close", "Close", 'icons/mob/screen1.dmi', "x", ui_storage_close, HUD_LAYER+1)
 		close.screen_loc = "[x+sx-1]:[pixel_y_adjust],[y-sy+1]:[pixel_y_adjust]"
 
-		if (!turfd && istype(usr,/mob/living/carbon/human))
-			if (usr && usr.client?.tg_layout) //MBC TG OVERRIDE IM SORTY
+		if (!turfd && istype(user,/mob/living/carbon/human))
+			if (user && user.client?.tg_layout) //MBC TG OVERRIDE IM SORTY
 				boxes.screen_loc = "[x-1],[y]:[pixel_y_adjust] to [x+sx-2],[y-sy+1]:[pixel_y_adjust]"
 				close.screen_loc = "[x-1],[y-sy+1]:[pixel_y_adjust]"
 

--- a/code/datums/hud/storage.dm
+++ b/code/datums/hud/storage.dm
@@ -178,8 +178,8 @@
 			I.tooltip_rebuild = 1
 		master.update_icon()
 
-	proc/add_item(obj/item/I)
-		update()
+	proc/add_item(obj/item/I, mob/user = usr)
+		update(user)
 
 	proc/remove_item(obj/item/I)
 		remove_object(I)

--- a/code/modules/economy/persistent_bank_purchases.dm
+++ b/code/modules/economy/persistent_bank_purchases.dm
@@ -438,7 +438,7 @@ var/global/list/persistent_bank_purchaseables =	list(\
 			if(istype(M.back, /obj/item/storage))
 				var/obj/item/storage/backpack = M.back
 				new /obj/item/tank/emergency_oxygen(backpack) // oh boy they'll need this if they are unlucky
-				backpack.hud.update()
+				backpack.hud.update(M)
 			var/mob/living/carbon/human/H = M
 			if(istype(H))
 				H.equip_new_if_possible(/obj/item/clothing/mask/breath, SLOT_WEAR_MASK)

--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -947,7 +947,7 @@
 			swapped_cell.set_loc(old_loc)
 			var/obj/item/storage/cell_container = old_loc
 			cell_container.hud.remove_item(src)
-			cell_container.hud.update()
+			cell_container.hud.update(user)
 		else
 			M.put_in_hand_or_drop(swapped_cell)
 

--- a/code/obj/item/storage/small_storage_parent.dm
+++ b/code/obj/item/storage/small_storage_parent.dm
@@ -163,7 +163,7 @@
 
 	dropped(mob/user as mob)
 		if (hud)
-			hud.update()
+			hud.update(user)
 		..()
 
 	proc/mousetrap_check(mob/user)
@@ -205,7 +205,7 @@
 			if (src.mousetrap_check(usr))
 				return
 			usr.s_active = src.hud
-			hud.update()
+			hud.update(usr)
 			usr.attach_hud(src.hud)
 			return
 		if (usr.is_in_hands(src))
@@ -250,7 +250,7 @@
 			if (src.mousetrap_check(user))
 				return
 			user.s_active = src.hud
-			hud.update()
+			hud.update(user)
 			user.attach_hud(src.hud)
 			src.add_fingerprint(user)
 			animate_storage_rustle(src)
@@ -259,7 +259,7 @@
 			for (var/mob/M as() in hud.mobs)
 				if (M != user)
 					M.detach_hud(hud)
-			hud.update()
+			hud.update(user)
 
 	attack_self(mob/user as mob)
 		..()

--- a/code/obj/item/storage/small_storage_parent.dm
+++ b/code/obj/item/storage/small_storage_parent.dm
@@ -152,7 +152,7 @@
 		else
 			src.add_contents(W)
 			user.u_equip(W)
-		hud.add_item(W)
+		hud.add_item(W, user)
 		update_icon()
 		add_fingerprint(user)
 		animate_storage_rustle(src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a user var to the item storage HUD update proc, and updates a bunch of calls to use it where sensible so that the storage should hopefully get the player's mob and use the right HUD setting. There's a few bugs around where the storage HUD updates as if  you don't have TG HUD on and it draws the storage HUD partially under your equipped stuff.

The two bugs I know of are item on item-in-storage interactions (a la cell swapping) and mousedragging and item from the floor/a table directly into a storage. Can't promise this patch watertight but it should be harder to find the bug happening now.

All usr/user is ever checked for in the proc is whether you're a human/have a client, so this shouldn't break anything.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
HUD mixup bugs can heck off
closes #3719 
