### PR TITLE
stop pulling stuff if it's inside other stuff

### DIFF
--- a/code/mob/input.dm
+++ b/code/mob/input.dm
@@ -220,7 +220,7 @@
 
 						var/list/pulling = list()
 						if (src.pulling)
-							if ((get_dist(old_loc, src.pulling) > 1 && get_dist(src, src.pulling) > 1)|| src.pulling == src) // fucks sake
+							if ((get_dist(old_loc, src.pulling) > 1 && get_dist(src, src.pulling) > 1) || src.z != src.pulling.z || src.pulling == src) // fucks sake
 								src.pulling = null
 								//hud.update_pulling() // FIXME
 							else

--- a/code/mob/input.dm
+++ b/code/mob/input.dm
@@ -220,7 +220,7 @@
 
 						var/list/pulling = list()
 						if (src.pulling)
-							if ((get_dist(old_loc, src.pulling) > 1 && get_dist(src, src.pulling) > 1) || src.z != src.pulling.z || src.pulling == src) // fucks sake
+							if ((!IN_RANGE(old_loc, src.pulling, 1) && !IN_RANGE(src, src.pulling, 1)) || !isturf(src.pulling.loc) || src.pulling == src) // fucks sake
 								src.pulling = null
 								//hud.update_pulling() // FIXME
 							else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This stops the pulling process if the item you are trying to pull is inside another thing. 
Not sure if this is the best way to implement this, but this is what I came up with.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Mainly because recently there is a really annoying bug where if you are pulling a thing that is inside another thing, for some reason you walk two or three times for every time you press a walk button and I couldn't find the actual cause of that.
The walk process seems to be triggered several times, but by what?? It's a mystery.

Apparently the get_dist check uses the loc of the container if the pulled thing is inside something? Who knew!

It mainly happens when you pull around artifacts and then put them into pods/artlab machines and suddenly you zoom around and can't control yourself until the pulling stops itself, which is really annoying.