### PR TITLE
Soundproof component cabinets

### DIFF
--- a/code/WorkInProgress/MechanicMadness.dm
+++ b/code/WorkInProgress/MechanicMadness.dm
@@ -1815,10 +1815,15 @@
 			sendsig.data_file = input.data_file.copy_file()
 		SPAWN_DBG(0)
 			if(src.noise_enabled)
-				src.noise_enabled = false
-				playsound(get_turf(src), "sound/machines/modem.ogg", WIFI_NOISE_VOLUME, 0, 0)
-				SPAWN_DBG(WIFI_NOISE_COOLDOWN)
-					src.noise_enabled = true
+				var/play_sound = 1
+				if(istype(src.loc,/obj/item/storage/mechanics/housing_large))
+					var/obj/item/storage/mechanics/housing_large/H = src.loc
+					play_sound = H.open // only play the sound if the cabinet is open
+				if(play_sound)
+					src.noise_enabled = false
+					playsound(get_turf(src), "sound/machines/modem.ogg", WIFI_NOISE_VOLUME, 0, 0)
+					SPAWN_DBG(WIFI_NOISE_COOLDOWN)
+						src.noise_enabled = true
 			src.radio_connection.post_signal(src, sendsig, src.range)
 
 		animate_flash_color_fill(src,"#FF0000",2, 2)
@@ -1842,10 +1847,15 @@
 
 				SPAWN_DBG(0.5 SECONDS) //Send a reply for those curious jerks
 					if(src.noise_enabled)
-						src.noise_enabled = false
-						playsound(get_turf(src), "sound/machines/modem.ogg", WIFI_NOISE_VOLUME, 0, 0)
-						SPAWN_DBG(WIFI_NOISE_COOLDOWN)
-							src.noise_enabled = true
+						var/play_sound = 1
+						if(istype(src.loc,/obj/item/storage/mechanics/housing_large))
+							var/obj/item/storage/mechanics/housing_large/H = src.loc
+							play_sound = H.open // only play the sound if the cabinet is open
+						if(play_sound)
+							src.noise_enabled = false
+							playsound(get_turf(src), "sound/machines/modem.ogg", WIFI_NOISE_VOLUME, 0, 0)
+							SPAWN_DBG(WIFI_NOISE_COOLDOWN)
+								src.noise_enabled = true
 					src.radio_connection.post_signal(src, pingsignal, src.range)
 
 			if(signal.data["command"] == "text_message" && signal.data["batt_adjust"] == netpass_syndicate)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE][BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Prevents wifi components from making their modem noise when inside a closed component cabinet. (Only the large ones, not the handheld version)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Building mechcomp machines that use wifi frequently are extremely noisy.

The big issues here is the return of the ability to use automated wifi stealthily. I feel that this is counteracted by the requirement for it to be in a closed cabinet, meaning that if you want a quite door hacker, you will have to lug the entire glowing server rack around with you.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Sidewinder7
(*)Wifi components are now silent when inside of a closed component cabinet.
```
