### PR TITLE
fix matsci anymat_canmix runtime

### DIFF
--- a/code/modules/materials/Mat_FabParts.dm
+++ b/code/modules/materials/Mat_FabParts.dm
@@ -163,9 +163,9 @@
 /datum/matfab_part/anymat_canmix
 	name = "Unprocessed Material"
 	checkMatch(var/obj/item/I)
+		if(!I.material) return 0
 		if(!I.material.canMix) return 0
 		if(!istype(I, /obj/item/material_piece) && !istype(I, /obj/item/raw_material)) return 0
-		if(!I.material) return 0
 		return ..()
 
 /datum/matfab_part/lens


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug][runtime]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves the material check on the unprocessed material matsci fabparts (for the infusion recipe) to the top, because currently teh canmix check causes a runtime for everything in the nanofab that doesn't have a material set.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Runtimes are stinky. At minimum this runtime happens with the beaker or whatever the chem is supplied in.