### PR TITLE
Fixes Cog1 HoS' war medal offset

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -18104,6 +18104,9 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
+/obj/decal/poster/wallsign/medal{
+	pixel_y = 27
+	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/hos)
 "aNQ" = (
@@ -30168,10 +30171,6 @@
 /obj/machinery/drainage,
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
-"bnu" = (
-/obj/decal/poster/wallsign/medal,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/hos)
 "bnv" = (
 /obj/grille/catwalk{
 	dir = 9
@@ -92319,7 +92318,7 @@ aGx
 aIZ
 aGx
 aGx
-bnu
+aME
 aNP
 aOQ
 aSZ


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The war medal on the wall of the HoS' office is place directly on the wall, and not offset inside the office onto the wall, meaning you can pick it up in the locker room which I can only assume isnt intended