### PR TITLE
sprinting into railings makes you start vaulting over them

### DIFF
--- a/code/obj/railing.dm
+++ b/code/obj/railing.dm
@@ -144,6 +144,14 @@
 				user.show_text("[src] is already reinforced!", "red")
 
 	attack_hand(mob/user)
+		src.try_vault(user)
+
+	Bumped(var/mob/AM as mob)
+		. = ..()
+		if(AM.client?.check_key(KEY_RUN))
+			src.try_vault(AM)
+
+	proc/try_vault(mob/user)
 		if (railing_is_broken(src))
 			user.show_text("[src] is broken! All you can really do is break it down...", "red")
 		else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Pretty much what it says in the title.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Not sure if there is any quicker way already in the game that I am not aware of, but having to click the tiny sprites all the time as rancher is pretty annoying.
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)zjdtmkhzt
(+)Sprinting into railings will make you start the process of vaulting over them.
```
