### PR TITLE
Add a golden crayon for the head of personnel to have.

### DIFF
--- a/code/datums/objective.dm
+++ b/code/datums/objective.dm
@@ -179,7 +179,7 @@ proc/create_fluff(var/datum/mind/target)
 #else
 	set_up()
 		var/list/items = list("Head of Security\'s beret", "prisoner\'s beret", "DetGadget hat", "horse mask", "authentication disk",
-		"\'freeform\' AI module", "gene power module", "mainframe memory board", "yellow cake", "aurora MKII utility belt", "much coveted Gooncode")
+		"\'freeform\' AI module", "gene power module", "mainframe memory board", "yellow cake", "aurora MKII utility belt", "much coveted Gooncode", "golden crayon")
 
 		target_name = pick(items)
 		switch(target_name)
@@ -205,6 +205,8 @@ proc/create_fluff(var/datum/mind/target)
 				steal_target = /obj/item/toy/gooncode
 			if("horse mask")
 				steal_target = /obj/item/clothing/mask/horse_mask
+			if("golden crayon")
+				steal_target = /obj/item/pen/crayon/golden
 #endif
 
 		explanation_text = "Steal the [target_name]."

--- a/code/obj/item/pens_writing_etc.dm
+++ b/code/obj/item/pens_writing_etc.dm
@@ -311,6 +311,19 @@
 		color = "#FF00FF"
 		font_color = "#FF00FF"
 		color_name = "pink"
+	
+	golden // HoP's crayon
+		name = "golden crayon"
+		desc = "The result of years of bribes and extreme bureaucracy."
+		color = "#D4AF37"
+		font_color = "#D4AF37"
+		mat_changename = 0
+		color_name = "golden"
+		material_uses = 123456 // it's not plated. its solid gold-wax alloy!
+
+		New()
+			..()
+			src.setMaterial(getMaterial("gold"))
 
 	random
 		New()

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -18058,6 +18058,8 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "TT" = (
+/obj/rack,
+/obj/item/pen/crayon/golden,
 /turf/simulated/floor/blue,
 /area/station/crew_quarters/heads)
 "TV" = (

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -27664,14 +27664,15 @@
 "aYe" = (
 /obj/machinery/light_switch/north,
 /obj/table/wood/auto,
+/obj/machinery/firealarm{
+	layer = 3.5;
+	pixel_y = 24
+	},
+/obj/item/pen/crayon/golden,
 /obj/machinery/light/lamp/green{
 	pixel_x = -6;
 	pixel_y = 4;
 	switchon = 1
-	},
-/obj/machinery/firealarm{
-	layer = 3.5;
-	pixel_y = 24
 	},
 /turf/simulated/floor/carpet{
 	dir = 9;

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -27664,15 +27664,14 @@
 "aYe" = (
 /obj/machinery/light_switch/north,
 /obj/table/wood/auto,
-/obj/machinery/firealarm{
-	layer = 3.5;
-	pixel_y = 24
-	},
-/obj/item/pen/crayon/golden,
 /obj/machinery/light/lamp/green{
 	pixel_x = -6;
 	pixel_y = 4;
 	switchon = 1
+	},
+/obj/machinery/firealarm{
+	layer = 3.5;
+	pixel_y = 24
 	},
 /turf/simulated/floor/carpet{
 	dir = 9;

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -24537,10 +24537,7 @@
 	pixel_x = -4;
 	pixel_y = 5
 	},
-/obj/item/pen{
-	pixel_x = -4;
-	pixel_y = 5
-	},
+/obj/item/pen/crayon/golden,
 /turf/simulated/floor/carpet{
 	dir = 8;
 	icon_state = "fgreen2"

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -34033,6 +34033,7 @@
 	},
 /obj/table/wood/auto,
 /obj/item/storage/firstaid/regular,
+/obj/item/pen/crayon/golden,
 /turf/simulated/floor/carpet{
 	icon_state = "fblue2"
 	},

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -1130,6 +1130,7 @@
 /obj/landmark/start{
 	name = "Head of Personnel"
 	},
+/obj/item/pen/crayon/golden,
 /turf/simulated/floor/carpet{
 	dir = 9;
 	icon_state = "fgreen2"

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -39106,6 +39106,7 @@
 /obj/table/wood/auto,
 /obj/bedsheetbin,
 /obj/machinery/light/incandescent/cool,
+/obj/item/pen/crayon/golden,
 /turf/simulated/floor/carpet/red/fancy/narrow{
 	dir = 6
 	},

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -22101,6 +22101,7 @@
 	dir = 4
 	},
 /obj/item/device/radio/intercom/cargo,
+/obj/item/pen/crayon/golden,
 /turf/simulated/floor,
 /area/station/bridge/hos)
 "aZv" = (

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -53086,6 +53086,7 @@
 "lpn" = (
 /obj/table/wood/auto,
 /obj/machinery/phone,
+/obj/item/pen/crayon/golden,
 /turf/simulated/floor/black,
 /area/station/bridge/hos)
 "lpu" = (

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -31294,6 +31294,7 @@
 /obj/item/storage/box/accessimp_kit{
 	pixel_y = 9
 	},
+/obj/item/pen/crayon/golden,
 /turf/simulated/floor/carpet{
 	icon_state = "green1"
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add a golden crayon, which is distinct from a gold-plated crayon, as this one can write in gold material forever<sup>\*</sup>. It can be found in the Head of Personnel's office on all rotation maps, other than Manta. (EDIT: or Clarion)

<sup>\* Technically, 123,456 times. Good as forever!</sup>

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The Head of Personnel lacks a consistent theft objective item. The only one they have is the First Dollar on Manta. The golden crayon has been added for the other maps. It's also a smaller but equally awesome counterpart to the Captain's golden toilet.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Stonepillar
(*)Added the HoP's golden crayon, which can be found in their office on most maps. Beware of possible theft!
```
