### PR TITLE
re-implements rad-wick with 80% resistance.

### DIFF
--- a/code/mob/living/life/Life.dm
+++ b/code/mob/living/life/Life.dm
@@ -693,6 +693,9 @@
 		if (bioHolder?.HasEffect("food_rad_resist"))
 			rad_protection += 100
 
+	if (src.hasStatus("food_rad_resist"))
+			rad_protection += 80 // 80 because that's what "food_disease_resist" does
+
 		rad_protection = clamp(rad_protection, 0, 100)
 		return rad_protection
 

--- a/code/mob/living/life/Life.dm
+++ b/code/mob/living/life/Life.dm
@@ -693,7 +693,7 @@
 		if (bioHolder?.HasEffect("food_rad_resist"))
 			rad_protection += 100
 
-	if (src.hasStatus("food_rad_resist"))
+		if (src.hasStatus("food_rad_resist"))
 			rad_protection += 80 // 80 because that's what "food_disease_resist" does
 
 		rad_protection = clamp(rad_protection, 0, 100)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR re-implements Rad-Wick with 80% resistance, 80% because it looks like 100% was not intended for this, and the cleanse food effect gives 80%.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Rad-Wick is currently broken, with the only indication of it being broken that it provides no resistance at all, 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Chickenish
(+)The Rad-Wick food effect works again.
```
