### PR TITLE
Movable toilets!

### DIFF
--- a/code/obj/item/toilets.dm
+++ b/code/obj/item/toilets.dm
@@ -42,7 +42,7 @@ TOILET
 		return
 	if (istype(W, /obj/item/storage))
 		return
-	if (istype(W, /obj/item/grab))
+	if (istype(W, /obj/item/grab) && !ON_COOLDOWN(src, "swirlie", 0.5 SECOND))
 		playsound(get_turf(src), "sound/effects/toilet_flush.ogg", 50, 1)
 		user.visible_message("<span class='notice'>[user] gives [W:affecting] a swirlie!</span>", "<span class='notice'>You give [W:affecting] a swirlie. It's like Middle School all over again!</span>")
 		return
@@ -105,7 +105,7 @@ TOILET
 			reset_anchored(M)
 			M.buckled = null
 			src.add_fingerprint(user)
-	if((src.clogged < 1) || (src.contents.len < 7) || (user.loc != src.loc))
+	if((src.clogged < 1 || src.contents.len < 7 || user.loc != src.loc) && !ON_COOLDOWN(src, "toilet flushing", 1 SECOND))
 		user.visible_message("<span class='notice'>[user] flushes [src].</span>", "<span class='notice'>You flush [src].</span>")
 		playsound(get_turf(src), "sound/effects/toilet_flush.ogg", 50, 1)
 
@@ -123,7 +123,7 @@ TOILET
 			qdel(item)
 			src.hud?.remove_item(item)
 
-	else if((src.clogged >= 1) || (src.contents.len >= 7) || (user.buckled != src.loc))
+	else if((src.clogged < 1 || src.contents.len < 7 || user.loc != src.loc) && !ON_COOLDOWN(src, "toilet flushing", 1 SECOND))
 		src.visible_message("<span class='notice'>The toilet is clogged!</span>")
 
 /obj/item/storage/toilet/custom_suicide = 1

--- a/code/obj/item/toilets.dm
+++ b/code/obj/item/toilets.dm
@@ -26,6 +26,16 @@ TOILET
 	..()
 
 /obj/item/storage/toilet/attackby(obj/item/W as obj, mob/user as mob, obj/item/storage/T)
+	if(istool(W, TOOL_SCREWING | TOOL_WRENCHING))
+		if(src.anchored)
+			user.visible_message("<b>[user]</b> unbolts the [src] from the floor.")
+			playsound(src.loc, "sound/items/Screwdriver.ogg", 100, 1)
+			src.anchored = 0
+		else
+			user.visible_message("<b>[user]</b> secures the [src] to the floor.")
+			playsound(src.loc, "sound/items/Screwdriver.ogg", 100, 1)
+			src.anchored = 1
+		return
 	if (src.contents.len >= 7)
 		boutput(user, "The toilet is clogged!")
 		user.unlock_medal("Try jiggling the handle",1) //new method to get this medal since the old one (fat person in disposal pipe) is gone


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->[FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Makes toilets able to be un-anchored by using a screwdriver or a wrench on it, you can anchor them back in place by using the wrench or screwdriver again.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Stealing a toilet is just way too funny and someone requested it on discord.