### PR TITLE
Makes prodoc heart unaffected by lighting

### DIFF
--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -201,6 +201,7 @@
 #endif
 
 	health_mon = image('icons/effects/healthgoggles.dmi',src,"100",10)
+	health_mon.plane = PLANE_OVERLAY_EFFECTS
 	health_mon_icons.Add(health_mon)
 
 	health_implant = image('icons/effects/healthgoggles.dmi',src,"100",10)

--- a/code/mob/living/life/health_mon.dm
+++ b/code/mob/living/life/health_mon.dm
@@ -35,6 +35,11 @@
 						H.health_mon.icon_state = "10"
 					if (-INFINITY to 0) //0
 						H.health_mon.icon_state = "0"
+
+			var/turf/T = get_turf(H)
+			H.health_mon.alpha = T.RL_GetBrightness() * 255
+			//var/turfbrightness = T.RL_GetBrightness() * 255
+			//H.health_mon.color = rgb(turfbrightness,turfbrightness,turfbrightness)
 		if (H.health_implant)
 			if (locate(/obj/item/implant/health) in H.implant)
 				H.health_implant.icon_state = "implant"

--- a/code/mob/living/life/health_mon.dm
+++ b/code/mob/living/life/health_mon.dm
@@ -37,9 +37,7 @@
 						H.health_mon.icon_state = "0"
 
 			var/turf/T = get_turf(H)
-			H.health_mon.alpha = T.RL_GetBrightness() * 255
-			//var/turfbrightness = T.RL_GetBrightness() * 255
-			//H.health_mon.color = rgb(turfbrightness,turfbrightness,turfbrightness)
+			H.health_mon.alpha = T.RL_GetBrightness() * 255 //The heart gets fainter in the dark, but isn't (as) discoloured by lighting colour
 		if (H.health_implant)
 			if (locate(/obj/item/implant/health) in H.implant)
 				H.health_implant.icon_state = "implant"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[qol][balance][input wanted]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR puts the prodoc heart image on the overlay effects plane, which means it's no longer affected by lighting intensity or colour.

There's a few side-effects: the hearts will display over other sprites like shrubs and trees, but they also can't be targeted to attack the associated mob anymore.
(There's no way to make them lighting-independent without showing through in one way or another.)
![afbeelding](https://user-images.githubusercontent.com/31984217/110329712-43830900-801d-11eb-99ff-087f2201d77d.png)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
People tend to complain that coloured lightning fucks with doctors especially on this point, and I think those two don't need to be in conflict. I think the accessibility/qol benefit is more important than prodocs showing people hiding behind large sprites.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)BatElite
(+)Prodoc hearts are less affected by coloured lighting.
```