### PR TITLE
Removes SounDreams cartridge from spares box

### DIFF
--- a/code/obj/item/storage/electronics.dm
+++ b/code/obj/item/storage/electronics.dm
@@ -23,7 +23,8 @@
 		/obj/item/disk/data/cartridge/nuclear,
 		/obj/item/disk/data/cartridge/syndicate,
 		/obj/item/disk/data/cartridge/ai,
-		/obj/item/disk/data/cartridge/cyborg)
+		/obj/item/disk/data/cartridge/cyborg,
+		/obj/item/disk/data/cartridge/ringtone_syndie)
 
 		var/list/spawnable = typesof(/obj/item/disk/data/cartridge)
 		spawnable -= invalid_carts


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #3631 Removes SounDreams cartridge from the spare cartridges box


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Syndicate items should spawn for free in boxes. 
