### PR TITLE
PTL Income Adjustment

### DIFF
--- a/code/modules/power/pt_laser.dm
+++ b/code/modules/power/pt_laser.dm
@@ -183,9 +183,9 @@
 	#define ACCEL_FACTOR 69 //our acceleration factor towards cap
 	#define STEAL_FACTOR 4 //Adjusts the curve of the stealing EQ (2nd deriv/concavity)
 
-	//For equation + explaination, https://www.desmos.com/calculator/sgpk5aj6hy
+	//For equation + explanation, https://www.desmos.com/calculator/r8bsyz5gf9
 	//Adjusted to give a decent amt. of cash/tick @ 50GW (said to be average hellburn)
-	var/generated_moolah =   (2*output_mw*BUX_PER_WORK_CAP)/(2*output_mw + BUX_PER_WORK_CAP*ACCEL_FACTOR) //used if output_mw > 0
+	var/generated_moolah = (2*output_mw*BUX_PER_WORK_CAP)/(2*output_mw+BUX_PER_WORK_CAP*ACCEL_FACTOR) //used if output_mw > 0
 	generated_moolah += (4*output_mw*LOW_CAP)/(4*output_mw + LOW_CAP)
 
 	if (output_mw < 0) //steals money since you emagged it
@@ -209,7 +209,7 @@
 
 		for(var/datum/data/record/t in accounts)
 			t.fields["current_money"] += round(generated_moolah/accounts.len)
-		undistributed_earnings += generated_moolah-(round(generated_moolah/accounts.len) * (accounts.len))
+		undistributed_earnings += generated_moolah-(round(generated_moolah/accounts.len) * (length(accounts)))
 	else
 		undistributed_earnings += generated_moolah
 

--- a/code/modules/power/pt_laser.dm
+++ b/code/modules/power/pt_laser.dm
@@ -33,6 +33,7 @@
 	var/output_multi = 1e6
 	var/emagged = FALSE
 	var/lifetime_earnings = 0
+	var/undistributed_earnings = 0
 	var/excess = null //for tgui readout
 	var/is_charging = FALSE //for tgui readout
 
@@ -144,7 +145,7 @@
 				dont_update = 1 //so the firing animation runs
 				charge -= adj_output
 				if(selling)
-					power_sold()
+					power_sold(adj_output)
 		else if(charge < adj_output && (adj_output >= PTLMINOUTPUT)) //firing but not enough charge to sustain
 			stop_firing()
 		else //firing and have enough power to carry on
@@ -177,18 +178,22 @@
 
 	var/output_mw = adjusted_output / 1e6
 
-	#define BUX_PER_SEC_CAP 5000 //at inf power, generate 5000$/tick, also max amt to drain/tick
+	#define LOW_CAP (20) //provide a nice scalar for deminishing returns instead of a slow steady climb
+	#define BUX_PER_WORK_CAP (5000-LOW_CAP) //at inf power, generate 5000$/tick, also max amt to drain/tick
 	#define ACCEL_FACTOR 69 //our acceleration factor towards cap
 	#define STEAL_FACTOR 4 //Adjusts the curve of the stealing EQ (2nd deriv/concavity)
 
-	//For equation + explaination, https://www.desmos.com/calculator/62w5igbqwo
+	//For equation + explaination, https://www.desmos.com/calculator/sgpk5aj6hy
 	//Adjusted to give a decent amt. of cash/tick @ 50GW (said to be average hellburn)
-	var/generated_moolah =   (2*output_mw*BUX_PER_SEC_CAP)/(2*output_mw + BUX_PER_SEC_CAP*ACCEL_FACTOR) //used if output_mw > 0
+	var/generated_moolah =   (2*output_mw*BUX_PER_WORK_CAP)/(2*output_mw + BUX_PER_WORK_CAP*ACCEL_FACTOR) //used if output_mw > 0
+	generated_moolah += (4*output_mw*LOW_CAP)/(4*output_mw + LOW_CAP)
 
 	if (output_mw < 0) //steals money since you emagged it
-		generated_moolah = (-2*output_mw*BUX_PER_SEC_CAP)/(2*STEAL_FACTOR*output_mw - BUX_PER_SEC_CAP*STEAL_FACTOR*ACCEL_FACTOR)
+		generated_moolah = (-2*output_mw*BUX_PER_WORK_CAP)/(2*STEAL_FACTOR*output_mw - BUX_PER_WORK_CAP*STEAL_FACTOR*ACCEL_FACTOR)
 
 	lifetime_earnings += generated_moolah
+	generated_moolah += undistributed_earnings
+	undistributed_earnings = 0
 
 	var/list/accounts = list()
 	for(var/datum/data/record/t in data_core.bank)
@@ -204,10 +209,13 @@
 
 		for(var/datum/data/record/t in accounts)
 			t.fields["current_money"] += round(generated_moolah/accounts.len)
+		undistributed_earnings += generated_moolah-(round(generated_moolah/accounts.len) * (accounts.len))
+	else
+		undistributed_earnings += generated_moolah
 
 	#undef STEAL_FACTOR
 	#undef ACCEL_FACTOR
-	#undef BUX_PER_SEC_CAP
+	#undef BUX_PER_WORK_CAP
 
 /obj/machinery/power/pt_laser/proc/get_barrel_turf()
 	var/x_off = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug][balance][input wanted]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adjusted Credit scaling:
* https://www.desmos.com/calculator/sgpk5aj6hy
* Lower MW values are scaled to provide a behavior that feels more like diminishing returns a function that is intended to scaling infinitely.  Result is "similar" to if output to be +600MW.

Keep track of power not sold, and add it to the next attempt, until it can eventually be distributed to station/crew.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Give reason to chamber burns when not attempting to "Hellburn".
Give reason to turn on PTL with Char burns.
Resolves bug when outputting in "bursts". 😱 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Azrun
(+)Nanotrasen no longer pockets money from rounding down when paying out for PTL.  Lower end MW drastically improved.
```
