### PR TITLE
Spacebux refund on item equip failure

### DIFF
--- a/code/modules/economy/persistent_bank.dm
+++ b/code/modules/economy/persistent_bank.dm
@@ -131,7 +131,10 @@
 		if (purchase.Create(src))
 			boutput( src, "<span class='notice'><b>[purchase.name] equipped successfully.</b></span>" )
 		else
-			boutput( src, "<span class='notice'><b>[purchase.name] is not available for the job you rolled. It will remain as your held item if possible.</b></span>" )
+			boutput( src, "<span class='notice'><b>[purchase.name] is not available for the job you rolled. It has been refunded.</b></span>" )
+			src.client.add_to_bank(purchase.cost)
+			src.client.set_last_purchase(null)
+			return
 	else
 		boutput( src, "<span class='notice'><b>The thing you previously purchased has been removed from your inventory due to it no longer existing.</b></span>")
 		src.client.set_last_purchase(null)


### PR DESCRIPTION
[bugfix]

## About the PR 
Spacebux purchases that fail to equip will refund (namely if AI hat fails to equip it won't persist as a held item until a person maybe hopefully rolls AI before dying and losing it, it'll just refund)

## Why's this needed?
Fixes #1368. Also pali wrote the actual refund code since I was originally just trying to do like a mind-check for AI to make things equip or not equip, which was Not Going to Get Me Very Far. 😔 