### PR TITLE
Renames both cryogenic machineries to have more distinct names

### DIFF
--- a/code/WorkInProgress/cryospawn.dm
+++ b/code/WorkInProgress/cryospawn.dm
@@ -12,7 +12,7 @@
 
 //Special destiny spawn point doodad
 /obj/cryotron
-	name = "industrial cryogenics unit"
+	name = "industrial cryogenic sleep unit"
 	desc = "The terminus of a large underfloor cryogenic storage complex."
 	anchored = 1
 	density = 1

--- a/code/modules/atmospherics/machinery/unary/cryo_cell.dm
+++ b/code/modules/atmospherics/machinery/unary/cryo_cell.dm
@@ -1,5 +1,5 @@
 /obj/machinery/atmospherics/unary/cryo_cell
-	name = "cryo cell"
+	name = "cryogenic healing pod"
 	icon = 'icons/obj/Cryogenic2.dmi'
 	icon_state = "celltop-P"
 	density = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Renames both cryogenic machineries to have more distinct names.
The industrial cryogenic unit is now the industrial cryogenic sleep unit and the Medbay one is called cryogenic healing pod.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
They both have very vague names currently and its easy to confuse which ones people are talking about. Being able to distinguish one from another would be better for new players and just general discussion.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Carbadox
(+)The industrial cryogenic unit has been renamed to the industrial cryogenic sleep unit and the Medical cyrogenic cell has been renamed to the cryogenic healing pod. This should make it easier to distinguish them from each other.
```
