### PR TITLE
allows borgs to inherit the material of their frame

### DIFF
--- a/code/obj/item/mob_parts/robot_parts.dm
+++ b/code/obj/item/mob_parts/robot_parts.dm
@@ -1222,6 +1222,8 @@
 		if(O.mind && (ticker?.mode && istype(ticker.mode, /datum/game_mode/revolution)))
 			if ((O.mind in ticker.mode:revolutionaries) || (O.mind in ticker.mode:head_revolutionaries))
 				ticker.mode:update_all_rev_icons() //So the icon actually appears
+		if(src.material)
+			O.setMaterial(src.material)
 		O.update_appearance()
 
 		qdel(src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This would allow borgs to inherit the material of their frame.
Some stuff would still need to be ironed out, I'd like to maybe make more materials trigger their effects on the mob itself when a mob is made out of that material, like for instance telecrystals.
Also, there are potential balance issues with erebite borgs, which can absorb about 20 or so of their own explosions before their limbs are destroyed, if they have a shield upgrade.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I think it'd be neat and fun! It might be a way for roboticists to put some extra customization on borgs, and it does kind of make sense from a logic standpoint that it'd be possible.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)zjdtmkhzt
(*)Cyborgs now inherit the material of the frame used to make them.
```
