### PR TITLE
Removes opossums from wizard polymorph list

### DIFF
--- a/code/datums/abilities/wizard/animal.dm
+++ b/code/datums/abilities/wizard/animal.dm
@@ -13,7 +13,6 @@ var/list/animal_spell_critter_paths = list(/mob/living/critter/small_animal/mous
 /mob/living/critter/small_animal/bird/goose/swan,
 /mob/living/critter/small_animal/cockroach,
 /mob/living/critter/small_animal/cockroach/robo,
-/mob/living/critter/small_animal/opossum,
 /mob/living/critter/small_animal/floateye,
 /mob/living/critter/small_animal/pig,
 /mob/living/critter/spider/clown,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[balance]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Title

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Basically https://forum.ss13.co/showthread.php?tid=15985
I planned to make a PR that removes them for a while now. They're extremely unfun to be polymorphed into and it usually forces you to either pray to be gibbed or AFK for the whole round.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)TTerc
(+)Removed opossums from wizard polymorph list.
```
