### PR TITLE
Fixes bot runtimes, and makes secbots no longer see through walls and lockers

### DIFF
--- a/code/modules/robotics/bot/bot_parent.dm
+++ b/code/modules/robotics/bot/bot_parent.dm
@@ -302,9 +302,9 @@
 
 	disposing()
 		if(istype(master))
-			if(master?.bot_mover == src)
+			if(master.bot_mover == src)
 				master.bot_mover = null
-			master?.moving = 0
+			master.moving = FALSE
 		src.master = null
 		src.the_target = null
 		..()

--- a/code/modules/robotics/bot/bot_parent.dm
+++ b/code/modules/robotics/bot/bot_parent.dm
@@ -173,7 +173,7 @@
 			else
 				maptext_color = src.bot_speech_color
 			chatbot_text = make_chat_maptext(src, message, "color: [maptext_color];" + src.bot_speech_style + singing_italics)
-			if(chatbot_text)
+			if(chatbot_text && src.chat_text && length(src.chat_text.lines))
 				chatbot_text.measure(src)
 				for(var/image/chat_maptext/I in src.chat_text.lines)
 					if(I != chatbot_text)

--- a/code/modules/robotics/bot/medbot.dm
+++ b/code/modules/robotics/bot/medbot.dm
@@ -389,6 +389,9 @@
 		if (C == src.oldpatient)
 			continue
 
+		if (C.loc && !isturf(C.loc)) // don't stab people while they're still in the cloner, wait till they're out first!
+			continue
+
 		if (src.assess_patient(C) && IN_RANGE(src,C,10))
 			src.patient = C
 			src.doing_something = 1
@@ -504,6 +507,12 @@
 	if(isdead(C))
 		var/death_message = pick("No! NO!","Live, damnit! LIVE!","I...I've never lost a patient before. Not today, I mean.")
 		src.speak(death_message)
+		src.KillPathAndGiveUp(1)
+		return FALSE
+
+	if (C.loc && !isturf(C.loc)) // don't stab people while they're still in the cloner, wait till they're out first!
+		var/missing_message = pick("Wait, where'd [he_or_she(C)] go?","That's okay, I'll just wait here until you're ready.")
+		src.speak(missing_message)
 		src.KillPathAndGiveUp(1)
 		return FALSE
 

--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -73,8 +73,8 @@
 	var/oldtarget_name
 	var/threatlevel = 0
 	var/target_lastloc //Loc of target when arrested.
-	/// Time after being emagged before they'll consider going after their emagger
-	var/last_target_cooldown = 20 SECONDS
+	/// Time after giving up on assaulting someone before they'll consider assaulting them again
+	var/last_target_cooldown = 10 SECONDS
 	emagged = 0 //Emagged Secbots view everyone as a criminal
 	health = 25
 	bot_voice = 'sound/misc/talk/bottalk_2.ogg'
@@ -145,8 +145,6 @@
 	var/static/chatspam_cooldown = 1 SECOND
 	/// Was on guard duty, apprehended someone, then went to return to guard duty? Keep it to yourself please
 	var/guard_start_no_announce
-	/// These people get a pass on getting secbotted. For a while
-	var/static/list/secbot_ignore = list()
 	var/static/image/bothat
 	var/static/image/chargepic
 
@@ -757,11 +755,19 @@
 
 		/// Tango never up to begin with? Or some kind of not-human? Eh whatever give up
 		if(!istype(src.target, /mob/living/carbon/human))
+			speak("???", just_float = 1)
+			src.KillPathAndGiveUp(kpagu)
+			return
+
+		/// Tango hidden inside something or someone? Welp, can't hit them through a locker, so may as well give up!
+		if(src.target?.loc && !isturf(src.target.loc))
+			speak("?", just_float = 1)
 			src.KillPathAndGiveUp(kpagu)
 			return
 
 		/// Tango down or tango hecked off or tango behind a bunch of stuff, give up and get back to work
 		if (src.target.hasStatus("handcuffed") || src.frustration >= 8)
+			speak("...", just_float = 1)
 			src.KillPathAndGiveUp(kpagu)
 			return
 
@@ -803,16 +809,11 @@
 	// look for a criminal in range of the bot
 	proc/look_for_perp()
 		src.anchored = 0
-		for_by_tcl(C, /mob/living/carbon) //Let's find us a criminal
-			if(!IN_RANGE(src, C, 7)) // We've made a plea bargain with opaque objects to turn in criminals hiding behind them
-				continue
+		for(var/mob/living/carbon/C in view(7, get_turf(src))) //Let's find us a criminal
 			if ((C.stat) || (C.hasStatus("handcuffed")))
 				continue
-			if (C.name in src.secbot_ignore)
-				if(src.secbot_ignore[C.name] <= TIME)
-					src.secbot_ignore -= C.name
-				else
-					continue
+			if(GET_COOLDOWN(src, "[SECBOT_LASTTARGET_COOLDOWN]-[C.name]"))
+				continue
 			if (ishuman(C))
 				src.threatlevel = src.assess_perp(C)
 			if (src.guard_area_lockdown && isarea(src.guard_area) && get_area(C) == src.guard_area)
@@ -1017,12 +1018,14 @@
 		src.anchored = 0
 		src.icon_state = "secbot[src.on][(src.on && src.emagged >= 2) ? "-wild" : null]"
 		if(give_up == KPAGU_RETURN_TO_GUARD || give_up == KPAGU_CLEAR_ALL)
-			src.target = null
 			src.oldtarget_name = src.target?.name
+			src.target = null
+			ON_COOLDOWN(src, "[SECBOT_LASTTARGET_COOLDOWN]-[src.oldtarget_name]", src.last_target_cooldown)
 			src.mode = SECBOT_GUARD_IDLE
 		if(give_up == KPAGU_RETURN_TO_PATROL || give_up == KPAGU_CLEAR_ALL)
-			src.target = null
 			src.oldtarget_name = src.target?.name
+			src.target = null
+			ON_COOLDOWN(src, "[SECBOT_LASTTARGET_COOLDOWN]-[src.oldtarget_name]", src.last_target_cooldown)
 			src.guard_area = null
 			src.guard_area_lockdown = FALSE
 			src.mode = SECBOT_IDLE
@@ -1247,7 +1250,7 @@
 					qbert += "[pick("!","?")]"
 				src.speak("[qbert]")
 		playsound(get_turf(src), say_thing, 50, 0, 0, 1)
-		src.secbot_ignore[src.target?.name] = (TIME + src.last_target_cooldown) // darn cooldowns
+		ON_COOLDOWN(src, "[SECBOT_LASTTARGET_COOLDOWN]-[src.target?.name]", src.last_target_cooldown)
 
 //secbot handcuff bar thing
 /datum/action/bar/icon/secbot_cuff


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Secbots now check if the target is in view before engaging them. They also give up and refuse to attack people hiding within things, so you can duck inside a locker now to escape Beepsky's wrath.

Similar thing for Medbots. They can still see through walls, but they'll refuse to medicate someone if they're within something, like a locker or clone tube.

Also added a few more messages when secbots are forced to give up.

Also changed up the bot mover to work directly from being initialized, and hopefully not runtime quite so much anymore.

Also fixes bots runtiming while inside things or saying things weirdly.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Shit busted, now less busted. #3842 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Superlagg
(*)Securitrons will no longer attack you if you're tucked away inside something.
```
