### PR TITLE
Allows the detective scanner to scan objects up to 2 tiles away.

### DIFF
--- a/code/obj/item/device/scanners.dm
+++ b/code/obj/item/device/scanners.dm
@@ -220,7 +220,7 @@ that cannot be itched
 		SPAWN_DBG(0.5 SECONDS)
 			.(T)
 
-/obj/item/device/detective_scanner/unique
+/obj/item/device/detective_scanner/detective
 	name = "cool forensic scanner"
 	desc = "Used to scan objects for DNA and fingerprints. This model seems to have an upgrade that lets it scan for prints at a distance. You feel cool holding it."
 	distancescan = 1

--- a/code/obj/item/device/scanners.dm
+++ b/code/obj/item/device/scanners.dm
@@ -129,7 +129,7 @@ that cannot be itched
 
 /obj/item/device/detective_scanner
 	name = "forensic scanner"
-	desc = "Used to scan objects for DNA and fingerprints. This model seems to have an upgrade that lets it scan for prints at a distance."
+	desc = "Used to scan objects for DNA and fingerprints."
 	icon_state = "fs"
 	w_class = 2 // PDA fits in a pocket, so why not the dedicated scanner (Convair880)?
 	item_state = "electronic"
@@ -137,6 +137,7 @@ that cannot be itched
 	mats = 3
 	hide_attack = 2
 	var/active = 0
+	var/distancescan = 0
 	var/target = null
 
 	attack_self(mob/user as mob)
@@ -166,10 +167,11 @@ that cannot be itched
 		return
 
 	pixelaction(atom/target, params, mob/user, reach)
-		if(get_dist(user, target) > 1 && get_dist(user, target) <= 2)
-			user.visible_message("<span class='notice'><b>[user]</b> takes a distant forensic scan of [target].</span>")
-			boutput(user, scan_forensic(target, visible = 1))
-			src.add_fingerprint(user)
+		if(distancescan)
+			if(!IN_RANGE(user, target, 1) && IN_RANGE(user, target, 3))
+				user.visible_message("<span class='notice'><b>[user]</b> takes a distant forensic scan of [target].</span>")
+				boutput(user, scan_forensic(target, visible = 1))
+				src.add_fingerprint(user)
 
 	afterattack(atom/A as mob|obj|turf|area, mob/user as mob)
 
@@ -217,6 +219,11 @@ that cannot be itched
 				icon_state = "fs_pinfar"
 		SPAWN_DBG(0.5 SECONDS)
 			.(T)
+
+/obj/item/device/detective_scanner/unique
+	name = "cool forensic scanner"
+	desc = "Used to scan objects for DNA and fingerprints. This model seems to have an upgrade that lets it scan for prints at a distance. You feel cool holding it."
+	distancescan = 1
 
 ///////////////////////////////////// Health analyzer ////////////////////////////////////////
 

--- a/code/obj/item/device/scanners.dm
+++ b/code/obj/item/device/scanners.dm
@@ -129,7 +129,7 @@ that cannot be itched
 
 /obj/item/device/detective_scanner
 	name = "forensic scanner"
-	desc = "Used to scan objects for DNA and fingerprints."
+	desc = "Used to scan objects for DNA and fingerprints. This model seems to have an upgrade that lets it scan for prints at a distance."
 	icon_state = "fs"
 	w_class = 2 // PDA fits in a pocket, so why not the dedicated scanner (Convair880)?
 	item_state = "electronic"
@@ -170,7 +170,6 @@ that cannot be itched
 			user.visible_message("<span class='notice'><b>[user]</b> takes a distant forensic scan of [target].</span>")
 			boutput(user, scan_forensic(target, visible = 1))
 			src.add_fingerprint(user)
-		return
 
 	afterattack(atom/A as mob|obj|turf|area, mob/user as mob)
 

--- a/code/obj/item/device/scanners.dm
+++ b/code/obj/item/device/scanners.dm
@@ -165,6 +165,13 @@ that cannot be itched
 		user.show_text("No match found in security records.", "red")
 		return
 
+	pixelaction(atom/target, params, mob/user, reach)
+		if(get_dist(user, target) > 1 && get_dist(user, target) <= 2)
+			user.visible_message("<span class='notice'><b>[user]</b> takes a distant forensic scan of [target].</span>")
+			boutput(user, scan_forensic(target, visible = 1))
+			src.add_fingerprint(user)
+		return
+
 	afterattack(atom/A as mob|obj|turf|area, mob/user as mob)
 
 		if (get_dist(A,user) > 1 || istype(A, /obj/ability_button)) // Scanning for fingerprints over the camera network is fun, but doesn't really make sense (Convair880).

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -192,7 +192,7 @@
 	/obj/item/storage/box/spy_sticker_kit/radio_only/detective,
 	/obj/item/storage/box/lglo_kit/random,
 	/obj/item/clothing/head/det_hat/gadget,
-	/obj/item/device/detective_scanner/unique,
+	/obj/item/device/detective_scanner/detective,
 	/obj/item/bloodtracker,
 	/obj/item/device/flash,
 	/obj/item/camera_film,

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -192,7 +192,7 @@
 	/obj/item/storage/box/spy_sticker_kit/radio_only/detective,
 	/obj/item/storage/box/lglo_kit/random,
 	/obj/item/clothing/head/det_hat/gadget,
-	/obj/item/device/detective_scanner,
+	/obj/item/device/detective_scanner/unique,
 	/obj/item/bloodtracker,
 	/obj/item/device/flash,
 	/obj/item/camera_film,


### PR DESCRIPTION
[BALANCE]
## About the PR 
Allows the detective scanner to scan objects up to 2 tiles away.
## Why's this needed?
This fixes the oversight where you put scanners into containers while allowing the detective to have a bit more latitude when conducting cases by scanning objects at a distance. I think this would increase quality of life for detective players, while not messing up game balance too much. This is a webeditor PR but the code was tested and confirmed to work in DM.
## Changelog

```changelog
(u)Fosstar
(+)The detective's scanner (not their PDA) can now scan objects up to two tiles away.
```
