### PR TITLE
Properly apply alloys material to MatiSci TEG

### DIFF
--- a/code/WorkInProgress/AzrunStuff.dm
+++ b/code/WorkInProgress/AzrunStuff.dm
@@ -154,11 +154,13 @@ datum/teg_transformation
 
 	/// Base transformation to assign material
 	proc/on_transform(obj/machinery/power/generatorTemp/teg)
+		var/datum/material/M
 		src.teg = teg
 		if(src.mat_id)
-			teg.setMaterial(getMaterial(src.mat_id))
-			teg.circ1.setMaterial(getMaterial(src.mat_id))
-			teg.circ2.setMaterial(getMaterial(src.mat_id))
+			M = copyMaterial(src.teg.semiconductor.material)
+			teg.setMaterial(M)
+			teg.circ1.setMaterial(M)
+			teg.circ2.setMaterial(M)
 
 	/// Revert material back to initial values
 	proc/on_revert()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Corrects usage of `setMaterial` with `getMaterial()` when alloys could be present.
  * Incorrectly assumed getMaterial() could be used with alloys when the material should have been directly or `copyMaterial` used. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Resolves periodic runtime when alloy is applied to TEG semiconductor.
Allow for MatSci alloys to properly apply to TEG Transformation


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Azrun
(+)Resolve issue with alloys in TEG Semiconductor.  Mix and match your favorite flavors!
```
