### PR TITLE
Merge Engineer and Mechanic access

### DIFF
--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -303,15 +303,13 @@
 			return list(access_maint_tunnels, access_tech_storage, access_research)
 
 		//////////////////////////// Engineering
-		if("Mechanic")
-			return list(access_maint_tunnels, access_external_airlocks,
+		if("Mechanic", "Engineer")
+			return list(access_engineering, access_maint_tunnels, access_external_airlocks,
+					  access_engineering_storage,access_engineering_atmos,access_engineering_engine,
 						access_tech_storage,access_engineering_mechanic,access_engineering_power)
 		if("Atmospheric Technician")
 			return list(access_maint_tunnels, access_external_airlocks, access_construction,
 						access_eva, access_engineering, access_engineering_storage, access_engineering_eva, access_engineering_atmos)
-		if("Engineer")
-			return list(access_engineering,access_maint_tunnels,access_external_airlocks,
-						access_engineering_storage,access_engineering_atmos,access_engineering_engine,access_engineering_power)
 		if("Miner")
 			return list(access_maint_tunnels, access_external_airlocks,
 						access_engineering_eva, access_mining_shuttle, access_mining,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[input wanted]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Merges access between Mechanics and Engineers.
   * Implications to RP rule 7. Stay in your lane.
   * Engineers will have immediate access to Mechcomp items [balance]
   * Mechanics will have immediate access to gases. [balance]

A slow boil until we can embrace #1304.  Sorry if this feel like a rehash, but I feel like it worth revisiting.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Tools available to Engineers and Mechanics allow them relatively easy access to... everything.  This allows them to access each others departments freely.

I think the differentiation between the Engineer and Mechanic is really interesting in regards to theme, starting equipment, and goals.  There is a lot of overlap in duties and this should help facilitate that, especially in low-population situations. 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Azrun
(*)Engineers and Mechanics now share access to the same areas. 
```
