### PR TITLE
Makes Donut 3 mineral magnet larger

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -315,7 +315,7 @@
 	name = "Magnet Area Boundary"
 	},
 /obj/grille/catwalk{
-	dir = 9
+	dir = 10
 	},
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
@@ -26374,7 +26374,7 @@
 	name = "Magnet Area Boundary"
 	},
 /obj/grille/catwalk{
-	dir = 9
+	dir = 10
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8
@@ -56898,7 +56898,7 @@
 /area/station/science/lab)
 "qNy" = (
 /obj/grille/catwalk{
-	dir = 6
+	icon_state = "catwalk_cross"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 1;

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -304,15 +304,15 @@
 	},
 /area/space)
 "aau" = (
-/obj/grille/catwalk{
-	dir = 4
-	},
 /obj/landmark/magnet_shield,
 /obj/securearea{
 	desc = "A warning that demarcates where the magnetic area begins.";
 	dir = 8;
 	icon_state = "magwarning";
 	name = "Magnet Area Boundary"
+	},
+/obj/grille/catwalk{
+	dir = 9
 	},
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk{

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -295,14 +295,17 @@
 /area/station/bridge/customs)
 "aat" = (
 /obj/grille/catwalk,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 1
+/obj/machinery/light/small/sticky{
+	dir = 4
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
 	icon_state = "catwalk_cross"
 	},
-/area/space)
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 1
+	},
+/area/station/mining/staff_room)
 "aau" = (
 /obj/landmark/magnet_shield,
 /obj/securearea{
@@ -420,6 +423,7 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
+/obj/machinery/light/small/floor/warm,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
 	tag = "icon-catwalk (WEST)"
@@ -427,7 +431,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8
 	},
-/area/space)
+/area/station/mining/staff_room)
 "aaE" = (
 /obj/storage/secure/closet/fridge/blood,
 /obj/machinery/light/emergency,
@@ -457,7 +461,7 @@
 	dir = 10;
 	icon_state = "catwalk_cross"
 	},
-/area/space)
+/area/station/mining/staff_room)
 "aaH" = (
 /obj/grille/catwalk/cross{
 	dir = 9
@@ -504,19 +508,19 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	icon_state = "catwalk_cross"
 	},
-/area/space)
+/area/station/mining/staff_room)
 "aaL" = (
 /obj/grille/catwalk{
 	dir = 6
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 10;
 	icon_state = "catwalk_cross"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
+	dir = 10;
 	icon_state = "catwalk_cross"
 	},
-/area/space)
+/area/station/mining/staff_room)
 "aaM" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 9
@@ -1324,23 +1328,6 @@
 "acb" = (
 /obj/decal/tile_edge/line/yellow{
 	icon_state = "line1"
-	},
-/obj/table/auto,
-/obj/item/device/gps{
-	pixel_x = -8;
-	rand_pos = 0
-	},
-/obj/item/device/gps{
-	pixel_x = -3;
-	rand_pos = 0
-	},
-/obj/item/device/gps{
-	pixel_x = 2;
-	rand_pos = 0
-	},
-/obj/item/device/gps{
-	pixel_x = 7;
-	rand_pos = 0
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -4651,11 +4638,11 @@
 "aZB" = (
 /obj/grille/catwalk,
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	icon_state = "catwalk_cross"
+	dir = 1
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 1
+	dir = 4;
+	icon_state = "catwalk_cross"
 	},
 /area/space)
 "aZQ" = (
@@ -8957,6 +8944,19 @@
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
+"cpv" = (
+/obj/decal/tile_edge/line/yellow{
+	dir = 8;
+	icon_state = "line1"
+	},
+/obj/stool/chair/yellow{
+	dir = 4
+	},
+/obj/landmark/start{
+	name = "Miner"
+	},
+/turf/simulated/floor/black,
+/area/station/mining/staff_room)
 "cpx" = (
 /obj/item/reagent_containers/glass/beaker/large{
 	pixel_x = 8;
@@ -13279,7 +13279,7 @@
 	dir = 1;
 	icon_state = "catwalk_cross"
 	},
-/area/space)
+/area/station/mining/staff_room)
 "dFZ" = (
 /obj/machinery/light/runway_light/delay4,
 /obj/lattice{
@@ -17177,6 +17177,23 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
+/obj/table/auto,
+/obj/item/device/gps{
+	pixel_x = -8;
+	rand_pos = 0
+	},
+/obj/item/device/gps{
+	pixel_x = -3;
+	rand_pos = 0
+	},
+/obj/item/device/gps{
+	pixel_x = 2;
+	rand_pos = 0
+	},
+/obj/item/device/gps{
+	pixel_x = 7;
+	rand_pos = 0
+	},
 /turf/simulated/floor/black/grime,
 /area/station/mining/staff_room)
 "eON" = (
@@ -18177,13 +18194,13 @@
 /turf/simulated/floor/purpleblack,
 /area/station/science/lobby)
 "fdg" = (
-/obj/table/auto,
-/obj/item/paper/book/pocketguide/mining2,
 /obj/machinery/light/incandescent/warm,
 /obj/decal/tile_edge/line/yellow{
 	dir = 6;
 	icon_state = "line2"
 	},
+/obj/table/auto,
+/obj/machinery/recharger,
 /turf/simulated/floor/black,
 /area/station/mining/staff_room)
 "fdm" = (
@@ -18508,6 +18525,18 @@
 /obj/item/clothing/under/misc/clown/blue,
 /turf/simulated/floor/specialroom/clown,
 /area/station/crew_quarters/clown)
+"fjv" = (
+/obj/grille/catwalk{
+	dir = 6
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8;
+	tag = "icon-catwalk (WEST)"
+	},
+/area/station/mining/staff_room)
 "fjz" = (
 /obj/machinery/light_switch{
 	name = "W light switch";
@@ -18950,29 +18979,6 @@
 	dir = 4
 	},
 /area/station/bridge/captain)
-"foZ" = (
-/obj/decal/mule/beacon/no_auto_dropoff_spawn,
-/obj/rack,
-/obj/item/clothing/suit/space/engineer{
-	pixel_x = 3;
-	pixel_y = -1
-	},
-/obj/item/clothing/mask/breath{
-	pixel_x = -1;
-	pixel_y = 5
-	},
-/obj/item/clothing/head/helmet/space/engineer{
-	pixel_y = 13
-	},
-/obj/decal/tile_edge/line/yellow{
-	icon_state = "line1"
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/simulated/floor/black,
-/area/station/mining/staff_room)
 "fpc" = (
 /turf/simulated/floor/greenwhite,
 /area/station/medical/cdc)
@@ -19547,6 +19553,7 @@
 	dir = 1;
 	icon_state = "line1"
 	},
+/obj/stool/bench/yellow/auto,
 /turf/simulated/floor/black,
 /area/station/mining/staff_room)
 "fyn" = (
@@ -23371,15 +23378,9 @@
 /turf/simulated/floor,
 /area/station/ai_monitored/armory)
 "gGu" = (
-/obj/grille/catwalk,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 1
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	icon_state = "catwalk_cross"
-	},
-/area/space)
+/turf/space,
+/turf/simulated/wall/auto/reinforced/jen/yellow,
+/area/station/mining/staff_room)
 "gGE" = (
 /obj/machinery/vending/pizza,
 /obj/machinery/light{
@@ -23631,6 +23632,18 @@
 	dir = 4
 	},
 /area/station/science/lobby)
+"gMk" = (
+/obj/grille/catwalk{
+	dir = 4
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8;
+	tag = "icon-catwalk (WEST)"
+	},
+/area/station/mining/staff_room)
 "gMo" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/grille/catwalk/jen,
@@ -24284,14 +24297,14 @@
 /area/station/medical/medbay/pharmacy)
 "gXc" = (
 /obj/table/reinforced/auto,
-/obj/item/cargotele{
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/obj/random_item_spawner/tools/one,
 /obj/decal/tile_edge/line/yellow{
 	dir = 8;
 	icon_state = "line1"
+	},
+/obj/machinery/recharger,
+/obj/item/cargotele{
+	pixel_x = 5;
+	pixel_y = 8
 	},
 /obj/item/cargotele{
 	pixel_x = -3
@@ -26353,8 +26366,20 @@
 /turf/simulated/floor,
 /area/station/ai_monitored/armory)
 "hCf" = (
-/turf/simulated/wall/auto/reinforced/jen/yellow,
-/area/space)
+/obj/landmark/magnet_shield,
+/obj/securearea{
+	desc = "A warning that demarcates where the magnetic area begins.";
+	dir = 8;
+	icon_state = "magwarning";
+	name = "Magnet Area Boundary"
+	},
+/obj/grille/catwalk{
+	dir = 9
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8
+	},
+/area/mining/magnet)
 "hCn" = (
 /obj/machinery/door/airlock/pyro/glass/engineering{
 	dir = 8;
@@ -27315,10 +27340,11 @@
 /turf/simulated/wall/auto/reinforced/jen/blue,
 /area/station/hallway/primary/west)
 "hRr" = (
-/obj/machinery/portable_reclaimer,
-/obj/decal/mule/beacon/no_auto_dropoff_spawn,
-/turf/simulated/floor/plating/airless,
-/area/space)
+/obj/grille/catwalk,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 1
+	},
+/area/station/mining/staff_room)
 "hRM" = (
 /obj/grille/catwalk/jen/side{
 	dir = 10
@@ -31798,22 +31824,11 @@
 /turf/simulated/floor/black,
 /area/station/engine/inner)
 "joX" = (
-/obj/table/auto,
-/obj/item/tank/jetpack{
-	pixel_x = -9;
-	pixel_y = 10
-	},
-/obj/item/tank/jetpack{
-	pixel_x = 7;
-	pixel_y = 10
-	},
-/obj/item/tank/jetpack{
-	pixel_x = -1
-	},
 /obj/decal/tile_edge/line/yellow{
-	dir = 1;
+	dir = 9;
 	icon_state = "line1"
 	},
+/obj/machinery/light/small/floor/warm,
 /turf/simulated/floor/black,
 /area/station/mining/staff_room)
 "jpf" = (
@@ -33918,11 +33933,22 @@
 /area/station/crew_quarters/stockex)
 "jXP" = (
 /obj/machinery/light/incandescent/warm,
-/obj/machinery/recharger,
 /obj/table/auto,
 /obj/decal/tile_edge/line/yellow{
 	icon_state = "line1"
 	},
+/obj/item/tank/jetpack{
+	pixel_x = -9;
+	pixel_y = 10
+	},
+/obj/item/tank/jetpack{
+	pixel_x = -1
+	},
+/obj/item/tank/jetpack{
+	pixel_x = 7;
+	pixel_y = 10
+	},
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /turf/simulated/floor/black,
 /area/station/mining/staff_room)
 "jYi" = (
@@ -34688,14 +34714,16 @@
 /turf/simulated/wall/auto/jen,
 /area/station/maintenance/outer/ne)
 "kkW" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/grille/catwalk{
+	dir = 4
 	},
-/obj/disposalpipe/segment/mail,
-/obj/machinery/light/small/floor/warm,
-/turf/simulated/floor/black,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8;
+	tag = "icon-catwalk (WEST)"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8
+	},
 /area/station/mining/staff_room)
 "kld" = (
 /obj/railing/red{
@@ -34923,15 +34951,9 @@
 /turf/simulated/floor/plating,
 /area/station/security/beepsky)
 "kpd" = (
-/obj/machinery/magnet_chassis{
-	dir = 1
-	},
-/obj/machinery/mining_magnet{
-	dir = 1
-	},
 /obj/grille/catwalk,
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 10
+	dir = 6
 	},
 /area/space)
 "kpv" = (
@@ -35180,6 +35202,11 @@
 	dir = 4
 	},
 /area/station/hallway/primary/west)
+"kur" = (
+/obj/machinery/portable_reclaimer,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
+/turf/simulated/floor/plating/airless,
+/area/station/mining/staff_room)
 "kuy" = (
 /obj/disposalpipe/segment{
 	dir = 1;
@@ -35363,12 +35390,21 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
 "kxa" = (
-/obj/decal/mule/dropoff,
-/obj/machinery/light/incandescent/warm{
-	dir = 1
+/obj/landmark/magnet_shield,
+/obj/securearea{
+	desc = "A warning that demarcates where the magnetic area begins.";
+	dir = 8;
+	icon_state = "magwarning";
+	name = "Magnet Area Boundary"
 	},
-/turf/simulated/floor/black,
-/area/station/mining/staff_room)
+/obj/grille/catwalk{
+	dir = 4
+	},
+/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
+/area/mining/magnet)
 "kxi" = (
 /turf/simulated/floor/carpet/green/fancy,
 /area/station/chapel/sanctuary{
@@ -37854,6 +37890,13 @@
 	},
 /turf/simulated/floor/white,
 /area/station/science/lobby)
+"lmA" = (
+/obj/decal/mule/dropoff,
+/obj/machinery/light/incandescent/warm{
+	dir = 1
+	},
+/turf/simulated/floor/black,
+/area/station/mining/staff_room)
 "lmB" = (
 /obj/cable{
 	d1 = 4;
@@ -43247,6 +43290,16 @@
 	},
 /turf/simulated/floor/purple/side,
 /area/station/hallway/primary/south)
+"mSA" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/obj/decal/mule/dropoff,
+/obj/firedoor_spawn,
+/obj/access_spawn/mining,
+/turf/space,
+/turf/simulated/floor/black/grime,
+/area/station/mining/staff_room)
 "mSD" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/blue/side,
@@ -45390,7 +45443,9 @@
 	dir = 8;
 	icon_state = "line1"
 	},
-/obj/machinery/arc_electroplater,
+/obj/machinery/arc_electroplater{
+	dir = 4
+	},
 /turf/simulated/floor/black,
 /area/station/quartermaster/refinery)
 "nyq" = (
@@ -47219,15 +47274,9 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
 "nZO" = (
-/obj/stool/chair/yellow{
-	dir = 4
-	},
 /obj/decal/tile_edge/line/yellow{
 	dir = 1;
 	icon_state = "line1"
-	},
-/obj/landmark/start{
-	name = "Miner"
 	},
 /turf/simulated/floor/black,
 /area/station/mining/staff_room)
@@ -48902,6 +48951,16 @@
 	},
 /turf/simulated/floor/circuit/purple,
 /area/station/crew_quarters/hor)
+"ozi" = (
+/obj/decal/tile_edge/line/yellow{
+	dir = 9;
+	icon_state = "line2"
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/black,
+/area/station/mining/staff_room)
 "ozp" = (
 /obj/machinery/light/incandescent/warm,
 /obj/cable{
@@ -49506,9 +49565,6 @@
 	},
 /area/shuttle/arrival/station)
 "oIX" = (
-/obj/machinery/computer/magnet{
-	dir = 8
-	},
 /obj/decal/poster/wallsign/poster_mining{
 	pixel_y = 30
 	},
@@ -49516,6 +49572,7 @@
 	dir = 5;
 	icon_state = "line2"
 	},
+/obj/machinery/manufacturer/mining,
 /turf/simulated/floor/black,
 /area/station/mining/staff_room)
 "oJf" = (
@@ -49663,6 +49720,17 @@
 /obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/plating/jen,
 /area/station/hallway/secondary/construction)
+"oMa" = (
+/obj/decal/tile_edge/line/yellow{
+	dir = 8;
+	icon_state = "line1"
+	},
+/obj/machinery/disposal/mail/small/autoname/mining/east,
+/obj/disposalpipe/trunk/mail{
+	dir = 4
+	},
+/turf/simulated/floor/black,
+/area/station/mining/staff_room)
 "oMe" = (
 /obj/decal/stage_edge{
 	dir = 2;
@@ -50321,18 +50389,12 @@
 	},
 /area/space)
 "oXv" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/grille/catwalk,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	icon_state = "catwalk_cross"
 	},
-/obj/decal/tile_edge/line/yellow{
-	dir = 9;
-	icon_state = "line1"
-	},
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/black,
-/area/station/mining/staff_room)
+/area/space)
 "oXw" = (
 /obj/stool/bar,
 /turf/simulated/floor/specialroom/arcade,
@@ -50855,15 +50917,18 @@
 	},
 /area/station/crew_quarters/hor)
 "php" = (
-/obj/machinery/light/incandescent/warm{
+/obj/machinery/magnet_chassis{
 	dir = 1
 	},
-/obj/decal/tile_edge/line/yellow{
-	dir = 1;
-	icon_state = "line1"
+/obj/machinery/mining_magnet{
+	dir = 1
 	},
-/turf/simulated/floor/black,
-/area/station/mining/staff_room)
+/obj/grille/catwalk,
+/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 10
+	},
+/area/space)
 "phx" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -56831,6 +56896,19 @@
 /obj/decal/mule/dropoff,
 /turf/simulated/floor/white,
 /area/station/science/lab)
+"qNy" = (
+/obj/grille/catwalk{
+	dir = 6
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 1;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8;
+	tag = "icon-catwalk (WEST)"
+	},
+/area/station/mining/staff_room)
 "qND" = (
 /obj/stool/chair/green,
 /turf/simulated/floor/carpet/arcade/half,
@@ -57635,10 +57713,10 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/north)
 "qYR" = (
-/obj/machinery/oreaccumulator,
 /obj/decal/mule/beacon/no_auto_dropoff_spawn,
+/obj/machinery/computer/magnet,
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/mining/staff_room)
 "qYT" = (
 /obj/machinery/atmospherics/valve/horizontal,
 /turf/simulated/floor,
@@ -61066,9 +61144,6 @@
 	dir = 4;
 	icon_state = "line1"
 	},
-/obj/landmark/start{
-	name = "Miner"
-	},
 /turf/simulated/floor/black,
 /area/station/mining/staff_room)
 "rWW" = (
@@ -64098,7 +64173,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 9
 	},
-/area/space)
+/area/station/mining/staff_room)
 "sVX" = (
 /obj/machinery/launcher_loader/north,
 /obj/decal/tile_edge/stripe/extra_big{
@@ -64688,7 +64763,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	icon_state = "catwalk_cross"
 	},
-/area/space)
+/area/station/mining/staff_room)
 "tgN" = (
 /obj/decal/tile_edge/line/black{
 	dir = 5;
@@ -66857,12 +66932,12 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "tMr" = (
-/obj/decal/tile_edge/line/yellow{
-	dir = 9;
-	icon_state = "line2"
+/obj/machinery/light/incandescent/warm{
+	dir = 1
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/decal/tile_edge/line/yellow{
+	dir = 1;
+	icon_state = "line1"
 	},
 /turf/simulated/floor/black,
 /area/station/mining/staff_room)
@@ -69292,11 +69367,11 @@
 	},
 /area/station/security/main)
 "uAB" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/decal/tile_edge/line/yellow{
+	dir = 1;
+	icon_state = "line1"
 	},
+/obj/stool/bench/yellow/auto,
 /obj/landmark/start{
 	name = "Miner"
 	},
@@ -72287,6 +72362,12 @@
 /obj/stool/bench/red,
 /turf/simulated/floor/wood/five,
 /area/station/medical/asylum/main)
+"vrQ" = (
+/obj/landmark/start{
+	name = "Miner"
+	},
+/turf/simulated/floor/black,
+/area/station/mining/staff_room)
 "vsn" = (
 /turf/simulated/wall/auto/reinforced/jen/blue{
 	icon_state = "R5"
@@ -75308,6 +75389,19 @@
 /obj/item/plate,
 /turf/simulated/floor/black,
 /area/station/engine/engineering/breakroom)
+"wlK" = (
+/obj/grille/catwalk{
+	dir = 4
+	},
+/obj/machinery/light/small/sticky,
+/turf/simulated/floor/airless/plating/catwalk{
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8;
+	tag = "icon-catwalk (WEST)"
+	},
+/area/station/mining/staff_room)
 "wlL" = (
 /obj/cable{
 	d1 = 1;
@@ -76112,17 +76206,15 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/west)
 "wxc" = (
-/obj/decal/tile_edge/line/yellow{
-	dir = 8;
-	icon_state = "line1"
-	},
 /obj/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/disposal/mail/small/autoname/mining/east,
-/obj/disposalpipe/trunk/mail,
+/obj/disposalpipe/segment/mail{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/black,
 /area/station/mining/staff_room)
 "wxh" = (
@@ -76250,11 +76342,10 @@
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering/private)
 "wyK" = (
-/obj/grille/catwalk,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 6
-	},
-/area/space)
+/obj/machinery/oreaccumulator,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
+/turf/simulated/floor/plating/airless,
+/area/station/mining/staff_room)
 "wyM" = (
 /obj/stool/chair/syndicate,
 /obj/decal/cleanable/dirt/jen,
@@ -80150,7 +80241,7 @@
 	dir = 1;
 	icon_state = "catwalk_cross"
 	},
-/area/space)
+/area/station/mining/staff_room)
 "xGu" = (
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/plating/jen,
@@ -80941,6 +81032,19 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/engine/gas)
+"xSZ" = (
+/obj/grille/catwalk{
+	dir = 4
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 1;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8;
+	tag = "icon-catwalk (WEST)"
+	},
+/area/station/mining/staff_room)
 "xTb" = (
 /obj/machinery/light/small/floor/cool,
 /turf/simulated/floor/blueblack/corner{
@@ -130731,7 +130835,7 @@ rdj
 rdj
 aLY
 ppP
-aaD
+kkW
 qfp
 qfp
 qfp
@@ -131033,7 +131137,7 @@ rdj
 rdj
 aLY
 ppP
-aaD
+kkW
 qfp
 qfp
 qfp
@@ -131333,8 +131437,8 @@ lmX
 lmX
 lmX
 vob
-aLY
-ppP
+kuM
+cjG
 xFO
 tgJ
 dCg
@@ -131635,10 +131739,10 @@ yli
 yli
 yli
 npG
-aLY
-ppP
-dFX
-aaK
+kuM
+wyK
+xSZ
+wlK
 mYB
 oGM
 ubm
@@ -131938,9 +132042,9 @@ yli
 yli
 npG
 kuM
-cjG
-dFX
-aaK
+kur
+xSZ
+gMk
 mYB
 crZ
 qZz
@@ -132243,7 +132347,7 @@ kuM
 qYR
 dFX
 aaK
-mYB
+fBA
 aaQ
 qZz
 muN
@@ -132540,11 +132644,11 @@ yli
 yli
 yli
 yli
-tkx
-kuM
+hCf
+oXv
 hRr
-dFX
-aaK
+qNy
+fjv
 fBA
 fEk
 qZz
@@ -133144,12 +133248,12 @@ yli
 yli
 yli
 yli
-aau
-aZB
+kxa
+php
 gGu
-aaG
-aaL
-fBA
+mSA
+mSA
+mYB
 mCZ
 oRh
 mCZ
@@ -133448,13 +133552,13 @@ yli
 yli
 npG
 kpd
-hCf
-qKR
-qKR
 mYB
+lmA
+wCJ
+mCZ
 kZP
 sFK
-sFK
+cpv
 fYG
 mhe
 ghg
@@ -133749,9 +133853,9 @@ yli
 yli
 yli
 npG
-wyK
-hCf
-kxa
+kuM
+fBA
+wCJ
 wCJ
 mCZ
 ugC
@@ -134053,8 +134157,8 @@ yli
 npG
 kuM
 fBA
-wCJ
-wCJ
+qKR
+qKR
 mCZ
 ugC
 fLf
@@ -134354,10 +134458,10 @@ yli
 yli
 npG
 kuM
-fBA
-qKR
-qKR
-mCZ
+mYB
+ozi
+sFK
+oMa
 joX
 fLf
 fLf
@@ -134656,12 +134760,12 @@ yli
 yli
 npG
 kuM
-mYB
+fBA
 tMr
-sFK
+fLf
 wxc
-oXv
-kkW
+mEA
+mEA
 mEA
 bUw
 dTI
@@ -134959,9 +135063,9 @@ iIL
 aaj
 kuM
 fBA
-php
+fyd
 fLf
-uAB
+vpR
 fLf
 fLf
 fLf
@@ -135261,13 +135365,13 @@ rdj
 rfc
 jRw
 fBA
-fyd
+uAB
 fLf
 vpR
 fLf
 fLf
-fLf
-foZ
+vrQ
+bQt
 cxc
 dTC
 mdA

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -304,6 +304,9 @@
 	},
 /area/space)
 "aau" = (
+/obj/grille/catwalk{
+	dir = 4
+	},
 /obj/landmark/magnet_shield,
 /obj/securearea{
 	desc = "A warning that demarcates where the magnetic area begins.";
@@ -311,15 +314,9 @@
 	icon_state = "magwarning";
 	name = "Magnet Area Boundary"
 	},
-/obj/grille/catwalk{
-	dir = 10
-	},
+/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 8
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 1;
-	icon_state = "catwalk_cross"
+	dir = 4
 	},
 /area/mining/magnet)
 "aav" = (
@@ -327,12 +324,13 @@
 /area/station/maintenance/inner/nw)
 "aaw" = (
 /obj/grille/catwalk{
-	dir = 5;
+	dir = 9;
 	icon_state = "catwalk_cross"
 	},
 /obj/landmark/magnet_shield,
 /obj/securearea{
 	desc = "A warning that demarcates where the magnetic area begins.";
+	dir = 1;
 	icon_state = "magwarning";
 	name = "Magnet Area Boundary"
 	},
@@ -344,7 +342,7 @@
 	},
 /obj/securearea{
 	desc = "A warning that demarcates where the magnetic area begins.";
-	dir = 5;
+	dir = 9;
 	icon_state = "magwarning";
 	name = "Magnet Area Boundary"
 	},
@@ -354,7 +352,7 @@
 	name = "ACTIVE MAGNET AREA"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 5
+	dir = 9
 	},
 /area/mining/magnet)
 "aax" = (
@@ -4650,6 +4648,16 @@
 "aZz" = (
 /turf/simulated/wall/auto/reinforced/jen/purple,
 /area/station/science/testchamber)
+"aZB" = (
+/obj/grille/catwalk,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 1
+	},
+/area/space)
 "aZQ" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -31686,13 +31694,12 @@
 /area/station/security/main)
 "jny" = (
 /obj/grille/catwalk{
-	dir = 9;
+	dir = 5;
 	icon_state = "catwalk_cross"
 	},
 /obj/landmark/magnet_shield,
 /obj/securearea{
 	desc = "A warning that demarcates where the magnetic area begins.";
-	dir = 1;
 	icon_state = "magwarning";
 	name = "Magnet Area Boundary"
 	},
@@ -31704,7 +31711,7 @@
 	},
 /obj/securearea{
 	desc = "A warning that demarcates where the magnetic area begins.";
-	dir = 9;
+	dir = 5;
 	icon_state = "magwarning";
 	name = "Magnet Area Boundary"
 	},
@@ -31714,7 +31721,7 @@
 	name = "ACTIVE MAGNET AREA"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 9
+	dir = 5
 	},
 /area/mining/magnet)
 "jnz" = (
@@ -55532,37 +55539,8 @@
 /turf/simulated/floor/darkblue,
 /area/station/ai_monitored/storage/eva)
 "qtm" = (
-/obj/grille/catwalk{
-	dir = 10;
-	icon_state = "catwalk_cross"
-	},
-/obj/landmark/magnet_shield,
-/obj/securearea{
-	desc = "A warning that demarcates where the magnetic area begins.";
-	dir = 1;
-	icon_state = "magwarning";
-	name = "Magnet Area Boundary"
-	},
-/obj/securearea{
-	desc = "A warning that demarcates where the magnetic area begins.";
-	dir = 8;
-	icon_state = "magwarning";
-	name = "Magnet Area Boundary"
-	},
-/obj/securearea{
-	desc = "A warning that demarcates where the magnetic area begins.";
-	dir = 10;
-	icon_state = "magwarning";
-	name = "Magnet Area Boundary"
-	},
-/obj/securearea{
-	desc = "A warning sign. I guess this area is dangerous.";
-	icon_state = "magwarning2";
-	name = "ACTIVE MAGNET AREA"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 10
-	},
+/obj/landmark/magnet_center,
+/turf/space,
 /area/mining/magnet)
 "qts" = (
 /obj/cable{
@@ -64984,6 +64962,21 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/south)
+"tkx" = (
+/obj/landmark/magnet_shield,
+/obj/securearea{
+	desc = "A warning that demarcates where the magnetic area begins.";
+	dir = 8;
+	icon_state = "magwarning";
+	name = "Magnet Area Boundary"
+	},
+/obj/grille/catwalk{
+	dir = 4
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8
+	},
+/area/mining/magnet)
 "tkQ" = (
 /obj/machinery/door/airlock/pyro/glass/engineering{
 	dir = 8;
@@ -72064,8 +72057,37 @@
 /turf/simulated/floor/plating/jen,
 /area/station/science/lobby)
 "vob" = (
-/obj/landmark/magnet_center,
-/turf/space,
+/obj/grille/catwalk{
+	dir = 10;
+	icon_state = "catwalk_cross"
+	},
+/obj/landmark/magnet_shield,
+/obj/securearea{
+	desc = "A warning that demarcates where the magnetic area begins.";
+	dir = 1;
+	icon_state = "magwarning";
+	name = "Magnet Area Boundary"
+	},
+/obj/securearea{
+	desc = "A warning that demarcates where the magnetic area begins.";
+	dir = 8;
+	icon_state = "magwarning";
+	name = "Magnet Area Boundary"
+	},
+/obj/securearea{
+	desc = "A warning that demarcates where the magnetic area begins.";
+	dir = 10;
+	icon_state = "magwarning";
+	name = "Magnet Area Boundary"
+	},
+/obj/securearea{
+	desc = "A warning sign. I guess this area is dangerous.";
+	icon_state = "magwarning2";
+	name = "ACTIVE MAGNET AREA"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 10
+	},
 /area/mining/magnet)
 "voc" = (
 /obj/cable{
@@ -131298,19 +131320,19 @@ hka
 vyr
 rdj
 rdj
-rdj
-rdj
-rdj
-rdj
-vVp
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-tXv
-rdj
+aaw
+lmX
+lmX
+lmX
+lmX
+lmX
+lmX
+lmX
+lmX
+lmX
+lmX
+lmX
+vob
 aLY
 ppP
 xFO
@@ -131600,19 +131622,19 @@ abG
 vyr
 rdj
 rdj
-rdj
-rdj
-rdj
-rdj
-vVp
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
+iAZ
+yli
+yli
+yli
+yli
+yli
+yli
+yli
+yli
+yli
+yli
+yli
+npG
 aLY
 ppP
 dFX
@@ -131902,19 +131924,19 @@ ePG
 vyr
 rdj
 rdj
-rdj
-rdj
-jny
-lmX
-lmX
-lmX
-lmX
-lmX
-lmX
-lmX
-lmX
-lmX
-qtm
+iAZ
+yli
+yli
+yli
+yli
+yli
+yli
+yli
+yli
+yli
+yli
+yli
+npG
 kuM
 cjG
 dFX
@@ -132204,8 +132226,6 @@ koX
 rAX
 cNV
 cNV
-cNV
-cNV
 iAZ
 yli
 yli
@@ -132216,7 +132236,9 @@ yli
 yli
 yli
 yli
-npG
+yli
+yli
+tkx
 kuM
 qYR
 dFX
@@ -132506,8 +132528,6 @@ jFv
 rAX
 rdj
 rdj
-rdj
-rdj
 iAZ
 yli
 yli
@@ -132518,7 +132538,9 @@ yli
 yli
 yli
 yli
-npG
+yli
+yli
+tkx
 kuM
 hRr
 dFX
@@ -132808,8 +132830,6 @@ sRc
 vyr
 rdj
 rdj
-rdj
-rdj
 iAZ
 yli
 yli
@@ -132820,8 +132840,10 @@ yli
 yli
 yli
 yli
+yli
+yli
 aau
-gGu
+aZB
 aat
 aaG
 aaL
@@ -133110,20 +133132,20 @@ pir
 vyr
 rdj
 rdj
-rdj
-rdj
 iAZ
 yli
 yli
 yli
 yli
 yli
+qtm
+yli
 yli
 yli
 yli
 yli
 aau
-gGu
+aZB
 gGu
 aaG
 aaL
@@ -133412,14 +133434,14 @@ nxP
 vyr
 rdj
 rdj
-rdj
-rdj
 iAZ
 yli
 yli
 yli
 yli
-vob
+yli
+yli
+yli
 yli
 yli
 yli
@@ -133714,9 +133736,9 @@ gfv
 vyr
 rdj
 rdj
-rdj
-rdj
 iAZ
+yli
+yli
 yli
 yli
 yli
@@ -134016,9 +134038,9 @@ wTu
 mTj
 rdj
 rdj
-rdj
-rdj
 iAZ
+yli
+yli
 yli
 yli
 yli
@@ -134318,9 +134340,9 @@ llt
 mTj
 rdj
 rdj
-tXv
-rdj
 iAZ
+yli
+yli
 yli
 yli
 yli
@@ -134620,9 +134642,9 @@ raj
 mTj
 cNV
 cNV
-cNV
-cNV
 iAZ
+yli
+yli
 yli
 yli
 yli
@@ -134922,9 +134944,9 @@ xdq
 mTj
 rdj
 rdj
-rdj
-rdj
-aaw
+jny
+iIL
+iIL
 iIL
 iIL
 iIL

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -131620,8 +131620,8 @@ pMH
 pMH
 abG
 vyr
-rdj
-rdj
+cNV
+cNV
 iAZ
 yli
 yli
@@ -132224,8 +132224,8 @@ rKu
 oXw
 koX
 rAX
-cNV
-cNV
+rdj
+rdj
 iAZ
 yli
 yli


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

As the title says. Instead of 9x9, the magnet inner area is now 11x11:

![0](https://user-images.githubusercontent.com/62990808/108555637-07019e80-72f6-11eb-966f-b06bda35193d.png)

Also made several other tweaks to mining office, scroll down to the comments section to see them.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

People have been saying donut 3 mineral magnet is too small and I agree with them. It's noticeable when some pulled asteroids are weirdly shaped, like they were "cut" from a larger asteroid


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)TTerc
(+)Donut 3: Made mineral magnet area larger, tweaked the mining office layout.
```
