### PR TITLE
fix some dumb artifact bugs

### DIFF
--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -35,7 +35,7 @@
 	// the sanity check detects that an artifact doesn't have the proper shit set up it'll just wipe out the artifact and stop
 	// the rest of the proc from occurring.
 	// This proc should be called in an if statement at the start of every artifact proc, since it returns 0 or 1.
-	if (!src.artifact)
+	if (!src.artifact || src.disposed)
 		return 0
 	// if the artifact var isn't set at all, it's probably not an artifact so don't bother continuing
 	if (!istype(src.artifact,/datum/artifact/))
@@ -422,10 +422,6 @@
 
 	var/datum/artifact/A = src.artifact
 
-	ArtifactLogs(usr, null, src, "destroyed", null, 0)
-
-	artifact_controls.artifacts -= src
-
 	var/turf/T = get_turf(src)
 	if (istype(T,/turf/))
 		switch(A.artitype.name)
@@ -439,6 +435,12 @@
 				T.visible_message("<span class='alert'><B>[src] warps in on itself and vanishes!</B></span>")
 			if("precursor")
 				T.visible_message("<span class='alert'><B>[src] implodes, crushing itself into dust!</B></span>")
+
+	src.ArtifactDeactivated()
+
+	ArtifactLogs(usr, null, src, "destroyed", null, 0)
+
+	artifact_controls.artifacts -= src
 
 	qdel(src)
 	return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a check for whether or not the artifact was disposed to the SanityCheck so that it will stop doing stuff after that.

Also makes it so that artifacts deactivate when destroyed, so that stuff like forcefields won't stick around forever.
I really thought I had already added that at some point, but I guess I must have dreamt it or something?

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Runtimes and fields of eternal force and darkness are bad.
