### PR TITLE
Provide encoded powernet info with multitool

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -237,7 +237,7 @@
 		if(PN && (PN.avail > 0))		// is it powered?
 			if(ispulsingtool(W))
 				// 3 Octets: Netnum, 4 Octets: Nodes+Data Nodes*2, 4 Octets: Cable Count
-				powernet_id = " ID#[num2text(PN.number,3,8)][num2text(length(PN.nodes)+(length(PN.data_nodes)<<2),4,8)][num2text(length(PN.cables),4,8)]"
+				powernet_id = " ID#[num2text(PN.number,3,8)]:[num2text(length(PN.nodes)+(length(PN.data_nodes)<<2),4,8)]:[num2text(length(PN.cables),4,8)]"
 
 			boutput(user, "<span class='alert'>[PN.avail]W in power network.[powernet_id]</span>")
 

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -232,9 +232,14 @@
 	else if (istype(W, /obj/item/device/t_scanner) || ispulsingtool(W) || (istype(W, /obj/item/device/pda2) && istype(W:module, /obj/item/device/pda_module/tray)))
 
 		var/datum/powernet/PN = get_powernet()		// find the powernet
+		var/powernet_id = ""
 
 		if(PN && (PN.avail > 0))		// is it powered?
-			boutput(user, "<span class='alert'>[PN.avail]W in power network.</span>")
+			if(ispulsingtool(W))
+				// 3 Octets: Netnum, 4 Octets: Nodes+Data Nodes*2, 4 Octets: Cable Count
+				powernet_id = " ID#[num2text(PN.number,3,8)][num2text(length(PN.nodes)+(length(PN.data_nodes)<<2),4,8)][num2text(length(PN.cables),4,8)]"
+
+			boutput(user, "<span class='alert'>[PN.avail]W in power network.[powernet_id]</span>")
 
 		else
 			boutput(user, "<span class='alert'>The cable is not powered.</span>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QoL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Implements idea brought up in Discord by Zamujasa during an interesting discussion on the state of power.  Seem like something that can be reasonably provided to the player without showing too many nuts and bolts.

![image](https://user-images.githubusercontent.com/1017374/108814373-88ac3300-7567-11eb-8da0-3f094e4b4165.png)

Encodes: Power Net ID, Number of Cables, Data Nodes + Nodes
  * Data is encoded in octets.
  * Data Nodes and Nodes are combined


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Provide engineering (engineers and mechanics) additional detail when attempting to troubleshoot power nets or building their own.  This allows for unique identification of the network as well as possibly any modifications.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Azrun
(*)Multitools now provide encoded information about the network a powered cable is connected to.
```
