### PR TITLE
Artifact gun stuff

### DIFF
--- a/code/obj/artifacts/artifact_items/energy_gun.dm
+++ b/code/obj/artifacts/artifact_items/energy_gun.dm
@@ -75,10 +75,20 @@
 
 		..()
 
-		A.ReduceHealth(src)
+		if(prob(5))
+			src.ArtifactTakeDamage(rand(5,30))
+
+		O.visible_message("<span class='alert'>[O] emits a terrible cracking noise.</span>")
 
 		src.ArtifactFaultUsed(user)
 		return
+
+	ArtifactDestroyed()
+		var/turf/T = get_turf(src)
+		if(T)
+			cell.set_loc(T)
+		. = ..()
+
 
 /datum/artifact/energygun
 	associated_object = /obj/item/gun/energy/artifact
@@ -86,8 +96,6 @@
 	validtypes = list("ancient","eldritch","precursor")
 	react_elec = list(0.02,0,5)
 	react_xray = list(10,75,100,11,"CAVITY")
-	var/integrity = 100
-	var/integrity_loss = 5
 	var/datum/projectile/artifact/bullet = null
 	examine_hint = "It seems to have a handle you're supposed to hold it by."
 	module_research = list("weapons" = 8, "energy" = 8)
@@ -98,21 +106,8 @@
 		bullet = new/datum/projectile/artifact
 		bullet.randomise()
 		// artifact tweak buff, people said guns were useless compared to their cells
-		// the next 3 lines override the randomize(). Doing this instead of editting randomize to avoid changing prismatic spray.
+		// the next 3 lines override the randomize(). Doing this instead of editing randomize to avoid changing prismatic spray.
 		bullet.power = rand(15,35) // randomise puts it between 2 and 50, let's make it less variable
 		bullet.dissipation_rate = rand(1,bullet.power)
 		bullet.cost = rand(35,100) // randomise puts it at 50-150
 
-		integrity = rand(50, 100)
-		integrity_loss = rand(1, 3) // was rand(1,7)
-		react_xray[3] = integrity
-
-	proc/ReduceHealth(var/obj/item/gun/energy/artifact/O)
-		var/prev_health = integrity
-		integrity -= integrity_loss
-		if (integrity <= 20 && prev_health > 20)
-			O.visible_message("<span class='alert'>[O] emits a terrible cracking noise.</span>")
-		if (integrity <= 0)
-			O.visible_message("<span class='alert'>[O] crumbles into nothingness.</span>")
-			O.ArtifactDestroyed()
-		react_xray[3] = integrity

--- a/code/obj/artifacts/artifact_items/energy_gun.dm
+++ b/code/obj/artifacts/artifact_items/energy_gun.dm
@@ -114,5 +114,5 @@
 			O.visible_message("<span class='alert'>[O] emits a terrible cracking noise.</span>")
 		if (integrity <= 0)
 			O.visible_message("<span class='alert'>[O] crumbles into nothingness.</span>")
-			qdel(O)
+			O.ArtifactDestroyed()
 		react_xray[3] = integrity

--- a/code/obj/artifacts/artifact_items/energy_gun.dm
+++ b/code/obj/artifacts/artifact_items/energy_gun.dm
@@ -84,11 +84,11 @@
 
 		src.ArtifactFaultUsed(user)
 
-		if(prob(10))
+		if(prob(20))
 			src.ArtifactDevelopFault(100)
 			src.visible_message("<span class='alert'>[src] emits \a [pick("ominous", "portentous", "sinister")] sound.</span>")
-		else if(prob(10))
-			src.ArtifactTakeDamage(15)
+		else if(prob(20))
+			src.ArtifactTakeDamage(20)
 			src.visible_message("<span class='alert'>[src] emits a terrible cracking noise.</span>")
 
 		return

--- a/code/obj/artifacts/artifact_items/energy_gun.dm
+++ b/code/obj/artifacts/artifact_items/energy_gun.dm
@@ -114,7 +114,7 @@
 	New()
 		..()
 		var/datum/projectile/artifact/bullet = null
-		var/mode_amount = pick(7;1, 2;2,	1;3) // 70% 1 mode, 20% 2 modes, 10% 3 modes
+		var/mode_amount = pick(7;1, 2;2, 1;3) // 70% 1 mode, 20% 2 modes, 10% 3 modes
 
 		for(var/i = 1 to mode_amount)
 			bullet = new/datum/projectile/artifact
@@ -125,4 +125,3 @@
 			bullet.dissipation_rate = rand(1,bullet.power)
 			bullet.cost = rand(35,100) // randomise puts it at 50-150
 			bullets += bullet
-

--- a/code/obj/artifacts/artifact_items/energy_gun.dm
+++ b/code/obj/artifacts/artifact_items/energy_gun.dm
@@ -86,10 +86,10 @@
 
 		if(prob(20))
 			src.ArtifactDevelopFault(100)
-			src.visible_message("<span class='alert'>[src] emits \a [pick("ominous", "portentous", "sinister")] sound.</span>")
+			user.visible_message("<span class='alert'>[src] emits \a [pick("ominous", "portentous", "sinister")] sound.</span>")
 		else if(prob(20))
 			src.ArtifactTakeDamage(20)
-			src.visible_message("<span class='alert'>[src] emits a terrible cracking noise.</span>")
+			user.visible_message("<span class='alert'>[src] emits a terrible cracking noise.</span>")
 
 		return
 

--- a/code/obj/artifacts/artifact_machines/turret.dm
+++ b/code/obj/artifacts/artifact_machines/turret.dm
@@ -2,6 +2,12 @@
 	name = "artifact turret"
 	associated_datum = /datum/artifact/turret
 
+	ArtifactDestroyed()
+		var/datum/artifact/turret/A = src.artifact
+		var/obj/item/gun/energy/artifact/newgun = new /obj/item/gun/energy/artifact(get_turf(src), A.artitype.name, list(A.bullet))
+		. = ..()
+
+
 /datum/artifact/turret
 	associated_object = /obj/machinery/artifact/turret
 	rarity_weight = 200

--- a/code/obj/artifacts/artifact_machines/turret.dm
+++ b/code/obj/artifacts/artifact_machines/turret.dm
@@ -4,7 +4,7 @@
 
 	ArtifactDestroyed()
 		var/datum/artifact/turret/A = src.artifact
-		var/obj/item/gun/energy/artifact/newgun = new /obj/item/gun/energy/artifact(get_turf(src), A.artitype.name, list(A.bullet))
+		new /obj/item/gun/energy/artifact(get_turf(src), A.artitype.name, list(A.bullet))
 		. = ..()
 
 

--- a/code/obj/artifacts/artifactdatums.dm
+++ b/code/obj/artifacts/artifactdatums.dm
@@ -178,6 +178,7 @@ ABSTRACT_TYPE(/datum/artifact/art)
 		var/namep1 = pick("neutrino","meson","photon","quark","disruptor","atomic","zero point","tachyon","plasma","quantum","neutron","baryon","hadron","electron","positron")
 		var/namep2 = pick("bolt","ray","beam","wave","burst","blast","torpedo","missile","bomb","shard","stream","string")
 		src.name = "[namep1] [namep2]"
+		src.sname = src.name
 		// Now randomise the damage type, power, energy cost and other fun stuff
 
 		src.damage_type = pick(D_KINETIC,D_PIERCING,D_SLASHING,D_ENERGY,D_BURNING,D_RADIOACTIVE,D_TOXIC)

--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -148,7 +148,7 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 	if(src.projectiles && src.projectiles.len > 1)
 		src.current_projectile_num = ((src.current_projectile_num) % src.projectiles.len) + 1
 		src.set_current_projectile(src.projectiles[src.current_projectile_num])
-		boutput(user, "<span class='notice'>you set the output to [src.current_projectile.sname].</span>")
+		boutput(user, "<span class='notice'>You set the output to [src.current_projectile.sname].</span>")
 	return
 
 /datum/action/bar/icon/guncharge

--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -423,6 +423,7 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 			H.gunshot_residue = 1
 
 	src.update_icon()
+	return TRUE
 
 /obj/item/gun/proc/canshoot()
 	return 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Artifact guns now have a chance on each shot to take damage or develop a fault, they used to have their own damage system that was weirdly separate from normal artifact damage.
I think this is still sufficient to dissuade rampages with artguns, but less in a "randomly my gun disappeared" way and more in a fun malfunction way.

Also, artifact guns can now have several switchable fire modes. The chances are 70% for 1 mode, 20% for 2, 10% for three.

When a turret type artifact is destroyed, it will drop an artifact gun with the same shot type that the turret had. (This gun will always only have one mode.)
When an artifact gun is destroyed (whether through its own wear and tear from firing, or external stimuli) it will drop the internal cell.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I think it'd be fun.
Right now artifact guns kind of just randomly disappear after you've used them for a while, and turret artifacts often feel like they don't have much use, so this would allow you to "recycle" them.

Also, switchable modes will draw more attention to the different randomly generated projectile names, which I think are neat.
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)zjdtmkhzt
(+)Artifact Guns can now sometimes have multiple different firing modes.
```
