### PR TITLE
Fix fluid prying tool pass-through

### DIFF
--- a/code/modules/fluids/fluid_core.dm
+++ b/code/modules/fluids/fluid_core.dm
@@ -210,7 +210,7 @@ var/mutable_appearance/fluid_ma
 			return
 
 		//floor overrides some construction clicks
-		if (istype(W,/obj/item/rcd) || istype(W,/obj/item/tile) || istype(W,/obj/item/sheet) || istype(W,/obj/item/crowbar) || istype(W,/obj/item/pen))
+		if (istype(W,/obj/item/rcd) || istype(W,/obj/item/tile) || istype(W,/obj/item/sheet) || ispryingtool(W) || istype(W,/obj/item/pen))
 			var/turf/T = get_turf(src)
 			T.attackby(W,user)
 			W.afterattack(T,user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes a crowbar check to a prying tool check on the fluid object attack pass-through thingy.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes omnitools work for this purpose, mostly for when borgs want to poke the floor when there's flooding. 