### PR TITLE
Gibber nerf

### DIFF
--- a/code/obj/machinery/gibber.dm
+++ b/code/obj/machinery/gibber.dm
@@ -56,7 +56,9 @@
 	if (!( istype(G, /obj/item/grab)) || !(ishuman(G.affecting)))
 		boutput(user, "<span class='alert'>This item is not suitable for the gibber!</span>")
 		return
-
+	if (!isdead(G.affecting))
+		boutput(user, "<span class='alert'>You can't force a living person into the gibber!</span>")
+		return
 	user.visible_message("<span class='alert'>[user] starts to put [G.affecting] into the gibber!</span>")
 	src.add_fingerprint(user)
 	sleep(3 SECONDS)
@@ -67,6 +69,9 @@
 		var/mob/M = G.affecting
 		M.set_loc(src)
 		src.occupant = M
+		var/turf/T = src.loc
+		T.fluid_react_single("blood",100)
+		playsound(src.loc, "sound/impact_sounds/Flesh_Break_2.ogg", 75, 1)
 		qdel(G)
 
 /obj/machinery/gibber/verb/eject()

--- a/code/obj/machinery/gibber.dm
+++ b/code/obj/machinery/gibber.dm
@@ -70,7 +70,7 @@
 		M.set_loc(src)
 		src.occupant = M
 		var/turf/T = src.loc
-		T.fluid_react_single("blood",100)
+		T.fluid_react_single(G.affecting.blood_id,100)
 		playsound(src.loc, "sound/impact_sounds/Flesh_Break_2.ogg", 75, 1)
 		qdel(G)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Prevents living humans being loaded into the gibber. Also adds a squelch noise and mutant race blood pool!

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The enzymatic reclaimer needs to be emagged to kill someone, this is located in a public place.
The gibber can kill people after 3 seconds with a flash/baton or other disable and leaves no evidence.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(+)Gibber no longer accepts living people for easy kills
```
