### PR TITLE
Oshan AI/Powernet connection

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -5115,6 +5115,9 @@
 	},
 /obj/grille/steel,
 /obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "alF" = (
@@ -5959,6 +5962,9 @@
 	},
 /obj/grille/steel,
 /obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "anD" = (


### PR DESCRIPTION
[mapping][bugfix]
## About the PR 
Adds some wires to the AI Core Room to connect the AI Core to the powernet so DWAINE users can talk to their AI bud.

## Why's this needed?
Talking with friends is good! Fixes #1972.