### PR TITLE
Adds eyepatches to medical manufacturer

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -2246,6 +2246,15 @@ proc/get_nice_mat_name_for_manufacturers(mat)
 	create = 1
 	category = "Clothing"
 
+/datum/manufacture/eyepatch
+	name = "Medical Eyepatch"
+	item_paths = list("FAB-1")
+	item_amounts = list(7)
+	item_outputs = list(/obj/item/clothing/glasses/eyepatch)
+	time = 15 SECONDS
+	create = 1
+	category = "Clothing"
+
 /datum/manufacture/blindfold
 	name = "Blindfold"
 	item_paths = list("FAB-1")

--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -2249,7 +2249,7 @@ proc/get_nice_mat_name_for_manufacturers(mat)
 /datum/manufacture/eyepatch
 	name = "Medical Eyepatch"
 	item_paths = list("FAB-1")
-	item_amounts = list(7)
+	item_amounts = list(5)
 	item_outputs = list(/obj/item/clothing/glasses/eyepatch)
 	time = 15 SECONDS
 	create = 1

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -2144,6 +2144,7 @@
 		/datum/manufacture/scrubs_orange,
 		/datum/manufacture/scrubs_pink,
 		/datum/manufacture/patient_gown,
+		/datum/manufacture/eyepatch,
 		/datum/manufacture/blindfold,
 		/datum/manufacture/muzzle,
 		/datum/manufacture/body_bag,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feature]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Title. They require 5 fabric to manufacture and producing one takes 5 seconds.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Medical eyepatches are very rare to the point of being unobtainable and it makes sense for them to be printable via medbay fabricators. Besides, they're cool and stylish.
I also know they're very useful in case of eye surgery so hopefully the production costs addresses that. I don't consider it a massive balance issue personally, eye surgery is rare and underused.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)TTerc
(+)Added medical eyepatches to medbay manufacturers.
```
