### PR TITLE
Add costs to weapon vendor ui

### DIFF
--- a/code/obj/submachine/weapon_vendor.dm
+++ b/code/obj/submachine/weapon_vendor.dm
@@ -79,10 +79,10 @@
 		</style>"}
 
 		src.temp += "<table border=1>"
-		src.temp += "<tr><th>Materiel</th><th>Category</th><th>Description</th></tr>"
+		src.temp += "<tr><th>Materiel</th><th>Category</th><th>Cost</th><th>Description</th></tr>"
 
 		for (var/datum/materiel/M in materiel_stock)
-			src.temp += "<tr style=\"color:[(M.cost > src.credits[M.category]) ? "red" : "black"]\"><td><a href='?src=\ref[src];buy=\ref[M]'><b><u>[M.name]</u></b></a></td><td>[M.category]</td><td>[M.description]</td></tr>"
+			src.temp += "<tr style=\"color:[(M.cost > src.credits[M.category]) ? "red" : "black"]\"><td><a href='?src=\ref[src];buy=\ref[M]'><b><u>[M.name]</u></b></a></td><td>[M.category]</td><td>[M.cost]</td><td>[M.description]</td></tr>"
 
 		src.temp += "</table></div>"
 		src.temp = jointext(src.temp, "")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[qol]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds the cost of a `materiel` (?) to the weapon vendor UI. #3760 introduced loadout options that costed more then 1 credit and it was not clear that the power cell costed 2 credits from a players perspective.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Better information on what a loadout option costs for players.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Luxizzle
(+)Weapon vendor now shows the cost of a loadout option.
```
