### PR TITLE
Remove duplicate table on oshan

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -24987,7 +24987,6 @@
 /area/station/storage/emergency)
 "bjs" = (
 /obj/table/auto,
-/obj/table/auto,
 /obj/item/storage/belt/utility{
 	pixel_y = 4
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[trivial]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes a duplicate table from Oshan's Emergency Storage A or whatever you'd call it. That place that gets looted within 10 minutes.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
No budget for double tables.