### PR TITLE
makes more chemicals reduce stimulant effect

### DIFF
--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -109,7 +109,6 @@ datum
 						M.setStatus("paralysis", max(M.getStatusDuration("paralysis"), 30 * mult))
 						M.drowsyness  = max(M.drowsyness, 20)
 
-
 				..()
 				return
 

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -97,6 +97,8 @@ datum
 				if(!M) M = holder.my_atom
 				if(!counter) counter = 1
 				M.jitteriness = max(M.jitteriness-25,0)
+				if(M.hasStatus("stimulants"))
+					M.changeStatus("stimulants", -7.5 SECONDS * mult)
 
 				switch(counter += 1 * mult)
 					if(1 to 15)
@@ -106,6 +108,7 @@ datum
 					if(36 to INFINITY)
 						M.setStatus("paralysis", max(M.getStatusDuration("paralysis"), 30 * mult))
 						M.drowsyness  = max(M.drowsyness, 20)
+
 
 				..()
 				return

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -147,6 +147,8 @@ datum
 				if(!M) M = holder.my_atom
 				if(!counter) counter = 1
 				M.jitteriness = max(M.jitteriness-25,0)
+				if(M.hasStatus("stimulants"))
+					M.changeStatus("stimulants", -7.5 SECONDS * mult)
 
 				switch(counter += 1 * mult)
 					if(1 to 15)

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -1080,6 +1080,8 @@ datum
 				if (!M) M = holder.my_atom
 				if (!counter) counter = 1
 				M.jitteriness = max(M.jitteriness-30,0)
+				if(M.hasStatus("stimulants"))
+					M.changeStatus("stimulants", -10 SECONDS * mult)
 
 				switch(counter+= (1 * mult))
 					if (1 to 10)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Gives morphine, ether, and sulfonal the ability to counter stimulants, but at a lesser effect than haloperidol. This adds more chemical counters to stims.

Chemicals changed:
Morphine reduces stims at half the rate of haloperidol (-7.5s per tick)
Ether reduces stims at equal rate to morphine (-7.5s per tick)
Sulfonal reduces stims near a middle ground between morphine/ether and haloperidol (-10s per tick)



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
With the change of how stimulants work, being a status effect rather than chemical, it made stims slightly harder to counter. Your only effective counters were reduced, before you could bleed the chemical out of a person's bloodstream. 

Now there's more, weaker, chemical counters to stims. The change to morphine specifically would also boost the usefulness of the security officer's morphine autoinjector utility item pick.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Sord
(+)Morphine, ether, and sulfonal now reduce stimulants active time
```
