### PR TITLE
Fixes serum bug and adds clarifications to lychanthropy and draculaculiasis

### DIFF
--- a/code/datums/abilities/vampire.dm
+++ b/code/datums/abilities/vampire.dm
@@ -52,7 +52,7 @@
 			SHOW_VAMPIRE_TIPS(src)
 
 		if(shitty || nonantag)
-			boutput(src, "<span class='alert'><h2>You are not an antagonist!</h2> Your vampireness was achieved by in-game means, you still have the powers but are <i>not</i> an antagonist.</span>")
+			boutput(src, "<span class='alert'><h2>You've been turned into a vampire!</h2> Your vampireness was achieved by in-game means, you are <i>not</i> an antagonist unless you already were one.</span>")
 
 	else return
 

--- a/code/datums/abilities/werewolf.dm
+++ b/code/datums/abilities/werewolf.dm
@@ -97,7 +97,7 @@
 
 			M.visible_message("<span class='alert'><B>[M] [pick("metamorphizes", "transforms", "changes")] into a werewolf! Holy shit!</B></span>")
 			if (M.find_ailment_by_type(/datum/ailment/disease/lycanthropy))
-				boutput(M, "<span class='alert'><h2>You are not an antagonist!</h2> Your transformation was achieved by in-game means, you have the form of a werewolf but are <i>not</i> an antagonist.</span></h3>")
+				boutput(M, "<span class='alert'><h2>You've been turned into a werewolf!</h2> Your transformation was achieved by in-game means, you are <i>not</i> an antagonist unless you already were one.</span>")
 			else
 				boutput(M, "<span class='notice'><h3>You are now a werewolf. You can remain in this form indefinitely or change back at any time.</span></h3>")
 

--- a/code/datums/abilities/werewolf.dm
+++ b/code/datums/abilities/werewolf.dm
@@ -97,7 +97,7 @@
 
 			M.visible_message("<span class='alert'><B>[M] [pick("metamorphizes", "transforms", "changes")] into a werewolf! Holy shit!</B></span>")
 			if (M.find_ailment_by_type(/datum/ailment/disease/lycanthropy))
-				boutput(M, "<span class='notice'><h3>You are now a werewolf.</span></h3>")
+				boutput(M, "<span class='alert'><h2>You are not an antagonist!</h2> Your transformation was achieved by in-game means, you have the form of a werewolf but are <i>not</i> an antagonist.</span></h3>")
 			else
 				boutput(M, "<span class='notice'><h3>You are now a werewolf. You can remain in this form indefinitely or change back at any time.</span></h3>")
 

--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -3604,12 +3604,8 @@ datum
 			mix_phrase = "The substance bubbles and gives off an almost lupine howl."
 			var/static/list/full_moon_days_2053 = list("Jan 04", "Feb 03", "Mar 04", "Apr 03", "May 02", "Jun 01", "Jul 01", "Jul 30", "Aug 29", "Sep 27", "Oct 27", "Nov 25", "Dec 25")
 
-			on_reaction(var/datum/reagents/holder, var/created_volume)
-
-				if (!(time2text(world.realtime, "MMM DD") in full_moon_days_2053))
-					holder.my_atom.visible_message("<span class='alert'>The solution bubbles even more rapidly and dissipates into nothing!</span>")
-					holder.remove_reagent("werewolf_serum",created_volume + 1)
-				return
+			does_react(var/datum/reagents/holder)
+				return time2text(world.realtime, "MMM DD") in full_moon_days_2053
 
 		 vampire_serum
 		 	name = "Vampire Serum Omega"

--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -3605,7 +3605,7 @@ datum
 			var/static/list/full_moon_days_2053 = list("Jan 04", "Feb 03", "Mar 04", "Apr 03", "May 02", "Jun 01", "Jul 01", "Jul 30", "Aug 29", "Sep 27", "Oct 27", "Nov 25", "Dec 25")
 
 			does_react(var/datum/reagents/holder)
-				return time2text(world.realtime, "MMM DD") in full_moon_days_2053
+				return time2text(world.realtime, "MMM DD") in full_moon_days_2053 //just doesn't react unless it's a full moon
 
 		 vampire_serum
 		 	name = "Vampire Serum Omega"

--- a/code/modules/medical/diseases/vamplague.dm
+++ b/code/modules/medical/diseases/vamplague.dm
@@ -59,7 +59,7 @@
 		else
 			if (prob(40))
 				boutput(affected_mob, "<span class='alert'>Your heart stops...</span>")
-				affected_mob.playsound_local(affected_mob.loc, "heartbeat.ogg", 50, 1)
+				affected_mob.playsound_local(affected_mob.loc, "sound/effects/heartbeat.ogg", 50, 1)
 				affected_mob.emote("collapse")
 
 				affected_mob.make_vampire(FALSE, TRUE)


### PR DESCRIPTION
[Bug] [Secret]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes a massive exploit in the werewolf serum's code, fixes a runtime in the vampire disease, and adds some clarification to the lychanthropy and draculaculiasis transformation.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
1. Bugs and exploits stink.
2. Clarification that people aren't antags when they become a werewolf or vampire is a good idea
