### PR TITLE
Adds opt-in on Job Preferences for the Conspirator antag role

### DIFF
--- a/code/datums/gamemodes/conspiracy.dm
+++ b/code/datums/gamemodes/conspiracy.dm
@@ -73,7 +73,7 @@
 	SPAWN_DBG (rand(waittime_l, waittime_h))
 		send_intercept()
 
-/datum/game_mode/conspiracy/proc/getPotentialAntags(minimum_traitors=1)
+/datum/game_mode/conspiracy/proc/getPotentialAntags(minimum_conspirators=2)
 	var/list/candidates = list()
 
 	for(var/client/C)
@@ -82,11 +82,11 @@
 
 		if (ishellbanned(player)) continue //No treason for you
 		if ((player.ready) && !(player.mind in traitors) && !(player.mind in token_players) && !candidates.Find(player.mind))
-			if(player.client.preferences.be_traitor)
+			if(player.client.preferences.be_conspirator)
 				candidates += player.mind
 
-	if(candidates.len < minimum_traitors)
-		logTheThing("debug", null, null, "<b>Enemy Assignment</b>: Only [candidates.len] players with be_traitor set to yes were ready. We need [minimum_traitors] traitors so including players who don't want to be traitors in the pool.")
+	if(candidates.len < minimum_conspirators)
+		logTheThing("debug", null, null, "<b>Enemy Assignment</b>: Only [candidates.len] players with be_conspirator set to yes were ready. We need [minimum_conspirators] conspirators so including players who don't want to be traitors in the pool.")
 		for(var/client/C)
 			var/mob/new_player/player = C.mob
 			if (!istype(player)) continue
@@ -95,7 +95,7 @@
 			if ((player.ready) && !(player.mind in traitors) && !(player.mind in token_players) && !candidates.Find(player.mind))
 				candidates += player.mind
 
-				if ((minimum_traitors > 1) && (candidates.len >= minimum_traitors))
+				if ((minimum_conspirators > 1) && (candidates.len >= minimum_conspirators))
 					break
 
 	if(candidates.len < 1)

--- a/code/datums/preferences.dm
+++ b/code/datums/preferences.dm
@@ -24,6 +24,7 @@ datum/preferences
 	var/employment_note
 
 
+	var/be_conspirator = 0
 	var/be_changeling = 0
 	var/be_revhead = 0
 	var/be_syndicate = 0
@@ -1161,6 +1162,7 @@ $(updateCharacterPreviewPos);
 
 		if (jobban_isbanned(user, "Syndicate"))
 			HTML += "You are banned from playing antagonist roles."
+			src.be_conspirator = 0
 			src.be_changeling = 0
 			src.be_revhead = 0
 			src.be_syndicate = 0
@@ -1176,6 +1178,7 @@ $(updateCharacterPreviewPos);
 		else
 
 			HTML += {"
+			<a href="byond://?src=\ref[src];preferences=1;b_conspirator=1" class="[src.be_conspirator ? "yup" : "nope"]">[crap_checkbox(src.be_conspirator)] Conspirator</a>
 			<a href="byond://?src=\ref[src];preferences=1;b_traitor=1" class="[src.be_traitor ? "yup" : "nope"]">[crap_checkbox(src.be_traitor)] Traitor</a>
 			<a href="byond://?src=\ref[src];preferences=1;b_syndicate=1" class="[src.be_syndicate ? "yup" : "nope"]">[crap_checkbox(src.be_syndicate)] Nuclear Operative</a>
 			<a href="byond://?src=\ref[src];preferences=1;b_spy=1" class="[src.be_spy ? "yup" : "nope"]">[crap_checkbox(src.be_spy)] Spy/Thief</a>
@@ -1759,6 +1762,11 @@ $(updateCharacterPreviewPos);
 			rebuild_data["popups"] = 1
 			src.view_tickets = !(src.view_tickets)
 
+		if (link_tags["b_conspirator"])
+			src.be_conspirator = !( src.be_conspirator )
+			src.SetChoices(user)
+			return
+
 		if (link_tags["b_changeling"])
 			src.be_changeling = !( src.be_changeling )
 			src.SetChoices(user)
@@ -1969,6 +1977,7 @@ $(updateCharacterPreviewPos);
 			admin_music_volume = 50
 			radio_music_volume = 50
 			use_click_buffer = 0
+			be_conspirator = 0
 			be_changeling = 0
 			be_revhead = 0
 			be_syndicate = 0

--- a/code/datums/savefile.dm
+++ b/code/datums/savefile.dm
@@ -81,6 +81,7 @@
 		F["[profileNum]_job_prefs_2"] << src.jobs_med_priority
 		F["[profileNum]_job_prefs_3"] << src.jobs_low_priority
 		F["[profileNum]_job_prefs_4"] << src.jobs_unwanted
+		F["[profileNum]_be_changeling"] << src.be_conspirator
 		F["[profileNum]_be_changeling"] << src.be_changeling
 		F["[profileNum]_be_revhead"] << src.be_revhead
 		F["[profileNum]_be_syndicate"] << src.be_syndicate
@@ -243,6 +244,7 @@
 		F["[profileNum]_job_prefs_2"] >> src.jobs_med_priority
 		F["[profileNum]_job_prefs_3"] >> src.jobs_low_priority
 		F["[profileNum]_job_prefs_4"] >> src.jobs_unwanted
+		F["[profileNum]_be_changeling"] >> src.be_conspirator
 		F["[profileNum]_be_changeling"] >> src.be_changeling
 		F["[profileNum]_be_revhead"] >> src.be_revhead
 		F["[profileNum]_be_syndicate"] >> src.be_syndicate


### PR DESCRIPTION
<--! I feel like this was...too easy so I probably got a lot wrong. I think it works but I only have 3 accounts to test with, but opting-in on two accounts resulted in those two being chosen as the conspirators, so I hope that wasn't just a fluke. Sorry in advance. !-->
[qol]
## About the PR 
Adds a checkbox on the traitor preferences menu to opt-in for conspirator separate of traitor
![conspiratorchecklist](https://user-images.githubusercontent.com/72267018/108409935-cbcb7680-71f4-11eb-8b3e-3c62f890e8c7.png)

## Why's this needed?
People asked for opt-in for traitors and conspirators to be split.
