### PR TITLE
Add flag to bypass abstract type check on get_matches

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -875,7 +875,7 @@
 			boutput(usr, "<span class='hint'>Type part of the path of the type.</span>")
 			var/typename = input("Part of type path.", "Part of type path.", "/obj") as null|text
 			if (typename)
-				var/match = get_one_match(typename, /datum)
+				var/match = get_one_match(typename, /datum, use_concrete_types = FALSE)
 				if (match)
 					if (set_global)
 						for (var/datum/x in world)
@@ -1043,7 +1043,7 @@
 				var/basetype = /obj
 				if (src.holder.rank in list("Host", "Coder", "Administrator"))
 					basetype = /datum
-				var/match = get_one_match(typename, basetype)
+				var/match = get_one_match(typename, basetype, use_concrete_types = FALSE)
 				if (match)
 					if (set_global)
 						for (var/datum/x in world)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -4617,8 +4617,12 @@ var/global/noir = 0
 
 	return chosen
 
-/proc/get_matches(var/object, var/base = /atom)
-	var/list/types = concrete_typesof(base)
+/proc/get_matches(var/object, var/base = /atom, use_concrete_types = TRUE)
+	var/list/types
+	if(use_concrete_types)
+		types = concrete_typesof(base)
+	else
+		types = childrentypesof(base)
 
 	var/list/matches = new()
 
@@ -4628,8 +4632,8 @@ var/global/noir = 0
 
 	. = matches
 
-/proc/get_one_match(var/object, var/base = /atom)
-	var/list/matches = get_matches(object, base)
+/proc/get_one_match(var/object, var/base = /atom, use_concrete_types = TRUE)
+	var/list/matches = get_matches(object, base, use_concrete_types)
 
 	if(!matches.len)
 		return null
@@ -4655,7 +4659,7 @@ var/global/noir = 0
 	var/client/client = usr.client
 
 	if (client.holder.level >= LEVEL_PA)
-		var/chosen = get_one_match(object)
+		var/chosen = get_one_match(object, use_concrete_types = FALSE)
 
 		if (chosen)
 			if (ispath(chosen, /turf))

--- a/code/modules/admin/atom_verbs.dm
+++ b/code/modules/admin/atom_verbs.dm
@@ -34,7 +34,7 @@ var/global/atom_emergency_stop = 0
 		var/transmute_thing = input("enter path of the things you want to transmute", "Enter Path", pick("/obj", "/mob", "/turf")) as null|text
 		if (!transmute_thing)
 			return
-		var/transmute_path = get_one_match(transmute_thing, /atom)
+		var/transmute_path = get_one_match(transmute_thing, /atom, use_concrete_types = FALSE)
 		if (!transmute_path)
 			return
 
@@ -139,7 +139,7 @@ var/global/atom_emergency_stop = 0
 		var/emag_thing = input("enter path of the things you want to emag", "Enter Path", pick("/obj", "/mob", "/turf")) as null|text
 		if (!emag_thing)
 			return
-		var/emag_path = get_one_match(emag_thing, /atom)
+		var/emag_path = get_one_match(emag_thing, /atom, use_concrete_types = FALSE)
 		if (!emag_path)
 			return
 
@@ -264,7 +264,7 @@ var/global/atom_emergency_stop = 0
 		var/scale_thing = input("enter path of the things you want to scale", "Enter Path", pick("/obj", "/mob", "/turf")) as null|text
 		if (!scale_thing)
 			return
-		var/scale_path = get_one_match(scale_thing, /atom)
+		var/scale_path = get_one_match(scale_thing, /atom, use_concrete_types = FALSE)
 		if (!scale_path)
 			return
 
@@ -397,7 +397,7 @@ var/global/atom_emergency_stop = 0
 		var/rotate_thing = input("enter path of the things you want to rotate", "Enter Path", pick("/obj", "/mob", "/turf")) as null|text
 		if (!rotate_thing)
 			return
-		var/rotate_path = get_one_match(rotate_thing, /atom)
+		var/rotate_path = get_one_match(rotate_thing, /atom, use_concrete_types = FALSE)
 		if (!rotate_path)
 			return
 
@@ -537,7 +537,7 @@ var/global/atom_emergency_stop = 0
 		var/spin_thing = input("enter path of the things you want to spin", "Enter Path", pick("/obj", "/mob", "/turf")) as null|text
 		if (!spin_thing)
 			return
-		var/spin_path = get_one_match(spin_thing, /atom)
+		var/spin_path = get_one_match(spin_thing, /atom, use_concrete_types = FALSE)
 		if (!spin_path)
 			return
 
@@ -686,7 +686,7 @@ var/global/atom_emergency_stop = 0
 		var/get_thing = input("enter path of the things you want to get", "Enter Path", pick("/obj", "/mob")) as null|text
 		if (!get_thing)
 			return
-		var/get_path = get_one_match(get_thing, /atom)
+		var/get_path = get_one_match(get_thing, /atom, use_concrete_types = FALSE)
 		if (!get_path)
 			return
 

--- a/code/modules/admin/buildmodes/varedit.dm
+++ b/code/modules/admin/buildmodes/varedit.dm
@@ -94,7 +94,7 @@ Hold down CTRL, ALT or SHIFT to modify, call or reset variable bound to those ke
 					var/basetype = /obj
 					if (holder.owner.holder.rank in list("Host", "Coder", "Administrator"))
 						basetype = /datum
-					var/match = get_one_match(typename, basetype)
+					var/match = get_one_match(typename, basetype, use_concrete_types = FALSE)
 					if (match)
 						newvalue = match
 						is_newinst = 1

--- a/code/modules/admin/debug.dm
+++ b/code/modules/admin/debug.dm
@@ -195,7 +195,7 @@ var/global/debug_messages = 0
 
 	if (!typename)
 		return
-	var/thetype = get_one_match(typename, /atom)
+	var/thetype = get_one_match(typename, /atom, use_concrete_types = FALSE)
 	if (thetype)
 		var/counter = 0
 		var/procname = input("Procpath","path:", null) as text
@@ -359,7 +359,7 @@ var/global/debug_messages = 0
 				boutput(usr, "<span class='notice'>Type part of the path of the type.</span>")
 				var/typename = input("Part of type path.", "Part of type path.", "/obj") as null|text
 				if (typename)
-					var/match = get_one_match(typename, /datum)
+					var/match = get_one_match(typename, /datum, use_concrete_types = FALSE)
 					if (match)
 						listargs += match
 
@@ -787,7 +787,7 @@ body
 	set name = "Find One"
 	set desc = "Show the location of one instance of type."
 
-	var/thetype = get_one_match(typename, /atom)
+	var/thetype = get_one_match(typename, /atom, use_concrete_types = FALSE)
 	if (thetype)
 		var/atom/theinstance = locate(thetype) in world
 		if (!theinstance)
@@ -804,7 +804,7 @@ body
 	set name = "Find All"
 	set desc = "Show the location of all instances of a type. Performance warning!!"
 
-	var/thetype = get_one_match(typename, /atom)
+	var/thetype = get_one_match(typename, /atom, use_concrete_types = FALSE)
 	if (thetype)
 		var/counter = 0
 		boutput(usr, "<span class='notice'><b>All instances of [thetype]: </b></span>")
@@ -836,7 +836,7 @@ body
 	set name = "Count All"
 	set desc = "Returns the number of all instances of a type that exist."
 
-	var/thetype = get_one_match(typename, /atom)
+	var/thetype = get_one_match(typename, /atom, use_concrete_types = FALSE)
 	if (thetype)
 		var/counter = 0
 		for (var/atom/theinstance in world)

--- a/code/modules/admin/modifyvariables.dm
+++ b/code/modules/admin/modifyvariables.dm
@@ -104,7 +104,7 @@
 				var/basetype = /obj
 				if (src.holder.rank in list("Host", "Coder", "Administrator"))
 					basetype = /datum
-				var/match = get_one_match(typename, basetype)
+				var/match = get_one_match(typename, basetype, use_concrete_types = FALSE)
 				if (match)
 					var_value = new match()
 
@@ -179,7 +179,7 @@
 				var/basetype = /obj
 				if (src.holder.rank in list("Host", "Coder", "Administrator"))
 					basetype = /datum
-				var/match = get_one_match(typename, basetype)
+				var/match = get_one_match(typename, basetype, use_concrete_types = FALSE)
 				if (match)
 					var_value = new match()
 
@@ -332,7 +332,7 @@
 			boutput(usr, "<span class='notice'>Type part of the path of the type.</span>")
 			var/typename = input("Part of type path.", "Part of type path.", "/obj") as null|text
 			if (typename)
-				var/match = get_one_match(typename, /datum)
+				var/match = get_one_match(typename, /datum, use_concrete_types = FALSE)
 				if (match)
 					L[variable_index] = match
 
@@ -373,7 +373,7 @@
 				var/basetype = /obj
 				if (src.holder.rank in list("Host", "Coder", "Administrator"))
 					basetype = /datum
-				var/match = get_one_match(typename, basetype)
+				var/match = get_one_match(typename, basetype, use_concrete_types = FALSE)
 				if (match)
 					L[variable_index] = new match()
 
@@ -640,7 +640,7 @@
 				var/basetype = /obj
 				if (src.holder.rank in list("Host", "Coder", "Administrator"))
 					basetype = /datum
-				var/match = get_one_match(typename, basetype)
+				var/match = get_one_match(typename, basetype, use_concrete_types = FALSE)
 				if (match)
 					O.vars[variable] = new match(O)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][FEATURE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Adds flag to bypass abstract type check on `get_matches`
* implements flag on a number of admin verbs that made use of `get_matches` and `get_one_match`
* was not implemented on a number of verbs where I felt abstract types would not be desired

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Sometimes admins wish to spawn in or reference abstract types for ease of mass var modification and atom manipulation.
