### PR TITLE
Fix breath suicide grammar

### DIFF
--- a/code/mob/suicide.dm
+++ b/code/mob/suicide.dm
@@ -150,7 +150,7 @@
 					src.suiciding = 0
 		else
 			//instead of killing them instantly, just put them at -175 health and let 'em gasp for a while
-			src.visible_message("<span class='alert'><b>[src] is holding [his_or_her(src)] breath. It looks like [he_or_she(src)]'s trying to commit suicide.</b></span>")
+			src.visible_message("<span class='alert'><b>[src] is holding [his_or_her(src)] breath. It looks like [hes_or_shes(src)] trying to commit suicide.</b></span>")
 			src.take_oxygen_deprivation(175)
 			SPAWN_DBG(20 SECONDS) //in case they get revived by cryo chamber or something stupid like that, let them suicide again in 20 seconds
 				if (src && !isdead(src))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[trivial]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Puts the right proc in the "X is holding their breath" message.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The current thing is grammatically wrong when someone uses they/them.