### PR TITLE
Ozymandias nano fix set (including icing compile fix)

### DIFF
--- a/maps/ozymandias.dmm
+++ b/maps/ozymandias.dmm
@@ -30983,7 +30983,9 @@
 	},
 /obj/machinery/door/poddoor/pyro{
 	dir = 8;
-	layer = 4
+	id = "beeguard";
+	layer = 4;
+	name = "Heisenbee's Office Shutters"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/hor{
@@ -42856,7 +42858,9 @@
 /obj/access_spawn/research_director,
 /obj/machinery/door/poddoor/pyro{
 	dir = 8;
-	layer = 4
+	id = "beeguard";
+	layer = 4;
+	name = "Heisenbee's Office Shutters"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/hor{
@@ -78117,6 +78121,12 @@
 	name = "autoname - SS13";
 	pixel_y = 20;
 	tag = ""
+	},
+/obj/machinery/door_control{
+	id = "beeguard";
+	name = "Heisenbee Office Shutters";
+	pixel_x = -8;
+	pixel_y = 22
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/hor/horprivate)

--- a/maps/ozymandias.dmm
+++ b/maps/ozymandias.dmm
@@ -1634,7 +1634,7 @@
 "azo" = (
 /obj/table/reinforced/auto,
 /obj/item/kitchen/rollingpin,
-/obj/item/reagent_containers/glass/bottle/icing,
+/obj/item/reagent_containers/food/drinks/drinkingglass/icing,
 /obj/cable{
 	icon_state = "0-2"
 	},
@@ -36229,7 +36229,7 @@
 "kyA" = (
 /obj/table/reinforced/auto,
 /obj/item/kitchen/rollingpin,
-/obj/item/reagent_containers/glass/bottle/icing,
+/obj/item/reagent_containers/food/drinks/drinkingglass/icing,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/quarters{
 	name = "Chapel Reception"
@@ -86224,7 +86224,7 @@
 "xYA" = (
 /obj/table/reinforced/auto,
 /obj/item/kitchen/rollingpin,
-/obj/item/reagent_containers/glass/bottle/icing,
+/obj/item/reagent_containers/food/drinks/drinkingglass/icing,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "xYB" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Swaps three icing tubes on Ozymandias to their new object pathing, and adds a missing pod door button for Heisenbee's office.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Ozymandias will not compile without this path update, so it's a pretty important fix in case the map ends up getting used. Bee office is a more minor issue, but still good to have fixed.