### PR TITLE
let borgs affix lights to walls and floors by dragging

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -19,6 +19,14 @@
 	var/light_type = /obj/item/light/tube
 	var/fitting = "tube"
 
+	MouseDrop(atom/over_object, src_location, over_location, over_control, params)
+		if(istype(over_object, /turf/simulated/wall) && istype(usr, /mob))
+			var/turf/simulated/wall/T = over_object
+			T.attach_light_fixture_parts(usr, src)
+		else
+			. = ..()
+
+
 // For metal sheets. Can't easily change an item's vars the way it's set up (Convair880).
 /obj/item/light_parts/bulb
 	icon_state = "bulb-fixture"
@@ -35,6 +43,13 @@
 	installed_base_state = "floor"
 	fitting = "floor"
 	light_type = /obj/item/light/bulb
+
+	MouseDrop(atom/over_object, src_location, over_location, over_control, params)
+		if(istype(over_object, /turf/simulated/floor) && istype(usr, /mob))
+			var/turf/simulated/floor/T = over_object
+			T.attach_light_fixture_parts(usr, src)
+		else
+			. = ..()
 
 /obj/item/light_parts/proc/copy_light(obj/machinery/light/target)
 	installed_icon_state = target.icon_state


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so that borgs (and other mobs too, I guess) can affix light fixtures to floors and walls by click dragging them.
Alternatively, we could just make it so that the light tube maker would allow borgs to place new fixtures too, that would only work for engineering borgs though.

Also, I didn't see a parameter for who did the dragging in MouseDrop(), so I had to use usr, I checked whether or not it was a mob though.
Please let me know if there is a less dumb way of doing that.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I saw some people sad that they couldn't light up the rooms they made as borgs.
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)zjdtmkhzt
(+)Cyborgs can now affix light fixtures to walls and floors by click dragging them.
```
