### PR TITLE
makes claw machines scannable by mechanics

### DIFF
--- a/code/modules/items/gimmick/plushies.dm
+++ b/code/modules/items/gimmick/plushies.dm
@@ -5,6 +5,7 @@
 	icon_state = "claw"
 	anchored = 1
 	density = 1
+	mats = list("MET-1"=5, "CON-1"=5, "CRY-1"=5, "FAB-1"=5)
 	deconstruct_flags = DECON_MULTITOOL | DECON_WRENCH | DECON_CROWBAR
 	var/busy = 0
 	var/list/prizes = list(/obj/item/toy/plush/small/bee,\


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Makes claw machines scannable by mechanics.

They cost 5 metal (frame), 5 crystal (glass display case), 5 conductive material (circuitry), and 5 fabric (plushies)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Claw machines are cool and we should be able to build more of them.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Camryn Buttes
(+)Claw machines are now scannable by mechanics.
```
