### PR TITLE
Gwydion pistol fixes

### DIFF
--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -946,15 +946,15 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 
 /obj/item/gun/kinetic/tranq_pistol
 	name = "Gwydion tranquilizer pistol"
-	desc = "A silenced tranquilizer pistol chambered in .308 caliber, developed by Mabinogi Firearms Company."
+	desc = "A silenced 9mm tranquilizer pistol, developed by Mabinogi Firearms Company."
 	icon_state = "tranq_pistol"
 	item_state = "tranq_pistol"
 	w_class = 2
 	force = 3
 	contraband = 4
 	caliber = 0.355
-	max_ammo_capacity = 30
-	auto_eject = 0
+	max_ammo_capacity = 15
+	auto_eject = 1
 	hide_attack = 1
 	muzzle_flash = null
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR and why it's needed!<!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The nuclear operative tranquilizer pistol (Gwydion) currently has a 30 round capacity, which is both rather overpowered, inaccurate to the mag sizes, and inaccurate to the sprite. Additionally, the description is misleading in regards to the caliber and what can be loaded into the firearm, and lastly it was functioning like a revolver rather than a semi-automatic in regards to casing ejection. This little PR fixes all of that.

Fixes #3785