### PR TITLE
Fixed soup applying a component to a datum, and bitemasks not bitemasking

### DIFF
--- a/code/datums/components/food_stuff.dm
+++ b/code/datums/components/food_stuff.dm
@@ -385,7 +385,7 @@
 	if(!istype(parent, /obj/item))
 		return COMPONENT_INCOMPATIBLE
 	src.food_parent = parent
-
+	src.start_amount = food_parent.amount
 	src.original_filters = food_parent.filters
 	RegisterSignal(parent, list(COMSIG_ITEM_CONSUMED_PARTIAL), .proc/apply_bitemask)
 
@@ -410,17 +410,12 @@
 /// Puts partially digested chunks in your mob
 /datum/component/consume/food_chunk
 	var/obj/item/food_parent
-	var/start_amount = 1
-	var/current_mask = 5
-	var/list/original_filters = list()
 
 /datum/component/consume/food_chunk/Initialize()
 	..()
 	if(!istype(parent, /obj/item))
 		return COMPONENT_INCOMPATIBLE
 	src.food_parent = parent
-	src.start_amount = food_parent.amount
-	src.original_filters = food_parent.filters
 	RegisterSignal(parent, list(COMSIG_ITEM_CONSUMED_PARTIAL, COMSIG_ITEM_CONSUMED_ALL), .proc/make_food_chunk)
 
 /datum/component/consume/food_chunk/proc/make_food_chunk(var/obj/item/I, var/mob/M)

--- a/code/obj/soup_pot.dm
+++ b/code/obj/soup_pot.dm
@@ -207,9 +207,6 @@
 			else
 				S.amount += F.w_class/pot.total_wclass/2
 				S.heal_amt -= F.w_class/pot.total_wclass/2
-			S.AddComponent(/datum/component/consume/food_effects, S.food_effects)
-			S.AddComponent(/datum/component/consume/foodheal, S.heal_amt)
-
 
 			if(I.reagents)
 				for(var/id in I.reagents.reagent_list)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUGFIX] [BLINDIDIOTCODENERD]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Made generate_soup() no longer add components to itself, since that's not how soup works. In fact, I didnt even need to add any components, they add themselves properly when the ladle ladles the soup into the soup. #3876

Also fixed the bitemask not working, since I had all the vars set up in the wrong component. Huh.