### PR TITLE
add missing data terminal and chaplain stuff to atlas

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -2271,13 +2271,13 @@
 	},
 /area/station/hallway/secondary/exit)
 "fJ" = (
-/obj/storage/closet/wardrobe/black/chaplain,
 /obj/item/ghostboard,
 /obj/machinery/light_switch/auto,
 /obj/machinery/crema_switch{
 	pixel_x = 5;
 	pixel_y = 28
 	},
+/obj/storage/secure/closet/civilian/chaplain,
 /turf/simulated/grimycarpet,
 /area/station/chapel/office)
 "fK" = (
@@ -13473,6 +13473,7 @@
 /obj/machinery/guardbot_dock,
 /obj/cable,
 /obj/machinery/bot/guardbot/ranger,
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "Hd" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The guardbuddy dock in Robotics had no data terminal, so it never got connected to the network.
The chapel used the chaplain wardrobe, which is apparently basically a chaplain locker but without all the new stuff in it and only outdated maps use it.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I wanted to use the buddy and it didn't work. >:(
And I was asked to add the witchfinder outfit to atlas too, so there's that.