### PR TITLE
Fluid changes for ungrouped ON_TOUCH behavior

### DIFF
--- a/code/modules/fluids/fluid_core.dm
+++ b/code/modules/fluids/fluid_core.dm
@@ -147,7 +147,7 @@ var/mutable_appearance/fluid_ma
 		if (src.group)
 			src.group.members -= src
 
-		src.group = 0
+		src.group = null
 
 		/*for (var/atom/A in src.floated_atoms) // ehh i dont like doing this, but I think we need it.
 			if (!A) continue
@@ -790,7 +790,7 @@ var/mutable_appearance/fluid_ma
 
 		for(var/current_id in reacted_ids)
 			if (!src.group) return
-			var/datum/reagent/current_reagent = F.group.reagents.reagent_list[current_id]
+			var/datum/reagent/current_reagent = F?.group.reagents.reagent_list[current_id]
 			if (!current_reagent) continue
 			F.group.reagents.remove_reagent(current_id, current_reagent.volume * volume_fraction)
 		/*
@@ -832,7 +832,7 @@ var/mutable_appearance/fluid_ma
 
 	var/do_reagent_reaction = 1
 
-	if (F.my_depth_level == 1 && src.shoes)
+	if (F.my_depth_level <= 1 && src.shoes)
 		do_reagent_reaction = 0
 	if (F.my_depth_level == 2 || F.my_depth_level == 3)
 		if (src.wear_suit && src.wear_suit.permeability_coefficient <= 0.01)

--- a/code/modules/fluids/fluid_groups.dm
+++ b/code/modules/fluids/fluid_groups.dm
@@ -124,7 +124,7 @@
 		for (var/fluid in src.members)
 			if(fluid)
 				var/obj/fluid/M = fluid
-				M.group = 0
+				M.group = null
 
 		//if (src in processing_fluid_groups)
 		//	processing_fluid_groups.Remove(src)
@@ -213,6 +213,20 @@
 
 		src.update_loop()
 
+		// recalculate depth level based on fluid amount
+		// to account for change to fluid until fluid_core
+		// can perform spread
+		update_amt_per_tile()
+		var/my_depth_level = 0
+		for(var/x in depth_levels)
+			if (src.amt_per_tile > x)
+				my_depth_level++
+			else
+				break
+
+		if (F.last_depth_level != my_depth_level)
+			F.last_depth_level = my_depth_level
+
 	//fluid has been removed from its tile. use 'lightweight' in evaporation procedure cause we dont need icon updates / try split / update loop checks at that point
 	// if 'lightweight' parameter is 2, invoke an update loop but still ignore icon updates
 	proc/remove(var/obj/fluid/F, var/lost_fluid = 1, var/lightweight = 0, var/allow_zero = 0)
@@ -242,7 +256,7 @@
 			src.reagents.remove_any(amt_per_tile)
 			src.contained_amt = src.reagents.total_volume
 
-		F.group = 0
+		F.group = null
 		var/turf/removed_loc = F.loc
 		if(removed_loc)
 			F.turf_remove_cleanup(F.loc)
@@ -290,7 +304,7 @@
 				R = src.reagents.remove_any_to(amt_to_remove)
 				src.contained_amt = src.reagents.total_volume
 
-			F.group = 0
+			F.group = null
 			var/turf/removed_loc = F.loc
 			if (removed_loc)
 				F.turf_remove_cleanup(F.loc)
@@ -459,6 +473,8 @@
 		for(var/x in depth_levels)
 			if (amt_per_tile > x)
 				my_depth_level++
+			else
+				break
 
 		LAGCHECK(LAG_MED)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug - minor][cleanliness]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Calculates a naive fluid depth immediately when a fluid is added to the ground.  The will help provide a reasonable baseline for which level of protection is required to ignore ON_TOUCH, favoring the defender.  Will regrouped and calculated correctly during next fluid_process pass.
Allow for shoes to protect you from fluid depth level of 1 or unknown, favoring the defender.

Minor code cleanup.

Based on findings from DMSO PR.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
`EnteredFluid` of unprocessed fluids on a turf would bypass shoes and permeability_coefficient of clothing resulting in behavior that would likely be inconsistent to the player. 