### PR TITLE
Donut3 tech storage access fix

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -36422,9 +36422,7 @@
 /turf/simulated/floor/white,
 /area/station/medical/asylum/main)
 "kOm" = (
-/obj/access_spawn/tech_storage{
-	req_access = null
-	},
+/obj/access_spawn/tech_storage,
 /obj/firedoor_spawn,
 /obj/cable{
 	d1 = 1;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes the door to tech storage on donut3, where the access spawner also had its access list nulled for some reason??

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Gotta keep the clown out of there.