### PR TITLE
Changes the job reward level of the Spectro Monocle from 0 to 5

### DIFF
--- a/code/WorkInProgress/JobXPRewards.dm
+++ b/code/WorkInProgress/JobXPRewards.dm
@@ -547,7 +547,7 @@ mob/verb/checkrewards()
 /datum/jobXpReward/bartender/spectromonocle
 	name = "Spectroscopic Monocle"
 	desc = "Now you can look dapper and know which drinks you poisoned at the same time"
-	required_levels = list("Bartender"=0)
+	required_levels = list("Bartender"=5)
 	icon_state = "?"
 	claimable = 1
 	var/path_to_spawn = /obj/item/clothing/glasses/spectro/monocle


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the job reward level of the Spectro Monocle from 0 to 5


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It wasn't supposed to be a level 0 reward, I set it to 0 during testing and forgot to give it a level requirement.
