### PR TITLE
Artifact Analysis II: Return of Analysis

### DIFF
--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -140,7 +140,7 @@
 			score_tracker.artifacts_correctly_analyzed++
 
 		// send artifact resupply
-		if(prob(modifier*40*pap.lastAnalysis)) // range from 0% to ~78% for fully researched t4 artifact
+		if(prob(modifier*40*pap?.lastAnalysis)) // range from 0% to ~78% for fully researched t4 artifact
 			if(!src.artifact_resupply_amount)
 				SPAWN_DBG(rand(3,8) MINUTES)
 					// message

--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -168,7 +168,7 @@
 		var/datum/signal/pdaSignal = get_free_signal()
 		var/message = "Notification: [price] credits earned from outgoing artifact [sell_art.name]. "
 		if(pap)
-			message += "Analysis was [pap.lastAnalysis]% correct."
+			message += "Analysis was [(pap.lastAnalysis/3)*100]% correct."
 		else
 			message += "Artifact was not analyzed."
 		pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="CARGO-MAILBOT",  "group"=list(MGD_CARGO, MGD_SCIENCE, MGA_SALES), "sender"="00000000", "message"=message)

--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -135,7 +135,8 @@
 		price = round(price, 5)
 
 		// track score
-		score_tracker.artifacts_analyzed++
+		if(pap)
+			score_tracker.artifacts_analyzed++
 		if(pap?.lastAnalysis >= 3)
 			score_tracker.artifacts_correctly_analyzed++
 

--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -126,6 +126,7 @@
 		var/price = 0
 		var/modifier = sell_art_datum.get_rarity_modifier()
 
+		// calculate price
 		price = modifier*modifier * 10000
 		var/obj/item/sticker/postit/artifact_paper/pap = locate(/obj/item/sticker/postit/artifact_paper/) in sell_art.vis_contents
 		if(pap?.lastAnalysis)
@@ -133,6 +134,12 @@
 		price += rand(-50,50)
 		price = round(price, 5)
 
+		// track score
+		score_tracker.artifacts_analyzed++
+		if(pap?.lastAnalysis >= 3)
+			score_tracker.artifacts_correctly_analyzed++
+
+		// send artifact resupply
 		if(prob(modifier*40*pap.lastAnalysis)) // range from 0% to ~78% for fully researched t4 artifact
 			if(!src.artifact_resupply_amount)
 				SPAWN_DBG(rand(3,8) MINUTES)
@@ -152,9 +159,11 @@
 					shippingmarket.receive_crate(artcrate)
 			src.artifact_resupply_amount++
 
+		// sell
 		wagesystem.shipping_budget += price
 		qdel(sell_art)
 
+		// give PDA group messages
 		var/datum/radio_frequency/transmit_connection = radio_controller.return_frequency("1149")
 		var/datum/signal/pdaSignal = get_free_signal()
 		pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="CARGO-MAILBOT",  "group"=list(MGD_CARGO, MGD_SCIENCE, MGA_SALES), "sender"="00000000", "message"="Notification: [price] credits earned from outgoing artifact [sell_art.name]. [pap?'Analysis was [pap.lastAnalysis]% correct.':'No analysis attached.']")

--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -153,7 +153,7 @@
 					// actual shipment
 					var/obj/storage/crate/artcrate = new /obj/storage/crate()
 					artcrate.name = "Artifact Resupply Crate"
-					for(var/i = 0 .. artifact_resupply_amount)
+					for(var/i = 0 to artifact_resupply_amount)
 						new /obj/artifact_type_spawner/vurdalak(artcrate)
 					artifact_resupply_amount = 0
 					shippingmarket.receive_crate(artcrate)
@@ -166,7 +166,12 @@
 		// give PDA group messages
 		var/datum/radio_frequency/transmit_connection = radio_controller.return_frequency("1149")
 		var/datum/signal/pdaSignal = get_free_signal()
-		pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="CARGO-MAILBOT",  "group"=list(MGD_CARGO, MGD_SCIENCE, MGA_SALES), "sender"="00000000", "message"="Notification: [price] credits earned from outgoing artifact [sell_art.name]. [pap?'Analysis was [pap.lastAnalysis]% correct.':'No analysis attached.']")
+		var/message = "Notification: [price] credits earned from outgoing artifact [sell_art.name]. "
+		if(pap)
+			message += "Analysis was [pap.lastAnalysis]% correct."
+		else
+			message += "Artifact was not analyzed."
+		pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="CARGO-MAILBOT",  "group"=list(MGD_CARGO, MGD_SCIENCE, MGA_SALES), "sender"="00000000", "message"=message)
 		pdaSignal.transmission_method = TRANSMISSION_RADIO
 		if(transmit_connection != null)
 			transmit_connection.post_signal(null, pdaSignal)

--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -167,7 +167,7 @@
 		// give PDA group messages
 		var/datum/radio_frequency/transmit_connection = radio_controller.return_frequency("1149")
 		var/datum/signal/pdaSignal = get_free_signal()
-		var/message = "Notification: [price] credits earned from outgoing artifact [sell_art.name]. "
+		var/message = "Notification: [price] credits earned from outgoing artifact \'[sell_art.name]\'. "
 		if(pap)
 			message += "Analysis was [(pap.lastAnalysis/3)*100]% correct."
 		else

--- a/code/obj/artifacts/artifactanalysis.dm
+++ b/code/obj/artifacts/artifactanalysis.dm
@@ -57,6 +57,10 @@
 		O.real_name = src.artifactName
 		O.UpdateName()
 
+	attack_hand(mob/user)
+		if(src.attached)
+			src.attached.attack_hand(user)
+
 	stick_to(atom/A, pox, poy)
 		. = ..()
 		if(isobj(A))
@@ -65,6 +69,11 @@
 	attackby(obj/item/W, mob/living/user)
 		if(istype(W, /obj/item/pen))
 			ui_interact(user)
+		else if((iscuttingtool(W) || issnippingtool(W)) && user.a_intent == INTENT_HELP)
+			boutput(user, "You manage to scrape \the [src] off of \the [src.attached].")
+			src.remove_from_attached()
+			src.add_fingerprint(user)
+			user.put_in_hand_or_drop(src)
 		else if (src.attached)
 			src.attached.attackby(W, user)
 			user.lastattacked = user

--- a/code/obj/artifacts/artifactanalysis.dm
+++ b/code/obj/artifacts/artifactanalysis.dm
@@ -2,7 +2,7 @@
 	name = "artifact analysis form"
 	icon = 'icons/obj/writing.dmi'
 	icon_state = "artifact_form"
-	desc = "A standardized form for classifying different alien artifacts."
+	desc = "A standardized form for classifying different alien artifacts, with some extra strong adhesive on the back."
 	appearance_flags = RESET_TRANSFORM | RESET_COLOR | RESET_ALPHA
 	var/artifactName = ""
 	var/artifactOrigin = ""

--- a/code/obj/artifacts/artifactanalysis.dm
+++ b/code/obj/artifacts/artifactanalysis.dm
@@ -58,8 +58,10 @@
 		O.UpdateName()
 
 	attack_hand(mob/user)
+		user.lastattacked = src.attached
 		if(src.attached)
 			src.attached.attack_hand(user)
+			user.lastattacked = src.attached
 
 	stick_to(atom/A, pox, poy)
 		. = ..()

--- a/code/obj/artifacts/artifactanalysis.dm
+++ b/code/obj/artifacts/artifactanalysis.dm
@@ -37,16 +37,27 @@
 		if(!length(A.triggers) || A.automatic_activation)
 			lastAnalysis++
 
-		if(lastAnalysis < 3)
-			// haha, they got it wrong, let's make up a fake name
-			src.artifactName = "Random Garbage"
-			for(var/datum/artifact_origin/origin as() in artifact_controls.artifact_origins)
-				if(origin.type_name == src.artifactOrigin)
-					src.artifactName = origin.generate_name()
+		// ok, let's make a name
+		// start with obscured name
+		src.artifactName = O.real_name
+		// get an instance of the artifact origin
+		for(var/datum/artifact_origin/origin as() in artifact_controls.artifact_origins)
+			if(origin.type_name == src.artifactOrigin)
+				// have we already generated a name for that origin?
+				if(!src.usednames[src.artifactOrigin])
+					// no, generate new one
+					if(src.artifactOrigin == A.artitype.type_name)
+						// origin is correct, use actual name
+						src.artifactName = A.internal_name
+					else
+						// origin is wrong, make name up
+						src.artifactName = origin.generate_name()
+					// store generated name
 					src.usednames[src.artifactOrigin] = src.artifactName
-		else
-			// ok you get the real name
-			src.artifactName = A.internal_name
+				else
+					// yes, use it
+					src.artifactName = src.usednames[src.artifactOrigin]
+				break
 
 		// all correct, let's set the name!
 		O.real_name = src.artifactName

--- a/code/obj/artifacts/artifactanalysis.dm
+++ b/code/obj/artifacts/artifactanalysis.dm
@@ -44,13 +44,13 @@
 			if(origin.type_name == src.artifactOrigin)
 				// have we already generated a name for that origin?
 				// the actual name with the actual origin should be in the list by default
-				if(!A.usednames[src.artifactOrigin])
+				if(!A.used_names[src.artifactOrigin])
 					// no, generate new one and store it
 					src.artifactName = origin.generate_name()
-					A.usednames[src.artifactOrigin] = src.artifactName
+					A.used_names[src.artifactOrigin] = src.artifactName
 				else
 					// yes, use it
-					src.artifactName = A.usednames[src.artifactOrigin]
+					src.artifactName = A.used_names[src.artifactOrigin]
 				break
 
 		// all correct, let's set the name!

--- a/code/obj/artifacts/artifactanalysis.dm
+++ b/code/obj/artifacts/artifactanalysis.dm
@@ -11,7 +11,6 @@
 	var/artifactFaults = ""
 	var/artifactDetails = ""
 	var/lastAnalysis = 0
-	var/usednames = list()
 
 	proc/checkArtifactVars(obj/O)
 		if(!O.artifact)
@@ -44,19 +43,14 @@
 		for(var/datum/artifact_origin/origin as() in artifact_controls.artifact_origins)
 			if(origin.type_name == src.artifactOrigin)
 				// have we already generated a name for that origin?
-				if(!src.usednames[src.artifactOrigin])
-					// no, generate new one
-					if(src.artifactOrigin == A.artitype.type_name)
-						// origin is correct, use actual name
-						src.artifactName = A.internal_name
-					else
-						// origin is wrong, make name up
-						src.artifactName = origin.generate_name()
-					// store generated name
-					src.usednames[src.artifactOrigin] = src.artifactName
+				// the actual name with the actual origin should be in the list by default
+				if(!A.usednames[src.artifactOrigin])
+					// no, generate new one and store it
+					src.artifactName = origin.generate_name()
+					A.usednames[src.artifactOrigin] = src.artifactName
 				else
 					// yes, use it
-					src.artifactName = src.usednames[src.artifactOrigin]
+					src.artifactName = A.usednames[src.artifactOrigin]
 				break
 
 		// all correct, let's set the name!

--- a/code/obj/artifacts/artifactanalysis.dm
+++ b/code/obj/artifacts/artifactanalysis.dm
@@ -11,6 +11,7 @@
 	var/artifactFaults = ""
 	var/artifactDetails = ""
 	var/lastAnalysis = 0
+	var/usednames = list()
 
 	proc/checkArtifactVars(obj/O)
 		if(!O.artifact)
@@ -37,14 +38,18 @@
 			lastAnalysis++
 
 		if(lastAnalysis < 3)
-			src.artifactName = ""
-			icon_state = "artifact_form_incorrect"
-			return // you didn't get it all correct, so no cool name for you
+			// haha, they got it wrong, let's make up a fake name
+			src.artifactName = "Random Garbage"
+			for(var/datum/artifact_origin/origin as() in artifact_controls.artifact_origins)
+				if(origin.type_name == src.artifactOrigin)
+					src.artifactName = origin.generate_name()
+					src.usednames[src.artifactOrigin] = src.artifactName
+		else
+			// ok you get the real name
+			src.artifactName = A.internal_name
 
 		// all correct, let's set the name!
-		src.icon_state = "artifact_form_correct"
-		src.artifactName = A.internal_name
-		O.real_name = A.internal_name
+		O.real_name = A.artifactName
 		O.UpdateName()
 
 	stick_to(atom/A, pox, poy)

--- a/code/obj/artifacts/artifactanalysis.dm
+++ b/code/obj/artifacts/artifactanalysis.dm
@@ -49,7 +49,7 @@
 			src.artifactName = A.internal_name
 
 		// all correct, let's set the name!
-		O.real_name = A.artifactName
+		O.real_name = src.artifactName
 		O.UpdateName()
 
 	stick_to(atom/A, pox, poy)

--- a/code/obj/artifacts/artifactdatums.dm
+++ b/code/obj/artifacts/artifactdatums.dm
@@ -15,6 +15,8 @@ ABSTRACT_TYPE(/datum/artifact/)
 	// any sense such as martian robot builders or ancient robot plant seeds.
 
 	var/internal_name = null
+	// one name for each origin
+	var/used_names = list()
 	var/image/fx_image = null
 	// var/image/effects_overlay = null
 	var/obj/holder = null

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -103,6 +103,7 @@
 	A.activ_sound = pick(AO.activation_sounds)
 	A.fault_types |= AO.fault_types - A.fault_blacklist
 	A.internal_name = AO.generate_name()
+	A.used_names[AO.type_name] = A.internal_name
 	A.nofx = AO.nofx
 
 	ArtifactDevelopFault(10)

--- a/code/obj/item/stickers.dm
+++ b/code/obj/item/stickers.dm
@@ -120,7 +120,6 @@
 		. = "<br><span class='notice'>It says:</span><br><blockquote style='margin: 0 0 0 1em;'>[words]</blockquote>"
 
 	attack_hand(mob/user as mob)
-		//boutput(user, "fart")
 		user.lastattacked = user
 		if (src.attached)
 			if (user.a_intent == INTENT_HELP)

--- a/code/obj/item/stickers.dm
+++ b/code/obj/item/stickers.dm
@@ -123,7 +123,7 @@
 		user.lastattacked = user
 		if (src.attached)
 			if (user.a_intent == INTENT_HELP)
-				boutput(user, "You peel \the [src] off of [src.attached].")
+				boutput(user, "You peel \the [src] off of \the [src.attached].")
 				src.remove_from_attached()
 				src.add_fingerprint(user)
 				user.put_in_hand_or_drop(src)

--- a/code/procs/scorestats.dm
+++ b/code/procs/scorestats.dm
@@ -135,7 +135,8 @@ var/datum/score_tracker/score_tracker
 			if(O.disposed)
 				return
 			var/obj/item/sticker/postit/artifact_paper/pap = locate(/obj/item/sticker/postit/artifact_paper/) in O.vis_contents
-			artifacts_analyzed++
+			if(pap)
+				artifacts_analyzed++
 			if(pap?.lastAnalysis >= 3)
 				artifacts_correctly_analyzed++
 		if(artifacts_analyzed)

--- a/code/procs/scorestats.dm
+++ b/code/procs/scorestats.dm
@@ -373,7 +373,8 @@ var/datum/score_tracker/score_tracker
 		score_tracker.score_text += "<BR>"
 
 		score_tracker.score_text += "<B><U>RESEARCH DEPARTMENT</U></B><BR>"
-		score_tracker.score_text += "Scores for this department are not done yet.<br>"
+		score_tracker.score_text += "<B>Artifacts correctly analyzed:</B> [round(score_tracker.final_score_eng)]% ([score_tracker.artifacts_correctly_analyzed]/[score_tracker.artifacts_analyzed])<BR>"
+		score_tracker.score_text += "<B>Total Department Score:</B> [round(score_tracker.final_score_res)]%<BR>"
 		score_tracker.score_text += "<BR>"
 
 		score_tracker.score_text += "<B><U>CIVILIAN DEPARTMENT</U></B><BR>"

--- a/code/procs/scorestats.dm
+++ b/code/procs/scorestats.dm
@@ -134,7 +134,7 @@ var/datum/score_tracker/score_tracker
 		for(var/obj/O in artifact_controls.artifacts)
 			if(O.disposed)
 				return
-			var/obj/item/sticker/postit/artifact_paper/pap = locate(/obj/item/sticker/postit/artifact_paper/) in sell_art.vis_contents
+			var/obj/item/sticker/postit/artifact_paper/pap = locate(/obj/item/sticker/postit/artifact_paper/) in O.vis_contents
 			artifacts_analyzed++
 			if(pap?.lastAnalysis >= 3)
 				artifacts_correctly_analyzed++

--- a/code/procs/scorestats.dm
+++ b/code/procs/scorestats.dm
@@ -373,7 +373,7 @@ var/datum/score_tracker/score_tracker
 		score_tracker.score_text += "<BR>"
 
 		score_tracker.score_text += "<B><U>RESEARCH DEPARTMENT</U></B><BR>"
-		score_tracker.score_text += "<B>Artifacts correctly analyzed:</B> [round(score_tracker.final_score_eng)]% ([score_tracker.artifacts_correctly_analyzed]/[score_tracker.artifacts_analyzed])<BR>"
+		score_tracker.score_text += "<B>Artifacts correctly analyzed:</B> [round(score_tracker.score_artifact_analysis)]% ([score_tracker.artifacts_correctly_analyzed]/[score_tracker.artifacts_analyzed])<BR>"
 		score_tracker.score_text += "<B>Total Department Score:</B> [round(score_tracker.final_score_res)]%<BR>"
 		score_tracker.score_text += "<BR>"
 

--- a/code/procs/scorestats.dm
+++ b/code/procs/scorestats.dm
@@ -15,6 +15,8 @@ var/datum/score_tracker/score_tracker
 	var/score_structural_damage = 0
 	var/final_score_eng = 0
 	// RESEARCH DEPARTMENT
+	var/artifacts_analyzed = 0
+	var/artifacts_correctly_analyzed = 0
 	var/score_artifact_analysis = 0
 	var/final_score_res = 0
 	// CIVILIAN DEPARTMENT
@@ -129,17 +131,15 @@ var/datum/score_tracker/score_tracker
 		final_score_eng = (score_power_outages + score_structural_damage) * 0.5
 
 		// RESEARCH DEPARTMENT SECTION
-		var/correctly_analyzed_artifacts = 0
-		var/analyzed_artifacts = 0
 		for(var/obj/O in artifact_controls.artifacts)
 			if(O.disposed)
 				return
 			var/obj/item/sticker/postit/artifact_paper/pap = locate(/obj/item/sticker/postit/artifact_paper/) in sell_art.vis_contents
-			analyzed_artifacts++
+			artifacts_analyzed++
 			if(pap?.lastAnalysis >= 3)
-				correctly_analyzed_artifacts++
-		if(analyzed_artifacts)
-			score_artifact_analysis = (correctly_analyzed_artifacts/analyzed_artifacts)*100
+				artifacts_correctly_analyzed++
+		if(artifacts_analyzed)
+			score_artifact_analysis = (artifacts_correctly_analyzed/artifacts_analyzed)*100
 
 		final_score_res = score_artifact_analysis
 

--- a/code/procs/scorestats.dm
+++ b/code/procs/scorestats.dm
@@ -15,6 +15,8 @@ var/datum/score_tracker/score_tracker
 	var/score_structural_damage = 0
 	var/final_score_eng = 0
 	// RESEARCH DEPARTMENT
+	var/score_artifact_analysis = 0
+	var/final_score_res = 0
 	// CIVILIAN DEPARTMENT
 	var/score_cleanliness = 0
 	var/score_expenses = 0
@@ -127,7 +129,19 @@ var/datum/score_tracker/score_tracker
 		final_score_eng = (score_power_outages + score_structural_damage) * 0.5
 
 		// RESEARCH DEPARTMENT SECTION
-		// yeah coming soon or w/e idgaf, fucking academics
+		var/correctly_analyzed_artifacts = 0
+		var/analyzed_artifacts = 0
+		for(var/obj/O in artifact_controls.artifacts)
+			if(O.disposed)
+				return
+			var/obj/item/sticker/postit/artifact_paper/pap = locate(/obj/item/sticker/postit/artifact_paper/) in sell_art.vis_contents
+			analyzed_artifacts++
+			if(pap?.lastAnalysis >= 3)
+				correctly_analyzed_artifacts++
+		if(analyzed_artifacts)
+			score_artifact_analysis = (correctly_analyzed_artifacts/analyzed_artifacts)*100
+
+		final_score_res = score_artifact_analysis
 
 		// CIVILIAN DEPARTMENT SECTION
 		if (!istype(wagesystem))
@@ -166,12 +180,12 @@ var/datum/score_tracker/score_tracker
 		// AND THE WINNER IS.....
 
 		var/department_score_sum = 0
-		department_score_sum = final_score_sec + final_score_eng + final_score_civ
+		department_score_sum = final_score_sec + final_score_eng + final_score_civ + final_score_res
 
 		if (department_score_sum == 0 || department_score_sum != department_score_sum) //check for 0 and for NaN values
 			final_score_all = 0
 		else
-			final_score_all = round(department_score_sum / 3)
+			final_score_all = round(department_score_sum / 4)
 
 		switch(final_score_all)
 			if (100 to INFINITY) grade = "NanoTrasen's Finest"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Artifacts will now always receive a name when an analysis form is applied to them
  - name depends on origin chosen on form
  - names will always be the same for artifact even if several forms are used or artifact origins are repeatedly switched on form
  - the name for the correct origin will be the actual artifact name
- when an artifact is sold, the research department now also receives the PDA notice
  - the message now also says how well the artifact was analyzed
  - artifact resupply now also sends a message (to research and QM)
- if several resupplies are queued, they should now arrive in a single crate instead of several staggered crates
- the research department now receives a score for the percentage of perfectly analyzed artifacts
  - this counts all artifacts that have a form attached to them at round end and all artifacts that have been sold with a form attached to them
- uh, I think I also fixed a runtime for when artifacts without a form are sold?
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
- being able to gain information via the labelling forms was weird and made no sense
- messages should give research better feedback on artifact selling and whether or not new artifacts are ready at QM
- lots of crates with single objects are annoying and several big artifacts squeezing into a tiny crate amuses me
- scores are fun, right? everyone loves scores
- runtimes bad

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)zjdtmkhzt
(+)Some minor changes to how artifact selling and the analysis forms work.
(+)The research department now receives a score based on the accuracy of the artifact analysis forms they filled out.
```
