### PR TITLE
Lets nukeop agent cards rename their players for crew credits.

### DIFF
--- a/code/obj/item/card.dm
+++ b/code/obj/item/card.dm
@@ -83,7 +83,7 @@ GAUNTLET CARDS
 	var/emagged = 0
 	var/datum/reagent_group_account/reagent_account = null
 	/// this determines if the icon_state of the ID changes if it is given a new job
-	var/keep_icon = FALSE 
+	var/keep_icon = FALSE
 
 	// YOU START WITH  NO  CREDITS
 	// WOW
@@ -281,7 +281,15 @@ GAUNTLET CARDS
 	input = jointext(namecheck, " ")
 	return input
 
-/obj/item/card/id/syndicate/commander
+/obj/item/card/id/syndicate/nukeop //sets one's real name too so the funky joke op names show up in the crew credits!
+	attack_self(mob/user as mob)
+		if(!src.registered)
+			..()
+			user.real_name = registered
+		else
+			..()
+
+/obj/item/card/id/syndicate/nukeop/commander
 	name = "commander card"
 	access = list(access_maint_tunnels, access_syndicate_shuttle, access_syndicate_commander)
 

--- a/code/procs/antagonist_procs.dm
+++ b/code/procs/antagonist_procs.dm
@@ -272,9 +272,9 @@
 	synd_mob.equip_if_possible(U, synd_mob.slot_r_store)
 */
 
-	var/obj/item/card/id/syndicate/I = new /obj/item/card/id/syndicate(synd_mob) // for whatever reason, this is neccessary
+	var/obj/item/card/id/syndicate/nukeop/I = new /obj/item/card/id/syndicate/nukeop(synd_mob) // for whatever reason, this is neccessary
 	if(leader)
-		I = new /obj/item/card/id/syndicate/commander(synd_mob)
+		I = new /obj/item/card/id/syndicate/nukeop/commander(synd_mob)
 	I.icon_state = "id"
 	I.icon = 'icons/obj/items/card.dmi'
 	synd_mob.equip_if_possible(I, synd_mob.slot_wear_id)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feat]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes nuke ops agent cards change their user's real name too, so players get credited under a custom name rather than "SomeCorp Agent Soandso" if they want.
![afbeelding](https://user-images.githubusercontent.com/31984217/108077501-dd821200-706c-11eb-900d-5120a8753053.png)
(Easiest nukie win yet btw)
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Gives nukeops a little more ability to do themed gimmicks and also shows of your skill with clever puns to all. Nukeops have a tendency to either shoot you with guns or explode during the round itself, so not many players will notice otherwise.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)BatElite
(+)Nuclear operatives now get credited with the name they put on their card at the end of the round!
```
