### PR TITLE
Hunter microbomb fix

### DIFF
--- a/code/datums/abilities/hunter.dm
+++ b/code/datums/abilities/hunter.dm
@@ -48,6 +48,7 @@
 		M.unequip_all()
 
 		var/obj/item/implant/microbomb/hunter/B = new /obj/item/implant/microbomb/hunter(M)
+		M.implant.Add(B)
 		B.implanted = 1
 		B.implanted(M)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes hunter not being implanted correctly with their microbomb.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Hunters are supposed to have a microbomb.
