### PR TITLE
fix pathologist always showing up in character preferences

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -588,7 +588,12 @@ ABSTRACT_TYPE(/datum/job/research)
 		src.access = get_access("Geneticist")
 		return
 
+
+#ifdef CREATE_PATHOGENS
 /datum/job/research/pathologist
+#else
+/datum/job/pathologist // pls no autogenerate list
+#endif
 	name = "Pathologist"
 	#ifdef CREATE_PATHOGENS
 	limit = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I think this should work to make it so that Pathologist doesn't show up in Character Preferences when Pathogens are not enabled.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
People were real confused and kept asking me about it on the Discord.
