### PR TITLE
Allows constructed asteroid magnets such as the one at the mining outpost to pull quantum telescope asteroids.

### DIFF
--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -343,6 +343,9 @@
 					SPAWN_DBG(0)
 						pull_new_source()
 
+		proc/get_encounter(var/rarity_mod)
+			return mining_controls.select_encounter(rarity_mod)
+
 		pull_new_source(var/selectable_encounter_id = null)
 			if (!target)
 				return
@@ -383,9 +386,9 @@
 					mining_controls.remove_selectable_encounter(selectable_encounter_id)
 				else
 					boutput(usr, "Uh oh, something's gotten really fucked up with the magnet system. Please report this to a coder! (ERROR: INVALID ENCOUNTER)")
-					MC = mining_controls.select_encounter(rarity_mod)
+					MC = get_encounter(rarity_mod)
 			else
-				MC = mining_controls.select_encounter(rarity_mod)
+				MC = get_encounter(rarity_mod)
 
 			if(MC)
 				MC.generate(target)
@@ -415,6 +418,8 @@
 
 		small
 			marker_type = /obj/magnet_target_marker/small
+			get_encounter(rarity_mod)
+				return mining_controls.select_small_encounter(rarity_mod)
 
 	New()
 		..()

--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -381,7 +381,7 @@
 			var/datum/mining_encounter/MC
 
 			if(selectable_encounter_id != null)
-				if(mining_controls.mining_encounters_selectable.Find(selectable_encounter_id))
+				if(selectable_encounter_id in mining_controls.mining_encounters_selectable)
 					MC = mining_controls.mining_encounters_selectable[selectable_encounter_id]
 					mining_controls.remove_selectable_encounter(selectable_encounter_id)
 				else
@@ -616,7 +616,7 @@
 		var/datum/mining_encounter/MC
 
 		if(selectable_encounter_id != null)
-			if(mining_controls.mining_encounters_selectable.Find(selectable_encounter_id))
+			if(selectable_encounter_id in mining_controls.mining_encounters_selectable)
 				MC = mining_controls.mining_encounters_selectable[selectable_encounter_id]
 				mining_controls.remove_selectable_encounter(selectable_encounter_id)
 			else

--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -343,9 +343,6 @@
 					SPAWN_DBG(0)
 						pull_new_source()
 
-		proc/get_encounter(var/rarity_mod)
-			return mining_controls.select_encounter(rarity_mod)
-
 		pull_new_source(var/selectable_encounter_id = null)
 			if (!target)
 				return
@@ -418,8 +415,6 @@
 
 		small
 			marker_type = /obj/magnet_target_marker/small
-			get_encounter(rarity_mod)
-				return mining_controls.select_small_encounter(rarity_mod)
 
 	New()
 		..()

--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -346,7 +346,7 @@
 		proc/get_encounter(var/rarity_mod)
 			return mining_controls.select_encounter(rarity_mod)
 
-		pull_new_source()
+		pull_new_source(var/selectable_encounter_id = null)
 			if (!target)
 				return
 
@@ -378,8 +378,28 @@
 				do_malfunction()
 			sleep(sleep_time)
 
-			var/datum/mining_encounter/MC = get_encounter(rarity_mod)
-			MC.generate(target)
+			var/datum/mining_encounter/MC
+
+			if(selectable_encounter_id != null)
+				if(mining_controls.mining_encounters_selectable.Find(selectable_encounter_id))
+					MC = mining_controls.mining_encounters_selectable[selectable_encounter_id]
+					mining_controls.remove_selectable_encounter(selectable_encounter_id)
+				else
+					boutput(usr, "Uh oh, something's gotten really fucked up with the magnet system. Please report this to a coder! (ERROR: INVALID ENCOUNTER)")
+					MC = mining_controls.select_encounter(rarity_mod)
+			else
+				MC = mining_controls.select_encounter(rarity_mod)
+
+			if(MC)
+				MC.generate(target)
+			else
+				for (var/obj/forcefield/mining/M in mining_controls.magnet_shields)
+					M.opacity = 0
+					M.set_density(0)
+					M.invisibility = 1
+				active = 0
+				boutput(usr, "Uh oh, something's gotten really fucked up with the magnet system. Please report this to a coder! (ERROR: NO ENCOUNTER)")
+				return
 
 			sleep(sleep_time)
 			if (malfunctioning && prob(20))

--- a/strings/changelog.txt
+++ b/strings/changelog.txt
@@ -1,5 +1,9 @@
 
 (t)fri mar 05 21
+(u)Carbadox
+(p)3855
+(e)🆕|feature
+(+)Added 2x rubber shell cartridges to hacked booze vendor menu.
 (u)TTerc
 (p)3903
 (e)🆕|feature


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The mining magnets that players can build from magnet parts can now pull asteroids from the mining database found via the quantum telescope. This changes the pull_new_source function in the construction mining magnet. It now accepts an input and sets the encounter accordingly.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Consoles connected to constructed mining magnets show the possible asteroids from the quantum telescope, but attempting to pull one will just pull a randomly generated one instead. This will allow magnet mining on Atlas and on other stations if the original magnet is destroyed. This issue is due to the some constructed magnets using the /obj/machinery/mining_magnet/construction mining magnet while the station magnet uses /obj/machinery/mining_magnet. The former does not accept asteroid types in its pull_new_source proc. So the arguments were ignored when pulling telescope asteroids.

## Changelog
```
(u)112358sam
(+)Player-built mining magnets are now compatible with quantum telescope.
```