### PR TITLE
Add a rapid crayon creation device for artists

### DIFF
--- a/code/modules/economy/persistent_bank_purchases.dm
+++ b/code/modules/economy/persistent_bank_purchases.dm
@@ -3,6 +3,7 @@ var/global/list/persistent_bank_purchaseables =	list(\
 	new /datum/bank_purchaseable/human_item/reset,\
 	new /datum/bank_purchaseable/human_item/crayon,\
 	new /datum/bank_purchaseable/human_item/paint_rainbow,\
+	new /datum/bank_purchaseable/human_item/crayon_box,\
 	new /datum/bank_purchaseable/human_item/paint_plaid,\
 	new /datum/bank_purchaseable/human_item/stickers,\
 	new /datum/bank_purchaseable/human_item/bee_egg,\
@@ -173,6 +174,11 @@ var/global/list/persistent_bank_purchaseables =	list(\
 			name = "Plaid Paint Can"
 			cost = 3000
 			path = /obj/item/paint_can/rainbow/plaid
+		
+		crayon_box
+			name = "Crayon Creator"
+			cost = 2500
+			path = /obj/item/item_box/crayon
 
 		stickers
 			name = "Sticker Box"

--- a/code/obj/item/generic_box.dm
+++ b/code/obj/item/generic_box.dm
@@ -106,6 +106,28 @@
 		desc = "It's like a box that a pile of sticky notes would come in, but it's actually the pile, too. So there's a pile in the box. Or the pile... IS the box? Quantum sticky note pile-box? Whatever, I've been trying to get this to work for a few hours and making a special little sticky note container is the last thing I want to do right now. Fuck."
 		contained_item = /obj/item/sticker/postit
 
+	crayon // stonepillar's crayon project
+		name = "rapid crayon creation device"
+		desc = "It's the StephiMatic(tm) rapid crayon creation device! Perfect for the budding artist. Ages 5 and up!"
+		contained_item = /obj/item/pen/crayon
+
+		add_to(var/obj/item/I)
+			if(..())
+				qdel(I)
+				return 1
+			return 0
+
+		take_from()
+			var/newColor = input("Pick crayon color:","Crayon color") as null|color
+			if(!isnull(newColor))
+				var/obj/item/pen/crayon/newCrayon = new /obj/item/pen/crayon
+				newCrayon.color = newColor
+				newCrayon.font_color = newColor
+				newCrayon.name = "cheap-looking [hex2color_name(newColor)] crayon"
+				return newCrayon
+			return 0
+
+
 	assorted
 		name = "box of assorted things"
 		desc = "Wow! A marvel of technology, this box doesn't store just ONE item, but an assortment of items! The future really is here."

--- a/code/obj/item/storage/toolbox.dm
+++ b/code/obj/item/storage/toolbox.dm
@@ -131,7 +131,7 @@
 	desc = "A metal container designed to hold various tools. This variety holds art supplies."
 	icon_state = "green"
 	item_state = "toolbox-green"
-	spawn_contents = list(/obj/item/paint_can/random = 7)
+	spawn_contents = list(/obj/item/paint_can/random = 6, /obj/item/item_box/crayon = 1)
 
 /* -------------------- Memetic Toolbox -------------------- */
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[feature]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a 'rapid crayon creation device', which allows you to create a crayon of any color using the color picker, and destroy crayons you don't need by putting them back into the device. Geared towards artists, its available for 2,500 spacebux or in an artistic toolbox.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

To help make crayon art a bit easier when it comes to finding the right colors. Oh, and @Xkeeper0 asked for it.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Stonepillar
(*)Added a rapid crayon creation device. It makes crayons. Purchase with spacebux or find in artistic toolboxes.
```
