### PR TITLE
Fixes Cairngorm announcement computer access

### DIFF
--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -44215,7 +44215,7 @@
 	dir = 4;
 	icon_state = "datasec";
 	name = "Commander's Announcement Computer";
-	req_access_txt = null
+	req_access_txt = "76"
 	},
 /turf/unsimulated/floor/carpet/red/fancy/edge/sw,
 /area/syndicate_station/battlecruiser)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Lets syndicate commanders access their own announcement computer again


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #3792

