### PR TITLE
Added a term_ping filtering option

### DIFF
--- a/code/modules/networks/computer3/terminal.dm
+++ b/code/modules/networks/computer3/terminal.dm
@@ -13,6 +13,7 @@
 	var/tmp/ping_wait = 0 //Are we waiting for a ping reply?
 	var/tmp/datum/computer/file/temp_file = null //Temp folder from our server
 	var/auto_accept = 1 //Do we automatically accept connection attempts?
+	var/ping_filter = null
 	//var/tmp/service_mode = 0
 
 	input_text(text)
@@ -95,6 +96,10 @@ file_save - Save file to local disk."}
 							src.net_number = new_net_number
 
 					src.peripheral_command("subnet[src.net_number]", null, "\ref[src.netcard]")
+				if (command_list.len > 1)
+					src.ping_filter = lowertext(command_list[2])
+				else
+					src.ping_filter = null
 
 				src.ping_wait = 4
 
@@ -490,7 +495,8 @@ file_save - Save file to local disk."}
 				var/reply_device = signal.data["device"]
 				var/reply_id = signal.data["netid"]
 
-				src.print_text("<b>P:</b> \[[reply_id]]-TYPE: [reply_device]")
+				if(src.ping_filter == null || findtext(lowertext(reply_device), src.ping_filter))
+					src.print_text("<b>P:</b> \[[reply_id]]-TYPE: [reply_device]")
 
 			//oh, somebody trying to connect!
 			else if(signal.data["command"] == "term_connect" && !src.serv_id)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE][QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Added an extra optional argument to term_ping. When given, all responses with device names that don't include the filter are ignored.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Searching through the entire ping response list looking for the mainframe is kind of a pain.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Sidewinder7
(*)The term_ping command now accepts a filter argument.
```
