### PR TITLE
Fixes Cogmap1 APC

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -63223,6 +63223,20 @@
 	},
 /turf/simulated/floor/dirt,
 /area/station/ranch)
+"usA" = (
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	areastring = "Medbay";
+	name = "Medbay APC";
+	pixel_y = -24
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southwest)
 "uvz" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -102112,7 +102126,7 @@ bWU
 bYj
 bLG
 ahf
-cbV
+usA
 cbQ
 cey
 cfH


### PR DESCRIPTION
(i set the wrong area string in my APC fix PR ages ago. oops)
[BUG]
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes the Medical Bay APC. Two of the APCs in Maintenance were connected to the Operating Theatre, with none connected to Medbay itself.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I'm a dumbass who didn't set the `areastring` & `name` vars on this APC in my APC fix PR