### PR TITLE
Makes plates, trash bags and satchels care about item weight

### DIFF
--- a/code/obj/item/clothing/trash_bags.dm
+++ b/code/obj/item/clothing/trash_bags.dm
@@ -41,6 +41,9 @@
 			src.item_state = src.base_state
 
 	attackby(obj/item/W as obj, mob/user as mob)
+		if(W.w_class > 3)
+			boutput(user, "<span class='alert'>\The [W] is too big to fit inside [src]!</span>")
+			return
 		if (W.cant_self_remove)
 			boutput(user, "<span class='alert'>You can't get [W] to come off of you!</span>")
 			return

--- a/code/obj/item/kitchen.dm
+++ b/code/obj/item/kitchen.dm
@@ -680,7 +680,7 @@ TRAYS
 		if(ordered_contents.len == max_food)
 			boutput(user, "That won't fit, \the [src] is too full!")
 			return
-		if(W.w_class < 3)
+		if(W.w_class > 3)
 			boutput(user, "You try to think of a way to put [W] on \the [src] but it's not possible! It's too large!")
 			return
 		user.drop_item()

--- a/code/obj/item/kitchen.dm
+++ b/code/obj/item/kitchen.dm
@@ -680,7 +680,7 @@ TRAYS
 		if(ordered_contents.len == max_food)
 			boutput(user, "That won't fit, \the [src] is too full!")
 			return
-		if(istype(W, /obj/item/reagent_containers/food/snacks/prison_loaf))
+		if(W.w_class < 3)
 			boutput(user, "You try to think of a way to put [W] on \the [src] but it's not possible! It's too large!")
 			return
 		user.drop_item()

--- a/code/obj/item/kitchen.dm
+++ b/code/obj/item/kitchen.dm
@@ -680,6 +680,9 @@ TRAYS
 		if(ordered_contents.len == max_food)
 			boutput(user, "That won't fit, \the [src] is too full!")
 			return
+		if(istype(W, /obj/item/reagent_containers/food/snacks/prison_loaf))
+			boutput(user, "You try to think of a way to put [W] on \the [src] but it's not possible! It's too large!")
+			return
 		user.drop_item()
 		W.set_loc(src)
 		src.add_contents(W)

--- a/code/obj/item/satchel.dm
+++ b/code/obj/item/satchel.dm
@@ -177,7 +177,7 @@
 		icon_state = "hydrosatchel"
 		allowed = list(/obj/item/seed,
 		/obj/item/plant,
-		/obj/item/reagent_containers/food,
+		/obj/item/reagent_containers/food/snacks,
 		/obj/item/organ,
 		/obj/item/clothing/head/butt,
 		/obj/item/parts/human_parts/arm,

--- a/code/obj/item/satchel.dm
+++ b/code/obj/item/satchel.dm
@@ -112,8 +112,8 @@
 
 	MouseDrop_T(atom/movable/O as obj, mob/user as mob)
 		var/proceed = 0
-		var/obj/item/W = O
 		for(var/check_path in src.allowed)
+			var/obj/item/W = O
 			if(istype(O, check_path) && W.w_class < 4)
 				proceed = 1
 				break

--- a/code/obj/item/satchel.dm
+++ b/code/obj/item/satchel.dm
@@ -19,7 +19,7 @@
 	attackby(obj/item/W as obj, mob/user as mob)
 		var/proceed = 0
 		for(var/check_path in src.allowed)
-			if(istype(W, check_path))
+			if(istype(W, check_path) && W.w_class < 4)
 				proceed = 1
 				break
 		if (!proceed)
@@ -112,8 +112,9 @@
 
 	MouseDrop_T(atom/movable/O as obj, mob/user as mob)
 		var/proceed = 0
+		var/obj/item/W = O
 		for(var/check_path in src.allowed)
-			if(istype(O, check_path))
+			if(istype(O, check_path) && W.w_class < 4)
 				proceed = 1
 				break
 		if (!proceed)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[balance]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR disallows putting items on plates and inside produce satchels and trash bags if their w_class is higher than 3 (basically, if the item doesn't fit in backpack, it won't fit inside satchel/trashbag/on a plate

Also fixes #2731 by allowing only the food to be inserted into the satchels, not all food related items

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Recently people started abusing loaves by putting them on plates, that essentially lets them hide loaves in the backpack. Normally you aren't able to do that, due to the loaf w_class. (in case of higher tiers, loaf w_class depends on the tier)
Noticing that pushed me into addressing the issue. Then, I also realized that satchels and trashbags are just as busted. So I ended up taking care of them aswell


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)TTerc:
(+)If an item does not fit in the backpack, you can no longer put it inside a produce satchel, trash bag or on a plate.
```
