### PR TITLE
Makes stun artifacts stamina damage based

### DIFF
--- a/code/obj/artifacts/artifact_items/melee_weapon.dm
+++ b/code/obj/artifacts/artifact_items/melee_weapon.dm
@@ -66,4 +66,4 @@
 				if ("toxin")
 					target.take_toxin_damage(rand(1, dmg_amount))
 			if (src.stamina_dmg)
-				target.do_disorient(stamina_damage = src.stamina_dmg, weakened = src.stamina_dmg + 40, disorient = src.stamina_dmg - 40)
+				target.do_disorient(stamina_damage = src.stamina_dmg, weakened = src.stamina_dmg - 20, disorient = src.stamina_dmg - 40)

--- a/code/obj/artifacts/artifact_items/melee_weapon.dm
+++ b/code/obj/artifacts/artifact_items/melee_weapon.dm
@@ -24,9 +24,7 @@
 	react_xray = list(14,95,95,7,"DENSE")
 	var/damtype = "brute"
 	var/dmg_amount = 5
-	var/stun = 0
 	var/stamina_dmg = 0
-	var/dmg_calc = 40
 	var/deadly = 0
 	var/sound/hitsound = null
 	examine_hint = "It seems to have a handle you're supposed to hold it by."
@@ -41,7 +39,6 @@
 		if (prob(5))
 			src.dmg_amount *= rand(1,5)
 		if (prob(45))
-			src.stun = 1
 			src.stamina_dmg = rand(50,120)
 		if (prob(1))
 			src.deadly = 1
@@ -68,5 +65,5 @@
 					random_burn_damage(target, dmg_amount)
 				if ("toxin")
 					target.take_toxin_damage(rand(1, dmg_amount))
-			if (src.stun)
-				target.do_disorient(stamina_damage = src.stamina_dmg, weakened = src.stamina_dmg + src.dmg_calc, disorient = src.stamina_dmg - src.dmg_calc)
+			if (src.stamina_dmg)
+				target.do_disorient(stamina_damage = src.stamina_dmg, weakened = src.stamina_dmg + 40, disorient = src.stamina_dmg - 40)

--- a/code/obj/artifacts/artifact_items/melee_weapon.dm
+++ b/code/obj/artifacts/artifact_items/melee_weapon.dm
@@ -24,8 +24,9 @@
 	react_xray = list(14,95,95,7,"DENSE")
 	var/damtype = "brute"
 	var/dmg_amount = 5
-	var/stun_time = 0
-	var/KO_time = 0
+	var/stun = 0
+	var/stamina_dmg = 0
+	var/dmg_calc = 40
 	var/deadly = 0
 	var/sound/hitsound = null
 	examine_hint = "It seems to have a handle you're supposed to hold it by."
@@ -39,10 +40,9 @@
 		src.dmg_amount *= rand(1,5)
 		if (prob(5))
 			src.dmg_amount *= rand(1,5)
-		if (prob(40))
-			src.stun_time = rand(3,12)
-		if (prob(15))
-			src.KO_time = rand(3,12)
+		if (prob(45))
+			src.stun = 1
+			src.stamina_dmg = rand(50,120)
 		if (prob(1))
 			src.deadly = 1
 		src.hitsound = pick('sound/impact_sounds/Metal_Hit_Heavy_1.ogg','sound/impact_sounds/Wood_Hit_1.ogg','sound/effects/exlow.ogg','sound/effects/mag_magmisimpact.ogg','sound/impact_sounds/Energy_Hit_1.ogg',
@@ -68,7 +68,5 @@
 					random_burn_damage(target, dmg_amount)
 				if ("toxin")
 					target.take_toxin_damage(rand(1, dmg_amount))
-			if (src.stun_time)
-				target.changeStatus("stunned", src.stun_time * 15)
-			if (src.KO_time)
-				target.changeStatus("paralysis", src.KO_time*15)
+			if (src.stun)
+				target.do_disorient(stamina_damage = src.stamina_dmg, weakened = src.stamina_dmg + src.dmg_calc, disorient = src.stamina_dmg - src.dmg_calc)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[balance][input wanted]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR balances how melee stun artifacts work:

-Melee artifacts have 45% chance of being stun artifacts (previously 40% chance for stun art, 15% chance for knockout art)
-Instead of being based on instant stuns/knockouts, they behave similarly to stun batons, with each hit applying disorient status effect and knockdown status effect after draining victim's stamina
-Stamina damage range is 50-120 (worst case scenario slightly better than toolbox, best case scenario, slightly better than stun baton)
-Disorient status effect and knockdown duration scales up with rolled stamina damage (disorient 1sec-8sec, knockdown 3sec-10sec) 

(the calculations are based on VERY basic maths but I believe it works alright in that case)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Instant stuns are not fun to fight against at all, and are the reason why the police baton was nerfed.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)TTerc
(*)Stun melee artifacts are now stamina damage based.
```
