### PR TITLE
Fixes feeding ghosts and bots, and eat-spam fixes

### DIFF
--- a/code/datums/components/food_stuff.dm
+++ b/code/datums/components/food_stuff.dm
@@ -5,6 +5,10 @@
 /// user = mob using the thing
 /// I = thing being eaten -- only does anything on components with a mob parent
 
+////// Argument formats! Any signals should really use these args in this order
+/// Eatsignal w/ mob parent  - M, user, I
+/// Eatsignal w/ item parent - I, M, user
+
 /* CONTENTS:
 * Can-eat inedible organs          - mob parent  - pre-eat check            - (Can it eat heads too?)
 * Eat-organ get-points             - mob parent  - post-eat all/part effect - (which abilityholder to give points to)
@@ -331,7 +335,7 @@
 		if (isnum_safe(_new_base_heal)) // C(duplicate component) wasn't initialized, so we don't know if the raw argument _new_base_heal is actually a number
 			src.base_heal = _new_base_heal
 
-/datum/component/consume/foodheal/proc/eat_stuff_get_heal(var/obj/item/I, var/obj/item/I, var/mob/M)
+/datum/component/consume/foodheal/proc/eat_stuff_get_heal(var/obj/item/I, var/mob/M, var/mob/user)
 	var/healing = src.base_heal
 
 	if (ishuman(M))
@@ -418,7 +422,7 @@
 	src.food_parent = parent
 	RegisterSignal(parent, list(COMSIG_ITEM_CONSUMED_PARTIAL, COMSIG_ITEM_CONSUMED_ALL), .proc/make_food_chunk)
 
-/datum/component/consume/food_chunk/proc/make_food_chunk(var/obj/item/I, var/mob/M)
+/datum/component/consume/food_chunk/proc/make_food_chunk(var/obj/item/I, var/mob/M, var/mob/user)
 	if (isliving(M))
 		if (food_parent.reagents && food_parent.reagents.total_volume) //only create food chunks for reagents
 			var/obj/item/reagent_containers/food/snacks/bite/B = unpool(/obj/item/reagent_containers/food/snacks/bite)
@@ -456,7 +460,7 @@
 			src.status_effects |= new_sfx
 
 
-/datum/component/consume/food_effects/proc/apply_food_effects(var/obj/item/I, var/mob/M)
+/datum/component/consume/food_effects/proc/apply_food_effects(var/obj/item/I, var/mob/M, var/mob/user)
 	if (src.status_effects.len && isliving(M) && M.bioHolder)
 		var/mob/living/L = M
 		for (var/effect in src.status_effects)
@@ -486,7 +490,7 @@
 		if (isnum_safe(_new_festivity))
 			src.festiveness = _new_festivity
 
-/datum/component/consume/festive_food/proc/alter_festivity(var/obj/item/I, var/mob/M)
+/datum/component/consume/festive_food/proc/alter_festivity(var/obj/item/I, var/mob/M, var/mob/user)
 	if (src.festiveness)
 		modify_christmas_cheer(src.festiveness)
 
@@ -561,7 +565,7 @@
 		if (_new_medal)
 			src.medal = _new_medal
 
-/datum/component/consume/unlock_medal_on_eaten/proc/give_medal(var/obj/item/I, var/mob/M)
+/datum/component/consume/unlock_medal_on_eaten/proc/give_medal(var/obj/item/I, var/mob/M, var/mob/user)
 	M.unlock_medal(src.medal, 1)
 
 /datum/component/consume/unlock_medal_on_eaten/UnregisterFromParent()

--- a/code/datums/components/food_stuff.dm
+++ b/code/datums/components/food_stuff.dm
@@ -5,9 +5,9 @@
 /// user = mob using the thing
 /// I = thing being eaten -- only does anything on components with a mob parent
 
-////// Argument formats! Any signals should really use these args in this order
-/// Eatsignal w/ mob parent  - M, user, I
-/// Eatsignal w/ item parent - I, M, user
+//--// Argument formats! Any signals should really use these args in this order
+// Eatsignal w/ mob parent  - M, user, I
+// Eatsignal w/ item parent - I, M, user
 
 /* CONTENTS:
 * Can-eat inedible organs          - mob parent  - pre-eat check            - (Can it eat heads too?)

--- a/code/datums/components/food_stuff.dm
+++ b/code/datums/components/food_stuff.dm
@@ -2,8 +2,8 @@
 /// Also eating stuff in general
 
 /// M = mob eating the thing
-/// user = mob using the thing
-/// I = thing being eaten -- only does anything on components with a mob parent
+// user = mob using the thing
+// I = thing being eaten -- only does anything on components with a mob parent
 
 //--// Argument formats! Any signals should really use these args in this order
 // Eatsignal w/ mob parent  - M, user, I

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -2980,7 +2980,7 @@
 	if(!istype(A) || !user)
 		return FALSE // who's eating what, now?
 
-	/// Apparently you could feed things to ghosts. So spooky everyone loses their appetite
+	// Apparently you could feed things to ghosts. So spooky everyone loses their appetite
 	if (isobserver(src))
 		if(isAIeye(src))
 			src.can_not_eat(A, user, "is_aieye")

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -2988,17 +2988,17 @@
 			src.can_not_eat(A, user, "is_ghost")
 		return FALSE
 
-	/// Science still hasn't found a way to install a cyberstomach into a cyberperson
+	// Science still hasn't found a way to install a cyberstomach into a cyberperson
 	if (issilicon(src))
 		src.can_not_eat(A, user, "is_silicon")
 		return FALSE
 
-	/// And just in case we're something that isnt caught by the above and isnt something that's supposed to eat things
+	// And just in case we're something that isnt caught by the above and isnt something that's supposed to eat things
 	if (!isliving(src))
 		src.can_not_eat(A, user, null)
 		return FALSE
 
-	/// Making sure the thing actually exists and isn't cheating the bite-rate. And is also edible, so we don't get people trying to stuff multitools in their mouth
+	// Making sure the thing actually exists and isn't cheating the bite-rate. And is also edible, so we don't get people trying to stuff multitools in their mouth
 	if(!src.bioHolder?.HasEffect("mattereater") && GET_COOLDOWN(src, "eat") && (A.edible || A.material?.edible))
 		if(!ON_COOLDOWN(src, "eat_cooldown_cooldown", EAT_COOLDOWN))
 			src.can_not_eat(A, user, "on_cooldown")

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -2980,9 +2980,28 @@
 	if(!istype(A) || !user)
 		return FALSE // who's eating what, now?
 
+	/// Apparently you could feed things to ghosts. So spooky everyone loses their appetite
+	if (isobserver(src))
+		if(isAIeye(src))
+			src.can_not_eat(A, user, "is_aieye")
+		else
+			src.can_not_eat(A, user, "is_ghost")
+		return FALSE
+
+	/// Science still hasn't found a way to install a cyberstomach into a cyberperson
+	if (issilicon(src))
+		src.can_not_eat(A, user, "is_silicon")
+		return FALSE
+
+	/// And just in case we're something that isnt caught by the above and isnt something that's supposed to eat things
+	if (!isliving(src))
+		src.can_not_eat(A, user, null)
+		return FALSE
+
 	/// Making sure the thing actually exists and isn't cheating the bite-rate. And is also edible, so we don't get people trying to stuff multitools in their mouth
 	if(!src.bioHolder?.HasEffect("mattereater") && GET_COOLDOWN(src, "eat") && (A.edible || A.material?.edible))
-		src.can_not_eat(A, user, "on_cooldown")
+		if(!ON_COOLDOWN(src, "eat_cooldown_cooldown", EAT_COOLDOWN))
+			src.can_not_eat(A, user, "on_cooldown")
 		return FALSE
 	else if (!A.amount)
 		src.can_not_eat(A, user, "all_gone")
@@ -3057,6 +3076,30 @@
 			user.tri_message("<span class='alert'>[user] tries to feed [A] to [src], but nothing happens!</span>",\
 			user, "<span class='alert'>You try to feed [A] to [src], but nothing happens!</span>",\
 			src, "<span class='alert'>[user] tries to feed [A] to you, but nothing happens!</span>")
+		if("is_silicon")
+			var/must_scream = prob(1)
+			var/has_head = 1 // most non-borg silicons are basically just a floating headmobile
+			if(isrobot(src))
+				var/mob/living/silicon/robot/R = src
+				has_head = istype(R.part_head)
+			user.tri_message("<span class='alert'>[user] waves [A] in front of [src]'s [has_head ? "head assembly" : "mass of exposed neckwires"], but it [has_head ? "[must_scream ? "has no mouth" : "doesn't have a mouth"]" : "doesn't have a head"]!</span>",\
+			user, "<span class='alert'>You hold [A] in front of [src]'s [has_head ? "cranial unit" : "mass of exposed neckwires"], but you can't seem to find a [has_head ? "mouth" : "place to put it"]!</span>",\
+			src, "<span class='alert'>[user] wishes for you to consume [A]. [must_scream ? "You are unable to comply, as it is incompatible with your cybernetic physiology." : "<b><i>But you don't have a mouth!</b></i>"]</span>")
+			if(must_scream)
+				src.emote("scream")
+		if("is_aieye")
+			user.tri_message("<span class='notice'>[user] waves [A] at a camera.</span>",\
+			user, "<span class='notice'>You hold [A] in front of one of [src]'s cameras. You're not sure what you were expecting to happen.</span>",\
+			src, "<span class='notice'>[user] shows [his_or_her(user)] [A] to you. It looks unappetizing.</span>")
+		if("is_ghost")
+			user.tri_message("<span class='alert'>[user] waves [A] around in front of [him_or_her(user)]self...?</span>",\
+			user, "<span class='alert'>You make an offering of [A] to the restless spirit of [src]. You feel vaguely uneasy and \the [A] starts to look a bit spooky, but otherwise, nothing seems to happen.</span>",\
+			src, "<span class='alert'>[user] waggles [A] around inside your phantom head, but you're not hungry.</span>")
+			if(istype(A))
+				if(!A.reagents)
+					A.create_reagents(5)
+				var/datum/reagents/reag = A.reagents
+				reag.add_reagent("ectoplasm", 5)
 		else
 			boutput(user, "<span class='alert'>You can't eat that!</span>")
 

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -382,12 +382,13 @@
 	if(!M.can_eat(src, user, bypass_utensils))
 		return 0
 
-	actions.start(new/datum/action/bar/icon/eatstuff(src, M, user), user)
-	return 1
+	if(!actions.hasAction(user, "eatstuff"))
+		actions.start(new/datum/action/bar/icon/eatstuff(src, M, user), user)
+		return 1
 
 /datum/action/bar/icon/eatstuff
 	duration = 3 SECONDS
-	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
+	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_STUNNED | INTERRUPT_ACTION
 	id = "eatstuff"
 	icon = null
 	icon_state = null
@@ -418,8 +419,6 @@
 			src.icon = null // action/bar/icon
 			src.icon_state = null // minus the action bar icon
 			duration = 0 // pretty much instant
-			REMOVE_FLAG(src.interrupt_flags, INTERRUPT_MOVE) // take it to go
-			REMOVE_FLAG(src.interrupt_flags, INTERRUPT_ACT) // And spam it if you want
 		else
 			src.icon = master.icon
 			src.icon_state = master.icon_state
@@ -431,42 +430,22 @@
 		if(src.failchecks())
 			interrupt(INTERRUPT_ALWAYS)
 
-		if(M_is_user && !is_it_organs)
-			bar.icon = null // Action bars
-			border.icon = null // minus action bar
-		else
-			eat_twitch(M)
-
-		M.on_eat(master)
-
-		if (src.M_is_user)
-			if(is_it_organs)
+		eat_twitch(M)
+		if(src.M_is_user)
+			if(!src.is_it_organs)
+				bar.icon = null // Action bars
+				border.icon = null // minus action bar
+			else
 				M.visible_message("<span class='alert'><b>[M]</b> starts cramming \the [master] into [his_or_her(M)] mouth[prob(30) ? " like a [pick(src.grody_adj)] [pick(src.grody_noun)]" : ""]!</span>",\
 				"<span class='[is_awful_monsterthing ? "notice" : "alert"]'>You start cramming \the [master] into your mouth!</span>")
-			else
-				boutput(M, "<span class='notice'>You go to take a bite out of [master].</span>")
+				logTheThing("diary", user, M, "attempts to eat [master], an organ. [log_reagents(master)]", "game") // Gotta keep track on who's eating who's brain
 		else
 			user.tri_message("<span class='alert'><b>[user]</b> tries to feed [M] [master]!</span>",\
 			user, "<span class='alert'>You try to feed [M] [master]!</span>",\
 			M, "<span class='[is_awful_monsterthing ? "notice" : "alert"]'><b>[user]</b> tries to feed you [master]!</span>")
-		logTheThing("combat", user, M, "attempts to feed [constructTarget(M,"combat")] [master] [log_reagents(master)]")
+			logTheThing("combat", user, M, "attempts to feed [constructTarget(M,"combat")] [master] [log_reagents(master)]")
 
-	onInterrupt(flag)
-		. = ..()
-		if(src.M_is_user)
-			if(src.is_it_organs)
-				M.visible_message("<span class='alert'>[M] spits out \the [master].</span>","<span class='[is_awful_monsterthing ? "alert" : "notice"]'>You spit out \the [master].</span>")
-			else
-				boutput(M, "<span class='notice'>You stop trying to eat [master].</span>")
-		else
-			if(src.is_it_organs)
-				user.tri_message("<span class='alert'><b>[user]</b> stops forcing \the [master] down [M]'s throat!</span>",\
-				user, "<span class='alert'>You remove \the [master] from [M]'s face!</span>",\
-				M, "<span class='[is_awful_monsterthing ? "alert" : "notice"]'><b>[user]</b> stops forcing \the [master] down your throat!</span>")
-			else
-				user.tri_message("<span class='alert'><b>[user]</b> stops trying to shove \the [master] down [M]'s throat!</span>",\
-				user, "<span class='alert'>You remove \the [master] from [M]'s face!</span>",\
-				M, "<span class='alert'><b>[user]</b> stops trying to shove \the [master] down your throat!</span>")
+		M.on_eat(master)
 
 	onUpdate()
 		..()
@@ -521,8 +500,10 @@
 		SEND_SIGNAL(M, COMSIG_ITEM_CONSUMED_PARTIAL, user, master)
 
 		if(ate_the_whole_thing)
-			SEND_SIGNAL(master, COMSIG_ITEM_CONSUMED_ALL, M, user)
-			SEND_SIGNAL(M, COMSIG_ITEM_CONSUMED_ALL, user, master)
+			/// procs effects specific to the item (master) onto whoever eats it (M)
+			SEND_SIGNAL(master, COMSIG_ITEM_CONSUMED_ALL, M, user) // item parent, format: I (thing being eaten), M (mob eating it), user (mob making M eat it)
+			/// procs effects specific to the mob (M) when eating the item (master) if applicable
+			SEND_SIGNAL(M, COMSIG_ITEM_CONSUMED_ALL, user, master) // mob parent, format: M (mob eating it), user (mob making M eat it), I (thing being eaten)
 			M.visible_message("<span class='alert'>[M] finishes eating [master].</span>",\
 			"<span class='alert'>You finish eating [master].</span>")
 

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -500,9 +500,9 @@
 		SEND_SIGNAL(M, COMSIG_ITEM_CONSUMED_PARTIAL, user, master)
 
 		if(ate_the_whole_thing)
-			/// procs effects specific to the item (master) onto whoever eats it (M)
+			// procs effects specific to the item (master) onto whoever eats it (M)
 			SEND_SIGNAL(master, COMSIG_ITEM_CONSUMED_ALL, M, user) // item parent, format: I (thing being eaten), M (mob eating it), user (mob making M eat it)
-			/// procs effects specific to the mob (M) when eating the item (master) if applicable
+			// procs effects specific to the mob (M) when eating the item (master) if applicable
 			SEND_SIGNAL(M, COMSIG_ITEM_CONSUMED_ALL, user, master) // mob parent, format: M (mob eating it), user (mob making M eat it), I (thing being eaten)
 			M.visible_message("<span class='alert'>[M] finishes eating [master].</span>",\
 			"<span class='alert'>You finish eating [master].</span>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUGFIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixed being able to feed things to bots and ghosts. Instead of them eating whatever you mash into them, there's now a message when you try to do so. Feeding robots has a chance to make them scream, and ghosts will put some ectoplasm into your food.

The eat action is now a lot more easily spammable:
- Repeatedly trying to eat something only throws the hold-ur-horses message once per bite.
- It won't try to run another eat action while another one's running.
 - Otherwise, you could stack eat-actions and force people to eat multiple bites. Kinda neat, but maybe later.
- The eat action won't be interrupted if you keep trying to click on someone while feeding them. So, you can keep spamclicking food at people without it looking like a bug!
- Removed the messages for being interrupted feeding people. Couldn't figure out how to make it only show when I wanted, and people kept thinking its a bug. Which it is. Just now its a lot better hidden.
- Fixed the eat comsigs calling the wrong things in the components. Also added some documentation on which args do what for the signals, mostly so I can remember what they do.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

shit broke, this lessbrokes it