### PR TITLE
Sec loadout utility tweaks

### DIFF
--- a/code/obj/item/storage/weapon_security.dm
+++ b/code/obj/item/storage/weapon_security.dm
@@ -121,12 +121,6 @@
 	spawn_contents = list(/obj/item/gun/kinetic/flaregun,\
 	/obj/item/ammo/bullets/flare)
 
-/obj/item/storage/box/riotrounds
-	name = "40mm riot rounds"
-	icon_state = "revolver"
-	desc = "A box containing two boxes of 40mm riot rounds"
-	spawn_contents = list(/obj/item/ammo/bullets/pbr = 2)
-
 /* -------------------- Grenades -------------------- */
 
 /obj/item/storage/box/flashbang_kit

--- a/code/obj/submachine/weapon_vendor.dm
+++ b/code/obj/submachine/weapon_vendor.dm
@@ -323,6 +323,7 @@
 	path = /obj/item/ammo/power_cell/high_power
 	category = "Utility"
 	description = "An additional high capacity power cell for your weapons. Note: Security Officers already spawn with one in their Security Pouch"
+	cost = 2
 
 /datum/materiel/utility/nightvisiongoggles
 	name = "Night Vision Goggles"
@@ -332,9 +333,9 @@
 
 /datum/materiel/utility/riotrounds
 	name = "40mm Riot Rounds"
-	path = /obj/item/storage/box/riotrounds
+	path = /obj/item/ammo/bullets/pbr
 	category = "Utility"
-	description = "Two boxes of 40mm Riot Rounds, totalling 4 shots, for the Riot Launcher."
+	description = "One case of 40mm Riot Rounds, totalling 2 shots, for the Riot Launcher."
 
 /datum/materiel/assistant
 	name = "Assistant"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Raises the price of the more combat-focused utility pickups (power cell costs both points, 40mmPBR gives 2 shots/point instead of 4)

This might be the wrong way of going about this idk.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bonus power cells and 40mmPBR rounds heavily outshine/overshadow the other utility items, and are more 'combat boost' than utility in the first place.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Tarmunora
(+)Raised costs of power cells and 40mmPBR rounds in the sec loadout vendor.
```
