### PR TITLE
Makes Securitrons unable to see trough cloaks.

### DIFF
--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -759,6 +759,12 @@
 			src.KillPathAndGiveUp(kpagu)
 			return
 
+		// If the target is or goes invisible, give up, securitrons don't have thermal vision! :p
+		if(src.target.invisibility > 0)
+			speak("?!", just_float = 1)
+			src.KillPathAndGiveUp(kpagu)
+			return
+
 		/// Tango hidden inside something or someone? Welp, can't hit them through a locker, so may as well give up!
 		if(src.target?.loc && !isturf(src.target.loc))
 			speak("?", just_float = 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] --> [BALANCE] [INPUT WANTED] [BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Makes securitrons stop targeting anyone who is invisible or becomes Invisible be it either trough a cloaking device, a genetics ability or the vampire ability, also makes them not target wizards that are in the middle of their doppelganger and phase shift abilities, as it is right now they can even baton the wizards while they are in the middle of those. there are probably more situations where it will occur but I can't think of them all. 

Input wanted label because some people were against the change when I talked about it.

Fixes #<2609>
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Still being able to be seen by them does not make sense and confuses new players and beepsky is way too strong and will still be if this gets merged, just a little less. Also, fixes a bug, those aren't good!


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Arthur Holiday
(*)Securitrons don't target invisible people anymore.
```
