### PR TITLE
Resolve pipe rupture runtime related to large explosions

### DIFF
--- a/code/modules/atmospherics/machinery/pipe.dm
+++ b/code/modules/atmospherics/machinery/pipe.dm
@@ -348,7 +348,7 @@ obj/machinery/atmospherics/pipe
 				ruptured = 4
 				src.destroyed = TRUE
 				src.desc = "The remnants of a section of pipe that needs to be replaced.  Perhaps rods would be sufficient?"
-				parent.mingle_with_turf(loc, volume)
+				parent?.mingle_with_turf(loc, volume)
 				node1?.disconnect(src)
 				node2?.disconnect(src)
 				update_icon()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug - minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Resolves issue of "destroy" level rupture the parent pipegroup has been nulled. 

<speculation> I'm assuming this is related to the pipe group clearing out when a subsection of the network is disconnected, likely then becomes an order of operations question depending on where the explosion is. </speculation>


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Runtimes bad mkay
