### PR TITLE
allow soulsteel mobs to be possessed

### DIFF
--- a/code/modules/materials/Mat_MaterialProcs.dm
+++ b/code/modules/materials/Mat_MaterialProcs.dm
@@ -550,6 +550,7 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 					if(MO.mind)
 						boutput(entering, "<span class='alert'>[owner] already has a soul controlling it!</span>")
 						return
+					MO.ai?.enabled = FALSE
 					boutput(entering, "<span class='alert'>You possess [owner]! Keep in mind you are not an antagonist!</span>")
 					O.mind.transfer_to(MO)
 		return

--- a/code/modules/materials/Mat_MaterialProcs.dm
+++ b/code/modules/materials/Mat_MaterialProcs.dm
@@ -526,14 +526,15 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 				qdel(I)
 		return
 
+#define SOULSTEEL_COOLDOWN 1800
 /datum/materialProc/soulsteel_entered
-	var/lastTrigger = 0
+	var/lastTrigger = -SOULSTEEL_COOLDOWN
 	execute(var/obj/item/owner, var/atom/movable/entering)
 		if (!isobj(owner) && !ismob(owner)) return
 		if (istype(entering, /mob/dead/observer) && prob(33))
 			var/mob/dead/observer/O = entering
 			if(O.observe_round) return
-			if(world.time - lastTrigger < 1800)
+			if(world.time - lastTrigger < SOULSTEEL_COOLDOWN)
 				boutput(entering, "<span class='alert'>[owner] can not be possessed again so soon!</span>")
 				return
 			lastTrigger = world.time
@@ -554,6 +555,7 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 					boutput(entering, "<span class='alert'>You possess [owner]! Keep in mind you are not an antagonist!</span>")
 					O.mind.transfer_to(MO)
 		return
+#undef SOULSTEEL_COOLDOWN
 
 /datum/materialProc/reflective_onbullet
 	execute(var/obj/item/owner, var/atom/attacked, var/obj/projectile/projectile)

--- a/code/modules/materials/Mat_MaterialProcs.dm
+++ b/code/modules/materials/Mat_MaterialProcs.dm
@@ -529,7 +529,7 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 /datum/materialProc/soulsteel_entered
 	var/lastTrigger = 0
 	execute(var/obj/item/owner, var/atom/movable/entering)
-		if (!isobj(owner)) return
+		if (!isobj(owner) && !ismob(owner)) return
 		if (istype(entering, /mob/dead/observer) && prob(33))
 			var/mob/dead/observer/O = entering
 			if(O.observe_round) return
@@ -539,11 +539,19 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 			lastTrigger = world.time
 			var/mob/mobenter = entering
 			if(mobenter.client)
-				var/mob/living/object/OB = new/mob/living/object(owner, mobenter)
-				OB.health = 8
-				OB.max_health = 8
-				OB.canspeak = 0
-				SHOW_SOULSTEEL_TIPS(OB)
+				if(isobj(owner))
+					var/mob/living/object/OB = new/mob/living/object(owner, mobenter)
+					OB.health = 8
+					OB.max_health = 8
+					OB.canspeak = 0
+					SHOW_SOULSTEEL_TIPS(OB)
+				else if(ismob(owner))
+					var/mob/MO = owner
+					if(MO.mind)
+						boutput(entering, "<span class='alert'>[owner] already has a soul controlling it!</span>")
+						return
+					boutput(entering, "<span class='alert'>You possess [owner]! Keep in mind you are not an antagonist!</span>")
+					O.mind.transfer_to(MO)
 		return
 
 /datum/materialProc/reflective_onbullet


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows soulsteel mobs to be possessed, if there isn't already a mind controlling them.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's pretty fun! And methods of turning mobs into soulsteel are few and far between. (I can really only think of transmutation bombs, finding one that did soulsteel would be exceedingly rare.
So this would probably mainly affect stuff like chickens.

Now, I'm not saying that this is a good idea or that it won't cause any issues.
I just think it'd be fun to have a conversation about whether or not this might be a neat addition to the game!
It could also be restricted to just certain types of mobs.
