### PR TITLE
Reagents are now clamped to the nearest 1000th, or 0.001

### DIFF
--- a/code/modules/chemistry/Chemistry-Holder.dm
+++ b/code/modules/chemistry/Chemistry-Holder.dm
@@ -566,10 +566,10 @@ datum
 			for(var/current_id in reagent_list)
 				var/datum/reagent/current_reagent = reagent_list[current_id]
 				if(current_reagent)
-					if(current_reagent.volume <= 0.00001)
+					if(current_reagent.volume <= 0.001)
 						del_reagent(current_id)
 					else
-						current_reagent.volume = max(round(current_reagent.volume, 0.00001), 0.00001)
+						current_reagent.volume = max(round(current_reagent.volume, 0.001), 0.001)
 						total_volume += current_reagent.volume
 			if(isitem(my_atom))
 				var/obj/item/I = my_atom

--- a/code/modules/chemistry/Chemistry-Holder.dm
+++ b/code/modules/chemistry/Chemistry-Holder.dm
@@ -566,10 +566,10 @@ datum
 			for(var/current_id in reagent_list)
 				var/datum/reagent/current_reagent = reagent_list[current_id]
 				if(current_reagent)
-					if(current_reagent.volume <= 0.00005)
+					if(current_reagent.volume <= 0.00001)
 						del_reagent(current_id)
 					else
-						current_reagent.volume = max(min(round(current_reagent.volume, 0.00005), (current_reagent.volume + 0.00005)), 0.00005)
+						current_reagent.volume = max(round(current_reagent.volume, 0.00001), 0.00001)
 						total_volume += current_reagent.volume
 			if(isitem(my_atom))
 				var/obj/item/I = my_atom

--- a/code/modules/chemistry/Chemistry-Holder.dm
+++ b/code/modules/chemistry/Chemistry-Holder.dm
@@ -566,9 +566,10 @@ datum
 			for(var/current_id in reagent_list)
 				var/datum/reagent/current_reagent = reagent_list[current_id]
 				if(current_reagent)
-					if(current_reagent.volume <= 0)
+					if(current_reagent.volume <= 0.00005)
 						del_reagent(current_id)
 					else
+						current_reagent.volume = max(min(round(current_reagent.volume, 0.00005), (current_reagent.volume + 0.00005)), 0.00005)
 						total_volume += current_reagent.volume
 			if(isitem(my_atom))
 				var/obj/item/I = my_atom


### PR DESCRIPTION
[CLEAN] 
## About the PR
This PR adds clamping in update_total to resolve long-standing bugs in which reagents would reach infinitesimally small levels. 

## Why's this needed?
1.37262e-19 grog bad

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Fosstar
(+)Reagents are now clamped to the nearest 1000th, or 0.001
```
