### PR TITLE
Removes debug message from food effect component thing

### DIFF
--- a/code/datums/components/food_stuff.dm
+++ b/code/datums/components/food_stuff.dm
@@ -453,15 +453,12 @@
 /datum/component/consume/food_effects/InheritComponent(datum/component/consume/food_effects/C, i_am_original, _new_status_effects)
 	if(C?.status_effects)
 		src.status_effects = C.status_effects
-		boutput(world, "[C] was already init'd. heal amt on it was [C.status_effects] is now [src.status_effects], supposed to be [_new_status_effects]")
 	else
 		if (islist(_new_status_effects)) // C(duplicate component) wasn't initialized, so we don't know if the raw argument _new_status_effects is a string / list
 			src.status_effects |= _new_status_effects
-			boutput(world, "[_new_status_effects] was list. [src.status_effects]")
 		else if(istext(_new_status_effects))
 			var/list/new_sfx = list(_new_status_effects)
 			src.status_effects |= new_sfx
-			boutput(world, "[_new_status_effects] not list. [src.status_effects]")
 
 
 /datum/component/consume/food_effects/proc/apply_food_effects(var/obj/item/I, var/mob/M)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

I left in some debug print shit, now its gone!