### PR TITLE
Fixes donks not working, and food not going into the fryer

### DIFF
--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -517,6 +517,8 @@
 		else if((master.amount -= 1) < 1)
 			ate_the_whole_thing = 1
 		ON_COOLDOWN(M, "eat", EAT_COOLDOWN)
+		SEND_SIGNAL(master, COMSIG_ITEM_CONSUMED_PARTIAL, M, user)
+		SEND_SIGNAL(M, COMSIG_ITEM_CONSUMED_PARTIAL, user, master)
 
 		if(ate_the_whole_thing)
 			SEND_SIGNAL(master, COMSIG_ITEM_CONSUMED_ALL, M, user)
@@ -553,8 +555,6 @@
 			user.u_equip(master)
 			qdel(master)
 		else
-			SEND_SIGNAL(master, COMSIG_ITEM_CONSUMED_PARTIAL, M, user)
-			SEND_SIGNAL(M, COMSIG_ITEM_CONSUMED_PARTIAL, user, master)
 			boutput(user, "<span class='notice'>There's still some left!</span>")
 		return 1
 

--- a/code/obj/machinery/deep_fryer.dm
+++ b/code/obj/machinery/deep_fryer.dm
@@ -35,7 +35,7 @@
 			boutput(user, "<span class='alert'>Your cooking skills are not up to the legendary Doublefry technique.</span>")
 			return
 
-		else if (istype(W, /obj/item/reagent_containers/))
+		else if (istype(W, /obj/item/reagent_containers/) && !istype(W, /obj/item/reagent_containers/food))
 			var/obj/item/reagent_containers/R = W
 			if (!R.reagents.total_volume)
 				boutput(user, "<span class='alert'>There is nothing in [R] to pour!</span>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Food that only had one bite in them never had on_bite() called, which is where most of the fun effects happen on food doing things. So, now its always called on every bite, so things like Donks now work again!

Also, in trying to remove a colon from deep_fryer.dm, I accidentally made it so that all reagent_containers would dump their contents into the fryer. This included food, because food is a reagent_container. Weird! Now it excludes food from that check, so food should go into the fryer just fine now.